### PR TITLE
Expand mypy coverage to factory and geometry modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,14 +34,14 @@ repos:
         args: [--maxkb=1000]
         exclude: ^uv\.lock$
 
-  # Type checking disabled for now - too many cross-module dependencies
-  # Can be re-enabled with:
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.11.2
-  #   hooks:
-  #     - id: mypy
-  #       files: ^mfg_pde/(core|alg|geometry|factory|types)/.*\.py$
-  #       additional_dependencies: [numpy, scipy, pydantic, types-tqdm, types-PyYAML]
+  # Type checking for core mathematical modules (gradual re-enablement)
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        files: ^mfg_pde/(simple\.py|core/mfg_problem\.py|types/.*\.py|geometry/base_geometry\.py|factory/solver_factory\.py)$
+        args: [--follow-imports=silent, --ignore-missing-imports]
+        additional_dependencies: [numpy, scipy, pydantic, types-tqdm, types-PyYAML, types-setuptools]
 
 # Performance optimizations
 default_language_version:

--- a/docs/development/MYPY_GRADUAL_REENABLEMENT_SUMMARY.md
+++ b/docs/development/MYPY_GRADUAL_REENABLEMENT_SUMMARY.md
@@ -1,0 +1,158 @@
+# MyPy Gradual Re-enablement Summary ✅ COMPLETED
+
+**Date**: 2025-09-23
+**Status**: Successfully implemented gradual mypy re-enablement for core modules
+**Issue**: Addresses GitHub Issue #2
+
+## 🎯 **Objective**
+
+Re-enable mypy type checking for core mathematical modules while maintaining development flexibility for research code.
+
+## 📊 **Initial Assessment**
+
+When we attempted to re-enable mypy for the entire codebase, we faced:
+- **800+ type errors** across the entire codebase
+- **Cross-module dependency issues** making full enablement impractical
+- **Blocking development workflow** due to complex scientific computing dependencies
+
+**Strategic Decision**: Implement gradual re-enablement starting with core mathematical modules.
+
+## 🔧 **Implementation Strategy**
+
+### **Phase 1: Module Assessment**
+Tested individual modules to identify manageable error counts:
+
+```bash
+# Clean modules (0 errors)
+mypy mfg_pde/types/internal.py --follow-imports=silent --ignore-missing-imports
+Success: no issues found
+
+# Manageable modules
+mypy mfg_pde/simple.py --follow-imports=silent --ignore-missing-imports
+Found 11 errors  # Fixed to 0
+
+mypy mfg_pde/core/mfg_problem.py --follow-imports=silent --ignore-missing-imports
+Found 5 errors   # Fixed to 0
+```
+
+### **Phase 2: Targeted Fixes**
+
+#### **mfg_pde/simple.py** (11 → 0 errors)
+1. **Undefined variable references**: Fixed string literals `"high"`, `"low"`, `"fast"`
+2. **Missing imports**: Added `Callable` import for type annotations
+3. **Function parameter typing**: Updated `callable` → `Callable` annotations
+4. **Complex kwargs expansion**: Resolved mypy confusion with **params by explicit parameter handling:
+
+```python
+# Before: Caused mypy confusion
+return solve_mfg(problem_type, accuracy="balanced", verbose=True, **params)
+
+# After: Clear parameter separation
+domain_size: float = params.get("domain_size", 1.0)
+time_horizon: float = params.get("time_horizon", 1.0)
+extra_kwargs: dict[str, Any] = {
+    k: v for k, v in params.items()
+    if k not in {"domain_size", "time_horizon", "accuracy", "fast", "verbose"}
+}
+return solve_mfg(problem_type, domain_size=domain_size, ...)
+```
+
+#### **mfg_pde/core/mfg_problem.py** (5 → 0 errors)
+1. **Missing return type annotations**: Added `-> None` to validation functions
+2. **Object type ambiguity**: Added explicit `float()` casting for `npart`/`ppart` results:
+   ```python
+   npart_val_fwd = float(npart(p_forward))  # Resolves "object" vs "float" issue
+   ```
+3. **Missing **kwargs type annotations**: Added `**kwargs: Any` to function signatures
+
+### **Phase 3: Pre-commit Integration**
+
+Updated `.pre-commit-config.yaml` to enable mypy for specific modules:
+
+```yaml
+# Type checking for core mathematical modules (gradual re-enablement)
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.11.2
+  hooks:
+    - id: mypy
+      files: ^mfg_pde/(simple\.py|core/mfg_problem\.py|types/.*\.py)$
+      args: [--follow-imports=silent, --ignore-missing-imports]
+      additional_dependencies: [numpy, scipy, pydantic, types-tqdm, types-PyYAML, types-setuptools]
+```
+
+## ✅ **Results**
+
+### **Type Safety Achieved**
+- **3 core modules** now have full mypy coverage: `simple.py`, `core/mfg_problem.py`, `types/internal.py`
+- **0 type errors** in production-critical mathematical code
+- **Improved code reliability** for user-facing APIs
+
+### **Development Workflow Preserved**
+- **No blocking** of development on research/experimental code
+- **Selective checking** only on stable core modules
+- **Research flexibility** maintained for utils, visualization, experimental modules
+
+### **Verification Results**
+```bash
+# ✅ Passes type checking for included files
+pre-commit run mypy --files mfg_pde/simple.py
+mypy.....................................................................Passed
+
+# ✅ Skips excluded files (no development blocking)
+pre-commit run mypy --files mfg_pde/utils/logging.py
+mypy.................................................(no files to check)Skipped
+
+# ✅ Full pre-commit with mypy enabled
+pre-commit run mypy --all-files
+mypy.....................................................................Passed
+```
+
+## 🔮 **Future Expansion Path**
+
+This implementation provides a foundation for gradual expansion:
+
+### **Next Candidates for Type Checking**
+1. **Factory modules** (`mfg_pde/factory/*.py`) - Well-structured APIs
+2. **Configuration modules** (`mfg_pde/config/*.py`) - Critical for user experience
+3. **Core geometry** (`mfg_pde/geometry/base_geometry.py`) - Mathematical foundations
+
+### **Expansion Process**
+```bash
+# Test module for manageable error count
+mypy mfg_pde/factory/solver_factory.py --follow-imports=silent --ignore-missing-imports
+
+# If < 20 errors: Fix issues and add to pre-commit pattern
+files: ^mfg_pde/(simple\.py|core/mfg_problem\.py|types/.*\.py|factory/solver_factory\.py)$
+```
+
+### **Long-term Vision**
+- **Core mathematical modules**: Full type coverage for reliability
+- **Public APIs**: Strong typing for user experience
+- **Research/experimental code**: Maintain flexibility without type checking
+
+## 🧠 **Key Learnings**
+
+1. **Gradual approach works**: Rather than attempting full codebase coverage, targeted module fixing is more effective
+2. **Scientific computing complexity**: Cross-module dependencies and numerical libraries make full mypy coverage impractical
+3. **Strategic filtering**: Pre-commit file patterns allow precise control over what gets checked
+4. **Type casting solutions**: Explicit `float()` casting resolves ambiguous return types from numerical functions
+5. **Parameter handling patterns**: Complex **kwargs expansion requires careful mypy-friendly restructuring
+
+## 📋 **Implementation Checklist**
+
+- [x] Analyze current mypy configuration and plan re-enablement strategy
+- [x] Test mypy on individual core modules to assess error count
+- [x] Fix type issues in core mathematical modules
+- [x] Update pre-commit configuration to include specific core modules
+- [x] Verify mypy works without blocking development
+- [x] Document the re-enablement approach for future reference
+
+---
+
+**Status**: ✅ **COMPLETED** - Core mathematical modules now have mypy coverage without blocking research development workflow.
+
+**Related Issues**:
+- GitHub Issue #2: "Implement gradual mypy re-enablement for core modules"
+- Previous work: Pre-commit fixes reduced errors from ~800 to manageable levels
+
+**Next Steps**: Consider expanding to factory and configuration modules following the same pattern.

--- a/docs/development/TYPEDDICT_VS_ANY_ANALYSIS.md
+++ b/docs/development/TYPEDDICT_VS_ANY_ANALYSIS.md
@@ -1,0 +1,232 @@
+# TypedDict vs **kwargs: Any Analysis
+
+**Date**: 2025-09-23
+**Status**: Analysis completed - Recommendations provided
+**Context**: Exploring better type safety alternatives to **kwargs: Any
+
+## 🎯 **Research Question**
+
+Can TypedDict provide better type safety than `**kwargs: Any` for MFG_PDE's parameter-heavy functions without sacrificing development flexibility?
+
+## 📊 **Analysis Summary**
+
+**TL;DR**: For MFG_PDE's use case, **constrained dict typing** (`**kwargs: int | float | str | bool`) offers the best balance of type safety and practicality, but `**kwargs: Any` remains the most pragmatic choice.
+
+## 🔍 **Approaches Tested**
+
+### **1. Current Approach: `**kwargs: Any`**
+```python
+def validate_problem_parameters(problem_type: str, **kwargs: Any) -> dict[str, Any]:
+    crowd_size = kwargs.get("crowd_size")  # Type: Any
+    if crowd_size is not None and crowd_size <= 0:  # Runtime error if crowd_size is str!
+        issues.append("crowd_size must be positive")
+```
+
+**Pros**:
+- ✅ Simple and fast
+- ✅ No type checking overhead
+- ✅ Works with any parameter structure
+- ✅ Flexible for research code
+
+**Cons**:
+- ❌ No type safety whatsoever
+- ❌ Runtime errors for type mismatches
+- ❌ No IDE autocompletion
+- ❌ Silent bugs from wrong parameter types
+
+### **2. Pure TypedDict Approach**
+```python
+class CrowdDynamicsParams(TypedDict, total=False):
+    domain_size: float
+    crowd_size: NotRequired[int]
+
+def validate_problem_parameters_typed(problem_type: str, params: CrowdDynamicsParams) -> ValidationResult:
+    crowd_size = params["crowd_size"]  # Type: int (guaranteed)
+```
+
+**Pros**:
+- ✅ Strong type safety for specific problem types
+- ✅ Excellent IDE support
+- ✅ Compile-time error detection
+
+**Cons**:
+- ❌ **TOO RESTRICTIVE**: Union types (CrowdDynamicsParams | PortfolioParams) create mypy errors
+- ❌ Can't access keys not in ALL TypedDict variants
+- ❌ Requires separate functions for each problem type
+- ❌ Poor fit for our multi-problem function design
+
+### **3. Constrained Dict Approach (RECOMMENDED)**
+```python
+def validate_problem_parameters(problem_type: str, **kwargs: int | float | str | bool) -> dict[str, Any]:
+    crowd_size = kwargs.get("crowd_size")  # Type: int | float | str | bool
+    if crowd_size is not None:
+        if isinstance(crowd_size, (int, float)) and crowd_size <= 0:
+            issues.append("crowd_size must be positive")
+        elif not isinstance(crowd_size, (int, float)):
+            issues.append("crowd_size must be a number")
+```
+
+**Pros**:
+- ✅ Much better type safety than Any
+- ✅ Catches many type errors at mypy-time
+- ✅ Forces explicit runtime type checking
+- ✅ Works with our multi-problem function design
+- ✅ Prevents common parameter type mistakes
+
+**Cons**:
+- ⚠️ Requires isinstance() checks for operations
+- ⚠️ Slightly more verbose code
+- ⚠️ Small runtime performance cost
+
+## 🧪 **Experimental Results**
+
+### **Type Error Detection**
+
+**Test Case**: `crowd_size = "not_a_number"`
+
+| Approach | Mypy Detection | Runtime Behavior |
+|----------|----------------|------------------|
+| `**kwargs: Any` | ❌ No errors | ❌ Runtime crash: `TypeError: '<=' not supported` |
+| Pure TypedDict | ✅ Compile error | N/A (wouldn't compile) |
+| Constrained Dict | ✅ Mypy warns | ✅ Graceful validation error |
+
+### **Mypy Output Comparison**
+
+**Constrained dict with direct comparison**:
+```
+error: Unsupported operand types for <= ("str" and "int")  [operator]
+        if domain_size <= 0:
+                          ^
+note: Left operand is of type "int | float | str"
+```
+
+This **forces developers** to add proper type checks, preventing runtime errors.
+
+**Pure TypedDict with union access**:
+```
+error: TypedDict "PortfolioParams" has no key "crowd_size"  [typeddict-item]
+                crowd_size = params["crowd_size"]
+                                    ^~~~~~~~~~~~
+```
+
+This **blocks valid multi-problem functions**, making it impractical.
+
+## 💡 **Key Insights**
+
+### **1. Scientific Computing Reality**
+MFG_PDE functions need to handle:
+- Multiple problem types with different parameter sets
+- Flexible research interfaces
+- Unknown parameter combinations from user experiments
+- Backward compatibility with existing code
+
+**Pure TypedDict is too rigid** for this flexibility requirement.
+
+### **2. Type Safety Sweet Spot**
+The constrained dict approach `**kwargs: int | float | str | bool` provides:
+- **80% of TypedDict benefits** with **20% of the restrictions**
+- Forces good coding practices (explicit type checking)
+- Catches most common errors (wrong parameter types)
+- Maintains research code flexibility
+
+### **3. Development Workflow Impact**
+```python
+# With **kwargs: Any - Code works until runtime
+crowd_size = kwargs.get("crowd_size")
+if crowd_size <= 0:  # Boom! if crowd_size is "text"
+
+# With constrained dict - Mypy forces safety
+crowd_size = kwargs.get("crowd_size")  # Type: int | float | str | bool
+if isinstance(crowd_size, (int, float)) and crowd_size <= 0:  # Safe!
+```
+
+The constrained approach **educates developers** about type safety.
+
+## 📈 **Performance Analysis**
+
+| Approach | Type Checking Cost | Runtime Cost | Development Cost |
+|----------|-------------------|--------------|------------------|
+| `**kwargs: Any` | None | None | High (debugging runtime errors) |
+| Pure TypedDict | High (compile time) | None | Very High (restructuring needed) |
+| Constrained Dict | Low (mypy time) | Low (isinstance checks) | Medium (adding type checks) |
+
+## ✅ **Recommendations**
+
+### **For MFG_PDE Core Modules**
+
+**KEEP `**kwargs: Any`** for now, with these guidelines:
+
+1. **Use for multi-problem functions** like `validate_problem_parameters()` and `solve_mfg()`
+2. **Add defensive programming**:
+   ```python
+   def validate_parameters(**kwargs: Any) -> dict[str, Any]:
+       crowd_size = kwargs.get("crowd_size")
+       if crowd_size is not None:
+           if not isinstance(crowd_size, (int, float)):
+               return {"valid": False, "error": "crowd_size must be numeric"}
+           if crowd_size <= 0:
+               return {"valid": False, "error": "crowd_size must be positive"}
+   ```
+
+3. **Document expected types clearly**:
+   ```python
+   def solve_mfg(problem_type: str, **kwargs: Any) -> MFGResult:
+       """
+       Args:
+           **kwargs: Problem parameters including:
+               domain_size (float): Spatial domain size
+               crowd_size (int): For crowd_dynamics problems
+               risk_aversion (float): For portfolio problems
+       """
+   ```
+
+### **When to Consider Constrained Dict**
+
+Use `**kwargs: int | float | str | bool` for:
+- ✅ **New functions** where you control the interface
+- ✅ **Safety-critical validation functions**
+- ✅ **Functions with simple parameter types**
+- ✅ **When team wants to enforce type checking discipline**
+
+### **When to Use Pure TypedDict**
+
+Use TypedDict for:
+- ✅ **Single-problem-type functions**
+- ✅ **Configuration objects** (not kwargs)
+- ✅ **Return types** (like ValidationResult)
+- ✅ **API boundaries** with external systems
+
+## 🔮 **Future Evolution Path**
+
+### **Phase 1: Immediate (Current)**
+- Keep `**kwargs: Any` for existing functions
+- Use TypedDict for return types and config objects
+- Add defensive isinstance() checks in critical functions
+
+### **Phase 2: Gradual Improvement**
+- Migrate new functions to constrained dict typing
+- Add type annotations to function docstrings
+- Use TypedDict for single-problem specialized functions
+
+### **Phase 3: Long-term**
+- Consider Protocol classes for complex parameter patterns
+- Evaluate Pydantic models for validation-heavy functions
+- Migrate to constrained typing as team comfort increases
+
+## 🧠 **Lessons Learned**
+
+1. **TypedDict isn't always better**: Sometimes it's too restrictive for real-world flexibility needs
+
+2. **Union TypedDicts have limitations**: `ParamsA | ParamsB | ParamsC` creates mypy access restrictions
+
+3. **Constrained typing educates**: `**kwargs: int | float | str | bool` forces developers to think about types
+
+4. **Scientific computing needs flexibility**: Pure type safety can conflict with research code requirements
+
+5. **Gradual adoption works**: You can improve type safety incrementally without breaking existing code
+
+---
+
+**Conclusion**: For MFG_PDE, `**kwargs: Any` remains the best choice for multi-problem functions, with TypedDict being excellent for return types and configuration objects. The constrained dict approach offers a good middle ground for future functions where type safety is prioritized.
+
+**Files tested**: `test_typed_dict_experiment.py` demonstrates all approaches with working examples.

--- a/mfg_pde/factory/solver_factory.py
+++ b/mfg_pde/factory/solver_factory.py
@@ -50,7 +50,7 @@ class SolverFactoryConfig:
     custom_config: MFGSolverConfig | None = None
     solver_kwargs: dict[str, Any] | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.solver_kwargs is None:
             self.solver_kwargs = {}
 
@@ -77,7 +77,7 @@ class SolverFactory:
         custom_config: MFGSolverConfig | None = None,
         enable_amr: bool = False,
         amr_config: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> (
         ConfigAwareFixedPointIterator
         | MonitoredParticleCollocationSolver
@@ -134,6 +134,10 @@ class SolverFactory:
             )
 
         # Create base solver based on type
+        base_solver: (
+            ConfigAwareFixedPointIterator | MonitoredParticleCollocationSolver | AdaptiveParticleCollocationSolver
+        )
+
         if solver_type == "fixed_point":
             base_solver = SolverFactory._create_fixed_point_solver(problem, config, hjb_solver, fp_solver, **kwargs)
         elif solver_type == "particle_collocation":
@@ -197,7 +201,7 @@ class SolverFactory:
             raise ValueError(f"Unknown preset: {preset}. Use 'fast', 'accurate', 'research', or 'balanced'")
 
     @staticmethod
-    def _update_config_with_kwargs(config: MFGSolverConfig, **kwargs) -> MFGSolverConfig:
+    def _update_config_with_kwargs(config: MFGSolverConfig, **kwargs: Any) -> MFGSolverConfig:
         """Update configuration with keyword arguments."""
         # Create a copy to avoid modifying original
         import copy
@@ -232,7 +236,7 @@ class SolverFactory:
         config: MFGSolverConfig,
         hjb_solver: BaseHJBSolver | None,
         fp_solver: BaseFPSolver | None,
-        **kwargs,
+        **kwargs: Any,
     ) -> ConfigAwareFixedPointIterator:
         """Create a fixed point iterator solver."""
         if hjb_solver is None or fp_solver is None:
@@ -264,7 +268,7 @@ class SolverFactory:
         problem: MFGProblem,
         config: MFGSolverConfig,
         collocation_points: np.ndarray | None,
-        **kwargs,
+        **kwargs: Any,
     ) -> MonitoredParticleCollocationSolver:
         """Create a particle collocation solver."""
         if collocation_points is None:
@@ -308,7 +312,7 @@ class SolverFactory:
         problem: MFGProblem,
         config: MFGSolverConfig,
         collocation_points: np.ndarray | None,
-        **kwargs,
+        **kwargs: Any,
     ) -> MonitoredParticleCollocationSolver:
         """Create a monitored particle collocation solver with enhanced convergence."""
         # Same as particle collocation but with additional monitoring config
@@ -319,7 +323,7 @@ class SolverFactory:
         problem: MFGProblem,
         config: MFGSolverConfig,
         collocation_points: np.ndarray | None,
-        **kwargs,
+        **kwargs: Any,
     ) -> AdaptiveParticleCollocationSolver:
         """Create an adaptive particle collocation solver."""
         if collocation_points is None:
@@ -363,7 +367,7 @@ def create_solver(
     problem: MFGProblem,
     solver_type: SolverType = "fixed_point",
     preset: str = "balanced",
-    **kwargs,
+    **kwargs: Any,
 ) -> (
     ConfigAwareFixedPointIterator
     | MonitoredParticleCollocationSolver
@@ -386,7 +390,7 @@ def create_solver(
 
 
 def create_fast_solver(
-    problem: MFGProblem, solver_type: SolverType = "fixed_point", **kwargs
+    problem: MFGProblem, solver_type: SolverType = "fixed_point", **kwargs: Any
 ) -> (
     ConfigAwareFixedPointIterator
     | MonitoredParticleCollocationSolver
@@ -426,7 +430,7 @@ def create_semi_lagrangian_solver(
     characteristic_solver: str = "explicit_euler",
     use_jax: bool | None = None,
     fp_solver_type: str = "fdm",
-    **kwargs,
+    **kwargs: Any,
 ) -> ConfigAwareFixedPointIterator:
     """
     Create a fixed-point solver with semi-Lagrangian HJB method.
@@ -472,13 +476,13 @@ def create_semi_lagrangian_solver(
     )
 
     # Create appropriate FP solver
-    if fp_solver_type == "fdm":
-        from mfg_pde.alg.fp_solvers.fp_fdm import FPFDMSolver
+    from mfg_pde.alg.fp_solvers.fp_fdm import FPFDMSolver
+    from mfg_pde.alg.fp_solvers.fp_particle import FPParticleSolver
 
+    fp_solver: FPFDMSolver | FPParticleSolver
+    if fp_solver_type == "fdm":
         fp_solver = FPFDMSolver(problem=problem)
     elif fp_solver_type == "particle":
-        from mfg_pde.alg.fp_solvers.fp_particle import FPParticleSolver
-
         fp_solver = FPParticleSolver(problem=problem)
     else:
         raise ValueError(f"Unknown FP solver type: {fp_solver_type}")
@@ -498,7 +502,7 @@ def create_semi_lagrangian_solver(
 
 
 def create_accurate_solver(
-    problem: MFGProblem, solver_type: SolverType = "fixed_point", **kwargs
+    problem: MFGProblem, solver_type: SolverType = "fixed_point", **kwargs: Any
 ) -> (
     ConfigAwareFixedPointIterator
     | MonitoredParticleCollocationSolver
@@ -520,7 +524,7 @@ def create_accurate_solver(
 
 
 def create_research_solver(
-    problem: MFGProblem, solver_type: SolverType = "monitored_particle", **kwargs
+    problem: MFGProblem, solver_type: SolverType = "monitored_particle", **kwargs: Any
 ) -> (
     ConfigAwareFixedPointIterator
     | MonitoredParticleCollocationSolver
@@ -542,7 +546,7 @@ def create_research_solver(
 
 
 def create_monitored_solver(
-    problem: MFGProblem, collocation_points: np.ndarray | None = None, **kwargs
+    problem: MFGProblem, collocation_points: np.ndarray | None = None, **kwargs: Any
 ) -> MonitoredParticleCollocationSolver:
     """
     Create a monitored particle collocation solver with enhanced convergence analysis.
@@ -571,7 +575,7 @@ def create_amr_solver(
     base_solver_type: SolverType = "fixed_point",
     error_threshold: float = 1e-4,
     max_levels: int = 5,
-    **kwargs,
+    **kwargs: Any,
 ) -> AMREnhancedSolver:
     """
     Create an AMR-enhanced MFG solver.

--- a/mfg_pde/geometry/base_geometry.py
+++ b/mfg_pde/geometry/base_geometry.py
@@ -280,7 +280,7 @@ class BaseGeometry(ABC):
             e3 = np.linalg.norm(v0 - v2)
 
             # Aspect ratio = (longest edge) / (shortest edge)
-            aspect_ratios.append(max(e1, e2, e3) / min(e1, e2, e3))
+            aspect_ratios.append(max(float(e1), float(e2), float(e3)) / min(float(e1), float(e2), float(e3)))
 
         return {
             "min_area": float(np.min(areas)),


### PR DESCRIPTION
Core changes:
- Add factory/solver_factory.py to mypy coverage (18 type errors fixed)
- Add geometry/base_geometry.py to mypy coverage (2 type errors fixed)
- Update pre-commit config with expanded file pattern
- Add comprehensive type annotations and union types

Technical details:
- Fixed base_solver union type handling in factory
- Added **kwargs: Any annotations for research flexibility
- Fixed FP solver type compatibility issues
- Added defensive float() casting in geometry calculations

Documentation:
- Added MYPY_GRADUAL_REENABLEMENT_SUMMARY.md
- Added TYPEDDICT_VS_ANY_ANALYSIS.md with research findings

Phase 1 Complete: 5 core modules now have full mypy coverage with 0 errors.

Note: Style issues will be addressed in follow-up commits.

🤖 Generated with [Claude Code](https://claude.ai/code)