### PR TITLE
🔧 Fix import paths in CommonNoiseMFGSolver

### DIFF
--- a/mfg_pde/alg/numerical/stochastic/common_noise_solver.py
+++ b/mfg_pde/alg/numerical/stochastic/common_noise_solver.py
@@ -49,7 +49,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from mfg_pde.utils.monte_carlo import MCConfig, QuasiMCSampler
+from mfg_pde.utils.numerical.monte_carlo import MCConfig, QuasiMCSampler
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -203,7 +203,7 @@ class CommonNoiseMFGSolver:
         Raises:
             ValueError: If problem doesn't have common noise
         """
-        if not problem.has_common_noise():
+        if not hasattr(problem, "has_common_noise") or not problem.has_common_noise():
             raise ValueError("Problem must have common noise process defined")
 
         self.problem = problem
@@ -304,7 +304,9 @@ class CommonNoiseMFGSolver:
             # Use quasi-Monte Carlo for better coverage
             # Note: Quasi-MC works best in [0,1]^d, so we sample uniform
             # then transform to noise paths
-            sampler = QuasiMCSampler(sequence_type="sobol", dimension=1, seed=self.seed)
+            domain = [(0.0, 1.0)]  # 1D unit interval for seed sampling
+            qmc_config = MCConfig(num_samples=self.K, seed=self.seed)
+            sampler = QuasiMCSampler(domain, qmc_config, sequence_type="sobol")
 
             # Generate K quasi-random seeds for noise paths
             quasi_seeds = sampler.sample(self.K)


### PR DESCRIPTION
## Overview

Fixes import issues in CommonNoiseMFGSolver after utils directory reorganization (Phase 2.2 Stochastic MFG).

Closes part of #68 (Phase 2.2 Weeks 9-10 validation)

## Changes

### Import Path Fixes
- monte_carlo import: utils.monte_carlo → utils.numerical.monte_carlo
- QuasiMCSampler API: Updated to match actual signature
- Graceful degradation: Added hasattr check for has_common_noise()

### Issues Fixed

1. ModuleNotFoundError for QuasiMCSampler import
2. TypeError from incorrect QuasiMCSampler initialization  
3. AttributeError when using non-stochastic MFGProblem

## Test Results

Integration Tests: 5 passed, 3 skipped (placeholders)

- test_solver_initialization PASSED
- test_solver_requires_common_noise PASSED
- test_noise_path_sampling PASSED
- test_confidence_interval_computation PASSED
- test_result_attributes PASSED

## Phase 2.2 Status Update

After this PR:
- Weeks 1-5: COMPLETED
- Weeks 6-8: PAUSED (Master Equation)
- Weeks 9-10: IN PROGRESS (validation working)

## Files Changed
- mfg_pde/alg/numerical/stochastic/common_noise_solver.py (3 lines)

## Backward Compatibility

Fully backward compatible - only fixes broken imports.