### PR TITLE
🐛 Fix boundary condition validation and config env_prefix

### DIFF
--- a/mfg_pde/config/pydantic_config.py
+++ b/mfg_pde/config/pydantic_config.py
@@ -428,7 +428,7 @@ class MFGSolverConfig(BaseModel):
             experiment_name="research_config",
         )
 
-    model_config = ConfigDict(validate_assignment=True)
+    model_config = ConfigDict(validate_assignment=True, env_prefix="MFG_")
 
 
 # Convenience factory functions for backward compatibility

--- a/mfg_pde/geometry/boundary_manager.py
+++ b/mfg_pde/geometry/boundary_manager.py
@@ -56,8 +56,11 @@ class GeometricBoundaryCondition:
             if self.alpha is None or self.beta is None:
                 raise ValueError("Robin boundary conditions require alpha and beta coefficients")
 
-        if self.bc_type in ["dirichlet", "neumann"] and self.value is None:
-            raise ValueError(f"{self.bc_type} boundary condition requires value")
+        if self.bc_type == "dirichlet" and self.value is None:
+            raise ValueError("Dirichlet boundary condition requires value")
+
+        if self.bc_type == "neumann" and self.gradient_value is None and self.value is None:
+            raise ValueError("Neumann boundary condition requires gradient_value or value")
 
     def evaluate(self, coordinates: np.ndarray, time: float = 0.0) -> np.ndarray:
         """


### PR DESCRIPTION
## Summary
Fixes 2 of the 3 miscellaneous test failures from Issue #76.

## Changes Made

### 1. **Neumann BC Validation** ✅
**File**: `mfg_pde/geometry/boundary_manager.py`

**Issue**: Validation required `value` for Neumann BC but test correctly passed `gradient_value`

**Fix**:
```python
# Before: Always required value
if self.bc_type in ["dirichlet", "neumann"] and self.value is None:
    raise ValueError(f"{self.bc_type} boundary condition requires value")

# After: Proper validation for each type
if self.bc_type == "dirichlet" and self.value is None:
    raise ValueError("Dirichlet boundary condition requires value")

if self.bc_type == "neumann" and self.gradient_value is None and self.value is None:
    raise ValueError("Neumann boundary condition requires gradient_value or value")
```

**Test Fixed**: `tests/test_geometry_pipeline.py::TestBoundaryManager::test_summary_generation`

### 2. **Config Environment Variables** ✅
**File**: `mfg_pde/config/pydantic_config.py`

**Issue**: `MFGSolverConfig` missing `env_prefix` in model_config

**Fix**:
```python
# Before
model_config = ConfigDict(validate_assignment=True)

# After
model_config = ConfigDict(validate_assignment=True, env_prefix="MFG_")
```

**Test Fixed**: `tests/unit/test_config/test_pydantic_config.py::TestMFGSolverConfig::test_environment_variable_configuration`

## Test Results
- **Before**: 725 passing, 41 failing
- **After**: 727 passing, 39 failing
- **Progress**: 2 tests fixed (Issue #76 miscellaneous category)

## Remaining Work (Issue #76)
- ❌ Robin BC boundary manager (requires deeper investigation)
- 🔴 Mass conservation (21 tests) - algorithmic bugs
- 🟡 DGM/Neural (7 tests) - architecture updates
- 🟡 GFDM/WENO (10 tests) - numerical methods

## Related Issues
- Issue #76: Test suite failures requiring algorithmic fixes