### PR TITLE
chore: Complete cleanup of simple API references from documentation

### DIFF
--- a/docs/development/STRATEGIC_DEVELOPMENT_ROADMAP_2026.md
+++ b/docs/development/STRATEGIC_DEVELOPMENT_ROADMAP_2026.md
@@ -40,32 +40,42 @@ Transform MFG_PDE into the premier platform for Mean Field Games computation, en
 
 ### **Current Capabilities** ✅ **EXPANDED**
 ```python
-# ✅ NEW: Multi-Paradigm Access (All 4 paradigms operational)
-from mfg_pde import solve_mfg, create_solver
-from mfg_pde.hooks import DebugHook, VisualizationHook
+# ✅ Two-Level Research-Grade API (v1.4+)
+from mfg_pde import MFGProblem
+from mfg_pde.factory import create_fast_solver, create_accurate_solver
 
-# Tier 1: Dead simple for 90% of users
-result = solve_mfg("crowd_dynamics", domain_size=10, num_agents=1000)
+# Level 1: Factory API for researchers (95% of users)
+class CrowdDynamicsProblem(MFGProblem):
+    def __init__(self):
+        super().__init__(T=1.0, Nt=20, xmin=0.0, xmax=10.0, Nx=100)
 
-# ✅ NEW: Paradigm Selection
+    def g(self, x):
+        return 0.5 * (x - 10.0)**2
+
+    def rho0(self, x):
+        return np.exp(-10 * (x - 2.0)**2)
+
+problem = CrowdDynamicsProblem()
+solver = create_fast_solver(problem, solver_type="fixed_point")
+result = solver.solve()
+
+# ✅ Multi-Paradigm Access (All 4 paradigms operational)
 from mfg_pde.alg.numerical import HJBWenoSolver  # 3D WENO ready
 from mfg_pde.alg.optimization import VariationalMFGSolver, WassersteinMFGSolver
 from mfg_pde.alg.neural import nn  # PyTorch architectures
 from mfg_pde.alg.reinforcement import BaseMFRLSolver  # MFRL foundation
 
-# ✅ NEW: Advanced Maze Environments for RL
+# ✅ Advanced Maze Environments for RL
 from mfg_pde.alg.reinforcement.environments import (
     RecursiveDivisionGenerator,
     CellularAutomataGenerator,
     add_loops,
 )
 
-# Tier 2: Object-oriented for 8% of users
-solver = create_solver(problem, solver_type="weno3d", backend="jax", device="gpu")
-result = solver.solve()  # ✅ 3D problems supported
-
-# Tier 3: Full customization for 2% of users
-solver = create_solver(problem, hooks=[DebugHook(), VisualizationHook()])
+# Level 2: Core API for developers (5% of users)
+from mfg_pde.alg.numerical.hjb_solvers import BaseHJBSolver
+from mfg_pde.alg.numerical.fp_solvers import BaseFPSolver
+# Extend framework with custom solvers...
 ```
 
 **Performance Achieved** ✅ **EXPANDED**:

--- a/docs/development/[COMPLETED]_PHASE_2_COMPLETION_SUMMARY.md
+++ b/docs/development/[COMPLETED]_PHASE_2_COMPLETION_SUMMARY.md
@@ -827,9 +827,12 @@ MFG_PDE is now the **first comprehensive open-source framework** supporting:
 **Migration Path**:
 Users can adopt Phase 2 features incrementally:
 ```python
-# Existing 1D code: unchanged
-from mfg_pde import solve_mfg
-result = solve_mfg("crowd_dynamics", domain_size=10)
+# Existing code using factory API: unchanged
+from mfg_pde import ExampleMFGProblem
+from mfg_pde.factory import create_fast_solver
+problem = ExampleMFGProblem(Nx=100, T=1.0)
+solver = create_fast_solver(problem, "fixed_point")
+result = solver.solve()
 
 # New 2D capabilities: opt-in
 from mfg_pde.geometry import TensorProductGrid

--- a/docs/development/analysis/TYPEDDICT_VS_ANY_ANALYSIS.md
+++ b/docs/development/analysis/TYPEDDICT_VS_ANY_ANALYSIS.md
@@ -156,7 +156,7 @@ The constrained approach **educates developers** about type safety.
 
 **KEEP `**kwargs: Any`** for now, with these guidelines:
 
-1. **Use for multi-problem functions** like `validate_problem_parameters()` and `solve_mfg()`
+1. **Use for multi-problem functions** like `validate_problem_parameters()` and flexible configuration functions
 2. **Add defensive programming**:
    ```python
    def validate_parameters(**kwargs: Any) -> dict[str, Any]:
@@ -170,13 +170,13 @@ The constrained approach **educates developers** about type safety.
 
 3. **Document expected types clearly**:
    ```python
-   def solve_mfg(problem_type: str, **kwargs: Any) -> MFGResult:
+   def configure_solver(solver_type: str, **kwargs: Any) -> SolverConfig:
        """
        Args:
-           **kwargs: Problem parameters including:
-               domain_size (float): Spatial domain size
-               crowd_size (int): For crowd_dynamics problems
-               risk_aversion (float): For portfolio problems
+           **kwargs: Solver parameters including:
+               max_iterations (int): Maximum solver iterations
+               tolerance (float): Convergence tolerance
+               damping (float): Damping parameter for iterative methods
        """
    ```
 

--- a/docs/development/strategy/optimization_integration_analysis.md
+++ b/docs/development/strategy/optimization_integration_analysis.md
@@ -67,7 +67,7 @@ import jax
 
 @jax.jit
 def mfg_parameter_objective(params, problem_data):
-    return solve_mfg_jax(params, problem_data)
+    return run_mfg_solver_jax(params, problem_data)
 
 optimizer = adam(learning_rate=0.01)
 # Direct usage - no custom wrapper needed

--- a/docs/development/strategy/strategic_recommendations.md
+++ b/docs/development/strategy/strategic_recommendations.md
@@ -82,8 +82,9 @@ def mfg_parameter_study():
     })
     
     # Parallel execution with automatic resource management
+    # Note: Use factory API to create and solve problems
     results = workflow.parallel_map(
-        solve_mfg_problem, 
+        lambda p: create_fast_solver(p, "fixed_point").solve(),
         problems,
         max_workers=workflow.detect_optimal_workers()
     )

--- a/docs/development/test_coverage_phase14_summary.md
+++ b/docs/development/test_coverage_phase14_summary.md
@@ -6,6 +6,8 @@
 **Final Achievement**: ~25% test coverage (+9%)
 **Time Spent**: ~2.25 hours
 
+> **📌 Historical Note**: This document describes test coverage work completed when the "simple API" (`solve_mfg()`, `create_mfg_problem()`) still existed in the codebase. **As of v1.4+, the simple API has been removed** and MFG_PDE now uses a two-level factory-based API. The tests described in this document for `simple.py` have been archived along with the module. This document is preserved for historical reference only.
+
 ---
 
 ## Executive Summary

--- a/docs/reference/python_typing.md
+++ b/docs/reference/python_typing.md
@@ -60,7 +60,7 @@ SolutionArray: TypeAlias = NDArray[np.float64]
 GridPoints: TypeAlias = tuple[int, ...]
 ParameterDict: TypeAlias = dict[str, float | int | str]
 
-def solve_mfg(
+def run_mfg_solver(
     initial_u: SolutionArray,
     grid_resolution: GridPoints,
     parameters: ParameterDict,
@@ -71,7 +71,7 @@ def solve_mfg(
 
 # ❌ LEGACY - Verbose and cluttered
 from typing import Optional, Callable, Dict, Tuple, Union
-def solve_mfg_old(
+def run_solver_old(
     initial_u: NDArray,
     grid_resolution: Tuple[int, ...],
     parameters: Dict[str, Union[float, int, str]],
@@ -166,30 +166,31 @@ def solve_problem(problem: MFGProblem) -> MFGResult:
 
 Structure your API to reveal complexity progressively. Not every user needs to see your full type system.
 
-### **Three-Layer Type Architecture**
+### **Two-Layer Type Architecture**
 
-#### **Layer 1: Simple Facade (90% of users)**
+#### **Layer 1: Factory API (95% of users - Researchers)**
 ```python
-# mfg_pde/__init__.py - Simple string-based configuration
-def solve_mfg(
-    problem_type: str,
-    domain_size: float = 1.0,
-    time_horizon: float = 1.0,
-    accuracy: str = "balanced"  # "fast" | "balanced" | "precise"
-) -> dict[str, Any]:
-    """Simple one-line solver for common use cases."""
+# mfg_pde/factory.py - Factory API for researchers
+from mfg_pde import MFGProblem
+
+def create_fast_solver(
+    problem: MFGProblem,
+    solver_type: str = "fixed_point",
+    backend: str = "auto"
+) -> FixedPointSolver:
+    """Factory function for fast solvers."""
     pass
 
-def solve_crowd_dynamics(
-    domain_bounds: tuple[float, float],
-    num_agents: int,
-    time_steps: int = 100
-) -> dict[str, Any]:
-    """Domain-specific simple interface."""
+def create_accurate_solver(
+    problem: MFGProblem,
+    solver_type: str = "fixed_point",
+    max_iterations: int = 500
+) -> FixedPointSolver:
+    """Factory function for accurate solvers."""
     pass
 ```
 
-#### **Layer 2: Core Objects (Advanced users)**
+#### **Layer 2: Core Classes (5% of users - Developers)**
 ```python
 # mfg_pde/core.py - Typed objects with clean interfaces
 class FixedPointSolver:
@@ -212,7 +213,7 @@ class MFGSolverConfig:
     solver_type: Literal["fixed_point", "newton", "quasi_newton"]
 ```
 
-#### **Layer 3: Advanced/Internal (Expert users)**
+**Advanced Features (Available to all researchers)**
 ```python
 # mfg_pde/types.py - Full internal type system
 class SpatialTemporalState(NamedTuple):
@@ -223,7 +224,7 @@ class SpatialTemporalState(NamedTuple):
     residual: float
     metadata: dict[str, Any]
 
-# mfg_pde/hooks.py - Expert customization
+# mfg_pde/hooks.py - Advanced customization for researchers
 class SolverHooks(Protocol):
     def on_iteration_start(self, state: SpatialTemporalState) -> None: ...
     def on_iteration_end(self, state: SpatialTemporalState) -> str | None: ...
@@ -470,7 +471,7 @@ from typing import Optional, List, Dict, Tuple, Union, Callable, Any
 import numpy as np
 from numpy.typing import NDArray
 
-def solve_mfg_system(
+def run_mfg_system(
     initial_u: NDArray[np.float64],
     initial_m: NDArray[np.float64],
     domain_bounds: Tuple[float, float],
@@ -495,7 +496,7 @@ SolverConfig: TypeAlias = dict[str, float | int | str]
 IterationCallback: TypeAlias = Callable[[int, float], None]
 SolverResult: TypeAlias = tuple[SolutionArray, SolutionArray, dict[str, Any]]
 
-def solve_mfg_system(
+def run_mfg_system(
     initial_u: SolutionArray,
     initial_m: SolutionArray,
     domain_bounds: DomainBounds,

--- a/mfg_pde/compat/legacy_config.py
+++ b/mfg_pde/compat/legacy_config.py
@@ -9,25 +9,27 @@ from mfg_pde.config import accurate_config, fast_config, research_config
 from . import DeprecatedAPI, deprecated
 
 
-@deprecated("Use fast_config(), accurate_config(), or research_config() instead")
+@deprecated("Use fast_config(), accurate_config(), or research_config() with factory API instead")
 class LegacyConfig(DeprecatedAPI):
     """
     DEPRECATED: Legacy configuration wrapper.
 
-    Use the new config system instead:
+    Use the new factory API with config presets:
 
     Old:
         config = LegacyConfig(max_iterations=500, tolerance=1e-6)
 
     New:
-        config = accurate_config().with_max_iterations(500).with_tolerance(1e-6)
+        from mfg_pde.factory import create_fast_solver
+        from mfg_pde.config import accurate_config
 
-    Or even simpler:
-        result = solve_mfg("crowd_dynamics", accuracy="high")
+        config = accurate_config().with_max_iterations(500).with_tolerance(1e-6)
+        solver = create_fast_solver(problem, solver_type="fixed_point")
+        result = solver.solve()
     """
 
     def __init__(self, **kwargs):
-        super().__init__("New config system or solve_mfg() with accuracy parameter")
+        super().__init__("New config system with factory API")
         self.params = kwargs
 
     def to_new_config(self):
@@ -61,38 +63,38 @@ class SolverConfig(LegacyConfig):
     pass
 
 
-@deprecated("Use solve_mfg() with accuracy='research' instead")
+@deprecated("Use research_config() with factory API instead")
 class DebugConfig(LegacyConfig):
     def __init__(self, **kwargs):
         super().__init__(debug=True, **kwargs)
 
 
-@deprecated("Use solve_mfg() with accuracy='fast' instead")
+@deprecated("Use fast_config() with factory API instead")
 class FastConfig(LegacyConfig):
     def __init__(self, **kwargs):
         super().__init__(fast=True, **kwargs)
 
 
-@deprecated("Use solve_mfg() with accuracy='high' instead")
+@deprecated("Use accurate_config() with factory API instead")
 class AccurateConfig(LegacyConfig):
     def __init__(self, **kwargs):
         super().__init__(high_accuracy=True, **kwargs)
 
 
 # Legacy factory functions
-@deprecated("Use solve_mfg() with automatic configuration instead")
+@deprecated("Use create_fast_solver() with automatic configuration instead")
 def create_enhanced_config(**kwargs):
-    """DEPRECATED: Use new automatic configuration system."""
+    """DEPRECATED: Use factory API with automatic configuration."""
     return LegacyConfig(**kwargs).to_new_config()
 
 
-@deprecated("Use solve_mfg() with backend parameter instead")
+@deprecated("Use factory API with backend parameter instead")
 def configure_backend(backend_name, **kwargs):
-    """DEPRECATED: Use backend parameter in solve_mfg() or FixedPointSolver."""
+    """DEPRECATED: Use backend parameter in create_fast_solver() or FixedPointSolver."""
     import warnings
 
     warnings.warn(
-        "configure_backend is deprecated. Use backend parameter in solve_mfg() or FixedPointSolver instead.",
+        "configure_backend is deprecated. Use backend parameter in factory API or FixedPointSolver instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/mfg_pde/compat/legacy_problems.py
+++ b/mfg_pde/compat/legacy_problems.py
@@ -7,25 +7,37 @@ Provides compatibility for old problem APIs with deprecation warnings.
 from . import DeprecatedAPI, deprecated
 
 
-@deprecated("Use create_mfg_problem() or solve_mfg() instead")
+@deprecated("Use MFGProblem class with factory API instead")
 class LegacyMFGProblem(DeprecatedAPI):
     """
     DEPRECATED: Legacy MFG problem wrapper.
 
-    Use the new API instead:
+    Use the new factory API instead:
 
     Old:
         problem = LegacyMFGProblem(domain, time_horizon)
 
-    New (Simple):
-        result = solve_mfg("crowd_dynamics", domain_size=5.0, time_horizon=2.0)
+    New (Factory API):
+        from mfg_pde import MFGProblem
+        from mfg_pde.factory import create_fast_solver
 
-    New (Advanced):
-        problem = create_mfg_problem("crowd_dynamics", domain=(0, 5), time_horizon=2.0)
+        class CustomProblem(MFGProblem):
+            def __init__(self):
+                super().__init__(T=2.0, Nt=20, xmin=0.0, xmax=5.0, Nx=50)
+
+            def g(self, x):
+                return 0.5 * (x - 5.0)**2
+
+            def rho0(self, x):
+                return np.exp(-10 * (x - 1.0)**2)
+
+        problem = CustomProblem()
+        solver = create_fast_solver(problem, solver_type="fixed_point")
+        result = solver.solve()
     """
 
     def __init__(self, domain_bounds=(0, 1), time_horizon=1.0, **kwargs):
-        super().__init__("create_mfg_problem() or solve_mfg()")
+        super().__init__("MFGProblem class with factory API")
         self._domain_bounds = domain_bounds
         self._time_horizon = time_horizon
         self.metadata = kwargs
@@ -55,34 +67,34 @@ class LegacyMFGProblem(DeprecatedAPI):
 
 
 # Legacy problem class aliases
-@deprecated("Use solve_mfg('crowd_dynamics') instead")
+@deprecated("Use MFGProblem class with factory API instead")
 class ExampleMFGProblem(LegacyMFGProblem):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.problem_type = "crowd_dynamics"
 
 
-@deprecated("Use create_mfg_problem('crowd_dynamics') instead")
+@deprecated("Use MFGProblem class with factory API instead")
 class CrowdDynamicsProblem(LegacyMFGProblem):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.problem_type = "crowd_dynamics"
 
 
-@deprecated("Use create_mfg_problem('portfolio_optimization') instead")
+@deprecated("Use MFGProblem class with factory API instead")
 class PortfolioOptimizationProblem(LegacyMFGProblem):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.problem_type = "portfolio_optimization"
 
 
-@deprecated("Use create_mfg_problem('traffic_flow') instead")
+@deprecated("Use MFGProblem class with factory API instead")
 class TrafficFlowProblem(LegacyMFGProblem):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.problem_type = "traffic_flow"
 
 
-@deprecated("Use create_mfg_problem('custom') instead")
+@deprecated("Use MFGProblem class with factory API instead")
 class CustomMFGProblem(LegacyMFGProblem):
     pass


### PR DESCRIPTION
## Summary

This PR completes the cleanup of all remaining simple API references from the codebase documentation, following PR #97 which removed the simple API implementation.

## Changes

### Code Files (2 files)
- ✅  - Updated deprecation messages to reference factory API
- ✅  - Updated deprecation messages to reference factory API

### Documentation Files (9 files)
- ✅  - Replaced `create_mfg_problem()` examples with `MFGProblem` class
- ✅  - Replaced simple API integration section with factory API examples
- ✅  - Added historical note about archived simple API
- ✅  - Updated typing examples to use factory API
- ✅  - Changed three-layer to two-layer architecture in examples
- ✅  - Updated examples to use factory API patterns
- ✅  - Updated migration example
- ✅  - Renamed `solve_mfg_jax`
- ✅  - Updated workflow examples
- ✅  - Updated current capabilities section

## Review Focus

- All documentation now consistently references the two-level factory API design
- Historical documents have appropriate notes indicating content is outdated
- No functional code changes beyond deprecation message updates

## Related Issues

Follows #97 (Simple API removal)

Part of the ongoing effort to enforce factory API as the primary interface for MFG_PDE.