### PR TITLE
fix: Resolve parameter mismatch in particle solver factory methods

### DIFF
--- a/mfg_pde/factory/pydantic_solver_factory.py
+++ b/mfg_pde/factory/pydantic_solver_factory.py
@@ -118,6 +118,9 @@ class PydanticSolverFactory:
         except ValidationError as e:
             self.logger.error(f"Configuration validation failed: {e}")
             raise ValidationError(f"Solver configuration validation failed: {e}") from e
+        except ValueError:
+            # Let ValueError propagate directly (user input errors)
+            raise
         except Exception as e:
             self.logger.error(f"Solver creation failed: {e}")
             raise RuntimeError(f"Failed to create solver: {e}") from e
@@ -285,15 +288,19 @@ class PydanticSolverFactory:
             # Create collocation points
             collocation_points = np.linspace(0, 1, 10).reshape(-1, 1)
 
-            # Extract legacy parameters
-            legacy_params = config.to_legacy_dict()
+            # Extract only parameters that AdaptiveParticleCollocationSolver accepts
+            # This solver does NOT accept max_picard_iterations
+            solver_params = {
+                "max_newton_iterations": config.newton.max_iterations,
+                "newton_tolerance": config.newton.tolerance,
+            }
 
             solver = AdaptiveParticleCollocationSolver(
                 problem=problem,
                 collocation_points=collocation_points,
                 num_particles=config.fp.particle.num_particles,
                 verbose=False,
-                **legacy_params,
+                **solver_params,
             )
 
             self.logger.info("Successfully created validated adaptive particle solver")
@@ -311,14 +318,18 @@ class PydanticSolverFactory:
             # Create collocation points
             collocation_points = np.linspace(0, 1, 10).reshape(-1, 1)
 
-            # Extract legacy parameters
-            legacy_params = config.to_legacy_dict()
+            # Extract only parameters that MonitoredParticleCollocationSolver accepts
+            # This solver does NOT accept max_picard_iterations
+            solver_params = {
+                "max_newton_iterations": config.newton.max_iterations,
+                "newton_tolerance": config.newton.tolerance,
+            }
 
             solver = MonitoredParticleCollocationSolver(
                 problem=problem,
                 collocation_points=collocation_points,
                 num_particles=config.fp.particle.num_particles,
-                **legacy_params,
+                **solver_params,
             )
 
             self.logger.info("Successfully created validated monitored particle solver")


### PR DESCRIPTION
## Summary

Fixes 4 failing factory tests by correcting parameter passing in particle solver factory methods.

## Problem

The factory was passing `max_picard_iterations` from `config.to_legacy_dict()` to solvers that don't accept this parameter:
- `AdaptiveParticleCollocationSolver` 
- `MonitoredParticleCollocationSolver`

These solvers only accept Newton iteration parameters, not Picard iteration parameters.

## Solution

1. **Filter parameters**: Extract only the parameters these solvers accept
   - Changed from unpacking all `legacy_params`
   - Now explicitly pass only `max_newton_iterations` and `newton_tolerance`

2. **Fix exception handling**: Allow `ValueError` to propagate for user input errors
   - Previously all exceptions were wrapped in `RuntimeError`
   - Now `ValueError` propagates directly for better error reporting

## Test Results

- Before: 45/49 tests passing (4 failures)
- After: **49/49 tests passing** ✅

## Changes

- `mfg_pde/factory/pydantic_solver_factory.py`:
  - `_create_validated_adaptive_particle_solver()`: Pass only Newton params
  - `_create_validated_monitored_particle_solver()`: Pass only Newton params
  - `create_validated_solver()`: Allow ValueError to propagate

## Related Issues

Resolves pre-existing test failures in factory test suite.