### PR TITLE
docs: Update RL theory README with complete documentation catalog

### DIFF
--- a/docs/theory/reinforcement_learning/README.md
+++ b/docs/theory/reinforcement_learning/README.md
@@ -2,75 +2,309 @@
 
 Mathematical foundations and theoretical analysis of reinforcement learning approaches to Mean Field Games.
 
-## 📚 Contents
+---
 
-- **[continuous_action_mfg_theory.md](continuous_action_mfg_theory.md)** - Comprehensive research roadmap for continuous action spaces in MFG-RL (6-12 month plan)
-- **[action_space_scalability.md](action_space_scalability.md)** - Technical analysis of action space scalability limitations and extensions
-- **[continuous_action_architecture_sketch.py](continuous_action_architecture_sketch.py)** - Code examples for continuous action architectures (DDPG, SAC, TD3)
+## 📚 Document Catalog
 
-## 🎯 Overview
+### 🎯 Core Algorithm Formulations (6 docs)
+Mathematical formulations for specific MFG-RL algorithms:
 
-This directory contains theoretical foundations for applying reinforcement learning to Mean Field Games, with particular focus on:
+| Document | Algorithm | Action Space | Status | Description |
+|:---------|:----------|:-------------|:-------|:------------|
+| [ddpg_mfg_formulation.md](ddpg_mfg_formulation.md) | DDPG | Continuous | Phase 3.3.1 | Deep Deterministic Policy Gradient for MFG |
+| [td3_mfg_formulation.md](td3_mfg_formulation.md) | TD3 | Continuous | Phase 3.3.2 | Twin Delayed DDPG with improved stability |
+| [sac_mfg_formulation.md](sac_mfg_formulation.md) | SAC | Continuous | Phase 3.3.3 | Soft Actor-Critic with maximum entropy |
+| [maddpg_for_mfg_formulation.md](maddpg_for_mfg_formulation.md) | MADDPG | Continuous | Theoretical | Multi-Agent DDPG for MFG |
+| [nash_q_learning_formulation.md](nash_q_learning_formulation.md) | Nash Q-Learning | Discrete | Theoretical | Nash equilibrium Q-learning for multi-agent MFG |
+| [population_ppo_formulation.md](population_ppo_formulation.md) | PPO | Both | ✅ Implemented | Proximal Policy Optimization for MFG |
 
-1. **Continuous Action Spaces**: Mathematical formulation and algorithmic approaches
-2. **Scalability Analysis**: Computational complexity and feasibility of different action space types
-3. **Architecture Patterns**: Network designs for continuous control in MFG settings
+**Algorithm Relationships**:
+- **DDPG**: Foundation for continuous action MFG-RL
+- **TD3**: Improves DDPG with twin critics and delayed updates
+- **SAC**: Alternative to DDPG/TD3 using stochastic policies with entropy regularization
+- **MADDPG**: Extends DDPG to multi-agent settings with centralized training
+- **Nash Q-Learning**: Multi-agent discrete actions with Nash equilibrium
+- **PPO**: Policy gradient method with clipped surrogate objective
 
-## 🔬 Key Concepts
+### 🏗️ Architecture & Implementation Design (2 docs)
+Implementation architecture for complex algorithms:
+
+| Document | Purpose | Related Formulation |
+|:---------|:--------|:-------------------|
+| [maddpg_architecture_design.md](maddpg_architecture_design.md) | MADDPG implementation architecture | [maddpg_for_mfg_formulation.md](maddpg_for_mfg_formulation.md) |
+| [nash_q_learning_architecture.md](nash_q_learning_architecture.md) | Nash Q-Learning implementation design | [nash_q_learning_formulation.md](nash_q_learning_formulation.md) |
+
+### 🌍 Multi-Population Theory (2 docs)
+Mathematical frameworks for heterogeneous agents and multi-population MFG:
+
+| Document | Focus | Scope |
+|:---------|:------|:------|
+| [heterogeneous_agents_formulation.md](heterogeneous_agents_formulation.md) | Multi-population MFG with different agent types | Phase 3.2.1 |
+| [multi_population_continuous_control.md](multi_population_continuous_control.md) | Multi-population with continuous action spaces | Phase 3.4 (Production) |
+
+**Key Concepts**:
+- **Heterogeneous Agents**: K different agent types with distinct objectives, dynamics, and capabilities
+- **Multi-Population Coupling**: Cross-population interactions through joint distribution $\mathbf{m} = (m^1, \ldots, m^K)$
+- **Nash Equilibrium**: No population can unilaterally improve by deviating
+
+### 📊 Scalability & Planning (3 docs)
+Technical analysis, roadmaps, and code examples:
+
+| Document | Type | Purpose |
+|:---------|:-----|:--------|
+| [action_space_scalability.md](action_space_scalability.md) | Technical Analysis | Action space limitations and scaling challenges |
+| [continuous_action_mfg_theory.md](continuous_action_mfg_theory.md) | Research Roadmap | 6-12 month implementation plan for continuous actions |
+| [continuous_action_architecture_sketch.py](continuous_action_architecture_sketch.py) | Code Examples | Working network architectures for continuous actions |
+
+---
+
+## 🎯 Key Concepts
 
 ### Discrete vs Continuous Actions
 
-**Discrete MFG-RL** (current implementation):
-- Q(s, a, m) → [Q(s,a₁,m), ..., Q(s,aₙ,m)] (vector output)
-- Works well for |A| ≤ 20
-- Fails for |A| > 100 or continuous actions
+**Discrete MFG-RL** (current stable implementation):
+```python
+Q(s, m) → [Q(s,a₁,m), Q(s,a₂,m), ..., Q(s,aₙ,m)]  # Vector output
+```
+- ✅ Works well for |A| ≤ 20
+- ⚠️ Challenging for 20 < |A| ≤ 100
+- ❌ Fails for |A| > 100 or continuous actions
 
-**Continuous MFG-RL** (theoretical framework):
-- Q(s, a, m) with action as INPUT (scalar output)
-- Handles a ∈ ℝᵈ (infinite action spaces)
-- Requires new architectures (DDPG, SAC, TD3)
+**Continuous MFG-RL** (theoretical/under development):
+```python
+# Actor-Critic Architecture
+actor: (s, m) → a ∈ ℝᵈ                    # Deterministic policy
+critic: (s, a, m) → Q(s, a, m) ∈ ℝ        # Action as input
+```
+- ✅ Handles $a \in \mathbb{R}^d$ (infinite action spaces)
+- ✅ Scales to high-dimensional actions
+- ⚠️ Requires new architectures (DDPG, TD3, SAC)
 
 ### Mean Field Reinforcement Learning Formulation
 
 **Standard RL** + **Population State**:
-- State: s ∈ S
-- Action: a ∈ A (discrete or continuous)
-- Population: m ∈ P(S) (distribution of agent states)
-- Reward: r(s, a, m)
-- Objective: Find π(a|s, m) maximizing J(π) where m = μ(π)
+
+**State Space**: Individual state $s \in \mathcal{S}$ + Population distribution $m \in \mathcal{P}(\mathcal{S})$
+
+**Key Equations**:
+$$
+\begin{align}
+\text{HJB:} \quad & -\partial_t u + H(s, \nabla u, m) = f(s, m) \\
+\text{FP:} \quad & \partial_t m - \Delta m - \nabla \cdot (m \nabla_p H) = 0 \\
+\text{Optimal Policy:} \quad & a^*(s, m) = \arg\max_a \left\{ -\nabla u \cdot b(s,a,m) - L(s,a,m) \right\}
+\end{align}
+$$
+
+**RL Objective**: Find policy $\pi(a|s,m)$ maximizing $J(\pi)$ where population $m = \mu(\pi)$ (consistency condition)
+
+---
 
 ## 📖 Document Summaries
 
-### continuous_action_mfg_theory.md
-Complete research roadmap covering:
+### Continuous Action Algorithms
+
+**[continuous_action_mfg_theory.md](continuous_action_mfg_theory.md)** - Complete Research Roadmap
+Comprehensive 6-12 month implementation plan covering:
 - Theoretical foundations (HJB with continuous control)
 - Algorithmic approaches (DDPG, TD3, SAC, PPO)
-- 5-phase implementation plan (6-12 months)
+- 5-phase implementation plan
 - Technical challenges (exploration, population estimation, constraints)
 - Research directions (high-D actions, multi-modal policies, model-based MFG)
 
-### action_space_scalability.md
-Technical analysis including:
-- Current limitations (discrete |A| ≤ 20 optimal)
-- Computational complexity analysis
+**[ddpg_mfg_formulation.md](ddpg_mfg_formulation.md)** - DDPG Foundation
+Deep Deterministic Policy Gradient adapted for MFG:
+- Deterministic policy $\mu_\theta(s, m) \to a$
+- Q-critic $Q_\phi(s, a, m)$ with action as input
+- Population-conditioned networks
+- Replay buffer with population state
+
+**[td3_mfg_formulation.md](td3_mfg_formulation.md)** - Improved DDPG
+Twin Delayed DDPG addressing overestimation bias:
+- Twin critics to mitigate Q-value overestimation
+- Delayed policy updates for stability
+- Target policy smoothing for exploration
+- Proven convergence improvements over DDPG
+
+**[sac_mfg_formulation.md](sac_mfg_formulation.md)** - Maximum Entropy RL
+Soft Actor-Critic with entropy regularization:
+- Stochastic policies (Gaussian distribution)
+- Entropy-regularized objective: $J = r + \alpha \mathcal{H}(\pi)$
+- Automatic temperature tuning
+- Superior exploration for complex action spaces
+
+**[maddpg_for_mfg_formulation.md](maddpg_for_mfg_formulation.md)** - Multi-Agent Extension
+Multi-Agent DDPG adapted to MFG:
+- Centralized training with decentralized execution
+- Centralized critic uses population state instead of all agent states
+- Scalable to large populations through mean field approximation
+- Addresses non-stationarity in multi-agent learning
+
+### Discrete Action Algorithms
+
+**[nash_q_learning_formulation.md](nash_q_learning_formulation.md)** - Nash Equilibrium Learning
+Nash Q-Learning for multi-agent MFG:
+- Learn Nash equilibrium policies instead of single-agent optimal
+- Joint Q-function accounting for strategic interactions
+- Mean field approximation for population-level Nash equilibrium
+- Convergence guarantees under monotonicity conditions
+
+**[population_ppo_formulation.md](population_ppo_formulation.md)** - Policy Gradient Method
+PPO adapted for MFG (✅ implemented in `mean_field_actor_critic.py`):
+- Clipped surrogate objective prevents destructive updates
+- GAE (Generalized Advantage Estimation) for variance reduction
+- Population state conditioning in both actor and critic
+- Compatible with both discrete and continuous actions
+
+### Multi-Population Theory
+
+**[heterogeneous_agents_formulation.md](heterogeneous_agents_formulation.md)** - General Multi-Population Framework
+Mathematical framework for K agent types:
+- Distinct objectives: $r^k(s, a, \mathbf{m})$ per type
+- Distinct dynamics: $P^k(s' | s, a, \mathbf{m})$ per type
+- Cross-population coupling through $\mathbf{m} = (m^1, \ldots, m^K)$
+- Nash equilibrium: No type can unilaterally improve
+- Applications: Traffic (cars/trucks), epidemiology (S-I-R), economics (buyers/sellers)
+
+**[multi_population_continuous_control.md](multi_population_continuous_control.md)** - Continuous Multi-Population
+Extends multi-population to continuous action spaces:
+- Heterogeneous action spaces: $\mathcal{A}_i \subseteq \mathbb{R}^{d_i}$
+- Coupled HJB-FP system for N populations
+- Existence and uniqueness theorems (Lasry-Lions conditions)
+- Convergence analysis for multi-population DDPG/SAC
+
+### Scalability & Implementation
+
+**[action_space_scalability.md](action_space_scalability.md)** - Technical Constraints
+Scalability analysis covering:
+- Current limitations: Discrete $|A| \leq 20$ optimal
+- Computational complexity: $O(|A|)$ output dimension bottleneck
 - Five extension strategies with trade-offs
 - Practical recommendations and timelines
-- Scalability tables and benchmarks
+- Benchmark tables: network size vs action space size
 
-### continuous_action_architecture_sketch.py
-Working code examples:
+**[continuous_action_architecture_sketch.py](continuous_action_architecture_sketch.py)** - Code Examples
+Working PyTorch implementations:
 - `MeanFieldContinuousQNetwork`: Q(s, a, m) with action as input
-- `MeanFieldContinuousActor`: Deterministic μ(s, m) → a
-- `MeanFieldStochasticActor`: Gaussian π(·|s, m)
+- `MeanFieldContinuousActor`: Deterministic policy $\mu(s, m) \to a$
+- `MeanFieldStochasticActor`: Gaussian policy $\pi(\cdot|s, m)$
 - Usage examples and complexity comparisons
 
-## 🔗 Related Documentation
+---
 
-- **Implementation Roadmap**: [/docs/planning/roadmaps/REINFORCEMENT_LEARNING_ROADMAP.md](../../planning/roadmaps/REINFORCEMENT_LEARNING_ROADMAP.md)
-- **Mathematical Background**: [/docs/theory/mathematical_background.md](../mathematical_background.md)
-- **User Guide**: See user documentation for practical usage
+## 🔗 Cross-References
+
+### Related Documentation
+
+**Implementation Guides**:
+- Main codebase: [mfg_pde/alg/reinforcement/](../../../mfg_pde/alg/reinforcement/)
+- Example usage: [examples/advanced/](../../../examples/advanced/)
+
+**Mathematical Foundations**:
+- Notation standards: [../foundations/NOTATION_STANDARDS.md](../foundations/NOTATION_STANDARDS.md)
+- MFG mathematical background: [../foundations/mfg_mathematical_background.md](../foundations/mfg_mathematical_background.md)
+
+**Development Roadmaps**:
+- Strategic roadmap: [../../development/planning/STRATEGIC_DEVELOPMENT_ROADMAP_2026.md](../../development/planning/STRATEGIC_DEVELOPMENT_ROADMAP_2026.md)
+
+### Algorithm Decision Tree
+
+```
+Choose MFG-RL Algorithm
+│
+├─ Discrete Actions (|A| ≤ 20)?
+│  ├─ Single population → Use existing Mean Field Q-Learning ✅
+│  └─ Multi-population → Nash Q-Learning (theoretical)
+│
+└─ Continuous Actions?
+   ├─ Deterministic policy needed?
+   │  ├─ Basic → DDPG (Phase 3.3.1)
+   │  └─ Stable & robust → TD3 (Phase 3.3.2)
+   │
+   ├─ Stochastic policy preferred?
+   │  └─ Maximum entropy → SAC (Phase 3.3.3)
+   │
+   └─ Multi-agent coordination?
+      └─ Centralized training → MADDPG (theoretical)
+```
+
+---
+
+## 🎓 Learning Path
+
+**For beginners** (understanding MFG-RL fundamentals):
+1. [../foundations/mfg_mathematical_background.md](../foundations/mfg_mathematical_background.md) - Core MFG theory
+2. [population_ppo_formulation.md](population_ppo_formulation.md) - Simplest MFG-RL algorithm
+3. [action_space_scalability.md](action_space_scalability.md) - Understanding limitations
+
+**For discrete action implementation**:
+1. [nash_q_learning_formulation.md](nash_q_learning_formulation.md) - Theory
+2. [nash_q_learning_architecture.md](nash_q_learning_architecture.md) - Implementation design
+3. Code: `mfg_pde/alg/reinforcement/algorithms/mean_field_q_learning.py`
+
+**For continuous action development**:
+1. [continuous_action_mfg_theory.md](continuous_action_mfg_theory.md) - Complete roadmap
+2. [ddpg_mfg_formulation.md](ddpg_mfg_formulation.md) → [td3_mfg_formulation.md](td3_mfg_formulation.md) → [sac_mfg_formulation.md](sac_mfg_formulation.md) - Algorithm progression
+3. [continuous_action_architecture_sketch.py](continuous_action_architecture_sketch.py) - Code examples
+
+**For multi-population problems**:
+1. [heterogeneous_agents_formulation.md](heterogeneous_agents_formulation.md) - Mathematical framework
+2. [multi_population_continuous_control.md](multi_population_continuous_control.md) - Continuous extensions
+3. [maddpg_for_mfg_formulation.md](maddpg_for_mfg_formulation.md) - Multi-agent coordination
+
+---
+
+## 📊 Implementation Status Matrix
+
+| Algorithm | Discrete Actions | Continuous Actions | Multi-Population | Status |
+|:----------|:----------------|:-------------------|:-----------------|:-------|
+| **Mean Field Q-Learning** | ✅ Implemented | ❌ N/A | ⚠️ Single pop only | Production |
+| **Mean Field Actor-Critic** | ✅ Implemented | ⚠️ Limited | ⚠️ Single pop only | Production |
+| **DDPG** | ❌ N/A | 🚧 Phase 3.3.1 | ❌ Single pop | In Development |
+| **TD3** | ❌ N/A | 📋 Phase 3.3.2 | ❌ Single pop | Planned |
+| **SAC** | ❌ N/A | 📋 Phase 3.3.3 | ❌ Single pop | Planned |
+| **MADDPG** | ❌ N/A | 📋 Theoretical | 📋 Multi-agent | Future Work |
+| **Nash Q-Learning** | 📋 Theoretical | ❌ N/A | ✅ Multi-population | Future Work |
+| **PPO** | ✅ Implemented | ⚠️ Limited | ⚠️ Single pop only | Production |
+
+**Legend**:
+- ✅ Fully implemented and tested
+- ⚠️ Partially implemented or limited scope
+- 🚧 Under active development
+- 📋 Planned/theoretical only
+- ❌ Not applicable or not planned
+
+---
+
+## 🔬 Research Directions
+
+Based on [continuous_action_mfg_theory.md](continuous_action_mfg_theory.md), promising research directions include:
+
+1. **High-Dimensional Action Spaces**: Scaling to $a \in \mathbb{R}^d$ with $d > 10$
+2. **Multi-Modal Policies**: Mixture of Gaussians for complex action distributions
+3. **Model-Based MFG-RL**: Learning dynamics models for sample efficiency
+4. **Transfer Learning**: Pre-trained policies across different MFG problems
+5. **Constrained MFG**: Safety constraints and action bounds
+6. **Hierarchical MFG**: Multi-scale temporal and spatial hierarchies
+
+---
+
+## 📝 Citation
+
+When using these theoretical frameworks, please cite:
+
+```bibtex
+@software{mfg_pde_rl_theory,
+  title = {Reinforcement Learning Theory for Mean Field Games},
+  author = {MFG\_PDE Development Team},
+  year = {2025},
+  note = {Part of MFG\_PDE package},
+  url = {https://github.com/derrring/MFG_PDE}
+}
+```
 
 ---
 
 **Target Audience**: Researchers, algorithm developers, theoretical MFG practitioners
 **Prerequisites**: Familiarity with RL, MFG theory, and numerical methods
+**Maintained by**: MFG_PDE Development Team
+**Last Updated**: 2025-10-12


### PR DESCRIPTION
## Summary

Updates reinforcement learning theory README to document all 13 files (previously only 3).

## Changes

- Document all 13 RL theory documents with categorization
- Add algorithm relationships and decision tree
- Include learning paths for different use cases
- Add implementation status matrix
- Improve documentation discoverability from 23% to 100%

## Type

Documentation only - no code changes, no test changes.

## Testing

N/A - Documentation update only

## Why separate PR?

This documentation improvement is independent of test fixes and can be merged immediately without waiting for CI issues to be resolved.

Addresses theory documentation quality review.