### PR TITLE
Fix: Unify WENO solver grid convention to standard Nx+1

### DIFF
--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
@@ -192,33 +192,33 @@ class HJBWenoSolver(BaseHJBSolver):
     def _setup_dimensional_grid(self) -> None:
         """Setup grid information based on problem dimension."""
         if self.dimension == 1:
-            # 1D case - existing logic
+            # 1D case - use standard grid convention: Nx intervals → Nx+1 grid points
             if hasattr(self.problem, "Nx"):
-                self.Nx = self.problem.Nx
+                self.Nx = self.problem.Nx + 1  # Grid points = intervals + 1
                 self.Dx = self.problem.Dx
             else:
-                self.Nx = getattr(self.problem, "nx", 64)
+                self.Nx = getattr(self.problem, "nx", 64) + 1
                 self.Dx = getattr(self.problem, "dx", 1.0 / (self.Nx - 1))
 
         elif self.dimension == 2:
-            # 2D case
+            # 2D case - use standard grid convention: Nx,Ny intervals → Nx+1,Ny+1 grid points
             if hasattr(self.problem, "geometry") and hasattr(self.problem.geometry, "get_computational_grid"):
                 grid = self.problem.geometry.get_computational_grid()
-                self.Nx, self.Ny = grid["nx"], grid["ny"]
+                self.Nx, self.Ny = grid["nx"] + 1, grid["ny"] + 1  # Grid points = intervals + 1
                 self.Dx, self.Dy = grid["dx"], grid["dy"]
                 self.X, self.Y = grid["X"], grid["Y"]
             else:
                 # Fallback for 2D
-                self.Nx = getattr(self.problem, "Nx", getattr(self.problem, "nx", 64))
-                self.Ny = getattr(self.problem, "Ny", getattr(self.problem, "ny", 64))
+                self.Nx = getattr(self.problem, "Nx", getattr(self.problem, "nx", 64)) + 1
+                self.Ny = getattr(self.problem, "Ny", getattr(self.problem, "ny", 64)) + 1
                 self.Dx = getattr(self.problem, "Dx", getattr(self.problem, "dx", 1.0 / (self.Nx - 1)))
                 self.Dy = getattr(self.problem, "Dy", getattr(self.problem, "dy", 1.0 / (self.Ny - 1)))
 
         elif self.dimension == 3:
-            # 3D case
-            self.Nx = getattr(self.problem, "Nx", getattr(self.problem, "nx", 32))
-            self.Ny = getattr(self.problem, "Ny", getattr(self.problem, "ny", 32))
-            self.Nz = getattr(self.problem, "Nz", getattr(self.problem, "nz", 32))
+            # 3D case - use standard grid convention: Nx,Ny,Nz intervals → Nx+1,Ny+1,Nz+1 grid points
+            self.Nx = getattr(self.problem, "Nx", getattr(self.problem, "nx", 32)) + 1
+            self.Ny = getattr(self.problem, "Ny", getattr(self.problem, "ny", 32)) + 1
+            self.Nz = getattr(self.problem, "Nz", getattr(self.problem, "nz", 32)) + 1
             self.Dx = getattr(self.problem, "Dx", getattr(self.problem, "dx", 1.0 / (self.Nx - 1)))
             self.Dy = getattr(self.problem, "Dy", getattr(self.problem, "dy", 1.0 / (self.Ny - 1)))
             self.Dz = getattr(self.problem, "Dz", getattr(self.problem, "dz", 1.0 / (self.Nz - 1)))

--- a/tests/unit/test_weno_family.py
+++ b/tests/unit/test_weno_family.py
@@ -295,7 +295,7 @@ class TestWenoSolverIntegration:
         solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
-        Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+        Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
         # Create inputs
         M_density = np.ones((Nt, Nx))
@@ -313,7 +313,7 @@ class TestWenoSolverIntegration:
         solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
-        Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+        Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
         # Create inputs with specific final condition
         M_density = np.ones((Nt, Nx))
@@ -332,7 +332,7 @@ class TestWenoSolverIntegration:
         solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
-        Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+        Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
         # Create inputs
         M_density = np.ones((Nt, Nx))
@@ -351,7 +351,7 @@ class TestWenoSolverIntegration:
         solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
-        Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+        Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
         # Create Gaussian density
         x_coords = np.linspace(integration_problem.xmin, integration_problem.xmax, Nx)
@@ -374,7 +374,7 @@ class TestWenoSolverIntegration:
         solver = HJBWenoSolver(integration_problem, weno_variant=variant)
 
         Nt = integration_problem.Nt + 1
-        Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+        Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
         M_density = np.ones((Nt, Nx))
         U_final = np.zeros(Nx)
@@ -390,7 +390,7 @@ class TestWenoSolverIntegration:
         solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
-        Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+        Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
         # Uniform density
         M_density = np.ones((Nt, Nx)) / Nx
@@ -412,7 +412,7 @@ class TestWenoSolverIntegration:
         solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
-        Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+        Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
         M_density = np.ones((Nt, Nx)) * 0.5
         x_coords = np.linspace(integration_problem.xmin, integration_problem.xmax, Nx)
@@ -430,7 +430,7 @@ class TestWenoSolverIntegration:
             solver = HJBWenoSolver(integration_problem, weno_variant="weno5", cfl_number=cfl)
 
             Nt = integration_problem.Nt + 1
-            Nx = integration_problem.Nx  # WENO uses Nx, not Nx+1
+            Nx = integration_problem.Nx + 1  # Standard convention: Nx intervals → Nx+1 grid points
 
             M_density = np.ones((Nt, Nx))
             U_final = np.zeros(Nx)


### PR DESCRIPTION
## Summary
Fixes grid convention inconsistency in WENO solver to match the standard used by 98% of the codebase.

## Problem
WENO solver was using `Nx` directly as number of grid points, while the standard convention throughout MFG_PDE is:
- `Nx` = number of **intervals**
- `Nx+1` = number of **grid points** (including endpoints)

This caused shape mismatches: when `MFGProblem(Nx=50)` creates 51 grid points, WENO only created 50.

## Changes
- **`hjb_weno.py`**: Added `+ 1` in 3 locations (1D, 2D, 3D cases)
  - Line 197: `self.Nx = self.problem.Nx + 1`
  - Line 207: `self.Nx, self.Ny = grid["nx"] + 1, grid["ny"] + 1`
  - Lines 219-221: Added `+ 1` to Nx, Ny, Nz
- **`test_weno_family.py`**: Updated 8 test occurrences to use `Nx+1`

## Testing
All 30 WENO unit tests pass (0.79s)

## Documentation
- Updated `NOTATION_STANDARDS.md` §7.2 with official grid convention
- Created `GRID_CONVENTION_ANALYSIS.md` with complete analysis

Fixes #156

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>