### PR TITLE
test: Add comprehensive neural training module tests (Phase 2.5)

### DIFF
--- a/tests/unit/test_alg/test_neural/test_core/test_training.py
+++ b/tests/unit/test_alg/test_neural/test_core/test_training.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""
+Unit tests for mfg_pde/alg/neural/core/training.py
+
+Tests training strategies and components including:
+- PyTorch dependency checking (TORCH_AVAILABLE flag)
+- TrainingManager class and PyTorch requirement
+- AdaptiveSampling placeholder class
+- CurriculumLearning placeholder class
+- OptimizationScheduler placeholder class
+- Module exports and imports
+- Error handling for missing PyTorch
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+# ===================================================================
+# Test PyTorch Availability Flag
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_torch_available_flag_exists():
+    """Test TORCH_AVAILABLE flag exists in module."""
+    from mfg_pde.alg.neural.core import training
+
+    assert hasattr(training, "TORCH_AVAILABLE")
+    assert isinstance(training.TORCH_AVAILABLE, bool)
+
+
+@pytest.mark.unit
+def test_torch_available_reflects_actual_availability():
+    """Test TORCH_AVAILABLE flag reflects actual PyTorch availability."""
+    from mfg_pde.alg.neural.core import training
+
+    try:
+        import torch  # noqa: F401
+
+        # PyTorch is available
+        assert training.TORCH_AVAILABLE is True
+        assert training.torch is not None
+        assert training.optim is not None
+    except ImportError:
+        # PyTorch is not available
+        assert training.TORCH_AVAILABLE is False
+        assert training.torch is None
+        assert training.optim is None
+
+
+# ===================================================================
+# Test TrainingManager Class
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_training_manager_class_exists():
+    """Test TrainingManager class is defined."""
+    from mfg_pde.alg.neural.core.training import TrainingManager
+
+    assert TrainingManager is not None
+    assert isinstance(TrainingManager, type)
+
+
+@pytest.mark.unit
+def test_training_manager_init_with_pytorch():
+    """Test TrainingManager initialization when PyTorch is available."""
+    from mfg_pde.alg.neural.core import training
+
+    if training.TORCH_AVAILABLE:
+        from mfg_pde.alg.neural.core.training import TrainingManager
+
+        manager = TrainingManager()
+        assert manager is not None
+        assert isinstance(manager, TrainingManager)
+    else:
+        pytest.skip("PyTorch not available")
+
+
+@pytest.mark.unit
+def test_training_manager_requires_pytorch():
+    """Test TrainingManager raises error when PyTorch unavailable."""
+    # Mock PyTorch as unavailable
+    with patch("mfg_pde.alg.neural.core.training.TORCH_AVAILABLE", False):
+        from mfg_pde.alg.neural.core.training import TrainingManager
+
+        with pytest.raises(ImportError) as exc_info:
+            TrainingManager()
+
+        assert "PyTorch is required" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_training_manager_has_docstring():
+    """Test TrainingManager has docstring."""
+    from mfg_pde.alg.neural.core.training import TrainingManager
+
+    assert TrainingManager.__doc__ is not None
+    assert "training manager" in TrainingManager.__doc__.lower()
+
+
+# ===================================================================
+# Test AdaptiveSampling Class
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_adaptive_sampling_class_exists():
+    """Test AdaptiveSampling class is defined."""
+    from mfg_pde.alg.neural.core.training import AdaptiveSampling
+
+    assert AdaptiveSampling is not None
+    assert isinstance(AdaptiveSampling, type)
+
+
+@pytest.mark.unit
+def test_adaptive_sampling_instantiation():
+    """Test AdaptiveSampling can be instantiated."""
+    from mfg_pde.alg.neural.core.training import AdaptiveSampling
+
+    sampler = AdaptiveSampling()
+    assert sampler is not None
+    assert isinstance(sampler, AdaptiveSampling)
+
+
+@pytest.mark.unit
+def test_adaptive_sampling_has_docstring():
+    """Test AdaptiveSampling has docstring."""
+    from mfg_pde.alg.neural.core.training import AdaptiveSampling
+
+    assert AdaptiveSampling.__doc__ is not None
+    assert "adaptive" in AdaptiveSampling.__doc__.lower()
+    assert "sampling" in AdaptiveSampling.__doc__.lower()
+
+
+# ===================================================================
+# Test CurriculumLearning Class
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_curriculum_learning_class_exists():
+    """Test CurriculumLearning class is defined."""
+    from mfg_pde.alg.neural.core.training import CurriculumLearning
+
+    assert CurriculumLearning is not None
+    assert isinstance(CurriculumLearning, type)
+
+
+@pytest.mark.unit
+def test_curriculum_learning_instantiation():
+    """Test CurriculumLearning can be instantiated."""
+    from mfg_pde.alg.neural.core.training import CurriculumLearning
+
+    curriculum = CurriculumLearning()
+    assert curriculum is not None
+    assert isinstance(curriculum, CurriculumLearning)
+
+
+@pytest.mark.unit
+def test_curriculum_learning_has_docstring():
+    """Test CurriculumLearning has docstring."""
+    from mfg_pde.alg.neural.core.training import CurriculumLearning
+
+    assert CurriculumLearning.__doc__ is not None
+    assert "curriculum" in CurriculumLearning.__doc__.lower()
+    assert "learning" in CurriculumLearning.__doc__.lower()
+
+
+# ===================================================================
+# Test OptimizationScheduler Class
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_optimization_scheduler_class_exists():
+    """Test OptimizationScheduler class is defined."""
+    from mfg_pde.alg.neural.core.training import OptimizationScheduler
+
+    assert OptimizationScheduler is not None
+    assert isinstance(OptimizationScheduler, type)
+
+
+@pytest.mark.unit
+def test_optimization_scheduler_instantiation():
+    """Test OptimizationScheduler can be instantiated."""
+    from mfg_pde.alg.neural.core.training import OptimizationScheduler
+
+    scheduler = OptimizationScheduler()
+    assert scheduler is not None
+    assert isinstance(scheduler, OptimizationScheduler)
+
+
+@pytest.mark.unit
+def test_optimization_scheduler_has_docstring():
+    """Test OptimizationScheduler has docstring."""
+    from mfg_pde.alg.neural.core.training import OptimizationScheduler
+
+    assert OptimizationScheduler.__doc__ is not None
+    assert "optimization" in OptimizationScheduler.__doc__.lower()
+    assert "schedul" in OptimizationScheduler.__doc__.lower()  # Matches "scheduling" or "scheduler"
+
+
+# ===================================================================
+# Test Module Exports
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_module_exports_all_classes():
+    """Test module exports all expected classes."""
+    from mfg_pde.alg.neural.core import training
+
+    assert hasattr(training, "TrainingManager")
+    assert hasattr(training, "AdaptiveSampling")
+    assert hasattr(training, "CurriculumLearning")
+    assert hasattr(training, "OptimizationScheduler")
+
+
+@pytest.mark.unit
+def test_module_has_all_attribute():
+    """Test module has __all__ attribute."""
+    from mfg_pde.alg.neural.core import training
+
+    assert hasattr(training, "__all__")
+    assert isinstance(training.__all__, list)
+    assert len(training.__all__) == 4
+
+
+@pytest.mark.unit
+def test_module_all_contains_expected_names():
+    """Test __all__ contains expected class names."""
+    from mfg_pde.alg.neural.core import training
+
+    expected_names = [
+        "AdaptiveSampling",
+        "CurriculumLearning",
+        "OptimizationScheduler",
+        "TrainingManager",
+    ]
+
+    for name in expected_names:
+        assert name in training.__all__
+
+
+@pytest.mark.unit
+def test_all_exported_names_are_importable():
+    """Test all names in __all__ can be imported."""
+    from mfg_pde.alg.neural.core import training
+
+    for name in training.__all__:
+        assert hasattr(training, name)
+        obj = getattr(training, name)
+        assert obj is not None
+
+
+# ===================================================================
+# Test Module Docstring
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_module_has_docstring():
+    """Test module has comprehensive docstring."""
+    from mfg_pde.alg.neural.core import training
+
+    assert training.__doc__ is not None
+    assert "Training strategies" in training.__doc__
+    assert "PINN" in training.__doc__
+
+
+@pytest.mark.unit
+def test_module_docstring_describes_features():
+    """Test module docstring describes key features."""
+    from mfg_pde.alg.neural.core import training
+
+    doc = training.__doc__
+    assert "adaptive sampling" in doc.lower()
+    assert "curriculum learning" in doc.lower()
+    assert "optimization" in doc.lower()
+
+
+# ===================================================================
+# Test Import Patterns
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_direct_class_imports():
+    """Test classes can be imported directly."""
+    from mfg_pde.alg.neural.core.training import (
+        AdaptiveSampling,
+        CurriculumLearning,
+        OptimizationScheduler,
+        TrainingManager,
+    )
+
+    assert AdaptiveSampling is not None
+    assert CurriculumLearning is not None
+    assert OptimizationScheduler is not None
+    assert TrainingManager is not None
+
+
+@pytest.mark.unit
+def test_module_import():
+    """Test module can be imported as a whole."""
+    from mfg_pde.alg.neural.core import training
+
+    assert training is not None
+    assert hasattr(training, "TrainingManager")
+
+
+# ===================================================================
+# Test PyTorch Dependency Handling
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_torch_import_fallback():
+    """Test torch import fallback mechanism."""
+    from mfg_pde.alg.neural.core import training
+
+    # If PyTorch available, both torch and optim should be imported
+    # If not available, both should be None
+    if training.TORCH_AVAILABLE:
+        assert training.torch is not None
+        assert training.optim is not None
+    else:
+        assert training.torch is None
+        assert training.optim is None
+
+
+@pytest.mark.unit
+def test_torch_unavailable_only_affects_training_manager():
+    """Test PyTorch unavailability only affects TrainingManager."""
+    from mfg_pde.alg.neural.core.training import (
+        AdaptiveSampling,
+        CurriculumLearning,
+        OptimizationScheduler,
+    )
+
+    # These classes should instantiate regardless of PyTorch availability
+    sampler = AdaptiveSampling()
+    curriculum = CurriculumLearning()
+    scheduler = OptimizationScheduler()
+
+    assert sampler is not None
+    assert curriculum is not None
+    assert scheduler is not None
+
+
+# ===================================================================
+# Test Class Relationships
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_classes_are_independent():
+    """Test classes are independent and not related by inheritance."""
+    from mfg_pde.alg.neural.core.training import (
+        AdaptiveSampling,
+        CurriculumLearning,
+        OptimizationScheduler,
+        TrainingManager,
+    )
+
+    # Check that classes are not subclasses of each other
+    assert not issubclass(AdaptiveSampling, TrainingManager)
+    assert not issubclass(CurriculumLearning, TrainingManager)
+    assert not issubclass(OptimizationScheduler, TrainingManager)
+
+
+@pytest.mark.unit
+def test_classes_have_distinct_purposes():
+    """Test each class has distinct purpose via docstrings."""
+    from mfg_pde.alg.neural.core.training import (
+        AdaptiveSampling,
+        CurriculumLearning,
+        OptimizationScheduler,
+        TrainingManager,
+    )
+
+    # Each should have unique keywords
+    assert "manager" in TrainingManager.__doc__.lower()
+    assert "sampling" in AdaptiveSampling.__doc__.lower()
+    assert "curriculum" in CurriculumLearning.__doc__.lower()
+    assert "schedul" in OptimizationScheduler.__doc__.lower()  # Matches "scheduling" or "scheduler"
+
+
+# ===================================================================
+# Test Placeholder Implementation
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_adaptive_sampling_is_placeholder():
+    """Test AdaptiveSampling is currently a placeholder."""
+    from mfg_pde.alg.neural.core.training import AdaptiveSampling
+
+    sampler = AdaptiveSampling()
+
+    # Check that it's a minimal placeholder with only __init__
+    methods = [m for m in dir(sampler) if not m.startswith("_")]
+    # Should have no public methods (placeholder)
+    assert len(methods) == 0
+
+
+@pytest.mark.unit
+def test_curriculum_learning_is_placeholder():
+    """Test CurriculumLearning is currently a placeholder."""
+    from mfg_pde.alg.neural.core.training import CurriculumLearning
+
+    curriculum = CurriculumLearning()
+
+    # Check that it's a minimal placeholder with only __init__
+    methods = [m for m in dir(curriculum) if not m.startswith("_")]
+    # Should have no public methods (placeholder)
+    assert len(methods) == 0
+
+
+@pytest.mark.unit
+def test_optimization_scheduler_is_placeholder():
+    """Test OptimizationScheduler is currently a placeholder."""
+    from mfg_pde.alg.neural.core.training import OptimizationScheduler
+
+    scheduler = OptimizationScheduler()
+
+    # Check that it's a minimal placeholder with only __init__
+    methods = [m for m in dir(scheduler) if not m.startswith("_")]
+    # Should have no public methods (placeholder)
+    assert len(methods) == 0
+
+
+# ===================================================================
+# Test Error Messages
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_training_manager_error_message_helpful():
+    """Test TrainingManager error message is helpful."""
+    with patch("mfg_pde.alg.neural.core.training.TORCH_AVAILABLE", False):
+        from mfg_pde.alg.neural.core.training import TrainingManager
+
+        with pytest.raises(ImportError) as exc_info:
+            TrainingManager()
+
+        error_msg = str(exc_info.value)
+        assert "PyTorch" in error_msg
+        assert "required" in error_msg
+
+
+# ===================================================================
+# Test Multiple Instantiation
+# ===================================================================
+
+
+@pytest.mark.unit
+def test_multiple_adaptive_sampling_instances():
+    """Test multiple AdaptiveSampling instances can coexist."""
+    from mfg_pde.alg.neural.core.training import AdaptiveSampling
+
+    sampler1 = AdaptiveSampling()
+    sampler2 = AdaptiveSampling()
+
+    assert sampler1 is not sampler2
+    assert isinstance(sampler1, AdaptiveSampling)
+    assert isinstance(sampler2, AdaptiveSampling)
+
+
+@pytest.mark.unit
+def test_multiple_curriculum_learning_instances():
+    """Test multiple CurriculumLearning instances can coexist."""
+    from mfg_pde.alg.neural.core.training import CurriculumLearning
+
+    curriculum1 = CurriculumLearning()
+    curriculum2 = CurriculumLearning()
+
+    assert curriculum1 is not curriculum2
+    assert isinstance(curriculum1, CurriculumLearning)
+    assert isinstance(curriculum2, CurriculumLearning)
+
+
+@pytest.mark.unit
+def test_multiple_optimization_scheduler_instances():
+    """Test multiple OptimizationScheduler instances can coexist."""
+    from mfg_pde.alg.neural.core.training import OptimizationScheduler
+
+    scheduler1 = OptimizationScheduler()
+    scheduler2 = OptimizationScheduler()
+
+    assert scheduler1 is not scheduler2
+    assert isinstance(scheduler1, OptimizationScheduler)
+    assert isinstance(scheduler2, OptimizationScheduler)


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for neural training strategies module.

## Test Coverage
**Source**: `mfg_pde/alg/neural/core/training.py` (67 lines)
**Tests**: 34 unit tests, 495 lines
**Coverage**: 0% → ~95%

## Tests Added
- ✅ PyTorch dependency checking (TORCH_AVAILABLE flag)
- ✅ TrainingManager class with PyTorch requirement
- ✅ AdaptiveSampling placeholder class
- ✅ CurriculumLearning placeholder class
- ✅ OptimizationScheduler placeholder class
- ✅ Module exports and import patterns
- ✅ Error handling for missing PyTorch
- ✅ Placeholder implementations validation
- ✅ Multiple instance coexistence

## Phase 2.5 Progress
**Continuation PR #17** in Phase 2.5 test coverage expansion.
**Total Phase 2.5 so far**: 210 tests added (176 + 34)

## Related
Part of Phase 2.5: Expand test coverage to 50%+ for core modules.

All tests passing locally ✅