### PR TITLE
feat(geometry): Add implicit domain infrastructure for meshfree methods

### DIFF
--- a/mfg_pde/geometry/implicit/__init__.py
+++ b/mfg_pde/geometry/implicit/__init__.py
@@ -1,0 +1,81 @@
+"""
+Implicit Domain Geometry for Meshfree Methods
+
+This module provides dimension-agnostic implicit domain representation using
+signed distance functions (SDFs). Complements MFG_PDE's existing mesh-based
+geometry for particle-collocation and meshfree methods.
+
+Key Advantages:
+- No mesh generation required (O(d) storage vs O(N^d))
+- Natural obstacle representation via CSG operations
+- Dimension-agnostic (works for 2D, 3D, 4D, ..., any d)
+- Efficient for particle methods
+
+Components:
+- ImplicitDomain: Abstract base class using signed distance functions
+- Hyperrectangle: Axis-aligned boxes in n dimensions
+- Hypersphere: Balls/spheres in n dimensions
+- CSG Operations: Union, Intersection, Complement, Difference
+
+Example - Domain with Obstacle:
+    >>> from mfg_pde.geometry.implicit import Hyperrectangle, Hypersphere, DifferenceDomain
+    >>> import numpy as np
+    >>>
+    >>> # Create base domain (unit square)
+    >>> square = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+    >>>
+    >>> # Add circular obstacle
+    >>> obstacle = Hypersphere(center=[0.5, 0.5], radius=0.2)
+    >>>
+    >>> # Navigable domain = base - obstacle
+    >>> domain = DifferenceDomain(square, obstacle)
+    >>>
+    >>> # Sample particles (automatically avoids obstacle)
+    >>> particles = domain.sample_uniform(5000, seed=42)
+    >>> assert np.all(domain.contains(particles))
+
+Example - 4D Hypercube:
+    >>> # Works for arbitrary dimensions
+    >>> hypercube_4d = Hyperrectangle(np.array([[0, 1]] * 4))
+    >>> particles_4d = hypercube_4d.sample_uniform(10000)
+    >>> assert particles_4d.shape == (10000, 4)
+
+Relation to Existing Geometry:
+- Complements Domain2D/Domain3D (mesh-based)
+- Use when:
+  - d > 3 (mesh generation impractical)
+  - Particle methods (no mesh needed)
+  - Complex obstacles (CSG operations easier than remeshing)
+
+For maze environments, see mfg_pde.alg.reinforcement.environments.
+
+Mathematical Foundation:
+    An implicit domain D ⊂ ℝ^d is defined by signed distance function φ:
+        x ∈ D  ⟺  φ(x) < 0   (interior)
+        x ∈ ∂D ⟺  φ(x) = 0   (boundary)
+        x ∉ D  ⟺  φ(x) > 0   (exterior)
+
+References:
+    - Osher & Fedkiw (2003): Level Set Methods and Dynamic Implicit Surfaces
+    - MFG_PDE geometry system: mfg_pde/geometry/README.md
+
+Author: MFG_PDE Team
+Date: October 2025
+"""
+
+from .csg_operations import ComplementDomain, DifferenceDomain, IntersectionDomain, UnionDomain
+from .hyperrectangle import Hyperrectangle
+from .hypersphere import Hypersphere
+from .implicit_domain import ImplicitDomain
+
+__all__ = [
+    "ComplementDomain",
+    "DifferenceDomain",
+    "Hyperrectangle",
+    "Hypersphere",
+    "ImplicitDomain",
+    "IntersectionDomain",
+    "UnionDomain",
+]
+
+__version__ = "0.1.0"

--- a/mfg_pde/geometry/implicit/csg_operations.py
+++ b/mfg_pde/geometry/implicit/csg_operations.py
@@ -1,0 +1,350 @@
+"""
+Constructive Solid Geometry (CSG) Operations
+
+CSG operations allow building complex domains from simple primitives:
+- Union: D₁ ∪ D₂ ∪ ... ∪ Dₙ
+- Intersection: D₁ ∩ D₂ ∩ ... ∩ Dₙ
+- Complement: ℝ^d \\ D
+- Difference: D₁ \\ D₂ = D₁ ∩ (ℝ^d \\ D₂)
+
+Key applications:
+- Obstacles: domain \\\\ obstacle
+- Mazes: base ∩ (complement of walls)
+- Complex geometry: unions/intersections of primitives
+
+For signed distance functions:
+- Union: φ_{D₁∪D₂}(x) = min(φ_{D₁}(x), φ_{D₂}(x))
+- Intersection: φ_{D₁∩D₂}(x) = max(φ_{D₁}(x), φ_{D₂}(x))
+- Complement: φ_{ℝ^d\\D}(x) = -φ_D(x)
+
+References:
+- Ricci (1973): An Constructive Geometry for Computer Graphics
+- TECHNICAL_REFERENCE_HIGH_DIMENSIONAL_MFG.md Section 4.3
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .implicit_domain import ImplicitDomain
+
+
+class UnionDomain(ImplicitDomain):
+    """
+    Union of multiple domains: D = D₁ ∪ D₂ ∪ ... ∪ Dₙ
+
+    A point is inside if it's inside ANY of the constituent domains.
+
+    Signed distance function:
+        φ_union(x) = min(φ₁(x), φ₂(x), ..., φₙ(x))
+
+    Example:
+        >>> # Two overlapping circles
+        >>> circle1 = Hypersphere(center=[0, 0], radius=1.0)
+        >>> circle2 = Hypersphere(center=[1, 0], radius=1.0)
+        >>> union = UnionDomain([circle1, circle2])  # Peanut shape
+        >>> union.contains([0.5, 0])  # True (in overlap)
+    """
+
+    def __init__(self, domains: list[ImplicitDomain]):
+        """
+        Initialize union of domains.
+
+        Args:
+            domains: List of ImplicitDomain objects
+
+        Raises:
+            ValueError: If domains list is empty or dimensions don't match
+        """
+        if not domains:
+            raise ValueError("domains list cannot be empty")
+
+        self.domains = domains
+        self._dimension = domains[0].dimension
+
+        # Verify all domains have same dimension
+        if not all(d.dimension == self._dimension for d in domains):
+            raise ValueError(f"All domains must have same dimension, got dimensions: {[d.dimension for d in domains]}")
+
+    @property
+    def dimension(self) -> int:
+        """Spatial dimension."""
+        return self._dimension
+
+    def signed_distance(self, x: NDArray) -> float | NDArray:
+        """
+        Compute signed distance to union.
+
+        φ_union(x) = min_i φ_i(x)
+
+        A point is inside union if it's inside any constituent domain.
+
+        Args:
+            x: Point(s) - shape (d,) or (N, d)
+
+        Returns:
+            Signed distance(s) - scalar or shape (N,)
+        """
+        x = np.asarray(x, dtype=float)
+        is_single = x.ndim == 1
+
+        # Compute SDF for each domain
+        distances = np.array([domain.signed_distance(x) for domain in self.domains])
+
+        # Union: minimum distance
+        sd = np.min(distances, axis=0)
+
+        return float(sd) if is_single and np.isscalar(sd) else sd
+
+    def get_bounding_box(self) -> NDArray:
+        """
+        Get bounding box containing all domains.
+
+        Returns:
+            bounds: Array of shape (d, 2) with min/max over all domain boxes
+        """
+        boxes = np.array([domain.get_bounding_box() for domain in self.domains])
+
+        # Union bounding box: min of lower bounds, max of upper bounds
+        bounds = np.zeros((self.dimension, 2))
+        bounds[:, 0] = np.min(boxes[:, :, 0], axis=0)
+        bounds[:, 1] = np.max(boxes[:, :, 1], axis=0)
+
+        return bounds
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"UnionDomain({len(self.domains)} domains)"
+
+
+class IntersectionDomain(ImplicitDomain):
+    """
+    Intersection of multiple domains: D = D₁ ∩ D₂ ∩ ... ∩ Dₙ
+
+    A point is inside if it's inside ALL of the constituent domains.
+
+    Signed distance function:
+        φ_intersection(x) = max(φ₁(x), φ₂(x), ..., φₙ(x))
+
+    Example:
+        >>> # Rectangle with circular hole removed
+        >>> rect = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+        >>> hole = Hypersphere(center=[0.5, 0.5], radius=0.2)
+        >>> domain = IntersectionDomain([rect, ComplementDomain(hole)])
+        >>> # domain = rect \\ hole
+    """
+
+    def __init__(self, domains: list[ImplicitDomain]):
+        """
+        Initialize intersection of domains.
+
+        Args:
+            domains: List of ImplicitDomain objects
+
+        Raises:
+            ValueError: If domains list is empty or dimensions don't match
+        """
+        if not domains:
+            raise ValueError("domains list cannot be empty")
+
+        self.domains = domains
+        self._dimension = domains[0].dimension
+
+        # Verify all domains have same dimension
+        if not all(d.dimension == self._dimension for d in domains):
+            raise ValueError(f"All domains must have same dimension, got dimensions: {[d.dimension for d in domains]}")
+
+    @property
+    def dimension(self) -> int:
+        """Spatial dimension."""
+        return self._dimension
+
+    def signed_distance(self, x: NDArray) -> float | NDArray:
+        """
+        Compute signed distance to intersection.
+
+        φ_intersection(x) = max_i φ_i(x)
+
+        A point is inside intersection only if inside all constituent domains.
+
+        Args:
+            x: Point(s) - shape (d,) or (N, d)
+
+        Returns:
+            Signed distance(s) - scalar or shape (N,)
+        """
+        x = np.asarray(x, dtype=float)
+        is_single = x.ndim == 1
+
+        # Compute SDF for each domain
+        distances = np.array([domain.signed_distance(x) for domain in self.domains])
+
+        # Intersection: maximum distance
+        sd = np.max(distances, axis=0)
+
+        return float(sd) if is_single and np.isscalar(sd) else sd
+
+    def get_bounding_box(self) -> NDArray:
+        """
+        Get bounding box for intersection (conservative estimate).
+
+        Uses the smallest bounding box among constituent domains.
+
+        Returns:
+            bounds: Array of shape (d, 2)
+        """
+        boxes = np.array([domain.get_bounding_box() for domain in self.domains])
+
+        # Intersection bounding box: max of lower bounds, min of upper bounds
+        bounds = np.zeros((self.dimension, 2))
+        bounds[:, 0] = np.max(boxes[:, :, 0], axis=0)
+        bounds[:, 1] = np.min(boxes[:, :, 1], axis=0)
+
+        # Check if intersection is empty
+        if np.any(bounds[:, 0] >= bounds[:, 1]):
+            # Empty intersection - return first domain's box as fallback
+            return self.domains[0].get_bounding_box()
+
+        return bounds
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"IntersectionDomain({len(self.domains)} domains)"
+
+
+class ComplementDomain(ImplicitDomain):
+    """
+    Complement of a domain: D^c = ℝ^d \\ D
+
+    A point is inside complement if it's OUTSIDE the original domain.
+
+    Signed distance function:
+        φ_complement(x) = -φ(x)
+
+    Example:
+        >>> # Everything outside a circle (infinite domain!)
+        >>> circle = Hypersphere(center=[0, 0], radius=1.0)
+        >>> exterior = ComplementDomain(circle)
+        >>> exterior.contains([2, 0])  # True (outside circle)
+        >>> exterior.contains([0, 0])  # False (inside circle)
+    """
+
+    def __init__(self, domain: ImplicitDomain):
+        """
+        Initialize complement of a domain.
+
+        Args:
+            domain: ImplicitDomain to complement
+
+        Note:
+            Complement domain is typically unbounded! Use with caution for
+            sampling - you'll need to provide an explicit bounding box.
+        """
+        self.domain = domain
+        self._dimension = domain.dimension
+        self._bounding_box = None  # Must be set manually for unbounded complements
+
+    @property
+    def dimension(self) -> int:
+        """Spatial dimension."""
+        return self._dimension
+
+    def signed_distance(self, x: NDArray) -> float | NDArray:
+        """
+        Compute signed distance to complement.
+
+        φ_complement(x) = -φ(x)
+
+        Args:
+            x: Point(s) - shape (d,) or (N, d)
+
+        Returns:
+            Signed distance(s) - scalar or shape (N,)
+        """
+        return -self.domain.signed_distance(x)
+
+    def get_bounding_box(self) -> NDArray:
+        """
+        Get bounding box for complement domain.
+
+        Warning: Complement is typically unbounded! This returns a user-specified
+        box if set, otherwise raises an error.
+
+        Returns:
+            bounds: Array of shape (d, 2) if manually set
+
+        Raises:
+            ValueError: If bounding box not manually specified
+        """
+        if self._bounding_box is None:
+            raise ValueError(
+                "ComplementDomain is unbounded. Set bounding box manually via:\ncomplement.set_bounding_box(bounds)"
+            )
+        return self._bounding_box.copy()
+
+    def set_bounding_box(self, bounds: NDArray):
+        """
+        Manually set bounding box for sampling from complement.
+
+        Args:
+            bounds: Array of shape (d, 2) where bounds[i] = [min_i, max_i]
+
+        Example:
+            >>> circle = Hypersphere(center=[0, 0], radius=0.5)
+            >>> exterior = ComplementDomain(circle)
+            >>> # Sample from unit square minus circle
+            >>> exterior.set_bounding_box(np.array([[0, 1], [0, 1]]))
+            >>> particles = exterior.sample_uniform(1000)
+        """
+        self._bounding_box = np.asarray(bounds, dtype=float)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"ComplementDomain({self.domain})"
+
+
+class DifferenceDomain(IntersectionDomain):
+    """
+    Set difference: D₁ \\ D₂ = D₁ ∩ (ℝ^d \\ D₂)
+
+    Points inside D₁ but outside D₂.
+
+    This is a convenience class that's equivalent to:
+        IntersectionDomain([D₁, ComplementDomain(D₂)])
+
+    Example:
+        >>> # Rectangle with circular hole
+        >>> rect = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+        >>> hole = Hypersphere(center=[0.5, 0.5], radius=0.2)
+        >>> domain_with_hole = DifferenceDomain(rect, hole)
+        >>> # Equivalent to: IntersectionDomain([rect, ComplementDomain(hole)])
+    """
+
+    def __init__(self, domain1: ImplicitDomain, domain2: ImplicitDomain):
+        """
+        Initialize set difference D₁ \\ D₂.
+
+        Args:
+            domain1: Base domain (what we start with)
+            domain2: Domain to subtract (the "hole")
+
+        Example:
+            >>> # Square with circular obstacle removed
+            >>> square = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+            >>> obstacle = Hypersphere(center=[0.5, 0.5], radius=0.3)
+            >>> navigable = DifferenceDomain(square, obstacle)
+        """
+        complement = ComplementDomain(domain2)
+
+        # Set bounding box for complement (use domain1's box)
+        complement.set_bounding_box(domain1.get_bounding_box())
+
+        # Initialize as intersection of domain1 and complement of domain2
+        super().__init__([domain1, complement])
+
+        # Store originals for repr
+        self.domain1 = domain1
+        self.domain2 = domain2
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"DifferenceDomain({self.domain1} \\ {self.domain2})"

--- a/mfg_pde/geometry/implicit/hyperrectangle.py
+++ b/mfg_pde/geometry/implicit/hyperrectangle.py
@@ -1,0 +1,304 @@
+"""
+Hyperrectangle Domain (Axis-Aligned Box in n-D)
+
+Hyperrectangle: Cartesian product of intervals in each dimension
+    D = [a₁, b₁] × [a₂, b₂] × ... × [aₐ, bₐ]
+
+Most common domain type in MFG applications:
+- 2D: Rectangle (e.g., [0,1] × [0,1] for unit square)
+- 3D: Box (e.g., [0,1]³ for unit cube)
+- 4D: Hypercube (e.g., [0,1]⁴ for unit tesseract)
+- nD: General hyperrectangle
+
+Advantages:
+- Exact signed distance function (O(d) complexity)
+- Efficient sampling (no rejection needed!)
+- Natural for grid-based problems
+- Easy periodic boundary conditions
+
+References:
+- TECHNICAL_REFERENCE_HIGH_DIMENSIONAL_MFG.md Section 4.1
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .implicit_domain import ImplicitDomain
+
+
+class Hyperrectangle(ImplicitDomain):
+    """
+    Axis-aligned hyperrectangle in n dimensions.
+
+    Domain: D = [a₁, b₁] × [a₂, b₂] × ... × [aₐ, bₐ]
+
+    Signed distance function (exact):
+        φ(x) = max(max(a - x), max(x - b))
+
+    where a = (a₁, ..., aₐ) and b = (b₁, ..., bₐ).
+
+    Attributes:
+        bounds: Array of shape (d, 2) where bounds[i] = [min_i, max_i]
+        dimension: Spatial dimension
+
+    Example:
+        >>> # 2D unit square
+        >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+        >>> domain.contains(np.array([0.5, 0.5]))  # True
+
+        >>> # 4D unit hypercube
+        >>> domain_4d = Hyperrectangle(np.array([[0, 1]] * 4))
+        >>> particles = domain_4d.sample_uniform(10000)
+        >>> assert particles.shape == (10000, 4)
+    """
+
+    def __init__(self, bounds: NDArray):
+        """
+        Initialize hyperrectangle domain.
+
+        Args:
+            bounds: Array of shape (d, 2) where bounds[i] = [min_i, max_i]
+
+        Raises:
+            ValueError: If bounds are invalid (min >= max)
+
+        Example:
+            >>> # 2D rectangle [0,2] × [0,1]
+            >>> domain = Hyperrectangle(np.array([[0, 2], [0, 1]]))
+
+            >>> # 3D box [-1,1]³
+            >>> domain_3d = Hyperrectangle(np.array([[-1, 1]] * 3))
+        """
+        bounds = np.asarray(bounds, dtype=float)
+
+        if bounds.ndim != 2 or bounds.shape[1] != 2:
+            raise ValueError(f"bounds must have shape (d, 2), got {bounds.shape}")
+
+        if np.any(bounds[:, 0] >= bounds[:, 1]):
+            raise ValueError("bounds must have min < max for all dimensions")
+
+        self.bounds = bounds
+        self._dimension = bounds.shape[0]
+
+    @property
+    def dimension(self) -> int:
+        """Spatial dimension of the hyperrectangle."""
+        return self._dimension
+
+    def signed_distance(self, x: NDArray) -> float | NDArray:
+        """
+        Compute exact signed distance to hyperrectangle.
+
+        For a point x and hyperrectangle [a, b]:
+            φ(x) = max(max(a - x), max(x - b))
+
+        This gives exact Euclidean distance to the boundary.
+
+        Args:
+            x: Point(s) - shape (d,) or (N, d)
+
+        Returns:
+            Signed distance(s) - scalar or shape (N,)
+
+        Complexity:
+            O(d) per point
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+            >>> domain.signed_distance(np.array([0.5, 0.5]))  # -0.5 (inside)
+            >>> domain.signed_distance(np.array([1.5, 0.5]))  #  0.5 (outside)
+            >>> domain.signed_distance(np.array([1.0, 0.5]))  #  0.0 (boundary)
+        """
+        x = np.asarray(x, dtype=float)
+        is_single = x.ndim == 1
+
+        if is_single:
+            x = x.reshape(1, -1)
+
+        if x.shape[1] != self.dimension:
+            raise ValueError(f"Point dimension {x.shape[1]} does not match domain dimension {self.dimension}")
+
+        # Distance to lower bounds: a - x (positive if x < a)
+        lower_dist = self.bounds[:, 0] - x
+
+        # Distance to upper bounds: x - b (positive if x > b)
+        upper_dist = x - self.bounds[:, 1]
+
+        # Maximum distance along each dimension
+        # If inside on dimension i: max(lower_dist[i], upper_dist[i]) < 0
+        max_dist_per_dim = np.maximum(lower_dist, upper_dist)
+
+        # Signed distance is max over all dimensions
+        sd = np.max(max_dist_per_dim, axis=1)
+
+        return sd[0] if is_single else sd
+
+    def get_bounding_box(self) -> NDArray:
+        """
+        Get bounding box (returns self for hyperrectangle).
+
+        Returns:
+            bounds: Array of shape (d, 2) where bounds[i] = [min_i, max_i]
+        """
+        return self.bounds.copy()
+
+    def sample_uniform(self, n_samples: int, max_attempts: int = 100, seed: int | None = None) -> NDArray:
+        """
+        Sample particles uniformly from hyperrectangle.
+
+        Efficient implementation: no rejection sampling needed!
+
+        Args:
+            n_samples: Number of particles
+            max_attempts: Unused (kept for interface compatibility)
+            seed: Random seed
+
+        Returns:
+            particles: Array of shape (n_samples, d)
+
+        Complexity:
+            O(n_samples * d) - no rejection!
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+            >>> particles = domain.sample_uniform(1000, seed=42)
+            >>> assert np.all(particles >= 0) and np.all(particles <= 1)
+        """
+        if seed is not None:
+            np.random.seed(seed)
+
+        # Sample uniformly from each dimension independently
+        particles = np.random.uniform(low=self.bounds[:, 0], high=self.bounds[:, 1], size=(n_samples, self.dimension))
+
+        return particles
+
+    def apply_boundary_conditions(self, particles: NDArray, bc_type: str = "reflecting") -> NDArray:
+        """
+        Apply boundary conditions (specialized for hyperrectangle).
+
+        Args:
+            particles: Particle positions - shape (N, d)
+            bc_type: Boundary condition type
+                - "reflecting": Reflect particles at boundaries
+                - "absorbing": Remove particles outside domain
+                - "periodic": Wrap particles to opposite side
+
+        Returns:
+            Updated particle positions
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+            >>> particles = np.array([[1.2, 0.5], [-0.1, 0.5]])
+            >>> particles_reflected = domain.apply_boundary_conditions(particles, "reflecting")
+            >>> # [1.2, 0.5] → [0.8, 0.5] (reflected from right wall)
+            >>> # [-0.1, 0.5] → [0.1, 0.5] (reflected from left wall)
+        """
+        particles = particles.copy()
+
+        if bc_type == "reflecting":
+            # Reflect particles at each boundary
+            for dim in range(self.dimension):
+                # Reflect from lower boundary
+                below = particles[:, dim] < self.bounds[dim, 0]
+                particles[below, dim] = 2 * self.bounds[dim, 0] - particles[below, dim]
+
+                # Reflect from upper boundary
+                above = particles[:, dim] > self.bounds[dim, 1]
+                particles[above, dim] = 2 * self.bounds[dim, 1] - particles[above, dim]
+
+            return particles
+
+        elif bc_type == "absorbing":
+            # Remove particles outside domain
+            inside = np.all(
+                (particles >= self.bounds[:, 0]) & (particles <= self.bounds[:, 1]),
+                axis=1,
+            )
+            return particles[inside]
+
+        elif bc_type == "periodic":
+            # Wrap particles to opposite side
+            for dim in range(self.dimension):
+                width = self.bounds[dim, 1] - self.bounds[dim, 0]
+
+                # Particles below lower bound
+                below = particles[:, dim] < self.bounds[dim, 0]
+                particles[below, dim] += width
+
+                # Particles above upper bound
+                above = particles[:, dim] > self.bounds[dim, 1]
+                particles[above, dim] -= width
+
+            return particles
+
+        else:
+            raise ValueError(f"Unknown boundary condition type: {bc_type}")
+
+    def compute_volume(self, n_monte_carlo: int = 100000) -> float:
+        """
+        Compute exact volume (no Monte Carlo needed for hyperrectangle).
+
+        Volume = ∏ᵢ (bᵢ - aᵢ)
+
+        Args:
+            n_monte_carlo: Unused (kept for interface compatibility)
+
+        Returns:
+            Exact volume
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 2], [0, 3]]))
+            >>> domain.compute_volume()  # 2 * 3 = 6
+        """
+        return np.prod(self.bounds[:, 1] - self.bounds[:, 0])
+
+    def get_center(self) -> NDArray:
+        """
+        Get center point of hyperrectangle.
+
+        Returns:
+            center: Array of shape (d,)
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 2], [0, 4]]))
+            >>> domain.get_center()  # array([1, 2])
+        """
+        return (self.bounds[:, 0] + self.bounds[:, 1]) / 2
+
+    def get_vertices(self) -> NDArray:
+        """
+        Get all vertices (corners) of hyperrectangle.
+
+        Returns:
+            vertices: Array of shape (2^d, d) with all corners
+
+        Warning:
+            Grows exponentially with dimension! Use only for low dimensions.
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))  # 2D square
+            >>> vertices = domain.get_vertices()
+            >>> # Returns: [[0,0], [0,1], [1,0], [1,1]]
+        """
+        if self.dimension > 10:
+            raise ValueError(
+                f"get_vertices() with dimension={self.dimension} would create "
+                f"2^{self.dimension} = {2**self.dimension} vertices. Use d≤10."
+            )
+
+        # Generate all combinations of (min, max) for each dimension
+        from itertools import product
+
+        vertices = []
+        for combo in product(*[(0, 1)] * self.dimension):
+            vertex = np.array([self.bounds[i, combo[i]] for i in range(self.dimension)])
+            vertices.append(vertex)
+
+        return np.array(vertices)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        bounds_str = ", ".join([f"[{self.bounds[i, 0]}, {self.bounds[i, 1]}]" for i in range(min(self.dimension, 3))])
+        if self.dimension > 3:
+            bounds_str += ", ..."
+        return f"Hyperrectangle({bounds_str})"

--- a/mfg_pde/geometry/implicit/hypersphere.py
+++ b/mfg_pde/geometry/implicit/hypersphere.py
@@ -1,0 +1,266 @@
+"""
+Hypersphere Domain (Ball in n-D)
+
+Hypersphere: All points within distance r from center c
+    D = {x ∈ ℝ^d : ||x - c|| ≤ r}
+
+Common uses:
+- 2D: Circle (e.g., circular obstacles)
+- 3D: Sphere (e.g., spherical regions)
+- nD: Hypersphere (e.g., safe zones in high-D)
+
+Advantages:
+- Exact signed distance function (O(d) complexity)
+- Rotationally symmetric
+- Natural for radial problems
+- Perfect for obstacles
+
+References:
+- TECHNICAL_REFERENCE_HIGH_DIMENSIONAL_MFG.md Section 4.2
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .implicit_domain import ImplicitDomain
+
+
+class Hypersphere(ImplicitDomain):
+    """
+    Hypersphere (ball) in n dimensions.
+
+    Domain: D = {x ∈ ℝ^d : ||x - c|| ≤ r}
+
+    Signed distance function (exact):
+        φ(x) = ||x - c|| - r
+
+    where c is the center and r is the radius.
+
+    Attributes:
+        center: Center point - array of shape (d,)
+        radius: Radius (positive scalar)
+        dimension: Spatial dimension
+
+    Example:
+        >>> # 2D unit circle centered at origin
+        >>> circle = Hypersphere(center=[0, 0], radius=1.0)
+        >>> circle.contains([0.5, 0.5])  # True
+
+        >>> # 4D hypersphere
+        >>> sphere_4d = Hypersphere(center=[0]*4, radius=1.0)
+        >>> particles = sphere_4d.sample_uniform(10000)
+        >>> assert particles.shape == (10000, 4)
+    """
+
+    def __init__(self, center: NDArray | list, radius: float):
+        """
+        Initialize hypersphere domain.
+
+        Args:
+            center: Center point - array-like of shape (d,)
+            radius: Radius (must be positive)
+
+        Raises:
+            ValueError: If radius <= 0
+
+        Example:
+            >>> # 2D circle at (1, 2) with radius 0.5
+            >>> circle = Hypersphere(center=[1.0, 2.0], radius=0.5)
+
+            >>> # 3D sphere at origin with radius 2
+            >>> sphere = Hypersphere(center=[0, 0, 0], radius=2.0)
+        """
+        self.center = np.asarray(center, dtype=float)
+        self.radius = float(radius)
+
+        if self.radius <= 0:
+            raise ValueError(f"Radius must be positive, got {radius}")
+
+        if self.center.ndim != 1:
+            raise ValueError(f"Center must be 1D array, got shape {self.center.shape}")
+
+        self._dimension = len(self.center)
+
+    @property
+    def dimension(self) -> int:
+        """Spatial dimension of the hypersphere."""
+        return self._dimension
+
+    def signed_distance(self, x: NDArray) -> float | NDArray:
+        """
+        Compute exact signed distance to hypersphere.
+
+        For a point x, center c, and radius r:
+            φ(x) = ||x - c|| - r
+
+        Args:
+            x: Point(s) - shape (d,) or (N, d)
+
+        Returns:
+            Signed distance(s) - scalar or shape (N,)
+
+        Complexity:
+            O(d) per point
+
+        Example:
+            >>> sphere = Hypersphere(center=[0, 0], radius=1.0)
+            >>> sphere.signed_distance([0, 0])       # -1.0 (center)
+            >>> sphere.signed_distance([1, 0])       #  0.0 (boundary)
+            >>> sphere.signed_distance([2, 0])       #  1.0 (outside)
+            >>> sphere.signed_distance([0.5, 0])     # -0.5 (inside)
+        """
+        x = np.asarray(x, dtype=float)
+        is_single = x.ndim == 1
+
+        if is_single:
+            x = x.reshape(1, -1)
+
+        if x.shape[1] != self.dimension:
+            raise ValueError(f"Point dimension {x.shape[1]} does not match domain dimension {self.dimension}")
+
+        # Euclidean distance from center
+        distances = np.linalg.norm(x - self.center, axis=1)
+
+        # Signed distance: dist - radius
+        sd = distances - self.radius
+
+        return sd[0] if is_single else sd
+
+    def get_bounding_box(self) -> NDArray:
+        """
+        Get axis-aligned bounding box containing the hypersphere.
+
+        Returns:
+            bounds: Array of shape (d, 2) where bounds[i] = [c_i - r, c_i + r]
+
+        Example:
+            >>> sphere = Hypersphere(center=[1, 2], radius=0.5)
+            >>> bounds = sphere.get_bounding_box()
+            >>> # array([[0.5, 1.5], [1.5, 2.5]])
+        """
+        bounds = np.zeros((self.dimension, 2))
+        bounds[:, 0] = self.center - self.radius
+        bounds[:, 1] = self.center + self.radius
+        return bounds
+
+    def sample_uniform(self, n_samples: int, max_attempts: int = 100, seed: int | None = None) -> NDArray:
+        """
+        Sample particles uniformly from hypersphere.
+
+        Uses rejection sampling from bounding box. For high dimensions (d>10),
+        most volume is near the surface, so acceptance rate drops.
+
+        Args:
+            n_samples: Number of particles
+            max_attempts: Maximum attempts per particle
+            seed: Random seed
+
+        Returns:
+            particles: Array of shape (n_samples, d)
+
+        Complexity:
+            Expected O(n_samples * d * (2/π)^(d/2)) attempts
+            Acceptance rate ≈ V_sphere / V_box ≈ (π/4)^(d/2)
+
+        Note:
+            For d > 10, consider using surface sampling + radial distribution.
+
+        Example:
+            >>> sphere = Hypersphere(center=[0, 0], radius=1.0)
+            >>> particles = sphere.sample_uniform(1000, seed=42)
+            >>> # All particles satisfy ||p|| <= 1
+            >>> assert np.all(np.linalg.norm(particles, axis=1) <= 1.0)
+        """
+        # Use parent class rejection sampling (efficient enough for d ≤ 10)
+        return super().sample_uniform(n_samples, max_attempts, seed)
+
+    def sample_surface(self, n_samples: int, seed: int | None = None) -> NDArray:
+        """
+        Sample particles uniformly on the surface of the hypersphere.
+
+        Uses Muller method: Sample from Gaussian, normalize, scale by radius.
+
+        Args:
+            n_samples: Number of particles
+            seed: Random seed
+
+        Returns:
+            surface_particles: Array of shape (n_samples, d) on boundary
+
+        Example:
+            >>> sphere = Hypersphere(center=[0, 0], radius=1.0)
+            >>> surface = sphere.sample_surface(1000, seed=42)
+            >>> # All particles have ||p|| = 1
+            >>> dists = np.linalg.norm(surface, axis=1)
+            >>> assert np.allclose(dists, 1.0)
+        """
+        if seed is not None:
+            np.random.seed(seed)
+
+        # Sample from standard Gaussian
+        samples = np.random.normal(size=(n_samples, self.dimension))
+
+        # Normalize to unit sphere
+        norms = np.linalg.norm(samples, axis=1, keepdims=True)
+        unit_sphere = samples / norms
+
+        # Scale to radius and shift to center
+        surface = self.center + self.radius * unit_sphere
+
+        return surface
+
+    def compute_volume(self, n_monte_carlo: int = 100000) -> float:
+        """
+        Compute exact volume (no Monte Carlo needed for hypersphere).
+
+        Volume of d-dimensional ball with radius r:
+            V_d(r) = (π^(d/2) / Γ(d/2 + 1)) * r^d
+
+        Args:
+            n_monte_carlo: Unused (kept for interface compatibility)
+
+        Returns:
+            Exact volume
+
+        Example:
+            >>> circle = Hypersphere(center=[0, 0], radius=1.0)
+            >>> circle.compute_volume()  # π ≈ 3.14159...
+
+            >>> sphere_3d = Hypersphere(center=[0, 0, 0], radius=1.0)
+            >>> sphere_3d.compute_volume()  # 4π/3 ≈ 4.18879...
+        """
+        from math import gamma, pi
+
+        # V_d(r) = (π^(d/2) / Γ(d/2 + 1)) * r^d
+        coefficient = pi ** (self.dimension / 2) / gamma(self.dimension / 2 + 1)
+        volume = coefficient * (self.radius**self.dimension)
+
+        return volume
+
+    def compute_surface_area(self) -> float:
+        """
+        Compute exact surface area of the hypersphere.
+
+        Surface area of (d-1)-sphere with radius r:
+            S_(d-1)(r) = d * V_d(r) / r
+
+        Returns:
+            Exact surface area
+
+        Example:
+            >>> circle = Hypersphere(center=[0, 0], radius=1.0)
+            >>> circle.compute_surface_area()  # 2π (circumference)
+
+            >>> sphere_3d = Hypersphere(center=[0, 0, 0], radius=1.0)
+            >>> sphere_3d.compute_surface_area()  # 4π
+        """
+        volume = self.compute_volume()
+        return self.dimension * volume / self.radius
+
+    def __repr__(self) -> str:
+        """String representation."""
+        if self.dimension <= 3:
+            center_str = str(self.center.tolist())
+        else:
+            center_str = f"[{self.center[0]:.2f}, {self.center[1]:.2f}, ..., {self.center[-1]:.2f}]"
+        return f"Hypersphere(center={center_str}, radius={self.radius:.3f})"

--- a/mfg_pde/geometry/implicit/implicit_domain.py
+++ b/mfg_pde/geometry/implicit/implicit_domain.py
@@ -1,0 +1,301 @@
+"""
+Implicit Domain Infrastructure for Meshfree Methods
+
+This module provides dimension-agnostic implicit domain representation via
+signed distance functions (SDFs). This enables:
+
+- No mesh generation required (O(d) storage instead of O(N^d))
+- Natural obstacle representation via CSG operations
+- Dimension-agnostic code (works for 2D, 3D, 4D, ..., 100D)
+- Particle-friendly boundary conditions
+
+Key concept: A domain D ⊂ ℝ^d is represented implicitly by a function:
+    φ: ℝ^d → ℝ  where  φ(x) < 0 ⟺ x ∈ D
+
+References:
+- Osher & Fedkiw (2003): Level Set Methods and Dynamic Implicit Surfaces
+- TECHNICAL_REFERENCE_HIGH_DIMENSIONAL_MFG.md Section 4
+"""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class ImplicitDomain(ABC):
+    """
+    Abstract base class for n-dimensional implicit domains.
+
+    An implicit domain D ⊂ ℝ^d is defined by a signed distance function φ:
+        x ∈ D  ⟺  φ(x) < 0   (interior)
+        x ∈ ∂D ⟺  φ(x) = 0   (boundary)
+        x ∉ D  ⟺  φ(x) > 0   (exterior)
+
+    Advantages over explicit mesh representation:
+    - Memory: O(d) vs O(N^d) for mesh
+    - Obstacles: Free with CSG operations
+    - Dimension-agnostic: Same code for any d
+    - Particle methods: Natural boundary handling
+
+    Subclasses must implement:
+    - signed_distance(x): Core SDF
+    - get_bounding_box(): For efficient sampling
+
+    Example:
+        >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))  # [0,1]²
+        >>> domain.contains(np.array([0.5, 0.5]))  # True (interior)
+        >>> domain.contains(np.array([1.5, 0.5]))  # False (exterior)
+        >>> particles = domain.sample_uniform(1000)  # Sample particles
+    """
+
+    @property
+    @abstractmethod
+    def dimension(self) -> int:
+        """Spatial dimension of the domain."""
+
+    @abstractmethod
+    def signed_distance(self, x: NDArray) -> float | NDArray:
+        """
+        Compute signed distance function φ(x).
+
+        Convention:
+            φ(x) < 0  ⟺  x inside domain
+            φ(x) = 0  ⟺  x on boundary
+            φ(x) > 0  ⟺  x outside domain
+
+        Args:
+            x: Point(s) to evaluate - shape (d,) or (N, d)
+
+        Returns:
+            Signed distance(s) - scalar or shape (N,)
+
+        Notes:
+            For exact SDFs, |φ(x)| = distance to boundary.
+            For approximations, only sign matters for containment.
+        """
+
+    @abstractmethod
+    def get_bounding_box(self) -> NDArray:
+        """
+        Get axis-aligned bounding box containing the domain.
+
+        Returns:
+            bounds: Array of shape (d, 2) where bounds[i] = [min_i, max_i]
+
+        Example:
+            >>> domain = Hypersphere(center=[0, 0], radius=1.0)
+            >>> bounds = domain.get_bounding_box()
+            >>> bounds  # array([[-1, 1], [-1, 1]])
+        """
+
+    def contains(self, x: NDArray, tol: float = 0.0) -> bool | NDArray:
+        """
+        Check if point(s) are inside the domain.
+
+        Args:
+            x: Point(s) to test - shape (d,) or (N, d)
+            tol: Tolerance for boundary (default 0)
+                 tol > 0 makes domain slightly larger
+                 tol < 0 makes domain slightly smaller
+
+        Returns:
+            Boolean or boolean array indicating containment
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+            >>> domain.contains(np.array([0.5, 0.5]))  # True
+            >>> domain.contains(np.array([[0.5, 0.5], [1.5, 0.5]]))  # [True, False]
+        """
+        return self.signed_distance(x) <= tol
+
+    def sample_uniform(self, n_samples: int, max_attempts: int = 100, seed: int | None = None) -> NDArray:
+        """
+        Sample particles uniformly inside the domain via rejection sampling.
+
+        Args:
+            n_samples: Number of particles to sample
+            max_attempts: Maximum rejection sampling attempts per particle
+            seed: Random seed for reproducibility
+
+        Returns:
+            particles: Array of shape (n_samples, d) with particles inside domain
+
+        Raises:
+            RuntimeError: If rejection sampling fails to find enough valid particles
+
+        Algorithm:
+            1. Get bounding box
+            2. Sample uniformly from bounding box
+            3. Reject samples outside domain
+            4. Repeat until n_samples accepted
+
+        Example:
+            >>> domain = Hypersphere(center=[0, 0], radius=1.0)
+            >>> particles = domain.sample_uniform(1000, seed=42)
+            >>> assert particles.shape == (1000, 2)
+            >>> assert np.all(domain.contains(particles))
+        """
+        if seed is not None:
+            np.random.seed(seed)
+
+        bounds = self.get_bounding_box()
+        dim = self.dimension
+
+        particles = []
+        attempts = 0
+        max_total_attempts = n_samples * max_attempts
+
+        while len(particles) < n_samples and attempts < max_total_attempts:
+            # Sample from bounding box
+            batch_size = min(n_samples - len(particles), 1000)
+            candidates = np.random.uniform(low=bounds[:, 0], high=bounds[:, 1], size=(batch_size, dim))
+
+            # Accept particles inside domain
+            inside = self.contains(candidates)
+            if np.isscalar(inside):
+                inside = np.array([inside])
+
+            valid = candidates[inside]
+            particles.append(valid)
+
+            attempts += batch_size
+
+        if len(particles) == 0 or sum(len(p) for p in particles) < n_samples:
+            raise RuntimeError(
+                f"Rejection sampling failed: only found {sum(len(p) for p in particles)}/{n_samples} "
+                f"valid particles after {attempts} attempts. Domain may be too small or complex."
+            )
+
+        all_particles = np.vstack(particles)
+        return all_particles[:n_samples]
+
+    def project_to_domain(self, x: NDArray, method: str = "simple") -> NDArray:
+        """
+        Project point(s) outside domain back inside.
+
+        Args:
+            x: Point(s) - shape (d,) or (N, d)
+            method: Projection method
+                - "simple": Scale toward centroid of bounding box
+                - "gradient": Use SDF gradient (requires smooth SDF)
+
+        Returns:
+            Projected point(s) - same shape as x
+
+        Example:
+            >>> domain = Hypersphere(center=[0, 0], radius=1.0)
+            >>> outside = np.array([2.0, 0.0])
+            >>> inside = domain.project_to_domain(outside)
+            >>> assert domain.contains(inside)
+        """
+        is_single = x.ndim == 1
+        if is_single:
+            x = x.reshape(1, -1)
+
+        # Check which points need projection
+        sd = self.signed_distance(x)
+        if np.isscalar(sd):
+            sd = np.array([sd])
+
+        outside = sd > 0
+
+        if not np.any(outside):
+            return x[0] if is_single else x
+
+        # Simple projection: scale toward bounding box center
+        if method == "simple":
+            bounds = self.get_bounding_box()
+            center = bounds.mean(axis=1)
+
+            x_projected = x.copy()
+            for i in np.where(outside)[0]:
+                # Move point toward center until inside
+                direction = center - x[i]
+                alpha = 0.0
+                step = 0.1
+
+                for _ in range(100):
+                    candidate = x[i] + alpha * direction
+                    if self.signed_distance(candidate) <= 0:
+                        x_projected[i] = candidate
+                        break
+                    alpha += step
+                else:
+                    # Fallback: use center
+                    x_projected[i] = center
+
+            return x_projected[0] if is_single else x_projected
+
+        else:
+            raise ValueError(f"Unknown projection method: {method}")
+
+    def apply_boundary_conditions(self, particles: NDArray, bc_type: str = "reflecting") -> NDArray:
+        """
+        Apply boundary conditions to particles that left the domain.
+
+        Args:
+            particles: Particle positions - shape (N, d)
+            bc_type: Boundary condition type
+                - "reflecting": Reflect particles back into domain
+                - "absorbing": Remove particles outside domain
+                - "periodic": Wrap particles to opposite side (box domains only)
+
+        Returns:
+            Updated particle positions (may have fewer particles for "absorbing")
+
+        Example:
+            >>> domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+            >>> particles = np.array([[0.5, 0.5], [1.2, 0.5]])  # One outside
+            >>> particles_updated = domain.apply_boundary_conditions(particles, "reflecting")
+            >>> assert np.all(domain.contains(particles_updated))
+        """
+        if bc_type == "reflecting":
+            return self.project_to_domain(particles, method="simple")
+
+        elif bc_type == "absorbing":
+            inside = self.contains(particles)
+            if np.isscalar(inside):
+                inside = np.array([inside])
+            return particles[inside]
+
+        elif bc_type == "periodic":
+            # Periodic BC requires special handling (only works for hyperrectangles)
+            raise NotImplementedError("Periodic BC requires Hyperrectangle-specific implementation")
+
+        else:
+            raise ValueError(f"Unknown boundary condition type: {bc_type}")
+
+    def compute_volume(self, n_monte_carlo: int = 100000) -> float:
+        """
+        Estimate domain volume via Monte Carlo integration.
+
+        Args:
+            n_monte_carlo: Number of samples for Monte Carlo
+
+        Returns:
+            Estimated volume
+
+        Example:
+            >>> sphere = Hypersphere(center=[0, 0], radius=1.0)
+            >>> vol = sphere.compute_volume(n_monte_carlo=1000000)
+            >>> assert np.abs(vol - np.pi) < 0.01  # π for unit circle in 2D
+        """
+        bounds = self.get_bounding_box()
+        bbox_volume = np.prod(bounds[:, 1] - bounds[:, 0])
+
+        # Sample uniformly from bounding box
+        samples = np.random.uniform(low=bounds[:, 0], high=bounds[:, 1], size=(n_monte_carlo, self.dimension))
+
+        # Fraction inside domain
+        inside = self.contains(samples)
+        if np.isscalar(inside):
+            inside = np.array([inside])
+
+        fraction_inside = np.mean(inside)
+
+        return bbox_volume * fraction_inside
+
+    def __repr__(self) -> str:
+        """String representation of the domain."""
+        return f"{self.__class__.__name__}(dimension={self.dimension})"

--- a/tests/unit/geometry/test_implicit_geometry.py
+++ b/tests/unit/geometry/test_implicit_geometry.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for implicit domain geometry infrastructure.
+
+Tests signed distance functions, containment, sampling, and CSG operations
+for dimension-agnostic implicit domains.
+
+Run with: pytest tests/unit/geometry/test_implicit_geometry.py -v
+"""
+
+import pytest
+
+import numpy as np
+
+from mfg_pde.geometry.implicit import (
+    ComplementDomain,
+    DifferenceDomain,
+    Hyperrectangle,
+    Hypersphere,
+    IntersectionDomain,
+    UnionDomain,
+)
+
+
+class TestHyperrectangle:
+    """Test hyperrectangle domain."""
+
+    def test_2d_unit_square(self):
+        """Test 2D unit square [0,1]²."""
+        domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+
+        assert domain.dimension == 2
+        assert domain.contains(np.array([0.5, 0.5]))  # Interior
+        assert domain.contains(np.array([1.0, 1.0]))  # Boundary
+        assert not domain.contains(np.array([1.5, 0.5]))  # Exterior
+
+    def test_4d_hypercube(self):
+        """Test 4D unit hypercube."""
+        domain = Hyperrectangle(np.array([[0, 1]] * 4))
+
+        assert domain.dimension == 4
+        particles = domain.sample_uniform(1000, seed=42)
+        assert particles.shape == (1000, 4)
+        assert np.all(domain.contains(particles))
+
+    def test_signed_distance(self):
+        """Test exact signed distance function."""
+        domain = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+
+        # Interior: should be negative
+        assert domain.signed_distance(np.array([0.5, 0.5])) < 0
+
+        # Boundary: should be zero
+        assert np.abs(domain.signed_distance(np.array([1.0, 0.5]))) < 1e-10
+
+        # Exterior: should be positive
+        assert domain.signed_distance(np.array([1.5, 0.5])) > 0
+
+    def test_volume(self):
+        """Test volume calculation."""
+        domain = Hyperrectangle(np.array([[0, 2], [0, 3]]))
+        assert np.abs(domain.compute_volume() - 6.0) < 1e-10  # 2 × 3
+
+
+class TestHypersphere:
+    """Test hypersphere domain."""
+
+    def test_2d_unit_circle(self):
+        """Test 2D unit circle."""
+        domain = Hypersphere(center=[0, 0], radius=1.0)
+
+        assert domain.dimension == 2
+        assert domain.contains(np.array([0, 0]))  # Center
+        assert domain.contains(np.array([0.5, 0]))  # Interior
+        assert not domain.contains(np.array([2, 0]))  # Exterior
+
+    def test_4d_hypersphere(self):
+        """Test 4D hypersphere."""
+        domain = Hypersphere(center=[0] * 4, radius=1.0)
+
+        assert domain.dimension == 4
+        particles = domain.sample_uniform(1000, seed=42)
+        assert particles.shape == (1000, 4)
+        assert np.all(domain.contains(particles))
+
+    def test_signed_distance(self):
+        """Test exact signed distance function."""
+        domain = Hypersphere(center=[0, 0], radius=1.0)
+
+        # Center: should be -radius
+        assert np.abs(domain.signed_distance(np.array([0, 0])) + 1.0) < 1e-10
+
+        # Boundary: should be zero
+        assert np.abs(domain.signed_distance(np.array([1, 0]))) < 1e-10
+
+        # Exterior: should be positive
+        assert domain.signed_distance(np.array([2, 0])) > 0
+
+    def test_volume_2d(self):
+        """Test volume (area) of 2D circle."""
+        circle = Hypersphere(center=[0, 0], radius=1.0)
+        volume = circle.compute_volume()
+        assert np.abs(volume - np.pi) < 1e-6
+
+    def test_volume_3d(self):
+        """Test volume of 3D sphere."""
+        sphere = Hypersphere(center=[0, 0, 0], radius=1.0)
+        volume = sphere.compute_volume()
+        expected = 4 * np.pi / 3
+        assert np.abs(volume - expected) < 1e-6
+
+
+class TestCSGOperations:
+    """Test CSG operations."""
+
+    def test_union_2_circles(self):
+        """Test union of two circles."""
+        circle1 = Hypersphere(center=[0, 0], radius=1.0)
+        circle2 = Hypersphere(center=[1, 0], radius=1.0)
+        union = UnionDomain([circle1, circle2])
+
+        # Point in overlap region
+        assert union.contains(np.array([0.5, 0]))
+
+        # Points in individual circles
+        assert union.contains(np.array([-0.5, 0]))  # Only in circle1
+        assert union.contains(np.array([1.5, 0]))  # Only in circle2
+
+        # Point outside both
+        assert not union.contains(np.array([3, 0]))
+
+    def test_intersection_rect_circle(self):
+        """Test intersection of rectangle and circle."""
+        rect = Hyperrectangle(np.array([[0, 2], [0, 2]]))
+        circle = Hypersphere(center=[1, 1], radius=0.8)  # Smaller radius
+        intersection = IntersectionDomain([rect, circle])
+
+        # Point in both
+        assert intersection.contains(np.array([1, 1]))
+
+        # Point in rect but not circle
+        assert not intersection.contains(np.array([0.1, 0.1]))
+
+        # Point in circle but not rect
+        assert not intersection.contains(np.array([-0.5, 1]))
+
+    def test_complement(self):
+        """Test complement of circle."""
+        circle = Hypersphere(center=[0, 0], radius=1.0)
+        exterior = ComplementDomain(circle)
+
+        # Inside circle → outside complement
+        assert not exterior.contains(np.array([0, 0]))
+
+        # Outside circle → inside complement
+        assert exterior.contains(np.array([2, 0]))
+
+    def test_difference_rect_minus_circle(self):
+        """Test rectangle with circular hole."""
+        rect = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+        hole = Hypersphere(center=[0.5, 0.5], radius=0.2)
+        domain = DifferenceDomain(rect, hole)
+
+        # Point in rectangle but outside hole
+        assert domain.contains(np.array([0.1, 0.1]))
+
+        # Point in hole
+        assert not domain.contains(np.array([0.5, 0.5]))
+
+        # Point outside rectangle
+        assert not domain.contains(np.array([1.5, 0.5]))
+
+    def test_complex_domain_obstacle_avoidance(self):
+        """Test domain with obstacle (key for particle-collocation methods)."""
+        # Base: unit square
+        base = Hyperrectangle(np.array([[0, 1], [0, 1]]))
+
+        # Obstacle: circular
+        obstacle = Hypersphere(center=[0.5, 0.5], radius=0.2)
+
+        # Navigable domain
+        domain = DifferenceDomain(base, obstacle)
+
+        # Sample particles
+        particles = domain.sample_uniform(1000, seed=42)
+
+        # Verify all particles avoid obstacle
+        dists = np.linalg.norm(particles - np.array([0.5, 0.5]), axis=1)
+        assert np.all(dists > 0.2)  # All particles outside obstacle
+
+        # Verify all particles in base domain
+        assert np.all((particles >= 0) & (particles <= 1))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds dimension-agnostic **implicit domain geometry** infrastructure for particle-collocation and meshfree MFG methods. Complements existing mesh-based `Domain2D`/`Domain3D` geometry.

## Motivation

**Problem**: Existing mesh-based geometry faces three limitations:
1. **High dimensions (d > 3)**: Mesh generation is impractical due to O(N^d) scaling
2. **Particle methods**: Meshfree methods don't need meshes, but still need domain representation
3. **Complex obstacles**: CSG operations are easier than remeshing for obstacle-rich environments

**Solution**: Use signed distance functions (SDFs) for implicit domain representation:
- O(d) storage vs O(N^d) for meshes
- Dimension-agnostic (works for 2D, 3D, 4D, ..., any d)
- Natural CSG operations (union, intersection, complement, difference)

## Implementation

### Components Added

**Base Class**:
- `ImplicitDomain`: Abstract base using signed distance functions φ(x)
  - φ(x) < 0 ⟺ x inside domain
  - φ(x) = 0 ⟺ x on boundary  
  - φ(x) > 0 ⟺ x outside domain

**Primitives**:
- `Hyperrectangle`: Axis-aligned boxes in n dimensions
- `Hypersphere`: Balls/spheres in n dimensions

**CSG Operations** (for complex geometry):
- `UnionDomain`: D₁ ∪ D₂ ∪ ... ∪ Dₙ
- `IntersectionDomain`: D₁ ∩ D₂ ∩ ... ∩ Dₙ
- `ComplementDomain`: ℝ^d \\ D
- `DifferenceDomain`: D₁ \\ D₂ (e.g., domain with holes/obstacles)

### Key Features

1. **Exact signed distances**: Closed-form SDFs for primitives
2. **Uniform sampling**: Rejection sampling inside arbitrary domains
3. **Volume computation**: Analytical for primitives, Monte Carlo for CSG
4. **Containment testing**: Vectorized for efficiency

### Example Usage

```python
from mfg_pde.geometry.implicit import Hyperrectangle, Hypersphere, DifferenceDomain
import numpy as np

# Domain with circular obstacle
square = Hyperrectangle(np.array([[0, 1], [0, 1]]))
obstacle = Hypersphere(center=[0.5, 0.5], radius=0.2)
domain = DifferenceDomain(square, obstacle)

# Sample particles (automatically avoids obstacle)
particles = domain.sample_uniform(5000, seed=42)
assert np.all(domain.contains(particles))  # All valid

# Works for arbitrary dimensions
hypercube_4d = Hyperrectangle(np.array([[0, 1]] * 4))
particles_4d = hypercube_4d.sample_uniform(10000)
assert particles_4d.shape == (10000, 4)
```

## Testing

**Tests**: 14/14 passing in 0.06s

Coverage includes:
- ✅ 2D/3D/4D domains
- ✅ Exact signed distance computation
- ✅ Volume calculations (analytical formulas)
- ✅ CSG operations (union, intersection, complement, difference)
- ✅ Obstacle avoidance (key for particle-collocation)
- ✅ Uniform sampling via rejection sampling

## Relation to Existing Geometry

**Complements, not replaces** `Domain2D`/`Domain3D`:

| Feature | Mesh-Based | Implicit Domains |
|---------|------------|------------------|
| Best for | d ≤ 3, FEM/FDM | d > 3, particle methods |
| Storage | O(N^d) | O(d) |
| Obstacles | Remeshing required | CSG operations |
| Boundary | Mesh edges | Signed distance |

**Use implicit domains when**:
- Working in d > 3 (mesh generation impractical)
- Using particle-collocation methods (no mesh needed)
- Need complex obstacles (CSG easier than remeshing)

**For maze environments**, see existing `mfg_pde.alg.reinforcement.environments` infrastructure.

## Related Work

This PR builds on:
- **PR #188**: Dimensional support for `TensorProductGrid` (merged)
- **Issue #187**: High-dimensional MFG infrastructure (resolved)

Together, these enable MFG_PDE to handle arbitrary dimensions d ≥ 4.

## Checklist

- ✅ All tests pass (14/14)
- ✅ Pre-commit hooks pass (ruff format, ruff check)
- ✅ Documentation added (docstrings + module-level docs)
- ✅ Examples provided in `__init__.py`
- ✅ Complements existing geometry (no breaking changes)

## Future Work

After this PR:
1. Example notebook demonstrating particle-collocation in 4D
2. Integration with reinforcement learning maze environments
3. Performance benchmarks vs mesh-based methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)