### PR TITLE
chore: Update ruff to v0.14.3 and pre-commit-hooks to v6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 repos:
   # Unified formatting and linting with Ruff (replaces Black + isort + Pylint)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.1
+    rev: v0.14.3
     hooks:
       # Format code (replaces Black + isort)
       - id: ruff-format
@@ -22,7 +22,7 @@ repos:
 
   # Essential safety checks (low friction, prevent bugs)
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: \.md$


### PR DESCRIPTION
## Summary
Updates pre-commit hooks to latest versions.

## Changes
- **Ruff**: v0.13.1 → v0.14.3
- **pre-commit-hooks**: v4.5.0 → v6.0.0

## Testing
- Pre-commit hooks tested locally and pass
- No code changes required (ruff 0.14.3 is compatible)

## Impact
- Latest bug fixes and features from ruff
- Latest safety checks from pre-commit-hooks
- Maintains consistent formatting and linting standards