### PR TITLE
fix: Correct RichProgressBar.set_postfix() argument passing

### DIFF
--- a/mfg_pde/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfg_pde/alg/numerical/coupling/fixed_point_iterator.py
@@ -290,12 +290,10 @@ class FixedPointIterator(BaseMFGSolver):
             if verbose and hasattr(picard_range, "set_postfix"):
                 accel_tag = "A" if self.use_anderson else ""
                 picard_range.set_postfix(
-                    {
-                        "U_err": f"{self.l2distu_rel[iiter]:.2e}",
-                        "M_err": f"{self.l2distm_rel[iiter]:.2e}",
-                        "t": f"{iter_time:.1f}s",
-                        "acc": accel_tag,
-                    }
+                    U_err=f"{self.l2distu_rel[iiter]:.2e}",
+                    M_err=f"{self.l2distm_rel[iiter]:.2e}",
+                    t=f"{iter_time:.1f}s",
+                    acc=accel_tag,
                 )
             elif not verbose:
                 # Print traditional output when not using progress bar

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -1535,7 +1535,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                 if self.qp_optimization_level in ["auto", "always"] and hasattr(self, "qp_stats"):
                     postfix["qp_solves"] = self.qp_stats.get("total_qp_solves", 0)
                 if postfix:
-                    timestep_range.set_postfix(postfix)
+                    timestep_range.set_postfix(**postfix)
 
         # Map back to grid
         U_solution = self._map_collocation_to_grid_batch(U_solution_collocation)


### PR DESCRIPTION
## Summary
Fixed incorrect `set_postfix()` calls that were passing dictionaries as positional arguments instead of unpacking as keyword arguments.

## Changes
- **fixed_point_iterator.py:292-297**: Changed `set_postfix({...})` to pass keyword arguments directly
- **hjb_gfdm.py:1538**: Changed `set_postfix(postfix)` to `set_postfix(**postfix)`

## Test Results
All 16 tests in `test_solve_mfg.py` now pass (previously 4 failures):
- `test_method_accurate` ✅ 
- `test_method_research` ✅
- `test_custom_max_iterations_and_tolerance` ✅
- `test_valid_methods_list` ✅

## Root Cause
`RichProgressBar.set_postfix()` is defined as `def set_postfix(self, **kwargs)` but was being called with a dict as positional argument, causing `TypeError: takes 1 positional argument but 2 were given`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)