### PR TITLE
feat: Export SimpleGrid2D and SimpleGrid3D

### DIFF
--- a/mfg_pde/geometry/__init__.py
+++ b/mfg_pde/geometry/__init__.py
@@ -94,6 +94,7 @@ from .network_geometry import (
     compute_network_statistics,
     create_network,
 )
+from .simple_grid import SimpleGrid2D, SimpleGrid3D
 from .simple_grid_1d import SimpleGrid1D
 from .tensor_product_grid import TensorProductGrid
 
@@ -118,6 +119,8 @@ __all__ = [
     "DirichletBC3D",
     # Geometry components (new naming convention)
     "SimpleGrid1D",
+    "SimpleGrid2D",
+    "SimpleGrid3D",
     "Mesh1D",
     "Mesh2D",
     "Mesh3D",


### PR DESCRIPTION
Completes CartesianGrid family exports for Issue #245 unification.

## Changes
- Export SimpleGrid2D and SimpleGrid3D from geometry module
- Add to __all__ for public API
- Tested: All three grids work correctly

## Purpose
Enables geometry-based MFGProblem unification:
- Legacy 1D → SimpleGrid1D
- Legacy 2D → SimpleGrid2D  
- Legacy 3D → SimpleGrid3D
- Unified internal representation

🤖 Generated with [Claude Code](https://claude.com/claude-code)