### PR TITLE
fix: Phase 3 - Update solvers to use CartesianGrid interface

### DIFF
--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
@@ -191,12 +191,14 @@ class HJBWenoSolver(BaseHJBSolver):
 
     def _setup_dimensional_grid(self) -> None:
         """Setup grid information based on problem dimension (dimension-agnostic)."""
-        # Try GridBasedMFGProblem first (supports arbitrary nD)
-        if hasattr(self.problem, "geometry") and hasattr(self.problem.geometry, "grid"):
-            grid_obj = self.problem.geometry.grid
+        # Try CartesianGrid geometry first (supports arbitrary nD)
+        from mfg_pde.geometry.base import CartesianGrid
+
+        if isinstance(getattr(self.problem, "geometry", None), CartesianGrid):
+            grid_obj = self.problem.geometry  # Geometry IS the grid
             # Store as lists for dimension-agnostic access
-            self.num_grid_points = list(grid_obj.num_points)
-            self.grid_spacing = list(grid_obj.spacing)
+            self.num_grid_points = list(grid_obj.get_grid_shape())
+            self.grid_spacing = list(grid_obj.get_grid_spacing())
 
             # Backward compatibility: set _x, _y, _z attributes for legacy code
             if self.dimension >= 1:

--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -1247,6 +1247,11 @@ class MFGProblem:
         if integral_m_init > 1e-10:
             self.m_init /= integral_m_init
 
+    @property
+    def dt(self) -> float:
+        """Time step size (lowercase alias for Dt for solver compatibility)."""
+        return self.Dt
+
     def _setup_default_initial_density(self) -> None:
         """Setup default initial density (Gaussian at center for n-D problems)."""
         if self.dimension == 1:

--- a/mfg_pde/geometry/simple_grid.py
+++ b/mfg_pde/geometry/simple_grid.py
@@ -51,6 +51,18 @@ class SimpleGrid2D(CartesianGrid):
         max_coords = np.array([self.xmax, self.ymax])
         return min_coords, max_coords
 
+    @property
+    def coordinates(self) -> list[NDArray]:
+        """
+        Get coordinate arrays for each dimension (TensorProductGrid compatible).
+
+        Returns:
+            List of 1D coordinate arrays [x_coords, y_coords]
+        """
+        x = np.linspace(self.xmin, self.xmax, self.nx + 1)
+        y = np.linspace(self.ymin, self.ymax, self.ny + 1)
+        return [x, y]
+
     def create_gmsh_geometry(self):
         """Not implemented for simple grid - raises NotImplementedError."""
         raise NotImplementedError("SimpleGrid2D does not use Gmsh")
@@ -362,6 +374,19 @@ class SimpleGrid3D(CartesianGrid):
         min_coords = np.array([self.xmin, self.ymin, self.zmin])
         max_coords = np.array([self.xmax, self.ymax, self.zmax])
         return min_coords, max_coords
+
+    @property
+    def coordinates(self) -> list[NDArray]:
+        """
+        Get coordinate arrays for each dimension (TensorProductGrid compatible).
+
+        Returns:
+            List of 1D coordinate arrays [x_coords, y_coords, z_coords]
+        """
+        x = np.linspace(self.xmin, self.xmax, self.nx + 1)
+        y = np.linspace(self.ymin, self.ymax, self.ny + 1)
+        z = np.linspace(self.zmin, self.zmax, self.nz + 1)
+        return [x, y, z]
 
     def create_gmsh_geometry(self):
         """Not implemented for simple grid - raises NotImplementedError."""


### PR DESCRIPTION
## Summary
Completes Phase 3 of Issue #245 MFGProblem unification by updating all nD solvers to use the unified CartesianGrid interface instead of accessing `.geometry.grid`.

## Changes

### Geometry Module
- **SimpleGrid2D/3D**: Added `coordinates` property returning list of 1D coordinate arrays (TensorProductGrid compatible)

### MFGProblem Core
- **Added `dt` property**: Lowercase alias for `Dt` to maintain solver compatibility

### Solver Updates (5 files)
1. **hjb_fdm.py**: 
   - Replace `hasattr(geometry, "grid")` with `isinstance(geometry, CartesianGrid)`
   - Use `get_grid_shape()` and `get_grid_spacing()` instead of direct attribute access
   - Geometry IS the grid (no `.grid` wrapper)

2. **fp_fdm.py**: 
   - Update `_detect_dimension()` to use `geometry.dimension`
   - Update grid access in 1D and nD solvers

3. **hjb_semi_lagrangian.py**: 
   - Use CartesianGrid check for nD problems
   - Access grid via geometry interface

4. **hjb_weno.py**: 
   - Update `_setup_dimensional_grid()` to use CartesianGrid methods

5. **fixed_point_iterator.py**: 
   - Update grid detection and initialization
   - Simplify spatial grid evaluation

## Compatibility

All solvers now work seamlessly with:
- ✅ **SimpleGrid2D/3D** (new geometry-based MFGProblem)
- ✅ **TensorProductGrid** (HighDimMFGProblem)
- ✅ **Legacy 1D MFGProblem**

## Testing

Comprehensive testing performed:
- ✅ 2D problem with SimpleGrid2D + HJB/FP FDM solvers
- ✅ 3D problem with SimpleGrid3D + HJB FDM solver
- ✅ 1D legacy problem + HJB FDM solver (backward compatibility)

## Related
- Continues Issue #245 (MFGProblem unification)
- Builds on PR #254 (Phase 1), PR #255 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)