### PR TITLE
chore: Remove empty DGM test stubs with redundant TODOs

### DIFF
--- a/tests/test_dgm_foundation.py
+++ b/tests/test_dgm_foundation.py
@@ -413,20 +413,5 @@ class TestDGMArchitectures:
         assert not torch.isnan(output).any()
 
 
-@pytest.mark.skipif(not pytorch_available, reason="PyTorch not available")
-class TestMFGDGMSolver:
-    """Test MFG DGM solver implementation."""
-
-    @pytest.mark.skip(reason="Solver tests need refactoring - abstract base class requires complex mocking")
-    def test_solver_initialization(self):
-        """Test solver initialization."""
-        # TODO: Refactor to test concrete solver implementation instead of base class
-
-    @pytest.mark.skip(reason="Solver tests need refactoring - abstract base class requires complex mocking")
-    def test_sampling_setup(self):
-        """Test sampling strategy setup."""
-        # TODO: Refactor to test concrete solver implementation instead of base class
-
-
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Removed `TestMFGDGMSolver` class containing two empty test methods with skip decorators and redundant TODO comments.

## Changes

- **Removed**: Empty test class `TestMFGDGMSolver` (15 lines)
- **Removed**: 2 TODO comments that duplicated skip decorator reasons
- **Verified**: All 25 remaining DGM tests pass

## Rationale

The empty test stubs provided no value:
- Empty test bodies (no assertions or code)
- Skip decorators already explain why they're skipped
- TODO comments duplicate the skip reasons
- Concrete `MFGDGMSolver` has working example in `examples/basic/dgm_simple_validation.py`

If comprehensive MFGDGMSolver tests are needed in the future, they should be implemented as new test methods with actual test logic.

## Testing

```bash
pytest tests/test_dgm_foundation.py -v
# ✓ All 25 tests pass
```

## Impact

- **Code quality**: +15 lines removed, -2 TODO comments
- **Test coverage**: No change (tests were already skipped)
- **Functionality**: No change