### PR TITLE
chore: Mark semi-Lagrangian solver as experimental (Issue #298)

### DIFF
--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -104,6 +104,14 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         super().__init__(problem)
         self.hjb_method_name = "Semi-Lagrangian"
 
+        # EXPERIMENTAL: Known convergence issues (Issue #298)
+        logger.warning(
+            "HJBSemiLagrangianSolver has known convergence issues (Issue #298). "
+            "The solver may not converge or produce incorrect results for standard MFG problems. "
+            "Use HJBFiniteDifferenceSolver or HJBGFDMSolver instead. "
+            "This solver is EXPERIMENTAL and requires further research to fix characteristic tracing."
+        )
+
         # Solver configuration
         self.interpolation_method = interpolation_method
         self.optimization_method = optimization_method


### PR DESCRIPTION
## Summary

Mark `HJBSemiLagrangianSolver` as **EXPERIMENTAL** due to known convergence issues (Issue #298). Add deprecation warning recommending alternative solvers until proper fix can be implemented.

## Root Cause

Semi-Lagrangian solver returns p*=0 as optimal control instead of p*=∇u, causing characteristics to not move:
```python
x_departure = x_current - 0*dt = x_current  # No movement!
```

This reduces the algorithm to backward Euler rather than true semi-Lagrangian method.

## Changes

- Add logger.warning in `HJBSemiLagrangianSolver.__init__()` referencing Issue #298
- Recommend `HJBFiniteDifferenceSolver` or `HJBGFDMSolver` instead
- Mark solver as EXPERIMENTAL pending proper fix

## Fix Attempt Results

Attempted gradient-based fix (p* = ∇u) caused numerical instability (NaN/Inf). Proper fix requires:
- CFL condition analysis and time step restrictions
- Gradient clipping and numerical stabilization  
- Proper discretization theory for characteristic tracing
- Extensive testing

## Decision

**Option A (chosen)**: Defer fix for future research, mark as experimental now.

## Testing

Pre-commit hooks pass. Solver will emit warning on instantiation.

## Related Issues

Fixes #298 (by marking as experimental, not by fixing the underlying issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)