### PR TITLE
fix: FDM solver infers timesteps from U_solution shape (Issue #311)

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
@@ -115,7 +115,9 @@ class FPFDMSolver(BaseFPSolver):
             Dx = self.problem.geometry.get_grid_spacing()[0]
             Dt = self.problem.dt
 
-        Nt = self.problem.Nt + 1
+        # Infer number of timesteps from U_solution shape, not problem.Nt
+        # This allows tests to pass edge cases like Nt=0 or Nt=1
+        Nt = U_solution_for_drift.shape[0]
         sigma = self.problem.sigma
         coupling_coefficient = getattr(self.problem, "coupling_coefficient", 1.0)
 

--- a/tests/unit/test_fp_fdm_solver.py
+++ b/tests/unit/test_fp_fdm_solver.py
@@ -107,7 +107,6 @@ class TestFPFDMSolverBasicSolution:
         # Initial condition should be preserved (approximately, after non-negativity enforcement)
         assert np.allclose(m_result[0, :], m_initial, rtol=0.1)
 
-    @pytest.mark.xfail(reason="Edge case: FDM solver doesn't handle Nt=0 (IndexError: index 0 out of bounds)")
     def test_solve_fp_system_zero_timesteps(self, standard_problem):
         """Test behavior with zero time steps (Nt=0)."""
         # Create problem with Nt=0 (results in 0 time steps)
@@ -126,7 +125,6 @@ class TestFPFDMSolverBasicSolution:
 
         assert m_result.shape == (0, Nx)
 
-    @pytest.mark.xfail(reason="Edge case: FDM solver doesn't handle Nt=1 (IndexError: index 1 out of bounds)")
     def test_solve_fp_system_one_timestep(self, standard_problem):
         """Test behavior with single time step (Nt=1)."""
         # Create problem with Nt=1 (results in 1 time step)


### PR DESCRIPTION
Fixes #311

## Changes

**FDM Solver** (fp_fdm.py:120):
- Changed from `Nt = self.problem.Nt + 1` to `Nt = U_solution_for_drift.shape[0]`
- Solver now infers timesteps from actual input array shape, not problem attribute
- Makes solver robust to shape mismatches

**Tests** (test_fp_fdm_solver.py):
- Removed `@pytest.mark.xfail` markers from:
  - `test_solve_fp_system_zero_timesteps` 
  - `test_solve_fp_system_one_timestep`
- Both edge case tests now pass (22/22 tests passing)

## Impact
- Edge cases (Nt=0, Nt=1) now fully supported
- No xfail markers in test suite
- Solver more robust to test inputs

## Testing
```bash
pytest tests/unit/test_fp_fdm_solver.py::TestFPFDMSolverBasicSolution::test_solve_fp_system_zero_timesteps
pytest tests/unit/test_fp_fdm_solver.py::TestFPFDMSolverBasicSolution::test_solve_fp_system_one_timestep
# Both: PASSED ✅
```