### PR TITLE
fix: Export policy iteration functions from utils.numerical

### DIFF
--- a/mfg_pde/utils/numerical/__init__.py
+++ b/mfg_pde/utils/numerical/__init__.py
@@ -6,6 +6,11 @@ in MFG research projects, including particle interpolation, signed distance
 functions, spatial operations, and computational utilities.
 """
 
+from mfg_pde.utils.numerical.hjb_policy_iteration import (
+    HJBPolicyProblem,
+    create_lq_policy_problem,
+    policy_iteration_hjb,
+)
 from mfg_pde.utils.numerical.nonlinear_solvers import FixedPointSolver, NewtonSolver, PolicyIterationSolver, SolverInfo
 from mfg_pde.utils.numerical.particle_interpolation import (
     estimate_kde_bandwidth,
@@ -25,6 +30,10 @@ from mfg_pde.utils.numerical.sdf_utils import (
 )
 
 __all__ = [
+    # HJB policy iteration
+    "HJBPolicyProblem",
+    "create_lq_policy_problem",
+    "policy_iteration_hjb",
     # Nonlinear solvers
     "FixedPointSolver",
     "NewtonSolver",


### PR DESCRIPTION
## Summary

Fixes ImportError in `policy_iteration_lq_demo.py` example by exporting policy iteration functions from public API.

## Bug

The example `examples/basic/solvers/policy_iteration_lq_demo.py` was trying to import:
```python
from mfg_pde.utils.numerical import create_lq_policy_problem
```

But this function was not exported from `mfg_pde/utils/numerical/__init__.py`, causing:
```
ImportError: cannot import name 'create_lq_policy_problem' from 'mfg_pde.utils.numerical'
```

## Fix

Exported three policy iteration utilities from `mfg_pde.utils.numerical`:
- `HJBPolicyProblem` (Protocol)
- `create_lq_policy_problem` (factory function)
- `policy_iteration_hjb` (main algorithm)

These functions exist in `hjb_policy_iteration.py` and are used by examples, so they should be part of the public API.

## Verification

```bash
python examples/basic/solvers/policy_iteration_lq_demo.py
# ✅ Runs successfully (only deprecation warnings, no errors)
```

## Type

- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Checklist

- [x] Verified example runs without import errors
- [x] Pre-commit hooks pass
- [x] No functional changes to existing code