### PR TITLE
fix: Remove non-existent print_system_info from PINN example

### DIFF
--- a/examples/advanced/machine_learning/pinn_mfg_example.py
+++ b/examples/advanced/machine_learning/pinn_mfg_example.py
@@ -34,7 +34,6 @@ from mfg_pde.alg.neural.pinn_solvers import (  # noqa: E402
     HJBPINNSolver,
     MFGPINNSolver,
     PINNConfig,
-    print_system_info,
 )
 from mfg_pde.core.mfg_problem import ExampleMFGProblem, MFGProblem  # noqa: E402
 
@@ -365,9 +364,6 @@ def main():
     """Main demonstration function."""
     print("Physics-Informed Neural Networks for Mean Field Games")
     print("=" * 60)
-
-    # Check system capabilities
-    print_system_info()
 
     # Create problem and configuration
     print("\nSetting up MFG problem...")


### PR DESCRIPTION
## Summary
Fixed ImportError in `pinn_mfg_example.py` by removing non-existent `print_system_info()` function.

## Root Cause
Example was importing and calling `print_system_info()` function that was never implemented in the pinn_solvers module.

## Changes
- Removed `print_system_info` from imports (line 37)
- Removed `print_system_info()` function call (line 370)

## Bug Discovery
Bug #5 found during systematic example testing.

## Testing
```bash
timeout 5 python examples/advanced/machine_learning/pinn_mfg_example.py
# Import error resolved - no traceback
```

Fixes import error preventing example execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)