### PR TITLE
fix: Correct Domain3D import path in optimization suite demo

### DIFF
--- a/examples/advanced/highdim_mfg_capabilities/demo_complete_optimization_suite.py
+++ b/examples/advanced/highdim_mfg_capabilities/demo_complete_optimization_suite.py
@@ -19,12 +19,12 @@ import numpy as np
 from mfg_pde import MFGComponents
 from mfg_pde.benchmarks import HighDimMFGBenchmark
 from mfg_pde.core.highdim_mfg_problem import GridBasedMFGProblem
+from mfg_pde.geometry import Domain3D
 from mfg_pde.geometry.boundary_conditions_3d import (
     BoundaryConditionManager3D,
     DirichletBC3D,
     NeumannBC3D,
 )
-from mfg_pde.geometry.domain_3d import Domain3D
 from mfg_pde.geometry.tetrahedral_amr import TetrahedralAMRMesh
 from mfg_pde.utils.mfg_logging import configure_research_logging, get_logger
 from mfg_pde.utils.performance_optimization import AdvancedSparseOperations, PerformanceMonitor, SparseMatrixOptimizer


### PR DESCRIPTION
## Summary
Fixed ModuleNotFoundError in `demo_complete_optimization_suite.py` by correcting the import path for `Domain3D`.

## Root Cause
Example was importing from non-existent `mfg_pde.geometry.domain_3d` module.  
`Domain3D` class is actually exported directly from `mfg_pde.geometry` package.

## Changes
- Changed import from `mfg_pde.geometry.domain_3d` to `mfg_pde.geometry` (line 27)

## Bug Discovery
Bug #6 found during systematic module-level testing.

## Testing
```bash
timeout 5 python examples/advanced/highdim_mfg_capabilities/demo_complete_optimization_suite.py
# Module error resolved - no ModuleNotFoundError
```

Fixes module import error preventing example execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)