### PR TITLE
fix: Update examples to match current API

### DIFF
--- a/examples/basic/geometry/geometry_first_api_demo.py
+++ b/examples/basic/geometry/geometry_first_api_demo.py
@@ -55,11 +55,12 @@ def demo_domain_1d():
     print("=" * 70)
 
     from mfg_pde.core.mfg_problem import MFGProblem
-    from mfg_pde.geometry import Domain1D
+    from mfg_pde.geometry import BoundaryConditions, Domain1D
 
-    # Create 1D periodic domain
-    domain = Domain1D(xmin=0.0, xmax=1.0, boundary_conditions="periodic")
-    domain.create_grid(Nx=101)
+    # Create 1D periodic domain with proper BoundaryConditions object
+    bc = BoundaryConditions(type="periodic")
+    domain = Domain1D(xmin=0.0, xmax=1.0, boundary_conditions=bc)
+    domain.create_grid(num_points=101)
 
     print(f"\nGeometry: {domain.geometry_type}")
     print(f"Dimension: {domain.dimension}")

--- a/examples/basic/utilities/utility_demo.py
+++ b/examples/basic/utilities/utility_demo.py
@@ -49,16 +49,24 @@ def demo_particle_interpolation():
     print("\n2. Particles → Grid (2D density estimation)")
     particles_2d = np.random.randn(500, 2) * 0.1 + 0.5  # Gaussian blob at (0.5, 0.5)
 
-    x = np.linspace(0, 1, 30)
-    y = np.linspace(0, 1, 30)
-    density = interpolate_particles_to_grid(particles_2d, (x, y), method="kde")
+    # For density estimation from particles (uniform weight = 1.0 for each particle)
+    particle_weights = np.ones(len(particles_2d))
+    density = interpolate_particles_to_grid(
+        particle_values=particle_weights,
+        particle_positions=particles_2d,
+        grid_shape=(30, 30),
+        grid_bounds=((0, 1), (0, 1)),
+        method="kde",
+    )
 
     print(f"   Particles: {len(particles_2d)}")
-    print(f"   Grid: {len(x)} × {len(y)} = {density.size} points")
-    print(f"   Density integral: {np.sum(density) * (x[1] - x[0]) * (y[1] - y[0]):.3f} (should be ≈ 1.0)")
-    print(
-        f"   Max density at: ({x[np.argmax(np.max(density, axis=1))]:.2f}, {y[np.argmax(np.max(density, axis=0))]:.2f})"
-    )
+    print(f"   Grid: {density.shape[0]} × {density.shape[1]} = {density.size} points")
+    dx = dy = 1.0 / (density.shape[0] - 1)
+    print(f"   Density integral: {np.sum(density) * dx * dy:.3f} (should be ≈ 1.0)")
+    max_i, max_j = np.unravel_index(np.argmax(density), density.shape)
+    max_x = max_i * dx
+    max_y = max_j * dy
+    print(f"   Max density at: ({max_x:.2f}, {max_y:.2f})")
 
 
 def demo_geometry_utilities():


### PR DESCRIPTION
Fixes two API mismatches discovered in basic examples during bug hunting:

**Bug #9**: `utility_demo.py` line 54
- `interpolate_particles_to_grid()` using old API signature  
- Fixed by providing correct arguments: `particle_values`, `particle_positions`, `grid_shape`, `grid_bounds`

**Bug #10**: `geometry_first_api_demo.py` lines 61-63
- `Domain1D` constructor receiving `boundary_conditions` as string
- `create_grid()` using `Nx=` instead of `num_points=`
- Fixed by creating `BoundaryConditions` object and using correct parameter name

**Testing**:
- ✅ `utility_demo.py` executes successfully
- ✅ `geometry_first_api_demo.py` Domain1D section executes successfully

**Files Changed**:
- `examples/basic/utilities/utility_demo.py` (+9, -3)
- `examples/basic/geometry/geometry_first_api_demo.py` (+3, -2)