### PR TITLE
fix: Add get_problem_config() to maze Grid class for GeometryProtocol compliance

### DIFF
--- a/mfg_pde/geometry/mazes/maze_generator.py
+++ b/mfg_pde/geometry/mazes/maze_generator.py
@@ -232,6 +232,34 @@ class Grid:
 
         return np.column_stack([x_coords, y_coords])
 
+    def get_problem_config(self) -> dict:
+        """
+        Return configuration dict for MFGProblem initialization.
+
+        This polymorphic method provides maze Grid-specific configuration
+        for MFGProblem, treating the maze as a 2D discrete spatial domain.
+
+        Returns:
+            Dictionary with keys:
+                - num_spatial_points: Total number of maze cells
+                - spatial_shape: Shape tuple (rows, cols)
+                - spatial_bounds: Bounds [(xmin, xmax), (ymin, ymax)]
+                - spatial_discretization: Grid resolution (rows, cols)
+                - legacy_1d_attrs: None (maze is 2D)
+
+        Note: Spatial bounds use cell center coordinates convention:
+            x ∈ [0.5, cols-0.5], y ∈ [0.5, rows-0.5]
+
+        Added in v0.11.0 for GeometryProtocol compliance.
+        """
+        return {
+            "num_spatial_points": self.rows * self.cols,
+            "spatial_shape": (self.rows, self.cols),
+            "spatial_bounds": [(0.0, float(self.cols)), (0.0, float(self.rows))],
+            "spatial_discretization": (self.rows, self.cols),
+            "legacy_1d_attrs": None,
+        }
+
 
 class PerfectMazeGenerator(GraphGeometry):
     """


### PR DESCRIPTION
## Summary

Fixes Bug #11 discovered during bug hunting session.

The maze Grid class was missing the get_problem_config() method required by GeometryProtocol (added in v0.10.1). This caused isinstance(grid, GeometryProtocol) checks to fail, preventing maze grids from being used with MFGProblem.

## Changes

- Add get_problem_config() method to Grid class (maze_generator.py:235-261)
- Returns proper configuration dict with 2D maze parameters:
  - num_spatial_points: Total maze cells (rows × cols)
  - spatial_shape: Tuple (rows, cols)
  - spatial_bounds: Cell coordinate bounds
  - spatial_discretization: Grid resolution
  - legacy_1d_attrs: None (maze is 2D)

## Testing

```python
from mfg_pde.geometry.mazes import PerfectMazeGenerator
from mfg_pde.geometry.geometry_protocol import is_geometry_compatible, validate_geometry

maze_gen = PerfectMazeGenerator(rows=5, cols=5)
grid = maze_gen.generate()

assert is_geometry_compatible(grid)  # Now passes
validate_geometry(grid)  # Now passes
```

## Impact

- **Before**: Grid failed GeometryProtocol validation
- **After**: Grid passes validation and can be used with geometry-aware components

## Related

- Bug #11 (maze Grid protocol compliance)
- Issue #320 (geometry module refactoring - will benefit from this fix)
