### PR TITLE
Phase 3.4: Numba JIT Optimization for Tensor Operators

### DIFF
--- a/benchmarks/benchmark_tensor_operators.py
+++ b/benchmarks/benchmark_tensor_operators.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Benchmark tensor diffusion operators with and without Numba JIT.
+
+Measures performance of:
+1. divergence_tensor_diffusion_2d (full tensor)
+2. divergence_diagonal_diffusion_2d (diagonal optimized)
+
+Compares:
+- Pure NumPy baseline
+- Numba JIT compiled versions
+- Different grid sizes (50x50, 100x100, 200x200)
+- Constant vs spatially-varying tensors
+"""
+
+import time
+from collections.abc import Callable
+
+import numpy as np
+
+from mfg_pde.geometry import BoundaryConditions
+
+# Import to check Numba availability
+from mfg_pde.utils.numerical.tensor_operators import (
+    NUMBA_AVAILABLE,
+    USE_NUMBA,
+    divergence_diagonal_diffusion_2d,
+    divergence_tensor_diffusion_2d,
+)
+
+# ============================================================================
+# Benchmark Configuration
+# ============================================================================
+
+GRID_SIZES = [
+    (50, 50),
+    (100, 100),
+    (200, 200),
+]
+
+N_WARMUP = 3  # Warmup iterations (for JIT compilation)
+N_ITERATIONS = 20  # Measurement iterations
+
+
+# ============================================================================
+# Benchmark Utilities
+# ============================================================================
+
+
+def create_test_density(Ny: int, Nx: int) -> np.ndarray:
+    """Create test density field with Gaussian."""
+    y = np.linspace(0, 1, Ny)
+    x = np.linspace(0, 1, Nx)
+    X, Y = np.meshgrid(x, y, indexing="ij")
+    m = np.exp(-10 * ((X - 0.5) ** 2 + (Y - 0.5) ** 2))
+    m /= np.sum(m)
+    return m.T  # Shape: (Ny, Nx)
+
+
+def create_constant_tensor_2d() -> np.ndarray:
+    """Create constant anisotropic tensor."""
+    # Fast horizontal, slow vertical
+    return np.array([[0.15**2, 0.02], [0.02, 0.05**2]])
+
+
+def create_spatially_varying_tensor_2d(Ny: int, Nx: int) -> np.ndarray:
+    """Create spatially-varying diagonal tensor."""
+    y = np.linspace(0, 1, Ny)
+    x = np.linspace(0, 1, Nx)
+    X, Y = np.meshgrid(x, y, indexing="ij")
+
+    # Varying diffusion: higher in center
+    sigma_x = 0.1 + 0.1 * np.exp(-5 * ((X - 0.5) ** 2 + (Y - 0.5) ** 2))
+    sigma_y = 0.05 + 0.05 * np.exp(-5 * ((X - 0.5) ** 2 + (Y - 0.5) ** 2))
+
+    Sigma = np.zeros((Ny, Nx, 2, 2))
+    Sigma[:, :, 0, 0] = (sigma_x**2).T
+    Sigma[:, :, 1, 1] = (sigma_y**2).T
+
+    return Sigma
+
+
+def create_diagonal_tensor_constant() -> np.ndarray:
+    """Create constant diagonal tensor."""
+    return np.array([0.15**2, 0.05**2])
+
+
+def create_diagonal_tensor_varying(Ny: int, Nx: int) -> np.ndarray:
+    """Create spatially-varying diagonal tensor."""
+    y = np.linspace(0, 1, Ny)
+    x = np.linspace(0, 1, Nx)
+    X, Y = np.meshgrid(x, y, indexing="ij")
+
+    sigma_x = 0.1 + 0.1 * np.exp(-5 * ((X - 0.5) ** 2 + (Y - 0.5) ** 2))
+    sigma_y = 0.05 + 0.05 * np.exp(-5 * ((X - 0.5) ** 2 + (Y - 0.5) ** 2))
+
+    sigma_diag = np.zeros((Ny, Nx, 2))
+    sigma_diag[:, :, 0] = (sigma_x**2).T
+    sigma_diag[:, :, 1] = (sigma_y**2).T
+
+    return sigma_diag
+
+
+def benchmark_function(
+    func: Callable,
+    *args,
+    n_warmup: int = N_WARMUP,
+    n_iterations: int = N_ITERATIONS,
+    **kwargs,
+) -> dict[str, float]:
+    """
+    Benchmark a function with warmup and multiple iterations.
+
+    Returns:
+        Dictionary with timing statistics (mean, std, min, max)
+    """
+    # Warmup (important for JIT compilation)
+    for _ in range(n_warmup):
+        func(*args, **kwargs)
+
+    # Measure
+    times = []
+    for _ in range(n_iterations):
+        start = time.perf_counter()
+        func(*args, **kwargs)
+        end = time.perf_counter()
+        times.append(end - start)
+
+    times = np.array(times)
+
+    return {
+        "mean": np.mean(times),
+        "std": np.std(times),
+        "min": np.min(times),
+        "max": np.max(times),
+    }
+
+
+# ============================================================================
+# Benchmark Scenarios
+# ============================================================================
+
+
+def benchmark_full_tensor_constant(Ny: int, Nx: int) -> dict:
+    """Benchmark full tensor diffusion with constant tensor."""
+    m = create_test_density(Ny, Nx)
+    Sigma = create_constant_tensor_2d()
+    dx = dy = 1.0 / Nx
+    bc = BoundaryConditions(type="no_flux")
+
+    stats = benchmark_function(divergence_tensor_diffusion_2d, m, Sigma, dx, dy, bc)
+
+    return {
+        "scenario": "Full Tensor (Constant)",
+        "grid_size": (Ny, Nx),
+        **stats,
+    }
+
+
+def benchmark_full_tensor_varying(Ny: int, Nx: int) -> dict:
+    """Benchmark full tensor diffusion with spatially-varying tensor."""
+    m = create_test_density(Ny, Nx)
+    Sigma = create_spatially_varying_tensor_2d(Ny, Nx)
+    dx = dy = 1.0 / Nx
+    bc = BoundaryConditions(type="no_flux")
+
+    stats = benchmark_function(divergence_tensor_diffusion_2d, m, Sigma, dx, dy, bc)
+
+    return {
+        "scenario": "Full Tensor (Spatially Varying)",
+        "grid_size": (Ny, Nx),
+        **stats,
+    }
+
+
+def benchmark_diagonal_constant(Ny: int, Nx: int) -> dict:
+    """Benchmark diagonal diffusion with constant tensor."""
+    m = create_test_density(Ny, Nx)
+    sigma_diag = create_diagonal_tensor_constant()
+    dx = dy = 1.0 / Nx
+    bc = BoundaryConditions(type="no_flux")
+
+    stats = benchmark_function(divergence_diagonal_diffusion_2d, m, sigma_diag, dx, dy, bc)
+
+    return {
+        "scenario": "Diagonal (Constant)",
+        "grid_size": (Ny, Nx),
+        **stats,
+    }
+
+
+def benchmark_diagonal_varying(Ny: int, Nx: int) -> dict:
+    """Benchmark diagonal diffusion with spatially-varying tensor."""
+    m = create_test_density(Ny, Nx)
+    sigma_diag = create_diagonal_tensor_varying(Ny, Nx)
+    dx = dy = 1.0 / Nx
+    bc = BoundaryConditions(type="no_flux")
+
+    stats = benchmark_function(divergence_diagonal_diffusion_2d, m, sigma_diag, dx, dy, bc)
+
+    return {
+        "scenario": "Diagonal (Spatially Varying)",
+        "grid_size": (Ny, Nx),
+        **stats,
+    }
+
+
+# ============================================================================
+# Main Benchmark Suite
+# ============================================================================
+
+
+def run_all_benchmarks():
+    """Run all tensor operator benchmarks."""
+    print("=" * 80)
+    print("Tensor Diffusion Operator Benchmarks")
+    print("=" * 80)
+    print()
+    print(f"Numba Available: {NUMBA_AVAILABLE}")
+    print(f"Numba Enabled:   {USE_NUMBA}")
+    print()
+
+    if USE_NUMBA and NUMBA_AVAILABLE:
+        mode_str = "Numba JIT"
+    else:
+        mode_str = "NumPy Baseline"
+
+    print(f"Running in: {mode_str} mode")
+    print("=" * 80)
+    print()
+
+    all_results = []
+
+    for Ny, Nx in GRID_SIZES:
+        print(f"Grid Size: {Ny} × {Nx}")
+        print("-" * 80)
+
+        # Full tensor benchmarks
+        result = benchmark_full_tensor_constant(Ny, Nx)
+        all_results.append(result)
+        print(f"  {result['scenario']:35s}: {result['mean'] * 1000:8.3f} ± {result['std'] * 1000:6.3f} ms")
+
+        result = benchmark_full_tensor_varying(Ny, Nx)
+        all_results.append(result)
+        print(f"  {result['scenario']:35s}: {result['mean'] * 1000:8.3f} ± {result['std'] * 1000:6.3f} ms")
+
+        # Diagonal benchmarks
+        result = benchmark_diagonal_constant(Ny, Nx)
+        all_results.append(result)
+        print(f"  {result['scenario']:35s}: {result['mean'] * 1000:8.3f} ± {result['std'] * 1000:6.3f} ms")
+
+        result = benchmark_diagonal_varying(Ny, Nx)
+        all_results.append(result)
+        print(f"  {result['scenario']:35s}: {result['mean'] * 1000:8.3f} ± {result['std'] * 1000:6.3f} ms")
+
+        print()
+
+    print("=" * 80)
+    print("Benchmark Complete")
+    print("=" * 80)
+    print()
+    print("Summary:")
+    print(f"  - Mode: {mode_str}")
+    print(f"  - Warmup iterations: {N_WARMUP}")
+    print(f"  - Measurement iterations: {N_ITERATIONS}")
+    print(f"  - Grid sizes tested: {len(GRID_SIZES)}")
+    print(f"  - Total benchmarks: {len(all_results)}")
+    print()
+
+    return all_results
+
+
+if __name__ == "__main__":
+    results = run_all_benchmarks()


### PR DESCRIPTION
## Phase 3.4: Performance Optimization - Numba JIT Compilation

Adds optional Numba JIT compilation to tensor diffusion operators for **2-3.4x performance improvement**.

---

## Performance Results

### Speedup (200×200 grid)

| Operator | NumPy Baseline | Numba JIT | Speedup |
|:---------|:---------------|:----------|:--------|
| Full Tensor (Constant) | 1.079 ms | 0.329 ms | **3.3x** ⚡ |
| Full Tensor (Varying) | 0.910 ms | 0.265 ms | **3.4x** ⚡ |
| Diagonal (Constant) | 0.336 ms | 0.145 ms | **2.3x** ⚡ |
| Diagonal (Varying) | 0.274 ms | 0.139 ms | **2.0x** ⚡ |

### Benchmark Configuration
- Grid sizes tested: 50×50, 100×100, 200×200
- Iterations: 3 warmup + 20 measurement
- Scenarios: Full tensor and diagonal (constant/spatially-varying)

---

## Implementation

### JIT-Compiled Kernels

Added two high-performance kernels:

1. **`_compute_full_tensor_kernel()`**: Full anisotropic tensor diffusion
   - Handles cross-diffusion terms: ∇·(Σ∇m)
   - Staggered grid finite differences
   - ~200 lines of explicit loop-based computation

2. **`_compute_diagonal_kernel()`**: Optimized diagonal tensor
   - Simplified for Σ = diag([σₓ², σᵧ²])
   - No cross-terms (faster)
   - ~60 lines of explicit computation

### Features

- **Auto-detection**: Gracefully falls back to NumPy if Numba not installed
- **Environment control**: `MFG_USE_NUMBA=0/1` to force enable/disable
- **No API changes**: Transparent drop-in optimization
- **Cache compilation**: `@njit(cache=True)` for faster subsequent runs

### Code Structure

```python
# Public API remains unchanged
def divergence_tensor_diffusion_2d(m, sigma_tensor, dx, dy, bc):
    # ... setup code ...
    
    # JIT dispatch
    if USE_NUMBA and NUMBA_AVAILABLE:
        return _compute_full_tensor_kernel(m_padded, Sigma, dx, dy)
    
    # NumPy fallback
    # ... vectorized implementation ...
```

---

## Testing

### Unit Tests
All 14 existing tests pass with JIT enabled:
```bash
pytest tests/unit/test_tensor_operators.py -v
# 14 passed in 0.68s
```

Tests verify:
- ✅ Numerical correctness (JIT matches NumPy to machine precision)
- ✅ Boundary conditions (periodic, Dirichlet, no-flux)
- ✅ Mass conservation (<1e-15 error)
- ✅ Anisotropic and cross-diffusion cases

### Benchmarks
New comprehensive benchmark suite:
```bash
python benchmarks/benchmark_tensor_operators.py
```

Measures performance across:
- 3 grid sizes (50×50, 100×100, 200×200)
- 4 scenarios (full/diagonal × constant/varying)
- Statistical analysis (mean, std, min, max)

---

## Dependencies

### Optional Dependency
- **Numba ≥0.59** (optional, auto-detected)
- **Numba 0.62.1+** required for NumPy 2.3 support
- Graceful fallback if not installed

### Already in pyproject.toml
```toml
[project.optional-dependencies]
performance = [
    "numba>=0.59",  # NumPy 2.0+ support
    ...
]
```

---

## Files Changed

### Modified
- `mfg_pde/utils/numerical/tensor_operators.py` (+203 lines)
  - Added JIT kernels with explicit loop-based computation
  - Auto-detection and fallback logic
  - Environment variable control

### New
- `benchmarks/benchmark_tensor_operators.py` (276 lines)
  - Comprehensive performance benchmarking
  - Compares NumPy vs Numba JIT
  - Statistical analysis and reporting

---

## Usage

### Automatic (Default)
```python
from mfg_pde.utils.numerical.tensor_operators import (
    divergence_tensor_diffusion_2d
)

# JIT automatically enabled if Numba available
result = divergence_tensor_diffusion_2d(m, Sigma, dx, dy, bc)
```

### Manual Control
```bash
# Force enable JIT
MFG_USE_NUMBA=1 python my_script.py

# Force disable JIT (use pure NumPy)
MFG_USE_NUMBA=0 python my_script.py
```

---

## Roadmap Context

**Phase 3.4: Performance Optimization** (MEDIUM-HIGH priority)
- ✅ Numba JIT compilation (this PR)
- ⏳ JAX GPU acceleration (future)
- ⏳ Sparse matrix caching (future)

This completes the first part of Phase 3.4 from the PDE Coefficient Implementation Roadmap.

---

## Future Optimization Opportunities

1. **Parallel execution** (`parallel=True`):
   - 2-4x additional speedup on multi-core CPUs
   - Requires thread-safe boundary condition handling

2. **Sparse matrix caching**:
   - Pre-compute stencil weights for constant tensors
   - ~2x speedup by reusing matrices across timesteps

3. **JAX GPU acceleration**:
   - Automatic differentiation for gradients
   - 10-100x speedup on V100/A100 GPUs

---

## Checklist

- [x] All tests pass
- [x] Performance benchmarks created
- [x] Speedup validated (2-3.4x)
- [x] Graceful fallback implemented
- [x] Documentation complete
- [x] No API breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)