### PR TITLE
chore: Add smoke tests to HJB solvers for faster development

### DIFF
--- a/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
@@ -971,3 +971,32 @@ def solve_hjb_system_backward(
             print(f"SYS_DEBUG: U_solution became NaN after Newton step for t_idx_n={n_idx_hjb}.")
 
     return U_solution_this_picard_iter
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing BaseHJBSolver...")
+
+    # Test base class and helper functions availability
+    assert BaseHJBSolver is not None
+    assert compute_hjb_residual is not None
+    assert compute_hjb_jacobian is not None
+    assert newton_hjb_step is not None
+    assert solve_hjb_timestep_newton is not None
+    assert solve_hjb_system_backward is not None
+    print("  Base HJB solver class and helpers available")
+
+    # Test that BaseHJBSolver is abstract
+    from mfg_pde import ExampleMFGProblem
+
+    problem = ExampleMFGProblem(Nx=10, Nt=5, T=1.0, sigma=0.1)
+
+    try:
+        base_solver = BaseHJBSolver(problem)
+        # Should fail because solve_hjb_system is abstract
+        base_solver.solve_hjb_system(None, None, None)
+        raise AssertionError("Should have raised NotImplementedError")
+    except (TypeError, NotImplementedError):
+        print("  BaseHJBSolver correctly abstract")
+
+    print("Smoke tests passed!")

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -1916,3 +1916,37 @@ class MonotonicityStats:
             "num_violating_points": num_violating_points,
             "max_violation_severity": max_violation,
         }
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing HJBGFDMSolver...")
+
+    import numpy as np
+
+    from mfg_pde import ExampleMFGProblem
+
+    # Test 1D problem with uniform collocation points matching problem grid
+    problem_1d = ExampleMFGProblem(Nx=20, Nt=10, T=1.0, sigma=0.1)
+
+    # Use problem grid points as collocation points to avoid index mismatch
+    collocation_points = problem_1d.xSpace.reshape(-1, 1)
+
+    solver_1d = HJBGFDMSolver(
+        problem_1d,
+        collocation_points=collocation_points,
+        delta=0.15,
+        taylor_order=2,
+        weight_function="wendland",
+    )
+
+    # Test solver initialization
+    assert solver_1d.dimension == 1
+    assert solver_1d.n_points == problem_1d.Nx + 1
+    assert solver_1d.delta == 0.15
+    assert solver_1d.taylor_order == 2
+    assert solver_1d.hjb_method_name == "GFDM"
+    print("  Solver initialized")
+    print(f"  Collocation points: {solver_1d.n_points}, Delta: {solver_1d.delta}")
+
+    print("Smoke tests passed!")

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_network.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_network.py
@@ -429,3 +429,19 @@ def create_network_hjb_solver(
         return NetworkPolicyIterationHJBSolver(problem, **kwargs)
     else:
         return NetworkHJBSolver(problem, scheme=solver_type, **kwargs)
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing NetworkHJBSolver classes...")
+
+    # Test class availability
+    assert NetworkHJBSolver is not None
+    assert NetworkPolicyIterationHJBSolver is not None
+    assert create_network_hjb_solver is not None
+    print("  Network HJB solver classes available")
+
+    # Note: Full smoke test requires NetworkMFGProblem setup
+    # See examples/networks/ for usage examples
+
+    print("Smoke tests passed!")

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
@@ -1174,3 +1174,38 @@ class HJBWenoSolver(BaseHJBSolver):
         }
 
         return variant_info[self.weno_variant]
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing HJBWenoSolver...")
+
+    import numpy as np
+
+    from mfg_pde import ExampleMFGProblem
+
+    # Test 1D problem
+    problem_1d = ExampleMFGProblem(Nx=30, Nt=20, T=1.0, sigma=0.1)
+
+    # Test standard WENO variant
+    solver_1d = HJBWenoSolver(problem_1d, weno_variant="weno-z")
+
+    # Test solver initialization
+    assert solver_1d.dimension == 1
+    assert solver_1d.weno_variant == "weno-z"
+    print("  Solver initialized")
+    print(f"  Variant: {solver_1d.weno_variant}, Method: {solver_1d.hjb_method_name}")
+
+    # Test solve_hjb_system with trivial inputs
+    M_test = np.ones((problem_1d.Nt + 1, problem_1d.Nx + 1)) * 0.5
+    U_final = np.zeros(problem_1d.Nx + 1)
+    U_prev = np.zeros((problem_1d.Nt + 1, problem_1d.Nx + 1))
+
+    U_solution = solver_1d.solve_hjb_system(M_test, U_final, U_prev)
+
+    assert U_solution.shape == (problem_1d.Nt + 1, problem_1d.Nx + 1)
+    assert not np.any(np.isnan(U_solution))
+    assert not np.any(np.isinf(U_solution))
+    print(f"  Solver converged, U range: [{U_solution.min():.3f}, {U_solution.max():.3f}]")
+
+    print("Smoke tests passed!")


### PR DESCRIPTION
## Summary

Add inline smoke tests to 4 HJB solver files to enable rapid validation during development without running full test suite.

## Changes

- **base_hjb.py**: Test abstract base class and helper functions availability
- **hjb_gfdm.py**: Test GFDM solver initialization with collocation points
- **hjb_weno.py**: Test WENO solver initialization and basic solve
- **hjb_network.py**: Test network solver class availability

All smoke tests follow the pattern from hjb_fdm.py and hjb_semi_lagrangian.py.

## Testing

All smoke tests pass:
```bash
python -m mfg_pde.alg.numerical.hjb_solvers.base_hjb
python -m mfg_pde.alg.numerical.hjb_solvers.hjb_gfdm
python -m mfg_pde.alg.numerical.hjb_solvers.hjb_weno
python -m mfg_pde.alg.numerical.hjb_solvers.hjb_network
```

## Progress

Toward CLAUDE.md target of 50-60 files with smoke tests:
- **HJB solvers**: 6/6 now have smoke tests (100% coverage)
- **Next**: Add smoke tests to FP solvers and coupling solvers

🤖 Generated with [Claude Code](https://claude.com/claude-code)