### PR TITLE
chore: Add smoke tests to actively-developed geometry modules

### DIFF
--- a/mfg_pde/geometry/grids/grid_2d.py
+++ b/mfg_pde/geometry/grids/grid_2d.py
@@ -347,3 +347,38 @@ class SimpleGrid2D(CartesianGrid):
     def get_boundary_handler(self):
         """Return boundary handler (placeholder)."""
         return {"type": "simple_grid_2d", "implementation": "placeholder"}
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing SimpleGrid2D...")
+
+    import numpy as np
+
+    # Test grid creation
+    grid = SimpleGrid2D(bounds=(0.0, 10.0, 0.0, 5.0), resolution=(11, 6))
+
+    assert grid.dimension == 2
+    assert grid.nx == 11
+    assert grid.ny == 6
+    assert np.isclose(grid.dx, 10.0 / 11)
+    assert np.isclose(grid.dy, 5.0 / 6)
+
+    print(f"  Grid: {grid.nx}×{grid.ny}, spacing dx={grid.dx:.3f}, dy={grid.dy:.3f}")
+
+    # Test coordinates
+    coords = grid.coordinates
+    assert len(coords) == 2
+    assert coords[0].shape == (grid.nx + 1,)
+    assert coords[1].shape == (grid.ny + 1,)
+
+    print(f"  Coordinates: x has {coords[0].shape[0]} points, y has {coords[1].shape[0]} points")
+
+    # Test bounds
+    min_coords, max_coords = grid.bounds
+    assert np.allclose(min_coords, [0.0, 0.0])
+    assert np.allclose(max_coords, [10.0, 5.0])
+
+    print(f"  Bounds: [{min_coords[0]:.1f}, {max_coords[0]:.1f}] × [{min_coords[1]:.1f}, {max_coords[1]:.1f}]")
+
+    print("Smoke tests passed!")

--- a/mfg_pde/geometry/grids/tensor_grid.py
+++ b/mfg_pde/geometry/grids/tensor_grid.py
@@ -715,3 +715,44 @@ class TensorProductGrid(CartesianGrid):
             f"  total_points={self.total_points()}\n"
             f")"
         )
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing TensorProductGrid...")
+
+    import numpy as np
+
+    # Test 2D grid creation
+    grid_2d = TensorProductGrid(dimension=2, bounds=[(0.0, 10.0), (0.0, 5.0)], num_points=[11, 6])
+
+    assert grid_2d.dimension == 2
+    assert grid_2d.total_points() == 11 * 6
+    assert len(grid_2d.coordinates) == 2
+
+    print(f"  2D grid: {grid_2d.num_points[0]}×{grid_2d.num_points[1]} = {grid_2d.total_points()} points")
+
+    # Test meshgrid
+    X, Y = grid_2d.meshgrid()
+    assert X.shape == (11, 6)
+    assert Y.shape == (11, 6)
+    assert X[0, 0] == 0.0
+    assert X[-1, 0] == 10.0
+    assert Y[0, 0] == 0.0
+    assert Y[0, -1] == 5.0
+
+    print(f"  Meshgrid: X shape {X.shape}, range [{X.min():.1f}, {X.max():.1f}]")
+
+    # Test flatten
+    points = grid_2d.flatten()
+    assert points.shape == (66, 2)
+
+    print(f"  Flattened: {points.shape[0]} points in {points.shape[1]}D")
+
+    # Test spacing
+    assert np.allclose(grid_2d.spacing[0], 1.0)  # 10/(11-1) = 1.0
+    assert np.allclose(grid_2d.spacing[1], 1.0)  # 5/(6-1) = 1.0
+
+    print(f"  Spacing: dx={grid_2d.spacing[0]:.2f}, dy={grid_2d.spacing[1]:.2f}")
+
+    print("Smoke tests passed!")


### PR DESCRIPTION
## Summary

Add inline smoke tests to 2 frequently-modified geometry modules:
- **mfg_pde/geometry/grids/tensor_grid.py** - Test 2D grid operations (meshgrid, flatten, spacing)
- **mfg_pde/geometry/grids/grid_2d.py** - Test grid initialization and properties

**Selection criteria**: Both modules have 11+ commits in the last 3 months (actively developed).

**Smoke test coverage**: 37 → 39 files (selective addition per CLAUDE.md guidelines)

## Test Plan

- [x] Run smoke tests directly: `python mfg_pde/geometry/grids/tensor_grid.py`
- [x] Run smoke tests directly: `python mfg_pde/geometry/grids/grid_2d.py`
- [x] Pre-commit hooks pass (ruff format, ruff check)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)