### PR TITLE
fix: API naming standardization and import fixes

### DIFF
--- a/mfg_pde/alg/numerical/coupling/__init__.py
+++ b/mfg_pde/alg/numerical/coupling/__init__.py
@@ -20,7 +20,8 @@ from .fixed_point_utils import (
     check_convergence_criteria,
     construct_solver_result,
     initialize_cold_start,
-    preserve_boundary_conditions,
+    preserve_initial_condition,
+    preserve_terminal_condition,
 )
 from .hybrid_fp_particle_hjb_fdm import HybridFPParticleHJBFDM
 
@@ -34,7 +35,8 @@ __all__ = [
     "check_convergence_criteria",
     "construct_solver_result",
     "initialize_cold_start",
-    "preserve_boundary_conditions",
+    "preserve_initial_condition",
+    "preserve_terminal_condition",
 ]
 
 # Solver categories for factory selection

--- a/mfg_pde/alg/numerical/stochastic/common_noise_solver.py
+++ b/mfg_pde/alg/numerical/stochastic/common_noise_solver.py
@@ -49,7 +49,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from mfg_pde.utils.numerical.monte_carlo import MCConfig, QuasiMCSampler
+from mfg_pde.utils.numerical.particle.sampling import MCConfig, QuasiMCSampler
 
 if TYPE_CHECKING:
     from collections.abc import Callable


### PR DESCRIPTION
## Summary
- Standardized API naming in fixed-point utilities to match canonical convention (M_initial, U_terminal)
- Split `preserve_boundary_conditions` into `preserve_initial_condition` and `preserve_terminal_condition`
- Fixed broken import in `common_noise_solver.py` (monte_carlo → particle.sampling)
- Added BC interface compatibility in `fp_fdm.py`

## Changes
- `mfg_pde/alg/numerical/coupling/fixed_point_utils.py`: Canonical naming (M_initial, U_terminal)
- `mfg_pde/alg/numerical/coupling/fixed_point_iterator.py`: Updated imports and variable names
- `mfg_pde/alg/numerical/coupling/__init__.py`: Updated exports
- `mfg_pde/alg/numerical/stochastic/common_noise_solver.py`: Fixed import path
- `mfg_pde/alg/numerical/fp_solvers/fp_fdm.py`: BC interface compatibility

## Test plan
- [x] Pre-commit hooks pass
- [ ] Verify fixed-point iterator works with updated API

🤖 Generated with [Claude Code](https://claude.com/claude-code)