### PR TITLE
fix: Correct broken smoothing_kernels imports

### DIFF
--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -552,9 +552,9 @@ class HJBGFDMSolver(BaseHJBSolver):
         """
         Compute weights based on distance and weight function using smoothing kernels.
 
-        Uses the unified smoothing kernel API from mfg_pde.utils.numerical.smoothing_kernels.
+        Uses the kernel API from mfg_pde.utils.numerical.particle.kernels.
         """
-        from mfg_pde.utils.numerical.smoothing_kernels import (
+        from mfg_pde.utils.numerical.particle.kernels import (
             GaussianKernel,
             WendlandKernel,
         )

--- a/mfg_pde/utils/numerical/gfdm_operators.py
+++ b/mfg_pde/utils/numerical/gfdm_operators.py
@@ -153,7 +153,7 @@ def gaussian_rbf_weight(r: np.ndarray, h: float) -> np.ndarray:
     """
     Gaussian RBF (Radial Basis Function) weight for GFDM.
 
-    This is a convenience wrapper around GaussianKernel from the smoothing_kernels module.
+    This is a convenience wrapper around GaussianKernel from the kernels module.
 
     Weight function: w(r) = exp(-(r/h)²)
 
@@ -172,15 +172,15 @@ def gaussian_rbf_weight(r: np.ndarray, h: float) -> np.ndarray:
 
     Notes
     -----
-    Uses GaussianKernel from mfg_pde.utils.numerical.smoothing_kernels with proper
+    Uses GaussianKernel from mfg_pde.utils.numerical.particle.kernels with proper
     normalization for arbitrary dimensions.
 
-    Alternative weight functions available in smoothing_kernels module:
+    Alternative weight functions available in kernels module:
     - WendlandKernel(k=0,1,2,3): Compact support, C^0, C^2, C^4, C^6 smoothness
     - CubicSplineKernel, QuinticSplineKernel: SPH B-spline kernels
     - CubicKernel, QuarticKernel: Simple polynomial kernels
 
-    See mfg_pde.utils.numerical.smoothing_kernels for full kernel API.
+    See mfg_pde.utils.numerical.particle.kernels for full kernel API.
 
     Examples
     --------
@@ -189,7 +189,7 @@ def gaussian_rbf_weight(r: np.ndarray, h: float) -> np.ndarray:
     >>> w
     array([1.        , 0.77880078, 0.36787944, 0.01831564])
     """
-    from mfg_pde.utils.numerical.smoothing_kernels import GaussianKernel
+    from mfg_pde.utils.numerical.particle.kernels import GaussianKernel
 
     kernel = GaussianKernel()
     return kernel(r, h=h)
@@ -950,7 +950,7 @@ def compute_kernel_density_gfdm(
     Notes
     -----
     This is a simplified KDE using Gaussian RBF weights from GFDM.
-    For more sophisticated kernel options, see mfg_pde.utils.numerical.smoothing_kernels.
+    For more sophisticated kernel options, see mfg_pde.utils.numerical.particle.kernels.
 
     The bandwidth h is chosen adaptively as the maximum neighbor distance.
 

--- a/mfg_pde/utils/numerical/particle/kernels.py
+++ b/mfg_pde/utils/numerical/particle/kernels.py
@@ -52,7 +52,7 @@ Properties of Good Kernels:
 
 Usage Examples:
 --------------
-    from mfg_pde.utils.numerical.smoothing_kernels import (
+    from mfg_pde.utils.numerical.particle.kernels import (
         GaussianKernel,
         WendlandKernel,
         CubicSplineKernel,


### PR DESCRIPTION
## Summary

Fixes broken imports referencing non-existent `smoothing_kernels` module.

## Problem

The codebase had imports like:
```python
from mfg_pde.utils.numerical.smoothing_kernels import GaussianKernel
```

But this module doesn't exist. The actual module is `particle.kernels`.

## Fix

Updated imports to use the correct path:
```python
from mfg_pde.utils.numerical.particle.kernels import GaussianKernel
```

## Files Changed

- `mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py` - Fixed import in `_compute_weights()`
- `mfg_pde/utils/numerical/gfdm_operators.py` - Fixed import in `gaussian_rbf_weight()` and docstrings
- `mfg_pde/utils/numerical/particle/kernels.py` - Fixed docstring example

## Test plan

- [x] Verified imports work: `python -c "from mfg_pde.utils.numerical.gfdm_operators import gaussian_rbf_weight"`
- [x] Verified HJBGFDMSolver imports correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)