### PR TITLE
chore: Add test tier markers for CI pipeline control (Issue #365 Phase 2)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,12 +18,19 @@ markers =
     performance: Performance tests (may be slow, measures timing/memory)
     mathematical: Mathematical property validation (mass conservation, etc.)
     fast: Fast tests (complete quickly, for rapid iteration)
-    slow: Slow tests (may take >10 seconds to complete)
+    slow: Slow tests (may take >30 seconds to complete, skipped on PRs)
     regression: Regression tests for specific bug fixes
     experimental: Tests for experimental features (may be unstable)
     optional_torch: Tests requiring PyTorch (RL algorithms, neural operators, GPU tests)
     benchmark: Performance measurement tests (not validation, results-only)
     environment: Environment-specific tests (maze generation, problem environments)
+    tier1: Fast unit tests (<1s) - run on every commit
+    tier2: Medium tests (1-30s) - run on PRs
+    tier3: Slow integration tests (>30s) - run on merge to main
+    tier4: Performance/stress tests - run weekly or manually
+    network: Tests requiring network/graph geometry
+    stochastic: Tests for stochastic MFG solvers
+    numerical: Tests for numerical algorithms (may have convergence issues)
 
 filterwarnings =
     ignore::DeprecationWarning:mfg_pde.*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,11 +24,23 @@ from mfg_pde.config.pydantic_config import MFGSolverConfig
 
 def pytest_configure(config):
     """Configure pytest with custom markers and settings."""
+    # Core test type markers
     config.addinivalue_line("markers", "unit: Unit tests (fast, isolated)")
     config.addinivalue_line("markers", "integration: Integration tests (slower, cross-component)")
     config.addinivalue_line("markers", "performance: Performance tests (may be slow)")
     config.addinivalue_line("markers", "mathematical: Mathematical property validation tests")
-    config.addinivalue_line("markers", "slow: Slow tests (may take >10 seconds)")
+    config.addinivalue_line("markers", "slow: Slow tests (may take >30 seconds)")
+
+    # Test tier markers (for CI pipeline control)
+    config.addinivalue_line("markers", "tier1: Fast unit tests (<1s) - run on every commit")
+    config.addinivalue_line("markers", "tier2: Medium tests (1-30s) - run on PRs")
+    config.addinivalue_line("markers", "tier3: Slow integration tests (>30s) - run on merge to main")
+    config.addinivalue_line("markers", "tier4: Performance/stress tests - run weekly or manually")
+
+    # Domain-specific markers
+    config.addinivalue_line("markers", "network: Tests requiring network/graph geometry")
+    config.addinivalue_line("markers", "stochastic: Tests for stochastic MFG solvers")
+    config.addinivalue_line("markers", "numerical: Tests for numerical algorithms")
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
## Summary
- Add test tier markers (tier1-tier4) for granular CI pipeline control
- Add domain-specific markers (network, stochastic, numerical)
- Update pytest.ini and conftest.py with new marker definitions

## Test Tier System
| Tier | Description | When to Run |
|:-----|:------------|:------------|
| tier1 | Fast unit tests (<1s) | Every commit |
| tier2 | Medium tests (1-30s) | PRs |
| tier3 | Slow integration tests (>30s) | Merge to main |
| tier4 | Performance/stress tests | Weekly/manual |

## Related
Part of Issue #365: Test Suite Modernization Plan (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)