### PR TITLE
test: Fix array validation tests (Phase 4 of #365)

### DIFF
--- a/tests/TEST_HEALTH.md
+++ b/tests/TEST_HEALTH.md
@@ -38,7 +38,7 @@ These tests are skipped when optional dependencies aren't installed:
 
 | Issue | Tests | Target |
 |:------|:------|:-------|
-| Array validation | 11 | Phase 3.5 |
+| Array validation | ~~11~~ **0 (fixed)** | ~~Phase 3.5~~ |
 | Factory signatures | 7 | Issue #277 |
 | Voronoi maze | 1 | Module not implemented |
 
@@ -79,7 +79,7 @@ pytest tests/ --ignore=tests/unit/test_alg/test_neural
 - solve_mfg shape mismatch (#365)
 
 ### Medium Priority
-- Array validation tests need fixing
+- ~~Array validation tests need fixing~~ (fixed)
 - Factory signature validation
 
 ### Low Priority

--- a/tests/unit/test_config/test_array_validation.py
+++ b/tests/unit/test_config/test_array_validation.py
@@ -224,7 +224,6 @@ class TestMFGArrays:
         with pytest.raises(ValidationError, match=r"U solution shape .* != expected"):
             MFGArrays(U_solution=wrong_shape_U, M_solution=valid_M_solution, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_U_solution_nan_values(self, grid_config, valid_M_solution):
         """Test U solution with NaN values raises error."""
         U_with_nan = np.random.randn(*grid_config.grid_shape)
@@ -233,7 +232,6 @@ class TestMFGArrays:
         with pytest.raises(ValidationError):
             MFGArrays(U_solution=U_with_nan, M_solution=valid_M_solution, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_U_solution_inf_values(self, grid_config, valid_M_solution):
         """Test U solution with infinite values raises error."""
         U_with_inf = np.random.randn(*grid_config.grid_shape)
@@ -242,7 +240,6 @@ class TestMFGArrays:
         with pytest.raises(ValidationError):
             MFGArrays(U_solution=U_with_inf, M_solution=valid_M_solution, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_U_solution_wrong_dtype(self, grid_config, valid_M_solution):
         """Test U solution with wrong dtype raises error."""
         U_int = np.zeros(grid_config.grid_shape, dtype=np.int32)
@@ -270,7 +267,6 @@ class TestMFGArrays:
         with pytest.raises(ValidationError):
             MFGArrays(U_solution=valid_U_solution, M_solution=wrong_shape_M, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_M_solution_nan_values(self, grid_config, valid_U_solution):
         """Test M solution with NaN values raises error."""
         M_with_nan = np.abs(np.random.randn(*grid_config.grid_shape))
@@ -279,16 +275,14 @@ class TestMFGArrays:
         with pytest.raises(ValidationError):
             MFGArrays(U_solution=valid_U_solution, M_solution=M_with_nan, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_M_solution_negative_values(self, grid_config, valid_U_solution):
         """Test M solution with negative values raises error."""
-        M_with_negative = np.random.randn(*grid_config.grid_shape)
-        M_with_negative[5, 10] = -0.1
+        M_with_negative = np.abs(np.random.randn(*grid_config.grid_shape))  # Start with positive
+        M_with_negative[5, 10] = -0.1  # Then add one negative value
 
         with pytest.raises(ValidationError):
             MFGArrays(U_solution=valid_U_solution, M_solution=M_with_negative, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_M_solution_mass_conservation_warning_initial(self, grid_config, valid_U_solution):
         """Test mass conservation warning for initial condition."""
         M_unnormalized = np.abs(np.random.randn(*grid_config.grid_shape))
@@ -298,11 +292,10 @@ class TestMFGArrays:
             warnings.simplefilter("always")
             MFGArrays(U_solution=valid_U_solution, M_solution=M_unnormalized, grid_config=grid_config)
 
-            # Should have warning about initial mass
-            mass_warnings = [warning for warning in w if "mass" in str(warning.message).lower()]
+            # Should have warning about initial mass (case-insensitive search)
+            mass_warnings = [warning for warning in w if "initial mass" in str(warning.message).lower()]
             assert len(mass_warnings) > 0
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_M_solution_mass_conservation_warning_final(self, grid_config, valid_U_solution):
         """Test mass conservation warning for final condition."""
         M = np.abs(np.random.randn(*grid_config.grid_shape))
@@ -316,7 +309,7 @@ class TestMFGArrays:
             warnings.simplefilter("always")
             MFGArrays(U_solution=valid_U_solution, M_solution=M, grid_config=grid_config)
 
-            # Should warn about final mass
+            # Should warn about final mass (case-insensitive search)
             mass_warnings = [warning for warning in w if "final mass" in str(warning.message).lower()]
             assert len(mass_warnings) > 0
 
@@ -402,7 +395,6 @@ class TestCollocationConfig:
         with pytest.raises(ValidationError):
             CollocationConfig(points=points, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_collocation_points_outside_domain_min(self, grid_config):
         """Test collocation points below xmin raises error."""
         points = np.array([[-0.1], [0.5], [0.8]])
@@ -410,7 +402,6 @@ class TestCollocationConfig:
         with pytest.raises(ValidationError):
             CollocationConfig(points=points, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_collocation_points_outside_domain_max(self, grid_config):
         """Test collocation points above xmax raises error."""
         points = np.array([[0.2], [0.5], [1.1]])
@@ -418,7 +409,6 @@ class TestCollocationConfig:
         with pytest.raises(ValidationError):
             CollocationConfig(points=points, grid_config=grid_config)
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_collocation_points_few_warning(self, grid_config):
         """Test warning for too few collocation points."""
         points = np.array([[0.5]])  # Only 1 point
@@ -427,10 +417,9 @@ class TestCollocationConfig:
             warnings.simplefilter("always")
             CollocationConfig(points=points, grid_config=grid_config)
 
-            assert len(w) >= 1
-            assert "Few collocation points" in str(w[0].message)
+            few_warnings = [warning for warning in w if "Few collocation points" in str(warning.message)]
+            assert len(few_warnings) >= 1
 
-    @pytest.mark.skip(reason="Array validation needs fixing - pre-existing test failure")
     def test_collocation_points_many_warning(self, grid_config):
         """Test warning for too many collocation points."""
         points = np.linspace(0.0, 1.0, 150).reshape(-1, 1)  # More than Nx=100
@@ -439,8 +428,8 @@ class TestCollocationConfig:
             warnings.simplefilter("always")
             CollocationConfig(points=points, grid_config=grid_config)
 
-            assert len(w) >= 1
-            assert "Many collocation points" in str(w[0].message)
+            many_warnings = [warning for warning in w if "Many collocation points" in str(warning.message)]
+            assert len(many_warnings) >= 1
 
     def test_collocation_points_duplicates_warning(self, grid_config):
         """Test warning for duplicate collocation points."""


### PR DESCRIPTION
## Summary
Phase 4 of Issue #365 - Test Suite Modernization

- Remove skip markers from 11 array validation tests that were incorrectly skipped
- The array validation module was already working correctly (NaN/Inf detection, dtype validation, negative density values, domain bounds, mass conservation warnings)
- Fix test assertions to filter warnings properly (multiple warnings may occur)
- Update TEST_HEALTH.md to reflect the fix

## Changes
- `tests/unit/test_config/test_array_validation.py`: Enable 11 tests that were incorrectly skipped
- `tests/TEST_HEALTH.md`: Mark array validation as fixed

## Test Results
All 54 array validation tests now pass locally.

Fixes part of #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)