### PR TITLE
feat: Add SDF-based boundary normals and projection for implicit domains

### DIFF
--- a/mfg_pde/geometry/base.py
+++ b/mfg_pde/geometry/base.py
@@ -784,6 +784,86 @@ class UnstructuredMesh(Geometry):
         return {"type": "unstructured_mesh", "implementation": "placeholder"}
 
     # ============================================================================
+    # Boundary Methods (FEM-specific overrides)
+    # ============================================================================
+
+    def get_boundary_normal(self, points: NDArray) -> NDArray:
+        """
+        Get outward normal vectors at boundary points for unstructured mesh.
+
+        For FEM meshes, boundary normals are computed from boundary face geometry:
+        - 2D: Normal to boundary edges
+        - 3D: Normal to boundary triangles
+
+        Args:
+            points: Array of shape (n, d) - boundary points
+
+        Returns:
+            Array of shape (n, d) - unit outward normal at each point
+
+        Note:
+            This is a placeholder implementation that falls back to the base class
+            axis-aligned normal computation. Full implementation requires:
+            1. Identify boundary faces from mesh topology
+            2. Find closest boundary face to each query point
+            3. Compute face normal from vertex positions
+
+            TODO: Implement proper mesh-based boundary normal computation
+        """
+        # Placeholder: fall back to base class axis-aligned implementation
+        return super().get_boundary_normal(points)
+
+    def project_to_boundary(self, points: NDArray) -> NDArray:
+        """
+        Project points onto the mesh boundary.
+
+        For FEM meshes, boundary projection finds the closest point on boundary faces:
+        - 2D: Project to nearest boundary edge
+        - 3D: Project to nearest boundary triangle
+
+        Args:
+            points: Array of shape (n, d) - points to project
+
+        Returns:
+            Array of shape (n, d) - projected points on boundary
+
+        Note:
+            This is a placeholder implementation that falls back to the base class
+            axis-aligned projection. Full implementation requires:
+            1. Build boundary face spatial index (e.g., BVH tree)
+            2. Find closest boundary face to each query point
+            3. Project point onto that face
+
+            TODO: Implement proper mesh-based boundary projection
+        """
+        # Placeholder: fall back to base class axis-aligned implementation
+        return super().project_to_boundary(points)
+
+    def is_on_boundary(self, points: NDArray, tolerance: float = 1e-10) -> NDArray:
+        """
+        Check if points are on the mesh boundary.
+
+        For FEM meshes, boundary detection checks distance to boundary faces.
+
+        Args:
+            points: Array of shape (n, d) - points to check
+            tolerance: Distance tolerance for boundary detection
+
+        Returns:
+            Boolean array of shape (n,) - True if point is on boundary
+
+        Note:
+            This is a placeholder implementation that falls back to the base class
+            bounds-based detection. Full implementation requires:
+            1. Compute distance to all boundary faces
+            2. Return True if min distance < tolerance
+
+            TODO: Implement proper mesh-based boundary detection
+        """
+        # Placeholder: fall back to base class bounds-based implementation
+        return super().is_on_boundary(points, tolerance)
+
+    # ============================================================================
     # Mesh Utilities (from old BaseGeometry)
     # ============================================================================
 

--- a/mfg_pde/geometry/implicit/implicit_domain.py
+++ b/mfg_pde/geometry/implicit/implicit_domain.py
@@ -298,6 +298,148 @@ class ImplicitDomain(ImplicitGeometry):
 
         return bbox_volume * fraction_inside
 
+    def get_boundary_normal(self, x: NDArray[np.float64], eps: float = 1e-6) -> NDArray[np.float64]:
+        """
+        Compute outward boundary normal at point(s) using SDF gradient.
+
+        The boundary normal is computed as n = ∇φ / ||∇φ|| where φ is the
+        signed distance function. For an exact SDF, ||∇φ|| = 1, but we
+        normalize to handle approximate SDFs.
+
+        Args:
+            x: Point(s) to evaluate - shape (d,) or (N, d)
+            eps: Finite difference step size for gradient computation
+
+        Returns:
+            Unit normal vector(s) pointing outward - same shape as x
+
+        Notes:
+            - The normal points outward (direction of increasing φ)
+            - For points not exactly on the boundary, this gives the normal
+              to the closest boundary point
+            - Uses central finite differences for gradient: O(eps²) accuracy
+
+        Example:
+            >>> sphere = Hypersphere(center=[0, 0], radius=1.0)
+            >>> normal = sphere.get_boundary_normal(np.array([1.0, 0.0]))
+            >>> np.allclose(normal, [1.0, 0.0])  # Points radially outward
+            True
+        """
+        is_single = x.ndim == 1
+        if is_single:
+            x = x.reshape(1, -1)
+
+        n_points, d = x.shape
+        normals = np.zeros_like(x)
+
+        # Compute gradient via central finite differences
+        for i in range(n_points):
+            grad = np.zeros(d)
+            for j in range(d):
+                # Create perturbation vectors
+                x_plus = x[i].copy()
+                x_minus = x[i].copy()
+                x_plus[j] += eps
+                x_minus[j] -= eps
+
+                # Central difference: ∂φ/∂x_j ≈ (φ(x+eps*e_j) - φ(x-eps*e_j)) / (2*eps)
+                phi_plus = self.signed_distance(x_plus)
+                phi_minus = self.signed_distance(x_minus)
+                grad[j] = (phi_plus - phi_minus) / (2 * eps)
+
+            # Normalize to get unit normal
+            norm = np.linalg.norm(grad)
+            if norm > 1e-12:
+                normals[i] = grad / norm
+            else:
+                # Degenerate case: gradient is zero (e.g., at singular point)
+                # Return arbitrary unit vector
+                normals[i, 0] = 1.0
+
+        return normals[0] if is_single else normals
+
+    def project_to_boundary(
+        self,
+        x: NDArray[np.float64],
+        max_iterations: int = 20,
+        tol: float = 1e-8,
+    ) -> NDArray[np.float64]:
+        """
+        Project point(s) onto the domain boundary using Newton iteration.
+
+        Uses the iteration: x_{k+1} = x_k - φ(x_k) * n(x_k)
+        where φ is the SDF and n is the unit outward normal.
+
+        This converges quickly for smooth boundaries and is exact in one
+        step for points where the SDF gradient is constant along the
+        projection direction (e.g., spheres, planes).
+
+        Args:
+            x: Point(s) to project - shape (d,) or (N, d)
+            max_iterations: Maximum Newton iterations
+            tol: Convergence tolerance for |φ(x)|
+
+        Returns:
+            Projected point(s) on boundary - same shape as x
+
+        Example:
+            >>> sphere = Hypersphere(center=[0, 0], radius=1.0)
+            >>> inside = np.array([0.5, 0.0])
+            >>> on_boundary = sphere.project_to_boundary(inside)
+            >>> np.allclose(on_boundary, [1.0, 0.0])
+            True
+        """
+        is_single = x.ndim == 1
+        if is_single:
+            x = x.reshape(1, -1)
+
+        x_proj = x.copy()
+        n_points = x.shape[0]
+
+        for i in range(n_points):
+            xi = x_proj[i].copy()
+
+            for _ in range(max_iterations):
+                phi = self.signed_distance(xi)
+
+                # Check convergence
+                if np.abs(phi) < tol:
+                    break
+
+                # Get outward normal at current point
+                normal = self.get_boundary_normal(xi)
+
+                # Newton step: move along normal by -φ
+                # (negative because we want to move toward boundary)
+                xi = xi - phi * normal
+
+            x_proj[i] = xi
+
+        return x_proj[0] if is_single else x_proj
+
+    def is_on_boundary(self, x: NDArray[np.float64], tol: float = 1e-8) -> bool | NDArray[np.bool_]:
+        """
+        Check if point(s) are on the domain boundary using SDF.
+
+        A point is on the boundary if |φ(x)| < tol where φ is the SDF.
+
+        Args:
+            x: Point(s) to check - shape (d,) or (N, d)
+            tol: Tolerance for boundary detection
+
+        Returns:
+            Boolean or array of booleans indicating if points are on boundary
+
+        Example:
+            >>> sphere = Hypersphere(center=[0, 0], radius=1.0)
+            >>> sphere.is_on_boundary(np.array([1.0, 0.0]))
+            True
+            >>> sphere.is_on_boundary(np.array([0.5, 0.0]))
+            False
+        """
+        sd = self.signed_distance(x)
+        return np.abs(sd) < tol
+
     def __repr__(self) -> str:
         """String representation of the domain."""
         return f"{self.__class__.__name__}(dimension={self.dimension})"


### PR DESCRIPTION
## Summary
- Add `get_boundary_normal()` method to compute outward normals using finite-difference gradient of SDF
- Add `project_to_boundary()` method for Newton-based projection onto domain boundary
- Add `is_on_boundary()` method for SDF-based boundary detection
- Add comprehensive unit tests (10 new tests) for all new methods

Implements Issue #352 (Lipschitz BC for Curved Domains).

## Implementation Details

**`get_boundary_normal(x, eps=1e-6)`**:
- Computes n = ∇φ / ||∇φ|| where φ is the signed distance function
- Uses central finite differences for O(eps²) accuracy
- Handles degenerate cases (zero gradient)

**`project_to_boundary(x, max_iterations=20, tol=1e-8)`**:
- Newton iteration: x_{k+1} = x_k - φ(x_k) * n(x_k)
- Converges in 1 step for spheres and planes
- Handles both interior and exterior points

**`is_on_boundary(x, tol=1e-8)`**:
- Returns True if |φ(x)| < tol

All methods support both single points (d,) and batch points (N, d).

## Test plan
- [x] 10 new unit tests for boundary normals and projection
- [x] Tests for spheres and rectangles
- [x] Tests for batch processing
- [x] Tests for high-dimensional domains (4D)
- [x] All 24 geometry tests pass locally

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)