### PR TITLE
refactor: Migrate MFGProblem to unified BC interface

### DIFF
--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-# Use 1D FDM BoundaryConditions for MFGProblem (1D-focused class)
-from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions
+# Use unified nD-capable BoundaryConditions from conditions.py
+from mfg_pde.geometry.boundary.conditions import BoundaryConditions, periodic_bc
 from mfg_pde.types import HamiltonianJacobians
 
 # Import npart and ppart from the utils module
@@ -411,7 +411,7 @@ class MFGProblem:
         import warnings
 
         from mfg_pde.geometry import SimpleGrid1D
-        from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions
+        from mfg_pde.geometry.boundary.conditions import periodic_bc
 
         # Emit deprecation warning for manual grid construction pattern
         warnings.warn(
@@ -432,7 +432,7 @@ class MFGProblem:
         Nx_scalar = Nx[0]
 
         # Create SimpleGrid1D geometry object (unified internal representation)
-        bc = BoundaryConditions(type="periodic")  # Default to periodic for backward compatibility
+        bc = periodic_bc(dimension=1)  # Default to periodic for backward compatibility
         geometry = SimpleGrid1D(xmin=xmin_scalar, xmax=xmax_scalar, boundary_conditions=bc)
         dx, _ = geometry.create_grid(num_points=Nx_scalar + 1)
 
@@ -529,9 +529,9 @@ class MFGProblem:
         if dimension == 1:
             # 1D case: use SimpleGrid1D
             from mfg_pde.geometry import SimpleGrid1D
-            from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions
+            from mfg_pde.geometry.boundary.conditions import periodic_bc
 
-            bc = BoundaryConditions(type="periodic")
+            bc = periodic_bc(dimension=1)
             geometry = SimpleGrid1D(xmin=spatial_bounds[0][0], xmax=spatial_bounds[0][1], boundary_conditions=bc)
             dx, _ = geometry.create_grid(num_points=spatial_discretization[0] + 1)
 
@@ -1915,7 +1915,7 @@ class MFGProblem:
             return self.components.boundary_conditions
         else:
             # Default periodic boundary conditions
-            return BoundaryConditions(type="periodic")
+            return periodic_bc(dimension=self.dimension)
 
     def get_potential_at_time(self, t_idx: int) -> np.ndarray:
         """Get potential function at specific time (for time-dependent potentials)."""

--- a/tests/unit/test_core/test_mfg_problem.py
+++ b/tests/unit/test_core/test_mfg_problem.py
@@ -18,8 +18,11 @@ import numpy as np
 
 from mfg_pde.core.mfg_problem import MFGComponents, MFGProblem
 
+# Unified BC from conditions.py (current API)
+from mfg_pde.geometry.boundary.conditions import BoundaryConditions
+
 # Legacy 1D BC: testing compatibility with 1D MFG problems (deprecated in v0.14, remove in v1.0)
-from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions
+from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions as LegacyBoundaryConditions
 
 # ===================================================================
 # Test MFGComponents Dataclass
@@ -341,14 +344,16 @@ def test_get_boundary_conditions_default():
 
 @pytest.mark.unit
 def test_get_boundary_conditions_custom():
-    """Test get_boundary_conditions with custom BC."""
-    custom_bc = BoundaryConditions(type="dirichlet", left_value=0.0, right_value=0.0)
+    """Test get_boundary_conditions with custom BC (legacy 1D BC backward compat)."""
+    # Uses legacy 1D BC to test backward compatibility
+    custom_bc = LegacyBoundaryConditions(type="dirichlet", left_value=0.0, right_value=0.0)
     components = MFGComponents(boundary_conditions=custom_bc)
     problem = MFGProblem(components=components)
 
     bc = problem.get_boundary_conditions()
 
-    assert isinstance(bc, BoundaryConditions)
+    # Custom BC is passed through as-is (legacy type)
+    assert isinstance(bc, LegacyBoundaryConditions)
     assert bc.type == "dirichlet"
 
 


### PR DESCRIPTION
## Summary
- Update MFGProblem imports from deprecated `fdm_bc_1d` to unified `conditions.py`
- Use `periodic_bc()` factory function instead of `BoundaryConditions(type="periodic")`
- Update `get_boundary_conditions()` to return unified BC
- Update test imports to distinguish unified vs legacy BC types

## Motivation
Phase 1 of issue #395: Replace `fdm_bc_1d` dependency with unified BC interface.

The unified BC from `conditions.py` supports nD boundary conditions while maintaining backward compatibility with legacy 1D BC passed through `MFGComponents`.

## Test plan
- [x] All 33 mfg_problem tests pass
- [x] All 392 geometry and core tests pass
- [ ] CI passes

Fixes #395 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)