### PR TITLE
chore: Add SimpleGrid deprecation warnings (Phase 5)

### DIFF
--- a/mfg_pde/geometry/grids/grid_1d.py
+++ b/mfg_pde/geometry/grids/grid_1d.py
@@ -3,10 +3,15 @@
 
 This module provides 1D regular grid specification for finite difference methods.
 Boundary conditions are managed in boundary_conditions_1d.py.
+
+.. deprecated:: 0.14
+    SimpleGrid1D is deprecated. Use TensorProductGrid with dimension=1 instead.
+    Will be removed in v1.0.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -33,11 +38,21 @@ class SimpleGrid1D(CartesianGrid):
         """
         Initialize 1D domain.
 
+        .. deprecated:: 0.14
+            Use TensorProductGrid with dimension=1 and unified BoundaryConditions instead.
+
         Args:
             xmin: Left boundary of domain
             xmax: Right boundary of domain
             boundary_conditions: Boundary condition specification
         """
+        warnings.warn(
+            "SimpleGrid1D is deprecated since v0.14 and will be removed in v1.0. "
+            "Use TensorProductGrid with dimension=1 and unified BoundaryConditions instead. "
+            "See mfg_pde.geometry.grids.tensor_grid.TensorProductGrid.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if xmax <= xmin:
             raise ValueError("xmax must be greater than xmin")
 

--- a/mfg_pde/geometry/grids/grid_2d.py
+++ b/mfg_pde/geometry/grids/grid_2d.py
@@ -3,10 +3,15 @@ Simple grid geometry for high-dimensional MFG problems.
 
 This module provides basic rectangular grid generation without external dependencies,
 suitable for regular domain problems and testing.
+
+.. deprecated:: 0.14
+    SimpleGrid2D is deprecated. Use TensorProductGrid with dimension=2 instead.
+    Will be removed in v1.0.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -30,10 +35,20 @@ class SimpleGrid2D(CartesianGrid):
         """
         Initialize 2D grid.
 
+        .. deprecated:: 0.14
+            Use TensorProductGrid with dimension=2 instead.
+
         Args:
             bounds: (xmin, xmax, ymin, ymax)
             resolution: (nx, ny) number of intervals (grid points = nx+1, ny+1)
         """
+        warnings.warn(
+            "SimpleGrid2D is deprecated since v0.14 and will be removed in v1.0. "
+            "Use TensorProductGrid with dimension=2 instead. "
+            "See mfg_pde.geometry.grids.tensor_grid.TensorProductGrid.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._dimension = 2
         self.xmin, self.xmax, self.ymin, self.ymax = bounds
         self.nx, self.ny = resolution

--- a/mfg_pde/geometry/grids/grid_3d.py
+++ b/mfg_pde/geometry/grids/grid_3d.py
@@ -3,10 +3,15 @@ Simple 3D grid geometry for MFG problems.
 
 This module provides basic 3D rectangular grid generation without external dependencies,
 suitable for regular domain problems and testing.
+
+.. deprecated:: 0.14
+    SimpleGrid3D is deprecated. Use TensorProductGrid with dimension=3 instead.
+    Will be removed in v1.0.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -32,10 +37,20 @@ class SimpleGrid3D(CartesianGrid):
         """
         Initialize 3D grid.
 
+        .. deprecated:: 0.14
+            Use TensorProductGrid with dimension=3 instead.
+
         Args:
             bounds: (xmin, xmax, ymin, ymax, zmin, zmax)
             resolution: (nx, ny, nz) number of intervals (grid points = nx+1, ny+1, nz+1)
         """
+        warnings.warn(
+            "SimpleGrid3D is deprecated since v0.14 and will be removed in v1.0. "
+            "Use TensorProductGrid with dimension=3 instead. "
+            "See mfg_pde.geometry.grids.tensor_grid.TensorProductGrid.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._dimension = 3
         self.xmin, self.xmax, self.ymin, self.ymax, self.zmin, self.zmax = bounds
         self.nx, self.ny, self.nz = resolution

--- a/tests/unit/geometry/test_geometry_projection.py
+++ b/tests/unit/geometry/test_geometry_projection.py
@@ -3,6 +3,9 @@ Unit tests for GeometryProjector (Issue #257).
 
 Tests projection operations between different geometry discretizations,
 including particle↔grid and grid↔grid projections.
+
+Note: Uses legacy SimpleGrid1D/2D/3D APIs which are deprecated in v0.14.
+These tests validate legacy behavior until removal in v1.0.
 """
 
 import pytest
@@ -10,6 +13,9 @@ import pytest
 import numpy as np
 
 from mfg_pde.geometry import GeometryProjector, SimpleGrid1D, SimpleGrid2D, SimpleGrid3D
+
+# Suppress deprecation warnings for SimpleGrid classes in this test module
+pytestmark = pytest.mark.filterwarnings("ignore:SimpleGrid.*deprecated:DeprecationWarning")
 
 
 class TestGeometryProjectorBasics:

--- a/tests/unit/test_fp_fdm_solver.py
+++ b/tests/unit/test_fp_fdm_solver.py
@@ -4,6 +4,9 @@ Unit tests for FPFDMSolver - comprehensive coverage.
 
 Tests the Finite Difference Method (FDM) solver for Fokker-Planck equations
 with different boundary conditions (periodic, Dirichlet, no-flux).
+
+Note: Uses legacy SimpleGrid1D API which is deprecated in v0.14.
+These tests validate legacy behavior until removal in v1.0.
 """
 
 import pytest
@@ -16,6 +19,9 @@ from mfg_pde.core.mfg_problem import MFGProblem
 # Legacy 1D BC: testing compatibility with 1D FDM solvers (deprecated in v0.14, remove in v1.0)
 from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions
 from mfg_pde.geometry.grids.grid_1d import SimpleGrid1D
+
+# Suppress deprecation warnings for SimpleGrid classes in this test module
+pytestmark = pytest.mark.filterwarnings("ignore:SimpleGrid.*deprecated:DeprecationWarning")
 
 
 @pytest.fixture

--- a/tests/unit/test_geometry/test_simple_grid.py
+++ b/tests/unit/test_geometry/test_simple_grid.py
@@ -4,6 +4,9 @@ Unit tests for Simple Grid Geometry
 
 Tests the SimpleGrid2D and SimpleGrid3D classes for mesh generation
 without external dependencies.
+
+Note: SimpleGrid classes are deprecated in v0.14 (use TensorProductGrid instead).
+These tests validate legacy behavior until removal in v1.0.
 """
 
 import tempfile
@@ -15,6 +18,9 @@ import numpy as np
 
 from mfg_pde.geometry.grids.grid_2d import SimpleGrid2D
 from mfg_pde.geometry.grids.grid_3d import SimpleGrid3D
+
+# Suppress deprecation warnings for SimpleGrid classes in this test module
+pytestmark = pytest.mark.filterwarnings("ignore:SimpleGrid.*deprecated:DeprecationWarning")
 
 # ============================================================================
 # Test: SimpleGrid2D - Initialization

--- a/tests/unit/test_hjb_gfdm_solver.py
+++ b/tests/unit/test_hjb_gfdm_solver.py
@@ -3,6 +3,9 @@
 Unit tests for HJBGFDMSolver - comprehensive coverage.
 
 Tests the GFDM (Generalized Finite Difference Method) solver for HJB equations.
+
+Note: Uses legacy SimpleGrid1D API which is deprecated in v0.14.
+These tests validate legacy behavior until removal in v1.0.
 """
 
 import pytest
@@ -15,6 +18,9 @@ from mfg_pde.core.mfg_problem import MFGProblem
 # Legacy 1D BC: testing compatibility with 1D HJB solvers (deprecated in v0.14, remove in v1.0)
 from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions
 from mfg_pde.geometry.grids.grid_1d import SimpleGrid1D
+
+# Suppress deprecation warnings for SimpleGrid classes in this test module
+pytestmark = pytest.mark.filterwarnings("ignore:SimpleGrid.*deprecated:DeprecationWarning")
 
 
 @pytest.fixture

--- a/tests/unit/test_pde_coefficients.py
+++ b/tests/unit/test_pde_coefficients.py
@@ -2,6 +2,9 @@
 Unit tests for PDE coefficient handling utilities.
 
 Tests CoefficientField abstraction for scalar, array, and callable coefficients.
+
+Note: Uses legacy SimpleGrid1D API which is deprecated in v0.14.
+These tests validate legacy behavior until removal in v1.0.
 """
 
 from __future__ import annotations
@@ -13,6 +16,9 @@ import numpy as np
 from mfg_pde.core.mfg_problem import MFGProblem
 from mfg_pde.geometry import SimpleGrid1D
 from mfg_pde.utils.pde_coefficients import CoefficientField, get_spatial_grid
+
+# Suppress deprecation warnings for SimpleGrid classes in this test module
+pytestmark = pytest.mark.filterwarnings("ignore:SimpleGrid.*deprecated:DeprecationWarning")
 
 
 class TestCoefficientFieldScalar:

--- a/tests/unit/test_weno_family.py
+++ b/tests/unit/test_weno_family.py
@@ -10,6 +10,9 @@ Validates:
 4. Interface consistency across variants
 5. Strategic typing compliance
 
+Note: Uses legacy SimpleGrid1D API which is deprecated in v0.14.
+These tests validate legacy behavior until removal in v1.0.
+
 Usage:
     python -m pytest tests/unit/test_weno_family.py -v
 """
@@ -24,6 +27,9 @@ from mfg_pde.core.mfg_problem import MFGProblem
 # Legacy 1D BC: testing compatibility with 1D HJB solvers (deprecated in v0.14, remove in v1.0)
 from mfg_pde.geometry.boundary.fdm_bc_1d import BoundaryConditions
 from mfg_pde.geometry.grids.grid_1d import SimpleGrid1D
+
+# Suppress deprecation warnings for SimpleGrid classes in this test module
+pytestmark = pytest.mark.filterwarnings("ignore:SimpleGrid.*deprecated:DeprecationWarning")
 
 
 class TestWenoFamilySolver:


### PR DESCRIPTION
## Summary

Part of issue #395 - Phase 5: Test & Deprecation

**Adds deprecation warnings to SimpleGrid classes:**
- `SimpleGrid1D` in `mfg_pde/geometry/grids/grid_1d.py`
- `SimpleGrid2D` in `mfg_pde/geometry/grids/grid_2d.py`
- `SimpleGrid3D` in `mfg_pde/geometry/grids/grid_3d.py`

All classes now emit `DeprecationWarning` on instantiation, recommending `TensorProductGrid` as the replacement.

**Updates 7 test files with warning suppression:**
- `tests/unit/test_geometry/test_simple_grid.py`
- `tests/unit/test_fp_fdm_solver.py`
- `tests/unit/test_hjb_gfdm_solver.py`
- `tests/unit/test_pde_coefficients.py`
- `tests/unit/test_weno_family.py`
- `tests/unit/geometry/test_geometry_projection.py`

Each test file now has a `pytestmark` that filters out the expected deprecation warnings.

## Migration Timeline
- **v0.14**: Deprecation warnings added (this PR)
- **v1.0**: Classes removed, users must use `TensorProductGrid`

## Test plan
- [x] All tests pass with deprecation warnings suppressed
- [x] Pre-commit hooks pass
- [ ] CI passes

Fixes part of #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)