### PR TITLE
refactor: Migrate GFDM QP solving to use QPSolver from qp_utils

### DIFF
--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -199,7 +199,8 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         # Initialize unified QP solver from qp_utils
         # Map qp_solver parameter to QPSolver backend
-        qp_backend = "osqp" if qp_solver == "osqp" else "scipy-slsqp"
+        # Use "auto" to allow fallback to scipy when OSQP not installed
+        qp_backend = "auto" if qp_solver == "osqp" else "scipy-slsqp"
         self._qp_cache = QPCache(max_size=1000)
         self._qp_solver_instance = QPSolver(
             backend=qp_backend,


### PR DESCRIPTION
## Summary
Phase 1 of GFDM refactoring (#389):

- Replace `_solve_monotone_constrained_qp` inline QP code with `QPSolver` calls
- Remove duplicate `_solve_qp_with_osqp` method (~105 lines)
- Update `print_qp_diagnostics` to show QPSolver statistics (cache hits, warm-starts)
- Remove unused `scipy.optimize.minimize` import

QPSolver from `qp_utils.py` provides:
- OSQP/scipy backend switching
- Warm-starting support
- Hash-based result caching (QPCache)
- Unified statistics tracking

**Net effect**: 79 insertions, 238 deletions (~160 lines removed), better separation of concerns.

## Test plan
- [x] `pytest tests/unit/test_hjb_gfdm_solver.py` - all 22 tests pass/xfail/skip
- [x] Import verification: `from mfg_pde.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver`
- [x] Pre-commit hooks pass (ruff format, ruff check)
- [ ] CI passes

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)