### PR TITLE
fix: Replace unsafe hasattr patterns with getattr for Nx checks

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
@@ -290,7 +290,8 @@ class FPFDMSolver(BaseFPSolver):
 
             # Create zero U field with appropriate shape
             if self.dimension == 1:
-                Nx = self.problem.Nx + 1 if hasattr(self.problem, "Nx") else self.problem.geometry.get_grid_shape()[0]
+                Nx_val = getattr(self.problem, "Nx", None)
+                Nx = Nx_val + 1 if Nx_val is not None else self.problem.geometry.get_grid_shape()[0]
                 effective_U = np.zeros((Nt, Nx))
             else:
                 grid_shape = self.problem.geometry.get_grid_shape()

--- a/mfg_pde/solvers/extensions/multi_population/fixed_point.py
+++ b/mfg_pde/solvers/extensions/multi_population/fixed_point.py
@@ -356,8 +356,8 @@ class _SinglePopulationAdapter:
             This is a helper method for fallback array creation.
         """
         # Try to extract spatial shape from problem
-        if hasattr(self._problem, "Nx"):
-            Nx = self._problem.Nx
+        Nx = getattr(self._problem, "Nx", None)
+        if Nx is not None:
             if isinstance(Nx, (list, tuple)):
                 return tuple(n + 1 for n in Nx)
             return (Nx + 1,)

--- a/mfg_pde/utils/pde_coefficients.py
+++ b/mfg_pde/utils/pde_coefficients.py
@@ -689,10 +689,10 @@ def get_spatial_grid(problem: MFGProblem) -> np.ndarray | tuple[np.ndarray, ...]
 
     # Legacy 1D API
     elif hasattr(problem, "xmin") and hasattr(problem, "xmax"):
-        Nx = problem.Nx + 1 if hasattr(problem, "Nx") else None
-        if Nx is None:
+        Nx_val = getattr(problem, "Nx", None)
+        if Nx_val is None:
             raise AttributeError("Problem must have either geometry.coordinates or (xmin, xmax, Nx) attributes")
-        return np.linspace(problem.xmin, problem.xmax, Nx)
+        return np.linspace(problem.xmin, problem.xmax, Nx_val + 1)
 
     else:
         raise AttributeError("Problem must have either geometry.coordinates or (xmin, xmax, Nx) attributes")


### PR DESCRIPTION
## Summary
- Replaces `hasattr(obj, "Nx")` with `getattr(obj, "Nx", None)` + explicit None check in 3 locations
- The hasattr pattern fails silently when Nx attribute exists but is None

## Files Changed
- `fixed_point.py:359` - _SinglePopulationAdapter._extract_spatial_shape()
- `pde_coefficients.py:692` - get_spatial_grid() legacy 1D API path
- `fp_fdm.py:293` - FPFDMSolver._solve_1d() effective U field creation

## Test plan
- [x] Verify imports work
- [ ] CI passes

Fixes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)