### PR TITLE
docs: Archive stale architecture docs with resolution notes

### DIFF
--- a/docs/architecture/archive/RESOLVED_FDM_SOLVER_LIMITATION_ANALYSIS.md
+++ b/docs/architecture/archive/RESOLVED_FDM_SOLVER_LIMITATION_ANALYSIS.md
@@ -1,8 +1,16 @@
-# FDM Solver Limitation: Cannot Use with 2D Maze
+# [RESOLVED] FDM Solver Limitation: Cannot Use with 2D Maze
+
+> **Resolution Note (2025-12-09)**: This analysis was based on incomplete understanding
+> of the codebase. FDM solvers actually DO support N-dimensional problems:
+> - `hjb_fdm.py`: Has full nD support via `_solve_hjb_nd()` using nonlinear solvers
+> - `fp_fdm.py`: Has full nD support via `solve_fp_nd_full_system()`
+>
+> The original concern was addressed. Issue #407 was closed as "not planned" because
+> the feature already exists. This document is archived for historical reference only.
 
 **Date**: 2025-10-30
 **Context**: Attempted pure FDM solver comparison for maze navigation problem
-**Status**: BLOCKED by architectural limitation
+**Status**: RESOLVED (FDM solvers support N-dimensional problems)
 
 ---
 

--- a/docs/architecture/archive/SUPERSEDED_MFG_PDE_ARCHITECTURE_AUDIT.md
+++ b/docs/architecture/archive/SUPERSEDED_MFG_PDE_ARCHITECTURE_AUDIT.md
@@ -1,4 +1,13 @@
-# MFG_PDE Architecture Audit: Comprehensive Refactoring Critique
+# [SUPERSEDED] MFG_PDE Architecture Audit: Comprehensive Refactoring Critique
+
+> **Superseded Note (2025-12-09)**: This audit contains outdated analysis. Key findings
+> have been addressed or found to be based on incomplete understanding:
+> - "FDM is 1D only" - INCORRECT: FDM solvers support N-dimensional problems
+>   (`hjb_fdm.py:_solve_hjb_nd`, `fp_fdm.py:solve_fp_nd_full_system`)
+> - The "6-12 month refactor" estimate was overstated
+>
+> This document is archived for historical reference. The codebase has evolved
+> significantly since this analysis. See current docs for accurate architecture info.
 
 **Date**: 2025-10-30
 **Purpose**: Validate refactoring proposal against actual MFG_PDE architecture


### PR DESCRIPTION
## Summary
- Move outdated architecture analysis documents to `docs/architecture/archive/` with clear status prefixes
- Add resolution notes explaining why each doc is archived
- Prevents future viewers from being misled by stale "BLOCKED" status

## Archived Documents

1. **FDM_SOLVER_LIMITATION_ANALYSIS.md** -> `archive/RESOLVED_*`
   - Original "BLOCKED" status was incorrect
   - FDM solvers actually DO support N-dimensional problems (`hjb_fdm.py:_solve_hjb_nd`, `fp_fdm.py:solve_fp_nd_full_system`)
   - Related issue #407 closed as "not planned" (feature already exists)

2. **MFG_PDE_ARCHITECTURE_AUDIT.md** -> `archive/SUPERSEDED_*`
   - Contains outdated analysis based on incomplete codebase understanding
   - "6-12 month refactor" estimate was overstated

## Rationale
Stale documentation with outdated status markers (like "BLOCKED") can mislead future reviewers into thinking issues are still open when they've been resolved. This cleanup addresses the documentation debt by archiving outdated docs with clear resolution notes.

## Test plan
- [x] Docs moved to archive with correct prefixes
- [x] Resolution notes added to top of each archived doc
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)