### PR TITLE
feat: Add Pydantic-OmegaConf bridge utilities

### DIFF
--- a/mfg_pde/config/__init__.py
+++ b/mfg_pde/config/__init__.py
@@ -65,6 +65,12 @@ from .mfg_methods import (
 # =============================================================================
 
 try:
+    # Bridge utilities for Pydantic-OmegaConf interoperability
+    from .bridge import (  # noqa: F401
+        bridge_to_pydantic,
+        load_effective_config,
+        save_effective_config,
+    )
     from .omegaconf_manager import (  # noqa: F401
         OmegaConfManager,
         create_omega_manager,
@@ -122,5 +128,9 @@ if OMEGACONF_AVAILABLE:
             "create_parameter_sweep_configs",
             "load_beach_config",
             "load_experiment_config",
+            # Bridge utilities
+            "bridge_to_pydantic",
+            "save_effective_config",
+            "load_effective_config",
         ]
     )

--- a/mfg_pde/config/bridge.py
+++ b/mfg_pde/config/bridge.py
@@ -1,0 +1,187 @@
+"""
+Bridge utilities for Pydantic-OmegaConf interoperability.
+
+This module provides generic adapters between OmegaConf DictConfigs and Pydantic
+models, enabling seamless conversion between the two configuration systems.
+
+Architecture Overview:
+- **Pydantic** (`*Config`): Runtime validation, API safety, type strictness
+- **OmegaConf** (`*Schema`): YAML management, CLI overrides, parameter sweeps
+
+The bridge functions allow:
+1. Converting OmegaConf configs to validated Pydantic models
+2. Saving effective (resolved) configs for reproducibility
+
+See `docs/development/PYDANTIC_OMEGACONF_COOPERATION.md` for the full guide.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+def bridge_to_pydantic[T: BaseModel](
+    omega_cfg: DictConfig,
+    pydantic_cls: type[T],
+    *,
+    strict: bool = True,
+) -> T:
+    """
+    Convert an OmegaConf DictConfig to a validated Pydantic model.
+
+    This generic adapter handles the common pattern of loading experiment
+    configuration from YAML (via OmegaConf) and validating it with Pydantic.
+
+    Parameters
+    ----------
+    omega_cfg : DictConfig
+        OmegaConf configuration, typically loaded from YAML.
+    pydantic_cls : type[T]
+        Target Pydantic model class.
+    strict : bool, optional
+        If True, use strict validation (no type coercion). Default True.
+
+    Returns
+    -------
+    T
+        Validated Pydantic model instance.
+
+    Raises
+    ------
+    ValidationError
+        If the config fails Pydantic validation.
+
+    Examples
+    --------
+    >>> from omegaconf import OmegaConf
+    >>> from mfg_pde.config import MFGSolverConfig
+    >>> from mfg_pde.config.bridge import bridge_to_pydantic
+    >>>
+    >>> # Load from YAML
+    >>> omega_cfg = OmegaConf.load("experiment.yaml")
+    >>>
+    >>> # Convert to validated Pydantic model
+    >>> config = bridge_to_pydantic(omega_cfg, MFGSolverConfig)
+    >>> print(config.tolerance)  # Type-safe access
+    """
+    from omegaconf import OmegaConf
+
+    # Resolve interpolations and missing values
+    OmegaConf.resolve(omega_cfg)
+
+    # Convert to plain Python dict
+    container: dict[str, Any] = OmegaConf.to_container(omega_cfg, resolve=True)  # type: ignore[assignment]
+
+    # Validate with Pydantic
+    if strict:
+        return pydantic_cls.model_validate(container, strict=True)
+    return pydantic_cls.model_validate(container)
+
+
+def save_effective_config(
+    config: BaseModel,
+    output_dir: str | Path,
+    *,
+    filename: str = "resolved_config.json",
+    include_defaults: bool = True,
+) -> Path:
+    """
+    Save the effective (resolved) Pydantic config to a JSON file.
+
+    This function saves the complete configuration with all defaults filled in,
+    enabling full reproducibility of experiment runs.
+
+    Parameters
+    ----------
+    config : BaseModel
+        Pydantic configuration model (e.g., MFGSolverConfig).
+    output_dir : str | Path
+        Directory to save the config file.
+    filename : str, optional
+        Output filename. Default "resolved_config.json".
+    include_defaults : bool, optional
+        If True, include fields with default values. Default True.
+
+    Returns
+    -------
+    Path
+        Path to the saved config file.
+
+    Examples
+    --------
+    >>> from mfg_pde.config import MFGSolverConfig
+    >>> from mfg_pde.config.bridge import save_effective_config
+    >>>
+    >>> config = MFGSolverConfig(tolerance=1e-8, max_iterations=200)
+    >>> path = save_effective_config(config, "results/experiment_001")
+    >>> print(f"Config saved to {path}")
+
+    Notes
+    -----
+    The output JSON includes all fields, including those with default values,
+    ensuring the exact configuration can be reconstructed later.
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    config_path = output_path / filename
+
+    # Export to JSON-serializable dict
+    if include_defaults:
+        config_dict = config.model_dump(mode="json")
+    else:
+        config_dict = config.model_dump(mode="json", exclude_defaults=True)
+
+    with open(config_path, "w") as f:
+        json.dump(config_dict, f, indent=2)
+
+    return config_path
+
+
+def load_effective_config[T: BaseModel](
+    config_path: str | Path,
+    pydantic_cls: type[T],
+) -> T:
+    """
+    Load a previously saved effective config from JSON.
+
+    Parameters
+    ----------
+    config_path : str | Path
+        Path to the JSON config file.
+    pydantic_cls : type[T]
+        Target Pydantic model class.
+
+    Returns
+    -------
+    T
+        Validated Pydantic model instance.
+
+    Examples
+    --------
+    >>> from mfg_pde.config import MFGSolverConfig
+    >>> from mfg_pde.config.bridge import load_effective_config
+    >>>
+    >>> config = load_effective_config(
+    ...     "results/experiment_001/resolved_config.json",
+    ...     MFGSolverConfig
+    ... )
+    """
+    with open(config_path) as f:
+        config_dict = json.load(f)
+
+    return pydantic_cls.model_validate(config_dict)
+
+
+__all__ = [
+    "bridge_to_pydantic",
+    "save_effective_config",
+    "load_effective_config",
+]

--- a/tests/unit/test_config/test_bridge.py
+++ b/tests/unit/test_config/test_bridge.py
@@ -1,0 +1,219 @@
+"""Tests for config bridge utilities."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mfg_pde.config import MFGSolverConfig
+
+# Skip all tests if OmegaConf is not available
+pytest.importorskip("omegaconf")
+
+
+class TestBridgeToPydantic:
+    """Tests for bridge_to_pydantic function."""
+
+    def test_simple_conversion(self) -> None:
+        """Test basic OmegaConf to Pydantic conversion."""
+        from omegaconf import OmegaConf
+
+        from mfg_pde.config.bridge import bridge_to_pydantic
+
+        # Create OmegaConf config with nested structure
+        omega_cfg = OmegaConf.create(
+            {
+                "picard": {
+                    "tolerance": 1e-8,
+                    "max_iterations": 200,
+                },
+            }
+        )
+
+        # Convert to Pydantic
+        config = bridge_to_pydantic(omega_cfg, MFGSolverConfig)
+
+        assert config.picard.tolerance == 1e-8
+        assert config.picard.max_iterations == 200
+
+    def test_nested_config(self) -> None:
+        """Test conversion with nested configurations."""
+        from omegaconf import OmegaConf
+
+        from mfg_pde.config.bridge import bridge_to_pydantic
+
+        omega_cfg = OmegaConf.create(
+            {
+                "picard": {
+                    "tolerance": 1e-6,
+                },
+                "hjb": {
+                    "method": "gfdm",
+                },
+                "fp": {
+                    "method": "particle",
+                },
+            }
+        )
+
+        config = bridge_to_pydantic(omega_cfg, MFGSolverConfig)
+
+        assert config.picard.tolerance == 1e-6
+        assert config.hjb.method == "gfdm"
+        assert config.fp.method == "particle"
+
+    def test_interpolation_resolution(self) -> None:
+        """Test that OmegaConf interpolations are resolved."""
+        from omegaconf import OmegaConf
+
+        from mfg_pde.config.bridge import bridge_to_pydantic
+
+        omega_cfg = OmegaConf.create(
+            {
+                "base_tol": 1e-6,
+                "picard": {
+                    "tolerance": "${base_tol}",  # Interpolation
+                    "max_iterations": 100,
+                },
+            }
+        )
+
+        config = bridge_to_pydantic(omega_cfg, MFGSolverConfig)
+
+        assert config.picard.tolerance == 1e-6
+
+    def test_validation_error(self) -> None:
+        """Test that Pydantic validation errors are raised."""
+        from omegaconf import OmegaConf
+        from pydantic import ValidationError
+
+        from mfg_pde.config.bridge import bridge_to_pydantic
+
+        omega_cfg = OmegaConf.create(
+            {
+                "picard": {
+                    "tolerance": "not_a_number",  # Invalid type
+                },
+            }
+        )
+
+        with pytest.raises(ValidationError):
+            bridge_to_pydantic(omega_cfg, MFGSolverConfig)
+
+
+class TestSaveEffectiveConfig:
+    """Tests for save_effective_config function."""
+
+    def test_save_config(self) -> None:
+        """Test saving config to JSON file."""
+        from mfg_pde.config.bridge import save_effective_config
+
+        config = MFGSolverConfig()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_effective_config(config, tmpdir)
+
+            assert path.exists()
+            assert path.name == "resolved_config.json"
+
+            with open(path) as f:
+                saved = json.load(f)
+
+            # Check nested structure
+            assert "picard" in saved
+            assert saved["picard"]["tolerance"] == 1e-6
+
+    def test_save_creates_directory(self) -> None:
+        """Test that output directory is created if it doesn't exist."""
+        from mfg_pde.config.bridge import save_effective_config
+
+        config = MFGSolverConfig()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nested_path = Path(tmpdir) / "nested" / "output"
+            path = save_effective_config(config, nested_path)
+
+            assert path.exists()
+            assert nested_path.exists()
+
+    def test_custom_filename(self) -> None:
+        """Test saving with custom filename."""
+        from mfg_pde.config.bridge import save_effective_config
+
+        config = MFGSolverConfig()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_effective_config(config, tmpdir, filename="custom.json")
+
+            assert path.name == "custom.json"
+
+    def test_include_defaults(self) -> None:
+        """Test that defaults are included by default."""
+        from mfg_pde.config.bridge import save_effective_config
+
+        config = MFGSolverConfig()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_effective_config(config, tmpdir)
+
+            with open(path) as f:
+                saved = json.load(f)
+
+            # All sections should be present with defaults
+            assert "hjb" in saved
+            assert "fp" in saved
+            assert "picard" in saved
+            assert "backend" in saved
+
+
+class TestLoadEffectiveConfig:
+    """Tests for load_effective_config function."""
+
+    def test_load_config(self) -> None:
+        """Test loading config from JSON file."""
+        from mfg_pde.config.bridge import load_effective_config, save_effective_config
+
+        original = MFGSolverConfig()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_effective_config(original, tmpdir)
+            loaded = load_effective_config(path, MFGSolverConfig)
+
+            assert loaded.picard.tolerance == original.picard.tolerance
+            assert loaded.picard.max_iterations == original.picard.max_iterations
+
+    def test_roundtrip(self) -> None:
+        """Test full save/load roundtrip preserves all values."""
+        from mfg_pde.config.bridge import load_effective_config, save_effective_config
+
+        original = MFGSolverConfig()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_effective_config(original, tmpdir)
+            loaded = load_effective_config(path, MFGSolverConfig)
+
+            assert loaded == original
+
+    def test_roundtrip_with_custom_values(self) -> None:
+        """Test roundtrip with custom config values."""
+        from mfg_pde.config import PicardConfig
+        from mfg_pde.config.bridge import load_effective_config, save_effective_config
+
+        original = MFGSolverConfig(
+            picard=PicardConfig(
+                tolerance=1e-10,
+                max_iterations=500,
+                damping_factor=0.8,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_effective_config(original, tmpdir)
+            loaded = load_effective_config(path, MFGSolverConfig)
+
+            assert loaded.picard.tolerance == 1e-10
+            assert loaded.picard.max_iterations == 500
+            assert loaded.picard.damping_factor == 0.8


### PR DESCRIPTION
## Summary

Implements Phase 2.2 of #429 (OmegaConf integration):

- `bridge_to_pydantic()` - Generic converter from OmegaConf DictConfig to validated Pydantic models with interpolation resolution
- `save_effective_config()` - Save resolved Pydantic config to JSON for experiment reproducibility  
- `load_effective_config()` - Load previously saved config from JSON

These utilities enable seamless interoperability between OmegaConf (YAML management, CLI overrides) and Pydantic (runtime validation, type safety) configuration systems.

Uses Python 3.12+ type parameter syntax (PEP 695) for generic functions.

## Test plan

- [x] All 11 bridge utility tests pass locally
- [ ] CI passes

Fixes part of #429