### PR TITLE
refactor: NetworkGeometry inherits from GraphGeometry

### DIFF
--- a/mfg_pde/geometry/graph/__init__.py
+++ b/mfg_pde/geometry/graph/__init__.py
@@ -20,15 +20,18 @@ from .network_backend import (
     set_preferred_backend,
 )
 from .network_geometry import (
-    BaseNetworkGeometry,
     GridNetwork,
     NetworkData,
+    NetworkGeometry,
     NetworkType,
     RandomNetwork,
     ScaleFreeNetwork,
     compute_network_statistics,
     create_network,
 )
+
+# Backward compatibility alias
+BaseNetworkGeometry = NetworkGeometry
 
 # Add maze_ prefixes for clarity
 maze_Geometry = MazeGeometry
@@ -45,7 +48,8 @@ __all__ = [
     # Network geometry
     "NetworkType",
     "NetworkData",
-    "BaseNetworkGeometry",
+    "NetworkGeometry",
+    "BaseNetworkGeometry",  # Backward compatibility alias
     "GridNetwork",
     "RandomNetwork",
     "ScaleFreeNetwork",


### PR DESCRIPTION
## Summary
- Fix geometry hierarchy so `NetworkGeometry` properly inherits from `GraphGeometry` instead of being a standalone ABC
- Rename `BaseNetworkGeometry` to `NetworkGeometry` for cleaner naming
- Add `get_adjacency_matrix()` abstract method to `NetworkGeometry`
- Add `get_sparse_laplacian()` for efficient sparse matrix access
- Update `get_laplacian_operator()` to return callable (GraphGeometry compatibility)
- Add `get_node_positions()` method
- Update all subclasses (`GridNetwork`, `RandomNetwork`, `ScaleFreeNetwork`)
- Add `BaseNetworkGeometry` backward compatibility alias

This ensures network geometries participate in the type hierarchy:
`Geometry -> GraphGeometry -> NetworkGeometry`

## Test plan
- [x] All 50 network solver tests pass (HJB + FP)
- [x] All 37 network integration tests pass
- [x] Inheritance verification passes
- [x] Backward compatibility alias works
- [ ] CI passes

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)