### PR TITLE
feat: Geometry-first unification - Phase 3 (attribute hiding)

### DIFF
--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -1062,12 +1062,18 @@ class MFGProblem:
         finally:
             del frame
 
-        # After initialization, block writes to deprecated attributes
+        # After initialization, warn about writes to deprecated attributes
+        # Note: We emit a warning instead of raising to maintain backward compatibility
+        # during the transition period. This will become an error in v1.0.0.
         if name in self._DEPRECATED_ATTRIBUTES:
-            raise AttributeError(
-                f"Cannot set '{name}': this attribute is deprecated and read-only.\n"
+            import warnings
+
+            warnings.warn(
+                f"Setting '{name}' directly is deprecated and will become read-only in v1.0.0.\n"
                 f"Use 'problem.geometry' for spatial configuration instead.\n"
-                f"See docs/development/MFGProblem_Conditional_Attributes_Report.md for migration guidance."
+                f"See docs/development/MFGProblem_Conditional_Attributes_Report.md for migration guidance.",
+                DeprecationWarning,
+                stacklevel=2,
             )
 
         # Allow all other attributes


### PR DESCRIPTION
## Summary
Implement Phase 3 of Issue #435: Hide deprecated attributes from autocomplete and warn on writes.

## Changes
1. **`__dir__()` override**: Hides deprecated attributes (`xmin`, `xmax`, `Nx`, `dx`, `Lx`, `xSpace`, `_grid`) from IDE autocomplete and tab completion
2. **`__setattr__()` override**: Emits `DeprecationWarning` when setting deprecated attributes after initialization
3. **`_initializing` flag**: Allows setting during `__init__` only (supports subclasses)

## Behavior
The deprecated attributes still exist and can be read/written for backward compatibility, but:
- They won't appear in autocomplete suggestions (guides users to modern API)
- Writes after initialization emit `DeprecationWarning` with migration guidance
- This will become an error (AttributeError) in v1.0.0

## Test plan
- [x] `dir(problem)` excludes deprecated attributes
- [x] `hasattr(problem, 'xmin')` still returns True
- [x] Reading `problem.xmin` works normally
- [x] Setting `problem.xmin = value` after init emits DeprecationWarning
- [x] Subclasses can set deprecated attrs in their `__init__`
- [x] All 1217+ tests pass
- [x] CI passes

Fixes Phase 3 of #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)