### PR TITLE
feat: Geometry-first unification - Phase 5 (pickle support)

### DIFF
--- a/mfg_pde/geometry/graph/network_geometry.py
+++ b/mfg_pde/geometry/graph/network_geometry.py
@@ -272,6 +272,33 @@ class NetworkGeometry(GraphGeometry):
         self.backend_manager = get_backend_manager(backend_preference)
 
     # =========================================================================
+    # Pickle Support (Phase 5 of Issue #435)
+    # =========================================================================
+
+    def __getstate__(self) -> dict[str, Any]:
+        """
+        Get state for pickling.
+
+        Excludes backend_manager which contains module references that
+        cannot be pickled. It will be recreated on unpickling.
+        """
+        state = self.__dict__.copy()
+        # Remove unpickleable backend manager
+        state.pop("backend_manager", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """
+        Restore state from pickle.
+
+        Recreates backend_manager from backend_preference.
+        """
+        self.__dict__.update(state)
+        # Recreate backend manager
+        backend_pref = getattr(self, "backend_preference", NetworkBackendType.IGRAPH)
+        self.backend_manager = get_backend_manager(backend_pref)
+
+    # =========================================================================
     # GraphGeometry abstract method implementations
     # =========================================================================
 


### PR DESCRIPTION
## Summary
Implement Phase 5 of Issue #435: Add pickle serialization support for NetworkGeometry.

## Problem
NetworkGeometry contained `backend_manager` which holds module references that cannot be pickled:
```
TypeError: cannot pickle 'module' object
```

## Solution
Add `__getstate__()` and `__setstate__()` to NetworkGeometry:
- `__getstate__`: Exclude `backend_manager` from pickle state
- `__setstate__`: Recreate `backend_manager` from `backend_preference` on unpickle

## Test plan
- [x] Network problems can be pickled and unpickled
- [x] Restored problems have correct attributes (T, Nt, geometry type, num_nodes)
- [x] All 145 network-related tests pass
- [x] All 7 serialization-related tests pass
- [ ] CI passes

## Example
```python
import pickle
import networkx as nx
from mfg_pde import MFGProblem

G = nx.grid_2d_graph(5, 5)
problem = MFGProblem(network=G, T=1.0, Nt=10)

# Now works!
data = pickle.dumps(problem)
restored = pickle.loads(data)
```

Fixes Phase 5 of #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)