### PR TITLE
refactor: Geometry-first unification - Phase 6 (type hints)

### DIFF
--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
+    from mfg_pde.geometry.protocol import GeometryProtocol
+
 # Define a limit for values before squaring to prevent overflow within H
 VALUE_BEFORE_SQUARE_LIMIT = 1e150
 
@@ -78,6 +80,12 @@ class MFGProblem:
     - Custom usage: Accepts MFGComponents for full mathematical control
     """
 
+    # Type annotations for geometry attributes (Phase 6 of Issue #435)
+    # These are always non-None after __init__ completes
+    geometry: GeometryProtocol
+    hjb_geometry: GeometryProtocol | None
+    fp_geometry: GeometryProtocol | None
+
     @staticmethod
     def _normalize_to_array(
         value: int | float | list[int] | list[float] | None,
@@ -134,11 +142,11 @@ class MFGProblem:
         spatial_bounds: list[tuple[float, float]] | None = None,
         spatial_discretization: list[int] | None = None,
         # Complex geometry parameters (NEW)
-        geometry: Any | None = None,  # BaseGeometry
+        geometry: GeometryProtocol | None = None,
         obstacles: list | None = None,
         # Dual geometry parameters (Issue #257)
-        hjb_geometry: Any | None = None,  # Geometry for HJB solver
-        fp_geometry: Any | None = None,  # Geometry for FP solver
+        hjb_geometry: GeometryProtocol | None = None,
+        fp_geometry: GeometryProtocol | None = None,
         # Network parameters (NEW)
         network: Any | None = None,  # NetworkGraph
         # Time domain parameters
@@ -656,7 +664,7 @@ class MFGProblem:
         self,
         Nx: list[int] | None,
         spatial_bounds: list[tuple[float, float]] | None,
-        geometry: Any | None,
+        geometry: GeometryProtocol | None,
         network: Any | None,
     ) -> str:
         """
@@ -707,7 +715,7 @@ class MFGProblem:
 
     def _init_geometry(
         self,
-        geometry: Any,
+        geometry: GeometryProtocol,
         obstacles: list | None,
         T: float,
         Nt: int,


### PR DESCRIPTION
## Summary
Phase 6 of Issue #435: Add proper GeometryProtocol type hints to MFGProblem.

## Changes
- Import `GeometryProtocol` in TYPE_CHECKING block
- Add class-level type annotations:
  - `geometry: GeometryProtocol` (non-optional - always set after init)
  - `hjb_geometry: GeometryProtocol | None`
  - `fp_geometry: GeometryProtocol | None`
- Update `__init__` parameter types from `Any` to `GeometryProtocol`
- Update `_init_geometry` and `_detect_init_mode` signatures

## Rationale
With Phases 1-5 ensuring `geometry` is always set after `__init__`, we can now properly type it as non-optional. This improves:
- IDE autocomplete and type inference
- Static type checking with mypy
- Documentation clarity

## Test plan
- [x] All 33 MFGProblem tests pass
- [x] mypy reports no errors in mfg_problem.py
- [ ] CI passes

Fixes Phase 6 of #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)