### PR TITLE
feat: Add AdaptiveGeometry protocol for AMR capability

### DIFF
--- a/mfg_pde/geometry/__init__.py
+++ b/mfg_pde/geometry/__init__.py
@@ -153,6 +153,8 @@ from .operators.projection import ProjectionRegistry
 
 # Unified geometry protocol
 from .protocol import (
+    # Adaptive geometry protocol (AMR capability marker)
+    AdaptiveGeometry,
     # Boundary-aware protocol (for unified BC handling)
     BoundaryAwareProtocol,
     BoundaryType,
@@ -160,6 +162,7 @@ from .protocol import (
     GeometryProtocol,
     GeometryType,
     detect_geometry_type,
+    is_adaptive,
     is_boundary_aware,
     is_geometry_compatible,
     validate_boundary_aware,
@@ -201,9 +204,12 @@ __all__ = [
     # Unified geometry protocol
     "GeometryProtocol",
     "GeometryType",
+    # Adaptive geometry protocol (AMR capability)
+    "AdaptiveGeometry",
     # Boundary-aware protocol
     "BoundaryAwareProtocol",
     "BoundaryType",
+    "is_adaptive",
     "is_boundary_aware",
     "validate_boundary_aware",
     # Geometry projection (Issue #257)


### PR DESCRIPTION
## Summary
- Add `AdaptiveGeometry` Protocol for runtime mesh adaptation (AMR) capability
- Add `is_adaptive()` helper function for runtime checking
- Export from `geometry/__init__.py`
- Add comprehensive tests

## Implementation Details

### AdaptiveGeometry Protocol
```python
@runtime_checkable
class AdaptiveGeometry(Protocol):
    def refine(self, criteria: object) -> int: ...
    def coarsen(self, criteria: object) -> int: ...
    def adapt(self, solution_data: dict[str, object]) -> dict[str, int]: ...
    @property
    def max_refinement_level(self) -> int: ...
    @property
    def num_leaf_cells(self) -> int: ...
```

### Design Rationale
- **Protocol not ABC**: Orthogonal capability marker that can be composed with any geometry base class
- **Future extensibility**: Enables AdaptivePointCloud, AdaptiveNetwork without modifying base hierarchy
- **Duck typing**: `@runtime_checkable` allows isinstance() checks

## Test Plan
- [x] Regular TensorProductGrid is not adaptive
- [x] Mock adaptive geometry satisfies protocol
- [x] Incomplete implementations rejected
- [x] Protocol is orthogonal to base Geometry ABC

Fixes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)