### PR TITLE
feat: OneDimensionalAMRMesh implements AdaptiveGeometry protocol

### DIFF
--- a/tests/unit/test_geometry/test_consolidated_base.py
+++ b/tests/unit/test_geometry/test_consolidated_base.py
@@ -9,7 +9,7 @@ import pytest
 
 import numpy as np
 
-from mfg_pde.geometry import TensorProductGrid
+from mfg_pde.geometry import OneDimensionalAMRMesh, TensorProductGrid
 from mfg_pde.geometry.base import CartesianGrid, Geometry
 from mfg_pde.geometry.protocol import AdaptiveGeometry, is_adaptive
 
@@ -460,6 +460,80 @@ class TestAdaptiveGeometryProtocol:
         assert isinstance(mock, CartesianGrid)
         assert isinstance(mock, AdaptiveGeometry)
         assert is_adaptive(mock)
+
+
+class TestOneDimensionalAMRMesh:
+    """Test OneDimensionalAMRMesh protocol compliance (Issue #460)."""
+
+    def test_amr_1d_is_adaptive(self):
+        """OneDimensionalAMRMesh implements AdaptiveGeometry."""
+        domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
+        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+
+        assert isinstance(amr, AdaptiveGeometry)
+        assert is_adaptive(amr)
+
+    def test_amr_1d_geometry_properties(self):
+        """OneDimensionalAMRMesh has required geometry properties."""
+        domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
+        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+
+        # Geometry properties
+        assert amr.dimension == 1
+        assert amr.num_spatial_points == 10
+        assert amr.num_leaf_cells == 10
+        assert amr.max_refinement_level == 0
+
+        # Grid-like properties
+        spacing = amr.get_grid_spacing()
+        assert len(spacing) == 1
+        assert np.isclose(spacing[0], 0.1, rtol=0.01)
+
+        shape = amr.get_grid_shape()
+        assert shape == (10,)
+
+    def test_amr_1d_refinement(self):
+        """OneDimensionalAMRMesh refinement works via AdaptiveGeometry protocol."""
+        domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
+        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+
+        initial_cells = amr.num_leaf_cells
+
+        # Refine using protocol method
+        refined = amr.refine({"interval_ids": [0]})
+        assert refined == 1
+        assert amr.num_leaf_cells == initial_cells + 1
+        assert amr.max_refinement_level == 1
+
+        # Test adapt (no-op without error estimator)
+        result = amr.adapt({})
+        assert result["total_cells"] == amr.num_leaf_cells
+
+    def test_amr_1d_operators(self):
+        """OneDimensionalAMRMesh provides working operators."""
+        domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
+        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+
+        # Get operators
+        laplacian = amr.get_laplacian_operator()
+        gradient = amr.get_gradient_operator()
+        interpolator = amr.get_interpolator()
+
+        # Test on simple function
+        u = np.sin(np.linspace(0, np.pi, amr.num_leaf_cells))
+
+        # Laplacian at interior point
+        lap_val = laplacian(u, 5)
+        assert isinstance(lap_val, float)
+
+        # Gradient at interior point
+        grad_val = gradient(u, 5)
+        assert grad_val.shape == (1,)
+
+        # Interpolation
+        interp_val = interpolator(u, np.array([0.5]))
+        assert isinstance(interp_val, float)
+        assert 0 < interp_val <= 1  # Should be somewhere on the sin curve
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- OneDimensionalAMRMesh now implements AdaptiveGeometry protocol and all CartesianGrid-compatible methods
- Uses duck typing (no ABC inheritance) to avoid circular imports
- Adds finite difference operators for non-uniform adaptive meshes

Closes #460

## Changes

**AdaptiveGeometry protocol methods:**
- `refine(criteria)` - Refine intervals meeting criteria (by ID or error estimator)
- `coarsen(criteria)` - Placeholder (returns 0, not implemented)
- `adapt(solution_data)` - Full adaptation cycle
- `max_refinement_level` property
- `num_leaf_cells` property

**CartesianGrid-compatible methods (duck typing):**
- `get_grid_spacing()` - Returns minimum cell width
- `get_grid_shape()` - Returns (num_leaf_cells,)

**Geometry ABC methods:**
- `dimension`, `geometry_type`, `num_spatial_points`
- `get_spatial_grid()`, `get_bounds()`, `get_problem_config()`

**Solver operators:**
- `get_laplacian_operator()` - Non-uniform FD stencil
- `get_gradient_operator()` - Non-uniform central differences
- `get_interpolator()` - Linear interpolation
- `get_boundary_handler()` - Boundary condition handler

## Test plan
- [x] `TestOneDimensionalAMRMesh::test_amr_1d_is_adaptive` - Protocol compliance
- [x] `TestOneDimensionalAMRMesh::test_amr_1d_geometry_properties` - Properties correct
- [x] `TestOneDimensionalAMRMesh::test_amr_1d_refinement` - Refinement works
- [x] `TestOneDimensionalAMRMesh::test_amr_1d_operators` - Operators work

🤖 Generated with [Claude Code](https://claude.com/claude-code)