### PR TITLE
refactor: Rename OneDimensionalAMRMesh to OneDimensionalAMRGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Renamed** `OneDimensionalAMRMesh` → `OneDimensionalAMRGrid` (Issue #466)
+  - The class is a structured grid, not an unstructured mesh
+  - Backward compatibility alias `OneDimensionalAMRMesh` remains (deprecated)
+- **Renamed** `create_1d_amr_mesh()` → `create_1d_amr_grid()`
+  - Backward compatibility alias remains (deprecated)
+
+### Deprecated
+
+- `OneDimensionalAMRMesh` - use `OneDimensionalAMRGrid` instead
+- `create_1d_amr_mesh()` - use `create_1d_amr_grid()` instead
+
 ## [0.16.2] - 2025-12-12
 
 **Patch Release: Grid Interpolator Batched Points Fix**

--- a/docs/development/GEOMETRY_DOMAIN_BC_ARCHITECTURE.md
+++ b/docs/development/GEOMETRY_DOMAIN_BC_ARCHITECTURE.md
@@ -74,7 +74,7 @@ This document describes the relationship between geometry, domain, and boundary 
 | Network | `BaseNetworkGeometry`, `GridNetwork` | `graph/network_geometry.py` | Graph MFG, traffic networks |
 | Maze Generation | `MazeGenerator`, `HybridMazeGenerator` | `graph/maze_*.py` | Maze-based MFG problems |
 | Unstructured Mesh | `Mesh1D`, `Mesh2D`, `Mesh3D` | `meshes/mesh_{1d,2d,3d}.py` | FEM, complex geometries |
-| AMR | `OneDimensionalAMRMesh`, `TriangularAMRMesh` | `amr/` | Adaptive refinement |
+| AMR | `OneDimensionalAMRGrid`, `TriangularAMRMesh` | `amr/` | Adaptive refinement |
 
 ### 2.2 GeometryProtocol (`protocol.py`)
 

--- a/docs/theory/numerical_methods/amr_for_mfg.md
+++ b/docs/theory/numerical_methods/amr_for_mfg.md
@@ -611,7 +611,7 @@ class AMREnhancedSolver:
 
 #### Dimensional AMR Classes
 
-**1D AMR**: `OneDimensionalAMRMesh` - Interval-based hierarchical refinement
+**1D AMR**: `OneDimensionalAMRGrid` - Interval-based hierarchical refinement
 **2D Structured AMR**: `AdaptiveMesh` - Quadtree-based refinement
 **2D Triangular AMR**: `TriangularAMRMesh` - Uses MeshData infrastructure (future)
 
@@ -990,9 +990,9 @@ def create_amr_enhanced_solver(
 
 ### Dimensional AMR Classes
 
-#### 1D AMR: `OneDimensionalAMRMesh`
+#### 1D AMR: `OneDimensionalAMRGrid`
 ```python
-class OneDimensionalAMRMesh:
+class OneDimensionalAMRGrid:
     """1D adaptive mesh using interval-based hierarchical refinement."""
 
     def __init__(self, domain_1d: Domain1D, initial_num_intervals: int = 10,
@@ -1128,7 +1128,7 @@ def create_amr_mesh(
     error_threshold: float = 1e-4,
     max_levels: int = 5,
     **kwargs
-) -> Union[OneDimensionalAMRMesh, AdaptiveMesh]:
+) -> Union[OneDimensionalAMRGrid, AdaptiveMesh]:
     """Create an adaptive mesh with specified parameters."""
 ```
 

--- a/examples/advanced/geometry_advanced/amr_1d_geometry_demo.py
+++ b/examples/advanced/geometry_advanced/amr_1d_geometry_demo.py
@@ -29,7 +29,7 @@ import numpy as np
 from mfg_pde import MFGProblem
 from mfg_pde.factory import create_fast_solver
 from mfg_pde.geometry import TensorProductGrid
-from mfg_pde.geometry.amr.amr_1d import AMRRefinementCriteria, OneDimensionalAMRMesh
+from mfg_pde.geometry.amr.amr_1d import AMRRefinementCriteria, OneDimensionalAMRGrid
 from mfg_pde.utils.mfg_logging import configure_research_logging, get_logger
 
 # Configure logging
@@ -139,7 +139,7 @@ def solve_mfg_with_amr(
 
     # Create AMR mesh
     logger.info(f"Creating 1D AMR mesh (initial intervals: {initial_num_intervals})")
-    amr_mesh = OneDimensionalAMRMesh(
+    amr_mesh = OneDimensionalAMRGrid(
         domain_1d=domain, initial_num_intervals=initial_num_intervals, refinement_criteria=refinement_criteria
     )
 

--- a/examples/basic/geometry/amr_geometry_protocol_demo.py
+++ b/examples/basic/geometry/amr_geometry_protocol_demo.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from mfg_pde.geometry import TensorProductGrid
-from mfg_pde.geometry.amr.amr_1d import AMRRefinementCriteria, OneDimensionalAMRMesh
+from mfg_pde.geometry.amr.amr_1d import AMRRefinementCriteria, OneDimensionalAMRGrid
 from mfg_pde.geometry.amr.amr_quadtree_2d import AdaptiveMesh
 from mfg_pde.geometry.protocol import (
     is_geometry_compatible,
@@ -49,7 +49,7 @@ def demonstrate_protocol_compliance():
     refinement_criteria = AMRRefinementCriteria(
         max_refinement_levels=2, gradient_threshold=0.5, coarsening_threshold=0.25, min_cell_size=0.001
     )
-    amr_1d = OneDimensionalAMRMesh(
+    amr_1d = OneDimensionalAMRGrid(
         domain_1d=base_domain, initial_num_intervals=20, refinement_criteria=refinement_criteria
     )
     geometries.append(("1D AMR Mesh", amr_1d))
@@ -106,7 +106,7 @@ def demonstrate_polymorphic_config():
 
     base_domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], num_points=[21])
     refinement_criteria = AMRRefinementCriteria(max_refinement_levels=2)
-    amr_1d = OneDimensionalAMRMesh(
+    amr_1d = OneDimensionalAMRGrid(
         domain_1d=base_domain, initial_num_intervals=20, refinement_criteria=refinement_criteria
     )
 
@@ -141,7 +141,7 @@ def visualize_amr_structure():
     refinement_criteria = AMRRefinementCriteria(
         max_refinement_levels=3, gradient_threshold=0.3, coarsening_threshold=0.15, min_cell_size=0.001
     )
-    amr_mesh = OneDimensionalAMRMesh(
+    amr_mesh = OneDimensionalAMRGrid(
         domain_1d=base_domain, initial_num_intervals=10, refinement_criteria=refinement_criteria
     )
 

--- a/mfg_pde/geometry/__init__.py
+++ b/mfg_pde/geometry/__init__.py
@@ -32,7 +32,16 @@ Note: SimpleGrid1D/2D/3D have been removed. Use TensorProductGrid instead.
 from __future__ import annotations
 
 # AMR imports (from subdirectory - canonical locations)
-from .amr.amr_1d import Interval1D, OneDimensionalAMRMesh, OneDimensionalErrorEstimator, create_1d_amr_mesh
+from .amr.amr_1d import (
+    Interval1D,
+    # New names (v0.16.6+)
+    OneDimensionalAMRGrid,
+    # Deprecated aliases (will be removed in v1.0.0)
+    OneDimensionalAMRMesh,
+    OneDimensionalErrorEstimator,
+    create_1d_amr_grid,
+    create_1d_amr_mesh,
+)
 from .amr.amr_triangular_2d import (
     TriangleElement,
     TriangularAMRMesh,
@@ -231,9 +240,12 @@ __all__ = [
     "NetworkType",
     "NeumannBC2D",
     "NeumannBC3D",
-    # AMR components (legacy names from old file structure)
-    "OneDimensionalAMRMesh",
+    # AMR components (1D)
+    "OneDimensionalAMRGrid",
+    "OneDimensionalAMRMesh",  # Deprecated alias
     "OneDimensionalErrorEstimator",
+    "create_1d_amr_grid",
+    "create_1d_amr_mesh",  # Deprecated alias
     "OperationType",
     "PeriodicBC2D",
     "PeriodicBC3D",

--- a/mfg_pde/geometry/amr/__init__.py
+++ b/mfg_pde/geometry/amr/__init__.py
@@ -9,7 +9,7 @@ Adaptive mesh refinement (AMR) for MFG problems.
     - GeometryProtocol: Compliant
     - Solver integration: NOT IMPLEMENTED
 
-    The AMR meshes can be created and refined, but HJB/FP solvers do not yet
+    The AMR grids can be created and refined, but HJB/FP solvers do not yet
     support adaptive mesh operations (interpolation between refinements,
     conservative mass transfer, time-stepping coordination).
 
@@ -19,7 +19,7 @@ This module provides AMR support for 1D, 2D, and 3D domains, enabling automatic
 grid refinement based on solution gradients and error estimation.
 
 Available classes:
-  - Interval1D, OneDimensionalAMRMesh, OneDimensionalErrorEstimator (1D)
+  - Interval1D, OneDimensionalAMRGrid, OneDimensionalErrorEstimator (1D)
   - QuadTreeNode, QuadTreeMesh, QuadTreeErrorEstimator (2D structured)
   - TriangleElement, TriangularAMRMesh, TriangularMeshErrorEstimator (2D triangular)
   - TetrahedralElement, TetrahedralAMRMesh (3D)
@@ -32,8 +32,12 @@ Available classes:
 from .amr_1d import (
     AMRRefinementCriteria,
     Interval1D,
+    # New names (v0.16.6+)
+    OneDimensionalAMRGrid,
+    # Deprecated aliases (will be removed in v1.0.0)
     OneDimensionalAMRMesh,
     OneDimensionalErrorEstimator,
+    create_1d_amr_grid,
     create_1d_amr_mesh,
 )
 from .amr_quadtree_2d import (
@@ -48,10 +52,13 @@ __all__ = [
     "AMRRefinementCriteria",
     "BaseErrorEstimator",
     "GradientErrorEstimator",
-    # 1D
+    # 1D (new names)
     "Interval1D",
-    "OneDimensionalAMRMesh",
+    "OneDimensionalAMRGrid",
     "OneDimensionalErrorEstimator",
+    "create_1d_amr_grid",
+    # 1D (deprecated aliases)
+    "OneDimensionalAMRMesh",
     "create_1d_amr_mesh",
     # 2D Quadtree
     "QuadTreeNode",

--- a/tests/unit/test_geometry/test_consolidated_base.py
+++ b/tests/unit/test_geometry/test_consolidated_base.py
@@ -9,7 +9,7 @@ import pytest
 
 import numpy as np
 
-from mfg_pde.geometry import OneDimensionalAMRMesh, TensorProductGrid
+from mfg_pde.geometry import OneDimensionalAMRGrid, TensorProductGrid
 from mfg_pde.geometry.base import CartesianGrid, Geometry
 from mfg_pde.geometry.protocol import AdaptiveGeometry, is_adaptive
 
@@ -462,21 +462,21 @@ class TestAdaptiveGeometryProtocol:
         assert is_adaptive(mock)
 
 
-class TestOneDimensionalAMRMesh:
-    """Test OneDimensionalAMRMesh protocol compliance (Issue #460)."""
+class TestOneDimensionalAMRGrid:
+    """Test OneDimensionalAMRGrid protocol compliance (Issue #460)."""
 
     def test_amr_1d_is_adaptive(self):
-        """OneDimensionalAMRMesh implements AdaptiveGeometry."""
+        """OneDimensionalAMRGrid implements AdaptiveGeometry."""
         domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
-        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+        amr = OneDimensionalAMRGrid(domain, initial_num_intervals=10)
 
         assert isinstance(amr, AdaptiveGeometry)
         assert is_adaptive(amr)
 
     def test_amr_1d_geometry_properties(self):
-        """OneDimensionalAMRMesh has required geometry properties."""
+        """OneDimensionalAMRGrid has required geometry properties."""
         domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
-        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+        amr = OneDimensionalAMRGrid(domain, initial_num_intervals=10)
 
         # Geometry properties
         assert amr.dimension == 1
@@ -493,9 +493,9 @@ class TestOneDimensionalAMRMesh:
         assert shape == (10,)
 
     def test_amr_1d_refinement(self):
-        """OneDimensionalAMRMesh refinement works via AdaptiveGeometry protocol."""
+        """OneDimensionalAMRGrid refinement works via AdaptiveGeometry protocol."""
         domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
-        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+        amr = OneDimensionalAMRGrid(domain, initial_num_intervals=10)
 
         initial_cells = amr.num_leaf_cells
 
@@ -510,9 +510,9 @@ class TestOneDimensionalAMRMesh:
         assert result["total_cells"] == amr.num_leaf_cells
 
     def test_amr_1d_operators(self):
-        """OneDimensionalAMRMesh provides working operators."""
+        """OneDimensionalAMRGrid provides working operators."""
         domain = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
-        amr = OneDimensionalAMRMesh(domain, initial_num_intervals=10)
+        amr = OneDimensionalAMRGrid(domain, initial_num_intervals=10)
 
         # Get operators
         laplacian = amr.get_laplacian_operator()


### PR DESCRIPTION
## Summary
- Rename `OneDimensionalAMRMesh` → `OneDimensionalAMRGrid`
- Rename `create_1d_amr_mesh()` → `create_1d_amr_grid()`
- Add backward compatibility aliases with deprecation warnings

Closes #466

## Rationale

The class is a **structured grid** (interval-based with FDM operators), not an **unstructured mesh** (FEM-style with element connectivity):

| Property | CartesianGrid | UnstructuredMesh |
|----------|---------------|------------------|
| Structure | Tensor product, indexed | Vertex + element connectivity |
| Spacing | Regular or hierarchical intervals | Arbitrary element sizes |
| Data access | `u[i]` array indexing | `u[vertex_id]` via mesh |
| Operators | FDM stencils | FEM assembly |

## Design Note

CartesianGrid ABC inheritance is not possible due to circular import:
```
amr_1d → base → meshes/__init__ → mesh_1d → base
```

The class uses duck typing for protocol compliance instead. This is documented in the module docstring.

## Test plan
- [x] All `TestOneDimensionalAMRGrid` tests pass
- [x] Deprecation warnings work for old aliases
- [x] Examples updated and run without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)