### PR TITLE
refactor: Move convergence module to utils/convergence (cross-paradigm)

### DIFF
--- a/mfg_pde/utils/__init__.py
+++ b/mfg_pde/utils/__init__.py
@@ -24,6 +24,36 @@ from . import mfg_logging as logging  # noqa: F401
 
 # Core utility functions (non-plotting)
 from .aux_func import npart, ppart
+from .convergence import (
+    # Backward compatibility aliases (deprecated)
+    AdaptiveConvergenceWrapper,
+    AdvancedConvergenceMonitor,
+    # NEW: Convergence checkers
+    ConvergenceChecker,
+    # New names (preferred)
+    ConvergenceConfig,
+    ConvergenceWrapper,
+    DistributionComparator,
+    DistributionConvergenceMonitor,
+    FPConvergenceChecker,
+    HJBConvergenceChecker,
+    MFGConvergenceChecker,
+    OscillationDetector,
+    ParticleMethodDetector,
+    RollingConvergenceMonitor,
+    SolverTypeDetector,
+    StochasticConvergenceMonitor,
+    adaptive_convergence,
+    calculate_error,
+    calculate_l2_convergence_metrics,
+    compute_norm,
+    create_default_monitor,
+    create_distribution_monitor,
+    create_rolling_monitor,
+    create_stochastic_monitor,
+    test_particle_detection,
+    wrap_solver_with_adaptive_convergence,
+)
 
 # Subdirectory imports
 from .data.validation import (
@@ -90,30 +120,6 @@ from .mfg_logging.logger import (
     log_solver_progress,
     log_solver_start,
     log_validation_error,
-)
-from .numerical.convergence import (
-    # Backward compatibility aliases (deprecated)
-    AdaptiveConvergenceWrapper,
-    AdvancedConvergenceMonitor,
-    # New names (preferred)
-    ConvergenceConfig,
-    ConvergenceWrapper,
-    DistributionComparator,
-    DistributionConvergenceMonitor,
-    OscillationDetector,
-    ParticleMethodDetector,
-    RollingConvergenceMonitor,
-    SolverTypeDetector,
-    StochasticConvergenceMonitor,
-    adaptive_convergence,
-    calculate_error,
-    calculate_l2_convergence_metrics,
-    create_default_monitor,
-    create_distribution_monitor,
-    create_rolling_monitor,
-    create_stochastic_monitor,
-    test_particle_detection,
-    wrap_solver_with_adaptive_convergence,
 )
 from .numerical.integration import get_integration_info, trapezoid
 from .numerical.particle.interpolation import (
@@ -308,6 +314,12 @@ __all__ = [
     "AdvancedConvergenceMonitor",
     "StochasticConvergenceMonitor",
     "create_stochastic_monitor",
+    # Convergence checkers (Protocol-based)
+    "ConvergenceChecker",
+    "HJBConvergenceChecker",
+    "FPConvergenceChecker",
+    "MFGConvergenceChecker",
+    "compute_norm",
     # Geometry utilities (obstacles, SDF)
     "BoxObstacle",
     "CircleObstacle",

--- a/mfg_pde/utils/convergence/__init__.py
+++ b/mfg_pde/utils/convergence/__init__.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Convergence monitoring utilities for all solver paradigms.
+
+This package provides convergence monitoring utilities that work across
+all MFG solver paradigms (numerical, neural, optimization, reinforcement).
+
+Modules:
+- **convergence_metrics.py**: General-purpose utilities
+  - DistributionComparator: Wasserstein, KL divergence, moments
+  - RollingConvergenceMonitor: Window-based statistical convergence
+  - calculate_error: Unified L1/L2/Linf error computation
+  - ConvergenceConfig: Configuration dataclass for solver integration
+
+- **convergence_monitors.py**: MFG-specific monitors
+  - DistributionConvergenceMonitor: Multi-criteria (Wasserstein, KL, moments)
+  - SolverTypeDetector: Detect particle vs grid-based solvers
+  - ConvergenceWrapper: Adaptive convergence based on solver type
+
+- **convergence_checkers.py**: Protocol-based convergence checking
+  - ConvergenceChecker: Protocol for all checkers
+  - HJBConvergenceChecker, FPConvergenceChecker, MFGConvergenceChecker
+
+Usage:
+    # General-purpose convergence checking
+    from mfg_pde.utils.convergence import calculate_error, RollingConvergenceMonitor
+
+    error = calculate_error(u_new, u_old, dx=0.01, norm='l2')
+    monitor = RollingConvergenceMonitor(window_size=10)
+
+    # MFG-specific monitoring
+    from mfg_pde.utils.convergence import DistributionConvergenceMonitor
+
+    monitor = DistributionConvergenceMonitor(wasserstein_tol=1e-4)
+    diagnostics = monitor.update(u_current, u_previous, m_current, x_grid)
+
+    # Solver integration
+    from mfg_pde.utils.convergence import ConvergenceConfig, MFGConvergenceChecker
+
+    config = ConvergenceConfig(tolerance=1e-6, require_both=True)
+    checker = MFGConvergenceChecker(config)
+    converged, metrics = checker.check(old_state, new_state)
+"""
+
+from __future__ import annotations
+
+import warnings
+
+# =============================================================================
+# CONVERGENCE CHECKERS (convergence_checkers.py)
+# =============================================================================
+from .convergence_checkers import (
+    ConvergenceChecker,
+    FPConvergenceChecker,
+    HJBConvergenceChecker,
+    MFGConvergenceChecker,
+    compute_norm,
+)
+
+# =============================================================================
+# GENERAL-PURPOSE IMPORTS (convergence_metrics.py)
+# =============================================================================
+from .convergence_metrics import (
+    ConvergenceConfig,
+    # Core utilities
+    DistributionComparator,
+    RollingConvergenceMonitor,
+    # Backward compatibility
+    StochasticConvergenceMonitor,
+    calculate_error,
+    calculate_l2_convergence_metrics,
+    # Factory
+    create_rolling_monitor,
+    create_stochastic_monitor,
+)
+
+# =============================================================================
+# MFG-SPECIFIC IMPORTS (convergence_monitors.py)
+# =============================================================================
+from .convergence_monitors import (
+    AdaptiveConvergenceWrapper,
+    AdvancedConvergenceMonitor,
+    ConvergenceWrapper,
+    # Core monitors
+    DistributionConvergenceMonitor,
+    # Backward compatibility
+    OscillationDetector,
+    ParticleMethodDetector,
+    SolverTypeDetector,
+    # Internal (exposed for testing)
+    _ErrorHistoryTracker,
+    adaptive_convergence,
+    create_default_monitor,
+    # Factory and decorators
+    create_distribution_monitor,
+    test_particle_detection,
+    wrap_solver_with_adaptive_convergence,
+)
+
+# =============================================================================
+# DEPRECATION HELPERS
+# =============================================================================
+
+
+def _warn_deprecated(old_name: str, new_name: str) -> None:
+    """Issue deprecation warning for renamed classes."""
+    warnings.warn(
+        f"{old_name} is deprecated and will be removed in v1.0.0. Use {new_name} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+# =============================================================================
+# PUBLIC API
+# =============================================================================
+
+__all__ = [
+    # General-purpose (convergence_metrics.py)
+    "DistributionComparator",
+    "RollingConvergenceMonitor",
+    "calculate_error",
+    "calculate_l2_convergence_metrics",
+    "ConvergenceConfig",
+    "create_rolling_monitor",
+    # MFG-specific (convergence_monitors.py)
+    "DistributionConvergenceMonitor",
+    "SolverTypeDetector",
+    "ConvergenceWrapper",
+    "_ErrorHistoryTracker",
+    "create_distribution_monitor",
+    "adaptive_convergence",
+    "wrap_solver_with_adaptive_convergence",
+    "test_particle_detection",
+    # Convergence checkers (convergence_checkers.py)
+    "ConvergenceChecker",
+    "HJBConvergenceChecker",
+    "FPConvergenceChecker",
+    "MFGConvergenceChecker",
+    "compute_norm",
+    # Backward compatibility aliases (deprecated)
+    "StochasticConvergenceMonitor",  # -> RollingConvergenceMonitor
+    "create_stochastic_monitor",  # -> create_rolling_monitor
+    "OscillationDetector",  # -> _ErrorHistoryTracker
+    "AdvancedConvergenceMonitor",  # -> DistributionConvergenceMonitor
+    "ParticleMethodDetector",  # -> SolverTypeDetector
+    "AdaptiveConvergenceWrapper",  # -> ConvergenceWrapper
+    "create_default_monitor",  # -> create_distribution_monitor
+]

--- a/mfg_pde/utils/convergence/convergence_checkers.py
+++ b/mfg_pde/utils/convergence/convergence_checkers.py
@@ -1,0 +1,370 @@
+"""
+Protocol-based convergence checkers for MFG solvers.
+
+This module provides a Strategy pattern implementation for convergence checking,
+allowing different solver types to use appropriate convergence criteria.
+
+The design decouples convergence logic from solver implementation, enabling:
+- Consistent convergence checking across all solver paradigms
+- Easy swapping of convergence strategies
+- Unified diagnostics and metrics collection
+
+Usage:
+    from mfg_pde.utils.convergence import (
+        ConvergenceConfig,
+        MFGConvergenceChecker,
+    )
+
+    config = ConvergenceConfig(tolerance=1e-6, require_both=True)
+    checker = MFGConvergenceChecker(config)
+
+    # In solver loop
+    converged, metrics = checker.check(old_state, new_state)
+    if converged:
+        break
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Protocol
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+from .convergence_metrics import ConvergenceConfig
+
+# =============================================================================
+# UTILITY FUNCTIONS
+# =============================================================================
+
+
+def compute_norm(
+    diff: NDArray[np.floating],
+    method: Literal["l1", "l2", "linf"] = "l2",
+) -> float:
+    """
+    Compute norm of difference array.
+
+    Args:
+        diff: Difference array (new - old)
+        method: Norm type ('l1', 'l2', 'linf')
+
+    Returns:
+        Scalar norm value
+    """
+    if method == "l1":
+        return float(np.sum(np.abs(diff)))
+    elif method == "linf":
+        return float(np.max(np.abs(diff)))
+    else:  # l2 default
+        return float(np.sqrt(np.sum(diff**2)))
+
+
+def _check_divergence(error: float, threshold: float = 1e10) -> tuple[bool, str]:
+    """
+    Check for divergence conditions.
+
+    Args:
+        error: Computed error value
+        threshold: Safety threshold for divergence detection
+
+    Returns:
+        Tuple of (is_diverged, status_string)
+    """
+    if np.isnan(error):
+        return True, "DIVERGED_NAN"
+    if np.isinf(error):
+        return True, "DIVERGED_INF"
+    if error > threshold:
+        return True, "DIVERGED_THRESHOLD"
+    return False, "OK"
+
+
+# =============================================================================
+# CONVERGENCE CHECKER PROTOCOL
+# =============================================================================
+
+
+class ConvergenceChecker(Protocol):
+    """
+    Protocol for convergence checkers.
+
+    All convergence checkers must implement this interface, allowing
+    solvers to work with any checker type polymorphically.
+
+    The check method receives explicit old and new states (not a single
+    combined dict) to keep solver memory management explicit and enable
+    stateless checkers.
+    """
+
+    def check(
+        self,
+        old_state: dict[str, NDArray[np.floating]],
+        new_state: dict[str, NDArray[np.floating]],
+    ) -> tuple[bool, dict[str, float]]:
+        """
+        Check convergence between old and new states.
+
+        Args:
+            old_state: Previous iteration state {'U': array, 'M': array, ...}
+            new_state: Current iteration state {'U': array, 'M': array, ...}
+
+        Returns:
+            Tuple of:
+                - bool: True if converged, False otherwise
+                - dict: Diagnostic metrics (e.g., {'error_U': 0.001, 'status': 'OK'})
+        """
+        ...
+
+
+# =============================================================================
+# HJB CONVERGENCE CHECKER
+# =============================================================================
+
+
+class HJBConvergenceChecker:
+    """
+    Convergence checker for standalone HJB (Hamilton-Jacobi-Bellman) solvers.
+
+    Checks convergence based on value function U:
+        ||U_new - U_old|| < tolerance
+
+    Args:
+        config: ConvergenceConfig with tolerance settings
+    """
+
+    def __init__(self, config: ConvergenceConfig) -> None:
+        self.config = config
+        self.tolerance = config.tolerance_U if config.tolerance_U is not None else config.tolerance
+
+    def check(
+        self,
+        old_state: dict[str, NDArray[np.floating]],
+        new_state: dict[str, NDArray[np.floating]],
+    ) -> tuple[bool, dict[str, float]]:
+        """
+        Check HJB convergence.
+
+        Args:
+            old_state: Must contain 'U' key
+            new_state: Must contain 'U' key
+
+        Returns:
+            (converged, {'error_U': float, 'status': str})
+        """
+        U_old = old_state["U"]
+        U_new = new_state["U"]
+
+        diff = U_new - U_old
+        error = compute_norm(diff, self.config.norm)
+
+        # Relative error if requested
+        if self.config.relative:
+            norm_new = compute_norm(U_new, self.config.norm)
+            if norm_new > 1e-15:  # Avoid division by zero
+                error = error / norm_new
+
+        # Check for divergence
+        is_diverged, status = _check_divergence(error)
+        if is_diverged:
+            return False, {"error_U": error, "status": status}
+
+        converged = error < self.tolerance
+        return converged, {"error_U": error, "status": "OK"}
+
+
+# =============================================================================
+# FP CONVERGENCE CHECKER
+# =============================================================================
+
+
+class FPConvergenceChecker:
+    """
+    Convergence checker for standalone FP (Fokker-Planck) solvers.
+
+    Checks convergence based on density M:
+        ||M_new - M_old|| < tolerance
+
+    Optionally tracks mass conservation error.
+
+    Args:
+        config: ConvergenceConfig with tolerance settings
+        check_mass: Whether to compute mass conservation error
+    """
+
+    def __init__(self, config: ConvergenceConfig, check_mass: bool = True) -> None:
+        self.config = config
+        self.tolerance = config.tolerance_M if config.tolerance_M is not None else config.tolerance
+        self.check_mass = check_mass
+
+    def check(
+        self,
+        old_state: dict[str, NDArray[np.floating]],
+        new_state: dict[str, NDArray[np.floating]],
+    ) -> tuple[bool, dict[str, float]]:
+        """
+        Check FP convergence.
+
+        Args:
+            old_state: Must contain 'M' key
+            new_state: Must contain 'M' key
+
+        Returns:
+            (converged, {'error_M': float, 'mass_error': float, 'status': str})
+        """
+        M_old = old_state["M"]
+        M_new = new_state["M"]
+
+        diff = M_new - M_old
+        error = compute_norm(diff, self.config.norm)
+
+        # Relative error if requested
+        if self.config.relative:
+            norm_new = compute_norm(M_new, self.config.norm)
+            if norm_new > 1e-15:
+                error = error / norm_new
+
+        # Check for divergence
+        is_diverged, status = _check_divergence(error)
+        if is_diverged:
+            metrics: dict[str, float] = {"error_M": error, "status": status}
+            if self.check_mass:
+                metrics["mass_error"] = float("nan")
+            return False, metrics
+
+        # Mass conservation check
+        metrics = {"error_M": error, "status": "OK"}
+        if self.check_mass:
+            mass_old = float(np.sum(M_old))
+            mass_new = float(np.sum(M_new))
+            metrics["mass_error"] = abs(mass_new - mass_old)
+
+        converged = error < self.tolerance
+        return converged, metrics
+
+
+# =============================================================================
+# MFG CONVERGENCE CHECKER (COUPLED SYSTEM)
+# =============================================================================
+
+
+class MFGConvergenceChecker:
+    """
+    Convergence checker for coupled MFG (Mean Field Game) solvers.
+
+    Orchestrates convergence checking for both HJB (U) and FP (M) components.
+    Supports different tolerances for each component and configurable
+    convergence criteria (both must converge vs either converges).
+
+    Args:
+        config: ConvergenceConfig with tolerance settings
+        check_mass: Whether to compute mass conservation error for FP
+
+    Example:
+        config = ConvergenceConfig(
+            tolerance_U=1e-6,
+            tolerance_M=1e-4,  # FP often harder to converge
+            require_both=True,
+        )
+        checker = MFGConvergenceChecker(config)
+
+        # In solver loop
+        old_state = {'U': U_old, 'M': M_old}
+        new_state = {'U': U_new, 'M': M_new}
+        converged, metrics = checker.check(old_state, new_state)
+    """
+
+    def __init__(self, config: ConvergenceConfig, check_mass: bool = True) -> None:
+        self.config = config
+        self.hjb_checker = HJBConvergenceChecker(config)
+        self.fp_checker = FPConvergenceChecker(config, check_mass=check_mass)
+
+    def check(
+        self,
+        old_state: dict[str, NDArray[np.floating]],
+        new_state: dict[str, NDArray[np.floating]],
+    ) -> tuple[bool, dict[str, float]]:
+        """
+        Check coupled MFG convergence.
+
+        Args:
+            old_state: Must contain 'U' and 'M' keys
+            new_state: Must contain 'U' and 'M' keys
+
+        Returns:
+            (converged, {
+                'error_U': float,
+                'error_M': float,
+                'mass_error': float,
+                'converged_U': bool,
+                'converged_M': bool,
+                'status': str
+            })
+        """
+        # Check each component
+        u_converged, u_metrics = self.hjb_checker.check(old_state, new_state)
+        m_converged, m_metrics = self.fp_checker.check(old_state, new_state)
+
+        # Combine metrics
+        metrics: dict[str, float] = {
+            **u_metrics,
+            **m_metrics,
+            "converged_U": float(u_converged),
+            "converged_M": float(m_converged),
+        }
+
+        # Check for any divergence
+        if u_metrics.get("status", "OK") != "OK":
+            metrics["status"] = u_metrics["status"]
+            return False, metrics
+        if m_metrics.get("status", "OK") != "OK":
+            metrics["status"] = m_metrics["status"]
+            return False, metrics
+
+        # Determine overall convergence
+        if self.config.require_both:
+            converged = u_converged and m_converged
+        else:
+            converged = u_converged or m_converged
+
+        metrics["status"] = "OK"
+        return converged, metrics
+
+
+# =============================================================================
+# FACTORY FUNCTION
+# =============================================================================
+
+
+def create_convergence_checker(
+    solver_type: Literal["hjb", "fp", "mfg"],
+    config: ConvergenceConfig | None = None,
+    **kwargs,
+) -> ConvergenceChecker:
+    """
+    Factory function to create appropriate convergence checker.
+
+    Args:
+        solver_type: Type of solver ('hjb', 'fp', 'mfg')
+        config: ConvergenceConfig (uses defaults if None)
+        **kwargs: Additional arguments passed to checker constructor
+
+    Returns:
+        Appropriate ConvergenceChecker instance
+
+    Example:
+        checker = create_convergence_checker('mfg', ConvergenceConfig(tolerance=1e-6))
+    """
+    if config is None:
+        config = ConvergenceConfig()
+
+    if solver_type == "hjb":
+        return HJBConvergenceChecker(config)
+    elif solver_type == "fp":
+        return FPConvergenceChecker(config, **kwargs)
+    elif solver_type == "mfg":
+        return MFGConvergenceChecker(config, **kwargs)
+    else:
+        raise ValueError(f"Unknown solver type: {solver_type}. Expected 'hjb', 'fp', or 'mfg'.")

--- a/mfg_pde/utils/convergence/convergence_metrics.py
+++ b/mfg_pde/utils/convergence/convergence_metrics.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""
+General-purpose convergence metrics and utilities.
+
+This module provides convergence utilities that work for any PDE solver,
+not just MFG problems. It includes:
+
+- DistributionComparator: Wasserstein, KL divergence, moments
+- RollingConvergenceMonitor: Window-based statistical convergence (renamed from StochasticConvergenceMonitor)
+- calculate_error: Unified error computation (L1, L2, Linf)
+- ConvergenceConfig: Configuration dataclass for future solver integration
+
+These utilities can be used for standalone HJB, FP, heat equation,
+or any iterative PDE solver.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import numpy as np
+
+# =============================================================================
+# DISTRIBUTION COMPARISON UTILITIES
+# =============================================================================
+
+
+class DistributionComparator:
+    """
+    Utilities for comparing probability distributions with robust metrics.
+
+    All methods are static and can be called without instantiation.
+    """
+
+    @staticmethod
+    def wasserstein_1d(p: np.ndarray, q: np.ndarray, x: np.ndarray) -> float:
+        """
+        Compute Wasserstein-1 distance (Earth Mover's Distance) for 1D distributions.
+
+        Args:
+            p, q: Probability distributions (must sum to 1)
+            x: Support points (spatial coordinates)
+
+        Returns:
+            Wasserstein-1 distance
+        """
+        # Ensure proper normalization
+        p = p / np.sum(p) if np.sum(p) > 0 else p
+        q = q / np.sum(q) if np.sum(q) > 0 else q
+
+        # Compute cumulative distributions
+        P_cdf = np.cumsum(p)
+        Q_cdf = np.cumsum(q)
+
+        # Wasserstein distance is the L1 distance between CDFs
+        # weighted by the grid spacing
+        dx = np.diff(x) if len(x) > 1 else np.array([1.0])
+        dx = np.append(dx, dx[-1])  # Handle last point
+
+        return float(np.sum(np.abs(P_cdf - Q_cdf) * dx))
+
+    @staticmethod
+    def kl_divergence(p: np.ndarray, q: np.ndarray, epsilon: float = 1e-12) -> float:
+        """
+        Compute Kullback-Leibler divergence with numerical stability.
+
+        Args:
+            p, q: Probability distributions
+            epsilon: Small value to avoid log(0) errors
+
+        Returns:
+            KL divergence D_KL(p || q)
+        """
+        # Add epsilon for numerical stability
+        p_safe = p + epsilon
+        q_safe = q + epsilon
+
+        # Normalize to ensure they're proper distributions
+        p_safe = p_safe / np.sum(p_safe)
+        q_safe = q_safe / np.sum(q_safe)
+
+        # Compute KL divergence
+        return float(np.sum(p_safe * np.log(p_safe / q_safe)))
+
+    @staticmethod
+    def statistical_moments(distribution: np.ndarray, x: np.ndarray) -> dict[str, float]:
+        """
+        Compute statistical moments of a distribution.
+
+        Args:
+            distribution: Probability distribution
+            x: Support points
+
+        Returns:
+            Dictionary with mean, variance, skewness, kurtosis
+        """
+        # Normalize distribution
+        dist = distribution / np.sum(distribution) if np.sum(distribution) > 0 else distribution
+
+        # Compute moments
+        mean = float(np.sum(x * dist))
+        variance = float(np.sum((x - mean) ** 2 * dist))
+
+        # Higher moments (if variance > 0)
+        if variance > 1e-12:
+            skewness = float(np.sum(((x - mean) / np.sqrt(variance)) ** 3 * dist))
+            kurtosis = float(np.sum(((x - mean) / np.sqrt(variance)) ** 4 * dist) - 3)
+        else:
+            skewness = 0.0
+            kurtosis = 0.0
+
+        return {
+            "mean": mean,
+            "variance": variance,
+            "std": float(np.sqrt(variance)),
+            "skewness": skewness,
+            "kurtosis": kurtosis,
+        }
+
+
+# =============================================================================
+# ROLLING CONVERGENCE MONITOR (renamed from StochasticConvergenceMonitor)
+# =============================================================================
+
+
+class RollingConvergenceMonitor:
+    """
+    Convergence monitoring using rolling window statistics.
+
+    Suitable for stochastic methods (particle-based solvers) where
+    error spikes from noise are normal. Uses statistical stopping criteria:
+    - Median error over rolling window (robust to outliers)
+    - Quantile-based thresholds
+    - Running average with confidence bounds
+
+    This monitor tracks scalar errors over time and assesses convergence
+    using robust statistics rather than instantaneous values.
+    """
+
+    def __init__(
+        self,
+        window_size: int = 10,
+        median_tolerance: float = 1e-4,
+        quantile: float = 0.9,
+        quantile_tolerance: float | None = None,
+        min_iterations: int = 5,
+    ):
+        """
+        Initialize rolling convergence monitor.
+
+        Args:
+            window_size: Number of recent iterations to analyze
+            median_tolerance: Tolerance for median error over window
+            quantile: Quantile to check (e.g., 0.9 for 90th percentile)
+            quantile_tolerance: Tolerance for quantile (defaults to 2x median_tolerance)
+            min_iterations: Minimum iterations before checking convergence
+        """
+        self.window_size = window_size
+        self.median_tolerance = median_tolerance
+        self.quantile = quantile
+        self.quantile_tolerance = quantile_tolerance or (2.0 * median_tolerance)
+        self.min_iterations = min_iterations
+
+        # Error history
+        self.errors_u: deque[float] = deque(maxlen=window_size)
+        self.errors_m: deque[float] = deque(maxlen=window_size)
+        self.iteration_count = 0
+
+    def add_iteration(self, error_u: float, error_m: float):
+        """Add iteration errors to history."""
+        self.errors_u.append(error_u)
+        self.errors_m.append(error_m)
+        self.iteration_count += 1
+
+    def get_statistics(self) -> dict[str, Any]:
+        """
+        Get statistical summary of recent errors.
+
+        Returns:
+            Dictionary with median, mean, std, quantiles, min, max
+        """
+        if len(self.errors_u) == 0:
+            return {"status": "no_data"}
+
+        errors_u_arr = np.array(self.errors_u)
+        errors_m_arr = np.array(self.errors_m)
+
+        return {
+            "iterations": self.iteration_count,
+            "window_size": len(self.errors_u),
+            "u_stats": {
+                "median": float(np.median(errors_u_arr)),
+                "mean": float(np.mean(errors_u_arr)),
+                "std": float(np.std(errors_u_arr)),
+                "quantile": float(np.quantile(errors_u_arr, self.quantile)),
+                "min": float(np.min(errors_u_arr)),
+                "max": float(np.max(errors_u_arr)),
+            },
+            "m_stats": {
+                "median": float(np.median(errors_m_arr)),
+                "mean": float(np.mean(errors_m_arr)),
+                "std": float(np.std(errors_m_arr)),
+                "quantile": float(np.quantile(errors_m_arr, self.quantile)),
+                "min": float(np.min(errors_m_arr)),
+                "max": float(np.max(errors_m_arr)),
+            },
+        }
+
+    def check_convergence(self) -> tuple[bool, dict[str, Any]]:
+        """
+        Check convergence using robust statistical criteria.
+
+        Returns:
+            (converged, diagnostics)
+        """
+        # Need sufficient history
+        if self.iteration_count < self.min_iterations or len(self.errors_u) < self.window_size:
+            return False, {
+                "status": "insufficient_history",
+                "iterations": self.iteration_count,
+                "window_filled": len(self.errors_u),
+                "required": self.window_size,
+            }
+
+        stats = self.get_statistics()
+
+        # Check median convergence (robust to spikes)
+        u_median = stats["u_stats"]["median"]
+        m_median = stats["m_stats"]["median"]
+
+        median_converged_u = u_median < self.median_tolerance
+        median_converged_m = m_median < self.median_tolerance
+
+        # Check quantile convergence (ensure most errors are small)
+        u_quantile = stats["u_stats"]["quantile"]
+        m_quantile = stats["m_stats"]["quantile"]
+
+        quantile_converged_u = u_quantile < self.quantile_tolerance
+        quantile_converged_m = m_quantile < self.quantile_tolerance
+
+        # Overall convergence: both median and quantile must satisfy criteria
+        converged = median_converged_u and median_converged_m and quantile_converged_u and quantile_converged_m
+
+        diagnostics = {
+            "status": "converged" if converged else "not_converged",
+            "iterations": self.iteration_count,
+            "statistics": stats,
+            "criteria": {
+                "median_u": {"value": u_median, "threshold": self.median_tolerance, "passed": median_converged_u},
+                "median_m": {"value": m_median, "threshold": self.median_tolerance, "passed": median_converged_m},
+                f"quantile_{int(self.quantile * 100)}%_u": {
+                    "value": u_quantile,
+                    "threshold": self.quantile_tolerance,
+                    "passed": quantile_converged_u,
+                },
+                f"quantile_{int(self.quantile * 100)}%_m": {
+                    "value": m_quantile,
+                    "threshold": self.quantile_tolerance,
+                    "passed": quantile_converged_m,
+                },
+            },
+        }
+
+        return converged, diagnostics
+
+    def is_stagnating(self, stagnation_threshold: float = 1e-6) -> bool:
+        """
+        Check if error has stagnated (no improvement over window).
+
+        Args:
+            stagnation_threshold: Minimum improvement required
+
+        Returns:
+            True if stagnating
+        """
+        if len(self.errors_u) < self.window_size:
+            return False
+
+        errors_arr = np.array(self.errors_u)
+
+        # Check if range of errors in window is very small
+        error_range = np.max(errors_arr) - np.min(errors_arr)
+
+        return bool(error_range < stagnation_threshold)
+
+
+# =============================================================================
+# UNIFIED ERROR CALCULATION
+# =============================================================================
+
+
+def calculate_error(
+    new: np.ndarray,
+    old: np.ndarray,
+    dx: float = 1.0,
+    dt: float = 1.0,
+    norm: Literal["l1", "l2", "linf"] = "l2",
+) -> dict[str, float]:
+    """
+    Calculate error between arrays with multiple norm options.
+
+    Args:
+        new, old: Arrays to compare
+        dx, dt: Grid spacing (for proper scaling in L1/L2 norms)
+        norm: 'l1', 'l2', or 'linf'
+
+    Returns:
+        dict with 'absolute' and 'relative' errors
+
+    Notes:
+        - L1: ||f||_1 = integral(|f|)dx  (mass/total variation)
+        - L2: ||f||_2 = sqrt(integral(f^2)dx)  (energy norm)
+        - Linf: ||f||_inf = max|f|  (pointwise, no grid scaling)
+    """
+    diff = new - old
+
+    if norm == "l1":
+        # L1 norm with grid scaling
+        scale = np.sqrt(dx * dt)
+        abs_error = float(np.sum(np.abs(diff)) * scale)
+        norm_new = float(np.sum(np.abs(new)) * scale)
+    elif norm == "l2":
+        # L2 norm with grid scaling
+        scale = np.sqrt(dx * dt)
+        abs_error = float(np.linalg.norm(diff) * scale)
+        norm_new = float(np.linalg.norm(new) * scale)
+    elif norm == "linf":
+        # Linf norm - no grid scaling
+        abs_error = float(np.max(np.abs(diff)))
+        norm_new = float(np.max(np.abs(new)))
+    else:
+        raise ValueError(f"Unknown norm: {norm}. Use 'l1', 'l2', or 'linf'.")
+
+    rel_error = abs_error / norm_new if norm_new > 1e-12 else abs_error
+
+    return {
+        "absolute": abs_error,
+        "relative": rel_error,
+        "norm": norm,
+    }
+
+
+def calculate_l2_convergence_metrics(
+    U_new: np.ndarray,
+    U_old: np.ndarray,
+    M_new: np.ndarray,
+    M_old: np.ndarray,
+    Dx: float,
+    Dt: float,
+) -> dict[str, float]:
+    """
+    Calculate L2 convergence metrics for MFG fixed-point iterations.
+
+    This helper eliminates code duplication between fixed-point iterator
+    implementations by providing a single source for computing both
+    absolute and relative L2 errors.
+
+    Args:
+        U_new: Current value function array
+        U_old: Previous value function array
+        M_new: Current density array
+        M_old: Previous density array
+        Dx: Spatial grid spacing
+        Dt: Temporal grid spacing
+
+    Returns:
+        Dictionary with keys:
+            - 'l2distu_abs': Absolute L2 error for U
+            - 'l2distu_rel': Relative L2 error for U
+            - 'l2distm_abs': Absolute L2 error for M
+            - 'l2distm_rel': Relative L2 error for M
+
+    Example:
+        >>> metrics = calculate_l2_convergence_metrics(U_new, U_old, M_new, M_old, Dx, Dt)
+        >>> print(f"U relative error: {metrics['l2distu_rel']:.2e}")
+
+    Note:
+        The normalization factor sqrt(Dx * Dt) accounts for grid discretization,
+        making errors comparable across different grid resolutions.
+    """
+    u_error = calculate_error(U_new, U_old, dx=Dx, dt=Dt, norm="l2")
+    m_error = calculate_error(M_new, M_old, dx=Dx, dt=Dt, norm="l2")
+
+    return {
+        "l2distu_abs": u_error["absolute"],
+        "l2distu_rel": u_error["relative"],
+        "l2distm_abs": m_error["absolute"],
+        "l2distm_rel": m_error["relative"],
+    }
+
+
+# =============================================================================
+# CONVERGENCE CONFIG (for future solver integration)
+# =============================================================================
+
+
+@dataclass
+class ConvergenceConfig:
+    """
+    Configuration for solver convergence criteria.
+
+    This dataclass can be passed to solvers to configure convergence
+    behavior. Designed for future integration (see issue #456).
+
+    Usage:
+        config = ConvergenceConfig(tolerance=1e-6, max_iterations=100)
+        result = solver.solve(convergence=config)
+
+        # Or use presets
+        result = solver.solve(convergence=ConvergenceConfig.strict())
+    """
+
+    # Basic settings
+    tolerance: float = 1e-6
+    max_iterations: int = 100
+    min_iterations: int = 0  # Avoid pseudo-convergence in early steps
+    norm: Literal["l1", "l2", "linf"] = "l2"
+    relative: bool = True
+    check_interval: int = 1
+    track_history: bool = True
+
+    # For coupled systems (MFG)
+    tolerance_U: float | None = None  # HJB tolerance (defaults to tolerance)
+    tolerance_M: float | None = None  # FP tolerance (defaults to tolerance)
+    require_both: bool = True  # Both U and M must converge
+
+    # For stochastic/particle methods
+    window_size: int | None = None
+    median_tolerance: float | None = None
+
+    # Divergence detection
+    divergence_threshold: float = 1e10  # Safety threshold for error explosion
+
+    # Internal tracking
+    _history: list[dict[str, float]] = field(default_factory=list, repr=False)
+
+    def get_tolerance_U(self) -> float:
+        """Get tolerance for U (HJB)."""
+        return self.tolerance_U if self.tolerance_U is not None else self.tolerance
+
+    def get_tolerance_M(self) -> float:
+        """Get tolerance for M (FP)."""
+        return self.tolerance_M if self.tolerance_M is not None else self.tolerance
+
+    @classmethod
+    def strict(cls) -> ConvergenceConfig:
+        """Create strict convergence config."""
+        return cls(tolerance=1e-8, max_iterations=500)
+
+    @classmethod
+    def relaxed(cls) -> ConvergenceConfig:
+        """Create relaxed convergence config."""
+        return cls(tolerance=1e-4, max_iterations=50)
+
+    @classmethod
+    def stochastic(cls, window_size: int = 10, median_tolerance: float = 1e-4) -> ConvergenceConfig:
+        """Create config for stochastic/particle methods."""
+        return cls(
+            window_size=window_size,
+            median_tolerance=median_tolerance,
+            tolerance=median_tolerance,
+        )
+
+
+# =============================================================================
+# FACTORY FUNCTIONS
+# =============================================================================
+
+
+def create_rolling_monitor(
+    window_size: int = 10,
+    median_tolerance: float = 1e-4,
+    quantile: float = 0.9,
+    **kwargs,
+) -> RollingConvergenceMonitor:
+    """
+    Create rolling convergence monitor with sensible defaults.
+
+    Args:
+        window_size: Rolling window size for statistics
+        median_tolerance: Threshold for median error
+        quantile: Quantile to monitor (default: 0.9 for 90th percentile)
+        **kwargs: Additional parameters
+
+    Returns:
+        Configured RollingConvergenceMonitor
+
+    Usage:
+        monitor = create_rolling_monitor()
+        for iteration in range(max_iterations):
+            # ... compute errors ...
+            monitor.add_iteration(error_u, error_m)
+            converged, diagnostics = monitor.check_convergence()
+            if converged:
+                break
+    """
+    return RollingConvergenceMonitor(
+        window_size=window_size,
+        median_tolerance=median_tolerance,
+        quantile=quantile,
+        **kwargs,
+    )
+
+
+# =============================================================================
+# BACKWARD COMPATIBILITY ALIASES
+# =============================================================================
+
+# Renamed class - keep old name for compatibility
+StochasticConvergenceMonitor = RollingConvergenceMonitor
+
+# Factory alias
+create_stochastic_monitor = create_rolling_monitor

--- a/mfg_pde/utils/convergence/convergence_monitors.py
+++ b/mfg_pde/utils/convergence/convergence_monitors.py
@@ -1,0 +1,785 @@
+#!/usr/bin/env python3
+"""
+MFG-specific convergence monitors and utilities.
+
+This module provides convergence monitoring specifically designed for
+Mean Field Game problems with coupled HJB-FP systems:
+
+- _ErrorHistoryTracker: Internal helper for tracking error statistics
+- DistributionConvergenceMonitor: Multi-criteria monitor with Wasserstein/KL/moments
+  (renamed from AdvancedConvergenceMonitor)
+- SolverTypeDetector: Detect if solver uses particle methods
+  (renamed from ParticleMethodDetector)
+- ConvergenceWrapper: Universal wrapper for adaptive convergence
+  (renamed from AdaptiveConvergenceWrapper)
+
+These utilities are designed for MFG problems where:
+- U (value function) and M (distribution) need separate convergence tracking
+- Distribution metrics (Wasserstein, KL) are relevant
+- Particle vs grid-based methods require different convergence criteria
+"""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from collections import deque
+from functools import wraps
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from .convergence_metrics import DistributionComparator
+
+if TYPE_CHECKING:
+    from mfg_pde.alg.base_mfg_solver import MFGSolver  # type: ignore[import-not-found]
+
+
+# =============================================================================
+# INTERNAL ERROR HISTORY TRACKER
+# =============================================================================
+
+
+class _ErrorHistoryTracker:
+    """
+    Internal helper to track error history and compute statistics.
+
+    This replaces OscillationDetector with a simpler, statistics-only interface.
+    No threshold-based decisions - just collects data and reports statistics.
+    """
+
+    def __init__(self, history_length: int = 10):
+        """
+        Initialize error history tracker.
+
+        Args:
+            history_length: Number of recent values to track
+        """
+        self.history_length = history_length
+        self.error_history: deque[float] = deque(maxlen=history_length)
+
+    def add_sample(self, error: float):
+        """Add new error sample to history."""
+        self.error_history.append(error)
+
+    def get_statistics(self) -> dict[str, float | int]:
+        """
+        Get statistics of tracked errors.
+
+        Returns:
+            Dictionary with mean, std, min, max, samples
+        """
+        if len(self.error_history) == 0:
+            return {"samples": 0}
+
+        errors = np.array(self.error_history)
+        return {
+            "mean": float(np.mean(errors)),
+            "std": float(np.std(errors)),
+            "min": float(np.min(errors)),
+            "max": float(np.max(errors)),
+            "samples": len(self.error_history),
+        }
+
+    def is_below_threshold(self, mean_threshold: float, std_threshold: float) -> tuple[bool, dict[str, Any]]:
+        """
+        Check if errors are below thresholds.
+
+        Args:
+            mean_threshold: Maximum acceptable mean error
+            std_threshold: Maximum acceptable standard deviation
+
+        Returns:
+            (passed, diagnostics)
+        """
+        if len(self.error_history) < self.history_length:
+            return False, {
+                "status": "insufficient_history",
+                "samples": len(self.error_history),
+                "required": self.history_length,
+            }
+
+        stats = self.get_statistics()
+        mean_ok = stats["mean"] < mean_threshold
+        std_ok = stats["std"] < std_threshold
+
+        return bool(mean_ok and std_ok), {
+            **stats,
+            "mean_ok": mean_ok,
+            "std_ok": std_ok,
+        }
+
+
+# =============================================================================
+# DISTRIBUTION CONVERGENCE MONITOR (renamed from AdvancedConvergenceMonitor)
+# =============================================================================
+
+
+class DistributionConvergenceMonitor:
+    """
+    Comprehensive convergence monitoring for MFG systems.
+
+    Implements robust convergence criteria combining:
+    - Wasserstein distance for distribution (M) convergence
+    - Error stabilization for value function (U) convergence
+    - Multi-criteria validation
+
+    This monitor is specifically designed for MFG problems where both
+    U and M need to converge, and distribution metrics are meaningful.
+    """
+
+    def __init__(
+        self,
+        wasserstein_tol: float = 1e-4,
+        kl_divergence_tol: float = 1e-3,
+        moment_tol: float = 1e-5,
+        u_magnitude_tol: float = 1e-3,
+        u_stability_tol: float = 1e-4,
+        history_length: int = 10,
+    ):
+        """
+        Initialize distribution convergence monitor.
+
+        Args:
+            wasserstein_tol: Tolerance for Wasserstein distance
+            kl_divergence_tol: Tolerance for KL divergence
+            moment_tol: Tolerance for statistical moment changes
+            u_magnitude_tol: Tolerance for mean L2 error of value function
+            u_stability_tol: Tolerance for L2 error standard deviation
+            history_length: Number of iterations to track for stability
+        """
+        self.wasserstein_tol = wasserstein_tol
+        self.kl_divergence_tol = kl_divergence_tol
+        self.moment_tol = moment_tol
+        self.u_magnitude_tol = u_magnitude_tol
+        self.u_stability_tol = u_stability_tol
+
+        # Initialize components
+        self.comparator = DistributionComparator()
+        self._error_tracker = _ErrorHistoryTracker(history_length)
+
+        # History tracking
+        self.iteration_count = 0
+        self.convergence_history: list[dict[str, Any]] = []
+        self.previous_m: np.ndarray | None = None
+        self.previous_m_moments: dict[str, float] | None = None
+        self.x_grid: np.ndarray | None = None
+
+    def update(
+        self,
+        u_current: np.ndarray,
+        u_previous: np.ndarray,
+        m_current: np.ndarray,
+        x_grid: np.ndarray,
+    ) -> dict[str, Any]:
+        """
+        Update convergence monitoring with current iteration data.
+
+        Args:
+            u_current, u_previous: Current and previous value functions
+            m_current: Current distribution
+            x_grid: Spatial grid points
+
+        Returns:
+            Dictionary with convergence diagnostics
+        """
+        self.iteration_count += 1
+        self.x_grid = x_grid
+
+        # Compute L2 error for value function
+        u_l2_error = float(np.linalg.norm(u_current - u_previous))
+        self._error_tracker.add_sample(u_l2_error)
+
+        # Initialize diagnostics
+        diagnostics: dict[str, Any] = {
+            "iteration": self.iteration_count,
+            "u_l2_error": u_l2_error,
+            "converged": False,
+            "convergence_criteria": {},
+        }
+
+        # Distribution convergence analysis
+        if self.previous_m is not None:
+            # Wasserstein distance
+            try:
+                wasserstein_dist = self.comparator.wasserstein_1d(m_current, self.previous_m, x_grid)
+                diagnostics["wasserstein_distance"] = wasserstein_dist
+                diagnostics["convergence_criteria"]["wasserstein"] = wasserstein_dist < self.wasserstein_tol
+            except Exception as e:
+                warnings.warn(f"Wasserstein computation failed: {e}")
+                diagnostics["convergence_criteria"]["wasserstein"] = False
+
+            # KL divergence
+            try:
+                kl_div = self.comparator.kl_divergence(m_current, self.previous_m)
+                diagnostics["kl_divergence"] = kl_div
+                diagnostics["convergence_criteria"]["kl_divergence"] = kl_div < self.kl_divergence_tol
+            except Exception as e:
+                warnings.warn(f"KL divergence computation failed: {e}")
+                diagnostics["convergence_criteria"]["kl_divergence"] = False
+
+            # Statistical moments
+            current_moments = self.comparator.statistical_moments(m_current, x_grid)
+            if self.previous_m_moments is not None:
+                mean_diff = abs(current_moments["mean"] - self.previous_m_moments["mean"])
+                var_diff = abs(current_moments["variance"] - self.previous_m_moments["variance"])
+
+                diagnostics["moment_differences"] = {
+                    "mean_diff": mean_diff,
+                    "var_diff": var_diff,
+                }
+                diagnostics["convergence_criteria"]["moments"] = (
+                    mean_diff < self.moment_tol and var_diff < self.moment_tol
+                )
+            else:
+                diagnostics["convergence_criteria"]["moments"] = False
+
+            self.previous_m_moments = current_moments
+        else:
+            # First iteration - no comparison possible
+            diagnostics["convergence_criteria"].update({"wasserstein": False, "kl_divergence": False, "moments": False})
+
+        # Value function stabilization analysis
+        u_stabilized, u_diagnostics = self._error_tracker.is_below_threshold(self.u_magnitude_tol, self.u_stability_tol)
+
+        diagnostics["u_stabilization"] = u_diagnostics
+        diagnostics["convergence_criteria"]["u_stabilized"] = u_stabilized
+
+        # Overall convergence assessment
+        criteria = diagnostics["convergence_criteria"]
+        if self.iteration_count >= 3:  # Need some history for meaningful assessment
+            diagnostics["converged"] = criteria.get("wasserstein", False) and criteria.get("u_stabilized", False)
+
+        # Store in history
+        self.convergence_history.append(diagnostics)
+        self.previous_m = m_current.copy()
+
+        return diagnostics
+
+    def get_convergence_summary(self) -> dict[str, Any]:
+        """
+        Get summary of convergence behavior over all iterations.
+
+        Returns:
+            Summary dictionary with convergence statistics
+        """
+        if not self.convergence_history:
+            return {"status": "no_data"}
+
+        # Extract time series
+        u_errors = [d["u_l2_error"] for d in self.convergence_history]
+        wasserstein_dists = [d.get("wasserstein_distance", np.nan) for d in self.convergence_history]
+
+        # Convergence detection
+        converged_iterations = [i for i, d in enumerate(self.convergence_history) if d["converged"]]
+
+        summary = {
+            "total_iterations": len(self.convergence_history),
+            "converged": len(converged_iterations) > 0,
+            "convergence_iteration": (converged_iterations[0] if converged_iterations else None),
+            "final_u_error": u_errors[-1],
+            "final_wasserstein": (wasserstein_dists[-1] if not np.isnan(wasserstein_dists[-1]) else None),
+            "u_error_trend": {
+                "min": float(np.min(u_errors)),
+                "max": float(np.max(u_errors)),
+                "final_mean": float(np.mean(u_errors[-5:]) if len(u_errors) >= 5 else np.mean(u_errors)),
+                "final_std": float(np.std(u_errors[-5:]) if len(u_errors) >= 5 else np.std(u_errors)),
+            },
+        }
+
+        return summary
+
+    def get_plot_data(self) -> dict[str, list[float]]:
+        """
+        Get data formatted for plotting.
+
+        Returns:
+            Dictionary with 'iterations', 'u_errors', 'wasserstein_distances'
+        """
+        if not self.convergence_history:
+            return {"iterations": [], "u_errors": [], "wasserstein_distances": []}
+
+        return {
+            "iterations": [d["iteration"] for d in self.convergence_history],
+            "u_errors": [d["u_l2_error"] for d in self.convergence_history],
+            "wasserstein_distances": [d.get("wasserstein_distance", np.nan) for d in self.convergence_history],
+        }
+
+
+# =============================================================================
+# SOLVER TYPE DETECTOR (renamed from ParticleMethodDetector)
+# =============================================================================
+
+
+class SolverTypeDetector:
+    """
+    Utility class to detect solver characteristics.
+
+    Primarily used to detect if a solver uses particle-based methods,
+    which require different convergence criteria than grid-based methods.
+    """
+
+    @staticmethod
+    def detect_particle_methods(solver: MFGSolver) -> tuple[bool, dict[str, Any]]:
+        """
+        Detect if solver uses particle-based methods.
+
+        Args:
+            solver: MFG solver instance
+
+        Returns:
+            (has_particles, detection_info)
+        """
+        detection_info: dict[str, Any] = {
+            "particle_components": [],
+            "detection_methods": [],
+            "confidence": 0.0,
+        }
+
+        # Check 1: Look for particle-related attributes
+        particle_attributes = [
+            "num_particles",
+            "particles",
+            "particle_solver",
+            "fp_solver",
+            "particle_fp",
+            "kde_bandwidth",
+        ]
+
+        found_attributes = []
+        for attr in particle_attributes:
+            if hasattr(solver, attr):
+                found_attributes.append(attr)
+                detection_info["particle_components"].append(f"attribute:{attr}")
+
+        if found_attributes:
+            detection_info["detection_methods"].append("attribute_scan")
+            detection_info["confidence"] += 0.3
+
+        # Check 2: Inspect solver components for particle classes
+        particle_class_names = [
+            "ParticleFP",
+            "FPParticle",
+            "ParticleCollocation",
+            "ParticleFPSolver",
+            "FPParticleSolver",
+        ]
+
+        # Check solver's fp_solver if it exists
+        fp_solver = getattr(solver, "fp_solver", None)
+        if fp_solver is not None:
+            fp_class_name = fp_solver.__class__.__name__
+            if any(particle_name in fp_class_name for particle_name in particle_class_names):
+                detection_info["particle_components"].append(f"fp_solver:{fp_class_name}")
+                detection_info["detection_methods"].append("component_class_inspection")
+                detection_info["confidence"] += 0.5
+
+        # Check solver's own class name
+        solver_class_name = solver.__class__.__name__
+        if any(particle_name in solver_class_name for particle_name in particle_class_names):
+            detection_info["particle_components"].append(f"solver:{solver_class_name}")
+            detection_info["detection_methods"].append("solver_class_inspection")
+            detection_info["confidence"] += 0.4
+
+        # Check 3: Look for particle-specific methods
+        particle_methods = [
+            "update_particles",
+            "particle_step",
+            "kde_estimation",
+            "particle_density",
+            "resample_particles",
+        ]
+
+        found_methods = []
+        for method in particle_methods:
+            if hasattr(solver, method) and callable(getattr(solver, method)):
+                found_methods.append(method)
+                detection_info["particle_components"].append(f"method:{method}")
+
+        if found_methods:
+            detection_info["detection_methods"].append("method_inspection")
+            detection_info["confidence"] += 0.2
+
+        # Check 4: Analyze solve method signature for particle-related parameters
+        if hasattr(solver, "solve"):
+            try:
+                sig = inspect.signature(solver.solve)
+                particle_params = [
+                    "num_particles",
+                    "kde_bandwidth",
+                    "normalize_kde_output",
+                ]
+                found_params = [p for p in particle_params if p in sig.parameters]
+                if found_params:
+                    detection_info["particle_components"].extend([f"param:{p}" for p in found_params])
+                    detection_info["detection_methods"].append("parameter_inspection")
+                    detection_info["confidence"] += 0.1
+            except Exception:
+                pass  # Ignore signature inspection errors
+
+        # Final decision based on confidence
+        has_particles = detection_info["confidence"] > 0.3
+
+        # Boost confidence if multiple detection methods agree
+        if len(detection_info["detection_methods"]) >= 2:
+            detection_info["confidence"] = min(1.0, detection_info["confidence"] * 1.2)
+            has_particles = True
+
+        return has_particles, detection_info
+
+
+# =============================================================================
+# CONVERGENCE WRAPPER (renamed from AdaptiveConvergenceWrapper)
+# =============================================================================
+
+
+class ConvergenceWrapper:
+    """
+    Wrapper that automatically applies appropriate convergence criteria
+    based on whether the solver uses particle methods.
+
+    Usage:
+        @adaptive_convergence()
+        class MySolver(BaseMFGSolver):
+            ...
+
+    Or as a wrapper:
+        solver = MySolver(...)
+        adaptive_solver = ConvergenceWrapper(solver)
+    """
+
+    def __init__(
+        self,
+        solver: MFGSolver | None = None,
+        classical_tol: float = 1e-3,
+        force_particle_mode: bool | None = None,
+        verbose: bool = True,
+        **advanced_convergence_kwargs,
+    ):
+        """
+        Initialize convergence wrapper.
+
+        Args:
+            solver: MFG solver to wrap (if used as wrapper)
+            classical_tol: L2 error tolerance for classical methods
+            force_particle_mode: Force particle/classical mode (overrides detection)
+            verbose: Print convergence mode information
+            **advanced_convergence_kwargs: Parameters for distribution convergence monitor
+        """
+        self._wrapped_solver = solver
+        self.classical_tol = classical_tol
+        self.force_particle_mode = force_particle_mode
+        self.verbose = verbose
+        self.advanced_convergence_kwargs = advanced_convergence_kwargs
+
+        # State variables
+        self._particle_mode: bool | None = None
+        self._detection_info: dict[str, Any] | None = None
+        self._convergence_monitor: DistributionConvergenceMonitor | None = None
+        self._original_solve = None
+
+        if solver is not None:
+            self._wrap_solver(solver)
+
+    def __call__(self, solver_class):
+        """Use as decorator on solver classes."""
+        original_init = solver_class.__init__
+        wrapper = self
+
+        @wraps(original_init)
+        def wrapped_init(self_solver, *args, **kwargs):
+            # Call original constructor
+            original_init(self_solver, *args, **kwargs)
+            # Apply convergence wrapper
+            wrapper._wrap_solver(self_solver)
+
+        solver_class.__init__ = wrapped_init
+        return solver_class
+
+    def _wrap_solver(self, solver: MFGSolver):
+        """Apply convergence wrapping to a solver instance."""
+        self._wrapped_solver = solver
+
+        # Detect particle methods
+        if self.force_particle_mode is not None:
+            self._particle_mode = self.force_particle_mode
+            self._detection_info = {"forced": True, "mode": self.force_particle_mode}
+        else:
+            self._particle_mode, self._detection_info = SolverTypeDetector.detect_particle_methods(solver)
+
+        # Set up convergence monitoring
+        if self._particle_mode:
+            self._convergence_monitor = create_distribution_monitor(**self.advanced_convergence_kwargs)
+
+        # Wrap the solve method
+        if hasattr(solver, "solve") and callable(solver.solve):
+            self._original_solve = solver.solve
+            solver.solve = self._adaptive_solve
+
+        # Store reference to wrapper in solver for debugging
+        solver._convergence_wrapper = self  # type: ignore[attr-defined]
+
+        if self.verbose:
+            self._print_convergence_mode()
+
+    def _print_convergence_mode(self):
+        """Print information about the detected convergence mode."""
+        print("ADAPTIVE CONVERGENCE DETECTION")
+        print("-" * 50)
+
+        if self._particle_mode:
+            print("PARTICLE METHODS DETECTED")
+            print("   -> Using DISTRIBUTION convergence criteria")
+            print("   -> Wasserstein distance + error stabilization")
+
+            # Show detection details
+            if self._detection_info and "particle_components" in self._detection_info:
+                particle_components = self._detection_info["particle_components"]
+                if isinstance(particle_components, list) and particle_components:
+                    components = particle_components[:3]  # Show first 3
+                    print(f"   -> Evidence: {', '.join(components)}")
+
+            confidence = self._detection_info.get("confidence", 0) if self._detection_info else 0
+            print(f"   -> Confidence: {confidence:.1%}")
+
+            # Show monitor settings
+            monitor = self._convergence_monitor
+            if monitor:
+                print(f"   -> Wasserstein tolerance: {monitor.wasserstein_tol}")
+                print(f"   -> U magnitude tolerance: {monitor.u_magnitude_tol}")
+                print(f"   -> Stability tolerance: {monitor.u_stability_tol}")
+        else:
+            print("GRID-BASED METHODS DETECTED")
+            print("   -> Using CLASSICAL L2 error convergence")
+            print(f"   -> L2 tolerance: {self.classical_tol}")
+
+        print()
+
+    def _adaptive_solve(self, *args, **kwargs):
+        """Adaptive solve method that uses appropriate convergence criteria."""
+        if not self._particle_mode:
+            return self._classical_solve(*args, **kwargs)
+        else:
+            return self._particle_aware_solve(*args, **kwargs)
+
+    def _classical_solve(self, *args, **kwargs):
+        """Classical solve with L2 error convergence."""
+        if self._original_solve is not None:
+            return self._original_solve(*args, **kwargs)
+        else:
+            raise RuntimeError("No original solve method available")
+
+    def _particle_aware_solve(
+        self, Niter: int = 20, l2errBound: float | None = None, verbose: bool | None = None, **kwargs
+    ):
+        """Particle-aware solve with distribution convergence criteria."""
+        if verbose is None:
+            verbose = self.verbose
+
+        if l2errBound is None:
+            l2errBound = self.classical_tol
+
+        if verbose:
+            print("SOLVING WITH DISTRIBUTION CONVERGENCE CRITERIA")
+            print("-" * 50)
+
+        solver = self._wrapped_solver
+        problem = getattr(solver, "problem", None)
+
+        if problem is None:
+            warnings.warn("Cannot access problem from solver - falling back to classical convergence")
+            return self._classical_solve(Niter, l2errBound, verbose, **kwargs)
+
+        # Initialize convergence monitoring
+        self._convergence_monitor = create_distribution_monitor(**self.advanced_convergence_kwargs)
+
+        # Extract spatial grid for convergence analysis
+        x_grid = np.linspace(problem.xmin, problem.xmax, problem.Nx)
+
+        try:
+            if self._original_solve is not None:
+                results = self._original_solve(Niter, l2errBound, verbose=False, **kwargs)
+            else:
+                raise RuntimeError("No original solve method available")
+
+            # Analyze results with distribution criteria
+            if len(results) >= 2:
+                U, M = results[0], results[1]
+                info = results[2] if len(results) > 2 else {}
+
+                advanced_info = self._analyze_solution_convergence(U, M, x_grid, info)
+
+                if isinstance(info, dict):
+                    info.update(advanced_info)
+                else:
+                    info = advanced_info
+
+                return U, M, info
+            else:
+                return results
+
+        except Exception as e:
+            warnings.warn(f"Distribution convergence analysis failed: {e}. Falling back to classical.")
+            return self._classical_solve(Niter, l2errBound, verbose, **kwargs)
+
+    def _analyze_solution_convergence(
+        self, U: np.ndarray, M: np.ndarray, x_grid: np.ndarray, original_info: dict
+    ) -> dict[str, Any]:
+        """Post-hoc analysis of solution convergence using distribution criteria."""
+        if U.ndim >= 2 and M.ndim >= 2:
+            final_m = M[-1, :]
+
+            # Compute distribution properties
+            comparator = DistributionComparator()
+            moments = comparator.statistical_moments(final_m, x_grid)
+
+            advanced_info: dict[str, Any] = {
+                "convergence_mode": "distribution_aware",
+                "particle_detection": self._detection_info,
+                "final_distribution_moments": moments,
+                "distribution_convergence_available": True,
+            }
+
+            # Add mass tracking
+            if M.shape[0] > 1:
+                dx = (x_grid[-1] - x_grid[0]) / (len(x_grid) - 1)
+                initial_mass = np.sum(M[0, :]) * dx
+                final_mass = np.sum(M[-1, :]) * dx
+                mass_change = abs(final_mass - initial_mass) / initial_mass * 100
+
+                advanced_info["mass_change_percent"] = mass_change
+
+            return advanced_info
+
+        return {
+            "convergence_mode": "distribution_aware",
+            "particle_detection": self._detection_info,
+            "distribution_convergence_available": True,
+        }
+
+    def get_convergence_mode(self) -> str:
+        """Get current convergence mode."""
+        return "particle_aware" if self._particle_mode else "classical"
+
+    def get_detection_info(self) -> dict[str, Any]:
+        """Get solver type detection information."""
+        return self._detection_info or {}
+
+    def __getattr__(self, name):
+        """Delegate attribute access to wrapped solver."""
+        if self._wrapped_solver is not None:
+            return getattr(self._wrapped_solver, name)
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+
+
+# =============================================================================
+# FACTORY FUNCTIONS
+# =============================================================================
+
+
+def create_distribution_monitor(**kwargs) -> DistributionConvergenceMonitor:
+    """
+    Create distribution convergence monitor with default settings.
+
+    Args:
+        **kwargs: Override default parameters
+
+    Returns:
+        Configured DistributionConvergenceMonitor
+    """
+    defaults = {
+        "wasserstein_tol": 1e-4,
+        "kl_divergence_tol": 1e-3,
+        "moment_tol": 1e-5,
+        "u_magnitude_tol": 1e-3,
+        "u_stability_tol": 1e-4,
+        "history_length": 10,
+    }
+    defaults.update(kwargs)
+
+    return DistributionConvergenceMonitor(**defaults)  # type: ignore[arg-type]
+
+
+def adaptive_convergence(
+    classical_tol: float = 1e-3,
+    force_particle_mode: bool | None = None,
+    verbose: bool = True,
+    **advanced_kwargs,
+):
+    """
+    Decorator factory for adaptive convergence.
+
+    Args:
+        classical_tol: L2 error tolerance for classical methods
+        force_particle_mode: Force particle/classical mode (overrides detection)
+        verbose: Print convergence mode information
+        **advanced_kwargs: Parameters for distribution convergence monitor
+
+    Usage:
+        @adaptive_convergence(classical_tol=1e-3, wasserstein_tol=1e-4)
+        class MySolver(BaseMFGSolver):
+            ...
+    """
+
+    def decorator(solver_class):
+        return ConvergenceWrapper(
+            classical_tol=classical_tol,
+            force_particle_mode=force_particle_mode,
+            verbose=verbose,
+            **advanced_kwargs,
+        )(solver_class)
+
+    return decorator
+
+
+def wrap_solver_with_adaptive_convergence(solver: MFGSolver, **kwargs) -> MFGSolver:
+    """
+    Wrap an existing solver instance with adaptive convergence.
+
+    Args:
+        solver: Solver instance to wrap
+        **kwargs: Parameters for ConvergenceWrapper
+
+    Returns:
+        Wrapped solver with adaptive convergence
+
+    Usage:
+        solver = ParticleCollocationSolver(...)
+        adaptive_solver = wrap_solver_with_adaptive_convergence(solver)
+        U, M, info = adaptive_solver.solve(...)
+    """
+    ConvergenceWrapper(solver, **kwargs)
+    return solver  # The solver is modified in-place by the wrapper
+
+
+def test_particle_detection(solver: MFGSolver) -> dict[str, Any]:
+    """
+    Test solver type detection without wrapping.
+
+    Args:
+        solver: Solver to test
+
+    Returns:
+        Detection results dictionary
+    """
+    has_particles, detection_info = SolverTypeDetector.detect_particle_methods(solver)
+
+    return {
+        "has_particles": has_particles,
+        "detection_info": detection_info,
+        "recommended_convergence": "distribution" if has_particles else "classical",
+    }
+
+
+# =============================================================================
+# BACKWARD COMPATIBILITY ALIASES
+# =============================================================================
+
+# Renamed classes - keep old names for compatibility
+OscillationDetector = _ErrorHistoryTracker
+AdvancedConvergenceMonitor = DistributionConvergenceMonitor
+ParticleMethodDetector = SolverTypeDetector
+AdaptiveConvergenceWrapper = ConvergenceWrapper
+
+# Factory alias
+create_default_monitor = create_distribution_monitor

--- a/mfg_pde/utils/numerical/convergence/__init__.py
+++ b/mfg_pde/utils/numerical/convergence/__init__.py
@@ -1,112 +1,67 @@
-#!/usr/bin/env python3
 """
-Convergence monitoring utilities for PDE solvers.
+Backward compatibility re-exports from mfg_pde.utils.convergence.
 
-This package provides convergence monitoring utilities organized into:
+DEPRECATED: This module has been moved to mfg_pde.utils.convergence.
+Import from there instead:
 
-- **convergence_metrics.py**: General-purpose utilities for any PDE
-  - DistributionComparator: Wasserstein, KL divergence, moments
-  - RollingConvergenceMonitor: Window-based statistical convergence
-  - calculate_error: Unified L1/L2/Linf error computation
-  - ConvergenceConfig: Configuration dataclass for solver integration
+    # Old (deprecated)
+    from mfg_pde.utils.numerical.convergence import ConvergenceConfig
 
-- **convergence_monitors.py**: MFG-specific monitors
-  - DistributionConvergenceMonitor: Multi-criteria (Wasserstein, KL, moments)
-  - SolverTypeDetector: Detect particle vs grid-based solvers
-  - ConvergenceWrapper: Adaptive convergence based on solver type
+    # New (preferred)
+    from mfg_pde.utils.convergence import ConvergenceConfig
 
-Usage:
-    # General-purpose convergence checking
-    from mfg_pde.utils.numerical.convergence import calculate_error, RollingConvergenceMonitor
-
-    error = calculate_error(u_new, u_old, dx=0.01, norm='l2')
-    monitor = RollingConvergenceMonitor(window_size=10)
-
-    # MFG-specific monitoring
-    from mfg_pde.utils.numerical.convergence import DistributionConvergenceMonitor
-
-    monitor = DistributionConvergenceMonitor(wasserstein_tol=1e-4)
-    diagnostics = monitor.update(u_current, u_previous, m_current, x_grid)
-
-    # Adaptive convergence wrapper
-    from mfg_pde.utils.numerical.convergence import adaptive_convergence
-
-    @adaptive_convergence()
-    class MySolver(BaseMFGSolver):
-        ...
+This re-export will be removed in v2.0.0.
 """
 
 from __future__ import annotations
 
 import warnings
 
-# =============================================================================
-# GENERAL-PURPOSE IMPORTS (convergence_metrics.py)
-# =============================================================================
-from .convergence_metrics import (
-    ConvergenceConfig,
-    # Core utilities
-    DistributionComparator,
-    RollingConvergenceMonitor,
-    # Backward compatibility
-    StochasticConvergenceMonitor,
-    calculate_error,
-    calculate_l2_convergence_metrics,
-    # Factory
-    create_rolling_monitor,
-    create_stochastic_monitor,
-)
-
-# =============================================================================
-# MFG-SPECIFIC IMPORTS (convergence_monitors.py)
-# =============================================================================
-from .convergence_monitors import (
+# Re-export everything from the new location
+from mfg_pde.utils.convergence import (
     AdaptiveConvergenceWrapper,
     AdvancedConvergenceMonitor,
+    ConvergenceChecker,
+    ConvergenceConfig,
     ConvergenceWrapper,
-    # Core monitors
+    DistributionComparator,
     DistributionConvergenceMonitor,
-    # Backward compatibility
+    FPConvergenceChecker,
+    HJBConvergenceChecker,
+    MFGConvergenceChecker,
     OscillationDetector,
     ParticleMethodDetector,
+    RollingConvergenceMonitor,
     SolverTypeDetector,
-    # Internal (exposed for testing)
+    StochasticConvergenceMonitor,
     _ErrorHistoryTracker,
     adaptive_convergence,
+    calculate_error,
+    calculate_l2_convergence_metrics,
+    compute_norm,
     create_default_monitor,
-    # Factory and decorators
     create_distribution_monitor,
+    create_rolling_monitor,
+    create_stochastic_monitor,
     test_particle_detection,
     wrap_solver_with_adaptive_convergence,
 )
 
-# =============================================================================
-# DEPRECATION HELPERS
-# =============================================================================
-
-
-def _warn_deprecated(old_name: str, new_name: str) -> None:
-    """Issue deprecation warning for renamed classes."""
-    warnings.warn(
-        f"{old_name} is deprecated and will be removed in v1.0.0. Use {new_name} instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-
-# =============================================================================
-# PUBLIC API
-# =============================================================================
+warnings.warn(
+    "mfg_pde.utils.numerical.convergence is deprecated. Import from mfg_pde.utils.convergence instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
-    # General-purpose (convergence_metrics.py)
+    # General-purpose
     "DistributionComparator",
     "RollingConvergenceMonitor",
     "calculate_error",
     "calculate_l2_convergence_metrics",
     "ConvergenceConfig",
     "create_rolling_monitor",
-    # MFG-specific (convergence_monitors.py)
+    # MFG-specific
     "DistributionConvergenceMonitor",
     "SolverTypeDetector",
     "ConvergenceWrapper",
@@ -115,12 +70,18 @@ __all__ = [
     "adaptive_convergence",
     "wrap_solver_with_adaptive_convergence",
     "test_particle_detection",
-    # Backward compatibility aliases (deprecated)
-    "StochasticConvergenceMonitor",  # -> RollingConvergenceMonitor
-    "create_stochastic_monitor",  # -> create_rolling_monitor
-    "OscillationDetector",  # -> _ErrorHistoryTracker
-    "AdvancedConvergenceMonitor",  # -> DistributionConvergenceMonitor
-    "ParticleMethodDetector",  # -> SolverTypeDetector
-    "AdaptiveConvergenceWrapper",  # -> ConvergenceWrapper
-    "create_default_monitor",  # -> create_distribution_monitor
+    # Convergence checkers
+    "ConvergenceChecker",
+    "HJBConvergenceChecker",
+    "FPConvergenceChecker",
+    "MFGConvergenceChecker",
+    "compute_norm",
+    # Backward compatibility aliases
+    "StochasticConvergenceMonitor",
+    "create_stochastic_monitor",
+    "OscillationDetector",
+    "AdvancedConvergenceMonitor",
+    "ParticleMethodDetector",
+    "AdaptiveConvergenceWrapper",
+    "create_default_monitor",
 ]


### PR DESCRIPTION
## Summary
- Move convergence utilities from `utils/numerical/convergence/` to `utils/convergence/` for cross-paradigm use
- Implement Protocol-based convergence checkers (Strategy Pattern)
- Add `min_iterations` and `divergence_threshold` to ConvergenceConfig
- Maintain backward compatibility with deprecation warnings

## Implementation (Phase 1-2 of #456)

### New Module Structure
```
mfg_pde/utils/convergence/
├── __init__.py               # Public API
├── convergence_metrics.py    # ConvergenceConfig, calculate_error, RollingConvergenceMonitor
├── convergence_monitors.py   # DistributionConvergenceMonitor, ConvergenceWrapper
└── convergence_checkers.py   # NEW: Protocol-based checkers
```

### New Convergence Checkers
- `ConvergenceChecker`: Protocol interface for all checkers
- `HJBConvergenceChecker`: For standalone HJB solvers
- `FPConvergenceChecker`: For standalone FP solvers (with mass conservation tracking)
- `MFGConvergenceChecker`: For coupled MFG systems (orchestrates HJB + FP)

### Why Cross-Paradigm?
Convergence checking is needed across all solver paradigms:
- Numerical (FDM, FEM, GFDM)
- Neural (DGM, PINN)
- Optimization-based
- Reinforcement learning (Actor-Critic, PPO)

### Backward Compatibility
Old imports still work with deprecation warning:
```python
# Old (deprecated)
from mfg_pde.utils.numerical.convergence import ConvergenceConfig

# New (preferred)
from mfg_pde.utils.convergence import ConvergenceConfig
```

## Test plan
- [x] All 62 convergence tests pass
- [x] New checkers verified manually
- [x] Ruff linting passes
- [ ] CI passes

Addresses #456 (Phase 1-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)