### PR TITLE
feat: Support DiffusionField type for sigma parameter in MFGProblem

### DIFF
--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -164,14 +164,16 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
                         Note: Both hjb_geometry and fp_geometry must be specified together
             network: NetworkGraph for network MFG problems
             T, Nt, time_domain: Time domain parameters (T, Nt) or tuple (T, Nt)
-            diffusion: Diffusion coefficient (primary parameter).
-                Supports multiple forms:
+            diffusion: Diffusion coefficient (primary parameter). None → 0 (deterministic).
+                Supports:
+                - None: No diffusion (deterministic dynamics)
                 - float: Constant isotropic diffusion σ²
                 - ndarray: Spatially/temporally varying diffusion
                 - Callable: State-dependent σ(t, x, m) -> float | ndarray
             sigma: Legacy alias for diffusion (deprecated, use diffusion instead).
-            drift: Optional drift field α(t, x, m) for FP equation.
+            drift: Drift field α(t, x, m) for FP equation. None → 0 (no drift).
                 Supports:
+                - None: No drift (no advection)
                 - float: Constant drift (same in all directions)
                 - ndarray: Precomputed drift array
                 - Callable: State-dependent α(t, x, m) -> float | ndarray
@@ -275,13 +277,17 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             )
             diffusion = sigma
 
-        # Set defaults for T, Nt, diffusion if not provided
+        # Set defaults for T, Nt if not provided
         if T is None:
             T = 1.0
         if Nt is None:
             Nt = 51
+
+        # Convert None to 0 for diffusion and drift (None = no diffusion/drift)
         if diffusion is None:
-            diffusion = 1.0
+            diffusion = 0.0
+        if drift is None:
+            drift = 0.0
 
         # Store the full diffusion field (may be float, array, or callable)
         # self.sigma will be the scalar/default for backward compatibility

--- a/mfg_pde/types/pde_coefficients.py
+++ b/mfg_pde/types/pde_coefficients.py
@@ -157,5 +157,5 @@ class DiffusionCallable(Protocol):
 
 
 # Type aliases for clarity in solver signatures
-DriftField = float | NDArray[np.floating] | DriftCallable | None  # None = no drift
-DiffusionField = float | NDArray[np.floating] | DiffusionCallable  # Always required (defaults to 1.0)
+DriftField = float | NDArray[np.floating] | DriftCallable | None  # None → 0 (no drift)
+DiffusionField = float | NDArray[np.floating] | DiffusionCallable | None  # None → 0 (deterministic)

--- a/tests/unit/test_core/test_mfg_problem.py
+++ b/tests/unit/test_core/test_mfg_problem.py
@@ -94,8 +94,10 @@ def test_mfg_problem_default_initialization():
     assert problem.Nt == 51
     assert problem.dt == pytest.approx(1.0 / 51)
 
-    # Physical parameters
-    assert problem.sigma == 1.0
+    # Physical parameters (None → 0 for diffusion/drift)
+    assert problem.sigma == 0.0
+    assert problem.diffusion_field == 0.0
+    assert problem.drift_field == 0.0
     assert problem.coupling_coefficient == 0.5
 
     # Custom components
@@ -609,11 +611,20 @@ def test_dual_geometry_legacy_mode_compatibility():
 
 
 @pytest.mark.unit
-def test_diffusion_field_scalar():
-    """Test MFGProblem with scalar diffusion coefficient (default behavior)."""
-    problem = MFGProblem(sigma=0.5)
+def test_diffusion_field_none():
+    """Test MFGProblem with no diffusion (deterministic). None → 0."""
+    problem = MFGProblem(diffusion=None)
 
-    # Scalar sigma should be stored as-is
+    assert problem.diffusion_field == 0.0
+    assert problem.sigma == 0.0
+    assert not problem.has_state_dependent_coefficients()
+
+
+@pytest.mark.unit
+def test_diffusion_field_scalar():
+    """Test MFGProblem with scalar diffusion coefficient."""
+    problem = MFGProblem(diffusion=0.5)
+
     assert problem.sigma == 0.5
     assert problem.diffusion_field == 0.5
     assert not problem.has_state_dependent_coefficients()
@@ -686,10 +697,10 @@ def test_sigma_deprecated_alias():
 
 @pytest.mark.unit
 def test_drift_field_none():
-    """Test MFGProblem with no drift field (default)."""
+    """Test MFGProblem with no drift field (default). None → 0."""
     problem = MFGProblem()
 
-    assert problem.drift_field is None
+    assert problem.drift_field == 0.0
     assert not problem.has_state_dependent_coefficients()
 
 


### PR DESCRIPTION
## Summary
- Enhance MFGProblem to accept DiffusionField type (float | NDArray | Callable) for diffusion parameter
- Add drift_field parameter for state-dependent drift coefficients
- Add helper methods for coefficient field access: `get_diffusion_coefficient_field()`, `get_drift_coefficient_field()`, `has_state_dependent_coefficients()`
- **API change**: `diffusion` is now the primary parameter, `sigma` is deprecated alias

## Changes
- `mfg_pde/core/mfg_problem.py`: 
  - Extended diffusion type to accept float, array, or callable
  - Added drift_field parameter
  - Added helper methods for CoefficientField access
  - Made `diffusion` the primary parameter, `sigma` now deprecated with warning
- `tests/unit/test_core/test_mfg_problem.py`: Added 13 new tests for DiffusionField support

## Test plan
- [x] All 45 tests in test_mfg_problem.py pass
- [x] New tests cover scalar, array, and callable diffusion
- [x] New tests cover drift_field parameter
- [x] New tests cover helper methods
- [x] New test verifies sigma deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)