### PR TITLE
feat: Implement ghost value pattern for HJB upwind schemes

### DIFF
--- a/mfg_pde/geometry/boundary/__init__.py
+++ b/mfg_pde/geometry/boundary/__init__.py
@@ -73,6 +73,7 @@ from .applicator_fdm import (
     apply_boundary_conditions_3d,
     apply_boundary_conditions_nd,
     create_boundary_mask_2d,
+    get_ghost_values_nd,
 )
 
 # =============================================================================
@@ -210,6 +211,7 @@ __all__ = [
     "apply_boundary_conditions_3d",
     "apply_boundary_conditions_nd",
     "create_boundary_mask_2d",
+    "get_ghost_values_nd",
     # FEM Applicator - dispatchers
     "FEMApplicator",
     "MFGBoundaryHandlerFEM",


### PR DESCRIPTION
## Summary
- Add `get_ghost_values_nd()` function to compute ghost values from boundary conditions without padding arrays
- Modify `HJBFDMSolver._compute_gradients_nd()` to use ghost values when geometry has boundary conditions
- Add `_get_ghost_values()` method to query BCs from geometry
- Add 6 unit tests for ghost value BC handling

## Problem
HJB upwind schemes need ghost values BEFORE computing the Hamiltonian (to compute proper gradients at boundaries). Previously, the solver used one-sided differences as fallback at boundaries, which didn't properly respect boundary conditions.

## Solution
Ghost values are now computed from BCs using these formulas:
- **Dirichlet**: `u_ghost = 2*g - u_interior` (cell-centered)
- **Neumann/No-flux**: `u_ghost = u_interior` (zero derivative)  
- **Periodic**: `u_ghost = u_opposite_boundary`

The HJB solver now queries ghost values from geometry before gradient computation, enabling proper upwind differences that respect BCs.

## Test plan
- [x] All existing HJB FDM tests pass (32 unit + 9 integration)
- [x] 6 new ghost value BC tests pass
- [x] Run full test suite

Fixes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)