### PR TITLE
fix: Pass time parameter to BC applicators for time-varying BCs

### DIFF
--- a/mfg_pde/geometry/boundary/applicator_fdm.py
+++ b/mfg_pde/geometry/boundary/applicator_fdm.py
@@ -1245,6 +1245,7 @@ def get_ghost_values_nd(
     boundary_conditions: BoundaryConditions | LegacyBoundaryConditions1D,
     spacing: tuple[float, ...] | NDArray[np.floating],
     config: GhostCellConfig | None = None,
+    time: float = 0.0,
 ) -> dict[tuple[int, int], NDArray[np.floating]]:
     """
     Compute ghost values for each boundary without padding the array.
@@ -1267,6 +1268,7 @@ def get_ghost_values_nd(
         boundary_conditions: BC specification (unified or legacy)
         spacing: Grid spacing for each dimension, tuple or array of length d
         config: Ghost cell configuration (grid type)
+        time: Current time for time-dependent BC values (default: 0.0)
 
     Returns:
         Dictionary mapping (dimension, side) to ghost value arrays:
@@ -1316,7 +1318,8 @@ def get_ghost_values_nd(
         elif bc_type == BCType.DIRICHLET:
             g = bc_value if bc_value is not None else 0.0
             if callable(g):
-                g = 0.0  # Uniform value for now
+                # Time-varying BC: call with current time
+                g = g(time)
 
             if config.grid_type == "vertex_centered":
                 # Vertex-centered: boundary is at grid point
@@ -1334,7 +1337,8 @@ def get_ghost_values_nd(
             # Right: u_ghost = u_int + 2*dx*g (outward normal)
             g = bc_value if bc_value is not None else 0.0
             if callable(g):
-                g = 0.0
+                # Time-varying flux: call with current time
+                g = g(time)
 
             ghosts[(axis, 0)] = u_int_left - 2 * dx * g
             ghosts[(axis, 1)] = u_int_right + 2 * dx * g


### PR DESCRIPTION
## Summary
- Add `time` parameter to `get_ghost_values_nd()` function
- Update callable BC value handling to call with time: `g(time)` 
- Pass current time through HJB solver gradient computation chain
- Add 2 tests for time-varying Dirichlet BC

## Problem
Time-varying boundary conditions (callable values) were always evaluated at t=0.0 instead of the current timestep. This caused incorrect behavior for problems with moving boundaries.

Example:
```python
def moving_wall(t):
    return np.sin(omega * t)

bc = dirichlet_bc(value=moving_wall, dimension=2)
# Previously: moving_wall(0.0) called for all timesteps
# Now: moving_wall(t_current) called correctly
```

## Changes
- `get_ghost_values_nd(field, bc, spacing, time=0.0)` - new time parameter
- HJB solver method chain updated:
  - `_solve_hjb_nd`: computes `t_current = n * dt`
  - `_solve_single_timestep(..., time)`: receives time
  - `_compute_gradients_nd(U, time)`: passes time to ghost values
  - `_get_ghost_values(U, time)`: passes time to BC applicator

## Test plan
- [x] `test_time_varying_dirichlet_bc` - verifies callable receives correct time
- [x] `test_hjb_solver_time_varying_bc` - verifies solver calls BC at multiple times
- [x] All 40 HJB FDM tests pass

Fixes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)