### PR TITLE
feat: Make BC dimension optional with lazy binding (#495)

### DIFF
--- a/mfg_pde/geometry/grids/tensor_grid.py
+++ b/mfg_pde/geometry/grids/tensor_grid.py
@@ -208,13 +208,10 @@ class TensorProductGrid(CartesianGrid):
                 raise ValueError(f"Coordinate array {i} has length {len(coords)}, expected {self._Nx_points[i]}")
 
         # Store boundary conditions (SSOT for spatial BC)
-        # Validate dimension if BC provided
+        # Use lazy binding to set/validate dimension
         if boundary_conditions is not None:
-            if boundary_conditions.dimension != dimension:
-                raise ValueError(
-                    f"BoundaryConditions dimension ({boundary_conditions.dimension}) "
-                    f"does not match grid dimension ({dimension})"
-                )
+            # bind_dimension returns a new BC with dimension set, or validates if already set
+            boundary_conditions = boundary_conditions.bind_dimension(dimension)
         self._boundary_conditions = boundary_conditions
 
         # Cache for flattened grid (computed lazily, perf optimization)


### PR DESCRIPTION
## Summary
- Make `dimension` optional (default None) in `BoundaryConditions` dataclass
- Add `bind_dimension()` method for explicit or lazy dimension binding  
- Add `is_bound` property to check if dimension is set
- Add `_require_dimension()` helper for methods requiring dimension
- Update factory functions (`dirichlet_bc`, `neumann_bc`, etc.) to make dimension optional
- Update `TensorProductGrid` to call `bind_dimension()` when BC attached
- Add 11 tests for lazy dimension binding

## Before (redundant)
```python
bc = dirichlet_bc(value=0.0, dimension=2)  # User specifies
grid = TensorProductGrid(dimension=2, ..., boundary_conditions=bc)
# If bc.dimension != grid.dimension → Error
```

## After (dimension-agnostic)
```python
bc = dirichlet_bc(value=0.0)  # No dimension needed
grid = TensorProductGrid(dimension=2, ..., boundary_conditions=bc)
# Grid infers: bc.dimension = grid.dimension
```

## Test plan
- [x] All 35 BC applicator tests pass
- [x] 11 new tests for lazy dimension binding pass
- [x] Linter passes
- [x] Existing code using explicit dimension still works

Fixes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)