### PR TITLE
feat: Implement SDFParticleBCHandler for complex geometry (#497)

### DIFF
--- a/mfg_pde/geometry/boundary/__init__.py
+++ b/mfg_pde/geometry/boundary/__init__.py
@@ -141,6 +141,7 @@ from .applicator_graph import (
 from .applicator_meshfree import (
     MeshfreeApplicator,
     ParticleReflector,
+    SDFParticleBCHandler,
 )
 
 # Unified BoundaryConditions class and factory functions
@@ -255,6 +256,7 @@ __all__ = [
     # Meshfree Applicator
     "MeshfreeApplicator",
     "ParticleReflector",
+    "SDFParticleBCHandler",
     # Graph Applicator
     "GraphApplicator",
     "GraphBCConfig",


### PR DESCRIPTION
## Summary
Add SDF-based particle boundary condition handler for complex geometry support.

- `SDFParticleBCHandler` class that works with any SDF function
- Detects boundary crossings: `(sdf_old < 0) & (sdf_new > 0)` 
- Finds exact intersection via bisection
- Computes normal from SDF gradient for proper reflection
- Reflects both positions and velocities at boundary

## Before
```python
# Only rectangular domains supported
for dim in range(ndim):
    x_min, x_max = self.bounds[dim]  # Axis-aligned only
```

## After
```python
# Any SDF-defined geometry
def circle_sdf(points):
    return sdf_sphere(points, center=[0, 0], radius=1.0)

handler = SDFParticleBCHandler(circle_sdf, dimension=2)
X_new, V_new = handler.apply_bc(X_old, X_new, velocities=V)
```

## Test plan
- [x] 7 tests for SDFParticleBCHandler pass
- [x] Test circular domain (sdf_sphere)
- [x] Test rectangular domain (sdf_box)
- [x] Test velocity reflection
- [x] Test multiple particles with mixed behavior
- [x] Linter passes

Fixes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)