### PR TITLE
feat: Add PreallocatedGhostBuffer for zero-copy BC updates (Issue #486 Phase 0c)

### DIFF
--- a/mfg_pde/geometry/boundary/__init__.py
+++ b/mfg_pde/geometry/boundary/__init__.py
@@ -68,6 +68,7 @@ from .applicator_base import (
 from .applicator_fdm import (
     FDMApplicator,
     GhostCellConfig,
+    PreallocatedGhostBuffer,
     apply_boundary_conditions_1d,
     apply_boundary_conditions_2d,
     apply_boundary_conditions_3d,
@@ -207,6 +208,7 @@ __all__ = [
     # FDM Applicator
     "FDMApplicator",
     "GhostCellConfig",
+    "PreallocatedGhostBuffer",
     "apply_boundary_conditions_1d",
     "apply_boundary_conditions_2d",
     "apply_boundary_conditions_3d",


### PR DESCRIPTION
## Summary

Phase 0c of Issue #486 (BC Unification).

- Adds `PreallocatedGhostBuffer` class for high-performance time-stepping loops
- Pre-allocates padded buffer once, avoiding repeated memory allocation
- `interior` property returns a view (no copy) for solver to modify directly
- `update_ghosts()` computes ghost cells in-place based on stored BC
- Supports all uniform BC types (Periodic, Dirichlet, Neumann, Robin, No-flux)
- Falls back to `apply_boundary_conditions_nd()` for mixed BCs
- Adds smoke tests for the FDM applicator module

## Usage

```python
from mfg_pde.geometry.boundary import PreallocatedGhostBuffer, neumann_bc

# Create buffer once
bc = neumann_bc(dimension=2)
buffer = PreallocatedGhostBuffer(
    interior_shape=(Ny, Nx),
    boundary_conditions=bc,
    domain_bounds=bounds,
)

# Time-stepping loop (zero allocation)
for t in timesteps:
    buffer.interior[:] = field  # Copy or modify in-place
    buffer.update_ghosts()       # In-place ghost computation
    padded = buffer.padded       # Zero-copy access
    # ... compute derivatives using padded ...
```

## Test plan

- [x] Linting passes (`ruff check`)
- [x] Existing boundary condition tests pass (185 tests)
- [x] New smoke tests verify PreallocatedGhostBuffer:
  - 2D Dirichlet BC ghost values correct
  - 3D Periodic BC wrapping correct
  - Zero-copy interior view verified

Closes part of #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)