### PR TITLE
fix(boundary): Enforce GridType enum consistency across FDM applicator

### DIFF
--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -521,6 +521,39 @@ class TestGridTypeConfiguration:
         assert np.isclose(padded[3, 0], 0.0)
         assert np.isclose(padded[3, -1], 0.0)
 
+    def test_grid_type_enum(self):
+        """Test using GridType enum directly (not string)."""
+        from mfg_pde.geometry.boundary import GridType
+
+        field = np.ones((5, 5))
+        bc = dirichlet_bc(value=0.0, dimension=2)
+
+        # Using enum directly
+        config = GhostCellConfig(grid_type=GridType.VERTEX_CENTERED)
+        padded = apply_boundary_conditions_2d(field, bc, config=config)
+
+        # Vertex-centered: ghost = g
+        assert np.isclose(padded[3, 0], 0.0)
+
+        # Test cell-centered with enum
+        config2 = GhostCellConfig(grid_type=GridType.CELL_CENTERED)
+        padded2 = apply_boundary_conditions_2d(field, bc, config=config2)
+
+        # Cell-centered: ghost = 2*g - interior = -1
+        assert np.isclose(padded2[3, 0], -1.0)
+
+    def test_vertex_centered_neumann(self):
+        """Test Neumann BC with vertex-centered grid."""
+        field = np.ones((5, 5))
+        bc = neumann_bc(value=0.0, dimension=2)
+
+        config = GhostCellConfig(grid_type="vertex_centered")
+        padded = apply_boundary_conditions_2d(field, bc, config=config)
+
+        # Neumann with zero flux: ghost = interior (for both grid types)
+        assert np.isclose(padded[3, 0], 1.0)
+        assert np.isclose(padded[3, -1], 1.0)
+
 
 class TestInputValidation:
     """Tests for input validation."""


### PR DESCRIPTION
## Summary

Enforce consistent use of `GridType` enum across all FDM boundary condition functions, resolving the inconsistency where `applicator_base.py` used the enum but `applicator_fdm.py` used string literals.

## Changes

### GhostCellConfig
- Now uses `GridType` enum instead of string literals
- Added `__post_init__` for string-to-enum backward compatibility
- Added `is_vertex_centered` and `is_cell_centered` properties

### FDMApplicator
- Updated `__init__` to accept both `GridType` enum and string
- Added `grid_type_str` property for backward compatibility
- Changed `grid_type` property to return `GridType` enum

### Code Updates
- Replaced all `config.grid_type == "vertex_centered"` with `config.is_vertex_centered`
- Removed unused `Literal` import

## Tests

- Added `test_grid_type_enum` - verifies direct enum usage
- Added `test_vertex_centered_neumann` - verifies Neumann BC with vertex-centered grid
- All 98 BC-related tests pass

## Backward Compatibility

Both enum and string arguments are supported:

```python
# New (preferred)
config = GhostCellConfig(grid_type=GridType.VERTEX_CENTERED)
applicator = FDMApplicator(dimension=2, grid_type=GridType.CELL_CENTERED)

# Legacy (still works)
config = GhostCellConfig(grid_type="vertex_centered")
applicator = FDMApplicator(dimension=2, grid_type="cell_centered")
```

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)