### PR TITLE
feat(boundary): Add linear and quadratic extrapolation BCs for unbounded domains

### DIFF
--- a/mfg_pde/geometry/boundary/__init__.py
+++ b/mfg_pde/geometry/boundary/__init__.py
@@ -61,7 +61,10 @@ from .applicator_base import (
     # Ghost cell helpers (2nd-order)
     ghost_cell_dirichlet,
     ghost_cell_fp_no_flux,
+    # Extrapolation ghost cell (for unbounded domains)
+    ghost_cell_linear_extrapolation,
     ghost_cell_neumann,
+    ghost_cell_quadratic_extrapolation,
     ghost_cell_robin,
 )
 
@@ -196,6 +199,9 @@ __all__ = [
     # Physics-aware ghost cell (for advection-diffusion/FP)
     "ghost_cell_fp_no_flux",
     "ghost_cell_advection_diffusion_no_flux",
+    # Extrapolation ghost cell (for unbounded domains)
+    "ghost_cell_linear_extrapolation",
+    "ghost_cell_quadratic_extrapolation",
     # Core types
     "BCType",
     "BCSegment",

--- a/mfg_pde/geometry/boundary/types.py
+++ b/mfg_pde/geometry/boundary/types.py
@@ -138,6 +138,15 @@ class BCType(Enum):
         - FP density equation (field) -> NO_FLUX
         - Particle simulation -> REFLECTING
         - HJB value function -> NEUMANN (with g=0)
+
+    Extrapolation Types (for unbounded/truncated domains):
+        EXTRAPOLATION_LINEAR: Zero second derivative (d²u/dx² = 0)
+            - Use for HJB value functions with linear growth
+            - Ghost = 2*u_0 - u_1
+
+        EXTRAPOLATION_QUADRATIC: Zero third derivative (d³u/dx³ = 0)
+            - Use for LQG-type problems with quadratic value growth
+            - Ghost = 3*u_0 - 3*u_1 + u_2
     """
 
     DIRICHLET = "dirichlet"
@@ -146,6 +155,8 @@ class BCType(Enum):
     PERIODIC = "periodic"
     REFLECTING = "reflecting"
     NO_FLUX = "no_flux"
+    EXTRAPOLATION_LINEAR = "extrapolation_linear"
+    EXTRAPOLATION_QUADRATIC = "extrapolation_quadratic"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Add extrapolation boundary conditions for handling unbounded/truncated domains in HJB solvers.

## New Features

### Ghost Cell Functions

```python
from mfg_pde.geometry.boundary import (
    ghost_cell_linear_extrapolation,
    ghost_cell_quadratic_extrapolation,
)

# Linear: u_ghost = 2*u_0 - u_1 (zero second derivative)
ghost = ghost_cell_linear_extrapolation((u[0], u[1]))

# Quadratic: u_ghost = 3*u_0 - 3*u_1 + u_2 (zero third derivative)
ghost = ghost_cell_quadratic_extrapolation((u[0], u[1], u[2]))
```

### BCType Enum Values

```python
BCType.EXTRAPOLATION_LINEAR    # For linear value growth
BCType.EXTRAPOLATION_QUADRATIC # For quadratic value growth (LQG)
```

### 1D Usage

```python
from mfg_pde.geometry.boundary import BCSegment, BCType, BoundaryConditions

bc = BoundaryConditions(
    dimension=1,
    segments=[
        BCSegment(name="left", bc_type=BCType.EXTRAPOLATION_LINEAR, boundary="x_min"),
        BCSegment(name="right", bc_type=BCType.EXTRAPOLATION_LINEAR, boundary="x_max"),
    ],
    domain_bounds=np.array([[0.0, 1.0]]),
)

padded = apply_boundary_conditions_1d(field, bc)
```

## Mathematical Background

| Type | Condition | Formula | Use Case |
|------|-----------|---------|----------|
| Linear | d²u/dx² = 0 | 2u₀ - u₁ | HJB with linear growth |
| Quadratic | d³u/dx³ = 0 | 3u₀ - 3u₁ + u₂ | LQG with quadratic growth |

## Tests

- 4 new tests for extrapolation functions and 1D integration
- All 48 BC tests pass

Fixes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)