### PR TITLE
refactor(internal): Migrate internal code to Geometry-First API (Issue #544 Phase 2)

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/base_fp.py
+++ b/mfg_pde/alg/numerical/fp_solvers/base_fp.py
@@ -228,8 +228,10 @@ if __name__ == "__main__":
 
     # Test that BaseFPSolver is abstract (cannot be instantiated)
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
-    problem = MFGProblem(Nx=20, Nt=10, T=1.0, diffusion=0.1)
+    geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[21])
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=10, diffusion=0.1)
 
     try:
         # This should fail because BaseFPSolver is abstract

--- a/mfg_pde/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_gfdm.py
@@ -408,10 +408,12 @@ if __name__ == "__main__":
     print("Testing FPGFDMSolver...")
 
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
     # Test 1D problem
     print("\n[1D] Testing 1D GFDM FP solver...")
-    problem = MFGProblem(Nx=30, Nt=20, T=1.0, diffusion=0.1)
+    geometry_1d = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[31])
+    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1)
 
     # Create 1D collocation points
     points_1d = np.linspace(0, 1, 50).reshape(-1, 1)

--- a/mfg_pde/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_particle.py
@@ -1784,9 +1784,11 @@ if __name__ == "__main__":
     print("Testing FPParticleSolver...")
 
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
     # Test 1D problem with particle solver
-    problem = MFGProblem(Nx=30, Nt=20, T=1.0, diffusion=0.1)
+    geometry_1d = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[31])
+    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1)
     solver = FPParticleSolver(problem, num_particles=1000)
 
     # Test solver initialization

--- a/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
@@ -1317,8 +1317,10 @@ if __name__ == "__main__":
 
     # Test that BaseHJBSolver is abstract
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
-    problem = MFGProblem(Nx=10, Nt=5, T=1.0, diffusion=0.1)
+    geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[11])
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=5, diffusion=0.1)
 
     try:
         base_solver = BaseHJBSolver(problem)

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -1063,8 +1063,10 @@ if __name__ == "__main__":
 
     # Test 1D problem
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
-    problem_1d = MFGProblem(Nx=30, Nt=20, T=1.0, diffusion=0.1)
+    geometry_1d = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[31])
+    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1)
     solver_1d = HJBFDMSolver(problem_1d, solver_type="newton")
 
     # Test solver initialization

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2339,9 +2339,11 @@ if __name__ == "__main__":
     import numpy as np
 
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
     # Test 1D problem with uniform collocation points matching problem grid
-    problem_1d = MFGProblem(Nx=20, Nt=10, T=1.0, diffusion=0.1)
+    geometry_1d = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[21])
+    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=10, diffusion=0.1)
 
     # Use problem grid points as collocation points to avoid index mismatch
     collocation_points = problem_1d.xSpace.reshape(-1, 1)
@@ -2387,7 +2389,8 @@ if __name__ == "__main__":
     xx, yy = np.meshgrid(x_grid, y_grid)
     points_2d = np.column_stack([xx.ravel(), yy.ravel()])
 
-    problem_2d = MFGProblem(Nx=Nx_2d, Nt=5, T=1.0, diffusion=0.1, dimension=2)
+    geometry_2d = TensorProductGrid(dimension=2, bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[Nx_2d, Nx_2d])
+    problem_2d = MFGProblem(geometry=geometry_2d, T=1.0, Nt=5, diffusion=0.1)
 
     solver_2d = HJBGFDMSolver(
         problem_2d,

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1612,10 +1612,12 @@ if __name__ == "__main__":
     print("Testing HJBSemiLagrangianSolver...")
 
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
     # Test 1: Solver initialization
     print("\n1. Testing solver initialization...")
-    problem = MFGProblem(Nx=50, Nt=100, T=1.0, diffusion=0.1)
+    geometry_1d = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[51])
+    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=100, diffusion=0.1)
     solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", optimization_method="brent")
 
     assert solver.dimension == 1

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
@@ -1479,9 +1479,11 @@ if __name__ == "__main__":
     import numpy as np
 
     from mfg_pde import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
     # Test 1D problem
-    problem_1d = MFGProblem(Nx=30, Nt=20, T=1.0, diffusion=0.1)
+    geometry_1d = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[31])
+    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1)
 
     # Test standard WENO variant
     solver_1d = HJBWenoSolver(problem_1d, weno_variant="weno-z")

--- a/mfg_pde/factory/backend_factory.py
+++ b/mfg_pde/factory/backend_factory.py
@@ -247,8 +247,10 @@ if __name__ == "__main__":
 
     # Create a test problem
     from mfg_pde.core.mfg_problem import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
-    problem = MFGProblem(T=1.0, Nx=100, Nt=50)
+    geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[101])
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=50)
 
     print("\n Backend Recommendations for Test Problem:")
     recommendations = BackendFactory.get_backend_recommendations(problem)

--- a/mfg_pde/meta/type_system.py
+++ b/mfg_pde/meta/type_system.py
@@ -442,8 +442,10 @@ def dispatch_solver(problem: TypedMFGProblem, method_preference: NumericalMethod
 if __name__ == "__main__":
     # Create a typed problem
     from mfg_pde.core.mfg_problem import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
 
-    problem = MFGProblem(xmin=0, xmax=1, T=1.0, Nx=100, Nt=50)
+    geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[101])
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=50)
     typed_problem = create_typed_problem(problem, QUADRATIC_MFG_TYPE)
 
     print(f"Problem type: {typed_problem.mfg_type}")

--- a/mfg_pde/workflow/__init__.py
+++ b/mfg_pde/workflow/__init__.py
@@ -182,9 +182,11 @@ def performance_benchmark_workflow(problem_sizes: list[tuple], solver_types: lis
         import time
 
         from mfg_pde import MFGProblem
+        from mfg_pde.geometry import TensorProductGrid
 
         Nx, Nt = params["problem_size"]
-        problem = MFGProblem(Nx=Nx, Nt=Nt, T=1.0)
+        geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[Nx + 1])
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=Nt)
 
         # Use problem.solve() API
         start_time = time.time()

--- a/mfg_pde/workflow/workflow_manager.py
+++ b/mfg_pde/workflow/workflow_manager.py
@@ -622,8 +622,10 @@ class WorkflowManager:
 
         def example_solve(sigma, Nx=20, Nt=10):
             from mfg_pde import MFGProblem
+            from mfg_pde.geometry import TensorProductGrid
 
-            problem = MFGProblem(Nx=Nx, Nt=Nt, diffusion=sigma)
+            geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[Nx + 1])
+            problem = MFGProblem(geometry=geometry, diffusion=sigma, Nt=Nt)
             result = problem.solve()
             return {
                 "converged": getattr(result, "converged", False),


### PR DESCRIPTION
## Summary

Continues Issue #544 Phase 2: Migrate internal MFGProblem usages from legacy API to Geometry-First API.

This PR migrates smoke tests and factory code within `mfg_pde/` itself, preparing for eventual removal of legacy parameters.

## Changes

### Files Migrated (12 total)

**Factory/Workflow:**
- `mfg_pde/factory/backend_factory.py`
- `mfg_pde/workflow/__init__.py`
- `mfg_pde/workflow/workflow_manager.py`
- `mfg_pde/meta/type_system.py`

**FP Solvers (smoke tests):**
- `mfg_pde/alg/numerical/fp_solvers/base_fp.py`
- `mfg_pde/alg/numerical/fp_solvers/fp_gfdm.py`
- `mfg_pde/alg/numerical/fp_solvers/fp_particle.py`

**HJB Solvers (smoke tests):**
- `mfg_pde/alg/numerical/hjb_solvers/base_hjb.py`
- `mfg_pde/alg/numerical/hjb_solvers/hjb_fdm.py`
- `mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py`
- `mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py`
- `mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py`

## Not Included (Future Work)

- **VariationalMFGProblem**: Separate class with own legacy API - needs dedicated migration
- **MFGProblem.__init__ cleanup**: Removal of legacy parameters is a breaking change, deferred
- **Docstring examples**: Will update when parameters are actually removed

## Test plan

- [x] Smoke tests run successfully after migration
- [ ] CI passes

## Related

- Part of #544 (Geometry-First API transition)
- Follows PR #559 (examples/tests migration)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)