### PR TITLE
feat(coupling): Add Newton MFG solver foundation

### DIFF
--- a/mfg_pde/alg/numerical/coupling/__init__.py
+++ b/mfg_pde/alg/numerical/coupling/__init__.py
@@ -5,6 +5,7 @@ This module provides complete Mean Field Games solvers that combine HJB and FP
 solvers to solve the coupled MFG system using classical numerical approaches:
 - Fixed point iterators (Picard iteration-based)
 - Fictitious Play (decaying learning rate, proven convergence)
+- Newton methods (quadratic convergence near solution)
 - Hybrid methods combining different techniques
 
 Note: Particle-collocation methods have been removed from core package.
@@ -27,6 +28,10 @@ from .fixed_point_utils import (
 )
 from .hybrid_fp_particle_hjb_fdm import HybridFPParticleHJBFDM
 
+# Newton family solvers (Issue #492)
+from .mfg_residual import MFGResidual
+from .newton_mfg_solver import NewtonMFGSolver
+
 # Note: ParticleCollocationSolver has been removed from core package
 
 __all__ = [
@@ -34,6 +39,10 @@ __all__ = [
     "FixedPointIterator",
     "FictitiousPlayIterator",
     "HybridFPParticleHJBFDM",
+    # Newton family (Issue #492)
+    "MFGResidual",
+    "NewtonMFGSolver",
+    # Utilities
     "apply_damping",
     "check_convergence_criteria",
     "construct_solver_result",
@@ -48,6 +57,11 @@ FIXED_POINT_SOLVERS = [
     "FictitiousPlayIterator",  # Fictitious play with decaying learning rate
 ]
 
+# Newton family solvers (Issue #492)
+NEWTON_SOLVERS = [
+    "NewtonMFGSolver",  # Newton's method for MFG coupling
+]
+
 # Note: PARTICLE_SOLVERS category removed - removed from core package
 
 HYBRID_SOLVERS = [
@@ -57,4 +71,4 @@ HYBRID_SOLVERS = [
 # JAX-accelerated solvers (optional)
 JAX_SOLVERS: list[str] = []
 
-ALL_MFG_SOLVERS = FIXED_POINT_SOLVERS + HYBRID_SOLVERS + JAX_SOLVERS
+ALL_MFG_SOLVERS = FIXED_POINT_SOLVERS + NEWTON_SOLVERS + HYBRID_SOLVERS + JAX_SOLVERS

--- a/mfg_pde/alg/numerical/coupling/mfg_residual.py
+++ b/mfg_pde/alg/numerical/coupling/mfg_residual.py
@@ -1,0 +1,388 @@
+"""
+MFG System Residual Computation.
+
+Issue #492 Phase 1: Foundation for Newton family solvers.
+
+Computes the residual F(U, M) of the coupled MFG system:
+    F_HJB(U, M) = HJB_solve(M) - U
+    F_FP(U, M) = FP_solve(U) - M
+
+At a fixed point (equilibrium), F(U, M) = 0.
+
+Usage:
+    residual_computer = MFGResidual(problem, hjb_solver, fp_solver)
+    F = residual_computer.compute_residual(U, M)  # Returns flattened residual
+    ||F|| < tol indicates convergence
+
+References:
+    - Achdou & Capuzzo-Dolcetta (2010): Mean field games: Numerical methods
+    - Nocedal & Wright (2006): Numerical Optimization
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from mfg_pde.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+    from mfg_pde.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+    from mfg_pde.core.mfg_problem import MFGProblem
+
+logger = logging.getLogger(__name__)
+
+
+class MFGResidual:
+    """
+    Computes residuals of the coupled MFG system.
+
+    The MFG system at equilibrium satisfies:
+        U = HJB_solve(M)  (value function solves HJB given density)
+        M = FP_solve(U)   (density solves FP given value function)
+
+    The residual measures deviation from this fixed point:
+        F(U, M) = [HJB_solve(M) - U, FP_solve(U) - M]
+
+    Attributes:
+        problem: MFG problem definition
+        hjb_solver: HJB solver instance
+        fp_solver: FP solver instance
+        M_initial: Initial density condition
+        U_terminal: Terminal value function
+
+    Example:
+        >>> residual_computer = MFGResidual(problem, hjb_solver, fp_solver)
+        >>> U, M = initial_guess(problem)
+        >>> F = residual_computer.compute_residual(U, M)
+        >>> print(f"Residual norm: {np.linalg.norm(F):.2e}")
+    """
+
+    def __init__(
+        self,
+        problem: MFGProblem,
+        hjb_solver: BaseHJBSolver,
+        fp_solver: BaseFPSolver,
+        *,
+        diffusion_field: float | NDArray | Any | None = None,
+        drift_field: NDArray | Any | None = None,
+    ):
+        """
+        Initialize MFG residual computer.
+
+        Args:
+            problem: MFG problem definition
+            hjb_solver: HJB solver instance
+            fp_solver: FP solver instance
+            diffusion_field: Optional diffusion override (Phase 2.3)
+            drift_field: Optional drift override for non-MFG problems
+        """
+        self.problem = problem
+        self.hjb_solver = hjb_solver
+        self.fp_solver = fp_solver
+        self.diffusion_field = diffusion_field
+        self.drift_field = drift_field
+
+        # Cache problem dimensions
+        self.num_time_steps = problem.Nt + 1
+        self.spatial_shape = tuple(problem.geometry.get_grid_shape())
+        self.solution_shape = (self.num_time_steps, *self.spatial_shape)
+
+        # Cache initial/terminal conditions
+        self.M_initial: NDArray | None = None
+        self.U_terminal: NDArray | None = None
+        self._initialize_conditions()
+
+        # Cache solver method signatures for parameter passing
+        self._hjb_sig_params: set[str] | None = None
+        self._fp_sig_params: set[str] | None = None
+        self._cache_solver_signatures()
+
+        # Evaluation counter for diagnostics
+        self.residual_evaluations = 0
+
+    def _initialize_conditions(self) -> None:
+        """Initialize initial density and terminal value from problem."""
+        shape = self.spatial_shape
+
+        # Try to get initial density
+        try:
+            self.M_initial = self.problem.get_m_init()
+            if self.M_initial.shape != shape:
+                self.M_initial = self.M_initial.reshape(shape)
+        except AttributeError:
+            try:
+                self.M_initial = self.problem.m_init
+                if self.M_initial is not None and self.M_initial.shape != shape:
+                    self.M_initial = self.M_initial.reshape(shape)
+            except AttributeError:
+                # Default: uniform density
+                self.M_initial = np.ones(shape) / np.prod(shape)
+                logger.warning("No initial density found, using uniform")
+
+        # Try to get terminal value
+        try:
+            self.U_terminal = self.problem.get_u_fin()
+            if self.U_terminal.shape != shape:
+                self.U_terminal = self.U_terminal.reshape(shape)
+        except AttributeError:
+            try:
+                self.U_terminal = self.problem.u_fin
+                if self.U_terminal is not None and self.U_terminal.shape != shape:
+                    self.U_terminal = self.U_terminal.reshape(shape)
+            except AttributeError:
+                # Default: zero terminal cost
+                self.U_terminal = np.zeros(shape)
+
+    def _cache_solver_signatures(self) -> None:
+        """Cache solver method signatures for parameter passing."""
+        import inspect
+
+        try:
+            sig = inspect.signature(self.hjb_solver.solve_hjb_system)
+            self._hjb_sig_params = set(sig.parameters.keys())
+        except AttributeError:
+            self._hjb_sig_params = None
+
+        try:
+            sig = inspect.signature(self.fp_solver.solve_fp_system)
+            self._fp_sig_params = set(sig.parameters.keys())
+        except AttributeError:
+            self._fp_sig_params = None
+
+    def compute_hjb_output(self, M: NDArray, U_prev: NDArray) -> NDArray:
+        """
+        Compute HJB solver output for given density.
+
+        Args:
+            M: Current density field (Nt+1, *spatial_shape)
+            U_prev: Previous value function (for Newton linearization)
+
+        Returns:
+            U_new: Value function from HJB solve
+        """
+        kwargs: dict[str, Any] = {}
+
+        if self._hjb_sig_params is not None:
+            if "show_progress" in self._hjb_sig_params:
+                kwargs["show_progress"] = False
+            if "diffusion_field" in self._hjb_sig_params and self.diffusion_field is not None:
+                kwargs["diffusion_field"] = self.diffusion_field
+
+        return self.hjb_solver.solve_hjb_system(M, self.U_terminal, U_prev, **kwargs)
+
+    def compute_fp_output(self, U: NDArray) -> NDArray:
+        """
+        Compute FP solver output for given value function.
+
+        Args:
+            U: Current value function (Nt+1, *spatial_shape)
+
+        Returns:
+            M_new: Density field from FP solve
+        """
+        kwargs: dict[str, Any] = {}
+
+        if self._fp_sig_params is not None:
+            if "show_progress" in self._fp_sig_params:
+                kwargs["show_progress"] = False
+
+            # Determine drift
+            effective_drift = self.drift_field if self.drift_field is not None else U
+
+            if "drift_field" in self._fp_sig_params:
+                kwargs["drift_field"] = effective_drift
+                if "diffusion_field" in self._fp_sig_params and self.diffusion_field is not None:
+                    kwargs["diffusion_field"] = self.diffusion_field
+                return self.fp_solver.solve_fp_system(self.M_initial, **kwargs)
+            else:
+                # Legacy interface
+                return self.fp_solver.solve_fp_system(self.M_initial, effective_drift, **kwargs)
+        else:
+            # Basic call
+            return self.fp_solver.solve_fp_system(self.M_initial, U)
+
+    def compute_residual(
+        self,
+        U: NDArray,
+        M: NDArray,
+        *,
+        return_components: bool = False,
+    ) -> NDArray | tuple[NDArray, NDArray, NDArray]:
+        """
+        Compute MFG system residual F(U, M).
+
+        The residual is defined as:
+            F_HJB = HJB_solve(M) - U
+            F_FP = FP_solve(U) - M
+            F = [F_HJB, F_FP]  (flattened)
+
+        Args:
+            U: Value function (Nt+1, *spatial_shape)
+            M: Density field (Nt+1, *spatial_shape)
+            return_components: If True, return (F, F_HJB, F_FP) tuple
+
+        Returns:
+            F: Flattened residual vector (2 * total_size,)
+            Or tuple (F, F_HJB, F_FP) if return_components=True
+        """
+        self.residual_evaluations += 1
+
+        # Compute solver outputs
+        U_new = self.compute_hjb_output(M, U)
+        M_new = self.compute_fp_output(U)
+
+        # Compute residuals (difference from fixed point)
+        F_HJB = U_new - U
+        F_FP = M_new - M
+
+        # Flatten for Newton solver
+        F = np.concatenate([F_HJB.flatten(), F_FP.flatten()])
+
+        if return_components:
+            return F, F_HJB, F_FP
+        return F
+
+    def compute_residual_norm(
+        self,
+        U: NDArray,
+        M: NDArray,
+        *,
+        norm_type: str = "l2",
+    ) -> float:
+        """
+        Compute norm of MFG residual.
+
+        Args:
+            U: Value function
+            M: Density field
+            norm_type: 'l2', 'linf', or 'relative'
+
+        Returns:
+            Residual norm
+        """
+        F = self.compute_residual(U, M)
+
+        if norm_type == "l2":
+            return float(np.linalg.norm(F))
+        elif norm_type == "linf":
+            return float(np.max(np.abs(F)))
+        elif norm_type == "relative":
+            state_norm = np.linalg.norm(np.concatenate([U.flatten(), M.flatten()]))
+            return float(np.linalg.norm(F) / (state_norm + 1e-10))
+        else:
+            raise ValueError(f"Unknown norm_type: {norm_type}")
+
+    def pack_state(self, U: NDArray, M: NDArray) -> NDArray:
+        """
+        Pack (U, M) into a single flattened state vector.
+
+        Args:
+            U: Value function (Nt+1, *spatial_shape)
+            M: Density field (Nt+1, *spatial_shape)
+
+        Returns:
+            x: Flattened state vector [U_flat, M_flat]
+        """
+        return np.concatenate([U.flatten(), M.flatten()])
+
+    def unpack_state(self, x: NDArray) -> tuple[NDArray, NDArray]:
+        """
+        Unpack flattened state vector into (U, M).
+
+        Args:
+            x: Flattened state vector [U_flat, M_flat]
+
+        Returns:
+            (U, M): Reshaped value function and density
+        """
+        total_size = np.prod(self.solution_shape)
+        U_flat = x[:total_size]
+        M_flat = x[total_size:]
+
+        U = U_flat.reshape(self.solution_shape)
+        M = M_flat.reshape(self.solution_shape)
+
+        return U, M
+
+    def residual_function(self, x: NDArray) -> NDArray:
+        """
+        Residual function in form suitable for Newton solver.
+
+        Args:
+            x: Flattened state [U_flat, M_flat]
+
+        Returns:
+            F(x): Flattened residual
+        """
+        U, M = self.unpack_state(x)
+        return self.compute_residual(U, M)
+
+    def get_initial_guess(self) -> NDArray:
+        """
+        Get initial guess for Newton iteration.
+
+        Returns cold start initialization: U = U_terminal, M = M_initial
+        propagated through time.
+
+        Returns:
+            x0: Flattened initial state
+        """
+        U = np.zeros(self.solution_shape)
+        M = np.zeros(self.solution_shape)
+
+        # Set boundary conditions
+        if self.U_terminal is not None:
+            U[-1] = self.U_terminal
+        if self.M_initial is not None:
+            M[0] = self.M_initial
+
+        return self.pack_state(U, M)
+
+    def reset_evaluation_count(self) -> None:
+        """Reset residual evaluation counter."""
+        self.residual_evaluations = 0
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing MFGResidual...")
+
+    from mfg_pde.alg.numerical.fp_solvers import FPFDMSolver
+    from mfg_pde.alg.numerical.hjb_solvers import HJBFDMSolver
+    from mfg_pde.core.mfg_problem import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
+
+    # Create simple 1D problem
+    geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[21])
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.1)
+
+    # Create solvers
+    hjb_solver = HJBFDMSolver(problem)
+    fp_solver = FPFDMSolver(problem)
+
+    # Create residual computer
+    residual = MFGResidual(problem, hjb_solver, fp_solver)
+
+    print(f"  Solution shape: {residual.solution_shape}")
+    print(f"  State size: {2 * np.prod(residual.solution_shape)}")
+
+    # Get initial guess
+    x0 = residual.get_initial_guess()
+    print(f"  Initial guess shape: {x0.shape}")
+
+    # Compute residual
+    F = residual.residual_function(x0)
+    print(f"  Initial residual norm: {np.linalg.norm(F):.2e}")
+    print(f"  Residual evaluations: {residual.residual_evaluations}")
+
+    # Test pack/unpack
+    U, M = residual.unpack_state(x0)
+    x_repacked = residual.pack_state(U, M)
+    assert np.allclose(x0, x_repacked), "Pack/unpack should be identity"
+    print("  Pack/unpack: OK")
+
+    print("MFGResidual smoke tests passed!")

--- a/mfg_pde/alg/numerical/coupling/newton_mfg_solver.py
+++ b/mfg_pde/alg/numerical/coupling/newton_mfg_solver.py
@@ -1,0 +1,382 @@
+"""
+Newton MFG Solver.
+
+Issue #492 Phase 1: Newton's method for MFG coupling systems.
+
+Solves the coupled MFG system using Newton's method for faster
+convergence near the solution. Falls back to Picard iteration
+for robustness during initial iterations.
+
+Algorithm:
+    1. (Optional) Run Picard iterations for warm-up
+    2. Apply Newton iteration: J·δx = -F(x), x += δx
+    3. Where F(x) = [HJB_solve(M) - U, FP_solve(U) - M]
+
+Features:
+    - Leverages existing NewtonSolver from utils/numerical/
+    - Hybrid strategy: Picard warm-up + Newton finish
+    - Automatic Jacobian via finite differences or JAX autodiff
+    - Line search for robustness
+    - Structured SolverResult output
+
+References:
+    - Achdou & Capuzzo-Dolcetta (2010): Mean field games: Numerical methods
+    - Nocedal & Wright (2006): Numerical Optimization
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from mfg_pde.utils.numerical.nonlinear_solvers import NewtonSolver, SolverInfo
+from mfg_pde.utils.solver_result import SolverResult
+
+from .base_mfg import BaseMFGSolver
+from .mfg_residual import MFGResidual
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from mfg_pde.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+    from mfg_pde.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+    from mfg_pde.core.mfg_problem import MFGProblem
+
+logger = logging.getLogger(__name__)
+
+
+class NewtonMFGSolver(BaseMFGSolver):
+    """
+    Newton's method solver for coupled MFG systems.
+
+    Uses Newton iteration to solve F(U, M) = 0 where:
+        F_HJB = HJB_solve(M) - U
+        F_FP = FP_solve(U) - M
+
+    Features:
+        - Quadratic convergence near solution
+        - Optional Picard warm-up for robustness
+        - Automatic Jacobian (finite diff or JAX)
+        - Line search for globalization
+
+    Args:
+        problem: MFG problem definition
+        hjb_solver: HJB solver instance
+        fp_solver: FP solver instance
+        picard_warmup: Number of Picard iterations before Newton (default: 3)
+        newton_tolerance: Convergence tolerance for Newton (default: 1e-6)
+        newton_max_iterations: Maximum Newton iterations (default: 20)
+        line_search: Enable backtracking line search (default: True)
+        use_jax_autodiff: Use JAX for Jacobian ('auto', True, False)
+        diffusion_field: Optional diffusion override
+        drift_field: Optional drift override
+
+    Example:
+        >>> solver = NewtonMFGSolver(problem, hjb_solver, fp_solver)
+        >>> U, M, info = solver.solve(max_iterations=30)
+        >>> print(f"Converged: {info['converged']}, iterations: {info['iterations']}")
+    """
+
+    def __init__(
+        self,
+        problem: MFGProblem,
+        hjb_solver: BaseHJBSolver,
+        fp_solver: BaseFPSolver,
+        *,
+        picard_warmup: int = 3,
+        picard_damping: float = 0.5,
+        newton_tolerance: float = 1e-6,
+        newton_max_iterations: int = 20,
+        line_search: bool = True,
+        use_jax_autodiff: bool | str = "auto",
+        diffusion_field: float | NDArray | Any | None = None,
+        drift_field: NDArray | Any | None = None,
+    ):
+        """Initialize Newton MFG solver."""
+        super().__init__(problem)
+
+        self.hjb_solver = hjb_solver
+        self.fp_solver = fp_solver
+
+        # Picard warm-up parameters
+        self.picard_warmup = picard_warmup
+        self.picard_damping = picard_damping
+
+        # Newton parameters
+        self.newton_tolerance = newton_tolerance
+        self.newton_max_iterations = newton_max_iterations
+        self.line_search = line_search
+        self.use_jax_autodiff = use_jax_autodiff
+
+        # PDE coefficient overrides
+        self.diffusion_field = diffusion_field
+        self.drift_field = drift_field
+
+        # Create MFG residual computer
+        self.mfg_residual = MFGResidual(
+            problem,
+            hjb_solver,
+            fp_solver,
+            diffusion_field=diffusion_field,
+            drift_field=drift_field,
+        )
+
+        # Solution state
+        self.U: NDArray | None = None
+        self.M: NDArray | None = None
+
+        # Convergence history
+        self.picard_residuals: list[float] = []
+        self.newton_residuals: list[float] = []
+        self.total_iterations = 0
+
+    def _run_picard_warmup(
+        self,
+        U: NDArray,
+        M: NDArray,
+        num_iterations: int,
+    ) -> tuple[NDArray, NDArray, list[float]]:
+        """
+        Run Picard fixed-point iterations for warm-up.
+
+        Args:
+            U: Initial value function
+            M: Initial density
+            num_iterations: Number of Picard iterations
+
+        Returns:
+            (U, M, residuals): Updated state and residual history
+        """
+        residuals = []
+
+        for i in range(num_iterations):
+            # Store old values
+            U_old = U.copy()
+            M_old = M.copy()
+
+            # HJB solve: U_new = HJB(M_old)
+            U_new = self.mfg_residual.compute_hjb_output(M_old, U_old)
+
+            # FP solve: M_new = FP(U_new)
+            M_new = self.mfg_residual.compute_fp_output(U_new)
+
+            # Apply damping
+            U = self.picard_damping * U_new + (1 - self.picard_damping) * U_old
+            M = self.picard_damping * M_new + (1 - self.picard_damping) * M_old
+
+            # Preserve boundary conditions
+            if self.mfg_residual.M_initial is not None:
+                M[0] = self.mfg_residual.M_initial
+            if self.mfg_residual.U_terminal is not None:
+                U[-1] = self.mfg_residual.U_terminal
+
+            # Compute residual norm
+            res_norm = self.mfg_residual.compute_residual_norm(U, M)
+            residuals.append(res_norm)
+
+            logger.debug(f"Picard iteration {i + 1}: residual = {res_norm:.2e}")
+
+        return U, M, residuals
+
+    def solve(
+        self,
+        max_iterations: int = 30,
+        tolerance: float = 1e-5,
+        verbose: bool = True,
+        **kwargs: Any,
+    ) -> tuple[NDArray, NDArray, dict[str, Any]]:
+        """
+        Solve MFG system using Newton's method.
+
+        Args:
+            max_iterations: Maximum total iterations (Picard + Newton)
+            tolerance: Convergence tolerance
+            verbose: Print progress information
+            **kwargs: Additional solver parameters
+
+        Returns:
+            (U, M, info): Solution and convergence information
+        """
+        start_time = time.time()
+
+        # Initialize from warm start or cold start
+        warm_start = self.get_warm_start_data()
+        if warm_start is not None:
+            U, M = warm_start
+            if verbose:
+                print("Using warm start from previous solution")
+        else:
+            x0 = self.mfg_residual.get_initial_guess()
+            U, M = self.mfg_residual.unpack_state(x0)
+
+        # Phase 1: Picard warm-up (for robustness)
+        if self.picard_warmup > 0:
+            if verbose:
+                print(f"Phase 1: Picard warm-up ({self.picard_warmup} iterations)")
+
+            U, M, picard_res = self._run_picard_warmup(U, M, self.picard_warmup)
+            self.picard_residuals = picard_res
+
+            if verbose and picard_res:
+                print(f"  Final Picard residual: {picard_res[-1]:.2e}")
+
+        # Check if already converged after Picard
+        current_residual = self.mfg_residual.compute_residual_norm(U, M)
+        if current_residual < tolerance:
+            self.U = U
+            self.M = M
+            self.total_iterations = self.picard_warmup
+            self._solution_computed = True
+
+            elapsed = time.time() - start_time
+            return self._create_result(
+                converged=True,
+                reason="Converged during Picard warm-up",
+                elapsed=elapsed,
+            )
+
+        # Phase 2: Newton iterations
+        remaining_iterations = max_iterations - self.picard_warmup
+        if remaining_iterations <= 0:
+            remaining_iterations = self.newton_max_iterations
+
+        if verbose:
+            print(f"Phase 2: Newton iterations (max {remaining_iterations})")
+
+        # Create Newton solver
+        newton_solver = NewtonSolver(
+            max_iterations=min(remaining_iterations, self.newton_max_iterations),
+            tolerance=self.newton_tolerance,
+            sparse=True,
+            line_search=self.line_search,
+            use_jax_autodiff=self.use_jax_autodiff,
+        )
+
+        # Pack current state
+        x_current = self.mfg_residual.pack_state(U, M)
+
+        # Run Newton solver
+        self.mfg_residual.reset_evaluation_count()
+        x_solution, newton_info = newton_solver.solve(
+            self.mfg_residual.residual_function,
+            x_current,
+        )
+
+        # Unpack solution
+        self.U, self.M = self.mfg_residual.unpack_state(x_solution)
+        self.newton_residuals = newton_info.residual_history
+        self.total_iterations = self.picard_warmup + newton_info.iterations
+
+        elapsed = time.time() - start_time
+
+        if verbose:
+            status = "converged" if newton_info.converged else "not converged"
+            print(f"Newton {status} in {newton_info.iterations} iterations")
+            print(f"  Final residual: {newton_info.residual:.2e}")
+            print(f"  Jacobian evaluations: {newton_info.extra.get('jacobian_evals', 'N/A')}")
+            print(f"  Total time: {elapsed:.2f}s")
+
+        self._solution_computed = True
+
+        return self._create_result(
+            converged=newton_info.converged,
+            reason="Newton converged" if newton_info.converged else "Newton max iterations",
+            elapsed=elapsed,
+            newton_info=newton_info,
+        )
+
+    def _create_result(
+        self,
+        converged: bool,
+        reason: str,
+        elapsed: float,
+        newton_info: SolverInfo | None = None,
+    ) -> tuple[NDArray, NDArray, dict[str, Any]]:
+        """Create result tuple with convergence information."""
+        info = {
+            "converged": converged,
+            "convergence_reason": reason,
+            "total_iterations": self.total_iterations,
+            "picard_iterations": self.picard_warmup,
+            "picard_residuals": self.picard_residuals,
+            "newton_iterations": len(self.newton_residuals),
+            "newton_residuals": self.newton_residuals,
+            "residual_evaluations": self.mfg_residual.residual_evaluations,
+            "elapsed_time": elapsed,
+        }
+
+        if newton_info is not None:
+            info["final_residual"] = newton_info.residual
+            info["jacobian_evaluations"] = newton_info.extra.get("jacobian_evals", 0)
+
+        return self.U, self.M, info
+
+    def get_results(self) -> tuple[NDArray, NDArray]:
+        """Get computed solution arrays."""
+        if self.U is None or self.M is None:
+            raise RuntimeError("Solver has not been run yet. Call solve() first.")
+        return self.U, self.M
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    # Fix imports for direct script execution
+    import sys
+    from pathlib import Path
+
+    # Add project root to path for absolute imports
+    project_root = Path(__file__).resolve().parent.parent.parent.parent.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    print("Testing NewtonMFGSolver...")
+
+    from mfg_pde.alg.numerical.coupling.base_mfg import BaseMFGSolver
+    from mfg_pde.alg.numerical.coupling.mfg_residual import MFGResidual
+    from mfg_pde.alg.numerical.fp_solvers import FPFDMSolver
+    from mfg_pde.alg.numerical.hjb_solvers import HJBFDMSolver
+    from mfg_pde.core.mfg_problem import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
+    from mfg_pde.utils.numerical.nonlinear_solvers import NewtonSolver, SolverInfo
+    from mfg_pde.utils.solver_result import SolverResult  # noqa: F401
+
+    # Create simple 1D problem
+    geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[21])
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.2)
+
+    # Create solvers
+    hjb_solver = HJBFDMSolver(problem)
+    fp_solver = FPFDMSolver(problem)
+
+    # Create Newton MFG solver
+    newton_solver = NewtonMFGSolver(
+        problem,
+        hjb_solver,
+        fp_solver,
+        picard_warmup=2,
+        newton_max_iterations=5,
+        line_search=True,
+    )
+
+    print(f"  Problem shape: {newton_solver.mfg_residual.solution_shape}")
+
+    # Solve
+    U, M, info = newton_solver.solve(max_iterations=10, tolerance=1e-4, verbose=True)
+
+    print("\nResults:")
+    print(f"  U shape: {U.shape}")
+    print(f"  M shape: {M.shape}")
+    print(f"  Converged: {info['converged']}")
+    print(f"  Total iterations: {info['total_iterations']}")
+    print(f"  Final residual: {info.get('final_residual', 'N/A')}")
+
+    # Verify shapes
+    assert U.shape == newton_solver.mfg_residual.solution_shape
+    assert M.shape == newton_solver.mfg_residual.solution_shape
+    assert np.all(np.isfinite(U)), "U contains inf/nan"
+    assert np.all(np.isfinite(M)), "M contains inf/nan"
+
+    print("\nNewtonMFGSolver smoke tests passed!")


### PR DESCRIPTION
## Summary
Issue #492 Phase 1: Foundation for Newton family solvers for MFG coupling systems.

## Changes

### New Modules

**`mfg_residual.py`** - MFG system residual computation:
- `MFGResidual` class computes F(U,M) = [HJB_solve(M) - U, FP_solve(U) - M]
- Pack/unpack state vector utilities for Newton solver interface
- Residual norm computation (L2, Linf, relative)
- Caches solver signatures for efficient parameter passing

**`newton_mfg_solver.py`** - Newton's method for MFG:
- `NewtonMFGSolver` class with hybrid Picard + Newton strategy
- Leverages existing `NewtonSolver` from `utils/numerical/`
- Automatic Jacobian via finite differences or JAX autodiff
- Optional line search for globalization
- Compatible output format with `FixedPointIterator`

### API

```python
from mfg_pde.alg.numerical.coupling import NewtonMFGSolver

solver = NewtonMFGSolver(
    problem, hjb_solver, fp_solver,
    picard_warmup=3,      # Robustness: run Picard before Newton
    newton_max_iterations=20,
    line_search=True,
)
U, M, info = solver.solve(max_iterations=30, tolerance=1e-5)
```

### Module Exports
- `MFGResidual`, `NewtonMFGSolver` added to coupling `__init__.py`
- `NEWTON_SOLVERS` category for factory selection

## Algorithm

1. **Picard warm-up** (configurable): Run fixed-point iterations for stability
2. **Newton iterations**: Solve J·δx = -F(x), x += δx
3. **Convergence**: ||F(U,M)|| < tolerance

## Test Plan
- [x] Smoke tests pass (`python -m mfg_pde.alg.numerical.coupling.mfg_residual`)
- [x] Newton solver runs (`python -m mfg_pde.alg.numerical.coupling.newton_mfg_solver`)
- [x] Lint passes
- [ ] Integration tests (future PR)

## Related
- Issue #492 Phase 1
- Builds on existing `NewtonSolver` in `utils/numerical/nonlinear_solvers.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)