### PR TITLE
refactor: Extract abstract iteration patterns to iterative/ (Issue #630)

### DIFF
--- a/mfg_pde/alg/iterative/__init__.py
+++ b/mfg_pde/alg/iterative/__init__.py
@@ -1,38 +1,104 @@
 """
-Iterative solvers for MFG systems.
+Iterative solvers and patterns for MFG systems.
 
-This module provides high-level iteration schemes that orchestrate
-the coupling between HJB and FP solvers:
+This module provides:
 
-- FixedPointSolver: Picard (fixed-point) iteration for MFG systems
-- MultiPopulationFixedPointSolver: Extension for multi-population games
+1. **Abstract Iteration Patterns** (paradigm-agnostic):
+   - PicardPattern: Fixed-point iteration protocol
+   - AveragingPattern: Fictitious Play protocol
+   - FixedPointIteratorBase: Base class for Picard iterators
+   - AveragingIterator: Base class for averaging iterators
 
-These solvers use the numerical solvers from `mfg_pde.alg.numerical`
-for the actual HJB/FP equation solving.
+2. **Learning Rate Schedules**:
+   - harmonic_schedule: 1/(k+1) - standard fictitious play
+   - sqrt_schedule: 1/sqrt(k+1) - faster initial progress
+   - polynomial_schedule: 1/(k+1)^p - configurable decay
 
-Example:
+3. **Convergence Utilities**:
+   - check_convergence: Generic convergence checking
+   - ConvergenceTracker: Track error history
+   - apply_damping_generic: Generic damping
+
+4. **Concrete Solvers** (for backward compatibility):
+   - FixedPointSolver: High-level solver with hooks
+   - MultiPopulationFixedPointSolver: Multi-population extension
+
+Example (Abstract Pattern):
+    from mfg_pde.alg.iterative.patterns import FixedPointIteratorBase
+
+    class MyIterator(FixedPointIteratorBase[MyState]):
+        def forward_step(self, state):
+            return compute_next(state)
+        # ... implement other methods
+
+Example (Concrete Solver):
     from mfg_pde.alg.iterative import FixedPointSolver
 
     solver = FixedPointSolver()
     result = solver.solve(problem)
-
-Example with hooks:
-    from mfg_pde.alg.iterative import FixedPointSolver
-    from mfg_pde.hooks import DebugHook
-
-    solver = FixedPointSolver()
-    result = solver.solve(problem, hooks=DebugHook())
 """
 
+# Abstract patterns (Issue #630)
+from .patterns import (
+    AveragingIterator,
+    AveragingPattern,
+    FixedPointIteratorBase,
+    PicardPattern,
+)
+
+# Learning rate schedules
+from .schedules import (
+    LEARNING_RATE_SCHEDULES,
+    constant_schedule,
+    get_schedule,
+    harmonic_schedule,
+    polynomial_schedule,
+    sqrt_schedule,
+)
+
+# Convergence utilities
+from .convergence import (
+    ConvergenceResult,
+    ConvergenceTracker,
+    apply_damping_arrays,
+    apply_damping_generic,
+    check_convergence,
+    check_convergence_simple,
+    compute_absolute_change,
+    compute_relative_change,
+)
+
+# Concrete solvers (backward compatibility)
 from .base import BaseIterativeSolver, BaseSolver
 from .fixed_point import FixedPointResult, FixedPointSolver
 from .multi_population import MultiPopulationFixedPointSolver
 
 __all__ = [
+    # Abstract patterns
+    "PicardPattern",
+    "AveragingPattern",
+    "FixedPointIteratorBase",
+    "AveragingIterator",
+    # Learning rate schedules
+    "harmonic_schedule",
+    "sqrt_schedule",
+    "polynomial_schedule",
+    "constant_schedule",
+    "get_schedule",
+    "LEARNING_RATE_SCHEDULES",
+    # Convergence utilities
+    "ConvergenceResult",
+    "ConvergenceTracker",
+    "check_convergence",
+    "check_convergence_simple",
+    "apply_damping_generic",
+    "apply_damping_arrays",
+    "compute_relative_change",
+    "compute_absolute_change",
     # Base classes
     "BaseIterativeSolver",
     "BaseSolver",  # Backward compatibility alias
-    # Solvers
+    # Concrete solvers
     "FixedPointSolver",
     "FixedPointResult",
     "MultiPopulationFixedPointSolver",

--- a/mfg_pde/alg/iterative/convergence.py
+++ b/mfg_pde/alg/iterative/convergence.py
@@ -1,0 +1,334 @@
+"""
+Generic Convergence Utilities for Iterative Methods.
+
+Provides convergence checking and damping utilities that are
+algorithm-agnostic and can be used across paradigms:
+- Numerical PDE solvers (MFG coupling)
+- Neural network training (PINN)
+- Reinforcement learning (Policy Iteration)
+- Optimization (Alternating minimization)
+
+These utilities operate on generic state types, not specific to
+grid-based or PDE representations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar
+
+import numpy as np
+from numpy.typing import NDArray
+
+# Generic type for iteration state
+T = TypeVar("T")
+
+
+class MetricComputable(Protocol):
+    """Protocol for objects that can compute distance metrics."""
+
+    def compute_distance(self, other: "MetricComputable") -> float:
+        """Compute distance/difference from another state."""
+        ...
+
+
+@dataclass
+class ConvergenceResult:
+    """Result of convergence check."""
+
+    converged: bool
+    reason: str
+    relative_error: float
+    absolute_error: float
+
+
+def apply_damping_generic(
+    new_value: T,
+    old_value: T,
+    alpha: float,
+    combine_fn=None,
+) -> T:
+    """
+    Apply damping to iteration update (generic version).
+
+    Damping formula:
+        result = alpha * new_value + (1 - alpha) * old_value
+
+    Args:
+        new_value: New value from forward operator
+        old_value: Previous value
+        alpha: Damping/learning rate in [0, 1]
+        combine_fn: Optional function to combine values
+                   (defaults to weighted sum for numpy arrays)
+
+    Returns:
+        Damped value
+
+    Note:
+        alpha=1 means full update (no damping)
+        alpha=0 means no update (keep old value)
+        alpha=0.5 is a common choice for stability
+    """
+    if combine_fn is not None:
+        return combine_fn(new_value, old_value, alpha)
+
+    # Default: weighted sum (works for numpy arrays)
+    return alpha * new_value + (1 - alpha) * old_value
+
+
+def apply_damping_arrays(
+    new_arrays: tuple[NDArray, ...],
+    old_arrays: tuple[NDArray, ...],
+    alpha: float,
+) -> tuple[NDArray, ...]:
+    """
+    Apply damping to multiple arrays simultaneously.
+
+    Args:
+        new_arrays: Tuple of new arrays from forward operator
+        old_arrays: Tuple of previous arrays
+        alpha: Damping parameter in [0, 1]
+
+    Returns:
+        Tuple of damped arrays
+
+    Example:
+        >>> U_new, M_new = compute_step(U_old, M_old)
+        >>> U_damped, M_damped = apply_damping_arrays(
+        ...     (U_new, M_new), (U_old, M_old), alpha=0.5
+        ... )
+    """
+    return tuple(alpha * new + (1 - alpha) * old for new, old in zip(new_arrays, old_arrays, strict=True))
+
+
+def check_convergence(
+    relative_errors: dict[str, float],
+    absolute_errors: dict[str, float],
+    tolerance: float,
+    mode: str = "all",
+) -> ConvergenceResult:
+    """
+    Check convergence based on relative and absolute errors.
+
+    Args:
+        relative_errors: Dict of {name: relative_error}
+        absolute_errors: Dict of {name: absolute_error}
+        tolerance: Convergence tolerance
+        mode: "all" (all must converge) or "any" (any can converge)
+
+    Returns:
+        ConvergenceResult with status and diagnostics
+
+    Example:
+        >>> result = check_convergence(
+        ...     {"U": 1e-7, "M": 1e-8},
+        ...     {"U": 1e-6, "M": 1e-7},
+        ...     tolerance=1e-6,
+        ... )
+        >>> print(result.converged)  # True
+    """
+    max_rel = max(relative_errors.values()) if relative_errors else 0.0
+    max_abs = max(absolute_errors.values()) if absolute_errors else 0.0
+
+    if mode == "all":
+        converged = max_rel < tolerance and max_abs < tolerance
+    else:  # "any"
+        converged = max_rel < tolerance or max_abs < tolerance
+
+    if converged:
+        reason = f"Converged: Rel err {max_rel:.1e}, Abs err {max_abs:.1e} < tol {tolerance:.1e}"
+    else:
+        reason = ""
+
+    return ConvergenceResult(
+        converged=converged,
+        reason=reason,
+        relative_error=max_rel,
+        absolute_error=max_abs,
+    )
+
+
+def check_convergence_simple(
+    rel_error: float,
+    abs_error: float,
+    tolerance: float,
+) -> tuple[bool, str]:
+    """
+    Simple convergence check (backward compatible interface).
+
+    Both relative AND absolute errors must be below tolerance.
+
+    Args:
+        rel_error: Maximum relative error
+        abs_error: Maximum absolute error
+        tolerance: Convergence tolerance
+
+    Returns:
+        Tuple of (converged: bool, reason: str)
+    """
+    if rel_error < tolerance and abs_error < tolerance:
+        reason = f"Converged: Rel err {rel_error:.1e}, Abs err {abs_error:.1e} < tol {tolerance:.1e}"
+        return True, reason
+    return False, ""
+
+
+def compute_relative_change(
+    new_value: NDArray,
+    old_value: NDArray,
+    epsilon: float = 1e-10,
+) -> float:
+    """
+    Compute relative change between iterations.
+
+    Formula: ||new - old|| / (||old|| + epsilon)
+
+    Args:
+        new_value: New array
+        old_value: Previous array
+        epsilon: Small constant to prevent division by zero
+
+    Returns:
+        Relative change (dimensionless)
+    """
+    diff_norm = np.linalg.norm(new_value - old_value)
+    old_norm = np.linalg.norm(old_value)
+    return diff_norm / (old_norm + epsilon)
+
+
+def compute_absolute_change(
+    new_value: NDArray,
+    old_value: NDArray,
+) -> float:
+    """
+    Compute absolute change between iterations.
+
+    Formula: ||new - old||
+
+    Args:
+        new_value: New array
+        old_value: Previous array
+
+    Returns:
+        Absolute change (same units as input)
+    """
+    return float(np.linalg.norm(new_value - old_value))
+
+
+class ConvergenceTracker:
+    """
+    Track convergence history over iterations.
+
+    Stores error history and provides analysis utilities.
+    """
+
+    def __init__(self, max_iterations: int, tracked_quantities: list[str] | None = None):
+        """
+        Initialize convergence tracker.
+
+        Args:
+            max_iterations: Maximum number of iterations to track
+            tracked_quantities: Names of quantities to track (default ["U", "M"])
+        """
+        self.max_iterations = max_iterations
+        self.tracked_quantities = tracked_quantities or ["U", "M"]
+
+        # Initialize history arrays
+        self.relative_errors: dict[str, NDArray] = {name: np.ones(max_iterations) for name in self.tracked_quantities}
+        self.absolute_errors: dict[str, NDArray] = {name: np.ones(max_iterations) for name in self.tracked_quantities}
+
+        self.iterations_run = 0
+
+    def record(self, iteration: int, relative: dict[str, float], absolute: dict[str, float]) -> None:
+        """
+        Record errors for an iteration.
+
+        Args:
+            iteration: Current iteration number
+            relative: Dict of {name: relative_error}
+            absolute: Dict of {name: absolute_error}
+        """
+        for name in self.tracked_quantities:
+            if name in relative:
+                self.relative_errors[name][iteration] = relative[name]
+            if name in absolute:
+                self.absolute_errors[name][iteration] = absolute[name]
+
+        self.iterations_run = max(self.iterations_run, iteration + 1)
+
+    def get_history(self) -> dict[str, NDArray]:
+        """Get truncated error history."""
+        result = {}
+        for name in self.tracked_quantities:
+            result[f"{name}_rel"] = self.relative_errors[name][: self.iterations_run]
+            result[f"{name}_abs"] = self.absolute_errors[name][: self.iterations_run]
+        return result
+
+    def get_convergence_rate(self, name: str = "U", window: int = 10) -> float:
+        """
+        Estimate convergence rate from recent history.
+
+        Uses linear regression on log(error) vs iteration.
+
+        Args:
+            name: Quantity to analyze
+            window: Number of recent iterations to use
+
+        Returns:
+            Estimated convergence rate (negative = converging)
+        """
+        if self.iterations_run < 2:
+            return 0.0
+
+        errors = self.relative_errors[name][: self.iterations_run]
+        start = max(0, self.iterations_run - window)
+        recent = errors[start:]
+
+        if len(recent) < 2 or np.any(recent <= 0):
+            return 0.0
+
+        # Linear regression on log(error)
+        x = np.arange(len(recent))
+        log_err = np.log(recent)
+        slope = np.polyfit(x, log_err, 1)[0]
+
+        return float(slope)
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing convergence utilities...")
+
+    # Test apply_damping_generic
+    new = np.array([1.0, 2.0])
+    old = np.array([0.0, 0.0])
+    damped = apply_damping_generic(new, old, 0.5)
+    assert np.allclose(damped, [0.5, 1.0])
+    print("  apply_damping_generic() works")
+
+    # Test apply_damping_arrays
+    U_new, M_new = np.ones(5), np.ones(5) * 2
+    U_old, M_old = np.zeros(5), np.zeros(5)
+    U_d, M_d = apply_damping_arrays((U_new, M_new), (U_old, M_old), 0.5)
+    assert np.allclose(U_d, 0.5)
+    assert np.allclose(M_d, 1.0)
+    print("  apply_damping_arrays() works")
+
+    # Test check_convergence
+    result = check_convergence({"U": 1e-7, "M": 1e-8}, {"U": 1e-7, "M": 1e-8}, tolerance=1e-6)
+    assert result.converged
+    print("  check_convergence() works")
+
+    # Test check_convergence_simple
+    converged, reason = check_convergence_simple(1e-7, 1e-7, 1e-6)
+    assert converged
+    print("  check_convergence_simple() works")
+
+    # Test ConvergenceTracker
+    tracker = ConvergenceTracker(100, ["U", "M"])
+    tracker.record(0, {"U": 0.1, "M": 0.2}, {"U": 1.0, "M": 2.0})
+    tracker.record(1, {"U": 0.01, "M": 0.02}, {"U": 0.1, "M": 0.2})
+    history = tracker.get_history()
+    assert len(history["U_rel"]) == 2
+    print("  ConvergenceTracker works")
+
+    print("All smoke tests passed!")

--- a/mfg_pde/alg/iterative/patterns/__init__.py
+++ b/mfg_pde/alg/iterative/patterns/__init__.py
@@ -1,0 +1,30 @@
+"""
+Abstract Iteration Patterns.
+
+Provides Protocol classes for common iteration patterns used across
+different solving paradigms:
+
+- PicardPattern: Fixed-point iteration with constant damping
+- AveragingPattern: Fictitious Play with decaying learning rate
+- NewtonPattern: Newton's method with quadratic convergence
+
+These patterns are algorithm-agnostic and define the iteration structure
+without coupling to specific problem types (PDE, RL, optimization).
+
+Implementations:
+- numerical/coupling/: PDE system coupling (HJB-FP)
+- neural/: PINN-based methods (future)
+- reinforcement/: Policy iteration (future)
+"""
+
+from .averaging import AveragingIterator, AveragingPattern
+from .picard import FixedPointIteratorBase, PicardPattern
+
+__all__ = [
+    # Protocols
+    "PicardPattern",
+    "AveragingPattern",
+    # Base classes
+    "FixedPointIteratorBase",
+    "AveragingIterator",
+]

--- a/mfg_pde/alg/iterative/patterns/averaging.py
+++ b/mfg_pde/alg/iterative/patterns/averaging.py
@@ -1,0 +1,276 @@
+"""
+Averaging (Fictitious Play) Iteration Pattern.
+
+Abstract pattern for averaging iteration with decaying learning rate:
+    x_{n+1} = (1 - alpha_n) * x_n + alpha_n * T(x_n)
+
+where alpha_n = 1/(n+1) (harmonic) or other decaying schedule.
+
+This is equivalent to Cesaro averaging:
+    x_n = (1/n) * sum_{k=1}^{n} T(x_{k-1})
+
+Key advantages over fixed damping:
+- Proven convergence for potential MFGs (even when Picard fails)
+- Noise suppression through averaging
+- Robust for long time horizons
+
+This pattern applies to:
+- MFG: Fictitious Play for potential games
+- RL: Fictitious Play for multi-agent learning
+- Game Theory: Learning in games
+- Optimization: Averaged gradient methods
+
+References:
+    Cardaliaguet & Hadikhanloo (2017). Learning in mean field games:
+    the fictitious play. ESAIM: COCV.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar, runtime_checkable
+
+from ..convergence import ConvergenceResult, ConvergenceTracker, check_convergence
+from ..schedules import get_schedule, harmonic_schedule
+from .picard import FixedPointIteratorBase
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Generic type for iteration state
+StateT = TypeVar("StateT")
+
+
+@runtime_checkable
+class AveragingPattern(Protocol[StateT]):
+    """
+    Protocol for averaging (Fictitious Play) iteration.
+
+    Extends PicardPattern with decaying learning rate support.
+    """
+
+    def forward_step(self, state: StateT) -> StateT:
+        """Compute forward step T(x_n)."""
+        ...
+
+    def get_learning_rate(self, iteration: int) -> float:
+        """
+        Get learning rate for iteration.
+
+        Standard Fictitious Play: alpha(k) = 1/(k+1)
+        """
+        ...
+
+    def apply_averaging(self, old_state: StateT, new_state: StateT, alpha: float) -> StateT:
+        """
+        Apply averaging update.
+
+        Formula: result = (1 - alpha) * old + alpha * new
+        """
+        ...
+
+
+class AveragingIterator(FixedPointIteratorBase[StateT], Generic[StateT]):
+    """
+    Base class for averaging (Fictitious Play) iterators.
+
+    Extends FixedPointIteratorBase with:
+    - Decaying learning rate schedules
+    - Learning rate history tracking
+    - Optional selective averaging (e.g., average M but not U)
+
+    The key difference from standard Picard iteration is that the
+    "damping" parameter decays over iterations following a schedule.
+
+    Example:
+        >>> class MyFictitiousPlay(AveragingIterator[tuple[NDArray, NDArray]]):
+        ...     def forward_step(self, state):
+        ...         U, M = state
+        ...         U_new = solve_hjb(M)  # Full best response
+        ...         M_new = solve_fp(U_new)
+        ...         return (U_new, M_new)
+        ...
+        ...     def apply_averaging(self, old, new, alpha):
+        ...         U_old, M_old = old
+        ...         U_new, M_new = new
+        ...         # Only average M (standard fictitious play)
+        ...         return (U_new, (1-alpha)*M_old + alpha*M_new)
+        ...
+        >>> fp = MyFictitiousPlay(schedule="harmonic")
+        >>> result = fp.solve(max_iterations=100)
+    """
+
+    def __init__(
+        self,
+        schedule: str | Callable[[int], float] = "harmonic",
+        initial_learning_rate: float = 1.0,
+        min_learning_rate: float = 0.01,
+        max_iterations: int = 100,
+        tolerance: float = 1e-6,
+        verbose: bool = True,
+    ):
+        """
+        Initialize averaging iterator.
+
+        Args:
+            schedule: Learning rate schedule name or callable
+                - "harmonic": 1/(k+1) - standard fictitious play
+                - "sqrt": 1/sqrt(k+1) - faster initial progress
+                - "polynomial": 1/(k+1)^0.6 - balanced
+                - Callable[[int], float]: Custom schedule
+            initial_learning_rate: Scale factor for learning rate
+            min_learning_rate: Floor for learning rate (prevents stalling)
+            max_iterations: Maximum iterations
+            tolerance: Convergence tolerance
+            verbose: Show progress
+        """
+        # Initialize base with damping=1.0 (will be overridden per-iteration)
+        super().__init__(
+            damping=1.0,
+            max_iterations=max_iterations,
+            tolerance=tolerance,
+            verbose=verbose,
+        )
+
+        # Learning rate schedule
+        self._schedule_fn = get_schedule(schedule)
+        self._schedule_name = schedule if isinstance(schedule, str) else "custom"
+        self.initial_learning_rate = initial_learning_rate
+        self.min_learning_rate = min_learning_rate
+
+        # Learning rate history
+        self.learning_rate_history: list[float] = []
+
+    def get_learning_rate(self, iteration: int) -> float:
+        """
+        Compute learning rate for given iteration.
+
+        Applies schedule, scales by initial rate, and clamps to minimum.
+
+        Args:
+            iteration: Current iteration (0-indexed)
+
+        Returns:
+            Learning rate in (0, 1]
+        """
+        alpha = self._schedule_fn(iteration)
+        alpha = self.initial_learning_rate * alpha
+        alpha = max(alpha, self.min_learning_rate)
+        return alpha
+
+    @abstractmethod
+    def apply_averaging(self, old_state: StateT, new_state: StateT, alpha: float) -> StateT:
+        """
+        Apply averaging update with learning rate alpha.
+
+        This may differ from standard damping. For example, in MFG
+        Fictitious Play, we typically:
+        - Use full best response for U (no averaging)
+        - Average only M with decaying rate
+
+        Args:
+            old_state: Previous state
+            new_state: State from forward_step
+            alpha: Learning rate from schedule
+
+        Returns:
+            Updated state
+        """
+        ...
+
+    def apply_damping(self, old_state: StateT, new_state: StateT, alpha: float) -> StateT:
+        """
+        Override base class damping to use averaging.
+
+        Note: alpha parameter from base class is ignored; we compute
+        learning rate based on iteration number.
+        """
+        # Get current iteration from tracker
+        iteration = self.iterations_run
+        lr = self.get_learning_rate(iteration)
+        self.learning_rate_history.append(lr)
+        return self.apply_averaging(old_state, new_state, lr)
+
+    def solve(
+        self,
+        max_iterations: int | None = None,
+        tolerance: float | None = None,
+        **kwargs,
+    ) -> ConvergenceResult:
+        """
+        Run averaging iteration until convergence.
+
+        Args:
+            max_iterations: Override max iterations
+            tolerance: Override tolerance
+
+        Returns:
+            ConvergenceResult with final status
+        """
+        # Reset learning rate history
+        self.learning_rate_history = []
+
+        # Call base class solve (damping parameter is ignored)
+        return super().solve(max_iterations=max_iterations, tolerance=tolerance, damping=1.0)
+
+    def get_convergence_data(self) -> dict:
+        """Get convergence data including learning rate history."""
+        data = super().get_convergence_history()
+        data["learning_rate_history"] = self.learning_rate_history
+        data["schedule"] = self._schedule_name
+        return data
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    import numpy as np
+
+    print("Testing AveragingPattern and AveragingIterator...")
+
+    # Test that Protocol is properly defined
+    assert AveragingPattern is not None
+    print("  AveragingPattern protocol defined")
+
+    # Test AveragingIterator with a simple example
+    class SimpleAveraging(AveragingIterator[np.ndarray]):
+        """Simple averaging: converge to mean of operator outputs."""
+
+        def __init__(self):
+            super().__init__(
+                schedule="harmonic",
+                max_iterations=100,
+                tolerance=1e-6,
+            )
+            self.target = 1.0
+            self._call_count = 0
+
+        def forward_step(self, state: np.ndarray) -> np.ndarray:
+            # Operator that outputs target + noise
+            self._call_count += 1
+            noise = 0.1 * np.sin(self._call_count)  # Deterministic "noise"
+            return np.array([self.target + noise])
+
+        def apply_averaging(self, old: np.ndarray, new: np.ndarray, alpha: float) -> np.ndarray:
+            return (1 - alpha) * old + alpha * new
+
+        def compute_error(self, old: np.ndarray, new: np.ndarray) -> dict[str, float]:
+            return {"x_rel": float(np.abs(new - old) / (np.abs(old) + 1e-10))}
+
+        def initialize_state(self) -> np.ndarray:
+            return np.array([0.0])
+
+    iterator = SimpleAveraging()
+    result = iterator.solve(max_iterations=50)
+    final_state = iterator.get_state()
+
+    # Should converge close to target despite noise
+    error_from_target = abs(final_state[0] - 1.0)
+    print(f"  Final state: {final_state[0]:.4f}, error from target: {error_from_target:.4f}")
+    print(f"  Learning rates: {iterator.learning_rate_history[:5]} ... {iterator.learning_rate_history[-3:]}")
+
+    # Verify learning rate schedule
+    assert abs(iterator.learning_rate_history[0] - 1.0) < 1e-10, "First LR should be 1.0"
+    assert abs(iterator.learning_rate_history[1] - 0.5) < 1e-10, "Second LR should be 0.5"
+    print("  Learning rate schedule verified")
+
+    print("All smoke tests passed!")

--- a/mfg_pde/alg/iterative/patterns/picard.py
+++ b/mfg_pde/alg/iterative/patterns/picard.py
@@ -1,0 +1,361 @@
+"""
+Picard (Fixed-Point) Iteration Pattern.
+
+Abstract pattern for fixed-point iteration:
+    x_{n+1} = (1 - alpha) * x_n + alpha * T(x_n)
+
+where T is a forward operator and alpha is a constant damping factor.
+
+This pattern applies to:
+- MFG: HJB-FP coupling with Picard iteration
+- RL: Policy Iteration
+- Optimization: Proximal point methods
+- Numerical: Nonlinear equation solving
+
+Implementations inherit from FixedPointIteratorBase and implement
+the forward_step() method for their specific problem type.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar, runtime_checkable
+
+from ..convergence import ConvergenceResult, ConvergenceTracker, check_convergence
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Generic type for iteration state
+StateT = TypeVar("StateT")
+
+
+@runtime_checkable
+class PicardPattern(Protocol[StateT]):
+    """
+    Protocol for Picard (fixed-point) iteration.
+
+    Defines the interface that all Picard-style iterators must implement.
+    This is the minimal contract for fixed-point iteration.
+
+    Type parameter StateT represents the state being iterated
+    (e.g., tuple[NDArray, NDArray] for MFG U, M).
+    """
+
+    def forward_step(self, state: StateT) -> StateT:
+        """
+        Compute one forward step: T(x_n).
+
+        This is the core operator being iterated. For MFG, this would be:
+        1. Solve HJB backward given M -> U_new
+        2. Solve FP forward given U_new -> M_new
+        3. Return (U_new, M_new)
+
+        Args:
+            state: Current iteration state
+
+        Returns:
+            New state from forward operator
+        """
+        ...
+
+    def apply_damping(self, old_state: StateT, new_state: StateT, alpha: float) -> StateT:
+        """
+        Apply damping to update.
+
+        Formula: result = (1 - alpha) * old + alpha * new
+
+        Args:
+            old_state: Previous state
+            new_state: State from forward_step
+            alpha: Damping parameter in (0, 1]
+
+        Returns:
+            Damped state
+        """
+        ...
+
+    def compute_error(self, old_state: StateT, new_state: StateT) -> dict[str, float]:
+        """
+        Compute error metrics between states.
+
+        Args:
+            old_state: Previous state
+            new_state: Current state
+
+        Returns:
+            Dict of error metrics (e.g., {"U_rel": 0.01, "M_rel": 0.02})
+        """
+        ...
+
+
+class FixedPointIteratorBase(ABC, Generic[StateT]):
+    """
+    Base class for fixed-point (Picard) iterators.
+
+    Provides the iteration loop structure with:
+    - Configurable damping
+    - Convergence tracking
+    - Progress reporting hooks
+    - Warm start support
+
+    Subclasses implement:
+    - forward_step(): The specific forward operator
+    - apply_damping(): How to combine old and new states
+    - compute_error(): How to measure convergence
+    - initialize_state(): Create initial state
+
+    Example:
+        >>> class MyIterator(FixedPointIteratorBase[tuple[NDArray, NDArray]]):
+        ...     def forward_step(self, state):
+        ...         U, M = state
+        ...         U_new = solve_hjb(M)
+        ...         M_new = solve_fp(U_new)
+        ...         return (U_new, M_new)
+        ...
+        ...     # ... implement other abstract methods
+        ...
+        >>> iterator = MyIterator(damping=0.5)
+        >>> result = iterator.solve(max_iterations=100, tolerance=1e-6)
+    """
+
+    def __init__(
+        self,
+        damping: float = 0.5,
+        max_iterations: int = 100,
+        tolerance: float = 1e-6,
+        verbose: bool = True,
+    ):
+        """
+        Initialize fixed-point iterator.
+
+        Args:
+            damping: Damping parameter alpha in (0, 1]
+            max_iterations: Maximum number of iterations
+            tolerance: Convergence tolerance
+            verbose: Whether to show progress
+        """
+        self.damping = damping
+        self.max_iterations = max_iterations
+        self.tolerance = tolerance
+        self.verbose = verbose
+
+        # State management
+        self._state: StateT | None = None
+        self._warm_start: StateT | None = None
+
+        # Convergence tracking
+        self._tracker: ConvergenceTracker | None = None
+        self.iterations_run = 0
+
+    @abstractmethod
+    def forward_step(self, state: StateT) -> StateT:
+        """
+        Compute one forward step: T(x_n).
+
+        Must be implemented by subclasses for their specific problem.
+        """
+        ...
+
+    @abstractmethod
+    def apply_damping(self, old_state: StateT, new_state: StateT, alpha: float) -> StateT:
+        """
+        Apply damping to combine old and new states.
+
+        Default implementation assumes StateT supports arithmetic operations.
+        Override for custom state types.
+        """
+        ...
+
+    @abstractmethod
+    def compute_error(self, old_state: StateT, new_state: StateT) -> dict[str, float]:
+        """
+        Compute error metrics for convergence checking.
+
+        Returns dict with keys like "U_rel", "M_rel", "U_abs", "M_abs".
+        """
+        ...
+
+    @abstractmethod
+    def initialize_state(self) -> StateT:
+        """
+        Create initial state for iteration.
+
+        Called when no warm start is provided.
+        """
+        ...
+
+    def preserve_constraints(self, state: StateT) -> StateT:
+        """
+        Preserve any constraints after damping.
+
+        Override to enforce constraints like:
+        - Boundary conditions (PDE)
+        - Positivity (probability distributions)
+        - Normalization (mass conservation)
+
+        Default: no-op (return state unchanged)
+        """
+        return state
+
+    def on_iteration_start(self, iteration: int, state: StateT) -> None:
+        """Hook called at start of each iteration."""
+        pass
+
+    def on_iteration_end(
+        self,
+        iteration: int,
+        old_state: StateT,
+        new_state: StateT,
+        errors: dict[str, float],
+    ) -> None:
+        """Hook called at end of each iteration."""
+        pass
+
+    def solve(
+        self,
+        max_iterations: int | None = None,
+        tolerance: float | None = None,
+        damping: float | None = None,
+    ) -> ConvergenceResult:
+        """
+        Run fixed-point iteration until convergence.
+
+        Args:
+            max_iterations: Override max iterations
+            tolerance: Override tolerance
+            damping: Override damping parameter
+
+        Returns:
+            ConvergenceResult with final status
+        """
+        max_iter = max_iterations or self.max_iterations
+        tol = tolerance or self.tolerance
+        alpha = damping or self.damping
+
+        # Initialize state
+        if self._warm_start is not None:
+            state = self._warm_start
+        else:
+            state = self.initialize_state()
+
+        self._state = state
+
+        # Initialize tracker
+        self._tracker = ConvergenceTracker(max_iter)
+
+        # Main iteration loop
+        converged = False
+        final_result = ConvergenceResult(
+            converged=False,
+            reason="Maximum iterations reached",
+            relative_error=1.0,
+            absolute_error=1.0,
+        )
+
+        for iteration in range(max_iter):
+            self.on_iteration_start(iteration, state)
+
+            old_state = state
+
+            # Forward step
+            new_state = self.forward_step(state)
+
+            # Apply damping
+            state = self.apply_damping(old_state, new_state, alpha)
+
+            # Preserve constraints
+            state = self.preserve_constraints(state)
+
+            self._state = state
+
+            # Compute errors
+            errors = self.compute_error(old_state, state)
+
+            # Separate relative and absolute errors
+            rel_errors = {k: v for k, v in errors.items() if "_rel" in k or not ("_abs" in k)}
+            abs_errors = {k: v for k, v in errors.items() if "_abs" in k}
+
+            # If no explicit separation, treat all as relative
+            if not abs_errors:
+                abs_errors = rel_errors
+
+            # Record in tracker
+            self._tracker.record(iteration, rel_errors, abs_errors)
+
+            self.iterations_run = iteration + 1
+
+            self.on_iteration_end(iteration, old_state, state, errors)
+
+            # Check convergence
+            result = check_convergence(rel_errors, abs_errors, tol)
+            if result.converged:
+                final_result = result
+                converged = True
+                break
+
+            final_result = result
+
+        return final_result
+
+    def get_state(self) -> StateT:
+        """Get current state."""
+        if self._state is None:
+            raise RuntimeError("No state available. Call solve() first.")
+        return self._state
+
+    def set_warm_start(self, state: StateT) -> None:
+        """Set warm start state."""
+        self._warm_start = state
+
+    def clear_warm_start(self) -> None:
+        """Clear warm start state."""
+        self._warm_start = None
+
+    def get_convergence_history(self) -> dict[str, list[float]]:
+        """Get convergence history."""
+        if self._tracker is None:
+            return {}
+        return self._tracker.get_history()
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    import numpy as np
+
+    print("Testing PicardPattern and FixedPointIteratorBase...")
+
+    # Test that Protocol is properly defined
+    assert PicardPattern is not None
+    print("  PicardPattern protocol defined")
+
+    # Test FixedPointIteratorBase with a simple example
+    class SimpleIterator(FixedPointIteratorBase[np.ndarray]):
+        """Simple contraction mapping: T(x) = 0.5 * x + 0.25"""
+
+        def __init__(self):
+            super().__init__(damping=1.0, max_iterations=100, tolerance=1e-8)
+            self.target = 0.5  # Fixed point of T(x) = 0.5x + 0.25
+
+        def forward_step(self, state: np.ndarray) -> np.ndarray:
+            return 0.5 * state + 0.25
+
+        def apply_damping(self, old: np.ndarray, new: np.ndarray, alpha: float) -> np.ndarray:
+            return alpha * new + (1 - alpha) * old
+
+        def compute_error(self, old: np.ndarray, new: np.ndarray) -> dict[str, float]:
+            rel = float(np.abs(new - old) / (np.abs(old) + 1e-10))
+            return {"x_rel": rel, "x_abs": float(np.abs(new - old))}
+
+        def initialize_state(self) -> np.ndarray:
+            return np.array([0.0])
+
+    iterator = SimpleIterator()
+    result = iterator.solve()
+    final_state = iterator.get_state()
+
+    assert result.converged, f"Should converge, got: {result.reason}"
+    assert np.abs(final_state[0] - 0.5) < 1e-6, f"Should converge to 0.5, got {final_state[0]}"
+    print(f"  SimpleIterator converged to {final_state[0]:.6f} in {iterator.iterations_run} iterations")
+
+    print("All smoke tests passed!")

--- a/mfg_pde/alg/iterative/schedules.py
+++ b/mfg_pde/alg/iterative/schedules.py
@@ -1,0 +1,249 @@
+"""
+Learning Rate Schedules for Iterative Methods.
+
+Provides decaying learning rate schedules for iterative algorithms:
+- Fictitious Play (MFG)
+- Policy Iteration (RL)
+- Gradient Descent variants (Optimization)
+
+These schedules are algorithm-agnostic and can be used across paradigms.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class LearningRateSchedule(Protocol):
+    """Protocol for learning rate schedules."""
+
+    def __call__(self, iteration: int) -> float:
+        """
+        Compute learning rate for given iteration.
+
+        Args:
+            iteration: Current iteration number (0-indexed)
+
+        Returns:
+            Learning rate alpha in (0, 1]
+        """
+        ...
+
+
+def harmonic_schedule(k: int) -> float:
+    """
+    Harmonic learning rate: alpha(k) = 1 / (k + 1).
+
+    This is the standard schedule for Fictitious Play with proven
+    convergence for potential Mean Field Games.
+
+    Properties:
+        - Sum diverges: sum(1/(k+1)) = infinity (ensures exploration)
+        - Sum of squares converges: sum(1/(k+1)^2) < infinity (ensures convergence)
+
+    Args:
+        k: Iteration number (0-indexed)
+
+    Returns:
+        Learning rate 1/(k+1)
+
+    Example:
+        >>> [harmonic_schedule(k) for k in range(5)]
+        [1.0, 0.5, 0.333..., 0.25, 0.2]
+    """
+    return 1.0 / (k + 1)
+
+
+def sqrt_schedule(k: int) -> float:
+    """
+    Square root learning rate: alpha(k) = 1 / sqrt(k + 1).
+
+    Decays slower than harmonic, providing faster initial progress
+    but potentially slower final convergence.
+
+    Args:
+        k: Iteration number (0-indexed)
+
+    Returns:
+        Learning rate 1/sqrt(k+1)
+
+    Example:
+        >>> [sqrt_schedule(k) for k in range(5)]
+        [1.0, 0.707..., 0.577..., 0.5, 0.447...]
+    """
+    return 1.0 / np.sqrt(k + 1)
+
+
+def polynomial_schedule(k: int, power: float = 0.6) -> float:
+    """
+    Polynomial learning rate: alpha(k) = 1 / (k + 1)^power.
+
+    Interpolates between constant (power=0), sqrt (power=0.5),
+    and harmonic (power=1) schedules.
+
+    Args:
+        k: Iteration number (0-indexed)
+        power: Decay exponent (default 0.6)
+
+    Returns:
+        Learning rate 1/(k+1)^power
+
+    Example:
+        >>> [polynomial_schedule(k, power=0.6) for k in range(5)]
+        [1.0, 0.659..., 0.517..., 0.435..., 0.380...]
+    """
+    return 1.0 / (k + 1) ** power
+
+
+def constant_schedule(alpha: float = 0.5) -> Callable[[int], float]:
+    """
+    Constant learning rate (for standard Picard iteration).
+
+    Args:
+        alpha: Fixed learning rate (default 0.5)
+
+    Returns:
+        Schedule function that always returns alpha
+
+    Example:
+        >>> schedule = constant_schedule(0.7)
+        >>> [schedule(k) for k in range(5)]
+        [0.7, 0.7, 0.7, 0.7, 0.7]
+    """
+
+    def _schedule(k: int) -> float:
+        return alpha
+
+    return _schedule
+
+
+def exponential_schedule(initial: float = 1.0, decay: float = 0.99) -> Callable[[int], float]:
+    """
+    Exponential decay: alpha(k) = initial * decay^k.
+
+    Common in deep learning but generally not recommended for
+    MFG/game-theoretic settings due to premature convergence.
+
+    Args:
+        initial: Initial learning rate
+        decay: Decay factor per iteration
+
+    Returns:
+        Schedule function
+
+    Example:
+        >>> schedule = exponential_schedule(1.0, 0.9)
+        >>> [schedule(k) for k in range(5)]
+        [1.0, 0.9, 0.81, 0.729, 0.656...]
+    """
+
+    def _schedule(k: int) -> float:
+        return initial * (decay**k)
+
+    return _schedule
+
+
+def warmup_schedule(
+    warmup_steps: int = 10,
+    base_schedule: Callable[[int], float] = harmonic_schedule,
+) -> Callable[[int], float]:
+    """
+    Linear warmup followed by base schedule.
+
+    Starts with small learning rate and linearly increases to 1.0
+    over warmup_steps, then follows base_schedule.
+
+    Args:
+        warmup_steps: Number of warmup iterations
+        base_schedule: Schedule to use after warmup
+
+    Returns:
+        Schedule function with warmup
+
+    Example:
+        >>> schedule = warmup_schedule(5, harmonic_schedule)
+        >>> [schedule(k) for k in range(10)]
+        [0.2, 0.4, 0.6, 0.8, 1.0, 0.166..., 0.142..., ...]
+    """
+
+    def _schedule(k: int) -> float:
+        if k < warmup_steps:
+            return (k + 1) / warmup_steps
+        else:
+            return base_schedule(k - warmup_steps)
+
+    return _schedule
+
+
+# Registry of named schedules for easy access
+LEARNING_RATE_SCHEDULES: dict[str, Callable[[int], float]] = {
+    "harmonic": harmonic_schedule,
+    "sqrt": sqrt_schedule,
+    "polynomial": lambda k: polynomial_schedule(k, power=0.6),
+    "constant": constant_schedule(0.5),
+}
+
+
+def get_schedule(name: str | Callable[[int], float]) -> Callable[[int], float]:
+    """
+    Get a learning rate schedule by name or return custom callable.
+
+    Args:
+        name: Schedule name ("harmonic", "sqrt", "polynomial", "constant")
+              or a custom callable
+
+    Returns:
+        Learning rate schedule function
+
+    Raises:
+        ValueError: If named schedule not found
+
+    Example:
+        >>> schedule = get_schedule("harmonic")
+        >>> schedule(0)
+        1.0
+        >>> custom = get_schedule(lambda k: 0.1)
+        >>> custom(100)
+        0.1
+    """
+    if callable(name):
+        return name
+
+    if name not in LEARNING_RATE_SCHEDULES:
+        raise ValueError(
+            f"Unknown learning rate schedule: {name}. "
+            f"Available: {list(LEARNING_RATE_SCHEDULES.keys())}"
+        )
+
+    return LEARNING_RATE_SCHEDULES[name]
+
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing learning rate schedules...")
+
+    # Test all schedules
+    for name, fn in LEARNING_RATE_SCHEDULES.items():
+        rates = [fn(k) for k in [0, 1, 4, 9, 29, 99]]
+        print(
+            f"  {name}: k=0:{rates[0]:.3f}, k=1:{rates[1]:.3f}, k=4:{rates[2]:.3f}, "
+            f"k=9:{rates[3]:.3f}, k=29:{rates[4]:.3f}, k=99:{rates[5]:.3f}"
+        )
+
+    # Verify harmonic matches theory
+    assert abs(harmonic_schedule(0) - 1.0) < 1e-10
+    assert abs(harmonic_schedule(1) - 0.5) < 1e-10
+    assert abs(harmonic_schedule(9) - 0.1) < 1e-10
+    print("  Harmonic schedule verified")
+
+    # Test get_schedule
+    assert get_schedule("harmonic")(0) == 1.0
+    assert get_schedule(lambda k: 0.5)(100) == 0.5
+    print("  get_schedule() works")
+
+    print("All smoke tests passed!")


### PR DESCRIPTION
## Summary
- Create shared iteration infrastructure in `alg/iterative/` for reuse across paradigms
- Extract learning rate schedules from `numerical/coupling/fictitious_play.py`
- Add abstract Protocol classes for iteration patterns

## New Files

### `iterative/schedules.py` - Learning Rate Schedules
```python
from mfg_pde.alg.iterative import harmonic_schedule, get_schedule

schedule = get_schedule("harmonic")  # or "sqrt", "polynomial", "constant"
alpha = schedule(iteration)  # alpha(k) = 1/(k+1)
```

### `iterative/convergence.py` - Convergence Utilities
```python
from mfg_pde.alg.iterative import check_convergence, ConvergenceTracker

result = check_convergence({"U": 1e-7}, {"U": 1e-7}, tolerance=1e-6)
print(result.converged)  # True
```

### `iterative/patterns/` - Abstract Patterns
```python
from mfg_pde.alg.iterative.patterns import FixedPointIteratorBase

class MyIterator(FixedPointIteratorBase[MyState]):
    def forward_step(self, state):
        return compute_next(state)
    # ... implement other abstract methods
```

## Integration
- `FictitiousPlayIterator` now imports schedules from shared module
- Eliminates ~30 lines of duplicate code

## Test plan
- [x] Smoke tests pass for all new modules
- [x] `FictitiousPlayIterator` import works
- [x] Learning rate schedules verified against theory

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)