### PR TITLE
refactor: Replace hasattr with getattr+callable pattern (Issue #643)

### DIFF
--- a/mfg_pde/geometry/boundary/applicator_interpolation.py
+++ b/mfg_pde/geometry/boundary/applicator_interpolation.py
@@ -284,9 +284,11 @@ class InterpolationApplicator(BaseBCApplicator):
 
         # Unified BoundaryConditions
         # Try to get value from get_bc_value_at_boundary if available
-        if hasattr(bc, "get_bc_value_at_boundary"):
+        # Issue #643: getattr+callable pattern
+        get_bc_value_method = getattr(bc, "get_bc_value_at_boundary", None)
+        if get_bc_value_method is not None and callable(get_bc_value_method):
             try:
-                value = bc.get_bc_value_at_boundary(boundary_name, time=time)
+                value = get_bc_value_method(boundary_name, time=time)
                 return float(value) if value is not None else None
             except (AttributeError, ValueError, KeyError):
                 pass


### PR DESCRIPTION
## Summary
- Convert 4 duck-typing `hasattr()` calls to explicit `getattr()+callable()` pattern
- Document acceptable array `.shape` checks (external library compatibility)

## Changes
| File | Change |
|------|--------|
| `backends/solver_wrapper.py` | 3 method existence checks → getattr+callable |
| `geometry/boundary/applicator_interpolation.py` | 1 method check → getattr+callable |

## Pattern Applied
```python
# Before
if hasattr(self._solver, "solve_hjb_system"):
    self._wrap_method("solve_hjb_system")

# After
solve_hjb = getattr(self._solver, "solve_hjb_system", None)
if solve_hjb is not None and callable(solve_hjb):
    self._wrap_method("solve_hjb_system")
```

## Test plan
- [x] `ruff check` passes
- [x] Import verification passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)