### PR TITLE
refactor: Migrate internal BC application to pad_array_with_ghosts (Issue #645)

### DIFF
--- a/mfg_pde/geometry/boundary/_compat.py
+++ b/mfg_pde/geometry/boundary/_compat.py
@@ -74,7 +74,7 @@ class GhostCellConfig:
 @deprecated(
     since="v0.17.0",
     replacement="Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
-    removal_blockers=["internal_usage"],  # Migration in progress (Issue #577)
+    # Issue #645: internal_usage blocker cleared - dispatch.py and applicator_fdm.py migrated
 )
 def apply_boundary_conditions_2d(
     field: NDArray[np.floating],

--- a/mfg_pde/geometry/boundary/applicator_fdm.py
+++ b/mfg_pde/geometry/boundary/applicator_fdm.py
@@ -177,14 +177,20 @@ class FDMApplicator(BaseStructuredApplicator):
         Returns:
             Padded field with ghost cells
         """
-        if self._dimension == 1:
-            return apply_boundary_conditions_1d(field, boundary_conditions, domain_bounds, time, self._config, geometry)
-        elif self._dimension == 2:
-            return apply_boundary_conditions_2d(field, boundary_conditions, domain_bounds, time, self._config, geometry)
-        elif self._dimension == 3:
-            return apply_boundary_conditions_3d(field, boundary_conditions, domain_bounds, time, self._config, geometry)
-        else:
+        # Issue #645: Use dimension-agnostic pad_array_with_ghosts()
+        # For region-based BCs that need geometry, fall back to legacy path.
+        has_region_based = False
+        if hasattr(boundary_conditions, "segments"):
+            for seg in boundary_conditions.segments:
+                if getattr(seg, "region_name", None) is not None:
+                    has_region_based = True
+                    break
+
+        if has_region_based:
+            # Region-based BCs need geometry parameter - use legacy path
             return apply_boundary_conditions_nd(field, boundary_conditions, domain_bounds, time, self._config, geometry)
+
+        return pad_array_with_ghosts(field, boundary_conditions, ghost_depth=1, time=time)
 
     @staticmethod
     def apply_1d(
@@ -195,7 +201,8 @@ class FDMApplicator(BaseStructuredApplicator):
         config: GhostCellConfig | None = None,
     ) -> NDArray[np.floating]:
         """Static method for 1D BC application."""
-        return apply_boundary_conditions_1d(field, boundary_conditions, domain_bounds, time, config)
+        # Issue #645: Use dimension-agnostic pad_array_with_ghosts()
+        return pad_array_with_ghosts(field, boundary_conditions, ghost_depth=1, time=time)
 
     @staticmethod
     def apply_2d(
@@ -206,7 +213,8 @@ class FDMApplicator(BaseStructuredApplicator):
         config: GhostCellConfig | None = None,
     ) -> NDArray[np.floating]:
         """Static method for 2D BC application."""
-        return apply_boundary_conditions_2d(field, boundary_conditions, domain_bounds, time, config)
+        # Issue #645: Use dimension-agnostic pad_array_with_ghosts()
+        return pad_array_with_ghosts(field, boundary_conditions, ghost_depth=1, time=time)
 
     @staticmethod
     def apply_3d(
@@ -217,7 +225,8 @@ class FDMApplicator(BaseStructuredApplicator):
         config: GhostCellConfig | None = None,
     ) -> NDArray[np.floating]:
         """Static method for 3D BC application."""
-        return apply_boundary_conditions_3d(field, boundary_conditions, domain_bounds, time, config)
+        # Issue #645: Use dimension-agnostic pad_array_with_ghosts()
+        return pad_array_with_ghosts(field, boundary_conditions, ghost_depth=1, time=time)
 
     @staticmethod
     def apply_nd(
@@ -228,7 +237,8 @@ class FDMApplicator(BaseStructuredApplicator):
         config: GhostCellConfig | None = None,
     ) -> NDArray[np.floating]:
         """Static method for nD BC application."""
-        return apply_boundary_conditions_nd(field, boundary_conditions, domain_bounds, time, config)
+        # Issue #645: Use dimension-agnostic pad_array_with_ghosts()
+        return pad_array_with_ghosts(field, boundary_conditions, ghost_depth=1, time=time)
 
     def enforce_values(
         self,


### PR DESCRIPTION
## Summary

- Migrated `dispatch.py` from dimension-specific `apply_boundary_conditions_*d()` calls to unified `pad_array_with_ghosts()`
- Migrated `FDMApplicator.apply()` and static methods to use `pad_array_with_ghosts()`
- Cleared `internal_usage` blocker from `apply_boundary_conditions_2d` deprecation

This completes the internal migration for Issue #645. The deprecated functions remain available for external callers (backward compatibility) but are no longer used by the library's core functionality.

## Test plan

- [x] Smoke test verifies `dispatch.apply_bc()` works for 1D/2D/3D
- [x] Smoke test verifies `FDMApplicator.apply()` works
- [x] Smoke test verifies static methods (`apply_1d`, `apply_2d`, etc.) work
- [x] Pre-commit hooks pass (ruff, format)

Fixes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)