### PR TITLE
chore(logging): Export all public symbols from mfg_logging (Issue #620 Phase 2)

### DIFF
--- a/mfg_pde/utils/mfg_logging/__init__.py
+++ b/mfg_pde/utils/mfg_logging/__init__.py
@@ -5,13 +5,95 @@ This module provides comprehensive logging capabilities including:
 - logger: Core logging functionality with research-oriented features
 - decorators: Logging decorators for functions and methods
 - analysis: Log file analysis and visualization tools
+
+Usage:
+    >>> from mfg_pde.utils.mfg_logging import get_logger, configure_research_logging
+    >>> logger = get_logger(__name__)
+    >>> configure_research_logging("my_experiment")
+    >>> logger.info("Starting computation...")
 """
 
 from __future__ import annotations
 
-# Re-export from submodules
-from .analysis import LogAnalyzer
-from .decorators import LoggingMixin, logged_operation
-from .logger import configure_research_logging, get_logger
+# =============================================================================
+# Analysis (analysis.py)
+# =============================================================================
+from .analysis import (
+    LogAnalyzer,
+    analyze_log_file,
+    analyze_recent_logs,
+    find_performance_bottlenecks,
+)
 
-__all__ = ["LogAnalyzer", "LoggingMixin", "configure_research_logging", "get_logger", "logged_operation"]
+# =============================================================================
+# Decorators (decorators.py)
+# =============================================================================
+from .decorators import (
+    LoggingMixin,
+    add_logging_to_class,
+    logged_operation,
+    logged_solver_method,
+    logged_validation,
+    performance_logged,
+)
+
+# =============================================================================
+# Core logging (logger.py)
+# =============================================================================
+from .logger import (
+    # Classes
+    LoggedOperation,
+    # Environment-specific configurations
+    configure_development_logging,
+    # Primary API
+    configure_logging,
+    configure_performance_logging,
+    configure_production_logging,
+    configure_research_logging,
+    get_logger,
+    # Structured logging helpers
+    log_convergence_analysis,
+    log_mass_conservation,
+    log_memory_usage,
+    log_performance_metric,
+    log_solver_completion,
+    log_solver_configuration,
+    log_solver_progress,
+    log_solver_start,
+    log_validation_error,
+)
+
+__all__ = [
+    # Core logging
+    "configure_logging",
+    "configure_research_logging",
+    "get_logger",
+    # Environment configurations
+    "configure_development_logging",
+    "configure_performance_logging",
+    "configure_production_logging",
+    # Structured logging helpers
+    "log_convergence_analysis",
+    "log_mass_conservation",
+    "log_memory_usage",
+    "log_performance_metric",
+    "log_solver_completion",
+    "log_solver_configuration",
+    "log_solver_progress",
+    "log_solver_start",
+    "log_validation_error",
+    # Classes
+    "LoggedOperation",
+    # Decorators
+    "LoggingMixin",
+    "add_logging_to_class",
+    "logged_operation",
+    "logged_solver_method",
+    "logged_validation",
+    "performance_logged",
+    # Analysis
+    "LogAnalyzer",
+    "analyze_log_file",
+    "analyze_recent_logs",
+    "find_performance_bottlenecks",
+]


### PR DESCRIPTION
## Summary

- Export all public functions from `mfg_logging/__init__.py` (26 symbols, up from 5)
- Organized imports into categories: Core, Decorators, Analysis

## Changes

**Before**: Only 5 symbols exported (`LogAnalyzer`, `LoggingMixin`, `configure_research_logging`, `get_logger`, `logged_operation`)

**After**: All 26 public symbols exported:
- **Core**: `get_logger`, `configure_*`, `log_*` helpers
- **Decorators**: `logged_*`, `performance_logged`, `add_logging_to_class`
- **Analysis**: `LogAnalyzer`, `analyze_*`, `find_performance_bottlenecks`

## Test plan

- [x] All imports verified working
- [x] Pre-commit hooks pass

Partial fix for #620 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)