### PR TITLE
refactor(fp_solvers): Extract unified dimension-agnostic modules (Issue #635)

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/__init__.py
+++ b/mfg_pde/alg/numerical/fp_solvers/__init__.py
@@ -12,6 +12,10 @@ Semi-Lagrangian Variants:
 - FPSLSolver: Backward SL (gather/interpolate) - for standalone FP problems
 - FPSLAdjointSolver: Forward SL (scatter/splat) - adjoint of HJB SL for MFG duality
 
+Internal modules (Issue #635 refactoring):
+- fp_particle_density: Dimension-agnostic density estimation utilities
+- fp_particle_bc: Dimension-agnostic boundary condition handling
+
 Note: Network solvers have been moved to `mfg_pde.alg.numerical.network_solvers`.
 FPNetworkSolver is re-exported here for backward compatibility.
 """

--- a/mfg_pde/alg/numerical/fp_solvers/fp_particle_bc.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_particle_bc.py
@@ -1,0 +1,484 @@
+"""
+Dimension-agnostic boundary condition handling for particle-based FP solvers (Issue #635).
+
+This module provides unified functions that work for any dimension:
+- Topology detection from boundary conditions
+- Boundary enforcement (periodic wrap, reflecting bounce)
+- Obstacle boundary handling (implicit domains)
+- Segment-aware BC checking
+
+All functions accept both 1D and nD inputs with consistent APIs.
+
+Usage:
+    from mfg_pde.alg.numerical.fp_solvers.fp_particle_bc import (
+        get_topology_per_dimension,
+        apply_boundary_conditions,
+        enforce_obstacle_boundary,
+        needs_segment_aware_bc,
+    )
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from mfg_pde.geometry import BoundaryConditions
+    from mfg_pde.geometry.implicit import ImplicitDomain
+
+from mfg_pde.geometry.boundary.types import BCType
+
+# Mapping from dimension index to boundary name prefix
+_DIM_TO_AXIS_PREFIX = {0: "x", 1: "y", 2: "z"}
+
+
+def _get_axis_prefix(dim_idx: int) -> str:
+    """Get axis prefix for dimension index (x, y, z, dim3, dim4, ...)."""
+    if dim_idx < 3:
+        return _DIM_TO_AXIS_PREFIX[dim_idx]
+    return f"dim{dim_idx}"
+
+
+# =============================================================================
+# Topology Detection (unified)
+# =============================================================================
+
+
+def get_topology_per_dimension(
+    boundary_conditions: BoundaryConditions | None,
+    dimension: int,
+) -> list[str]:
+    """
+    Get grid topology for each dimension from boundary conditions (dimension-agnostic).
+
+    This determines the INDEXING STRATEGY for particles, not the physical BC:
+    - "periodic": Space wraps around (particles use modular arithmetic)
+    - "bounded": Space has walls (particles reflect at boundaries)
+
+    Note: This is about topology (how space connects), not physics (what values
+    are prescribed). For particles, all non-periodic boundaries are treated as
+    reflecting walls, regardless of whether the underlying BC is Dirichlet,
+    Neumann, Robin, or no-flux.
+
+    Parameters
+    ----------
+    boundary_conditions : BoundaryConditions or None
+        Boundary condition specification
+    dimension : int
+        Number of spatial dimensions
+
+    Returns
+    -------
+    topologies : list[str]
+        Topology per dimension: ["periodic", "bounded", ...]
+
+    Examples
+    --------
+    >>> from mfg_pde.geometry.boundary import periodic_bc, neumann_bc
+    >>> get_topology_per_dimension(periodic_bc(1), 1)  # ["periodic"]
+    >>> get_topology_per_dimension(neumann_bc(2), 2)   # ["bounded", "bounded"]
+    """
+    # Default to bounded (reflecting walls) for all dimensions
+    topologies = ["bounded"] * dimension
+
+    if boundary_conditions is None:
+        return topologies
+
+    bc = boundary_conditions
+
+    # For uniform BCs, check if periodic - Issue #543: use getattr instead of hasattr
+    is_uniform = getattr(bc, "is_uniform", False)
+    if is_uniform:
+        bc_type = getattr(bc, "type", None)
+        if bc_type == "periodic":
+            return ["periodic"] * dimension
+        return topologies
+
+    # For mixed BCs, check per dimension
+    # Periodic requires BOTH min and max to be periodic (topological constraint)
+    # Issue #543: use callable() for method existence check
+    if not callable(getattr(bc, "get_bc_type_at_boundary", None)):
+        return topologies  # Method doesn't exist, use default bounded
+
+    for d in range(dimension):
+        axis_prefix = _get_axis_prefix(d)
+        min_boundary = f"{axis_prefix}_min"
+        max_boundary = f"{axis_prefix}_max"
+
+        try:
+            bc_min = bc.get_bc_type_at_boundary(min_boundary)
+            bc_max = bc.get_bc_type_at_boundary(max_boundary)
+
+            # Periodic topology requires both boundaries to be periodic
+            if bc_min == BCType.PERIODIC and bc_max == BCType.PERIODIC:
+                topologies[d] = "periodic"
+            # All other cases: bounded topology (reflecting for particles)
+        except (KeyError, AttributeError):
+            pass  # Keep default "bounded"
+
+    return topologies
+
+
+def needs_segment_aware_bc(boundary_conditions: BoundaryConditions | None) -> bool:
+    """
+    Check if boundary conditions require segment-aware handling.
+
+    Returns True if:
+    - BC has multiple segments with different types
+    - BC has absorbing (DIRICHLET) segments that should remove particles
+
+    Returns False for uniform periodic/reflecting BC where fast path can be used.
+
+    Parameters
+    ----------
+    boundary_conditions : BoundaryConditions or None
+        Boundary condition specification
+
+    Returns
+    -------
+    bool
+        True if segment-aware handling is needed
+
+    Examples
+    --------
+    >>> needs_segment_aware_bc(periodic_bc(1))  # False (uniform)
+    >>> needs_segment_aware_bc(mixed_bc_with_exit)  # True (has DIRICHLET)
+    """
+    if boundary_conditions is None:
+        return False
+
+    bc = boundary_conditions
+
+    # Check if uniform BC (same type everywhere) - Issue #543: use getattr instead of hasattr
+    is_uniform = getattr(bc, "is_uniform", False)
+    if is_uniform:
+        # Uniform BC - use fast path unless it's DIRICHLET (absorbing)
+        segments = getattr(bc, "segments", [])
+        return len(segments) > 0 and segments[0].bc_type == BCType.DIRICHLET
+
+    # Mixed BC with segments - need segment-aware handling
+    segments = getattr(bc, "segments", [])
+    if len(segments) > 1:
+        return True
+
+    # Check for DIRICHLET segments (absorbing BC)
+    return any(segment.bc_type == BCType.DIRICHLET for segment in segments)
+
+
+# =============================================================================
+# Boundary Enforcement (unified)
+# =============================================================================
+
+
+def apply_boundary_conditions(
+    particles: np.ndarray,
+    bounds: list[tuple[float, float]] | tuple[tuple[float, float], ...],
+    topology: str | list[str] = "bounded",
+) -> np.ndarray:
+    """
+    Apply boundary handling per dimension based on topology (dimension-agnostic).
+
+    Parameters
+    ----------
+    particles : np.ndarray
+        Particle positions.
+        - 1D: shape (num_particles,) or (num_particles, 1)
+        - nD: shape (num_particles, dimension)
+    bounds : list of tuple or tuple of tuple
+        Bounds per dimension [(xmin, xmax), (ymin, ymax), ...]
+    topology : str or list[str]
+        Grid topology: "periodic" (wrap) or "bounded" (reflect).
+        Can be a single string (same for all dims) or per-dimension list.
+
+    Returns
+    -------
+    particles : np.ndarray
+        Updated particle positions (may be modified in place for efficiency)
+
+    Examples
+    --------
+    >>> particles_1d = np.array([1.5, -0.2, 0.5])  # Some outside [0, 1]
+    >>> apply_boundary_conditions(particles_1d, [(0, 1)], "bounded")
+    >>> # particles_1d now reflected into [0, 1]
+    """
+    particles = np.asarray(particles)
+    bounds = list(bounds)
+
+    # Handle 1D case: convert to 2D for uniform processing
+    is_1d_flat = particles.ndim == 1
+    if is_1d_flat:
+        particles = particles[:, np.newaxis]
+
+    dimension = particles.shape[1] if particles.ndim > 1 else 1
+
+    # Handle per-dimension topologies
+    if isinstance(topology, str):
+        topologies = [topology] * dimension
+    else:
+        topologies = list(topology)
+
+    for d in range(dimension):
+        xmin, xmax = bounds[d]
+        Lx = xmax - xmin
+
+        if Lx < 1e-14:
+            continue  # Skip degenerate dimension
+
+        dim_topology = topologies[d] if d < len(topologies) else "bounded"
+
+        if dim_topology == "periodic":
+            # Periodic topology: wrap around
+            particles[:, d] = xmin + (particles[:, d] - xmin) % Lx
+
+        else:  # "bounded" -> reflecting walls
+            # Reflecting boundaries: use modular reflection for arbitrary displacement
+            # This handles particles that travel multiple domain widths in one step
+            # Uses "fold" reflection: position bounces back and forth within domain
+            shifted = particles[:, d] - xmin
+            period = 2 * Lx
+            # Position within one period [0, 2*Lx)
+            pos_in_period = shifted % period
+            # If in second half of period, reflect back
+            in_second_half = pos_in_period > Lx
+            pos_in_period[in_second_half] = period - pos_in_period[in_second_half]
+            # Shift back to original domain
+            particles[:, d] = xmin + pos_in_period
+
+    # Convert back to 1D if input was 1D
+    if is_1d_flat:
+        return particles.ravel()
+
+    return particles
+
+
+# =============================================================================
+# Obstacle Boundary Handling (unified)
+# =============================================================================
+
+
+def enforce_obstacle_boundary(
+    particles: np.ndarray,
+    implicit_domain: ImplicitDomain | None,
+) -> np.ndarray:
+    """
+    Enforce obstacle boundaries via implicit domain geometry (dimension-agnostic).
+
+    If an implicit domain with obstacles is defined, particles that have
+    entered obstacle regions (domain.contains() returns False) are projected
+    back to the valid domain using domain.project_to_domain().
+
+    Parameters
+    ----------
+    particles : np.ndarray
+        Particle positions.
+        - 1D: shape (num_particles,) or (num_particles, 1)
+        - nD: shape (num_particles, dimension)
+    implicit_domain : ImplicitDomain or None
+        Domain definition with contains() and project_to_domain() methods
+
+    Returns
+    -------
+    particles : np.ndarray
+        Updated particle positions with obstacle violations corrected
+
+    Examples
+    --------
+    >>> from mfg_pde.geometry.implicit import DifferenceDomain, Hyperrectangle, Hypersphere
+    >>> domain = DifferenceDomain(Hyperrectangle(...), Hypersphere(center=[0.5, 0.5], radius=0.1))
+    >>> particles = enforce_obstacle_boundary(particles, domain)
+    """
+    if implicit_domain is None:
+        return particles
+
+    particles = np.asarray(particles)
+
+    # Handle 1D case
+    is_1d_flat = particles.ndim == 1
+    if is_1d_flat:
+        particles = particles[:, np.newaxis]
+
+    # Check which particles are outside the valid domain (inside obstacles)
+    inside_valid = implicit_domain.contains(particles)
+
+    # Handle scalar return (single particle case)
+    if np.isscalar(inside_valid):
+        inside_valid = np.array([inside_valid])
+
+    # Project invalid particles back to domain
+    if not np.all(inside_valid):
+        outside_indices = np.where(~inside_valid)[0]
+        particles[outside_indices] = implicit_domain.project_to_domain(particles[outside_indices])
+
+    # Convert back to 1D if input was 1D
+    if is_1d_flat:
+        return particles.ravel()
+
+    return particles
+
+
+# =============================================================================
+# Coordinate/Grid Utilities (unified)
+# =============================================================================
+
+
+def create_coordinate_arrays(
+    bounds: list[tuple[float, float]] | tuple[tuple[float, float], ...],
+    grid_shape: tuple[int, ...],
+) -> list[np.ndarray]:
+    """
+    Create coordinate arrays from bounds and grid shape (dimension-agnostic).
+
+    Parameters
+    ----------
+    bounds : list or tuple of (min, max) tuples
+        Domain bounds per dimension
+    grid_shape : tuple[int, ...]
+        Number of grid points per dimension
+
+    Returns
+    -------
+    coordinates : list[np.ndarray]
+        1D coordinate arrays for each dimension
+
+    Examples
+    --------
+    >>> coords = create_coordinate_arrays([(0, 1), (0, 2)], (11, 21))
+    >>> coords[0]  # array([0.0, 0.1, ..., 1.0])
+    >>> coords[1]  # array([0.0, 0.1, ..., 2.0])
+    """
+    coordinates = []
+    for d, (bmin, bmax) in enumerate(bounds):
+        n_points = grid_shape[d]
+        coords = np.linspace(bmin, bmax, n_points)
+        coordinates.append(coords)
+    return coordinates
+
+
+def compute_spacings(
+    bounds: list[tuple[float, float]] | tuple[tuple[float, float], ...],
+    grid_shape: tuple[int, ...],
+) -> list[float]:
+    """
+    Compute grid spacings from bounds and shape (dimension-agnostic).
+
+    Parameters
+    ----------
+    bounds : list or tuple of (min, max) tuples
+        Domain bounds per dimension
+    grid_shape : tuple[int, ...]
+        Number of grid points per dimension
+
+    Returns
+    -------
+    spacings : list[float]
+        Grid spacing per dimension [dx, dy, ...]
+
+    Examples
+    --------
+    >>> compute_spacings([(0, 1), (0, 2)], (11, 21))
+    [0.1, 0.1]
+    """
+    spacings = []
+    for d, (bmin, bmax) in enumerate(bounds):
+        n_points = grid_shape[d]
+        if n_points > 1:
+            dx = (bmax - bmin) / (n_points - 1)
+        else:
+            dx = bmax - bmin  # Single point
+        spacings.append(dx)
+    return spacings
+
+
+# =============================================================================
+# Smoke Tests
+# =============================================================================
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing unified fp_particle_bc functions...")
+
+    # Test 1: Topology detection
+    # We can't easily test with real BoundaryConditions without imports
+    # So test the None case and basic logic
+    topo_none = get_topology_per_dimension(None, 2)
+    assert topo_none == ["bounded", "bounded"], f"Expected bounded, got {topo_none}"
+    print("  get_topology_per_dimension (None BC): OK")
+
+    # Test 2: needs_segment_aware_bc
+    result = needs_segment_aware_bc(None)
+    assert result is False, "None BC should not need segment-aware"
+    print("  needs_segment_aware_bc (None BC): OK")
+
+    # Test 3: Boundary conditions - bounded (reflecting)
+    # Test 1D
+    particles_1d = np.array([-0.1, 0.5, 1.1, 1.5, 2.5])
+    result_1d = apply_boundary_conditions(particles_1d, [(0.0, 1.0)], "bounded")
+    assert result_1d.shape == (5,), f"Expected (5,), got {result_1d.shape}"
+    assert np.all(result_1d >= 0), f"Negative values: {result_1d}"
+    assert np.all(result_1d <= 1), f"Values > 1: {result_1d}"
+    print("  apply_boundary_conditions (1D bounded): OK")
+
+    # Test 2D
+    particles_2d = np.array(
+        [
+            [-0.1, 0.5],  # x out of bounds (left)
+            [0.5, -0.2],  # y out of bounds (bottom)
+            [1.1, 0.5],  # x out of bounds (right)
+            [0.5, 1.3],  # y out of bounds (top)
+            [0.5, 0.5],  # inside
+        ]
+    )
+    result_2d = apply_boundary_conditions(particles_2d, [(0.0, 1.0), (0.0, 1.0)], "bounded")
+    assert result_2d.shape == (5, 2), f"Expected (5, 2), got {result_2d.shape}"
+    assert np.all(result_2d >= 0), f"Negative values: {result_2d}"
+    assert np.all(result_2d <= 1), f"Values > 1: {result_2d}"
+    print("  apply_boundary_conditions (2D bounded): OK")
+
+    # Test 4: Boundary conditions - periodic
+    particles_periodic = np.array([-0.1, 0.5, 1.1, 1.5])
+    result_periodic = apply_boundary_conditions(particles_periodic, [(0.0, 1.0)], "periodic")
+    assert np.all(result_periodic >= 0), f"Negative values: {result_periodic}"
+    assert np.all(result_periodic <= 1), f"Values > 1: {result_periodic}"
+    # -0.1 should wrap to 0.9, 1.1 should wrap to 0.1
+    assert np.abs(result_periodic[0] - 0.9) < 1e-10, f"Expected 0.9, got {result_periodic[0]}"
+    assert np.abs(result_periodic[2] - 0.1) < 1e-10, f"Expected 0.1, got {result_periodic[2]}"
+    print("  apply_boundary_conditions (1D periodic): OK")
+
+    # Test 5: Mixed topology (x periodic, y bounded)
+    particles_mixed = np.array(
+        [
+            [-0.1, -0.1],  # Both out
+            [1.1, 1.1],  # Both out
+        ]
+    )
+    result_mixed = apply_boundary_conditions(particles_mixed, [(0.0, 1.0), (0.0, 1.0)], ["periodic", "bounded"])
+    # x should wrap, y should reflect
+    assert np.abs(result_mixed[0, 0] - 0.9) < 1e-10, f"x periodic: expected 0.9, got {result_mixed[0, 0]}"
+    assert np.abs(result_mixed[0, 1] - 0.1) < 1e-10, f"y bounded: expected 0.1, got {result_mixed[0, 1]}"
+    print("  apply_boundary_conditions (mixed periodic/bounded): OK")
+
+    # Test 6: Coordinate array creation
+    coords = create_coordinate_arrays([(0.0, 1.0), (0.0, 2.0)], (11, 21))
+    assert len(coords) == 2
+    assert len(coords[0]) == 11
+    assert len(coords[1]) == 21
+    assert np.abs(coords[0][-1] - 1.0) < 1e-10
+    assert np.abs(coords[1][-1] - 2.0) < 1e-10
+    print("  create_coordinate_arrays: OK")
+
+    # Test 7: Spacing computation
+    spacings = compute_spacings([(0.0, 1.0), (0.0, 2.0)], (11, 21))
+    assert len(spacings) == 2
+    assert np.abs(spacings[0] - 0.1) < 1e-10
+    assert np.abs(spacings[1] - 0.1) < 1e-10
+    print("  compute_spacings: OK")
+
+    # Test 8: Obstacle boundary (None domain - should pass through)
+    particles_obs = np.array([[0.5, 0.5], [0.3, 0.3]])
+    result_obs = enforce_obstacle_boundary(particles_obs, None)
+    assert np.allclose(result_obs, particles_obs)
+    print("  enforce_obstacle_boundary (None domain): OK")
+
+    print("\nAll smoke tests passed!")

--- a/mfg_pde/alg/numerical/fp_solvers/fp_particle_density.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_particle_density.py
@@ -1,0 +1,583 @@
+"""
+Dimension-agnostic density estimation for particle-based FP solvers (Issue #635).
+
+This module provides unified functions that work for any dimension:
+- Density normalization
+- KDE density estimation (particles → grid)
+- Gradient computation
+- Brownian increment generation
+- Particle sampling from density
+
+All functions accept both 1D and nD inputs with consistent APIs.
+Internal optimizations (e.g., scipy fast path for 1D) are implementation details.
+
+Usage:
+    from mfg_pde.alg.numerical.fp_solvers.fp_particle_density import (
+        normalize_density,
+        estimate_density_kde,
+        compute_gradient,
+        generate_brownian_increment,
+        sample_particles_from_density,
+    )
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import numpy as np
+
+# Optional scipy for KDE
+try:  # pragma: no cover - optional SciPy dependency
+    from scipy.stats import gaussian_kde as scipy_gaussian_kde
+
+    SCIPY_AVAILABLE = True
+except ImportError:  # pragma: no cover - graceful fallback when SciPy missing
+    scipy_gaussian_kde = None
+    SCIPY_AVAILABLE = False
+
+from mfg_pde.utils.numerical.particle import (
+    interpolate_particles_to_grid,
+    sample_from_density,
+)
+from mfg_pde.utils.numerical.tensor_calculus import gradient_simple
+
+# =============================================================================
+# Density Normalization (unified)
+# =============================================================================
+
+
+def normalize_density(
+    density: np.ndarray,
+    spacings: float | list[float] | tuple[float, ...],
+) -> np.ndarray:
+    """
+    Normalize density to integrate to 1 (dimension-agnostic).
+
+    Parameters
+    ----------
+    density : np.ndarray
+        Density values on grid, shape (N1,) for 1D or (N1, N2, ..., Nd) for nD
+    spacings : float or list[float]
+        Grid spacing(s). Single float for 1D, list for nD.
+
+    Returns
+    -------
+    normalized : np.ndarray
+        Normalized density (integrates to 1)
+
+    Examples
+    --------
+    >>> density_1d = np.array([0.5, 1.0, 0.5])
+    >>> normalize_density(density_1d, 0.1)  # 1D
+    >>> density_2d = np.random.rand(20, 20)
+    >>> normalize_density(density_2d, [0.05, 0.05])  # 2D
+    """
+    # Normalize spacings to list
+    if isinstance(spacings, (int, float)):
+        spacings = [float(spacings)]
+    else:
+        spacings = list(spacings)
+
+    # Volume element = product of all spacings
+    dV = float(np.prod(spacings))
+
+    if dV < 1e-14:
+        # Degenerate case: zero volume element
+        sum_val = np.sum(density)
+        if sum_val > 1e-9:
+            return density / sum_val
+        return density
+
+    total_mass = np.sum(density) * dV
+    if total_mass > 1e-14:
+        return density / total_mass
+    return density
+
+
+# =============================================================================
+# Gradient Computation (unified)
+# =============================================================================
+
+
+def compute_gradient(
+    grid_values: np.ndarray,
+    spacings: float | list[float] | tuple[float, ...],
+) -> np.ndarray:
+    """
+    Compute gradient of a scalar field on a grid (dimension-agnostic).
+
+    Uses central differences via gradient_simple utility.
+
+    Parameters
+    ----------
+    grid_values : np.ndarray
+        Scalar field values on grid, shape (N1,) for 1D or (N1, N2, ..., Nd) for nD
+    spacings : float or list[float]
+        Grid spacing(s). Single float for 1D, list for nD.
+
+    Returns
+    -------
+    gradient : np.ndarray
+        Gradient field.
+        - 1D: shape (N1,) - single component
+        - nD: shape (N1, N2, ..., Nd, d) - last axis is gradient components
+
+    Examples
+    --------
+    >>> field_1d = np.linspace(0, 1, 50)**2
+    >>> grad_1d = compute_gradient(field_1d, 0.02)  # shape (50,)
+    >>> field_2d = X**2 + Y**2  # meshgrid
+    >>> grad_2d = compute_gradient(field_2d, [0.05, 0.05])  # shape (Nx, Ny, 2)
+    """
+    # Normalize spacings to list
+    if isinstance(spacings, (int, float)):
+        spacings = [float(spacings)]
+    else:
+        spacings = list(spacings)
+
+    # gradient_simple returns list of arrays (one per dimension)
+    grad_components = gradient_simple(grid_values, spacings)
+
+    if len(grad_components) == 1:
+        # 1D: return flat array (backward compatible)
+        return grad_components[0]
+
+    # nD: stack into single array with last axis = dimension
+    return np.stack(grad_components, axis=-1)
+
+
+# =============================================================================
+# Brownian Increment Generation (unified)
+# =============================================================================
+
+
+def generate_brownian_increment(
+    num_particles: int,
+    dimension: int,
+    dt: float,
+    sigma: float,
+) -> np.ndarray:
+    """
+    Generate Brownian increment for SDE evolution (dimension-agnostic).
+
+    The increment follows dX = sigma * dW where dW ~ N(0, sqrt(dt)).
+
+    Parameters
+    ----------
+    num_particles : int
+        Number of particles
+    dimension : int
+        Spatial dimension (1, 2, 3, ...)
+    dt : float
+        Time step size
+    sigma : float
+        Diffusion coefficient
+
+    Returns
+    -------
+    dW : np.ndarray
+        Brownian increments.
+        - 1D: shape (num_particles,)
+        - nD: shape (num_particles, dimension)
+
+    Examples
+    --------
+    >>> dW_1d = generate_brownian_increment(1000, 1, 0.01, 0.1)  # (1000,)
+    >>> dW_2d = generate_brownian_increment(1000, 2, 0.01, 0.1)  # (1000, 2)
+    """
+    if dt < 1e-14:
+        if dimension == 1:
+            return np.zeros(num_particles)
+        return np.zeros((num_particles, dimension))
+
+    # Independent Brownian motion in each dimension
+    if dimension == 1:
+        return sigma * np.random.normal(0, np.sqrt(dt), num_particles)
+
+    return sigma * np.random.normal(0, np.sqrt(dt), (num_particles, dimension))
+
+
+# =============================================================================
+# KDE Density Estimation (unified)
+# =============================================================================
+
+
+def estimate_density_kde(
+    particles: np.ndarray,
+    grid_shape: tuple[int, ...],
+    bounds: tuple[tuple[float, float], ...],
+    kde_bandwidth: Any = "scott",
+    backend: str | None = None,
+    coordinates: np.ndarray | list[np.ndarray] | None = None,
+) -> np.ndarray:
+    """
+    Estimate density from particles using KDE (dimension-agnostic).
+
+    Automatically selects optimal implementation based on dimension and backend:
+    - 1D + CPU: scipy.stats.gaussian_kde (fast, mature)
+    - 1D + GPU: gaussian_kde_gpu
+    - nD: interpolate_particles_to_grid utility
+
+    Parameters
+    ----------
+    particles : np.ndarray
+        Particle positions.
+        - 1D: shape (num_particles,) or (num_particles, 1)
+        - nD: shape (num_particles, dimension)
+    grid_shape : tuple[int, ...]
+        Grid shape, e.g., (Nx,) for 1D, (Nx, Ny) for 2D
+    bounds : tuple[tuple[float, float], ...]
+        Bounds per dimension, e.g., ((xmin, xmax),) for 1D
+    kde_bandwidth : Any
+        Bandwidth for KDE. Options:
+        - "scott" or "silverman": automatic bandwidth selection
+        - float: fixed bandwidth value
+    backend : str, optional
+        Backend for GPU acceleration (e.g., "jax", "torch").
+        Currently only affects 1D; nD GPU support planned.
+    coordinates : np.ndarray or list[np.ndarray], optional
+        Grid coordinates for evaluation. If None, computed from bounds/shape.
+
+    Returns
+    -------
+    density : np.ndarray
+        Density on grid, shape matches grid_shape
+
+    Examples
+    --------
+    >>> particles_1d = np.random.normal(0.5, 0.1, 500)
+    >>> density = estimate_density_kde(particles_1d, (50,), ((0, 1),))
+    >>> particles_2d = np.random.normal(0.5, 0.1, (500, 2))
+    >>> density = estimate_density_kde(particles_2d, (30, 30), ((0, 1), (0, 1)))
+    """
+    # Determine dimension from bounds
+    dimension = len(bounds)
+
+    # Normalize particles shape
+    particles = np.asarray(particles)
+    if particles.ndim == 1:
+        # 1D particles as flat array
+        if dimension != 1:
+            raise ValueError(f"1D particles but {dimension}D bounds provided")
+        particles_flat = particles
+        particles_nd = particles[:, np.newaxis]
+    else:
+        particles_nd = particles
+        particles_flat = particles.ravel() if dimension == 1 else None
+
+    num_particles = len(particles_nd)
+
+    # Edge case: no particles
+    if num_particles == 0:
+        return np.zeros(grid_shape)
+
+    # Edge case: degenerate distribution (all at same location)
+    unique_count = len(np.unique(particles_nd, axis=0))
+    if unique_count < 2:
+        return _handle_degenerate_particles(particles_nd, grid_shape, bounds, num_particles)
+
+    # Route to optimal implementation
+    if dimension == 1:
+        return _estimate_density_kde_1d(
+            particles_flat,
+            grid_shape[0],
+            bounds[0],
+            kde_bandwidth,
+            backend,
+            coordinates[0] if coordinates is not None else None,
+        )
+    else:
+        return _estimate_density_kde_nd(
+            particles_nd,
+            num_particles,
+            grid_shape,
+            bounds,
+            kde_bandwidth,
+        )
+
+
+def _handle_degenerate_particles(
+    particles: np.ndarray,
+    grid_shape: tuple[int, ...],
+    bounds: tuple[tuple[float, float], ...],
+    num_particles: int,
+) -> np.ndarray:
+    """Handle edge case where all particles are at the same location."""
+    dimension = len(bounds)
+    density = np.zeros(grid_shape)
+    mean_pos = np.mean(particles, axis=0)
+
+    indices = []
+    for d in range(dimension):
+        coords = np.linspace(bounds[d][0], bounds[d][1], grid_shape[d])
+        idx = np.argmin(np.abs(coords - mean_pos[d]))
+        indices.append(idx)
+
+    density[tuple(indices)] = num_particles
+    return density
+
+
+def _estimate_density_kde_1d(
+    particles: np.ndarray,
+    nx: int,
+    bounds: tuple[float, float],
+    kde_bandwidth: Any,
+    backend: str | None,
+    coordinates: np.ndarray | None,
+) -> np.ndarray:
+    """
+    1D KDE implementation using scipy (CPU) or GPU backend.
+
+    This is the optimized fast path for 1D problems.
+    """
+    xmin, xmax = bounds
+    dx = (xmax - xmin) / (nx - 1) if nx > 1 else 1.0
+
+    # Compute evaluation coordinates if not provided
+    if coordinates is None:
+        x_coords = np.linspace(xmin, xmax, nx)
+    else:
+        x_coords = coordinates
+
+    # Check for degenerate case
+    if np.std(particles) < 1e-9 * (xmax - xmin):
+        density = np.zeros(nx)
+        if len(particles) > 0:
+            mean_pos = np.mean(particles)
+            closest_idx = np.argmin(np.abs(x_coords - mean_pos))
+            if dx > 1e-14:
+                density[closest_idx] = 1.0 / dx
+            elif nx == 1:
+                density[closest_idx] = 1.0
+        return density
+
+    try:
+        # GPU path
+        if backend is not None:
+            from mfg_pde.alg.numerical.density_estimation import gaussian_kde_gpu
+
+            # Convert bandwidth to float if needed
+            if isinstance(kde_bandwidth, str):
+                from mfg_pde.alg.numerical.density_estimation import adaptive_bandwidth_selection
+
+                bandwidth_value = adaptive_bandwidth_selection(particles, method=kde_bandwidth)
+            else:
+                bandwidth_value = float(kde_bandwidth)
+
+            density = gaussian_kde_gpu(particles, x_coords, bandwidth_value, backend)
+
+        # CPU path: scipy
+        elif SCIPY_AVAILABLE and scipy_gaussian_kde is not None:
+            kde = scipy_gaussian_kde(particles, bw_method=kde_bandwidth)
+            density = kde(x_coords)
+
+        else:
+            raise RuntimeError("SciPy not available for KDE")
+
+        # Clip to domain bounds
+        density[x_coords < xmin] = 0
+        density[x_coords > xmax] = 0
+
+        return density
+
+    except Exception as e:
+        error_msg = (
+            f"KDE density estimation failed: {e}\n"
+            f"Number of particles: {len(particles)}\n"
+            f"Grid size: {nx}\n"
+            f"Bandwidth: {kde_bandwidth}\n"
+            "Suggestions:\n"
+            "  - Increase number of particles (Np > 100 recommended)\n"
+            "  - Use fixed bandwidth: kde_bandwidth=0.1\n"
+            "  - Check particle initialization and drift/diffusion"
+        )
+        raise RuntimeError(error_msg) from e
+
+
+def _estimate_density_kde_nd(
+    particles: np.ndarray,
+    num_particles: int,
+    grid_shape: tuple[int, ...],
+    bounds: tuple[tuple[float, float], ...],
+    kde_bandwidth: Any,
+) -> np.ndarray:
+    """
+    nD KDE implementation using interpolate_particles_to_grid utility.
+
+    Future: Will support GPU backends when nD KDE is implemented.
+    """
+    try:
+        # Delegate to utils for KDE computation
+        particle_values = np.ones(num_particles)
+
+        density = interpolate_particles_to_grid(
+            particle_values=particle_values,
+            particle_positions=particles,
+            grid_shape=grid_shape,
+            grid_bounds=bounds,
+            method="kde",
+            bandwidth=kde_bandwidth,
+        )
+
+        return density
+
+    except Exception as e:
+        warnings.warn(f"KDE failed in nD: {e}. Returning histogram estimate.")
+        # Fallback to histogram
+        density, _ = np.histogramdd(
+            particles,
+            bins=list(grid_shape),
+            range=list(bounds),
+            density=True,
+        )
+        return density
+
+
+# =============================================================================
+# Particle Sampling from Density (unified)
+# =============================================================================
+
+
+def sample_particles_from_density(
+    density: np.ndarray,
+    num_particles: int,
+    bounds: tuple[tuple[float, float], ...],
+    implicit_domain: Any | None = None,
+) -> np.ndarray:
+    """
+    Sample particles from a density distribution (dimension-agnostic).
+
+    Uses importance sampling via sample_from_density utility.
+    Supports implicit domains (obstacles) for valid region sampling.
+
+    Parameters
+    ----------
+    density : np.ndarray
+        Density on grid, shape (N1,) for 1D or (N1, N2, ..., Nd) for nD
+    num_particles : int
+        Number of particles to sample
+    bounds : tuple[tuple[float, float], ...]
+        Bounds per dimension, e.g., ((xmin, xmax),) for 1D
+    implicit_domain : ImplicitDomain, optional
+        If provided, only sample in valid regions (outside obstacles)
+
+    Returns
+    -------
+    particles : np.ndarray
+        Sampled particle positions.
+        - 1D: shape (num_particles,)
+        - nD: shape (num_particles, dimension)
+
+    Examples
+    --------
+    >>> density_1d = np.exp(-((x - 0.5)**2) / 0.1)
+    >>> particles = sample_particles_from_density(density_1d, 1000, ((0, 1),))
+    """
+    dimension = len(bounds)
+
+    # Convert bounds to coordinate arrays (required by sample_from_density)
+    coordinates = []
+    for d in range(dimension):
+        n_points = density.shape[d]
+        coords = np.linspace(bounds[d][0], bounds[d][1], n_points)
+        coordinates.append(coords)
+
+    if implicit_domain is not None:
+        # Domain-aware sampling (avoids obstacles)
+        from mfg_pde.utils.numerical.particle import sample_from_density_with_domain
+
+        particles = sample_from_density_with_domain(
+            density=density,
+            coordinates=coordinates,
+            num_samples=num_particles,
+            domain=implicit_domain,
+        )
+    else:
+        # Standard sampling
+        particles = sample_from_density(
+            density=density,
+            coordinates=coordinates,
+            num_samples=num_particles,
+        )
+
+    # For 1D, return flat array (backward compatible)
+    if dimension == 1 and particles.ndim > 1:
+        return particles.ravel()
+
+    return particles
+
+
+# =============================================================================
+# Smoke Tests
+# =============================================================================
+
+if __name__ == "__main__":
+    """Quick smoke test for development."""
+    print("Testing unified fp_particle_density functions...")
+
+    # Test 1: Brownian increments (1D and 2D)
+    dW_1d = generate_brownian_increment(1000, 1, 0.01, 0.1)
+    assert dW_1d.shape == (1000,), f"Expected (1000,), got {dW_1d.shape}"
+    dW_2d = generate_brownian_increment(1000, 2, 0.01, 0.1)
+    assert dW_2d.shape == (1000, 2), f"Expected (1000, 2), got {dW_2d.shape}"
+    print("  generate_brownian_increment: OK (1D and 2D)")
+
+    # Test 2: Density normalization (1D and 2D)
+    density_1d = np.random.rand(50)
+    normalized_1d = normalize_density(density_1d, 0.02)
+    mass_1d = np.sum(normalized_1d) * 0.02
+    assert np.abs(mass_1d - 1.0) < 1e-10, f"1D mass: {mass_1d}"
+
+    density_2d = np.random.rand(20, 20)
+    normalized_2d = normalize_density(density_2d, [0.05, 0.05])
+    mass_2d = np.sum(normalized_2d) * 0.05 * 0.05
+    assert np.abs(mass_2d - 1.0) < 1e-10, f"2D mass: {mass_2d}"
+    print("  normalize_density: OK (1D and 2D)")
+
+    # Test 3: Gradient computation (1D and 2D)
+    x = np.linspace(0, 1, 50)
+    field_1d = x**2
+    grad_1d = compute_gradient(field_1d, 0.02)
+    assert grad_1d.shape == (50,), f"Expected (50,), got {grad_1d.shape}"
+
+    x2 = np.linspace(0, 1, 20)
+    y2 = np.linspace(0, 1, 20)
+    X, Y = np.meshgrid(x2, y2, indexing="ij")
+    field_2d = X**2 + Y**2
+    grad_2d = compute_gradient(field_2d, [0.05, 0.05])
+    assert grad_2d.shape == (20, 20, 2), f"Expected (20, 20, 2), got {grad_2d.shape}"
+    print("  compute_gradient: OK (1D and 2D)")
+
+    # Test 4: KDE density estimation (1D)
+    if SCIPY_AVAILABLE:
+        particles_1d = np.random.normal(0.5, 0.1, 500)
+        particles_1d = np.clip(particles_1d, 0, 1)
+        density_est_1d = estimate_density_kde(particles_1d, (50,), ((0.0, 1.0),))
+        assert density_est_1d.shape == (50,), f"Expected (50,), got {density_est_1d.shape}"
+        assert np.all(density_est_1d >= 0)
+        print("  estimate_density_kde (1D): OK")
+
+    # Test 5: KDE density estimation (2D)
+    particles_2d = np.random.normal(0.5, 0.15, (500, 2))
+    particles_2d = np.clip(particles_2d, 0, 1)
+    density_est_2d = estimate_density_kde(particles_2d, (20, 20), ((0.0, 1.0), (0.0, 1.0)))
+    assert density_est_2d.shape == (20, 20), f"Expected (20, 20), got {density_est_2d.shape}"
+    assert np.all(density_est_2d >= 0)
+    print("  estimate_density_kde (2D): OK")
+
+    # Test 6: Particle sampling (1D and 2D)
+    # Create 1D density
+    x_sample = np.linspace(0, 1, 50)
+    density_for_sample = np.exp(-((x_sample - 0.5) ** 2) / 0.05)
+    sampled_1d = sample_particles_from_density(density_for_sample, 200, ((0.0, 1.0),))
+    assert sampled_1d.shape == (200,), f"Expected (200,), got {sampled_1d.shape}"
+
+    # Create 2D density
+    density_2d_sample = np.exp(-((X - 0.5) ** 2 + (Y - 0.5) ** 2) / 0.1)
+    sampled_2d = sample_particles_from_density(density_2d_sample, 200, ((0.0, 1.0), (0.0, 1.0)))
+    assert sampled_2d.shape == (200, 2), f"Expected (200, 2), got {sampled_2d.shape}"
+    print("  sample_particles_from_density: OK (1D and 2D)")
+
+    print("\nAll smoke tests passed!")


### PR DESCRIPTION
## Summary

Refactors FPParticleSolver by extracting dimension-agnostic utility modules (Issue #635).

**Changes:**
- Extract `fp_particle_density.py` (583 lines) - Unified KDE/density estimation
- Extract `fp_particle_bc.py` (484 lines) - Unified boundary condition handling  
- Add DRY helpers: `_should_normalize_density()`, `_increment_time_step()`, `_compute_total_mass()`
- Main solver reduced from 2800+ to 2059 lines

**Design Decision:** The remaining 2059 lines in `fp_particle.py` represent a cohesive solver class. Particle methods are inherently dimension-agnostic (same SDE integration, same evolution equations in any ℝⁿ), so further splitting would reduce cohesion without benefit.

## Test plan

- [x] All 55 particle solver unit tests pass
- [x] Smoke tests for both new modules pass
- [x] No import changes needed for external code

🤖 Generated with [Claude Code](https://claude.com/claude-code)