### PR TITLE
feat(utils): Add validation module infrastructure (Issue #689)

### DIFF
--- a/mfg_pde/utils/validation/__init__.py
+++ b/mfg_pde/utils/validation/__init__.py
@@ -1,0 +1,108 @@
+"""
+Validation utilities for MFG_PDE.
+
+This module provides comprehensive validation for MFG problem inputs,
+custom functions, arrays, and runtime solver outputs.
+
+Modules:
+    protocol: Core types (ValidationResult, ValidationError, ValidationIssue)
+    components: IC/BC validation (m_initial, u_final)
+    functions: Custom function validation (Hamiltonian, drift, running_cost)
+    arrays: Array validation (dtype, shape, dimension)
+    runtime: Runtime checks (NaN/Inf, bounds)
+
+Usage:
+    from mfg_pde.utils.validation import (
+        validate_components,
+        validate_custom_functions,
+        check_finite,
+    )
+
+    # Validate components at problem construction
+    result = validate_components(components, geometry)
+    if not result.is_valid:
+        raise ValidationError(result)
+
+Note: For convergence/divergence monitoring during solving, use:
+    from mfg_pde.utils.convergence import DistributionConvergenceMonitor
+
+Issue #689: Validation module infrastructure
+Parent: #685 (Comprehensive Input Validation Initiative)
+"""
+
+# Array validation (Issue #687)
+from mfg_pde.utils.validation.arrays import (
+    validate_array_dtype,
+    validate_array_shape,
+    validate_field_dimension,
+    validate_field_shape,
+    validate_finite,
+    validate_non_negative,
+)
+
+# Components validation (Issue #679, #681-#684)
+from mfg_pde.utils.validation.components import (
+    detect_callable_signature,
+    validate_components,
+    validate_m_initial,
+    validate_mass_normalization,
+    validate_u_final,
+)
+
+# Custom function validation (Issue #686)
+from mfg_pde.utils.validation.functions import (
+    validate_custom_functions,
+    validate_drift,
+    validate_hamiltonian,
+    validate_hamiltonian_consistency,
+    validate_hamiltonian_derivative,
+    validate_running_cost,
+)
+from mfg_pde.utils.validation.protocol import (
+    ValidationError,
+    ValidationIssue,
+    ValidationResult,
+    ValidationSeverity,
+    Validator,
+)
+
+# Runtime validation (Issue #688)
+# Note: For convergence/divergence monitors, use mfg_pde.utils.convergence
+from mfg_pde.utils.validation.runtime import (
+    check_bounds,
+    check_finite,
+    validate_solver_output,
+)
+
+__all__ = [
+    # Protocol
+    "ValidationResult",
+    "ValidationError",
+    "ValidationIssue",
+    "ValidationSeverity",
+    "Validator",
+    # Components
+    "validate_components",
+    "validate_m_initial",
+    "validate_u_final",
+    "validate_mass_normalization",
+    "detect_callable_signature",
+    # Functions
+    "validate_custom_functions",
+    "validate_hamiltonian",
+    "validate_hamiltonian_derivative",
+    "validate_hamiltonian_consistency",
+    "validate_drift",
+    "validate_running_cost",
+    # Arrays
+    "validate_array_dtype",
+    "validate_array_shape",
+    "validate_field_shape",
+    "validate_field_dimension",
+    "validate_finite",
+    "validate_non_negative",
+    # Runtime
+    "check_finite",
+    "check_bounds",
+    "validate_solver_output",
+]

--- a/mfg_pde/utils/validation/arrays.py
+++ b/mfg_pde/utils/validation/arrays.py
@@ -1,0 +1,295 @@
+"""
+Validation for array inputs (dtype, shape, dimension).
+
+This module validates numpy arrays for correct dtype, shape, and
+dimension compatibility with geometry.
+
+Issue #687: Array/Tensor validation (dtype, shape, dimension)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from mfg_pde.utils.validation.protocol import ValidationResult
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike, NDArray
+
+
+def validate_array_dtype(
+    arr: NDArray,
+    name: str,
+    required_dtype: DTypeLike = np.float64,
+    *,
+    auto_convert: bool = False,
+) -> ValidationResult:
+    """
+    Validate array has correct dtype.
+
+    Args:
+        arr: Array to validate
+        name: Name for error messages
+        required_dtype: Required dtype (default: float64)
+        auto_convert: If True, add warning instead of error for convertible types
+
+    Returns:
+        ValidationResult
+
+    Issue #687: Array dtype validation
+    """
+    result = ValidationResult()
+
+    if arr.dtype == required_dtype:
+        return result
+
+    # Check if it's a compatible floating type
+    if np.issubdtype(arr.dtype, np.floating):
+        if auto_convert:
+            result.add_warning(
+                f"{name} has dtype {arr.dtype}, expected {required_dtype}. Auto-converting.",
+                location=name,
+            )
+            result.context["needs_conversion"] = True
+            result.context["original_dtype"] = arr.dtype
+        else:
+            result.add_warning(
+                f"{name} has dtype {arr.dtype}, expected {required_dtype}. This may cause precision loss.",
+                location=name,
+                suggestion=f"Use {name}.astype({required_dtype})",
+            )
+    elif np.issubdtype(arr.dtype, np.integer):
+        result.add_warning(
+            f"{name} has integer dtype {arr.dtype}, expected {required_dtype}. Implicit conversion may occur.",
+            location=name,
+            suggestion=f"Use {name}.astype({required_dtype})",
+        )
+    else:
+        result.add_error(
+            f"{name} has incompatible dtype {arr.dtype}, expected {required_dtype}",
+            location=name,
+        )
+
+    return result
+
+
+def validate_array_shape(
+    arr: NDArray,
+    expected_shape: tuple[int, ...],
+    name: str,
+) -> ValidationResult:
+    """
+    Validate array has expected shape.
+
+    Args:
+        arr: Array to validate
+        expected_shape: Expected shape tuple
+        name: Name for error messages
+
+    Returns:
+        ValidationResult
+
+    Issue #687: Array shape validation
+    """
+    result = ValidationResult()
+
+    if arr.shape != expected_shape:
+        result.add_error(
+            f"{name} has shape {arr.shape}, expected {expected_shape}",
+            location=name,
+            suggestion=f"Reshape {name} to {expected_shape}",
+        )
+
+    return result
+
+
+def validate_field_shape(
+    field: NDArray,
+    spatial_shape: tuple[int, ...],
+    name: str,
+    *,
+    allow_temporal: bool = True,
+    n_timesteps: int | None = None,
+) -> ValidationResult:
+    """
+    Validate a field array (spatial or spatiotemporal).
+
+    A field can be:
+    - Spatial only: shape matches spatial_shape
+    - Spatiotemporal: shape is (Nt, *spatial_shape)
+
+    Args:
+        field: Field array to validate
+        spatial_shape: Expected spatial shape
+        name: Name for error messages
+        allow_temporal: Whether to allow spatiotemporal shape
+        n_timesteps: Expected number of timesteps (if known)
+
+    Returns:
+        ValidationResult
+
+    Issue #687: Field shape validation
+    """
+    result = ValidationResult()
+
+    # Check spatial shape
+    if field.shape == spatial_shape:
+        result.context["is_temporal"] = False
+        return result
+
+    # Check spatiotemporal shape
+    if allow_temporal and len(field.shape) == len(spatial_shape) + 1:
+        if field.shape[1:] == spatial_shape:
+            result.context["is_temporal"] = True
+            result.context["n_timesteps"] = field.shape[0]
+
+            # Verify timestep count if known
+            if n_timesteps is not None and field.shape[0] != n_timesteps:
+                result.add_error(
+                    f"{name} has {field.shape[0]} timesteps, expected {n_timesteps}",
+                    location=name,
+                )
+            return result
+
+    # Shape doesn't match
+    expected = f"{spatial_shape}"
+    if allow_temporal:
+        expected += f" or (Nt, {', '.join(map(str, spatial_shape))})"
+
+    result.add_error(
+        f"{name} has shape {field.shape}, expected {expected}",
+        location=name,
+    )
+
+    return result
+
+
+def validate_field_dimension(
+    field: NDArray,
+    expected_dimension: int,
+    name: str,
+) -> ValidationResult:
+    """
+    Validate field has correct spatial dimension.
+
+    Args:
+        field: Field array
+        expected_dimension: Expected spatial dimension (1, 2, or 3)
+        name: Name for error messages
+
+    Returns:
+        ValidationResult
+
+    Issue #687: Dimension validation
+    """
+    result = ValidationResult()
+
+    # Infer spatial dimension from array
+    ndim = field.ndim
+
+    # Could be spatial only or spatiotemporal
+    # Assume first dimension is time if ndim > expected_dimension
+    if ndim == expected_dimension:
+        inferred_dim = ndim
+    elif ndim == expected_dimension + 1:
+        inferred_dim = ndim - 1  # Subtract time dimension
+    else:
+        result.add_error(
+            f"{name} has {ndim} dimensions, expected {expected_dimension} "
+            f"(spatial) or {expected_dimension + 1} (spatiotemporal)",
+            location=name,
+        )
+        return result
+
+    if inferred_dim != expected_dimension:
+        result.add_error(
+            f"{name} has spatial dimension {inferred_dim}, expected {expected_dimension}",
+            location=name,
+        )
+
+    return result
+
+
+def validate_finite(
+    arr: NDArray,
+    name: str,
+) -> ValidationResult:
+    """
+    Validate array contains only finite values (no NaN or Inf).
+
+    Args:
+        arr: Array to validate
+        name: Name for error messages
+
+    Returns:
+        ValidationResult with location of first non-finite value
+
+    Issue #687: NaN/Inf detection
+    """
+    result = ValidationResult()
+
+    if np.all(np.isfinite(arr)):
+        return result
+
+    # Find non-finite values
+    nan_mask = np.isnan(arr)
+    inf_mask = np.isinf(arr)
+
+    n_nan = np.sum(nan_mask)
+    n_inf = np.sum(inf_mask)
+
+    # Get location of first issue
+    if n_nan > 0:
+        first_idx = np.unravel_index(np.argmax(nan_mask), arr.shape)
+        result.add_error(
+            f"{name} contains {n_nan} NaN values. First at index {first_idx}",
+            location=name,
+        )
+    if n_inf > 0:
+        first_idx = np.unravel_index(np.argmax(inf_mask), arr.shape)
+        result.add_error(
+            f"{name} contains {n_inf} Inf values. First at index {first_idx}",
+            location=name,
+        )
+
+    result.context["n_nan"] = n_nan
+    result.context["n_inf"] = n_inf
+
+    return result
+
+
+def validate_non_negative(
+    arr: NDArray,
+    name: str,
+    *,
+    tolerance: float = 0.0,
+) -> ValidationResult:
+    """
+    Validate array values are non-negative.
+
+    Args:
+        arr: Array to validate
+        name: Name for error messages
+        tolerance: Allow small negative values up to this magnitude
+
+    Returns:
+        ValidationResult
+
+    Useful for density validation (m >= 0).
+    """
+    result = ValidationResult()
+
+    min_val = np.min(arr)
+    if min_val < -tolerance:
+        n_negative = np.sum(arr < -tolerance)
+        result.add_error(
+            f"{name} has {n_negative} negative values (min={min_val:.6e})",
+            location=name,
+            suggestion=f"Ensure {name} is non-negative",
+        )
+        result.context["min_value"] = min_val
+        result.context["n_negative"] = n_negative
+
+    return result

--- a/mfg_pde/utils/validation/components.py
+++ b/mfg_pde/utils/validation/components.py
@@ -1,0 +1,416 @@
+"""
+Validation for MFG problem components (IC/BC).
+
+This module validates initial conditions (m_initial) and terminal conditions (u_final)
+provided via MFGComponents.
+
+Issues:
+- #679: IC/BC Validation
+- #681: Core IC/BC array and callable validation
+- #682: Geometry-agnostic IC/BC validation
+- #683: Mass normalization validation
+- #684: Callable signature detection
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from mfg_pde.utils.validation.protocol import ValidationResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+    from mfg_pde.core.mfg_components import MFGComponents
+    from mfg_pde.geometry.protocol import GeometryProtocol
+
+
+def validate_components(
+    components: MFGComponents | None,
+    geometry: GeometryProtocol,
+    *,
+    require_m_initial: bool = True,
+    require_u_final: bool = True,
+    check_mass_normalization: bool = False,
+) -> ValidationResult:
+    """
+    Validate MFGComponents against geometry.
+
+    Args:
+        components: MFGComponents to validate
+        geometry: Geometry to validate against
+        require_m_initial: Whether m_initial is required
+        require_u_final: Whether u_final is required
+        check_mass_normalization: Whether to verify integral of m_initial = 1
+
+    Returns:
+        ValidationResult with any issues found
+
+    Example:
+        result = validate_components(components, geometry)
+        if not result.is_valid:
+            raise ValidationError(result)
+    """
+    result = ValidationResult()
+
+    if components is None:
+        if require_m_initial or require_u_final:
+            result.add_error(
+                "MFGComponents is required but was None",
+                location="components",
+                suggestion="Pass components=MFGComponents(m_initial=..., u_final=...)",
+            )
+        return result
+
+    # Validate m_initial
+    if require_m_initial:
+        m_result = validate_m_initial(components.m_initial, geometry)
+        result.issues.extend(m_result.issues)
+        if not m_result.is_valid:
+            result.is_valid = False
+
+    # Validate u_final
+    if require_u_final:
+        u_result = validate_u_final(components.u_final, geometry)
+        result.issues.extend(u_result.issues)
+        if not u_result.is_valid:
+            result.is_valid = False
+
+    # Check mass normalization if requested
+    if check_mass_normalization and components.m_initial is not None:
+        mass_result = validate_mass_normalization(components.m_initial, geometry)
+        result.issues.extend(mass_result.issues)
+        # Mass normalization is a warning, not an error
+        # (doesn't invalidate the result)
+
+    return result
+
+
+def validate_m_initial(
+    m_initial: Callable | NDArray[np.floating] | None,
+    geometry: GeometryProtocol,
+) -> ValidationResult:
+    """
+    Validate initial density m_initial.
+
+    Checks:
+    - Not None (required)
+    - If callable: correct signature and return type
+    - If array: correct shape matching geometry
+    - Values are finite (no NaN/Inf)
+
+    Args:
+        m_initial: Initial density (callable or array)
+        geometry: Geometry for shape validation
+
+    Returns:
+        ValidationResult
+
+    Issue #681: Core IC/BC validation
+    """
+    result = ValidationResult()
+
+    if m_initial is None:
+        result.add_error(
+            "m_initial (initial density) is required but was None",
+            location="m_initial",
+            suggestion="Provide m_initial=lambda x: ... or m_initial=np.array(...)",
+        )
+        return result
+
+    # Validate based on type
+    if callable(m_initial):
+        return _validate_callable_ic(m_initial, geometry, "m_initial")
+    elif isinstance(m_initial, np.ndarray):
+        return _validate_array_ic(m_initial, geometry, "m_initial")
+    else:
+        result.add_error(
+            f"m_initial must be callable or ndarray, got {type(m_initial).__name__}",
+            location="m_initial",
+        )
+
+    return result
+
+
+def validate_u_final(
+    u_final: Callable | NDArray[np.floating] | None,
+    geometry: GeometryProtocol,
+) -> ValidationResult:
+    """
+    Validate terminal value function u_final.
+
+    Checks:
+    - Not None (required)
+    - If callable: correct signature and return type
+    - If array: correct shape matching geometry
+    - Values are finite (no NaN/Inf)
+
+    Args:
+        u_final: Terminal value function (callable or array)
+        geometry: Geometry for shape validation
+
+    Returns:
+        ValidationResult
+
+    Issue #681: Core IC/BC validation
+    """
+    result = ValidationResult()
+
+    if u_final is None:
+        result.add_error(
+            "u_final (terminal condition) is required but was None",
+            location="u_final",
+            suggestion="Provide u_final=lambda x: ... or u_final=np.array(...)",
+        )
+        return result
+
+    # Validate based on type
+    if callable(u_final):
+        return _validate_callable_ic(u_final, geometry, "u_final")
+    elif isinstance(u_final, np.ndarray):
+        return _validate_array_ic(u_final, geometry, "u_final")
+    else:
+        result.add_error(
+            f"u_final must be callable or ndarray, got {type(u_final).__name__}",
+            location="u_final",
+        )
+
+    return result
+
+
+def validate_mass_normalization(
+    m_initial: Callable | NDArray[np.floating],
+    geometry: GeometryProtocol,
+    tolerance: float = 0.1,
+) -> ValidationResult:
+    """
+    Validate that initial density integrates to 1.
+
+    For probability density interpretation, we expect:
+        integral of m_initial over domain = 1
+
+    Args:
+        m_initial: Initial density (callable or array)
+        geometry: Geometry for integration
+        tolerance: Relative tolerance for mass check
+
+    Returns:
+        ValidationResult with warning if mass != 1
+
+    Issue #683: Mass normalization validation
+    """
+    result = ValidationResult()
+
+    try:
+        # Evaluate m_initial on grid if callable
+        if callable(m_initial):
+            grid = geometry.get_spatial_grid()
+            if isinstance(grid, tuple):
+                # Multi-dimensional grid
+                from itertools import product
+
+                coords = list(product(*grid))
+                values = np.array([m_initial(c) for c in coords])
+            else:
+                values = np.array([m_initial(x) for x in grid])
+        else:
+            values = m_initial
+
+        # Compute mass (simple sum * dx for now)
+        # TODO: Use geometry.integrate() when available (Issue #682)
+        total_mass = np.sum(values)
+
+        # Normalize by grid spacing if available
+        if hasattr(geometry, "dx"):
+            dx = geometry.dx
+            if isinstance(dx, (list, tuple, np.ndarray)):
+                total_mass *= np.prod(dx)
+            else:
+                total_mass *= dx
+
+        # Check if mass is approximately 1
+        if abs(total_mass - 1.0) > tolerance:
+            result.add_warning(
+                f"Initial density mass = {total_mass:.4f}, expected 1.0",
+                location="m_initial",
+                suggestion="Normalize m_initial so that its integral equals 1",
+            )
+            result.context["computed_mass"] = total_mass
+
+    except Exception as e:
+        result.add_warning(
+            f"Could not verify mass normalization: {e}",
+            location="m_initial",
+        )
+
+    return result
+
+
+def detect_callable_signature(
+    func: Callable,
+    name: str = "function",
+) -> ValidationResult:
+    """
+    Detect and validate callable signature.
+
+    Attempts to determine if the callable has signature:
+    - f(x) - spatial only
+    - f(x, t) or f(t, x) - spatiotemporal
+    - f(x, y, ...) - multi-argument spatial
+
+    Args:
+        func: Callable to analyze
+        name: Name for error messages
+
+    Returns:
+        ValidationResult with signature info in context
+
+    Issue #684: Callable signature detection
+    """
+    import inspect
+
+    result = ValidationResult()
+
+    try:
+        sig = inspect.signature(func)
+        params = list(sig.parameters.values())
+
+        # Filter out *args, **kwargs
+        positional_params = [
+            p
+            for p in params
+            if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            and p.default is inspect.Parameter.empty
+        ]
+
+        n_required = len(positional_params)
+        param_names = [p.name for p in positional_params]
+
+        result.context["n_required_args"] = n_required
+        result.context["param_names"] = param_names
+
+        # Infer signature type
+        if n_required == 1:
+            result.context["signature_type"] = "spatial"
+        elif n_required == 2:
+            # Check if one parameter is 't' or 'time'
+            if any(n in ("t", "time") for n in param_names):
+                result.context["signature_type"] = "spatiotemporal"
+            else:
+                result.context["signature_type"] = "multi_spatial"
+        else:
+            result.context["signature_type"] = "unknown"
+
+    except (ValueError, TypeError) as e:
+        result.add_warning(
+            f"Could not inspect signature of {name}: {e}",
+            location=name,
+        )
+        result.context["signature_type"] = "unknown"
+
+    return result
+
+
+# --- Internal helpers ---
+
+
+def _validate_callable_ic(
+    func: Callable,
+    geometry: GeometryProtocol,
+    name: str,
+) -> ValidationResult:
+    """Validate a callable initial/terminal condition."""
+    result = ValidationResult()
+
+    # Get a sample point from geometry
+    try:
+        grid = geometry.get_spatial_grid()
+        if isinstance(grid, tuple):
+            # Multi-dimensional: take center point
+            sample_point = tuple(g[len(g) // 2] for g in grid)
+        else:
+            sample_point = grid[len(grid) // 2]
+    except Exception as e:
+        result.add_error(
+            f"Could not get sample point from geometry: {e}",
+            location=name,
+        )
+        return result
+
+    # Try to evaluate the callable
+    try:
+        value = func(sample_point)
+    except Exception as e:
+        result.add_error(
+            f"{name} callable raised exception at sample point {sample_point}: {e}",
+            location=name,
+            suggestion=f"Ensure {name} accepts the coordinate format from geometry",
+        )
+        return result
+
+    # Check return type
+    if not isinstance(value, (int, float, np.integer, np.floating, np.ndarray)):
+        result.add_error(
+            f"{name} must return numeric value, got {type(value).__name__}",
+            location=name,
+        )
+        return result
+
+    # Check for NaN/Inf
+    if np.isscalar(value):
+        if not np.isfinite(value):
+            result.add_error(
+                f"{name} returned non-finite value at sample point",
+                location=name,
+            )
+    elif isinstance(value, np.ndarray):
+        if not np.all(np.isfinite(value)):
+            result.add_error(
+                f"{name} returned array with NaN or Inf values",
+                location=name,
+            )
+
+    return result
+
+
+def _validate_array_ic(
+    arr: NDArray[np.floating],
+    geometry: GeometryProtocol,
+    name: str,
+) -> ValidationResult:
+    """Validate an array initial/terminal condition."""
+    result = ValidationResult()
+
+    # Get expected shape from geometry
+    try:
+        expected_shape = geometry.get_grid_shape()
+    except Exception as e:
+        result.add_error(
+            f"Could not get grid shape from geometry: {e}",
+            location=name,
+        )
+        return result
+
+    # Check shape
+    if arr.shape != expected_shape:
+        result.add_error(
+            f"{name} has shape {arr.shape}, expected {expected_shape}",
+            location=name,
+            suggestion=f"Reshape {name} to match geometry grid shape",
+        )
+        return result
+
+    # Check for NaN/Inf
+    if not np.all(np.isfinite(arr)):
+        n_nan = np.sum(np.isnan(arr))
+        n_inf = np.sum(np.isinf(arr))
+        result.add_error(
+            f"{name} contains {n_nan} NaN and {n_inf} Inf values",
+            location=name,
+        )
+
+    return result

--- a/mfg_pde/utils/validation/functions.py
+++ b/mfg_pde/utils/validation/functions.py
@@ -1,0 +1,405 @@
+"""
+Validation for custom MFG functions (Hamiltonian, drift, running_cost).
+
+This module validates user-provided mathematical functions to catch
+errors before they propagate into solver iterations.
+
+Issue #686: Custom function validation (Hamiltonian, drift, running_cost)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from mfg_pde.utils.validation.protocol import ValidationResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mfg_pde.geometry.protocol import GeometryProtocol
+
+
+def validate_custom_functions(
+    hamiltonian: Callable | None,
+    dH_dm: Callable | None,
+    dH_dp: Callable | None,
+    geometry: GeometryProtocol,
+    *,
+    check_consistency: bool = False,
+) -> ValidationResult:
+    """
+    Validate all custom Hamiltonian-related functions.
+
+    Args:
+        hamiltonian: H(x, p, m) function
+        dH_dm: Derivative dH/dm
+        dH_dp: Derivative dH/dp (optimal control)
+        geometry: Geometry for sample point generation
+        check_consistency: If True, verify dH_dm/dH_dp are consistent with H
+
+    Returns:
+        ValidationResult with any issues found
+
+    Issue #686: Custom function validation
+    """
+    result = ValidationResult()
+
+    if hamiltonian is not None:
+        h_result = validate_hamiltonian(hamiltonian, geometry)
+        result.issues.extend(h_result.issues)
+        if not h_result.is_valid:
+            result.is_valid = False
+
+    if dH_dm is not None:
+        dm_result = validate_hamiltonian_derivative(dH_dm, geometry, "dH_dm")
+        result.issues.extend(dm_result.issues)
+        if not dm_result.is_valid:
+            result.is_valid = False
+
+    if dH_dp is not None:
+        dp_result = validate_hamiltonian_derivative(dH_dp, geometry, "dH_dp")
+        result.issues.extend(dp_result.issues)
+        if not dp_result.is_valid:
+            result.is_valid = False
+
+    # Check consistency if requested and all functions provided
+    if check_consistency and all([hamiltonian, dH_dm]):
+        cons_result = validate_hamiltonian_consistency(hamiltonian, dH_dm, geometry)
+        result.issues.extend(cons_result.issues)
+
+    return result
+
+
+def validate_hamiltonian(
+    hamiltonian: Callable,
+    geometry: GeometryProtocol,
+) -> ValidationResult:
+    """
+    Validate Hamiltonian function H(x, p, m).
+
+    Checks:
+    - Callable with correct signature
+    - Returns float or array
+    - No NaN/Inf in output
+
+    Args:
+        hamiltonian: H(x, p, m) function
+        geometry: Geometry for sample point
+
+    Returns:
+        ValidationResult
+    """
+    result = ValidationResult()
+
+    # Get sample inputs
+    try:
+        grid = geometry.get_spatial_grid()
+        if isinstance(grid, tuple):
+            x_sample = tuple(g[len(g) // 2] for g in grid)
+            dimension = len(grid)
+        else:
+            x_sample = grid[len(grid) // 2]
+            dimension = 1
+    except Exception as e:
+        result.add_error(
+            f"Could not get sample point from geometry: {e}",
+            location="hamiltonian",
+        )
+        return result
+
+    p_sample = np.zeros(dimension)
+    m_sample = 1.0
+
+    # Try to evaluate
+    try:
+        value = hamiltonian(x_sample, p_sample, m_sample)
+    except TypeError as e:
+        result.add_error(
+            f"Hamiltonian has wrong signature: {e}",
+            location="hamiltonian",
+            suggestion="Hamiltonian should have signature H(x, p, m)",
+        )
+        return result
+    except Exception as e:
+        result.add_error(
+            f"Hamiltonian raised exception: {e}",
+            location="hamiltonian",
+        )
+        return result
+
+    # Check return type
+    if not isinstance(value, (int, float, np.integer, np.floating, np.ndarray)):
+        result.add_error(
+            f"Hamiltonian must return float or ndarray, got {type(value).__name__}",
+            location="hamiltonian",
+        )
+        return result
+
+    # Check for NaN/Inf
+    if np.isscalar(value):
+        if not np.isfinite(value):
+            result.add_error(
+                "Hamiltonian returned NaN or Inf at sample point",
+                location="hamiltonian",
+            )
+    elif isinstance(value, np.ndarray) and not np.all(np.isfinite(value)):
+        result.add_error(
+            "Hamiltonian returned array with NaN or Inf values",
+            location="hamiltonian",
+        )
+
+    return result
+
+
+def validate_hamiltonian_derivative(
+    derivative_func: Callable,
+    geometry: GeometryProtocol,
+    name: str,
+) -> ValidationResult:
+    """
+    Validate a Hamiltonian derivative function (dH_dm or dH_dp).
+
+    Args:
+        derivative_func: Derivative function
+        geometry: Geometry for sample point
+        name: Name for error messages ("dH_dm" or "dH_dp")
+
+    Returns:
+        ValidationResult
+    """
+    result = ValidationResult()
+
+    # Get sample inputs
+    try:
+        grid = geometry.get_spatial_grid()
+        if isinstance(grid, tuple):
+            x_sample = tuple(g[len(g) // 2] for g in grid)
+            dimension = len(grid)
+        else:
+            x_sample = grid[len(grid) // 2]
+            dimension = 1
+    except Exception as e:
+        result.add_error(
+            f"Could not get sample point from geometry: {e}",
+            location=name,
+        )
+        return result
+
+    p_sample = np.zeros(dimension)
+    m_sample = 1.0
+
+    # Try to evaluate
+    try:
+        value = derivative_func(x_sample, p_sample, m_sample)
+    except TypeError as e:
+        result.add_error(
+            f"{name} has wrong signature: {e}",
+            location=name,
+            suggestion=f"{name} should have signature {name}(x, p, m)",
+        )
+        return result
+    except Exception as e:
+        result.add_error(
+            f"{name} raised exception: {e}",
+            location=name,
+        )
+        return result
+
+    # Check return type
+    if not isinstance(value, (int, float, np.integer, np.floating, np.ndarray)):
+        result.add_error(
+            f"{name} must return float or ndarray, got {type(value).__name__}",
+            location=name,
+        )
+
+    return result
+
+
+def validate_hamiltonian_consistency(
+    hamiltonian: Callable,
+    dH_dm: Callable,
+    geometry: GeometryProtocol,
+    tolerance: float = 1e-4,
+) -> ValidationResult:
+    """
+    Check if dH_dm is consistent with H using finite differences.
+
+    This is a numerical check that computes:
+        dH_dm_numerical = (H(x, p, m+eps) - H(x, p, m-eps)) / (2*eps)
+
+    And compares with the provided dH_dm.
+
+    Args:
+        hamiltonian: H(x, p, m) function
+        dH_dm: Claimed derivative dH/dm
+        geometry: Geometry for sample point
+        tolerance: Relative tolerance for consistency check
+
+    Returns:
+        ValidationResult with warning if inconsistent
+    """
+    result = ValidationResult()
+
+    try:
+        # Get sample inputs
+        grid = geometry.get_spatial_grid()
+        if isinstance(grid, tuple):
+            x_sample = tuple(g[len(g) // 2] for g in grid)
+            dimension = len(grid)
+        else:
+            x_sample = grid[len(grid) // 2]
+            dimension = 1
+
+        p_sample = np.zeros(dimension)
+        m_sample = 1.0
+        eps = 1e-6
+
+        # Compute numerical derivative
+        H_plus = hamiltonian(x_sample, p_sample, m_sample + eps)
+        H_minus = hamiltonian(x_sample, p_sample, m_sample - eps)
+        dH_dm_numerical = (H_plus - H_minus) / (2 * eps)
+
+        # Compute analytical derivative
+        dH_dm_analytical = dH_dm(x_sample, p_sample, m_sample)
+
+        # Compare
+        diff = abs(dH_dm_numerical - dH_dm_analytical)
+        scale = max(abs(dH_dm_analytical), 1e-10)
+
+        if diff / scale > tolerance:
+            result.add_warning(
+                f"dH_dm may be inconsistent with H: numerical={dH_dm_numerical:.6f}, analytical={dH_dm_analytical:.6f}",
+                location="dH_dm",
+                suggestion="Verify dH_dm is the correct derivative of H with respect to m",
+            )
+            result.context["dH_dm_numerical"] = dH_dm_numerical
+            result.context["dH_dm_analytical"] = dH_dm_analytical
+
+    except Exception as e:
+        result.add_warning(
+            f"Could not verify Hamiltonian consistency: {e}",
+            location="hamiltonian",
+        )
+
+    return result
+
+
+def validate_drift(
+    drift: Callable,
+    geometry: GeometryProtocol,
+) -> ValidationResult:
+    """
+    Validate drift function for FP equation.
+
+    The drift should have signature drift(x, m) or drift(t, x, m)
+    and return a vector of the same dimension as x.
+
+    Args:
+        drift: Drift function
+        geometry: Geometry for sample point
+
+    Returns:
+        ValidationResult
+    """
+    result = ValidationResult()
+
+    try:
+        grid = geometry.get_spatial_grid()
+        if isinstance(grid, tuple):
+            x_sample = tuple(g[len(g) // 2] for g in grid)
+            dimension = len(grid)
+        else:
+            x_sample = grid[len(grid) // 2]
+            dimension = 1
+    except Exception as e:
+        result.add_error(f"Could not get sample point: {e}", location="drift")
+        return result
+
+    m_sample = np.ones(dimension if dimension > 1 else 1)
+
+    # Try different signatures
+    value = None
+    for args in [(x_sample, m_sample), (0.0, x_sample, m_sample)]:
+        try:
+            value = drift(*args)
+            break
+        except TypeError:
+            continue
+
+    if value is None:
+        result.add_error(
+            "Drift has wrong signature",
+            location="drift",
+            suggestion="Drift should have signature drift(x, m) or drift(t, x, m)",
+        )
+        return result
+
+    # Check return shape
+    if isinstance(value, np.ndarray):
+        if value.shape != (dimension,) and value.shape != ():
+            result.add_warning(
+                f"Drift returned shape {value.shape}, expected ({dimension},)",
+                location="drift",
+            )
+
+    return result
+
+
+def validate_running_cost(
+    running_cost: Callable,
+    geometry: GeometryProtocol,
+) -> ValidationResult:
+    """
+    Validate running cost function.
+
+    The running cost should have signature f(x, m) or f(t, x, m)
+    and return a scalar.
+
+    Args:
+        running_cost: Running cost function
+        geometry: Geometry for sample point
+
+    Returns:
+        ValidationResult
+    """
+    result = ValidationResult()
+
+    try:
+        grid = geometry.get_spatial_grid()
+        if isinstance(grid, tuple):
+            x_sample = tuple(g[len(g) // 2] for g in grid)
+        else:
+            x_sample = grid[len(grid) // 2]
+    except Exception as e:
+        result.add_error(f"Could not get sample point: {e}", location="running_cost")
+        return result
+
+    m_sample = 1.0
+
+    # Try different signatures
+    value = None
+    for args in [(x_sample, m_sample), (0.0, x_sample, m_sample)]:
+        try:
+            value = running_cost(*args)
+            break
+        except TypeError:
+            continue
+
+    if value is None:
+        result.add_error(
+            "Running cost has wrong signature",
+            location="running_cost",
+            suggestion="Running cost should have signature f(x, m) or f(t, x, m)",
+        )
+        return result
+
+    # Check return type
+    if not np.isscalar(value):
+        result.add_warning(
+            f"Running cost should return scalar, got {type(value).__name__}",
+            location="running_cost",
+        )
+
+    return result

--- a/mfg_pde/utils/validation/protocol.py
+++ b/mfg_pde/utils/validation/protocol.py
@@ -1,0 +1,212 @@
+"""
+Validation protocols and shared types.
+
+This module defines the core types used across all validation modules:
+- ValidationResult: Outcome of a validation check
+- ValidationError: Exception for validation failures
+- Validator protocol: Interface for custom validators
+
+Issue #689: Validation module infrastructure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import numpy as np
+
+    from mfg_pde.geometry.protocol import GeometryProtocol
+
+
+class ValidationSeverity(Enum):
+    """Severity level for validation issues."""
+
+    ERROR = "error"  # Must fix before proceeding
+    WARNING = "warning"  # Proceed with caution
+    INFO = "info"  # Informational only
+
+
+@dataclass
+class ValidationIssue:
+    """A single validation issue found during checking."""
+
+    message: str
+    severity: ValidationSeverity = ValidationSeverity.ERROR
+    location: str | None = None  # e.g., "m_initial", "diffusion[5,:]"
+    suggestion: str | None = None  # How to fix
+
+    def __str__(self) -> str:
+        parts = [f"[{self.severity.value.upper()}]"]
+        if self.location:
+            parts.append(f"({self.location})")
+        parts.append(self.message)
+        if self.suggestion:
+            parts.append(f"Suggestion: {self.suggestion}")
+        return " ".join(parts)
+
+
+@dataclass
+class ValidationResult:
+    """
+    Result of a validation check.
+
+    Attributes:
+        is_valid: True if validation passed (no errors)
+        issues: List of validation issues found
+        context: Additional context about the validation
+
+    Usage:
+        result = validate_m_initial(m_initial, geometry)
+        if not result.is_valid:
+            raise ValidationError(result)
+
+        # Or collect all issues
+        results = [
+            validate_m_initial(...),
+            validate_u_final(...),
+        ]
+        combined = ValidationResult.combine(results)
+    """
+
+    is_valid: bool = True
+    issues: list[ValidationIssue] = field(default_factory=list)
+    context: dict[str, object] = field(default_factory=dict)
+
+    def add_error(
+        self,
+        message: str,
+        location: str | None = None,
+        suggestion: str | None = None,
+    ) -> None:
+        """Add an error issue and mark result as invalid."""
+        self.issues.append(
+            ValidationIssue(
+                message=message,
+                severity=ValidationSeverity.ERROR,
+                location=location,
+                suggestion=suggestion,
+            )
+        )
+        self.is_valid = False
+
+    def add_warning(
+        self,
+        message: str,
+        location: str | None = None,
+        suggestion: str | None = None,
+    ) -> None:
+        """Add a warning issue (does not invalidate result)."""
+        self.issues.append(
+            ValidationIssue(
+                message=message,
+                severity=ValidationSeverity.WARNING,
+                location=location,
+                suggestion=suggestion,
+            )
+        )
+
+    def add_info(self, message: str, location: str | None = None) -> None:
+        """Add an informational issue."""
+        self.issues.append(
+            ValidationIssue(
+                message=message,
+                severity=ValidationSeverity.INFO,
+                location=location,
+            )
+        )
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        """Get only error-level issues."""
+        return [i for i in self.issues if i.severity == ValidationSeverity.ERROR]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        """Get only warning-level issues."""
+        return [i for i in self.issues if i.severity == ValidationSeverity.WARNING]
+
+    @classmethod
+    def combine(cls, results: list[ValidationResult]) -> ValidationResult:
+        """Combine multiple validation results into one."""
+        combined = cls()
+        for result in results:
+            combined.issues.extend(result.issues)
+            combined.context.update(result.context)
+            if not result.is_valid:
+                combined.is_valid = False
+        return combined
+
+    @classmethod
+    def ok(cls, context: dict[str, object] | None = None) -> ValidationResult:
+        """Create a successful validation result."""
+        return cls(is_valid=True, context=context or {})
+
+    @classmethod
+    def fail(
+        cls,
+        message: str,
+        location: str | None = None,
+        suggestion: str | None = None,
+    ) -> ValidationResult:
+        """Create a failed validation result with a single error."""
+        result = cls(is_valid=False)
+        result.add_error(message, location, suggestion)
+        return result
+
+    def __str__(self) -> str:
+        if self.is_valid:
+            return "Validation passed"
+        return "\n".join(str(issue) for issue in self.errors)
+
+
+class ValidationError(Exception):
+    """
+    Exception raised when validation fails.
+
+    Attributes:
+        result: The ValidationResult that triggered this error
+        message: Human-readable error message
+    """
+
+    def __init__(self, result: ValidationResult, message: str | None = None):
+        self.result = result
+        if message is None:
+            message = str(result)
+        super().__init__(message)
+
+    @classmethod
+    def from_message(
+        cls,
+        message: str,
+        location: str | None = None,
+        suggestion: str | None = None,
+    ) -> ValidationError:
+        """Create a ValidationError from a simple message."""
+        result = ValidationResult.fail(message, location, suggestion)
+        return cls(result, message)
+
+
+@runtime_checkable
+class Validator(Protocol):
+    """
+    Protocol for validator objects.
+
+    Validators perform a specific validation check and return a ValidationResult.
+    """
+
+    def validate(self) -> ValidationResult:
+        """Perform validation and return result."""
+        ...
+
+
+# Type aliases for common validation signatures
+# These are for documentation/type hints only
+if TYPE_CHECKING:
+    ValidatorFunc = Callable[..., ValidationResult]
+    ArrayValidator = Callable[["np.ndarray", str], ValidationResult]
+    CallableValidator = Callable[[Callable, "GeometryProtocol"], ValidationResult]

--- a/mfg_pde/utils/validation/runtime.py
+++ b/mfg_pde/utils/validation/runtime.py
@@ -1,0 +1,177 @@
+"""
+Runtime validation utilities (NaN/Inf detection, divergence monitoring).
+
+This module provides utilities for validating solver outputs during
+and after execution.
+
+Issue #688: Runtime safety (NaN/Inf detection, divergence, bounds checking)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from mfg_pde.utils.validation.protocol import ValidationResult
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def check_finite(
+    arr: NDArray,
+    name: str,
+    location: str | None = None,
+    *,
+    raise_on_error: bool = True,
+) -> ValidationResult:
+    """
+    Check array for NaN/Inf values.
+
+    Args:
+        arr: Array to check
+        name: Name for error messages (e.g., "u", "m")
+        location: Additional location info (e.g., "timestep 10")
+        raise_on_error: If True, raise ValueError on non-finite values
+
+    Returns:
+        ValidationResult
+
+    Raises:
+        ValueError: If raise_on_error=True and non-finite values found
+
+    Issue #688: NaN/Inf detection
+    """
+    result = ValidationResult()
+
+    if np.all(np.isfinite(arr)):
+        return result
+
+    # Find non-finite values
+    nan_mask = np.isnan(arr)
+    inf_mask = np.isinf(arr)
+
+    n_nan = np.sum(nan_mask)
+    n_inf = np.sum(inf_mask)
+
+    # Build message
+    parts = [name]
+    if location:
+        parts.append(f"({location})")
+
+    if n_nan > 0:
+        first_nan = np.unravel_index(np.argmax(nan_mask), arr.shape)
+        msg = f"{' '.join(parts)} contains {n_nan} NaN values. First at index {first_nan}"
+        result.add_error(msg, location=name)
+
+    if n_inf > 0:
+        first_inf = np.unravel_index(np.argmax(inf_mask), arr.shape)
+        msg = f"{' '.join(parts)} contains {n_inf} Inf values. First at index {first_inf}"
+        result.add_error(msg, location=name)
+
+    result.context["n_nan"] = n_nan
+    result.context["n_inf"] = n_inf
+
+    if raise_on_error and not result.is_valid:
+        raise ValueError(str(result))
+
+    return result
+
+
+def check_bounds(
+    arr: NDArray,
+    name: str,
+    *,
+    lower: float | None = None,
+    upper: float | None = None,
+    tolerance: float = 0.0,
+) -> ValidationResult:
+    """
+    Check array values are within bounds.
+
+    Args:
+        arr: Array to check
+        name: Name for error messages
+        lower: Lower bound (None = no check)
+        upper: Upper bound (None = no check)
+        tolerance: Allow values slightly outside bounds
+
+    Returns:
+        ValidationResult
+
+    Issue #688: Bounds checking
+    """
+    result = ValidationResult()
+
+    if lower is not None:
+        min_val = np.min(arr)
+        if min_val < lower - tolerance:
+            n_violations = np.sum(arr < lower - tolerance)
+            result.add_error(
+                f"{name} has {n_violations} values below lower bound {lower} (min={min_val:.6e})",
+                location=name,
+            )
+            result.context["min_value"] = min_val
+
+    if upper is not None:
+        max_val = np.max(arr)
+        if max_val > upper + tolerance:
+            n_violations = np.sum(arr > upper + tolerance)
+            result.add_error(
+                f"{name} has {n_violations} values above upper bound {upper} (max={max_val:.6e})",
+                location=name,
+            )
+            result.context["max_value"] = max_val
+
+    return result
+
+
+# Note: DivergenceMonitor and ConvergenceMonitor intentionally NOT included here.
+# Use mfg_pde.utils.convergence.convergence_monitors instead, which provides
+# comprehensive MFG-specific monitoring: DistributionConvergenceMonitor,
+# _ErrorHistoryTracker, ConvergenceWrapper, etc.
+
+
+def validate_solver_output(
+    U: NDArray,
+    M: NDArray,
+    *,
+    check_finite: bool = True,
+    check_density_positive: bool = True,
+    density_tolerance: float = -1e-10,
+) -> ValidationResult:
+    """
+    Validate complete solver output.
+
+    Args:
+        U: Value function array
+        M: Density array
+        check_finite: Check for NaN/Inf
+        check_density_positive: Check density is non-negative
+        density_tolerance: Tolerance for density non-negativity
+
+    Returns:
+        ValidationResult
+
+    Issue #688: Solver output validation
+    """
+    from mfg_pde.utils.validation.arrays import validate_finite, validate_non_negative
+
+    result = ValidationResult()
+
+    if check_finite:
+        u_result = validate_finite(U, "U (value function)")
+        m_result = validate_finite(M, "M (density)")
+        result.issues.extend(u_result.issues)
+        result.issues.extend(m_result.issues)
+        if not u_result.is_valid or not m_result.is_valid:
+            result.is_valid = False
+
+    if check_density_positive:
+        density_result = validate_non_negative(M, "M (density)", tolerance=-density_tolerance)
+        result.issues.extend(density_result.issues)
+        if not density_result.is_valid:
+            result.is_valid = False
+
+    return result


### PR DESCRIPTION
## Summary

Add comprehensive validation utilities for MFG problems as part of the Comprehensive Input Validation Initiative (Issue #685).

**New module: `mfg_pde/utils/validation/`**

### Components

| File | Purpose |
|------|---------|
| `protocol.py` | Core types: `ValidationResult`, `ValidationError`, `ValidationIssue`, `ValidationSeverity` |
| `components.py` | IC/BC validation: `validate_m_initial`, `validate_u_final`, `validate_components` |
| `functions.py` | Function validation: `validate_hamiltonian`, `validate_drift`, `validate_running_cost` |
| `arrays.py` | Array validation: `validate_array_shape`, `validate_finite`, `validate_non_negative` |
| `runtime.py` | Runtime checks: `check_finite`, `check_bounds`, `validate_solver_output` |

### Usage

```python
from mfg_pde.utils.validation import (
    validate_components,
    validate_custom_functions,
    check_finite,
)

# Validate components at problem construction
result = validate_components(components, geometry)
if not result.is_valid:
    raise ValidationError(result)
```

## Replaces

This is a clean version of PR #690 which had merge conflicts due to overlapping BC fix commits. The BC fixes are already in main (PR #678), so this PR contains only the new validation module code.

## Related Issues

- Implements: #689 (Validation module infrastructure)
- Part of: #685 (Comprehensive Input Validation Initiative)
- Enables: #681 (Phase 1 - Core IC/BC validation), #686 (Phase 2 - Custom function validation)

## Test Plan

- [ ] Verify module imports correctly
- [ ] Run existing test suite to ensure no regressions
- [ ] Add unit tests for validation functions (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)