### PR TITLE
chore(tests): Mark slow tests with @pytest.mark.slow (Issue #691)

### DIFF
--- a/tests/integration/test_block_iterators.py
+++ b/tests/integration/test_block_iterators.py
@@ -138,6 +138,7 @@ class TestBlockIteratorConvergence:
         problem = MFGProblem(geometry=geometry, T=0.4, Nt=12, diffusion=0.18, components=_default_components())
         return problem
 
+    @pytest.mark.slow
     def test_gauss_seidel_converges(self, convergence_problem):
         """Test that Gauss-Seidel converges with sufficient iterations."""
         hjb_solver = HJBFDMSolver(convergence_problem)
@@ -160,6 +161,7 @@ class TestBlockIteratorConvergence:
             # Errors should generally decrease
             assert second_half < first_half * 5, "Errors not decreasing"
 
+    @pytest.mark.slow
     def test_gauss_seidel_faster_than_jacobi(self, convergence_problem):
         """Gauss-Seidel typically converges faster than Jacobi."""
         # Create separate solver instances

--- a/tests/integration/test_fdm_solvers_mfg_complete.py
+++ b/tests/integration/test_fdm_solvers_mfg_complete.py
@@ -242,6 +242,7 @@ class TestFDMSolversCoupling:
 class TestFDMSolversNumericalProperties:
     """Test numerical properties of FDM solutions."""
 
+    @pytest.mark.slow
     def test_solution_smoothness(self):
         """Test that solutions have reasonable smoothness."""
         geometry = TensorProductGrid(

--- a/tests/integration/test_mass_conservation_1d.py
+++ b/tests/integration/test_mass_conservation_1d.py
@@ -430,6 +430,7 @@ class TestMassConservation1D:
             f"Mass conservation violated: max error = {max_mass_error:.6e}\nMasses over time: {masses}"
         )
 
+    @pytest.mark.slow
     def test_compare_mass_conservation_methods(self, problem, boundary_conditions):
         """
         Compare mass conservation between FDM and GFDM methods.

--- a/tests/integration/test_three_mode_api.py
+++ b/tests/integration/test_three_mode_api.py
@@ -266,6 +266,7 @@ class TestBackwardCompatibility:
 class TestConfigIntegration:
     """Test that config parameter works with three-mode API."""
 
+    @pytest.mark.slow
     def test_safe_mode_with_config(self):
         """Test Safe Mode with custom config."""
         from mfg_pde.config import MFGSolverConfig
@@ -282,6 +283,7 @@ class TestConfigIntegration:
 
         assert result is not None
 
+    @pytest.mark.slow
     def test_expert_mode_with_config(self):
         """Test Expert Mode with custom config."""
         from mfg_pde.config import MFGSolverConfig

--- a/tests/test_neural_operators.py
+++ b/tests/test_neural_operators.py
@@ -408,6 +408,7 @@ class TestOperatorTraining:
         assert manager.config.device == "cpu"
         assert manager.device.type == "cpu"
 
+    @pytest.mark.slow
     def test_operator_training_workflow(self, sample_training_data):
         """Test complete training workflow."""
         # Create simple operator matching training data dimensions


### PR DESCRIPTION
## Summary

Add `@pytest.mark.slow` to tests that take >10 seconds but were not previously marked. These tests will now be excluded from PR CI runs (which use `-m "not slow"`), reducing CI time while still running on releases.

## Tests Marked

| Test | Duration | File |
|------|----------|------|
| `test_compare_mass_conservation_methods` | 28.84s | `test_mass_conservation_1d.py` |
| `test_operator_training_workflow` | 23.09s | `test_neural_operators.py` |
| `test_safe_mode_with_config` | 22.72s | `test_three_mode_api.py` |
| `test_expert_mode_with_config` | 22.75s | `test_three_mode_api.py` |
| `test_solution_smoothness` | 17.03s | `test_fdm_solvers_mfg_complete.py` |
| `test_gauss_seidel_converges` | 16.47s | `test_block_iterators.py` |
| `test_gauss_seidel_faster_than_jacobi` | 12.94s | `test_block_iterators.py` |

**Total time saved per PR CI run: ~144 seconds (~2.4 minutes)**

## Impact

- PR CI runs will be faster (these slow tests are skipped)
- Release CI runs will still execute all tests (including slow tests)
- No test coverage is lost, just deferred to release validation

## Related

- Refs: #691 (Test suite cleanup)
- Analysis: See [Issue #691 comment](https://github.com/derrring/MFG_PDE/issues/691#issuecomment-3798643903)

## Test Plan

- [x] Verify tests still run with `pytest -m slow`
- [x] Verify tests are skipped with `pytest -m "not slow"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)