### PR TITLE
refactor(sl): Simplify SL solver naming - FPSLSolver is forward SL (#710)

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/__init__.py
+++ b/mfg_pde/alg/numerical/fp_solvers/__init__.py
@@ -5,12 +5,14 @@ This module provides classical numerical analysis approaches for solving
 individual Fokker-Planck equations, including:
 - Finite difference methods (FPFDMSolver)
 - Particle-based methods (FPParticleSolver)
-- Semi-Lagrangian methods (FPSLSolver, FPSLAdjointSolver)
+- Semi-Lagrangian methods (FPSLSolver)
 - GFDM meshfree methods (FPGFDMSolver)
 
-Semi-Lagrangian Variants:
-- FPSLSolver: Backward SL (gather/interpolate) - for standalone FP problems
-- FPSLAdjointSolver: Forward SL (scatter/splat) - adjoint of HJB SL for MFG duality
+Semi-Lagrangian Variants (Issue #710):
+- FPSLSolver: Forward SL (scatter/splat) - adjoint of HJB SL, RECOMMENDED
+- FPSLJacobianSolver: Backward SL with Jacobian correction - DEPRECATED
+
+Note: FPSLAdjointSolver is a deprecated alias for FPSLSolver (renamed in v0.17.6).
 
 Internal modules (Issue #635 refactoring):
 - fp_particle_density: Dimension-agnostic density estimation utilities
@@ -27,8 +29,15 @@ from .base_fp import BaseFPSolver
 from .fp_fdm import FPFDMSolver
 from .fp_gfdm import FPGFDMSolver
 from .fp_particle import FPParticleSolver, KDEMethod, KDENormalization
-from .fp_semi_lagrangian import FPSLSolver
-from .fp_semi_lagrangian_adjoint import FPSLAdjointSolver
+
+# FPSLJacobianSolver (Backward SL) is deprecated
+from .fp_semi_lagrangian import FPSLJacobianSolver
+
+# FPSLSolver (Forward SL) is the recommended solver - exported from adjoint file
+from .fp_semi_lagrangian_adjoint import (
+    FPSLAdjointSolver,  # Deprecated alias
+    FPSLSolver,
+)
 from .particle_density_query import ParticleDensityQuery
 from .particle_result import FPParticleResult
 
@@ -38,8 +47,9 @@ __all__ = [
     "FPGFDMSolver",
     "FPNetworkSolver",  # Backward compat - prefer network_solvers import
     "FPParticleSolver",
-    "FPSLSolver",
-    "FPSLAdjointSolver",  # Forward SL (adjoint of HJB SL for MFG)
+    "FPSLSolver",  # Forward SL (adjoint of HJB SL) - RECOMMENDED
+    "FPSLJacobianSolver",  # Backward SL with Jacobian - DEPRECATED
+    "FPSLAdjointSolver",  # Deprecated alias for FPSLSolver
     "KDEMethod",  # Issue #709 - KDE boundary correction methods
     "KDENormalization",
     "ParticleDensityQuery",  # Issue #489 - Direct particle query

--- a/mfg_pde/factory/scheme_factory.py
+++ b/mfg_pde/factory/scheme_factory.py
@@ -175,7 +175,7 @@ def _create_sl_pair(
     Create Semi-Lagrangian HJB-FP solver pair.
 
     Discrete duality (Type A): Forward splatting (FP) is transpose of backward
-    interpolation (HJB). Uses FPSLAdjointSolver (forward SL) for proper duality.
+    interpolation (HJB). Uses FPSLSolver (forward SL) for proper duality.
 
     Args:
         problem: MFG problem
@@ -184,13 +184,13 @@ def _create_sl_pair(
         fp_config: FP solver config
 
     Returns:
-        (HJBSemiLagrangianSolver, FPSLAdjointSolver) tuple
+        (HJBSemiLagrangianSolver, FPSLSolver) tuple
 
     Note:
-        For standalone FP problems (no HJB coupling), use FPSLSolver (backward SL).
-        For MFG duality, use FPSLAdjointSolver (forward SL, adjoint of HJB).
+        FPSLSolver (forward SL, splatting) is the adjoint of HJB backward SL.
+        FPSLJacobianSolver (backward SL with Jacobian) is deprecated.
     """
-    from mfg_pde.alg.numerical.fp_solvers import FPSLAdjointSolver
+    from mfg_pde.alg.numerical.fp_solvers import FPSLSolver
     from mfg_pde.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
 
     # Map scheme to interpolation method
@@ -207,7 +207,7 @@ def _create_sl_pair(
 
     # Create solvers
     hjb_solver = HJBSemiLagrangianSolver(problem, **hjb_config)
-    fp_solver = FPSLAdjointSolver(problem, **fp_config)
+    fp_solver = FPSLSolver(problem, **fp_config)
 
     return hjb_solver, fp_solver
 

--- a/mfg_pde/utils/adjoint_validation.py
+++ b/mfg_pde/utils/adjoint_validation.py
@@ -215,7 +215,7 @@ def check_solver_duality(
                 f"  • Violation of MFG equilibrium conditions\n\n"
                 f"Recommendation: Use matching families:\n"
                 f"  • HJBFDMSolver ↔ FPFDMSolver (discrete duality)\n"
-                f"  • HJBSemiLagrangianSolver ↔ FPSLAdjointSolver (discrete duality)\n"
+                f"  • HJBSemiLagrangianSolver ↔ FPSLSolver (discrete duality)\n"
                 f"  • HJBGFDMSolver ↔ FPGFDMSolver (continuous duality, needs renorm)\n"
                 f"{'=' * 70}\n",
                 UserWarning,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfg_pde"
-version = "0.17.5"  # v0.17.5: Unified volatility API across all FP solvers - Issue #717
+version = "0.17.6"  # v0.17.6: Simplified SL solver naming - FPSLSolver is forward SL - Issue #710
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.

--- a/tests/unit/test_alg/test_solver_traits.py
+++ b/tests/unit/test_alg/test_solver_traits.py
@@ -271,20 +271,18 @@ class TestFPSolverTraits:
         assert FPFDMSolver._scheme_family == SchemeFamily.FDM
 
     def test_fp_sl_has_sl_trait(self):
-        """Test that FPSLSolver has SL scheme family."""
-        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLSolver
+        """Test that FPSLSolver (forward SL) has SL scheme family."""
+        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
 
         assert hasattr(FPSLSolver, "_scheme_family")
         assert FPSLSolver._scheme_family == SchemeFamily.SL
 
-    def test_fp_sl_adjoint_has_sl_trait(self):
-        """Test that FPSLAdjointSolver has SL scheme family."""
-        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import (
-            FPSLAdjointSolver,
-        )
+    def test_fp_sl_jacobian_has_sl_trait(self):
+        """Test that FPSLJacobianSolver (backward SL, deprecated) has SL scheme family."""
+        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
 
-        assert hasattr(FPSLAdjointSolver, "_scheme_family")
-        assert FPSLAdjointSolver._scheme_family == SchemeFamily.SL
+        assert hasattr(FPSLJacobianSolver, "_scheme_family")
+        assert FPSLJacobianSolver._scheme_family == SchemeFamily.SL
 
     def test_fp_gfdm_has_gfdm_trait(self):
         """Test that FPGFDMSolver has GFDM scheme family."""
@@ -305,15 +303,13 @@ class TestFPSolverTraits:
         from mfg_pde.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
         from mfg_pde.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
         from mfg_pde.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
-        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLSolver
-        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import (
-            FPSLAdjointSolver,
-        )
+        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
+        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
 
         fp_solvers = [
             FPFDMSolver,
             FPSLSolver,
-            FPSLAdjointSolver,
+            FPSLJacobianSolver,
             FPGFDMSolver,
             FPParticleSolver,
         ]
@@ -325,15 +321,13 @@ class TestFPSolverTraits:
             )
 
     def test_fp_sl_variants_both_sl(self):
-        """Test that both SL and SL Adjoint solvers have SL family."""
-        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLSolver
-        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import (
-            FPSLAdjointSolver,
-        )
+        """Test that both forward SL and backward SL (Jacobian) solvers have SL family."""
+        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
+        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
 
-        # Both should be SL family (backward and forward variants)
+        # Both should be SL family (forward splatting and backward Jacobian variants)
         assert FPSLSolver._scheme_family == SchemeFamily.SL
-        assert FPSLAdjointSolver._scheme_family == SchemeFamily.SL
+        assert FPSLJacobianSolver._scheme_family == SchemeFamily.SL
 
 
 class TestHJBFPPairing:
@@ -349,7 +343,7 @@ class TestHJBFPPairing:
 
     def test_sl_hjb_fp_match(self):
         """Test that SL HJB and FP solvers have matching families."""
-        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLSolver
+        from mfg_pde.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
         from mfg_pde.alg.numerical.hjb_solvers.hjb_semi_lagrangian import (
             HJBSemiLagrangianSolver,
         )

--- a/tests/unit/test_factory/test_scheme_factory.py
+++ b/tests/unit/test_factory/test_scheme_factory.py
@@ -112,11 +112,11 @@ class TestCreatePairedSolversSL:
         hjb, fp = create_paired_solvers(problem, NumericalScheme.SL_LINEAR)
 
         # Check solver types
-        from mfg_pde.alg.numerical.fp_solvers import FPSLAdjointSolver
+        from mfg_pde.alg.numerical.fp_solvers import FPSLSolver
         from mfg_pde.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
 
         assert isinstance(hjb, HJBSemiLagrangianSolver)
-        assert isinstance(fp, FPSLAdjointSolver)  # Forward SL, not backward
+        assert isinstance(fp, FPSLSolver)  # Forward SL, not backward
 
         # Check duality
         result = check_solver_duality(hjb, fp)
@@ -140,25 +140,25 @@ class TestCreatePairedSolversSL:
         hjb, fp = create_paired_solvers(problem, NumericalScheme.SL_CUBIC)
 
         # Check solver types
-        from mfg_pde.alg.numerical.fp_solvers import FPSLAdjointSolver
+        from mfg_pde.alg.numerical.fp_solvers import FPSLSolver
         from mfg_pde.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
 
         assert isinstance(hjb, HJBSemiLagrangianSolver)
-        assert isinstance(fp, FPSLAdjointSolver)
+        assert isinstance(fp, FPSLSolver)
 
         # Check interpolation
         assert hjb.interpolation_method == "cubic"
 
     def test_sl_uses_adjoint_solver_not_backward(self):
-        """Test that SL pairing uses FPSLAdjointSolver for duality."""
+        """Test that SL pairing uses FPSLSolver (forward SL) for duality."""
         problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
 
         _, fp = create_paired_solvers(problem, NumericalScheme.SL_LINEAR)
 
-        # Must be FPSLAdjointSolver (forward splatting), not FPSLSolver (backward interpolation)
-        from mfg_pde.alg.numerical.fp_solvers import FPSLAdjointSolver
+        # Must be FPSLSolver (forward splatting), not FPSLJacobianSolver (backward interpolation)
+        from mfg_pde.alg.numerical.fp_solvers import FPSLSolver
 
-        assert isinstance(fp, FPSLAdjointSolver)
+        assert isinstance(fp, FPSLSolver)
         assert fp.fp_method_name == "Adjoint Semi-Lagrangian"
 
 


### PR DESCRIPTION
## Summary
- **`FPSLSolver`** is now the forward (adjoint) Semi-Lagrangian solver (was `FPSLAdjointSolver`)
- **`FPSLJacobianSolver`** is the deprecated backward SL solver (was `FPSLSolver`)
- Deprecated aliases (`FPSLAdjointSolver`, old `FPSLSolver`) emit `DeprecationWarning` with migration guidance
- Version bump to v0.17.6

## Rationale
The "adjoint" in `FPSLAdjointSolver` was an implementation detail — the forward SL solver is the mathematically correct default for MFG discrete duality. Making it the primary `FPSLSolver` aligns naming with intent: users pick `FPSLSolver` and get the right solver.

## Changes
| File | Change |
|------|--------|
| `fp_semi_lagrangian_adjoint.py` | Renamed class `FPSLAdjointSolver` → `FPSLSolver`, added deprecated alias factory |
| `fp_semi_lagrangian.py` | Renamed class `FPSLSolver` → `FPSLJacobianSolver`, added deprecation warning |
| `fp_solvers/__init__.py` | Updated exports with documentation |
| `factory/scheme_factory.py` | Updated imports to use new `FPSLSolver` |
| `adjoint_validation.py` | Updated docstring references |
| `test_scheme_factory.py` | Updated isinstance checks |

## Backward Compatibility
- `FPSLAdjointSolver` still works → warns and delegates to `FPSLSolver`
- Old `FPSLSolver` import from `fp_semi_lagrangian` → warns and delegates to `FPSLJacobianSolver`
- Removal planned for v1.0

## Test plan
- [x] All 21 scheme factory tests pass
- [x] All 26 adjoint validation tests pass
- [x] Smoke tests in both `fp_semi_lagrangian.py` and `fp_semi_lagrangian_adjoint.py` pass
- [x] Deprecation warnings verified
- [ ] CI pipeline

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)