### PR TITLE
chore(hjb): Remove deprecated bc_mode parameter (#703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to MFG_PDE will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-02-05
+
+**Breaking Release: Remove Deprecated `bc_mode` Parameter**
+
+### Removed
+
+- **`bc_mode` parameter from `HJBFDMSolver`** (Issue #703, #625)
+  - Removed deprecated `bc_mode` parameter from `__init__` signature
+  - Removed adjoint-consistent BC logic block from `solve_hjb_system`
+  - **Migration**: Use `AdjointConsistentProvider` in `BCSegment.value` instead
+  - The provider pattern (v0.17.1+) is the replacement: store BC intent in `BCSegment.value`,
+    `FixedPointIterator` resolves providers via `problem.using_resolved_bc(state)` each iteration
+  - Callers passing `bc_mode=` will now get `TypeError` (Python's standard behavior for removed parameters)
+  - See `examples/tutorials/06_boundary_condition_coupling.py` for updated usage
+
+### Changed
+
+- **Tutorial 06 rewritten** to use provider pattern instead of `bc_mode`
+  - Two separate problem creation functions (standard vs adjoint-consistent)
+  - Both use `FixedPointIterator` — BC resolution is automatic
+- **CLAUDE.md** BC coupling section updated with provider pattern documentation
+
 ## [Unreleased]
 
 ### Fixed

--- a/docs/development/boundary_condition_handling_summary.md
+++ b/docs/development/boundary_condition_handling_summary.md
@@ -219,24 +219,14 @@ def _apply_bc_to_solution(self, U, ...):
 
 ---
 
-### 4.6 WRONG DESIGN: bc_mode on Solver (Fixed in v0.18.0)
+### 4.6 WRONG DESIGN: bc_mode on Solver (Removed in v0.18.0) ✅ COMPLETED
 
-**Problem (now fixed):** MFG coupling logic was embedded in HJB solver.
+**Problem (removed):** MFG coupling logic was embedded in HJB solver via `bc_mode` parameter.
 
-```python
-# OLD - Solver knows about FP density (wrong!)
-class HJBFDMSolver:
-    def __init__(self, ..., bc_mode="adjoint_consistent"):
-        ...
-    def solve(self, m_current, ...):
-        if self.bc_mode == "adjoint_consistent":
-            bc = create_adjoint_consistent_bc(m_current, ...)  # Coupling logic here!
-```
-
-**Fix (Issue #625):** Provider pattern moves coupling to iterator.
+**Fix (Issue #625, #703):** Provider pattern moves coupling to iterator. The `bc_mode` parameter was removed in v0.18.0.
 
 ```python
-# NEW - Solver is generic, iterator handles coupling
+# Current (v0.18.0+) - Solver is generic, iterator handles coupling
 class HJBFDMSolver:
     def solve(self, ...):
         bc = self.problem.boundary_conditions  # Just uses what it's given
@@ -247,7 +237,7 @@ class FixedPointIterator:
             U = self.hjb_solver.solve(...)  # Provider resolved here
 ```
 
-**Status:** ✅ Fixed, but `bc_mode` parameter still exists (deprecated).
+**Status:** ✅ Removed. Callers passing `bc_mode=` get `TypeError`.
 
 ---
 
@@ -371,7 +361,7 @@ except AttributeError:
 | `apply_boundary_conditions_1d()` | v0.19.0 | `GhostBuffer` | 2 calls | dispatch.py |
 | `apply_boundary_conditions_3d()` | v0.19.0 | `GhostBuffer` | 1 call | dispatch.py |
 | `mixed_bc()` | v0.18.0 | `BoundaryConditions(segments=)` | ~5 calls | Various |
-| `bc_mode` parameter | v0.18.0 | `BCValueProvider` | 1 location | hjb_fdm.py:114 |
+| `bc_mode` parameter | v0.18.0 | `BCValueProvider` | **Removed in v0.18.0** | — |
 
 **Deprecation warning locations in applicator_fdm.py:** Lines 155, 1100, 1592, 1634, 1707
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfg_pde"
-version = "0.17.6"  # v0.17.6: Simplified SL solver naming - FPSLSolver is forward SL - Issue #710
+version = "0.18.0"  # v0.18.0: Remove deprecated bc_mode parameter from HJBFDMSolver - Issue #703
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Summary

- **BREAKING**: Remove deprecated `bc_mode` parameter from `HJBFDMSolver.__init__()` (Issue #703)
- Callers passing `bc_mode=` now get `TypeError` (Python's standard behavior for removed kwargs)
- Migration: Use `AdjointConsistentProvider` in `BCSegment.value` — the `FixedPointIterator` resolves providers automatically
- Apply `@deprecated_parameter` decorator for `NiterNewton` and `l2errBoundNewton` (replacing manual `warnings.warn()`)
- Rewrite tutorial 06 to use provider pattern
- Bump version to **v0.18.0**

## Files Changed (7)

| File | Change |
|------|--------|
| `mfg_pde/alg/numerical/hjb_solvers/hjb_fdm.py` | Remove parameter + logic, apply `@deprecated_parameter` |
| `examples/tutorials/06_boundary_condition_coupling.py` | Rewrite (provider pattern) |
| `CLAUDE.md` | Update BC coupling section |
| `pyproject.toml` | Version bump 0.17.6 → 0.18.0 |
| `CHANGELOG.md` | Add `[0.18.0]` Removed entry |
| `docs/development/boundary_condition_handling_summary.md` | Mark bc_mode as removed |
| `docs/theory/state_dependent_bc_coupling.md` | Update to past tense |

## Test plan

- [x] `pytest tests/unit/test_alg/ tests/unit/test_factory/ tests/unit/test_geometry/test_bc_providers.py` — 212 passed
- [x] `ruff check hjb_fdm.py` — all checks passed
- [x] `grep -r "bc_mode" mfg_pde/` — zero hits
- [x] Verify `bc_mode` not in `HJBFDMSolver.__init__` signature
- [x] Verify `@deprecated_parameter` metadata discoverable via `get_deprecated_parameters()`
- [x] Pre-commit hooks pass

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)