### PR TITLE
feat(hjb): Add Newton-to-Value-Iteration adaptive fallback (#669)

### DIFF
--- a/mfg_pde/alg/numerical/hjb_solvers/__init__.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/__init__.py
@@ -14,13 +14,14 @@ All solvers inherit from BaseNumericalSolver and follow the new paradigm structu
 """
 
 from .base_hjb import BaseHJBSolver
-from .hjb_fdm import HJBFDMSolver
+from .hjb_fdm import ConvergenceError, HJBFDMSolver
 from .hjb_gfdm import HJBGFDMSolver
 from .hjb_semi_lagrangian import HJBSemiLagrangianSolver
 from .hjb_weno import HJBWenoSolver
 
 __all__ = [
     "BaseHJBSolver",
+    "ConvergenceError",
     "HJBFDMSolver",
     "HJBGFDMSolver",
     "HJBSemiLagrangianSolver",


### PR DESCRIPTION
## Summary

- Add `on_newton_failure` parameter to `HJBFDMSolver` controlling behavior when Newton iteration fails in nD path
- Default `"raise"`: fail-fast via new `ConvergenceError` exception (preserves current fail behavior)
- Opt-in `"warn_and_fallback"`: emit warning and retry with fixed-point Value Iteration (10x iteration budget)
- Add `ConvergenceError(RuntimeError)` with `solver_type`, `iterations`, `residual` attributes for structured error handling

## Design

```python
# Default: fail fast (unchanged behavior)
solver = HJBFDMSolver(problem, solver_type="newton", on_newton_failure="raise")

# Opt-in: graceful degradation for production MFG coupling
solver = HJBFDMSolver(problem, solver_type="newton", on_newton_failure="warn_and_fallback")
```

**Failure detection**: `LinAlgError` (singular Jacobian), `SolverInfo.converged == False`, `ValueError`/`RuntimeError` from linear solver.

**Scope**: nD path only (`_solve_single_timestep`). 1D path (`base_hjb.py`) already has built-in error resilience.

## Test plan

- [x] 7 new unit tests in `TestHJBFDMSolverNewtonFallback`
- [x] All 47 HJB FDM solver tests pass
- [x] All 111 algorithm unit tests pass
- [x] Ruff clean

Fixes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)