### PR TITLE
feat: Wire runtime safety validation into FixedPointIterator (Issue #688)

### DIFF
--- a/tests/unit/test_utils/test_runtime_validation.py
+++ b/tests/unit/test_utils/test_runtime_validation.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Unit tests for runtime safety validation (Issue #688).
+
+Tests that:
+- check_finite detects NaN/Inf with location info
+- check_bounds detects out-of-range values
+- validate_solver_output catches NaN in U/M and negative density
+- FixedPointIterator terminates early on NaN (integration)
+
+Follows the pattern of test_array_field_validation.py.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfg_pde.utils.validation.runtime import (
+    check_bounds,
+    check_finite,
+    validate_solver_output,
+)
+
+# ===========================================================================
+# check_finite
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_check_finite_clean_array():
+    """Clean array should pass finiteness check."""
+    arr = np.linspace(0.0, 1.0, 20)
+    result = check_finite(arr, "test", raise_on_error=False)
+    assert result.is_valid
+
+
+@pytest.mark.unit
+def test_check_finite_nan_detected():
+    """Array with NaN should fail with location info."""
+    arr = np.ones((10, 5))
+    arr[3, 2] = np.nan
+    result = check_finite(arr, "U", location="timestep 3", raise_on_error=False)
+    assert not result.is_valid
+    assert result.context.get("n_nan") == 1
+    assert any("NaN" in str(issue) for issue in result.issues)
+
+
+@pytest.mark.unit
+def test_check_finite_raise_on_error():
+    """check_finite with raise_on_error=True should raise ValueError."""
+    arr = np.ones(10)
+    arr[5] = np.inf
+    with pytest.raises(ValueError, match="Inf"):
+        check_finite(arr, "M", raise_on_error=True)
+
+
+# ===========================================================================
+# check_bounds
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_check_bounds_within():
+    """Array within bounds should pass."""
+    arr = np.linspace(0.0, 1.0, 20)
+    result = check_bounds(arr, "density", lower=0.0, upper=1.0)
+    assert result.is_valid
+
+
+@pytest.mark.unit
+def test_check_bounds_violation():
+    """Array with values outside bounds should fail."""
+    arr = np.array([0.5, 1.5, -0.1, 0.8])
+    result = check_bounds(arr, "density", lower=0.0, upper=1.0)
+    assert not result.is_valid
+    assert any("above" in str(issue).lower() for issue in result.issues)
+    assert any("below" in str(issue).lower() for issue in result.issues)
+
+
+# ===========================================================================
+# validate_solver_output
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_validate_solver_output_valid():
+    """Clean U and M should pass output validation."""
+    Nt, Nx = 10, 20
+    U = np.random.randn(Nt, Nx)
+    M = np.abs(np.random.randn(Nt, Nx))  # Non-negative
+    result = validate_solver_output(U, M)
+    assert result.is_valid
+
+
+@pytest.mark.unit
+def test_validate_solver_output_nan_u():
+    """NaN in U should be detected."""
+    Nt, Nx = 10, 20
+    U = np.ones((Nt, Nx))
+    U[5, 10] = np.nan
+    M = np.ones((Nt, Nx))
+    result = validate_solver_output(U, M)
+    assert not result.is_valid
+    assert any("NaN" in str(issue) for issue in result.issues)
+
+
+@pytest.mark.unit
+def test_validate_solver_output_negative_density():
+    """Negative density should be detected."""
+    Nt, Nx = 10, 20
+    U = np.ones((Nt, Nx))
+    M = np.ones((Nt, Nx))
+    M[3, 5] = -0.5
+    result = validate_solver_output(U, M, check_finite=False, check_density_positive=True)
+    assert not result.is_valid
+    assert any("negative" in str(issue).lower() for issue in result.issues)
+
+
+# ===========================================================================
+# Integration: FixedPointIterator NaN early termination
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_fixed_point_nan_early_termination():
+    """FixedPointIterator should terminate early when NaN appears in iteration."""
+    from unittest.mock import Mock
+
+    from mfg_pde.alg.numerical.coupling.fixed_point_iterator import (
+        FixedPointIterator,
+    )
+    from mfg_pde.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfg_pde.core.mfg_components import MFGComponents
+    from mfg_pde.core.mfg_problem import MFGProblem
+    from mfg_pde.geometry import TensorProductGrid
+    from mfg_pde.geometry.boundary.conditions import no_flux_bc
+
+    # Real problem setup (Nx=11 for speed)
+    Nx = 11
+    geom = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx_points=[Nx],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: -(m**2),
+        coupling_dm=lambda m: -2 * m,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_final=lambda x: x**2,
+    )
+    problem = MFGProblem(geometry=geom, components=components, Nt=10)
+
+    Nt = problem.Nt
+    num_time_steps = Nt + 1
+    spatial_shape = problem.spatial_shape
+
+    # Mock HJB solver: returns NaN on second call
+    hjb_solver = Mock()
+    call_count = [0]
+
+    def hjb_side_effect(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            return np.full((num_time_steps, *spatial_shape), np.nan)
+        return np.zeros((num_time_steps, *spatial_shape))
+
+    hjb_solver.solve_hjb_system.side_effect = hjb_side_effect
+
+    # Mock FP solver: returns valid density
+    fp_solver = Mock()
+    fp_solver.solve_fp_system.return_value = np.ones((num_time_steps, *spatial_shape)) / Nx
+
+    # Create iterator and solve
+    iterator = FixedPointIterator(
+        problem=problem,
+        hjb_solver=hjb_solver,
+        fp_solver=fp_solver,
+        damping_factor=0.5,
+    )
+    result = iterator.solve(max_iterations=10, tolerance=1e-6)
+
+    # Verify early termination
+    assert not result.converged
+    assert result.iterations < 10
+    assert result.metadata.get("convergence_reason") == "diverged_nan"
+
+    # Verify output validation detected the NaN
+    output_val = result.metadata.get("output_validation")
+    assert output_val is not None
+    assert output_val["is_valid"] is False


### PR DESCRIPTION
## Summary

Phase 4 of the Comprehensive Input Validation Initiative (#685). Wires the existing runtime validators from `mfg_pde/utils/validation/runtime.py` into the `FixedPointIterator` solver loop.

- **Per-iteration NaN/Inf early termination**: Lightweight `np.isfinite` check after each U/M update in the Picard loop. Sets `convergence_reason="diverged_nan"` and breaks immediately, avoiding wasted compute on a diverged solution.
- **Final output validation**: Calls `validate_solver_output(U, M)` before constructing `SolverResult`. Stores diagnostic details (NaN count, first index, negative density) in `metadata["output_validation"]` for user inspection.

Closes #688

## Design Decisions

- **Two-tier approach**: Fast `np.isfinite` in hot loop (O(N) per iteration) vs. detailed `validate_solver_output` once at end. This keeps per-iteration overhead minimal while providing rich diagnostics at completion.
- **Reports but doesn't raise**: Consistent with the validation module design — issues are stored in metadata, callers decide action. The `SolverResult.converged` flag already indicates solver status.
- **No changes to runtime.py**: All validators were already fully implemented; this PR only wires them in.

## Test plan

- [x] 8 standalone tests for `check_finite`, `check_bounds`, `validate_solver_output`
- [x] 1 integration test: `test_fixed_point_nan_early_termination` using real `MFGProblem` with mocked HJB/FP solvers — verifies early termination, convergence_reason, and output_validation metadata
- [x] All 542 unit tests pass (core + utils)
- [x] ruff clean on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)