### PR TITLE
chore: Consolidate duplicate patterns in workflow/ module

### DIFF
--- a/mfg_pde/workflow/__init__.py
+++ b/mfg_pde/workflow/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import warnings
 from typing import Any
 
+from .common import ExecutionStatus
 from .decorators import experiment, parameter_study, workflow_step
 from .experiment_tracker import Experiment, ExperimentResult, ExperimentTracker
 from .parameter_sweep import ParameterSweep, SweepConfiguration
@@ -213,6 +214,7 @@ def performance_benchmark_workflow(problem_sizes: list[tuple], solver_types: lis
 
 # Export public API
 __all__ = [
+    "ExecutionStatus",
     "Experiment",
     "ExperimentResult",
     "ExperimentTracker",

--- a/mfg_pde/workflow/common.py
+++ b/mfg_pde/workflow/common.py
@@ -1,0 +1,111 @@
+"""Shared utilities for the MFG_PDE workflow module.
+
+Consolidates duplicate patterns across experiment_tracker, workflow_manager,
+and parameter_sweep: status enums, serialization, and logging setup.
+
+Issue #621: Consolidate duplicate patterns in workflow/ module.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import numpy as np
+
+from mfg_pde.utils.mfg_logging import get_logger
+
+
+class ExecutionStatus(Enum):
+    """Unified execution status for workflows and experiments.
+
+    Superset of the previously separate ExperimentStatus and WorkflowStatus enums.
+    """
+
+    CREATED = "created"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    PAUSED = "paused"
+
+
+def serialize_value(value: Any, name: str = "") -> Any:
+    """Serialize a value for JSON-compatible storage.
+
+    Handles numpy arrays, objects with ``to_dict()``, JSON-native types,
+    and falls back to ``str()`` for everything else.
+
+    Args:
+        value: The value to serialize.
+        name: Optional name used for the numpy data_file key.
+
+    Returns:
+        A JSON-serializable representation of *value*.
+    """
+    if isinstance(value, np.ndarray):
+        return {
+            "type": "numpy_array",
+            "shape": value.shape,
+            "dtype": str(value.dtype),
+            "data_file": f"result_{name}.npy" if name else "result.npy",
+        }
+
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return to_dict()
+
+    if isinstance(value, (dict, list, str, int, float, bool)):
+        return value
+
+    return str(value)
+
+
+def setup_workflow_logging(
+    name: str,
+    log_file: Path,
+    *,
+    console: bool = False,
+) -> logging.Logger:
+    """Configure a logger with a file handler and optional console handler.
+
+    All five ``_setup_logging()`` methods across the workflow module follow the
+    same pattern. This function consolidates that pattern.
+
+    Args:
+        name: Logger name passed to :func:`get_logger`.
+        log_file: Path to the log file.
+        console: If ``True``, also attach a :class:`~logging.StreamHandler`.
+
+    Returns:
+        Configured :class:`~logging.Logger`.
+    """
+    logger = get_logger(name)
+    logger.setLevel(logging.INFO)
+
+    if not logger.handlers:
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+        if console:
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(logging.INFO)
+            console_handler.setFormatter(formatter)
+            logger.addHandler(console_handler)
+
+    return logger
+
+
+__all__ = [
+    "ExecutionStatus",
+    "serialize_value",
+    "setup_workflow_logging",
+]

--- a/mfg_pde/workflow/decorators.py
+++ b/mfg_pde/workflow/decorators.py
@@ -230,7 +230,7 @@ def timed(func: Callable) -> Callable:
             result = func(*args, **kwargs)
             execution_time = time.time() - start_time
 
-            print(f"🕐 {func.__name__} completed in {execution_time:.3f}s")
+            print(f"{func.__name__} completed in {execution_time:.3f}s")
 
             # Add timing to result if it's a dictionary
             if isinstance(result, dict):
@@ -318,7 +318,7 @@ def cached(
                         },
                         f,
                     )
-                print(f"💾 Cached result for {func.__name__}")
+                print(f"Cached result for {func.__name__}")
             except Exception as e:
                 print(f"WARNING: Failed to cache result: {e}")
 

--- a/mfg_pde/workflow/parameter_sweep.py
+++ b/mfg_pde/workflow/parameter_sweep.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import itertools
 import json
-import logging
 import multiprocessing as mp
 import pickle
 import time
@@ -23,9 +22,10 @@ import pandas as pd
 
 import numpy as np
 
-from mfg_pde.utils.mfg_logging import get_logger
+from .common import setup_workflow_logging
 
 if TYPE_CHECKING:
+    import logging
     from collections.abc import Callable
 
 
@@ -507,31 +507,15 @@ class ParameterSweep:
 
     def _setup_logging(self) -> logging.Logger:
         """Set up logging for parameter sweep."""
-        logger = get_logger("mfg_parameter_sweep")
-        logger.setLevel(logging.INFO)
-
-        if not logger.handlers:
-            # File handler
-            if self.config.output_dir is not None:
-                log_file = self.config.output_dir / "parameter_sweep.log"
-            else:
-                log_file = Path("parameter_sweep.log")
-            file_handler = logging.FileHandler(log_file)
-            file_handler.setLevel(logging.DEBUG)
-
-            # Console handler
-            console_handler = logging.StreamHandler()
-            console_handler.setLevel(logging.INFO)
-
-            # Formatter
-            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-            file_handler.setFormatter(formatter)
-            console_handler.setFormatter(formatter)
-
-            logger.addHandler(file_handler)
-            logger.addHandler(console_handler)
-
-        return logger
+        if self.config.output_dir is not None:
+            log_file = self.config.output_dir / "parameter_sweep.log"
+        else:
+            log_file = Path("parameter_sweep.log")
+        return setup_workflow_logging(
+            "mfg_parameter_sweep",
+            log_file,
+            console=True,
+        )
 
 
 def create_grid_sweep(parameters: dict[str, list]) -> ParameterSweep:

--- a/tests/unit/test_workflow/test_common.py
+++ b/tests/unit/test_workflow/test_common.py
@@ -1,0 +1,165 @@
+"""Tests for mfg_pde.workflow.common — shared workflow utilities.
+
+Issue #621: Consolidate duplicate patterns in workflow/ module.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from mfg_pde.workflow.common import (
+    ExecutionStatus,
+    serialize_value,
+    setup_workflow_logging,
+)
+
+# ---------------------------------------------------------------------------
+# ExecutionStatus tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExecutionStatus:
+    """ExecutionStatus enum covers all expected values."""
+
+    def test_execution_status_values(self):
+        """All six status values exist and have the expected string values."""
+        assert ExecutionStatus.CREATED.value == "created"
+        assert ExecutionStatus.RUNNING.value == "running"
+        assert ExecutionStatus.COMPLETED.value == "completed"
+        assert ExecutionStatus.FAILED.value == "failed"
+        assert ExecutionStatus.CANCELLED.value == "cancelled"
+        assert ExecutionStatus.PAUSED.value == "paused"
+
+    def test_execution_status_backward_compat(self):
+        """ExperimentStatus and WorkflowStatus aliases resolve to ExecutionStatus."""
+        from mfg_pde.workflow.experiment_tracker import ExperimentStatus
+        from mfg_pde.workflow.workflow_manager import WorkflowStatus
+
+        assert ExperimentStatus is ExecutionStatus
+        assert WorkflowStatus is ExecutionStatus
+
+        # Existing value checks work identically
+        assert ExperimentStatus.COMPLETED is ExecutionStatus.COMPLETED
+        assert WorkflowStatus.PAUSED is ExecutionStatus.PAUSED
+
+
+# ---------------------------------------------------------------------------
+# serialize_value tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSerializeValue:
+    """serialize_value handles all expected types."""
+
+    def test_numpy_array(self):
+        """Numpy arrays produce a metadata dict."""
+        arr = np.ones((3, 4), dtype=np.float64)
+        result = serialize_value(arr, name="my_arr")
+
+        assert result["type"] == "numpy_array"
+        assert result["shape"] == (3, 4)
+        assert result["dtype"] == "float64"
+        assert result["data_file"] == "result_my_arr.npy"
+
+    def test_passthrough_types(self):
+        """Primitive JSON-native types are returned unchanged."""
+        assert serialize_value({"a": 1}) == {"a": 1}
+        assert serialize_value([1, 2, 3]) == [1, 2, 3]
+        assert serialize_value("hello") == "hello"
+        assert serialize_value(42) == 42
+        assert serialize_value(3.14) == 3.14
+        assert serialize_value(True) is True
+
+    def test_custom_to_dict(self):
+        """Objects with .to_dict() are serialized via that method."""
+
+        class Custom:
+            def to_dict(self):
+                return {"custom": True}
+
+        result = serialize_value(Custom())
+        assert result == {"custom": True}
+
+    def test_fallback_str(self):
+        """Unknown types fall back to str()."""
+
+        class Opaque:
+            def __str__(self):
+                return "opaque_repr"
+
+        result = serialize_value(Opaque())
+        assert result == "opaque_repr"
+
+
+# ---------------------------------------------------------------------------
+# setup_workflow_logging tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetupWorkflowLogging:
+    """setup_workflow_logging configures handlers correctly.
+
+    We patch ``get_logger`` to return a bare logger (no pre-existing handlers)
+    so that the handler-attachment logic inside ``setup_workflow_logging``
+    can be tested in isolation — independent of MFGLogger's own initialization.
+    """
+
+    def _bare_logger(self, name: str) -> logging.Logger:
+        """Create a bare logger with no handlers for testing."""
+        logger = logging.Logger(name, level=logging.DEBUG)
+        logger.handlers.clear()
+        return logger
+
+    def test_file_handler_only(self, tmp_path: Path):
+        """Without console=True, only a file handler is attached."""
+        log_file = tmp_path / "test.log"
+        bare = self._bare_logger("test_file_only")
+
+        with patch("mfg_pde.workflow.common.get_logger", return_value=bare):
+            logger = setup_workflow_logging("test_file_only", log_file)
+
+        assert isinstance(logger, logging.Logger)
+        assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
+        # No console handler should be attached
+        stream_only = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(stream_only) == 0
+
+        # Clean up
+        logger.handlers.clear()
+
+    def test_with_console(self, tmp_path: Path):
+        """With console=True, both file and stream handlers are attached."""
+        log_file = tmp_path / "test_console.log"
+        bare = self._bare_logger("test_with_console")
+
+        with patch("mfg_pde.workflow.common.get_logger", return_value=bare):
+            logger = setup_workflow_logging("test_with_console", log_file, console=True)
+
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        stream_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+
+        assert len(file_handlers) >= 1
+        assert len(stream_handlers) >= 1
+
+        # Clean up
+        logger.handlers.clear()


### PR DESCRIPTION
## Summary

- Extract shared utilities into `mfg_pde/workflow/common.py`: `ExecutionStatus` enum, `serialize_value()`, and `setup_workflow_logging()` — consolidating ~200 lines of duplicate code across 3 files
- Backward-compatible aliases (`ExperimentStatus = ExecutionStatus`, `WorkflowStatus = ExecutionStatus`) preserve all existing usage
- Fix 2 emoji violations in `decorators.py` and 1 `hasattr()` duck-typing violation in serialization

Fixes #621

## Test plan

- [x] New `test_common.py` — 8 tests covering all 3 shared utilities
- [x] Full `tests/unit/test_workflow/` suite — 202 passed, 2 skipped (pre-existing)
- [x] `ruff check mfg_pde/workflow/` — clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)