### PR TITLE
fix(workflow): Extract process pool worker for pickling (#764)

### DIFF
--- a/tests/unit/test_workflow/test_parameter_sweep_extended.py
+++ b/tests/unit/test_workflow/test_parameter_sweep_extended.py
@@ -135,9 +135,6 @@ def _test_compute_process(x):
 
 
 @pytest.mark.unit
-@pytest.mark.skip(
-    reason="Process pool pickling issues with local worker_function in ParameterSweep._execute_parallel_processes"
-)
 def test_execute_parallel_processes_basic():
     """Test parallel execution using process pool."""
     params = {"x": [1, 2, 3]}
@@ -154,9 +151,6 @@ def test_execute_parallel_processes_basic():
 
 
 @pytest.mark.unit
-@pytest.mark.skip(
-    reason="Process pool pickling issues with local worker_function in ParameterSweep._execute_parallel_processes"
-)
 def test_execute_parallel_processes_correctness():
     """Test parallel processes produce same results as sequential."""
     params = {"x": [1, 2, 3, 4]}


### PR DESCRIPTION
## Summary
- Extracted nested `worker_function` from `_execute_parallel_processes()` to module-level `_process_worker()` so it can be pickled by `ProcessPoolExecutor`
- The ParameterSweep instance is passed explicitly in the args tuple instead of captured via closure
- Un-skipped 2 tests that were disabled due to this pickle failure

## Details
`ProcessPoolExecutor` serializes callables via `pickle` to send them to worker processes. The previous nested `worker_function` captured `self` through its closure, making it unpickleable. The fix moves the function to module level and passes the `ParameterSweep` instance as an explicit argument.

Fixes #764

## Test plan
- [x] Both previously-skipped tests now pass: `test_execute_parallel_processes_basic`, `test_execute_parallel_processes_correctness`
- [x] Full test suite: 33/33 pass in `test_parameter_sweep_extended.py`
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)