### PR TITLE
feat(core): Batch-polymorphic Hamiltonian __call__/dp/dm (#775)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -877,5 +877,5 @@ Before marking an issue as complete or creating a PR:
 ---
 
 **Last Updated**: 2026-02-06
-**Repository Version**: v0.17.5 (Pre-1.0.0)
+**Repository Version**: v0.17.10 (Pre-1.0.0)
 **Claude Code**: Always reference this file for MFG_PDE conventions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfg_pde"
-version = "0.17.9"  # v0.17.9: FEM infrastructure prep (SchemeFamily, NumericalScheme, FEMConfig, scikit-fem)
+version = "0.17.10"  # v0.17.10: Batch-polymorphic Hamiltonian __call__/dp/dm (Issue #775)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Summary

- `HamiltonianBase.dp()`/`dm()` detect batch via `p.ndim == 2` and loop `_finite_diff_*` per point
- `SeparableHamiltonian.__call__()` skips the `float(H_control.sum())` squash for batch inputs; vectorizes potential/coupling with try/except fallback for scalar-only callables
- `SeparableHamiltonian.dp()` quadratic/bounded paths already broadcast; added batch dispatch in FD fallback
- `SeparableHamiltonian.dm()` batch path for `_coupling_dm`, no-coupling zeros, and FD fallback
- 9 new tests in `TestBatchPolymorphism`: shape checks, pointwise-match, base-class FD fallback, backward compat
- Version bump to v0.17.10

Closes #775

## Test plan

- [x] `pytest tests/unit/test_core/test_hamiltonian_classes.py` — 29 passed
- [x] `pytest tests/unit/test_core/` — 333 passed
- [x] `pytest tests/integration/test_coupled_hjb_fp_2d.py tests/integration/test_fdm_solvers_mfg_complete.py` — 18 passed, 1 xfailed
- [x] `ruff check` clean on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)