### PR TITLE
refactor(core): Add CongestionHamiltonian for density-dependent kinetic cost (#782)

### DIFF
--- a/mfg_pde/core/__init__.py
+++ b/mfg_pde/core/__init__.py
@@ -17,6 +17,8 @@ from .hamiltonian import (
     # Control cost base classes (original)
     BoundedControlCost,
     BoundedHamiltonian,
+    # Non-separable Hamiltonian with density-dependent kinetic cost (Issue #782)
+    CongestionHamiltonian,
     ControlCostBase,
     # Dual classes (Legendre transform)
     DualHamiltonian,
@@ -72,10 +74,11 @@ __all__ = [
     "L1Hamiltonian",
     "BoundedControlCost",
     "BoundedHamiltonian",
-    # Full MFG Hamiltonian classes (Issue #673)
+    # Full MFG Hamiltonian classes (Issue #673, #782)
     "HamiltonianBase",
     "HamiltonianState",
     "SeparableHamiltonian",
+    "CongestionHamiltonian",
     "QuadraticMFGHamiltonian",
     "create_hamiltonian",
     # Lagrangian classes (Issue #651)


### PR DESCRIPTION
## Summary

- Add `CongestionHamiltonian(HamiltonianBase)` for non-separable Hamiltonians where density modifies the kinetic term: `H = |p|^2 / (2*lambda*c(m)) + V(x,t) + f(m)`
- Batch-polymorphic `__call__`, `dp`, `dm` with analytic derivatives (follows PR #780 pattern)
- Accepts a user-provided `congestion_factor` callable `c(m)`, covering the GFDM solver's multiplicative mode `c(m) = 1 + gamma*|Omega|*m`
- Export from `mfg_pde.core`

## Test plan

- [x] 10 new tests in `TestCongestionHamiltonian`: single-point correctness, batch shapes, batch-matches-pointwise, c(m)=1 reduces to separable, analytic vs finite-diff dm, optimal control
- [x] All 39 Hamiltonian tests pass
- [x] Ruff clean

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)