### PR TITLE
chore(alg): Add SchemeFamily.GENERIC to base solver classes

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/base_fp.py
+++ b/mfg_pde/alg/numerical/fp_solvers/base_fp.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from mfg_pde.alg.base_solver import BaseNumericalSolver
+from mfg_pde.alg.base_solver import BaseNumericalSolver, SchemeFamily
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -53,6 +53,9 @@ class BaseFPSolver(BaseNumericalSolver):
         - Support anisotropic diffusion tensors for realistic applications
         - Enable state-dependent coefficients for nonlinear PDEs
     """
+
+    # Scheme family trait for duality validation (Issue #580)
+    _scheme_family = SchemeFamily.GENERIC
 
     def __init__(self, problem: MFGProblem, config: BaseConfig | None = None) -> None:
         """

--- a/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import scipy.sparse as sparse
 
-from mfg_pde.alg.base_solver import BaseNumericalSolver
+from mfg_pde.alg.base_solver import BaseNumericalSolver, SchemeFamily
 from mfg_pde.backends.compat import backend_aware_assign, backend_aware_copy, has_nan_or_inf
 from mfg_pde.utils.mfg_logging import get_logger
 
@@ -398,6 +398,9 @@ def _get_bc_info_1d(
 
 class BaseHJBSolver(BaseNumericalSolver):
     """Base class for Hamilton-Jacobi-Bellman equation solvers."""
+
+    # Scheme family trait for duality validation (Issue #580)
+    _scheme_family = SchemeFamily.GENERIC
 
     def __init__(self, problem: MFGProblem, config: BaseConfig | None = None) -> None:
         # Maintain backward compatibility - if no config provided, create a minimal one


### PR DESCRIPTION
## Summary
- Adds `_scheme_family = SchemeFamily.GENERIC` to `BaseHJBSolver` and `BaseFPSolver`
- Network solvers (`NetworkHJBSolver`, `NetworkPolicyIterationHJBSolver`, `FPNetworkSolver`) inherit GENERIC from the bases
- Closes the annotation gap from Issue #768 Phase 4 quick wins

## Test plan
- [x] 333 core unit tests pass
- [x] 51 SchemeFamily/solver trait tests pass
- [x] Verified all 5 classes resolve to `SchemeFamily.GENERIC` at runtime
- [x] ruff clean

Closes #768 (Phase 4 item: SchemeFamily annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)