### PR TITLE
fix(alg): Add nD diffusion term and remove legacy Hamiltonian code (#787)

### DIFF
--- a/tests/integration/test_coupled_hjb_fp_2d.py
+++ b/tests/integration/test_coupled_hjb_fp_2d.py
@@ -247,9 +247,12 @@ class TestCoupledHJBFP2DConvergence:
     @pytest.mark.slow
     def test_2d_grid_refinement(self):
         """Both coarse and fine grids should produce finite solutions."""
-        # Use sigma=0.5 for stability with T=0.3 (higher diffusion needed for larger T)
+        # Issue #787: With explicit diffusion -(sigma^2/2)*Laplacian(U), the CFL
+        # constraint requires finer time steps. For N=15, sigma=0.5:
+        #   D=0.125, sum(1/dx^2)=112.5, need dt < 0.5/(D*sum) = 0.036
+        #   Nt=20 gives dt=0.015, CFL=0.21 (stable)
         for N in (10, 15):
-            problem = _create_2d_problem(N=N, T=0.3, Nt=10, sigma=0.5)
+            problem = _create_2d_problem(N=N, T=0.3, Nt=20, sigma=0.5)
             solver = _create_2d_mfg_solver(problem)
 
             result = solver.solve(max_iterations=8, tolerance=1e-4)


### PR DESCRIPTION
## Summary

- Adds the missing diffusion term `-(σ²/2)Δu` to the nD HJB-FDM solver, fixing a bug where it was solving the **inviscid** HJB instead of the viscous one
- Removes ~140 lines of dead legacy code (per-point fallback loop, `problem.hamiltonian()` vectorized fallback, `DerivativeTensors` imports) since `hamiltonian_class` is guaranteed by Issue #670
- Non-diagonal tensor diffusion now handled in the vectorized path with diagonal approximation + warning (was previously in the removed per-point fallback)

**Net**: 2 files changed, 70 insertions, 212 deletions

Fixes #787. Part of #784.

## Test plan

- [x] `pytest tests/unit/test_alg/test_hjb_fdm_solver.py` — 47 passed
- [x] `pytest tests/integration/test_coupled_hjb_fp_2d.py` — 8 passed (Nt adjusted for CFL)
- [x] `pytest tests/integration/test_hjb_fdm_2d_validation.py` — 9 passed, 1 xfailed
- [x] `pytest tests/integration/test_fdm_solvers_mfg_complete.py` — 10 passed
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)