### PR TITLE
refactor: Migrate isinstance(TensorProductGrid) to CartesianGrid ABC (#794)

### DIFF
--- a/mfg_pde/alg/numerical/coupling/fictitious_play.py
+++ b/mfg_pde/alg/numerical/coupling/fictitious_play.py
@@ -343,7 +343,7 @@ class FictitiousPlayIterator(BaseMFGSolver):
             raise ValueError("Problem geometry cannot be None")
 
         if not isinstance(geometry, CartesianGrid):
-            raise ValueError("Problem geometry must be CartesianGrid (TensorProductGrid)")
+            raise ValueError("Problem geometry must be CartesianGrid")
 
         shape = tuple(self.problem.geometry.get_grid_shape())
         grid_spacing = self.problem.geometry.get_grid_spacing()[0]

--- a/mfg_pde/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfg_pde/alg/numerical/coupling/fixed_point_iterator.py
@@ -344,7 +344,7 @@ class FixedPointIterator(BaseMFGSolver):
             raise ValueError("Problem geometry cannot be None")
 
         if not isinstance(geometry, CartesianGrid):
-            raise ValueError("Problem geometry must be CartesianGrid (TensorProductGrid)")
+            raise ValueError("Problem geometry must be CartesianGrid")
 
         shape = tuple(self.problem.geometry.get_grid_shape())
         grid_spacing = self.problem.geometry.get_grid_spacing()[0]  # For compatibility

--- a/mfg_pde/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -151,19 +151,20 @@ class FPSLSolver(BaseFPSolver):
             self.spacing = np.array([self.dx])
             self.grid_coordinates = (self.x_grid,)
         else:
-            # nD problem: Use CartesianGrid interface
-            # TensorProductGrid uses 'coordinates' attribute
-            if not hasattr(problem.geometry, "coordinates"):
+            # nD problem: Requires TensorProductGrid for per-axis coordinates
+            from mfg_pde.geometry.grids.tensor_grid import TensorProductGrid
+
+            if not isinstance(problem.geometry, TensorProductGrid):
                 raise TypeError(
-                    f"Multi-dimensional problem must have CartesianGrid geometry (TensorProductGrid). "
-                    f"Got dimension={self.dimension}, geometry type={type(problem.geometry).__name__}"
+                    f"Multi-dimensional FP semi-Lagrangian adjoint requires TensorProductGrid. "
+                    f"Got {type(problem.geometry).__name__} (dimension={self.dimension})"
                 )
 
             # Grid shape and spacing
             self.grid_shape = problem.geometry.get_grid_shape()
             self.spacing = np.array(problem.geometry.get_grid_spacing())
 
-            # Grid coordinates for each dimension (TensorProductGrid uses 'coordinates')
+            # Grid coordinates for each dimension
             self.grid_coordinates = tuple(problem.geometry.coordinates)
 
             # Domain bounds

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -229,15 +229,15 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             self.x_grid = np.linspace(xmin, xmax, Nx)
             self.dt = problem.dt
             self.dx = problem.geometry.get_grid_spacing()[0]
-            self.grid = None  # No TensorProductGrid for 1D
+            self.grid = None  # 1D uses direct arrays, not grid object
         else:
             # nD problem: Use CartesianGrid interface
             from mfg_pde.geometry.base import CartesianGrid
 
             if not isinstance(problem.geometry, CartesianGrid):
                 raise ValueError(
-                    f"Multi-dimensional problem must have CartesianGrid geometry (TensorProductGrid). "
-                    f"Got dimension={self.dimension}"
+                    f"Multi-dimensional problem requires CartesianGrid geometry. "
+                    f"Got {type(problem.geometry).__name__} (dimension={self.dimension})"
                 )
             self.grid = problem.geometry  # Geometry IS the grid
             self.dt = problem.dt

--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -1300,10 +1300,10 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         if self._dx_override is not None:
             return self._dx_override
         if self.geometry is not None and self.dimension == 1:
-            from mfg_pde.geometry import TensorProductGrid
+            from mfg_pde.geometry.base import CartesianGrid
 
-            if isinstance(self.geometry, TensorProductGrid):
-                return float(self.geometry.spacing[0])
+            if isinstance(self.geometry, CartesianGrid):
+                return float(self.geometry.get_grid_spacing()[0])
             else:
                 # Compute from bounds
                 bounds = self.geometry.get_bounds()
@@ -1404,10 +1404,10 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
     def _get_spacing(self) -> float | None:
         """Get grid spacing for 1D problems (internal use, no warning)."""
         if self.geometry is not None and self.dimension == 1:
-            from mfg_pde.geometry import TensorProductGrid
+            from mfg_pde.geometry.base import CartesianGrid
 
-            if isinstance(self.geometry, TensorProductGrid):
-                return float(self.geometry.spacing[0])
+            if isinstance(self.geometry, CartesianGrid):
+                return float(self.geometry.get_grid_spacing()[0])
             else:
                 bounds = self.geometry.get_bounds()
                 if bounds is not None:

--- a/mfg_pde/geometry/level_set/core.py
+++ b/mfg_pde/geometry/level_set/core.py
@@ -101,10 +101,10 @@ class LevelSetFunction:
 
     def _get_field_shape(self) -> tuple[int, ...]:
         """Extract field shape from geometry."""
-        from mfg_pde.geometry.grids.tensor_grid import TensorProductGrid
+        from mfg_pde.geometry.base import CartesianGrid
 
-        if isinstance(self.geometry, TensorProductGrid):
-            return tuple(self.geometry.Nx_points)
+        if isinstance(self.geometry, CartesianGrid):
+            return self.geometry.get_grid_shape()
         # ImplicitDomain - infer from phi
         return self.phi.shape
 
@@ -116,7 +116,7 @@ class LevelSetFunction:
         with shape (Nx, Ny), returns [x_coords, y_coords].
 
         Raises:
-            TypeError: If geometry is not a TensorProductGrid.
+            TypeError: If geometry is not a TensorProductGrid (requires per-axis coordinates).
         """
         from mfg_pde.geometry.grids.tensor_grid import TensorProductGrid
 


### PR DESCRIPTION
## Summary

- Replace 4 `isinstance(TensorProductGrid)` checks with `CartesianGrid` ABC
- Fix 1 `hasattr()` CLAUDE.md violation in FP semi-Lagrangian adjoint solver
- Update error messages in 3 coupling/solver files to remove legacy "(TensorProductGrid)" references

## Changes

| File | Change |
|:-----|:-------|
| `core/mfg_problem.py` | `dx` property + `_get_spacing()`: `.spacing[0]` → `get_grid_spacing()[0]` |
| `geometry/level_set/core.py` | `_get_field_shape()`: `.Nx_points` → `get_grid_shape()` |
| `fp_semi_lagrangian_adjoint.py` | `hasattr("coordinates")` → `isinstance(TensorProductGrid)` (needs per-axis coords) |
| `fixed_point_iterator.py` | Error message cleanup |
| `fictitious_play.py` | Error message cleanup |
| `hjb_semi_lagrangian.py` | Error message cleanup + comment |

**Note**: `level_set/core.py:_get_grid_coordinates()` and `fp_semi_lagrangian_adjoint.py` keep `TensorProductGrid` because they need `.coordinates` (per-axis 1D arrays), which is a TensorProductGrid-specific attribute not guaranteed by the CartesianGrid ABC.

## Test plan

- [x] Core tests: 343 passed
- [x] Geometry tests: 842 passed
- [x] HJB FDM tests: 47 passed
- [x] ruff check: all clean
- [x] Pre-commit hooks: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)