### PR TITLE
feat(boundary): BCSegment int tags + Robin LinearConstraint (#732 Tier 1)

### DIFF
--- a/mfg_pde/geometry/boundary/types.py
+++ b/mfg_pde/geometry/boundary/types.py
@@ -215,8 +215,9 @@ class BCSegment:
     alpha: float = 1.0  # Weight on u (Dirichlet term)
     beta: float = 0.0  # Weight on du/dn (Neumann term)
 
-    # Rectangular domain matching
-    boundary: str | None = None
+    # Boundary matching: str for named boundaries ("x_min", "left"),
+    # int for Gmsh physical group tags (Issue #732 Tier 1)
+    boundary: str | int | None = None
     region: dict[str | int, tuple[float, float]] | None = None
 
     # SDF-based matching (general domains)


### PR DESCRIPTION
## Summary

- Accept integer Gmsh physical group tags in `BCSegment.boundary` field
- Complete Robin BC case in `calculator_to_constraint()` with correct ghost cell formula
- Note: Tier 1 item 3 (wire into FP-FDM) is moot — consumer is deprecated/uncalled

## Changes

| File | Change |
|:-----|:-------|
| `boundary/types.py` | `boundary: str \| None` → `str \| int \| None` |
| `boundary/applicator_base.py` | Robin branch: derive `u_ghost = w·u_inner + bias` from `α·u + β·∂u/∂n = g` |

### Robin math

For `α·u + β·∂u/∂n = g` with central difference `∂u/∂n ≈ (u_ghost - u_inner)/(2·dx)`:
```
weight = (β_eff - 2·α·dx) / (β_eff + 2·α·dx)
bias   = 2·g·dx / (β_eff + 2·α·dx)
```
where `β_eff = β · outward_sign`.

Reduces to Neumann when α→0, Dirichlet when β→0 (both handled by earlier branches).

## Test plan

- [x] Boundary tests: 458 passed
- [x] Manual verification: Robin constraint math verified (both min/max sides)
- [x] Manual verification: BCSegment int boundary matching works
- [x] ruff check: all clean
- [x] Pre-commit hooks: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)