### PR TITLE
refactor(core): Derive domain_type from geometry property (#794)

### DIFF
--- a/mfg_pde/extensions/topology.py
+++ b/mfg_pde/extensions/topology.py
@@ -156,11 +156,10 @@ class NetworkMFGProblem(MFGProblem):
         self.problem_name = problem_name
 
         # Phase 3.1 integration: geometry is already set by parent
-        self.domain_type = "network"  # Domain classification for solver selection
         self.dimension = "network"  # Special dimension indicator for network problems
 
-        # Re-detect solver compatibility now that domain_type is set correctly
-        # (parent __init__ called _detect_solver_compatibility() with grid domain)
+        # Re-detect solver compatibility after overriding dimension
+        # (parent __init__ called _detect_solver_compatibility() before this override)
         self._detect_solver_compatibility()
 
         # Override spatial properties for network


### PR DESCRIPTION
## Summary

- Replace 8 imperative `self.domain_type = ...` assignments with a single `@property` that derives the value from `self.geometry.geometry_type`
- Remove redundant assignment from `TopologicalMFGProblem.__init__` in `topology.py`
- Simplify `is_network`/`is_cartesian`/`is_implicit` helpers — remove defensive `getattr` guards since the property is always available

Addresses the "Medium: Derive domain_type from traits" sub-task in #794.

## Test plan

- [x] 343 core tests pass (`tests/unit/test_core/`)
- [x] 576 algorithm tests pass (`tests/unit/test_alg/`)
- [x] ruff lint clean on both modified files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)