### PR TITLE
refactor(geometry): Unify DOMAIN_2D/DOMAIN_3D into UNSTRUCTURED_MESH (#802)

### DIFF
--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -900,7 +900,7 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             self.spatial_bounds = config["spatial_bounds"]
             self.spatial_discretization = config["spatial_discretization"]
 
-        elif geometry.geometry_type in (GeometryType.DOMAIN_2D, GeometryType.DOMAIN_3D):
+        elif geometry.geometry_type == GeometryType.UNSTRUCTURED_MESH:
             # BaseGeometry - unstructured mesh via Gmsh
             self.mesh_data = geometry.generate_mesh()
             self.collocation_points = self.mesh_data.vertices
@@ -1034,7 +1034,7 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         gt = self.geometry.geometry_type
         if gt == GeometryType.CARTESIAN_GRID:
             return "grid"
-        elif gt in (GeometryType.DOMAIN_2D, GeometryType.DOMAIN_3D):
+        elif gt == GeometryType.UNSTRUCTURED_MESH:
             return "mesh"
         elif gt == GeometryType.IMPLICIT:
             return "implicit"

--- a/mfg_pde/geometry/base.py
+++ b/mfg_pde/geometry/base.py
@@ -141,14 +141,14 @@ class Geometry(ABC):
         Check if this is an unstructured mesh geometry.
 
         Returns:
-            True if geometry_type is DOMAIN_2D or DOMAIN_3D
+            True if geometry_type is UNSTRUCTURED_MESH
 
         Examples:
             >>> mesh = Mesh2D(...)
             >>> mesh.is_mesh
             True
         """
-        return self.geometry_type in (GeometryType.DOMAIN_2D, GeometryType.DOMAIN_3D)
+        return self.geometry_type == GeometryType.UNSTRUCTURED_MESH
 
     @property
     def is_implicit(self) -> bool:
@@ -982,15 +982,10 @@ class UnstructuredMesh(Geometry):
         """
         Type of geometry.
 
-        Returns DOMAIN_2D or DOMAIN_3D based on dimension.
+        Returns UNSTRUCTURED_MESH for all dimensions.
         Subclasses can override for more specific types.
         """
-        if self._dimension == 2:
-            return GeometryType.DOMAIN_2D
-        elif self._dimension == 3:
-            return GeometryType.DOMAIN_3D
-        else:
-            return GeometryType.CUSTOM
+        return GeometryType.UNSTRUCTURED_MESH
 
     @property
     def num_spatial_points(self) -> int:

--- a/mfg_pde/geometry/protocol.py
+++ b/mfg_pde/geometry/protocol.py
@@ -33,8 +33,7 @@ class GeometryType(Enum):
         CARTESIAN_GRID: Rectangular tensor product grid
         NETWORK: Graph/network topology
         MAZE: Grid-based maze with obstacles
-        DOMAIN_2D: 2D complex geometry with boundary
-        DOMAIN_3D: 3D complex geometry with boundary
+        UNSTRUCTURED_MESH: Unstructured mesh geometry (any dimension)
         IMPLICIT: Implicit geometry (level set or SDF)
         CUSTOM: User-defined custom geometry
     """
@@ -42,8 +41,7 @@ class GeometryType(Enum):
     CARTESIAN_GRID = "cartesian_grid"
     NETWORK = "network"
     MAZE = "maze"
-    DOMAIN_2D = "domain_2d"
-    DOMAIN_3D = "domain_3d"
+    UNSTRUCTURED_MESH = "unstructured_mesh"
     IMPLICIT = "implicit"
     CUSTOM = "custom"
 
@@ -638,10 +636,21 @@ def detect_geometry_type(geometry: object) -> GeometryType:
         return GeometryType.NETWORK
     elif "maze" in class_name:
         return GeometryType.MAZE
-    elif "domain2d" in class_name or "domain_2d" in class_name:
-        return GeometryType.DOMAIN_2D
-    elif "domain3d" in class_name or "domain_3d" in class_name:
-        return GeometryType.DOMAIN_3D
+    elif any(
+        x in class_name
+        for x in [
+            "domain2d",
+            "domain_2d",
+            "domain3d",
+            "domain_3d",
+            "mesh2d",
+            "mesh_2d",
+            "mesh3d",
+            "mesh_3d",
+            "unstructured",
+        ]
+    ):
+        return GeometryType.UNSTRUCTURED_MESH
     elif "implicit" in class_name or "levelset" in class_name or "sdf" in class_name:
         return GeometryType.IMPLICIT
     elif any(x in class_name for x in ["domain1d", "domain_1d", "cartesian", "grid"]):


### PR DESCRIPTION
## Summary

- Replace `GeometryType.DOMAIN_2D` and `DOMAIN_3D` with a single `UNSTRUCTURED_MESH` value
- All consumer sites treated these identically (always tupled together) — dimension is already available via `geometry.dimension`
- Simplify `BaseGeometry.geometry_type`, `is_mesh`, `_init_geometry()`, `domain_type` property, and `detect_geometry_type()`

Phase 1 of #802 (dimension-specific unification).

## Test plan

- [x] 343 core tests pass
- [x] 848 geometry tests pass
- [x] 576 algorithm tests pass (1767 total)
- [x] ruff lint clean on all 3 modified files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)