### PR TITLE
feat(solvers): Add source_term for MMS verification

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/base_fp.py
+++ b/mfg_pde/alg/numerical/fp_solvers/base_fp.py
@@ -163,6 +163,8 @@ class BaseFPSolver(BaseNumericalSolver):
         progress_callback: Callable[[int], None] | None = None,  # Issue #640
         # Deprecated parameter (Issue #717)
         diffusion_field: float | np.ndarray | Callable | None = None,
+        # MMS verification support
+        source_term: Callable[[float, np.ndarray], np.ndarray] | None = None,
     ) -> np.ndarray:
         """
         Solves the full Fokker-Planck (FP) system forward in time.
@@ -224,6 +226,13 @@ class BaseFPSolver(BaseNumericalSolver):
                 Default: None
 
             diffusion_field: DEPRECATED. Use volatility_field instead.
+
+            source_term: Source term for MMS verification (optional):
+                - None: No source term (default, standard PDE)
+                - Callable: Function S(t, x_grid) -> np.ndarray
+                  Evaluated analytically at each timestep.
+                  Used for Method of Manufactured Solutions verification.
+                Default: None
 
             show_progress: Display progress bar for timesteps
                 Default: True

--- a/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
@@ -240,6 +240,8 @@ class FPFDMSolver(BaseFPSolver):
         diffusion_field: float | np.ndarray | Callable | None = None,  # Issue #717: deprecated
         tensor_diffusion_field: np.ndarray | Callable | None = None,  # Issue #717: deprecated
         volatility_matrix: np.ndarray | Callable | None = None,  # Deprecated: use volatility_field
+        # MMS verification support
+        source_term: Callable | None = None,
     ) -> np.ndarray:
         """
         Solve FP system forward in time with general drift and diffusion support.
@@ -421,6 +423,7 @@ class FPFDMSolver(BaseFPSolver):
                 drift_field=drift_field,
                 advection_scheme=self.advection_scheme,
                 progress_callback=progress_callback,
+                source_term=source_term,
             )
         else:
             raise TypeError(f"drift_field must be None, np.ndarray, or Callable, got {type(drift_field)}")
@@ -534,6 +537,7 @@ class FPFDMSolver(BaseFPSolver):
                 tensor_diffusion_field=effective_sigma,  # Internal API uses old name
                 advection_scheme=self.advection_scheme,
                 progress_callback=progress_callback,
+                source_term=source_term,
             )
 
         # Issue #641: Always route to unified nD solver (works for all dimensions)
@@ -548,6 +552,7 @@ class FPFDMSolver(BaseFPSolver):
             diffusion_field=effective_sigma if volatility_field is not None else None,
             advection_scheme=self.advection_scheme,
             progress_callback=progress_callback,
+            source_term=source_term,
         )
 
     # =========================================================================


### PR DESCRIPTION
## Summary
- Thread `source_term: Callable[[float, np.ndarray], np.ndarray] | None` through FP and HJB FDM solver chains
- FP: implicit RHS addition (`b_rhs += source`) and explicit update (`M_next += dt * source`) in all 3 time-stepping paths
- HJB: subtract from Newton residual F and fixed-point map G in both 1D (`base_hjb`) and nD (`hjb_fdm`) solvers
- Un-skip `test_backward_heat_periodic_convergence` with backward heat source `S = |∇u_exact|²/2`

Closes #523 (partial — source term infrastructure complete; additional manufactured solutions can be added incrementally)

## Test plan
- [x] All 11 MMS integration tests pass (previously-skipped HJB test now passes)
- [x] All 576 solver unit tests pass
- [x] Ruff lint clean on all 5 modified solver files
- [x] Backward compatible — all parameters default to `None`, zero overhead when unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)