### PR TITLE
chore: Remove unused imports identified by vulture (#808)

### DIFF
--- a/mfg_pde/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_particle.py
@@ -14,12 +14,10 @@ if TYPE_CHECKING:
     from mfg_pde.geometry.implicit import ImplicitDomain
 
 try:  # pragma: no cover - optional SciPy dependency
-    import scipy.interpolate as _scipy_interpolate
     from scipy.stats import gaussian_kde
 
     SCIPY_AVAILABLE = True
 except ImportError:  # pragma: no cover - graceful fallback when SciPy missing
-    _scipy_interpolate = None
     gaussian_kde = None
     SCIPY_AVAILABLE = False
 

--- a/mfg_pde/config/omegaconf_manager.py
+++ b/mfg_pde/config/omegaconf_manager.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     # For static typing, use minimal type definitions
 
     DictConfig = dict[str, Any]
-    ListConfig = list[Any]
 
     class OmegaConf:
         @staticmethod
@@ -62,7 +61,7 @@ if TYPE_CHECKING:
 else:
     # Runtime imports and fallbacks
     try:
-        from omegaconf import DictConfig, ListConfig, OmegaConf
+        from omegaconf import DictConfig, OmegaConf
         from omegaconf.errors import ConfigAttributeError
 
         try:
@@ -74,7 +73,6 @@ else:
     except ImportError:
         OMEGACONF_AVAILABLE = False
         DictConfig = dict
-        ListConfig = list
 
         class OmegaConf:
             @staticmethod


### PR DESCRIPTION
## Summary
- Remove unused `_scipy_interpolate` import from `fp_particle.py` (only `gaussian_kde` is used from scipy)
- Remove unused `ListConfig` from `omegaconf_manager.py` (all 3 definitions: TYPE_CHECKING stub, runtime import, fallback)

Identified by vulture static analysis. These are the safe, no-interface-change items from #808.

## Test plan
- [x] `ruff check` passes on both files
- [x] Import smoke tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)