### PR TITLE
chore: Remove 9 dead function parameters (#808)

### DIFF
--- a/mfg_pde/alg/neural/operator_learning/deeponet.py
+++ b/mfg_pde/alg/neural/operator_learning/deeponet.py
@@ -475,7 +475,6 @@ if TORCH_AVAILABLE:
             self,
             low_fidelity_data: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
             high_fidelity_data: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
-            fidelity_weight: float = 0.1,
         ) -> None:
             """
             Train DeepONet with multi-fidelity data.
@@ -483,7 +482,6 @@ if TORCH_AVAILABLE:
             Args:
                 low_fidelity_data: (branch, trunk, solution) low-fidelity data
                 high_fidelity_data: (branch, trunk, solution) high-fidelity data
-                fidelity_weight: Weight for low-fidelity data in loss
             """
             # Combine datasets with different weights
             low_branch, low_trunk, low_solution = low_fidelity_data

--- a/mfg_pde/alg/neural/operator_learning/operator_training.py
+++ b/mfg_pde/alg/neural/operator_learning/operator_training.py
@@ -357,7 +357,7 @@ if TORCH_AVAILABLE:
             optimizer = self._create_optimizer(operator)
 
             # Setup scheduler
-            scheduler = self._create_scheduler(optimizer, len(train_loader))
+            scheduler = self._create_scheduler(optimizer)
 
             # Setup loss function
             criterion = self._create_loss_function()
@@ -438,9 +438,7 @@ if TORCH_AVAILABLE:
             else:
                 raise ValueError(f"Unknown optimizer: {self.config.optimizer}")
 
-        def _create_scheduler(
-            self, optimizer: optim.Optimizer, steps_per_epoch: int
-        ) -> optim.lr_scheduler.LRScheduler | None:
+        def _create_scheduler(self, optimizer: optim.Optimizer) -> optim.lr_scheduler.LRScheduler | None:
             """Create learning rate scheduler."""
             if self.config.scheduler.lower() == "cosine":
                 return optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=self.config.max_epochs)
@@ -553,16 +551,13 @@ if TORCH_AVAILABLE:
             self.parameter_sampler = parameter_sampler
             self.logger = get_logger(__name__)
 
-        def generate_dataset(
-            self, num_samples: int, save_path: Path | None = None, cache_solutions: bool = True
-        ) -> OperatorDataset:
+        def generate_dataset(self, num_samples: int, save_path: Path | None = None) -> OperatorDataset:
             """
             Generate training dataset.
 
             Args:
                 num_samples: Number of parameter-solution pairs to generate
                 save_path: Path to save generated dataset
-                cache_solutions: Whether to cache solutions
 
             Returns:
                 Generated operator dataset

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2134,13 +2134,11 @@ class HJBGFDMSolver(BaseHJBSolver):
         if is_meshfree_input:
             # Pure meshfree mode: input already at collocation points
             M_collocation = M_density.copy()
-            U_prev_collocation = U_coupling_prev.copy()
             # U_terminal should also be at collocation points
             U_solution_collocation[n_time_points - 1, :] = U_terminal.copy()
         else:
             # Hybrid mode: map grid data to collocation points
             M_collocation = self._mapper.map_grid_to_collocation_batch(M_density)
-            U_prev_collocation = self._mapper.map_grid_to_collocation_batch(U_coupling_prev)
             # Set final condition at t=T (last time index = n_time_points - 1)
             U_solution_collocation[n_time_points - 1, :] = self._mapper.map_grid_to_collocation(U_terminal.flatten())
 
@@ -2157,7 +2155,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         for n in timestep_range:
             U_solution_collocation[n, :] = self._solve_timestep(
                 U_solution_collocation[n + 1, :],
-                U_prev_collocation[n, :],
                 M_collocation[n, :],  # FIXED: Use m^n, not m^{n+1} (same-time coupling)
                 n,
             )
@@ -2178,7 +2175,6 @@ class HJBGFDMSolver(BaseHJBSolver):
     def _solve_timestep(
         self,
         u_n_plus_1: np.ndarray,
-        u_prev_picard: np.ndarray,
         m_n_plus_1: np.ndarray,
         time_idx: int,
     ) -> np.ndarray:
@@ -2421,7 +2417,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         self,
         u_current: np.ndarray,
         u_n_plus_1: np.ndarray,  # FIXED: Added actual u_n_plus_1 parameter
-        u_prev_picard: np.ndarray,
         m_n_plus_1: np.ndarray,
         time_idx: int,
     ) -> np.ndarray:

--- a/mfg_pde/config/omegaconf_manager.py
+++ b/mfg_pde/config/omegaconf_manager.py
@@ -446,13 +446,12 @@ class OmegaConfManager:
 
         return sweep_configs
 
-    def validate_config(self, config: OmegaConfig, schema_name: str | None = None) -> bool:
+    def validate_config(self, config: OmegaConfig) -> bool:
         """
-        Validate configuration against schema.
+        Validate configuration.
 
         Args:
             config: Configuration to validate
-            schema_name: Optional schema name for validation
 
         Returns:
             True if valid, False otherwise

--- a/mfg_pde/meta/optimization_meta.py
+++ b/mfg_pde/meta/optimization_meta.py
@@ -170,7 +170,7 @@ class OptimizationCompiler:
 
             # Add memory optimization if needed
             if profile.memory_constraint:
-                optimized = self._add_memory_optimization(optimized, profile.memory_constraint)
+                optimized = self._add_memory_optimization(optimized)
 
             return optimized
 
@@ -219,7 +219,7 @@ class OptimizationCompiler:
 
         return optimized_func
 
-    def _add_memory_optimization(self, func: Callable, memory_limit: int) -> Callable:
+    def _add_memory_optimization(self, func: Callable) -> Callable:
         """Add memory optimization wrapper."""
 
         @functools.wraps(func)

--- a/mfg_pde/utils/convergence/convergence_monitors.py
+++ b/mfg_pde/utils/convergence/convergence_monitors.py
@@ -612,7 +612,7 @@ class ConvergenceWrapper:
                 U, M = results[0], results[1]
                 info = results[2] if len(results) > 2 else {}
 
-                advanced_info = self._analyze_solution_convergence(U, M, x_grid, info)
+                advanced_info = self._analyze_solution_convergence(U, M, x_grid)
 
                 if isinstance(info, dict):
                     info.update(advanced_info)
@@ -627,9 +627,7 @@ class ConvergenceWrapper:
             warnings.warn(f"Distribution convergence analysis failed: {e}. Falling back to classical.")
             return self._classical_solve(Niter, l2errBound, verbose, **kwargs)
 
-    def _analyze_solution_convergence(
-        self, U: np.ndarray, M: np.ndarray, x_grid: np.ndarray, original_info: dict
-    ) -> dict[str, Any]:
+    def _analyze_solution_convergence(self, U: np.ndarray, M: np.ndarray, x_grid: np.ndarray) -> dict[str, Any]:
         """Post-hoc analysis of solution convergence using distribution criteria."""
         if U.ndim >= 2 and M.ndim >= 2:
             final_m = M[-1, :]

--- a/mfg_pde/utils/performance/optimization.py
+++ b/mfg_pde/utils/performance/optimization.py
@@ -640,14 +640,13 @@ class ParallelSparseOperations:
     """Parallel sparse matrix operations for multi-core systems."""
 
     @staticmethod
-    def parallel_matvec(matrix: csr_matrix, vectors: np.ndarray, num_threads: int | None = None) -> np.ndarray:
+    def parallel_matvec(matrix: csr_matrix, vectors: np.ndarray) -> np.ndarray:
         """
         Parallel matrix-vector multiplication for multiple vectors.
 
         Args:
             matrix: Sparse matrix
             vectors: Array of vectors (shape: n_vectors x matrix_size)
-            num_threads: Number of threads (None for auto-detect)
 
         Returns:
             Result of matrix-vector products


### PR DESCRIPTION
## Summary
Removes 9 unused function parameters identified by vulture static analysis across 7 files.

- **deeponet.py**: `fidelity_weight` — multi-fidelity training just concatenates datasets without weighting
- **operator_training.py**: `steps_per_epoch` (scheduler uses config values), `cache_solutions` (never referenced)
- **hjb_gfdm.py**: `u_prev_picard` x2 — leftover from Picard iteration refactoring (PR #781), plus dead `U_prev_collocation` computation that only existed to feed this param
- **omegaconf_manager.py**: `schema_name` — validation is hardcoded to check `["problem", "solver"]` fields
- **optimization_meta.py**: `memory_limit` — pass-through stub, memory optimization is a no-op
- **convergence_monitors.py**: `original_info` — method builds info dict from scratch, never reads input
- **optimization.py**: `num_threads` — dispatches to numba without passing thread count

**Not changed**: `mfg_components.py` interface methods (`U_for_jacobian_terms`, `U_n_current_guess_derivatives`) — these define an active caller contract with `base_hjb.py`, kept for API stability.

## Test plan
- [x] `ruff check` passes on all 7 files
- [x] 495 config+core tests pass
- [x] 192 backend tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)