### PR TITLE
fix: Adopt physics convention for diffusion parameter D = sigma^2/2

### DIFF
--- a/tests/integration/test_block_iterators.py
+++ b/tests/integration/test_block_iterators.py
@@ -54,7 +54,7 @@ class TestBlockIteratorBasic:
     def simple_problem(self):
         """Create a simple 1D MFG problem for testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.2, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=0.2, components=_default_components())
         return problem
 
     @pytest.fixture
@@ -146,7 +146,7 @@ class TestBlockIteratorConvergence:
     def convergence_problem(self):
         """Problem sized for convergence testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[25], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.4, Nt=12, diffusion=0.18, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.4, Nt=12, sigma=0.18, components=_default_components())
         return problem
 
     @pytest.mark.slow
@@ -206,7 +206,7 @@ class TestBlockIteratorParameters:
     def param_problem(self):
         """Small problem for parameter testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, diffusion=0.2, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, sigma=0.2, components=_default_components())
         return problem
 
     def test_no_damping(self, param_problem):
@@ -269,7 +269,7 @@ class TestBlockVsFixedPoint:
     def comparison_problem(self):
         """Problem for comparison testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, diffusion=0.2, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, sigma=0.2, components=_default_components())
         return problem
 
     def test_gauss_seidel_similar_to_fixed_point(self, comparison_problem):

--- a/tests/integration/test_hybrid_mass_conservation.py
+++ b/tests/integration/test_hybrid_mass_conservation.py
@@ -78,7 +78,7 @@ class TestHybridMassConservation:
             geometry=geometry,
             T=1.0,
             Nt=20,
-            diffusion=0.1,
+            sigma=0.1,
             coupling_coefficient=1.0,  # Running cost coefficient
             components=_default_components(),
         )
@@ -221,7 +221,7 @@ class TestHybridMassConservationFast:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)
         )  # Nx=20 -> 21 points
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=0.1, components=_default_components())
 
         bc = no_flux_bc(dimension=1)
         problem.boundary_conditions = bc

--- a/tests/integration/test_kde_mass_conservation.py
+++ b/tests/integration/test_kde_mass_conservation.py
@@ -37,7 +37,7 @@ def test_kde_normalization():
         bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)
     )  # Nx=20 -> 21 points
     problem = MFGProblem(
-        geometry=geometry, T=0.1, Nt=5, diffusion=1.0, coupling_coefficient=0.5, components=_default_components()
+        geometry=geometry, T=0.1, Nt=5, sigma=1.0, coupling_coefficient=0.5, components=_default_components()
     )
 
     bc = no_flux_bc(dimension=1)

--- a/tests/integration/test_mass_conservation_1d.py
+++ b/tests/integration/test_mass_conservation_1d.py
@@ -71,7 +71,7 @@ class TestMassConservation1D:
             geometry=geometry,
             T=1.0,
             Nt=20,
-            diffusion=0.1,
+            sigma=0.1,
             coupling_coefficient=1.0,
             components=_default_components(),
         )
@@ -322,7 +322,7 @@ class TestMassConservation1D:
                 geometry=geometry,
                 T=1.0,
                 Nt=20,
-                diffusion=0.1,
+                sigma=0.1,
                 coupling_coefficient=1.0,
                 components=make_custom_components(center_frac, std_frac, L),
             )

--- a/tests/integration/test_mfg_callable_coefficients.py
+++ b/tests/integration/test_mfg_callable_coefficients.py
@@ -52,7 +52,7 @@ class TestMFGCallableCoefficients:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[31]
         )  # Nx=30 intervals
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, sigma=0.1, components=_default_components())
 
         # Porous medium diffusion: D(m) = σ² m
         def porous_medium_diffusion(t, x, m):
@@ -90,7 +90,7 @@ class TestMFGCallableCoefficients:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[31]
         )  # Nx=30 intervals
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, sigma=0.1, components=_default_components())
 
         # Crowd diffusion: lower diffusion in high-density regions
         def crowd_diffusion(t, x, m):
@@ -127,7 +127,7 @@ class TestMFGCallableCoefficients:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[31]
         )  # Nx=30 intervals
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, diffusion=0.15, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, sigma=0.15, components=_default_components())
 
         # Callable returning constant
         def constant_diffusion(t, x, m):
@@ -171,7 +171,7 @@ class TestMFGCallableCoefficients:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[31]
         )  # Nx=30 intervals
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, sigma=0.1, components=_default_components())
 
         # Spatially varying diffusion (higher at boundaries)
         (Nx_points,) = problem.geometry.get_grid_shape()  # 1D spatial grid
@@ -212,7 +212,7 @@ class TestMFGCallableCoefficients:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[21]
         )  # Nx=20 intervals
-        problem = MFGProblem(geometry=geometry, T=0.3, Nt=10, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.3, Nt=10, sigma=0.1, components=_default_components())
 
         # Simple state-dependent diffusion
         def state_diffusion(t, x, m):

--- a/tests/integration/test_mms_validation.py
+++ b/tests/integration/test_mms_validation.py
@@ -244,7 +244,7 @@ class TestMMSFokkerPlanck1D:
                 geometry=geometry,
                 T=T,
                 Nt=Nx,  # Keep CFL-like ratio
-                diffusion=sigma,
+                sigma=sigma,
                 components=_default_components(),
             )
 
@@ -308,7 +308,7 @@ class TestMMSFokkerPlanck1D:
             geometry=geometry,
             T=T,
             Nt=100,  # Fine time stepping
-            diffusion=sigma,
+            sigma=sigma,
             components=_default_components(),
         )
 
@@ -364,7 +364,7 @@ class TestMMSFokkerPlanck1D:
             )
             # Fine time stepping to minimize temporal error
             Nt = max(200, Nx * 4)
-            problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+            problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
             x_grid = geometry.coordinates[0]
             m_init = manufactured.solution(0.0, x_grid)
@@ -417,7 +417,7 @@ class TestMMSFokkerPlanck1D:
         manufactured = DiffusionSinusoid1D(sigma=sigma, amplitude=0.3)
 
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=T, Nt=50, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=T, Nt=50, sigma=sigma, components=_default_components())
 
         x_grid = geometry.coordinates[0]  # 1D grid
         m_init = manufactured.solution(0.0, x_grid)
@@ -488,7 +488,7 @@ class TestMMSConvergenceRates:
             )
             # Use more time steps to minimize temporal error
             Nt = max(100, Nx * 2)
-            problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+            problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
             x_grid = geometry.coordinates[0]  # 1D grid
             m_init = manufactured.solution(0.0, x_grid)
@@ -537,7 +537,7 @@ class TestMassConservationStress:
         Nt = 1000  # Many time steps
 
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         x_grid = geometry.coordinates[0]  # 1D grid
         dx = geometry.get_grid_spacing()[0]
@@ -580,7 +580,7 @@ class TestMassConservationStress:
             geometry=geometry,
             T=T,
             Nt=Nt,
-            diffusion=sigma,
+            sigma=sigma,
             coupling_coefficient=0.1,  # Weak coupling
             components=_default_components(),
         )
@@ -756,7 +756,7 @@ class TestMMSHJB1D:
             # Pass BC to geometry - solvers retrieve BC via geometry.get_boundary_conditions()
             bc = periodic_bc(dimension=1)
             geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=bc)
-            problem = MFGProblem(geometry=geometry, T=T, Nt=Nx, diffusion=sigma, components=_default_components())
+            problem = MFGProblem(geometry=geometry, T=T, Nt=Nx, sigma=sigma, components=_default_components())
 
             x_grid = geometry.coordinates[0]
 
@@ -814,7 +814,7 @@ class TestMMSHJB1D:
         # Pass BC to geometry - solvers retrieve BC via geometry.get_boundary_conditions()
         bc = periodic_bc(dimension=1)
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=bc)
-        problem = MFGProblem(geometry=geometry, T=T, Nt=50, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=T, Nt=50, sigma=sigma, components=_default_components())
 
         x_grid = geometry.coordinates[0]
 
@@ -867,7 +867,7 @@ class TestCoupledHJBFPValidation:
         # Pass BC to geometry - both HJB and FP solvers retrieve BC via geometry
         bc = no_flux_bc(dimension=1)
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=bc)
-        problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         hjb_solver = HJBFDMSolver(problem)
         fp_solver = FPFDMSolver(problem)
@@ -924,7 +924,7 @@ class TestCoupledHJBFPValidation:
         # Pass BC to geometry - both HJB and FP solvers retrieve BC via geometry
         bc = no_flux_bc(dimension=1)
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=bc)
-        problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, sigma=sigma, components=_default_components())
         dx = geometry.get_grid_spacing()[0]
 
         hjb_solver = HJBFDMSolver(problem)

--- a/tests/integration/test_newton_mfg_solver.py
+++ b/tests/integration/test_newton_mfg_solver.py
@@ -58,7 +58,7 @@ class TestNewtonMFGSolverBasic:
     def simple_1d_problem(self):
         """Create a simple 1D MFG problem for testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[21])
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.2, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=0.2, components=_default_components())
         return problem
 
     @pytest.fixture
@@ -135,7 +135,7 @@ class TestNewtonMFGSolverHybrid:
     def moderate_problem(self):
         """Create moderate-size problem for hybrid testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[31])
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=15, diffusion=0.15, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=15, sigma=0.15, components=_default_components())
         return problem
 
     def test_picard_warmup_executed(self, moderate_problem):
@@ -207,7 +207,7 @@ class TestNewtonVsPicard:
     def comparison_problem(self):
         """Create problem for Picard vs Newton comparison."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[25])
-        problem = MFGProblem(geometry=geometry, T=0.4, Nt=12, diffusion=0.18, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.4, Nt=12, sigma=0.18, components=_default_components())
         return problem
 
     def test_both_solvers_produce_similar_results(self, comparison_problem):
@@ -257,7 +257,7 @@ class TestNewtonMFGSolverParameters:
     def param_test_problem(self):
         """Create problem for parameter testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[21])
-        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, diffusion=0.2, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, sigma=0.2, components=_default_components())
         return problem
 
     def test_line_search_disabled(self, param_test_problem):
@@ -326,7 +326,7 @@ class TestMFGResidualComputation:
     def residual_test_problem(self):
         """Create problem for residual testing."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[21])
-        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, diffusion=0.2, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.3, Nt=8, sigma=0.2, components=_default_components())
         return problem
 
     def test_residual_computation(self, residual_test_problem):

--- a/tests/integration/test_particle_collocation_mfg.py
+++ b/tests/integration/test_particle_collocation_mfg.py
@@ -59,7 +59,7 @@ class SimpleLQMFG2D(MFGProblem):
             Nx=30,
             Lx=1.0,
             xmin=0.0,
-            diffusion=0.2,
+            sigma=0.2,
             coupling_coefficient=0.5,
             dimension=2,
             components=_default_components_2d(),

--- a/tests/integration/test_weight_functions.py
+++ b/tests/integration/test_weight_functions.py
@@ -38,7 +38,7 @@ def test_weight_functions():
         bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1)
     )  # Nx=10 intervals
     problem = MFGProblem(
-        geometry=geometry, T=0.02, Nt=2, diffusion=0.1, coupling_coefficient=0.1, components=_default_components()
+        geometry=geometry, T=0.02, Nt=2, sigma=0.1, coupling_coefficient=0.1, components=_default_components()
     )
 
     num_collocation_points = 5

--- a/tests/unit/test_alg/test_base_fp.py
+++ b/tests/unit/test_alg/test_base_fp.py
@@ -59,7 +59,7 @@ class MockMFGProblem(MFGProblem):
             geometry=geometry,
             T=1.0,
             Nt=100,
-            diffusion=0.1,
+            sigma=0.1,
             components=_default_components(),
         )
         self.dim = 1

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -61,10 +61,10 @@ def standard_problem():
     Standard MFGProblem configuration:
     - Domain: [0, 1] with 51 grid points
     - Time: T=1.0 with 51 time steps
-    - Diffusion: diffusion=1.0
+    - Diffusion: sigma=1.0
     """
     domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
-    return MFGProblem(geometry=domain, T=1.0, Nt=51, diffusion=1.0, components=_default_components())
+    return MFGProblem(geometry=domain, T=1.0, Nt=51, sigma=1.0, components=_default_components())
 
 
 class TestFPFDMSolverInitialization:
@@ -768,7 +768,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[31, 21], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="no_flux")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -802,7 +802,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[26, 26], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="periodic")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -834,7 +834,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[26, 16], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="no_flux")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -872,7 +872,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[21, 16], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="no_flux")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -905,7 +905,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[26, 26], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="periodic")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -940,7 +940,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[26, 26], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="no_flux")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -979,7 +979,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[21, 21], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=5, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=5, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="no_flux")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -1001,7 +1001,7 @@ class TestFPFDMSolverTensorDiffusion:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[31, 21], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=50, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=50, sigma=0.1, components=_default_components_2d())
 
         boundary_conditions = BoundaryConditions(type="no_flux")
         solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
@@ -1137,7 +1137,7 @@ class TestFPFDMSolverCallableDrift:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[21, 21], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.1, Nt=10, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.1, Nt=10, sigma=0.1, components=_default_components_2d())
 
         solver = FPFDMSolver(problem)
 

--- a/tests/unit/test_alg/test_fp_particle.py
+++ b/tests/unit/test_alg/test_fp_particle.py
@@ -58,7 +58,7 @@ class Simple2DMFGProblem(MFGProblem):
             Nx=20,
             Lx=1.0,
             xmin=0.0,
-            diffusion=0.1,
+            sigma=0.1,
             coupling_coefficient=0.5,
             dimension=2,
             components=_default_components_2d(),

--- a/tests/unit/test_alg/test_fp_particle_solver.py
+++ b/tests/unit/test_alg/test_fp_particle_solver.py
@@ -392,7 +392,7 @@ class TestFPParticleSolverNumericalProperties:
     def test_forward_time_propagation(self):
         """Test that solution is computed for all time steps."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=1.0, Nt=30, diffusion=0.3, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=30, sigma=0.3, components=_default_components())
         solver = FPParticleSolver(problem, num_particles=2000)
 
         Nx_points = problem.geometry.get_grid_shape()[0]
@@ -633,7 +633,7 @@ class TestFPParticleSolverCallableDrift:
         # Expected displacement: drift * T = 0.5 * 0.5 = 0.25
         # With diffusion = 0.05, drift dominates (Peclet number ~ 10)
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=25, diffusion=0.05, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=25, sigma=0.05, components=_default_components())
         # Increase particles to reduce statistical variance
         solver = FPParticleSolver(problem, num_particles=2000)
 
@@ -671,7 +671,7 @@ class TestFPParticleSolverCallableDrift:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[21, 21], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.3, Nt=15, diffusion=0.05, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.3, Nt=15, sigma=0.05, components=_default_components_2d())
         solver = FPParticleSolver(problem, num_particles=2000)
 
         Nx, Ny = domain.num_points[0], domain.num_points[1]
@@ -706,7 +706,7 @@ class TestFPParticleSolverCallableDrift:
     def test_state_dependent_drift_1d(self):
         """Test state-dependent drift: alpha(t, x, m) depends on density."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=25, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=25, sigma=0.1, components=_default_components())
         solver = FPParticleSolver(problem, num_particles=1000)
 
         Nx_points = problem.geometry.get_grid_shape()[0]
@@ -732,7 +732,7 @@ class TestFPParticleSolverCallableDrift:
     def test_time_dependent_drift_1d(self):
         """Test time-dependent drift: alpha(t, x, m) varies with time."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=1.0, Nt=30, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=30, sigma=0.1, components=_default_components())
         solver = FPParticleSolver(problem, num_particles=1000)
 
         Nx_points = problem.geometry.get_grid_shape()[0]
@@ -756,7 +756,7 @@ class TestFPParticleSolverCallableDrift:
     def test_callable_drift_with_array_diffusion(self):
         """Test callable drift combined with array diffusion."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, sigma=0.1, components=_default_components())
         solver = FPParticleSolver(problem, num_particles=1000)
 
         Nx_points = problem.geometry.get_grid_shape()[0]

--- a/tests/unit/test_alg/test_hjb_fdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_fdm_solver.py
@@ -481,7 +481,7 @@ class TestHJBFDMSolverDiagonalTensor:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[16, 11], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=5, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=5, sigma=0.1, components=_default_components_2d())
 
         solver = HJBFDMSolver(problem, solver_type="newton")
 
@@ -519,7 +519,7 @@ class TestHJBFDMSolverDiagonalTensor:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[16, 11], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=5, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=5, sigma=0.1, components=_default_components_2d())
 
         solver = HJBFDMSolver(problem, solver_type="newton")
 
@@ -581,7 +581,7 @@ class TestHJBFDMSolverDiagonalTensor:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[16, 11], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=3, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=3, sigma=0.1, components=_default_components_2d())
 
         solver = HJBFDMSolver(problem, solver_type="newton")
 
@@ -624,7 +624,7 @@ class TestHJBFDMSolverDiagonalTensor:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[11, 9], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=3, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=3, sigma=0.1, components=_default_components_2d())
 
         solver = HJBFDMSolver(problem, solver_type="newton")
 
@@ -664,7 +664,7 @@ class TestHJBFDMSolverDiagonalTensor:
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[11, 9], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=domain, T=0.05, Nt=3, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=3, sigma=0.1, components=_default_components_2d())
 
         solver = HJBFDMSolver(problem, solver_type="newton")
 
@@ -758,7 +758,7 @@ class TestHJBFDMSolverGhostValueBC:
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[10, 10], boundary_conditions=no_flux_bc(dimension=2)
         )
 
-        problem = MFGProblem(geometry=domain, T=0.1, Nt=5, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.1, Nt=5, sigma=0.1, components=_default_components_2d())
         solver = HJBFDMSolver(problem, solver_type="fixed_point", advection_scheme="gradient_upwind")
 
         # Get grid shape
@@ -786,7 +786,7 @@ class TestHJBFDMSolverGhostValueBC:
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[8, 8], boundary_conditions=dirichlet_bc(dimension=2, value=0.0)
         )
 
-        problem = MFGProblem(geometry=domain, T=0.1, Nt=3, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.1, Nt=3, sigma=0.1, components=_default_components_2d())
         solver = HJBFDMSolver(problem, solver_type="fixed_point", advection_scheme="gradient_upwind")
 
         # Test gradient computation directly
@@ -818,7 +818,7 @@ class TestHJBFDMSolverGhostValueBC:
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[10, 10], boundary_conditions=no_flux_bc(dimension=2)
         )
 
-        problem = MFGProblem(geometry=domain, T=0.1, Nt=3, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=0.1, Nt=3, sigma=0.1, components=_default_components_2d())
         # Use centered scheme (non-upwind)
         solver = HJBFDMSolver(problem, solver_type="fixed_point", advection_scheme="gradient_centered")
 
@@ -884,7 +884,7 @@ class TestHJBFDMSolverGhostValueBC:
 
         T = 0.4
         Nt = 4
-        problem = MFGProblem(geometry=domain, T=T, Nt=Nt, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=domain, T=T, Nt=Nt, sigma=0.1, components=_default_components_2d())
         solver = HJBFDMSolver(problem, solver_type="fixed_point", advection_scheme="gradient_upwind")
 
         Nx, Ny = domain.get_grid_shape()
@@ -933,7 +933,7 @@ class TestHJBFDMSolverNewtonFallback:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[8, 8], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, sigma=0.1, components=_default_components_2d())
         solver = HJBFDMSolver(problem, solver_type="newton", on_newton_failure="raise")
 
         Nx, Ny = 8, 8
@@ -959,7 +959,7 @@ class TestHJBFDMSolverNewtonFallback:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[8, 8], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, sigma=0.1, components=_default_components_2d())
         solver = HJBFDMSolver(problem, solver_type="newton", on_newton_failure="raise")
 
         Nx, Ny = 8, 8
@@ -985,7 +985,7 @@ class TestHJBFDMSolverNewtonFallback:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[8, 8], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, sigma=0.1, components=_default_components_2d())
         solver = HJBFDMSolver(problem, solver_type="newton", on_newton_failure="warn_and_fallback")
 
         # Mock Newton solver to return non-converged result
@@ -1026,7 +1026,7 @@ class TestHJBFDMSolverNewtonFallback:
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[8, 8], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, diffusion=0.1, components=_default_components_2d())
+        problem = MFGProblem(geometry=geometry, T=0.1, Nt=2, sigma=0.1, components=_default_components_2d())
 
         # Should accept the parameter without error even for fixed_point
         solver = HJBFDMSolver(problem, solver_type="fixed_point", on_newton_failure="warn_and_fallback")

--- a/tests/unit/test_alg/test_hjb_gfdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_solver.py
@@ -42,10 +42,10 @@ def standard_problem():
     Standard MFGProblem configuration:
     - Domain: [0, 1] with 51 grid points
     - Time: T=1.0 with 51 time steps
-    - Diffusion: diffusion=1.0
+    - Diffusion: sigma=1.0
     """
     domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
-    return MFGProblem(geometry=domain, T=1.0, Nt=51, diffusion=1.0, components=_default_components())
+    return MFGProblem(geometry=domain, T=1.0, Nt=51, sigma=1.0, components=_default_components())
 
 
 class TestHJBGFDMSolverInitialization:

--- a/tests/unit/test_alg/test_particle_multi_exit.py
+++ b/tests/unit/test_alg/test_particle_multi_exit.py
@@ -70,7 +70,7 @@ def test_particle_solver_multi_exit_1d():
         geometry=geometry,
         T=3.0,
         Nt=60,
-        diffusion=0.05,
+        sigma=0.05,
         coupling_coefficient=1.0,
         components=_default_components_1d(),
     )

--- a/tests/unit/test_alg/test_weno_family.py
+++ b/tests/unit/test_alg/test_weno_family.py
@@ -51,7 +51,7 @@ class TestWenoFamilySolver:
     def simple_problem(self) -> MFGProblem:
         """Create simple MFG problem for testing using modern geometry-first API."""
         domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[33], boundary_conditions=no_flux_bc(dimension=1))
-        return MFGProblem(geometry=domain, T=0.1, Nt=10, diffusion=0.1, components=_default_components())
+        return MFGProblem(geometry=domain, T=0.1, Nt=10, sigma=0.1, components=_default_components())
 
     @pytest.fixture
     def test_values(self) -> np.ndarray:
@@ -322,7 +322,7 @@ class TestWenoSolverIntegration:
     def integration_problem(self) -> MFGProblem:
         """Create MFG problem for integration testing using modern geometry-first API."""
         domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1))
-        return MFGProblem(geometry=domain, T=1.0, Nt=30, diffusion=0.1, components=_default_components())
+        return MFGProblem(geometry=domain, T=1.0, Nt=30, sigma=0.1, components=_default_components())
 
     def test_solve_hjb_system_shape(self, integration_problem):
         """Test that solve_hjb_system returns correct shape."""

--- a/tests/unit/test_alg/test_weno_ghost_order.py
+++ b/tests/unit/test_alg/test_weno_ghost_order.py
@@ -41,7 +41,7 @@ def test_weno_uses_high_order_ghosts():
         geometry=domain,
         T=1.0,
         Nt=10,
-        diffusion=0.1,
+        sigma=0.1,
         components=_default_components(),
     )
 
@@ -70,7 +70,7 @@ def test_weno_ghost_cells_work():
         geometry=domain,
         T=1.0,
         Nt=10,
-        diffusion=0.1,
+        sigma=0.1,
         components=_default_components(),
     )
 

--- a/tests/unit/test_core/test_hamiltonian_derivative.py
+++ b/tests/unit/test_core/test_hamiltonian_derivative.py
@@ -42,7 +42,7 @@ def _default_components():
 def simple_problem():
     """Create a simple 1D MFG problem for testing."""
     geometry = TensorProductGrid(bounds=[(0, 1)], Nx=[10], boundary_conditions=no_flux_bc(dimension=1))
-    return MFGProblem(geometry=geometry, T=1.0, Nt=10, diffusion=0.1, components=_default_components())
+    return MFGProblem(geometry=geometry, T=1.0, Nt=10, sigma=0.1, components=_default_components())
 
 
 @pytest.fixture

--- a/tests/unit/test_core/test_pde_coefficients.py
+++ b/tests/unit/test_core/test_pde_coefficients.py
@@ -329,7 +329,7 @@ class TestGetSpatialGrid:
     def test_geometry_based_api_1d(self):
         """Test grid extraction with geometry-based API (1D)."""
         domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=domain, T=1.0, Nt=50, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=domain, T=1.0, Nt=50, sigma=0.1, components=_default_components())
 
         grid = get_spatial_grid(problem)
 
@@ -341,7 +341,7 @@ class TestGetSpatialGrid:
         """Test grid extraction with legacy API (1D)."""
         # This test now uses Geometry-First API instead of deprecated legacy API
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, diffusion=0.1, components=_default_components())
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, sigma=0.1, components=_default_components())
 
         grid = get_spatial_grid(problem)
 

--- a/tests/unit/test_factory/test_factory_patterns.py
+++ b/tests/unit/test_factory/test_factory_patterns.py
@@ -32,7 +32,7 @@ class MockMFGProblem:
         xmin=0.0,
         xmax=1.0,
         Nx=100,
-        diffusion=0.1,
+        sigma=0.1,
         coupling_coefficient=0.5,
     ):
         self.T = T
@@ -44,8 +44,8 @@ class MockMFGProblem:
         self.Dx = (xmax - xmin) / Nx if Nx > 0 else 0.0
         # Dt = T / Nt (number of intervals)
         self.Dt = T / Nt if Nt > 0 else 0.0
-        self.diffusion = diffusion
-        self.sigma = diffusion  # Backward compat alias
+        self.sigma = sigma
+        self.diffusion = sigma**2 / 2.0  # PDE coefficient D = sigma^2/2
         self.coupling_coefficient = coupling_coefficient
 
 

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -65,7 +65,7 @@ class TestDualityConvergence:
             Nx=[40],
             Nt=20,
             T=1.0,
-            diffusion=0.1,
+            sigma=0.1,
             components=_default_components(),
         )
 
@@ -97,7 +97,7 @@ class TestDualityConvergence:
             Nx=[40],
             Nt=20,
             T=1.0,
-            diffusion=0.1,
+            sigma=0.1,
             components=_default_components(),
         )
 
@@ -122,7 +122,7 @@ class TestDualityConvergence:
                 Nx=[Nx],
                 Nt=Nx // 2,  # Keep CFL condition reasonable
                 T=1.0,
-                diffusion=0.1,
+                sigma=0.1,
                 components=_default_components(),
             )
 
@@ -207,7 +207,7 @@ class TestConvergenceRate:
                 Nx=[Nx],
                 Nt=Nx,  # Match time steps to space steps
                 T=1.0,
-                diffusion=0.1,
+                sigma=0.1,
                 components=_default_components(),
             )
 
@@ -241,7 +241,7 @@ class TestNumericalStability:
             Nx=[40],
             Nt=20,
             T=1.0,
-            diffusion=0.1,
+            sigma=0.1,
             components=_default_components(),
         )
 
@@ -264,7 +264,7 @@ class TestNumericalStability:
             Nx=[40],
             Nt=20,
             T=1.0,
-            diffusion=0.1,
+            sigma=0.1,
             components=_default_components(),
         )
 
@@ -298,7 +298,7 @@ if __name__ == "__main__":
 
     # Test 2: Verify convergence
     print("\nTest 2: Convergence with dual pair")
-    problem = MFGProblem(Nx=[40], Nt=20, T=1.0, diffusion=0.1, components=_default_components())
+    problem = MFGProblem(Nx=[40], Nt=20, T=1.0, sigma=0.1, components=_default_components())
     solve_result = problem.solve(
         scheme=NumericalScheme.FDM_UPWIND,
         max_iterations=30,


### PR DESCRIPTION
## Summary

Fixes #811. Resolves the `diffusion`/`sigma` convention mismatch in `MFGProblem.__init__`.

- **`diffusion=D`** now means PDE coefficient (physics convention: `D = sigma^2/2`), converted internally via `sigma = sqrt(2D)`
- **`sigma=`** remains SDE volatility (direct storage, no conversion) — no longer deprecated
- **`volatility=`** added as alias for `sigma=`
- Mutual exclusion enforced: specifying more than one raises `ValueError`
- New `.volatility` and `.diffusion` read-only properties on `MFGProblem`
- Conversion helpers `_diffusion_to_volatility()` / `_volatility_to_diffusion()` support scalar, diagonal, and full tensor cases
- Zero solver changes needed — all solvers use `problem.sigma` which remains SDE volatility
- Updated `DiffusionCallable` protocol docstring and `NAMING_CONVENTIONS.md`
- 27 test files updated across unit, integration, and validation suites

## Test plan

- [x] All 346 core unit tests pass
- [x] All 8 factory pattern tests pass (fixed mock `MockMFGProblem`)
- [x] All 17 integration tests pass (callable coefficients, MMS validation)
- [x] New dedicated tests: `test_sigma_direct_sde_volatility`, `test_volatility_alias_for_sigma`, `test_diffusion_sigma_mutual_exclusion`, `test_diffusion_sigma_equivalence`, `test_diffusion_converts_to_sigma`
- [x] Ruff check passes on all modified files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)