### PR TITLE
chore: Complete diffusion= to sigma= migration across codebase

### DIFF
--- a/benchmarks/parallel_computation_benchmark.py
+++ b/benchmarks/parallel_computation_benchmark.py
@@ -43,7 +43,7 @@ def mfg_solve_function(Nx, Nt, sigma):
     from mfg_pde.core.mfg_problem import MFGProblem
     from mfg_pde.factory import create_fast_solver
 
-    problem = MFGProblem(Nx=Nx, Nt=Nt, diffusion=sigma)
+    problem = MFGProblem(Nx=Nx, Nt=Nt, sigma=sigma)
     solver = create_fast_solver(problem)
     result = solver.solve()
 

--- a/benchmarks/particle_query_performance.py
+++ b/benchmarks/particle_query_performance.py
@@ -73,7 +73,7 @@ def benchmark_1d_sparse_queries():
     print("=" * 70)
 
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[101], boundary_conditions=no_flux_bc(dimension=1))
-    problem = MFGProblem(geometry=geometry, T=0.5, Nt=1, diffusion=0.05)
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=1, sigma=0.05)
 
     num_particles = 10000
     solver = FPParticleSolver(problem, num_particles=num_particles, density_mode="hybrid")
@@ -154,7 +154,7 @@ def benchmark_1d_scaling():
 
     for Nx in grid_sizes:
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.5, Nt=1, diffusion=0.05)
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=1, sigma=0.05)
 
         solver = FPParticleSolver(problem, num_particles=num_particles, density_mode="hybrid")
 
@@ -229,7 +229,7 @@ def benchmark_2d_semi_lagrangian():
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[Nx, Ny], boundary_conditions=no_flux_bc(dimension=2)
         )
-        problem = MFGProblem(geometry=geometry, T=0.3, Nt=1, diffusion=0.05)
+        problem = MFGProblem(geometry=geometry, T=0.3, Nt=1, sigma=0.05)
 
         solver = FPParticleSolver(problem, num_particles=num_particles, density_mode="hybrid")
 
@@ -307,7 +307,7 @@ def benchmark_query_methods():
     print("=" * 70)
 
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[101], boundary_conditions=no_flux_bc(dimension=1))
-    problem = MFGProblem(geometry=geometry, T=0.5, Nt=1, diffusion=0.05)
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=1, sigma=0.05)
 
     num_particles = 10000
     solver = FPParticleSolver(problem, num_particles=num_particles, density_mode="hybrid")

--- a/benchmarks/solver_comparisons/visualize_stochastic_mass_conservation.py
+++ b/benchmarks/solver_comparisons/visualize_stochastic_mass_conservation.py
@@ -24,7 +24,7 @@ def main():
 
     # Setup
     np.random.seed(42)
-    problem = MFGProblem(xmin=0.0, xmax=1.0, Nx=51, T=1.0, Nt=51, diffusion=1.0, coupling_coefficient=0.5)
+    problem = MFGProblem(xmin=0.0, xmax=1.0, Nx=51, T=1.0, Nt=51, sigma=1.0, coupling_coefficient=0.5)
     bc = neumann_bc(dimension=1, value=0.0)
 
     fp_solver = FPParticleSolver(problem, num_particles=1000, normalize_kde_output=True, boundary_conditions=bc)

--- a/benchmarks/test_solver_performance.py
+++ b/benchmarks/test_solver_performance.py
@@ -198,7 +198,7 @@ def test_problem_creation_overhead(benchmark):
             Nx=40,
             T=1.0,
             Nt=50,
-            diffusion=0.12,
+            sigma=0.12,
             coupling_coefficient=0.02,
         )
 

--- a/benchmarks/validation/diagnose_mass_loss.py
+++ b/benchmarks/validation/diagnose_mass_loss.py
@@ -23,7 +23,7 @@ class CrowdMotion2D(MFGProblem):
         grid_resolution=8,
         time_horizon=0.4,
         num_timesteps=15,
-        diffusion=0.05,
+        sigma=0.05,
         congestion_weight=0.3,
         goal=(0.8, 0.8),
         start=(0.2, 0.2),
@@ -33,7 +33,7 @@ class CrowdMotion2D(MFGProblem):
             spatial_discretization=[grid_resolution, grid_resolution],
             T=time_horizon,
             Nt=num_timesteps,
-            sigma=diffusion,
+            sigma=sigma,
         )
         self.grid_resolution = grid_resolution  # Store for convenience
         self.congestion_weight = congestion_weight

--- a/benchmarks/validation/test_1d_simple_mfg.py
+++ b/benchmarks/validation/test_1d_simple_mfg.py
@@ -28,14 +28,14 @@ class Simple1DMFG(MFGProblem):
         grid_resolution=32,
         time_horizon=0.5,
         num_timesteps=15,
-        diffusion=0.05,
+        sigma=0.05,
     ):
         super().__init__(
             spatial_bounds=[(0.0, 1.0)],
             spatial_discretization=[grid_resolution],
             T=time_horizon,
             Nt=num_timesteps,
-            sigma=diffusion,
+            sigma=sigma,
         )
         self.grid_resolution = grid_resolution  # Store for convenience
         self.center = 0.3  # Initial density center
@@ -153,7 +153,7 @@ def test_1d_mass_conservation():
         grid_resolution=grid_resolution,
         time_horizon=0.5,
         num_timesteps=num_timesteps,
-        diffusion=0.05,
+        sigma=0.05,
     )
 
     # Check grid spacing

--- a/benchmarks/validation/test_2d_crowd_motion.py
+++ b/benchmarks/validation/test_2d_crowd_motion.py
@@ -37,7 +37,7 @@ class CrowdMotion2D(MFGProblem):
         grid_resolution=15,
         time_horizon=0.5,
         num_timesteps=20,
-        diffusion=0.05,
+        sigma=0.05,
         congestion_weight=0.5,
         goal=(0.8, 0.8),
         start=(0.2, 0.2),
@@ -47,7 +47,7 @@ class CrowdMotion2D(MFGProblem):
             spatial_discretization=[grid_resolution, grid_resolution],
             T=time_horizon,
             Nt=num_timesteps,
-            sigma=diffusion,
+            sigma=sigma,
         )
         self.grid_resolution = grid_resolution  # Store for convenience
         self.congestion_weight = congestion_weight
@@ -163,7 +163,7 @@ def run_fdm_solver(grid_resolution: int, num_timesteps: int, max_iterations: int
         grid_resolution=grid_resolution,
         time_horizon=0.4,
         num_timesteps=num_timesteps,
-        diffusion=0.05,
+        sigma=0.05,
         congestion_weight=0.3,
         goal=(0.8, 0.8),
         start=(0.2, 0.2),

--- a/benchmarks/validation/test_semi_lagrangian_2d_hjb.py
+++ b/benchmarks/validation/test_semi_lagrangian_2d_hjb.py
@@ -36,7 +36,7 @@ class Simple2DMFGProblem(MFGProblem):
         grid_resolution=25,
         time_horizon=1.0,
         num_timesteps=20,
-        diffusion=0.1,
+        sigma=0.1,
         coupling_strength=0.5,
         goal_position=None,
     ):
@@ -45,7 +45,7 @@ class Simple2DMFGProblem(MFGProblem):
             spatial_discretization=[grid_resolution, grid_resolution],
             T=time_horizon,
             Nt=num_timesteps,
-            sigma=diffusion,
+            sigma=sigma,
         )
         self.grid_resolution = grid_resolution
         self.coupling_strength = coupling_strength

--- a/examples/advanced/capacity_constrained_mfg/example_maze_mfg.py
+++ b/examples/advanced/capacity_constrained_mfg/example_maze_mfg.py
@@ -138,7 +138,7 @@ def create_capacity_constrained_problem(
         spatial_discretization=[Nx, Ny],
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
     )
 
     print(f"   Problem created: dimension={problem.dimension}")
@@ -305,7 +305,7 @@ def main():
         Ny=63,
         T=1.0,
         Nt=50,
-        diffusion=0.01,
+        sigma=0.01,
     )
 
     # Solve and visualize

--- a/examples/advanced/capacity_constrained_mfg/problem.py
+++ b/examples/advanced/capacity_constrained_mfg/problem.py
@@ -319,7 +319,7 @@ if __name__ == "__main__":
         spatial_discretization=[50, 50],
         T=1.0,
         Nt=50,
-        diffusion=0.01,
+        sigma=0.01,
     )
     print(f"   Created problem: dimension={problem.dimension}, T={problem.T}, Nt={problem.Nt}")
     print("   ✓ Initialization successful")
@@ -386,7 +386,7 @@ if __name__ == "__main__":
         spatial_discretization=[50, 50],
         T=1.0,
         Nt=50,
-        diffusion=0.01,
+        sigma=0.01,
     )
 
     # Test at overcapacity (m > C)

--- a/examples/advanced/geometry_advanced/dual_geometry_fem_mesh.py
+++ b/examples/advanced/geometry_advanced/dual_geometry_fem_mesh.py
@@ -67,7 +67,7 @@ def demonstrate_fem_mesh_projection_basic():
         hjb_geometry=grid,  # Regular grid for HJB
         fp_geometry=mesh,  # FEM mesh for FP
         time_domain=(1.0, 50),
-        diffusion=0.1,
+        sigma=0.1,
     )
 
     # Check projection methods

--- a/examples/advanced/geometry_advanced/mfg_2d_geometry_example.py
+++ b/examples/advanced/geometry_advanced/mfg_2d_geometry_example.py
@@ -34,14 +34,14 @@ class MFGProblem2D(MFGProblem):
     providing a template for future 2D/3D MFG implementations.
     """
 
-    def __init__(self, geometry_config: dict, time_domain: tuple = (1.0, 51), diffusion: float = 1.0, **kwargs):
+    def __init__(self, geometry_config: dict, time_domain: tuple = (1.0, 51), sigma: float = 1.0, **kwargs):
         """
         Initialize 2D MFG problem.
 
         Args:
             geometry_config: Configuration for 2D domain geometry
             time_domain: (T_final, N_time_steps)
-            diffusion: Diffusion coefficient
+            sigma: SDE volatility
             **kwargs: Additional MFG problem parameters
         """
 
@@ -62,7 +62,7 @@ class MFGProblem2D(MFGProblem):
             Nx=int(np.sqrt(self.mesh_data.num_vertices)),  # Approximate 1D grid size
             T=time_domain[0],
             Nt=time_domain[1],
-            diffusion=diffusion,
+            sigma=sigma,
             **kwargs,
         )
 
@@ -133,9 +133,7 @@ def create_rectangle_with_holes_problem():
     }
 
     # Create MFG problem
-    problem = MFGProblem2D(
-        geometry_config=geometry_config, time_domain=(1.0, 51), diffusion=0.5, coupling_coefficient=1.0
-    )
+    problem = MFGProblem2D(geometry_config=geometry_config, time_domain=(1.0, 51), sigma=0.5, coupling_coefficient=1.0)
 
     return problem
 
@@ -150,7 +148,7 @@ def create_l_shaped_domain_problem():
     geometry_config = {"domain_type": "polygon", "vertices": l_vertices, "mesh_size": 0.06}
 
     # Create MFG problem
-    problem = MFGProblem2D(geometry_config=geometry_config, time_domain=(1.0, 51), diffusion=0.8)
+    problem = MFGProblem2D(geometry_config=geometry_config, time_domain=(1.0, 51), sigma=0.8)
 
     return problem
 
@@ -274,7 +272,7 @@ def integration_with_existing_config():
     problem = MFGProblem2D(
         geometry_config=dict(config.geometry),
         time_domain=(config.problem.T, config.problem.Nt),
-        diffusion=config.problem.diffusion,
+        sigma=config.problem.sigma,
         coupling_coefficient=config.problem.coupling_coefficient,
     )
 

--- a/examples/advanced/machine_learning/pinn_mfg_example.py
+++ b/examples/advanced/machine_learning/pinn_mfg_example.py
@@ -72,7 +72,7 @@ def create_mfg_problem() -> MFGProblem:
 
     # Create MFG problem with Geometry-First API
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[65], boundary_conditions=no_flux_bc(dimension=1))
-    problem = MFGProblem(geometry=geometry, T=1.0, diffusion=0.1)
+    problem = MFGProblem(geometry=geometry, T=1.0, sigma=0.1)
 
     # Set terminal and initial conditions
     problem.terminal_condition = terminal_condition

--- a/examples/advanced/mfg_economics_utility.py
+++ b/examples/advanced/mfg_economics_utility.py
@@ -273,7 +273,7 @@ def main():
         geometry=geometry,
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         coupling_coefficient=0.0,  # No density coupling for clarity
     )
 

--- a/examples/advanced/mfg_expanding_exit.py
+++ b/examples/advanced/mfg_expanding_exit.py
@@ -156,7 +156,7 @@ def create_mfg_problem(phi_current: np.ndarray) -> MFGProblem:
         geometry=grid,
         T=T_final,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         components=components,
     )
 

--- a/examples/advanced/mfg_l1_control.py
+++ b/examples/advanced/mfg_l1_control.py
@@ -258,7 +258,7 @@ def main():
         geometry=geometry,
         T=1.0,
         Nt=50,
-        diffusion=0.1,  # Diffusion coefficient
+        sigma=0.1,  # Diffusion coefficient
         coupling_coefficient=0.0,  # No coupling for this demo
     )
 

--- a/examples/advanced/solvers_advanced/particle_collocation_dual_mode_demo.py
+++ b/examples/advanced/solvers_advanced/particle_collocation_dual_mode_demo.py
@@ -48,7 +48,7 @@ class SimpleLQMFG2D(MFGProblem):
             Nx=30,  # Not used in collocation mode, but required by base class
             Lx=1.0,
             xmin=0.0,
-            diffusion=0.2,
+            sigma=0.2,
             coupling_coefficient=0.5,
             dimension=2,
         )

--- a/examples/advanced/solvers_advanced/semi_lagrangian_2d_enhancements.py
+++ b/examples/advanced/solvers_advanced/semi_lagrangian_2d_enhancements.py
@@ -52,7 +52,7 @@ class Simple2DCrowdNavigationProblem(MFGProblem):
         grid_resolution=15,
         time_horizon=0.5,
         num_timesteps=25,
-        diffusion=0.05,
+        sigma=0.05,
         coupling_strength=0.5,
     ):
         super().__init__(
@@ -60,7 +60,7 @@ class Simple2DCrowdNavigationProblem(MFGProblem):
             spatial_discretization=[grid_resolution, grid_resolution],
             T=time_horizon,
             Nt=num_timesteps,
-            diffusion=diffusion,
+            sigma=sigma,
         )
         self.grid_resolution = grid_resolution
         self.coupling_strength = coupling_strength

--- a/examples/advanced/solvers_advanced/semi_lagrangian_validation.py
+++ b/examples/advanced/solvers_advanced/semi_lagrangian_validation.py
@@ -94,7 +94,7 @@ def create_validation_problem(nx: int = 51, nt: int = 51) -> MFGProblem:
         Nx=nx,
         T=0.5,
         Nt=nt,
-        diffusion=0.1,
+        sigma=0.1,
         coupling_coefficient=0.5,  # Moderate diffusion  # Standard control cost
     )
 

--- a/examples/advanced/visualization/visualize_2d_density_evolution.py
+++ b/examples/advanced/visualization/visualize_2d_density_evolution.py
@@ -57,7 +57,7 @@ class SimpleCoupledMFGProblem(MFGProblem):
             spatial_discretization=[grid_resolution, grid_resolution],
             T=T,
             Nt=Nt,
-            diffusion=diffusion_coeff,
+            sigma=diffusion_coeff,
         )
         self.grid_resolution = grid_resolution
         self.coupling_strength = coupling_strength

--- a/examples/applications/economics/santa_fe_bar_demo.py
+++ b/examples/applications/economics/santa_fe_bar_demo.py
@@ -189,7 +189,7 @@ def create_santa_fe_problem(
         Nx=Nx,
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         components=components,
     )
 

--- a/examples/applications/economics/towel_beach_demo.py
+++ b/examples/applications/economics/towel_beach_demo.py
@@ -166,7 +166,7 @@ def create_towel_beach_problem(
         geometry=geometry,
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         components=components,
     )
 

--- a/examples/basic/diagonal_tensor_mfg.py
+++ b/examples/basic/diagonal_tensor_mfg.py
@@ -90,7 +90,7 @@ problem = MFGProblem(
     geometry=domain,
     T=0.1,  # Short time horizon
     Nt=20,  # 20 timesteps (dt=0.005 for CFL stability)
-    diffusion=0.1,  # Base diffusion (tensor_diffusion_field overrides)
+    sigma=0.1,  # Base diffusion (tensor_diffusion_field overrides)
     components=components,
 )
 

--- a/examples/basic/geometry/2d_crowd_motion_fdm.py
+++ b/examples/basic/geometry/2d_crowd_motion_fdm.py
@@ -37,7 +37,7 @@ class CrowdMotion2D(MFGProblem):
         grid_resolution=15,
         time_horizon=0.5,
         num_timesteps=20,
-        diffusion=0.05,
+        sigma=0.05,
         congestion_weight=0.5,
         goal=(0.8, 0.8),
         start=(0.2, 0.2),
@@ -67,7 +67,7 @@ class CrowdMotion2D(MFGProblem):
             spatial_discretization=[grid_resolution, grid_resolution],
             T=time_horizon,
             Nt=num_timesteps,
-            diffusion=diffusion,
+            sigma=sigma,
         )
         self.grid_resolution = grid_resolution
 
@@ -149,7 +149,7 @@ def main():
         grid_resolution=12,  # 12×12 grid
         time_horizon=0.4,
         num_timesteps=15,
-        diffusion=0.05,
+        sigma=0.05,
         congestion_weight=0.3,
         goal=(0.8, 0.8),
         start=(0.2, 0.2),

--- a/examples/basic/mfg_1d_explicit_formulation.py
+++ b/examples/basic/mfg_1d_explicit_formulation.py
@@ -203,7 +203,7 @@ problem = MFGProblem(
     geometry=geometry,
     T=T,
     Nt=Nt,
-    diffusion=sigma,
+    sigma=sigma,
     coupling_coefficient=coupling_coefficient,
     components=components,
 )

--- a/examples/basic/state_dependent_diffusion.py
+++ b/examples/basic/state_dependent_diffusion.py
@@ -72,7 +72,7 @@ def scenario_porous_medium():
         geometry=domain,
         T=1.0,
         Nt=100,
-        diffusion=0.1,  # Base diffusion (used if diffusion_field=None)
+        sigma=0.1,  # Base diffusion (used if diffusion_field=None)
         components=create_lq_components(coupling_strength=1.0),
     )
 
@@ -135,7 +135,7 @@ def scenario_crowd_dynamics():
         geometry=domain,
         T=1.0,
         Nt=100,
-        diffusion=0.1,
+        sigma=0.1,
         components=create_lq_components(coupling_strength=1.0),
     )
 
@@ -192,7 +192,7 @@ def scenario_spatially_varying():
         geometry=domain,
         T=1.0,
         Nt=100,
-        diffusion=0.1,
+        sigma=0.1,
         components=create_lq_components(coupling_strength=1.0),
     )
 

--- a/examples/basic/three_mode_api_demo.py
+++ b/examples/basic/three_mode_api_demo.py
@@ -47,7 +47,7 @@ def create_problem():
         geometry=geometry,
         Nt=20,
         T=1.0,
-        diffusion=0.1,
+        sigma=0.1,
         components=create_lq_components(),
     )
 

--- a/examples/basic/utilities/common_noise_lq_demo.py
+++ b/examples/basic/utilities/common_noise_lq_demo.py
@@ -111,7 +111,7 @@ def create_market_volatility_problem():
         Nx=Nx,
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         noise_process=market_volatility,
         conditional_hamiltonian=conditional_hamiltonian,
         theta_initial=0.0,  # Start at mean volatility

--- a/examples/tutorials/01_hello_mfg.py
+++ b/examples/tutorials/01_hello_mfg.py
@@ -49,7 +49,7 @@ print()
 # ==============================================================================
 
 # Physical parameters
-diffusion = 0.1  # Controls agent randomness
+sigma = 0.1  # SDE volatility (controls agent randomness)
 coupling = 0.5  # Congestion cost strength
 
 
@@ -87,14 +87,14 @@ problem = MFGProblem(
     geometry=grid,
     T=1.0,  # Time horizon
     Nt=50,  # Time steps
-    diffusion=diffusion,
+    sigma=sigma,
     components=components,
 )
 
 print("Problem created:")
 print(f"  Time horizon: T = {problem.T}")
 print(f"  Time steps: {problem.Nt}")
-print(f"  Diffusion: {diffusion}")
+print(f"  Sigma (volatility): {sigma}")
 print()
 
 print("Solving MFG system...")

--- a/examples/tutorials/02_custom_hamiltonian.py
+++ b/examples/tutorials/02_custom_hamiltonian.py
@@ -104,7 +104,7 @@ grid = TensorProductGrid(
 )
 
 # Physical parameters
-diffusion = 0.1
+sigma = 0.1  # SDE volatility
 congestion_strength = 2.0
 
 
@@ -140,7 +140,7 @@ problem = MFGProblem(
     geometry=grid,
     T=1.0,
     Nt=50,
-    diffusion=diffusion,
+    sigma=sigma,
     components=components,
 )
 
@@ -176,7 +176,7 @@ baseline = MFGProblem(
     geometry=grid,
     T=1.0,
     Nt=50,
-    diffusion=diffusion,
+    sigma=sigma,
     components=baseline_components,
 )
 result_baseline = baseline.solve(verbose=False)

--- a/examples/tutorials/03_2d_geometry.py
+++ b/examples/tutorials/03_2d_geometry.py
@@ -38,7 +38,7 @@ print()
 TARGET = np.array([5.0, 5.0])  # Target location (center of room)
 CONGESTION_WEIGHT = 1.0
 GRID_RESOLUTION = 15  # Reduced from 30 for faster execution
-DIFFUSION = 0.3  # Slightly higher for stability
+SIGMA = 0.3  # Slightly higher for stability
 
 # Create 2D geometry
 print("Creating 2D geometry...")
@@ -101,7 +101,7 @@ problem = MFGProblem(
     geometry=geometry,
     T=2.0,  # Reduced terminal time for faster demo
     Nt=20,  # Reduced time steps
-    diffusion=DIFFUSION,
+    sigma=SIGMA,
     components=components,
 )
 

--- a/examples/tutorials/04_particle_methods.py
+++ b/examples/tutorials/04_particle_methods.py
@@ -55,7 +55,7 @@ problem = MFGProblem(
     geometry=grid,
     T=1.0,
     Nt=50,
-    diffusion=0.15,
+    sigma=0.15,
     components=components,
 )
 

--- a/examples/tutorials/05_config_system.py
+++ b/examples/tutorials/05_config_system.py
@@ -75,18 +75,18 @@ print()
 diffusion_values = [0.05, 0.15, 0.30]
 results_diffusion = {}
 
-for diffusion in diffusion_values:
-    print(f"Solving with diffusion={diffusion}...")
+for sigma in diffusion_values:
+    print(f"Solving with sigma={sigma}...")
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
     problem = MFGProblem(
         geometry=geometry,
         T=1.0,
         Nt=50,
-        diffusion=diffusion,
+        sigma=sigma,
         components=create_lq_components(coupling_strength=0.5),
     )
-    results_diffusion[diffusion] = problem.solve(verbose=False)
-    print(f"  Converged in {results_diffusion[diffusion].iterations} iterations")
+    results_diffusion[sigma] = problem.solve(verbose=False)
+    print(f"  Converged in {results_diffusion[sigma].iterations} iterations")
 
 print()
 
@@ -113,7 +113,7 @@ for coupling in coupling_values:
         geometry=geometry,
         T=1.0,
         Nt=50,
-        diffusion=0.15,
+        sigma=0.15,
         components=create_lq_components(coupling_strength=coupling),
     )
     results_coupling[coupling] = problem.solve(verbose=False)
@@ -144,7 +144,7 @@ for Nx in Nx_values:
         geometry=geometry,
         T=1.0,
         Nt=Nx,  # Keep dt/dx ratio constant
-        diffusion=0.15,
+        sigma=0.15,
         components=create_lq_components(coupling_strength=0.5),
     )
     results_grid[Nx] = problem.solve(verbose=False)
@@ -174,14 +174,14 @@ print()
 
 # Example analysis: mass conservation
 print("Mass Conservation Check (diffusion variations):")
-for diffusion, result in results_diffusion.items():
+for sigma, result in results_diffusion.items():
     # Use the stored result's shape to compute dx
     Nx = result.M.shape[1]
     dx = 1.0 / (Nx - 1)
     initial_mass = np.sum(result.M[0, :]) * dx
     final_mass = np.sum(result.M[-1, :]) * dx
     print(
-        f"  diffusion={diffusion}: Initial={initial_mass:.4f}, "
+        f"  sigma={sigma}: Initial={initial_mass:.4f}, "
         f"Final={final_mass:.4f}, Drift={abs(final_mass - initial_mass):.2e}"
     )
 
@@ -227,9 +227,9 @@ try:
 
     # Row 1: Diffusion study - final densities
     ax = axes[0, 0]
-    for diffusion, result in results_diffusion.items():
+    for sigma, result in results_diffusion.items():
         x_grid = np.linspace(0, 1, result.M.shape[1])
-        ax.plot(x_grid, result.M[-1, :], label=f"diff={diffusion}")
+        ax.plot(x_grid, result.M[-1, :], label=f"sigma={sigma}")
     ax.set_xlabel("x")
     ax.set_ylabel("m(T, x)")
     ax.set_title("Final Density: Diffusion Study")
@@ -260,9 +260,9 @@ try:
 
     # Row 2: Value functions
     ax = axes[1, 0]
-    for diffusion, result in results_diffusion.items():
+    for sigma, result in results_diffusion.items():
         x_grid = np.linspace(0, 1, result.U.shape[1])
-        ax.plot(x_grid, result.U[-1, :], label=f"diff={diffusion}")
+        ax.plot(x_grid, result.U[-1, :], label=f"sigma={sigma}")
     ax.set_xlabel("x")
     ax.set_ylabel("u(T, x)")
     ax.set_title("Terminal Value: Diffusion Study")

--- a/examples/tutorials/06_boundary_condition_coupling.py
+++ b/examples/tutorials/06_boundary_condition_coupling.py
@@ -95,7 +95,7 @@ def create_standard_problem() -> MFGProblem:
         geometry=geometry,
         T=T,
         Nt=NT,
-        diffusion=SIGMA,
+        sigma=SIGMA,
         components=create_lq_components(),
     )
 
@@ -148,7 +148,7 @@ def create_adjoint_consistent_problem() -> MFGProblem:
         geometry=geometry,
         T=T,
         Nt=NT,
-        diffusion=SIGMA,
+        sigma=SIGMA,
         components=create_lq_components(),
     )
 

--- a/examples/validation/adjoint_consistent_bc_provider_validation.py
+++ b/examples/validation/adjoint_consistent_bc_provider_validation.py
@@ -152,7 +152,7 @@ def create_towel_problem_standard_bc(
         geometry=geometry,
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         components=components,
     )
 
@@ -248,7 +248,7 @@ def create_towel_problem_adjoint_bc(
         geometry=geometry,
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         components=components,
     )
 

--- a/examples/validation/diagnose_ac_bc_stall_cases.py
+++ b/examples/validation/diagnose_ac_bc_stall_cases.py
@@ -129,7 +129,7 @@ def create_towel_problem(
         geometry=geometry,
         T=T,
         Nt=Nt,
-        diffusion=sigma,
+        sigma=sigma,
         components=components,
     )
 

--- a/mfg_pde/alg/numerical/coupling/block_iterators.py
+++ b/mfg_pde/alg/numerical/coupling/block_iterators.py
@@ -700,7 +700,7 @@ if __name__ == "__main__":
 
     # Create simple 1D problem
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
-    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.2)
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=0.2)
 
     # Create solvers
     hjb_solver = HJBFDMSolver(problem)

--- a/mfg_pde/alg/numerical/coupling/mfg_residual.py
+++ b/mfg_pde/alg/numerical/coupling/mfg_residual.py
@@ -360,7 +360,7 @@ if __name__ == "__main__":
 
     # Create simple 1D problem
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
-    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.1)
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=0.1)
 
     # Create solvers
     hjb_solver = HJBFDMSolver(problem)

--- a/mfg_pde/alg/numerical/coupling/newton_mfg_solver.py
+++ b/mfg_pde/alg/numerical/coupling/newton_mfg_solver.py
@@ -350,7 +350,7 @@ if __name__ == "__main__":
 
     # Create simple 1D problem
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
-    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, diffusion=0.2)
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=0.2)
 
     # Create solvers
     hjb_solver = HJBFDMSolver(problem)

--- a/mfg_pde/alg/numerical/fp_solvers/base_fp.py
+++ b/mfg_pde/alg/numerical/fp_solvers/base_fp.py
@@ -320,7 +320,7 @@ if __name__ == "__main__":
         Nx_points=[21],
         boundary_conditions=neumann_bc(dimension=1),
     )
-    problem = MFGProblem(geometry=geometry, T=1.0, Nt=10, diffusion=0.1, components=components)
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=10, sigma=0.1, components=components)
 
     try:
         # This should fail because BaseFPSolver is abstract

--- a/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_fdm.py
@@ -1311,7 +1311,7 @@ if __name__ == "__main__":
         geometry=grid_1d,
         Nt=25,
         T=1.0,
-        diffusion=0.1,  # Use 'diffusion' instead of deprecated 'sigma'
+        sigma=0.1,
         coupling_coefficient=1.0,
     )
 
@@ -1375,7 +1375,7 @@ if __name__ == "__main__":
         geometry=grid_2d,
         Nt=20,
         T=0.5,
-        diffusion=0.2,  # Use 'diffusion' instead of deprecated 'sigma'
+        sigma=0.2,
         coupling_coefficient=1.0,
     )
 

--- a/mfg_pde/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_gfdm.py
@@ -56,7 +56,7 @@ class FPGFDMSolver(BaseFPSolver):
         >>> from mfg_pde import MFGProblem
         >>> from mfg_pde.alg.numerical.fp_solvers import FPGFDMSolver
         >>>
-        >>> problem = MFGProblem(Nx=30, Nt=20, T=1.0, diffusion=0.1)
+        >>> problem = MFGProblem(Nx=30, Nt=20, T=1.0, sigma=0.1)
         >>> points = np.random.rand(100, 1)  # Scattered 1D points
         >>> solver = FPGFDMSolver(problem, collocation_points=points)
         >>>
@@ -581,7 +581,7 @@ if __name__ == "__main__":
         Nx_points=[31],
         boundary_conditions=neumann_bc(dimension=1),
     )
-    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1, components=components)
+    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, sigma=0.1, components=components)
 
     # Create 1D collocation points
     points_1d = np.linspace(0, 1, 50).reshape(-1, 1)
@@ -616,7 +616,7 @@ if __name__ == "__main__":
         Nx_points=[10, 10],
         boundary_conditions=neumann_bc(dimension=2),
     )
-    problem_2d = MFGProblem(geometry=geometry_2d, Nt=10, T=0.5, diffusion=0.1, components=components)
+    problem_2d = MFGProblem(geometry=geometry_2d, Nt=10, T=0.5, sigma=0.1, components=components)
 
     # Create 2D scattered points
     np.random.seed(42)

--- a/mfg_pde/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_particle.py
@@ -2173,7 +2173,7 @@ if __name__ == "__main__":
         Nx_points=[31],
         boundary_conditions=neumann_bc(dimension=1),
     )
-    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1, components=components)
+    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, sigma=0.1, components=components)
     solver = FPParticleSolver(problem, num_particles=1000)
 
     # Test solver initialization
@@ -2207,7 +2207,7 @@ if __name__ == "__main__":
         Nx_points=[16, 16],
         boundary_conditions=neumann_bc(dimension=2),
     )
-    problem_2d = MFGProblem(geometry=geometry_2d, Nt=10, T=0.5, diffusion=0.1, components=components)
+    problem_2d = MFGProblem(geometry=geometry_2d, Nt=10, T=0.5, sigma=0.1, components=components)
 
     solver_2d = FPParticleSolver(problem_2d, num_particles=500, mode="hybrid")
 

--- a/mfg_pde/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -570,7 +570,7 @@ if __name__ == "__main__":
         geometry=domain,
         T=T,
         Nt=Nt,
-        diffusion=SIGMA,
+        sigma=SIGMA,
         components=components,
     )
 

--- a/mfg_pde/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfg_pde/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -596,7 +596,7 @@ if __name__ == "__main__":
         geometry=domain,
         T=T,
         Nt=Nt,
-        diffusion=SIGMA,
+        sigma=SIGMA,
         components=components,
     )
 
@@ -700,7 +700,7 @@ if __name__ == "__main__":
         geometry=domain_2d,
         T=T2D,
         Nt=Nt2D,
-        diffusion=SIGMA2D,
+        sigma=SIGMA2D,
         components=components_2d,
     )
 

--- a/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/base_hjb.py
@@ -1379,7 +1379,7 @@ if __name__ == "__main__":
     from mfg_pde.geometry import TensorProductGrid
 
     geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
-    problem = MFGProblem(geometry=geometry, T=1.0, Nt=5, diffusion=0.1)
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=5, sigma=0.1)
 
     try:
         base_solver = BaseHJBSolver(problem)

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -1158,7 +1158,7 @@ if __name__ == "__main__":
     from mfg_pde.geometry import TensorProductGrid
 
     geometry_1d = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31])
-    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1)
+    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, sigma=0.1)
     solver_1d = HJBFDMSolver(problem_1d, solver_type="newton")
 
     # Test solver initialization
@@ -1208,7 +1208,7 @@ if __name__ == "__main__":
     # Test 2D problem
     print("\nTesting 2D solver...")
     geometry_2d = TensorProductGrid(bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[11, 11])
-    problem_2d = MFGProblem(geometry=geometry_2d, T=1.0, Nt=5, diffusion=0.1)
+    problem_2d = MFGProblem(geometry=geometry_2d, T=1.0, Nt=5, sigma=0.1)
     solver_2d = HJBFDMSolver(problem_2d, solver_type="newton")
 
     # Quick 2D build_advection_matrix test

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2530,7 +2530,7 @@ if __name__ == "__main__":
 
     # Test 1D problem with uniform collocation points matching problem grid
     geometry_1d = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21])
-    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=10, diffusion=0.1)
+    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=10, sigma=0.1)
 
     # Use problem grid points as collocation points to avoid index mismatch
     collocation_points = problem_1d.xSpace.reshape(-1, 1)
@@ -2577,7 +2577,7 @@ if __name__ == "__main__":
     points_2d = np.column_stack([xx.ravel(), yy.ravel()])
 
     geometry_2d = TensorProductGrid(bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[Nx_2d, Nx_2d])
-    problem_2d = MFGProblem(geometry=geometry_2d, T=1.0, Nt=5, diffusion=0.1)
+    problem_2d = MFGProblem(geometry=geometry_2d, T=1.0, Nt=5, sigma=0.1)
 
     solver_2d = HJBGFDMSolver(
         problem_2d,

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1917,7 +1917,7 @@ if __name__ == "__main__":
     # Test 1: Solver initialization
     print("\n1. Testing solver initialization...")
     geometry_1d = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51])
-    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=100, diffusion=0.1)
+    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=100, sigma=0.1)
     solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", optimization_method="brent")
 
     assert solver.dimension == 1

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_weno.py
@@ -1488,7 +1488,7 @@ if __name__ == "__main__":
 
     # Test 1D problem
     geometry_1d = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31])
-    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, diffusion=0.1)
+    problem_1d = MFGProblem(geometry=geometry_1d, T=1.0, Nt=20, sigma=0.1)
 
     # Test standard WENO variant
     solver_1d = HJBWenoSolver(problem_1d, weno_variant="weno-z")

--- a/mfg_pde/core/base_problem.py
+++ b/mfg_pde/core/base_problem.py
@@ -72,7 +72,7 @@ class MFGProblemProtocol(Protocol):
         ...     return u
 
         >>> # Runtime validation
-        >>> problem = MFGProblem(xmin=0, xmax=1, Nx=100, T=1, Nt=50, diffusion=0.1)
+        >>> problem = MFGProblem(xmin=0, xmax=1, Nx=100, T=1, Nt=50, sigma=0.1)
         >>> assert isinstance(problem, MFGProblemProtocol)  # Should pass!
     """
 

--- a/mfg_pde/core/mfg_problem.py
+++ b/mfg_pde/core/mfg_problem.py
@@ -2349,7 +2349,7 @@ Use MFGComponents for custom problem definitions:
   problem = MFGProblem(
       geometry=my_geometry,
       T=T, Nt=Nt,
-      diffusion=sigma,
+      sigma=sigma,
       components=components,
   )
 

--- a/mfg_pde/workflow/workflow_manager.py
+++ b/mfg_pde/workflow/workflow_manager.py
@@ -588,7 +588,7 @@ class WorkflowManager:
             geometry = TensorProductGrid(
                 bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
             )
-            problem = MFGProblem(geometry=geometry, diffusion=sigma, Nt=Nt)
+            problem = MFGProblem(geometry=geometry, sigma=sigma, Nt=Nt)
             result = problem.solve()
             return {
                 "converged": getattr(result, "converged", False),

--- a/scripts/test_2d_fdm_dirichlet_bc.py
+++ b/scripts/test_2d_fdm_dirichlet_bc.py
@@ -31,7 +31,7 @@ def test_2d_dirichlet_x_boundaries():
 
     grid = TensorProductGrid(dimension=2, bounds=[(0.0, 1.0), (0.0, 1.0)], Nx=[40, 40], boundary_conditions=bc)
 
-    problem = MFGProblem(geometry=grid, T=0.5, Nt=5, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.5, Nt=5, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()
@@ -101,7 +101,7 @@ def test_2d_dirichlet_all_boundaries():
 
     grid = TensorProductGrid(dimension=2, bounds=[(0.0, 1.0), (0.0, 1.0)], Nx=[30, 30], boundary_conditions=bc)
 
-    problem = MFGProblem(geometry=grid, T=0.3, Nt=3, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.3, Nt=3, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()

--- a/scripts/test_bc_enforcement_no_corners.py
+++ b/scripts/test_bc_enforcement_no_corners.py
@@ -30,7 +30,7 @@ def test_same_value_all_boundaries():
     )
 
     grid = TensorProductGrid(dimension=2, bounds=[(0, 1), (0, 1)], Nx=[20, 20], boundary_conditions=bc)
-    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, sigma=0.1)
     solver = HJBFDMSolver(problem, max_newton_iterations=10)
     U = solver.solve()
 
@@ -71,7 +71,7 @@ def test_opposite_boundaries_only():
     )
 
     grid = TensorProductGrid(dimension=2, bounds=[(0, 1), (0, 1)], Nx=[20, 20], boundary_conditions=bc)
-    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, sigma=0.1)
     solver = HJBFDMSolver(problem, max_newton_iterations=10)
     U = solver.solve()
 
@@ -111,7 +111,7 @@ def test_homogeneous_bc():
     )
 
     grid = TensorProductGrid(dimension=2, bounds=[(0, 1), (0, 1)], Nx=[20, 20], boundary_conditions=bc)
-    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, sigma=0.1)
     solver = HJBFDMSolver(problem, max_newton_iterations=10)
     U = solver.solve()
 

--- a/scripts/test_ghost_nodes_smoke.py
+++ b/scripts/test_ghost_nodes_smoke.py
@@ -39,7 +39,7 @@ def test_ghost_nodes_initialization():
         geometry=geometry,
         T=1.0,
         Nt=10,
-        diffusion=0.1,
+        sigma=0.1,
         lambda_=1.0,
         gamma=0.5,
         boundary_conditions=bc,

--- a/scripts/test_nd_periodic_bc.py
+++ b/scripts/test_nd_periodic_bc.py
@@ -19,7 +19,7 @@ def test_2d_periodic_bc():
 
     # No BC specified -> should use periodic
     grid = TensorProductGrid(dimension=2, bounds=[(0.0, 1.0), (0.0, 1.0)], Nx=[50, 50])
-    problem = MFGProblem(geometry=grid, T=0.5, Nt=5, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.5, Nt=5, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()
@@ -44,7 +44,7 @@ def test_3d_periodic_bc():
 
     # No BC specified -> should use periodic
     grid = TensorProductGrid(dimension=3, bounds=[(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)], Nx=[20, 20, 20])
-    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.2, Nt=3, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()

--- a/scripts/validate_issue_542_fix.py
+++ b/scripts/validate_issue_542_fix.py
@@ -36,7 +36,7 @@ def test_neumann_bc():
         ]
     )
     grid = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx=[100], boundary_conditions=bc)
-    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()
@@ -72,7 +72,7 @@ def test_dirichlet_bc():
         ]
     )
     grid = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx=[100], boundary_conditions=bc)
-    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()
@@ -106,7 +106,7 @@ def test_mixed_bc():
         ]
     )
     grid = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx=[100], boundary_conditions=bc)
-    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()
@@ -136,7 +136,7 @@ def test_periodic_fallback():
 
     grid = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx=[100])
     # No BC specified → should fall back to periodic
-    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, diffusion=0.1)
+    problem = MFGProblem(geometry=grid, T=0.5, Nt=10, sigma=0.1)
 
     solver = HJBFDMSolver(problem)
     U = solver.solve()

--- a/scripts/visualize_ghost_nodes.py
+++ b/scripts/visualize_ghost_nodes.py
@@ -39,7 +39,7 @@ def visualize_ghost_nodes():
         geometry=geometry,
         T=1.0,
         Nt=10,
-        diffusion=0.1,
+        sigma=0.1,
         lambda_=1.0,
         gamma=0.5,
         boundary_conditions=bc,

--- a/tests/integration/test_hjb_with_obstacle.py
+++ b/tests/integration/test_hjb_with_obstacle.py
@@ -73,7 +73,7 @@ class TestHJBWithLowerObstacle:
             return (x_coords[0] - 0.5) ** 2
 
         # Create MFGProblem with minimal parameters (HJB solver uses explicit inputs)
-        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         # Obstacle: ψ(x) = -κ(x - 0.5)²
         x = grid.coordinates[0]
@@ -118,7 +118,7 @@ class TestHJBWithLowerObstacle:
             return (x_coords[0] - 0.5) ** 2 + (x_coords[1] - 0.5) ** 2
 
         # Create MFGProblem with minimal parameters (HJB solver uses explicit inputs)
-        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, diffusion=sigma, components=_default_components_2d())
+        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, sigma=sigma, components=_default_components_2d())
 
         # Obstacle: Bowl-shaped
         X, Y = grid.meshgrid()
@@ -160,7 +160,7 @@ class TestHJBWithLowerObstacle:
             return (x_coords[0] - 0.5) ** 2
 
         # Create MFGProblem with minimal parameters
-        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         x = grid.coordinates[0]
         psi = -kappa * (x - 0.5) ** 2
@@ -213,7 +213,7 @@ class TestHJBWithUpperObstacle:
             return (x_coords[0] - 0.5) ** 2
 
         # Create MFGProblem with minimal parameters
-        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         # Upper obstacle: ceiling at ψ_upper = 0.3
         x = grid.coordinates[0]
@@ -260,7 +260,7 @@ class TestHJBWithBilateralObstacle:
             return 0.5 * (x_coords[0] - 0.5) ** 2
 
         # Create MFGProblem with minimal parameters
-        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         # Bilateral obstacle: corridor between -0.2 and 0.3
         x = grid.coordinates[0]
@@ -311,7 +311,7 @@ class TestObstacleConvergenceProperties:
             return (x_coords[0] - 0.5) ** 2
 
         # Create MFGProblem with minimal parameters
-        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         x = grid.coordinates[0]
         psi = -kappa * (x - 0.5) ** 2
@@ -363,7 +363,7 @@ class TestObstacleConvergenceProperties:
             return (x_coords[0] - 0.5) ** 2
 
         # Create MFGProblem with minimal parameters
-        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, diffusion=sigma, components=_default_components())
+        problem = MFGProblem(geometry=grid, T=T, Nt=Nt, sigma=sigma, components=_default_components())
 
         x = grid.coordinates[0]
         psi = -kappa * (x - 0.5) ** 2

--- a/tests/unit/test_core/test_array_field_validation.py
+++ b/tests/unit/test_core/test_array_field_validation.py
@@ -207,7 +207,7 @@ def test_mfg_problem_valid_diffusion_array_accepted():
     problem = _problem(
         m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
         u_terminal=lambda x: x**2,
-        diffusion=sigma_array,
+        sigma=sigma_array,
     )
     assert problem is not None
     assert isinstance(problem.diffusion_field, np.ndarray)
@@ -223,7 +223,7 @@ def test_mfg_problem_nan_diffusion_array_rejected():
         _problem(
             m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
             u_terminal=lambda x: x**2,
-            diffusion=sigma_array,
+            sigma=sigma_array,
         )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #812. Migrates all remaining `MFGProblem(diffusion=X)` calls to `sigma=X` across the entire codebase.

- 61 files: examples, tutorials, benchmarks, scripts, solver smoke tests, docstrings
- Renames confusing local variables named `diffusion` that held SDE volatility to `sigma`
- Only intentional `diffusion=` usages remain: negative-D test, new-convention docstring examples
- Ruff clean, pre-commit hooks pass

## Test plan

- [x] 353 core + obstacle integration tests pass
- [x] Ruff check passes on all 61 modified files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)