### PR TITLE
feat(gfdm): Add per-criterion monotonicity violation diagnostics

### DIFF
--- a/mfg_pde/alg/numerical/gfdm_components/monotonicity_enforcer.py
+++ b/mfg_pde/alg/numerical/gfdm_components/monotonicity_enforcer.py
@@ -145,6 +145,11 @@ class MonotonicityEnforcer:
             "lbfgsb_solves": 0,
             "points_checked": 0,
             "violations_detected": 0,
+            "violation_point_indices": set(),
+            # Per-criterion violation counters (for diagnostics)
+            "violation_laplacian": 0,
+            "violation_gradient": 0,
+            "violation_higher_order": 0,
         }
 
         # Optional MFG coupling
@@ -415,6 +420,15 @@ class MonotonicityEnforcer:
 
         # Basic violation check
         has_violation = violation_1 or violation_2 or violation_3
+
+        # Track per-criterion stats
+        if has_violation:
+            if violation_1:
+                self.stats["violation_laplacian"] += 1
+            if violation_2:
+                self.stats["violation_gradient"] += 1
+            if violation_3:
+                self.stats["violation_higher_order"] += 1
 
         if not use_adaptive:
             return has_violation

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -742,6 +742,10 @@ class HJBGFDMSolver(BaseHJBSolver):
                 "total_qp_solves": 0,
                 "qp_times": [],
                 "violations_detected": 0,
+                "violation_point_indices": set(),
+                "violation_laplacian": 0,
+                "violation_gradient": 0,
+                "violation_higher_order": 0,
                 "points_checked": 0,
                 "qp_successes": 0,
                 "qp_failures": 0,
@@ -1371,6 +1375,7 @@ class HJBGFDMSolver(BaseHJBSolver):
             if needs_constraints:
                 # Apply constrained QP to enforce monotonicity
                 self.qp_stats["violations_detected"] += 1
+                self.qp_stats["violation_point_indices"].add(point_idx)
                 derivative_coeffs = self._monotonicity_enforcer.solve_constrained_qp(taylor_data, b, point_idx)  # type: ignore[union-attr]
             else:
                 # Use faster unconstrained solution


### PR DESCRIPTION
## Summary
- Decompose DMP violation counters by source: `violation_laplacian`, `violation_gradient`, `violation_higher_order` in `MonotonicityEnforcer.stats`
- Track `violation_point_indices` (set of ints) in `HJBGFDMSolver.qp_stats` for spatial analysis
- Pure diagnostic additions — no behavioral change

## Motivation
2D multi-obstacle experiments (research repo) showed that violation sources differ by region: Laplacian violations dominate near boundaries, gradient violations in narrow channels. Without decomposition, debugging is guesswork.

## Test plan
- [x] Import check passes (`MonotonicityEnforcer`, `HJBGFDMSolver`)
- [ ] Existing GFDM tests pass (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)