### PR TITLE
feat(gfdm): Obstacle-aware visibility filtering for stencil neighbors

### DIFF
--- a/mfg_pde/alg/numerical/gfdm_components/neighborhood_builder.py
+++ b/mfg_pde/alg/numerical/gfdm_components/neighborhood_builder.py
@@ -21,6 +21,10 @@ import numpy as np
 from scipy.spatial.distance import cdist
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
     from mfg_pde.alg.numerical.gfdm_components.boundary_handler import BoundaryHandler
 
 
@@ -164,8 +168,23 @@ class NeighborhoodBuilder:
         gfdm_operator: Any,
         use_local_coordinate_rotation: bool,
         boundary_handler: BoundaryHandler | None = None,
+        obstacle_sdf: Callable[[NDArray[np.float64]], NDArray[np.float64]] | None = None,
+        visibility_samples: int = 10,
+        visibility_margin: float = 0.0,
     ):
-        """Initialize neighborhood builder."""
+        """Initialize neighborhood builder.
+
+        Args:
+            obstacle_sdf: Signed distance function of obstacle regions. When provided,
+                neighbors whose line of sight to the center point passes through the
+                obstacle (SDF < 0) are excluded. This prevents cross-wall stencils in
+                narrow channels between obstacles.
+            visibility_samples: Number of interior samples along each segment for
+                obstacle intersection testing. Default 10.
+            visibility_margin: Safety margin for obstacle proximity. Neighbors with
+                line-of-sight passing within this distance of an obstacle are excluded.
+                Default 0.0.
+        """
         self.collocation_points = np.asarray(collocation_points)
         self.n_points = len(collocation_points)
         self.dimension = dimension
@@ -182,6 +201,9 @@ class NeighborhoodBuilder:
         self._gfdm_operator = gfdm_operator
         self._use_local_coordinate_rotation = use_local_coordinate_rotation
         self._boundary_handler = boundary_handler
+        self._obstacle_sdf = obstacle_sdf
+        self._visibility_samples = visibility_samples
+        self._visibility_margin = visibility_margin
 
         # Initialize adaptive stats
         self.adaptive_stats: dict[str, Any] = {
@@ -223,9 +245,20 @@ class NeighborhoodBuilder:
         # Pre-compute boundary set for fast lookup
         boundary_set = set(self.boundary_indices) if len(self.boundary_indices) > 0 else set()
 
+        # Visibility filtering stats
+        visibility_stats = {"n_filtered": 0, "total_removed": 0}
+
         for i in range(self.n_points):
             # Start with GFDMOperator's neighborhood (pure one-sided stencils, no ghost particles)
             base_neighborhood = self._gfdm_operator.get_neighborhood(i)
+
+            # Visibility filtering: remove neighbors whose line of sight crosses an obstacle
+            if self._obstacle_sdf is not None:
+                base_neighborhood = self._apply_visibility_filter(i, base_neighborhood)
+                if base_neighborhood.get("visibility_removed", 0) > 0:
+                    visibility_stats["n_filtered"] += 1
+                    visibility_stats["total_removed"] += base_neighborhood["visibility_removed"]
+
             n_neighbors = base_neighborhood["size"]
 
             # Check if this is a boundary point
@@ -285,6 +318,21 @@ class NeighborhoodBuilder:
                     # Recompute neighborhood with enlarged delta
                     neighbor_mask = distances[i, :] < delta_current
                     neighbor_indices = np.where(neighbor_mask)[0]
+
+                    # Apply visibility filter to expanded neighbors
+                    if self._obstacle_sdf is not None and len(neighbor_indices) > 0:
+                        from mfg_pde.geometry.visibility import filter_visible_neighbors
+
+                        expanded_points = self.collocation_points[neighbor_indices]
+                        vis_mask = filter_visible_neighbors(
+                            self.collocation_points[i],
+                            expanded_points,
+                            self._obstacle_sdf,
+                            n_samples=self._visibility_samples,
+                            margin=self._visibility_margin,
+                        )
+                        neighbor_indices = neighbor_indices[vis_mask]
+
                     real_neighbor_count = len(neighbor_indices)
                     was_adapted = True
 
@@ -402,6 +450,88 @@ class NeighborhoodBuilder:
                     stacklevel=2,
                 )
 
+        # Store visibility stats for external access
+        self.visibility_stats = visibility_stats
+
+        # Report visibility filtering statistics
+        if self._obstacle_sdf is not None and visibility_stats["n_filtered"] > 0:
+            pct = 100.0 * visibility_stats["n_filtered"] / self.n_points
+            avg_removed = visibility_stats["total_removed"] / visibility_stats["n_filtered"]
+            from mfg_pde.utils.mfg_logging import get_logger
+
+            logger = get_logger(__name__)
+            logger.info(
+                "Visibility filtering: %d/%d points (%.1f%%) had neighbors removed. "
+                "Total removed: %d, avg %.1f per affected point.",
+                visibility_stats["n_filtered"],
+                self.n_points,
+                pct,
+                visibility_stats["total_removed"],
+                avg_removed,
+            )
+
+    def _apply_visibility_filter(self, point_idx: int, neighborhood: dict) -> dict:
+        """Filter out neighbors whose line of sight to point_idx crosses an obstacle.
+
+        Uses SDF sampling along line segments to detect obstacle crossings.
+        Ghost neighbors (negative indices) are preserved unconditionally.
+
+        Args:
+            point_idx: Index of the center point.
+            neighborhood: Base neighborhood dict from TaylorOperator.
+
+        Returns:
+            Filtered neighborhood dict with same structure. Adds 'visibility_removed'
+            key tracking how many neighbors were removed.
+        """
+        from mfg_pde.geometry.visibility import filter_visible_neighbors
+
+        indices = neighborhood["indices"]
+        points = neighborhood["points"]
+        distances = neighborhood["distances"]
+
+        if len(indices) == 0:
+            return {**neighborhood, "visibility_removed": 0}
+
+        # Separate ghost neighbors (negative indices) from real ones
+        ghost_mask = indices < 0
+        real_mask = ~ghost_mask
+
+        if not np.any(real_mask):
+            return {**neighborhood, "visibility_removed": 0}
+
+        center = self.collocation_points[point_idx]
+        real_points = points[real_mask]
+
+        # Check visibility for real neighbors only
+        visible_mask = filter_visible_neighbors(
+            center,
+            real_points,
+            self._obstacle_sdf,
+            n_samples=self._visibility_samples,
+            margin=self._visibility_margin,
+        )
+
+        n_removed = int(np.sum(~visible_mask))
+        if n_removed == 0:
+            return {**neighborhood, "visibility_removed": 0}
+
+        # Reconstruct: keep visible real neighbors + all ghost neighbors
+        keep_real = np.where(real_mask)[0][visible_mask]
+        keep_ghost = np.where(ghost_mask)[0]
+        keep = np.concatenate([keep_real, keep_ghost])
+        keep.sort()  # Preserve original ordering
+
+        return {
+            "indices": indices[keep],
+            "points": points[keep],
+            "distances": distances[keep],
+            "size": len(keep),
+            "has_ghost": neighborhood.get("has_ghost", False),
+            "ghost_count": neighborhood.get("ghost_count", 0),
+            "visibility_removed": n_removed,
+        }
+
     def build_reverse_neighborhoods(self) -> None:
         """
         Build reverse neighborhood map: for each point j, find all points i that have j in their neighborhood.
@@ -470,11 +600,14 @@ class NeighborhoodBuilder:
                 self.taylor_matrices[i] = None
                 continue
 
-            # Check if we can reuse GFDMOperator's Taylor matrices
-            # (only if neighborhood wasn't adapted AND no LCR rotation applied)
-            # For LCR boundary points, we need to rebuild with rotated offsets
+            # Check if we can reuse GFDMOperator's Taylor matrices.
+            # Requires: (1) neighborhood not adapted by delta enlargement,
+            # (2) no LCR rotation, and (3) neighbor count matches operator's
+            # original (may differ if visibility filtering removed neighbors).
             has_lcr_rotation = "rotated_offsets" in neighborhood and self._use_local_coordinate_rotation
-            if not neighborhood.get("adapted", False) and not has_lcr_rotation:
+            operator_neighborhood = self._gfdm_operator.get_neighborhood(i)
+            size_matches = n_neighbors == operator_neighborhood["size"]
+            if not neighborhood.get("adapted", False) and not has_lcr_rotation and size_matches:
                 base_taylor = self._gfdm_operator.get_taylor_data(i)
                 if base_taylor is not None:
                     # Compute condition number safely

--- a/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfg_pde/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -257,6 +257,10 @@ class HJBGFDMSolver(BaseHJBSolver):
         congestion_mode: str = "additive",
         # Collocation geometry for periodic domains (Issue #711)
         collocation_geometry: object | None = None,
+        # Obstacle-aware visibility filtering for stencil neighbors
+        obstacle_sdf: object | None = None,
+        visibility_samples: int = 10,
+        visibility_margin: float = 0.0,
     ):
         """
         Initialize the GFDM HJB solver.
@@ -627,6 +631,9 @@ class HJBGFDMSolver(BaseHJBSolver):
                 gfdm_operator=self._gfdm_operator,
                 use_local_coordinate_rotation=self._use_local_coordinate_rotation,
                 boundary_handler=self._boundary_handler,
+                obstacle_sdf=obstacle_sdf,
+                visibility_samples=visibility_samples,
+                visibility_margin=visibility_margin,
             )
         else:
             # Legacy: GFDMOperator (deprecated, for backward compatibility)

--- a/mfg_pde/geometry/visibility.py
+++ b/mfg_pde/geometry/visibility.py
@@ -1,0 +1,204 @@
+"""
+Visibility queries for meshfree methods in domains with obstacles.
+
+Provides line-of-sight checking between points using signed distance functions (SDF).
+Primary use case: filtering GFDM stencil neighbors to prevent "cross-wall" stencils
+in narrow channels between obstacles.
+
+The core idea is simple: sample the SDF along the line segment between two points.
+If any sample falls inside an obstacle (SDF < 0), the line of sight is blocked.
+
+SDF Convention (consistent with mfg_pde.geometry.implicit):
+    phi(x) < 0  =>  x inside obstacle (blocked)
+    phi(x) = 0  =>  x on obstacle boundary
+    phi(x) > 0  =>  x outside obstacle (clear)
+
+Note: The obstacle_sdf here should be the SDF of the *obstacle region* (e.g., a
+UnionDomain of pillars), NOT the full computational domain. For a DifferenceDomain
+(rectangle minus pillars), pass the SDF of the pillars union.
+
+Example:
+    >>> from mfg_pde.geometry.implicit import Hypersphere, UnionDomain
+    >>> pillars = UnionDomain([
+    ...     Hypersphere(center=[6.0, 3.5], radius=1.3),
+    ...     Hypersphere(center=[6.0, 6.5], radius=1.3),
+    ... ])
+    >>> from mfg_pde.geometry.visibility import filter_visible_neighbors
+    >>> mask = filter_visible_neighbors(
+    ...     center=np.array([5.0, 5.0]),
+    ...     candidates=candidate_points,
+    ...     obstacle_sdf=pillars.signed_distance,
+    ... )
+    >>> visible_candidates = candidate_points[mask]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+
+def segments_clear(
+    p1: NDArray[np.float64],
+    p2: NDArray[np.float64],
+    obstacle_sdf: Callable[[NDArray[np.float64]], NDArray[np.float64]],
+    n_samples: int = 10,
+    margin: float = 0.0,
+) -> NDArray[np.bool_]:
+    """Check whether line segments between point pairs avoid obstacles.
+
+    For each pair (p1[i], p2[i]), samples n_samples points along the segment
+    and checks that the obstacle SDF is > margin at all samples.
+
+    Args:
+        p1: Start points, shape (N, d) or (d,) for a single point.
+        p2: End points, shape (N, d) or (M, d). If p1 is (d,) and p2 is (M, d),
+            broadcasts p1 to all segments (1-to-many check).
+        obstacle_sdf: Callable that maps (K, d) points to (K,) SDF values.
+            Negative values = inside obstacle.
+        n_samples: Number of interior samples along each segment (excluding
+            endpoints, which are assumed to be valid collocation points).
+            More samples = fewer false positives but slower. Default 10 is
+            sufficient for convex obstacles (spheres, rectangles).
+        margin: Safety margin. A segment is blocked if any sample has
+            SDF < margin. Use margin > 0 for conservative filtering
+            (keep stencils away from obstacle surfaces).
+
+    Returns:
+        Boolean array of shape (N,) or (M,). True = segment is clear (no
+        obstacle intersection), False = blocked.
+
+    Complexity:
+        O(N * n_samples * d) for SDF evaluation. Fully vectorized.
+    """
+    p1 = np.asarray(p1, dtype=np.float64)
+    p2 = np.asarray(p2, dtype=np.float64)
+
+    # Handle broadcasting: single p1 with multiple p2
+    if p1.ndim == 1:
+        p1 = p1[np.newaxis, :]  # (1, d)
+    if p2.ndim == 1:
+        p2 = p2[np.newaxis, :]
+
+    n_segments = max(p1.shape[0], p2.shape[0])
+
+    # Sample interior points along each segment: t in (0, 1) exclusive
+    # Excluding endpoints avoids false positives from points ON obstacle boundary
+    t = np.linspace(0.0, 1.0, n_samples + 2)[1:-1]  # (n_samples,)
+
+    # Build sample points: shape (n_segments, n_samples, d)
+    # p1: (N, 1, d), p2: (M, 1, d), t: (1, n_samples, 1)
+    t_col = t[np.newaxis, :, np.newaxis]  # (1, n_samples, 1)
+    samples = p1[:, np.newaxis, :] * (1.0 - t_col) + p2[:, np.newaxis, :] * t_col
+
+    # Flatten for batch SDF evaluation: (n_segments * n_samples, d)
+    d = samples.shape[-1]
+    flat_samples = samples.reshape(-1, d)
+
+    # Evaluate SDF at all sample points
+    sdf_values = obstacle_sdf(flat_samples)  # (n_segments * n_samples,)
+    sdf_values = np.asarray(sdf_values).reshape(n_segments, n_samples)
+
+    # Segment is clear if ALL samples are outside obstacle (SDF > margin)
+    return np.all(sdf_values > margin, axis=1)
+
+
+def filter_visible_neighbors(
+    center: NDArray[np.float64],
+    candidates: NDArray[np.float64],
+    obstacle_sdf: Callable[[NDArray[np.float64]], NDArray[np.float64]],
+    n_samples: int = 10,
+    margin: float = 0.0,
+) -> NDArray[np.bool_]:
+    """Filter candidate neighbors by line-of-sight visibility from a center point.
+
+    Returns a boolean mask indicating which candidates are visible (not occluded
+    by obstacles) from the center point.
+
+    This is the primary API for GFDM stencil filtering. Typical usage:
+
+        neighbors = tree.query_ball_point(center, delta)
+        mask = filter_visible_neighbors(center, points[neighbors], obstacle_sdf)
+        visible_neighbors = neighbors[mask]
+
+    Args:
+        center: Reference point, shape (d,).
+        candidates: Candidate neighbor points, shape (M, d).
+        obstacle_sdf: SDF of the obstacle region. See module docstring for convention.
+        n_samples: Interior samples per segment. Default 10.
+        margin: Safety margin for obstacle proximity. Default 0.0.
+
+    Returns:
+        Boolean mask of shape (M,). True = visible (line of sight clear).
+    """
+    if candidates.ndim == 1:
+        candidates = candidates[np.newaxis, :]
+
+    if len(candidates) == 0:
+        return np.array([], dtype=bool)
+
+    return segments_clear(center, candidates, obstacle_sdf, n_samples, margin)
+
+
+if __name__ == "__main__":
+    """Smoke test: visibility through pillar pair."""
+    from mfg_pde.geometry.implicit import Hypersphere
+
+    # Two pillars forming a narrow channel at y=5
+    pillar_top = Hypersphere(center=[6.0, 6.5], radius=1.3)
+    pillar_bot = Hypersphere(center=[6.0, 3.5], radius=1.3)
+
+    # Union SDF: min of individual SDFs (inside either = blocked)
+    def pillars_sdf(x: NDArray[np.float64]) -> NDArray[np.float64]:
+        return np.minimum(
+            pillar_top.signed_distance(x),
+            pillar_bot.signed_distance(x),
+        )
+
+    # Test 1: Line through the channel (should be clear)
+    p_left = np.array([4.0, 5.0])
+    p_right = np.array([8.0, 5.0])
+    clear = segments_clear(p_left, p_right, pillars_sdf)
+    print(f"Through channel (y=5.0): clear={clear[0]}")  # Expected: True
+
+    # Test 2: Line that misses pillars (x=4 is far from pillar center x=6)
+    p_top = np.array([4.0, 7.0])
+    clear2 = segments_clear(p_left, p_top, pillars_sdf)
+    print(f"Vertical at x=4 (misses pillars): clear={clear2[0]}")  # Expected: True
+
+    # Test 3: Line across both pillars (should be blocked)
+    p_bottom = np.array([6.0, 1.0])
+    p_top2 = np.array([6.0, 9.0])
+    clear3 = segments_clear(p_bottom, p_top2, pillars_sdf)
+    print(f"Vertical through both pillars: clear={clear3[0]}")  # Expected: False
+
+    # Test 4: Batch filter - multiple candidates from one center
+    center = np.array([4.0, 5.0])
+    candidates = np.array(
+        [
+            [8.0, 5.0],  # Through channel - visible
+            [6.0, 7.5],  # Inside top pillar - blocked
+            [6.0, 2.5],  # Inside bottom pillar - blocked
+            [8.0, 8.0],  # Diagonal cuts through top pillar - blocked
+            [7.0, 5.0],  # Short segment through channel - visible
+        ]
+    )
+    mask = filter_visible_neighbors(center, candidates, pillars_sdf)
+    labels = ["channel", "top_pillar", "bot_pillar", "above", "short_channel"]
+    print("\nBatch visibility from (4, 5):")
+    for label, visible in zip(labels, mask, strict=True):
+        print(f"  {label}: {'visible' if visible else 'BLOCKED'}")
+
+    # Test 5: Margin test
+    mask_margin = filter_visible_neighbors(center, candidates, pillars_sdf, margin=0.2)
+    print("\nWith margin=0.2:")
+    for label, visible in zip(labels, mask_margin, strict=True):
+        print(f"  {label}: {'visible' if visible else 'BLOCKED'}")
+
+    print("\nAll smoke tests passed.")


### PR DESCRIPTION
## Summary
- New module `mfg_pde/geometry/visibility.py`: SDF-based line-of-sight checking (vectorized, O(N·k·n_samples))
- `NeighborhoodBuilder`: integrates visibility filter via `_apply_visibility_filter()`, preserves ghost neighbors
- `HJBGFDMSolver`: exposes `obstacle_sdf`, `visibility_samples`, `visibility_margin` parameters

## Motivation
In non-convex domains with obstacles, KD-tree ball queries find neighbors by Euclidean distance — they don't know about walls. A stencil reaching through a pillar mixes function values from disconnected regions, producing nonsensical gradients. Discovered in 2D multi-obstacle evacuation experiments with narrow channels (0.4m–1.6m gaps between pillars).

## Design
- Reuses existing SDF infrastructure (`mfg_pde.geometry.implicit`) — any `ImplicitDomain` works as obstacle
- Samples `n_samples` interior points along each center→neighbor segment
- If any sample has SDF < margin (inside obstacle), the neighbor is dropped
- Ghost neighbors (negative indices, for boundary treatment) are preserved unconditionally

## Test plan
- [x] Smoke test passes (`python mfg_pde/geometry/visibility.py`)
- [x] All imports verified
- [ ] Existing GFDM tests pass (no behavioral change when `obstacle_sdf=None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)