### PR TITLE
chore: Fix deprecation warnings and stale DOMAIN_2D/3D references

### DIFF
--- a/docs/architecture/GEOMETRY_BC_INFRASTRUCTURE.md
+++ b/docs/architecture/GEOMETRY_BC_INFRASTRUCTURE.md
@@ -60,8 +60,7 @@ GeometryType
 ├── IMPLICIT         → Hyperrectangle + SDF (GFDM, meshfree)
 ├── NETWORK          → NetworkGeometry      (graph MFG)
 ├── MAZE             → MazeGeometry         (grid with obstacles)
-├── DOMAIN_2D        → Mesh2D              (future FEM)
-├── DOMAIN_3D        → Mesh3D              (future FEM)
+├── UNSTRUCTURED_MESH → Mesh2D / Mesh3D    (future FEM)
 └── CUSTOM           → user extension
 ```
 
@@ -190,7 +189,7 @@ free boundaries) without structural changes.
 ║  ├── dimension, geometry_type         ├── CARTESIAN_GRID         ║
 ║  ├── get_collocation_points()         ├── IMPLICIT               ║
 ║  ├── get_bounds()                     ├── NETWORK / MAZE         ║
-║  ├── is_on_boundary()                 ├── DOMAIN_2D / 3D         ║
+║  ├── is_on_boundary()                 ├── UNSTRUCTURED_MESH      ║
 ║  └── ...                              └── CUSTOM                 ║
 ║                                                                  ║
 ║  TimeDependentDomain (wrapper)                                   ║
@@ -541,8 +540,8 @@ class DomainSpec:
                                    StructureType.UNSTRUCTURED, BoundaryDef.NONE),
             GeometryType.IMPLICIT: (ConnectivityType.DYNAMIC,
                                     StructureType.UNSTRUCTURED, BoundaryDef.IMPLICIT),
-            GeometryType.DOMAIN_2D: (ConnectivityType.EXPLICIT,
-                                     StructureType.UNSTRUCTURED, BoundaryDef.MESH),
+            GeometryType.UNSTRUCTURED_MESH: (ConnectivityType.EXPLICIT,
+                                           StructureType.UNSTRUCTURED, BoundaryDef.MESH),
         }
         c, s, b = _MAP[geometry.geometry_type]
         return cls(c, s, b)
@@ -564,7 +563,7 @@ Replace `GeometryType` checks one site at a time:
 # Before:
 if geometry.geometry_type == GeometryType.CARTESIAN_GRID:
     ...
-elif geometry.geometry_type in (GeometryType.DOMAIN_2D, GeometryType.DOMAIN_3D):
+elif geometry.geometry_type == GeometryType.UNSTRUCTURED_MESH:
     ...
 
 # After:
@@ -847,7 +846,7 @@ mfgarchon/geometry/
 ├── base.py                      BaseGeometry (convenience properties)
 ├── grids/tensor_grid.py         TensorProductGrid (CARTESIAN_GRID)
 ├── implicit/hyperrectangle.py   Hyperrectangle (IMPLICIT)
-├── meshes/mesh_2d.py            Mesh2D (DOMAIN_2D)
+├── meshes/mesh_2d.py            Mesh2D (UNSTRUCTURED_MESH)
 ├── graph/network_geometry.py    NetworkGeometry (NETWORK, MAZE)
 └── boundary/
     ├── types.py                 BCType, BCSegment

--- a/docs/development/planning/PROTOCOL_REVISION_GEOMETRY_AGNOSTIC.md
+++ b/docs/development/planning/PROTOCOL_REVISION_GEOMETRY_AGNOSTIC.md
@@ -15,7 +15,7 @@
 | **CARTESIAN_GRID** | Tensor product grid | ✅ YES |
 | **NETWORK** | Graph topology | ❌ NO |
 | **MAZE** | Grid with obstacles | ⚠️ PARTIAL |
-| **DOMAIN_2D/3D** | Complex boundary | ❌ NO (mesh-based) |
+| **UNSTRUCTURED_MESH** | Complex boundary | ❌ NO (mesh-based) |
 | **IMPLICIT** | Level set/SDF | ❌ NO |
 | **AMR** | Adaptive mesh | ❌ NO (irregular) |
 

--- a/docs/user/GEOMETRY_FIRST_API_GUIDE.md
+++ b/docs/user/GEOMETRY_FIRST_API_GUIDE.md
@@ -26,7 +26,7 @@ As of v0.16.0, `MFGProblem.geometry` is **always non-None** after initialization
 |:---------------|:-----|:------------|:-----------|
 | `TensorProductGrid` | CARTESIAN_GRID | Structured regular grid | 1D-nD |
 | `Domain1D` | DOMAIN_1D | 1D domain with BC | 1D |
-| `Domain2D`, `Domain3D` | DOMAIN_2D/3D | Unstructured mesh via Gmsh | 2D, 3D |
+| `Domain2D`, `Domain3D` | UNSTRUCTURED_MESH | Unstructured mesh via Gmsh | 2D, 3D |
 | `Hyperrectangle` | IMPLICIT | Box domain via SDF | nD |
 | `Hypersphere` | IMPLICIT | Sphere/ball via SDF | nD |
 | `Grid` (mazes) | MAZE | Maze-based grid | 2D |

--- a/mfgarchon/geometry/base.py
+++ b/mfgarchon/geometry/base.py
@@ -86,7 +86,7 @@ class Geometry(ABC):
         Type of geometry (enum).
 
         Returns:
-            GeometryType: CARTESIAN_GRID, NETWORK, DOMAIN_2D, etc.
+            GeometryType: CARTESIAN_GRID, NETWORK, UNSTRUCTURED_MESH, etc.
 
         Examples:
             >>> grid = TensorProductGrid(...)

--- a/tests/unit/test_types/test_arrays.py
+++ b/tests/unit/test_types/test_arrays.py
@@ -22,11 +22,9 @@ from mfgarchon.types.arrays import (  # noqa: TC001
     ParticleArray,
     SolutionArray,
     SpatialArray,
-    SpatialCoordinates,
     SpatialGrid,
     StateArray,
     TemporalArray,
-    TemporalCoordinates,
     TimeGrid,
     WeightArray,
 )
@@ -276,12 +274,9 @@ def test_spatial_coordinates_deprecated_alias():
         assert "SpatialCoordinates" in str(deprecation_warnings[-1].message)
         assert "SpatialGrid" in str(deprecation_warnings[-1].message)
 
-    # Test functionality still works
-    arr: SpatialCoordinates = np.linspace(0, 1, 51)
+    # Test functionality still works (use the reloaded module's alias)
+    arr: SpatialGrid = np.linspace(0, 1, 51)
     assert arr.shape == (51,)
-    # Should be same as SpatialGrid
-    arr2: SpatialGrid = arr
-    assert arr is arr2
 
 
 @pytest.mark.unit
@@ -305,12 +300,9 @@ def test_temporal_coordinates_deprecated_alias():
         assert "TemporalCoordinates" in str(deprecation_warnings[-1].message)
         assert "TimeGrid" in str(deprecation_warnings[-1].message)
 
-    # Test functionality still works
-    arr: TemporalCoordinates = np.linspace(0, 2, 31)
+    # Test functionality still works (use the reloaded module's alias)
+    arr: TimeGrid = np.linspace(0, 2, 31)
     assert arr.shape == (31,)
-    # Should be same as TimeGrid
-    arr2: TimeGrid = arr
-    assert arr is arr2
 
 
 # ===================================================================
@@ -477,9 +469,13 @@ def test_module_exports():
     assert hasattr(arrays, "WeightArray")
     assert hasattr(arrays, "DensityArray")
 
-    # Legacy
-    assert hasattr(arrays, "SpatialCoordinates")
-    assert hasattr(arrays, "TemporalCoordinates")
+    # Legacy aliases (suppress expected deprecation warnings)
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert hasattr(arrays, "SpatialCoordinates")
+        assert hasattr(arrays, "TemporalCoordinates")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Remove module-level imports of deprecated `SpatialCoordinates`/`TemporalCoordinates` aliases from `test_arrays.py` — silences warnings on every test collection
- Suppress expected deprecation warnings in legacy alias existence checks
- Update stale `DOMAIN_2D`/`DOMAIN_3D` references in code and active docs to `UNSTRUCTURED_MESH` (enum was already unified; this cleans up leftover doc references)

Partial progress on #802 (Phase 1 already complete, this cleans up stale references).

## Test plan
- [x] `test_arrays.py`: 31 passed, 0 warnings
- [x] `test_geometry/`: 879 passed