### PR TITLE
refactor: Rename _GmshMeshBase -> _MeshGeneratorBase

### DIFF
--- a/mfgarchon/geometry/meshes/mesh_2d.py
+++ b/mfgarchon/geometry/meshes/mesh_2d.py
@@ -11,14 +11,14 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from mfgarchon.geometry.meshes.mesh_base import _GmshMeshBase
+from mfgarchon.geometry.meshes.mesh_base import _MeshGeneratorBase
 from mfgarchon.geometry.meshes.mesh_data import MeshData
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class Mesh2D(_GmshMeshBase):
+class Mesh2D(_MeshGeneratorBase):
     """2D unstructured triangular mesh for FEM/FVM methods using Gmsh pipeline."""
 
     def __init__(

--- a/mfgarchon/geometry/meshes/mesh_3d.py
+++ b/mfgarchon/geometry/meshes/mesh_3d.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from mfgarchon.geometry.meshes.mesh_base import _GmshMeshBase
+from mfgarchon.geometry.meshes.mesh_base import _MeshGeneratorBase
 from mfgarchon.geometry.meshes.mesh_data import MeshData
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-class Mesh3D(_GmshMeshBase):
+class Mesh3D(_MeshGeneratorBase):
     """3D unstructured tetrahedral mesh for FEM/FVM methods using Gmsh pipeline."""
 
     def __init__(

--- a/mfgarchon/geometry/meshes/mesh_base.py
+++ b/mfgarchon/geometry/meshes/mesh_base.py
@@ -1,4 +1,4 @@
-"""Shared Gmsh mesh base class for 2D and 3D unstructured meshes.
+"""Shared mesh generator base class for 2D and 3D unstructured meshes.
 
 Extracts common constructor, ``set_mesh_parameters``, and ``create_gmsh_geometry``
 from Mesh2D and Mesh3D into a single intermediate base class using the
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class _GmshMeshBase(UnstructuredMesh):
-    """Shared Gmsh-based mesh generation logic for 2D and 3D meshes.
+class _MeshGeneratorBase(UnstructuredMesh):
+    """Shared mesh generation logic for 2D and 3D meshes.
 
     Uses the Template Method pattern: ``create_gmsh_geometry`` defines the
     Gmsh pipeline (initialise -> create shape -> cut holes -> set options),


### PR DESCRIPTION
## Summary
- Rename `_GmshMeshBase` to `_MeshGeneratorBase` for backend-agnostic naming
- Prepares for potential non-Gmsh backends (scikit-fem #773)
- Internal class only — no public API change

Relates to #802.

## Test plan
- [x] `test_geometry/`: 848 passed