### PR TITLE
chore: Bump version to v0.17.12

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Jiongyi
     alias: Jeremy
     email: jiongyiwang@gmail.com
-version: "0.17.11"
+version: "0.17.12"
 date-released: "2026-02-15"
 url: "https://github.com/derrring/mfgarchon"
 repository-code: "https://github.com/derrring/mfgarchon"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -877,5 +877,5 @@ Before marking an issue as complete or creating a PR:
 ---
 
 **Last Updated**: 2026-02-15
-**Repository Version**: v0.17.11 (Pre-1.0.0)
+**Repository Version**: v0.17.12 (Pre-1.0.0)
 **Claude Code**: Always reference this file for MFGarchon conventions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.17.11"  # v0.17.11: Geometry trait dispatch, BC infrastructure, boundary test coverage (#732, #794)
+version = "0.17.12"  # v0.17.12: Package rename cleanup, deprecation fixes, README update
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Summary
Bump version to v0.17.12 reflecting this session's work:
- Package rename cleanup (mfg_pde -> mfgarchon, #821 follow-up)
- Deprecation warning fixes (SpatialCoordinates, TemporalCoordinates, tensor_calculus)
- README and CITATION.cff updates (#822)
- `_GmshMeshBase` -> `_MeshGeneratorBase` rename (#824)
- Tensor calculus internalization (#825)
- Deprecation guide update (#826)
- Dependabot CI bumps (#815, #816, #817)

## Test plan
- [x] All CI checks pass on prior PRs