### PR TITLE
chore: Bump version to v0.17.13

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Jiongyi
     alias: Jeremy
     email: jiongyiwang@gmail.com
-version: "0.17.12"
+version: "0.17.13"
 date-released: "2026-02-15"
 url: "https://github.com/derrring/mfgarchon"
 repository-code: "https://github.com/derrring/mfgarchon"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -877,5 +877,5 @@ Before marking an issue as complete or creating a PR:
 ---
 
 **Last Updated**: 2026-02-15
-**Repository Version**: v0.17.12 (Pre-1.0.0)
+**Repository Version**: v0.17.13 (Pre-1.0.0)
 **Claude Code**: Always reference this file for MFGarchon conventions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.17.12"  # v0.17.12: Package rename cleanup, deprecation fixes, README update
+version = "0.17.13"  # v0.17.13: True adjoint mode (#707), dead module removal
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Summary
Bump version to v0.17.13:
- True adjoint mode via linearized HJB operator (#707, #829)
- Dead deprecated shim module removal (#828)

## Test plan
- [x] CI passes on prior PRs