### PR TITLE
chore: Deprecate old adjoint modes and return_tuple (#476)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/block_iterators.py
+++ b/mfgarchon/alg/numerical/coupling/block_iterators.py
@@ -148,10 +148,24 @@ class BlockIterator(BaseMFGSolver):
         self.diffusion_field = diffusion_field
         self.drift_field = drift_field
 
-        # Issue #622, #704: Adjoint mode
+        # Issue #622, #704, #707: Adjoint mode
         _valid_adjoint_modes = ("off", "transpose", "jacobian_transpose", "auto")
         if adjoint_mode not in _valid_adjoint_modes:
             raise ValueError(f"adjoint_mode must be one of {_valid_adjoint_modes}, got '{adjoint_mode}'")
+
+        # Deprecate old modes (#706, #707)
+        if adjoint_mode in ("transpose", "auto"):
+            import warnings
+
+            warnings.warn(
+                f"adjoint_mode='{adjoint_mode}' is deprecated since v0.17.13. "
+                "Use adjoint_mode='jacobian_transpose' instead, which correctly "
+                "transposes the linearized HJB Jacobian (Issue #707). "
+                f"The '{adjoint_mode}' mode will be removed in v1.0.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.adjoint_mode = adjoint_mode
         self.adjoint_verify = adjoint_verify
         self._adjoint_mismatch_count = 0

--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -531,6 +531,15 @@ class FictitiousPlayIterator(BaseMFGSolver):
         )
 
         if return_tuple:
+            import warnings
+
+            warnings.warn(
+                "return_tuple=True is deprecated since v0.17.13. "
+                "Use SolverResult object instead (the default). "
+                "Will be removed in v1.0.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return (
                 self.U,
                 self.M,

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -691,6 +691,15 @@ class FixedPointIterator(BaseMFGSolver):
 
         # Return tuple for backward compatibility if requested
         if return_tuple:
+            import warnings
+
+            warnings.warn(
+                "return_tuple=True is deprecated since v0.17.13. "
+                "Use SolverResult object instead (the default). "
+                "Will be removed in v1.0.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return (
                 self.U,
                 self.M,


### PR DESCRIPTION
## Summary
Coupling module cleanup following #707 (True Adjoint Mode) completion:

- **Deprecate `adjoint_mode="transpose"` and `"auto"`** in `BlockIterator` — these use the velocity-based advection matrix transpose, which is incorrect for non-quadratic Hamiltonians (#706). Use `"jacobian_transpose"` instead (#707).
- **Deprecate `return_tuple=True`** in `FixedPointIterator` and `FictitiousPlay` — use `SolverResult` object instead (the default since v0.17.0). The tuple return silently gives relative errors while `SolverResult` gives absolute errors (#476 audit finding).

Both emit `DeprecationWarning` with migration guidance. Removal in v1.0.0.

Partial progress on #476.

## Test plan
- [x] 22 integration tests pass (block_iterators + true_adjoint)
- [x] No existing code uses the deprecated modes