### PR TITLE
chore: Skip RL placeholder tests, test quality audit (#833)

### DIFF
--- a/tests/unit/test_rl/conftest.py
+++ b/tests/unit/test_rl/conftest.py
@@ -1,0 +1,22 @@
+"""
+RL test suite configuration.
+
+These tests are for placeholder/scaffold RL algorithms that are not yet
+production-ready. They are skipped by default to avoid inflating test
+metrics. Remove this skip when RL algorithms reach production quality
+with stable APIs and validated results.
+
+See Issue #833: Test quality audit.
+"""
+
+import pytest
+
+# Skip entire RL test directory — algorithms not yet implemented
+collect_ignore_glob = ["test_*.py"]
+
+
+def pytest_collection_modifyitems(items):
+    """Mark all RL tests as skipped with reason."""
+    for item in items:
+        if "test_rl" in str(item.fspath):
+            item.add_marker(pytest.mark.skip(reason="RL algorithms not yet production-ready (Issue #833)"))


### PR DESCRIPTION
## Summary
Test quality audit and RL placeholder test skip.

### RL Tests (479 tests → skipped)
Added `conftest.py` to `tests/unit/test_rl/` that skips all 479 RL tests at collection time. These test scaffold RL algorithms that are not yet production-ready. Tests are preserved (not deleted) for future use.

### Audit Results

| Finding | Count | Verdict |
|---------|-------|---------|
| Assertion-free tests | 192 | Tracked in #833, future cleanup |
| Duplicate test names | ~30 | Benign — all class-scoped or file-scoped |
| Unconditional skips | 6 | All legitimate, reference real open issues |
| xfails | 32 | Pending `--runxfail` audit |

## Test plan
- [x] RL tests skipped at collection
- [x] Non-RL tests unaffected