### PR TITLE
chore: Rename display name MFGarchon -> MFGArchon

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,4 @@
-# Codecov Configuration for MFGarchon
+# Codecov Configuration for MFGArchon
 # See: https://docs.codecov.com/docs/codecov-yaml
 
 coverage:

--- a/.github/CONTRIBUTOR_PRIVACY.md
+++ b/.github/CONTRIBUTOR_PRIVACY.md
@@ -1,6 +1,6 @@
 # Contributor Privacy and Personal Workflow Guide
 
-This document explains how to maintain personal development preferences while contributing to MFGarchon.
+This document explains how to maintain personal development preferences while contributing to MFGArchon.
 
 ## 🔒 Personal Development Environment
 
@@ -72,7 +72,7 @@ echo "- Focus on Python typing when possible" >> CLAUDE.md.personal
 1. **Clone the repository**
    ```bash
    git clone <repo-url>
-   cd MFGarchon
+   cd MFGArchon
    ```
 
 2. **Set up personal AI guidelines (optional)**

--- a/.github/RELEASE_NOTES_580.md
+++ b/.github/RELEASE_NOTES_580.md
@@ -11,7 +11,7 @@
 
 ### Three-Mode Solving API
 
-MFGarchon now provides **guaranteed adjoint duality** between HJB and FP solvers through a new three-mode solving API. This prevents a subtle but critical numerical error that can break Nash equilibrium convergence.
+MFGArchon now provides **guaranteed adjoint duality** between HJB and FP solvers through a new three-mode solving API. This prevents a subtle but critical numerical error that can break Nash equilibrium convergence.
 
 **Key Benefit**: You can now safely experiment with different numerical schemes knowing that duality is guaranteed by construction.
 
@@ -376,7 +376,7 @@ A: Safe Mode guarantees duality. Expert Mode validates automatically and emits w
 
 ## Summary
 
-The three-mode solving API represents a major improvement in MFGarchon's usability and scientific correctness. By making it **impossible** to accidentally break adjoint duality, this release ensures your MFG simulations converge correctly while maintaining complete backward compatibility.
+The three-mode solving API represents a major improvement in MFGArchon's usability and scientific correctness. By making it **impossible** to accidentally break adjoint duality, this release ensures your MFG simulations converge correctly while maintaining complete backward compatibility.
 
 **Key Takeaway**: Better defaults, stronger guarantees, zero breaking changes.
 

--- a/.github/local-dev-setup.md
+++ b/.github/local-dev-setup.md
@@ -148,11 +148,11 @@ python -m pytest tests/integration/ -v
 
 ### Advanced Pre-Commit Configuration
 
-#### Custom Hooks for MFGarchon
+#### Custom Hooks for MFGArchon
 Add MFG-specific checks to `.pre-commit-config.yaml`:
 
 ```yaml
-  # MFGarchon specific checks
+  # MFGArchon specific checks
   - repo: local
     hooks:
       # Ensure no emojis in Python files (per CLAUDE.md standards)

--- a/.github/scripts/check_critical_issues.py
+++ b/.github/scripts/check_critical_issues.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Critical security issues checker for MFGarchon CI/CD pipeline.
+Critical security issues checker for MFGArchon CI/CD pipeline.
 
 This script analyzes all security scan results and determines if there are
 any critical issues that should fail the CI/CD pipeline.

--- a/.github/scripts/container_security_check.py
+++ b/.github/scripts/container_security_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Container security configuration checking script for MFGarchon.
+Container security configuration checking script for MFGArchon.
 Checks Docker configuration for security best practices.
 """
 

--- a/.github/scripts/custom_secrets_scan.py
+++ b/.github/scripts/custom_secrets_scan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Custom secrets scanning script for MFGarchon security pipeline.
+Custom secrets scanning script for MFGArchon security pipeline.
 Scans for hardcoded secrets, API keys, and sensitive information.
 """
 

--- a/.github/scripts/custom_security_checks.py
+++ b/.github/scripts/custom_security_checks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Custom security checks for MFGarchon scientific computing package.
+Custom security checks for MFGArchon scientific computing package.
 
 This script performs domain-specific security checks that are relevant
 for scientific computing packages but may not be covered by general
@@ -25,7 +25,7 @@ class CustomSecurityChecker:
 
     def run_all_checks(self) -> dict[str, Any]:
         """Run all custom security checks."""
-        print("🔍 Running custom security checks for MFGarchon...")
+        print("🔍 Running custom security checks for MFGArchon...")
 
         # Scientific computing specific checks
         self.check_numerical_stability_patterns()

--- a/.github/scripts/generate_security_report.py
+++ b/.github/scripts/generate_security_report.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Security report generation script for MFGarchon security pipeline.
+Security report generation script for MFGArchon security pipeline.
 Aggregates all security scan results into comprehensive reports.
 """
 
@@ -275,7 +275,7 @@ class SecurityReportGenerator:
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MFGarchon Security Dashboard</title>
+    <title>MFGArchon Security Dashboard</title>
     <style>
         body {{ font-family: Arial, sans-serif; margin: 20px; background: #f5f5f5; }}
         .container {{ max-width: 1200px; margin: 0 auto; background: white; padding: 20px; border-radius: 8px; }}
@@ -295,7 +295,7 @@ class SecurityReportGenerator:
 <body>
     <div class="container">
         <div class="header">
-            <h1>🔒 MFGarchon Security Dashboard</h1>
+            <h1>🔒 MFGArchon Security Dashboard</h1>
             <span class="status-badge status-{self.summary["overall_status"].lower()}">{
             self.summary["overall_status"]
         }</span>
@@ -350,7 +350,7 @@ class SecurityReportGenerator:
     def generate_markdown_summary(self) -> str:
         """Generate markdown security summary."""
         lines = []
-        lines.append("# MFGarchon Security Summary")
+        lines.append("# MFGArchon Security Summary")
         lines.append("")
         lines.append(f"**Generated**: {self.summary['timestamp']}")
         lines.append(f"**Overall Status**: {self.summary['overall_status']}")

--- a/.github/scripts/license_compliance_check.py
+++ b/.github/scripts/license_compliance_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-License compliance checking script for MFGarchon security pipeline.
+License compliance checking script for MFGArchon security pipeline.
 Checks dependencies for license compatibility and compliance.
 """
 

--- a/.github/scripts/parse_security_results.py
+++ b/.github/scripts/parse_security_results.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Security results parser for MFGarchon CI/CD pipeline.
+Security results parser for MFGArchon CI/CD pipeline.
 
 This script parses various security scan results and generates
 unified reports for the security dashboard.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
     steps:
     - name: Generate CI summary
       run: |
-        echo "# 🚀 MFGarchon CI/CD Pipeline Summary" >> $GITHUB_STEP_SUMMARY
+        echo "# 🚀 MFGArchon CI/CD Pipeline Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "## Build Information" >> $GITHUB_STEP_SUMMARY
         echo "- **Event**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Modern pre-commit configuration for MFGarchon using Ruff
+# Modern pre-commit configuration for MFGArchon using Ruff
 # Unified linting and formatting with 10-100x faster performance
 # Uses pyproject.toml settings for all configuration
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to MFGarchon will be documented in this file.
+All notable changes to MFGArchon will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
-title: "MFGarchon: A Research-Grade Framework for Mean Field Games"
+title: "MFGArchon: A Research-Grade Framework for Mean Field Games"
 authors:
   - family-names: Wang
     given-names: Jiongyi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Claude Code Preferences for MFGarchon
+# Claude Code Preferences for MFGArchon
 
-This file contains preferences and conventions for Claude Code when working with the MFGarchon repository.
+This file contains preferences and conventions for Claude Code when working with the MFGArchon repository.
 
 ## ⚠️ **Communication Principles**
 
@@ -18,7 +18,7 @@ This file contains preferences and conventions for Claude Code when working with
 
 ## 🎯 **Repository Mission & Scope** ⚠️ **CRITICAL**
 
-### **MFGarchon: Public Infrastructure Package**
+### **MFGArchon: Public Infrastructure Package**
 Production-ready infrastructure for Mean Field Games research and applications.
 
 **Scope**:
@@ -33,11 +33,11 @@ Novel research, experimental algorithms, unpublished methods.
 - 🔬 Research algorithms (novel schemes, experimental architectures)
 - 🔬 Research applications (case studies, parameter studies, publications)
 
-**Key Principle**: MFG-Research **imports** MFGarchon but **never modifies** it.
+**Key Principle**: MFG-Research **imports** MFGArchon but **never modifies** it.
 
 ### **Decision Criteria**
 
-| Criterion | MFGarchon (Public) | MFG-Research (Private) |
+| Criterion | MFGArchon (Public) | MFG-Research (Private) |
 |:----------|:-----------------|:-----------------------|
 | **Maturity** | Production-ready, tested | Experimental |
 | **Publication** | Published methods | Unpublished |
@@ -46,12 +46,12 @@ Novel research, experimental algorithms, unpublished methods.
 | **Testing** | Full coverage | Exploratory |
 
 ### **Migration Path: Research → Infrastructure**
-When research matures: Add tests, write docs, ensure API consistency, open PR in MFGarchon.
+When research matures: Add tests, write docs, ensure API consistency, open PR in MFGArchon.
 
 ### **Bug Fixes from Research** ⚠️ **CRITICAL**
 When bugs are discovered and validated in mfg-research:
 
-**Requirements before modifying MFGarchon**:
+**Requirements before modifying MFGArchon**:
 1. GitHub issue created with quantified validation evidence
 2. Standalone validation experiment in mfg-research demonstrating the fix
 3. Discussion and approval of approach
@@ -434,7 +434,7 @@ For long-running computations (GFDM solvers, Picard iterations, parameter sweeps
 
 ## 🧪 **Testing Philosophy**
 
-MFGarchon uses a **hybrid testing approach** optimized for research code that evolves rapidly.
+MFGArchon uses a **hybrid testing approach** optimized for research code that evolves rapidly.
 
 ### **1. Unit Tests (`tests/`) - For Stable APIs**
 
@@ -878,4 +878,4 @@ Before marking an issue as complete or creating a PR:
 
 **Last Updated**: 2026-02-15
 **Repository Version**: v0.17.13 (Pre-1.0.0)
-**Claude Code**: Always reference this file for MFGarchon conventions
+**Claude Code**: Always reference this file for MFGArchon conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to MFGarchon
+# Contributing to MFGArchon
 
-Thank you for your interest in contributing to the Mean Field Games Partial Differential Equations (MFGarchon) library! This guide will help you understand our development workflow and coding standards.
+Thank you for your interest in contributing to the Mean Field Games Partial Differential Equations (MFGArchon) library! This guide will help you understand our development workflow and coding standards.
 
 ## Repository Structure
 
@@ -21,7 +21,7 @@ Our codebase follows a strict organizational pattern:
 
 ### Import Conventions
 ```python
-# Preferred imports for MFGarchon
+# Preferred imports for MFGArchon
 from mfgarchon import MFGProblem, BoundaryConditions
 from mfgarchon.factory import create_fast_solver
 from mfgarchon.config import create_fast_config
@@ -57,7 +57,7 @@ logger = get_logger(__name__)
 # 1. Install pre-commit (one-time setup)
 pip install pre-commit
 
-# 2. Install the MFGarchon hooks (from project root)
+# 2. Install the MFGArchon hooks (from project root)
 pre-commit install
 
 # 3. Run on all files (optional - hooks run automatically on commit)
@@ -161,4 +161,4 @@ For mathematical foundations, see `docs/theory/` directory.
 
 ---
 
-By contributing to MFGarchon, you agree to maintain these standards and help build a high-quality, research-grade mathematical software library.
+By contributing to MFGArchon, you agree to maintain these standards and help build a high-quality, research-grade mathematical software library.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MFGarchon: Mean Field Games Framework
+# MFGArchon: Mean Field Games Framework
 
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![CI/CD](https://github.com/derrring/mfgarchon/actions/workflows/ci.yml/badge.svg)](https://github.com/derrring/mfgarchon/actions/workflows/ci.yml)
@@ -176,12 +176,12 @@ Optional: PyTorch, JAX, igraph, plotly (for advanced features)
 
 ## Citation
 
-If you use MFGarchon in your research, please cite it. You can use GitHub's
+If you use MFGArchon in your research, please cite it. You can use GitHub's
 "Cite this repository" button in the sidebar, or use the following BibTeX:
 
 ```bibtex
 @software{mfgarchon,
-  title={MFGarchon: A Research-Grade Framework for Mean Field Games},
+  title={MFGArchon: A Research-Grade Framework for Mean Field Games},
   author={Wang, Jiongyi},
   year={2025},
   url={https://github.com/derrring/mfgarchon}

--- a/archive/2026-01-development/SILENT_FALLBACK_COMPLETION_547.md
+++ b/archive/2026-01-development/SILENT_FALLBACK_COMPLETION_547.md
@@ -207,7 +207,7 @@ except (RuntimeError, OSError) as e:
 
 **12. `utils/performance/monitoring.py:250`** ✅ COMPLETE
 - Performance tracking
-- Replaced `print()` with `logger.warning()` + MFGarchon logger initialization
+- Replaced `print()` with `logger.warning()` + MFGArchon logger initialization
 - Correctly keeps `except Exception:` (re-raises with context)
 
 ### Deferred Items (3/13)
@@ -229,7 +229,7 @@ These were documented in audit but determined to already have acceptable pattern
 **After**:
 - ✅ All 13 instances use specific exceptions (except legitimate re-raise case)
 - ✅ Critical bugs now surface with clear warnings
-- ✅ Consistent MFGarchon logging infrastructure throughout
+- ✅ Consistent MFGArchon logging infrastructure throughout
 - ✅ All fallback behavior preserved for robustness
 - ✅ Performance degradations explicitly warned
 

--- a/archive/2026-01-development/VARIATIONAL_INEQUALITY_CONSTRAINTS_SUMMARY.md
+++ b/archive/2026-01-development/VARIATIONAL_INEQUALITY_CONSTRAINTS_SUMMARY.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Implemented comprehensive variational inequality constraint infrastructure for MFGarchon, enabling obstacle problems and box constraints on PDE solutions. The implementation supports unilateral constraints (u ≥ ψ or u ≤ ψ), bilateral constraints (ψ_lower ≤ u ≤ ψ_upper), and regional constraints (constraints active only in spatial subdomains).
+Implemented comprehensive variational inequality constraint infrastructure for MFGArchon, enabling obstacle problems and box constraints on PDE solutions. The implementation supports unilateral constraints (u ≥ ψ or u ≤ ψ), bilateral constraints (ψ_lower ≤ u ≤ ψ_upper), and regional constraints (constraints active only in spatial subdomains).
 
 ## Implementation
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,4 +1,4 @@
-# MFGarchon Benchmarking Framework
+# MFGArchon Benchmarking Framework
 
 This directory contains comprehensive benchmarking suites for evaluating different aspects of MFG solver performance, organized by benchmark category for clarity and extensibility.
 

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -1,4 +1,4 @@
-# MFGarchon Naming Conventions
+# MFGArchon Naming Conventions
 
 **Last Updated**: 2026-02-16
 **Status**: Current reference document (v0.17.11+)
@@ -8,7 +8,7 @@
 
 ## Purpose
 
-This document defines Python code naming conventions for MFGarchon based on actual codebase standards, not aspirational goals. Use this as the authoritative reference for parameter and variable naming.
+This document defines Python code naming conventions for MFGArchon based on actual codebase standards, not aspirational goals. Use this as the authoritative reference for parameter and variable naming.
 
 ---
 
@@ -311,7 +311,7 @@ Nx_points = Nx + 1  # 51 points
 - **Clarity**: `Nx_points` explicitly means grid points
 - **Grid spacing**: `dx = L / Nx` (NOT `L / (Nx-1)`)
 - **Arrays**: Solution arrays have shape `(Nt_points, Nx_points[0], Nx_points[1], ...)`
-- **Interoperability**: All MFGarchon solvers assume this convention
+- **Interoperability**: All MFGArchon solvers assume this convention
 
 ### Spatial Discretization
 
@@ -751,7 +751,7 @@ def solve(self) -> tuple[np.ndarray, np.ndarray]:
 
 ### ⚠️ CRITICAL: Unified Derivative Representation (v0.17.0+)
 
-MFGarchon uses **tensor-based derivative representation** as the canonical standard. Derivatives of order p in dimension d are stored as tensors of shape `(d,) * p`.
+MFGArchon uses **tensor-based derivative representation** as the canonical standard. Derivatives of order p in dimension d are stored as tensors of shape `(d,) * p`.
 
 ### DerivativeTensors Class
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
-# MFGarchon Documentation
+# MFGArchon Documentation
 
 **Last Updated**: December 14, 2025
 **Version**: v0.16.8 - Current Release
 **Status**: Production-Ready Framework with Validated Examples
 
-Welcome to the comprehensive documentation for MFGarchon - a state-of-the-art computational framework for Mean Field Games with network capabilities, GPU acceleration, and professional research tools.
+Welcome to the comprehensive documentation for MFGArchon - a state-of-the-art computational framework for Mean Field Games with network capabilities, GPU acceleration, and professional research tools.
 
 ---
 
@@ -79,7 +79,7 @@ docs/
 ├── user/                              # 👥 USER-FACING DOCUMENTATION
 │   ├── README.md                      # User documentation index
 │   ├── quickstart.md                  # Quick start guide
-│   ├── core_objects.md                # Core MFGarchon objects
+│   ├── core_objects.md                # Core MFGArchon objects
 │   ├── guides/                        # Feature usage guides
 │   │   ├── multi_population_quick_start.md  # Multi-population guide
 │   │   ├── backend_usage.md           # Computational backends
@@ -333,7 +333,7 @@ Complete framework documentation for achieving 100% type safety in scientific co
 
 ---
 
-## 🎉 **Welcome to MFGarchon**
+## 🎉 **Welcome to MFGArchon**
 
 **The premier platform for Mean Field Games computational research - now with enterprise-grade performance, professional research tools, GPU acceleration capabilities, and user-centric documentation.**
 

--- a/docs/architecture/ARCHITECTURE_DOCUMENTATION_INDEX.md
+++ b/docs/architecture/ARCHITECTURE_DOCUMENTATION_INDEX.md
@@ -1,4 +1,4 @@
-# MFGarchon Architecture Documentation Index
+# MFGArchon Architecture Documentation Index
 
 **Complete guide to architecture analysis and audit documentation**
 
@@ -9,7 +9,7 @@
 ### 0. Geometry-BC Infrastructure (2026-02-14)
 
 **0a. Implementation Blueprint**: `GEOMETRY_BC_INFRASTRUCTURE.md`
-**Purpose**: How topology-geometry-BC concerns are realized in MFGarchon
+**Purpose**: How topology-geometry-BC concerns are realized in MFGArchon
 
 **What's Inside**:
 - The actual 4-axis orthogonal BC design (WHAT x WHERE x WHEN x HOW)
@@ -36,7 +36,7 @@
 
 ### 1. Factory Pattern Design (UPDATED - 2026-01-17)
 **File**: `FACTORY_PATTERN_DESIGN.md`
-**Purpose**: Three-concern factory architecture for MFGarchon
+**Purpose**: Three-concern factory architecture for MFGArchon
 **Version**: 1.3 (Consolidated with infrastructure audit)
 
 **What's Inside**:
@@ -102,10 +102,10 @@
 ---
 
 ### 3. Original Architecture Audit
-**File**: `experiments/maze_navigation/MFGarchon_ARCHITECTURE_AUDIT.md`
+**File**: `experiments/maze_navigation/MFGArchon_ARCHITECTURE_AUDIT.md`
 **Pages**: 200+
 **Date**: 2025-10-30 (before research)
-**Purpose**: Comprehensive theoretical analysis of MFGarchon architecture
+**Purpose**: Comprehensive theoretical analysis of MFGArchon architecture
 
 **What's Inside**:
 - Part 1: What proposal got right
@@ -119,7 +119,7 @@
 ---
 
 ### 4. Architecture Refactoring Proposal
-**File**: `MFGarchon_ARCHITECTURE_REFACTOR_PROPOSAL.md`
+**File**: `MFGArchon_ARCHITECTURE_REFACTOR_PROPOSAL.md`
 **Purpose**: Original refactoring proposal (pre-audit)
 
 **Status**: Needs revision based on audit and research findings
@@ -145,7 +145,7 @@
 
 ### Bug #14: GFDM Gradient Sign Error
 **Location**: `experiments/maze_navigation/archives/bugs/bug14_gfdm_sign/`
-**Main Report**: `BUG_14_MFGarchon_REPORT.md`
+**Main Report**: `BUG_14_MFGArchon_REPORT.md`
 **Documents**: 10 files
 
 **Status**: FIXED, merged, GitHub issue filed
@@ -159,7 +159,7 @@
 **Main Report**: `BUG_15_QP_SIGMA_METHOD.md`
 **Documents**: 7 files
 
-**Status**: Workaround exists (`SmartSigma`), NOT FIXED in MFGarchon
+**Status**: Workaround exists (`SmartSigma`), NOT FIXED in MFGArchon
 
 **Impact**: Cannot use QP constraints without workaround
 
@@ -300,7 +300,7 @@
 ### For Complete Understanding (4 hours)
 1. `AUDIT_ENRICHMENT_SUMMARY.md` (15 min)
 2. `ARCHITECTURE_AUDIT_ENRICHMENT.md` (2 hours)
-3. `MFGarchon_ARCHITECTURE_AUDIT.md` Part 1-2 (1 hour)
+3. `MFGArchon_ARCHITECTURE_AUDIT.md` Part 1-2 (1 hour)
 4. Bug #13, #14, #15 main reports (45 min)
 
 ### For Specific Issues
@@ -350,7 +350,7 @@
 ### Path 2: Technical (4 hours)
 ```
 1. ARCHITECTURE_AUDIT_ENRICHMENT.md (complete)
-2. MFGarchon_ARCHITECTURE_AUDIT.md Parts 1-2
+2. MFGArchon_ARCHITECTURE_AUDIT.md Parts 1-2
 3. Bug #13 Lessons Learned
 4. QP Analysis Comprehensive
 → Outcome: Full technical understanding
@@ -411,7 +411,7 @@
 
 ## Related Documentation
 
-**In MFGarchon Repository**:
+**In MFGArchon Repository**:
 - `ARCHITECTURE.md` (if exists)
 - `CONTRIBUTING.md`
 - API documentation
@@ -434,7 +434,7 @@
 | Full evidence | ARCHITECTURE_AUDIT_ENRICHMENT.md | 2 hours |
 | Theory | anisotropic_crowd_qp/docs/theory/theory.md | 3 hours |
 | Bug #13 | BUG_13_INDEX.md → Quick Reference | 5 min |
-| Bug #14 | BUG_14_MFGarchon_REPORT.md | 30 min |
+| Bug #14 | BUG_14_MFGArchon_REPORT.md | 30 min |
 | Bug #15 | BUG_15_QP_SIGMA_METHOD.md | 20 min |
 | FDM issue | FDM_SOLVER_LIMITATION_ANALYSIS.md | 15 min |
 | Anderson | ANDERSON_ISSUE_POSTED.md | 10 min |

--- a/docs/architecture/FACTORY_PATTERN_DESIGN.md
+++ b/docs/architecture/FACTORY_PATTERN_DESIGN.md
@@ -1,4 +1,4 @@
-# MFGarchon Factory Pattern Design
+# MFGArchon Factory Pattern Design
 
 **Document**: Factory Pattern Design
 **Status**: Active Design Reference (Issue #580 Implementation)
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-MFGarchon uses a **three-concern factory organization** to separate concerns:
+MFGArchon uses a **three-concern factory organization** to separate concerns:
 - **Concern 1 (WHAT)**: Application-domain problem configuration
 - **Concern 2 (HOW)**: Numerical scheme selection with mathematical guarantees
 - **Concern 3 (WHO)**: Solver assembly and iteration control
@@ -63,7 +63,7 @@ scheme = NumericalScheme.FDM_UPWIND  # Enum, not factory call
 
 ### Comparison with Other Architecture "Layers"
 
-To avoid confusion with other uses of "layer" terminology in MFGarchon:
+To avoid confusion with other uses of "layer" terminology in MFGArchon:
 
 **Boundary Conditions Architecture** (different context):
 - Layer 1: BC Specification (`geometry/boundary/conditions.py`)
@@ -85,7 +85,7 @@ These are **separable concerns** (orthogonal dimensions), not stacked layers.
 
 ## Current Implementation Status
 
-**Purpose**: Ground factory design in MFGarchon's actual codebase state (as of 2026-01-16).
+**Purpose**: Ground factory design in MFGArchon's actual codebase state (as of 2026-01-16).
 
 ### What Currently Exists ✅
 
@@ -908,7 +908,7 @@ def check_solver_duality(hjb_solver, fp_solver) -> AdjointType:
 - ✅ Plugin-friendly: Custom solvers declare their family
 
 **Note on Validator Pattern** (Issue #543):
-MFGarchon uses `try/except AttributeError` instead of `hasattr()` for attribute validation (see Issue #543). The `getattr(..., default)` pattern above is preferred for optional attributes like `_scheme_family`. For required attributes, use:
+MFGArchon uses `try/except AttributeError` instead of `hasattr()` for attribute validation (see Issue #543). The `getattr(..., default)` pattern above is preferred for optional attributes like `_scheme_family`. For required attributes, use:
 ```python
 try:
     family = solver._scheme_family
@@ -1503,7 +1503,7 @@ def create_paired_solvers(
 ```
 
 **Benefits**:
-- ✅ **Extensibility**: Users can register custom schemes without modifying MFGarchon
+- ✅ **Extensibility**: Users can register custom schemes without modifying MFGArchon
 - ✅ **Separation**: Each scheme's pairing logic isolated in single function
 - ✅ **Testability**: Individual factories unit-testable
 - ✅ **Plugin-friendly**: Third-party packages can register schemes

--- a/docs/architecture/GEOMETRY_AND_TOPOLOGY.md
+++ b/docs/architecture/GEOMETRY_AND_TOPOLOGY.md
@@ -1,4 +1,4 @@
-# MFGarchon Geometry & Topology System Architecture — Conceptual Reference
+# MFGArchon Geometry & Topology System Architecture — Conceptual Reference
 
 **Document ID**: MFG-SPEC-GEO-1.0
 **Status**: **CONCEPTUAL REFERENCE**
@@ -11,7 +11,7 @@
 > in practice (see GEOMETRY_BC_INFRASTRUCTURE.md Section 5.3 for where each
 > concern is realized in the current architecture).
 >
-> **Relationship to implementation**: MFGarchon distributes these concerns across
+> **Relationship to implementation**: MFGArchon distributes these concerns across
 > three layers (geometry, BC, coupling) rather than colocating them in geometry
 > traits. The flat `GeometryProtocol` with `GeometryType` enum handles the
 > geometry layer; the 4-axis BC design (WHAT x WHERE x WHEN x HOW) handles
@@ -26,7 +26,7 @@
 
 ## 1. Executive Summary: The "Zero-Cost" & "Complete" Philosophy
 
-This specification defines the architecture for the Geometry and Topology module of the `MFGarchon` library. Addressing the eternal conflict between **"High-Level Abstraction"** and **"Low-Level Performance"** in scientific computing, this architecture establishes the following core principles:
+This specification defines the architecture for the Geometry and Topology module of the `MFGArchon` library. Addressing the eternal conflict between **"High-Level Abstraction"** and **"Low-Level Performance"** in scientific computing, this architecture establishes the following core principles:
 
 1.  **Trait-Based Static Polymorphism**: Abandoning traditional runtime virtual function inheritance in favor of compile-time Trait composition. This allows the compiler to generate highly optimized kernel code for specific geometric characteristics, achieving **Zero-Cost Abstraction**.
 2.  **Atomicity & Orthogonality**: Deconstructing all physical domains into 8 orthogonal atomic properties (Atomic Traits).
@@ -37,7 +37,7 @@ This specification defines the architecture for the Geometry and Topology module
 
 ## 2. The Type System: 8 Atomic Traits (The Core)
 
-A `Domain` in `MFGarchon` is not a class hierarchy but a **Signature**. This signature is uniquely determined by the following 8 compile-time characteristics:
+A `Domain` in `MFGArchon` is not a class hierarchy but a **Signature**. This signature is uniquely determined by the following 8 compile-time characteristics:
 
 ### 2.1 Connectivity (Topology)
 Defines how neighbor relationships are determined, directly dictating the memory access pattern of computational kernels.

--- a/docs/architecture/GEOMETRY_BC_INFRASTRUCTURE.md
+++ b/docs/architecture/GEOMETRY_BC_INFRASTRUCTURE.md
@@ -10,7 +10,7 @@
 
 ## 1. Context
 
-MFGarchon solves coupled HJB-FP systems on various spatial domains. The
+MFGArchon solves coupled HJB-FP systems on various spatial domains. The
 topology-geometry-BC infrastructure is how the library represents domains,
 identifies boundaries, and enforces boundary conditions across different
 discretization methods.
@@ -28,7 +28,7 @@ abstraction:
 SPEC-GEO-1.0 was conceived from practical experience across diverse PDE domains
 and identifies fundamental concerns (metric structure, temporality, composition)
 through abstract inference. This document describes how those concerns are
-realized in MFGarchon's current architecture — some in the geometry layer, some in
+realized in MFGArchon's current architecture — some in the geometry layer, some in
 the BC layer, some in the coupling layer. The concerns are decomposed and
 relocated, not discarded.
 

--- a/docs/architecture/ISSUE_580_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/ISSUE_580_IMPLEMENTATION_PLAN.md
@@ -1163,7 +1163,7 @@ result = problem.solve(hjb_solver=hjb, fp_solver=fp)
 ```python
 problem = create_crowd_problem(...)
 
-# Let MFGarchon choose based on geometry
+# Let MFGArchon choose based on geometry
 result = problem.solve()
 ```
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,4 +1,4 @@
-# MFGarchon Architecture Documentation
+# MFGArchon Architecture Documentation
 
 **Last Updated**: 2025-12-14
 **Current Version**: v0.16.8
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This directory contains architecture documentation for MFGarchon. Historical audit documents and completed phase plans have been archived to `docs/archive/historical/`.
+This directory contains architecture documentation for MFGArchon. Historical audit documents and completed phase plans have been archived to `docs/archive/historical/`.
 
 ## Current Architecture
 
@@ -69,7 +69,7 @@ This directory contains architecture documentation for MFGarchon. Historical aud
 | `GEOMETRY_AND_TOPOLOGY.md` | Geometry trait system design |
 | `FACTORY_PATTERN_DESIGN.md` | Three-concern factory architecture |
 | `proposals/DIMENSION_AGNOSTIC_FDM_ANALYSIS.md` | FDM extension analysis |
-| `proposals/MFGarchon_ARCHITECTURE_REFACTOR_PROPOSAL.md` | Long-term refactoring plan |
+| `proposals/MFGArchon_ARCHITECTURE_REFACTOR_PROPOSAL.md` | Long-term refactoring plan |
 | `proposals/EXTERNAL_PDE_INTEROPERABILITY_PROPOSAL.md` | **[DEFERRED]** External PDE framework interop & problem extension (post-v1.0) |
 
 ## Archived Documents

--- a/docs/architecture/dimension_agnostic_solvers.md
+++ b/docs/architecture/dimension_agnostic_solvers.md
@@ -1,6 +1,6 @@
 # Dimension-Agnostic MFG Solver Landscape
 
-**Purpose**: Comprehensive overview of dimension-agnostic approaches for Mean Field Games in MFGarchon
+**Purpose**: Comprehensive overview of dimension-agnostic approaches for Mean Field Games in MFGArchon
 **Date**: 2025-10-31
 **Status**: Living document
 
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-MFGarchon supports multiple strategies for solving Mean Field Games in arbitrary dimensions (2D, 3D, 4D, ...). This document categorizes approaches by:
+MFGArchon supports multiple strategies for solving Mean Field Games in arbitrary dimensions (2D, 3D, 4D, ...). This document categorizes approaches by:
 - **Grid structure**: Regular vs irregular vs dynamic
 - **Dimension handling**: Direct vs dimensional splitting
 - **Implementation status**: Production vs research
@@ -233,7 +233,7 @@ where S_i(Δt) is the solution operator for dimension i.
 
 **Approach**: Meshfree method using local polynomial approximation
 **Key Idea**: Compute derivatives from scattered neighbors via least squares
-**Implementation**: Production-ready in MFGarchon
+**Implementation**: Production-ready in MFGArchon
 
 ### Algorithm
 
@@ -393,7 +393,7 @@ where w_j are weights (e.g., inverse distance).
 
 **Location**: `mfg-research/algorithms/particle_collocation/`
 
-> **Note**: For basic meshfree density evolution in MFGarchon, use `FPGFDMSolver`.
+> **Note**: For basic meshfree density evolution in MFGArchon, use `FPGFDMSolver`.
 > This section describes more advanced fully-Lagrangian research methods.
 
 ### Algorithm
@@ -502,7 +502,7 @@ Different MFG problems have different needs:
 
 ### Principle 3: Production + Research
 
-- **Production code** (MFGarchon): Stable, tested, documented
+- **Production code** (MFGArchon): Stable, tested, documented
 - **Research code** (mfg-research): Experimental, flexible, evolving
 - Clear separation prevents research instability from affecting production
 
@@ -631,7 +631,7 @@ START: Need to solve nD MFG problem
 
 ## Related Documentation
 
-### MFGarchon
+### MFGArchon
 
 - `docs/architecture/README.md`: Overall architecture
 - `docs/architecture/proposals/DIMENSION_AGNOSTIC_FDM_ANALYSIS.md`: FDM splitting design
@@ -666,4 +666,4 @@ START: Need to solve nD MFG problem
 
 **Document Version**: 1.0
 **Last Updated**: 2025-10-31
-**Maintainer**: MFGarchon Development Team
+**Maintainer**: MFGArchon Development Team

--- a/docs/architecture/proposals/EXTERNAL_PDE_INTEROPERABILITY_PROPOSAL.md
+++ b/docs/architecture/proposals/EXTERNAL_PDE_INTEROPERABILITY_PROPOSAL.md
@@ -10,11 +10,11 @@
 
 ## 1. Executive Summary
 
-This document analyzes MFGarchon's structural relationship to general PDE frameworks and proposes a phased interoperability strategy. Implementation is deferred, but the analysis and design thinking are recorded now while the strategic context is fresh.
+This document analyzes MFGArchon's structural relationship to general PDE frameworks and proposes a phased interoperability strategy. Implementation is deferred, but the analysis and design thinking are recorded now while the strategic context is fresh.
 
-**Core observation**: Mean Field Games are inherently PDE-constrained optimal control problems. The HJB equation *is* the optimality condition for controlling the Fokker-Planck dynamics. As MFGarchon matures toward richer problem classes (state constraints, multi-physics coupling, PDE control), interaction with general PDE solvers becomes structurally necessary, not merely convenient.
+**Core observation**: Mean Field Games are inherently PDE-constrained optimal control problems. The HJB equation *is* the optimality condition for controlling the Fokker-Planck dynamics. As MFGArchon matures toward richer problem classes (state constraints, multi-physics coupling, PDE control), interaction with general PDE solvers becomes structurally necessary, not merely convenient.
 
-**Core thesis**: MFGarchon should remain the specialized orchestrator for MFG-specific logic (backward-forward coupling, density-value iteration, control extraction), while providing clean delegation interfaces for the generic PDE capabilities that external frameworks do better (complex geometry, advanced discretization, parallel linear algebra).
+**Core thesis**: MFGArchon should remain the specialized orchestrator for MFG-specific logic (backward-forward coupling, density-value iteration, control extraction), while providing clean delegation interfaces for the generic PDE capabilities that external frameworks do better (complex geometry, advanced discretization, parallel linear algebra).
 
 **Current State**: Self-contained with NumPy/SciPy. No external PDE framework integration. Problem definition limited to standard separable HJB-FP coupling.
 
@@ -45,9 +45,9 @@ And the optimal control is recovered from the value function: $\alpha^* = -D_p H
 
 This structure has three consequences for interoperability:
 
-1. **The FP equation is the "physics"** --- any enrichment of the underlying dynamics (convection, reaction, nonlinear diffusion, obstacles) directly changes the PDE constraint, requiring PDE solver capabilities beyond what MFGarchon currently provides.
+1. **The FP equation is the "physics"** --- any enrichment of the underlying dynamics (convection, reaction, nonlinear diffusion, obstacles) directly changes the PDE constraint, requiring PDE solver capabilities beyond what MFGArchon currently provides.
 
-2. **The HJB equation adapts automatically** --- when the FP constraint changes, the adjoint (HJB) equation changes correspondingly. The Hamiltonian encodes this relationship. MFGarchon's Hamiltonian class hierarchy is well-positioned to express these variations.
+2. **The HJB equation adapts automatically** --- when the FP constraint changes, the adjoint (HJB) equation changes correspondingly. The Hamiltonian encodes this relationship. MFGArchon's Hamiltonian class hierarchy is well-positioned to express these variations.
 
 3. **New problem classes = new PDE constraints** --- MFG with congestion, MFG with obstacles, MFG on networks with continuum limits, multi-population MFG with inter-species dynamics --- all introduce additional PDE components that may benefit from external solver capabilities.
 
@@ -66,12 +66,12 @@ This structure has three consequences for interoperability:
 
 These are not speculative. Published MFG literature covers all of these, and any serious MFG infrastructure will eventually need to handle a subset.
 
-### 2.3 What MFGarchon Owns vs. What It Delegates
+### 2.3 What MFGArchon Owns vs. What It Delegates
 
-The key architectural question is: **where does MFGarchon's responsibility end and the external framework's begin?**
+The key architectural question is: **where does MFGArchon's responsibility end and the external framework's begin?**
 
 ```
-MFGarchon's Domain (KEEP)                External Framework's Domain (DELEGATE)
+MFGArchon's Domain (KEEP)                External Framework's Domain (DELEGATE)
 ┌─────────────────────────┐            ┌─────────────────────────────────┐
 │ Problem definition:     │            │ Spatial discretization:         │
 │   Hamiltonian H(x,m,p,t)│            │   FEM assembly on complex mesh  │
@@ -95,7 +95,7 @@ MFGarchon's Domain (KEEP)                External Framework's Domain (DELEGATE)
 └─────────────────────────┘            └─────────────────────────────────┘
 ```
 
-**Principle**: MFGarchon is the **control-theoretic orchestrator**. External frameworks are **computational backends**.
+**Principle**: MFGArchon is the **control-theoretic orchestrator**. External frameworks are **computational backends**.
 
 ---
 
@@ -111,24 +111,24 @@ MFGarchon's Domain (KEEP)                External Framework's Domain (DELEGATE)
 | **Trilinos** | C++ | Linear algebra toolkit | Modular solver packages | Alternative to PETSc |
 | **OpenFOAM** | C++ | FVM | CFD | Fluid-coupled MFG |
 | **SciML (Julia)** | Julia | Multi-paradigm | ML + PDE, multiple dispatch | Autodiff, neural operators |
-| **Firedrake** | Python/C | FEM (variational) | Composable solvers, PETSc backend | Closest philosophy to MFGarchon |
+| **Firedrake** | Python/C | FEM (variational) | Composable solvers, PETSc backend | Closest philosophy to MFGArchon |
 | **scikit-fem** | Python | FEM | Lightweight, Pythonic | Quick FEM prototyping |
 | **DUNE** | C++ | Multi-method | Flexible grid interface | Advanced discretization |
 
-### 3.2 Why MFGarchon Is Not (and Should Not Become) a General PDE Framework
+### 3.2 Why MFGArchon Is Not (and Should Not Become) a General PDE Framework
 
-MFGarchon exploits the specific **structure of the HJB-FP coupling**:
+MFGArchon exploits the specific **structure of the HJB-FP coupling**:
 
 1. **Backward-forward time structure**: HJB solves backward, FP solves forward. General frameworks don't optimize for this.
 2. **Picard iteration semantics**: The outer loop alternates between two PDEs with coupling through density $m$ and value function $u$. This is domain-specific.
-3. **Control-theoretic quantities**: $D_pH$ (optimal control), $D_mH$ (density coupling) are first-class objects in MFGarchon; in a general framework they would be user-level derived quantities.
+3. **Control-theoretic quantities**: $D_pH$ (optimal control), $D_mH$ (density coupling) are first-class objects in MFGArchon; in a general framework they would be user-level derived quantities.
 4. **Validation semantics**: Mass conservation $\int m \, dx = 1$, coupled convergence criteria, adjoint-consistent boundary conditions --- all MFG-specific invariants.
 
 General frameworks provide the building blocks (mesh, assembly, linear solve) but not the orchestration logic.
 
 ### 3.3 Capability Comparison
 
-| Criterion | MFGarchon (Specialized) | General PDE Framework |
+| Criterion | MFGArchon (Specialized) | General PDE Framework |
 |:----------|:----------------------|:----------------------|
 | **HJB-FP coupling** | Native, optimized | Manual, no special support |
 | **Complex geometry** | Limited (structured grids, GFDM) | Full (unstructured, AMR) |
@@ -144,10 +144,10 @@ General frameworks provide the building blocks (mesh, assembly, linear solve) bu
 
 ### 4.1 Design Principle
 
-MFGarchon delegates to external frameworks at well-defined boundaries, without coupling its internal representations to any specific external API. The adapter pattern keeps MFGarchon's core independent.
+MFGArchon delegates to external frameworks at well-defined boundaries, without coupling its internal representations to any specific external API. The adapter pattern keeps MFGArchon's core independent.
 
 ```
-MFGarchon Core          Adapter Layer           External Framework
+MFGArchon Core          Adapter Layer           External Framework
 +--------------+     +---------------+     +------------------+
 | MFGProblem   |---->| GeometryExport|---->| FEniCS Mesh      |
 | HJB/FP solve |     | FieldExport   |     | PETSc Mat/Vec    |
@@ -201,7 +201,7 @@ class FieldExporter(Protocol):
 
 
 class GeometryAdapter(Protocol):
-    """Convert between MFGarchon geometry and external mesh formats."""
+    """Convert between MFGArchon geometry and external mesh formats."""
 
     def to_meshio(self, geometry: GeometryProtocol) -> meshio.Mesh: ...
     def from_meshio(self, mesh: meshio.Mesh) -> GeometryProtocol: ...
@@ -209,9 +209,9 @@ class GeometryAdapter(Protocol):
 
 #### Tier 2: Solver Backend Delegation (Medium cost, targeted value)
 
-Replace internal linear algebra with external solvers at runtime. MFGarchon's discretization and iteration logic remain unchanged; only the inner $Ax = b$ solve is delegated.
+Replace internal linear algebra with external solvers at runtime. MFGArchon's discretization and iteration logic remain unchanged; only the inner $Ax = b$ solve is delegated.
 
-**Current internal state** --- MFGarchon already has partial infrastructure for this tier:
+**Current internal state** --- MFGArchon already has partial infrastructure for this tier:
 
 - **`SparseSolver`** (`mfgarchon/utils/sparse_operations.py:466-620`): Unified interface supporting `direct`/`cg`/`gmres`/`bicgstab` methods with ILU/Jacobi preconditioning and CuPy GPU backend. However, only 1-2 files use it; the remaining ~15 `spsolve` call sites across 9 files (`hjb_gfdm.py`, `base_hjb.py`, `fp_fdm.py`, `fp_fdm_time_stepping.py`, `fp_network.py`, `hjb_network.py`, `nonlinear_solvers.py`, `sparse_operations.py`, `optimization.py`) bypass it with direct `scipy.sparse.linalg.spsolve` imports.
 - **`BaseBackend`** (`mfgarchon/backends/`): Array operation abstraction (NumPy, JAX, PyTorch, Numba) with a `solve(A, b)` method, but for **dense** systems only. Sparse linear algebra is not covered by the backend hierarchy.
@@ -225,7 +225,7 @@ Replace internal linear algebra with external solvers at runtime. MFGarchon's di
 class LinearSolverBackend(Protocol):
     """Pluggable linear solver backend.
 
-    MFGarchon assembles the system; the backend solves it.
+    MFGArchon assembles the system; the backend solves it.
     This is the narrowest possible delegation boundary.
     """
 
@@ -284,20 +284,20 @@ class PETScSolver:
 
 **Why PETSc first**:
 - Operates at linear algebra level --- minimal semantic gap
-- MFGarchon keeps full control of FDM/GFDM discretization and Picard iteration
+- MFGArchon keeps full control of FDM/GFDM discretization and Picard iteration
 - `petsc4py` is mature and well-maintained
 - Immediate benefit: parallel solvers, AMG preconditioners for large 2D/3D problems
-- No changes to MFGarchon's problem definition or solver structure
+- No changes to MFGArchon's problem definition or solver structure
 
-**Integration point in MFGarchon**: The `LinearSolverBackend` would be injected into HJB/FP solvers where they currently call `scipy.sparse.linalg.spsolve`. This is a single point of delegation per solver.
+**Integration point in MFGArchon**: The `LinearSolverBackend` would be injected into HJB/FP solvers where they currently call `scipy.sparse.linalg.spsolve`. This is a single point of delegation per solver.
 
 #### Tier 3: Discretization Delegation (High cost, specialized value)
 
-Full coupling where an external framework handles spatial discretization while MFGarchon orchestrates the MFG-specific backward-forward iteration.
+Full coupling where an external framework handles spatial discretization while MFGArchon orchestrates the MFG-specific backward-forward iteration.
 
-**Scenario**: FEniCS assembles FEM stiffness matrices for the HJB equation on a complex 2D domain with holes. MFGarchon's Picard iterator calls FEniCS at each iteration to solve the spatial problem, then feeds the result into the FP solver.
+**Scenario**: FEniCS assembles FEM stiffness matrices for the HJB equation on a complex 2D domain with holes. MFGArchon's Picard iterator calls FEniCS at each iteration to solve the spatial problem, then feeds the result into the FP solver.
 
-**Key design decision**: The `SpatialSolverBackend` should NOT have MFG-specific methods like `solve_hjb_step()` or `solve_fp_step()`. That would leak MFG semantics into what should be a generic spatial solver. Instead, MFGarchon's Picard iterator translates MFG semantics into generic PDE coefficients, and the backend sees only a general evolution PDE.
+**Key design decision**: The `SpatialSolverBackend` should NOT have MFG-specific methods like `solve_hjb_step()` or `solve_fp_step()`. That would leak MFG semantics into what should be a generic spatial solver. Instead, MFGArchon's Picard iterator translates MFG semantics into generic PDE coefficients, and the backend sees only a general evolution PDE.
 
 **Why not `ParabolicCoefficients`?** The name "parabolic" assumes second-order MFG ($\sigma > 0$). But first-order MFG ($\sigma = 0$) produces a Hamilton-Jacobi equation (hyperbolic HJB) and a continuity equation (hyperbolic FP). Nonlinear diffusion, obstacle problems, and conservation laws further blur PDE type boundaries. The structure we actually need is the **convection-diffusion-reaction (CDR) form** --- a type-agnostic representation of a linearized evolution PDE at each Picard step:
 
@@ -319,7 +319,7 @@ class PDECoefficients:
     - D = 0, v = 0, R ≠ 0: reaction equation
     - Steady state (no ∂t): elliptic (Poisson, Laplace)
 
-    MFGarchon maps both HJB and FP to this form before delegation.
+    MFGArchon maps both HJB and FP to this form before delegation.
     The backend never sees MFG-specific types.
     """
     diffusion: np.ndarray | float       # D(x): diffusion coefficient or tensor (0 for 1st-order MFG)
@@ -332,7 +332,7 @@ class SpatialSolverBackend(Protocol):
     """Delegate spatial PDE solve to an external framework.
 
     The backend is PDE-generic: it sees evolution equations in CDR
-    coefficient form, NOT MFG-specific quantities. MFGarchon's Picard
+    coefficient form, NOT MFG-specific quantities. MFGArchon's Picard
     iterator handles the translation.
     """
 
@@ -354,7 +354,7 @@ class SpatialSolverBackend(Protocol):
         ...
 ```
 
-**How MFGarchon maps to CDR coefficients** --- the Picard iterator translates MFG semantics at each iteration:
+**How MFGArchon maps to CDR coefficients** --- the Picard iterator translates MFG semantics at each iteration:
 
 ```
 Second-order MFG (σ > 0):
@@ -398,26 +398,26 @@ First-order MFG (σ = 0):
         # Backend must use conservative discretization
 ```
 
-This separation means: (a) the backend adapter is reusable for any evolution PDE, not just MFG; (b) new MFG problem classes only require new coefficient mappings in the iterator, not new backend methods; (c) the backend never imports MFGarchon types; (d) first-order and second-order MFG use the same interface, differing only in coefficient values.
+This separation means: (a) the backend adapter is reusable for any evolution PDE, not just MFG; (b) new MFG problem classes only require new coefficient mappings in the iterator, not new backend methods; (c) the backend never imports MFGArchon types; (d) first-order and second-order MFG use the same interface, differing only in coefficient values.
 
 **Challenges** (honest assessment):
 
 | Challenge | Description | Severity |
 |:----------|:-----------|:---------|
-| DOF ordering | FEniCS numbers unknowns differently than MFGarchon's structured grids | High |
+| DOF ordering | FEniCS numbers unknowns differently than MFGArchon's structured grids | High |
 | Quadrature mismatch | Different numerical integration rules give slightly different matrices | Medium |
-| Time discretization mismatch | MFGarchon defaults to backward Euler; external frameworks may use Crank-Nicolson or $\theta$-schemes. Different time integrators produce different spatial operators at each step. If the HJB backend uses a different temporal scheme than the FP backend, the Picard iteration may not converge to the correct coupled solution. **Mitigation**: the `PDECoefficients` + `dt` interface above intentionally delegates only the spatial discretization per time step, keeping time stepping under MFGarchon's control. | High |
+| Time discretization mismatch | MFGArchon defaults to backward Euler; external frameworks may use Crank-Nicolson or $\theta$-schemes. Different time integrators produce different spatial operators at each step. If the HJB backend uses a different temporal scheme than the FP backend, the Picard iteration may not converge to the correct coupled solution. **Mitigation**: the `PDECoefficients` + `dt` interface above intentionally delegates only the spatial discretization per time step, keeping time stepping under MFGArchon's control. | High |
 | Scheme selection for hyperbolic case | When $D = 0$ (first-order MFG), the backend must use upwind/Godunov schemes, not central differences. The `PDECoefficients` interface must communicate whether the PDE is advection-dominated so the backend selects an appropriate discretization. | Medium |
 | Memory ownership | Python ↔ C++ boundary requires careful reference management | Medium |
 | Error debugging | Failures span two frameworks with different error models | High |
-| Conceptual gap | FEniCS: variational forms. MFGarchon: finite differences. Different abstractions. | High |
+| Conceptual gap | FEniCS: variational forms. MFGArchon: finite differences. Different abstractions. | High |
 | Performance | Format conversion overhead may negate solver speedup for small problems | Medium |
 
 **Estimated effort**: Multi-person-month per adapter. Justified only when MFG research requires complex 2D/3D geometry that structured grids cannot handle.
 
 #### Tier 4: Auxiliary PDE Solver Plugins (Medium cost, high research value)
 
-MFGarchon calls external solvers for **auxiliary equations** that arise in extended MFG formulations, while the core HJB-FP coupling remains internal.
+MFGArchon calls external solvers for **auxiliary equations** that arise in extended MFG formulations, while the core HJB-FP coupling remains internal.
 
 ```python
 class AuxiliarySolverPlugin(Protocol):
@@ -436,7 +436,7 @@ class AuxiliarySolverPlugin(Protocol):
         boundary_conditions: BoundaryConditions | None,
         **params: Any,
     ) -> np.ndarray:
-        """Solve the auxiliary equation, return field on MFGarchon's grid."""
+        """Solve the auxiliary equation, return field on MFGArchon's grid."""
         ...
 
     @property
@@ -445,7 +445,7 @@ class AuxiliarySolverPlugin(Protocol):
         ...
 ```
 
-**Why this tier is valuable**: Many MFG extensions need a "pre-computed field" (distance to obstacle, background velocity, external potential) that is computed once or infrequently, then fed into the Hamiltonian. This is a **loose coupling** --- the auxiliary solve is essentially a preprocessing step. The semantic gap is small because MFGarchon only needs the result as a numpy array on its grid.
+**Why this tier is valuable**: Many MFG extensions need a "pre-computed field" (distance to obstacle, background velocity, external potential) that is computed once or infrequently, then fed into the Hamiltonian. This is a **loose coupling** --- the auxiliary solve is essentially a preprocessing step. The semantic gap is small because MFGArchon only needs the result as a numpy array on its grid.
 
 **Examples**:
 - `EikonalPlugin(scikit_fmm)`: Compute signed distance field for obstacle avoidance
@@ -503,7 +503,7 @@ Agents move in a physical environment governed by its own PDE:
 
 Each coupling adds a PDE that must be solved at each Picard iteration.
 
-### 5.2 Extension Architecture: How MFGarchon Should Grow
+### 5.2 Extension Architecture: How MFGArchon Should Grow
 
 Rather than building a generic extension framework now, identify the **minimal structural changes** that would make future extensions clean.
 
@@ -523,7 +523,7 @@ Each hook is independent — implementing one doesn't require the others:
 
 #### 5.2.1 Hamiltonian Extensibility (Already Good)
 
-MFGarchon's `HamiltonianBase` class hierarchy already supports custom Hamiltonians:
+MFGArchon's `HamiltonianBase` class hierarchy already supports custom Hamiltonians:
 
 ```python
 class CongestionHamiltonian(HamiltonianBase):
@@ -568,7 +568,7 @@ class AuxiliaryField:
     as a penalty: H(x,m,p,t) = H_0(p,m) + λ/d(x)
     """
     name: str
-    values: np.ndarray          # On MFGarchon's spatial grid
+    values: np.ndarray          # On MFGArchon's spatial grid
     solver: AuxiliarySolverPlugin | None  # Optional: recompute during iteration
 
     def needs_update(self, iteration: int) -> bool:
@@ -681,7 +681,7 @@ def test_petsc_solver_matches_scipy():
 1. Implement the extension as a prototype in mfg-research
 2. Validate on research experiments with quantified metrics
 3. Extract the minimal necessary abstraction
-4. Add to MFGarchon with tests and documentation
+4. Add to MFGArchon with tests and documentation
 5. Update this document with lessons learned
 
 ---

--- a/docs/architecture/proposals/MFGARCHON_ARCHITECTURE_REFACTOR_PROPOSAL.md
+++ b/docs/architecture/proposals/MFGARCHON_ARCHITECTURE_REFACTOR_PROPOSAL.md
@@ -1,4 +1,4 @@
-# MFGarchon Architecture Refactoring Proposal: Unified Problem Interface
+# MFGArchon Architecture Refactoring Proposal: Unified Problem Interface
 
 **Date**: 2025-10-30
 **Status**: ~~Proposal~~ **SUPERSEDED**
@@ -8,11 +8,11 @@
 
 ## ⚠️ PROPOSAL SUPERSEDED - DO NOT IMPLEMENT ⚠️
 
-**This proposal has been superseded by the current MFGarchon architecture.**
+**This proposal has been superseded by the current MFGArchon architecture.**
 
 ### Why This Proposal Was Not Implemented
 
-After thorough analysis during Phase 3 gradient notation standardization (October 2025), we discovered that the **current MFGarchon architecture already achieves all the goals of this proposal** through a superior design pattern:
+After thorough analysis during Phase 3 gradient notation standardization (October 2025), we discovered that the **current MFGArchon architecture already achieves all the goals of this proposal** through a superior design pattern:
 
 **Current Design (Implemented)**:
 - ✅ Concrete `MFGProblem` class with **composition via `MFGComponents`**
@@ -46,7 +46,7 @@ This proves the current architecture is **excellent** and does **not** need the 
 
 ### Conclusion
 
-**DO NOT implement this proposal.** The current MFGarchon architecture already provides:
+**DO NOT implement this proposal.** The current MFGArchon architecture already provides:
 - Composition over inheritance (via MFGComponents)
 - Solver flexibility (via protocol interfaces)
 - Progressive complexity disclosure (ExampleMFGProblem → MFGProblem)
@@ -58,7 +58,7 @@ The original proposal text below is preserved for historical reference only.
 
 ## Executive Summary (HISTORICAL - DO NOT IMPLEMENT)
 
-MFGarchon currently has three separate problem classes (`MFGProblem`, `HighDimMFGProblem`, `NetworkMFGProblem`) with incompatible APIs and different spatial discretization assumptions. This creates artificial limitations where:
+MFGArchon currently has three separate problem classes (`MFGProblem`, `HighDimMFGProblem`, `NetworkMFGProblem`) with incompatible APIs and different spatial discretization assumptions. This creates artificial limitations where:
 
 - FDM solvers only work with 1D problems
 - GFDM solvers only work with high-dimensional implicit geometry
@@ -690,14 +690,14 @@ solver = HJBFDMSolver(problem, Nx=100)
 
 ## Conclusion
 
-The current MFGarchon architecture artificially limits solver applicability to specific problem types. The proposed refactoring:
+The current MFGArchon architecture artificially limits solver applicability to specific problem types. The proposed refactoring:
 
 - **Enables**: Using any solver with any compatible geometry
 - **Simplifies**: Adding new geometries and discretization methods
 - **Maintains**: Backward compatibility during migration
 - **Improves**: Code clarity and extensibility
 
-This refactoring aligns MFGarchon with modern computational frameworks and removes a major barrier to research flexibility.
+This refactoring aligns MFGArchon with modern computational frameworks and removes a major barrier to research flexibility.
 
 ---
 
@@ -707,4 +707,4 @@ This refactoring aligns MFGarchon with modern computational frameworks and remov
 3. Benchmark and validate
 4. Roll out migration plan
 
-**Contact**: Submit issues/PRs to MFGarchon repository with tag `architecture-refactor`
+**Contact**: Submit issues/PRs to MFGArchon repository with tag `architecture-refactor`

--- a/docs/architecture/spacetime-bc/CURRENT_STATE_ANALYSIS.md
+++ b/docs/architecture/spacetime-bc/CURRENT_STATE_ANALYSIS.md
@@ -43,14 +43,14 @@ existing code and identifies the real gaps.
 ### 2.3 What's Already Better Than the Spec
 
 1. **BCValueProvider pattern** (Issue #625): The spec's `DataField(array)` is static.
-   MFGarchon has *dynamic* providers that compute BC values from solver state each
+   MFGArchon has *dynamic* providers that compute BC values from solver state each
    iteration. This is more powerful.
 
 2. **5 matching modes**: The spec has 3 region types. BCSegment has 5 matching modes
    (boundary name, axis ranges, SDF region, normal direction, marked region name)
    with validated non-mixing rules.
 
-3. **Corner handling**: The spec mentions corner consistency briefly. MFGarchon has a
+3. **Corner handling**: The spec mentions corner consistency briefly. MFGArchon has a
    full corner handling subsystem (`boundary/corner/`) with strategies (priority,
    average, mollify) and particle reflection algorithms.
 

--- a/docs/architecture/spacetime-bc/PROJECT_EVALUATION.md
+++ b/docs/architecture/spacetime-bc/PROJECT_EVALUATION.md
@@ -20,7 +20,7 @@ The project's main contribution was validating that existing BC infrastructure i
 
 ### README.md
 **Purpose**: Project overview and scope guard.
-**Assessment**: Correctly distinguishes MFG infrastructure from general PDE framework. The scope guard ("MFGarchon is production MFG infrastructure, not a general PDE framework") is the most valuable sentence in the entire project.
+**Assessment**: Correctly distinguishes MFG infrastructure from general PDE framework. The scope guard ("MFGArchon is production MFG infrastructure, not a general PDE framework") is the most valuable sentence in the entire project.
 
 ### SPEC_SPACETIME_SOLVERS.md (MFG-SPEC-ST-0.8)
 **Proposes**: SpacetimeField, SpacetimeBoundaryData, TrajectorySolver protocol, SequentialMarchingSolver.

--- a/docs/architecture/spacetime-bc/README.md
+++ b/docs/architecture/spacetime-bc/README.md
@@ -8,7 +8,7 @@
 
 ## 1. Vision
 
-This project explores a paradigm shift for MFGarchon's PDE substrate:
+This project explores a paradigm shift for MFGArchon's PDE substrate:
 
 - **The Cylinder Manifold**: Treat time $t$ as a dimension parallel to space $x$.
   The computational domain becomes $\mathcal{Q} = [0,T] \times \Omega$.
@@ -20,7 +20,7 @@ This project explores a paradigm shift for MFGarchon's PDE substrate:
 
 ## 2. Scope Guard
 
-> **MFGarchon is production-ready infrastructure for Mean Field Games.**
+> **MFGArchon is production-ready infrastructure for Mean Field Games.**
 > It is NOT a general-purpose PDE framework.
 
 These specs contain ideas that serve MFG directly and ideas that belong

--- a/docs/architecture/spacetime-bc/SPEC_COMPOSITIONAL_BC.md
+++ b/docs/architecture/spacetime-bc/SPEC_COMPOSITIONAL_BC.md
@@ -14,7 +14,7 @@
 A boundary condition is not an object — it is a **modification** to the
 discrete operator. A complete BC is defined by 4 orthogonal axes.
 
-> **Implementation note**: MFGarchon already implements 3 of these 4 axes in
+> **Implementation note**: MFGArchon already implements 3 of these 4 axes in
 > `BCSegment`. The 4th axis (Enforcement) is correctly handled as a solver-side
 > concern via the applicator hierarchy. See `CURRENT_STATE_ANALYSIS.md` for mapping.
 
@@ -26,7 +26,7 @@ discrete operator. A complete BC is defined by 4 orthogonal axes.
 
 Defines which part of the geometry boundary the BC applies to.
 
-| Trait | Description | MFGarchon Mapping |
+| Trait | Description | MFGArchon Mapping |
 |:------|:------------|:----------------|
 | `GlobalBoundary` | Entire boundary | `BCSegment(boundary=None)` (no restriction) |
 | `TaggedRegion(ID)` | Marked boundary segment | `BCSegment(boundary="left")`, `.region_name` |
@@ -37,26 +37,26 @@ SDF region, normal direction, marked region name. Exceeds the spec.
 
 #### 2.2 Mathematical Type (what equation?)
 
-| Trait | Equation | MFGarchon Mapping |
+| Trait | Equation | MFGArchon Mapping |
 |:------|:---------|:----------------|
 | `Dirichlet` | $u = g$ | `BCType.DIRICHLET` |
 | `Neumann` | $\partial u / \partial n = g$ | `BCType.NEUMANN` |
 | `Robin` | $\alpha u + \beta \partial u / \partial n = g$ | `BCType.ROBIN` |
 | `Cauchy` | Both value and gradient | Not implemented (needed for high-order) |
 
-**Additional types in MFGarchon**: `PERIODIC`, `REFLECTING`, `NO_FLUX`,
+**Additional types in MFGArchon**: `PERIODIC`, `REFLECTING`, `NO_FLUX`,
 `EXTRAPOLATION_LINEAR`, `EXTRAPOLATION_QUADRATIC`.
 
 #### 2.3 Value Source (equals what?)
 
-| Trait | Description | Optimization | MFGarchon Mapping |
+| Trait | Description | Optimization | MFGArchon Mapping |
 |:------|:------------|:-------------|:----------------|
 | `Zero` | $g = 0$ (homogeneous) | Eliminate additions | `value=0.0` |
 | `Constant(c)` | $g = c$ | Scalar broadcast | `value=c` |
 | `Functional(func)` | $g = f(x, t)$ | JIT-compilable | `value=callable` |
 | `DataField(array)` | $g$ from discrete data | Direct indexing | `value=np.ndarray` |
 
-**MFGarchon extension**: `BCValueProvider` protocol for state-dependent values
+**MFGArchon extension**: `BCValueProvider` protocol for state-dependent values
 (e.g., `AdjointConsistentProvider` computes $g = -\sigma^2/2 \cdot \partial \ln(m)/\partial n$
 from current density). More powerful than static `DataField`.
 
@@ -94,7 +94,7 @@ from current density). More powerful than static `DataField`.
 
 - **Geometry side**: `get_boundary_nodes(tag_id)` via `FacetMarkers`.
 - **BC side**: Solver loops over node indices, applies Strong or Weak.
-- **MFGarchon**: `GeometryProtocol.get_boundary_indices()`, `get_boundary_regions()`.
+- **MFGArchon**: `GeometryProtocol.get_boundary_indices()`, `get_boundary_regions()`.
 
 #### Protocol B: Structured Grid
 
@@ -102,13 +102,13 @@ from current density). More powerful than static `DataField`.
 - **BC side**: JIT-compiled kernel loops on boundary slices
   (`field[0, :, :]`, `field[-1, :, :]`, etc.).
 - **Ghost Cell mode**: Geometry allocates halo layer; BC fills halo data.
-- **MFGarchon**: `FDMApplicator.apply_2d()` implements exactly this pattern.
+- **MFGArchon**: `FDMApplicator.apply_2d()` implements exactly this pattern.
 
 #### Protocol C: Level Set (Implicit Boundary)
 
 - **Geometry side**: Provides SDF $\phi(x)$.
 - **BC side**: Solver checks `sign(phi)` changes; triggers GhostFluid or penalty.
-- **MFGarchon**: `ImplicitApplicator` uses SDF but projection-based, not ghost fluid.
+- **MFGArchon**: `ImplicitApplicator` uses SDF but projection-based, not ghost fluid.
 
 ---
 

--- a/docs/architecture/spacetime-bc/SPEC_LINEAR_SOLVER.md
+++ b/docs/architecture/spacetime-bc/SPEC_LINEAR_SOLVER.md
@@ -9,7 +9,7 @@
 
 ## 1. Motivation
 
-Every implicit time step in MFGarchon ends with a linear solve: `A x = b`.
+Every implicit time step in MFGArchon ends with a linear solve: `A x = b`.
 The system matrix $A$ varies in structure depending on the PDE, discretization,
 and dimension. Currently, solver selection is manual — mostly `spsolve()` everywhere,
 with `splu()` in the implicit heat solver and iterative methods available but rarely used.

--- a/docs/architecture/spacetime-bc/SPEC_OPERATOR_SYSTEM.md
+++ b/docs/architecture/spacetime-bc/SPEC_OPERATOR_SYSTEM.md
@@ -9,7 +9,7 @@
 
 ## 1. Motivation
 
-MFGarchon has a mature operator library (`mfgarchon/operators/differential/`)
+MFGArchon has a mature operator library (`mfgarchon/operators/differential/`)
 with 8+ concrete operators inheriting from `scipy.sparse.linalg.LinearOperator`.
 Geometries advertise operator support via 4 protocol traits. This system works
 but has structural gaps:
@@ -161,7 +161,7 @@ class OperatorTraits:
 
 ```python
 class PDEOperator(LinearOperator):
-    """Base class for all MFGarchon differential operators.
+    """Base class for all MFGArchon differential operators.
 
     Extends scipy.sparse.linalg.LinearOperator with:
     - Operator traits (metadata)

--- a/docs/architecture/spacetime-bc/SPEC_PERIODIC_IMPLICIT.md
+++ b/docs/architecture/spacetime-bc/SPEC_PERIODIC_IMPLICIT.md
@@ -10,13 +10,13 @@
 ## 1. Overview: Topology vs. Function
 
 While periodic BCs on arbitrary implicit manifolds require complex tessellation,
-MFGarchon identifies canonical cases where $O(1)$ complexity is achievable.
+MFGArchon identifies canonical cases where $O(1)$ complexity is achievable.
 
 Two types of periodicity:
 - **Topological**: Domain connectivity wraps around (e.g., Torus).
 - **Functional**: The SDF $\phi(x)$ repeats in space (e.g., TPMS).
 
-**MFGarchon relevance**: Periodic domains arise in:
+**MFGArchon relevance**: Periodic domains arise in:
 - Homogenization-based MFG (periodic cost landscapes)
 - Crowd models on periodic structures (corridors, transit systems)
 - Mean field limit with wrap-around state space (angular variables)
@@ -37,7 +37,7 @@ Most common case. Used in DNS turbulence and homogenization.
 - **Kernel**: `idx_neighbor = (idx + stride) % total_size`
 - **Performance**: Zero memory overhead; ALU-only.
 
-**MFGarchon status**: Partially supported via `BCType.PERIODIC` and
+**MFGArchon status**: Partially supported via `BCType.PERIODIC` and
 `SupportsPeriodic` protocol. Modulo-based stencils implemented in
 `boundary/periodic.py`.
 

--- a/docs/architecture/spacetime-bc/SPEC_SPACETIME_SOLVERS.md
+++ b/docs/architecture/spacetime-bc/SPEC_SPACETIME_SOLVERS.md
@@ -10,7 +10,7 @@
 ## 1. Executive Summary
 
 This specification defines the architecture for **Time Integration** and
-**Global Solution** modules of MFGarchon. It marks a paradigm shift from
+**Global Solution** modules of MFGArchon. It marks a paradigm shift from
 imperative time-stepping loops to declarative **Space-Time Operators**.
 
 **Core Philosophy**:
@@ -58,7 +58,7 @@ $$
 
 ### 3.1 StoragePolicy (Memory Management)
 
-> **Status**: DEFERRED for MFGarchon v1.0. Documented for future reference.
+> **Status**: DEFERRED for MFGArchon v1.0. Documented for future reference.
 
 - **`InCore`**: Full trajectory $(N_t, N_x)$ in RAM/VRAM. Enables global optimization and AD.
 - **`Streaming`**: Only current time-slab stored. Standard time-stepping.

--- a/docs/architecture/spacetime-bc/SPEC_TIME_INTEGRATION.md
+++ b/docs/architecture/spacetime-bc/SPEC_TIME_INTEGRATION.md
@@ -9,7 +9,7 @@
 
 ## 1. Motivation
 
-MFGarchon's time integration is currently embedded inside individual solvers.
+MFGArchon's time integration is currently embedded inside individual solvers.
 Each solver owns its time loop, scheme selection, and step-size logic. This
 works for the current solver count (7 HJB + 4 FP) but creates issues:
 

--- a/docs/archive/COMPLETED_MIXED_BC_DESIGN.md
+++ b/docs/archive/COMPLETED_MIXED_BC_DESIGN.md
@@ -2,12 +2,12 @@
 
 **Status**: Planning Phase
 **Target**: v0.13.0
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team
 **Created**: 2025-11-23
 
 ## Executive Summary
 
-MFGarchon currently only supports **uniform** boundary conditions (periodic, Dirichlet, Neumann) across the entire domain boundary. This document proposes a design for **mixed boundary conditions**, where different BC types apply to different boundary segments.
+MFGArchon currently only supports **uniform** boundary conditions (periodic, Dirichlet, Neumann) across the entire domain boundary. This document proposes a design for **mixed boundary conditions**, where different BC types apply to different boundary segments.
 
 **Critical Use Case**: 2D crowd motion with exit (Dirichlet `u=0`) and reflective walls (Neumann `∂u/∂n=0`).
 

--- a/docs/archive/RESOLVED_FDM_SOLVER_LIMITATION_ANALYSIS.md
+++ b/docs/archive/RESOLVED_FDM_SOLVER_LIMITATION_ANALYSIS.md
@@ -20,13 +20,13 @@ User requested results from two MFG solver configurations:
 1. **Pure FDM**: HJB-FDM + FP-FDM (baseline comparison)
 2. **Hybrid**: HJB-FDM + FP-Particle
 
-The maze navigation problem is 2D (6×6 maze on regular grid), but FDM solvers in MFGarchon only work with 1D problems.
+The maze navigation problem is 2D (6×6 maze on regular grid), but FDM solvers in MFGArchon only work with 1D problems.
 
 ---
 
 ## Architecture Analysis
 
-### What Exists in MFGarchon
+### What Exists in MFGArchon
 
 **1D Grid-Based**: `MFGProblem` (mfg_problem.py:70)
 ```python
@@ -81,7 +81,7 @@ def create_1d_adapter_problem(self) -> MFGProblem:
     Create a 1D adapter MFG problem for use with existing solvers.
 
     This method maps the high-dimensional problem to a 1D representation
-    that can be used with the existing MFGarchon solver infrastructure.
+    that can be used with the existing MFGArchon solver infrastructure.
     """
     # Create 1D problem using linearized indexing of spatial points
     adapter_problem = MFGProblem(
@@ -128,7 +128,7 @@ FDM 1D neighbors: 3, 5 (only left/right)
 The FDM solver will compute `∂u/∂x` using indices `3, 4, 5`, which in the original 2D grid are `(0,1), (1,1), (2,1)` — a horizontal line, not a proper 2D derivative.
 
 ### 4. **Confirmed by Audit**
-The architecture audit (MFGarchon_ARCHITECTURE_AUDIT.md) identified this exact issue:
+The architecture audit (MFGArchon_ARCHITECTURE_AUDIT.md) identified this exact issue:
 - **Finding #2**: "Five problem classes with incompatible APIs"
 - **Finding #3**: "Solver-problem incompatibilities require workarounds"
 - **Finding #5**: "1D adapter pattern breaks semantics"
@@ -144,13 +144,13 @@ User asked for:
 
 **Fundamental Issue**:
 - Pure FDM (HJB-FDM + FP-FDM) requires both solvers to work with a regular 2D grid
-- MFGarchon's FDM solvers are 1D-only by design
+- MFGArchon's FDM solvers are 1D-only by design
 - The 1D adapter would produce mathematically incorrect results (wrong derivatives)
 
 **User's Insight Was Correct**:
 > "maze can still have grids under coordinate system ,right?"
 
-Yes, mazes can have regular grids! The problem is not mathematical — it's architectural. MFGarchon artificially separates:
+Yes, mazes can have regular grids! The problem is not mathematical — it's architectural. MFGArchon artificially separates:
 - Problem definition (`GridBasedMFGProblem` for 2D grids)
 - Solver implementation (`HJBFDMSolver` for 1D only)
 
@@ -224,7 +224,7 @@ Skip pure FDM comparison and note the architectural limitation. Focus on:
 
 **Verification**:
 ```bash
-$ ls -la /path/to/MFGarchon/mfgarchon/alg/numerical/hjb_solvers/ | grep hjb_fd
+$ ls -la /path/to/MFGArchon/mfgarchon/alg/numerical/hjb_solvers/ | grep hjb_fd
 -rw-r--r-- hjb_fdm.py  # Correct module name
 -rw-r--r-- hjb_gfdm.py  # Meshfree alternative (works for 2D)
 ```
@@ -238,7 +238,7 @@ This is honored in MFGProblem (Nx intervals → Nx+1 grid points), but the 1D-on
 
 ## Conclusion
 
-**Pure FDM comparison cannot be completed** due to MFGarchon's architectural limitation: FDM solvers are 1D-only, while the maze problem is inherently 2D.
+**Pure FDM comparison cannot be completed** due to MFGArchon's architectural limitation: FDM solvers are 1D-only, while the maze problem is inherently 2D.
 
 **User's request confirmed the architecture audit findings**: The fragmented design prevents natural use of grid-based solvers on 2D regular grids.
 

--- a/docs/archive/SUPERSEDED_ARCHITECTURE_AUDIT_ENRICHMENT.md
+++ b/docs/archive/SUPERSEDED_ARCHITECTURE_AUDIT_ENRICHMENT.md
@@ -1,8 +1,8 @@
-# MFGarchon Architecture Audit Enrichment: Evidence from Research
+# MFGArchon Architecture Audit Enrichment: Evidence from Research
 
 **Date**: 2025-10-30
 **Source**: Comprehensive analysis of mfg-research repository
-**Purpose**: Enrich MFGarchon architecture audit with empirical evidence from research sessions
+**Purpose**: Enrich MFGArchon architecture audit with empirical evidence from research sessions
 **Documents Analyzed**: 181 markdown files, 94 test/experiment files, 3 weeks of research sessions
 
 ---
@@ -39,7 +39,7 @@
 | 2025-10-20 | `ModuleNotFoundError: algorithms` | Python path issue after reorganization | Set PYTHONPATH manually | Blocked all experiment execution | `maze_navigation/archives/investigations_2025-10/completed_investigations/API_ISSUES_LOG.md` |
 | 2025-10-20 | Function `sample_particles_in_maze` doesn't exist | Function never implemented | Had to implement custom sampling | 2 hours investigating API | `maze_navigation/archives/investigations_2025-10/completed_investigations/API_ISSUES_LOG.md` |
 | 2025-10-24 | Hamiltonian receives wrong gradient keys | `maze_mfg_problem.py` used `'grad_u_x'` instead of `'dpx'` | Changed 2 characters (Bug #13) | 3 days debugging, entire MFG system broken | `docs/archived_bug_investigations/BUG_13_INDEX.md` |
-| 2025-10-26 | GFDM gradients have wrong sign | Line 453: `b = u_center - u_neighbors` | Changed to `b = u_neighbors - u_center` (Bug #14) | Agents move away from goals, MFG doesn't converge | `maze_navigation/archives/bugs/bug14_gfdm_sign/BUG_14_MFGarchon_REPORT.md` |
+| 2025-10-26 | GFDM gradients have wrong sign | Line 453: `b = u_center - u_neighbors` | Changed to `b = u_neighbors - u_center` (Bug #14) | Agents move away from goals, MFG doesn't converge | `maze_navigation/archives/bugs/bug14_gfdm_sign/BUG_14_MFGArchon_REPORT.md` |
 | 2025-10-26 | QP monotonicity checker calls `sigma**2` on method | `getattr(problem, "sigma")` returns method, not value | Created `SmartSigma` wrapper class (Bug #15) | Cannot validate QP constraints | `maze_navigation/archives/bugs/bug15_qp_sigma/BUG_15_QP_SIGMA_METHOD.md` |
 | 2025-10-29 | Anderson accelerator fails on 2D arrays | `np.column_stack` behavior difference for 1D vs 2D | Flatten before calling, reshape after | MFG density arrays naturally (Nt, N) shape | `maze_navigation/ANDERSON_ISSUE_POSTED.md` |
 | 2025-10-30 | Cannot use FDM solvers with 2D maze | FDM solvers only accept 1D `MFGProblem` | Impossible - switched to GFDM | BLOCKED: Pure FDM comparison for baseline | `maze_navigation/FDM_SOLVER_LIMITATION_ANALYSIS.md` |
@@ -48,7 +48,7 @@
 | 2025-10-27 | Grid-based problems cannot use particle FP solver | Type mismatch in `create_1d_adapter_problem()` | Manual adapter creation | Complex workaround code (50 lines) | `maze_navigation/archives/investigations_2025-10/api_unification_2025-10-27/API_MISMATCH_ANALYSIS.md` |
 | 2025-10-25 | QP constraints applied excessively | Called in every HJB iteration | Cached QP results | 100× speedup after fix | `maze_navigation/archives/bugs/bug15_qp_sigma/BUG_15_EXCESSIVE_QP_INVOCATIONS.md` |
 | 2025-10-22 | Gradient computation returns wrong derivative types | Expected 1D `float`, got 2D `dict` | Manual type conversion at every call site | Fragile adapter code | `maze_navigation/test_gfdm_derivative_types.py` |
-| 2025-10-20 | Hamiltonian signature incompatibility | MFGarchon expects `H(x, p, m)`, research code passes `H(**kwargs)` | Wrapper functions at every boundary | 150+ lines of adapter code | `maze_navigation/test_hamiltonian_types.py` |
+| 2025-10-20 | Hamiltonian signature incompatibility | MFGArchon expects `H(x, p, m)`, research code passes `H(**kwargs)` | Wrapper functions at every boundary | 150+ lines of adapter code | `maze_navigation/test_hamiltonian_types.py` |
 | 2025-10-17 | Cannot mix FDM-HJB with Particle-FP | Requires grid-to-particle interpolation | Feature abandoned | BLOCKED: Hybrid solver comparison | `docs/FP_PARTICLE_HYBRID_VS_COLLOCATION.md` |
 | 2025-10-16 | Network geometry not compatible with regular grids | `NetworkMFGProblem` uses graph structure | Separate code paths for network vs grid | Code duplication | `docs/HYBRID_SOLVER_INTERFACE_ANALYSIS.md` |
 | 2025-10-15 | Adaptive solver doesn't pass backend parameter | `create_fast_solver` ignores backend setting | Manual backend injection | GPU acceleration unavailable | `anisotropic_crowd_qp/research_logs/ADAPTIVE_SOLVER_FIX_2025-10-16.md` |
@@ -95,7 +95,7 @@
 **User's Insight**:
 > "maze can still have grids under coordinate system, right?"
 
-Yes - the maze HAS a regular grid. The problem is MFGarchon's artificial separation of problem definition (`GridBasedMFGProblem` for 2D) and solver implementation (`HJBFDMSolver` for 1D only).
+Yes - the maze HAS a regular grid. The problem is MFGArchon's artificial separation of problem definition (`GridBasedMFGProblem` for 2D) and solver implementation (`HJBFDMSolver` for 1D only).
 
 ---
 
@@ -139,7 +139,7 @@ M_new = M_new_flat.reshape(shape_2d)
 2. **Excessive QP Invocations**: QP solver called 12000+ times per iteration
    - **Cause**: No caching of QP results
    - **Impact**: 50ms × 12000 = 10 minutes per iteration
-   - **Fix**: Add caching logic (not in MFGarchon)
+   - **Fix**: Add caching logic (not in MFGArchon)
    - **Time Lost**: 4 hours optimization
 
 3. **OSQP Performance**: Each QP call takes 50ms
@@ -211,7 +211,7 @@ M_new = M_new_flat.reshape(shape_2d)
    - Evidence: 6 different config imports across experiment files
 
 5. **"Hamiltonian signature keeps changing"**
-   - MFGarchon main: `H(x, p, m)`
+   - MFGArchon main: `H(x, p, m)`
    - GFDM: `H(t, x, p, m, sigma, **kwargs)`
    - Collocation: `H(**derivs)` where `derivs` is dictionary
    - Required 150+ lines of wrapper code to reconcile
@@ -247,7 +247,7 @@ M_new = M_new_flat.reshape(shape_2d)
    - Evidence: `anisotropic_crowd_qp/docs/phase_history/PHASE2_CRITICAL_BUG_REPORT.md`
 
 2. **"Can we use GPU acceleration?"**
-   - MFGarchon has `torch_backend.py`
+   - MFGArchon has `torch_backend.py`
    - BUT: Not wired through `create_fast_solver()`
    - Workaround: Manual backend injection
    - Status: **GPU acceleration unavailable** in practice
@@ -351,7 +351,7 @@ Gradient approximation: ∇u^(k) ≈ GFDM_gradient(u, X, k)
 
 ### 3.4 Notation Inconsistencies Discovered
 
-**Problem**: MFGarchon uses different notations for gradients across modules:
+**Problem**: MFGArchon uses different notations for gradients across modules:
 
 | Module | Gradient Notation | Example | Dimension Handling |
 |--------|-------------------|---------|-------------------|
@@ -589,7 +589,7 @@ def solve_hjb_system_2d(self, M_density, U_final, ...):
 ```
 
 **Effort to implement**: ~200 lines, 2-3 days
-**Status**: Not implemented in MFGarchon
+**Status**: Not implemented in MFGArchon
 
 ---
 
@@ -604,7 +604,7 @@ Discovered bugs:
 2. **Bug #15**: QP monotonicity check assumes numeric sigma
    - Impact: Cannot use QP constraints with particle methods
    - Workaround: `SmartSigma` class
-   - Status: Not fixed in MFGarchon
+   - Status: Not fixed in MFGArchon
 
 ---
 
@@ -664,7 +664,7 @@ if dimension not in [1, 2, 3]:
 **Impact**: Cannot create 4D, 5D, 6D problems
 **User Request**: 4D drone swarms, 5D portfolio optimization
 **Status**: **BLOCKED** by explicit check
-**Evidence**: `docs/MFGarchon_NDIM_ISSUE_DRAFT.md`
+**Evidence**: `docs/MFGArchon_NDIM_ISSUE_DRAFT.md`
 
 ---
 
@@ -862,7 +862,7 @@ class MazeNavigationMFG(HighDimMFGProblem):
 **1. Particle Sampling in Domains with Obstacles** (~80 lines)
 
 ```python
-# Should exist in MFGarchon geometry module, but doesn't
+# Should exist in MFGArchon geometry module, but doesn't
 def sample_particles_in_domain_with_obstacles(domain, n_particles, obstacles):
     """Sample particles uniformly in domain, rejecting those in obstacles."""
     particles = []
@@ -881,7 +881,7 @@ def sample_particles_in_domain_with_obstacles(domain, n_particles, obstacles):
 **2. Particle-to-Grid Interpolation** (~120 lines)
 
 ```python
-# Should exist in MFGarchon as standard operation
+# Should exist in MFGArchon as standard operation
 def interpolate_particles_to_grid(values_particles, particle_positions, grid):
     """Interpolate particle values to regular grid."""
     # Kernel density estimation OR
@@ -898,7 +898,7 @@ def interpolate_particles_to_grid(values_particles, particle_positions, grid):
 **3. Grid-to-Particle Interpolation** (~100 lines)
 
 ```python
-# Should exist in MFGarchon as standard operation
+# Should exist in MFGArchon as standard operation
 def interpolate_grid_to_particles(values_grid, grid, particle_positions):
     """Interpolate grid values to particle positions."""
     # Bilinear/trilinear interpolation for regular grids
@@ -926,7 +926,7 @@ class AdaptiveNeighborhoods:
 
 **Research finding**: Fixed k_neighbors performs poorly near obstacles
 **Solution**: Custom adaptive selection (Bug #6 fix)
-**Status**: Implemented in research, NOT in MFGarchon
+**Status**: Implemented in research, NOT in MFGArchon
 **Evidence**: `maze_navigation/ADAPTIVE_NEIGHBORHOODS.md`
 
 ---
@@ -974,7 +974,7 @@ class QPConstraintCache:
 ```
 
 **Impact of NOT having this**: 100× slowdown (12000 QP solves per iteration)
-**Fix**: Custom caching (not in MFGarchon)
+**Fix**: Custom caching (not in MFGArchon)
 **Evidence**: Bug #15 investigation
 
 ---
@@ -1060,7 +1060,7 @@ class ConvergenceMonitor:
 | Convergence monitoring | 60 | 3 | 180 |
 | **TOTAL** | | | **1655** |
 
-**1655 lines of utility code that should be in MFGarchon but isn't.**
+**1655 lines of utility code that should be in MFGArchon but isn't.**
 
 ---
 
@@ -1221,7 +1221,7 @@ class ConvergenceMonitor:
 **Based on research blockers, these items block ALL progress**:
 
 #### Item 1: Fix Bug #15 (QP Sigma API)
-**Status**: Workaround exists (`SmartSigma`), not fixed in MFGarchon
+**Status**: Workaround exists (`SmartSigma`), not fixed in MFGArchon
 **Blocks**: QP-constrained particle collocation (major research direction)
 **Effort**: 1 day
 **Priority**: **CRITICAL - DO FIRST**
@@ -1516,7 +1516,7 @@ experiments/maze_navigation/
   archives/bugs/bug13_gfdm_gradient/
     [15 files - see BUG_13_INDEX.md for complete list]
   archives/bugs/bug14_gfdm_sign/
-    BUG_14_MFGarchon_REPORT.md
+    BUG_14_MFGArchon_REPORT.md
     BUG_14_GFDM_SIGN_ERROR.md
     BUG_14_STATUS_FINAL.md
     BUG_14_FIX_VERIFIED.md
@@ -1555,16 +1555,16 @@ experiments/maze_navigation/
 **Architecture Analysis** (5 files):
 ```
 experiments/maze_navigation/
-  MFGarchon_ARCHITECTURE_AUDIT.md (200+ pages)
+  MFGArchon_ARCHITECTURE_AUDIT.md (200+ pages)
   ARCHITECTURE_AUDIT_SUMMARY.md
   ARCHITECTURE_AUDIT_INDEX.md
   analysis/PARTICLE_COLLOCATION_ARCHITECTURE_ANALYSIS.md
 
 mfg-research/
-  MFGarchon_ARCHITECTURE_REFACTOR_PROPOSAL.md
+  MFGArchon_ARCHITECTURE_REFACTOR_PROPOSAL.md
 
 docs/
-  MFGarchon_NDIM_ISSUE_DRAFT.md
+  MFGArchon_NDIM_ISSUE_DRAFT.md
   HYBRID_SOLVER_INTERFACE_ANALYSIS.md
 ```
 
@@ -1740,7 +1740,7 @@ TypeError: unsupported operand type(s) for ** or pow(): 'method' and 'int'
 - Backend inaccessibility (MEDIUM)
 - Picard damping (LOW)
 
-### Recommendations for MFGarchon
+### Recommendations for MFGArchon
 
 **Immediate (2 weeks)**:
 1. Fix Bug #15 (sigma API) - 1 day
@@ -1788,12 +1788,12 @@ The original architecture audit identified the problems theoretically. This enri
 - Bugs analyzed: 5 (3 critical)
 
 **Cross-references**:
-- Original audit: MFGarchon_ARCHITECTURE_AUDIT.md
-- Refactoring proposal: MFGarchon_ARCHITECTURE_REFACTOR_PROPOSAL.md
+- Original audit: MFGArchon_ARCHITECTURE_AUDIT.md
+- Refactoring proposal: MFGArchon_ARCHITECTURE_REFACTOR_PROPOSAL.md
 - Research repository: 181 documentation files analyzed
 
 ---
 
 **Last Updated**: 2025-10-30
 **Authors**: Research team (mfg-research repository)
-**Status**: Complete and ready for MFGarchon maintainers review
+**Status**: Complete and ready for MFGArchon maintainers review

--- a/docs/archive/SUPERSEDED_ARCHITECTURE_AUDIT_SUMMARY.md
+++ b/docs/archive/SUPERSEDED_ARCHITECTURE_AUDIT_SUMMARY.md
@@ -1,7 +1,7 @@
-# MFGarchon Architecture Audit - Executive Summary
+# MFGArchon Architecture Audit - Executive Summary
 
 **Date**: 2025-10-30
-**Full Report**: See MFGarchon_ARCHITECTURE_AUDIT.md
+**Full Report**: See MFGArchon_ARCHITECTURE_AUDIT.md
 
 ---
 
@@ -412,7 +412,7 @@ From maze navigation research, adopt:
 
 **Key Takeaways**:
 
-1. **Diagnosis is correct** - MFGarchon needs unification
+1. **Diagnosis is correct** - MFGArchon needs unification
 2. **But solution is underspecified** - Missing critical infrastructure
 3. **And timeline is unrealistic** - 18 months, not weeks
 4. **And testing plan is absent** - Need comprehensive suite
@@ -429,5 +429,5 @@ From maze navigation research, adopt:
 ---
 
 **Document Prepared By**: MFG Research Team
-**Full Analysis**: MFGarchon_ARCHITECTURE_AUDIT.md (9 parts, 70+ pages)
+**Full Analysis**: MFGArchon_ARCHITECTURE_AUDIT.md (9 parts, 70+ pages)
 **Last Updated**: 2025-10-30

--- a/docs/archive/SUPERSEDED_AUDIT_ENRICHMENT_SUMMARY.md
+++ b/docs/archive/SUPERSEDED_AUDIT_ENRICHMENT_SUMMARY.md
@@ -57,13 +57,13 @@
 - **Root Cause**: Line 453: `b = u_center - u_neighbors` (should be reversed)
 - **Impact**: Agents move away from goals, MFG doesn't converge
 - **Status**: FIXED, merged, GitHub issue filed
-- **Evidence**: `experiments/maze_navigation/archives/bugs/bug14_gfdm_sign/BUG_14_MFGarchon_REPORT.md`
+- **Evidence**: `experiments/maze_navigation/archives/bugs/bug14_gfdm_sign/BUG_14_MFGArchon_REPORT.md`
 
 #### Bug #15: QP Sigma Type Error
 - **Symptom**: `TypeError: 'method' and 'int'` in QP monotonicity check
 - **Root Cause**: Code expects numeric `sigma`, particle methods use callable `sigma(x)`
 - **Impact**: Cannot use QP constraints without workaround
-- **Status**: Workaround exists (`SmartSigma`), NOT FIXED in MFGarchon
+- **Status**: Workaround exists (`SmartSigma`), NOT FIXED in MFGArchon
 - **Evidence**: `experiments/maze_navigation/archives/bugs/bug15_qp_sigma/BUG_15_QP_SIGMA_METHOD.md`
 
 ---
@@ -92,7 +92,7 @@
 | Component | Lines | Reason |
 |-----------|-------|--------|
 | Custom problem classes | 1,080 | Standard classes don't fit 2D+obstacles |
-| Utility functions | 1,655 | Missing from MFGarchon (interpolation, SDF, QP caching) |
+| Utility functions | 1,655 | Missing from MFGArchon (interpolation, SDF, QP caching) |
 | Adapter/wrapper code | 150 | Type incompatibilities |
 | Test workarounds | 400 | Broken solver combinations |
 
@@ -359,13 +359,13 @@ U, M, info = solution
 
 **Quick Links**:
 - Bug #13 Index: `docs/archived_bug_investigations/BUG_13_INDEX.md`
-- Bug #14 Report: `experiments/maze_navigation/archives/bugs/bug14_gfdm_sign/BUG_14_MFGarchon_REPORT.md`
+- Bug #14 Report: `experiments/maze_navigation/archives/bugs/bug14_gfdm_sign/BUG_14_MFGArchon_REPORT.md`
 - Bug #15 Analysis: `experiments/maze_navigation/archives/bugs/bug15_qp_sigma/BUG_15_QP_SIGMA_METHOD.md`
 - FDM Limitation: `experiments/maze_navigation/FDM_SOLVER_LIMITATION_ANALYSIS.md`
 - Anderson Issue: `experiments/maze_navigation/ANDERSON_ISSUE_POSTED.md`
-- Original Audit: `experiments/maze_navigation/MFGarchon_ARCHITECTURE_AUDIT.md`
+- Original Audit: `experiments/maze_navigation/MFGArchon_ARCHITECTURE_AUDIT.md`
 
 ---
 
-**Status**: Complete and ready for MFGarchon maintainers
+**Status**: Complete and ready for MFGArchon maintainers
 **Last Updated**: 2025-10-30

--- a/docs/archive/SUPERSEDED_MFGARCHON_ARCHITECTURE_AUDIT.md
+++ b/docs/archive/SUPERSEDED_MFGARCHON_ARCHITECTURE_AUDIT.md
@@ -1,4 +1,4 @@
-# [SUPERSEDED] MFGarchon Architecture Audit: Comprehensive Refactoring Critique
+# [SUPERSEDED] MFGArchon Architecture Audit: Comprehensive Refactoring Critique
 
 > **Superseded Note (2025-12-09)**: This audit contains outdated analysis. Key findings
 > have been addressed or found to be based on incomplete understanding:
@@ -10,14 +10,14 @@
 > significantly since this analysis. See current docs for accurate architecture info.
 
 **Date**: 2025-10-30
-**Purpose**: Validate refactoring proposal against actual MFGarchon architecture
+**Purpose**: Validate refactoring proposal against actual MFGArchon architecture
 **Context**: Analysis based on current codebase structure and maze navigation research findings
 
 ---
 
 ## Executive Summary
 
-This audit evaluates the proposed refactoring against the **actual** MFGarchon architecture as of commit 02e0066. The analysis reveals significant gaps between the idealized proposal and production reality.
+This audit evaluates the proposed refactoring against the **actual** MFGArchon architecture as of commit 02e0066. The analysis reveals significant gaps between the idealized proposal and production reality.
 
 **Key Findings**:
 - Proposal correctly identifies major pain points (dimensional limitations, API inconsistency)
@@ -116,7 +116,7 @@ def solve_hjb_system(self, M_density_evolution_from_FP, U_final_condition_at_T, 
 
 ### 2.1 Backend System (Not Mentioned)
 
-**Reality**: MFGarchon has a sophisticated backend abstraction layer.
+**Reality**: MFGArchon has a sophisticated backend abstraction layer.
 
 ```python
 # mfgarchon/backends/
@@ -180,7 +180,7 @@ def backend_aware_assign(target, indices, values, backend=None):
 
 ### 2.2 Configuration System (Oversimplified)
 
-**Reality**: MFGarchon has **three** configuration systems (not one).
+**Reality**: MFGArchon has **three** configuration systems (not one).
 
 ```python
 # mfgarchon/config/
@@ -334,7 +334,7 @@ def create_solver(problem, solver_type, config=None, backend="auto"):
 
 ### 2.4 Geometry System (More Complex Than Proposed)
 
-**Reality**: MFGarchon has dimension-specific geometry classes.
+**Reality**: MFGArchon has dimension-specific geometry classes.
 
 ```python
 # mfgarchon/geometry/
@@ -397,7 +397,7 @@ def create_solver(problem, solver_type, config=None, backend="auto"):
 
 ### 2.5 Plugin System (Completely Ignored)
 
-**Reality**: MFGarchon has an extensibility mechanism.
+**Reality**: MFGArchon has an extensibility mechanism.
 
 ```python
 # mfgarchon/core/plugin_system.py
@@ -467,12 +467,12 @@ Current Inventory:
    - HYBRID mode: Particles internally, grid output (1D)
    - COLLOCATION mode: Particles in, particles out (N-D)
 
-2. MFGarchon's FPParticleSolver - IMPLICIT HYBRID
+2. MFGArchon's FPParticleSolver - IMPLICIT HYBRID
    - Input: Grid density (Nx,)
    - Internal: Particles (sampled from grid)
    - Output: Grid density via KDE
 
-3. MFGarchon's HJBGFDMSolver - Flexible (not dual-mode)
+3. MFGArchon's HJBGFDMSolver - Flexible (not dual-mode)
    - Grid mode: Problem has Nx, maps grid → collocation
    - Collocation mode: No Nx, identity mapping
 ```
@@ -1367,7 +1367,7 @@ Plus:
 
 ### What We Learned
 
-1. **Proposal is directionally correct** - MFGarchon needs unification
+1. **Proposal is directionally correct** - MFGArchon needs unification
 2. **BUT significantly underestimates complexity** - 6-12 months, not weeks
 3. **AND misses critical infrastructure** - backends, factories, configs
 4. **AND overlooks existing solutions** - dual-mode patterns, geometry subsystem
@@ -1379,7 +1379,7 @@ Plus:
 1. Fix known bugs (Issue #14, #199)
 2. Graduate `PureParticleFPSolver` from research to production
 3. Document domain-solver compatibility matrix
-4. Add 2D maze navigation example to MFGarchon docs
+4. Add 2D maze navigation example to MFGArchon docs
 
 **Medium-term (Months 4-9)**:
 1. Implement Domain abstraction with backward compatibility
@@ -1397,7 +1397,7 @@ Plus:
 
 **Key Message to Proposal Author**:
 
-> Your diagnosis is correct - MFGarchon needs architectural improvements.
+> Your diagnosis is correct - MFGArchon needs architectural improvements.
 > However, this is not a simple refactoring. It's a **v2.0 → v3.0 redesign**.
 >
 > The codebase has:
@@ -1422,7 +1422,7 @@ Plus:
 
 **Document Prepared By**: MFG Research Team
 **Based On**:
-- MFGarchon codebase commit 02e0066
+- MFGArchon codebase commit 02e0066
 - Maze navigation research findings (PR #197)
 - Issues #14 (GFDM gradient), #199 (Anderson), #13 (Picard)
 - Analysis documents: SOLVER_ORGANIZATION_ANALYSIS.md, PURE_PARTICLE_FP_PROPOSAL.md

--- a/docs/archive/[COMPLETED]_DEPRECATION_AND_FIXES_SUMMARY_2025_11_23.md
+++ b/docs/archive/[COMPLETED]_DEPRECATION_AND_FIXES_SUMMARY_2025_11_23.md
@@ -1,8 +1,8 @@
-# MFGarchon Improvements Summary - 2025-11-23
+# MFGArchon Improvements Summary - 2025-11-23
 
 ## Overview
 
-This document summarizes three critical improvements to MFGarchon based on gaps discovered during Protocol v1.4 implementation:
+This document summarizes three critical improvements to MFGArchon based on gaps discovered during Protocol v1.4 implementation:
 
 1. **Complete removal of deprecated `ExampleMFGProblem`**
 2. **Fixed Gap 1: 2D/nD Hamiltonian indexing**
@@ -230,7 +230,7 @@ assert problem.u_fin.max() == 125.0  # (10-0)^2 + (5-0)^2
 ### Problem
 
 **Current Limitation**:
-- MFGarchon only supports **uniform** BC types (periodic, Dirichlet, Neumann)
+- MFGArchon only supports **uniform** BC types (periodic, Dirichlet, Neumann)
 - Cannot specify different BC on different boundary segments
 - **Critical blocker**: Protocol v1.4 requires mixed BC:
   - Exit (x=10, y∈[4.25, 5.75]): Dirichlet `u=0` (absorbing)
@@ -392,6 +392,6 @@ SUCCESS: All fixes working!
 
 ---
 
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team
 **Date**: 2025-11-23
 **Version**: v0.13.0-dev

--- a/docs/archive/[COMPLETED]_PHASE_2.5_COMPLETION_SUMMARY.md
+++ b/docs/archive/[COMPLETED]_PHASE_2.5_COMPLETION_SUMMARY.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Phase 2.5 implemented anisotropic tensor diffusion operators for MFGarchon, completing infrastructure originally planned for Phase 3. This work enables direction-dependent diffusion with applications in:
+Phase 2.5 implemented anisotropic tensor diffusion operators for MFGArchon, completing infrastructure originally planned for Phase 3. This work enables direction-dependent diffusion with applications in:
 
 - Crowd dynamics (preferential flow directions)
 - Traffic networks (road orientation effects)
@@ -334,7 +334,7 @@ Tensor diffusion involves 7× more operations than scalar Laplacian. Performance
 
 ## Conclusion
 
-Phase 2.5 successfully delivered anisotropic tensor diffusion infrastructure for MFGarchon. The work completed ~80% of the original Phase 3.3 feature (tensor diffusion) but deliberately stopped before full MFG integration to allow thorough validation.
+Phase 2.5 successfully delivered anisotropic tensor diffusion infrastructure for MFGArchon. The work completed ~80% of the original Phase 3.3 feature (tensor diffusion) but deliberately stopped before full MFG integration to allow thorough validation.
 
 **Key Achievements**:
 - Production-ready tensor operators with comprehensive tests

--- a/docs/archive/amr_removed_2025-12/README.md
+++ b/docs/archive/amr_removed_2025-12/README.md
@@ -2,7 +2,7 @@
 
 **Status**: ARCHIVED (December 2025)
 
-**Reason**: AMR implementation was removed from MFGarchon. The custom AMR code (~3100 lines) was replaced with a minimal API stub that will wrap external libraries when AMR is needed.
+**Reason**: AMR implementation was removed from MFGArchon. The custom AMR code (~3100 lines) was replaced with a minimal API stub that will wrap external libraries when AMR is needed.
 
 ## Recommended External Libraries
 

--- a/docs/archive/amr_removed_2025-12/amr_for_mfg.md
+++ b/docs/archive/amr_removed_2025-12/amr_for_mfg.md
@@ -1222,5 +1222,5 @@ amr_solver = create_amr_solver(
 ---
 
 **Last Updated**: August 1, 2025
-**Module Version**: MFGarchon 2.0+
-**Maintainer**: MFGarchon Development Team
+**Module Version**: MFGArchon 2.0+
+**Maintainer**: MFGArchon Development Team

--- a/docs/archive/amr_removed_2025-12/amr_quick_reference.md
+++ b/docs/archive/amr_removed_2025-12/amr_quick_reference.md
@@ -312,7 +312,7 @@ values_new = JAXAcceleratedAMR.gradient_preserving_interpolation_2d(
 )
 ```
 
-## Integration with MFGarchon
+## Integration with MFGArchon
 
 ### Factory Integration
 ```python
@@ -376,4 +376,4 @@ Mass conservation enforced:
 ---
 
 **Last Updated**: August 1, 2025  
-**Version**: MFGarchon 2.0+
+**Version**: MFGArchon 2.0+

--- a/docs/archive/amr_removed_2025-12/tutorial_amr.md
+++ b/docs/archive/amr_removed_2025-12/tutorial_amr.md
@@ -2,13 +2,13 @@
 
 **Date**: August 1, 2025  
 **Difficulty**: Intermediate to Advanced  
-**Prerequisites**: Basic MFGarchon usage, understanding of numerical methods  
+**Prerequisites**: Basic MFGArchon usage, understanding of numerical methods  
 **Estimated Time**: 45-60 minutes  
 **Architecture**: AMR as solver enhancement (not standalone solver)
 
 ## Tutorial Overview
 
-This tutorial covers the practical use of Adaptive Mesh Refinement (AMR) in MFGarchon, from basic concepts to advanced optimization techniques. You'll learn when to use AMR, how to configure it effectively, and how to interpret the results.
+This tutorial covers the practical use of Adaptive Mesh Refinement (AMR) in MFGArchon, from basic concepts to advanced optimization techniques. You'll learn when to use AMR, how to configure it effectively, and how to interpret the results.
 
 **Important Architectural Note**: AMR is implemented as an **enhancement wrapper** that can be applied to any base MFG solver (FDM, particle, spectral, etc.). AMR is a mesh adaptation technique, not a solution method itself. This tutorial reflects this correct understanding.
 
@@ -1155,4 +1155,4 @@ def epidemic_spread_amr_example():
 
 ---
 
-This completes the comprehensive AMR tutorial. The adaptive mesh refinement system in MFGarchon provides powerful capabilities for efficiently solving Mean Field Games with complex solution features, offering both automatic adaptation and fine-grained control for advanced users.
+This completes the comprehensive AMR tutorial. The adaptive mesh refinement system in MFGArchon provides powerful capabilities for efficiently solving Mean Field Games with complex solution features, offering both automatic adaptation and fine-grained control for advanced users.

--- a/docs/archive/bc_completed_2026-02/BC_FLOW_CLARIFICATION.md
+++ b/docs/archive/bc_completed_2026-02/BC_FLOW_CLARIFICATION.md
@@ -1,4 +1,4 @@
-# Boundary Condition Flow in MFGarchon
+# Boundary Condition Flow in MFGArchon
 
 **Status**: Clarification Document
 **Date**: 2025-12-17

--- a/docs/archive/bc_completed_2026-02/BC_SPECIFICATION_VS_APPLICATOR.md
+++ b/docs/archive/bc_completed_2026-02/BC_SPECIFICATION_VS_APPLICATOR.md
@@ -8,7 +8,7 @@
 
 ## 1. Executive Summary
 
-The MFGarchon boundary condition system has two distinct layers:
+The MFGArchon boundary condition system has two distinct layers:
 
 | Layer | Purpose | Question Answered | Key Classes |
 |-------|---------|-------------------|-------------|

--- a/docs/archive/bc_completed_2026-02/[SUPERSEDED]_spacetime_boundary_unification.md
+++ b/docs/archive/bc_completed_2026-02/[SUPERSEDED]_spacetime_boundary_unification.md
@@ -92,9 +92,9 @@ Benefits:
 
 ## 2. Time-Varying Spatial Boundaries
 
-### 2.1 Current MFGarchon Design
+### 2.1 Current MFGArchon Design
 
-MFGarchon **already supports** time-dependent BCs via `Callable(point, time)`:
+MFGArchon **already supports** time-dependent BCs via `Callable(point, time)`:
 
 ```python
 from mfgarchon.geometry.boundary import dirichlet_bc
@@ -675,15 +675,15 @@ u_solution = stefan_solver.solve()
 
 **Research Relevance**: MFG with **congestion** (crowds avoiding overcrowded regions) can be formulated as free boundary problems. This design enables future support for such models.
 
-**Status**: Conceptual design only - not currently planned for MFGarchon v1.0
+**Status**: Conceptual design only - not currently planned for MFGArchon v1.0
 
 ---
 
-## 6. Connection to Current MFGarchon Architecture
+## 6. Connection to Current MFGArchon Architecture
 
 ### 6.1 What Already Exists
 
-MFGarchon **already has** the foundation for space-time BCs:
+MFGArchon **already has** the foundation for space-time BCs:
 
 1. ✅ **Time-varying spatial BCs**: `value=callable(x, t)` in `BCSegment`
 2. ✅ **Initial/terminal conditions**: Passed separately to solvers
@@ -1027,7 +1027,7 @@ Can use Lagrange multipliers or penalty methods to enforce BCs weakly:
 
 ### Implementation Status
 
-**MFGarchon Current**:
+**MFGArchon Current**:
 - ✅ Supports time-varying BCs via `callable(x, t)`
 - ✅ Evaluates at each timestep
 - ⏸️ No unified space-time BC class

--- a/docs/archive/bc_completed_2026-02/[SUPERSEDED]_spacetime_operator_architecture_proposal.md
+++ b/docs/archive/bc_completed_2026-02/[SUPERSEDED]_spacetime_operator_architecture_proposal.md
@@ -941,7 +941,7 @@ The Space-Time Operator Architecture offers a mathematically principled and comp
 
 **Recommendation**: **Proceed with phased adoption** starting with protocol definitions and wrappers (v0.17), followed by gradual solver refactoring (v0.18-v1.0), culminating in advanced features (v1.1+).
 
-This positions MFGarchon as a cutting-edge research platform while preserving stability for existing users.
+This positions MFGArchon as a cutting-edge research platform while preserving stability for existing users.
 
 ---
 

--- a/docs/archive/bc_completed_2026-02/bc_architecture_analysis.md
+++ b/docs/archive/bc_completed_2026-02/bc_architecture_analysis.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-This document analyzes the boundary condition (BC) architecture in MFGarchon, synthesizing lessons learned from implementing FP solver BC integration. The key insight is that **boundary conditions involve three distinct concerns that are often conflated**:
+This document analyzes the boundary condition (BC) architecture in MFGArchon, synthesizing lessons learned from implementing FP solver BC integration. The key insight is that **boundary conditions involve three distinct concerns that are often conflated**:
 
 1. **Topology**: How space connects (periodic vs bounded)
 2. **Discretization**: Where values are stored (cell-centered vs vertex-centered)

--- a/docs/archive/bc_docs_consolidated_2025-12/BC_UNIFICATION_TECHNICAL_REPORT.md
+++ b/docs/archive/bc_docs_consolidated_2025-12/BC_UNIFICATION_TECHNICAL_REPORT.md
@@ -4,14 +4,14 @@
 **Date**: 2025-12-16
 **Revision**: 1.2 (Performance & Scalability Review)
 **Status**: Proposed
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team
 **Reviewer**: External Technical Expert
 
 ---
 
 ## Executive Summary
 
-This report documents the current state of boundary condition (BC) handling across the MFGarchon solver ecosystem, identifies architectural inconsistencies, and proposes a unified approach. The goal is to enable all solvers to leverage the existing BC infrastructure in `geometry/boundary/` rather than using ad-hoc implementations.
+This report documents the current state of boundary condition (BC) handling across the MFGArchon solver ecosystem, identifies architectural inconsistencies, and proposes a unified approach. The goal is to enable all solvers to leverage the existing BC infrastructure in `geometry/boundary/` rather than using ad-hoc implementations.
 
 ---
 

--- a/docs/archive/bc_docs_consolidated_2025-12/GEOMETRY_DOMAIN_BC_ARCHITECTURE.md
+++ b/docs/archive/bc_docs_consolidated_2025-12/GEOMETRY_DOMAIN_BC_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the relationship between geometry, domain, and boundary conditions in MFGarchon at both the implementation and application levels.
+This document describes the relationship between geometry, domain, and boundary conditions in MFGArchon at both the implementation and application levels.
 
 ---
 
@@ -396,4 +396,4 @@ mfgarchon/geometry/
 
 *Generated: 2025-12-09*
 *Last audited: 2025-12-10*
-*Part of: MFGarchon Deprecation Cleanup Phase 2*
+*Part of: MFGArchon Deprecation Cleanup Phase 2*

--- a/docs/archive/bc_docs_consolidated_2025-12/boundary_conditions_and_geometry.md
+++ b/docs/archive/bc_docs_consolidated_2025-12/boundary_conditions_and_geometry.md
@@ -4,7 +4,7 @@ This document provides guidance for choosing discretization methods based on dom
 
 ## Architecture Overview
 
-MFGarchon separates boundary condition handling into three layers:
+MFGArchon separates boundary condition handling into three layers:
 
 ```
 Layer 1: BC Specification (geometry/boundary/conditions.py)
@@ -101,7 +101,7 @@ This works because obstacles are still axis-aligned.
 - Matrix assembly more complex than FDM
 - Mesh quality affects solution quality
 
-**Implementation status in MFGarchon**:
+**Implementation status in MFGArchon**:
 - `FEMApplicator` available
 - 1D/2D/3D boundary condition classes implemented
 - Less tested than FDM solvers
@@ -121,7 +121,7 @@ This works because obstacles are still axis-aligned.
 - Consistency/stability analysis more complex
 - Less mature solvers than FDM/FEM
 
-**Implementation status in MFGarchon**:
+**Implementation status in MFGArchon**:
 - `MeshfreeApplicator` with `ParticleReflector`
 - GFDM solvers available
 - Good for particle-based MFG methods

--- a/docs/archive/development/issues/issue_592_level_set_completion_summary.md
+++ b/docs/archive/development/issues/issue_592_level_set_completion_summary.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-Successfully implemented production-ready level set method infrastructure for free boundary problems in MFGarchon. All core functionality complete, validated through smoke tests and 18 unit tests (100% passing).
+Successfully implemented production-ready level set method infrastructure for free boundary problems in MFGArchon. All core functionality complete, validated through smoke tests and 18 unit tests (100% passing).
 
 **Key Achievement**: Dimension-agnostic level set framework leveraging 95% of existing operator infrastructure from Issue #595, with zero breaking changes.
 
@@ -330,7 +330,7 @@ for t in timesteps:
 
 ---
 
-## Integration with MFGarchon
+## Integration with MFGArchon
 
 ### Dependency Graph
 
@@ -344,7 +344,7 @@ Leverages: GradientOperator, DivergenceOperator, LaplacianOperator
 
 ### API Consistency
 
-Level set methods follow established MFGarchon patterns:
+Level set methods follow established MFGArchon patterns:
 
 1. **Operator Pattern**
    ```python

--- a/docs/archive/development/issues/level_set_v1_0_assessment.md
+++ b/docs/archive/development/issues/level_set_v1_0_assessment.md
@@ -12,7 +12,7 @@
 
 **Verdict**: Competent Research Prototype.
 
-The implementation successfully integrates the Level Set Method (LSM) into the existing MFGarchon framework without breaking changes. It meets the critical accuracy targets for the Stefan Problem (< 5% error), but relies on computationally expensive explicit time-stepping and first-order spatial schemes. It is "correct but inefficient," making it suitable for research demonstrations but not yet ready for high-performance production workloads.
+The implementation successfully integrates the Level Set Method (LSM) into the existing MFGArchon framework without breaking changes. It meets the critical accuracy targets for the Stefan Problem (< 5% error), but relies on computationally expensive explicit time-stepping and first-order spatial schemes. It is "correct but inefficient," making it suitable for research demonstrations but not yet ready for high-performance production workloads.
 
 ---
 
@@ -272,7 +272,7 @@ Additional References:
 
 ## 10. Conclusion
 
-The Level Set v1.0 implementation successfully integrates LSM into MFGarchon with:
+The Level Set v1.0 implementation successfully integrates LSM into MFGArchon with:
 - ✅ Correct physics (Stefan < 5% error)
 - ✅ Clean architecture (composition, operator reuse)
 - ✅ No breaking changes

--- a/docs/archive/development/maintenance/CLEANUP_JULY_2025.md
+++ b/docs/archive/development/maintenance/CLEANUP_JULY_2025.md
@@ -94,7 +94,7 @@ examples/
 Added targeted MFG-specific patterns that prevent accumulation while preserving valuable examples and tests:
 
 ```gitignore
-# MFGarchon specific - prevent accumulation of analysis outputs
+# MFGArchon specific - prevent accumulation of analysis outputs
 # Only ignore output directories, not source code
 *_results/
 *_demo_data/

--- a/docs/archive/development/proposals/DIMENSION_AGNOSTIC_FDM_ANALYSIS.md
+++ b/docs/archive/development/proposals/DIMENSION_AGNOSTIC_FDM_ANALYSIS.md
@@ -11,7 +11,7 @@
 
 ## Executive Summary
 
-MFGarchon already has substantial dimension-agnostic infrastructure (`HighDimMFGProblem`, `GridBasedMFGProblem`, `TensorProductGrid`). The task is to extend the FDM solvers to work with this infrastructure, not to build dimension-agnostic support from scratch.
+MFGArchon already has substantial dimension-agnostic infrastructure (`HighDimMFGProblem`, `GridBasedMFGProblem`, `TensorProductGrid`). The task is to extend the FDM solvers to work with this infrastructure, not to build dimension-agnostic support from scratch.
 
 **Current State**:
 - ✅ Dimension-agnostic problem classes exist (`GridBasedMFGProblem`)
@@ -794,7 +794,7 @@ def test_2d_fp_mass_conservation():
 
 ### Architecture Consistency
 
-**MFGarchon Design Principle**: Dimension is a parameter, not a constraint
+**MFGArchon Design Principle**: Dimension is a parameter, not a constraint
 
 ```
 Component                    Dimensions Supported
@@ -1007,7 +1007,7 @@ U, M, info = solver.solve()     # Just works
 - ✅ Leverages existing dimension-agnostic problem classes
 - ✅ Well-established numerical method (proven accuracy)
 - ✅ Single implementation works for 2D, 3D, 4D, ... (automatic 3D support)
-- ✅ Matches MFGarchon architecture principle: dimension is a parameter, not a constraint
+- ✅ Matches MFGArchon architecture principle: dimension is a parameter, not a constraint
 - ✅ Provides classical FDM baseline for nD research
 
 **Design Choice**: Generic `_sweep_dimension(U, M, problem, dt, dim)` function

--- a/docs/archive/ghost_nodes_investigation_2025-12/GFDM_BC_INVESTIGATION_REPORT.md
+++ b/docs/archive/ghost_nodes_investigation_2025-12/GFDM_BC_INVESTIGATION_REPORT.md
@@ -1,6 +1,6 @@
 # GFDM Boundary Condition Handling Investigation Report
 
-**Date**: 2025-12-18 (Updated: Integration with MFGarchon Infrastructure)
+**Date**: 2025-12-18 (Updated: Integration with MFGArchon Infrastructure)
 **Status**: In Progress - Infrastructure Integration Phase
 **Authors**: Claude Code Investigation
 
@@ -12,11 +12,11 @@ Investigation of HJB-GFDM solver producing catastrophic negative values (U(0) mi
 
 1. **Geometric Issue (Fixed)**: Ghost particles corrupting derivative computation
 2. **Algebraic Issue (Partially Implemented)**: Missing Row Replacement for Neumann BC
-3. **Infrastructure Integration (New)**: GFDM should use existing MFGarchon BC infrastructure
+3. **Infrastructure Integration (New)**: GFDM should use existing MFGArchon BC infrastructure
 
 Both issues stem from conflating **derivative computation** with **boundary condition enforcement**.
 
-**Key Finding**: The MFGarchon codebase already has mature BC infrastructure (`BoundaryConditions`, `MeshfreeApplicator`, Calculator/Topology pattern) that GFDM should integrate with rather than bypass. See **Section 11** for integration details.
+**Key Finding**: The MFGArchon codebase already has mature BC infrastructure (`BoundaryConditions`, `MeshfreeApplicator`, Calculator/Topology pattern) that GFDM should integrate with rather than bypass. See **Section 11** for integration details.
 
 ---
 
@@ -521,11 +521,11 @@ def test_neumann_bc_row_replacement():
 
 ---
 
-## 11. Existing MFGarchon Boundary Condition Infrastructure
+## 11. Existing MFGArchon Boundary Condition Infrastructure
 
 ### 11.1 Architecture Overview
 
-The MFGarchon codebase already has a mature BC infrastructure that GFDM should integrate with rather than bypass:
+The MFGArchon codebase already has a mature BC infrastructure that GFDM should integrate with rather than bypass:
 
 ```
 mfgarchon/geometry/boundary/
@@ -708,7 +708,7 @@ class BoundaryConditionManager:
     """
     Single source of truth for GFDM boundary condition handling.
 
-    Integrates with existing MFGarchon infrastructure to provide:
+    Integrates with existing MFGArchon infrastructure to provide:
     - Consistent BC type resolution
     - Normal vector computation (via BoundaryConditions/MeshfreeApplicator)
     - Row Replacement matrix assembly
@@ -1296,7 +1296,7 @@ u^{n+1} = u^n + Δt · L(u^n)
 | Hermite GFDM | ❌ No | Low priority for MFG |
 | Explicit GFDM | ✅ Yes | Time-stepping in solvers |
 
-### 14.6 Recommendations for MFGarchon
+### 14.6 Recommendations for MFGArchon
 
 **Priority Order**:
 

--- a/docs/archive/ghost_nodes_investigation_2025-12/GHOST_NODES_EXPERIMENTS.md
+++ b/docs/archive/ghost_nodes_investigation_2025-12/GHOST_NODES_EXPERIMENTS.md
@@ -61,7 +61,7 @@ hjb_solver = HJBGFDMSolver(
 
 ## Files Created/Modified
 
-### MFGarchon Repository
+### MFGArchon Repository
 
 **Core Implementation**:
 - `mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py`:

--- a/docs/archive/ghost_nodes_investigation_2025-12/GHOST_NODES_RESULTS.md
+++ b/docs/archive/ghost_nodes_investigation_2025-12/GHOST_NODES_RESULTS.md
@@ -233,7 +233,7 @@ GFDM-Ghost:   3.06 → 10.12  (Δx = + 7.06 units,  63% of baseline)
 
 **Immediate**:
 - ✅ **Deploy ghost nodes** as default for GFDM with Neumann BC
-- ✅ **Document method** in MFGarchon user guide
+- ✅ **Document method** in MFGArchon user guide
 - ⚠️ **Set user expectations**: Ghost nodes improve GFDM but don't match FDM
 
 **Future Research**:

--- a/docs/archive/historical/2025/GEOMETRY_PROJECTION_IMPLEMENTATION_GUIDE.md
+++ b/docs/archive/historical/2025/GEOMETRY_PROJECTION_IMPLEMENTATION_GUIDE.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This guide covers the implementation details of the geometry projection system for MFGarchon developers who need to:
+This guide covers the implementation details of the geometry projection system for MFGArchon developers who need to:
 - Understand the codebase structure
 - Add new projection methods
 - Extend to new geometry types

--- a/docs/archive/historical/2025/ISSUE_257_COMPLETION_SUMMARY.md
+++ b/docs/archive/historical/2025/ISSUE_257_COMPLETION_SUMMARY.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Successfully implemented comprehensive dual geometry support for MFGarchon, enabling HJB and FP solvers to use different discretizations. This enables hybrid methods (particle FP + grid HJB), multi-resolution (fine HJB + coarse FP), and network-based agents.
+Successfully implemented comprehensive dual geometry support for MFGArchon, enabling HJB and FP solvers to use different discretizations. This enables hybrid methods (particle FP + grid HJB), multi-resolution (fine HJB + coarse FP), and network-based agents.
 
 ## Implementation Phases
 

--- a/docs/archive/historical/ACCELERATION_DECISION_PROCEDURE_2025-10-09.md
+++ b/docs/archive/historical/ACCELERATION_DECISION_PROCEDURE_2025-10-09.md
@@ -28,7 +28,7 @@ DONE
 
 ### Task 1.1: Identify Actual Bottleneck
 ```bash
-cd /Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGarchon
+cd /Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGArchon
 
 # Profile WENO5 solver
 python -m cProfile -o weno_profile.prof -s cumtime << 'EOF'
@@ -430,7 +430,7 @@ python benchmarks/numpy/weno5_vectorized_benchmark.py
 ### Task 4.1: Create Rust Extension Skeleton
 ```bash
 # Create Rust crate
-cd /Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGarchon
+cd /Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGArchon
 cargo new --lib mfgarchon_rust
 cd mfgarchon_rust
 

--- a/docs/archive/historical/API_SIMPLIFICATION_PROPOSAL.md
+++ b/docs/archive/historical/API_SIMPLIFICATION_PROPOSAL.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-Current MFGarchon API has **4 layers** of problem construction:
+Current MFGArchon API has **4 layers** of problem construction:
 
 1. **Factory level**: `create_fast_solver()`, `create_accurate_solver()` (in `factory.py`)
 2. **Problem factories**: `create_mfg_problem()` (redundant)

--- a/docs/archive/historical/ARCHITECTURE_ISSUE_CREATED.md
+++ b/docs/archive/historical/ARCHITECTURE_ISSUE_CREATED.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Comprehensive architecture refactoring issue created in MFGarchon repository based on 3 weeks of intensive research usage (2025-10-06 to 2025-10-30).
+Comprehensive architecture refactoring issue created in MFGArchon repository based on 3 weeks of intensive research usage (2025-10-06 to 2025-10-30).
 
 ---
 
@@ -42,7 +42,7 @@ Comprehensive architecture refactoring issue created in MFGarchon repository bas
 
 ## Repository State Verified
 
-**MFGarchon Branches**:
+**MFGArchon Branches**:
 - `main` (current)
 - `feature/osqp-and-adaptive-neighborhoods` (remote)
 - `refactor/remove-use-monotone-constraints` (remote)
@@ -64,7 +64,7 @@ Comprehensive architecture refactoring issue created in MFGarchon repository bas
 
 ## Documentation Organized
 
-All comprehensive documentation is in `MFGarchon/docs/architecture/`:
+All comprehensive documentation is in `MFGArchon/docs/architecture/`:
 
 ```
 docs/architecture/
@@ -72,10 +72,10 @@ docs/architecture/
 ├── audit/
 │   ├── AUDIT_ENRICHMENT_SUMMARY.md        # Executive summary (371 lines)
 │   ├── ARCHITECTURE_AUDIT_ENRICHMENT.md   # Full audit (1,799 lines)
-│   ├── MFGarchon_ARCHITECTURE_AUDIT.md      # Original audit
+│   ├── MFGArchon_ARCHITECTURE_AUDIT.md      # Original audit
 │   └── ARCHITECTURE_AUDIT_SUMMARY.md      # Original summary
 ├── proposals/
-│   └── MFGarchon_ARCHITECTURE_REFACTOR_PROPOSAL.md
+│   └── MFGArchon_ARCHITECTURE_REFACTOR_PROPOSAL.md
 ├── evidence/
 │   └── FDM_SOLVER_LIMITATION_ANALYSIS.md
 └── navigation/
@@ -99,7 +99,7 @@ docs/architecture/
 - 1,080 lines of custom problem code required
 
 ### 3. Bug #15: QP Sigma Type Error (HIGH PRIORITY)
-- NOT YET FIXED in MFGarchon
+- NOT YET FIXED in MFGArchon
 - Workaround exists (`SmartSigma`)
 - 5-line fix proposed in issue
 
@@ -166,7 +166,7 @@ docs/architecture/
 **Documentation Trail**:
 - 181 markdown files analyzed
 - 94 Python test/experiment files
-- 251 Python files in MFGarchon (100% coverage)
+- 251 Python files in MFGArchon (100% coverage)
 - 15 documents for Bug #13
 - 10 documents for Bug #14
 - 7 documents for Bug #15
@@ -180,7 +180,7 @@ docs/architecture/
 
 ---
 
-## Related Issues in MFGarchon
+## Related Issues in MFGArchon
 
 **This Issue Consolidates**:
 - Bug #15: QP sigma type error (NEW)
@@ -251,7 +251,7 @@ U, M, info = solution
 - ✅ Repository state verified (branches, issues, PRs)
 - ✅ Comprehensive issue created (#200)
 - ✅ Appropriate labels added
-- ✅ All documentation organized in `MFGarchon/docs/architecture/`
+- ✅ All documentation organized in `MFGArchon/docs/architecture/`
 - ✅ Related issues and PRs cross-referenced
 - ✅ Evidence and quantification included
 - ✅ Clear action plan with timeline
@@ -266,8 +266,8 @@ U, M, info = solution
 
 **For Questions**:
 - GitHub Issue: https://github.com/derrring/mfgarchon/issues/200
-- Full documentation: `MFGarchon/docs/architecture/README.md`
-- Quick navigation: `MFGarchon/docs/architecture/navigation/ARCHITECTURE_DOCUMENTATION_INDEX.md`
+- Full documentation: `MFGArchon/docs/architecture/README.md`
+- Quick navigation: `MFGArchon/docs/architecture/navigation/ARCHITECTURE_DOCUMENTATION_INDEX.md`
 
 ---
 

--- a/docs/archive/historical/BRANCH_STRATEGY_PARADIGMS.md
+++ b/docs/archive/historical/BRANCH_STRATEGY_PARADIGMS.md
@@ -1,4 +1,4 @@
-# MFGarchon Paradigm Development Branch Strategy
+# MFGArchon Paradigm Development Branch Strategy
 
 ## Overview
 

--- a/docs/archive/historical/DEVELOPMENT_ROADMAP_2025-Q4.md
+++ b/docs/archive/historical/DEVELOPMENT_ROADMAP_2025-Q4.md
@@ -1,4 +1,4 @@
-# MFGarchon Development Roadmap: Q4 2025 - Q2 2026
+# MFGArchon Development Roadmap: Q4 2025 - Q2 2026
 
 **Last Updated**: 2025-10-09  
 **Current Version**: v0.7.1  
@@ -41,7 +41,7 @@
 ## 🎯 Strategic Vision
 
 ### Mission
-Transform MFGarchon from **research-grade** to **production-grade** while maintaining mathematical rigor and flexibility for research.
+Transform MFGArchon from **research-grade** to **production-grade** while maintaining mathematical rigor and flexibility for research.
 
 ### Guiding Principles
 

--- a/docs/archive/historical/DOCUMENTATION_AUDIT_2025-11-16.md
+++ b/docs/archive/historical/DOCUMENTATION_AUDIT_2025-11-16.md
@@ -1,4 +1,4 @@
-# MFGarchon Documentation Audit Report
+# MFGArchon Documentation Audit Report
 **Date**: 2025-11-16
 **Post**: v0.12.5 Geometry Reorganization
 **Total Files**: 181 markdown files
@@ -80,7 +80,7 @@ Old import paths still referenced in docs:
 | GEOMETRY_CONSOLIDATION_QUICK_START.md | `geometry.boundary_conditions_1d` | `geometry.boundary.bc_1d` |
 | v0.10.1_amr_geometry_protocol.md | `geometry.domain_1d` | `geometry` (alias) |
 | anisotropic_mfg_mathematical_formulation.md | `geometry/domain_2d.py` | `geometry/meshes/mesh_2d.py` |
-| MFGarchon_ARCHITECTURE_AUDIT.md | `geometry/domain_3d.py` | `geometry/meshes/mesh_3d.py` |
+| MFGArchon_ARCHITECTURE_AUDIT.md | `geometry/domain_3d.py` | `geometry/meshes/mesh_3d.py` |
 
 **Impact**: Medium - documentation references are informational, not code-breaking
 
@@ -231,7 +231,7 @@ Files marked ✅ COMPLETED still in active directories:
 
 ## Appendix: Detailed Broken Links
 
-See: `/Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGarchon/broken_links_report.md`
+See: `/Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGArchon/broken_links_report.md`
 
 ---
 

--- a/docs/archive/historical/IMPLEMENTATION_ROADMAP.md
+++ b/docs/archive/historical/IMPLEMENTATION_ROADMAP.md
@@ -4,16 +4,16 @@
 **Author:** Implementation Planning Team  
 **Status:** Strategic Roadmap  
 **Timeline:** 12 Months  
-**Based on:** MFGarchon Success Patterns  
+**Based on:** MFGArchon Success Patterns  
 
 ## Executive Summary
 
-This roadmap outlines a 12-month implementation plan for building an abstract scientific computing framework, leveraging the proven patterns from MFGarchon. The plan is structured in 4 phases, each building on the previous phase's accomplishments while demonstrating increasing capability and value.
+This roadmap outlines a 12-month implementation plan for building an abstract scientific computing framework, leveraging the proven patterns from MFGArchon. The plan is structured in 4 phases, each building on the previous phase's accomplishments while demonstrating increasing capability and value.
 
 ## Strategic Objectives
 
 ### Primary Goals
-1. **Generalize MFGarchon Success** - Extract and abstract proven patterns
+1. **Generalize MFGArchon Success** - Extract and abstract proven patterns
 2. **Multi-Domain Capability** - Support 3+ scientific domains  
 3. **Production Readiness** - Professional tooling and deployment
 4. **Community Adoption** - Open source with commercial features
@@ -27,7 +27,7 @@ This roadmap outlines a 12-month implementation plan for building an abstract sc
 ## Implementation Phases
 
 ## Phase 1: Foundation (Months 1-3)
-**Goal**: Extract and generalize core MFGarchon patterns
+**Goal**: Extract and generalize core MFGArchon patterns
 
 ### Month 1: Core Abstractions
 
@@ -35,7 +35,7 @@ This roadmap outlines a 12-month implementation plan for building an abstract sc
 ```
 Tasks:
 ├── Set up framework repository structure
-├── Extract core abstractions from MFGarchon
+├── Extract core abstractions from MFGArchon
 │   ├── ScientificProblem base class
 │   ├── ScientificSolver interface  
 │   ├── ScientificConfig system
@@ -53,7 +53,7 @@ Deliverables:
 #### Week 3-4: Configuration System
 ```
 Tasks:
-├── Generalize MFGarchon Pydantic configuration
+├── Generalize MFGArchon Pydantic configuration
 ├── Create universal configuration presets
 ├── Implement configuration validation
 ├── Build configuration composition system
@@ -71,7 +71,7 @@ Deliverables:
 #### Week 1-2: Logging and Observability
 ```
 Tasks:
-├── Generalize MFGarchon logging system
+├── Generalize MFGArchon logging system
 ├── Create universal convergence analysis
 ├── Implement structured event system
 ├── Add performance monitoring
@@ -87,7 +87,7 @@ Deliverables:
 #### Week 3-4: Validation Framework
 ```
 Tasks:
-├── Generalize MFGarchon array validation
+├── Generalize MFGArchon array validation
 ├── Create universal physical constraint system
 ├── Implement solution quality metrics
 ├── Build validation report generation
@@ -105,7 +105,7 @@ Deliverables:
 #### Week 1-2: Universal Factory System
 ```
 Tasks:
-├── Generalize MFGarchon solver factory
+├── Generalize MFGArchon solver factory
 ├── Create universal solver creation with DI
 ├── Implement plugin-based solver registration
 ├── Add factory validation and error handling
@@ -160,14 +160,14 @@ Success Criteria:
 ```
 Tasks:
 ├── Create MFG domain plugin structure
-├── Migrate MFGarchon problems to framework
-├── Port MFGarchon solvers to universal interface
+├── Migrate MFGArchon problems to framework
+├── Port MFGArchon solvers to universal interface
 ├── Implement MFG-specific validation
 └── Add MFG reporting and visualization
 
 Deliverables:
 ├── Complete MFG domain plugin
-├── All MFGarchon solvers working in framework
+├── All MFGArchon solvers working in framework
 ├── MFG-specific physical constraint validation
 └── MFG analysis and reporting capabilities
 ```
@@ -176,7 +176,7 @@ Deliverables:
 ```
 Tasks:
 ├── Comprehensive MFG plugin testing
-├── Performance comparison vs original MFGarchon
+├── Performance comparison vs original MFGArchon
 ├── Validation of all MFG features
 ├── Documentation and examples
 └── Bug fixes and optimizations
@@ -597,7 +597,7 @@ Success Criteria:
 
 #### Low Risk: Adoption
 - **Risk**: Scientific community slow to adopt new framework
-- **Mitigation**: Start with existing MFGarchon users, incremental migration
+- **Mitigation**: Start with existing MFGArchon users, incremental migration
 - **Contingency**: Focus on industry adoption, consulting services
 
 ## Success Metrics and Milestones
@@ -686,10 +686,10 @@ Success Criteria:
 
 ## Conclusion
 
-This roadmap provides a comprehensive 12-month plan for building a production-ready abstract scientific computing framework based on the proven success patterns from MFGarchon. The phased approach ensures steady progress while validating each component before building the next layer.
+This roadmap provides a comprehensive 12-month plan for building a production-ready abstract scientific computing framework based on the proven success patterns from MFGArchon. The phased approach ensures steady progress while validating each component before building the next layer.
 
 Key success factors:
-1. **Leverage Proven Patterns** - Build on MFGarchon's demonstrated success
+1. **Leverage Proven Patterns** - Build on MFGArchon's demonstrated success
 2. **Progressive Complexity** - Start simple, add sophistication incrementally  
 3. **Multi-Domain Validation** - Prove universality with diverse domains
 4. **Community Focus** - Design for adoption and contribution from day one
@@ -703,4 +703,4 @@ The framework will provide the scientific computing community with a powerful, f
 3. Establish community presence and early user engagement
 4. Start partnerships with potential early adopters
 
-This roadmap represents a ambitious but achievable vision for transforming scientific computing infrastructure, building on the solid foundation established by the MFGarchon project.
+This roadmap represents a ambitious but achievable vision for transforming scientific computing infrastructure, building on the solid foundation established by the MFGArchon project.

--- a/docs/archive/historical/IMPROVEMENT_PROPOSAL_2025Q4.md
+++ b/docs/archive/historical/IMPROVEMENT_PROPOSAL_2025Q4.md
@@ -1,4 +1,4 @@
-# MFGarchon Improvement Proposal - Q4 2025
+# MFGArchon Improvement Proposal - Q4 2025
 
 **Date**: October 8, 2025
 **Author**: Claude (AI Assistant)
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-This document proposes **three strategic improvement tracks** for MFGarchon, prioritized by impact on research capability and user experience. All proposals leverage existing infrastructure and require minimal disruption to current codebase.
+This document proposes **three strategic improvement tracks** for MFGArchon, prioritized by impact on research capability and user experience. All proposals leverage existing infrastructure and require minimal disruption to current codebase.
 
 ### Proposed Tracks
 
@@ -707,7 +707,7 @@ def main():
 
 ```python
 """
-Quickstart: 5-Minute Introduction to MFGarchon.
+Quickstart: 5-Minute Introduction to MFGArchon.
 
 Solves the simplest possible MFG problem in ~10 seconds:
 - Linear-Quadratic Hamiltonian

--- a/docs/archive/historical/INVESTIGATION_SCOPE.md
+++ b/docs/archive/historical/INVESTIGATION_SCOPE.md
@@ -1,6 +1,6 @@
 # Architecture Audit Investigation: Scope and Scale
 
-**Comprehensive investigation of mfg-research to enrich MFGarchon architecture audit**
+**Comprehensive investigation of mfg-research to enrich MFGArchon architecture audit**
 
 ---
 
@@ -318,7 +318,7 @@ Bug #15: QP Sigma Type Error
 ├── Discovered: Week 2
 ├── Impact: Cannot use QP without workaround
 ├── Fix: SmartSigma class (workaround)
-└── Status: NOT FIXED in MFGarchon
+└── Status: NOT FIXED in MFGArchon
 ```
 
 ### Performance Issues
@@ -394,7 +394,7 @@ Solver Return Formats:
 ```
 ⚠️ Research Code Focus:
 ├── mfg-research repository only
-├── Did not analyze MFGarchon source deeply
+├── Did not analyze MFGArchon source deeply
 └── Relied on documented experiences
 
 ⚠️ Time Constraint:
@@ -541,7 +541,7 @@ ROI Calculation:
 - [x] Found ALL theory.md files
 - [x] Cataloged ALL *BUG*, *ISSUE* documents
 - [x] Counted total problem instances (48)
-- [x] Cross-referenced with MFGarchon_ARCHITECTURE_AUDIT.md
+- [x] Cross-referenced with MFGArchon_ARCHITECTURE_AUDIT.md
 - [x] Provided specific file:line evidence for each claim
 - [x] Estimated impact (time/complexity) quantitatively
 
@@ -596,7 +596,7 @@ DELIVERABLES:
 
 **Investigation Status**: COMPLETE
 **Quality Level**: Production-grade with full traceability
-**Next Step**: Review by MFGarchon maintainers
+**Next Step**: Review by MFGArchon maintainers
 **Contact**: Research team (mfg-research repository)
 
 ---

--- a/docs/archive/historical/ISSUE_HJBWENO_INFLEXIBILITY.md
+++ b/docs/archive/historical/ISSUE_HJBWENO_INFLEXIBILITY.md
@@ -9,7 +9,7 @@
 
 ## Issue Summary
 
-`hjb_weno.py` hardcodes a specific Hamiltonian form instead of using the flexible `problem.H()` interface. This limits the solver to one specific problem type and is inconsistent with MFGarchon's extensible design philosophy.
+`hjb_weno.py` hardcodes a specific Hamiltonian form instead of using the flexible `problem.H()` interface. This limits the solver to one specific problem type and is inconsistent with MFGArchon's extensible design philosophy.
 
 **Impact**: Users cannot use WENO solver with custom Hamiltonians (obstacle costs, running costs, nonlinear control, etc.)
 
@@ -416,7 +416,7 @@ def test_weno_backward_compatibility():
 
 `hjb_weno.py`'s hardcoded Hamiltonian is a **design limitation** that:
 1. Restricts WENO solver to one specific problem type
-2. Is inconsistent with MFGarchon's extensible architecture
+2. Is inconsistent with MFGArchon's extensible architecture
 3. Has NO significant performance justification (< 1% overhead)
 
 **Recommendation**: Refactor to use `problem.H()` interface while preserving WENO's gradient computation advantages.

--- a/docs/archive/historical/PARQUET_INTEGRATION_DECISION.md
+++ b/docs/archive/historical/PARQUET_INTEGRATION_DECISION.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-MFGarchon has a **partial Parquet implementation** with 543 lines of well-tested Polars integration code but missing the PyArrow dependency required for Parquet I/O. This document justifies the decision to **complete the integration** by adding `pyarrow>=10.0` to optional dependencies, making MFGarchon ready for Phase 3 HPC workflows.
+MFGArchon has a **partial Parquet implementation** with 543 lines of well-tested Polars integration code but missing the PyArrow dependency required for Parquet I/O. This document justifies the decision to **complete the integration** by adding `pyarrow>=10.0` to optional dependencies, making MFGArchon ready for Phase 3 HPC workflows.
 
 **Key Decision**: Add PyArrow to the `performance` optional dependency group in `pyproject.toml`.
 
@@ -190,7 +190,7 @@ class MFGParquetDataset(Dataset):
 - **Big Data**: Apache Spark, Apache Flink
 - **HPC**: Distributed computing workflows
 
-**MFGarchon Future Compatibility**:
+**MFGArchon Future Compatibility**:
 - Neural operator training pipelines
 - Cloud deployment (Docker/Kubernetes)
 - Large-scale parameter optimization
@@ -279,7 +279,7 @@ print("✅ Parquet integration working")
 ```markdown
 ### Data Export Formats
 
-MFGarchon supports multiple export formats for parameter sweeps and solutions:
+MFGArchon supports multiple export formats for parameter sweeps and solutions:
 
 - **CSV**: Human-readable, universal compatibility (default)
 - **JSON**: Structured data, web-friendly
@@ -404,7 +404,7 @@ def export_to_parquet(self, df: MFGDataFrame, filepath: str | Path) -> None:
 - Apache Parquet Format: https://parquet.apache.org/docs/
 - PyArrow Documentation: https://arrow.apache.org/docs/python/
 
-### MFGarchon Code References
+### MFGArchon Code References
 - Polars integration: `mfgarchon/utils/data/polars_integration.py:459-526`
 - Usage in analytics: `mfgarchon/visualization/mfg_analytics.py:230,446`
 - Phase 3 preparation: `docs/development/PHASE_3_PREPARATION_2025.md`

--- a/docs/archive/historical/PHASE_2.2_STOCHASTIC_MFG_PLAN.md
+++ b/docs/archive/historical/PHASE_2.2_STOCHASTIC_MFG_PLAN.md
@@ -9,7 +9,7 @@
 
 ## 🎯 Executive Summary
 
-Implement advanced stochastic formulations for Mean Field Games, enabling modeling of uncertain environments and common noise scenarios. This positions MFGarchon at the research frontier by supporting both Common Noise MFG and Master Equation formulations.
+Implement advanced stochastic formulations for Mean Field Games, enabling modeling of uncertain environments and common noise scenarios. This positions MFGArchon at the research frontier by supporting both Common Noise MFG and Master Equation formulations.
 
 **Strategic Impact**:
 - **Research Leadership**: First comprehensive framework for stochastic MFG

--- a/docs/archive/historical/PHASE_2.5_ANISOTROPIC_DIFFUSION_DESIGN.md
+++ b/docs/archive/historical/PHASE_2.5_ANISOTROPIC_DIFFUSION_DESIGN.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Extend MFGarchon to support anisotropic diffusion via diffusion tensors **D(t, x, m)**, enabling direction-dependent diffusion coefficients. This generalizes scalar diffusion σ²(t, x, m) to full tensors supporting cross-diffusion and preferential directions.
+Extend MFGArchon to support anisotropic diffusion via diffusion tensors **D(t, x, m)**, enabling direction-dependent diffusion coefficients. This generalizes scalar diffusion σ²(t, x, m) to full tensors supporting cross-diffusion and preferential directions.
 
 ### Mathematical Formulation
 

--- a/docs/archive/historical/PHASE_2.5_COMPLETION_SUMMARY.md
+++ b/docs/archive/historical/PHASE_2.5_COMPLETION_SUMMARY.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Phase 2.5 implemented anisotropic tensor diffusion operators for MFGarchon, completing infrastructure originally planned for Phase 3. This work enables direction-dependent diffusion with applications in:
+Phase 2.5 implemented anisotropic tensor diffusion operators for MFGArchon, completing infrastructure originally planned for Phase 3. This work enables direction-dependent diffusion with applications in:
 
 - Crowd dynamics (preferential flow directions)
 - Traffic networks (road orientation effects)
@@ -334,7 +334,7 @@ Tensor diffusion involves 7× more operations than scalar Laplacian. Performance
 
 ## Conclusion
 
-Phase 2.5 successfully delivered anisotropic tensor diffusion infrastructure for MFGarchon. The work completed ~80% of the original Phase 3.3 feature (tensor diffusion) but deliberately stopped before full MFG integration to allow thorough validation.
+Phase 2.5 successfully delivered anisotropic tensor diffusion infrastructure for MFGArchon. The work completed ~80% of the original Phase 3.3 feature (tensor diffusion) but deliberately stopped before full MFG integration to allow thorough validation.
 
 **Key Achievements**:
 - Production-ready tensor operators with comprehensive tests

--- a/docs/archive/historical/PHASE_2_DESIGN_STATE_DEPENDENT_COEFFICIENTS.md
+++ b/docs/archive/historical/PHASE_2_DESIGN_STATE_DEPENDENT_COEFFICIENTS.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-Phase 2 extends MFGarchon to support **state-dependent (nonlinear) PDEs** by enabling:
+Phase 2 extends MFGArchon to support **state-dependent (nonlinear) PDEs** by enabling:
 1. Array diffusion in FP solvers (spatially varying)
 2. Callable coefficients evaluated at runtime (state-dependent)
 3. Seamless integration with MFG fixed-point coupling

--- a/docs/archive/historical/PHASE_2_SHORT_TERM_PLAN.md
+++ b/docs/archive/historical/PHASE_2_SHORT_TERM_PLAN.md
@@ -581,7 +581,7 @@ raise ConvergenceError(
 
 **Release Notes Structure**:
 ```markdown
-# MFGarchon v0.8.0 - Phase 2 Short-Term Improvements
+# MFGArchon v0.8.0 - Phase 2 Short-Term Improvements
 
 ## New Features
 

--- a/docs/archive/historical/PHASE_3_MIGRATION_GUIDE.md
+++ b/docs/archive/historical/PHASE_3_MIGRATION_GUIDE.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Phase 3 (v0.9.0) introduces a **unified architecture** that dramatically simplifies the MFGarchon API while maintaining full backward compatibility. The key changes:
+Phase 3 (v0.9.0) introduces a **unified architecture** that dramatically simplifies the MFGArchon API while maintaining full backward compatibility. The key changes:
 
 1. **Unified `solve_mfg()` interface** - Single entry point for all MFG problems
 2. **Unified `SolverConfig` system** - Three patterns: YAML, Builder, Presets
@@ -784,5 +784,5 @@ Use this checklist to track your migration progress:
 
 **Migration Guide Version**: 1.0
 **Last Updated**: 2025-11-03
-**Applies to**: MFGarchon v0.9.0
+**Applies to**: MFGArchon v0.9.0
 **Next Review**: v0.10.0 release

--- a/docs/archive/historical/PHASE_3_VALIDATION_PERFORMANCE_PLAN.md
+++ b/docs/archive/historical/PHASE_3_VALIDATION_PERFORMANCE_PLAN.md
@@ -10,7 +10,7 @@
 
 ## Executive Summary
 
-Phase 3 focuses on **validating dimension-agnostic FDM solvers** and **optimizing performance** for practical 2D/3D MFG applications. This phase establishes MFGarchon's nD solvers as production-ready through systematic benchmarking, validation, and performance enhancement.
+Phase 3 focuses on **validating dimension-agnostic FDM solvers** and **optimizing performance** for practical 2D/3D MFG applications. This phase establishes MFGArchon's nD solvers as production-ready through systematic benchmarking, validation, and performance enhancement.
 
 **Deliverables**:
 1. Validation suite comparing FDM vs GFDM on canonical problems
@@ -426,7 +426,7 @@ Phase 3 is complete when:
 ### Risk 4: Insufficient Baseline Data (GFDM)
 **Likelihood**: Low
 **Impact**: Medium
-**Mitigation**: GFDM solvers already exist in MFGarchon. If needed, use published results from literature as baseline.
+**Mitigation**: GFDM solvers already exist in MFGArchon. If needed, use published results from literature as baseline.
 
 ---
 

--- a/docs/archive/historical/RUST_ACCELERATION_ROADMAP_2025-10-09.md
+++ b/docs/archive/historical/RUST_ACCELERATION_ROADMAP_2025-10-09.md
@@ -1,4 +1,4 @@
-# Rust Acceleration Roadmap for MFGarchon
+# Rust Acceleration Roadmap for MFGArchon
 
 **Date**: 2025-10-09
 **Status**: Planning Phase
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-Strategic plan for integrating Rust extensions into MFGarchon to accelerate compute-intensive numerical operations. Primary focus: WENO5 stencil computations with expected 5-10× speedup.
+Strategic plan for integrating Rust extensions into MFGArchon to accelerate compute-intensive numerical operations. Primary focus: WENO5 stencil computations with expected 5-10× speedup.
 
 ## Strategic Analysis: Where to Use Rust
 
@@ -301,7 +301,7 @@ class RustBackend(BackendProtocol):
 ## Project Structure
 
 ```
-MFGarchon/
+MFGArchon/
 ├── mfgarchon/                  # Python package
 │   ├── backends/
 │   │   └── rust_backend.py   # Rust backend interface

--- a/docs/archive/historical/[EVALUATION]_monitoring_tools_comparison.md
+++ b/docs/archive/historical/[EVALUATION]_monitoring_tools_comparison.md
@@ -2,7 +2,7 @@
 
 **Date**: July 26, 2025  
 **Status**: DEFERRED - Focus on core MFG functionality first  
-**Context**: Scientific Computing & Mathematical Research (MFGarchon)  
+**Context**: Scientific Computing & Mathematical Research (MFGArchon)  
 **Purpose**: Compare experiment tracking and visualization tools for research workflows
 
 **Decision**: Advanced monitoring tools evaluation postponed until core MFG and network features are stable.
@@ -200,7 +200,7 @@ wandb.init(project="mfg_research")
 
 ### 6. **Scientific Computing Specific Features**
 
-#### **For MFGarchon Research**
+#### **For MFGArchon Research**
 
 **Weights & Biases Advantages:**
 ```python
@@ -302,17 +302,17 @@ writer.add_hparams(
 - Standard loss curves
 - Minimal collaboration requirements
 
-## 🚀 Specific Recommendation for MFGarchon
+## 🚀 Specific Recommendation for MFGArchon
 
 ### **Best Fit: Weights & Biases**
 
 **Rationale:**
-1. **Mathematical Research Focus**: MFGarchon involves complex mathematical experiments that benefit from rich visualization and experiment tracking
+1. **Mathematical Research Focus**: MFGArchon involves complex mathematical experiments that benefit from rich visualization and experiment tracking
 2. **Collaboration Value**: Research often involves sharing results with advisors, colleagues, and the broader community
 3. **Publication Quality**: Mathematical research benefits from high-quality visualizations for papers and presentations
 4. **Experiment Management**: Solver parameter optimization naturally fits wandb's hyperparameter sweep capabilities
 
-### **Implementation Example for MFGarchon:**
+### **Implementation Example for MFGArchon:**
 
 ```python
 # Enhanced notebook_reporting.py integration
@@ -402,4 +402,4 @@ def log_metrics(iteration, metrics):
 | **Mathematical Research** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | wandb |
 | **Publication Quality** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | wandb |
 
-**Overall Recommendation for MFGarchon: Weights & Biases** - The collaboration features, experiment management capabilities, and publication-quality visualizations make it ideal for mathematical research workflows.
+**Overall Recommendation for MFGArchon: Weights & Biases** - The collaboration features, experiment management capabilities, and publication-quality visualizations make it ideal for mathematical research workflows.

--- a/docs/archive/historical/apple_silicon_acceleration.md
+++ b/docs/archive/historical/apple_silicon_acceleration.md
@@ -13,7 +13,7 @@ Track Apple Silicon (M1/M2/M3) GPU acceleration support across backend framework
 ### PyTorch MPS
 - **Status**: ✅ Available and stable
 - **Detection**: Working (`torch.backends.mps.is_available()`)
-- **MFGarchon Integration**: ⚠️ Backend initializes, but solver has tensor type incompatibilities
+- **MFGArchon Integration**: ⚠️ Backend initializes, but solver has tensor type incompatibilities
 - **Issue**: `"can't assign numpy.ndarray to torch.FloatTensor"`
 - **Root Cause**: Solver internals mix NumPy arrays with PyTorch tensors
 - **Required Work**: Consistent tensor type handling in solver pipeline
@@ -22,7 +22,7 @@ Track Apple Silicon (M1/M2/M3) GPU acceleration support across backend framework
 - **Status**: 🧪 Experimental (`jax-metal` package)
 - **Official Support**: Not yet production-ready
 - **Documentation**: https://github.com/google/jax/tree/main/jax_plugins/metal_plugin
-- **MFGarchon Integration**: ❌ Not attempted (waiting for stable release)
+- **MFGArchon Integration**: ❌ Not attempted (waiting for stable release)
 - **Tracking**: Monitor JAX releases for production-ready Metal backend
 
 ### Current Workaround
@@ -90,7 +90,7 @@ All backends run on CPU on Apple Silicon:
 ### Community Tracking
 - JAX GitHub Discussions: https://github.com/google/jax/discussions
 - PyTorch Forums: https://discuss.pytorch.org/c/mps/
-- MFGarchon should check quarterly for updates
+- MFGArchon should check quarterly for updates
 
 ## Expected Performance Gains
 
@@ -166,7 +166,7 @@ def get_available_backends():
 1. **JAX Metal Plugin**: https://github.com/google/jax/tree/main/jax_plugins/metal_plugin
 2. **PyTorch MPS Backend**: https://pytorch.org/docs/stable/notes/mps.html
 3. **Apple Metal Performance Shaders**: https://developer.apple.com/metal/
-4. **MFGarchon Backend System**: `mfgarchon/backends/`
+4. **MFGArchon Backend System**: `mfgarchon/backends/`
 
 ---
 

--- a/docs/archive/historical/framework_design_philosophy.md
+++ b/docs/archive/historical/framework_design_philosophy.md
@@ -3,11 +3,11 @@
 **Date:** July 26, 2025  
 **Author:** Framework Design Team  
 **Status:** Conceptual Design  
-**Based on:** MFGarchon Success Patterns  
+**Based on:** MFGArchon Success Patterns  
 
 ## Executive Summary
 
-This document outlines the design for a next-generation abstract scientific computing framework, building on the successful patterns demonstrated in MFGarchon. The framework aims to provide a unified, production-ready platform for multi-domain scientific computation with professional tooling, type safety, and scalable architecture.
+This document outlines the design for a next-generation abstract scientific computing framework, building on the successful patterns demonstrated in MFGArchon. The framework aims to provide a unified, production-ready platform for multi-domain scientific computation with professional tooling, type safety, and scalable architecture.
 
 ## Vision Statement
 
@@ -24,13 +24,13 @@ This document outlines the design for a next-generation abstract scientific comp
 5. **Reproducible by Default** - Complete environment and experiment tracking
 6. **Scalable Architecture** - From laptop to HPC clusters
 
-### Proven Patterns from MFGarchon
+### Proven Patterns from MFGArchon
 
-Based on our successful MFGarchon implementation, these patterns should be generalized:
+Based on our successful MFGArchon implementation, these patterns should be generalized:
 
 ✅ **Pydantic Configuration Management**
 ```python
-# Successful pattern from MFGarchon
+# Successful pattern from MFGArchon
 from typing import Dict, Any
 from mfgarchon.config.pydantic_config import ScientificConfig
 from mfgarchon.solvers.base import ScientificSolver
@@ -383,7 +383,7 @@ class GPUBackend(ComputeBackend):
 
 ### 1. Universal Validation Framework
 
-Building on MFGarchon's successful Pydantic validation:
+Building on MFGArchon's successful Pydantic validation:
 
 ```python
 class PhysicalConstraints(BaseModel):
@@ -474,11 +474,11 @@ class ResourceManager:
 ## Implementation Roadmap
 
 ### Phase 1: Foundation (Months 1-3)
-- [ ] Extract and generalize MFGarchon patterns
+- [ ] Extract and generalize MFGArchon patterns
 - [ ] Implement core abstractions (Problem, Solver, Config, Result)
 - [ ] Create plugin system architecture
 - [ ] Build universal validation framework
-- [ ] Migrate MFGarchon as first domain plugin
+- [ ] Migrate MFGArchon as first domain plugin
 
 ### Phase 2: Multi-Domain Demonstration (Months 4-6)
 - [ ] Implement 2nd domain plugin (e.g., Optimization)
@@ -523,7 +523,7 @@ class ResourceManager:
 
 ### Performance Targets
 
-Based on MFGarchon benchmarks:
+Based on MFGArchon benchmarks:
 - **Startup Overhead:** <5 seconds for framework initialization
 - **Memory Overhead:** <100MB framework overhead
 - **Scaling:** Linear scaling to 1000+ cores
@@ -740,7 +740,7 @@ new_config = migrator.migrate_config(
 
 ## Conclusion
 
-The abstract scientific computing framework represents a natural evolution from the successful patterns demonstrated in MFGarchon. By generalizing the type safety, professional tooling, and domain expertise that made MFGarchon successful, we can create a platform that accelerates scientific discovery across multiple domains.
+The abstract scientific computing framework represents a natural evolution from the successful patterns demonstrated in MFGArchon. By generalizing the type safety, professional tooling, and domain expertise that made MFGArchon successful, we can create a platform that accelerates scientific discovery across multiple domains.
 
 The framework's success will be measured not just by technical metrics, but by its ability to democratize access to advanced computational methods and accelerate the pace of scientific discovery.
 

--- a/docs/archive/historical/optimization_integration_analysis.md
+++ b/docs/archive/historical/optimization_integration_analysis.md
@@ -1,4 +1,4 @@
-# [DEFERRED] Optimization Integration Analysis for MFGarchon
+# [DEFERRED] Optimization Integration Analysis for MFGArchon
 
 **Date**: July 31, 2025  
 **Status**: DEFERRED - Lower priority after core MFG functionality  
@@ -7,7 +7,7 @@
 
 ## Executive Summary
 
-Analysis of optimization integration options for MFGarchon concluded that a **minimal integration layer** is preferred over custom optimization implementations. The focus should remain on leveraging mature optimization libraries (scipy, optax, cvxpy) with MFG-specific convenience functions rather than reimplementing optimization algorithms.
+Analysis of optimization integration options for MFGArchon concluded that a **minimal integration layer** is preferred over custom optimization implementations. The focus should remain on leveraging mature optimization libraries (scipy, optax, cvxpy) with MFG-specific convenience functions rather than reimplementing optimization algorithms.
 
 ## Optimization Library Comparison
 

--- a/docs/archive/historical/project_summary.md
+++ b/docs/archive/historical/project_summary.md
@@ -2,7 +2,7 @@
 
 **Date:** July 27, 2025  
 **Project:** Abstract Scientific Computing Framework  
-**Based on:** MFGarchon Success Patterns  
+**Based on:** MFGArchon Success Patterns  
 **Investment Required:** $1.3M over 12 months  
 **Expected ROI:** 10x improvement in scientific computing productivity  
 
@@ -32,7 +32,7 @@ Gap: No unified, professional-grade, multi-domain framework
 ## Solution Overview
 
 ### Built on Proven Success
-Our framework builds directly on the **proven patterns from MFGarchon**, which demonstrated:
+Our framework builds directly on the **proven patterns from MFGArchon**, which demonstrated:
 - ✅ **Type Safety**: Zero runtime configuration errors through Pydantic validation
 - ✅ **Professional Logging**: Research-grade observability and debugging
 - ✅ **Physical Validation**: Automatic constraint checking (mass conservation, stability)
@@ -61,7 +61,7 @@ ml_result = framework.solve("neural_ode", problem_config)
 ## Competitive Advantages
 
 ### 1. **Proven Foundation**
-- Built on **battle-tested patterns** from successful MFGarchon implementation
+- Built on **battle-tested patterns** from successful MFGArchon implementation
 - **Zero greenfield risk** - we know these patterns work in production
 - **Immediate validation** with existing MFG user base
 
@@ -195,13 +195,13 @@ Year 5: $100M+ (market leadership, platform effects)
 ### 12-Month Roadmap
 
 #### **Months 1-3: Foundation**
-- Extract and generalize MFGarchon patterns
+- Extract and generalize MFGArchon patterns
 - Build universal configuration and validation
 - Create plugin architecture
 - **Milestone**: Core framework functional
 
 #### **Months 4-6: Multi-Domain**
-- Port MFGarchon as first domain plugin
+- Port MFGArchon as first domain plugin
 - Add optimization and neural ODE plugins  
 - Demonstrate cross-domain capabilities
 - **Milestone**: 3 domains working, early users
@@ -223,7 +223,7 @@ Year 5: $100M+ (market leadership, platform effects)
 ### Technical Risks (Low-Medium)
 - **Performance overhead** - *Mitigation*: Continuous benchmarking, proven optimization
 - **Complex integrations** - *Mitigation*: Incremental complexity, community contributions
-- **Adoption challenges** - *Mitigation*: Start with proven MFGarchon user base
+- **Adoption challenges** - *Mitigation*: Start with proven MFGArchon user base
 
 ### Market Risks (Low)
 - **Competition from established players** - *Mitigation*: Unique multi-domain value prop
@@ -231,7 +231,7 @@ Year 5: $100M+ (market leadership, platform effects)
 - **Technical complexity** - *Mitigation*: Proven patterns, extensive testing
 
 ### Mitigation Strategies
-- **Technical de-risking**: Build on proven MFGarchon patterns
+- **Technical de-risking**: Build on proven MFGArchon patterns
 - **Market validation**: Start with existing user base
 - **Partnership approach**: Work with universities and labs
 - **Open source strategy**: Build community before commercialization
@@ -259,13 +259,13 @@ Year 5: $100M+ (market leadership, platform effects)
 ## Investment Opportunity
 
 ### Why Now?
-1. **Technical Readiness** - Proven patterns from MFGarchon success
+1. **Technical Readiness** - Proven patterns from MFGArchon success
 2. **Market Demand** - Growing need for better scientific computing tools
 3. **Competitive Timing** - First-mover advantage in universal framework space
 4. **Team Capability** - Demonstrated ability to build successful scientific software
 
 ### Investment Highlights
-- **Proven Technology** - Built on battle-tested MFGarchon patterns
+- **Proven Technology** - Built on battle-tested MFGArchon patterns
 - **Large Market** - $50B+ scientific computing market growing 15% annually
 - **Strong Team** - Track record of successful scientific software development
 - **Multiple Revenue Streams** - SaaS, enterprise, services, marketplace
@@ -304,7 +304,7 @@ Expected Outcomes:
 
 ## Conclusion
 
-The Abstract Scientific Computing Framework represents a **once-in-a-decade opportunity** to transform how science is conducted computationally. Built on the **proven success of MFGarchon**, we have demonstrated that this approach works in practice.
+The Abstract Scientific Computing Framework represents a **once-in-a-decade opportunity** to transform how science is conducted computationally. Built on the **proven success of MFGArchon**, we have demonstrated that this approach works in practice.
 
 **The vision is clear**: Create a universal platform that makes advanced computational methods accessible to all scientists while maintaining the rigor required for cutting-edge research.
 

--- a/docs/archive/historical/strategic_recommendations.md
+++ b/docs/archive/historical/strategic_recommendations.md
@@ -1,4 +1,4 @@
-# Strategic Package Recommendations for MFGarchon
+# Strategic Package Recommendations for MFGArchon
 
 **Date:** July 27, 2025  
 **Version:** 1.0  
@@ -7,9 +7,9 @@
 
 ## Executive Summary
 
-The MFGarchon package represents a sophisticated scientific computing framework that has undergone significant modernization efforts, achieving an A- quality rating (88/100) with comprehensive testing infrastructure. This strategic analysis identifies key opportunities to transform the already excellent academic package into a definitive research platform for computational mean field games.
+The MFGArchon package represents a sophisticated scientific computing framework that has undergone significant modernization efforts, achieving an A- quality rating (88/100) with comprehensive testing infrastructure. This strategic analysis identifies key opportunities to transform the already excellent academic package into a definitive research platform for computational mean field games.
 
-**Strategic Vision:** Position MFGarchon as the industry-leading platform for mean field games research, serving researchers, educators, and industry practitioners while establishing new standards for scientific computing software quality.
+**Strategic Vision:** Position MFGArchon as the industry-leading platform for mean field games research, serving researchers, educators, and industry practitioners while establishing new standards for scientific computing software quality.
 
 ---
 
@@ -1289,7 +1289,7 @@ class VideoTutorialGenerator:
 
 ## 🏆 **Vision for Success**
 
-By implementing these strategic recommendations, MFGarchon will transform from an excellent academic package into **the definitive platform for computational mean field games research and applications**. The platform will serve as:
+By implementing these strategic recommendations, MFGArchon will transform from an excellent academic package into **the definitive platform for computational mean field games research and applications**. The platform will serve as:
 
 ### **For Researchers**
 - **The gold standard** for reproducible mean field games research
@@ -1315,7 +1315,7 @@ By implementing these strategic recommendations, MFGarchon will transform from a
 - **A standards leader** influencing the broader ecosystem
 - **A legacy project** supporting decades of future research
 
-**The ultimate goal:** Establish MFGarchon as an essential tool that every researcher, educator, and practitioner in mean field games considers indispensable for their work, while setting new standards for quality, performance, and usability in scientific computing software.
+**The ultimate goal:** Establish MFGArchon as an essential tool that every researcher, educator, and practitioner in mean field games considers indispensable for their work, while setting new standards for quality, performance, and usability in scientific computing software.
 
 ---
 

--- a/docs/archive/historical/unified_problem_migration.md
+++ b/docs/archive/historical/unified_problem_migration.md
@@ -1,6 +1,6 @@
 # Migration Guide: Unified MFGProblem Interface
 
-**Version**: MFGarchon v0.10.x - v0.11.x
+**Version**: MFGArchon v0.10.x - v0.11.x
 **Status**: Stable API (v0.10.x+), Dual Geometry Added (v0.11.x)
 **Deprecation Timeline**: v0.9.0 (warnings) → v2.0.0 (removal)
 
@@ -8,7 +8,7 @@
 
 ## Overview
 
-MFGarchon v0.9.0 introduces a unified `MFGProblem` class that supports all problem types through a single interface. The old `GridBasedMFGProblem` class has been converted to a factory function with deprecation warnings.
+MFGArchon v0.9.0 introduces a unified `MFGProblem` class that supports all problem types through a single interface. The old `GridBasedMFGProblem` class has been converted to a factory function with deprecation warnings.
 
 **v0.11.0 Update**: The unified API now includes complete dual geometry support, enabling HJB and FP solvers to use different discretizations.
 
@@ -505,7 +505,7 @@ assert np.allclose(result_old.U, result_new.U, atol=1e-12)
 
 **Problem**: `AttributeError: module 'mfgarchon' has no attribute 'GridBasedMFGProblem'`
 
-**Solution**: Update MFGarchon to v0.9.0+:
+**Solution**: Update MFGArchon to v0.9.0+:
 ```bash
 pip install --upgrade mfgarchon>=0.9.0
 ```

--- a/docs/archive/issue_580_factory_pattern_2026-01/INFRASTRUCTURE_AUDIT_2026-01-16.md
+++ b/docs/archive/issue_580_factory_pattern_2026-01/INFRASTRUCTURE_AUDIT_2026-01-16.md
@@ -2,14 +2,14 @@
 
 **Document**: Infrastructure Survey for Factory Pattern Design
 **Date**: 2026-01-16
-**Purpose**: Ground factory design in MFGarchon's actual codebase
+**Purpose**: Ground factory design in MFGArchon's actual codebase
 **Related**: `FACTORY_PATTERN_DESIGN.md`, Issue #580
 
 ---
 
 ## Executive Summary
 
-**Survey Scope**: Comprehensive analysis of MFGarchon infrastructure to validate factory pattern design assumptions.
+**Survey Scope**: Comprehensive analysis of MFGArchon infrastructure to validate factory pattern design assumptions.
 
 **Key Finding**: Infrastructure is **80% ready** for factory pattern implementation:
 - ✅ **Ready**: Config system (Pydantic), solver hierarchy, geometry protocol, BC applicators
@@ -520,7 +520,7 @@ Reality: No `is_convex()` method exists.
 ```markdown
 ## Current Implementation Status
 
-Before implementing Issue #580, understand MFGarchon's current state:
+Before implementing Issue #580, understand MFGArchon's current state:
 
 ### What Currently Exists ✅
 

--- a/docs/development/ORGANIZATION.md
+++ b/docs/development/ORGANIZATION.md
@@ -1,9 +1,9 @@
-# MFGarchon Repository Organization
+# MFGArchon Repository Organization
 
 ## Directory Structure
 
 ```
-MFGarchon/
+MFGArchon/
 ├── README.md                    # Project overview and quick start
 ├── CONTRIBUTING.md             # Development guidelines
 ├── CLAUDE.md                   # AI interaction preferences
@@ -157,4 +157,4 @@ MFGarchon/
 - Performance benchmarks for critical paths
 - Documentation updated with code changes
 
-This organizational structure supports both rapid development and long-term maintainability while providing clear pathways for users, developers, and researchers to engage with the MFGarchon framework.
+This organizational structure supports both rapid development and long-term maintainability while providing clear pathways for users, developers, and researchers to engage with the MFGArchon framework.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,9 +1,9 @@
-# MFGarchon Development Documentation
+# MFGArchon Development Documentation
 
 **Last Updated**: 2026-02-13
 **Status**: Production-Ready Framework v0.17.8
 
-This directory contains comprehensive development documentation for MFGarchon contributors and maintainers.
+This directory contains comprehensive development documentation for MFGArchon contributors and maintainers.
 
 ---
 

--- a/docs/development/boundary_conditions/BC_CAPABILITY_MATRIX.md
+++ b/docs/development/boundary_conditions/BC_CAPABILITY_MATRIX.md
@@ -13,7 +13,7 @@
 
 ## Overview
 
-This document maps boundary condition support across all numerical solvers in MFGarchon. It serves as:
+This document maps boundary condition support across all numerical solvers in MFGArchon. It serves as:
 1. Reference for users selecting appropriate solvers
 2. Gap analysis for infrastructure integration
 3. Guide for new solver development

--- a/docs/development/boundary_conditions/BOUNDARY_HANDLING.md
+++ b/docs/development/boundary_conditions/BOUNDARY_HANDLING.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-This document defines the **unified workflow** for boundary condition handling across all MFGarchon solvers. It eliminates duplicate BC detection logic and mixin hell by standardizing how solvers use the existing geometry and BC infrastructure.
+This document defines the **unified workflow** for boundary condition handling across all MFGArchon solvers. It eliminates duplicate BC detection logic and mixin hell by standardizing how solvers use the existing geometry and BC infrastructure.
 
 ## Problem: Mixin Hell
 

--- a/docs/development/boundary_conditions/PERIODIC_BOUNDARY_CONDITIONS_IMPLEMENTATION.md
+++ b/docs/development/boundary_conditions/PERIODIC_BOUNDARY_CONDITIONS_IMPLEMENTATION.md
@@ -1,4 +1,4 @@
-# [WIP] Periodic Boundary Conditions (PBC) Implementation in MFGarchon
+# [WIP] Periodic Boundary Conditions (PBC) Implementation in MFGArchon
 
 **Status**: [WIP] - Under Development and Review
 **Version**: 0.4 (Added compatibility requirements)
@@ -9,7 +9,7 @@
 
 Periodic Boundary Conditions (PBCs) play a crucial role in many physics and engineering problems, especially when simulating infinite periodic systems or eliminating artificial boundary effects. In the field of Mean Field Games (MFG), PBCs are also widely used to model the behavior of particles, crowds, or agents in macroscopically large or infinite spaces.
 
-This report aims to detail the implementation strategy and architectural considerations for PBCs within the `MFGarchon` library, with the goal of building a solution that is both general-purpose and high-performance. We will analyze the topological nature of PBCs, explore the two core implementation approaches—real space and Fourier space—and propose a "three-tier" implementation architecture. We will also highlight potential "performance killers" and "logical pitfalls" in numerical implementation.
+This report aims to detail the implementation strategy and architectural considerations for PBCs within the `MFGArchon` library, with the goal of building a solution that is both general-purpose and high-performance. We will analyze the topological nature of PBCs, explore the two core implementation approaches—real space and Fourier space—and propose a "three-tier" implementation architecture. We will also highlight potential "performance killers" and "logical pitfalls" in numerical implementation.
 
 ## 2. The Topological Nature and Numerical Differences of PBCs
 
@@ -50,13 +50,13 @@ This topological property is directly reflected in the algebraic structure of th
     \end{pmatrix} $$
     This fundamental difference in algebraic structure is the primary reason why PBCs must be treated distinctly from other BCs in implementation.
 
-## 3. PBC Implementation Architecture in MFGarchon: The "Three-Tier" Model
+## 3. PBC Implementation Architecture in MFGArchon: The "Three-Tier" Model
 
-To balance generality, robustness, and performance, `MFGarchon` will adopt a tiered architecture for handling PBCs.
+To balance generality, robustness, and performance, `MFGArchon` will adopt a tiered architecture for handling PBCs.
 
 ### 3.1. Foundational Tier: Real Space Topology
 
-This is the core and foundation for handling PBCs in `MFGarchon`, providing the broadest generality.
+This is the core and foundation for handling PBCs in `MFGArchon`, providing the broadest generality.
 
 #### **Implementation Strategy: Ghost Cells (Halo Regions)**
 
@@ -232,9 +232,9 @@ where $Z = \iint \exp(-V/T_{eff}) \, dx\,dy$ and $T_{eff} = C_2 + \sigma^2/2$.
 
 ... (Remaining sections on `Evolution Path` and `References` would be translated similarly) ...
 
-## 5. Core Evolution Path for PBC in MFGarchon
+## 5. Core Evolution Path for PBC in MFGArchon
 
-This architectural report establishes the **"Topology First, Performance Specialized"** roadmap. The evolution of PBC support in `MFGarchon` will follow these steps:
+This architectural report establishes the **"Topology First, Performance Specialized"** roadmap. The evolution of PBC support in `MFGArchon` will follow these steps:
 
 1.  **Phase 1: Foundational Bedrock (Real Space Topology)**
     *   Refine the `Grid` object's topology management to **fully support Ghost-Cell-based periodic boundaries**, ensuring interfaces like `get_neighbors(index)` can handle the wrap-around logic seamlessly.
@@ -250,7 +250,7 @@ This architectural report establishes the **"Topology First, Performance Special
     *   Implement the **`method="auto"` logic** in the factory layer (`problem.solve()`) to intelligently route to the most appropriate solver based on problem characteristics.
     *   Provide clear documentation and error messages to guide users in selecting and debugging PBC-related issues.
 
-By following this architecture and its implementation details, `MFGarchon` will offer powerful, flexible, and high-performance handling of periodic boundary conditions to meet the demands of Mean Field Game research and applications.
+By following this architecture and its implementation details, `MFGArchon` will offer powerful, flexible, and high-performance handling of periodic boundary conditions to meet the demands of Mean Field Game research and applications.
 
 ---
 

--- a/docs/development/boundary_conditions/boundary_condition_handling_summary.md
+++ b/docs/development/boundary_conditions/boundary_condition_handling_summary.md
@@ -7,7 +7,7 @@
 
 ## 1. Executive Summary
 
-The boundary condition (BC) handling in MFGarchon is **architecturally ambitious but inconsistently executed**. The core data model (`BoundaryConditions`, `BCSegment`) is well-designed, but the application layer suffers from:
+The boundary condition (BC) handling in MFGArchon is **architecturally ambitious but inconsistently executed**. The core data model (`BoundaryConditions`, `BCSegment`) is well-designed, but the application layer suffers from:
 
 - **Parallel implementations** that were never unified
 - **Deprecated code** still in active use

--- a/docs/development/boundary_conditions/boundary_framework_implementation_design.md
+++ b/docs/development/boundary_conditions/boundary_framework_implementation_design.md
@@ -2,14 +2,14 @@
 
 **Status**: Active Development Plan
 **Created**: 2025-01-03
-**GitHub Issues**: [#535](https://github.com/zvezda/MFGarchon/issues/535) (Framework Enhancement), [#536](https://github.com/zvezda/MFGarchon/issues/536) (Particle Absorbing BC)
+**GitHub Issues**: [#535](https://github.com/zvezda/MFGArchon/issues/535) (Framework Enhancement), [#536](https://github.com/zvezda/MFGArchon/issues/536) (Particle Absorbing BC)
 **Theory Reference**: [boundary_framework_mathematical_foundation.md](../theory/boundary_framework_mathematical_foundation.md)
 
 ---
 
 ## Overview
 
-This document outlines the implementation design for enhancing the MFGarchon boundary condition framework. It complements the mathematical theory document with concrete architecture, API design, and implementation phases.
+This document outlines the implementation design for enhancing the MFGArchon boundary condition framework. It complements the mathematical theory document with concrete architecture, API design, and implementation phases.
 
 **Design Philosophy**: Specification-Application-Validation separation with solver-agnostic BC definition and solver-specific interpretation.
 

--- a/docs/development/guides/API_STYLE_GUIDE.md
+++ b/docs/development/guides/API_STYLE_GUIDE.md
@@ -1,10 +1,10 @@
-# MFGarchon API Style Guide
+# MFGArchon API Style Guide
 
 **Version**: 1.0
 **Date**: 2025-10-10
 **Status**: Official Reference
 
-This guide establishes the API design standards for MFGarchon, ensuring consistency, clarity, and usability across the entire codebase.
+This guide establishes the API design standards for MFGArchon, ensuring consistency, clarity, and usability across the entire codebase.
 
 ---
 
@@ -643,6 +643,6 @@ When designing or reviewing API, ask:
 
 ---
 
-**Enforcement**: This guide is the official API design standard for MFGarchon. All new code must follow these conventions. Existing code should be gradually migrated using the deprecation procedures outlined above.
+**Enforcement**: This guide is the official API design standard for MFGArchon. All new code must follow these conventions. Existing code should be gradually migrated using the deprecation procedures outlined above.
 
 **Exceptions**: Any exceptions to these rules must be documented and justified in code comments and design documents.

--- a/docs/development/guides/ARCHITECTURE_1D_VS_ND_SOLVERS.md
+++ b/docs/development/guides/ARCHITECTURE_1D_VS_ND_SOLVERS.md
@@ -1,4 +1,4 @@
-# Architecture Analysis: 1D vs nD Solvers in MFGarchon
+# Architecture Analysis: 1D vs nD Solvers in MFGArchon
 
 **Date**: 2025-11-19
 **Question**: Do we need separate 1D solvers inside FP/HJB solvers?
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-**Current Architecture**: MFGarchon **already uses** dimension-based routing with specialized 1D and nD solvers.
+**Current Architecture**: MFGArchon **already uses** dimension-based routing with specialized 1D and nD solvers.
 
 **Key Finding**: This is the **correct design pattern** for PDE solvers. Keep and enhance it.
 

--- a/docs/development/guides/BENCHMARKING_GUIDE.md
+++ b/docs/development/guides/BENCHMARKING_GUIDE.md
@@ -1,4 +1,4 @@
-# MFGarchon Benchmark Design Guide
+# MFGArchon Benchmark Design Guide
 
 **Document Version**: 1.0  
 **Last Updated**: August 1, 2025  
@@ -6,7 +6,7 @@
 
 ## 📋 **Executive Summary**
 
-This document describes the design principles, architecture, and implementation guidelines for the MFGarchon benchmarking framework. The framework provides comprehensive evaluation capabilities for MFG solvers across multiple performance dimensions with an extensible, category-based organization.
+This document describes the design principles, architecture, and implementation guidelines for the MFGArchon benchmarking framework. The framework provides comprehensive evaluation capabilities for MFG solvers across multiple performance dimensions with an extensible, category-based organization.
 
 ## 🎯 **Design Objectives**
 
@@ -619,7 +619,7 @@ dependencies = {
 
 ## 🎯 **Conclusion**
 
-The MFGarchon benchmark design provides a **comprehensive, extensible, and scientifically rigorous framework** for evaluating MFG solver performance. Key design achievements:
+The MFGArchon benchmark design provides a **comprehensive, extensible, and scientifically rigorous framework** for evaluating MFG solver performance. Key design achievements:
 
 ### **Technical Excellence**
 - **Modular Architecture**: Clean separation of concerns with standardized interfaces

--- a/docs/development/guides/CI_CD_ARCHITECTURE_FINAL.md
+++ b/docs/development/guides/CI_CD_ARCHITECTURE_FINAL.md
@@ -1,4 +1,4 @@
-# MFGarchon CI/CD Architecture - Final State
+# MFGArchon CI/CD Architecture - Final State
 
 **Date**: 2025-10-13
 **Version**: Post-Consolidation (Phase 1 & 2 Complete)
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This document describes the final CI/CD architecture for the MFGarchon repository after the consolidation initiative (Issue #138). The architecture eliminates duplicate checks, implements fail-fast execution, and achieves a 20% reduction in compute time.
+This document describes the final CI/CD architecture for the MFGArchon repository after the consolidation initiative (Issue #138). The architecture eliminates duplicate checks, implements fail-fast execution, and achieves a 20% reduction in compute time.
 
 ---
 
@@ -556,7 +556,7 @@ paths:
 
 ## Summary
 
-The MFGarchon CI/CD architecture has been successfully consolidated to eliminate waste, improve efficiency, and maintain quality. The architecture achieves:
+The MFGArchon CI/CD architecture has been successfully consolidated to eliminate waste, improve efficiency, and maintain quality. The architecture achieves:
 
 - ✅ **20% compute time reduction** (66min → 53min)
 - ✅ **10-15% faster developer feedback** (45min → 35-40min)

--- a/docs/development/guides/CONSISTENCY_GUIDE.md
+++ b/docs/development/guides/CONSISTENCY_GUIDE.md
@@ -1,8 +1,8 @@
-# MFGarchon Comprehensive Consistency Guide
+# MFGArchon Comprehensive Consistency Guide
 
 **Version:** 1.0  
 **Date:** July 26, 2025  
-**Purpose:** Master guide for maintaining consistency across all aspects of the MFGarchon repository  
+**Purpose:** Master guide for maintaining consistency across all aspects of the MFGArchon repository  
 
 This document consolidates all consistency standards into a single authoritative reference, covering code, documentation, mathematical notation, naming conventions, testing patterns, and architectural decisions.
 
@@ -564,9 +564,9 @@ def create_solver(problem, solver_type, config=None, **kwargs):
 
 **✅ STANDARD EXCEPTION CLASSES:**
 ```python
-# Base exception for MFGarchon
+# Base exception for MFGArchon
 class MFGPDEError(Exception):
-    """Base exception for MFGarchon package"""
+    """Base exception for MFGArchon package"""
     pass
 
 # Specific exception categories
@@ -639,7 +639,7 @@ def __init__(self, problem, NiterNewton=None, max_newton_iterations=None, **kwar
 **✅ __init__.py EXPORT STANDARDS:**
 ```python
 # mfgarchon/__init__.py
-"""MFGarchon: Numerical Solvers for Mean Field Games"""
+"""MFGArchon: Numerical Solvers for Mean Field Games"""
 
 # Core exports (most commonly used)
 from .core.mfg_problem import MFGProblem, MFGProblem
@@ -655,7 +655,7 @@ from .config import MFGSolverConfig, create_fast_config, create_accurate_config
 
 # Version info
 __version__ = "1.4.0"
-__author__ = "MFGarchon Development Team"
+__author__ = "MFGArchon Development Team"
 
 # All exports for * imports (discouraged but needed)
 __all__ = [

--- a/docs/development/guides/DEPENDENCY_MANAGEMENT.md
+++ b/docs/development/guides/DEPENDENCY_MANAGEMENT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MFGarchon provides clear error messages and diagnostics for optional dependencies through `mfgarchon/utils/dependencies.py`.
+MFGArchon provides clear error messages and diagnostics for optional dependencies through `mfgarchon/utils/dependencies.py`.
 
 ## Core Utilities
 
@@ -38,7 +38,7 @@ show_optional_features()
 
 **Output**:
 ```
-MFGarchon Optional Features Status
+MFGArchon Optional Features Status
 ================================================================================
 
 Core (always available):

--- a/docs/development/guides/PROTOCOL_DUCK_TYPING_ANALYSIS.md
+++ b/docs/development/guides/PROTOCOL_DUCK_TYPING_ANALYSIS.md
@@ -61,7 +61,7 @@ The **Interface Segregation Principle** states that no client should be forced t
 | **Coupling** | High (Client depends on full hierarchy). | Low (Client depends on single method). |
 | **Flexibility** | Rigid taxonomy. | Mix-and-match traits. |
 
-**Example in MFGarchon**:
+**Example in MFGArchon**:
 
 ```python
 # ✅ GOOD: Focused protocols (Interface Segregation)
@@ -108,7 +108,7 @@ render(external_lib.ThirdPartyShape())
 
 ### ✅ Case 3: Gradual Typing of Legacy Code
 
-For mature codebases like portions of `MFGarchon`, refactoring deep inheritance hierarchies to add type hints is risky. Protocols allow you to define types for existing behaviors without changing the runtime code structure.
+For mature codebases like portions of `MFGArchon`, refactoring deep inheritance hierarchies to add type hints is risky. Protocols allow you to define types for existing behaviors without changing the runtime code structure.
 
 ```python
 # Legacy code (no types, no inheritance)
@@ -280,9 +280,9 @@ class ObstacleConstraint(ConstraintBase):  # Inherits ABC utilities
 
 ---
 
-## 5. MFGarchon Contextual Audit
+## 5. MFGArchon Contextual Audit
 
-Based on the current architecture of `MFGarchon`, here is the specific guidance:
+Based on the current architecture of `MFGArchon`, here is the specific guidance:
 
 ### ✅ Approved Uses (Keep as Protocols)
 
@@ -401,7 +401,7 @@ To decide between a Protocol and an ABC, ask these three questions:
 2. **ABCs** define **how** (behavior, implementation, identity)
 3. **Hybrid approach** often optimal: Protocol for public API, ABC for internal utilities
 
-**MFGarchon Recommendation**:
+**MFGArchon Recommendation**:
 - ✅ Keep: `ConstraintProtocol`, geometry traits, minimal handler interfaces
 - ⚠️ Refactor: `BCApplicatorProtocol` → `BCApplicatorBase(ABC)` with template method
 - 📋 Guideline: Default to Protocol for < 5 methods with no shared logic, ABC otherwise
@@ -423,5 +423,5 @@ To decide between a Protocol and an ABC, ask these three questions:
 **Document Metadata**:
 - **Last Updated**: 2026-01-17
 - **Context**: Design review during Issue #591 (Variational Inequality Constraints)
-- **Status**: Authoritative architectural reference for MFGarchon
+- **Status**: Authoritative architectural reference for MFGArchon
 - **Format**: Typora/Obsidian compatible with proper footnotes

--- a/docs/development/guides/PYDANTIC_OMEGACONF_COOPERATION.md
+++ b/docs/development/guides/PYDANTIC_OMEGACONF_COOPERATION.md
@@ -1,4 +1,4 @@
-# Pydantic and OmegaConf Cooperation in MFGarchon
+# Pydantic and OmegaConf Cooperation in MFGArchon
 
 **Status**: [APPROVED / ARCHITECTURE_V2]
 **Created**: 2025-12-10
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary
 
-MFGarchon employs a **Dual-System Configuration Architecture** to balance runtime safety with experimental flexibility.
+MFGArchon employs a **Dual-System Configuration Architecture** to balance runtime safety with experimental flexibility.
 
 | System | Role | Primary Responsibility |
 |:-------|:-----|:-----------------------|
@@ -324,7 +324,7 @@ This architecture adopts a **"Loose Coupling, Tight Validation"** strategy.
 - **Loose Coupling** allows researchers to organize YAMLs however they like.
 - **Tight Validation** ensures the Math Kernel never receives invalid parameters.
 
-By implementing the **Generic Bridge** and **Strict Naming Strategy** defined in this revision, `MFGarchon` achieves production-grade robustness while maintaining research-grade flexibility.
+By implementing the **Generic Bridge** and **Strict Naming Strategy** defined in this revision, `MFGArchon` achieves production-grade robustness while maintaining research-grade flexibility.
 
 ---
 

--- a/docs/development/guides/SELF_GOVERNANCE_PROTOCOL.md
+++ b/docs/development/guides/SELF_GOVERNANCE_PROTOCOL.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-As the primary maintainer of MFGarchon, this protocol ensures disciplined, high-quality changes through structured decision-making and comprehensive quality gates.
+As the primary maintainer of MFGArchon, this protocol ensures disciplined, high-quality changes through structured decision-making and comprehensive quality gates.
 
 ## Protocol Workflow
 
@@ -79,7 +79,7 @@ git commit -m "Add AMR solver with error estimation"
 
 ## Next Steps
 
-This protocol is now operational and should be used for all significant changes to MFGarchon. The next implementation task is to complete the remaining type modernization work using this structured approach.
+This protocol is now operational and should be used for all significant changes to MFGArchon. The next implementation task is to complete the remaining type modernization work using this structured approach.
 
 ---
 

--- a/docs/development/guides/code_quality/CODE_REVIEW_GUIDELINES.md
+++ b/docs/development/guides/code_quality/CODE_REVIEW_GUIDELINES.md
@@ -1,4 +1,4 @@
-# Code Review Guidelines for MFGarchon
+# Code Review Guidelines for MFGArchon
 
 **Date**: 2025-09-23
 **Status**: ✅ **ACTIVE** - Standard code review practices
@@ -144,7 +144,7 @@ gh pr review [PR_NUMBER] --approve --body "LGTM! Ready to merge"
 **Nitpicky**: "Use single quotes instead of double quotes" (when both are acceptable)
 ```
 
-## 🎯 **Special Considerations for MFGarchon**
+## 🎯 **Special Considerations for MFGArchon**
 
 ### **Research Code Flexibility**
 - **Accept** `**kwargs: Any` patterns for research interfaces

--- a/docs/development/guides/code_quality/DOCSTRING_STANDARDS.md
+++ b/docs/development/guides/code_quality/DOCSTRING_STANDARDS.md
@@ -1,4 +1,4 @@
-# Docstring Standards for MFGarchon Package
+# Docstring Standards for MFGArchon Package
 
 **Version:** 1.4.0  
 **Last Updated:** 2025-07-27  
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This document establishes comprehensive docstring standards for the MFGarchon package to ensure consistency, clarity, and maintainability across all modules. All public code must follow these standards.
+This document establishes comprehensive docstring standards for the MFGArchon package to ensure consistency, clarity, and maintainability across all modules. All public code must follow these standards.
 
 ## Docstring Format
 
@@ -400,4 +400,4 @@ Configure your IDE for docstring support:
 - Set up auto-formatting for docstring text
 - Configure spell-checking for documentation
 
-This comprehensive standard ensures that all MFGarchon documentation is consistent, informative, and maintainable while supporting the mathematical and computational nature of the package.
+This comprehensive standard ensures that all MFGArchon documentation is consistent, informative, and maintainable while supporting the mathematical and computational nature of the package.

--- a/docs/development/guides/code_quality/TESTING_STRATEGY_GUIDE.md
+++ b/docs/development/guides/code_quality/TESTING_STRATEGY_GUIDE.md
@@ -1,12 +1,12 @@
-# Unit Testing Strategy Guide for MFGarchon
+# Unit Testing Strategy Guide for MFGArchon
 
 **Date:** July 27, 2025  
 **Purpose:** Comprehensive guide for implementing effective unit testing in scientific computing packages  
-**Target Audience:** Developers and researchers working on MFGarchon  
+**Target Audience:** Developers and researchers working on MFGArchon  
 
 ## Executive Summary
 
-Unit testing in scientific computing requires a balanced approach that validates both computational correctness and software engineering principles. This guide provides a comprehensive strategy for implementing effective testing throughout the MFGarchon package.
+Unit testing in scientific computing requires a balanced approach that validates both computational correctness and software engineering principles. This guide provides a comprehensive strategy for implementing effective testing throughout the MFGArchon package.
 
 **Key Principle:** *Test strategically, not everywhere* - Focus on critical functionality, edge cases, and public APIs while maintaining computational efficiency.
 
@@ -31,7 +31,7 @@ Unit testing in scientific computing requires a balanced approach that validates
 
 ### Recommended Directory Layout:
 ```
-MFGarchon/
+MFGArchon/
 ├── mfgarchon/                    # Source code
 ├── tests/                      # Test suite (separate from source)
 │   ├── unit/                   # Fast, isolated tests

--- a/docs/development/guides/tooling/UV_INTEGRATION_GUIDE.md
+++ b/docs/development/guides/tooling/UV_INTEGRATION_GUIDE.md
@@ -1,4 +1,4 @@
-# UV Integration Guide for MFGarchon
+# UV Integration Guide for MFGArchon
 
 **Date**: 2025-08-12  
 **Status**: ✅ **IMPLEMENTED**  
@@ -15,7 +15,7 @@ pip install uv
 uv sync --extra dev
 
 # 3. Verify installation
-uv run python -c "import mfgarchon; print('✅ MFGarchon ready!')"
+uv run python -c "import mfgarchon; print('✅ MFGArchon ready!')"
 ```
 
 ### **Daily Development Workflow**
@@ -47,7 +47,7 @@ uv run jupyter lab   # Jupyter with full MFG environment
 | Lock file generation | 30-60 seconds | 1-3 seconds | **20x faster** |
 | Clean environment rebuild | 3-5 minutes | 15-30 seconds | **10x faster** |
 
-## 🔧 **UV Features for MFGarchon**
+## 🔧 **UV Features for MFGArchon**
 
 ### **1. Exact Reproducible Environments**
 ```bash
@@ -138,7 +138,7 @@ uv run sphinx-autobuild docs/ build/html
 ## 📁 **File Structure Created**
 
 ```
-MFGarchon/
+MFGArchon/
 ├── .venv/                   # UV-managed virtual environment  
 ├── uv.lock                  # Exact dependency versions (294 packages)
 ├── .pre-commit-config-uv.yaml    # UV-powered pre-commit hooks
@@ -332,7 +332,7 @@ uv sync --all-extras
 
 ## 🏆 **Summary**
 
-**UV integration is successful** and provides significant performance improvements for MFGarchon development:
+**UV integration is successful** and provides significant performance improvements for MFGArchon development:
 
 - ✅ **10-100x faster** dependency management
 - ✅ **Perfect reproducibility** with uv.lock (294 packages)  

--- a/docs/development/guides/tooling/UV_SCIENTIFIC_COMPUTING_GUIDE.md
+++ b/docs/development/guides/tooling/UV_SCIENTIFIC_COMPUTING_GUIDE.md
@@ -1,8 +1,8 @@
-# UV for Scientific Computing - MFGarchon Guide
+# UV for Scientific Computing - MFGArchon Guide
 
 ## Overview
 
-UV is an optional, high-performance package manager that provides significant benefits for MFG research and scientific computing workflows. While MFGarchon works perfectly with standard pip, UV offers enhanced performance and reproducibility features.
+UV is an optional, high-performance package manager that provides significant benefits for MFG research and scientific computing workflows. While MFGArchon works perfectly with standard pip, UV offers enhanced performance and reproducibility features.
 
 ## When to Use UV
 
@@ -39,7 +39,7 @@ export NUMEXPR_MAX_THREADS="4"    # NumPy expression evaluator
 - **Dependency conflict resolution** for complex scientific packages
 
 ### 3. **Performance Characteristics**
-Based on MFGarchon testing:
+Based on MFGArchon testing:
 - **10-100x faster** dependency resolution vs pip
 - **Parallel downloads** of packages during installation
 - **Efficient caching** reduces repeated download times
@@ -88,7 +88,7 @@ cd ~/research/mfg_finance && uv sync   # Financial MFG environment
 cd ~/research/mfg_control && uv sync   # Control theory environment
 ```
 
-## Integration with MFGarchon
+## Integration with MFGArchon
 
 ### Pre-commit Hooks
 Our modern `.pre-commit-config.yaml` uses standard Ruff tooling, not UV:
@@ -127,7 +127,7 @@ pre-commit install  # Uses same hooks regardless of package manager
 
 ### Package Resolution Speed
 ```bash
-# Benchmark on MFGarchon dependencies (294 packages)
+# Benchmark on MFGArchon dependencies (294 packages)
 pip install -e ".[dev]"  # ~180-300 seconds
 uv sync --extra dev      # ~5-15 seconds (10-20x faster)
 ```
@@ -181,17 +181,17 @@ pip install -r requirements.txt            # Standard pip installation
 
 ### Getting Help
 - **UV Documentation**: https://docs.astral.sh/uv/
-- **MFGarchon Issues**: Standard GitHub issue tracker
+- **MFGArchon Issues**: Standard GitHub issue tracker
 - **Scientific computing setup**: Check `.uvrc` configuration
 
 ## Conclusion
 
-UV provides significant benefits for research-intensive MFG workflows, but MFGarchon's pip-first approach ensures accessibility for all users. Choose based on your specific needs:
+UV provides significant benefits for research-intensive MFG workflows, but MFGArchon's pip-first approach ensures accessibility for all users. Choose based on your specific needs:
 
 - **Use pip** for simplicity and standard Python workflows
 - **Use UV** for performance, reproducibility, and intensive research development
 
-Both approaches are fully supported and tested in the MFGarchon ecosystem.
+Both approaches are fully supported and tested in the MFGArchon ecosystem.
 
 ---
 

--- a/docs/development/guides/tooling/UV_SETUP.md
+++ b/docs/development/guides/tooling/UV_SETUP.md
@@ -1,6 +1,6 @@
-# Using UV with MFGarchon
+# Using UV with MFGArchon
 
-This document explains how to use the modern `uv` package manager with MFGarchon instead of conda.
+This document explains how to use the modern `uv` package manager with MFGArchon instead of conda.
 
 ## Why UV?
 

--- a/docs/development/guides/tooling/logging_guide.md
+++ b/docs/development/guides/tooling/logging_guide.md
@@ -1,13 +1,13 @@
-# MFGarchon Logging System Guide
+# MFGArchon Logging System Guide
 
 **Date**: August 15, 2025
 **Updated**: January 24, 2026 - Added thread safety documentation (Issue #620)  
 **Quality Score**: 8.7/10 - Excellent scientific computing logging infrastructure  
-**Purpose**: Complete guide for using the professional logging system in MFGarchon
+**Purpose**: Complete guide for using the professional logging system in MFGArchon
 
 ## Overview
 
-The MFGarchon logging system provides a **sophisticated, multi-layered logging infrastructure** specifically designed for scientific computing and mathematical research workflows. The system demonstrates professional-grade engineering with extensive configurability, performance monitoring integration, and analytical capabilities.
+The MFGArchon logging system provides a **sophisticated, multi-layered logging infrastructure** specifically designed for scientific computing and mathematical research workflows. The system demonstrates professional-grade engineering with extensive configurability, performance monitoring integration, and analytical capabilities.
 
 **Key Features**:
 - **Multi-destination logging**: Console and file output with independent formatting
@@ -636,7 +636,7 @@ logger.error("Error level test")
 
 # Inspect active loggers
 import logging
-print("Active MFGarchon loggers:")
+print("Active MFGArchon loggers:")
 for name in sorted(logging.Logger.manager.loggerDict.keys()):
     if name.startswith('mfgarchon'):
         logger_obj = logging.getLogger(name)
@@ -712,7 +712,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# New MFGarchon logging
+# New MFGArchon logging
 from mfgarchon.utils import configure_logging, get_logger
 configure_logging(level="INFO", use_colors=True)
 logger = get_logger(__name__)
@@ -740,4 +740,4 @@ logger = get_logger(__name__)
 
 ---
 
-This logging system provides professional debugging and monitoring capabilities while maintaining the clean, text-based formatting preferences established for the MFGarchon project.
+This logging system provides professional debugging and monitoring capabilities while maintaining the clean, text-based formatting preferences established for the MFGArchon project.

--- a/docs/development/maintenance/API_AUDIT_REPORT_2025-11-11.md
+++ b/docs/development/maintenance/API_AUDIT_REPORT_2025-11-11.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-Systematic audit of MFGarchon codebase for API consistency violations. This report catalogs naming convention issues, boolean pair patterns, and tuple return opportunities for Phase 2 standardization.
+Systematic audit of MFGArchon codebase for API consistency violations. This report catalogs naming convention issues, boolean pair patterns, and tuple return opportunities for Phase 2 standardization.
 
 **Status**: ✅ Mostly consistent, minor violations found
 

--- a/docs/development/maintenance/COLLOCATION_POINT_GENERATION_REPORT.md
+++ b/docs/development/maintenance/COLLOCATION_POINT_GENERATION_REPORT.md
@@ -2,7 +2,7 @@
 
 ## Technical Report
 
-**Project**: MFGarchon (Mean Field Games PDE Solver Framework)
+**Project**: MFGArchon (Mean Field Games PDE Solver Framework)
 **Date**: 2025-12-16
 **Status**: ✅ AUDITED - Ready for Implementation
 

--- a/docs/development/maintenance/RUFF_VERSION_MANAGEMENT.md
+++ b/docs/development/maintenance/RUFF_VERSION_MANAGEMENT.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-MFGarchon pins the ruff version to ensure consistent formatting across all environments (local dev, pre-commit hooks, CI/CD). This provides:
+MFGArchon pins the ruff version to ensure consistent formatting across all environments (local dev, pre-commit hooks, CI/CD). This provides:
 
 - ✅ **Consistency**: Same formatting behavior everywhere
 - ✅ **Reproducibility**: Code formatting is deterministic

--- a/docs/development/maintenance/SOLVER_INFRASTRUCTURE_AUDIT_REPORT.md
+++ b/docs/development/maintenance/SOLVER_INFRASTRUCTURE_AUDIT_REPORT.md
@@ -4,13 +4,13 @@
 **Date**: 2025-12-16
 **Revision**: 1.0
 **Status**: Assessment Complete
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team
 
 ---
 
 ## Executive Summary
 
-This report documents a comprehensive audit of the MFGarchon solver infrastructure, identifying critical gaps, incomplete implementations, and architectural defects that limit solver capabilities. The audit covers HJB solvers (FDM, WENO, GFDM, Semi-Lagrangian), FP solvers (FDM, Particle, GFDM), and supporting utilities.
+This report documents a comprehensive audit of the MFGArchon solver infrastructure, identifying critical gaps, incomplete implementations, and architectural defects that limit solver capabilities. The audit covers HJB solvers (FDM, WENO, GFDM, Semi-Lagrangian), FP solvers (FDM, Particle, GFDM), and supporting utilities.
 
 **Key Findings**:
 - 3 critical blockers preventing 3D+ support

--- a/docs/development/paradigms/NEURAL_PARADIGM_OVERVIEW.md
+++ b/docs/development/paradigms/NEURAL_PARADIGM_OVERVIEW.md
@@ -7,7 +7,7 @@
 
 ## 🎯 Overview
 
-The neural paradigm in MFGarchon provides **data-driven and physics-informed approaches** for solving Mean Field Games using deep learning. This paradigm complements traditional numerical methods by enabling:
+The neural paradigm in MFGArchon provides **data-driven and physics-informed approaches** for solving Mean Field Games using deep learning. This paradigm complements traditional numerical methods by enabling:
 
 - **High-dimensional problems** (d > 15) through neural network parameterization
 - **Mesh-free solving** without explicit spatial discretization
@@ -687,7 +687,7 @@ solution = operator.predict(new_params)  # Milliseconds!
 
 ## ✅ Summary
 
-The neural paradigm in MFGarchon provides **state-of-the-art deep learning approaches** for solving Mean Field Games:
+The neural paradigm in MFGArchon provides **state-of-the-art deep learning approaches** for solving Mean Field Games:
 
 **✅ Production-Ready**: 7,553 lines of code, comprehensive testing
 **✅ Three Solver Families**: PINN, DGM, Neural Operators

--- a/docs/development/paradigms/NUMERICAL_PARADIGM_OVERVIEW.md
+++ b/docs/development/paradigms/NUMERICAL_PARADIGM_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Numerical Methods Paradigm for Mean Field Games
 
-**Status**: ✅ ACTIVE (Core paradigm for MFGarchon)
+**Status**: ✅ ACTIVE (Core paradigm for MFGArchon)
 **Last Updated**: 2025-10-11
 **Related Issues**: #105
 
@@ -759,7 +759,7 @@ $$
 \frac{\sigma^2 \Delta t}{\Delta x^2} \leq \frac{1}{2}
 $$
 
-(Implicit FDM used in MFGarchon removes this restriction.)
+(Implicit FDM used in MFGArchon removes this restriction.)
 
 ### Mass Conservation
 
@@ -798,5 +798,5 @@ print(f"Max mass conservation error: {mass_error.max():.2e}")
 
 ---
 
-**Maintained by**: MFGarchon Development Team
+**Maintained by**: MFGArchon Development Team
 **Last Updated**: 2025-10-11

--- a/docs/development/paradigms/OPTIMIZATION_PARADIGM_OVERVIEW.md
+++ b/docs/development/paradigms/OPTIMIZATION_PARADIGM_OVERVIEW.md
@@ -7,7 +7,7 @@
 
 ## 🎯 Overview
 
-The optimization paradigm in MFGarchon provides **variational and direct optimization approaches** for solving Mean Field Games by reformulating the classical HJB-FPK coupled system as an optimization problem on probability measure spaces. This paradigm complements PDE-based methods by enabling:
+The optimization paradigm in MFGArchon provides **variational and direct optimization approaches** for solving Mean Field Games by reformulating the classical HJB-FPK coupled system as an optimization problem on probability measure spaces. This paradigm complements PDE-based methods by enabling:
 
 - **Convexity-based uniqueness** for potential MFG problems
 - **Gradient-based optimization** using Wasserstein geometry
@@ -672,7 +672,7 @@ print(f"Final energy: {result.final_energy:.6f}")
 
 ## ✅ Summary
 
-The optimization paradigm in MFGarchon provides **state-of-the-art variational and optimal transport methods** for solving Mean Field Games:
+The optimization paradigm in MFGArchon provides **state-of-the-art variational and optimal transport methods** for solving Mean Field Games:
 
 **✅ Production-Ready**: 2,218 lines of code, comprehensive implementation
 **✅ Four Solver Families**: Variational, Optimal Transport, Primal-Dual, Augmented Lagrangian

--- a/docs/development/paradigms/REINFORCEMENT_LEARNING_PARADIGM_OVERVIEW.md
+++ b/docs/development/paradigms/REINFORCEMENT_LEARNING_PARADIGM_OVERVIEW.md
@@ -7,7 +7,7 @@
 
 ## 🎯 Overview
 
-The reinforcement learning (RL) paradigm in MFGarchon provides **agent-based, data-driven approaches** for solving Mean Field Games through multi-agent reinforcement learning (MARL). This paradigm bridges classical MFG theory with modern deep RL, enabling:
+The reinforcement learning (RL) paradigm in MFGArchon provides **agent-based, data-driven approaches** for solving Mean Field Games through multi-agent reinforcement learning (MARL). This paradigm bridges classical MFG theory with modern deep RL, enabling:
 
 - **Agent-based learning** without solving PDEs explicitly
 - **Model-free methods** learning from environment interactions
@@ -763,7 +763,7 @@ solver.visualize_trajectories(num_agents=50)
 
 ## ✅ Summary
 
-The reinforcement learning paradigm in MFGarchon provides **state-of-the-art multi-agent RL approaches** for solving Mean Field Games:
+The reinforcement learning paradigm in MFGArchon provides **state-of-the-art multi-agent RL approaches** for solving Mean Field Games:
 
 **✅ Production-Ready**: 16,472 lines of code, comprehensive implementation
 **✅ 10+ RL Algorithms**: Q-learning, DDPG, SAC, TD3, MADDPG, PPO

--- a/docs/development/planning/EXAMPLES_REDESIGN_PROPOSAL.md
+++ b/docs/development/planning/EXAMPLES_REDESIGN_PROPOSAL.md
@@ -2,7 +2,7 @@
 
 **Date**: 2025-11-11
 **Status**: PROPOSAL
-**Purpose**: Comprehensive cleanup and reorganization of MFGarchon examples
+**Purpose**: Comprehensive cleanup and reorganization of MFGArchon examples
 
 ---
 
@@ -93,7 +93,7 @@ examples/archive/
 
 ### Philosophy
 
-**MFGarchon Examples** (Public Infrastructure):
+**MFGArchon Examples** (Public Infrastructure):
 - ✅ Demonstrate core infrastructure features
 - ✅ Educational progression (beginner → advanced)
 - ✅ Single-concept focused examples
@@ -295,7 +295,7 @@ examples/archive/  → mfg-research/archives/legacy_examples/
    git rm -r examples/archive
    ```
 
-### Phase 4: Reorganize MFGarchon Examples
+### Phase 4: Reorganize MFGArchon Examples
 1. Create new structure:
    ```bash
    mkdir -p examples/tutorials
@@ -338,13 +338,13 @@ examples/archive/  → mfg-research/archives/legacy_examples/
 
 3. Commit changes in both repositories:
    ```bash
-   # In MFGarchon
+   # In MFGArchon
    git add examples/
    git commit -m "refactor: Reorganize examples into clear infrastructure demos"
 
    # In mfg-research
    git add experiments/particle_methods_comparison_2d/ experiments/anisotropic_crowd_dynamics_2d/
-   git commit -m "feat: Add particle methods and anisotropic research from MFGarchon"
+   git commit -m "feat: Add particle methods and anisotropic research from MFGArchon"
    ```
 
 ---
@@ -356,7 +356,7 @@ examples/archive/  → mfg-research/archives/legacy_examples/
 
 **Option A**: Move to mfg-research/archives/legacy_examples
 **Option B**: Delete entirely
-**Option C**: Keep in MFGarchon but document as "Historical API demos"
+**Option C**: Keep in MFGArchon but document as "Historical API demos"
 
 **Recommendation**: Option A (move to research)
 
@@ -430,7 +430,7 @@ examples/archive/  → mfg-research/archives/legacy_examples/
 1. ✅ All examples execute successfully after reorganization
 2. ✅ Clear README in each subdirectory explains purpose
 3. ✅ Tutorials provide learning path for new users
-4. ✅ No research experiments remain in MFGarchon examples/
+4. ✅ No research experiments remain in MFGArchon examples/
 5. ✅ examples/outputs/ contains only regenerable outputs
 6. ✅ Git history preserved for all moved files
 7. ✅ Both repositories pass CI after changes
@@ -496,7 +496,7 @@ examples/archive/ (9 files, optional)
 
 **Total**: ~15-24 files (depending on archive decision)
 
-### Files Staying in MFGarchon (Reorganized)
+### Files Staying in MFGArchon (Reorganized)
 ```
 examples/basic/ (10 files) - All retained, reorganized into subdirectories
 examples/advanced/ (32 files) - Retained after removing anisotropic package

--- a/docs/development/planning/LIPSCHITZ_BC_IMPLEMENTATION_PLAN.md
+++ b/docs/development/planning/LIPSCHITZ_BC_IMPLEMENTATION_PLAN.md
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary
 
-This document provides the complete implementation roadmap for Lipschitz boundary support in MFGarchon. Lipschitz boundaries include curves, surfaces, and manifolds with bounded gradients - essential for realistic crowd dynamics, evacuation, and obstacle avoidance problems.
+This document provides the complete implementation roadmap for Lipschitz boundary support in MFGArchon. Lipschitz boundaries include curves, surfaces, and manifolds with bounded gradients - essential for realistic crowd dynamics, evacuation, and obstacle avoidance problems.
 
 ### Current State
 

--- a/docs/development/planning/MIXED_BC_DESIGN.md
+++ b/docs/development/planning/MIXED_BC_DESIGN.md
@@ -2,12 +2,12 @@
 
 **Status**: Planning Phase
 **Target**: v0.13.0
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team
 **Created**: 2025-11-23
 
 ## Executive Summary
 
-MFGarchon currently only supports **uniform** boundary conditions (periodic, Dirichlet, Neumann) across the entire domain boundary. This document proposes a design for **mixed boundary conditions**, where different BC types apply to different boundary segments.
+MFGArchon currently only supports **uniform** boundary conditions (periodic, Dirichlet, Neumann) across the entire domain boundary. This document proposes a design for **mixed boundary conditions**, where different BC types apply to different boundary segments.
 
 **Critical Use Case**: 2D crowd motion with exit (Dirichlet `u=0`) and reflective walls (Neumann `∂u/∂n=0`).
 

--- a/docs/development/planning/NOTEBOOK_EXPORT_ENHANCEMENT_PLAN.md
+++ b/docs/development/planning/NOTEBOOK_EXPORT_ENHANCEMENT_PLAN.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-Currently, `SolverResult.export_summary()` supports only `markdown` and `latex` output formats. However, MFGarchon has comprehensive Jupyter notebook support through `mfgarchon.utils.notebooks.reporting.MFGNotebookReporter`.
+Currently, `SolverResult.export_summary()` supports only `markdown` and `latex` output formats. However, MFGArchon has comprehensive Jupyter notebook support through `mfgarchon.utils.notebooks.reporting.MFGNotebookReporter`.
 
 **User Request**: Add notebook export support to `export_summary()` method to enable interactive exploration of solver results.
 

--- a/docs/development/planning/PDE_COEFFICIENT_IMPLEMENTATION_ROADMAP.md
+++ b/docs/development/planning/PDE_COEFFICIENT_IMPLEMENTATION_ROADMAP.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-This document provides **status tracking and task checklists** for implementing flexible drift and diffusion coefficients in MFGarchon.
+This document provides **status tracking and task checklists** for implementing flexible drift and diffusion coefficients in MFGArchon.
 
 **For detailed technical specifications, algorithms, and implementation guides**, see:
 - **`PHASE_2_DESIGN_STATE_DEPENDENT_COEFFICIENTS.md`** - Complete implementation spec (1,380 lines)

--- a/docs/development/planning/PRIORITY_LIST_2026-01.md
+++ b/docs/development/planning/PRIORITY_LIST_2026-01.md
@@ -73,7 +73,7 @@ Code catches broad exceptions and silently falls back to lower-fidelity methods 
 - ✅ 100% completion (13/13 fixes)
 - ✅ All broad `except Exception:` replaced with specific exception types
 - ✅ Comprehensive logging with context throughout
-- ✅ Consistent MFGarchon logging infrastructure
+- ✅ Consistent MFGArchon logging infrastructure
 - ✅ All fallback behavior preserved for robustness
 - ✅ Critical bugs (Newton solver) now surface instead of silently failing
 

--- a/docs/development/planning/PROTOCOL_REVISION_GEOMETRY_AGNOSTIC.md
+++ b/docs/development/planning/PROTOCOL_REVISION_GEOMETRY_AGNOSTIC.md
@@ -8,7 +8,7 @@
 
 ## Problem: Not All Geometries Are Grid-Based
 
-### Geometry Types in MFGarchon
+### Geometry Types in MFGArchon
 
 | Geometry Type | Structure | Has Regular Grid? |
 |:--------------|:----------|:------------------|

--- a/docs/development/planning/REINFORCEMENT_LEARNING_ROADMAP.md
+++ b/docs/development/planning/REINFORCEMENT_LEARNING_ROADMAP.md
@@ -1,4 +1,4 @@
-# Reinforcement Learning Development Roadmap for MFGarchon
+# Reinforcement Learning Development Roadmap for MFGArchon
 
 **Status**: [IN PROGRESS] Phase 1 Complete - Core algorithms in development
 **Date**: 2025-10-01
@@ -11,8 +11,8 @@ With the successful completion of the algorithm reorganization establishing thre
 
 ## Strategic Context
 
-### Position in MFGarchon Evolution
-The RL paradigm represents the next major expansion of MFGarchon's capabilities:
+### Position in MFGArchon Evolution
+The RL paradigm represents the next major expansion of MFGArchon's capabilities:
 
 **Completed Foundation** (September 2025):
 - ✅ **Numerical Paradigm**: 16 algorithms (finite difference, particle methods)
@@ -367,7 +367,7 @@ wandb>=0.15.0  # Experiment tracking
 - **Voronoi-Based Environments**: Non-grid MFG spaces for robustness testing
 
 ### Long-Term Vision
-**5-Year Goal**: Establish MFGarchon as the definitive framework for RL-based approaches to Mean Field Games, with:
+**5-Year Goal**: Establish MFGArchon as the definitive framework for RL-based approaches to Mean Field Games, with:
 - **Comprehensive Algorithm Library**: 20+ RL algorithms for MFG
 - **Diverse Environment Suite**: Grid-based, Voronoi, continuous, and hybrid spaces
 - **Real-World Impact**: Deployed solutions in transportation, finance, and energy

--- a/docs/development/planning/STRATEGIC_DEVELOPMENT_ROADMAP_2026.md
+++ b/docs/development/planning/STRATEGIC_DEVELOPMENT_ROADMAP_2026.md
@@ -1,4 +1,4 @@
-# MFGarchon Strategic Development Roadmap 2026
+# MFGArchon Strategic Development Roadmap 2026
 
 **Document Version**: 1.9
 **Created**: September 28, 2025
@@ -9,10 +9,10 @@
 
 ## 🎯 **Executive Summary**
 
-This strategic roadmap charts MFGarchon's evolution from a comprehensive research platform to the definitive computational framework for Mean Field Games. Building on substantial 2025 achievements, the roadmap focuses on high-dimensional neural methods, multi-dimensional problems, and production-scale capabilities.
+This strategic roadmap charts MFGArchon's evolution from a comprehensive research platform to the definitive computational framework for Mean Field Games. Building on substantial 2025 achievements, the roadmap focuses on high-dimensional neural methods, multi-dimensional problems, and production-scale capabilities.
 
 ### **Vision Statement**
-Transform MFGarchon into the premier platform for Mean Field Games computation, enabling breakthrough research in high-dimensional problems while providing production-ready solutions for industrial applications.
+Transform MFGArchon into the premier platform for Mean Field Games computation, enabling breakthrough research in high-dimensional problems while providing production-ready solutions for industrial applications.
 
 ## ✅ **Foundation Achieved (2025)**
 
@@ -136,7 +136,7 @@ result = dgm_solver.solve()  # Handles d > 10 efficiently
 
 ### **🎉 PHASE 1 COMPLETION SUMMARY (October 2025)**
 
-**BREAKTHROUGH ACHIEVEMENT**: Complete neural paradigm implementation finished **6 months ahead of Q1 2026 timeline**, establishing MFGarchon as the first comprehensive neural framework for high-dimensional Mean Field Games.
+**BREAKTHROUGH ACHIEVEMENT**: Complete neural paradigm implementation finished **6 months ahead of Q1 2026 timeline**, establishing MFGArchon as the first comprehensive neural framework for high-dimensional Mean Field Games.
 
 **✅ Technical Achievements**:
 - **Complete DGM Framework**: High-dimensional solver (d > 10) with variance reduction
@@ -161,7 +161,7 @@ pinn_solver = MFGPINNSolver(problem, bayesian=True)
 posterior_samples = pinn_solver.sample_posterior(mcmc_samples=1000)  # ✅ WORKS NOW
 ```
 
-**✅ Research Impact**: MFGarchon now enables breakthrough research in dimensions previously computationally intractable (d > 10).
+**✅ Research Impact**: MFGArchon now enables breakthrough research in dimensions previously computationally intractable (d > 10).
 
 **✅ Next Priority**: Neural Operator Methods (FNO/DeepONet) for rapid parameter studies.
 
@@ -209,7 +209,7 @@ solution = fno.evaluate(new_parameters)  # 100x faster than solving
 - Comprehensive documentation and working examples
 
 **✅ Research Impact**:
-MFGarchon is now the first comprehensive framework enabling:
+MFGArchon is now the first comprehensive framework enabling:
 - High-dimensional MFG problems (d > 10) via DGM
 - Uncertainty quantification via Bayesian PINNs
 - Real-time control via neural operators
@@ -398,7 +398,7 @@ result = solve_mfg(problem, config=config_builder.build())     # Builder
 
 ### **🎉 PHASE 3 COMPLETION SUMMARY (November 2025)**
 
-**BREAKTHROUGH ACHIEVEMENT**: Most significant architectural improvement in MFGarchon history, delivering production-ready unified system that resolves 48 documented issues and enables all future development.
+**BREAKTHROUGH ACHIEVEMENT**: Most significant architectural improvement in MFGArchon history, delivering production-ready unified system that resolves 48 documented issues and enables all future development.
 
 **✅ Results Delivered**:
 - **Issues closed**: #200 (Architecture Refactoring), #221 (Config), #223 (Factory Integration)
@@ -480,7 +480,7 @@ Functional Derivatives: Efficient computation of δU/δm
 
 **Status**: Foundation complete (functional calculus implemented), solver deferred to future phase
 
-**✅ Research Impact**: MFGarchon is now the **first comprehensive open-source framework** for stochastic MFG with common noise, enabling:
+**✅ Research Impact**: MFGArchon is now the **first comprehensive open-source framework** for stochastic MFG with common noise, enabling:
 - Financial applications with market volatility
 - Epidemic modeling with random events
 - Robotics with shared sensor noise
@@ -493,7 +493,7 @@ Functional Derivatives: Efficient computation of δU/δm
 
 ### **🎉 PHASE 2 COMPLETION SUMMARY (October 2025)**
 
-**BREAKTHROUGH ACHIEVEMENT**: Complete multi-dimensional framework and stochastic MFG extensions finished **6 months ahead of Q2-Q3 2026 timeline**, establishing MFGarchon as the first comprehensive framework for both spatial multi-dimensional and stochastic Mean Field Games.
+**BREAKTHROUGH ACHIEVEMENT**: Complete multi-dimensional framework and stochastic MFG extensions finished **6 months ahead of Q2-Q3 2026 timeline**, establishing MFGArchon as the first comprehensive framework for both spatial multi-dimensional and stochastic Mean Field Games.
 
 #### **✅ Phase 2.1: Multi-Dimensional Framework**
 **Delivered Components**:
@@ -532,7 +532,7 @@ Functional Derivatives: Efficient computation of δU/δm
 - Complete documentation and examples
 - 3 diverse application domains demonstrated
 
-**Research Significance**: MFGarchon is now the **only comprehensive open-source framework** supporting:
+**Research Significance**: MFGArchon is now the **only comprehensive open-source framework** supporting:
 1. High-dimensional problems (d > 10) via neural methods
 2. Multi-dimensional spatial domains (2D/3D) with memory efficiency
 3. Stochastic MFG with common noise and uncertainty quantification
@@ -1134,10 +1134,10 @@ MFGC Formulation:
 **Publication Strategy**:
 - **Method Paper**: "Non-Asymptotic Convergence Rates for Stochastic Mean Field Games"
 - **Application Paper**: "Regime-Switching MFG for Financial Market Modeling"
-- **Software Paper**: "MFGarchon: A Comprehensive Framework for Stochastic Differential Games"
+- **Software Paper**: "MFGArchon: A Comprehensive Framework for Stochastic Differential Games"
 
 **Competitive Advantage**:
-MFGarchon will be the **only open-source framework** providing:
+MFGArchon will be the **only open-source framework** providing:
 - Complete spectrum: N-player games → MFG limit with convergence analysis
 - Stochastic extensions: Common noise, regime-switching, control interaction
 - Quantitative validation: Non-asymptotic convergence rate estimation
@@ -1275,7 +1275,7 @@ result = npg.update(trajectories)
 **Publication Strategy**:
 - **Method Paper**: "Information-Geometric Optimization for Mean Field Games"
 - **Application Paper**: "Robust Mean Field Control via KL Regularization"
-- **Software Paper**: "MFGarchon: Information Geometry Implementation"
+- **Software Paper**: "MFGArchon: Information Geometry Implementation"
 
 **Novel Contributions**:
 - First open-source IG-enhanced MFG framework
@@ -1340,7 +1340,7 @@ result = npg.update(trajectories)
 ### **Research Impact**
 | Metric | Current | 2026 Target | 2027 Target |
 |--------|---------|-------------|-------------|
-| **Publications** | Research ready | 10+ papers using MFGarchon | 25+ citations |
+| **Publications** | Research ready | 10+ papers using MFGArchon | 25+ citations |
 | **GitHub Stars** | ~100 | 1000+ | 2000+ |
 | **Contributors** | Core team | 50+ contributors | 200+ community |
 | **Industrial Users** | Academic | 10+ companies | 25+ production users |
@@ -1500,4 +1500,4 @@ result = npg.update(trajectories)
 - **Quarterly**: Strategic direction and resource allocation
 - **Annually**: Vision refinement and long-term planning
 
-This roadmap represents MFGarchon's evolution from a comprehensive research platform to the definitive computational framework for Mean Field Games, positioned to enable breakthrough discoveries while serving production applications across academia and industry.
+This roadmap represents MFGArchon's evolution from a comprehensive research platform to the definitive computational framework for Mean Field Games, positioned to enable breakthrough discoveries while serving production applications across academia and industry.

--- a/docs/development/planning/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/development/planning/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-This plan strategically improves MFGarchon test coverage from **37% to 50-60%** by focusing on:
+This plan strategically improves MFGArchon test coverage from **37% to 50-60%** by focusing on:
 1. **Quick wins** (0% coverage utils) → 42%
 2. **High-impact core** (backends, config, geometry) → 50%
 3. **Comprehensive validation** (RL, factory, performance) → 60%

--- a/docs/development/status/CODE_QUALITY_STATUS.md
+++ b/docs/development/status/CODE_QUALITY_STATUS.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-The MFGarchon codebase has undergone systematic code quality improvement, reducing linting errors from **199 to 3 warnings** (98.5% reduction). The remaining 3 warnings are **false positives** caused by interaction between different ruff rule enforcement contexts.
+The MFGArchon codebase has undergone systematic code quality improvement, reducing linting errors from **199 to 3 warnings** (98.5% reduction). The remaining 3 warnings are **false positives** caused by interaction between different ruff rule enforcement contexts.
 
 ## Current State
 
@@ -171,6 +171,6 @@ If this passes, the code is production-ready.
 
 ## Conclusion
 
-The MFGarchon codebase has achieved **98.5% error reduction** while maintaining correct behavior. The 3 remaining warnings are false positives from ruff's noqa detection interacting with different rule enforcement contexts. The pre-commit hooks serve as the authoritative quality gate and currently pass successfully.
+The MFGArchon codebase has achieved **98.5% error reduction** while maintaining correct behavior. The 3 remaining warnings are false positives from ruff's noqa detection interacting with different rule enforcement contexts. The pre-commit hooks serve as the authoritative quality gate and currently pass successfully.
 
 **Bottom line**: The codebase is in excellent condition for production use.

--- a/docs/development/status/GFDM_QP_MONOTONICITY_IMPLEMENTATION.md
+++ b/docs/development/status/GFDM_QP_MONOTONICITY_IMPLEMENTATION.md
@@ -401,4 +401,4 @@ solver = HJBGFDMSolver(
 ---
 
 **Last Updated**: 2025-10-15
-**Implemented by**: Claude Code following MFGarchon production standards
+**Implemented by**: Claude Code following MFGArchon production standards

--- a/docs/development/status/MFGProblem_Conditional_Attributes_Report.md
+++ b/docs/development/status/MFGProblem_Conditional_Attributes_Report.md
@@ -13,7 +13,7 @@
 
 ## Executive Summary
 
-`MFGProblem` is the central domain object in MFGarchon, representing a Mean Field Game problem. Currently, it has ~30 public attributes whose availability depends on the initialization mode (1D legacy, n-D grid, geometry, network, mesh). This creates type safety issues and runtime errors.
+`MFGProblem` is the central domain object in MFGArchon, representing a Mean Field Game problem. Currently, it has ~30 public attributes whose availability depends on the initialization mode (1D legacy, n-D grid, geometry, network, mesh). This creates type safety issues and runtime errors.
 
 Two architectural solutions are proposed:
 - **Option A**: Domain-Specific Subclasses

--- a/docs/development/status/REPOSITORY_HEALTH_CHECK_2025_10_07.md
+++ b/docs/development/status/REPOSITORY_HEALTH_CHECK_2025_10_07.md
@@ -8,7 +8,7 @@
 
 ## 🎯 Executive Summary
 
-MFGarchon repository is in **excellent health** with all quality metrics passing, clean git state, comprehensive test coverage, and zero blocking issues. The repository is fully prepared for Phase 3 HPC development.
+MFGArchon repository is in **excellent health** with all quality metrics passing, clean git state, comprehensive test coverage, and zero blocking issues. The repository is fully prepared for Phase 3 HPC development.
 
 **Overall Health Score**: **100/100** ✅
 
@@ -20,7 +20,7 @@ MFGarchon repository is in **excellent health** with all quality metrics passing
 ```
 ✅ Package: mfgarchon v1.5.0
 ✅ Install Mode: Editable (development mode)
-✅ Location: /Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGarchon
+✅ Location: /Users/zvezda/Library/CloudStorage/OneDrive-Personal/code/MFGArchon
 ✅ Python Version: 3.12
 ```
 

--- a/docs/development/status/TYPE_SAFETY_IMPROVEMENT_SYNTHESIS.md
+++ b/docs/development/status/TYPE_SAFETY_IMPROVEMENT_SYNTHESIS.md
@@ -1,4 +1,4 @@
-# MFGarchon Type Safety Improvement: Complete Journey ✅
+# MFGArchon Type Safety Improvement: Complete Journey ✅
 
 **Document Status**: Synthesis of Phases 4-13.1 (October 2025)
 **Supersedes**: Individual phase documents (`type_safety_phase*.md`)
@@ -434,7 +434,7 @@ def select_action(self) -> tuple[int, float]:
 
 ### Recommendations 🎯
 
-**For MFGarchon Project**:
+**For MFGArchon Project**:
 1. ✅ **Accept 50% milestone as completion point**
    - Substantial improvement achieved
    - Diminishing returns make further work inefficient

--- a/docs/development/typing/CI_CD_STRATEGIC_TYPING_EXPERIENCE_GUIDE.md
+++ b/docs/development/typing/CI_CD_STRATEGIC_TYPING_EXPERIENCE_GUIDE.md
@@ -3,11 +3,11 @@
 **Status**: ✅ COMPLETED - Production-Ready Framework
 **Created**: 2025-09-25
 **Last Updated**: 2025-09-25
-**Repository**: MFGarchon Strategic Typing Excellence Framework
+**Repository**: MFGArchon Strategic Typing Excellence Framework
 
 ## 🎯 Executive Summary
 
-This document captures the complete experience and lessons learned from achieving **100% strategic typing excellence** (366 → 0 MyPy errors) while establishing a **research-optimized CI/CD pipeline** for the MFGarchon scientific computing framework.
+This document captures the complete experience and lessons learned from achieving **100% strategic typing excellence** (366 → 0 MyPy errors) while establishing a **research-optimized CI/CD pipeline** for the MFGArchon scientific computing framework.
 
 **Key Achievement**: Successfully balanced local development typing excellence with CI/CD environment compatibility, creating a blueprint for complex scientific computing projects.
 
@@ -371,7 +371,7 @@ jobs:
 
 ### Documentation
 - [Strategic Typing Methodology](./STRATEGIC_TYPING_METHODOLOGY.md)
-- [MFGarchon Development Guide](../DEVELOPMENT_GUIDE.md)
+- [MFGArchon Development Guide](../DEVELOPMENT_GUIDE.md)
 - [CI/CD Optimization Patterns](./CI_CD_OPTIMIZATION_PATTERNS.md)
 
 ### External Resources

--- a/docs/development/typing/CI_CD_TROUBLESHOOTING_QUICK_REFERENCE.md
+++ b/docs/development/typing/CI_CD_TROUBLESHOOTING_QUICK_REFERENCE.md
@@ -2,7 +2,7 @@
 
 **Status**: ✅ PRODUCTION REFERENCE
 **Created**: 2025-09-25
-**Context**: MFGarchon Strategic Typing & CI/CD Success
+**Context**: MFGArchon Strategic Typing & CI/CD Success
 
 ## 🚨 Common CI/CD Failures & Quick Fixes
 

--- a/docs/development/typing/STRATEGIC_TYPING_PATTERNS_REFERENCE.md
+++ b/docs/development/typing/STRATEGIC_TYPING_PATTERNS_REFERENCE.md
@@ -2,11 +2,11 @@
 
 **Status**: ✅ COMPLETED - Production Reference
 **Created**: 2025-09-25
-**Context**: MFGarchon Strategic Typing Excellence (366 → 0 errors)
+**Context**: MFGArchon Strategic Typing Excellence (366 → 0 errors)
 
 ## 🎯 Overview
 
-This document provides specific code patterns and examples for implementing strategic typing in scientific computing codebases, based on the successful MFGarchon framework implementation.
+This document provides specific code patterns and examples for implementing strategic typing in scientific computing codebases, based on the successful MFGArchon framework implementation.
 
 ## 🔧 Strategic Ignore Patterns
 
@@ -219,7 +219,7 @@ def compute_metric(edges: list[float]) -> float:
 3. **Is it specific?** Uses specific error code rather than general ignore?
 4. **Is it strategic?** Preserves code clarity while handling type system limitations?
 
-## 📊 Pattern Usage Statistics (MFGarchon)
+## 📊 Pattern Usage Statistics (MFGArchon)
 
 Based on the successful 366 → 0 error reduction:
 
@@ -273,12 +273,12 @@ max_edge = max(edges)  # type: ignore[type-var]  # TODO: Remove when MyPy 1.x su
 
 Strategic typing patterns enable **100% MyPy compliance** in complex scientific computing codebases while preserving code clarity and development velocity.
 
-The key is **strategic application**: use ignores to handle type system limitations, not to avoid proper typing. This approach delivered unprecedented results in the MFGarchon framework and provides a blueprint for similar scientific computing projects.
+The key is **strategic application**: use ignores to handle type system limitations, not to avoid proper typing. This approach delivered unprecedented results in the MFGArchon framework and provides a blueprint for similar scientific computing projects.
 
 **Remember**: Strategic ignores are a **bridge to excellence**, not a destination. They enable immediate typing benefits while the ecosystem continues to evolve toward even better type safety.
 
 ---
 
-**Pattern Status**: ✅ Production-tested in MFGarchon framework
+**Pattern Status**: ✅ Production-tested in MFGArchon framework
 **Maintenance**: Review patterns quarterly for ecosystem evolution
 **Applicability**: Scientific computing, mathematical software, complex array operations

--- a/docs/development/typing/mypy_implementation_summary.md
+++ b/docs/development/typing/mypy_implementation_summary.md
@@ -6,7 +6,7 @@
 
 ## 🎯 Implementation Overview
 
-MyPy static type checking has been successfully integrated into the MFGarchon package, providing immediate benefits for code quality and development experience.
+MyPy static type checking has been successfully integrated into the MFGArchon package, providing immediate benefits for code quality and development experience.
 
 ## ✅ Completed Tasks
 
@@ -165,4 +165,4 @@ pip install mypy>=1.0 types-tqdm types-setuptools types-psutil
 
 ---
 
-**Final Assessment**: MyPy integration successfully implemented with immediate benefits for development quality and long-term maintainability. The progressive approach ensures compatibility while providing substantial value for the MFGarchon research platform.
+**Final Assessment**: MyPy integration successfully implemented with immediate benefits for development quality and long-term maintainability. The progressive approach ensures compatibility while providing substantial value for the MFGArchon research platform.

--- a/docs/development/typing/mypy_integration.md
+++ b/docs/development/typing/mypy_integration.md
@@ -1,4 +1,4 @@
-# MyPy Integration for MFGarchon
+# MyPy Integration for MFGArchon
 
 **Date**: July 26, 2025  
 **Status**: ✅ **IMPLEMENTED**  
@@ -6,7 +6,7 @@
 
 ## Overview
 
-MyPy integration has been successfully implemented in MFGarchon to provide static type checking, catching errors before runtime and improving development experience with better IDE support.
+MyPy integration has been successfully implemented in MFGArchon to provide static type checking, catching errors before runtime and improving development experience with better IDE support.
 
 ## Configuration
 
@@ -300,7 +300,7 @@ def setup_logging() -> None:  # or appropriate return type
 
 - **MyPy Documentation**: https://mypy.readthedocs.io/
 - **Type Hints Guide**: https://docs.python.org/3/library/typing.html
-- **MFGarchon Issues**: Use GitHub issues for package-specific problems
+- **MFGArchon Issues**: Use GitHub issues for package-specific problems
 
 ---
 

--- a/docs/development/typing/mypy_usage.md
+++ b/docs/development/typing/mypy_usage.md
@@ -364,4 +364,4 @@ Based on remaining error distribution:
 ---
 
 *Document created from Phase 1 implementation results*
-*All patterns tested in production environment with MFGarchon codebase*
+*All patterns tested in production environment with MFGArchon codebase*

--- a/docs/development/typing/python_typing.md
+++ b/docs/development/typing/python_typing.md
@@ -2,11 +2,11 @@
 
 **Date**: 2025-09-20 (Updated: 2025-12-14)
 **Context**: Best practices for type hints in scientific Python projects
-**Target**: Python 3.12+ (MFGarchon requires Python 3.12+)
+**Target**: Python 3.12+ (MFGArchon requires Python 3.12+)
 
 ## 🎯 **Executive Summary**
 
-This guide synthesizes modern Python typing best practices specifically for scientific computing projects like MFGarchon. It emphasizes clean, maintainable code using Python 3.9+ built-in collection types and Python 3.10+ union syntax.
+This guide synthesizes modern Python typing best practices specifically for scientific computing projects like MFGArchon. It emphasizes clean, maintainable code using Python 3.9+ built-in collection types and Python 3.10+ union syntax.
 
 ## 📖 **Table of Contents**
 
@@ -463,7 +463,7 @@ ruff check --select UP .
 
 ---
 
-## 🔧 **Practical Example: MFGarchon Modernization**
+## 🔧 **Practical Example: MFGArchon Modernization**
 
 ### **Before (Legacy Typing)**
 ```python

--- a/docs/development/typing/typing_methodology.md
+++ b/docs/development/typing/typing_methodology.md
@@ -1,4 +1,4 @@
-# Systematic Typing Methodology - MFGarchon Success Story
+# Systematic Typing Methodology - MFGArchon Success Story
 
 ## 🎯 **Spectacular Results**
 
@@ -281,5 +281,5 @@ The systematic approach scales: **identify, categorize, apply tools in order of 
 
 ---
 
-*Generated during MFGarchon systematic typing improvement sessions (Phase 1 & 2)*
+*Generated during MFGArchon systematic typing improvement sessions (Phase 1 & 2)*
 *Methodology proven reproducible and scalable for complex Python projects*

--- a/docs/theory/BOUNDARY_CONDITIONS_REFERENCE.md
+++ b/docs/theory/BOUNDARY_CONDITIONS_REFERENCE.md
@@ -24,7 +24,7 @@
 
 ## 1. Overview
 
-Boundary condition (BC) handling in MFGarchon follows a layered architecture separating **specification** (what conditions apply), **application** (how to enforce them numerically), and **solver integration** (when to apply them during computation).
+Boundary condition (BC) handling in MFGArchon follows a layered architecture separating **specification** (what conditions apply), **application** (how to enforce them numerically), and **solver integration** (when to apply them during computation).
 
 ### 1.1 Design Principles
 
@@ -625,4 +625,4 @@ This reference consolidates and supersedes:
 
 ---
 
-*This document is the canonical reference for boundary condition handling in MFGarchon.*
+*This document is the canonical reference for boundary condition handling in MFGArchon.*

--- a/docs/theory/GEOMETRY_BC_ARCHITECTURE_DESIGN.md
+++ b/docs/theory/GEOMETRY_BC_ARCHITECTURE_DESIGN.md
@@ -3,13 +3,13 @@
 **Document Type**: Theoretical Design Specification
 **Status**: Design Phase (v0.17.1 baseline, v1.0.0 vision)
 **Date**: 2026-01-17
-**Authors**: MFGarchon Core Team, Expert Consultation
+**Authors**: MFGArchon Core Team, Expert Consultation
 
 ---
 
 ## Executive Summary
 
-This document defines the **comprehensive architectural design** for geometry and boundary condition handling in MFGarchon. The design synthesizes:
+This document defines the **comprehensive architectural design** for geometry and boundary condition handling in MFGArchon. The design synthesizes:
 
 1. **Modern PDE solver practices** (FEniCS, PETSc, Dedalus patterns)
 2. **MFG-specific requirements** (coupled systems, equilibrium consistency)
@@ -178,7 +178,7 @@ $$\alpha u + \beta \frac{\partial u}{\partial n} = g(x,t) \quad \text{on } \part
 
 **Implementation**: Standard ghost cell, matrix row modification, or weak form assembly.
 
-**Status in MFGarchon**: ✅ Production-ready (v0.17.1)
+**Status in MFGArchon**: ✅ Production-ready (v0.17.1)
 
 ---
 
@@ -219,7 +219,7 @@ problem.solve(
 )
 ```
 
-**Status in MFGarchon**: ❌ Not implemented (planned v0.18.0)
+**Status in MFGArchon**: ❌ Not implemented (planned v0.18.0)
 
 ---
 
@@ -249,7 +249,7 @@ V_{\text{interface}} &= \mathcal{F}(\nabla u, m, ...) \quad \text{on } \partial\
 - Works on fixed grids (no remeshing)
 - Natural for TensorProductGrid
 
-**Status in MFGarchon**: ❌ Not implemented (research-level, v0.19.0+)
+**Status in MFGArchon**: ❌ Not implemented (research-level, v0.19.0+)
 
 ---
 
@@ -416,7 +416,7 @@ class SupportsBoundary(Protocol):
 
 ### 2.3 Multi-Backend Support: The Geometry Zoo
 
-MFGarchon supports **four geometry families**, each with different strengths:
+MFGArchon supports **four geometry families**, each with different strengths:
 
 #### Family 1: Structured Grids (TensorProductGrid)
 
@@ -1040,7 +1040,7 @@ b_total = b + b_bc
 u = solve(A_total, b_total)
 ```
 
-**Status in MFGarchon**: ❌ Not implemented (FEM infrastructure incomplete)
+**Status in MFGArchon**: ❌ Not implemented (FEM infrastructure incomplete)
 
 ---
 
@@ -1612,7 +1612,7 @@ Grid-based FP:  DIRICHLET(0) ←→  Particle-based FP: ABSORBING
 - **Sommerfeld BC** (wave radiation):
   - Assumes: ∂u/∂t + c·∂u/∂n = 0 (outgoing wave)
   - Application: Hyperbolic problems
-  - Not yet implemented in MFGarchon
+  - Not yet implemented in MFGArchon
 
 **Use Case**: MFG on large domains where agents can "leave to infinity".
 
@@ -1736,7 +1736,7 @@ class TensorProductGrid(
 **MFG-Specific**:
 1. Achdou, Capuzzo-Dolcetta: "Mean Field Games: Numerical Methods" (2010)
 2. Lasry, Lions: "Mean Field Games" (2007)
-3. Issue #574 (MFGarchon): Adjoint-consistent boundary conditions
+3. Issue #574 (MFGArchon): Adjoint-consistent boundary conditions
 
 ---
 

--- a/docs/theory/adjoint_discretization_mfg.md
+++ b/docs/theory/adjoint_discretization_mfg.md
@@ -1057,4 +1057,4 @@ The adjoint relationship $A_{\text{FP}} = A_{\text{HJB}}^\top$ must hold **at ea
 - **Last Updated:** 2026-01
 - **Related Files:** `fp_fdm.py`, `hjb_fdm.py`, `advection_discretization_methods.md`
 - **Related Issues:** Issue #706 (Deprecation), Issue #707 (True Adjoint Implementation)
-- **Author:** MFGarchon Development Team
+- **Author:** MFGArchon Development Team

--- a/docs/theory/adjoint_operators_mfg.md
+++ b/docs/theory/adjoint_operators_mfg.md
@@ -1,6 +1,6 @@
 # Adjoint Operators and Discrete Duality in Mean Field Games
 
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team
 **Date**: 2026-01-16
 **Status**: Active Theory Reference
 **Related**: Issue #580 (Adjoint-aware solver pairing), Issue #578 (FP SL adjoint solver)
@@ -163,13 +163,13 @@ This is the discrete analogue of $\nabla^T = -\text{div}$.
 
 **Examples**: Lax-Friedrichs, Godunov, Engquist-Osher schemes.
 
-**Status in MFGarchon**: Not yet implemented (future extension).
+**Status in MFGArchon**: Not yet implemented (future extension).
 
 ### 4.2 Schemes with Continuous Duality Only (Approximate)
 
 #### 4.2.1 Generalized Finite Difference Method (GFDM)
 
-**Current usage in MFGarchon**:
+**Current usage in MFGArchon**:
 - HJB: `HJBGFDMSolver` using weighted least-squares on collocation points
 - FP: `FPGFDMSolver` using same framework
 
@@ -242,7 +242,7 @@ $$(\mathbf{L}_{\text{GFDM}})_{ij} \neq (\mathbf{L}_{\text{GFDM}})_{ji}$$
 
 **Consequence**: Numerical artifacts (artificial aggregation, texturing) even in smooth regions.
 
-#### Approach B: Primal-Primal (Current MFGarchon)
+#### Approach B: Primal-Primal (Current MFGArchon)
 
 **Method**: Independently discretize both HJB and FP using GFDM.
 
@@ -406,7 +406,7 @@ assert fp.is_asymptotically_dual(hjb)  # True in limit h→0
 
 ### 6.5 The Value Proposition of Type B Schemes
 
-**GFDM in MFGarchon represents this tradeoff**:
+**GFDM in MFGArchon represents this tradeoff**:
 
 ✅ **What you gain**:
 - Irregular domains (no mesh generation)
@@ -592,4 +592,4 @@ assert np.allclose(L_fp, L_hjb.T)  # Should be exact transpose
 
 **End of Document**
 
-For questions or corrections, please open an issue on the MFGarchon GitHub repository.
+For questions or corrections, please open an issue on the MFGArchon GitHub repository.

--- a/docs/theory/advection_discretization_methods.md
+++ b/docs/theory/advection_discretization_methods.md
@@ -16,7 +16,7 @@ A comprehensive comparison of discretization approaches for advection-diffusion 
    - [Method Selection Guide](#method-selection-guide)
 5. [Part III: MFG Context](#part-iii-mfg-context)
    - [Why Method Diversity Matters](#why-method-diversity-matters)
-   - [MFGarchon Solver Portfolio](#mfgarchon-solver-portfolio)
+   - [MFGArchon Solver Portfolio](#mfgarchon-solver-portfolio)
 6. [Implementation Notes](#implementation-notes)
 7. [References](#references)
 
@@ -367,7 +367,7 @@ For high-dimensional MFG (multi-agent systems), **only particle/Monte Carlo meth
 
 ---
 
-## MFGarchon Solver Portfolio
+## MFGArchon Solver Portfolio
 
 Our solver ecosystem reflects these trade-offs:
 
@@ -391,7 +391,7 @@ Coupled MFG:
 
 # Implementation Notes
 
-## Current State in MFGarchon (v0.17.3+)
+## Current State in MFGArchon (v0.17.3+)
 
 - `FPFDMSolver` uses **divergence_upwind** (conservative flux form) by default
 - Four advection schemes available via `advection_scheme` parameter:
@@ -462,4 +462,4 @@ For no-flux BC at left boundary with Flux FDM:
   - #382 (FDM mass conservation investigation - Dec 2025)
   - #490 (4 FDM advection schemes - Dec 2025)
   - #615 (Mass conservation fix - Jan 2026)
-- **Author**: MFGarchon Development Team
+- **Author**: MFGArchon Development Team

--- a/docs/theory/applications/coordination_games_mfg.md
+++ b/docs/theory/applications/coordination_games_mfg.md
@@ -469,7 +469,7 @@ where $\bar{F} = m F(m) + (1-m) U_{\text{home}}$ is average fitness.
 
 ---
 
-## 11. Implementation in MFGarchon
+## 11. Implementation in MFGArchon
 
 ### 11.1 Discrete MFG Solver
 

--- a/docs/theory/applications/spatial_competition_mfg.md
+++ b/docs/theory/applications/spatial_competition_mfg.md
@@ -441,7 +441,7 @@ $$L(x, u, m, m_{\text{hist}}) = |x - x_{\text{stall}}| + \lambda \ln(m) + \beta 
 
 ---
 
-## 9. Implementation in MFGarchon
+## 9. Implementation in MFGArchon
 
 ### 9.1 Core Components
 

--- a/docs/theory/bc_stability_verification.md
+++ b/docs/theory/bc_stability_verification.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-This document records GKS (Gustafsson-Kreiss-Sundström) stability validation results for standard boundary condition discretizations used in MFGarchon.
+This document records GKS (Gustafsson-Kreiss-Sundström) stability validation results for standard boundary condition discretizations used in MFGArchon.
 
 **Purpose**: Developer-facing validation, ensuring BC implementations don't introduce numerical instabilities.
 
@@ -410,7 +410,7 @@ The GKS validation framework successfully verifies discrete stability for standa
 3. Extend to 2D/3D operators (Issue #535 coordination)
 4. Document in user-facing BC API
 
-This validation provides confidence in the numerical stability of MFGarchon's boundary condition implementations and establishes a framework for validating future BC methods.
+This validation provides confidence in the numerical stability of MFGArchon's boundary condition implementations and establishes a framework for validating future BC methods.
 
 ---
 

--- a/docs/theory/boundary_framework_mathematical_foundation.md
+++ b/docs/theory/boundary_framework_mathematical_foundation.md
@@ -5,7 +5,7 @@
 **Related**:
 - [BOUNDARY_CONDITIONS_REFERENCE.md](./BOUNDARY_CONDITIONS_REFERENCE.md) (practical usage)
 - [boundary_framework_implementation_design.md](../development/boundary_framework_implementation_design.md) (implementation roadmap)
-- GitHub Issues: [#535](https://github.com/zvezda/MFGarchon/issues/535), [#536](https://github.com/zvezda/MFGarchon/issues/536)
+- GitHub Issues: [#535](https://github.com/zvezda/MFGArchon/issues/535), [#536](https://github.com/zvezda/MFGArchon/issues/536)
 
 ---
 

--- a/docs/theory/capacity_constrained_mfg_design.md
+++ b/docs/theory/capacity_constrained_mfg_design.md
@@ -1,12 +1,12 @@
 # Capacity-Constrained Mean Field Games: Example Pattern
 
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team
 **Date**: 2025-11-12
 **Status**: ✅ IMPLEMENTED AS EXAMPLE
 **Location**: `examples/advanced/capacity_constrained_mfg/`
 **Related Issues**: Capacity-constrained MFG, maze navigation, congestion modeling
 
-**Architecture Note**: This implementation demonstrates how to extend the MFGarchon framework
+**Architecture Note**: This implementation demonstrates how to extend the MFGArchon framework
 with application-specific features. It resides in `examples/` rather than `mfgarchon/core/`
 to keep the core framework minimal. Users can adapt this pattern for their own
 capacity-constrained or congestion-aware MFG applications.
@@ -589,7 +589,7 @@ The capacity-constrained framework is compatible with:
 **Total Implementation**: ~1,879 lines (example pattern complete)
 
 **Note**: This is an example implementation residing in `examples/` to demonstrate
-how users can extend the MFGarchon framework with application-specific features.
+how users can extend the MFGArchon framework with application-specific features.
 Users can adapt this pattern for their own capacity-constrained problems.
 
 ---

--- a/docs/theory/dimensional_splitting_advection_analysis.md
+++ b/docs/theory/dimensional_splitting_advection_analysis.md
@@ -400,7 +400,7 @@ u_corrected = u_split + (Δt²/12) * [L_x, L_y]u
 - Flow strongly misaligned with axes → unsplit better
 - Very complex boundary geometry → unsplit or body-fitted coordinates
 
-### Current MFGarchon Implementation
+### Current MFGArchon Implementation
 
 **Verdict**: ✅ **Appropriate and well-designed**
 

--- a/docs/theory/foundations/MATHEMATICAL_NOTATIONS.md
+++ b/docs/theory/foundations/MATHEMATICAL_NOTATIONS.md
@@ -1,4 +1,4 @@
-# MFGarchon Theory Documentation: Notation Standards and Consistency Guide
+# MFGArchon Theory Documentation: Notation Standards and Consistency Guide
 
 **Document Type**: Cross-Document Standards
 **Created**: October 8, 2025

--- a/docs/theory/foundations/THEORY_DOCUMENTATION_INDEX.md
+++ b/docs/theory/foundations/THEORY_DOCUMENTATION_INDEX.md
@@ -1,4 +1,4 @@
-# MFGarchon Theory Documentation Index
+# MFGArchon Theory Documentation Index
 
 **Document Type**: Navigation and Reference Guide
 **Created**: October 8, 2025
@@ -9,7 +9,7 @@
 
 ## Overview
 
-This index provides a comprehensive guide to all theoretical documentation in the MFGarchon package. Documents are organized by topic with status indicators, cross-references, and implementation connections.
+This index provides a comprehensive guide to all theoretical documentation in the MFGArchon package. Documents are organized by topic with status indicators, cross-references, and implementation connections.
 
 **Enhancement Status Legend**:
 - ✅ **Enhanced**: Comprehensive mathematical rigor with footnoted references
@@ -393,7 +393,7 @@ mathematical_background.md (foundation)
 
 ---
 
-**Document Status**: Comprehensive index of all MFGarchon theory documentation
+**Document Status**: Comprehensive index of all MFGArchon theory documentation
 **Last Updated**: October 8, 2025
 **Maintained By**: Primary maintainer with AI assistance
 **Next Review**: January 2026

--- a/docs/theory/foundations/convergence_criteria.md
+++ b/docs/theory/foundations/convergence_criteria.md
@@ -241,9 +241,9 @@ $$\mathbb{E}[W_2^2(m_k^N, m_k)] = O(N^{-1/d}) \quad \text{(curse of dimensionali
 
 ---
 
-## 5. Implementation in MFGarchon
+## 5. Implementation in MFGArchon
 
-The MFGarchon package implements these convergence criteria through:
+The MFGArchon package implements these convergence criteria through:
 
 ### 5.1 Core Components
 

--- a/docs/theory/foundations/mathematical_background.md
+++ b/docs/theory/foundations/mathematical_background.md
@@ -385,6 +385,6 @@ $$F(u_1, \ldots, u_k) \text{ is non-decreasing in each argument}$$
 ---
 
 **Document Status**: Complete mathematical foundations
-**Usage**: Reference for all MFGarchon theory and implementation
+**Usage**: Reference for all MFGArchon theory and implementation
 **Notation Standards**: See `NOTATION_STANDARDS.md`
 **Implementation**: Mathematical foundations for all numerical solvers in `mfgarchon.alg.numerical`

--- a/docs/theory/gfdm_monotonicity/README.md
+++ b/docs/theory/gfdm_monotonicity/README.md
@@ -401,7 +401,7 @@ $$
 
 **Last Updated**: 2025-12-03
 
-**Maintainers**: MFGarchon Development Team
+**Maintainers**: MFGArchon Development Team
 
 **Status**:
 - ✅ Mathematical foundation documented

--- a/docs/theory/godunov_paradox_and_defect_correction.md
+++ b/docs/theory/godunov_paradox_and_defect_correction.md
@@ -1,4 +1,4 @@
-# The Godunov Paradox and Defect Correction in MFGarchon
+# The Godunov Paradox and Defect Correction in MFGArchon
 
 **Document Type**: Theory & Implementation Note
 **Related Issue**: #597 Milestone 3
@@ -13,7 +13,7 @@
 
 **The Solution**: Defect Correction framework - use linear velocity-based Jacobian (LHS) with Godunov residual evaluation (RHS). This is standard CFD practice for nonlinear conservation laws.
 
-**Impact on MFGarchon**: Explicit solvers use AdvectionOperator (Godunov), implicit solvers use manual sparse matrix construction (velocity-based linear upwind). Both are mathematically correct for their respective roles.
+**Impact on MFGArchon**: Explicit solvers use AdvectionOperator (Godunov), implicit solvers use manual sparse matrix construction (velocity-based linear upwind). Both are mathematically correct for their respective roles.
 
 ---
 
@@ -178,7 +178,7 @@ Method:
 - Point in a descent direction
 - Be "close enough" to F'(m) for convergence
 
-### Applied to MFGarchon
+### Applied to MFGArchon
 
 **Residual** (RHS):
 ```
@@ -232,7 +232,7 @@ Then Defect Correction converges linearly to the solution of `F(m) = 0`.
 
 ---
 
-## Part IV: Implementation in MFGarchon
+## Part IV: Implementation in MFGArchon
 
 ### Architecture
 
@@ -328,7 +328,7 @@ def add_interior_entries_gradient_upwind(...):
 **Picard Iteration**:
 - Linearize nonlinear terms using previous iterate
 - Iterate until residual vanishes
-- MFGarchon implicit solver is essentially Picard with one iteration per timestep
+- MFGArchon implicit solver is essentially Picard with one iteration per timestep
 
 ---
 

--- a/docs/theory/high_dimensional_mfg.md
+++ b/docs/theory/high_dimensional_mfg.md
@@ -43,9 +43,9 @@
 
 ## The Dimensional Problem
 
-### MFGarchon's Explicit Dimensional Limits
+### MFGArchon's Explicit Dimensional Limits
 
-MFGarchon has **hard-coded dimension checks** that prevent 4D+ usage:
+MFGArchon has **hard-coded dimension checks** that prevent 4D+ usage:
 
 ```python
 # From mfgarchon/geometry/tensor_product_grid.py (line 80-81)
@@ -634,7 +634,7 @@ assert domain.contains(np.array([0.1]*4))
 
 ### Why Refactor for All Methods?
 
-**Question:** Should MFGarchon be dimension-agnostic even for mesh methods that can't scale to d>3?
+**Question:** Should MFGArchon be dimension-agnostic even for mesh methods that can't scale to d>3?
 
 **Answer:** **YES** - Benefits both mesh-based AND meshfree methods.
 

--- a/docs/theory/kernels_mathematical_formulation.md
+++ b/docs/theory/kernels_mathematical_formulation.md
@@ -14,7 +14,7 @@
 4. [Mollifiers and Regularization](#mollifiers-and-regularization)
 5. [Convolution and Approximation](#convolution-and-approximation)
 6. [Kernel Types](#kernel-types)
-7. [Applications in MFGarchon](#applications-in-mfgarchon)
+7. [Applications in MFGArchon](#applications-in-mfgarchon)
 8. [References](#references)
 
 ---
@@ -233,7 +233,7 @@ If $\int K_h = 1$, then $(f * K_h)(\mathbf{x}) \to f(\mathbf{x})$ as $h \to 0$ (
 Given particles $\{\mathbf{x}_i\}_{i=1}^N$, approximate density:
 $$\rho_h(\mathbf{x}) = \frac{1}{N} \sum_{i=1}^N K_h(\mathbf{x} - \mathbf{x}_i)$$
 
-**Used in MFGarchon**: `FPParticleSolver` in hybrid mode uses KDE to project particle density onto grid.
+**Used in MFGArchon**: `FPParticleSolver` in hybrid mode uses KDE to project particle density onto grid.
 
 ### 5.3 SPH Approximation
 
@@ -256,7 +256,7 @@ $$w_{ij} = K_h(\mathbf{x}_i - \mathbf{x}_j)$$
 Minimize weighted residual:
 $$\min_{\nabla f} \sum_j w_{ij} \left[ f(\mathbf{x}_j) - f(\mathbf{x}_i) - \nabla f \cdot (\mathbf{x}_j - \mathbf{x}_i) \right]^2$$
 
-**Used in MFGarchon**: `gfdm_operators.py` uses Gaussian RBF weights for GFDM derivative approximation.
+**Used in MFGArchon**: `gfdm_operators.py` uses Gaussian RBF weights for GFDM derivative approximation.
 
 ---
 
@@ -275,7 +275,7 @@ $$K_h(r) = \frac{1}{(\pi h^2)^{d/2}} \exp\left(-\frac{r^2}{h^2}\right)$$
 - Infinite support (practically zero for $r > 3h$)
 - Fourier transform: Gaussian (ideal low-pass filter)
 
-**MFGarchon Implementation**: `GaussianKernel()` in `mfgarchon.utils.numerical.kernels`
+**MFGArchon Implementation**: `GaussianKernel()` in `mfgarchon.utils.numerical.kernels`
 
 ### 6.2 Wendland Kernels (Compact Support)
 
@@ -325,7 +325,7 @@ $$\frac{dk}{dq} = \begin{cases}
 Wendland kernels require normalization constants $\sigma_d$:
 $$K_h(r) = \frac{\sigma_d}{h^d} k\left(\frac{r}{h}\right)$$
 
-**MFGarchon Implementation**: `WendlandKernel(k, dimension)` with $k \in \{0, 1, 2, 3\}$
+**MFGArchon Implementation**: `WendlandKernel(k, dimension)` with $k \in \{0, 1, 2, 3\}$
 - Unified parameterized class replaces separate C0/C2/C4/C6 classes
 - Automatic polynomial coefficient generation based on $k$
 - Factory: `create_kernel('wendland_c2')` → `WendlandKernel(k=1)`
@@ -372,7 +372,7 @@ The cubic spline is the B-spline of order 4, obtained by convolving the box func
 - Computational efficiency
 - Numerical stability
 
-**MFGarchon Implementation**: `CubicSplineKernel(dimension=d)`
+**MFGArchon Implementation**: `CubicSplineKernel(dimension=d)`
 
 ### 6.4 Quintic Spline (B-Spline M6)
 
@@ -435,7 +435,7 @@ However, the larger support radius (3h vs 2h) increases computational cost by ~3
 | Accuracy | Good | Excellent |
 | Cost | Low | Medium |
 
-**MFGarchon Implementation**: `QuinticSplineKernel(dimension=d)`
+**MFGArchon Implementation**: `QuinticSplineKernel(dimension=d)`
 
 **Note on Implementation**: B-splines are kept as separate classes (cubic and quintic) rather than parameterized by degree because:
 1. Only these two orders are standard in SPH literature
@@ -477,11 +477,11 @@ These simple kernels are useful for:
 - Educational examples
 - Cases where C^n continuity is not critical
 
-**MFGarchon Implementation**: `CubicKernel()`, `QuarticKernel()`
+**MFGArchon Implementation**: `CubicKernel()`, `QuarticKernel()`
 
 ---
 
-## 7. Applications in MFGarchon
+## 7. Applications in MFGArchon
 
 ### 6.1 Kernel Density Estimation (KDE)
 
@@ -577,7 +577,7 @@ u_interp = Σ_i w_i u_i / Σ_i w_i
 
 ## Summary
 
-This document provides the mathematical foundation for the `kernels` module in MFGarchon. Key concepts:
+This document provides the mathematical foundation for the `kernels` module in MFGArchon. Key concepts:
 
 1. **Kernels** are normalized, non-negative functions for smoothing and approximation
 2. **Mollifiers** are $C^\infty$ compactly supported kernels for regularization

--- a/docs/theory/lagrangian_formulation.md
+++ b/docs/theory/lagrangian_formulation.md
@@ -315,7 +315,7 @@ def plot_lagrangian_solution(result, problem):
 
 ## Conclusion
 
-The Lagrangian formulation provides essential capabilities that significantly enhance the MFGarchon framework:
+The Lagrangian formulation provides essential capabilities that significantly enhance the MFGArchon framework:
 
 1. **Mathematical Completeness**: Dual perspective to Hamiltonian methods
 2. **Constraint Handling**: Natural framework for complex constraints  
@@ -329,5 +329,5 @@ The Lagrangian formulation provides essential capabilities that significantly en
 
 **Implementation Status**: Complete core system with examples and validation  
 **Documentation**: Comprehensive system documentation  
-**Integration**: Full compatibility with existing MFGarchon framework  
+**Integration**: Full compatibility with existing MFGArchon framework  
 **Examples**: Basic usage, constraints, comparisons with Hamiltonian methods

--- a/docs/theory/network_mfg_mathematical_formulation.md
+++ b/docs/theory/network_mfg_mathematical_formulation.md
@@ -384,7 +384,7 @@ where $μ_i$ is the uniform distribution on $N(i)$ and $d(i,j)$ is graph distanc
 
 ---
 
-## 8. Implementation in MFGarchon
+## 8. Implementation in MFGArchon
 
 ### 8.1 Core Files
 

--- a/docs/theory/reinforcement_learning/README.md
+++ b/docs/theory/reinforcement_learning/README.md
@@ -311,5 +311,5 @@ When using these theoretical frameworks, please cite:
 
 **Target Audience**: Researchers, algorithm developers, theoretical MFG practitioners
 **Prerequisites**: Familiarity with RL, MFG theory, and numerical methods
-**Maintained by**: MFGarchon Development Team
+**Maintained by**: MFGArchon Development Team
 **Last Updated**: 2025-10-12

--- a/docs/theory/reinforcement_learning/action_space_scalability.md
+++ b/docs/theory/reinforcement_learning/action_space_scalability.md
@@ -251,7 +251,7 @@ class DuelingQNetwork(nn.Module):
 
 ---
 
-## Practical Recommendations for MFGarchon
+## Practical Recommendations for MFGArchon
 
 ### Immediate Extensions (Can Implement Now)
 

--- a/docs/theory/reinforcement_learning/continuous_action_mfg_theory.md
+++ b/docs/theory/reinforcement_learning/continuous_action_mfg_theory.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-This document outlines a comprehensive research and implementation plan for extending MFGarchon's reinforcement learning paradigm to **continuous action spaces**. Current implementations support discrete actions (|A| ≤ 20 optimal), but many real-world Mean Field Games require continuous control: crowd navigation with velocity control, price formation with continuous prices, resource allocation with continuous quantities.
+This document outlines a comprehensive research and implementation plan for extending MFGArchon's reinforcement learning paradigm to **continuous action spaces**. Current implementations support discrete actions (|A| ≤ 20 optimal), but many real-world Mean Field Games require continuous control: crowd navigation with velocity control, price formation with continuous prices, resource allocation with continuous quantities.
 
 **Strategic Goal**: Develop production-quality continuous action MFG-RL algorithms that maintain the same level of rigor, performance, and usability as our discrete implementations.
 
@@ -176,7 +176,7 @@ class MeanFieldSAC:
 
 ### 2.4 Proximal Policy Optimization (PPO) for Continuous Actions
 
-**Current Status**: MFGarchon has discrete-action PPO-style Actor-Critic
+**Current Status**: MFGArchon has discrete-action PPO-style Actor-Critic
 
 **Extension to Continuous**:
 - Replace categorical policy with Gaussian: $\pi(a|s,m) = \mathcal{N}(\mu(s,m), \sigma)$
@@ -1233,7 +1233,7 @@ $$
 
 ### Summary
 
-This roadmap outlines a comprehensive plan to extend MFGarchon's RL paradigm to **continuous action spaces**, addressing a critical gap between classical MFG theory (which assumes continuous control) and current RL implementations (which use discrete actions).
+This roadmap outlines a comprehensive plan to extend MFGArchon's RL paradigm to **continuous action spaces**, addressing a critical gap between classical MFG theory (which assumes continuous control) and current RL implementations (which use discrete actions).
 
 **Key Deliverables**:
 1. **Algorithms**: DDPG, TD3, SAC, continuous PPO for MFG
@@ -1243,7 +1243,7 @@ This roadmap outlines a comprehensive plan to extend MFGarchon's RL paradigm to 
 
 **Timeline**: 3-6 months for core implementation (Phase 1-4), additional 2-3 months for applications (Phase 5)
 
-**Impact**: Enable realistic MFG applications requiring continuous control, bringing MFGarchon closer to practical deployment in robotics, economics, and social systems.
+**Impact**: Enable realistic MFG applications requiring continuous control, bringing MFGArchon closer to practical deployment in robotics, economics, and social systems.
 
 ### Immediate Next Steps
 

--- a/docs/theory/reinforcement_learning/maddpg_architecture_design.md
+++ b/docs/theory/reinforcement_learning/maddpg_architecture_design.md
@@ -1,4 +1,4 @@
-# MADDPG Architecture Design for MFGarchon
+# MADDPG Architecture Design for MFGArchon
 
 **Date**: October 2, 2025
 **Status**: Architecture Design (Future Extension)
@@ -8,9 +8,9 @@
 
 ## Executive Summary
 
-This document presents the architecture design for implementing **Mean Field MADDPG (MF-MADDPG)** in MFGarchon. MADDPG extends the current discrete-action RL paradigm to **continuous action spaces**, which is essential for many real-world MFG applications.
+This document presents the architecture design for implementing **Mean Field MADDPG (MF-MADDPG)** in MFGArchon. MADDPG extends the current discrete-action RL paradigm to **continuous action spaces**, which is essential for many real-world MFG applications.
 
-**Status**: This is a design document for future implementation. Current MFGarchon focuses on discrete actions. Continuous action support requires:
+**Status**: This is a design document for future implementation. Current MFGArchon focuses on discrete actions. Continuous action support requires:
 1. New network architectures (action as input to critic)
 2. Deterministic policy gradient updates
 3. Exploration strategies for continuous spaces
@@ -393,7 +393,7 @@ class MeanFieldMADDPG:
 
 ---
 
-## Integration with MFGarchon
+## Integration with MFGArchon
 
 ### Factory Function
 

--- a/docs/theory/reinforcement_learning/maddpg_for_mfg_formulation.md
+++ b/docs/theory/reinforcement_learning/maddpg_for_mfg_formulation.md
@@ -564,5 +564,5 @@ Encourage exploration in under-explored regions of population state.
 ---
 
 **Status**: ✅ Theoretical foundation complete
-**Next**: Design MF-MADDPG architecture for MFGarchon
+**Next**: Design MF-MADDPG architecture for MFGArchon
 **Key Insight**: MADDPG's centralized critic + mean field = scalable continuous control for MFG

--- a/docs/theory/reinforcement_learning/nash_q_learning_architecture.md
+++ b/docs/theory/reinforcement_learning/nash_q_learning_architecture.md
@@ -1,4 +1,4 @@
-# Nash Q-Learning Architecture Design for MFGarchon
+# Nash Q-Learning Architecture Design for MFGArchon
 
 **Date**: October 2, 2025
 **Status**: Architecture Design
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-This document presents the architectural design for implementing Nash Q-Learning in MFGarchon. Based on the theoretical formulation, we identify that:
+This document presents the architectural design for implementing Nash Q-Learning in MFGArchon. Based on the theoretical formulation, we identify that:
 
 1. **For symmetric MFG**: Nash Q-Learning ≈ Mean Field Q-Learning (already implemented)
 2. **Extension needed**: Support for heterogeneous agents and multi-population games

--- a/docs/theory/reinforcement_learning/nash_q_learning_formulation.md
+++ b/docs/theory/reinforcement_learning/nash_q_learning_formulation.md
@@ -212,7 +212,7 @@ This is because in symmetric MFG, all agents follow the same policy $\pi^*$, so 
 
 ---
 
-## Implementation Design for MFGarchon
+## Implementation Design for MFGArchon
 
 ### Architecture
 
@@ -353,5 +353,5 @@ Where:
 ---
 
 **Status**: ✅ Theoretical foundation complete
-**Next**: Design and implement Nash Q-Learning for MFGarchon
+**Next**: Design and implement Nash Q-Learning for MFGArchon
 **Key Insight**: For symmetric MFG, Nash Q-Learning simplifies to standard Q-learning with population state (which we already have!). The extension is mainly for heterogeneous/competitive scenarios.

--- a/docs/theory/reinforcement_learning/population_ppo_formulation.md
+++ b/docs/theory/reinforcement_learning/population_ppo_formulation.md
@@ -243,7 +243,7 @@ m* = μ(π*)
 
 ---
 
-## Implementation in MFGarchon
+## Implementation in MFGArchon
 
 ### Network Architecture
 

--- a/docs/theory/semi_lagrangian_methods_for_hjb.md
+++ b/docs/theory/semi_lagrangian_methods_for_hjb.md
@@ -521,7 +521,7 @@ where $p$ is the interpolation order (1 for linear, 3 for cubic).
 
 ## Recommendations
 
-### For MFGarchon Library
+### For MFGArchon Library
 
 **Current Implementation** (Explicit + Clipping):
 - **Use Case**: General MFG problems with moderate gradients

--- a/docs/theory/stochastic/MFG_Initial_Distribution_Sensitivity_Analysis.md
+++ b/docs/theory/stochastic/MFG_Initial_Distribution_Sensitivity_Analysis.md
@@ -3,7 +3,7 @@
 **Research Report**  
 **Date**: August 2025  
 **Classification**: Theoretical Analysis  
-**Framework**: MFGarchon  
+**Framework**: MFGArchon  
 
 ---
 
@@ -90,7 +90,7 @@ The coupling term $\kappa m(x)^2$ creates **feedback loops**:
 3. This creates persistent **spatial segregation**
 4. Final equilibrium reflects initial clustering patterns
 
-**Computational Verification** (MFGarchon):
+**Computational Verification** (MFGArchon):
 ```python
 from mfgarchon import MFGProblem, create_fast_solver
 import numpy as np
@@ -298,9 +298,9 @@ hub_problem = create_grid_mfg_problem(
 
 ## 6. Computational Methods and Verification
 
-### 6.1 Numerical Implementation in MFGarchon
+### 6.1 Numerical Implementation in MFGArchon
 
-The MFGarchon framework provides robust tools for studying $m_0$-sensitivity:
+The MFGArchon framework provides robust tools for studying $m_0$-sensitivity:
 
 **Solver Configuration**:
 ```python
@@ -557,7 +557,7 @@ class SensitivityAwareNNSolver(NeuralMFGSolver):
    - **Type II**: Moderately $m_0$-sensitive (balanced systems)  
    - **Type III**: Strongly $m_0$-sensitive (interaction-dominated, slow dynamics)
 
-5. **Computational Verification**: The MFGarchon framework successfully demonstrates these theoretical predictions numerically.
+5. **Computational Verification**: The MFGArchon framework successfully demonstrates these theoretical predictions numerically.
 
 ### 11.2 Implications
 
@@ -599,7 +599,7 @@ The dichotomy between $m_0$-sensitive and $m_0$-insensitive MFG systems represen
 
 4. **Achdou, Y., et al.** (2012). Mean field games: numerical methods. *SIAM Journal on Numerical Analysis*, 50(1), 77-109.
 
-5. **MFGarchon Documentation** (2025). *Advanced Mean Field Games Framework*. Available at: https://github.com/derrring/mfgarchon
+5. **MFGArchon Documentation** (2025). *Advanced Mean Field Games Framework*. Available at: https://github.com/derrring/mfgarchon
 
 6. **Gomes, D. A., et al.** (2014). *Regularity Theory for Mean Field Game Systems*. Springer Briefs in Mathematics.
 
@@ -760,6 +760,6 @@ def generate_phase_diagram():
 
 **Report Status**: ✅ **COMPLETED**  
 **Total Length**: ~15,000 words  
-**Code Examples**: Fully executable with MFGarchon framework  
+**Code Examples**: Fully executable with MFGArchon framework  
 **Mathematical Rigor**: Graduate research level  
 **Practical Applications**: Urban planning, economics, social dynamics  

--- a/docs/theory/stochastic/stochastic_mfg_common_noise.md
+++ b/docs/theory/stochastic/stochastic_mfg_common_noise.md
@@ -328,7 +328,7 @@ This analytical solution serves as a benchmark for testing the Common Noise MFG 
 
 ---
 
-## Implementation in MFGarchon
+## Implementation in MFGArchon
 
 ### Basic Usage
 

--- a/docs/theory/variational_mfg_theory.md
+++ b/docs/theory/variational_mfg_theory.md
@@ -17,7 +17,7 @@
 4. **Connects** to statistical physics (free energy minimization)
 5. **Extends** to non-potential games via monotonicity conditions
 
-This document provides rigorous mathematical foundations for variational formulations and their computational implementation in MFGarchon.
+This document provides rigorous mathematical foundations for variational formulations and their computational implementation in MFGArchon.
 
 ---
 
@@ -307,7 +307,7 @@ $$\lim_{\epsilon \to 0} \epsilon W_{2,\epsilon}^2(m_0, m_1) = \text{Schrödinger
 
 ---
 
-## 8. Implementation in MFGarchon
+## 8. Implementation in MFGArchon
 
 ### 8.1 Core Components
 

--- a/docs/user/DEPRECATION_MODERNIZATION_GUIDE.md
+++ b/docs/user/DEPRECATION_MODERNIZATION_GUIDE.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-This guide documents deprecated usage patterns in MFGarchon and provides migration paths to modern APIs. All deprecated patterns will continue to work until v1.0.0 but will emit deprecation warnings.
+This guide documents deprecated usage patterns in MFGArchon and provides migration paths to modern APIs. All deprecated patterns will continue to work until v1.0.0 but will emit deprecation warnings.
 
 ---
 
@@ -77,13 +77,13 @@ from mfgarchon.utils.progress import console, Progress, Panel, Table
 from tqdm import tqdm
 from tqdm.auto import tqdm
 
-# New MFGarchon progress (use this)
+# New MFGArchon progress (use this)
 from mfgarchon.utils.progress import tqdm  # Alias for RichProgressBar
 from mfgarchon.utils.progress import solver_progress  # Preferred for solvers
 ```
 
 **Benefits**:
-- ✅ Consistent Rich-based UI across all MFGarchon tools
+- ✅ Consistent Rich-based UI across all MFGArchon tools
 - ✅ No fallback complexity (Rich is required, not optional)
 - ✅ Enhanced solver-specific utilities with error tracking
 - ✅ Unified console output with panels and tables
@@ -857,7 +857,7 @@ geometry.plot(mode='quality')
 - Document conversion pattern
 
 ### Phase 3: Systematic Migration (✅ Complete - 2025-12-18)
-- ✅ Batch convert remaining test files (55 files in MFGarchon)
+- ✅ Batch convert remaining test files (55 files in MFGArchon)
 - ✅ Update all `examples/` to use modern API
 - ✅ Migrate mfg-research repository (8 files)
 - ✅ Issue deprecation warnings for all legacy patterns

--- a/docs/user/GEOMETRY_FIRST_API_GUIDE.md
+++ b/docs/user/GEOMETRY_FIRST_API_GUIDE.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The geometry-first API is the **recommended way** to construct MFG problems in MFGarchon. Instead of manually specifying grid parameters in `MFGProblem`, you first create a geometry object and pass it to `MFGProblem`.
+The geometry-first API is the **recommended way** to construct MFG problems in MFGArchon. Instead of manually specifying grid parameters in `MFGProblem`, you first create a geometry object and pass it to `MFGProblem`.
 
 As of v0.16.0, `MFGProblem.geometry` is **always non-None** after initialization, and all spatial information is derived from the geometry object. Legacy attributes (`xmin`, `xmax`, `Nx`, `dx`, etc.) emit `DeprecationWarning` when accessed.
 

--- a/docs/user/HJB_SOLVER_SELECTION_GUIDE.md
+++ b/docs/user/HJB_SOLVER_SELECTION_GUIDE.md
@@ -543,4 +543,4 @@ From `benchmarks/hjb_solver_comparison.py`:
 ---
 
 **Last Updated**: 2025-11-02
-**Version**: MFGarchon 0.8.1+
+**Version**: MFGArchon 0.8.1+

--- a/docs/user/LEGACY_PARAMETERS.md
+++ b/docs/user/LEGACY_PARAMETERS.md
@@ -202,4 +202,4 @@ geometry = TensorProductGrid(dimension=1, bounds=[(0.0, 1.0)], Nx_points=[101])
 ---
 
 **Last Updated**: 2026-01-18
-**Author**: MFGarchon Development Team
+**Author**: MFGArchon Development Team

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,4 +1,4 @@
-# MFGarchon User Documentation
+# MFGArchon User Documentation
 
 **Research-grade Mean Field Games solver for academic and industrial applications**
 
@@ -24,7 +24,7 @@ print(result.M)  # Density m(t,x)
 
 ## 📚 **Two-Level API Design**
 
-MFGarchon is designed for users who **understand Mean Field Games** (HJB-FP systems, Nash equilibria).
+MFGArchon is designed for users who **understand Mean Field Games** (HJB-FP systems, Nash equilibria).
 
 | **API Level** | **Target Users** | **Entry Point** | **What You Get** |
 |---------------|------------------|-----------------|------------------|
@@ -193,7 +193,7 @@ result = solver.solve()
 
 ## 🔄 **Migration from Old API**
 
-Already using MFGarchon? The new API is backward compatible. See [quickstart](quickstart.md) for the latest patterns.
+Already using MFGArchon? The new API is backward compatible. See [quickstart](quickstart.md) for the latest patterns.
 
 ---
 
@@ -206,7 +206,7 @@ Already using MFGarchon? The new API is backward compatible. See [quickstart](qu
 
 ## 📋 **What You Should Know**
 
-MFGarchon assumes you understand:
+MFGArchon assumes you understand:
 - **Mean Field Games**: HJB-FP coupled systems, Nash equilibria
 - **Numerical PDEs**: Finite difference methods, stability, convergence
 - **Python**: Basic programming and scientific computing (NumPy)

--- a/docs/user/advanced_boundary_conditions.md
+++ b/docs/user/advanced_boundary_conditions.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This guide introduces **advanced boundary condition methods** implemented in MFGarchon v0.18.0+, covering:
+This guide introduces **advanced boundary condition methods** implemented in MFGArchon v0.18.0+, covering:
 
 - **Tier 2 BCs**: Variational inequalities and constraint-based boundary conditions
 - **Tier 3 BCs**: Time-dependent boundaries and free boundary problems
@@ -85,7 +85,7 @@ $$
 - You know the active set a priori (use strong BC on that region)
 - The constraint is nonlinear or non-convex (obstacle methods require convex constraints)
 
-### 1.4 Implementation in MFGarchon
+### 1.4 Implementation in MFGArchon
 
 **Step 1**: Define the obstacle constraint
 ```python
@@ -214,7 +214,7 @@ where $V_n$ is the **normal velocity** of the interface.
 - Boundary motion is simple and known (use time-dependent coordinate transform)
 - You need **exact** mass conservation (Level Set can drift; use Volume-of-Fluid instead)
 
-### 2.4 Implementation in MFGarchon
+### 2.4 Implementation in MFGArchon
 
 **Step 1**: Set up time-dependent domain
 ```python

--- a/docs/user/collaboration/github_workflow.md
+++ b/docs/user/collaboration/github_workflow.md
@@ -1,11 +1,11 @@
-# GitHub Label System for MFGarchon
+# GitHub Label System for MFGArchon
 
 **Date**: 2025-09-23
 **Status**: ✅ **IMPLEMENTED** - Comprehensive label system established
 
 ## 🏷️ **Label Categories Overview**
 
-The MFGarchon repository uses a structured label system to organize issues and pull requests effectively. All labels follow consistent naming patterns and color coding.
+The MFGArchon repository uses a structured label system to organize issues and pull requests effectively. All labels follow consistent naming patterns and color coding.
 
 ### **📊 Priority Labels** (Required for all issues)
 - `priority: high` 🔴 - High priority issues requiring immediate attention

--- a/docs/user/collaboration/issue_templates.md
+++ b/docs/user/collaboration/issue_templates.md
@@ -6,7 +6,7 @@
 
 ## 🎯 Problem Statement
 
-Complete the modernization of typing patterns across MFGarchon to Python 3.12+ standards. While most typing errors have been resolved through recent systematic fixes, there are remaining type narrowing issues in `network_geometry.py` that were deferred due to complexity.
+Complete the modernization of typing patterns across MFGArchon to Python 3.12+ standards. While most typing errors have been resolved through recent systematic fixes, there are remaining type narrowing issues in `network_geometry.py` that were deferred due to complexity.
 
 **Current State**:
 - ✅ Utils directory typing modernized (logging.py, convergence.py, etc.)

--- a/docs/user/configuration_system.md
+++ b/docs/user/configuration_system.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-MFGarchon uses a **Dual-System Configuration Architecture** that balances runtime safety with experimental flexibility. This guide explains how to use the configuration system effectively.
+MFGArchon uses a **Dual-System Configuration Architecture** that balances runtime safety with experimental flexibility. This guide explains how to use the configuration system effectively.
 
 ---
 

--- a/docs/user/continuous_environments_guide.md
+++ b/docs/user/continuous_environments_guide.md
@@ -1,6 +1,6 @@
 # Continuous MFG Environments User Guide
 
-Comprehensive guide to the continuous action space environments in MFGarchon's reinforcement learning framework.
+Comprehensive guide to the continuous action space environments in MFGArchon's reinforcement learning framework.
 
 ## Overview
 
@@ -575,7 +575,7 @@ pip install gymnasium
 
 ## Related Documentation
 
-- [Quickstart Guide](quickstart.md) - Getting started with MFGarchon
+- [Quickstart Guide](quickstart.md) - Getting started with MFGArchon
 - [Advanced Examples](../../examples/advanced/) - More complex examples
 
 ---

--- a/docs/user/core_objects.md
+++ b/docs/user/core_objects.md
@@ -6,7 +6,7 @@ This is the primary API tier for research users who need to define custom Hamilt
 
 ## Architecture Overview
 
-The MFGarchon core objects follow a clean pipeline:
+The MFGArchon core objects follow a clean pipeline:
 
 ```python
 MFGProblem → FixedPointSolver → MFGResult

--- a/docs/user/dual_geometry_usage.md
+++ b/docs/user/dual_geometry_usage.md
@@ -2,7 +2,7 @@
 
 **Status**: ✅ COMPLETED (Issue #257)
 **Created**: 2025-11-10
-**Audience**: MFGarchon users (researchers, application developers)
+**Audience**: MFGArchon users (researchers, application developers)
 
 ## Overview
 
@@ -676,4 +676,4 @@ For true 3D, use `TensorProductGrid` for HJB geometry.
 
 **Document Version**: 1.0
 **Last Updated**: 2025-11-10
-**Feature Status**: ✅ Available in MFGarchon v1.0+
+**Feature Status**: ✅ Available in MFGArchon v1.0+

--- a/docs/user/geometry_traits.md
+++ b/docs/user/geometry_traits.md
@@ -1,6 +1,6 @@
 # Guide: Geometry Trait Protocols for Solver Developers
 
-**Audience**: Solver developers, advanced users extending MFGarchon
+**Audience**: Solver developers, advanced users extending MFGArchon
 **Prerequisites**: Python protocols, linear algebra, numerical PDEs
 **Version**: 1.0 (2026-01-18)
 
@@ -20,7 +20,7 @@
 
 ## Introduction
 
-MFGarchon uses **trait protocols** to decouple solvers from geometry implementations. Solvers request **capabilities** (e.g., "can compute Laplacian"), and geometries provide **operators** (e.g., finite difference Laplacian matrix).
+MFGArchon uses **trait protocols** to decouple solvers from geometry implementations. Solvers request **capabilities** (e.g., "can compute Laplacian"), and geometries provide **operators** (e.g., finite difference Laplacian matrix).
 
 ### What Are Trait Protocols?
 
@@ -112,7 +112,7 @@ Trait protocols move **capability checking from runtime to design time**. If a g
 
 ## Core Trait Protocols
 
-MFGarchon provides the following trait protocols for geometry capabilities:
+MFGArchon provides the following trait protocols for geometry capabilities:
 
 ### 1. SupportsLaplacian
 
@@ -881,5 +881,5 @@ def my_solver(geometry: SupportsLaplacian):
 ---
 
 **Last Updated**: 2026-01-18
-**Author**: MFGarchon Documentation Team
+**Author**: MFGArchon Documentation Team
 **Related Issues**: #590 (Geometry Traits), #594 (Documentation)

--- a/docs/user/guides/backend_usage.md
+++ b/docs/user/guides/backend_usage.md
@@ -1,8 +1,8 @@
-# MFGarchon Backend Usage Guide
+# MFGArchon Backend Usage Guide
 
 ## 🚀 **Quick Start: Choose Your Backend**
 
-MFGarchon automatically selects the best available backend, but you can also manually choose based on your hardware and problem type.
+MFGArchon automatically selects the best available backend, but you can also manually choose based on your hardware and problem type.
 
 ### **One-Line Backend Selection**
 ```python
@@ -355,7 +355,7 @@ backend = create_backend("numba")
 
 ### **Automatic Backend Selection (Recommended)**
 ```python
-# Let MFGarchon choose the best backend
+# Let MFGArchon choose the best backend
 from mfgarchon import MFGProblem
 from mfgarchon.factory import create_solver
 

--- a/docs/user/guides/boundary_conditions.md
+++ b/docs/user/guides/boundary_conditions.md
@@ -1,6 +1,6 @@
 # Boundary Conditions Guide
 
-This guide explains how to specify and apply boundary conditions in MFGarchon.
+This guide explains how to specify and apply boundary conditions in MFGArchon.
 
 ## Quick Start
 

--- a/docs/user/guides/maze_generation.md
+++ b/docs/user/guides/maze_generation.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-MFGarchon provides a complete suite of maze generation algorithms optimized for Mean Field Games reinforcement learning research. This guide covers all implemented algorithms, hybrid composition methods, and recommendations for different MFG scenarios.
+MFGArchon provides a complete suite of maze generation algorithms optimized for Mean Field Games reinforcement learning research. This guide covers all implemented algorithms, hybrid composition methods, and recommendations for different MFG scenarios.
 
 ## Implemented Algorithms
 

--- a/docs/user/guides/plugin_development.md
+++ b/docs/user/guides/plugin_development.md
@@ -1,19 +1,19 @@
-# Plugin Development Guide for MFGarchon
+# Plugin Development Guide for MFGArchon
 
 **Date:** July 27, 2025  
 **Version:** 1.0  
-**Purpose:** Comprehensive guide for developing plugins for the MFGarchon framework  
+**Purpose:** Comprehensive guide for developing plugins for the MFGArchon framework  
 **Target Audience:** Plugin developers, researchers, and third-party contributors  
 
 ## Overview
 
-The MFGarchon plugin system enables researchers and developers to extend the framework with custom solvers, analysis tools, and algorithms without modifying the core codebase. This guide provides everything needed to create, test, and distribute MFGarchon plugins.
+The MFGArchon plugin system enables researchers and developers to extend the framework with custom solvers, analysis tools, and algorithms without modifying the core codebase. This guide provides everything needed to create, test, and distribute MFGArchon plugins.
 
 ## Plugin Architecture
 
 ### Plugin Types
 
-MFGarchon supports two main types of plugins:
+MFGArchon supports two main types of plugins:
 
 1. **Solver Plugins** (`SolverPlugin`): Provide new solver algorithms
 2. **Analysis Plugins** (`AnalysisPlugin`): Provide post-processing and analysis tools
@@ -281,7 +281,7 @@ from setuptools import setup, find_packages
 setup(
     name="mfg-custom-solver-plugin",
     version="1.0.0",
-    description="Custom solver plugin for MFGarchon",
+    description="Custom solver plugin for MFGArchon",
     author="Your Name",
     author_email="your.email@example.com",
     packages=find_packages(),
@@ -637,7 +637,7 @@ class ParallelSolver:
 2. **Version Compatibility**
    - Update min_mfg_version in metadata
    - Check dependency versions
-   - Test with target MFGarchon version
+   - Test with target MFGArchon version
 
 3. **Import Errors**
    - Verify all dependencies are installed
@@ -692,4 +692,4 @@ validate_solver_result(result, problem)
 - Provide example notebooks
 - Include citation information for academic use
 
-This guide provides the foundation for creating powerful, extensible plugins for MFGarchon. The plugin system enables the community to collaborate and extend the framework while maintaining code quality and user experience standards.
+This guide provides the foundation for creating powerful, extensible plugins for MFGArchon. The plugin system enables the community to collaborate and extend the framework while maintaining code quality and user experience standards.

--- a/docs/user/level_set_tutorial.md
+++ b/docs/user/level_set_tutorial.md
@@ -1,7 +1,7 @@
 # Tutorial: Level Set Methods for Free Boundary Problems
 
 **Tutorial Level**: Advanced
-**Prerequisites**: PDEs, basic numerical methods, MFGarchon geometry module
+**Prerequisites**: PDEs, basic numerical methods, MFGArchon geometry module
 **Estimated Time**: 60-90 minutes
 **Version**: 1.0 (2026-01-18)
 
@@ -946,7 +946,7 @@ if n % 10 == 0:
 **Upgrade**: WENO5 (5th-order Weighted Essentially Non-Oscillatory).
 
 ```python
-# MFGarchon currently uses Godunov (Issue #592)
+# MFGArchon currently uses Godunov (Issue #592)
 # Future: WENO5 for reduced diffusion
 
 # Expected improvement:
@@ -1036,5 +1036,5 @@ vapor_region = (phi_water_vapor > 0)
 ---
 
 **Last Updated**: 2026-01-18
-**Author**: MFGarchon Documentation Team
+**Author**: MFGArchon Documentation Team
 **Related Issues**: #592 (Level Set Methods), #594 (Documentation)

--- a/docs/user/migration.md
+++ b/docs/user/migration.md
@@ -10,11 +10,11 @@
 >
 > See [quickstart.md](quickstart.md) and [GEOMETRY_FIRST_API_GUIDE.md](../migration/GEOMETRY_FIRST_API_GUIDE.md) for current patterns.
 
-**Smooth transition from old MFGarchon API to the two-level factory-based API**
+**Smooth transition from old MFGArchon API to the two-level factory-based API**
 
 ## Overview
 
-MFGarchon now provides a **two-level research-grade API**:
+MFGArchon now provides a **two-level research-grade API**:
 - **Level 1 (Users - 95%)**: Factory API for researchers and practitioners
 - **Level 2 (Developers - 5%)**: Core API for framework contributors
 

--- a/docs/user/multidimensional_mfg_guide.md
+++ b/docs/user/multidimensional_mfg_guide.md
@@ -1,6 +1,6 @@
 # Multi-Dimensional Mean Field Games: User Guide
 
-Complete guide for setting up and solving 2D and 3D Mean Field Game problems using MFGarchon's multi-dimensional infrastructure.
+Complete guide for setting up and solving 2D and 3D Mean Field Game problems using MFGArchon's multi-dimensional infrastructure.
 
 ## Table of Contents
 
@@ -17,7 +17,7 @@ Complete guide for setting up and solving 2D and 3D Mean Field Game problems usi
 
 ## Overview
 
-MFGarchon's multi-dimensional framework enables efficient solution of Mean Field Games on 2D and 3D spatial domains with memory-efficient data structures, sparse linear algebra, and interactive visualizations.
+MFGArchon's multi-dimensional framework enables efficient solution of Mean Field Games on 2D and 3D spatial domains with memory-efficient data structures, sparse linear algebra, and interactive visualizations.
 
 ### Key Features
 
@@ -551,4 +551,4 @@ u = SparseSolver(method='cg').solve(L, b)  # Direct sparse solve
 ---
 
 *Last Updated: 2025-10-06*
-*MFGarchon Version: 1.4.0+*
+*MFGArchon Version: 1.4.0+*

--- a/docs/user/obstacle_problems.md
+++ b/docs/user/obstacle_problems.md
@@ -22,7 +22,7 @@
 
 ## Introduction
 
-This tutorial teaches you how to solve **obstacle problems** and **variational inequalities** using MFGarchon. These problems arise when solutions must satisfy inequality constraints (e.g., $u(t,x) \geq \psi(x)$) rather than just equalities.
+This tutorial teaches you how to solve **obstacle problems** and **variational inequalities** using MFGArchon. These problems arise when solutions must satisfy inequality constraints (e.g., $u(t,x) \geq \psi(x)$) rather than just equalities.
 
 ### What You'll Learn
 
@@ -364,7 +364,7 @@ print(f"Mean capacity: {capacity.mean_capacity:.3f}")
 
 ### Step 2: Choose Congestion Model
 
-MFGarchon provides three congestion models:
+MFGArchon provides three congestion models:
 
 | Model | Formula | Derivative | Best For |
 |:------|:--------|:-----------|:---------|
@@ -893,5 +893,5 @@ for picard_iter in range(max_picard):
 ---
 
 **Last Updated**: 2026-01-18
-**Author**: MFGarchon Documentation Team
+**Author**: MFGArchon Documentation Team
 **Related Issues**: #591 (Variational Constraints), #594 (Documentation)

--- a/docs/user/particle_interpolation.md
+++ b/docs/user/particle_interpolation.md
@@ -304,4 +304,4 @@ See `tests/unit/utils/test_particle_interpolation.py` for comprehensive examples
 
 **Documentation Version**: 1.0
 **Last Updated**: 2025-11-03
-**MFGarchon Version**: v0.9.0+
+**MFGArchon Version**: v0.9.0+

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -1,12 +1,12 @@
-# MFGarchon Quickstart
+# MFGArchon Quickstart
 
-**Get started with MFGarchon in 5 minutes**
+**Get started with MFGArchon in 5 minutes**
 
 ---
 
 ## Prerequisites
 
-MFGarchon assumes you understand:
+MFGArchon assumes you understand:
 - **Mean Field Games**: HJB-FP coupled systems, Nash equilibria
 - **Numerical PDEs**: Finite difference methods, stability
 - **Python**: NumPy and basic scientific computing
@@ -114,7 +114,7 @@ print(f"Mass error: {result.mass_conservation_error:.2e}")
 
 ## Three Solver Tiers
 
-MFGarchon provides three solver tiers based on **quality**:
+MFGArchon provides three solver tiers based on **quality**:
 
 | Tier | Name | Mass Error | Convergence | Use Case |
 |:-----|:-----|:-----------|:------------|:---------|

--- a/docs/user/sdf_utilities.md
+++ b/docs/user/sdf_utilities.md
@@ -447,4 +447,4 @@ See `tests/unit/utils/test_sdf_utils.py` for comprehensive examples covering:
 
 **Documentation Version**: 1.0
 **Last Updated**: 2025-11-03
-**MFGarchon Version**: v0.9.0+
+**MFGArchon Version**: v0.9.0+

--- a/docs/user/stochastic_mfg_guide.md
+++ b/docs/user/stochastic_mfg_guide.md
@@ -1,6 +1,6 @@
 # Stochastic MFG User Guide
 
-**Target Audience**: Researchers and practitioners using MFGarchon for stochastic problems
+**Target Audience**: Researchers and practitioners using MFGArchon for stochastic problems
 **Prerequisites**: Basic understanding of Mean Field Games and HJB-FP systems
 **Related Documentation**: [High Dimensional MFG](../theory/high_dimensional_mfg.md)
 

--- a/docs/user/tutorial_network_mfg.md
+++ b/docs/user/tutorial_network_mfg.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide provides comprehensive documentation for the Network MFG implementation in MFGarchon, which extends Mean Field Games from continuous domains to discrete network/graph structures.
+This guide provides comprehensive documentation for the Network MFG implementation in MFGArchon, which extends Mean Field Games from continuous domains to discrete network/graph structures.
 
 ## Table of Contents
 

--- a/docs/user/usage_patterns.md
+++ b/docs/user/usage_patterns.md
@@ -1,17 +1,17 @@
-# MFGarchon Success Patterns for Generalization
+# MFGArchon Success Patterns for Generalization
 
 **Date:** July 26, 2025  
 **Author:** Pattern Analysis Team  
 **Status:** Analysis Complete  
-**Purpose:** Extract generalizable patterns from MFGarchon success for abstract framework design  
+**Purpose:** Extract generalizable patterns from MFGArchon success for abstract framework design  
 
 ## Executive Summary
 
-This document analyzes the successful patterns demonstrated in the MFGarchon project and identifies which elements should be generalized for the abstract scientific computing framework. These patterns represent proven approaches to building production-ready scientific software with professional tooling.
+This document analyzes the successful patterns demonstrated in the MFGArchon project and identifies which elements should be generalized for the abstract scientific computing framework. These patterns represent proven approaches to building production-ready scientific software with professional tooling.
 
 ## Pattern Analysis Methodology
 
-### Success Metrics from MFGarchon
+### Success Metrics from MFGArchon
 - ✅ **Type Safety**: Zero runtime type errors through Pydantic validation
 - ✅ **Professional Logging**: Research-grade observability and debugging
 - ✅ **Physical Validation**: Automatic constraint checking (mass conservation, CFL stability)
@@ -26,7 +26,7 @@ This document analyzes the successful patterns demonstrated in the MFGarchon pro
 
 #### What Made This Successful:
 ```python
-# MFGarchon Success Pattern
+# MFGArchon Success Pattern
 from mfgarchon.config.pydantic_config import create_research_config
 from mfgarchon.config.array_validation import MFGGridConfig
 
@@ -75,7 +75,7 @@ class MFGConfig(ScientificConfig):
 
 #### What Made This Successful:
 ```python
-# MFGarchon Success Pattern
+# MFGArchon Success Pattern
 from mfgarchon.utils.mfg_logging import configure_research_logging, log_convergence_analysis
 
 # Professional logging setup
@@ -137,7 +137,7 @@ class MFGLogger(UniversalLogger):
 
 #### What Made This Successful:
 ```python
-# MFGarchon Success Pattern
+# MFGArchon Success Pattern
 from mfgarchon.config.array_validation import MFGArrays
 
 # Automatic validation of solution arrays
@@ -207,7 +207,7 @@ class MFGPhysicalConstraints(PhysicalConstraints):
 
 #### What Made This Successful:
 ```python
-# MFGarchon Success Pattern
+# MFGArchon Success Pattern
 from mfgarchon.factory.pydantic_solver_factory import create_validated_solver
 from mfgarchon.config.pydantic_config import create_research_config
 
@@ -279,7 +279,7 @@ class UniversalSolverFactory:
 
 #### What Made This Successful:
 ```python
-# MFGarchon Success Pattern
+# MFGArchon Success Pattern
 @dataclass
 class SolverResult:
     """Structured result container"""
@@ -362,7 +362,7 @@ class PerformanceMetrics(BaseModel):
 
 #### What Made This Successful:
 ```python
-# MFGarchon Success Pattern
+# MFGArchon Success Pattern
 from mfgarchon.utils.notebook_reporting import create_mfg_research_report
 
 # Automatic generation of professional research notebooks
@@ -440,7 +440,7 @@ class DomainReportingPlugin(ABC):
 
 #### What Made This Successful:
 ```python
-# MFGarchon Success Pattern
+# MFGArchon Success Pattern
 from mfgarchon.config.pydantic_config import (
     create_fast_config,
     create_accurate_config, 
@@ -529,7 +529,7 @@ class PresetDefinitions:
 
 ## Anti-Patterns to Avoid
 
-### ❌ **What Didn't Work in Early MFGarchon Development**
+### ❌ **What Didn't Work in Early MFGArchon Development**
 
 1. **Scattered Configuration Parameters**
    ```python
@@ -574,7 +574,7 @@ class PresetDefinitions:
    # Easy to forget or implement inconsistently
    ```
 
-### ✅ **How MFGarchon Fixed These Issues**
+### ✅ **How MFGArchon Fixed These Issues**
 
 1. **Centralized Configuration with Validation**
 2. **Strong Type Safety with Pydantic**  
@@ -587,7 +587,7 @@ class PresetDefinitions:
 
 #### Optimization Problems
 ```python
-# Apply MFGarchon patterns to optimization
+# Apply MFGArchon patterns to optimization
 class OptimizationConfig(ScientificConfig):
     """Optimization-specific configuration"""
     objective: str = "minimize"
@@ -611,7 +611,7 @@ class OptimizationArrays(BaseModel):
 
 #### Machine Learning Problems  
 ```python
-# Apply MFGarchon patterns to ML
+# Apply MFGArchon patterns to ML
 class MLConfig(ScientificConfig):
     """ML-specific configuration"""
     model_type: str
@@ -639,7 +639,7 @@ class MLArrays(BaseModel):
 - [ ] Implement universal factory pattern
 
 ### Phase 2: Multi-Domain Demonstration (Month 3-4)
-- [ ] Port MFGarchon as first domain plugin
+- [ ] Port MFGArchon as first domain plugin
 - [ ] Implement optimization domain plugin
 - [ ] Create ML/Neural ODE domain plugin
 - [ ] Validate pattern consistency across domains
@@ -672,7 +672,7 @@ class MLArrays(BaseModel):
 
 ## Conclusion
 
-The MFGarchon project demonstrates that scientific computing frameworks can achieve both ease of use and professional quality through careful attention to:
+The MFGArchon project demonstrates that scientific computing frameworks can achieve both ease of use and professional quality through careful attention to:
 
 1. **Type Safety** - Pydantic validation catches errors early
 2. **Domain Expertise** - Physical constraints encoded in validation  

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,10 @@
-# MFGarchon Examples
+# MFGArchon Examples
 
 Comprehensive examples and demonstrations organized by complexity and learning path.
 
 ## Quick Start
 
-**New to MFGarchon?** Start here:
+**New to MFGArchon?** Start here:
 
 ```bash
 # Complete the 5-tutorial learning path (90 minutes total)
@@ -42,7 +42,7 @@ python examples/tutorials/05_config_system.py
 Focused examples demonstrating one concept at a time.
 
 #### [core_infrastructure/](basic/core_infrastructure/)
-Core MFGarchon API usage:
+Core MFGArchon API usage:
 - `solve_mfg_demo.py` - Basic `solve_mfg()` usage
 - `lq_mfg_demo.py` - Linear-Quadratic MFG problems
 - `custom_hamiltonian_derivs_demo.py` - Custom Hamiltonian derivatives
@@ -152,7 +152,7 @@ Generated outputs and visualizations (gitignored, auto-regenerated).
 
 | I want to... | Go to... |
 |--------------|----------|
-| **Learn MFGarchon from scratch** | [tutorials/](tutorials/) (start with 01) |
+| **Learn MFGArchon from scratch** | [tutorials/](tutorials/) (start with 01) |
 | **See a basic LQ problem** | [basic/core_infrastructure/lq_mfg_demo.py](basic/core_infrastructure/lq_mfg_demo.py) |
 | **Work with 2D problems** | [tutorials/03_2d_geometry.py](tutorials/03_2d_geometry.py) or [basic/geometry/2d_crowd_motion_fdm.py](basic/geometry/2d_crowd_motion_fdm.py) |
 | **Use particle methods** | [tutorials/04_particle_methods.py](tutorials/04_particle_methods.py) |
@@ -181,7 +181,7 @@ pip install torch       # Optional: Neural network solvers
 **From source**:
 ```bash
 git clone https://github.com/derrring/mfgarchon.git
-cd MFGarchon
+cd MFGArchon
 pip install -e .
 ```
 
@@ -233,7 +233,7 @@ ls examples/outputs/tutorials/
 ## Contributing
 
 Found an issue or want to add an example?
-1. Check if it belongs in MFGarchon (infrastructure) or mfg-research (experiments)
+1. Check if it belongs in MFGArchon (infrastructure) or mfg-research (experiments)
 2. Place it in the appropriate category
 3. Follow naming conventions: `{topic}_{variant}_demo.py`
 4. Include docstrings with mathematical background

--- a/examples/advanced/highdim_mfg_capabilities/README.md
+++ b/examples/advanced/highdim_mfg_capabilities/README.md
@@ -2,7 +2,7 @@
 
 > **⚠️ DEPRECATED (v0.14.0)**: `GridBasedMFGProblem`, `HighDimMFGProblem`, and `HybridMFGSolver` have been removed. Use `MFGProblem` with `spatial_bounds` and `spatial_discretization` parameters for nD problems on tensor product grids.
 
-This directory demonstrates the extended high-dimensional capabilities of the MFGarchon package, including 2D, 3D, and nD Mean Field Games.
+This directory demonstrates the extended high-dimensional capabilities of the MFGArchon package, including 2D, 3D, and nD Mean Field Games.
 
 ## 🎯 **Key Features Implemented**
 
@@ -233,4 +233,4 @@ m(x,0) = m₀(x)                         in Ω
 
 ---
 
-**Package Integration**: These capabilities are fully integrated with the existing MFGarchon infrastructure, maintaining backward compatibility while providing powerful extensions for high-dimensional applications.
+**Package Integration**: These capabilities are fully integrated with the existing MFGArchon infrastructure, maintaining backward compatibility while providing powerful extensions for high-dimensional applications.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -12,7 +12,7 @@ python examples/basic/geometry/2d_crowd_motion_fdm.py
 # Outputs saved to examples/outputs/basic/
 ```
 
-**New to MFGarchon?** Start with [tutorials/](../tutorials/) for structured learning path.
+**New to MFGArchon?** Start with [tutorials/](../tutorials/) for structured learning path.
 
 ---
 

--- a/examples/tutorials/01_getting_started.md
+++ b/examples/tutorials/01_getting_started.md
@@ -1,4 +1,4 @@
-# Getting Started with MFGarchon
+# Getting Started with MFGArchon
 
 **Tutorial Level**: Beginner
 **Estimated Time**: 30 minutes
@@ -9,7 +9,7 @@
 ## What You'll Learn
 
 In this tutorial, you'll learn:
-1. How to install MFGarchon
+1. How to install MFGArchon
 2. How to solve your first Mean Field Game
 3. How to visualize the results
 4. The three core concepts: Problems, Configs, and Results
@@ -95,7 +95,7 @@ print(f"Solve time: {result.execution_time:.3f}s")
 
 ## Visualizing the Results
 
-MFGarchon includes built-in visualization tools:
+MFGArchon includes built-in visualization tools:
 
 ```python
 from mfgarchon.visualization import plot_results
@@ -417,20 +417,20 @@ Now that you've solved your first MFG problem, here's what to explore next:
 
 - **API Reference**: `docs/api/` - Complete API documentation
 - **Research Guide**: `docs/development/AI_INTERACTION_DESIGN.md` - Research-grade usage
-- **Contributing**: `CONTRIBUTING.md` - Contribute to MFGarchon
+- **Contributing**: `CONTRIBUTING.md` - Contribute to MFGArchon
 
 ---
 
 ## Summary
 
 **You've learned**:
-- ✅ How to install MFGarchon
+- ✅ How to install MFGArchon
 - ✅ How to solve an MFG problem in 3 lines: `problem = MFGProblem()` → `result = solve_mfg(problem, preset="fast")`
 - ✅ How to access and visualize results
 - ✅ The three core concepts: Problems (what), Configs (how), Results (output)
 - ✅ Common troubleshooting techniques
 
-**Key takeaway**: MFGarchon makes solving Mean Field Games **simple**. The unified `solve_mfg()` interface handles all the complexity for you.
+**Key takeaway**: MFGArchon makes solving Mean Field Games **simple**. The unified `solve_mfg()` interface handles all the complexity for you.
 
 ---
 
@@ -464,5 +464,5 @@ result = solve_mfg(problem, config=config)
 
 **Tutorial Version**: 1.0
 **Last Updated**: 2025-11-03
-**MFGarchon Version**: v0.9.0+
+**MFGArchon Version**: v0.9.0+
 **Next Tutorial**: [02_configuration_patterns.md](02_configuration_patterns.md)

--- a/examples/tutorials/02_configuration_patterns.md
+++ b/examples/tutorials/02_configuration_patterns.md
@@ -1,4 +1,4 @@
-# Configuration Patterns in MFGarchon
+# Configuration Patterns in MFGArchon
 
 **Tutorial Level**: Beginner-Intermediate
 **Estimated Time**: 20 minutes
@@ -8,7 +8,7 @@
 
 ## Three Ways to Configure Solvers
 
-MFGarchon offers three configuration patterns, each suited to different use cases:
+MFGArchon offers three configuration patterns, each suited to different use cases:
 
 1. **Presets** - Quick start with sensible defaults
 2. **Builder API** - Programmatic configuration

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -1,4 +1,4 @@
-# MFGarchon Tutorials
+# MFGArchon Tutorials
 
 A structured 5-step learning path for getting started with Mean Field Games in Python.
 
@@ -115,7 +115,7 @@ Each tutorial:
 **Required**:
 - Python 3.9+
 - NumPy, SciPy
-- MFGarchon installed (`pip install -e .`)
+- MFGArchon installed (`pip install -e .`)
 
 **Optional** (for visualizations):
 - Matplotlib
@@ -164,7 +164,7 @@ examples/outputs/tutorials/
 ## Troubleshooting
 
 **Problem**: ImportError when running tutorials
-**Solution**: Install MFGarchon: `pip install -e .` from repo root
+**Solution**: Install MFGArchon: `pip install -e .` from repo root
 
 **Problem**: No visualizations generated
 **Solution**: Install matplotlib: `pip install matplotlib`
@@ -181,4 +181,4 @@ Found an issue or have a suggestion? Please open an issue on GitHub!
 
 ## License
 
-Same as MFGarchon (see repository root LICENSE file)
+Same as MFGArchon (see repository root LICENSE file)

--- a/examples/tutorials/state_dependent_coefficients.md
+++ b/examples/tutorials/state_dependent_coefficients.md
@@ -1,4 +1,4 @@
-# State-Dependent Coefficients in MFGarchon
+# State-Dependent Coefficients in MFGArchon
 
 **Tutorial**: Using flexible drift and diffusion fields in Mean Field Games
 
@@ -10,7 +10,7 @@
 
 ## Overview
 
-MFGarchon provides a **unified, flexible API** for specifying drift and diffusion coefficients in Fokker-Planck equations. This tutorial shows how to use:
+MFGArchon provides a **unified, flexible API** for specifying drift and diffusion coefficients in Fokker-Planck equations. This tutorial shows how to use:
 
 1. **Constant coefficients** (classical MFG)
 2. **Spatially varying coefficients**
@@ -617,7 +617,7 @@ M = solver.solve_fp_system(m0, drift_field=state_dependent_drift)
 
 ## Summary
 
-MFGarchon's coefficient API supports:
+MFGArchon's coefficient API supports:
 
 | Feature | Type | Example |
 |:--------|:-----|:--------|

--- a/mfgarchon/config/configs/experiment.yaml
+++ b/mfgarchon/config/configs/experiment.yaml
@@ -4,7 +4,7 @@
 experiment:
   name: "beach_parameter_sweep"
   description: "Parameter sweep for Towel on Beach problem"
-  author: "MFGarchon User"
+  author: "MFGArchon User"
   timestamp: null  # Auto-generated
 
   # Output configuration

--- a/mfgarchon/geometry/implicit/README.md
+++ b/mfgarchon/geometry/implicit/README.md
@@ -1,6 +1,6 @@
 # Implicit Domain Geometry for Meshfree MFG Methods
 
-Production-ready dimension-agnostic implicit domain representation for particle-collocation methods. **Preparing for graduation to MFGarchon**.
+Production-ready dimension-agnostic implicit domain representation for particle-collocation methods. **Preparing for graduation to MFGArchon**.
 
 ## Overview
 
@@ -11,16 +11,16 @@ This module provides meshfree geometry infrastructure using **signed distance fu
 - **Natural obstacle handling** via CSG operations
 - **Particle-friendly** sampling and boundary conditions
 
-### Key Advantage Over MFGarchon's Current Approach
+### Key Advantage Over MFGArchon's Current Approach
 
-| Feature | MFGarchon (Gmsh) | This Module (SDF) |
+| Feature | MFGArchon (Gmsh) | This Module (SDF) |
 |---------|----------------|-------------------|
 | **Dimensions** | d ∈ {1,2,3} | Any d ≥ 1 |
 | **Memory** | O(N^d) vertices | O(d) parameters |
 | **Obstacles** | Boolean mesh cuts | Min/max operations |
 | **Use Case** | Low-dim FEM/FVM | High-dim particles |
 
-These approaches are **complementary**, not competing. Both will coexist in MFGarchon after graduation.
+These approaches are **complementary**, not competing. Both will coexist in MFGArchon after graduation.
 
 ---
 
@@ -354,7 +354,7 @@ Examples:
 
 ---
 
-## Graduation Plan to MFGarchon
+## Graduation Plan to MFGArchon
 
 ### Status: **Phase 1 Complete** ✅
 
@@ -363,15 +363,15 @@ Examples:
 - ✅ Documentation (this README + inline docstrings)
 - ✅ Proven on research problems (anisotropic_crowd_qp)
 
-### Next Steps (Phase 2): Integration into MFGarchon
+### Next Steps (Phase 2): Integration into MFGArchon
 
-1. **Create branch** `feature/implicit-domains` in MFGarchon
+1. **Create branch** `feature/implicit-domains` in MFGArchon
 2. **Port module** to `mfgarchon/geometry/implicit/`
 3. **Add tests** to `tests/unit/geometry/test_implicit_domain.py`
-4. **Update docs** in MFGarchon documentation
+4. **Update docs** in MFGArchon documentation
 5. **Open PR** with reference to high-dimensional support (PR #188)
 
-### Expected MFGarchon Structure
+### Expected MFGArchon Structure
 
 ```
 mfgarchon/
@@ -404,7 +404,7 @@ from mfgarchon.geometry.implicit import (
 
 ### Design Decisions
 
-1. **Type hints:** Full production-quality hints for MFGarchon standards
+1. **Type hints:** Full production-quality hints for MFGArchon standards
 2. **Rejection sampling:** Used for spheres and complex domains
 3. **Bounding boxes:** Required for efficient sampling
 4. **CSG via min/max:** Simple, fast, dimension-agnostic
@@ -413,7 +413,7 @@ from mfgarchon.geometry.implicit import (
 
 1. **Rejection sampling inefficiency:** Hypersphere sampling becomes slow for d>10 due to curse of dimensionality
 2. **Approximate SDFs:** CSG operations (union/intersection) don't preserve exact distance, only sign
-3. **No mesh output:** Cannot export to Gmsh format (by design - use MFGarchon's Domain2D for that)
+3. **No mesh output:** Cannot export to Gmsh format (by design - use MFGArchon's Domain2D for that)
 
 ### Future Enhancements
 
@@ -439,7 +439,7 @@ See `CLAUDE.md` for research repository conventions.
 
 ## License
 
-Part of mfg-research repository. Will graduate to MFGarchon under its license after publication.
+Part of mfg-research repository. Will graduate to MFGArchon under its license after publication.
 
 ---
 
@@ -448,4 +448,4 @@ Part of mfg-research repository. Will graduate to MFGarchon under its license af
 For questions about:
 - **Implementation**: See inline docstrings
 - **Mathematics**: See TECHNICAL_REFERENCE_HIGH_DIMENSIONAL_MFG.md
-- **MFGarchon integration**: Open issue in MFGarchon repository
+- **MFGArchon integration**: Open issue in MFGArchon repository

--- a/mfgarchon/utils/README.md
+++ b/mfgarchon/utils/README.md
@@ -1,12 +1,12 @@
-# MFGarchon Utils Module
+# MFGArchon Utils Module
 
-**Purpose**: Comprehensive utility components for enhanced MFGarchon functionality  
+**Purpose**: Comprehensive utility components for enhanced MFGArchon functionality  
 **Location**: `mfgarchon/utils/`  
 **Status**: Production Ready  
 
 ## 📋 Overview
 
-The `utils` module provides essential utilities that enhance the MFGarchon platform with modern features like progress monitoring, validation, error handling, CLI support, and solver enhancements. These components transform MFGarchon from a research prototype into a professional scientific computing platform.
+The `utils` module provides essential utilities that enhance the MFGArchon platform with modern features like progress monitoring, validation, error handling, CLI support, and solver enhancements. These components transform MFGArchon from a research prototype into a professional scientific computing platform.
 
 ## 🗂️ Module Components
 
@@ -209,7 +209,7 @@ class MySolver:
 
 ### 6. CLI Framework (`cli.py`)
 
-**Purpose**: Professional command-line interface for MFGarchon.
+**Purpose**: Professional command-line interface for MFGArchon.
 
 **Key Features**:
 - Comprehensive argument parsing
@@ -422,7 +422,7 @@ python -m mfgarchon.utils.cli solve \
 
 ### Core Dependencies
 ```bash
-# Essential (already included in MFGarchon)
+# Essential (already included in MFGArchon)
 numpy>=1.19.0
 scipy>=1.7.0
 ```
@@ -589,7 +589,7 @@ The utils module is designed for extensibility. Planned enhancements include:
 ### Getting Help
 - Check the examples in each module for usage patterns
 - Review the comprehensive test suites for integration examples
-- Consult the main MFGarchon documentation for context
+- Consult the main MFGArchon documentation for context
 
 ### Contributing
 - Follow existing code patterns and documentation standards
@@ -599,4 +599,4 @@ The utils module is designed for extensibility. Planned enhancements include:
 
 ---
 
-**The MFGarchon utils module transforms the platform into a modern, professional scientific computing environment while maintaining simplicity and backward compatibility.** 🚀
+**The MFGArchon utils module transforms the platform into a modern, professional scientific computing environment while maintaining simplicity and backward compatibility.** 🚀

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,7 +287,7 @@ module = [
 ]
 ignore_missing_imports = true
 
-# Core MFGarchon modules - stricter checking
+# Core MFGArchon modules - stricter checking
 [[tool.mypy.overrides]]
 module = [
     "mfgarchon.factory.*",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,4 @@
-# MFGarchon Scripts Directory
+# MFGArchon Scripts Directory
 
 **Status**: ✅ Audited and Current (2025-10-04)
 
@@ -116,7 +116,7 @@ For new developers:
 ```bash
 # 1. Clone repository
 git clone <repository-url>
-cd MFGarchon
+cd MFGArchon
 
 # 2. Run modern setup (handles everything)
 ./scripts/setup_development.sh


### PR DESCRIPTION
## Summary
Capitalize the 'A' in Archon for better readability: `MFGarchon` -> `MFGArchon`.

Python package name stays `mfgarchon` (lowercase). Only display/branding contexts changed.

Updated: README, CITATION.cff, CONTRIBUTING, CHANGELOG, CLAUDE.md, key user docs.

**Note**: The GitHub repo should also be renamed to `MFGArchon` in Settings -> General -> Repository name. GitHub auto-redirects the old URL.

## Test plan
- [x] No Python code changed — only markdown/yaml display names