### PR TITLE
chore: Migrate ~111 raw deprecation warnings to structured decorators

### DIFF
--- a/mfgarchon/alg/neural/dgm/base_dgm.py
+++ b/mfgarchon/alg/neural/dgm/base_dgm.py
@@ -20,7 +20,6 @@ Key Features:
 
 from __future__ import annotations
 
-import warnings
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -29,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from mfgarchon.alg.base_solver import BaseNeuralSolver
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
 if TYPE_CHECKING:
@@ -116,21 +116,6 @@ class DGMConfig:
         """Set default hidden layers and handle deprecated parameters."""
         # Handle deprecated variance reduction parameters
         if self.use_control_variates is not None or self.use_importance_sampling is not None:
-            warnings.warn(
-                "Parameters 'use_control_variates' and 'use_importance_sampling' are deprecated "
-                "and will be removed in v1.0.0. Use 'variance_reduction' instead.\n\n"
-                "Migration guide:\n"
-                "  Old: DGMConfig(use_control_variates=True, use_importance_sampling=False)\n"
-                "  New: DGMConfig(variance_reduction=VarianceReductionMethod.CONTROL_VARIATES)\n\n"
-                "Available variance reduction methods:\n"
-                "  - NONE: No variance reduction\n"
-                "  - CONTROL_VARIATES: Control variates only\n"
-                "  - IMPORTANCE_SAMPLING: Importance sampling only\n"
-                "  - BOTH: Both techniques",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
             # Map deprecated booleans to variance reduction enum
             if self.variance_reduction == VarianceReductionMethod.CONTROL_VARIATES:  # Default value
                 cv = self.use_control_variates if self.use_control_variates is not None else True
@@ -149,6 +134,16 @@ class DGMConfig:
         if self.hidden_layers is None:
             # Default architecture for high-dimensional approximation
             self.hidden_layers = [256, 256, 256, 256]
+
+
+# Apply deprecated_parameter decorators to auto-generated __init__
+DGMConfig.__init__ = deprecated_parameter(  # type: ignore[misc]
+    param_name="use_control_variates", since="v0.17.0", replacement="variance_reduction"
+)(
+    deprecated_parameter(param_name="use_importance_sampling", since="v0.17.0", replacement="variance_reduction")(
+        DGMConfig.__init__
+    )
+)
 
 
 @dataclass

--- a/mfgarchon/alg/neural/operator_learning/deeponet.py
+++ b/mfgarchon/alg/neural/operator_learning/deeponet.py
@@ -30,9 +30,9 @@ References:
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.neural import NormalizationType
 
 # Import with availability checking
@@ -85,22 +85,12 @@ if TORCH_AVAILABLE:
 
         def __post_init__(self):
             """Handle deprecated parameters and set defaults."""
-            # Handle deprecated boolean parameters
+            # Handle deprecated boolean parameters (warnings issued by deprecated_parameter decorator on __init__)
             if self.use_batch_norm is not None:
-                warnings.warn(
-                    "Parameter 'use_batch_norm' is deprecated, use 'normalization=NormalizationType.BATCH' instead",
-                    DeprecationWarning,
-                    stacklevel=3,
-                )
                 if self.use_batch_norm and self.normalization == NormalizationType.LAYER:
                     self.normalization = NormalizationType.BATCH
 
             if self.use_layer_norm is not None:
-                warnings.warn(
-                    "Parameter 'use_layer_norm' is deprecated, use 'normalization=NormalizationType.LAYER' instead",
-                    DeprecationWarning,
-                    stacklevel=3,
-                )
                 if self.use_layer_norm and self.normalization == NormalizationType.LAYER:
                     # Already default
                     pass
@@ -118,6 +108,15 @@ if TORCH_AVAILABLE:
 
             super().__post_init__()
             self.operator_type = "deeponet"
+
+    # Apply deprecated_parameter decorators to auto-generated __init__
+    DeepONetConfig.__init__ = deprecated_parameter(  # type: ignore[misc]
+        param_name="use_batch_norm", since="v0.17.0", replacement="normalization"
+    )(
+        deprecated_parameter(param_name="use_layer_norm", since="v0.17.0", replacement="normalization")(
+            DeepONetConfig.__init__
+        )
+    )
 
     class BranchNetwork(nn.Module):
         """Branch network for encoding parameter functions."""

--- a/mfgarchon/alg/neural/pinn_solvers/adaptive_training.py
+++ b/mfgarchon/alg/neural/pinn_solvers/adaptive_training.py
@@ -27,11 +27,11 @@ Applications:
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
 if TYPE_CHECKING:
@@ -125,21 +125,6 @@ class AdaptiveTrainingConfig:
         )
 
         if deprecated_params_used:
-            warnings.warn(
-                "Parameters 'enable_curriculum', 'enable_multiscale', and 'enable_refinement' "
-                "are deprecated and will be removed in v1.0.0. Use 'training_mode' instead.\n\n"
-                "Migration guide:\n"
-                "  Old: AdaptiveTrainingConfig(enable_curriculum=True, enable_multiscale=True, enable_refinement=True)\n"
-                "  New: AdaptiveTrainingConfig(training_mode=AdaptiveTrainingMode.FULL_ADAPTIVE)\n\n"
-                "Available modes:\n"
-                "  - BASIC: No adaptive features\n"
-                "  - CURRICULUM: Curriculum learning only\n"
-                "  - MULTISCALE: Multi-resolution training only\n"
-                "  - FULL_ADAPTIVE: All features (default)",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
             # Map deprecated booleans to training mode (only if training_mode not explicitly set)
             if self.training_mode == AdaptiveTrainingMode.FULL_ADAPTIVE:  # Default value
                 # Determine mode from boolean combination
@@ -171,6 +156,18 @@ class AdaptiveTrainingConfig:
     def uses_refinement(self) -> bool:
         """Whether residual-based refinement is enabled."""
         return self.training_mode == AdaptiveTrainingMode.FULL_ADAPTIVE
+
+
+# Apply deprecated_parameter decorators to auto-generated __init__
+AdaptiveTrainingConfig.__init__ = deprecated_parameter(  # type: ignore[misc]
+    param_name="enable_curriculum", since="v0.17.0", replacement="training_mode"
+)(
+    deprecated_parameter(param_name="enable_multiscale", since="v0.17.0", replacement="training_mode")(
+        deprecated_parameter(param_name="enable_refinement", since="v0.17.0", replacement="training_mode")(
+            AdaptiveTrainingConfig.__init__
+        )
+    )
+)
 
 
 @dataclass

--- a/mfgarchon/alg/neural/pinn_solvers/base_pinn.py
+++ b/mfgarchon/alg/neural/pinn_solvers/base_pinn.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from mfgarchon.alg.base_solver import BaseNeuralSolver
+from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
     from mfgarchon.core.mfg_problem import MFGProblem
@@ -167,22 +168,8 @@ class PINNConfig:
         if not TORCH_AVAILABLE:
             raise ImportError("PyTorch is required for PINN functionality. Install with: pip install torch torchvision")
 
-        # Handle deprecated normalization parameters
+        # Handle deprecated normalization parameters (warnings issued by deprecated_parameter decorator on __init__)
         if self.use_batch_norm is not None or self.use_layer_norm is not None:
-            warnings.warn(
-                "Parameters 'use_batch_norm' and 'use_layer_norm' are deprecated "
-                "and will be removed in v1.0.0. Use 'normalization' instead.\n\n"
-                "Migration guide:\n"
-                "  Old: PINNConfig(use_batch_norm=True)\n"
-                "  New: PINNConfig(normalization=NormalizationType.BATCH)\n\n"
-                "Available normalization types:\n"
-                "  - NONE: No normalization (default)\n"
-                "  - BATCH: Batch normalization\n"
-                "  - LAYER: Layer normalization",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
             # Map deprecated booleans to normalization enum
             if self.normalization == NormalizationType.NONE:  # Only if not explicitly set
                 if self.use_batch_norm:
@@ -207,6 +194,12 @@ class PINNConfig:
         # Warning for potential issues
         if self.batch_size > self.n_interior_points:
             warnings.warn("Batch size larger than number of interior points")
+
+
+# Apply deprecated_parameter decorators to auto-generated __init__
+PINNConfig.__init__ = deprecated_parameter(  # type: ignore[misc]
+    param_name="use_batch_norm", since="v0.17.0", replacement="normalization"
+)(deprecated_parameter(param_name="use_layer_norm", since="v0.17.0", replacement="normalization")(PINNConfig.__init__))
 
 
 class PINNBase(BaseNeuralSolver, ABC):

--- a/mfgarchon/alg/numerical/adjoint/protocols.py
+++ b/mfgarchon/alg/numerical/adjoint/protocols.py
@@ -21,8 +21,9 @@ See docs/theory/adjoint_discretization_mfg.md for mathematical foundations.
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from mfgarchon.utils.deprecation import deprecated
 
 if TYPE_CHECKING:
     import numpy as np
@@ -107,6 +108,12 @@ class LinearizedOperatorCapable(Protocol):
         ...
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="validate_scheme_pairing",
+    reason="The adjoint_mode approach (using A_hjb.T for FP) is mathematically incorrect. "
+    "Use scheme pairing instead: gradient_upwind + divergence_upwind. See Issue #706.",
+)
 def validate_adjoint_capability(
     hjb_solver: object,
     fp_solver: object,
@@ -131,14 +138,6 @@ def validate_adjoint_capability(
 
     See Issue #706 and docs/theory/adjoint_discretization_mfg.md.
     """
-    warnings.warn(
-        "validate_adjoint_capability is deprecated. The adjoint_mode approach "
-        "(using A_hjb.T for FP) is mathematically incorrect. Use scheme pairing "
-        "instead: gradient_upwind + divergence_upwind. See Issue #706.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
     issues = []
 
     if not isinstance(hjb_solver, AdjointCapableHJBSolver):

--- a/mfgarchon/alg/numerical/coupling/hybrid_fp_particle_hjb_fdm.py
+++ b/mfgarchon/alg/numerical/coupling/hybrid_fp_particle_hjb_fdm.py
@@ -40,6 +40,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated_parameter
+
 from .base_mfg import BaseMFGSolver
 
 if TYPE_CHECKING:
@@ -67,6 +69,26 @@ class HybridFPParticleHJBFDM(BaseMFGSolver):
         See HJBFDMSolver docstring for trait details.
     """
 
+    @deprecated_parameter(
+        param_name="mfg_problem",
+        since="v0.17.0",
+        replacement="problem",
+    )
+    @deprecated_parameter(
+        param_name="hjb_newton_iterations",
+        since="v0.17.0",
+        replacement="max_newton_iterations",
+    )
+    @deprecated_parameter(
+        param_name="hjb_newton_tolerance",
+        since="v0.17.0",
+        replacement="newton_tolerance",
+    )
+    @deprecated_parameter(
+        param_name="hjb_fd_scheme",
+        since="v0.17.0",
+        replacement="none (HJBFDMSolver handles scheme internally)",
+    )
     def __init__(
         self,
         problem: MFGProblem | None = None,
@@ -103,15 +125,8 @@ class HybridFPParticleHJBFDM(BaseMFGSolver):
             hjb_fd_scheme: (Deprecated) No longer used, HJBFDMSolver handles scheme internally
             **kwargs: Additional parameters
         """
-        import warnings
-
-        # Handle deprecated 'mfg_problem' parameter
+        # Handle deprecated 'mfg_problem' parameter (warning via decorator)
         if mfg_problem is not None:
-            warnings.warn(
-                "Parameter 'mfg_problem' is deprecated. Use 'problem' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if problem is None:
                 problem = mfg_problem
 
@@ -119,32 +134,15 @@ class HybridFPParticleHJBFDM(BaseMFGSolver):
         if problem is None:
             raise ValueError("Parameter 'problem' is required")
 
-        # Handle deprecated 'hjb_newton_iterations' parameter
+        # Handle deprecated 'hjb_newton_iterations' parameter (warning via decorator)
         if hjb_newton_iterations is not None:
-            warnings.warn(
-                "Parameter 'hjb_newton_iterations' is deprecated. Use 'max_newton_iterations' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             max_newton_iterations = hjb_newton_iterations
 
-        # Handle deprecated 'hjb_newton_tolerance' parameter
+        # Handle deprecated 'hjb_newton_tolerance' parameter (warning via decorator)
         if hjb_newton_tolerance is not None:
-            warnings.warn(
-                "Parameter 'hjb_newton_tolerance' is deprecated. Use 'newton_tolerance' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             newton_tolerance = hjb_newton_tolerance
 
-        # Warn about hjb_fd_scheme being removed
-        if hjb_fd_scheme is not None:
-            warnings.warn(
-                "Parameter 'hjb_fd_scheme' is deprecated and ignored. "
-                "HJBFDMSolver handles finite difference scheme internally.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        # hjb_fd_scheme is deprecated and ignored (warning via decorator)
 
         super().__init__(problem)
 
@@ -189,6 +187,16 @@ class HybridFPParticleHJBFDM(BaseMFGSolver):
             newton_tolerance=self.newton_tolerance,
         )
 
+    @deprecated_parameter(
+        param_name="max_picard_iterations",
+        since="v0.17.0",
+        replacement="max_iterations",
+    )
+    @deprecated_parameter(
+        param_name="picard_tolerance",
+        since="v0.17.0",
+        replacement="tolerance",
+    )
     def solve(
         self,
         max_iterations: int | None = None,
@@ -213,17 +221,10 @@ class HybridFPParticleHJBFDM(BaseMFGSolver):
         Returns:
             Tuple of (U_solution, M_solution, convergence_info)
         """
-        import warnings
-
-        # Handle parameter precedence: standardized > deprecated
+        # Handle parameter precedence: standardized > deprecated (warnings via decorator)
         if max_iterations is not None:
             final_max_iterations = max_iterations
         elif max_picard_iterations is not None:
-            warnings.warn(
-                "Parameter 'max_picard_iterations' is deprecated. Use 'max_iterations' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             final_max_iterations = max_picard_iterations
         else:
             final_max_iterations = 50  # Default for hybrid solver
@@ -231,11 +232,6 @@ class HybridFPParticleHJBFDM(BaseMFGSolver):
         if tolerance is not None:
             final_tolerance = tolerance
         elif picard_tolerance is not None:
-            warnings.warn(
-                "Parameter 'picard_tolerance' is deprecated. Use 'tolerance' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             final_tolerance = picard_tolerance
         else:
             final_tolerance = 1e-6  # Default for hybrid solver

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -8,6 +8,7 @@ import scipy.sparse as sparse
 from mfgarchon.backends.compat import has_nan_or_inf
 from mfgarchon.geometry import BoundaryConditions
 from mfgarchon.utils.aux_func import npart, ppart
+from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 
 from .base_fp import BaseFPSolver
 from .fp_fdm_time_stepping import (
@@ -228,6 +229,10 @@ class FPFDMSolver(BaseFPSolver):
 
     # _detect_dimension() inherited from BaseNumericalSolver (Issue #633)
 
+    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
+    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
+    @deprecated_parameter(param_name="tensor_diffusion_field", since="v0.17.0", replacement="volatility_field")
+    @deprecated_parameter(param_name="volatility_matrix", since="v0.17.0", replacement="volatility_field")
     def solve_fp_system(
         self,
         M_initial: np.ndarray | None = None,
@@ -367,8 +372,6 @@ class FPFDMSolver(BaseFPSolver):
         >>> alpha_quartic = -np.sign(grad_U) * np.abs(grad_U) ** (1/3)  # α* = -(∇U)^(1/3)
         >>> M = solver.solve_fp_system(m0, drift_field=alpha_quartic)
         """
-        import warnings
-
         # Handle deprecated parameter name
         if m_initial_condition is not None:
             if M_initial is not None:
@@ -376,11 +379,6 @@ class FPFDMSolver(BaseFPSolver):
                     "Cannot specify both M_initial and m_initial_condition. "
                     "Use M_initial (m_initial_condition is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'm_initial_condition' is deprecated. Use 'M_initial' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_initial = m_initial_condition
 
         # Validate required parameter
@@ -435,12 +433,6 @@ class FPFDMSolver(BaseFPSolver):
                     "Cannot specify both volatility_field and diffusion_field. "
                     "Use volatility_field (diffusion_field is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'diffusion_field' is deprecated. Use 'volatility_field' instead. "
-                "Note: Both accept volatility σ, not diffusion D. The solver computes D = σ²/2 internally.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             volatility_field = diffusion_field
 
         # Handle deprecated tensor_diffusion_field → volatility_field
@@ -452,12 +444,6 @@ class FPFDMSolver(BaseFPSolver):
                     "Cannot specify both volatility_field and tensor_diffusion_field. "
                     "Use volatility_field (tensor_diffusion_field is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'tensor_diffusion_field' is deprecated. Use 'volatility_field' instead. "
-                "Note: Pass (d,d) array for matrix volatility. The solver computes D = ΣΣᵀ/2 internally.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             volatility_field = tensor_diffusion_field
             _from_tensor_param = True
 
@@ -468,12 +454,6 @@ class FPFDMSolver(BaseFPSolver):
                     "Cannot specify both volatility_field and volatility_matrix. "
                     "Use volatility_field (volatility_matrix is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'volatility_matrix' is deprecated. Use 'volatility_field' instead. "
-                "Note: Pass (d,d) array for matrix volatility. The solver computes D = ΣΣᵀ/2 internally.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             volatility_field = volatility_matrix
             _from_tensor_param = True
 
@@ -666,6 +646,7 @@ class FPFDMSolver(BaseFPSolver):
 
         return M_next
 
+    @deprecated(since="v0.17.1", replacement="solve_fp_system")
     def _solve_fp_1d(
         self,
         m_initial_condition: np.ndarray,
@@ -685,14 +666,6 @@ class FPFDMSolver(BaseFPSolver):
             - Full BC support (no_flux, neumann, robin, periodic, dirichlet)
             - Cleaner codebase with less code path branching
         """
-        import warnings
-
-        warnings.warn(
-            "_solve_fp_1d is deprecated. Use solve_fp_system() which now routes "
-            "all cases through the unified nD solver. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         # Use geometry-based interface (geometry is always available)
         Nx = self.problem.geometry.get_grid_shape()[0]
         Dx = self.problem.geometry.get_grid_spacing()[0]
@@ -1140,6 +1113,7 @@ class FPFDMSolver(BaseFPSolver):
 
         return output
 
+    @deprecated(since="v0.17.1", replacement="solve_fp_system")
     def _solve_fp_1d_with_callable(
         self,
         m_initial_condition: np.ndarray,
@@ -1174,14 +1148,6 @@ class FPFDMSolver(BaseFPSolver):
         np.ndarray
             Density evolution, shape (Nt, Nx)
         """
-        import warnings
-
-        warnings.warn(
-            "_solve_fp_1d_with_callable is deprecated. Use solve_fp_system() which now routes "
-            "callable diffusion through the unified nD solver. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         from mfgarchon.types.pde_coefficients import DiffusionCallable
 
         # Validate callable signature using protocol

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_advection.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_advection.py
@@ -38,7 +38,10 @@ from typing import Any
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated
 
+
+@deprecated(since="v0.18.0", replacement="AdvectionOperator")
 def _compute_upwind_advection(
     M: np.ndarray,
     drift_per_dim: list[np.ndarray],
@@ -76,13 +79,6 @@ def _compute_upwind_advection(
     np.ndarray
         Advection term div(alpha * m), same shape as M
     """
-    import warnings
-
-    warnings.warn(
-        "_compute_upwind_advection is deprecated. Use AdvectionOperator instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     advection = np.zeros_like(M)
 
     for d in range(ndim):

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.numerical.gfdm_strategies import TaylorOperator
 
 if TYPE_CHECKING:
@@ -378,6 +379,7 @@ class FPGFDMSolver(BaseFPSolver):
 
         return divergence
 
+    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     def solve_fp_system(
         self,
         m_initial_condition: np.ndarray,
@@ -442,20 +444,12 @@ class FPGFDMSolver(BaseFPSolver):
         dt = self.problem.T / self.problem.Nt
 
         # Handle deprecated diffusion_field parameter (Issue #717)
-        import warnings
-
         if diffusion_field is not None:
             if volatility_field is not None:
                 raise ValueError(
                     "Cannot specify both volatility_field and diffusion_field. "
                     "Use volatility_field (diffusion_field is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'diffusion_field' is deprecated. Use 'volatility_field' instead. "
-                "Note: volatility_field expects σ (SDE noise), same as diffusion_field did.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             volatility_field = diffusion_field
 
         # Volatility coefficient (Issue #717: unified API)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated_parameter
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -114,6 +116,10 @@ class FPParticleSolver(BaseFPSolver):
 
     _scheme_family = SchemeFamily.GENERIC  # Particle methods don't fit standard families
 
+    @deprecated_parameter(param_name="mode", since="v0.17.0", replacement="density_mode")
+    @deprecated_parameter(param_name="external_particles", since="v0.17.0", replacement="num_particles")
+    @deprecated_parameter(param_name="normalize_kde_output", since="v0.17.0", replacement="kde_normalization")
+    @deprecated_parameter(param_name="normalize_only_initial", since="v0.17.0", replacement="kde_normalization")
     def __init__(
         self,
         problem: MFGProblem,
@@ -146,27 +152,8 @@ class FPParticleSolver(BaseFPSolver):
             # Map old 'mode' to new 'density_mode' (hybrid was the old name)
             density_mode = mode
 
-        # Handle deprecated 'external_particles' parameter
-        if external_particles is not None:
-            import warnings
-
-            warnings.warn(
-                "external_particles is deprecated. External particle injection is no longer supported. "
-                "Use num_particles to control particle count.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         # Handle deprecated normalization parameters
         if normalize_kde_output is not None or normalize_only_initial is not None:
-            import warnings
-
-            warnings.warn(
-                "normalize_kde_output and normalize_only_initial are deprecated. "
-                "Use kde_normalization='all', 'initial_only', or 'none' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             # Map old parameters to new enum
             if normalize_kde_output is False:
                 kde_normalization = KDENormalization.NONE
@@ -1177,6 +1164,8 @@ class FPParticleSolver(BaseFPSolver):
         else:
             return m_density_estimated  # Return raw KDE output on grid
 
+    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
+    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     def solve_fp_system(
         self,
         M_initial: np.ndarray | None = None,
@@ -1235,11 +1224,6 @@ class FPParticleSolver(BaseFPSolver):
                     "Cannot specify both M_initial and m_initial_condition. "
                     "Use M_initial (m_initial_condition is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'm_initial_condition' is deprecated. Use 'M_initial' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_initial = m_initial_condition
 
         # Handle deprecated diffusion_field parameter
@@ -1249,12 +1233,6 @@ class FPParticleSolver(BaseFPSolver):
                     "Cannot specify both volatility_field and diffusion_field. "
                     "Use volatility_field (diffusion_field is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'diffusion_field' is deprecated. Use 'volatility_field' instead. "
-                "Note: volatility_field expects σ (SDE noise), same as diffusion_field did.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             volatility_field = diffusion_field
 
         # Validate required parameter - either M_initial or initial_particles

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -42,6 +42,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
 
 # Issue #625: Migrated from tensor_calculus to operators/stencils
 from mfgarchon.operators.stencils.finite_difference import laplacian_with_bc
+from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
 from .base_fp import BaseFPSolver
@@ -93,6 +94,7 @@ class FPSLJacobianSolver(BaseFPSolver):
 
     _scheme_family = SchemeFamily.SL
 
+    @deprecated(since="v0.17.6", replacement="FPSLSolver")
     def __init__(
         self,
         problem: MFGProblem,
@@ -114,16 +116,6 @@ class FPSLJacobianSolver(BaseFPSolver):
                 - 'rk4': Fourth-order Runge-Kutta
             boundary_conditions: Optional boundary conditions (defaults to no-flux)
         """
-        import warnings
-
-        warnings.warn(
-            "FPSLJacobianSolver is deprecated since v0.17.6. "
-            "Use FPSLSolver (Forward SL) for adjoint consistency with HJB Semi-Lagrangian. "
-            "FPSLJacobianSolver will be removed in v1.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         super().__init__(problem)
         self.fp_method_name = "Semi-Lagrangian (Jacobian)"
 
@@ -195,6 +187,8 @@ class FPSLJacobianSolver(BaseFPSolver):
         bc_type = get_bc_type_string(self.boundary_conditions)
         return bc_type_to_geometric_operation(bc_type)
 
+    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
+    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     def solve_fp_system(
         self,
         M_initial: np.ndarray | None = None,
@@ -233,17 +227,10 @@ class FPSLJacobianSolver(BaseFPSolver):
             drift_field is the VALUE FUNCTION U, not the velocity alpha.
             The velocity is computed internally as alpha = -grad(U).
         """
-        import warnings
-
         # Handle deprecated parameter
         if m_initial_condition is not None:
             if M_initial is not None:
                 raise ValueError("Cannot specify both M_initial and m_initial_condition")
-            warnings.warn(
-                "Parameter 'm_initial_condition' is deprecated. Use 'M_initial' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_initial = m_initial_condition
 
         if M_initial is None:
@@ -265,12 +252,6 @@ class FPSLJacobianSolver(BaseFPSolver):
                     "Cannot specify both volatility_field and diffusion_field. "
                     "Use volatility_field (diffusion_field is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'diffusion_field' is deprecated. Use 'volatility_field' instead. "
-                "Note: volatility_field expects σ (SDE noise), same as diffusion_field did.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             volatility_field = diffusion_field
 
         # Handle volatility (Issue #717: unified API)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -25,7 +25,7 @@ Issue #578: Adjoint SL implementation for proper SL-SL MFG coupling
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 from scipy.linalg import solve_banded
@@ -38,6 +38,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
     get_bc_type_string,
 )
+from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
 from .base_fp import BaseFPSolver
@@ -214,6 +215,8 @@ class FPSLSolver(BaseFPSolver):
         bc_type = get_bc_type_string(self.boundary_conditions)
         return bc_type_to_geometric_operation(bc_type)
 
+    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
+    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     def solve_fp_system(
         self,
         M_initial: np.ndarray | None = None,
@@ -245,17 +248,10 @@ class FPSLSolver(BaseFPSolver):
         Returns:
             Density evolution M(t,x). Shape: (Nt+1, Nx)
         """
-        import warnings
-
         # Handle deprecated parameter
         if m_initial_condition is not None:
             if M_initial is not None:
                 raise ValueError("Cannot specify both M_initial and m_initial_condition")
-            warnings.warn(
-                "Parameter 'm_initial_condition' is deprecated. Use 'M_initial' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_initial = m_initial_condition
 
         if M_initial is None:
@@ -273,12 +269,6 @@ class FPSLSolver(BaseFPSolver):
                     "Cannot specify both volatility_field and diffusion_field. "
                     "Use volatility_field (diffusion_field is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'diffusion_field' is deprecated. Use 'volatility_field' instead. "
-                "Note: volatility_field expects σ (SDE noise), same as diffusion_field did.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             volatility_field = diffusion_field
 
         # Handle volatility (Issue #717: unified API)
@@ -761,29 +751,31 @@ if __name__ == "__main__":
 # =============================================================================
 
 
-def _deprecated_alias_factory(new_cls, old_name: str, new_name: str):
-    """Create a deprecated alias class that warns on instantiation."""
-    import warnings
-
-    class DeprecatedAlias(new_cls):
-        def __init__(self, *args, **kwargs):
-            warnings.warn(
-                f"{old_name} is deprecated since v0.17.6. Use {new_name} instead. {old_name} will be removed in v1.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            super().__init__(*args, **kwargs)
-
-    DeprecatedAlias.__name__ = old_name
-    DeprecatedAlias.__qualname__ = old_name
-    DeprecatedAlias.__doc__ = f"""
-    DEPRECATED: Use :class:`{new_name}` instead.
+# Backward compatibility: FPSLAdjointSolver -> FPSLSolver
+# Uses subclass pattern (not deprecated_alias) to preserve isinstance checks
+# and class attribute inheritance (_scheme_family trait for duality validation).
+class FPSLAdjointSolver(FPSLSolver):
+    """
+    DEPRECATED: Use :class:`FPSLSolver` instead.
 
     .. deprecated:: 0.17.6
-        {old_name} has been renamed to {new_name} (Issue #710).
+        Renamed to FPSLSolver. Will be removed in v1.0.0.
     """
-    return DeprecatedAlias
 
+    _deprecation_meta: ClassVar[dict[str, Any]] = {
+        "since": "v0.17.6",
+        "replacement": "FPSLSolver",
+        "reason": "Renamed to FPSLSolver",
+        "removal": "v1.0.0",
+        "removal_blockers": ["internal_usage", "equivalence_test"],
+        "symbol": "FPSLAdjointSolver",
+        "alias_for": "FPSLSolver",
+    }
 
-# Backward compatibility: FPSLAdjointSolver -> FPSLSolver
-FPSLAdjointSolver = _deprecated_alias_factory(FPSLSolver, "FPSLAdjointSolver", "FPSLSolver")
+    @deprecated(
+        since="v0.17.6",
+        replacement="FPSLSolver",
+        reason="FPSLAdjointSolver was renamed to FPSLSolver",
+    )
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -8,6 +8,7 @@ import scipy.sparse as sparse
 
 from mfgarchon.alg.base_solver import BaseNumericalSolver, SchemeFamily
 from mfgarchon.backends.compat import backend_aware_assign, backend_aware_copy, has_nan_or_inf
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
 if TYPE_CHECKING:
@@ -92,6 +93,11 @@ def _compute_gradient_array_1d(
     return grad
 
 
+@deprecated_parameter(
+    param_name="bc_values",
+    since="v0.17.0",
+    replacement="Robin BC segments via AdjointConsistentProvider",
+)
 def _compute_laplacian_1d(
     U_array: np.ndarray,
     Dx: float,
@@ -124,16 +130,7 @@ def _compute_laplacian_1d(
         return np.zeros(Nx)
 
     # Issue #574: bc_values parameter deprecated — Robin BC framework handles this
-    if bc_values is not None:
-        import warnings
-
-        warnings.warn(
-            "bc_values parameter is deprecated and no longer used. "
-            "Adjoint-consistent BC is now handled via proper Robin BC segments. "
-            "This parameter will be removed in v0.18.0.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+    # Warning now handled by @deprecated_parameter decorator
 
     # Delegate to unified stencil infrastructure (Issue #639)
     return laplacian_with_bc(U_array, [Dx], bc=bc, time=time)
@@ -1001,6 +998,16 @@ def newton_hjb_step(
     return U_n_next_newton_iterate, l2_error_of_step
 
 
+@deprecated_parameter(
+    param_name="NiterNewton",
+    since="v0.17.0",
+    replacement="max_newton_iterations",
+)
+@deprecated_parameter(
+    param_name="l2errBoundNewton",
+    since="v0.17.0",
+    replacement="newton_tolerance",
+)
 def solve_hjb_timestep_newton(
     U_n_plus_1_from_hjb_step: np.ndarray,  # U_new[n+1] in notebook
     U_k_n_from_prev_picard: np.ndarray,  # U_k[n] in notebook
@@ -1036,24 +1043,12 @@ def solve_hjb_timestep_newton(
         l2errBoundNewton: DEPRECATED - use newton_tolerance
         bc_values: Per-boundary BC values (Issue #574)
     """
-    import warnings
-
-    # Handle backward compatibility
+    # Handle backward compatibility (warnings handled by @deprecated_parameter decorators)
     if NiterNewton is not None:
-        warnings.warn(
-            "Parameter 'NiterNewton' is deprecated. Use 'max_newton_iterations' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if max_newton_iterations is None:
             max_newton_iterations = NiterNewton
 
     if l2errBoundNewton is not None:
-        warnings.warn(
-            "Parameter 'l2errBoundNewton' is deprecated. Use 'newton_tolerance' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if newton_tolerance is None:
             newton_tolerance = l2errBoundNewton
 
@@ -1210,6 +1205,16 @@ def solve_hjb_timestep_newton(
     return U_n_current_newton_iterate
 
 
+@deprecated_parameter(
+    param_name="NiterNewton",
+    since="v0.17.0",
+    replacement="max_newton_iterations",
+)
+@deprecated_parameter(
+    param_name="l2errBoundNewton",
+    since="v0.17.0",
+    replacement="newton_tolerance",
+)
 def solve_hjb_system_backward(
     M_density_from_prev_picard: np.ndarray,  # M_k in notebook
     U_final_condition_at_T: np.ndarray,
@@ -1244,24 +1249,12 @@ def solve_hjb_system_backward(
             {"x_min": gradient_left, "x_max": gradient_right}
             For adjoint-consistent BC. Default: None (standard BC with 0 gradient).
     """
-    import warnings
-
-    # Handle backward compatibility
+    # Handle backward compatibility (warnings handled by @deprecated_parameter decorators)
     if NiterNewton is not None:
-        warnings.warn(
-            "Parameter 'NiterNewton' is deprecated. Use 'max_newton_iterations' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if max_newton_iterations is None:
             max_newton_iterations = NiterNewton
 
     if l2errBoundNewton is not None:
-        warnings.warn(
-            "Parameter 'l2errBoundNewton' is deprecated. Use 'newton_tolerance' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if newton_tolerance is None:
             newton_tolerance = l2errBoundNewton
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -304,6 +304,36 @@ class HJBFDMSolver(BaseHJBSolver):
             self._laplacian_op = self.problem.geometry.get_laplacian_operator(order=2, bc=bc)
         return self._laplacian_op
 
+    @deprecated_parameter(
+        param_name="M_density_evolution",
+        since="v0.17.0",
+        replacement="M_density",
+    )
+    @deprecated_parameter(
+        param_name="M_density_evolution_from_FP",
+        since="v0.17.0",
+        replacement="M_density",
+    )
+    @deprecated_parameter(
+        param_name="U_final_condition",
+        since="v0.17.0",
+        replacement="U_terminal",
+    )
+    @deprecated_parameter(
+        param_name="U_final_condition_at_T",
+        since="v0.17.0",
+        replacement="U_terminal",
+    )
+    @deprecated_parameter(
+        param_name="U_from_prev_picard",
+        since="v0.17.0",
+        replacement="U_coupling_prev",
+    )
+    @deprecated_parameter(
+        param_name="bc_values",
+        since="v0.17.0",
+        replacement="BCValueProvider in BoundaryConditions",
+    )
     def solve_hjb_system(
         self,
         M_density: NDArray | None = None,
@@ -315,7 +345,7 @@ class HJBFDMSolver(BaseHJBSolver):
         progress_callback: Callable[[int], None] | None = None,  # Issue #640
         # MMS verification support
         source_term: Callable | None = None,
-        # Deprecated parameter names for backward compatibility
+        # Deprecated parameter names for backward compatibility (decorators handle warnings)
         M_density_evolution_from_FP: NDArray | None = None,
         U_final_condition_at_T: NDArray | None = None,
         U_from_prev_picard: NDArray | None = None,
@@ -342,68 +372,31 @@ class HJBFDMSolver(BaseHJBSolver):
             providers each iteration via problem.using_resolved_bc(state).
             See mfgarchon/geometry/boundary/providers.py for details.
         """
-        import warnings
-
-        # Handle deprecated parameter names (oldest first)
+        # Handle deprecated parameter names (decorators handle warnings, keep redirect logic)
         if M_density_evolution is not None:
             if M_density is not None or M_density_evolution_from_FP is not None:
                 raise ValueError("Cannot specify M_density_evolution with M_density or M_density_evolution_from_FP")
-            warnings.warn(
-                "Parameter 'M_density_evolution' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution
 
         if M_density_evolution_from_FP is not None:
             if M_density is not None:
                 raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            warnings.warn(
-                "Parameter 'M_density_evolution_from_FP' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution_from_FP
 
         if U_final_condition is not None:
             if U_terminal is not None or U_final_condition_at_T is not None:
                 raise ValueError("Cannot specify U_final_condition with U_terminal or U_final_condition_at_T")
-            warnings.warn(
-                "Parameter 'U_final_condition' is deprecated. Use 'U_terminal' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_terminal = U_final_condition
 
         if U_final_condition_at_T is not None:
             if U_terminal is not None:
                 raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            warnings.warn(
-                "Parameter 'U_final_condition_at_T' is deprecated. Use 'U_terminal' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_terminal = U_final_condition_at_T
 
         if U_from_prev_picard is not None:
             if U_coupling_prev is not None:
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            warnings.warn(
-                "Parameter 'U_from_prev_picard' is deprecated. Use 'U_coupling_prev' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_coupling_prev = U_from_prev_picard
-
-        # Warn about deprecated bc_values parameter
-        if bc_values is not None:
-            warnings.warn(
-                "Parameter 'bc_values' is deprecated and no longer used. "
-                "Adjoint-consistent BC is handled via BCValueProvider in BoundaryConditions. "
-                "See AdjointConsistentProvider in mfgarchon.geometry.boundary.providers.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
         # Validate required parameters
         if M_density is None:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -19,6 +19,7 @@ from mfgarchon.alg.numerical.gfdm_components import (
 )
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
 from mfgarchon.geometry.boundary.types import BCType
+from mfgarchon.utils.deprecation import deprecated_parameter, deprecated_value
 from mfgarchon.utils.mfg_logging import get_logger
 
 # GFDM infrastructure (Strategy Pattern)
@@ -211,6 +212,21 @@ class HJBGFDMSolver(BaseHJBSolver):
         kwargs.update(extra)
         return cls(problem, collocation_points, **kwargs)
 
+    @deprecated_value(
+        param_name="qp_optimization_level",
+        deprecated_values={"smart": "auto", "tuned": "auto", "basic": "auto"},
+        since="v0.17.0",
+    )
+    @deprecated_parameter(
+        param_name="NiterNewton",
+        since="v0.17.0",
+        replacement="max_newton_iterations",
+    )
+    @deprecated_parameter(
+        param_name="l2errBoundNewton",
+        since="v0.17.0",
+        replacement="newton_tolerance",
+    )
     def __init__(
         self,
         problem: MFGProblem,
@@ -355,18 +371,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         """
         super().__init__(problem)
 
-        # Handle deprecated QP level names
-        if qp_optimization_level in ["smart", "tuned", "basic"]:
-            import warnings
-
-            warnings.warn(
-                f"qp_optimization_level='{qp_optimization_level}' is deprecated. Use 'auto' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            qp_optimization_level = "auto"
-
-        # Store QP optimization level
+        # Store QP optimization level (deprecated values remapped by @deprecated_value)
         self.qp_optimization_level = qp_optimization_level
 
         # Set method name based on QP optimization level
@@ -381,24 +386,12 @@ class HJBGFDMSolver(BaseHJBSolver):
         else:
             self.hjb_method_name = f"GFDM-{qp_optimization_level}"
 
-        import warnings
-
-        # Handle backward compatibility
+        # Handle backward compatibility (warnings issued by @deprecated_parameter decorators)
         if NiterNewton is not None:
-            warnings.warn(
-                "Parameter 'NiterNewton' is deprecated. Use 'max_newton_iterations' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if max_newton_iterations is None:
                 max_newton_iterations = NiterNewton
 
         if l2errBoundNewton is not None:
-            warnings.warn(
-                "Parameter 'l2errBoundNewton' is deprecated. Use 'newton_tolerance' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if newton_tolerance is None:
                 newton_tolerance = l2errBoundNewton
 
@@ -2054,6 +2047,21 @@ class HJBGFDMSolver(BaseHJBSolver):
     # Note: _build_monotonicity_constraints moved to MonotonicityEnforcer component
     # Note: _build_hamiltonian_gradient_constraints moved to MonotonicityEnforcer component
 
+    @deprecated_parameter(
+        param_name="M_density_evolution_from_FP",
+        since="v0.17.0",
+        replacement="M_density",
+    )
+    @deprecated_parameter(
+        param_name="U_final_condition_at_T",
+        since="v0.17.0",
+        replacement="U_terminal",
+    )
+    @deprecated_parameter(
+        param_name="U_from_prev_picard",
+        since="v0.17.0",
+        replacement="U_coupling_prev",
+    )
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
@@ -2085,35 +2093,20 @@ class HJBGFDMSolver(BaseHJBSolver):
         Returns:
             (Nt, *spatial_shape) solution array
         """
-        # Handle deprecated parameter names with warnings
+        # Handle deprecated parameter names (warnings issued by @deprecated_parameter decorators)
         if M_density_evolution_from_FP is not None:
             if M_density is not None:
                 raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            warnings.warn(
-                "Parameter 'M_density_evolution_from_FP' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution_from_FP
 
         if U_final_condition_at_T is not None:
             if U_terminal is not None:
                 raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            warnings.warn(
-                "Parameter 'U_final_condition_at_T' is deprecated. Use 'U_terminal' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_terminal = U_final_condition_at_T
 
         if U_from_prev_picard is not None:
             if U_coupling_prev is not None:
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            warnings.warn(
-                "Parameter 'U_from_prev_picard' is deprecated. Use 'U_coupling_prev' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_coupling_prev = U_from_prev_picard
 
         # Validate required parameters

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -19,7 +19,6 @@ where û^n is the value interpolated at the departure point of the characteristi
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -31,6 +30,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
     get_bc_type_string,
 )
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import check_adi_compatibility
 
@@ -728,6 +728,9 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # Use InterpolationApplicator for dimension-agnostic BC enforcement
         return self.interp_bc_applicator.enforce_values(U, bc, time=time)
 
+    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
+    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
+    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
@@ -761,35 +764,20 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         Returns:
             (Nt, *grid_shape) solution array for value function
         """
-        # Handle deprecated parameter names with warnings
+        # Handle deprecated parameter names (warnings issued by @deprecated_parameter decorator)
         if M_density_evolution_from_FP is not None:
             if M_density is not None:
                 raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            warnings.warn(
-                "Parameter 'M_density_evolution_from_FP' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution_from_FP
 
         if U_final_condition_at_T is not None:
             if U_terminal is not None:
                 raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            warnings.warn(
-                "Parameter 'U_final_condition_at_T' is deprecated. Use 'U_terminal' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_terminal = U_final_condition_at_T
 
         if U_from_prev_picard is not None:
             if U_coupling_prev is not None:
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            warnings.warn(
-                "Parameter 'U_from_prev_picard' is deprecated. Use 'U_coupling_prev' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_coupling_prev = U_from_prev_picard
 
         # Validate required parameters

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -37,7 +37,6 @@ References:
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -45,6 +44,7 @@ import numpy as np
 from mfgarchon.core.derivatives import DerivativeTensors, to_multi_index_dict
 from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
 from mfgarchon.geometry.boundary.conditions import neumann_bc
+from mfgarchon.utils.deprecation import deprecated_parameter
 
 from .base_hjb import BaseHJBSolver
 
@@ -821,6 +821,9 @@ class HJBWenoSolver(BaseHJBSolver):
 
         return max(dt_stable, 1e-10)  # Ensure positive time step
 
+    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
+    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
+    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
@@ -848,35 +851,20 @@ class HJBWenoSolver(BaseHJBSolver):
         Returns:
             U_solved: Complete solution u(t,x) over time domain
         """
-        # Handle deprecated parameter names with warnings
+        # Handle deprecated parameter names (warnings handled by @deprecated_parameter decorators)
         if M_density_evolution_from_FP is not None:
             if M_density is not None:
                 raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            warnings.warn(
-                "Parameter 'M_density_evolution_from_FP' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution_from_FP
 
         if U_final_condition_at_T is not None:
             if U_terminal is not None:
                 raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            warnings.warn(
-                "Parameter 'U_final_condition_at_T' is deprecated. Use 'U_terminal' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_terminal = U_final_condition_at_T
 
         if U_from_prev_picard is not None:
             if U_coupling_prev is not None:
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            warnings.warn(
-                "Parameter 'U_from_prev_picard' is deprecated. Use 'U_coupling_prev' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_coupling_prev = U_from_prev_picard
 
         # Validate required parameters

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -30,6 +30,7 @@ import scipy.sparse as sp
 from scipy.sparse.linalg import spsolve
 
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -123,6 +124,7 @@ class FPNetworkSolver(BaseFPSolver):
             if self.dt > self.dt_stable:
                 print(f"Warning: dt={self.dt:.2e} > dt_stable={self.dt_stable:.2e}")
 
+    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
     def solve_fp_system(
         self,
         M_initial: np.ndarray | None = None,
@@ -151,20 +153,13 @@ class FPNetworkSolver(BaseFPSolver):
         Returns:
             (Nt+1, num_nodes) density evolution
         """
-        import warnings
-
-        # Handle deprecated parameter name
+        # Handle deprecated parameter redirect
         if m_initial_condition is not None:
             if M_initial is not None:
                 raise ValueError(
                     "Cannot specify both M_initial and m_initial_condition. "
                     "Use M_initial (m_initial_condition is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'm_initial_condition' is deprecated. Use 'M_initial' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_initial = m_initial_condition
 
         # Validate required parameter

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -29,6 +29,7 @@ import scipy.sparse as sp
 from scipy.sparse.linalg import spsolve
 
 from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
     from mfgarchon.extensions.topology import NetworkMFGProblem
@@ -113,6 +114,10 @@ class NetworkHJBSolver(BaseHJBSolver):
             if self.dt > self.dt_stable:
                 print(f"Warning: dt={self.dt:.2e} > dt_stable={self.dt_stable:.2e}")
 
+    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
+    @deprecated_parameter(param_name="M_density_evolution", since="v0.17.0", replacement="M_density")
+    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
+    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
@@ -141,20 +146,13 @@ class NetworkHJBSolver(BaseHJBSolver):
         Returns:
             (Nt+1, num_nodes) value function evolution
         """
-        import warnings
-
-        # Handle deprecated parameter names
+        # Handle deprecated parameter redirects
         if M_density_evolution_from_FP is not None:
             if M_density is not None:
                 raise ValueError(
                     "Cannot specify both M_density and M_density_evolution_from_FP. "
                     "Use M_density (M_density_evolution_from_FP is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'M_density_evolution_from_FP' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution_from_FP
 
         if M_density_evolution is not None:
@@ -163,11 +161,6 @@ class NetworkHJBSolver(BaseHJBSolver):
                     "Cannot specify both M_density and M_density_evolution. "
                     "Use M_density (M_density_evolution is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'M_density_evolution' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution
 
         if U_final_condition_at_T is not None:
@@ -176,11 +169,6 @@ class NetworkHJBSolver(BaseHJBSolver):
                     "Cannot specify both U_terminal and U_final_condition_at_T. "
                     "Use U_terminal (U_final_condition_at_T is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'U_final_condition_at_T' is deprecated. Use 'U_terminal' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_terminal = U_final_condition_at_T
 
         if U_from_prev_picard is not None:
@@ -189,11 +177,6 @@ class NetworkHJBSolver(BaseHJBSolver):
                     "Cannot specify both U_coupling_prev and U_from_prev_picard. "
                     "Use U_coupling_prev (U_from_prev_picard is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'U_from_prev_picard' is deprecated. Use 'U_coupling_prev' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_coupling_prev = U_from_prev_picard
 
         # Validate required parameters
@@ -369,6 +352,10 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
         # Current policy (action for each node)
         self.current_policy: dict[int, int] = {}
 
+    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
+    @deprecated_parameter(param_name="M_density_evolution", since="v0.17.0", replacement="M_density")
+    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
+    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
@@ -382,20 +369,13 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
         M_density_evolution: np.ndarray | None = None,
     ) -> np.ndarray:
         """Solve HJB using policy iteration."""
-        import warnings
-
-        # Handle deprecated parameter names
+        # Handle deprecated parameter redirects
         if M_density_evolution_from_FP is not None:
             if M_density is not None:
                 raise ValueError(
                     "Cannot specify both M_density and M_density_evolution_from_FP. "
                     "Use M_density (M_density_evolution_from_FP is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'M_density_evolution_from_FP' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution_from_FP
 
         if M_density_evolution is not None:
@@ -404,11 +384,6 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
                     "Cannot specify both M_density and M_density_evolution. "
                     "Use M_density (M_density_evolution is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'M_density_evolution' is deprecated. Use 'M_density' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             M_density = M_density_evolution
 
         if U_final_condition_at_T is not None:
@@ -417,11 +392,6 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
                     "Cannot specify both U_terminal and U_final_condition_at_T. "
                     "Use U_terminal (U_final_condition_at_T is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'U_final_condition_at_T' is deprecated. Use 'U_terminal' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_terminal = U_final_condition_at_T
 
         if U_from_prev_picard is not None:
@@ -430,11 +400,6 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
                     "Cannot specify both U_coupling_prev and U_from_prev_picard. "
                     "Use U_coupling_prev (U_from_prev_picard is deprecated)."
                 )
-            warnings.warn(
-                "Parameter 'U_from_prev_picard' is deprecated. Use 'U_coupling_prev' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             U_coupling_prev = U_from_prev_picard
 
         # Validate required parameters

--- a/mfgarchon/backends/compat.py
+++ b/mfgarchon/backends/compat.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated
+
 if TYPE_CHECKING:
     from mfgarchon.backends.base_backend import BaseBackend
 
@@ -319,21 +321,16 @@ def ensure_same_device(target, source, backend: BaseBackend | None = None):
 # ==================================================================
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="Use backend.zeros() instead for device consistency.",
+)
 def _deprecated_xp_zeros(backend, shape, dtype=None):
     """
     DEPRECATED: Use backend.zeros() instead.
 
     This function shows the OLD problematic pattern.
     """
-    import warnings
-
-    warnings.warn(
-        "Using xp = backend.array_module; xp.zeros() is deprecated. "
-        "Use backend.zeros() instead for device consistency. Will be removed in v1.0.0.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
     if backend is not None:
         return backend.zeros(shape, dtype)
     else:

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -17,7 +17,7 @@ from mfgarchon.core.mfg_components import (
 from mfgarchon.geometry.protocol import GeometryProtocol  # noqa: TC001
 
 # Deprecation utilities (Issue #616, #666)
-from mfgarchon.utils.deprecation import deprecated_parameter, validate_kwargs
+from mfgarchon.utils.deprecation import deprecated, deprecated_parameter, validate_kwargs
 
 # Use unified nD-capable BoundaryConditions from conditions.py
 
@@ -647,6 +647,11 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         # Detect solver compatibility
         self._detect_solver_compatibility()
 
+    @deprecated(
+        since="v0.17.0",
+        replacement="geometry-first API with TensorProductGrid",
+        reason="Manual grid construction is deprecated. See docs/migration/GEOMETRY_PARAMETER_MIGRATION.md",
+    )
     def _init_1d_legacy(
         self,
         xmin: list[float],
@@ -674,21 +679,7 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             the geometry-first API with TensorProductGrid instead.
             See migration guide: docs/migration/GEOMETRY_PARAMETER_MIGRATION.md
         """
-        import warnings
-
         from mfgarchon.geometry import TensorProductGrid
-
-        # Emit deprecation warning for manual grid construction pattern
-        warnings.warn(
-            "Manual grid construction in MFGProblem is deprecated and will be "
-            "restricted in v1.0.0. Use the geometry-first API instead:\n\n"
-            "  from mfgarchon.geometry import TensorProductGrid\n"
-            f"  domain = TensorProductGrid(bounds=[({xmin[0]}, {xmax[0]})], Nx_points=[{Nx[0] + 1}])\n"
-            f"  problem = MFGProblem(geometry=domain, T={T}, Nt={Nt})\n\n"
-            "See docs/migration/GEOMETRY_PARAMETER_MIGRATION.md for details.",
-            DeprecationWarning,
-            stacklevel=4,  # Point to user's code, not internal calls
-        )
 
         # Extract scalar values from arrays for backward compatibility
         xmin_scalar = xmin[0]
@@ -729,6 +720,11 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         self.spatial_bounds = [(xmin_scalar, xmax_scalar)]
         self.spatial_discretization = [Nx_scalar]
 
+    @deprecated(
+        since="v0.17.0",
+        replacement="geometry-first API with TensorProductGrid",
+        reason="Manual grid construction is deprecated. See docs/migration/GEOMETRY_PARAMETER_MIGRATION.md",
+    )
     def _init_nd(
         self,
         spatial_bounds: list[tuple[float, float]],
@@ -747,29 +743,11 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             the geometry-first API with TensorProductGrid instead.
             See migration guide: docs/migration/GEOMETRY_PARAMETER_MIGRATION.md
         """
-        import warnings
-
         # Validate inputs
         if not spatial_bounds:
             raise ValueError("spatial_bounds must be a non-empty list of (min, max) tuples")
 
         dimension = len(spatial_bounds)
-
-        # Emit deprecation warning for manual grid construction pattern
-        warnings.warn(
-            "Manual grid construction in MFGProblem is deprecated and will be "
-            "restricted in v1.0.0. Use the geometry-first API instead:\n\n"
-            "  from mfgarchon.geometry import TensorProductGrid\n"
-            "  geometry = TensorProductGrid(\n"
-            f"      dimension={dimension},\n"
-            f"      bounds={spatial_bounds},\n"
-            f"      Nx_points={spatial_discretization if spatial_discretization else [51] * dimension}\n"
-            "  )\n"
-            f"  problem = MFGProblem(geometry=geometry, T={T}, Nt={Nt})\n\n"
-            "See docs/migration/GEOMETRY_PARAMETER_MIGRATION.md for details.",
-            DeprecationWarning,
-            stacklevel=4,  # Point to user's code, not internal calls
-        )
 
         if spatial_discretization is None:
             # Default: 51 points per dimension
@@ -1288,20 +1266,13 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
     # =========================================================================
 
     @property
+    @deprecated(since="v0.17.0", replacement="problem.geometry.get_bounds()[0][0]")
     def xmin(self) -> float | None:
         """
         DEPRECATED: Use problem.geometry.get_bounds() instead.
 
         Returns the minimum x-coordinate for 1D problems.
         """
-        import warnings
-
-        warnings.warn(
-            "Accessing 'xmin' is deprecated. Use 'problem.geometry.get_bounds()[0][0]' instead. "
-            "Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         # Check for stored value first (for backward compat with tests that set it)
         if getattr(self, "_xmin_override", None) is not None:
             return self._xmin_override
@@ -1312,32 +1283,19 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         return None
 
     @xmin.setter
+    @deprecated(since="v0.17.0", replacement="geometry-first API")
     def xmin(self, value: float | None) -> None:
         """Allow setting for backward compatibility (with warning)."""
-        import warnings
-
-        warnings.warn(
-            "Setting 'xmin' is deprecated. Use geometry-first API instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self._xmin_override = value
 
     @property
+    @deprecated(since="v0.17.0", replacement="problem.geometry.get_bounds()[1][0]")
     def xmax(self) -> float | None:
         """
         DEPRECATED: Use problem.geometry.get_bounds() instead.
 
         Returns the maximum x-coordinate for 1D problems.
         """
-        import warnings
-
-        warnings.warn(
-            "Accessing 'xmax' is deprecated. Use 'problem.geometry.get_bounds()[1][0]' instead. "
-            "Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if getattr(self, "_xmax_override", None) is not None:
             return self._xmax_override
         if self.geometry is not None and self.dimension == 1:
@@ -1347,31 +1305,19 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         return None
 
     @xmax.setter
+    @deprecated(since="v0.17.0", replacement="geometry-first API")
     def xmax(self, value: float | None) -> None:
         """Allow setting for backward compatibility (with warning)."""
-        import warnings
-
-        warnings.warn(
-            "Setting 'xmax' is deprecated. Use geometry-first API instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self._xmax_override = value
 
     @property
+    @deprecated(since="v0.17.0", replacement="compute from geometry bounds")
     def Lx(self) -> float | None:
         """
         DEPRECATED: Compute from geometry bounds instead.
 
         Returns the domain length for 1D problems.
         """
-        import warnings
-
-        warnings.warn(
-            "Accessing 'Lx' is deprecated. Compute from geometry bounds instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._Lx_override is not None:
             return self._Lx_override
         if self.geometry is not None and self.dimension == 1:
@@ -1381,32 +1327,19 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         return None
 
     @Lx.setter
+    @deprecated(since="v0.17.0", replacement="geometry-first API")
     def Lx(self, value: float | None) -> None:
         """Allow setting for backward compatibility (with warning)."""
-        import warnings
-
-        warnings.warn(
-            "Setting 'Lx' is deprecated. Use geometry-first API instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self._Lx_override = value
 
     @property
+    @deprecated(since="v0.17.0", replacement="problem.geometry.num_spatial_points - 1")
     def Nx(self) -> int | None:
         """
         DEPRECATED: Use problem.geometry.num_spatial_points instead.
 
         Returns the number of intervals (not points) for 1D problems.
         """
-        import warnings
-
-        warnings.warn(
-            "Accessing 'Nx' is deprecated. Use 'problem.geometry.num_spatial_points - 1' for intervals. "
-            "Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._Nx_override is not None:
             return self._Nx_override
         if self.geometry is not None and self.dimension == 1:
@@ -1415,32 +1348,19 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         return None
 
     @Nx.setter
+    @deprecated(since="v0.17.0", replacement="geometry-first API")
     def Nx(self, value: int | None) -> None:
         """Allow setting for backward compatibility (with warning)."""
-        import warnings
-
-        warnings.warn(
-            "Setting 'Nx' is deprecated. Use geometry-first API instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self._Nx_override = value
 
     @property
+    @deprecated(since="v0.17.0", replacement="compute from geometry bounds and num_points")
     def dx(self) -> float | None:
         """
         DEPRECATED: Compute from geometry bounds and num_points instead.
 
         Returns the grid spacing for 1D problems.
         """
-        import warnings
-
-        warnings.warn(
-            "Accessing 'dx' is deprecated. Compute from geometry bounds and num_points instead. "
-            "Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._dx_override is not None:
             return self._dx_override
         if self.geometry is not None and self.dimension == 1:
@@ -1458,32 +1378,19 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         return None
 
     @dx.setter
+    @deprecated(since="v0.17.0", replacement="geometry-first API")
     def dx(self, value: float | None) -> None:
         """Allow setting for backward compatibility (with warning)."""
-        import warnings
-
-        warnings.warn(
-            "Setting 'dx' is deprecated. Use geometry-first API instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self._dx_override = value
 
     @property
+    @deprecated(since="v0.17.0", replacement="problem.geometry.get_spatial_grid()")
     def xSpace(self) -> np.ndarray | None:
         """
         DEPRECATED: Use problem.geometry.get_spatial_grid() instead.
 
         Returns the spatial grid array.
         """
-        import warnings
-
-        warnings.warn(
-            "Accessing 'xSpace' is deprecated. Use 'problem.geometry.get_spatial_grid()' instead. "
-            "Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._xSpace_override is not None:
             return self._xSpace_override
         if self.geometry is not None:
@@ -1491,45 +1398,27 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         return None
 
     @xSpace.setter
+    @deprecated(since="v0.17.0", replacement="geometry-first API")
     def xSpace(self, value: np.ndarray | None) -> None:
         """Allow setting for backward compatibility (with warning)."""
-        import warnings
-
-        warnings.warn(
-            "Setting 'xSpace' is deprecated. Use geometry-first API instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self._xSpace_override = value
 
     @property
+    @deprecated(since="v0.17.0", replacement="problem.geometry")
     def _grid(self) -> Any:
         """
         DEPRECATED: Use problem.geometry instead.
 
         Returns the geometry object (for backward compatibility).
         """
-        import warnings
-
-        warnings.warn(
-            "Accessing '_grid' is deprecated. Use 'problem.geometry' instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._grid_override is not None:
             return self._grid_override
         return self.geometry
 
     @_grid.setter
+    @deprecated(since="v0.17.0", replacement="geometry-first API")
     def _grid(self, value: Any) -> None:
         """Allow setting for backward compatibility (with warning)."""
-        import warnings
-
-        warnings.warn(
-            "Setting '_grid' is deprecated. Use geometry-first API instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self._grid_override = value
 
     # =========================================================================

--- a/mfgarchon/factory/solver_factory.py
+++ b/mfgarchon/factory/solver_factory.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from mfgarchon.alg.numerical.coupling import FixedPointIterator
 from mfgarchon.config import MFGSolverConfig
+from mfgarchon.utils.deprecation import deprecated
 
 if TYPE_CHECKING:
     from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
@@ -174,6 +175,16 @@ class SolverFactory:
 # Convenience function
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement=(
+        "Use the new three-mode solving API instead (Issue #580):\n"
+        "  - Safe Mode: problem.solve(scheme=NumericalScheme.FDM_UPWIND)\n"
+        "  - Expert Mode: problem.solve(hjb_solver=hjb, fp_solver=fp)\n"
+        "  - Auto Mode: problem.solve()\n"
+        "See examples/basic/three_mode_api_demo.py for details."
+    ),
+)
 def create_solver(
     problem: MFGProblem,
     hjb_solver: BaseHJBSolver | None = None,
@@ -213,19 +224,6 @@ def create_solver(
     Note:
         Prefer problem.solve() which handles solver creation and duality validation.
     """
-    import warnings
-
-    warnings.warn(
-        "create_solver() is deprecated since v0.17.0 (Issue #580). "
-        "Use the new three-mode solving API instead:\n"
-        "  • Safe Mode: problem.solve(scheme=NumericalScheme.FDM_UPWIND)\n"
-        "  • Expert Mode: problem.solve(hjb_solver=hjb, fp_solver=fp)\n"
-        "  • Auto Mode: problem.solve()\n"
-        "See examples/basic/three_mode_api_demo.py for details.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
     return SolverFactory.create_solver(
         problem=problem,
         hjb_solver=hjb_solver,

--- a/mfgarchon/geometry/base.py
+++ b/mfgarchon/geometry/base.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated_parameter
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -1278,6 +1280,16 @@ class UnstructuredMesh(Geometry):
         """
         ...
 
+    @deprecated_parameter(
+        param_name="show_edges",
+        since="v0.17.0",
+        replacement="mode",
+    )
+    @deprecated_parameter(
+        param_name="show_quality",
+        since="v0.17.0",
+        replacement="mode",
+    )
     def visualize_mesh(
         self,
         mode: MeshVisualizationMode | str = MeshVisualizationMode.WITH_EDGES,
@@ -1320,15 +1332,6 @@ class UnstructuredMesh(Geometry):
 
         # Handle backward compatibility
         if show_edges is not None or show_quality is not None:
-            import warnings
-
-            warnings.warn(
-                "Parameters 'show_edges' and 'show_quality' are deprecated. "
-                "Use 'mode' parameter instead: MeshVisualizationMode.SURFACE, .WITH_EDGES, "
-                ".QUALITY, or .QUALITY_WITH_EDGES",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             # Convert old API to new
             edges = show_edges if show_edges is not None else True
             quality = show_quality if show_quality is not None else False

--- a/mfgarchon/geometry/boundary/_compat.py
+++ b/mfgarchon/geometry/boundary/_compat.py
@@ -15,7 +15,6 @@ The canonical way to apply boundary conditions is via `FDMApplicator` or
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -1017,6 +1016,10 @@ def _apply_corner_values_nd(padded: NDArray[np.floating], d: int) -> None:
                 padded[intersection_slice] = avg_val
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
+)
 def apply_boundary_conditions_nd(
     field: NDArray[np.floating],
     boundary_conditions: BoundaryConditions | LegacyBoundaryConditions1D,
@@ -1045,12 +1048,6 @@ def apply_boundary_conditions_nd(
         Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead.
         See issue #577 for migration guide.
     """
-    warnings.warn(
-        "apply_boundary_conditions_nd is deprecated and will be removed in v0.19.0. "
-        "Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if config is None:
         config = GhostCellConfig()
 
@@ -1510,6 +1507,10 @@ def create_boundary_mask_2d(
 # =============================================================================
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
+)
 def apply_boundary_conditions_1d(
     field: NDArray[np.floating],
     boundary_conditions: BoundaryConditions | LegacyBoundaryConditions1D,
@@ -1540,18 +1541,16 @@ def apply_boundary_conditions_1d(
         Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead.
         See issue #577 for migration guide.
     """
-    warnings.warn(
-        "apply_boundary_conditions_1d is deprecated and will be removed in v0.19.0. "
-        "Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if config is None:
         config = GhostCellConfig()
 
     return _apply_bc_1d(field, boundary_conditions, domain_bounds, time, config, geometry)
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
+)
 def apply_boundary_conditions_3d(
     field: NDArray[np.floating],
     boundary_conditions: BoundaryConditions | LegacyBoundaryConditions1D,
@@ -1582,12 +1581,6 @@ def apply_boundary_conditions_3d(
         Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead.
         See issue #577 for migration guide.
     """
-    warnings.warn(
-        "apply_boundary_conditions_3d is deprecated and will be removed in v0.19.0. "
-        "Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if config is None:
         config = GhostCellConfig()
 
@@ -1603,6 +1596,10 @@ def apply_boundary_conditions_3d(
 # =============================================================================
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
+)
 def get_ghost_values_nd(
     field: NDArray[np.floating],
     boundary_conditions: BoundaryConditions | LegacyBoundaryConditions1D,
@@ -1654,12 +1651,6 @@ def get_ghost_values_nd(
         Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead.
         See issue #577 for migration guide.
     """
-    warnings.warn(
-        "get_ghost_values_nd is deprecated and will be removed in v0.19.0. "
-        "Use pad_array_with_ghosts() or PreallocatedGhostBuffer instead. See issue #577.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if config is None:
         config = GhostCellConfig()
 

--- a/mfgarchon/geometry/boundary/applicator_base.py
+++ b/mfgarchon/geometry/boundary/applicator_base.py
@@ -24,7 +24,6 @@ Hierarchy:
 
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -32,6 +31,8 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import numpy as np
 from numpy.typing import NDArray
+
+from mfgarchon.utils.deprecation import deprecated
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -578,14 +579,11 @@ class NoFluxCalculator(ZeroGradientCalculator):
         For mass-conserving flux BC (J·n = 0), use :class:`ZeroFluxCalculator`.
     """
 
+    @deprecated(
+        since="v0.16.11",
+        replacement="Use ZeroGradientCalculator for du/dn = 0, or ZeroFluxCalculator for J*n = 0.",
+    )
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "NoFluxCalculator is deprecated since v0.16.11. "
-            "Use ZeroGradientCalculator for du/dn = 0 (edge extension), "
-            "or ZeroFluxCalculator for J·n = 0 (mass conservation).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(*args, **kwargs)
 
 
@@ -757,13 +755,11 @@ class FPNoFluxCalculator(ZeroFluxCalculator):
         Use :class:`ZeroFluxCalculator` instead for J·n = 0 (mass conservation).
     """
 
+    @deprecated(
+        since="v0.16.11",
+        replacement="Use ZeroFluxCalculator instead for J*n = 0 (mass conservation).",
+    )
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "FPNoFluxCalculator is deprecated since v0.16.11. "
-            "Use ZeroFluxCalculator instead for J·n = 0 (mass conservation).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(*args, **kwargs)
 
 

--- a/mfgarchon/geometry/boundary/bc_coupling.py
+++ b/mfgarchon/geometry/boundary/bc_coupling.py
@@ -15,10 +15,11 @@ See Issue #704 for details on the unified adjoint module.
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
+
+from mfgarchon.utils.deprecation import deprecated
 
 # Import from submodules directly (deprecated module, see Issue #704)
 from .conditions import BoundaryConditions
@@ -27,18 +28,11 @@ from .types import BCSegment, BCType
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-_DEPRECATION_MSG = (
-    "Importing from 'mfgarchon.geometry.boundary.bc_coupling' is deprecated since v0.17.0. "
-    "Use 'mfgarchon.alg.numerical.adjoint' instead. "
-    "This module will be removed in v1.0.0."
+
+@deprecated(
+    since="v0.17.0",
+    replacement="Use mfgarchon.alg.numerical.adjoint.compute_boundary_log_density_gradient_1d instead.",
 )
-
-
-def _warn_deprecated() -> None:
-    """Emit deprecation warning once per session."""
-    warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
-
-
 def compute_boundary_log_density_gradient_1d(
     m: NDArray[np.floating],
     dx: float,
@@ -50,8 +44,6 @@ def compute_boundary_log_density_gradient_1d(
 
     Compute dln(m)/dn at 1D boundary using one-sided finite differences.
     """
-    _warn_deprecated()
-
     m_safe = m + regularization
     ln_m = np.log(m_safe)
 
@@ -65,6 +57,10 @@ def compute_boundary_log_density_gradient_1d(
     return float(grad_ln_m)
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="Use mfgarchon.alg.numerical.adjoint.create_adjoint_consistent_bc_1d instead.",
+)
 def create_adjoint_consistent_bc_1d(
     m_current: NDArray[np.floating],
     dx: float,
@@ -77,7 +73,6 @@ def create_adjoint_consistent_bc_1d(
 
     Create adjoint-consistent Robin BC for 1D HJB equation.
     """
-    _warn_deprecated()
 
     # Inline implementation to avoid circular import
     m_safe = m_current + regularization
@@ -120,6 +115,10 @@ def create_adjoint_consistent_bc_1d(
     )
 
 
+@deprecated(
+    since="v0.17.0",
+    replacement="Use mfgarchon.alg.numerical.adjoint.compute_adjoint_consistent_bc_values instead.",
+)
 def compute_adjoint_consistent_bc_values(
     m_current: NDArray[np.floating],
     geometry: object,
@@ -132,7 +131,6 @@ def compute_adjoint_consistent_bc_values(
 
     Create adjoint-consistent Robin BC for HJB equation (dimension-agnostic).
     """
-    _warn_deprecated()
 
     if dimension == 1:
         dx = geometry.get_grid_spacing()[0]
@@ -148,7 +146,7 @@ def compute_adjoint_consistent_bc_values(
         raise NotImplementedError(f"Adjoint-consistent BC not yet implemented for {dimension}D.")
 
 
-# Backward compatibility alias
+# Backward compatibility alias (the target already warns via @deprecated)
 compute_coupled_hjb_bc_values = compute_adjoint_consistent_bc_values
 
 

--- a/mfgarchon/geometry/boundary/corner/position.py
+++ b/mfgarchon/geometry/boundary/corner/position.py
@@ -28,6 +28,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
@@ -131,6 +133,10 @@ def absorb_positions(
 
 # Backward compatibility: import from new location
 # TODO: Remove in v1.0.0 after deprecation period
+@deprecated(
+    since="v0.17.0",
+    replacement="Use mfgarchon.geometry.boundary.periodic.wrap_positions instead.",
+)
 def wrap_positions(
     positions: NDArray[np.floating],
     bounds: list[tuple[float, float]] | NDArray[np.floating],
@@ -140,16 +146,8 @@ def wrap_positions(
 
     This function is kept for backward compatibility and will be removed in v1.0.0.
     """
-    import warnings
-
     from mfgarchon.geometry.boundary.periodic import wrap_positions as _wrap
 
-    warnings.warn(
-        "wrap_positions in corner/position.py is deprecated. "
-        "Use mfgarchon.geometry.boundary.periodic.wrap_positions instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return _wrap(positions, bounds)
 
 

--- a/mfgarchon/geometry/boundary/fdm_bc_1d.py
+++ b/mfgarchon/geometry/boundary/fdm_bc_1d.py
@@ -24,21 +24,9 @@ For multi-dimensional or segment-based BC specification, use conditions.py.
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 
-
-def _emit_deprecation_warning(func_name: str = "BoundaryConditions") -> None:
-    """Emit deprecation warning for fdm_bc_1d module usage."""
-    warnings.warn(
-        f"mfgarchon.geometry.boundary.fdm_bc_1d.{func_name} is deprecated. "
-        "Use the unified API instead:\n"
-        "  from mfgarchon.geometry import periodic_bc, dirichlet_bc, neumann_bc\n"
-        "  bc = periodic_bc(dimension=1)\n"
-        "This module will be removed in v1.0.0.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
+from mfgarchon.utils.deprecation import deprecated
 
 
 @dataclass
@@ -178,46 +166,62 @@ class BoundaryConditions:
 
 
 # Convenience functions for common boundary condition types
+@deprecated(
+    since="v0.14.0",
+    replacement="Use from mfgarchon.geometry import periodic_bc; bc = periodic_bc(dimension=1).",
+)
 def periodic_bc() -> BoundaryConditions:
     """Create periodic boundary conditions.
 
     .. deprecated:: 0.14.0
         Use ``from mfgarchon.geometry import periodic_bc; bc = periodic_bc(dimension=1)``
     """
-    _emit_deprecation_warning("periodic_bc")
     return BoundaryConditions(type="periodic")
 
 
+@deprecated(
+    since="v0.14.0",
+    replacement="Use from mfgarchon.geometry import dirichlet_bc; bc = dirichlet_bc(value=..., dimension=1).",
+)
 def dirichlet_bc(left_value: float, right_value: float) -> BoundaryConditions:
     """Create Dirichlet boundary conditions.
 
     .. deprecated:: 0.14.0
         Use ``from mfgarchon.geometry import dirichlet_bc; bc = dirichlet_bc(value=..., dimension=1)``
     """
-    _emit_deprecation_warning("dirichlet_bc")
     return BoundaryConditions(type="dirichlet", left_value=left_value, right_value=right_value)
 
 
+@deprecated(
+    since="v0.14.0",
+    replacement="Use from mfgarchon.geometry import neumann_bc; bc = neumann_bc(value=..., dimension=1).",
+)
 def neumann_bc(left_gradient: float, right_gradient: float) -> BoundaryConditions:
     """Create Neumann boundary conditions.
 
     .. deprecated:: 0.14.0
         Use ``from mfgarchon.geometry import neumann_bc; bc = neumann_bc(value=..., dimension=1)``
     """
-    _emit_deprecation_warning("neumann_bc")
     return BoundaryConditions(type="neumann", left_value=left_gradient, right_value=right_gradient)
 
 
+@deprecated(
+    since="v0.14.0",
+    replacement="Use from mfgarchon.geometry import no_flux_bc; bc = no_flux_bc(dimension=1).",
+)
 def no_flux_bc() -> BoundaryConditions:
     """Create no-flux boundary conditions.
 
     .. deprecated:: 0.14.0
         Use ``from mfgarchon.geometry import no_flux_bc; bc = no_flux_bc(dimension=1)``
     """
-    _emit_deprecation_warning("no_flux_bc")
     return BoundaryConditions(type="no_flux")
 
 
+@deprecated(
+    since="v0.14.0",
+    replacement="Use from mfgarchon.geometry import robin_bc; bc = robin_bc(alpha=..., beta=..., dimension=1).",
+)
 def robin_bc(
     left_alpha: float,
     left_beta: float,
@@ -231,7 +235,6 @@ def robin_bc(
     .. deprecated:: 0.14.0
         Use ``from mfgarchon.geometry import robin_bc; bc = robin_bc(alpha=..., beta=..., dimension=1)``
     """
-    _emit_deprecation_warning("robin_bc")
     return BoundaryConditions(
         type="robin",
         left_alpha=left_alpha,

--- a/mfgarchon/geometry/boundary/providers.py
+++ b/mfgarchon/geometry/boundary/providers.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypedDict, runtime_ch
 import numpy as np
 
 from mfgarchon.geometry.boundary.bc_coupling import compute_boundary_log_density_gradient_1d
+from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -247,6 +248,11 @@ class AdjointConsistentProvider(BaseBCValueProvider):
         "back": "z_max",
     }
 
+    @deprecated_parameter(
+        param_name="sigma",
+        since="v0.17.0",
+        replacement="diffusion",
+    )
     def __init__(
         self,
         side: str,
@@ -268,19 +274,12 @@ class AdjointConsistentProvider(BaseBCValueProvider):
                            to prevent log(0). Default 1e-10.
             sigma: DEPRECATED. Use diffusion instead.
         """
-        import warnings
-
         if side not in self._SIDE_ALIASES:
             valid = sorted(self._SIDE_ALIASES.keys())
             raise ValueError(f"side must be one of {valid}, got '{side}'")
 
         # Handle sigma as legacy alias (deprecated)
         if sigma is not None:
-            warnings.warn(
-                "Parameter 'sigma' is deprecated. Use 'diffusion' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if diffusion is None:
                 diffusion = sigma
 

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -39,6 +39,7 @@ from mfgarchon.geometry.protocols import (
     SupportsPeriodic,
     SupportsRegionMarking,
 )
+from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -120,6 +121,16 @@ class TensorProductGrid(
         ... )
     """
 
+    @deprecated_parameter(
+        param_name="num_points",
+        since="v0.17.0",
+        replacement="Nx_points",
+    )
+    @deprecated_parameter(
+        param_name="dimension",
+        since="v0.17.0",
+        replacement="len(bounds) (dimension is inferred from bounds)",
+    )
     def __init__(
         self,
         bounds: Sequence[tuple[float, float]],
@@ -183,16 +194,8 @@ class TensorProductGrid(
                     f"dimension={dimension} doesn't match len(bounds)={inferred_dimension}. "
                     f"Dimension is inferred from bounds; remove explicit dimension parameter."
                 )
-            # Issue #674: Fail Fast - warn on redundant parameter
-            import warnings
-
-            warnings.warn(
-                f"dimension={dimension} is redundant when bounds is provided. "
-                f"Dimension is inferred from len(bounds). "
-                f"Remove the dimension= parameter. Will error in v1.0.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            # Issue #674: dimension is deprecated, inferred from bounds
+            # Warning already emitted by @deprecated_parameter decorator
         dimension = inferred_dimension
 
         if dimension < 1:
@@ -212,13 +215,7 @@ class TensorProductGrid(
             Nx_points = [Nx_points]
 
         if num_points is not None:
-            import warnings
-
-            warnings.warn(
-                "num_points is deprecated, use Nx_points instead. Will be removed in v1.0.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            # Warning already emitted by @deprecated_parameter decorator
             Nx_points = num_points
 
         # Convert to internal storage (always store as points)
@@ -328,15 +325,12 @@ class TensorProductGrid(
         return self._Nx_points.copy()
 
     @property
+    @deprecated(
+        since="v0.17.0",
+        replacement="Use Nx_points instead.",
+    )
     def num_points(self) -> list[int]:
         """Deprecated: Use Nx_points instead. Number of grid points along each dimension."""
-        import warnings
-
-        warnings.warn(
-            "num_points is deprecated, use Nx_points instead. Will be removed in v1.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self._Nx_points.copy()
 
     def get_spatial_grid(self) -> NDArray:

--- a/mfgarchon/geometry/implicit/hyperrectangle.py
+++ b/mfgarchon/geometry/implicit/hyperrectangle.py
@@ -22,10 +22,11 @@ References:
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
+
+from mfgarchon.utils.deprecation import deprecated
 
 from .implicit_domain import ImplicitDomain
 
@@ -287,6 +288,10 @@ class Hyperrectangle(ImplicitDomain):
 
         return particles
 
+    @deprecated(
+        since="v0.12.0",
+        replacement="Use MeshfreeApplicator from mfgarchon.geometry.boundary instead.",
+    )
     def apply_boundary_conditions(
         self,
         particles: NDArray[np.float64],
@@ -319,15 +324,6 @@ class Hyperrectangle(ImplicitDomain):
             >>> applicator = MeshfreeApplicator(domain)
             >>> particles_reflected = applicator.apply_particle_bc(particles, "reflecting")
         """
-        warnings.warn(
-            "Hyperrectangle.apply_boundary_conditions() is deprecated. "
-            "Use MeshfreeApplicator from mfgarchon.geometry.boundary instead:\n"
-            "  from mfgarchon.geometry.boundary import MeshfreeApplicator\n"
-            "  applicator = MeshfreeApplicator(domain)\n"
-            "  particles_updated = applicator.apply_particle_bc(particles, bc_type)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         particles = particles.copy()
 
         if bc_type == "reflecting":

--- a/mfgarchon/geometry/implicit/implicit_domain.py
+++ b/mfgarchon/geometry/implicit/implicit_domain.py
@@ -17,7 +17,6 @@ References:
 - TECHNICAL_REFERENCE_HIGH_DIMENSIONAL_MFG.md Section 4
 """
 
-import warnings
 from abc import abstractmethod
 from collections.abc import Callable
 from typing import Literal
@@ -35,6 +34,7 @@ from mfgarchon.geometry.protocols import (
     SupportsManifold,
 )
 from mfgarchon.geometry.traits import BoundaryDef, ConnectivityType, StructureType
+from mfgarchon.utils.deprecation import deprecated
 from mfgarchon.utils.mfg_logging import get_logger
 
 # Module logger
@@ -257,6 +257,10 @@ class ImplicitDomain(
         else:
             raise ValueError(f"Unknown projection method: {method}")
 
+    @deprecated(
+        since="v0.12.0",
+        replacement="Use MeshfreeApplicator from mfgarchon.geometry.boundary instead.",
+    )
     def apply_boundary_conditions(
         self,
         particles: NDArray[np.float64],
@@ -289,15 +293,6 @@ class ImplicitDomain(
             >>> applicator = MeshfreeApplicator(domain)
             >>> particles_updated = applicator.apply_particle_bc(particles, "reflecting")
         """
-        warnings.warn(
-            "ImplicitDomain.apply_boundary_conditions() is deprecated. "
-            "Use MeshfreeApplicator from mfgarchon.geometry.boundary instead:\n"
-            "  from mfgarchon.geometry.boundary import MeshfreeApplicator\n"
-            "  applicator = MeshfreeApplicator(domain)\n"
-            "  particles_updated = applicator.apply_particle_bc(particles, bc_type)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if bc_type == "reflecting":
             return self.project_to_domain(particles, method="simple")
 

--- a/mfgarchon/meta/mathematical_dsl.py
+++ b/mfgarchon/meta/mathematical_dsl.py
@@ -10,11 +10,12 @@ manipulated, optimized, and compiled to different backends (NumPy, JAX, Numba).
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -197,6 +198,8 @@ class MFGSystemBuilder:
         self.parameters[name] = value
         return self
 
+    @deprecated_parameter(param_name="nx", since="v0.17.0", replacement="Nx")
+    @deprecated_parameter(param_name="nt", since="v0.17.0", replacement="Nt")
     def domain(
         self,
         xmin: float,
@@ -223,24 +226,12 @@ class MFGSystemBuilder:
         Returns:
             Self for method chaining
         """
-        # Handle deprecated lowercase parameters
-        if nx is not None:
-            warnings.warn(
-                "Parameter 'nx' is deprecated, use 'Nx' (uppercase) instead. Will be removed in v1.0.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if Nx is None:
-                Nx = nx
+        # Handle deprecated lowercase parameters (redirect to new names)
+        if nx is not None and Nx is None:
+            Nx = nx
 
-        if nt is not None:
-            warnings.warn(
-                "Parameter 'nt' is deprecated, use 'Nt' (uppercase) instead. Will be removed in v1.0.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if Nt is None:
-                Nt = nt
+        if nt is not None and Nt is None:
+            Nt = nt
 
         # Set defaults if not provided
         if Nx is None:

--- a/mfgarchon/utils/acceleration/__init__.py
+++ b/mfgarchon/utils/acceleration/__init__.py
@@ -16,8 +16,6 @@ This replaces the old mfgarchon/accelerated/ directory with better organization.
 
 from __future__ import annotations
 
-import warnings
-
 from mfgarchon.utils.mfg_logging import get_logger
 
 logger = get_logger(__name__)
@@ -122,16 +120,6 @@ def get_acceleration_info():
             logger.debug(f"Could not retrieve PyTorch detailed info: {e}")
 
     return info
-
-
-# Backward compatibility warning for old imports
-def _warn_deprecated_import():
-    """Warn about deprecated import paths."""
-    warnings.warn(
-        "Importing from mfgarchon.accelerated is deprecated. Use mfgarchon.utils.acceleration instead. Will be removed in v1.0.0.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
 
 
 __all__ = [

--- a/mfgarchon/utils/convergence/__init__.py
+++ b/mfgarchon/utils/convergence/__init__.py
@@ -44,8 +44,6 @@ Usage:
 
 from __future__ import annotations
 
-import warnings
-
 # =============================================================================
 # CONVERGENCE CHECKERS (convergence_checkers.py)
 # =============================================================================
@@ -98,20 +96,6 @@ from .convergence_monitors import (
     test_particle_detection,
     wrap_solver_with_adaptive_convergence,
 )
-
-# =============================================================================
-# DEPRECATION HELPERS
-# =============================================================================
-
-
-def _warn_deprecated(old_name: str, new_name: str) -> None:
-    """Issue deprecation warning for renamed classes."""
-    warnings.warn(
-        f"{old_name} is deprecated and will be removed in v1.0.0. Use {new_name} instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
 
 # =============================================================================
 # PUBLIC API

--- a/mfgarchon/utils/convergence/convergence_metrics.py
+++ b/mfgarchon/utils/convergence/convergence_metrics.py
@@ -16,12 +16,13 @@ or any iterative PDE solver.
 
 from __future__ import annotations
 
-import warnings as _warnings
 from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import numpy as np
+
+from mfgarchon.utils.deprecation import deprecated, deprecated_alias
 
 # =============================================================================
 # DISTRIBUTION COMPARISON UTILITIES
@@ -735,23 +736,12 @@ def create_moment_monitor(
 # =============================================================================
 
 
-class StochasticConvergenceMonitor(RollingConvergenceMonitor):
-    """
-    Deprecated alias for RollingConvergenceMonitor.
-
-    .. deprecated:: 0.17.0
-        Use :class:`RollingConvergenceMonitor` instead.
-    """
-
-    def __init__(self, *args, **kwargs):
-        _warnings.warn(
-            "StochasticConvergenceMonitor is deprecated since v0.17.0. Use RollingConvergenceMonitor instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)
+StochasticConvergenceMonitor = deprecated_alias(
+    "StochasticConvergenceMonitor", RollingConvergenceMonitor, since="v0.17.0"
+)
 
 
+@deprecated(since="v0.17.0", replacement="Use create_rolling_monitor() instead.")
 def create_stochastic_monitor(*args, **kwargs) -> RollingConvergenceMonitor:
     """
     Deprecated alias for create_rolling_monitor.
@@ -759,9 +749,4 @@ def create_stochastic_monitor(*args, **kwargs) -> RollingConvergenceMonitor:
     .. deprecated:: 0.17.0
         Use :func:`create_rolling_monitor` instead.
     """
-    _warnings.warn(
-        "create_stochastic_monitor is deprecated since v0.17.0. Use create_rolling_monitor instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return create_rolling_monitor(*args, **kwargs)

--- a/mfgarchon/utils/convergence/convergence_monitors.py
+++ b/mfgarchon/utils/convergence/convergence_monitors.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated, deprecated_alias
 from mfgarchon.utils.mfg_logging import get_logger
 
 from .convergence_metrics import DistributionComparator
@@ -779,39 +780,11 @@ def test_particle_detection(solver: MFGSolver) -> dict[str, Any]:
 # =============================================================================
 
 
-class OscillationDetector(_ErrorHistoryTracker):
-    """
-    Deprecated alias for _ErrorHistoryTracker.
+OscillationDetector = deprecated_alias("OscillationDetector", _ErrorHistoryTracker, since="v0.17.0")
 
-    .. deprecated:: 0.17.0
-        Use :class:`_ErrorHistoryTracker` instead (or use external code
-        for oscillation detection).
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "OscillationDetector is deprecated since v0.17.0. Use _ErrorHistoryTracker instead (internal class).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)
-
-
-class AdvancedConvergenceMonitor(DistributionConvergenceMonitor):
-    """
-    Deprecated alias for DistributionConvergenceMonitor.
-
-    .. deprecated:: 0.17.0
-        Use :class:`DistributionConvergenceMonitor` instead.
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "AdvancedConvergenceMonitor is deprecated since v0.17.0. Use DistributionConvergenceMonitor instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)
+AdvancedConvergenceMonitor = deprecated_alias(
+    "AdvancedConvergenceMonitor", DistributionConvergenceMonitor, since="v0.17.0"
+)
 
 
 class ParticleMethodDetector(SolverTypeDetector):
@@ -820,34 +793,16 @@ class ParticleMethodDetector(SolverTypeDetector):
 
     .. deprecated:: 0.17.0
         Use :class:`SolverTypeDetector` instead.
+
+    Note: Kept as class (not deprecated_alias) to preserve static method access
+    (e.g., ParticleMethodDetector.detect_particle_methods).
     """
 
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "ParticleMethodDetector is deprecated since v0.17.0. Use SolverTypeDetector instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)
+
+AdaptiveConvergenceWrapper = deprecated_alias("AdaptiveConvergenceWrapper", ConvergenceWrapper, since="v0.17.0")
 
 
-class AdaptiveConvergenceWrapper(ConvergenceWrapper):
-    """
-    Deprecated alias for ConvergenceWrapper.
-
-    .. deprecated:: 0.17.0
-        Use :class:`ConvergenceWrapper` instead.
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "AdaptiveConvergenceWrapper is deprecated since v0.17.0. Use ConvergenceWrapper instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)
-
-
+@deprecated(since="v0.17.0", replacement="Use create_distribution_monitor() instead.")
 def create_default_monitor(*args, **kwargs) -> DistributionConvergenceMonitor:
     """
     Deprecated alias for create_distribution_monitor.
@@ -855,9 +810,4 @@ def create_default_monitor(*args, **kwargs) -> DistributionConvergenceMonitor:
     .. deprecated:: 0.17.0
         Use :func:`create_distribution_monitor` instead.
     """
-    warnings.warn(
-        "create_default_monitor is deprecated since v0.17.0. Use create_distribution_monitor instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return create_distribution_monitor(*args, **kwargs)

--- a/mfgarchon/utils/deprecation.py
+++ b/mfgarchon/utils/deprecation.py
@@ -195,6 +195,90 @@ def deprecated_parameter(
     return decorator
 
 
+def deprecated_value(
+    param_name: str,
+    deprecated_values: dict[Any, Any],
+    since: str,
+    removal: str = "v1.0.0",
+) -> Callable[[F], F]:
+    """
+    Mark specific parameter values as deprecated, with automatic remapping.
+
+    Use this when a parameter still exists but certain values have been renamed
+    or replaced. The decorator automatically remaps deprecated values to their
+    replacements and issues a warning.
+
+    Args:
+        param_name: Name of the parameter whose values are deprecated
+        deprecated_values: Mapping of {old_value: new_value}. When old_value is
+            passed, it is silently replaced with new_value after warning.
+        since: Version when deprecation started (e.g., "v0.17.0")
+        removal: Version when deprecated values will stop working
+
+    Example:
+        >>> @deprecated_value(
+        ...     param_name="qp_optimization_level",
+        ...     deprecated_values={"smart": "auto", "tuned": "auto", "basic": "auto"},
+        ...     since="v0.17.0",
+        ... )
+        ... def __init__(self, qp_optimization_level="auto"):
+        ...     # qp_optimization_level is already remapped when we get here
+        ...     self.level = qp_optimization_level
+
+    Note:
+        Unlike @deprecated_parameter (which detects deprecated parameter *names*),
+        this detects deprecated parameter *values*. The function body receives the
+        remapped value directly -- no manual redirect logic needed.
+    """
+
+    def decorator(func: F) -> F:
+        # Store value deprecation metadata
+        if getattr(func, "_deprecated_values", None) is None:
+            func._deprecated_values = []  # type: ignore[attr-defined]
+
+        func._deprecated_values.append(  # type: ignore[attr-defined]
+            {
+                "param": param_name,
+                "values": deprecated_values,
+                "since": since,
+                "removal": removal,
+            }
+        )
+
+        sig = inspect.signature(func)
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+
+                if param_name in bound.arguments:
+                    value = bound.arguments[param_name]
+                    if value in deprecated_values:
+                        new_value = deprecated_values[value]
+                        warnings.warn(
+                            f"Value '{value}' for parameter '{param_name}' in "
+                            f"'{func.__qualname__}' is deprecated since {since}. "
+                            f"Use '{new_value}' instead. "
+                            f"Will be removed in {removal}.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
+                        bound.arguments[param_name] = new_value
+                        return func(*bound.args, **bound.kwargs)
+            except TypeError:
+                pass
+
+            return func(*args, **kwargs)
+
+        wrapper._deprecated_values = func._deprecated_values  # type: ignore[attr-defined]
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
 def get_deprecation_metadata(obj: Any) -> dict[str, Any] | None:
     """
     Get deprecation metadata from a decorated object.
@@ -470,11 +554,16 @@ def validate_kwargs(
 
 def _scan_object(obj: Any, name: str, module_name: str, results: list[dict[str, Any]]) -> None:
     """Scan a single object for deprecation metadata."""
+    # For property descriptors, check the underlying fget function
+    is_property = isinstance(obj, property)
+    if is_property and obj.fget is not None:
+        obj = obj.fget
+
     meta = getattr(obj, "_deprecation_meta", None)
     if meta is not None:
         results.append(
             {
-                "type": "function" if callable(obj) else "alias",
+                "type": "property" if is_property else ("function" if callable(obj) else "alias"),
                 "name": meta.get("symbol", name),
                 "module": module_name,
                 "since": meta.get("since", ""),
@@ -497,13 +586,29 @@ def _scan_object(obj: Any, name: str, module_name: str, results: list[dict[str, 
                 }
             )
 
+    dep_values = getattr(obj, "_deprecated_values", None)
+    if dep_values:
+        for v in dep_values:
+            old_vals = ", ".join(str(k) for k in v["values"])
+            new_vals = ", ".join(str(val) for val in v["values"].values())
+            results.append(
+                {
+                    "type": "value",
+                    "name": f"{name}.{v['param']}",
+                    "module": module_name,
+                    "since": v.get("since", ""),
+                    "replacement": f"values [{old_vals}] -> [{new_vals}]",
+                    "removal": v.get("removal", "v1.0.0"),
+                }
+            )
+
 
 def scan_deprecated(module: Any, *, recursive: bool = True) -> list[dict[str, Any]]:
     """
     Scan a module tree for all decorated deprecated items.
 
     Returns a list of metadata dicts for every `@deprecated`, `@deprecated_parameter`,
-    and `deprecated_alias` found in the module and its submodules.
+    `@deprecated_value`, and `deprecated_alias` found in the module and its submodules.
 
     Args:
         module: Top-level module to scan (e.g., `import mfgarchon; scan_deprecated(mfgarchon)`)
@@ -636,6 +741,7 @@ def audit_all_deprecations(
 __all__ = [
     "deprecated",
     "deprecated_parameter",
+    "deprecated_value",
     "deprecated_alias",
     "get_deprecation_metadata",
     "get_deprecated_parameters",

--- a/mfgarchon/utils/numerical/_compat/gfdm_operators.py
+++ b/mfgarchon/utils/numerical/_compat/gfdm_operators.py
@@ -71,10 +71,11 @@ Updated: 2025-12-03 (Added GFDMOperator class)
 from __future__ import annotations
 
 import math
-import warnings
 
 import numpy as np
 from scipy.spatial import cKDTree
+
+from mfgarchon.utils.deprecation import deprecated
 
 # =============================================================================
 # GFDMOperator Class - Primary Interface
@@ -137,6 +138,11 @@ class GFDMOperator:
         >>> lap = gfdm.laplacian(u)      # Shape: (100,), ≈ 4.0
     """
 
+    @deprecated(
+        since="v0.17.0",
+        replacement="Use TaylorOperator from gfdm_strategies instead: "
+        "from mfgarchon.utils.numerical.gfdm_strategies import TaylorOperator",
+    )
     def __init__(
         self,
         points: np.ndarray,
@@ -168,14 +174,6 @@ class GFDMOperator:
                 - "knn": Use exactly k nearest neighbors
                 - "hybrid": Use delta, but ensure at least k neighbors (default, most robust)
         """
-        warnings.warn(
-            "GFDMOperator is deprecated since v0.17.0 and will be removed in v1.0.0. "
-            "Use TaylorOperator from gfdm_strategies instead:\n"
-            "  from mfgarchon.utils.numerical.gfdm_strategies import TaylorOperator\n"
-            "  op = TaylorOperator(points, delta=0.1, taylor_order=2)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self.points = np.asarray(points)
         self.n_points, self.dimension = self.points.shape
         self.delta = delta

--- a/mfgarchon/utils/performance/optimization.py
+++ b/mfgarchon/utils/performance/optimization.py
@@ -19,6 +19,8 @@ import numpy as np
 from scipy.sparse import csc_matrix, csr_matrix, lil_matrix
 from scipy.sparse import linalg as sp_linalg
 
+from mfgarchon.utils.deprecation import deprecated_parameter
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -143,6 +145,9 @@ class SparseMatrixOptimizer:
     """Sparse matrix operations optimized for MFG problems."""
 
     @staticmethod
+    @deprecated_parameter(param_name="nx", since="v0.17.0", replacement="Nx")
+    @deprecated_parameter(param_name="ny", since="v0.17.0", replacement="Ny")
+    @deprecated_parameter(param_name="nz", since="v0.17.0", replacement="Nz")
     def create_laplacian_3d(
         Nx: int | None = None,
         Ny: int | None = None,
@@ -174,29 +179,14 @@ class SparseMatrixOptimizer:
         """
         # Handle deprecated lowercase parameters
         if nx is not None:
-            warnings.warn(
-                "Parameter 'nx' is deprecated, use 'Nx' (uppercase) instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if Nx is None:
                 Nx = nx
 
         if ny is not None:
-            warnings.warn(
-                "Parameter 'ny' is deprecated, use 'Ny' (uppercase) instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if Ny is None:
                 Ny = ny
 
         if nz is not None:
-            warnings.warn(
-                "Parameter 'nz' is deprecated, use 'Nz' (uppercase) instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             if Nz is None:
                 Nz = nz
 

--- a/mfgarchon/utils/solver_decorators.py
+++ b/mfgarchon/utils/solver_decorators.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import functools
 from enum import Flag, auto
 
+from mfgarchon.utils.deprecation import deprecated_parameter
+
 from .progress import IterationProgress, SolverTimer, time_solver_operation
 
 
@@ -156,6 +158,13 @@ def with_progress_monitoring(
     return decorator
 
 
+@deprecated_parameter(
+    param_name="monitor_convergence", since="v0.17.0", replacement="options=SolverMonitoringOptions.CONVERGENCE"
+)
+@deprecated_parameter(
+    param_name="auto_progress", since="v0.17.0", replacement="options=SolverMonitoringOptions.PROGRESS"
+)
+@deprecated_parameter(param_name="timing", since="v0.17.0", replacement="options=SolverMonitoringOptions.TIMING")
 def enhanced_solver_method(
     options: SolverMonitoringOptions | None = None,
     *,
@@ -188,18 +197,8 @@ def enhanced_solver_method(
         ... def solve(self):
         ...     ...
     """
-    # Handle backward compatibility
+    # Handle backward compatibility -- convert old API to new
     if monitor_convergence is not None or auto_progress is not None or timing is not None:
-        import warnings
-
-        warnings.warn(
-            "Parameters 'monitor_convergence', 'auto_progress', and 'timing' are deprecated. "
-            "Use 'options' parameter instead: SolverMonitoringOptions.CONVERGENCE, .PROGRESS, .TIMING, or .ALL",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        # Convert old API to new
         flags = SolverMonitoringOptions.NONE
         if monitor_convergence:
             flags |= SolverMonitoringOptions.CONVERGENCE

--- a/tests/unit/test_utils/test_solver_decorators.py
+++ b/tests/unit/test_utils/test_solver_decorators.py
@@ -141,9 +141,10 @@ class TestSolverMonitoringOptions:
             def solve(self, max_iterations=10, verbose=False, **kwargs):
                 return {"converged": True}
 
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "deprecated" in str(w[0].message).lower()
+            # Each deprecated parameter triggers its own warning
+            assert len(w) >= 1
+            assert all(issubclass(warning.category, DeprecationWarning) for warning in w)
+            assert any("deprecated" in str(warning.message).lower() for warning in w)
 
 
 class TestWithProgressMonitoring:


### PR DESCRIPTION
## Summary

Closes #841.

- Migrate 111 raw `warnings.warn(..., DeprecationWarning)` calls to structured `@deprecated`, `@deprecated_parameter`, `@deprecated_value`, and `deprecated_alias` decorators across 42 files
- Add `@deprecated_value` decorator for parameter value deprecations (e.g., `qp_optimization_level="smart"` -> `"auto"`)
- Enhance `_scan_object` to detect deprecated properties via `property.fget` unwrapping
- Net -350 lines (575 added, 925 removed)

### Before/After

| Metric | Before | After |
|--------|--------|-------|
| Raw `warnings.warn(..., DeprecationWarning)` | 135 | 24 |
| `scan_deprecated()` trackable items | ~18 | 153 |

### Remaining 24 raw sites (intentionally kept)

These are structurally incompatible with decorators:
- Module-level `__getattr__` type alias deprecations (3)
- Infrastructure code (`parameter_migration.py`) (1)
- Value deprecation without remapping (4)
- `return_tuple` with `False` default -- decorator triggers on `False` (2)
- Runtime conditional deprecations (4)
- Dataclass field deprecations (3)
- Compatibility shims / runtime detection (4)
- Non-deprecation warning (1)

### New deprecation module features

- `@deprecated_value(param_name, deprecated_values, since)` -- for value renames
- Scanner detects `@property` + `@deprecated` combinations
- Scanner reports `"property"` and `"value"` types

## Test plan

- [x] 3873 unit tests pass (0 failures introduced)
- [x] `scan_deprecated()` audit shows 153 trackable items
- [x] Pre-commit hooks pass (ruff format + lint)
- [x] FPSLAdjointSolver preserved as subclass (not deprecated_alias) to maintain `_scheme_family` trait inheritance for duality validation
- [ ] Integration tests (2 pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)