### PR TITLE
feat: Add Jupyter Book v2 (MyST) docs configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,27 @@
 # MFGArchon Documentation
 
 **Version**: v0.17.16
-**Status**: User-facing documentation (future book source)
 
-## Structure
+Production-ready infrastructure for Mean Field Games research and applications.
 
-### User Documentation (`user/`)
-Tutorials, guides, API usage patterns, migration guides.
+## What is MFGArchon?
 
-## Internal Development Notes
+MFGArchon provides solvers, geometry primitives, boundary condition frameworks, and workflow tools for solving Mean Field Game systems. It supports:
 
-Architecture design, roadmaps, issue analysis, and mathematical theory notes
-are maintained in the private `mfg-research` repository under
-`docs/archon-notes/`. This separation keeps the public repo focused on
-user-facing content.
+- **HJB solvers**: FDM, GFDM, WENO, Semi-Lagrangian
+- **FP solvers**: FDM, GFDM, Particle, Semi-Lagrangian
+- **Coupling**: Fixed-point iteration, Newton, fictitious play
+- **Geometry**: Tensor product grids, implicit (SDF) domains, meshfree
+- **Boundary conditions**: Dirichlet, Neumann, Robin, periodic, no-flux, mixed
 
-## Future: Jupyter Book
+## Building the docs
 
-This directory will be restructured as a Jupyter Book source for
-GitHub Pages deployment. See issue tracking for progress.
+```bash
+cd docs/
+jupyter-book start .     # Local dev server with hot reload
+jupyter-book build .     # Static HTML build
+```
+
+## Internal development notes
+
+Architecture design, roadmaps, and issue analysis are in the private `mfg-research` repository under `docs/archon-notes/`.

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -1,0 +1,74 @@
+version: 1
+
+project:
+  title: MFGArchon Documentation
+  description: Production-ready infrastructure for Mean Field Games research
+  keywords:
+    - mean field games
+    - numerical methods
+    - PDE solvers
+    - optimal control
+  github: https://github.com/derrring/MFGArchon
+  license:
+    code: MIT
+
+  toc:
+    - file: user/README.md
+      title: Introduction
+
+    - title: Getting Started
+      children:
+        - file: user/quickstart.md
+        - file: user/core_objects.md
+        - file: user/configuration_system.md
+        - file: user/usage_patterns.md
+        - file: user/migration.md
+
+    - title: Solver Guides
+      children:
+        - file: user/SOLVER_SELECTION_GUIDE.md
+        - file: user/HJB_SOLVER_SELECTION_GUIDE.md
+        - file: user/stochastic_mfg_guide.md
+        - file: user/multidimensional_mfg_guide.md
+        - file: user/traffic_flow_control_mfg.md
+
+    - title: Geometry & Boundaries
+      children:
+        - file: user/GEOMETRY_FIRST_API_GUIDE.md
+        - file: user/geometry_traits.md
+        - file: user/dual_geometry_usage.md
+        - file: user/sdf_utilities.md
+        - file: user/guides/boundary_conditions.md
+        - file: user/advanced_boundary_conditions.md
+        - file: user/obstacle_problems.md
+        - file: user/continuous_environments_guide.md
+
+    - title: Tutorials
+      children:
+        - file: user/level_set_tutorial.md
+        - file: user/tutorial_network_mfg.md
+        - file: user/guides/maze_generation.md
+        - file: user/guides/multi_population_quick_start.md
+        - file: user/particle_interpolation.md
+        - file: user/fem_mesh_projection_guide.md
+
+    - title: Advanced Topics
+      children:
+        - file: user/guides/backend_usage.md
+        - file: user/guides/hooks.md
+        - file: user/advanced_hooks.md
+        - file: user/guides/plugin_development.md
+        - file: user/guides/phase2_features.md
+        - file: user/notebook_execution_guide.md
+
+    - title: Reference
+      children:
+        - file: user/three_mode_api_migration_guide.md
+        - file: user/DEPRECATION_MODERNIZATION_GUIDE.md
+        - file: user/LEGACY_PARAMETERS.md
+
+site:
+  title: MFGArchon
+  options:
+    favicon: ""
+    logo: ""


### PR DESCRIPTION
## Summary
- Add `docs/myst.yml` — Jupyter Book v2 (MyST) config with table of contents
- 34 user docs organized into 6 sections: Getting Started, Solver Guides, Geometry & Boundaries, Tutorials, Advanced Topics, Reference
- Update `docs/README.md` as book landing page with build instructions

## Usage
```bash
cd docs/
jupyter-book start .     # Dev server with hot reload
jupyter-book build .     # Static build
```

## Notes
- All 34 docs build successfully (tested with `jupyter-book start`)
- JB v2 uses MyST engine, not Sphinx
- `docs/_build/` already in .gitignore
- GitHub Pages deployment not yet configured (separate PR)

## Test plan
- [x] `jupyter-book start .` builds all 34 docs without errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)