### PR TITLE
chore: Add DeprecationWarning on legacy MFGProblem path

### DIFF
--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -476,6 +476,16 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             self._v1_conditions = None
             self._v1_constraints = None
 
+            # Issue #875: Deprecation warning for legacy API path
+            warnings.warn(
+                "Legacy MFGProblem(geometry=, components=, sigma=, T=, Nt=) is deprecated. "
+                "Use the v1.0 API: MFGProblem(model=Model(...), domain=grid, "
+                "conditions=Conditions(...), Nt=50). "
+                "Legacy support will be removed in v1.0.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Normalize parameter aliases
         if time_domain is not None:
             if T is not None or Nt is not None:


### PR DESCRIPTION
## Summary

- Legacy `MFGProblem(geometry=, components=, sigma=, T=, Nt=)` now emits `DeprecationWarning`
- Directs users to v1.0 API: `MFGProblem(model=, domain=, conditions=, Nt=)`
- v1.0 path does NOT warn
- Existing `pytest.ini` already suppresses `DeprecationWarning` from mfgarchon — no test impact

## Test plan

- [x] Legacy path fires exactly 1 deprecation warning
- [x] v1.0 path fires 0 warnings
- [x] Tests unaffected (pytest.ini filterwarnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)