### PR TITLE
fix: Network solver bugs — upwind rates, multi-pop geometry (#914, #915)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -181,7 +181,22 @@ class MultiPopulationIterator:
 
     @staticmethod
     def _compute_drift_field(U, M, H_class, problem):
-        """Compute synthetic U from H.optimal_control (same as FixedPointIterator)."""
+        """Compute drift field from H.optimal_control.
+
+        Dispatches on problem type:
+        - Network (spatial_dimension == 0): return U directly (FP network
+          solver handles drift extraction internally)
+        - Continuous: synthetic U whose differences reproduce alpha*
+        """
+        # Issue #915: dispatch on problem type
+        spatial_dim = getattr(problem, "spatial_dimension", None)
+        if spatial_dim == 0:
+            # Network problem: pass U directly.
+            # FPNetworkSolver computes flows from U differences.
+            # TODO (#913): FPNetworkSolver should use H.optimal_control()
+            return U
+
+        # Continuous problem: synthetic U approach (same as FixedPointIterator)
         geometry = problem.geometry
         grid_spacing = geometry.get_grid_spacing()
         dx = grid_spacing[0]

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -110,8 +110,10 @@ class NetworkHamiltonian(HamiltonianBase):
     def optimal_control(self, x, m, p, t=0.0):
         """Optimal transition rates from node x.
 
-        For quadratic H: alpha_{ij} = -w_ij * (p_j - p_i).
-        Returns array of rates to neighbors.
+        For quadratic H: alpha_{ij} = w_ij * (p_j - p_i)_+ (upwind).
+        Transition rates are non-negative by construction, ensuring
+        the generator Q preserves positivity of m.
+        Returns array of rates to neighbors (zero for non-neighbors).
         """
         node = int(np.asarray(x).flat[0])
         p_arr = np.atleast_1d(p)
@@ -120,7 +122,9 @@ class NetworkHamiltonian(HamiltonianBase):
         alpha = np.zeros_like(p_arr)
         for neighbor in neighbors:
             w = self.network_data.get_edge_weight(node, neighbor)
-            alpha[neighbor] = -self._sign * w * (p_arr[neighbor] - p_arr[node])
+            dp = p_arr[neighbor] - p_arr[node]
+            # Issue #914: upwind truncation ensures alpha >= 0
+            alpha[neighbor] = w * max(dp, 0.0)
         return alpha
 
     def dp(self, x, m, p, t=0.0):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.18.4"  # v0.18.4: ControlCostBase redesign (#898), non-quadratic drift fix (#896)
+version = "0.18.5"  # v0.18.5: LagrangianBase, multi-population, network solver fixes
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Summary

Fix two bugs found in theory ↔ implementation audit.

## Changes

### #914: NetworkHamiltonian.optimal_control() upwind truncation
- Added $(p_j - p_i)_+$ truncation to ensure non-negative transition rates
- Matches finite-state MFG theory: agents only transition toward higher-value nodes
- Ensures generator $Q_{ij} \geq 0$ for $i \neq j$, preserving FP positivity

### #915: MultiPopulationIterator network geometry dispatch
- `_compute_drift_field()` now checks `problem.spatial_dimension == 0`
- Network problems: pass U directly (no synthetic U, no grid spacing)
- Continuous problems: existing synthetic U approach unchanged

### Version bump to v0.18.5

## Test plan
- [x] 50 network tests pass (0 regressions)

Fixes #914, #915. #913 (FP network drift) noted as TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)