### PR TITLE
feature: Add regime-switching MFG iterator (#925)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
@@ -1,0 +1,296 @@
+"""
+Regime-switching MFG iterator with Markov chain coupling.
+
+Solves K coupled HJB-FP systems with inter-regime transition terms:
+
+  HJB_k: -dv^k/dt + H^k(x, m^k, Dv^k) + sum_{j!=k} Q[k,j](v^k - v^j) = 0
+  FP_k:  dm^k/dt - L^k[m^k] = sum_{j!=k} Q[j,k] m^j - Q[k,j] m^k
+
+Unlike MultiPopulationIterator (independent populations coupled through
+density in Hamiltonian), this handles OPERATOR-LEVEL coupling: each HJB
+reads other regimes' value functions, each FP has mass transfer terms.
+
+Issue #925: Part of Phase 2 (Generalized PDE & Institutional MFG Plan).
+
+Design constraints (from Dev Plan Rev 4):
+- Default Gauss-Seidel update (Constraint #3): uses updated v^j for j < k
+- Cross-terms injected via source_term parameter (#921)
+- FP source_term uses existing BaseFPSolver parameter (no FP changes needed)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+
+from mfgarchon.alg.base_solver import BaseMFGSolver
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+    from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+    from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.core.regime_switching import RegimeSwitchingConfig
+
+
+@dataclass
+class RegimeSwitchingResult:
+    """Result container for regime-switching MFG."""
+
+    values: list[NDArray]
+    """Value functions v^k for each regime, shape (Nt+1, Nx) each."""
+
+    densities: list[NDArray]
+    """Density fields m^k for each regime, shape (Nt+1, Nx) each."""
+
+    converged: bool
+    """Whether the Picard iteration converged."""
+
+    iterations: int
+    """Number of Picard iterations performed."""
+
+    error_history: list[float] = field(default_factory=list)
+    """Max error across all regimes per iteration."""
+
+    regime_config: RegimeSwitchingConfig | None = None
+    """The regime switching configuration used."""
+
+
+class RegimeSwitchingIterator(BaseMFGSolver):
+    """Picard iteration for Markov-switching MFG systems.
+
+    Solves K coupled HJB equations (backward) and K coupled FP equations
+    (forward) with inter-regime transition terms injected via source_term.
+
+    Differs from MultiPopulationIterator in coupling structure:
+    - Multi-population: K independent HJBs, coupled through m in Hamiltonian
+    - Regime switching: K HJBs with explicit cross-terms Q[k,j](v^k - v^j)
+                        K FPs with mass transfer Q[j,k]*m^j - Q[k,j]*m^k
+
+    Parameters
+    ----------
+    problems : list[MFGProblem]
+        One MFGProblem per regime. Each defines its own Hamiltonian, sigma, etc.
+    regime_config : RegimeSwitchingConfig
+        Transition rate matrix Q and regime metadata.
+    hjb_solvers : list[BaseHJBSolver]
+        One HJB solver per regime.
+    fp_solvers : list[BaseFPSolver]
+        One FP solver per regime.
+    max_iterations : int
+        Maximum Picard iterations (default 50).
+    tolerance : float
+        Convergence tolerance on max |v^k_{n+1} - v^k_n| (default 1e-5).
+    damping : float
+        Damping factor for Picard update (default 0.5).
+    update_scheme : Literal["jacobi", "gauss_seidel"]
+        Update order for regimes (default "gauss_seidel").
+        Gauss-Seidel uses already-updated v^j for j < k (faster convergence).
+        Jacobi uses all old values (parallelizable but slower).
+
+    Example
+    -------
+    >>> from mfgarchon.core.regime_switching import RegimeSwitchingConfig
+    >>> Q = np.array([[-0.1, 0.1], [0.2, -0.2]])
+    >>> config = RegimeSwitchingConfig(transition_matrix=Q)
+    >>> iterator = RegimeSwitchingIterator(
+    ...     problems=[problem_high, problem_low],
+    ...     regime_config=config,
+    ...     hjb_solvers=[hjb_high, hjb_low],
+    ...     fp_solvers=[fp_high, fp_low],
+    ... )
+    >>> result = iterator.solve()
+    """
+
+    def __init__(
+        self,
+        problems: list[MFGProblem],
+        regime_config: RegimeSwitchingConfig,
+        hjb_solvers: list[BaseHJBSolver],
+        fp_solvers: list[BaseFPSolver],
+        max_iterations: int = 50,
+        tolerance: float = 1e-5,
+        damping: float = 0.5,
+        update_scheme: Literal["jacobi", "gauss_seidel"] = "gauss_seidel",
+    ):
+        # Use first problem as representative for base class
+        super().__init__(problems[0])
+        self._problems = problems
+        self._regime = regime_config
+        self._hjb = hjb_solvers
+        self._fp = fp_solvers
+        self._max_iter = max_iterations
+        self._tol = tolerance
+        self._damping = damping
+        self._update_scheme = update_scheme
+
+        # Validate dimensions
+        K = regime_config.n_regimes
+        if len(problems) != K:
+            msg = f"Need {K} problems for {K} regimes, got {len(problems)}"
+            raise ValueError(msg)
+        if len(hjb_solvers) != K:
+            msg = f"Need {K} HJB solvers for {K} regimes, got {len(hjb_solvers)}"
+            raise ValueError(msg)
+        if len(fp_solvers) != K:
+            msg = f"Need {K} FP solvers for {K} regimes, got {len(fp_solvers)}"
+            raise ValueError(msg)
+
+        regime_config.validate()
+
+    def _make_hjb_source(
+        self,
+        k: int,
+        K: int,
+        Q: NDArray,
+        Us_full: list[NDArray],
+        Us_new: list[NDArray | None],
+    ) -> Callable:
+        """Build HJB source term for regime k with cross-coupling.
+
+        Captures current state via explicit arguments (not closures over
+        loop variables) to satisfy ruff B023.
+        """
+        update_scheme = self._update_scheme
+        dt_k = self._problems[k].dt
+        Nt_k = self._problems[k].Nt
+
+        def source(t: float, x: NDArray) -> NDArray:
+            s = np.zeros(x.shape[0])
+            n = min(round(t / dt_k), Nt_k) if dt_k > 0 else 0
+            for j in range(K):
+                if j != k:
+                    # Gauss-Seidel: use updated v^j if already solved
+                    if update_scheme == "gauss_seidel" and Us_new[j] is not None:
+                        u_j = Us_new[j]
+                    else:
+                        u_j = Us_full[j]
+                    u_k_n = Us_full[k][n] if n < Us_full[k].shape[0] else Us_full[k][-1]
+                    u_j_n = u_j[n] if n < u_j.shape[0] else u_j[-1]
+                    s += Q[k, j] * (u_k_n - u_j_n)
+            return s
+
+        return source
+
+    def _make_fp_source(
+        self,
+        k: int,
+        K: int,
+        Q: NDArray,
+        Ms: list[NDArray],
+    ) -> Callable:
+        """Build FP source term for regime k with mass transfer."""
+        dt_k = self._problems[k].dt
+        Nt_k = self._problems[k].Nt
+
+        def source(t: float, x: NDArray) -> NDArray:
+            n = min(round(t / dt_k), Nt_k) if dt_k > 0 else 0
+            s = np.zeros(x.shape[0])
+            for j in range(K):
+                if j != k:
+                    m_j = Ms[j] if Ms[j].ndim == 1 else (Ms[j][n] if n < Ms[j].shape[0] else Ms[j][-1])
+                    m_k = Ms[k] if Ms[k].ndim == 1 else (Ms[k][n] if n < Ms[k].shape[0] else Ms[k][-1])
+                    s += Q[j, k] * m_j  # inflow from j
+                    s -= Q[k, j] * m_k  # outflow to j
+            return s
+
+        return source
+
+    def solve(self) -> RegimeSwitchingResult:
+        """Run Picard iteration over K coupled regime systems.
+
+        Returns
+        -------
+        RegimeSwitchingResult
+            Contains value functions, densities, convergence info.
+        """
+        K = self._regime.n_regimes
+        Q = self._regime.transition_matrix
+
+        # Initialize: terminal conditions and initial densities
+        Us = [p.get_final_u() for p in self._problems]
+        # Expand terminal to full time-space arrays
+        Us_full = []
+        for k in range(K):
+            p = self._problems[k]
+            Nt = p.Nt
+            u_terminal = Us[k]
+            U_k = np.zeros((Nt + 1, len(u_terminal)))
+            U_k[-1] = u_terminal
+            Us_full.append(U_k)
+
+        Ms = [p.get_initial_density() for p in self._problems]
+
+        error_history = []
+
+        for iteration in range(self._max_iter):
+            Us_new = [None] * K
+            Ms_new = [None] * K
+
+            # --- HJB step: solve K backward equations with cross-terms ---
+            for k in range(K):
+                hjb_source = self._make_hjb_source(k, K, Q, Us_full, Us_new)
+
+                U_k = self._hjb[k].solve_hjb_system(
+                    Ms[k]
+                    if isinstance(Ms[k], np.ndarray) and Ms[k].ndim == 2
+                    else np.tile(Ms[k], (self._problems[k].Nt + 1, 1)),
+                    Us_full[k][-1],  # terminal condition
+                    Us_full[k],  # previous iterate
+                    source_term=hjb_source,
+                )
+                Us_new[k] = U_k
+
+            # --- FP step: solve K forward equations with mass transfer ---
+            for k in range(K):
+                fp_source = self._make_fp_source(k, K, Q, Ms)
+
+                m0_k = Ms[k][0] if Ms[k].ndim == 2 else Ms[k]
+                M_k = self._fp[k].solve_fp_system(
+                    m0_k,
+                    drift_field=Us_new[k],  # Use updated value function
+                    source_term=fp_source,
+                )
+                Ms_new[k] = M_k
+
+            # --- Damping ---
+            theta = self._damping
+            for k in range(K):
+                Us_new[k] = theta * Us_new[k] + (1 - theta) * Us_full[k]
+                if Ms_new[k] is not None and Ms[k].ndim == Ms_new[k].ndim:
+                    Ms_new[k] = theta * Ms_new[k] + (1 - theta) * Ms[k]
+
+            # --- Convergence check ---
+            error = max(np.max(np.abs(Us_new[k] - Us_full[k])) for k in range(K))
+            error_history.append(error)
+
+            Us_full = Us_new
+            Ms = Ms_new
+
+            if error < self._tol:
+                return RegimeSwitchingResult(
+                    values=Us_full,
+                    densities=Ms,
+                    converged=True,
+                    iterations=iteration + 1,
+                    error_history=error_history,
+                    regime_config=self._regime,
+                )
+
+        return RegimeSwitchingResult(
+            values=Us_full,
+            densities=Ms,
+            converged=False,
+            iterations=self._max_iter,
+            error_history=error_history,
+            regime_config=self._regime,
+        )
+
+    def validate_solution(self) -> dict[str, Any]:
+        """Placeholder for solution validation."""
+        return {}

--- a/mfgarchon/core/regime_switching.py
+++ b/mfgarchon/core/regime_switching.py
@@ -1,0 +1,160 @@
+"""
+Regime switching configuration for Markov-switching MFG.
+
+Defines the transition rate matrix Q for K regimes in a continuous-time
+Markov chain. Used by RegimeSwitchingIterator to solve coupled HJB-FP
+systems with inter-regime transition terms.
+
+Issue #925: Part of Phase 2 (Generalized PDE & Institutional MFG Plan).
+
+Mathematical background:
+    The regime process xi_t in {1, ..., K} has generator matrix Q:
+      Q[k,j] >= 0 for k != j  (transition rate from k to j)
+      Q[k,k] = -sum_{j!=k} Q[k,j]  (rows sum to zero)
+
+    In the MFG system, regime switching adds cross-terms:
+      HJB: lambda_{kj}(v^k - v^j) coupling between value functions
+      FP:  lambda_{jk} m^j - lambda_{kj} m^k mass transfer between populations
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+@dataclass
+class RegimeSwitchingConfig:
+    """Markov chain generator matrix for regime switching.
+
+    Parameters
+    ----------
+    transition_matrix : NDArray
+        K x K generator matrix Q where:
+        - Q[k,j] >= 0 for k != j (transition rate from regime k to regime j)
+        - Q[k,k] = -sum_{j!=k} Q[k,j] (each row sums to zero)
+    regime_names : list[str] | None
+        Optional descriptive names for regimes (e.g., ["high_protection", "low_protection"]).
+
+    Example
+    -------
+    Two-state regime switching (high/low property rights protection):
+
+    >>> Q = np.array([[-0.1, 0.1],   # high -> low at rate 0.1
+    ...               [0.2, -0.2]])   # low -> high at rate 0.2
+    >>> config = RegimeSwitchingConfig(
+    ...     transition_matrix=Q,
+    ...     regime_names=["high_protection", "low_protection"],
+    ... )
+    >>> config.validate()
+    >>> pi = config.stationary_distribution()  # [2/3, 1/3]
+    """
+
+    transition_matrix: NDArray
+    regime_names: list[str] | None = field(default=None)
+
+    @property
+    def n_regimes(self) -> int:
+        """Number of regimes K."""
+        return self.transition_matrix.shape[0]
+
+    def validate(self) -> None:
+        """Check that Q is a valid generator matrix.
+
+        Raises
+        ------
+        ValueError
+            If Q is not square, has negative off-diagonal entries,
+            or rows don't sum to zero.
+        """
+        Q = self.transition_matrix
+        K = Q.shape[0]
+
+        if Q.shape != (K, K):
+            msg = f"Transition matrix must be square, got shape {Q.shape}"
+            raise ValueError(msg)
+
+        # Off-diagonal entries must be non-negative
+        off_diag = Q - np.diag(np.diag(Q))
+        if np.any(off_diag < -1e-12):
+            msg = f"Off-diagonal entries must be non-negative, min={off_diag.min():.2e}"
+            raise ValueError(msg)
+
+        # Rows must sum to zero
+        row_sums = Q.sum(axis=1)
+        if not np.allclose(row_sums, 0, atol=1e-10):
+            msg = f"Rows must sum to zero, got row sums: {row_sums}"
+            raise ValueError(msg)
+
+        if self.regime_names is not None and len(self.regime_names) != K:
+            msg = f"regime_names length ({len(self.regime_names)}) must match n_regimes ({K})"
+            raise ValueError(msg)
+
+    def stationary_distribution(self) -> NDArray:
+        """Solve pi @ Q = 0, sum(pi) = 1 for the stationary distribution.
+
+        Returns
+        -------
+        NDArray
+            Stationary probability vector, shape (K,).
+        """
+        from scipy.linalg import null_space
+
+        ns = null_space(self.transition_matrix.T)
+        if ns.shape[1] == 0:
+            msg = "Generator matrix has no null space — check validity"
+            raise ValueError(msg)
+        pi = ns[:, 0].real
+        pi = pi / pi.sum()
+        # Ensure non-negative (numerical artifacts)
+        pi = np.maximum(pi, 0.0)
+        pi = pi / pi.sum()
+        return pi
+
+    def transition_rate(self, from_regime: int, to_regime: int) -> float:
+        """Get transition rate from regime k to regime j.
+
+        Parameters
+        ----------
+        from_regime : int
+            Source regime index.
+        to_regime : int
+            Target regime index.
+
+        Returns
+        -------
+        float
+            Transition rate Q[from_regime, to_regime].
+        """
+        return float(self.transition_matrix[from_regime, to_regime])
+
+
+if __name__ == "__main__":
+    """Smoke test for RegimeSwitchingConfig."""
+
+    print("Testing RegimeSwitchingConfig...")
+
+    # Two-state switching
+    Q = np.array([[-0.1, 0.1], [0.2, -0.2]])
+    config = RegimeSwitchingConfig(transition_matrix=Q, regime_names=["high", "low"])
+    config.validate()
+
+    pi = config.stationary_distribution()
+    print(f"  Stationary distribution: {pi}")
+    assert abs(pi[0] - 2 / 3) < 1e-10, f"Expected 2/3, got {pi[0]}"
+    assert abs(pi[1] - 1 / 3) < 1e-10, f"Expected 1/3, got {pi[1]}"
+
+    # Three-state
+    Q3 = np.array([[-0.3, 0.2, 0.1], [0.1, -0.2, 0.1], [0.05, 0.15, -0.2]])
+    config3 = RegimeSwitchingConfig(transition_matrix=Q3)
+    config3.validate()
+    pi3 = config3.stationary_distribution()
+    print(f"  3-state stationary: {pi3}")
+    assert abs(sum(pi3) - 1.0) < 1e-10
+
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

Phase 2: Regime-switching MFG with Markov chain coupling.

New components:
- `RegimeSwitchingConfig` (core/) — generator matrix Q, validation, stationary distribution
- `RegimeSwitchingIterator` (coupling/) — Picard iteration for K coupled HJB-FP systems

## Coupling structure

Unlike `MultiPopulationIterator` (independent populations coupled through density), this handles **operator-level coupling**:

| Equation | Cross-term | Mechanism |
|----------|-----------|-----------|
| HJB | `Q[k,j](v^k - v^j)` | source_term (#921) |
| FP | `Q[j,k]*m^j - Q[k,j]*m^k` | source_term (existing) |

## Design (Dev Plan Constraints)

- **Gauss-Seidel** default (Constraint #3): uses updated v^j for j < k, converges faster due to Q's diagonal dominance
- Configurable **Jacobi** for parallel scenarios
- Source functions extracted as methods (`_make_hjb_source`, `_make_fp_source`) to avoid closure-over-loop-variable issues (ruff B023)

## Test plan

- [x] RegimeSwitchingConfig: 2-state and 3-state validation + stationary distribution
- [x] Iterator imports and instantiation
- [x] 437 existing tests pass unchanged
- [ ] Full 2-regime coupled solve integration test (follow-up)

## Enables

Institutional Proposal Project B: property rights uncertainty with Markov switching between high/low protection regimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)