### PR TITLE
perf: Vectorize Hamiltonian batch evaluation (#929)

### DIFF
--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -2003,12 +2003,17 @@ class SeparableHamiltonian(HamiltonianBase):
         N = x_batch.shape[0]
 
         if self._potential_is_vectorized is None:
-            # Probe with 2-point batch
-            try:
-                probe = np.asarray(self._potential(x_batch[:2], t), dtype=float)
-                self._potential_is_vectorized = probe.shape == (2,)
-            except (TypeError, IndexError, ValueError):
+            # Probe with small batch (at least 2 points needed for shape check)
+            probe_size = min(2, N)
+            if probe_size < 2:
+                # Single-point batch — can't distinguish scalar from vectorized
                 self._potential_is_vectorized = False
+            else:
+                try:
+                    probe = np.asarray(self._potential(x_batch[:2], t), dtype=float)
+                    self._potential_is_vectorized = probe.shape == (2,)
+                except (TypeError, IndexError, ValueError):
+                    self._potential_is_vectorized = False
 
         if self._potential_is_vectorized:
             return np.asarray(self._potential(x_batch, t), dtype=float)


### PR DESCRIPTION
## Summary

Three vectorization improvements to Hamiltonian batch evaluation:

1. **`SeparableHamiltonian._evaluate_potential_batch()`**: auto-detect vectorized potential callable. Probes with 2-point batch on first call, caches result.

2. **`HamiltonianBase.dp()` fallback**: 2d batch `__call__` evals instead of 2dN scalar evals.

3. **`HamiltonianBase.dm()` fallback**: 2 batch `__call__` evals instead of 2N scalar evals.

All backward compatible — custom Hamiltonians that don't support batch fall back to per-point loop via try/except.

## Impact

For N=10^4 2D grid with scalar potential:
- Before: 10^4 Python function calls per H evaluation (potential loop)
- After: 1 NumPy call (vectorized) or 10^4 (scalar fallback, same as before)

Unblocks #930 (SL vectorization) which needs batch `optimal_control` (already works for SeparableHamiltonian).

## Test plan

- [x] 148 passed (Hamiltonian + HJB + integration), 0 failed
- [x] `test_base_dp_batch_fallback` passes (exercises try/catch fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)