### PR TITLE
refactor: Migrate BC dispatch to BoundaryFace — steps 2-4 (#946)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -65,6 +65,7 @@ from mfgarchon.geometry.boundary import no_flux_bc
 from mfgarchon.geometry.boundary.applicator_base import (
     LinearConstraint,
 )
+from mfgarchon.geometry.boundary.types import BoundaryFace
 from mfgarchon.utils.pde_coefficients import CoefficientField, _DriftDispatcher
 
 if TYPE_CHECKING:
@@ -211,7 +212,7 @@ def _get_bc_type(boundary_conditions: Any) -> str | None:
         return getattr(boundary_conditions, "type", None)
 
 
-def _get_bc_value(boundary_conditions: Any, boundary: str) -> float:
+def _get_bc_value(boundary_conditions: Any, face: BoundaryFace) -> float:
     """
     Get BC value at a specific boundary.
 
@@ -219,22 +220,23 @@ def _get_bc_value(boundary_conditions: Any, boundary: str) -> float:
     - Unified BoundaryConditions with get_bc_value_at_boundary()
     - Legacy BoundaryConditions1DFDM with left_value/right_value
 
+    Issue #946: Uses BoundaryFace instead of string identifiers for internal dispatch.
+
     Args:
         boundary_conditions: Any BC object
-        boundary: Boundary identifier ("x_min" or "x_max")
+        face: Boundary face identifier
 
     Returns:
         BC value at the specified boundary
     """
-    # Issue #543 Phase 2: Replace hasattr with try/except
-    # Try unified BC first (modern API)
+    # Try unified BC first (modern API) — still takes string
     try:
-        return boundary_conditions.get_bc_value_at_boundary(boundary)
+        return boundary_conditions.get_bc_value_at_boundary(face.to_string())
     except AttributeError:
         # Fall back to legacy BC: use left_value/right_value
-        if boundary == "x_min":
+        if face.side == "min":
             return getattr(boundary_conditions, "left_value", 0.0)
-        elif boundary == "x_max":
+        elif face.side == "max":
             return getattr(boundary_conditions, "right_value", 0.0)
 
     return 0.0
@@ -706,8 +708,8 @@ def solve_fp_nd_full_system(
     # Uses helper functions for unified/legacy BC compatibility
     bc_type = _get_bc_type(boundary_conditions)
     if bc_type == "dirichlet" and ndim == 1:
-        M_solution[0, 0] = _get_bc_value(boundary_conditions, "x_min")
-        M_solution[0, -1] = _get_bc_value(boundary_conditions, "x_max")
+        M_solution[0, 0] = _get_bc_value(boundary_conditions, BoundaryFace(0, "min"))
+        M_solution[0, -1] = _get_bc_value(boundary_conditions, BoundaryFace(0, "max"))
 
     # Edge cases
     if Nt <= 1:
@@ -874,8 +876,8 @@ def solve_fp_nd_full_system(
 
         # Enforce Dirichlet BC (using unified/legacy compatible helper)
         if bc_type == "dirichlet" and ndim == 1:
-            M_solution[k + 1, 0] = _get_bc_value(boundary_conditions, "x_min")
-            M_solution[k + 1, -1] = _get_bc_value(boundary_conditions, "x_max")
+            M_solution[k + 1, 0] = _get_bc_value(boundary_conditions, BoundaryFace(0, "min"))
+            M_solution[k + 1, -1] = _get_bc_value(boundary_conditions, BoundaryFace(0, "max"))
 
         # Issue #640: Report progress to hierarchical progress bar
         if progress_callback is not None:

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -157,20 +157,21 @@ def _get_bc_info_1d(
     Returns:
         Tuple (BCType, value, alpha, beta)
     """
-    from mfgarchon.geometry.boundary.types import BCType
+    from mfgarchon.geometry.boundary.types import BCType, BoundaryFace
 
-    boundary_key = "x_min" if side == "left" else "x_max"
+    target_face = BoundaryFace(0, "min" if side == "left" else "max")
     default_alpha, default_beta = 1.0, 0.0
 
     # Priority 1: Try segment-based access (supports Robin with alpha/beta)
+    # Issue #946: Match via seg.face instead of string comparison
     try:
         for seg in bc.segments:
-            if seg.boundary == boundary_key:
+            seg_face = seg.face
+            if seg_face is not None and seg_face == target_face:
                 value = seg.value
                 if callable(value):
                     value = value(time)
                 value = value if value is not None else 0.0
-                # Extract Robin coefficients if present
                 alpha = getattr(seg, "alpha", default_alpha)
                 beta = getattr(seg, "beta", default_beta)
                 return seg.bc_type, value, alpha, beta
@@ -181,6 +182,8 @@ def _get_bc_info_1d(
         pass  # No segments attribute, try unified interface
 
     # Priority 2: Try unified interface (get_boundary_type method)
+    # These methods still take string keys (public API)
+    boundary_key = target_face.to_string()
     try:
         bc_type = bc.get_boundary_type(boundary_key)
         bc_value = bc.get_boundary_value(boundary_key, time=time)

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -93,7 +93,7 @@ from .conditions import BoundaryConditions
 from .enforcement import enforce_dirichlet_value_nd, enforce_neumann_value_nd
 from .fdm_bc_1d import BoundaryConditions as BoundaryConditions1DFDM
 from .ghost_cells import GhostCellConfig
-from .types import BCSegment, BCType
+from .types import BCSegment, BCType, BoundaryFace, parse_boundary_face
 
 logger = get_logger(__name__)
 
@@ -334,10 +334,7 @@ class FDMApplicator(BaseStructuredApplicator):
         """
         Parse boundary identifier string to (dimension, side).
 
-        Supports standard tensor-product grid boundary naming:
-        - "x_min", "x_max" → (0, 'min'), (0, 'max')
-        - "y_min", "y_max" → (1, 'min'), (1, 'max')
-        - "z_min", "z_max" → (2, 'min'), (2, 'max')
+        Uses BoundaryFace for dimension-agnostic parsing (Issue #946).
 
         Args:
             boundary_id: Boundary identifier string
@@ -345,28 +342,10 @@ class FDMApplicator(BaseStructuredApplicator):
         Returns:
             (dimension_index, 'min' or 'max') or (None, None) if unrecognized
         """
-        if not isinstance(boundary_id, str):
+        face = parse_boundary_face(boundary_id)
+        if face is None:
             return None, None
-
-        # Parse format: "{axis}_{side}" e.g., "x_min", "y_max"
-        parts = boundary_id.lower().split("_")
-        if len(parts) != 2:
-            return None, None
-
-        axis, side = parts
-
-        # Map axis to dimension index
-        axis_map = {"x": 0, "y": 1, "z": 2}
-        if axis not in axis_map:
-            return None, None
-
-        dim = axis_map[axis]
-
-        # Validate side
-        if side not in ["min", "max"]:
-            return None, None
-
-        return dim, side
+        return face.axis, face.side
 
     def _apply_dirichlet_enforcement(self, field: NDArray[np.floating], dim: int, side: str, value: float) -> None:
         """
@@ -1377,19 +1356,12 @@ class PreallocatedGhostBuffer:
         g = self._ghost_depth
         buf = self._buffer
 
-        # Standard boundary names for FDM grids
-        axis_names = ["x", "y", "z", "w", "v"]  # Extend as needed
-
         for axis in range(d):
             for side in ["min", "max"]:
-                # Construct standard boundary name (e.g., "x_min", "y_max")
-                if axis < len(axis_names):
-                    boundary_name = f"{axis_names[axis]}_{side}"
-                else:
-                    boundary_name = f"dim{axis}_{side}"
+                target_face = BoundaryFace(axis, side)
 
-                # Find matching BC segment for this face
-                segment = self._find_segment_for_face(bc, boundary_name, axis, side)
+                # Find matching BC segment for this face (Issue #946)
+                segment = self._find_segment_for_face(bc, target_face)
 
                 if segment is None:
                     # No explicit segment - use default BC (first segment or Neumann)
@@ -1403,47 +1375,36 @@ class PreallocatedGhostBuffer:
     def _find_segment_for_face(
         self,
         bc: BoundaryConditions,
-        boundary_name: str,
-        axis: int,
-        side: str,
+        target_face: BoundaryFace,
     ) -> BCSegment | None:
         """
         Find the BC segment that applies to a specific face.
 
+        Uses BoundaryFace for dimension-agnostic matching (Issue #946).
+
         Matching priority:
-        1. boundary field matches exactly (e.g., "x_min")
-        2. region_name matches standard boundary name
+        1. seg.face matches target_face (handles all string aliases: "left", "x_min", etc.)
+        2. region_name matches face string label
         3. region_name matches via geometry.get_region_mask()
 
         Args:
             bc: Boundary conditions
-            boundary_name: Standard face name (e.g., "x_min")
-            axis: Axis index (0=x, 1=y, ...)
-            side: "min" or "max"
+            target_face: Target boundary face
 
         Returns:
             Matching BCSegment or None if no explicit match
         """
-
         for segment in bc.segments:
-            # Method 1: Direct boundary field match
+            # Method 1: Structured face match via seg.face (Issue #946)
             if segment.boundary is not None:
-                seg_boundary = segment.boundary.lower()
-                # Normalize: "left"/"right" → "x_min"/"x_max" for 1D
-                if seg_boundary in ["left", "bottom", "back"]:
-                    seg_boundary = f"{['x', 'y', 'z'][min(axis, 2)]}_{side}" if side == "min" else None
-                elif seg_boundary in ["right", "top", "front"]:
-                    seg_boundary = f"{['x', 'y', 'z'][min(axis, 2)]}_{side}" if side == "max" else None
-                # Check exact match
-                if seg_boundary == boundary_name:
-                    return segment
-                # Also check if segment.boundary matches boundary_name directly
-                if segment.boundary.lower() == boundary_name:
+                seg_face = segment.face
+                if seg_face is not None and seg_face == target_face:
                     return segment
 
-            # Method 2: region_name matches standard boundary name
+            # Method 2: region_name matches standard face label
             if segment.region_name is not None:
-                if segment.region_name.lower() == boundary_name:
+                face_label = target_face.to_string()
+                if segment.region_name.lower() == face_label:
                     return segment
 
                 # Method 3: Use geometry to check if region covers this boundary face
@@ -1454,14 +1415,10 @@ class PreallocatedGhostBuffer:
                         if isinstance(self._geometry, SupportsRegionMarking):
                             region_names = self._geometry.get_region_names()
                             if segment.region_name in region_names:
-                                # Get region mask and check if boundary point is in region
                                 mask = self._geometry.get_region_mask(segment.region_name)
-                                # For FDM, check boundary index
-                                # side="min" -> index 0, side="max" -> index -1
                                 d = self._dimension
                                 boundary_idx = [slice(None)] * d
-                                boundary_idx[axis] = 0 if side == "min" else -1
-                                # Check if any point on this face is in the region
+                                boundary_idx[target_face.axis] = 0 if target_face.side == "min" else -1
                                 face_mask = mask[tuple(boundary_idx)]
                                 if np.any(face_mask):
                                     return segment


### PR DESCRIPTION
## Summary
- Migrates internal BC dispatch from string comparison to `BoundaryFace` in `applicator_fdm.py`, `fp_fdm_time_stepping.py`, and `base_hjb.py` (steps 2-4 of #946)
- Eliminates f-string construction (`f"{axis_names[axis]}_{side}"`), legacy name normalization ("left"→"x_min"), and string equality checks
- Uses `seg.face == BoundaryFace(axis, side)` for structured, dimension-agnostic matching

## Test plan
- [x] 190 BC applicator/HJB tests pass
- [x] 97 FP solver/integration tests pass
- [x] Ruff lint clean

Closes #946