### PR TITLE
refactor: Unify progress bar decision in HJB solvers (#934)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -367,6 +367,7 @@ class HJBFDMSolver(BaseHJBSolver):
         tensor_volatility_field: NDArray | None = None,
         bc_values: dict[str, float] | None = None,
         progress_callback: Callable[[int], None] | None = None,  # Issue #640
+        show_progress: bool | None = None,  # Issue #934
         # MMS verification support
         source_term: Callable | None = None,
         # Deprecated parameter names for backward compatibility (decorators handle warnings)
@@ -499,6 +500,7 @@ class HJBFDMSolver(BaseHJBSolver):
                 volatility_field,
                 progress_callback=progress_callback,
                 source_term=source_term,
+                show_progress=show_progress,
             )
 
     def _solve_hjb_nd(
@@ -509,6 +511,7 @@ class HJBFDMSolver(BaseHJBSolver):
         volatility_field: float | NDArray | None = None,
         progress_callback: Callable[[int], None] | None = None,  # Issue #640
         source_term: Callable | None = None,  # MMS verification
+        show_progress: bool | None = None,  # Issue #934
     ) -> NDArray:
         """Solve nD HJB using centralized nonlinear solvers with variable diffusion.
 
@@ -540,7 +543,7 @@ class HJBFDMSolver(BaseHJBSolver):
 
         timestep_iter = create_progress_bar(
             range(n_time_points - 2, -1, -1),
-            verbose=should_show_progress(True) and not use_external_progress,
+            verbose=should_show_progress(show_progress) and not use_external_progress,
             desc=f"HJB {self.dimension}D-FDM ({self.solver_type})",
         )
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2164,11 +2164,11 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         # Backward time stepping: Nt steps from index (n_time_points-2) down to 0
         # This covers all Nt intervals in the backward direction (Issue #587 Protocol pattern)
-        from mfgarchon.utils.progress import create_progress_bar
+        from mfgarchon.utils.progress import create_progress_bar, should_show_progress
 
         timestep_range = create_progress_bar(
             range(n_time_points - 2, -1, -1),
-            verbose=show_progress,
+            verbose=should_show_progress(show_progress),
             desc="HJB (backward)",
         )
 


### PR DESCRIPTION
## Summary
- `hjb_fdm.py`: Add `show_progress` parameter, replace hardcoded `should_show_progress(True)` so iterators can suppress inner progress
- `hjb_gfdm.py`: Wrap raw `show_progress` with `should_show_progress()` for terminal auto-detection

## Context
Issue #934 identified three progress bar design issues. Most FP solvers already use the correct pattern. These two HJB solvers were the remaining gaps in decision logic unification.

## Test plan
- [x] 146 HJB/integration tests pass
- [x] Ruff clean

Partial progress on #934