### PR TITLE
refactor: Remove progress kwargs from iterators — context routing cleanup (#934)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/base_mfg.py
+++ b/mfgarchon/alg/numerical/coupling/base_mfg.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 
     from mfgarchon.core.mfg_problem import MFGProblem
     from mfgarchon.types.solver_types import SolverReturnTuple
-    from mfgarchon.utils.progress import HierarchicalProgress
 else:
     pass
 
@@ -61,27 +60,18 @@ class BaseCouplingIterator(ABC):
     def _build_hjb_kwargs(
         self,
         *,
-        progress: HierarchicalProgress | None = None,
         volatility_field: float | np.ndarray | Any | None = None,
         source_term: Callable | None = None,
     ) -> dict[str, Any]:
         """Build kwargs for solve_hjb_system, respecting solver capabilities.
 
-        Uses cached signature to pass only parameters the solver accepts.
-        Prefers ``progress`` injection; falls back to ``show_progress=False``
-        for legacy solvers.
+        Progress is handled automatically via context routing (Issue #934) —
+        solver's ``create_progress_bar`` detects the parent ``HierarchicalProgress``.
         """
         kwargs: dict[str, Any] = {}
         params = self._hjb_sig_params
         if params is None:
             return kwargs
-        # Progress injection (Issue #934)
-        if "progress" in params:
-            kwargs["progress"] = progress
-        elif "show_progress" in params:
-            kwargs["show_progress"] = False
-        # Legacy progress callback — skip if progress injection is used
-        # (solver handles its own subtask via get_progress)
         if "volatility_field" in params and volatility_field is not None:
             kwargs["volatility_field"] = volatility_field
         if "source_term" in params and source_term is not None:
@@ -91,24 +81,18 @@ class BaseCouplingIterator(ABC):
     def _build_fp_kwargs(
         self,
         *,
-        progress: HierarchicalProgress | None = None,
         drift_field: np.ndarray | Callable | Any | None = None,
         volatility_field: float | np.ndarray | Any | None = None,
         source_term: Callable | None = None,
     ) -> dict[str, Any]:
         """Build kwargs for solve_fp_system, respecting solver capabilities.
 
-        Uses cached signature to pass only parameters the solver accepts.
-        Prefers ``progress`` injection; falls back to ``show_progress=False``.
+        Progress is handled automatically via context routing (Issue #934).
         """
         kwargs: dict[str, Any] = {}
         params = self._fp_sig_params
         if params is None:
             return kwargs
-        if "progress" in params:
-            kwargs["progress"] = progress
-        elif "show_progress" in params:
-            kwargs["show_progress"] = False
         if "drift_field" in params and drift_field is not None:
             kwargs["drift_field"] = drift_field
         if "volatility_field" in params and volatility_field is not None:

--- a/mfgarchon/alg/numerical/coupling/block_iterators.py
+++ b/mfgarchon/alg/numerical/coupling/block_iterators.py
@@ -236,14 +236,8 @@ class BlockIterator(BaseCouplingIterator):
         U_prev: NDArray,
     ) -> NDArray:
         """Solve HJB equation with given density."""
-        kwargs: dict[str, Any] = {}
-
-        if self._hjb_sig_params is not None:
-            if "show_progress" in self._hjb_sig_params:
-                kwargs["show_progress"] = False
-            if "volatility_field" in self._hjb_sig_params and self.volatility_field is not None:
-                kwargs["volatility_field"] = self.volatility_field
-
+        # Issue #934: Progress handled via context routing
+        kwargs = self._build_hjb_kwargs(volatility_field=self.volatility_field)
         return self.hjb_solver.solve_hjb_system(M, U_terminal, U_prev, **kwargs)
 
     def _solve_fp(self, M_initial: NDArray, U: NDArray) -> NDArray:
@@ -252,23 +246,14 @@ class BlockIterator(BaseCouplingIterator):
         if self.adjoint_mode != "off":
             return self._solve_fp_strict_adjoint(M_initial, U)
 
-        kwargs: dict[str, Any] = {}
-
         if self._fp_sig_params is not None:
-            if "show_progress" in self._fp_sig_params:
-                kwargs["show_progress"] = False
-
             effective_drift = self.drift_field if self.drift_field is not None else U
-
-            # Issue #919: pass U as potential_field (drift_field now means velocity)
+            kwargs = self._build_fp_kwargs(volatility_field=self.volatility_field)
+            # Issue #919: prefer potential_field over drift_field
             if "potential_field" in self._fp_sig_params:
                 kwargs["potential_field"] = effective_drift
             elif "drift_field" in self._fp_sig_params:
-                # Fallback for FP solvers without potential_field (e.g. GFDM)
                 kwargs["drift_field"] = effective_drift
-
-            if "volatility_field" in self._fp_sig_params and self.volatility_field is not None:
-                kwargs["volatility_field"] = self.volatility_field
             return self.fp_solver.solve_fp_system(M_initial, **kwargs)
         else:
             return self.fp_solver.solve_fp_system(M_initial, U)

--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -381,51 +381,22 @@ class FictitiousPlayIterator(BaseCouplingIterator):
             alpha = self.get_learning_rate(k)
             self.learning_rate_history.append(alpha)
 
-            # 1. Solve HJB backward - FULL best response (no damping on U)
-            # Issue #543 Phase 2: Use cached signature instead of hasattr
-            # Note: Inner solver progress is disabled when outer verbose=True (to avoid nested bars)
-            # When verbose=False (non-TTY), we also disable inner progress (use iteration_callback instead)
-            show_hjb_progress = False  # Always suppress inner progress bars
-            if self._hjb_sig_params is not None:
-                # Method exists and signature is cached
-                params = self._hjb_sig_params
-                hjb_kwargs: dict[str, Any] = {}
-                if "show_progress" in params:
-                    hjb_kwargs["show_progress"] = show_hjb_progress
-                if "volatility_field" in params and self.volatility_field is not None:
-                    hjb_kwargs["volatility_field"] = self.volatility_field
-
-                # Solve HJB with current averaged M
-                U_new = self.hjb_solver.solve_hjb_system(M_old, U_terminal, U_old, **hjb_kwargs)
-            else:
-                # No signature cached - use basic call
-                U_new = self.hjb_solver.solve_hjb_system(M_old, U_terminal, U_old)
+            # 1. Solve HJB backward — progress handled via context routing (#934)
+            hjb_kwargs = self._build_hjb_kwargs(volatility_field=self.volatility_field)
+            U_new = self.hjb_solver.solve_hjb_system(M_old, U_terminal, U_old, **hjb_kwargs)
 
             # 2. Solve FP forward with new U
-            # Issue #543 Phase 2: Use cached signature instead of hasattr
-            # Note: Inner solver progress is disabled - use iteration_callback for custom logging
-            show_fp_progress = False  # Always suppress inner progress bars
-            if self._fp_sig_params is not None:
-                # Method exists and signature is cached
-                params = self._fp_sig_params
-                fp_kwargs: dict[str, Any] = {}
-                if "show_progress" in params:
-                    fp_kwargs["show_progress"] = show_fp_progress
-
-                effective_drift = self.drift_field if self.drift_field is not None else U_new
-
-                if "drift_field" in params:
-                    fp_kwargs["drift_field"] = effective_drift
-                if "volatility_field" in params and self.volatility_field is not None:
-                    fp_kwargs["volatility_field"] = self.volatility_field
-
-                if "drift_field" in params:
-                    M_candidate = self.fp_solver.solve_fp_system(M_initial, **fp_kwargs)
-                else:
-                    M_candidate = self.fp_solver.solve_fp_system(M_initial, effective_drift, **fp_kwargs)
+            effective_drift = self.drift_field if self.drift_field is not None else U_new
+            fp_kwargs = self._build_fp_kwargs(
+                drift_field=effective_drift,
+                volatility_field=self.volatility_field,
+            )
+            if self._fp_sig_params is not None and (
+                "drift_field" in self._fp_sig_params or "potential_field" in self._fp_sig_params
+            ):
+                M_candidate = self.fp_solver.solve_fp_system(M_initial, **fp_kwargs)
             else:
-                # No signature cached - use basic call
-                M_candidate = self.fp_solver.solve_fp_system(M_initial, U_new)
+                M_candidate = self.fp_solver.solve_fp_system(M_initial, effective_drift, **fp_kwargs)
 
             # 3. Fictitious Play update: average M with decaying learning rate
             # This is the key difference from fixed-point iteration

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -611,98 +611,54 @@ class FixedPointIterator(BaseCouplingIterator):
                 # Issue #922: Compose source terms from problem fields
                 hjb_source = self._compose_hjb_source(M_old)
 
-                with (
-                    progress.subtask("HJB", total=num_time_steps) as hjb_subtask,
-                    self.problem.using_resolved_bc(bc_resolution_state),
-                ):
-                    # Issue #543 Phase 2: Use cached signature instead of hasattr
-                    if self._hjb_sig_params is not None:
-                        # Method exists and signature is cached
-                        params = self._hjb_sig_params
-                        kwargs = {}
-                        if "show_progress" in params:
-                            kwargs["show_progress"] = False  # Subtask replaces inner bar
-                        if "volatility_field" in params and self.volatility_field is not None:
-                            kwargs["volatility_field"] = self.volatility_field
-                        # Issue #640: Pass progress callback for incremental updates
-                        if "progress_callback" in params:
-                            kwargs["progress_callback"] = hjb_subtask.advance
-                        # Issue #922: Pass composed source term from problem fields
-                        if "source_term" in params and hjb_source is not None:
-                            kwargs["source_term"] = hjb_source
-
-                        U_new = self.hjb_solver.solve_hjb_system(M_old, U_terminal, U_old, **kwargs)
-                    else:
-                        # No signature cached - use basic call
-                        U_new = self.hjb_solver.solve_hjb_system(M_old, U_terminal, U_old)
-                        # Fallback: advance all at once if no callback support
-                        hjb_subtask.advance(num_time_steps)
+                # Issue #934: Context routing handles progress automatically —
+                # solver's create_progress_bar detects parent HierarchicalProgress
+                with self.problem.using_resolved_bc(bc_resolution_state):
+                    kwargs = self._build_hjb_kwargs(
+                        volatility_field=self.volatility_field,
+                        source_term=hjb_source,
+                    )
+                    U_new = self.hjb_solver.solve_hjb_system(M_old, U_terminal, U_old, **kwargs)
 
                 # 2. Solve FP forward with new U (transient subtask)
                 # Issue #614: Use hierarchical subtask for inner solver visibility
                 # Issue #922: Compose FP source terms from problem fields
                 fp_source = self._compose_fp_source(M_old, U_new)
 
-                with progress.subtask("FP", total=num_time_steps) as fp_subtask:
-                    if self._fp_sig_params is not None:
-                        # Standard mode: FP builds its own matrix
-                        # Issue #543 Phase 2: Use cached signature instead of hasattr
-                        # Method exists and signature is cached
-                        params = self._fp_sig_params
-                        kwargs = {}
-                        if "show_progress" in params:
-                            kwargs["show_progress"] = False  # Subtask replaces inner bar
-                        # Issue #922: Pass composed FP source term
-                        if "source_term" in params and fp_source is not None:
-                            kwargs["source_term"] = fp_source
+                # Issue #934: Context routing handles progress automatically
+                kwargs = self._build_fp_kwargs(
+                    volatility_field=self.volatility_field,
+                    source_term=fp_source,
+                )
 
-                        # Pass drift/potential to FP solver.
-                        # drift_field = velocity alpha*, potential_field = U-potential (deprecated).
-                        if self.drift_field is not None:
-                            # User-provided drift override (for non-MFG problems)
-                            if "drift_field" in params:
-                                kwargs["drift_field"] = self.drift_field
-                        else:
-                            H_class = self.problem.hamiltonian_class
-                            from mfgarchon.core.hamiltonian import SeparableHamiltonian
-
-                            use_velocity = (
-                                H_class is not None
-                                and "drift_field" in params
-                                and not (isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth())
-                            )
-                            if use_velocity:
-                                # Non-smooth H: face-centered velocity via H.optimal_control
-                                kwargs["drift_field"] = self._compute_velocity_field(U_new, M_old, H_class)
-                            elif "potential_field" in params:
-                                # Smooth H: pass U as potential (deprecated path)
-                                kwargs["potential_field"] = U_new
-                            elif "drift_field" in params:
-                                # FP solver without potential_field (e.g. GFDM): pass U as drift
-                                kwargs["drift_field"] = U_new
-
-                        if "volatility_field" in params and self.volatility_field is not None:
-                            kwargs["volatility_field"] = self.volatility_field
-
-                        # Issue #640: Pass progress callback for incremental updates
-                        if "progress_callback" in params:
-                            kwargs["progress_callback"] = fp_subtask.advance
-
-                        # Call with appropriate arguments
-                        if "drift_field" in params or "potential_field" in params:
-                            M_new = self.fp_solver.solve_fp_system(M_initial, **kwargs)
-                        else:
-                            # Legacy interface: second positional arg is U for drift
-                            M_new = self.fp_solver.solve_fp_system(M_initial, U_new, **kwargs)
-
-                        # If no callback support, advance all at once
-                        if "progress_callback" not in params:
-                            fp_subtask.advance(num_time_steps)
+                # Drift/potential logic (FP-specific, not in _build_fp_kwargs)
+                if self._fp_sig_params is not None:
+                    params = self._fp_sig_params
+                    if self.drift_field is not None:
+                        if "drift_field" in params:
+                            kwargs["drift_field"] = self.drift_field
                     else:
-                        # No signature cached - use basic call
-                        M_new = self.fp_solver.solve_fp_system(M_initial, U_new)
-                        # Fallback: advance all at once
-                        fp_subtask.advance(num_time_steps)
+                        H_class = self.problem.hamiltonian_class
+                        from mfgarchon.core.hamiltonian import SeparableHamiltonian
+
+                        use_velocity = (
+                            H_class is not None
+                            and "drift_field" in params
+                            and not (isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth())
+                        )
+                        if use_velocity:
+                            kwargs["drift_field"] = self._compute_velocity_field(U_new, M_old, H_class)
+                        elif "potential_field" in params:
+                            kwargs["potential_field"] = U_new
+                        elif "drift_field" in params:
+                            kwargs["drift_field"] = U_new
+
+                    if "drift_field" in params or "potential_field" in params:
+                        M_new = self.fp_solver.solve_fp_system(M_initial, **kwargs)
+                    else:
+                        M_new = self.fp_solver.solve_fp_system(M_initial, U_new, **kwargs)
+                else:
+                    M_new = self.fp_solver.solve_fp_system(M_initial, U_new)
 
                 # 3. Apply damping or Anderson acceleration
                 # Issue #719: Per-variable damping + Phase 2 schedule support


### PR DESCRIPTION
## Summary
- Remove `show_progress=False`, `progress_callback=subtask.advance`, and subtask wrapping from all coupling iterators (FixedPointIterator, BlockIterator, FictitiousPlayIterator)
- Simplify `_build_hjb_kwargs` / `_build_fp_kwargs` — progress parameter removed, only handles `volatility_field`, `source_term`, `drift_field`
- Net reduction: **-104 lines** of progress coordination boilerplate

## How it works
Context-based routing (PR #952) makes this possible: solvers' `create_progress_bar()` auto-detects the parent `HierarchicalProgress` via `contextvars` and renders as a transient subtask. No explicit parameter passing needed.

## Test plan
- [x] 32 coupling tests pass (three-mode API, block iterators, source_term wiring)
- [x] Ruff clean

Partial progress on #934