### PR TITLE
chore: Bump version to v0.18.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.18.13"  # v0.18.13: Hamiltonian batch vectorization, SL 1D vectorization
+version = "0.18.14"  # v0.18.14: BoundaryFace migration, Layer 1 tests, context-based progress routing
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Changes since v0.18.13

- **#946**: BoundaryFace migration — internal BC dispatch uses structured types
- **#887**: Layer 1 test coverage — 44 tests for Levy operator, regime switching, source_term wiring
- **#934**: Context-based progress routing — `create_progress_bar` auto-detects parent `HierarchicalProgress` via contextvars. Eliminates progress parameter boilerplate from all coupling iterators (-104 lines)
- **Rename**: `coupling/BaseMFGSolver` → `BaseCouplingIterator`
- **Bug fixes**: `_NullSubtask.update_metrics()`, `_format_metrics` duplication, metric accumulation