### PR TITLE
feat: MeasureRepresentation Protocol + ParticleMeasure (#956)

### DIFF
--- a/mfgarchon/core/measure.py
+++ b/mfgarchon/core/measure.py
@@ -1,0 +1,181 @@
+"""
+Measure representations for MFG on measure space (Layer 2).
+
+Provides the ``MeasureRepresentation`` Protocol and concrete implementations
+for representing probability measures mu in P_2(R^d). These are the building
+blocks for:
+- Master Equation: v(x, mu, t) where mu is a measure argument
+- Common Noise PDE: conditional measures mu^theta evolving in measure space
+- Lions derivative: delta U / delta m computed via measure perturbation
+
+Design reference:
+    Joplin Dev: "Generalized PDE & Institutional MFG Plan" Layer 2 section
+    Joplin Dev: "Layer 2 Readiness Assessment"
+    Issue #956: Layer 2 alignment
+
+Current implementations:
+    - ParticleMeasure: empirical measure m_N = (1/N) sum_i w_i delta_{y_i}
+
+Planned (not yet implemented):
+    - BasisExpansionMeasure: density expanded in basis (d <= 2)
+    - NeuralMeasure: neural network parametrization (high-dimensional)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+@runtime_checkable
+class MeasureRepresentation(Protocol):
+    """Protocol for probability measure representations.
+
+    Any object satisfying this protocol can be used as a measure argument
+    in MFG solvers operating on measure space (Layer 2).
+
+    Methods:
+        to_density: Project measure onto a spatial grid as density array.
+        total_mass: Return total mass (should be 1.0 for probability measures).
+        dimension: Spatial dimension of the measure support.
+    """
+
+    def to_density(self, grid_points: NDArray) -> NDArray:
+        """Project measure onto spatial grid as density array.
+
+        Args:
+            grid_points: Spatial grid, shape (N,) for 1D or (N, d) for dD.
+
+        Returns:
+            Density values at grid points, shape (N,).
+        """
+        ...
+
+    def total_mass(self) -> float:
+        """Return total mass of the measure."""
+        ...
+
+    @property
+    def dimension(self) -> int:
+        """Spatial dimension of the measure support."""
+        ...
+
+
+class ParticleMeasure:
+    """Empirical measure: m_N = sum_i w_i delta_{y_i}.
+
+    Represents a probability measure as a weighted sum of Dirac masses
+    at particle positions. This is the natural representation for:
+    - Monte Carlo methods (common noise sampling)
+    - N-player game convergence
+    - Particle-based FP solvers
+    - Functional derivative computation via position perturbation
+
+    Parameters
+    ----------
+    positions : NDArray
+        Particle positions, shape (N,) for 1D or (N, d) for dD.
+    weights : NDArray | None
+        Particle weights, shape (N,). Default: uniform 1/N.
+
+    Example
+    -------
+    >>> mu = ParticleMeasure(np.array([0.2, 0.5, 0.8]))
+    >>> density = mu.to_density(np.linspace(0, 1, 101))
+    >>> mu.total_mass()  # 1.0
+    """
+
+    def __init__(self, positions: NDArray, weights: NDArray | None = None):
+        self._positions = np.asarray(positions, dtype=float)
+        if self._positions.ndim == 1:
+            self._positions = self._positions.reshape(-1, 1)
+        self._n_particles = self._positions.shape[0]
+        self._dim = self._positions.shape[1]
+
+        if weights is None:
+            self._weights = np.ones(self._n_particles) / self._n_particles
+        else:
+            self._weights = np.asarray(weights, dtype=float)
+            self._weights = self._weights / self._weights.sum()
+
+    @property
+    def positions(self) -> NDArray:
+        """Particle positions, shape (N, d)."""
+        return self._positions
+
+    @property
+    def weights(self) -> NDArray:
+        """Particle weights, shape (N,), sum to 1."""
+        return self._weights
+
+    @property
+    def n_particles(self) -> int:
+        """Number of particles."""
+        return self._n_particles
+
+    @property
+    def dimension(self) -> int:
+        """Spatial dimension."""
+        return self._dim
+
+    def total_mass(self) -> float:
+        """Total mass (should be 1.0 for probability measure)."""
+        return float(self._weights.sum())
+
+    def to_density(self, grid_points: NDArray, bandwidth: float | None = None) -> NDArray:
+        """Project onto spatial grid via kernel density estimation.
+
+        Uses Gaussian KDE with bandwidth selected by Scott's rule if not specified.
+
+        Args:
+            grid_points: Grid points, shape (M,) for 1D or (M, d) for dD.
+            bandwidth: KDE bandwidth. None = Scott's rule: h = N^{-1/(d+4)} * std.
+
+        Returns:
+            Density values at grid points, shape (M,).
+        """
+        grid = np.asarray(grid_points, dtype=float)
+        if grid.ndim == 1:
+            grid = grid.reshape(-1, 1)
+
+        if self._dim == 1:
+            return self._kde_1d(grid[:, 0], bandwidth)
+
+        # General dD KDE
+        return self._kde_nd(grid, bandwidth)
+
+    def _kde_1d(self, x: NDArray, bandwidth: float | None) -> NDArray:
+        """1D kernel density estimation."""
+        positions = self._positions[:, 0]
+        if bandwidth is None:
+            std = np.std(positions)
+            bandwidth = std * self._n_particles ** (-1 / 5) if std > 0 else 0.1
+
+        # Gaussian kernel: K(u) = (1/sqrt(2*pi)) * exp(-u^2/2)
+        # density(x) = sum_i w_i * K((x - y_i) / h) / h
+        diff = x[:, None] - positions[None, :]  # (M, N)
+        kernel_vals = np.exp(-0.5 * (diff / bandwidth) ** 2) / (bandwidth * np.sqrt(2 * np.pi))
+        return kernel_vals @ self._weights  # (M,)
+
+    def _kde_nd(self, x: NDArray, bandwidth: float | None) -> NDArray:
+        """General dD kernel density estimation (product kernel)."""
+        d = self._dim
+        if bandwidth is None:
+            std = np.std(self._positions, axis=0).mean()
+            bandwidth = std * self._n_particles ** (-1 / (d + 4)) if std > 0 else 0.1
+
+        M = x.shape[0]
+        density = np.zeros(M)
+        for i in range(self._n_particles):
+            diff = x - self._positions[i]  # (M, d)
+            sq_dist = np.sum(diff**2, axis=1)  # (M,)
+            kernel_vals = np.exp(-0.5 * sq_dist / bandwidth**2) / (bandwidth * np.sqrt(2 * np.pi)) ** d
+            density += self._weights[i] * kernel_vals
+        return density
+
+    def __repr__(self) -> str:
+        return f"ParticleMeasure(n={self._n_particles}, d={self._dim})"

--- a/tests/unit/test_core/test_measure.py
+++ b/tests/unit/test_core/test_measure.py
@@ -1,0 +1,101 @@
+"""Tests for measure representations (Layer 2 foundation).
+
+Tests MeasureRepresentation Protocol and ParticleMeasure implementation
+from mfgarchon.core.measure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.core.measure import MeasureRepresentation, ParticleMeasure
+
+
+class TestMeasureRepresentationProtocol:
+    def test_particle_measure_satisfies_protocol(self):
+        mu = ParticleMeasure(np.array([0.5]))
+        assert isinstance(mu, MeasureRepresentation)
+
+    def test_protocol_is_runtime_checkable(self):
+        assert hasattr(MeasureRepresentation, "__protocol_attrs__") or isinstance(MeasureRepresentation, type)
+
+
+class TestParticleMeasureInit:
+    def test_1d_from_flat_array(self):
+        mu = ParticleMeasure(np.array([0.1, 0.5, 0.9]))
+        assert mu.n_particles == 3
+        assert mu.dimension == 1
+        assert mu.positions.shape == (3, 1)
+
+    def test_2d_particles(self):
+        pos = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        mu = ParticleMeasure(pos)
+        assert mu.n_particles == 3
+        assert mu.dimension == 2
+
+    def test_uniform_weights_default(self):
+        mu = ParticleMeasure(np.array([0.0, 1.0, 2.0]))
+        np.testing.assert_allclose(mu.weights, [1 / 3, 1 / 3, 1 / 3])
+
+    def test_custom_weights_normalized(self):
+        mu = ParticleMeasure(np.array([0.0, 1.0]), weights=np.array([3.0, 1.0]))
+        np.testing.assert_allclose(mu.weights, [0.75, 0.25])
+
+    def test_total_mass_is_one(self):
+        mu = ParticleMeasure(np.random.RandomState(42).randn(50))
+        assert mu.total_mass() == pytest.approx(1.0)
+
+
+class TestParticleMeasureToDensity:
+    def test_1d_density_shape(self):
+        mu = ParticleMeasure(np.array([0.2, 0.5, 0.8]))
+        grid = np.linspace(0, 1, 101)
+        density = mu.to_density(grid)
+        assert density.shape == (101,)
+
+    def test_1d_density_nonnegative(self):
+        mu = ParticleMeasure(np.array([0.2, 0.5, 0.8]))
+        density = mu.to_density(np.linspace(0, 1, 101))
+        assert np.all(density >= 0)
+
+    def test_1d_density_peaks_near_particles(self):
+        mu = ParticleMeasure(np.array([0.3, 0.7]))
+        grid = np.linspace(0, 1, 201)
+        density = mu.to_density(grid)
+        # Peaks should be near 0.3 and 0.7
+        peak_idx = np.argmax(density)
+        assert abs(grid[peak_idx] - 0.3) < 0.15 or abs(grid[peak_idx] - 0.7) < 0.15
+
+    def test_1d_weighted_density(self):
+        """Heavier weight at 0.2 should produce higher peak there."""
+        mu = ParticleMeasure(np.array([0.2, 0.8]), weights=np.array([9.0, 1.0]))
+        grid = np.linspace(0, 1, 201)
+        density = mu.to_density(grid)
+        idx_02 = 40  # ~0.2
+        idx_08 = 160  # ~0.8
+        assert density[idx_02] > density[idx_08]
+
+    def test_2d_density(self):
+        pos = np.random.RandomState(7).randn(30, 2)
+        mu = ParticleMeasure(pos)
+        grid_2d = np.random.RandomState(8).randn(50, 2)
+        density = mu.to_density(grid_2d)
+        assert density.shape == (50,)
+        assert np.all(np.isfinite(density))
+
+    def test_custom_bandwidth(self):
+        mu = ParticleMeasure(np.array([0.5]))
+        grid = np.linspace(0, 1, 101)
+        # Narrow bandwidth -> sharper peak
+        d_narrow = mu.to_density(grid, bandwidth=0.01)
+        d_wide = mu.to_density(grid, bandwidth=0.5)
+        assert d_narrow.max() > d_wide.max()
+
+
+class TestParticleMeasureRepr:
+    def test_repr(self):
+        mu = ParticleMeasure(np.zeros((10, 3)))
+        assert "n=10" in repr(mu)
+        assert "d=3" in repr(mu)


### PR DESCRIPTION
## Summary
- `MeasureRepresentation`: runtime-checkable Protocol defining the abstract measure interface from the Layer 2 dev plan (`to_density()`, `total_mass()`, `dimension`)
- `ParticleMeasure`: empirical measure m_N = sum w_i delta_{y_i} with Gaussian KDE projection to grid density (1D and nD, Scott's rule bandwidth)
- 14 tests covering Protocol compliance, initialization, density projection, weighted measures, 2D support

## Context
Phase A of Layer 2 alignment (#956). This formalizes the measure representation abstraction that the dev plan specifies but didn't exist as code. The existing `functional_calculus.py` particle code operates on raw arrays — this Protocol provides the type-safe interface that `MeasureField` and `CommonNoiseHJBSolver` (Phase B) will build on.

## Test plan
- [x] 14 tests pass (0.04s)
- [x] Ruff clean

Partial progress on #956