### PR TITLE
chore: Bump version to v0.18.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.18.14"  # v0.18.14: BoundaryFace migration, Layer 1 tests, context-based progress routing
+version = "0.18.15"  # v0.18.15: MeasureRepresentation Protocol, Phase 1.5 validation, RegimeSwitching bugfixes
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Changes since v0.18.14

- **#957**: MeasureRepresentation Protocol + ParticleMeasure (Layer 2 foundation)
- **#958**: Phase 1.5 integration validation — all 4 items pass:
  - Multi-population cross-coupling via source_term
  - Regime switching with asymmetric Q (3 bugs fixed in iterator)
  - Network HJB/FP solvers end-to-end
  - Homotopy continuation branch tracing
- **#665**: Closed as superseded (non-smooth H infrastructure)
- **#956**: Layer 2 alignment issue created
- Joplin: Clarke subdifferential note, GitHub Pages note, dev plan Rev 6