### PR TITLE
refactor: Consolidate Newton solver defaults (#966)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -39,6 +39,10 @@ if TYPE_CHECKING:
 # Clipping limit for p_values ONLY when using numerical FD for Jacobian H-part (fallback)
 P_VALUE_CLIP_LIMIT_FD_JAC = 1e6
 
+# Default Newton solver parameters shared across HJB solvers (Issue #966)
+DEFAULT_NEWTON_MAX_ITERATIONS: int = 30
+DEFAULT_NEWTON_TOLERANCE: float = 1e-6
+
 
 def _compute_gradient_array_1d(
     U_array: np.ndarray,
@@ -1066,9 +1070,9 @@ def solve_hjb_timestep_newton(
 
     # Set defaults if still None
     if max_newton_iterations is None:
-        max_newton_iterations = 30
+        max_newton_iterations = DEFAULT_NEWTON_MAX_ITERATIONS
     if newton_tolerance is None:
-        newton_tolerance = 1e-6
+        newton_tolerance = DEFAULT_NEWTON_TOLERANCE
 
     # Initial guess for Newton for U_n is U_{n+1} (from current HJB backward step)
     # Use backend-aware copy from compatibility layer
@@ -1272,9 +1276,9 @@ def solve_hjb_system_backward(
 
     # Set defaults if still None
     if max_newton_iterations is None:
-        max_newton_iterations = 30
+        max_newton_iterations = DEFAULT_NEWTON_MAX_ITERATIONS
     if newton_tolerance is None:
-        newton_tolerance = 1e-6
+        newton_tolerance = DEFAULT_NEWTON_TOLERANCE
 
     Nt = problem.Nt + 1
     Nx = problem.geometry.get_grid_shape()[0]

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -201,8 +201,10 @@ class HJBFDMSolver(BaseHJBSolver):
             newton_tolerance = newton_tolerance or l2errBoundNewton
 
         # Set defaults (use None check to avoid treating 0 as falsy)
-        self.max_newton_iterations = max_newton_iterations if max_newton_iterations is not None else 30
-        self.newton_tolerance = newton_tolerance if newton_tolerance is not None else 1e-6
+        self.max_newton_iterations = (
+            max_newton_iterations if max_newton_iterations is not None else base_hjb.DEFAULT_NEWTON_MAX_ITERATIONS
+        )
+        self.newton_tolerance = newton_tolerance if newton_tolerance is not None else base_hjb.DEFAULT_NEWTON_TOLERANCE
         self.solver_type = solver_type
         self.damping_factor = damping_factor
         self.constraint = constraint  # Variational inequality constraint (Issue #591)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -30,7 +30,11 @@ from mfgarchon.utils.deprecation import deprecated_parameter, deprecated_value
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical.qp_utils import QPCache, QPSolver
 
-from .base_hjb import BaseHJBSolver
+from .base_hjb import (
+    DEFAULT_NEWTON_MAX_ITERATIONS,
+    DEFAULT_NEWTON_TOLERANCE,
+    BaseHJBSolver,
+)
 
 logger = get_logger(__name__)
 
@@ -397,9 +401,9 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         # Set defaults if still None
         if max_newton_iterations is None:
-            max_newton_iterations = 30
+            max_newton_iterations = DEFAULT_NEWTON_MAX_ITERATIONS
         if newton_tolerance is None:
-            newton_tolerance = 1e-6
+            newton_tolerance = DEFAULT_NEWTON_TOLERANCE
 
         # Collocation parameters
         self.collocation_points = collocation_points


### PR DESCRIPTION
## Summary

- Define `DEFAULT_NEWTON_MAX_ITERATIONS` (30) and `DEFAULT_NEWTON_TOLERANCE` (1e-6) as named constants in `base_hjb.py`
- Replace 4 scattered magic numbers across `base_hjb.py` (2 locations), `hjb_fdm.py` (1), and `hjb_gfdm.py` (1) with references to these constants
- Single source of truth for Newton defaults

Closes #966

## Test plan

- [x] 80 tests passed (`test_hjb_fdm_solver.py` + `test_hjb_semi_lagrangian.py`)
- [x] Ruff clean
- [x] Import verification for all three modules
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)