### PR TITLE
chore: Bump version to v0.18.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.18.15"  # v0.18.15: MeasureRepresentation Protocol, Phase 1.5 validation, RegimeSwitching bugfixes
+version = "0.18.16"  # v0.18.16: Hard-coded refactors (SL/Newton/WENO), Layer 1 test hardening (33 tests)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Summary

Bump version to v0.18.16. Changes since v0.18.15:

- **refactor**: SL characteristic ODE params delegation (#965)
- **refactor**: Newton solver defaults consolidation (#966)
- **refactor**: Dimension-agnostic WENO CFL/diffusion caps (#967)
- **test**: Layer 1 test hardening — 33 tests for PenaltyHJB, HomotopyContinuation, RegimeSwitchingIterator (#971-973)

🤖 Generated with [Claude Code](https://claude.com/claude-code)