### PR TITLE
feat: Lions derivative correction bridge for nonlocal MFG coupling (#956)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/lions_correction.py
+++ b/mfgarchon/alg/numerical/coupling/lions_correction.py
@@ -1,0 +1,185 @@
+"""
+Lions derivative correction bridge for MFG source term injection.
+
+Connects the functional calculus infrastructure (FunctionalDerivative)
+to the HJB source term pipeline (MFGProblem.source_term_hjb).
+
+For a coupling energy F[m], the Lions correction adds the first variation
+delta F / delta m[m](x) as a source term to the HJB equation:
+
+    -du/dt + H(x, Du, m) - sigma^2/2 Du + delta F / delta m[m](x) = 0
+
+This is the "measure-dependent" coupling that goes beyond local f(m(x))
+coupling (which is already handled by the Hamiltonian).
+
+Issue #956: Part of Layer 2 (Measure-Dependent MFG).
+
+Mathematical background:
+    For nonlocal coupling F[m] = (1/2) int int W(x,y) m(x) m(y) dx dy,
+    the first variation is:
+        delta F / delta m[m](x) = int W(x,y) m(y) dy = (W * m)(x)
+
+    For local coupling F[m] = int f(m(x)) dx:
+        delta F / delta m[m](x) = f'(m(x))
+
+    The FunctionalDerivative infrastructure computes this via finite
+    differences or particle approximation, making this bridge agnostic
+    to the specific coupling form.
+
+Usage:
+    >>> from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
+    >>> from mfgarchon.alg.numerical.coupling.lions_correction import create_lions_source
+    >>>
+    >>> # Define nonlocal energy functional
+    >>> W = ...  # interaction kernel matrix (Nx, Nx)
+    >>> dx = 1.0 / Nx
+    >>> def energy(m):
+    ...     return 0.5 * np.sum(m * (W @ m)) * dx
+    >>>
+    >>> fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4)
+    >>> source_hjb = create_lions_source(energy, fd)
+    >>>
+    >>> problem = MFGProblem(..., source_term_hjb=source_hjb)
+    >>> result = problem.solve()
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+    from mfgarchon.utils.functional_calculus import FunctionalDerivative, FunctionalOnMeasures
+
+
+def create_lions_source(
+    energy_functional: FunctionalOnMeasures,
+    functional_derivative: FunctionalDerivative,
+) -> Callable[[NDArray, NDArray, NDArray, float], NDArray]:
+    """Create a source_term_hjb from a measure-dependent energy functional.
+
+    Bridges the functional calculus infrastructure to the MFGProblem
+    source_term_hjb interface by computing delta F / delta m[m](x)
+    at each Picard iteration.
+
+    Args:
+        energy_functional: F[m] -> float. The coupling energy functional
+            that depends on the full measure (not just local density).
+            Takes a density array m (shape (Nx,)) and returns a scalar.
+        functional_derivative: FunctionalDerivative instance for computing
+            delta F / delta m. Can be FiniteDifferenceFunctionalDerivative
+            or ParticleApproximationFunctionalDerivative.
+
+    Returns:
+        source_term_hjb(x, m, v, t) -> NDArray compatible with
+        MFGProblem.source_term_hjb field. The returned array has shape
+        matching x (one value per spatial grid point).
+
+    Example:
+        >>> import numpy as np
+        >>> from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
+        >>>
+        >>> # Quadratic interaction: F[m] = (1/2) int m(x)^2 dx
+        >>> dx = 0.02
+        >>> def energy(m):
+        ...     return 0.5 * np.sum(m**2) * dx
+        >>>
+        >>> fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4)
+        >>> source = create_lions_source(energy, fd)
+        >>>
+        >>> # source(x, m, v, t) returns delta F / delta m = m(x) * dx
+        >>> m = np.ones(50) / 50
+        >>> result = source(np.linspace(0, 1, 50), m, np.zeros(50), 0.0)
+    """
+
+    def source_term_hjb(
+        x: NDArray,
+        m: NDArray,
+        v: NDArray,
+        t: float,
+    ) -> NDArray:
+        """Evaluate Lions correction delta F / delta m[m](x).
+
+        Args:
+            x: Spatial grid points, shape (Nx,) or (Nx, d)
+            m: Current density — may be (Nx,) for single time slice or
+                (Nt+1, Nx) for full time-space array (as passed by FixedPointIterator).
+            v: Current value function (unused — correction depends on m only)
+            t: Current time (unused for time-independent F[m])
+
+        Returns:
+            Source term values, shape (Nx,)
+        """
+        # Extract spatial density at current time if m is time-space array
+        if m.ndim == 2:
+            # m is (Nt+1, Nx) — use last time step as representative
+            # (consistent with explicit source term treatment)
+            m_flat = m[-1].ravel()
+        else:
+            m_flat = m.ravel()
+        Nx = len(m_flat)
+
+        # Compute delta F / delta m at each grid point
+        # y_points = all grid indices (perturb at each point)
+        y_indices = np.arange(Nx)
+
+        deriv = functional_derivative.compute(
+            energy_functional,
+            m_flat,
+            x_points=x,
+            y_points=y_indices,
+        )
+
+        return np.asarray(deriv).ravel()
+
+    return source_term_hjb
+
+
+def create_nonlocal_source(
+    interaction_kernel: NDArray,
+    grid_spacing: float,
+) -> Callable[[NDArray, NDArray, NDArray, float], NDArray]:
+    """Create source_term_hjb for nonlocal interaction coupling.
+
+    Optimized path for the common case F[m] = (1/2) int int W(x,y) m(x) m(y) dx dy,
+    where delta F / delta m[m](x) = int W(x,y) m(y) dy = (W @ m) * dx.
+
+    This avoids the overhead of finite-difference functional derivatives
+    by computing the convolution directly.
+
+    Args:
+        interaction_kernel: W(x_i, x_j) matrix, shape (N, N) where N is the
+            total number of spatial grid points (N = Nx for 1D, Nx*Ny for 2D, etc.).
+            Symmetric for undirected interaction. Operates on flattened density arrays.
+        grid_spacing: Spatial grid spacing dx for quadrature (1D cell volume).
+            For nD, pass the cell volume dx*dy*... instead.
+
+    Returns:
+        source_term_hjb(x, m, v, t) -> NDArray.
+
+    Example:
+        >>> # Gaussian interaction kernel
+        >>> x = np.linspace(0, 1, 50)
+        >>> W = np.exp(-((x[:, None] - x[None, :]) ** 2) / (2 * 0.1**2))
+        >>> source = create_nonlocal_source(W, dx=x[1] - x[0])
+    """
+    W = interaction_kernel
+    dx = grid_spacing
+
+    def source_term_hjb(
+        x: NDArray,
+        m: NDArray,
+        v: NDArray,
+        t: float,
+    ) -> NDArray:
+        """Evaluate (W * m)(x) = int W(x,y) m(y) dy."""
+        # Handle (Nt+1, Nx) time-space array from FixedPointIterator
+        m_spatial = m[-1].ravel() if m.ndim == 2 else m.ravel()
+        return (W @ m_spatial) * dx
+
+    return source_term_hjb

--- a/tests/integration/test_lions_correction.py
+++ b/tests/integration/test_lions_correction.py
@@ -1,0 +1,242 @@
+"""
+Integration tests for Lions derivative correction bridge.
+
+Tests that the functional calculus infrastructure correctly feeds
+into the HJB source term pipeline via create_lions_source and
+create_nonlocal_source.
+"""
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling import FixedPointIterator
+from mfgarchon.alg.numerical.coupling.lions_correction import (
+    create_lions_source,
+    create_nonlocal_source,
+)
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.config import MFGSolverConfig
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
+
+
+def _make_problem(Nx: int = 51, source_term_hjb=None) -> MFGProblem:
+    """Create a 1D MFG problem with optional source term."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(
+        Nx=Nx,
+        xmin=0.0,
+        xmax=1.0,
+        T=0.5,
+        Nt=10,
+        sigma=0.3,
+        components=components,
+        source_term_hjb=source_term_hjb,
+    )
+
+
+class TestCreateLionsSource:
+    """Test create_lions_source bridge function."""
+
+    def test_returns_callable(self):
+        """Bridge should return a callable with correct signature."""
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4)
+
+        def energy(m):
+            return 0.5 * np.sum(m**2) * 0.02
+
+        source = create_lions_source(energy, fd)
+        assert callable(source)
+
+    def test_source_signature(self):
+        """Source should accept (x, m, v, t) and return array."""
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4)
+
+        def energy(m):
+            return 0.5 * np.sum(m**2) * 0.02
+
+        source = create_lions_source(energy, fd)
+        x = np.linspace(0, 1, 50)
+        m = np.ones(50) / 50
+        v = np.zeros(50)
+        result = source(x, m, v, 0.0)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (50,)
+
+    def test_quadratic_functional_derivative(self):
+        """For F[m] = (1/2) int m^2 dx, delta F/delta m = m * dx."""
+        Nx = 50
+        dx = 1.0 / Nx
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4, method="central")
+
+        def energy(m):
+            return 0.5 * np.sum(m**2) * dx
+
+        source = create_lions_source(energy, fd)
+        x = np.linspace(0, 1, Nx)
+        m = np.ones(Nx) * 2.0  # uniform density = 2
+
+        result = source(x, m, np.zeros(Nx), 0.0)
+
+        # Analytical: delta F/delta m[m](x_i) = m(x_i) * dx = 2 * dx
+        expected = m * dx
+        np.testing.assert_allclose(result, expected, rtol=1e-2)
+
+    def test_linear_functional_derivative(self):
+        """For F[m] = int V(x) m(x) dx, delta F/delta m = V(x) * dx."""
+        Nx = 50
+        dx = 1.0 / Nx
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4, method="central")
+
+        x = np.linspace(0, 1, Nx)
+        V = np.sin(np.pi * x)
+
+        def energy(m):
+            return np.sum(V * m) * dx
+
+        source = create_lions_source(energy, fd)
+        m = np.ones(Nx)
+
+        result = source(x, m, np.zeros(Nx), 0.0)
+
+        # Analytical: delta F/delta m = V(x_i) * dx
+        expected = V * dx
+        np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-10)
+
+
+class TestCreateNonlocalSource:
+    """Test create_nonlocal_source optimized path."""
+
+    def test_returns_callable(self):
+        Nx = 30
+        x = np.linspace(0, 1, Nx)
+        W = np.exp(-((x[:, None] - x[None, :]) ** 2) / (2 * 0.1**2))
+        source = create_nonlocal_source(W, grid_spacing=x[1] - x[0])
+        assert callable(source)
+
+    def test_convolution_result(self):
+        """W @ m should give the convolution integral."""
+        Nx = 50
+        dx = 1.0 / Nx
+        x = np.linspace(0, 1, Nx)
+
+        # Identity kernel: W = I -> (W @ m) = m
+        W = np.eye(Nx)
+        source = create_nonlocal_source(W, grid_spacing=dx)
+        m = np.sin(np.pi * x) + 1.0
+
+        result = source(x, m, np.zeros(Nx), 0.0)
+        np.testing.assert_allclose(result, m * dx, atol=1e-12)
+
+    def test_gaussian_kernel_symmetry(self):
+        """Gaussian kernel convolution should be symmetric for symmetric m."""
+        Nx = 51
+        dx = 1.0 / (Nx - 1)
+        x = np.linspace(0, 1, Nx)
+
+        W = np.exp(-((x[:, None] - x[None, :]) ** 2) / (2 * 0.1**2))
+        source = create_nonlocal_source(W, grid_spacing=dx)
+
+        # Symmetric density
+        m = np.exp(-((x - 0.5) ** 2) / (2 * 0.15**2))
+
+        result = source(x, m, np.zeros(Nx), 0.0)
+
+        # Result should be approximately symmetric around 0.5
+        np.testing.assert_allclose(result, result[::-1], atol=1e-6)
+
+    def test_matches_lions_source(self):
+        """Nonlocal source should match create_lions_source for same kernel."""
+        Nx = 30
+        dx = 1.0 / Nx
+        x = np.linspace(0, 1, Nx)
+
+        W = np.exp(-((x[:, None] - x[None, :]) ** 2) / (2 * 0.2**2))
+
+        # Direct path
+        source_direct = create_nonlocal_source(W, grid_spacing=dx)
+
+        # FD path
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4, method="central")
+
+        def energy(m):
+            return 0.5 * np.sum(m * (W @ m)) * dx
+
+        source_fd = create_lions_source(energy, fd)
+
+        m = np.sin(np.pi * x) + 1.5
+
+        result_direct = source_direct(x, m, np.zeros(Nx), 0.0)
+        result_fd = source_fd(x, m, np.zeros(Nx), 0.0)
+
+        # Should be close (FD has epsilon error)
+        np.testing.assert_allclose(result_direct, result_fd, rtol=0.05)
+
+
+class TestLionsCorrectionEndToEnd:
+    """Test Lions correction flows through the full MFG solve pipeline."""
+
+    def test_source_term_affects_solution(self):
+        """MFG solve with Lions correction should differ from without."""
+        Nx = 31
+        problem_plain = _make_problem(Nx=Nx)
+
+        # Get actual grid from geometry to match solver dimensions
+        actual_grid = problem_plain.geometry.get_spatial_grid().ravel()
+        dx = actual_grid[1] - actual_grid[0]
+
+        # Gaussian interaction kernel sized to actual grid
+        W = np.exp(-((actual_grid[:, None] - actual_grid[None, :]) ** 2) / (2 * 0.2**2))
+        source = create_nonlocal_source(W, grid_spacing=dx)
+
+        problem_lions = _make_problem(Nx=Nx, source_term_hjb=source)
+
+        # Solve both
+        hjb1, fp1 = HJBFDMSolver(problem_plain), FPFDMSolver(problem_plain)
+        hjb2, fp2 = HJBFDMSolver(problem_lions), FPFDMSolver(problem_lions)
+
+        config = MFGSolverConfig(max_iterations=5)
+        iter1 = FixedPointIterator(problem_plain, hjb1, fp1, config=config)
+        iter2 = FixedPointIterator(problem_lions, hjb2, fp2, config=config)
+
+        result1 = iter1.solve()
+        result2 = iter2.solve()
+
+        U1 = result1.U if hasattr(result1, "U") else result1[0]
+        U2 = result2.U if hasattr(result2, "U") else result2[0]
+
+        # Solutions should differ due to nonlocal coupling
+        assert not np.allclose(U1, U2, atol=1e-4)
+
+    def test_solution_is_finite(self):
+        """MFG with Lions correction should produce finite solution."""
+        Nx = 31
+        problem_tmp = _make_problem(Nx=Nx)
+        actual_grid = problem_tmp.geometry.get_spatial_grid().ravel()
+        dx = actual_grid[1] - actual_grid[0]
+
+        W = 0.1 * np.exp(-((actual_grid[:, None] - actual_grid[None, :]) ** 2) / (2 * 0.2**2))
+        source = create_nonlocal_source(W, grid_spacing=dx)
+
+        problem = _make_problem(Nx=Nx, source_term_hjb=source)
+        hjb, fp = HJBFDMSolver(problem), FPFDMSolver(problem)
+        config = MFGSolverConfig(max_iterations=5)
+        iterator = FixedPointIterator(problem, hjb, fp, config=config)
+
+        result = iterator.solve()
+        U = result.U if hasattr(result, "U") else result[0]
+        M = result.M if hasattr(result, "M") else result[1]
+        assert np.all(np.isfinite(U))
+        assert np.all(np.isfinite(M))


### PR DESCRIPTION
## Summary

Layer 2 entry point: bridges the functional calculus infrastructure to the HJB source term pipeline.

- `create_lions_source(energy_functional, functional_derivative)` — generic bridge via `FunctionalDerivative.compute()`, works with any energy functional F[m]
- `create_nonlocal_source(interaction_kernel, grid_spacing)` — optimized direct path for `F[m] = (1/2) int int W(x,y) m(x) m(y) dx dy`, computes `(W @ m) * dx`
- Both handle `(Nt+1, Nx)` time-space density arrays from `FixedPointIterator`
- Dimension-agnostic (operates on flattened grid arrays, documented for nD)

Returns `source_term_hjb(x, m, v, t)` callable compatible with `MFGProblem.source_term_hjb`.

10 integration tests covering: functional derivative accuracy (quadratic, linear), kernel symmetry, FD/direct path agreement, end-to-end MFG solve with nonlocal coupling.

Partial progress on #956 (Layer 2 alignment).

## Test plan

- [x] 10 integration tests pass (108s total)
- [x] Ruff clean
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)