### PR TITLE
chore: Bump version to v0.18.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.18.17"  # v0.18.17: Layer 2 entry (Lions correction, Wasserstein distance), deps simplified to 3 tiers
+version = "0.18.18"  # v0.18.18: Layer 2 foundation complete (MeasureField, iterator wiring, sensitivity diagnostics)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
MeasureField + iterator wiring since v0.18.17.