### PR TITLE
feat: GraphCouplingOperator Protocol + AdjacencyCoupling + LaplacianCoupling (#961)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/graph_coupling.py
+++ b/mfgarchon/alg/numerical/coupling/graph_coupling.py
@@ -1,0 +1,306 @@
+"""
+Graph coupling operators for network MFG systems.
+
+Defines the GraphCouplingOperator Protocol and concrete implementations
+for inter-node coupling in graph-structured Mean Field Games.
+
+Three types of network MFG share the same coupling structure:
+- Type 1 (finite-state ODE): NetworkHJBSolver handles internally
+- Type 2 (PDE at each node, graph-coupled): uses GraphCouplingOperator
+- Type 3 (hybrid PDE-ODE): Type 2 + RegimeSwitchingIterator
+
+The coupling enters each node's HJB/FP equations via source_term injection:
+    HJB_k: -dv^k/dt + H^k(x, Dv^k, m^k) + S_hjb^k = 0
+    FP_k:  dm^k/dt - L^k[m^k] + S_fp^k = 0
+
+where S_hjb^k, S_fp^k encode the inter-node interaction.
+
+Issue #961: GraphCouplingOperator Protocol for inter-node coupling.
+
+Design reference:
+    Joplin: "Unified Network MFG Solver Architecture" (Graph MFG folder)
+    Joplin: "Graphon MFG: From Finite Graph to Continuum Limit"
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+
+@runtime_checkable
+class GraphCouplingOperator(Protocol):
+    """Protocol for inter-node coupling in graph MFG systems.
+
+    Given the current state of all N nodes (value functions and densities),
+    produces source_term callables for each node's HJB and FP equations.
+
+    The source terms have signature (t: float, x: NDArray) -> NDArray,
+    compatible with BaseHJBSolver.solve_hjb_system(source_term=...) and
+    BaseFPSolver.solve_fp_system(source_term=...).
+
+    Implementations:
+        AdjacencyCoupling: sum_j A_{ij} g(v_j, m_j)
+        LaplacianCoupling: L_{ij} v_j (diffusive coupling)
+    """
+
+    def compute_hjb_source(
+        self,
+        node_idx: int,
+        values: list[NDArray],
+        densities: list[NDArray],
+        t: float,
+    ) -> Callable[[float, NDArray], NDArray]:
+        """Build HJB source term for node_idx given all nodes' state.
+
+        Args:
+            node_idx: Index of the node being solved.
+            values: Value functions v^k for all nodes, each shape (Nt+1, Nx).
+            densities: Densities m^k for all nodes, each shape (Nt+1, Nx) or (Nx,).
+            t: Current time (for time-dependent coupling).
+
+        Returns:
+            source_term(t, x) -> NDArray compatible with HJB solver.
+        """
+        ...
+
+    def compute_fp_source(
+        self,
+        node_idx: int,
+        values: list[NDArray],
+        densities: list[NDArray],
+        t: float,
+    ) -> Callable[[float, NDArray], NDArray]:
+        """Build FP source term for node_idx given all nodes' state.
+
+        Args:
+            node_idx: Index of the node being solved.
+            values: Value functions v^k for all nodes.
+            densities: Densities m^k for all nodes.
+            t: Current time.
+
+        Returns:
+            source_term(t, x) -> NDArray compatible with FP solver.
+        """
+        ...
+
+    @property
+    def n_nodes(self) -> int:
+        """Number of nodes in the graph."""
+        ...
+
+
+class AdjacencyCoupling:
+    """Inter-node coupling via adjacency matrix.
+
+    HJB source for node i: S_i(t, x) = sum_j A_{ij} * g_hjb(v_j(t, x), m_j(t, x))
+    FP source for node i:  S_i(t, x) = sum_j A_{ij} * g_fp(v_j(t, x), m_j(t, x))
+
+    The coupling functions g_hjb, g_fp define how neighbor states affect
+    each node. Common choices:
+    - Value difference: g_hjb(v_j, m_j) = alpha * (v_i - v_j)  (migration incentive)
+    - Density interaction: g_fp(v_j, m_j) = beta * m_j  (population inflow)
+
+    Parameters
+    ----------
+    adjacency : NDArray
+        Adjacency matrix A, shape (N, N). A_{ij} > 0 if node j affects node i.
+        Can be weighted (interaction strength) or binary.
+    coupling_hjb : Callable[[int, int, NDArray, NDArray, float], NDArray] | None
+        Custom HJB coupling function: (i, j, v_j_at_t, m_j_at_t, t) -> contribution.
+        Default: alpha * (v_i_at_t - v_j_at_t) (value difference).
+    coupling_fp : Callable[[int, int, NDArray, NDArray, float], NDArray] | None
+        Custom FP coupling function: (i, j, v_j_at_t, m_j_at_t, t) -> contribution.
+        Default: beta * (m_j_at_t - m_i_at_t) (mass transfer).
+    alpha : float
+        Default HJB coupling strength (default 0.1).
+    beta : float
+        Default FP coupling strength (default 0.1).
+
+    Example
+    -------
+    >>> # 3-node ring graph
+    >>> A = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=float)
+    >>> coupling = AdjacencyCoupling(A, alpha=0.1, beta=0.05)
+    """
+
+    def __init__(
+        self,
+        adjacency: NDArray,
+        coupling_hjb: Callable | None = None,
+        coupling_fp: Callable | None = None,
+        alpha: float = 0.1,
+        beta: float = 0.1,
+    ):
+        self._A = np.asarray(adjacency, dtype=float)
+        N = self._A.shape[0]
+        if self._A.shape != (N, N):
+            raise ValueError(f"Adjacency must be square, got {self._A.shape}")
+        self._N = N
+        self._alpha = alpha
+        self._beta = beta
+        self._coupling_hjb = coupling_hjb
+        self._coupling_fp = coupling_fp
+
+    @property
+    def n_nodes(self) -> int:
+        return self._N
+
+    def compute_hjb_source(
+        self,
+        node_idx: int,
+        values: list[NDArray],
+        densities: list[NDArray],
+        t: float,
+    ) -> Callable[[float, NDArray], NDArray]:
+        i = node_idx
+        A_row = self._A[i]
+        alpha = self._alpha
+        custom = self._coupling_hjb
+
+        def source(t_eval: float, x: NDArray) -> NDArray:
+            Nx = x.shape[0]
+            s = np.zeros(Nx)
+            for j in range(len(values)):
+                if j == i or A_row[j] == 0:
+                    continue
+                # Extract time slice
+                v_i = _get_time_slice(values[i], t_eval)
+                v_j = _get_time_slice(values[j], t_eval)
+                m_j = _get_time_slice(densities[j], t_eval)
+                if custom is not None:
+                    s += A_row[j] * custom(i, j, v_j, m_j, t_eval)
+                else:
+                    # Default: value difference (migration incentive)
+                    # Truncate to match spatial dimension
+                    n = min(len(v_i), len(v_j), Nx)
+                    s[:n] += A_row[j] * alpha * (v_i[:n] - v_j[:n])
+            return s
+
+        return source
+
+    def compute_fp_source(
+        self,
+        node_idx: int,
+        values: list[NDArray],
+        densities: list[NDArray],
+        t: float,
+    ) -> Callable[[float, NDArray], NDArray]:
+        i = node_idx
+        A_row = self._A[i]
+        beta = self._beta
+        custom = self._coupling_fp
+
+        def source(t_eval: float, x: NDArray) -> NDArray:
+            Nx = x.shape[0]
+            s = np.zeros(Nx)
+            for j in range(len(densities)):
+                if j == i or A_row[j] == 0:
+                    continue
+                v_j = _get_time_slice(values[j], t_eval)
+                m_i = _get_time_slice(densities[i], t_eval)
+                m_j = _get_time_slice(densities[j], t_eval)
+                if custom is not None:
+                    s += A_row[j] * custom(i, j, v_j, m_j, t_eval)
+                else:
+                    # Default: mass transfer (inflow from j, outflow to j)
+                    n = min(len(m_i), len(m_j), Nx)
+                    s[:n] += A_row[j] * beta * (m_j[:n] - m_i[:n])
+            return s
+
+        return source
+
+
+class LaplacianCoupling:
+    """Diffusive coupling via graph Laplacian.
+
+    HJB source for node i: S_i(t, x) = kappa * sum_j L_{ij} * v_j(t, x)
+    FP source for node i:  S_i(t, x) = kappa * sum_j L_{ij} * m_j(t, x)
+
+    where L = D - A is the graph Laplacian (D = degree matrix).
+    This models diffusion of value/density across the network.
+
+    Parameters
+    ----------
+    adjacency : NDArray
+        Adjacency matrix A, shape (N, N).
+    kappa : float
+        Diffusion strength (default 0.1).
+    """
+
+    def __init__(self, adjacency: NDArray, kappa: float = 0.1):
+        A = np.asarray(adjacency, dtype=float)
+        N = A.shape[0]
+        if A.shape != (N, N):
+            raise ValueError(f"Adjacency must be square, got {A.shape}")
+        # Graph Laplacian: L = D - A
+        D = np.diag(A.sum(axis=1))
+        self._L = D - A
+        self._N = N
+        self._kappa = kappa
+
+    @property
+    def n_nodes(self) -> int:
+        return self._N
+
+    def compute_hjb_source(
+        self,
+        node_idx: int,
+        values: list[NDArray],
+        densities: list[NDArray],
+        t: float,
+    ) -> Callable[[float, NDArray], NDArray]:
+        i = node_idx
+        L_row = self._L[i]
+        kappa = self._kappa
+
+        def source(t_eval: float, x: NDArray) -> NDArray:
+            Nx = x.shape[0]
+            s = np.zeros(Nx)
+            for j in range(len(values)):
+                if L_row[j] == 0:
+                    continue
+                v_j = _get_time_slice(values[j], t_eval)
+                n = min(len(v_j), Nx)
+                s[:n] += kappa * L_row[j] * v_j[:n]
+            return s
+
+        return source
+
+    def compute_fp_source(
+        self,
+        node_idx: int,
+        values: list[NDArray],
+        densities: list[NDArray],
+        t: float,
+    ) -> Callable[[float, NDArray], NDArray]:
+        i = node_idx
+        L_row = self._L[i]
+        kappa = self._kappa
+
+        def source(t_eval: float, x: NDArray) -> NDArray:
+            Nx = x.shape[0]
+            s = np.zeros(Nx)
+            for j in range(len(densities)):
+                if L_row[j] == 0:
+                    continue
+                m_j = _get_time_slice(densities[j], t_eval)
+                n = min(len(m_j), Nx)
+                s[:n] += kappa * L_row[j] * m_j[:n]
+            return s
+
+        return source
+
+
+def _get_time_slice(arr: NDArray, t: float, dt: float = 0.05) -> NDArray:
+    """Extract spatial slice from (Nt+1, Nx) or (Nx,) array at time t."""
+    if arr.ndim == 1:
+        return arr
+    n = min(round(t / dt) if dt > 0 else 0, arr.shape[0] - 1)
+    return arr[n]

--- a/tests/unit/test_core/test_graph_coupling.py
+++ b/tests/unit/test_core/test_graph_coupling.py
@@ -1,0 +1,188 @@
+"""Tests for GraphCouplingOperator Protocol and implementations."""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.graph_coupling import (
+    AdjacencyCoupling,
+    GraphCouplingOperator,
+    LaplacianCoupling,
+)
+
+
+def _ring_adjacency(n: int) -> np.ndarray:
+    """Create adjacency matrix for n-node ring graph."""
+    A = np.zeros((n, n))
+    for i in range(n):
+        A[i, (i + 1) % n] = 1.0
+        A[i, (i - 1) % n] = 1.0
+    return A
+
+
+def _mock_values(n_nodes: int, Nt: int = 6, Nx: int = 11) -> list[np.ndarray]:
+    """Create mock value functions for n nodes."""
+    rng = np.random.RandomState(42)
+    return [rng.randn(Nt, Nx) for _ in range(n_nodes)]
+
+
+def _mock_densities(n_nodes: int, Nt: int = 6, Nx: int = 11) -> list[np.ndarray]:
+    """Create mock density arrays (non-negative)."""
+    rng = np.random.RandomState(7)
+    return [np.abs(rng.randn(Nt, Nx)) + 0.1 for _ in range(n_nodes)]
+
+
+class TestGraphCouplingProtocol:
+    def test_adjacency_satisfies_protocol(self):
+        A = _ring_adjacency(3)
+        coupling = AdjacencyCoupling(A)
+        assert isinstance(coupling, GraphCouplingOperator)
+
+    def test_laplacian_satisfies_protocol(self):
+        A = _ring_adjacency(3)
+        coupling = LaplacianCoupling(A)
+        assert isinstance(coupling, GraphCouplingOperator)
+
+
+class TestAdjacencyCoupling:
+    def test_n_nodes(self):
+        A = _ring_adjacency(4)
+        coupling = AdjacencyCoupling(A)
+        assert coupling.n_nodes == 4
+
+    def test_non_square_raises(self):
+        with pytest.raises(ValueError, match="square"):
+            AdjacencyCoupling(np.zeros((3, 4)))
+
+    def test_hjb_source_returns_callable(self):
+        A = _ring_adjacency(3)
+        coupling = AdjacencyCoupling(A, alpha=0.1)
+        values = _mock_values(3)
+        densities = _mock_densities(3)
+        source = coupling.compute_hjb_source(0, values, densities, t=0.0)
+        assert callable(source)
+
+    def test_hjb_source_shape(self):
+        A = _ring_adjacency(3)
+        coupling = AdjacencyCoupling(A, alpha=0.1)
+        values = _mock_values(3, Nx=21)
+        densities = _mock_densities(3, Nx=21)
+        source = coupling.compute_hjb_source(0, values, densities, t=0.0)
+        x = np.linspace(0, 1, 21)
+        result = source(0.0, x)
+        assert result.shape == (21,)
+
+    def test_hjb_source_zero_for_identical_values(self):
+        """Default coupling is value difference — zero if all nodes same."""
+        A = _ring_adjacency(3)
+        coupling = AdjacencyCoupling(A, alpha=0.1)
+        V = np.ones((6, 11))
+        values = [V.copy(), V.copy(), V.copy()]
+        densities = _mock_densities(3)
+        source = coupling.compute_hjb_source(0, values, densities, t=0.0)
+        result = source(0.0, np.linspace(0, 1, 11))
+        np.testing.assert_allclose(result, 0.0, atol=1e-12)
+
+    def test_fp_source_shape(self):
+        A = _ring_adjacency(3)
+        coupling = AdjacencyCoupling(A, beta=0.05)
+        values = _mock_values(3, Nx=21)
+        densities = _mock_densities(3, Nx=21)
+        source = coupling.compute_fp_source(1, values, densities, t=0.0)
+        x = np.linspace(0, 1, 21)
+        result = source(0.0, x)
+        assert result.shape == (21,)
+
+    def test_fp_source_mass_transfer(self):
+        """Mass transfer from high-density neighbor to low-density node."""
+        A = np.array([[0, 1], [1, 0]], dtype=float)
+        coupling = AdjacencyCoupling(A, beta=1.0)
+        values = [np.zeros((6, 11)), np.zeros((6, 11))]
+        # Node 0: low density, Node 1: high density
+        m0 = np.ones((6, 11)) * 0.1
+        m1 = np.ones((6, 11)) * 0.9
+        densities = [m0, m1]
+        source = coupling.compute_fp_source(0, values, densities, t=0.0)
+        result = source(0.0, np.linspace(0, 1, 11))
+        # Inflow to node 0: beta * (m1 - m0) = 1.0 * (0.9 - 0.1) = 0.8
+        np.testing.assert_allclose(result, 0.8, atol=1e-10)
+
+    def test_no_self_coupling(self):
+        """Node should not couple with itself even if A_{ii} != 0."""
+        A = np.eye(3)  # Only self-loops
+        coupling = AdjacencyCoupling(A, alpha=1.0)
+        values = _mock_values(3)
+        densities = _mock_densities(3)
+        source = coupling.compute_hjb_source(0, values, densities, t=0.0)
+        result = source(0.0, np.linspace(0, 1, 11))
+        # Self-loop skipped (j == i check)
+        np.testing.assert_allclose(result, 0.0, atol=1e-12)
+
+    def test_custom_coupling_function(self):
+        A = np.array([[0, 1], [1, 0]], dtype=float)
+
+        def custom_hjb(i, j, v_j, m_j, t):
+            return m_j * 2.0  # density-based coupling
+
+        coupling = AdjacencyCoupling(A, coupling_hjb=custom_hjb)
+        values = [np.zeros((6, 11)), np.zeros((6, 11))]
+        densities = [np.ones((6, 11)), np.ones((6, 11)) * 3.0]
+        source = coupling.compute_hjb_source(0, values, densities, t=0.0)
+        result = source(0.0, np.linspace(0, 1, 11))
+        # A[0,1] * custom(0, 1, v_1, m_1=3, t=0) = 1 * 3 * 2 = 6
+        np.testing.assert_allclose(result, 6.0, atol=1e-10)
+
+
+class TestLaplacianCoupling:
+    def test_n_nodes(self):
+        A = _ring_adjacency(5)
+        coupling = LaplacianCoupling(A)
+        assert coupling.n_nodes == 5
+
+    def test_laplacian_structure(self):
+        """L = D - A should have zero row sums."""
+        A = _ring_adjacency(3)
+        coupling = LaplacianCoupling(A)
+        row_sums = coupling._L.sum(axis=1)
+        np.testing.assert_allclose(row_sums, 0.0, atol=1e-12)
+
+    def test_hjb_source_zero_for_uniform(self):
+        """Laplacian of constant function is zero."""
+        A = _ring_adjacency(3)
+        coupling = LaplacianCoupling(A, kappa=1.0)
+        V = np.ones((6, 11)) * 5.0
+        values = [V.copy(), V.copy(), V.copy()]
+        densities = _mock_densities(3)
+        source = coupling.compute_hjb_source(0, values, densities, t=0.0)
+        result = source(0.0, np.linspace(0, 1, 11))
+        np.testing.assert_allclose(result, 0.0, atol=1e-10)
+
+    def test_fp_source_conservation(self):
+        """Total FP source across all nodes should sum to zero (mass conservation)."""
+        A = _ring_adjacency(3)
+        coupling = LaplacianCoupling(A, kappa=0.5)
+        values = _mock_values(3, Nx=11)
+        densities = _mock_densities(3, Nx=11)
+        x = np.linspace(0, 1, 11)
+
+        total = np.zeros(11)
+        for i in range(3):
+            source = coupling.compute_fp_source(i, values, densities, t=0.0)
+            total += source(0.0, x)
+
+        # L has zero row sums -> sum of all sources = kappa * sum_i L_i @ m = 0
+        # (when all nodes have same Nx)
+        np.testing.assert_allclose(total, 0.0, atol=1e-10)
+
+    def test_1d_density_input(self):
+        """Should handle (Nx,) density arrays (no time dimension)."""
+        A = _ring_adjacency(2)
+        coupling = LaplacianCoupling(A, kappa=1.0)
+        values = [np.zeros(11), np.ones(11)]
+        densities = [np.ones(11) * 0.5, np.ones(11) * 1.5]
+        source = coupling.compute_fp_source(0, values, densities, t=0.0)
+        result = source(0.0, np.linspace(0, 1, 11))
+        assert result.shape == (11,)
+        assert np.all(np.isfinite(result))


### PR DESCRIPTION
## Summary

Protocol for inter-node coupling in graph-structured MFG (Type 2/3 network problems):

**GraphCouplingOperator Protocol**: `compute_hjb_source()` and `compute_fp_source()` produce `source_term(t, x)` callables compatible with existing HJB/FP solvers.

**AdjacencyCoupling**: `sum_j A_{ij} * g(v_j, m_j)` with customizable coupling functions. Default: value difference (HJB), mass transfer (FP).

**LaplacianCoupling**: `L_{ij}` diffusive coupling via graph Laplacian `L = D - A`. Conserves total mass (Laplacian row sums = 0, tested).

Placed in `alg/numerical/coupling/` alongside RegimeSwitchingIterator. 16 unit tests.

Closes #961

## Test plan

- [x] 16 tests pass
- [x] Ruff clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)