### PR TITLE
feat: GraphMFGSolver — N-node graph Picard iteration (#962)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
@@ -1,0 +1,252 @@
+"""
+Graph MFG Solver — Picard iteration over N-node graph with per-node PDE solvers.
+
+Solves N coupled MFG systems (one per graph node) with inter-node coupling
+injected via GraphCouplingOperator source terms:
+
+    HJB_k: -dv^k/dt + H^k(x, Dv^k, m^k) + S_hjb^k(all nodes) = 0
+    FP_k:  dm^k/dt - L^k[m^k] + S_fp^k(all nodes) = 0
+
+Each node has its own MFGProblem, HJB solver, and FP solver. The graph
+coupling enters via source_term injection — no solver modification needed.
+
+This is the **Type 2** network MFG solver:
+- Type 1 (finite-state ODE): NetworkHJBSolver (existing)
+- Type 2 (PDE at each node, graph-coupled): **this module**
+- Type 3 (hybrid): Type 2 + RegimeSwitchingIterator per node
+
+Issue #962: GraphMFGSolver — unified orchestrator for network MFG types 2 and 3.
+
+Design reference:
+    Joplin: "Unified Network MFG Solver Architecture" (Graph MFG folder)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from mfgarchon.alg.numerical.coupling.graph_coupling import GraphCouplingOperator
+    from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+    from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+    from mfgarchon.core.mfg_problem import MFGProblem
+
+
+@dataclass
+class GraphMFGResult:
+    """Result container for graph MFG solver."""
+
+    values: list[NDArray]
+    """Value functions v^k for each node, shape (Nt+1, Nx) each."""
+
+    densities: list[NDArray]
+    """Density fields m^k for each node, shape (Nt+1, Nx) each."""
+
+    converged: bool
+    """Whether the Picard iteration converged."""
+
+    iterations: int
+    """Number of Picard iterations performed."""
+
+    error_history: list[float] = field(default_factory=list)
+    """Max error across all nodes per iteration."""
+
+    n_nodes: int = 0
+    """Number of nodes in the graph."""
+
+
+class GraphMFGSolver(BaseCouplingIterator):
+    """Picard iteration over N-node graph with per-node MFG solvers.
+
+    Each node runs its own HJB-FP solver pair. Inter-node coupling
+    is provided by a GraphCouplingOperator that produces source_term
+    callables for each node's HJB and FP equations.
+
+    This generalizes RegimeSwitchingIterator: instead of a fixed
+    transition matrix Q, any GraphCouplingOperator can define the
+    inter-node interaction (adjacency, Laplacian, custom).
+
+    Parameters
+    ----------
+    problems : list[MFGProblem]
+        One MFGProblem per graph node. Each defines its own
+        Hamiltonian, sigma, geometry, etc.
+    coupling : GraphCouplingOperator
+        Inter-node coupling operator (AdjacencyCoupling,
+        LaplacianCoupling, or custom).
+    hjb_solvers : list[BaseHJBSolver]
+        One HJB solver per node.
+    fp_solvers : list[BaseFPSolver]
+        One FP solver per node.
+    max_iterations : int
+        Maximum Picard iterations (default 50).
+    tolerance : float
+        Convergence tolerance on max |v^k_{n+1} - v^k_n| (default 1e-5).
+    damping : float
+        Damping factor for Picard update (default 0.5).
+
+    Example
+    -------
+    >>> from mfgarchon.alg.numerical.coupling.graph_coupling import AdjacencyCoupling
+    >>> A = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=float)
+    >>> coupling = AdjacencyCoupling(A, alpha=0.1, beta=0.05)
+    >>> solver = GraphMFGSolver(
+    ...     problems=[p1, p2, p3],
+    ...     coupling=coupling,
+    ...     hjb_solvers=[hjb1, hjb2, hjb3],
+    ...     fp_solvers=[fp1, fp2, fp3],
+    ... )
+    >>> result = solver.solve()
+    """
+
+    def __init__(
+        self,
+        problems: list[MFGProblem],
+        coupling: GraphCouplingOperator,
+        hjb_solvers: list[BaseHJBSolver],
+        fp_solvers: list[BaseFPSolver],
+        max_iterations: int = 50,
+        tolerance: float = 1e-5,
+        damping: float = 0.5,
+    ):
+        # Use first problem as representative for base class
+        super().__init__(problems[0])
+        self._problems = problems
+        self._coupling = coupling
+        self._hjb = hjb_solvers
+        self._fp = fp_solvers
+        self._max_iter = max_iterations
+        self._tol = tolerance
+        self._damping = damping
+
+        # Validate dimensions
+        N = coupling.n_nodes
+        if len(problems) != N:
+            raise ValueError(f"Need {N} problems for {N} nodes, got {len(problems)}")
+        if len(hjb_solvers) != N:
+            raise ValueError(f"Need {N} HJB solvers for {N} nodes, got {len(hjb_solvers)}")
+        if len(fp_solvers) != N:
+            raise ValueError(f"Need {N} FP solvers for {N} nodes, got {len(fp_solvers)}")
+
+        self._N = N
+        self._last_result: GraphMFGResult | None = None
+
+    def solve(self) -> GraphMFGResult:
+        """Run Picard iteration over N-node graph.
+
+        Returns
+        -------
+        GraphMFGResult
+            Contains value functions, densities, convergence info for all nodes.
+        """
+        N = self._N
+
+        # Initialize: terminal conditions and initial densities
+        Us_full = []
+        for k in range(N):
+            p = self._problems[k]
+            u_terminal = p.get_u_terminal()
+            U_k = np.zeros((p.Nt + 1, len(u_terminal)))
+            U_k[-1] = u_terminal
+            Us_full.append(U_k)
+
+        Ms = []
+        for k in range(N):
+            m_init = self._problems[k].get_m_initial()
+            Ms.append(m_init)
+
+        error_history: list[float] = []
+
+        for iteration in range(self._max_iter):
+            Us_new: list[NDArray] = [np.empty(0)] * N
+            Ms_new: list[NDArray | None] = [None] * N
+
+            # --- HJB step: solve N backward equations with coupling ---
+            for k in range(N):
+                hjb_source = self._coupling.compute_hjb_source(
+                    k, Us_full, [self._expand_density(k, Ms[k]) for k in range(N)], 0.0
+                )
+
+                M_k_full = self._expand_density(k, Ms[k])
+                U_k = self._hjb[k].solve_hjb_system(
+                    M_k_full,
+                    Us_full[k][-1],  # terminal condition
+                    Us_full[k],  # previous iterate
+                    source_term=hjb_source,
+                )
+                Us_new[k] = U_k
+
+            # --- FP step: solve N forward equations with coupling ---
+            for k in range(N):
+                fp_source = self._coupling.compute_fp_source(
+                    k, Us_new, [self._expand_density(k, Ms[k]) for k in range(N)], 0.0
+                )
+
+                m0_k = Ms[k][0] if isinstance(Ms[k], np.ndarray) and Ms[k].ndim == 2 else Ms[k]
+                M_k = self._fp[k].solve_fp_system(
+                    m0_k,
+                    drift_field=Us_new[k],
+                    source_term=fp_source,
+                )
+                Ms_new[k] = M_k
+
+            # --- Damping ---
+            theta = self._damping
+            for k in range(N):
+                Us_new[k] = theta * Us_new[k] + (1 - theta) * Us_full[k]
+                if Ms_new[k] is not None:
+                    Ms_expanded = self._expand_density(k, Ms[k])
+                    if Ms_new[k].shape == Ms_expanded.shape:
+                        Ms_new[k] = theta * Ms_new[k] + (1 - theta) * Ms_expanded
+
+            # --- Convergence check ---
+            error = max(np.max(np.abs(Us_new[k] - Us_full[k])) for k in range(N))
+            error_history.append(error)
+
+            Us_full = Us_new
+            Ms = Ms_new
+
+            if error < self._tol:
+                self._last_result = GraphMFGResult(
+                    values=Us_full,
+                    densities=Ms,
+                    converged=True,
+                    iterations=iteration + 1,
+                    error_history=error_history,
+                    n_nodes=N,
+                )
+                return self._last_result
+
+        self._last_result = GraphMFGResult(
+            values=Us_full,
+            densities=Ms,
+            converged=False,
+            iterations=self._max_iter,
+            error_history=error_history,
+            n_nodes=N,
+        )
+        return self._last_result
+
+    def _expand_density(self, k: int, m: NDArray) -> NDArray:
+        """Expand density to (Nt+1, Nx) if needed."""
+        if isinstance(m, np.ndarray) and m.ndim == 2:
+            return m
+        Nt = self._problems[k].Nt
+        return np.tile(m, (Nt + 1, 1))
+
+    def get_results(self) -> tuple:
+        """Get computed solution arrays (required by BaseCouplingIterator)."""
+        if self._last_result is not None:
+            return self._last_result.values[0], self._last_result.densities[0]
+        raise RuntimeError("No solution computed yet. Call solve() first.")
+
+    def validate_solution(self) -> dict[str, Any]:
+        """Placeholder for solution validation."""
+        return {}

--- a/tests/integration/test_graph_mfg_solver.py
+++ b/tests/integration/test_graph_mfg_solver.py
@@ -1,0 +1,244 @@
+"""Integration tests for GraphMFGSolver (Type 2 network MFG)."""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.graph_coupling import (
+    AdjacencyCoupling,
+    LaplacianCoupling,
+)
+from mfgarchon.alg.numerical.coupling.graph_mfg_solver import (
+    GraphMFGResult,
+    GraphMFGSolver,
+)
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+
+
+def _make_node_problem(coupling_strength: float = 1.0, sigma: float = 0.3) -> MFGProblem:
+    """Create a 1D MFG problem for one graph node."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: coupling_strength * m,
+        coupling_dm=lambda m: coupling_strength,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(
+        Nx=21,
+        xmin=0.0,
+        xmax=1.0,
+        T=0.5,
+        Nt=10,
+        sigma=sigma,
+        components=components,
+    )
+
+
+def _make_3node_system():
+    """Create a 3-node ring graph with per-node FDM solvers."""
+    problems = [_make_node_problem(c) for c in [1.0, 0.5, 0.8]]
+    A = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=float)
+    coupling = AdjacencyCoupling(A, alpha=0.05, beta=0.02)
+    hjbs = [HJBFDMSolver(p) for p in problems]
+    fps = [FPFDMSolver(p) for p in problems]
+    return problems, coupling, hjbs, fps
+
+
+class TestGraphMFGSolverInstantiation:
+    def test_basic_3node(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+        )
+        assert solver._N == 3
+
+    def test_mismatched_counts_raises(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        with pytest.raises(ValueError, match="Need 3 problems"):
+            GraphMFGSolver(
+                problems=problems[:2],
+                coupling=coupling,
+                hjb_solvers=hjbs,
+                fp_solvers=fps,
+            )
+
+    def test_custom_params(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=20,
+            tolerance=1e-3,
+            damping=0.3,
+        )
+        assert solver._max_iter == 20
+        assert solver._tol == 1e-3
+
+
+class TestGraphMFGSolverSolve:
+    def test_returns_result(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=3,
+        )
+        result = solver.solve()
+        assert isinstance(result, GraphMFGResult)
+
+    def test_result_shapes(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=3,
+        )
+        result = solver.solve()
+        assert len(result.values) == 3
+        assert len(result.densities) == 3
+        assert result.n_nodes == 3
+        Nt = problems[0].Nt
+        Nx = problems[0].geometry.get_grid_shape()[0]
+        for k in range(3):
+            assert result.values[k].shape == (Nt + 1, Nx)
+
+    def test_solutions_finite(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=5,
+        )
+        result = solver.solve()
+        for k in range(3):
+            assert np.all(np.isfinite(result.values[k]))
+            assert np.all(np.isfinite(result.densities[k]))
+
+    def test_error_history(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=5,
+        )
+        result = solver.solve()
+        assert len(result.error_history) > 0
+        assert len(result.error_history) <= 5
+
+    def test_iterations_reported(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=3,
+        )
+        result = solver.solve()
+        assert 0 < result.iterations <= 3
+
+
+class TestGraphMFGSolverCouplingEffect:
+    def test_coupling_affects_solution(self):
+        """With coupling, node solutions should differ from uncoupled."""
+        # Heterogeneous nodes so coupling has something to mix
+        problems = [_make_node_problem(0.5), _make_node_problem(2.0)]
+        A = np.array([[0, 1], [1, 0]], dtype=float)
+
+        # Strong coupling
+        coupling_strong = AdjacencyCoupling(A, alpha=0.5, beta=0.1)
+        hjbs1 = [HJBFDMSolver(p) for p in problems]
+        fps1 = [FPFDMSolver(p) for p in problems]
+        solver_coupled = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling_strong,
+            hjb_solvers=hjbs1,
+            fp_solvers=fps1,
+            max_iterations=5,
+            damping=0.5,
+        )
+
+        # Zero coupling
+        coupling_zero = AdjacencyCoupling(A, alpha=0.0, beta=0.0)
+        hjbs2 = [HJBFDMSolver(p) for p in problems]
+        fps2 = [FPFDMSolver(p) for p in problems]
+        solver_uncoupled = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling_zero,
+            hjb_solvers=hjbs2,
+            fp_solvers=fps2,
+            max_iterations=5,
+            damping=0.5,
+        )
+
+        r1 = solver_coupled.solve()
+        r2 = solver_uncoupled.solve()
+
+        # Coupled solutions should differ
+        assert not np.allclose(r1.values[0], r2.values[0], atol=1e-6)
+
+    def test_laplacian_coupling(self):
+        """GraphMFGSolver should work with LaplacianCoupling."""
+        problems = [_make_node_problem(1.0) for _ in range(3)]
+        A = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=float)
+        coupling = LaplacianCoupling(A, kappa=0.05)
+        hjbs = [HJBFDMSolver(p) for p in problems]
+        fps = [FPFDMSolver(p) for p in problems]
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=3,
+        )
+        result = solver.solve()
+        assert np.all(np.isfinite(result.values[0]))
+
+
+class TestGraphMFGSolverGetResults:
+    def test_get_results_after_solve(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=3,
+        )
+        solver.solve()
+        U, _M = solver.get_results()
+        assert U.shape[0] == problems[0].Nt + 1
+
+    def test_get_results_before_solve_raises(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+        )
+        with pytest.raises(RuntimeError, match="No solution"):
+            solver.get_results()


### PR DESCRIPTION
## Summary

Type 2 network MFG solver: N nodes, each with its own PDE problem, coupled via GraphCouplingOperator source term injection.

- Each node runs HJBFDMSolver + FPFDMSolver (or any BaseHJB/BaseFP pair)
- Inter-node coupling via `GraphCouplingOperator.compute_hjb_source()` / `compute_fp_source()` from #961
- Picard iteration with damping, convergence monitoring
- `GraphMFGResult` container with per-node values/densities/error history

Follows `RegimeSwitchingIterator` pattern but parameterized by arbitrary coupling operator (adjacency, Laplacian, custom).

12 integration tests. Closes #962.

## Test plan

- [x] 12 tests pass (32s — 3-node graphs with FDM solvers)
- [x] Coupling effect verified (heterogeneous nodes differ from uncoupled)
- [x] Laplacian coupling works
- [x] Ruff clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)