### PR TITLE
chore: migrate pydantic v1 .dict()/.json() to v2 equivalents

### DIFF
--- a/mfgarchon/config/array_validation.py
+++ b/mfgarchon/config/array_validation.py
@@ -511,7 +511,7 @@ class ExperimentConfig(BaseModel):
             "description": self.description,
             "researcher": self.researcher,
             "tags": self.tags,
-            "grid_config": self.grid_config.dict(),
+            "grid_config": self.grid_config.model_dump(),
         }
 
         if self.arrays:

--- a/mfgarchon/utils/notebooks/pydantic_integration.py
+++ b/mfgarchon/utils/notebooks/pydantic_integration.py
@@ -75,7 +75,7 @@ class PydanticNotebookReporter(MFGNotebookReporter):
                 raise NotebookReportError("experiment_config must be ExperimentConfig instance")
 
             # Extract validated configuration
-            validated_config = experiment_config.dict()
+            validated_config = experiment_config.model_dump()
             notebook_metadata = experiment_config.to_notebook_metadata()
 
             # Create enhanced problem configuration
@@ -279,10 +279,10 @@ SUCCESS: **CFL Condition**: Satisfied with safety margin of {0.5 - grid_config.c
         return f"""# Configuration Management with Pydantic
 
 # Experiment configuration (validated)
-experiment_config = {experiment_config.dict()!r}
+experiment_config = {experiment_config.model_dump()!r}
 
 # Grid configuration with automatic validation
-grid_config = {experiment_config.grid_config.dict()!r}
+grid_config = {experiment_config.grid_config.model_dump()!r}
 
 # Computed grid properties
 print(f"Grid spacing: dx = {experiment_config.grid_config.dx:.6f}, dt = {experiment_config.grid_config.dt:.6f}")
@@ -291,7 +291,7 @@ print(f"Expected array shape: {{experiment_config.grid_config.grid_shape}}")
 
 # JSON serialization (automatic with Pydantic)
 import json
-config_json = experiment_config.json(indent=2)
+config_json = experiment_config.model_dump_json(indent=2)
 print("\\nJSON-serialized configuration:")
 print(config_json[:200] + "..." if len(config_json) > 200 else config_json)
 """
@@ -483,10 +483,10 @@ This experiment uses **Pydantic configuration management** ensuring:
 - Version control compatibility
 - Environment variable support
 
-**Configuration Hash**: `{hash(str(experiment_config.dict()))}`
+**Configuration Hash**: `{hash(str(experiment_config.model_dump()))}`
 
 ### Next Steps
-- Configuration can be saved with: `experiment_config.json()`
+- Configuration can be saved with: `experiment_config.model_dump_json()`
 - Arrays can be reloaded with full validation
 - Parameters can be modified with automatic re-validation
 - Results are ready for publication or further analysis


### PR DESCRIPTION
## Summary

Migrates 7 call sites from pydantic v1 `.dict()` / `.json()` (deprecated in v2, scheduled for removal in v3) to v2 `.model_dump()` / `.model_dump_json()`.

- 1 runtime call in `mfgarchon/config/array_validation.py` (`ExperimentConfig.to_notebook_metadata()`)
- 6 sites in `mfgarchon/utils/notebooks/pydantic_integration.py`:
  - 2 runtime calls
  - 4 inside notebook-code templates that previously generated deprecated v1 API for end users

Templates now emit v2-compliant API so user-generated notebooks run clean on pydantic 2.12.5+.

## Context

Part of dual-config-system audit prompted by the pydantic dependency bump (PR #1002, `>=2.12.5,<3.0`). This is the mechanical portion; design-level follow-ups (legacy `pydantic_config.py` deprecation redirect, missing tests for canonical config modules, schema-config pairing gaps) will land in subsequent PRs.

## Test plan

- [x] `MFGGridConfig().model_dump()` returns valid dict (6 fields)
- [x] Modified modules import cleanly with `warnings.simplefilter('error', PydanticDeprecatedSince20)`
- [x] No pydantic v1 API calls remain in modified files (verified via grep)
- [ ] CI green