### PR TITLE
chore: remove unused hydra-core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dependencies = [
     "igraph>=0.10.0",          # Graph backend (C-based, fast)
 
     # Configuration management
-    "hydra-core>=1.3",
     "omegaconf>=2.3",
 
     # System monitoring


### PR DESCRIPTION
## Summary

Removes `hydra-core>=1.3` from `pyproject.toml`. It has been declared since v0.17.x but never actually imported or used.

## Evidence

| Check | Result |
|---|---|
| `import hydra` / `from hydra` across `mfgarchon/`, `examples/`, `tests/` | Zero hits |
| `@hydra.main`, `HydraConfig`, `hydra.core`, `hydra.compose` | Zero hits |
| Internal development roadmap mentions of: hydra, HPC, cluster, distributed, multirun, sweep, CLI, launcher, submitit, slurm, optuna | **Zero** |

## What replaces it

Nothing — the codebase never used Hydra patterns:
- CLI: `mfgarchon/utils/cli.py` uses `argparse`
- YAML load/interpolation: OmegaConf directly (unchanged)
- Parameter sweeps: plain Python loops in `OmegaConfManager.create_parameter_sweep_configs`
- No `@hydra.main` entry points anywhere

OmegaConf (`>=2.3`) remains as a direct dependency for its actual uses.

## Test plan

- [x] `grep` confirms zero Hydra references in code, tests, or examples
- [x] OmegaConf interpolation still works after removal (verified locally)
- [ ] CI green

## Context

Surfaced during the dual-config-system audit (internal design notes). Roadmap analysis confirmed Hydra is not on the project's planned feature path. Can be re-added deliberately if/when HPC sweep workflows or config-group based solver selection become priorities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)