### PR TITLE
refactor: PicardConfig damping_* -> relaxation_* rename with alias (v0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-04-17
+
+### Changed
+
+- **`PicardConfig` field rename** (naming abstraction): the five damping-related
+  fields are renamed from `damping_*` to `relaxation_*`:
+
+  | Legacy field (deprecated) | Canonical field |
+  |---|---|
+  | `damping_factor` | `relaxation` |
+  | `damping_factor_M` | `relaxation_M` |
+  | `damping_schedule` | `relaxation_schedule` |
+  | `damping_schedule_M` | `relaxation_schedule_M` |
+  | `adaptive_damping` | `adaptive_relaxation` |
+
+  `relaxation` is the more abstract name — it extends cleanly to over-relaxation
+  (omega > 1) if the range constraint is loosened in future work, whereas
+  "damping" is conceptually under-relaxation only. `FixedPointIterator` reads
+  of `config.picard.*` updated to canonical names.
+
+### Deprecated
+
+- Legacy `damping_*` kwargs on `PicardConfig(...)` still accepted via
+  `@model_validator(mode="before")` translation, with `DeprecationWarning`
+  emitted. Removal scheduled for **v0.25.0** per standard 3-version window.
+  Passing both legacy and canonical names for the same concept raises
+  `ValueError` immediately (e.g. `PicardConfig(damping_factor=0.5, relaxation=0.8)`).
+
+### Tests
+
+- New `tests/unit/test_config/test_picard_relaxation_alias.py` (15 tests)
+  provides the mandatory equivalence tests per CLAUDE.md deprecation policy:
+  each legacy kwarg produces an instance `==` to the canonical kwarg.
+
+### Out of scope (future patches)
+
+- Solver constructor kwargs (`FixedPointIterator(damping_factor=...)`,
+  `HJBFDMSolver(damping_factor=...)`, etc.) are **not** renamed in this
+  release. The runtime-layer rename via `@deprecated_parameter` is B1.5b,
+  tracked in #1010.
+
 ## [0.19.0] - 2026-04-17
 
 ### Removed (BREAKING)

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -484,13 +484,13 @@ class FixedPointIterator(BaseCouplingIterator):
         if solve_config is not None:
             final_max_iterations = solve_config.picard.max_iterations
             final_tolerance = solve_config.picard.tolerance
-            final_damping_factor = solve_config.picard.damping_factor
-            # Issue #719: Per-variable damping and schedules from config
-            # damping_factor_M / damping_schedule_M use `or` because None means "follow U"
-            final_damping_factor_M = solve_config.picard.damping_factor_M or self.damping_factor_M
-            final_schedule = solve_config.picard.damping_schedule
-            final_schedule_M = solve_config.picard.damping_schedule_M or self.damping_schedule_M
-            final_adaptive_damping = solve_config.picard.adaptive_damping or self.adaptive_damping
+            final_damping_factor = solve_config.picard.relaxation
+            # Issue #719: Per-variable relaxation and schedules from config
+            # relaxation_M / relaxation_schedule_M use `or` because None means "follow U"
+            final_damping_factor_M = solve_config.picard.relaxation_M or self.damping_factor_M
+            final_schedule = solve_config.picard.relaxation_schedule
+            final_schedule_M = solve_config.picard.relaxation_schedule_M or self.damping_schedule_M
+            final_adaptive_damping = solve_config.picard.adaptive_relaxation or self.adaptive_damping
             verbose = solve_config.picard.verbose
         else:
             # Legacy parameter precedence

--- a/mfgarchon/config/core.py
+++ b/mfgarchon/config/core.py
@@ -163,8 +163,7 @@ class PicardConfig(BaseModel):
                         f"'{canonical}'. Pass only the canonical name."
                     )
                 warnings.warn(
-                    f"PicardConfig field '{legacy}' is deprecated since v0.19.1. "
-                    f"Use '{canonical}' instead.",
+                    f"PicardConfig field '{legacy}' is deprecated since v0.19.1. Use '{canonical}' instead.",
                     DeprecationWarning,
                     stacklevel=3,
                 )

--- a/mfgarchon/config/core.py
+++ b/mfgarchon/config/core.py
@@ -13,7 +13,7 @@ Key Principle
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -83,7 +83,7 @@ class BackendConfig(BaseModel):
 
 class PicardConfig(BaseModel):
     """
-    Configuration for Picard (fixed-point) iteration with damping.
+    Configuration for Picard (fixed-point) iteration with under-relaxation.
 
     Attributes
     ----------
@@ -91,36 +91,85 @@ class PicardConfig(BaseModel):
         Maximum number of iterations (default: 100)
     tolerance : float
         Convergence tolerance (default: 1e-6)
-    damping_factor : float
-        Damping factor θ ∈ (0, 1] for update: u^{n+1} = θu_new + (1-θ)u^n
-        - 1.0: No damping (faster but may diverge)
-        - 0.5: Moderate damping (balanced, default)
-        - <0.3: Heavy damping (slower but more stable)
-    damping_factor_M : float | None
-        Separate damping factor for M (None = use damping_factor for both).
-        Issue #719: Per-variable damping support.
-    damping_schedule : str
-        Iteration-based damping schedule for U: "constant", "harmonic",
+    relaxation : float
+        Relaxation (under-relaxation) factor omega in (0, 1] for the update:
+        u^{n+1} = omega * u_new + (1 - omega) * u^n.
+        - 1.0: No relaxation (faster but may diverge)
+        - 0.5: Moderate relaxation (balanced, default)
+        - <0.3: Heavy relaxation (slower but more stable)
+    relaxation_M : float | None
+        Separate relaxation factor for M (None = use `relaxation` for both).
+        Issue #719: Per-variable relaxation support.
+    relaxation_schedule : str
+        Iteration-based relaxation schedule for U: "constant", "harmonic",
         "sqrt", or "exponential". Issue #719 Phase 2.
-    damping_schedule_M : str | None
+    relaxation_schedule_M : str | None
         Separate schedule for M (None = follow U schedule).
-    adaptive_damping : bool
-        Enable error-reactive adaptive damping (Issue #583).
+    adaptive_relaxation : bool
+        Enable error-reactive adaptive relaxation (Issue #583).
     anderson_memory : int
         Anderson acceleration memory depth (0 = disabled, default: 0)
     verbose : bool
         Print iteration progress (default: True)
+
+    Legacy field names
+    ------------------
+    The fields were renamed from `damping_*` to `relaxation_*` in v0.19.1 for
+    naming abstraction (`relaxation` extends cleanly to over-relaxation ω>1 if
+    the range constraint is loosened in future work). Legacy names are still
+    accepted with a `DeprecationWarning` via a `mode="before"` validator.
+
+    Mapping: damping_factor -> relaxation, damping_factor_M -> relaxation_M,
+    damping_schedule -> relaxation_schedule, damping_schedule_M ->
+    relaxation_schedule_M, adaptive_damping -> adaptive_relaxation.
     """
 
     max_iterations: int = Field(default=100, ge=1)
     tolerance: float = Field(default=1e-6, gt=0)
-    damping_factor: float = Field(default=0.5, gt=0, le=1.0)
-    damping_factor_M: float | None = Field(default=None, gt=0, le=1.0)
-    damping_schedule: Literal["constant", "harmonic", "sqrt", "exponential"] = "constant"
-    damping_schedule_M: Literal["constant", "harmonic", "sqrt", "exponential"] | None = None
-    adaptive_damping: bool = False
+    relaxation: float = Field(default=0.5, gt=0, le=1.0)
+    relaxation_M: float | None = Field(default=None, gt=0, le=1.0)
+    relaxation_schedule: Literal["constant", "harmonic", "sqrt", "exponential"] = "constant"
+    relaxation_schedule_M: Literal["constant", "harmonic", "sqrt", "exponential"] | None = None
+    adaptive_relaxation: bool = False
     anderson_memory: int = Field(default=0, ge=0)
     verbose: bool = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _translate_legacy_damping_names(cls, values: Any) -> Any:
+        """Accept legacy `damping_*` field names with DeprecationWarning (v0.19.1).
+
+        Translates old names to canonical `relaxation_*` before Pydantic
+        validation. Users hitting this path are on the deprecated API surface
+        that will be removed per the standard 3-version deprecation window.
+        """
+        import warnings
+
+        if not isinstance(values, dict):
+            return values
+        data = dict(values)
+        legacy_map = {
+            "damping_factor": "relaxation",
+            "damping_factor_M": "relaxation_M",
+            "damping_schedule": "relaxation_schedule",
+            "damping_schedule_M": "relaxation_schedule_M",
+            "adaptive_damping": "adaptive_relaxation",
+        }
+        for legacy, canonical in legacy_map.items():
+            if legacy in data:
+                if canonical in data:
+                    raise ValueError(
+                        f"PicardConfig: received both legacy '{legacy}' and canonical "
+                        f"'{canonical}'. Pass only the canonical name."
+                    )
+                warnings.warn(
+                    f"PicardConfig field '{legacy}' is deprecated since v0.19.1. "
+                    f"Use '{canonical}' instead.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                data[canonical] = data.pop(legacy)
+        return data
 
     @model_validator(mode="after")
     def validate_anderson(self) -> PicardConfig:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.0"  # v0.19.0: removed legacy pydantic_config.py (BREAKING, see migration_v0.19.md)
+version = "0.19.1"  # v0.19.1: PicardConfig damping_* -> relaxation_* rename (backward-compat aliasing)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.

--- a/tests/integration/test_graph_mfg_solver.py
+++ b/tests/integration/test_graph_mfg_solver.py
@@ -262,7 +262,12 @@ class TestIssue1006Regression:
         # Node 1: T=1.0, Nt=10 -> dt=0.1 (different!)
         H = p_ok.components.hamiltonian
         p_bad = MFGProblem(
-            Nx=21, xmin=0.0, xmax=1.0, T=1.0, Nt=10, sigma=0.3,
+            Nx=21,
+            xmin=0.0,
+            xmax=1.0,
+            T=1.0,
+            Nt=10,
+            sigma=0.3,
             components=MFGComponents(
                 hamiltonian=H,
                 u_terminal=lambda x: 0.0,
@@ -288,8 +293,10 @@ class TestIssue1006Regression:
         problems[0].source_term_hjb = lambda x, m, v, t: np.full_like(x, 7.0)
 
         solver = GraphMFGSolver(
-            problems=problems, coupling=coupling,
-            hjb_solvers=hjbs, fp_solvers=fps,
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
         )
 
         # Prepare fake state to invoke _compose_hjb_source directly
@@ -316,8 +323,10 @@ class TestIssue1006Regression:
             assert p.nonlocal_operator is None
 
         solver = GraphMFGSolver(
-            problems=problems, coupling=coupling,
-            hjb_solvers=hjbs, fp_solvers=fps,
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
         )
         Nt, Nx = problems[0].Nt, 21
         Us = [np.ones((Nt + 1, Nx)) for _ in range(3)]
@@ -333,8 +342,10 @@ class TestIssue1006Regression:
         problems[1].source_term_fp = lambda x, m, v, t: np.full_like(x, -2.0)
 
         solver = GraphMFGSolver(
-            problems=problems, coupling=coupling,
-            hjb_solvers=hjbs, fp_solvers=fps,
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
         )
         Nt, Nx = problems[1].Nt, 21
         Us = [np.ones((Nt + 1, Nx)) for _ in range(3)]

--- a/tests/unit/test_config/test_bridge.py
+++ b/tests/unit/test_config/test_bridge.py
@@ -206,7 +206,7 @@ class TestLoadEffectiveConfig:
             picard=PicardConfig(
                 tolerance=1e-10,
                 max_iterations=500,
-                damping_factor=0.8,
+                relaxation=0.8,
             )
         )
 
@@ -216,4 +216,4 @@ class TestLoadEffectiveConfig:
 
             assert loaded.picard.tolerance == 1e-10
             assert loaded.picard.max_iterations == 500
-            assert loaded.picard.damping_factor == 0.8
+            assert loaded.picard.relaxation == 0.8

--- a/tests/unit/test_config/test_picard_relaxation_alias.py
+++ b/tests/unit/test_config/test_picard_relaxation_alias.py
@@ -1,0 +1,137 @@
+"""Equivalence tests for PicardConfig damping_* -> relaxation_* rename (v0.19.1).
+
+Per CLAUDE.md deprecation policy: every deprecated API must have an equivalence
+test proving the old and new paths produce identical behavior. These tests
+guard against silent divergence during the deprecation window (Issue #616
+lesson).
+
+The legacy names are accepted via `@model_validator(mode="before")` in
+`PicardConfig._translate_legacy_damping_names`. Removal is scheduled for
+v0.25.0 per the standard 3-version window.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from mfgarchon.config import PicardConfig
+
+
+class TestPicardRelaxationAliasEquivalence:
+    """Prove legacy `damping_*` kwargs produce identical instances to canonical `relaxation_*`."""
+
+    def test_damping_factor_equivalent_to_relaxation(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = PicardConfig(damping_factor=0.7)
+        canonical = PicardConfig(relaxation=0.7)
+        assert legacy.relaxation == canonical.relaxation == 0.7
+        assert legacy == canonical
+
+    def test_damping_factor_M_equivalent_to_relaxation_M(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = PicardConfig(damping_factor=0.5, damping_factor_M=0.3)
+        canonical = PicardConfig(relaxation=0.5, relaxation_M=0.3)
+        assert legacy.relaxation_M == canonical.relaxation_M == 0.3
+        assert legacy == canonical
+
+    def test_damping_schedule_equivalent_to_relaxation_schedule(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = PicardConfig(damping_schedule="harmonic", damping_schedule_M="sqrt")
+        canonical = PicardConfig(relaxation_schedule="harmonic", relaxation_schedule_M="sqrt")
+        assert legacy.relaxation_schedule == canonical.relaxation_schedule == "harmonic"
+        assert legacy.relaxation_schedule_M == canonical.relaxation_schedule_M == "sqrt"
+        assert legacy == canonical
+
+    def test_adaptive_damping_equivalent_to_adaptive_relaxation(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = PicardConfig(adaptive_damping=True)
+        canonical = PicardConfig(adaptive_relaxation=True)
+        assert legacy.adaptive_relaxation is canonical.adaptive_relaxation is True
+        assert legacy == canonical
+
+    def test_all_five_legacy_names_together(self):
+        """Full equivalence: every legacy kwarg translated correctly in one call."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = PicardConfig(
+                damping_factor=0.6,
+                damping_factor_M=0.2,
+                damping_schedule="exponential",
+                damping_schedule_M="harmonic",
+                adaptive_damping=True,
+            )
+        canonical = PicardConfig(
+            relaxation=0.6,
+            relaxation_M=0.2,
+            relaxation_schedule="exponential",
+            relaxation_schedule_M="harmonic",
+            adaptive_relaxation=True,
+        )
+        assert legacy == canonical
+
+    def test_model_dump_produces_canonical_keys_only(self):
+        """Serialization must use canonical field names only, regardless of input names."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = PicardConfig(damping_factor=0.9, damping_factor_M=0.1)
+        dumped = legacy.model_dump()
+        assert "relaxation" in dumped
+        assert "relaxation_M" in dumped
+        # Legacy names must not leak into the serialized form
+        assert "damping_factor" not in dumped
+        assert "damping_factor_M" not in dumped
+
+
+class TestPicardRelaxationAliasWarnings:
+    """Verify DeprecationWarning semantics."""
+
+    @pytest.mark.parametrize(
+        "legacy_name,canonical_name,value",
+        [
+            ("damping_factor", "relaxation", 0.7),
+            ("damping_factor_M", "relaxation_M", 0.3),
+            ("damping_schedule", "relaxation_schedule", "harmonic"),
+            ("damping_schedule_M", "relaxation_schedule_M", "sqrt"),
+            ("adaptive_damping", "adaptive_relaxation", True),
+        ],
+    )
+    def test_each_legacy_name_emits_deprecation_warning(self, legacy_name, canonical_name, value):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            PicardConfig(**{legacy_name: value})
+            dep_warnings = [
+                x for x in w
+                if issubclass(x.category, DeprecationWarning)
+                and legacy_name in str(x.message)
+            ]
+        assert len(dep_warnings) == 1, f"Expected 1 DeprecationWarning for '{legacy_name}', got {len(dep_warnings)}"
+        assert canonical_name in str(dep_warnings[0].message)
+
+    def test_canonical_name_emits_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            PicardConfig(relaxation=0.7, relaxation_M=0.3)
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) == 0
+
+
+class TestPicardRelaxationAliasCollision:
+    """Passing both the legacy name and canonical name must raise."""
+
+    def test_both_damping_factor_and_relaxation_raises(self):
+        with pytest.raises(ValueError, match="both legacy .* and canonical"):
+            PicardConfig(damping_factor=0.5, relaxation=0.8)
+
+    def test_both_damping_factor_M_and_relaxation_M_raises(self):
+        with pytest.raises(ValueError, match="both legacy .* and canonical"):
+            PicardConfig(damping_factor_M=0.5, relaxation_M=0.8)
+
+    def test_both_damping_schedule_and_relaxation_schedule_raises(self):
+        with pytest.raises(ValueError, match="both legacy .* and canonical"):
+            PicardConfig(damping_schedule="harmonic", relaxation_schedule="sqrt")

--- a/tests/unit/test_config/test_picard_relaxation_alias.py
+++ b/tests/unit/test_config/test_picard_relaxation_alias.py
@@ -92,7 +92,7 @@ class TestPicardRelaxationAliasWarnings:
     """Verify DeprecationWarning semantics."""
 
     @pytest.mark.parametrize(
-        "legacy_name,canonical_name,value",
+        ("legacy_name", "canonical_name", "value"),
         [
             ("damping_factor", "relaxation", 0.7),
             ("damping_factor_M", "relaxation_M", 0.3),
@@ -106,9 +106,7 @@ class TestPicardRelaxationAliasWarnings:
             warnings.simplefilter("always")
             PicardConfig(**{legacy_name: value})
             dep_warnings = [
-                x for x in w
-                if issubclass(x.category, DeprecationWarning)
-                and legacy_name in str(x.message)
+                x for x in w if issubclass(x.category, DeprecationWarning) and legacy_name in str(x.message)
             ]
         assert len(dep_warnings) == 1, f"Expected 1 DeprecationWarning for '{legacy_name}', got {len(dep_warnings)}"
         assert canonical_name in str(dep_warnings[0].message)
@@ -125,13 +123,13 @@ class TestPicardRelaxationAliasCollision:
     """Passing both the legacy name and canonical name must raise."""
 
     def test_both_damping_factor_and_relaxation_raises(self):
-        with pytest.raises(ValueError, match="both legacy .* and canonical"):
+        with pytest.raises(ValueError, match=r"both legacy .* and canonical"):
             PicardConfig(damping_factor=0.5, relaxation=0.8)
 
     def test_both_damping_factor_M_and_relaxation_M_raises(self):
-        with pytest.raises(ValueError, match="both legacy .* and canonical"):
+        with pytest.raises(ValueError, match=r"both legacy .* and canonical"):
             PicardConfig(damping_factor_M=0.5, relaxation_M=0.8)
 
     def test_both_damping_schedule_and_relaxation_schedule_raises(self):
-        with pytest.raises(ValueError, match="both legacy .* and canonical"):
+        with pytest.raises(ValueError, match=r"both legacy .* and canonical"):
             PicardConfig(damping_schedule="harmonic", relaxation_schedule="sqrt")


### PR DESCRIPTION
Part of #1010 (B1.5a).

## Summary

Applies the abstract-naming principle to `PicardConfig`: the five damping-related fields are renamed from `damping_*` to `relaxation_*`. Legacy names are still accepted via `@model_validator(mode="before")` with a `DeprecationWarning`, so existing user code keeps working with no changes.

| Legacy (deprecated) | Canonical |
|---|---|
| `damping_factor` | `relaxation` |
| `damping_factor_M` | `relaxation_M` |
| `damping_schedule` | `relaxation_schedule` |
| `damping_schedule_M` | `relaxation_schedule_M` |
| `adaptive_damping` | `adaptive_relaxation` |

Why `relaxation` is better: it extends cleanly to over-relaxation (ω > 1) if the range constraint is loosened in future work. "Damping" is conceptually under-relaxation only; the field name should be more general than the current range happens to be.

## Diff scope

- `mfgarchon/config/core.py`: field rename + `@model_validator(mode="before")` alias + collision detection
- `mfgarchon/alg/numerical/coupling/fixed_point_iterator.py`: 5 config reads updated to canonical names (attribute lookup — mandatory change, not cosmetic)
- `tests/unit/test_config/test_bridge.py`: update one test that asserted on legacy attribute name
- `tests/unit/test_config/test_picard_relaxation_alias.py` (new, 120 LOC): 15 equivalence tests per CLAUDE.md deprecation policy
- `CHANGELOG.md` + `pyproject.toml`: v0.19.1 entry

## Test plan

- [x] 131 config tests pass (includes 15 new equivalence tests)
- [x] 3734 unit tests pass across full suite (0 regressions)
- [x] Equivalence verified: every legacy kwarg produces an instance `==` to canonical
- [x] Collision: passing both legacy and canonical names raises `ValueError` (not silent coercion)
- [x] `model_dump()` produces only canonical keys regardless of input names
- [ ] CI green

## Out of scope

Solver constructor kwargs (`FixedPointIterator(damping_factor=...)`, `HJBFDMSolver(damping_factor=...)`, etc.) are **not** renamed in this PR. That's B1.5b — will use `@deprecated_parameter` decorator for backward compat with no test breakage. Tracked in #1010.

## Deprecation timeline

- v0.19.1 (this release): legacy names accepted with `DeprecationWarning`
- v0.25.0 (scheduled): legacy names removed

Per CLAUDE.md: "Immediate redirection" guaranteed by `@model_validator(mode="before")` translating at construction time. No silent divergence possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)