### PR TITLE
refactor: FixedPointIterator damping_* → relaxation_* (v0.19.2, B1.5b.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,48 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.2] - 2026-04-17
+### Changed — B1.5b series (solver ctor kwargs damping_* → relaxation_*)
 
-### Changed
+Incremental rename propagating the naming change landed in v0.19.1 (`PicardConfig`)
+through the solver constructors. The whole B1.5b arc will ship as one version bump
+(`v0.19.2`) once complete; individual sub-PRs land under `[Unreleased]` and are
+listed here with their scope.
 
-- **`FixedPointIterator` kwarg rename** (B1.5b.1): the seven damping-related
-  constructor kwargs and instance attributes are renamed from `damping_*` to
-  `relaxation_*`, matching the `PicardConfig` naming landed in v0.19.1:
-
-  | Legacy kwarg (deprecated) | Canonical kwarg |
-  |---|---|
-  | `damping_factor` | `relaxation` |
-  | `damping_factor_M` | `relaxation_M` |
-  | `adaptive_damping` | `adaptive_relaxation` |
-  | `adaptive_damping_decay` | `adaptive_relaxation_decay` |
-  | `adaptive_damping_min` | `adaptive_relaxation_min` |
-  | `damping_schedule` | `relaxation_schedule` |
-  | `damping_schedule_M` | `relaxation_schedule_M` |
-
-  All internal attribute reads within the iterator now use `self.relaxation_*`.
-
-### Deprecated
-
-- Legacy `damping_*` ctor kwargs accepted via `@deprecated_parameter`
-  decorators — emits `DeprecationWarning` at construction, then redirects
-  internally to the canonical kwarg. Removal scheduled for v0.25.0.
-- Backward-compat attribute access (`iter.damping_factor` etc.) provided by
-  silent `@property` aliases (no warning on read, to avoid log-flooding
-  inside Picard iteration hot loops). Also removal in v0.25.0.
-
-### Tests
-
-- New `tests/unit/test_alg/test_fixed_point_iterator_relaxation_alias.py`
-  (16 tests): equivalence, warning semantics, and backward-compat property
-  reads. Existing 3744 unit tests continue to pass — the rename is fully
-  backward-compatible, only the DeprecationWarning is new.
-
-### Out of scope (future B1.5b.x PRs)
-
-The same rename pattern will be applied incrementally to remaining solvers:
-`BlockGaussSeidelIterator`, `BlockJacobiIterator`, `NetworkMFGSolver`,
-`MultiPopulationIterator`, `HJBFDMSolver`, `FixedPointSolver`. Tracked in
-#1010 as B1.5b.
+- **B1.5b.1** (PR #1012): `FixedPointIterator` — 7 ctor kwargs renamed
+  (`damping_factor`, `damping_factor_M`, `adaptive_damping`, `adaptive_damping_decay`,
+  `adaptive_damping_min`, `damping_schedule`, `damping_schedule_M`). Legacy kwargs
+  accepted via `@deprecated_parameter` + body redirect. Silent `@property` aliases
+  preserve `iter.damping_factor` attribute reads without warning-flooding Picard
+  hot loops. 16 equivalence tests in
+  `tests/unit/test_alg/test_fixed_point_iterator_relaxation_alias.py`.
 
 ## [0.19.1] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-04-17
+
+### Changed
+
+- **`FixedPointIterator` kwarg rename** (B1.5b.1): the seven damping-related
+  constructor kwargs and instance attributes are renamed from `damping_*` to
+  `relaxation_*`, matching the `PicardConfig` naming landed in v0.19.1:
+
+  | Legacy kwarg (deprecated) | Canonical kwarg |
+  |---|---|
+  | `damping_factor` | `relaxation` |
+  | `damping_factor_M` | `relaxation_M` |
+  | `adaptive_damping` | `adaptive_relaxation` |
+  | `adaptive_damping_decay` | `adaptive_relaxation_decay` |
+  | `adaptive_damping_min` | `adaptive_relaxation_min` |
+  | `damping_schedule` | `relaxation_schedule` |
+  | `damping_schedule_M` | `relaxation_schedule_M` |
+
+  All internal attribute reads within the iterator now use `self.relaxation_*`.
+
+### Deprecated
+
+- Legacy `damping_*` ctor kwargs accepted via `@deprecated_parameter`
+  decorators — emits `DeprecationWarning` at construction, then redirects
+  internally to the canonical kwarg. Removal scheduled for v0.25.0.
+- Backward-compat attribute access (`iter.damping_factor` etc.) provided by
+  silent `@property` aliases (no warning on read, to avoid log-flooding
+  inside Picard iteration hot loops). Also removal in v0.25.0.
+
+### Tests
+
+- New `tests/unit/test_alg/test_fixed_point_iterator_relaxation_alias.py`
+  (16 tests): equivalence, warning semantics, and backward-compat property
+  reads. Existing 3744 unit tests continue to pass — the rename is fully
+  backward-compatible, only the DeprecationWarning is new.
+
+### Out of scope (future B1.5b.x PRs)
+
+The same rename pattern will be applied incrementally to remaining solvers:
+`BlockGaussSeidelIterator`, `BlockJacobiIterator`, `NetworkMFGSolver`,
+`MultiPopulationIterator`, `HJBFDMSolver`, `FixedPointSolver`. Tracked in
+#1010 as B1.5b.
+
 ## [0.19.1] - 2026-04-17
 
 ### Changed

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.solver_result import SolverResult
 
@@ -81,34 +82,68 @@ class FixedPointIterator(BaseCouplingIterator):
             - Callable: State-dependent drift α(t, x, m) -> ndarray
     """
 
+    @deprecated_parameter(param_name="damping_factor", since="v0.19.2", replacement="relaxation")
+    @deprecated_parameter(param_name="damping_factor_M", since="v0.19.2", replacement="relaxation_M")
+    @deprecated_parameter(param_name="adaptive_damping", since="v0.19.2", replacement="adaptive_relaxation")
+    @deprecated_parameter(param_name="adaptive_damping_decay", since="v0.19.2", replacement="adaptive_relaxation_decay")
+    @deprecated_parameter(param_name="adaptive_damping_min", since="v0.19.2", replacement="adaptive_relaxation_min")
+    @deprecated_parameter(param_name="damping_schedule", since="v0.19.2", replacement="relaxation_schedule")
+    @deprecated_parameter(param_name="damping_schedule_M", since="v0.19.2", replacement="relaxation_schedule_M")
     def __init__(
         self,
         problem: MFGProblem,
         hjb_solver: BaseHJBSolver,
         fp_solver: BaseFPSolver,
         config: MFGSolverConfig | None = None,
-        damping_factor: float = 0.5,  # Renamed from thetaUM
-        damping_factor_M: float | None = None,  # Issue #719: Per-variable damping
+        # Canonical relaxation parameters (v0.19.2+)
+        relaxation: float = 0.5,
+        relaxation_M: float | None = None,
         use_anderson: bool = False,
         anderson_depth: int = 5,
         anderson_beta: float = 1.0,
         backend: str | None = None,
         volatility_field: float | np.ndarray | Any | None = None,  # Phase 2.3
         drift_field: np.ndarray | Any | None = None,  # Phase 2.3
-        adaptive_damping: bool = False,  # Issue #583: Adaptive Picard damping
-        adaptive_damping_decay: float = 0.5,  # Damping reduction on oscillation
-        adaptive_damping_min: float = 0.05,  # Minimum damping bound
-        damping_schedule: str = "constant",  # Issue #719: "constant", "harmonic", "sqrt", "exponential"
-        damping_schedule_M: str | None = None,  # Separate M schedule (None = follow U)
+        adaptive_relaxation: bool = False,
+        adaptive_relaxation_decay: float = 0.5,
+        adaptive_relaxation_min: float = 0.05,
+        relaxation_schedule: str = "constant",
+        relaxation_schedule_M: str | None = None,
+        # Legacy damping_* kwargs (deprecated since v0.19.2, removal v0.25.0)
+        damping_factor: float | None = None,
+        damping_factor_M: float | None = None,
+        adaptive_damping: bool | None = None,
+        adaptive_damping_decay: float | None = None,
+        adaptive_damping_min: float | None = None,
+        damping_schedule: str | None = None,
+        damping_schedule_M: str | None = None,
     ):
         """
         Args:
-            damping_factor: Damping for U (theta_U). Default 0.5.
-            damping_factor_M: Damping for M (theta_M). If None, uses damping_factor.
-                Issue #719: Per-variable damping support.
-                Recommended for MFG: damping_factor=1.0, damping_factor_M=0.2
-                (U adapts fully, M filters particle noise)
+            relaxation: Under-relaxation factor for U (omega_U) in (0, 1]. Default 0.5.
+            relaxation_M: Under-relaxation factor for M (omega_M). If None, uses `relaxation`
+                for both. Issue #719: Per-variable relaxation support.
+                Recommended for MFG: relaxation=1.0, relaxation_M=0.2 (U adapts fully,
+                M filters particle noise).
+
+            Legacy `damping_*` kwargs are still accepted with DeprecationWarning.
         """
+        # Redirect legacy kwargs -> canonical (decorator already warned)
+        if damping_factor is not None:
+            relaxation = damping_factor
+        if damping_factor_M is not None:
+            relaxation_M = damping_factor_M
+        if adaptive_damping is not None:
+            adaptive_relaxation = adaptive_damping
+        if adaptive_damping_decay is not None:
+            adaptive_relaxation_decay = adaptive_damping_decay
+        if adaptive_damping_min is not None:
+            adaptive_relaxation_min = adaptive_damping_min
+        if damping_schedule is not None:
+            relaxation_schedule = damping_schedule
+        if damping_schedule_M is not None:
+            relaxation_schedule_M = damping_schedule_M
+
         super().__init__(problem)
         self.backend = backend
         self.hjb_solver = hjb_solver
@@ -127,19 +162,19 @@ class FixedPointIterator(BaseCouplingIterator):
 
             self.anderson_accelerator = AndersonAccelerator(depth=anderson_depth, beta=anderson_beta)
 
-        # Damping parameters (overridden by config if provided)
-        # Issue #719: Per-variable damping support
-        self.damping_factor = damping_factor
-        self.damping_factor_M = damping_factor_M  # None = use damping_factor for both
+        # Canonical relaxation state (config can override at solve() time)
+        # Issue #719: Per-variable relaxation support
+        self.relaxation = relaxation
+        self.relaxation_M = relaxation_M  # None = use `relaxation` for both
 
-        # Issue #583: Adaptive Picard damping
-        self.adaptive_damping = adaptive_damping
-        self.adaptive_damping_decay = adaptive_damping_decay
-        self.adaptive_damping_min = adaptive_damping_min
+        # Issue #583: Adaptive Picard relaxation
+        self.adaptive_relaxation = adaptive_relaxation
+        self.adaptive_relaxation_decay = adaptive_relaxation_decay
+        self.adaptive_relaxation_min = adaptive_relaxation_min
 
-        # Issue #719 Phase 2: Damping schedules
-        self.damping_schedule = damping_schedule
-        self.damping_schedule_M = damping_schedule_M
+        # Issue #719 Phase 2: Relaxation schedules
+        self.relaxation_schedule = relaxation_schedule
+        self.relaxation_schedule_M = relaxation_schedule_M
 
         # State arrays (initialized in solve)
         self.U: np.ndarray | None = None
@@ -158,6 +193,48 @@ class FixedPointIterator(BaseCouplingIterator):
 
         # Cache solver signatures via base class (Issue #934)
         self._init_solver_signatures(self.hjb_solver, self.fp_solver)
+
+    # ------------------------------------------------------------------
+    # Backward-compat attribute aliases (damping_* -> relaxation_*)
+    # Added in v0.19.2. Silent (no DeprecationWarning on read) to avoid
+    # log flooding inside Picard iteration hot loops. Removal in v0.25.0;
+    # the ctor kwargs already emit DeprecationWarning via @deprecated_parameter.
+    # ------------------------------------------------------------------
+
+    @property
+    def damping_factor(self) -> float:
+        """Deprecated alias for `relaxation` (v0.19.2+). Removal in v0.25.0."""
+        return self.relaxation
+
+    @property
+    def damping_factor_M(self) -> float | None:
+        """Deprecated alias for `relaxation_M` (v0.19.2+). Removal in v0.25.0."""
+        return self.relaxation_M
+
+    @property
+    def adaptive_damping(self) -> bool:
+        """Deprecated alias for `adaptive_relaxation` (v0.19.2+). Removal in v0.25.0."""
+        return self.adaptive_relaxation
+
+    @property
+    def adaptive_damping_decay(self) -> float:
+        """Deprecated alias for `adaptive_relaxation_decay` (v0.19.2+). Removal in v0.25.0."""
+        return self.adaptive_relaxation_decay
+
+    @property
+    def adaptive_damping_min(self) -> float:
+        """Deprecated alias for `adaptive_relaxation_min` (v0.19.2+). Removal in v0.25.0."""
+        return self.adaptive_relaxation_min
+
+    @property
+    def damping_schedule(self) -> str:
+        """Deprecated alias for `relaxation_schedule` (v0.19.2+). Removal in v0.25.0."""
+        return self.relaxation_schedule
+
+    @property
+    def damping_schedule_M(self) -> str | None:
+        """Deprecated alias for `relaxation_schedule_M` (v0.19.2+). Removal in v0.25.0."""
+        return self.relaxation_schedule_M
 
     def _compose_hjb_source(self, m_current: np.ndarray) -> Callable | None:
         """Compose problem-level source terms into a solver-level source_term callable.
@@ -487,10 +564,10 @@ class FixedPointIterator(BaseCouplingIterator):
             final_damping_factor = solve_config.picard.relaxation
             # Issue #719: Per-variable relaxation and schedules from config
             # relaxation_M / relaxation_schedule_M use `or` because None means "follow U"
-            final_damping_factor_M = solve_config.picard.relaxation_M or self.damping_factor_M
+            final_damping_factor_M = solve_config.picard.relaxation_M or self.relaxation_M
             final_schedule = solve_config.picard.relaxation_schedule
-            final_schedule_M = solve_config.picard.relaxation_schedule_M or self.damping_schedule_M
-            final_adaptive_damping = solve_config.picard.adaptive_relaxation or self.adaptive_damping
+            final_schedule_M = solve_config.picard.relaxation_schedule_M or self.relaxation_schedule_M
+            final_adaptive_damping = solve_config.picard.adaptive_relaxation or self.adaptive_relaxation
             verbose = solve_config.picard.verbose
         else:
             # Legacy parameter precedence
@@ -498,11 +575,11 @@ class FixedPointIterator(BaseCouplingIterator):
                 max_iterations or kwargs.get("max_picard_iterations") or kwargs.get("Niter_max") or 100
             )
             final_tolerance = tolerance or kwargs.get("picard_tolerance") or kwargs.get("l2errBoundPicard") or 1e-6
-            final_damping_factor = self.damping_factor
-            final_damping_factor_M = self.damping_factor_M  # Issue #719
-            final_schedule = self.damping_schedule  # Issue #719 Phase 2
-            final_schedule_M = self.damping_schedule_M
-            final_adaptive_damping = self.adaptive_damping
+            final_damping_factor = self.relaxation
+            final_damping_factor_M = self.relaxation_M  # Issue #719
+            final_schedule = self.relaxation_schedule  # Issue #719 Phase 2
+            final_schedule_M = self.relaxation_schedule_M
+            final_adaptive_damping = self.adaptive_relaxation
             from mfgarchon.utils.progress import should_show_progress
 
             verbose = should_show_progress()
@@ -686,13 +763,13 @@ class FixedPointIterator(BaseCouplingIterator):
                     iiter,
                     final_damping_factor,
                     final_schedule,
-                    self.adaptive_damping_min,
+                    self.adaptive_relaxation_min,
                 )
                 effective_theta_M = compute_scheduled_damping(
                     iiter,
                     base_theta_M,
                     final_schedule_M if final_schedule_M is not None else final_schedule,
-                    self.adaptive_damping_min,
+                    self.adaptive_relaxation_min,
                 )
 
                 if self.use_anderson and self.anderson_accelerator is not None:
@@ -768,8 +845,8 @@ class FixedPointIterator(BaseCouplingIterator):
                         error_history_M=_error_history_M,
                         theta_U_initial=_theta_U_initial,
                         theta_M_initial=_theta_M_initial,
-                        decay=self.adaptive_damping_decay,
-                        min_damping=self.adaptive_damping_min,
+                        decay=self.adaptive_relaxation_decay,
+                        min_damping=self.adaptive_relaxation_min,
                     )
                     # Update base M damping for next iteration
                     if final_damping_factor_M is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.1"  # v0.19.1: PicardConfig damping_* -> relaxation_* rename (backward-compat aliasing)
+version = "0.19.2"  # v0.19.2: FixedPointIterator damping_* -> relaxation_* rename (backward-compat aliasing)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.2"  # v0.19.2: FixedPointIterator damping_* -> relaxation_* rename (backward-compat aliasing)
+version = "0.19.1"  # v0.19.1: PicardConfig damping_* -> relaxation_* rename (backward-compat aliasing)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.

--- a/tests/unit/test_alg/test_fixed_point_iterator_relaxation_alias.py
+++ b/tests/unit/test_alg/test_fixed_point_iterator_relaxation_alias.py
@@ -1,0 +1,197 @@
+"""Equivalence tests for FixedPointIterator damping_* -> relaxation_* rename (v0.19.2).
+
+Per CLAUDE.md deprecation policy: old API must produce identical behavior to
+new API. The legacy `damping_*` ctor kwargs are accepted via
+`@deprecated_parameter` decorators that emit `DeprecationWarning` and then
+redirect internally. Backward-compat attribute access (`iter.damping_factor`)
+is provided via silent `@property` aliases (no warning on read; loop-friendly).
+
+Removal of legacy kwargs and properties scheduled for v0.25.0.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from mfgarchon.alg.numerical.coupling import FixedPointIterator
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+
+
+def _make_test_problem():
+    """Minimal MFG problem for iterator construction tests."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(Nx=11, xmin=0.0, xmax=1.0, T=0.2, Nt=5, sigma=0.3, components=components)
+
+
+@pytest.fixture
+def solvers():
+    """Build a (problem, hjb, fp) triple for iterator construction."""
+    problem = _make_test_problem()
+    return problem, HJBFDMSolver(problem), FPFDMSolver(problem)
+
+
+class TestLegacyKwargsEquivalent:
+    """Prove every legacy `damping_*` ctor kwarg yields the same instance state as canonical."""
+
+    @pytest.mark.parametrize(
+        ("legacy_name", "canonical_name", "value"),
+        [
+            ("damping_factor", "relaxation", 0.7),
+            ("damping_factor_M", "relaxation_M", 0.3),
+            ("adaptive_damping", "adaptive_relaxation", True),
+            ("adaptive_damping_decay", "adaptive_relaxation_decay", 0.8),
+            ("adaptive_damping_min", "adaptive_relaxation_min", 0.01),
+            ("damping_schedule", "relaxation_schedule", "harmonic"),
+            ("damping_schedule_M", "relaxation_schedule_M", "sqrt"),
+        ],
+    )
+    def test_legacy_kwarg_assigns_same_canonical_attribute(self, solvers, legacy_name, canonical_name, value):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy_iter = FixedPointIterator(problem, hjb, fp, **{legacy_name: value})
+        canonical_iter = FixedPointIterator(problem, hjb, fp, **{canonical_name: value})
+        assert getattr(legacy_iter, canonical_name) == getattr(canonical_iter, canonical_name)
+
+    def test_all_seven_legacy_kwargs_together(self, solvers):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy_iter = FixedPointIterator(
+                problem,
+                hjb,
+                fp,
+                damping_factor=0.6,
+                damping_factor_M=0.2,
+                adaptive_damping=True,
+                adaptive_damping_decay=0.8,
+                adaptive_damping_min=0.01,
+                damping_schedule="exponential",
+                damping_schedule_M="harmonic",
+            )
+        canonical_iter = FixedPointIterator(
+            problem,
+            hjb,
+            fp,
+            relaxation=0.6,
+            relaxation_M=0.2,
+            adaptive_relaxation=True,
+            adaptive_relaxation_decay=0.8,
+            adaptive_relaxation_min=0.01,
+            relaxation_schedule="exponential",
+            relaxation_schedule_M="harmonic",
+        )
+        for attr in [
+            "relaxation",
+            "relaxation_M",
+            "adaptive_relaxation",
+            "adaptive_relaxation_decay",
+            "adaptive_relaxation_min",
+            "relaxation_schedule",
+            "relaxation_schedule_M",
+        ]:
+            assert getattr(legacy_iter, attr) == getattr(canonical_iter, attr)
+
+
+class TestDeprecationWarnings:
+    """Ctor must emit DeprecationWarning once per legacy kwarg passed."""
+
+    @pytest.mark.parametrize(
+        ("legacy_name", "value"),
+        [
+            ("damping_factor", 0.7),
+            ("damping_factor_M", 0.3),
+            ("adaptive_damping", True),
+            ("damping_schedule", "harmonic"),
+        ],
+    )
+    def test_each_legacy_kwarg_warns(self, solvers, legacy_name, value):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            FixedPointIterator(problem, hjb, fp, **{legacy_name: value})
+            dep_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning) and legacy_name in str(x.message)
+            ]
+        assert len(dep_warnings) >= 1, f"Expected DeprecationWarning for '{legacy_name}'"
+
+    def test_canonical_kwargs_emit_no_warning(self, solvers):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            FixedPointIterator(
+                problem,
+                hjb,
+                fp,
+                relaxation=0.7,
+                relaxation_M=0.3,
+                adaptive_relaxation=True,
+                relaxation_schedule="harmonic",
+            )
+            dep_warnings = [
+                x
+                for x in w
+                if issubclass(x.category, DeprecationWarning)
+                and ("damping" in str(x.message) or "relaxation" in str(x.message))
+            ]
+        assert len(dep_warnings) == 0
+
+
+class TestBackwardCompatAttributes:
+    """Legacy `iter.damping_*` attribute access must still work (silent alias via @property)."""
+
+    def test_damping_factor_property_reads_relaxation(self, solvers):
+        problem, hjb, fp = solvers
+        iter_ = FixedPointIterator(problem, hjb, fp, relaxation=0.8)
+        assert iter_.damping_factor == 0.8
+        assert iter_.damping_factor == iter_.relaxation
+
+    def test_all_legacy_properties_return_canonical_values(self, solvers):
+        problem, hjb, fp = solvers
+        iter_ = FixedPointIterator(
+            problem,
+            hjb,
+            fp,
+            relaxation=0.6,
+            relaxation_M=0.2,
+            adaptive_relaxation=True,
+            adaptive_relaxation_decay=0.7,
+            adaptive_relaxation_min=0.05,
+            relaxation_schedule="harmonic",
+            relaxation_schedule_M="sqrt",
+        )
+        assert iter_.damping_factor == 0.6
+        assert iter_.damping_factor_M == 0.2
+        assert iter_.adaptive_damping is True
+        assert iter_.adaptive_damping_decay == 0.7
+        assert iter_.adaptive_damping_min == 0.05
+        assert iter_.damping_schedule == "harmonic"
+        assert iter_.damping_schedule_M == "sqrt"
+
+    def test_property_read_emits_no_warning(self, solvers):
+        """Property reads are silent — no DeprecationWarning flooding inside hot loops."""
+        problem, hjb, fp = solvers
+        iter_ = FixedPointIterator(problem, hjb, fp, relaxation=0.5)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = iter_.damping_factor
+            _ = iter_.damping_factor_M
+            _ = iter_.adaptive_damping
+            _ = iter_.damping_schedule
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) == 0


### PR DESCRIPTION
Part of #1010 (B1.5b, scoped per-solver per "three iterations before abstraction" discipline — FixedPointIterator is iteration 1/6).

## Summary

Renames 7 damping-related ctor kwargs and instance attributes on `FixedPointIterator` to match the `PicardConfig` rename shipped in v0.19.1. Legacy names remain accepted with `DeprecationWarning` via `@deprecated_parameter` stack; silent `@property` aliases preserve attribute access.

| Legacy (deprecated) | Canonical |
|---|---|
| `damping_factor` | `relaxation` |
| `damping_factor_M` | `relaxation_M` |
| `adaptive_damping` | `adaptive_relaxation` |
| `adaptive_damping_decay` | `adaptive_relaxation_decay` |
| `adaptive_damping_min` | `adaptive_relaxation_min` |
| `damping_schedule` | `relaxation_schedule` |
| `damping_schedule_M` | `relaxation_schedule_M` |

## Backward-compat design (two layers)

| Layer | Mechanism | Warning on use? |
|---|---|---|
| Ctor kwargs | `@deprecated_parameter` stack (7 decorators) + body redirect | **Yes** (DeprecationWarning at `__init__`) |
| Instance attributes | `@property` aliases (`iter.damping_factor` → `self.relaxation`) | **No** (silent, to avoid flooding Picard hot loops) |

Both layers target removal in v0.25.0 per the 3-version deprecation window.

## Test plan

- [x] 3744 unit tests pass (existing tests continue using legacy kwargs — they still work through the deprecation bridge)
- [x] 16 new equivalence tests in `test_fixed_point_iterator_relaxation_alias.py`:
  - Each legacy kwarg → canonical kwarg state equivalence
  - All 7 legacy kwargs together == all 7 canonical
  - DeprecationWarning fires once per legacy kwarg, never on canonical
  - Property reads are silent (warning-free hot loops)
- [x] `ruff format` and `ruff check` clean (caught locally before push this time)
- [ ] CI green

## Out of scope — next PRs in B1.5b series

Same pattern will be applied mechanically (~15-30 min each) to:
- `BlockGaussSeidelIterator`, `BlockJacobiIterator`, `BlockIteratorBase` (`block_iterators.py`)
- `NetworkMFGSolver` (`network_mfg_solver.py`)
- `MultiPopulationIterator` (`multi_population_iterator.py`)
- `HJBFDMSolver` (`hjb_fdm.py`)
- `FixedPointSolver` (`utils/numerical/nonlinear_solvers.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)