### PR TITLE
refactor: BlockIterator family damping_* → relaxation_* (v0.19.3, B1.5b.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,39 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.3] - 2026-04-17
+### Changed — B1.5b series (solver ctor kwargs damping_* → relaxation_*)
 
-### Changed
+Incremental rename propagating the naming change landed in v0.19.1 (`PicardConfig`)
+through the solver constructors. The whole B1.5b arc will ship as one version bump
+(`v0.19.2`) once complete; individual sub-PRs land under `[Unreleased]` and are
+listed here with their scope.
 
-- **Block iterators kwarg rename** (B1.5b.2): applies the `damping_* → relaxation_*`
-  rename to the block-iteration solver family — `BlockIterator` (base),
-  `BlockJacobiIterator`, and `BlockGaussSeidelIterator`. Parameters and attribute
-  storage now use `relaxation` / `relaxation_M`.
-- **`SolverResult.metadata` key rename**: the "damping_factor" key produced by
-  block iterators is now "relaxation". This is a breaking change for code that
-  inspected the metadata dict, but no user-facing warnings are available for
-  string-keyed dict reads — the change is documented here and in the migration
-  guide. Impact is narrow: only code that does
-  `result.metadata["damping_factor"]` on a block-iterator result.
-
-### Deprecated
-
-- Legacy `damping_factor` / `damping_factor_M` ctor kwargs accepted via
-  `@deprecated_parameter` on each of the three classes — emits
-  `DeprecationWarning`, redirects internally. Removal v0.25.0.
-- Silent `@property` aliases on `BlockIterator` for `damping_factor` and
-  `damping_factor_M` attribute access. Removal v0.25.0.
-
-### Tests
-
-- New `tests/unit/test_alg/test_block_iterators_relaxation_alias.py` (18 tests):
-  equivalence, warning semantics, silent property reads, and metadata-key
-  verification across all three classes via `@pytest.mark.parametrize`.
-
-### Out of scope (next PRs)
-
-Remaining solvers in the B1.5b series: `NetworkMFGSolver`,
-`MultiPopulationIterator`, `HJBFDMSolver`, `FixedPointSolver`. Tracked in #1010.
+- **B1.5b.2** (PR #1013): Block iterators — `BlockIterator` (base),
+  `BlockJacobiIterator`, `BlockGaussSeidelIterator`. Renames `damping_factor` →
+  `relaxation` and `damping_factor_M` → `relaxation_M` on all three. Legacy kwargs
+  accepted via `@deprecated_parameter`. Silent `@property` aliases on base
+  class. Plus `SolverResult.metadata` key `"damping_factor"` → `"relaxation"`
+  (narrow break; no bridge available for dict-key reads; impact limited to code
+  that inspects `result.metadata["damping_factor"]`). 18 equivalence tests in
+  `tests/unit/test_alg/test_block_iterators_relaxation_alias.py`.
 
 ## [0.19.1] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-04-17
+
+### Changed
+
+- **Block iterators kwarg rename** (B1.5b.2): applies the `damping_* → relaxation_*`
+  rename to the block-iteration solver family — `BlockIterator` (base),
+  `BlockJacobiIterator`, and `BlockGaussSeidelIterator`. Parameters and attribute
+  storage now use `relaxation` / `relaxation_M`.
+- **`SolverResult.metadata` key rename**: the "damping_factor" key produced by
+  block iterators is now "relaxation". This is a breaking change for code that
+  inspected the metadata dict, but no user-facing warnings are available for
+  string-keyed dict reads — the change is documented here and in the migration
+  guide. Impact is narrow: only code that does
+  `result.metadata["damping_factor"]` on a block-iterator result.
+
+### Deprecated
+
+- Legacy `damping_factor` / `damping_factor_M` ctor kwargs accepted via
+  `@deprecated_parameter` on each of the three classes — emits
+  `DeprecationWarning`, redirects internally. Removal v0.25.0.
+- Silent `@property` aliases on `BlockIterator` for `damping_factor` and
+  `damping_factor_M` attribute access. Removal v0.25.0.
+
+### Tests
+
+- New `tests/unit/test_alg/test_block_iterators_relaxation_alias.py` (18 tests):
+  equivalence, warning semantics, silent property reads, and metadata-key
+  verification across all three classes via `@pytest.mark.parametrize`.
+
+### Out of scope (next PRs)
+
+Remaining solvers in the B1.5b series: `NetworkMFGSolver`,
+`MultiPopulationIterator`, `HJBFDMSolver`, `FixedPointSolver`. Tracked in #1010.
+
 ## [0.19.1] - 2026-04-17
 
 ### Changed

--- a/mfgarchon/alg/numerical/coupling/block_iterators.py
+++ b/mfgarchon/alg/numerical/coupling/block_iterators.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.solver_result import SolverResult
 
@@ -107,6 +108,8 @@ class BlockIterator(BaseCouplingIterator):
         >>> result = solver.solve(max_iterations=100, tolerance=1e-5)
     """
 
+    @deprecated_parameter(param_name="damping_factor", since="v0.19.2", replacement="relaxation")
+    @deprecated_parameter(param_name="damping_factor_M", since="v0.19.2", replacement="relaxation_M")
     def __init__(
         self,
         problem: MFGProblem,
@@ -114,22 +117,34 @@ class BlockIterator(BaseCouplingIterator):
         fp_solver: BaseFPSolver,
         *,
         method: str | BlockMethod = BlockMethod.GAUSS_SEIDEL,
-        damping_factor: float = 1.0,
-        damping_factor_M: float | None = None,
+        relaxation: float = 1.0,
+        relaxation_M: float | None = None,
         volatility_field: float | NDArray | Any | None = None,
         drift_field: NDArray | Any | None = None,
         adjoint_mode: str = "off",
         adjoint_verify: bool = False,
+        # Legacy damping_* kwargs (deprecated since v0.19.2, removal v0.25.0)
+        damping_factor: float | None = None,
+        damping_factor_M: float | None = None,
     ):
         """Initialize block iterator.
 
         Args:
-            damping_factor: Damping for U (theta_U). Default 1.0 = no damping.
-            damping_factor_M: Damping for M (theta_M). If None, uses damping_factor.
-                Issue #719: Per-variable damping support.
-                Recommended for MFG: damping_factor=1.0, damping_factor_M=0.2
-                (U adapts fully, M filters particle noise)
+            relaxation: Under-relaxation factor for U (omega_U). Default 1.0 = no relaxation.
+            relaxation_M: Under-relaxation factor for M (omega_M). If None, uses `relaxation`.
+                Issue #719: Per-variable relaxation support.
+                Recommended for MFG: relaxation=1.0, relaxation_M=0.2
+                (U adapts fully, M filters particle noise).
+
+            Legacy `damping_factor` / `damping_factor_M` kwargs still accepted with
+            DeprecationWarning.
         """
+        # Redirect legacy kwargs -> canonical (decorator already warned)
+        if damping_factor is not None:
+            relaxation = damping_factor
+        if damping_factor_M is not None:
+            relaxation_M = damping_factor_M
+
         super().__init__(problem)
 
         self.hjb_solver = hjb_solver
@@ -140,9 +155,9 @@ class BlockIterator(BaseCouplingIterator):
             method = BlockMethod(method.lower())
         self.method = method
 
-        # Iteration parameters - Issue #719: Per-variable damping
-        self.damping_factor = damping_factor
-        self.damping_factor_M = damping_factor_M  # None = use damping_factor for both
+        # Canonical relaxation state - Issue #719: Per-variable relaxation
+        self.relaxation = relaxation
+        self.relaxation_M = relaxation_M  # None = use `relaxation` for both
 
         # PDE coefficient overrides
         self.volatility_field = volatility_field
@@ -188,6 +203,23 @@ class BlockIterator(BaseCouplingIterator):
         # Cache initial/terminal conditions
         self._M_initial: NDArray | None = None
         self._U_terminal: NDArray | None = None
+
+    # ------------------------------------------------------------------
+    # Backward-compat attribute aliases (damping_* -> relaxation_*)
+    # Added in v0.19.2. Silent (no DeprecationWarning on read) to avoid
+    # log flooding in block iteration loops. Removal in v0.25.0;
+    # the ctor kwargs already emit DeprecationWarning via @deprecated_parameter.
+    # ------------------------------------------------------------------
+
+    @property
+    def damping_factor(self) -> float:
+        """Deprecated alias for `relaxation` (v0.19.2+). Removal in v0.25.0."""
+        return self.relaxation
+
+    @property
+    def damping_factor_M(self) -> float | None:
+        """Deprecated alias for `relaxation_M` (v0.19.2+). Removal in v0.25.0."""
+        return self.relaxation_M
 
     def _validate_strict_adjoint_capability(self) -> None:
         """
@@ -487,7 +519,7 @@ class BlockIterator(BaseCouplingIterator):
             method_name = "Block Gauss-Seidel"
 
         if verbose:
-            print(f"Starting {method_name} iteration (damping={self.damping_factor})")
+            print(f"Starting {method_name} iteration (relaxation={self.relaxation})")
 
         # Progress bar (Issue #587 Protocol pattern)
         from mfgarchon.utils.progress import create_progress_bar
@@ -517,8 +549,8 @@ class BlockIterator(BaseCouplingIterator):
                 U_old,
                 M_new,
                 M_old,
-                theta=self.damping_factor,
-                theta_M=self.damping_factor_M,
+                theta=self.relaxation,
+                theta_M=self.relaxation_M,
             )
 
             # Preserve boundary conditions
@@ -568,7 +600,7 @@ class BlockIterator(BaseCouplingIterator):
         # Build metadata
         metadata = {
             "method": self.method.value,
-            "damping_factor": self.damping_factor,
+            "relaxation": self.relaxation,
             "convergence_reason": convergence_reason,
             "elapsed_time": elapsed,
             "adjoint_mode": self.adjoint_mode,
@@ -624,21 +656,25 @@ class BlockJacobiIterator(BlockIterator):
         >>> result = solver.solve(max_iterations=100)
     """
 
+    @deprecated_parameter(param_name="damping_factor", since="v0.19.2", replacement="relaxation")
     def __init__(
         self,
         problem: MFGProblem,
         hjb_solver: BaseHJBSolver,
         fp_solver: BaseFPSolver,
         *,
-        damping_factor: float = 0.5,
+        relaxation: float = 0.5,
+        damping_factor: float | None = None,
         **kwargs: Any,
     ):
+        if damping_factor is not None:
+            relaxation = damping_factor
         super().__init__(
             problem,
             hjb_solver,
             fp_solver,
             method=BlockMethod.JACOBI,
-            damping_factor=damping_factor,
+            relaxation=relaxation,
             **kwargs,
         )
 
@@ -655,21 +691,25 @@ class BlockGaussSeidelIterator(BlockIterator):
         >>> result = solver.solve(max_iterations=50)
     """
 
+    @deprecated_parameter(param_name="damping_factor", since="v0.19.2", replacement="relaxation")
     def __init__(
         self,
         problem: MFGProblem,
         hjb_solver: BaseHJBSolver,
         fp_solver: BaseFPSolver,
         *,
-        damping_factor: float = 0.5,
+        relaxation: float = 0.5,
+        damping_factor: float | None = None,
         **kwargs: Any,
     ):
+        if damping_factor is not None:
+            relaxation = damping_factor
         super().__init__(
             problem,
             hjb_solver,
             fp_solver,
             method=BlockMethod.GAUSS_SEIDEL,
-            damping_factor=damping_factor,
+            relaxation=relaxation,
             **kwargs,
         )
 
@@ -703,7 +743,7 @@ if __name__ == "__main__":
 
     # Test Block Gauss-Seidel
     print("\nTesting Block Gauss-Seidel...")
-    gs_solver = BlockGaussSeidelIterator(problem, hjb_solver, fp_solver, damping_factor=0.5)
+    gs_solver = BlockGaussSeidelIterator(problem, hjb_solver, fp_solver, relaxation=0.5)
     result_gs = gs_solver.solve(max_iterations=10, tolerance=1e-4, verbose=True)
     print(f"  Converged: {result_gs.converged}, iterations: {result_gs.iterations}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.3"  # v0.19.3: Block iterators damping_* -> relaxation_* rename (backward-compat aliasing)
+version = "0.19.1"  # v0.19.1: PicardConfig damping_* -> relaxation_* rename (backward-compat aliasing)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.1"  # v0.19.1: PicardConfig damping_* -> relaxation_* rename (backward-compat aliasing)
+version = "0.19.3"  # v0.19.3: Block iterators damping_* -> relaxation_* rename (backward-compat aliasing)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.

--- a/tests/integration/test_block_iterators.py
+++ b/tests/integration/test_block_iterators.py
@@ -242,7 +242,7 @@ class TestBlockIteratorParameters:
 
         assert np.all(np.isfinite(result.U))
         assert np.all(np.isfinite(result.M))
-        assert result.metadata["damping_factor"] == 0.3
+        assert result.metadata["relaxation"] == 0.3
 
     def test_density_nonnegative(self, param_problem):
         """Test that density remains non-negative."""

--- a/tests/unit/test_alg/test_block_iterators_relaxation_alias.py
+++ b/tests/unit/test_alg/test_block_iterators_relaxation_alias.py
@@ -1,0 +1,126 @@
+"""Equivalence tests for BlockIterator damping_* -> relaxation_* rename (v0.19.3).
+
+Per CLAUDE.md deprecation policy: legacy `damping_factor` / `damping_factor_M`
+ctor kwargs must produce behavior identical to the canonical `relaxation` /
+`relaxation_M`. Accepts via `@deprecated_parameter` + body redirect on three
+classes: `BlockIterator` (base), `BlockJacobiIterator`, `BlockGaussSeidelIterator`.
+
+Silent `@property` aliases keep `solver.damping_factor` attribute access working
+without warning flooding.
+
+Removal of legacy kwargs and attribute aliases scheduled for v0.25.0.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from mfgarchon.alg.numerical.coupling.block_iterators import (
+    BlockGaussSeidelIterator,
+    BlockIterator,
+    BlockJacobiIterator,
+)
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+
+
+def _make_test_problem():
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(Nx=11, xmin=0.0, xmax=1.0, T=0.2, Nt=5, sigma=0.3, components=components)
+
+
+@pytest.fixture
+def solvers():
+    problem = _make_test_problem()
+    return problem, HJBFDMSolver(problem), FPFDMSolver(problem)
+
+
+@pytest.mark.parametrize("cls", [BlockIterator, BlockJacobiIterator, BlockGaussSeidelIterator])
+class TestEquivalenceAcrossAllThreeClasses:
+    """All three block-iterator classes honor the rename consistently."""
+
+    def test_legacy_damping_factor_equivalent_to_relaxation(self, solvers, cls):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = cls(problem, hjb, fp, damping_factor=0.7)
+        canonical = cls(problem, hjb, fp, relaxation=0.7)
+        assert legacy.relaxation == canonical.relaxation == 0.7
+
+    def test_damping_factor_property_reads_relaxation(self, solvers, cls):
+        problem, hjb, fp = solvers
+        inst = cls(problem, hjb, fp, relaxation=0.8)
+        assert inst.damping_factor == 0.8
+        assert inst.damping_factor == inst.relaxation
+
+    def test_property_reads_silent(self, solvers, cls):
+        problem, hjb, fp = solvers
+        inst = cls(problem, hjb, fp, relaxation=0.5)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = inst.damping_factor
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) == 0
+
+    def test_canonical_kwarg_emits_no_warning(self, solvers, cls):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cls(problem, hjb, fp, relaxation=0.5)
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning) and "damping" in str(x.message)]
+        assert len(dep_warnings) == 0
+
+    def test_legacy_kwarg_emits_deprecation_warning(self, solvers, cls):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cls(problem, hjb, fp, damping_factor=0.5)
+            dep_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning) and "damping_factor" in str(x.message)
+            ]
+        assert len(dep_warnings) >= 1
+
+
+class TestBaseClassBothKwargs:
+    """BlockIterator base accepts damping_factor_M as well as damping_factor."""
+
+    def test_both_legacy_kwargs_equivalent_to_both_canonical(self, solvers):
+        problem, hjb, fp = solvers
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy = BlockIterator(problem, hjb, fp, damping_factor=0.8, damping_factor_M=0.2)
+        canonical = BlockIterator(problem, hjb, fp, relaxation=0.8, relaxation_M=0.2)
+        assert legacy.relaxation == canonical.relaxation == 0.8
+        assert legacy.relaxation_M == canonical.relaxation_M == 0.2
+
+    def test_damping_factor_M_property_reads_relaxation_M(self, solvers):
+        problem, hjb, fp = solvers
+        inst = BlockIterator(problem, hjb, fp, relaxation=0.5, relaxation_M=0.2)
+        assert inst.damping_factor_M == 0.2
+        assert inst.damping_factor_M == inst.relaxation_M
+
+
+class TestMetadataKey:
+    """Result metadata uses canonical `relaxation` key (legacy key removed in v0.19.3)."""
+
+    def test_solve_result_metadata_has_relaxation_key(self, solvers):
+        problem, hjb, fp = solvers
+        solver = BlockGaussSeidelIterator(problem, hjb, fp, relaxation=0.6)
+        result = solver.solve(max_iterations=2, tolerance=1e-4, verbose=False)
+        assert "relaxation" in result.metadata
+        assert result.metadata["relaxation"] == 0.6
+        assert "damping_factor" not in result.metadata


### PR DESCRIPTION
Part of #1010 (B1.5b iteration 2/6).

## Summary

Applies the same rename pattern from #1012 (FixedPointIterator, B1.5b.1) to the three block-iteration classes:

- `BlockIterator` (base)
- `BlockJacobiIterator`
- `BlockGaussSeidelIterator`

Renames `damping_factor` → `relaxation` and `damping_factor_M` → `relaxation_M` on each.

## One extra change: metadata dict key

`SolverResult.metadata` produced by block iterators now has the key `"relaxation"` (was `"damping_factor"`). This is a narrow breaking change — code that did `result.metadata["damping_factor"]` needs to read `result.metadata["relaxation"]` instead. No deprecation bridge is available for string-keyed dict reads, so this is documented in the CHANGELOG and the migration guide. Impact scope: one integration test (`test_block_iterators.py:245`, updated in this PR).

## Two-layer backward compat (same pattern as #1012)

| Layer | Mechanism | Warns on use? |
|---|---|---|
| Ctor kwargs | `@deprecated_parameter` on all three classes + body redirect | Yes (DeprecationWarning at `__init__`) |
| Attribute access | `@property` aliases on `BlockIterator` (inherited) | No (silent, hot-loop safe) |

Both target removal in v0.25.0.

## Test plan

- [x] 10 existing `test_block_iterators.py` integration tests pass (0 regressions)
- [x] 18 new equivalence tests in `test_block_iterators_relaxation_alias.py`:
  - 15 via `@pytest.mark.parametrize` across all 3 classes (5 tests × 3 classes)
  - 2 for `damping_factor_M` on `BlockIterator` base
  - 1 for metadata key (`"relaxation"` present, `"damping_factor"` absent)
- [x] ruff format and ruff check clean (applied locally pre-commit)
- [ ] CI green

## Merge-order note

Branched from main (v0.19.1), assuming #1012 (v0.19.2) lands first. If #1012 merges after this PR, the CHANGELOG section can be renumbered at merge time.

## Out of scope — next B1.5b PRs

Remaining solvers (4/6 done after this lands):
- `NetworkMFGSolver` (`network_mfg_solver.py`)
- `MultiPopulationIterator` (`multi_population_iterator.py`)
- `HJBFDMSolver` (`hjb_fdm.py`)
- `FixedPointSolver` (`utils/numerical/nonlinear_solvers.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)