### PR TITLE
chore: bump to v0.19.2 — close B1.5b solver-kwarg rename arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-04-18
+
 ### Changed — B1.5b series (solver ctor kwargs damping_* → relaxation_*)
 
 Incremental rename propagating the naming change landed in v0.19.1 (`PicardConfig`)
-through the solver constructors. The whole B1.5b arc will ship as one version bump
-(`v0.19.2`) once complete; individual sub-PRs land under `[Unreleased]` and are
-listed here with their scope.
+through the solver constructors. Four sub-PRs shipped together in this release,
+each adding `@deprecated_parameter` decorators + silent `@property` aliases for
+backward compatibility. Removal of legacy names scheduled for v0.25.0 per the
+3-version deprecation window.
 
 - **B1.5b.1** (PR #1012): `FixedPointIterator` — 7 ctor kwargs renamed
   (`damping_factor`, `damping_factor_M`, `adaptive_damping`, `adaptive_damping_decay`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.1"  # v0.19.1: PicardConfig damping_* -> relaxation_* rename (backward-compat aliasing)
+version = "0.19.2"  # v0.19.2: B1.5b solver kwarg rename damping_* -> relaxation_* (backward-compat aliasing)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
Closes #1010 (B1.5b sub-tasks complete).

## Summary

One-line version bump + `[Unreleased]` → `[0.19.2]` in CHANGELOG. No code changes; this PR exists purely to ceremonially cut the B1.5b release.

## What v0.19.2 contains (all previously merged)

| Sub-PR | Scope |
|---|---|
| #1012 | `FixedPointIterator` — 7 ctor kwargs + attribute renames |
| #1013 | `BlockIterator` / `BlockJacobiIterator` / `BlockGaussSeidelIterator` + metadata key |
| #1014 | `NetworkMFGSolver` factories + `MultiPopulationIterator` |
| #1015 | `HJBFDMSolver` + `FixedPointSolver` (utils/numerical) |

All four apply the same `@deprecated_parameter` + silent `@property` pattern. **No user code breaks on upgrade** — legacy `damping_*` kwargs and attribute reads still work, just emit `DeprecationWarning`. Removal scheduled for v0.25.0.

## User-facing migration

Trivial. Over the next 3 versions, replace each `damping_factor=` / `damping_factor_M=` / `adaptive_damping=` / `damping_schedule=` with their `relaxation`-prefixed canonical equivalents. Applies to: `FixedPointIterator`, `BlockIterator` family, `MultiPopulationIterator`, `HJBFDMSolver`, `FixedPointSolver`, `create_network_mfg_solver`, `create_simple_network_solver`.

## Test plan

- [x] All prior B1.5b CI passed on main
- [x] `pyproject.toml` version matches CHANGELOG top section
- [ ] CI green on this tiny diff

## Policy note

This release pattern — N sub-PRs land under `[Unreleased]`, then one ceremonial bump PR renames the section — is the first application of [one-version-per-refactor feedback memory](./feedback_one_version_per_refactor.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)