### PR TITLE
fix: ExperimentConfig NDArray forward-ref crash under pydantic 2.12.5 (B5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ExperimentConfig` forward-ref crash under pydantic 2.12.5** (Issue #1010 B5):
+  `NDArray` was imported under `TYPE_CHECKING` in `mfgarchon/config/array_validation.py`
+  but used as an annotation on the `MFGArrays.U_solution` / `M_solution` fields.
+  Pydantic 2.12.5+ resolves field annotations at model-build time and rejected the
+  unresolved forward reference with `PydanticUserError: class-not-fully-defined`,
+  breaking any instantiation of `ExperimentConfig`, `MFGArrays`, or
+  `CollocationConfig`. Fixed by importing `NDArray` at runtime (not under
+  `TYPE_CHECKING`), with a `noqa: TC002` on the import explaining why the
+  runtime import is deliberate. The `MFGArrays.model_rebuild()` and
+  `ExperimentConfig.model_rebuild()` workaround calls in `test_array_validation.py`
+  are no longer needed and have been removed.
+
 ## [0.19.2] - 2026-04-18
 
 ### Changed — B1.5b series (solver ctor kwargs damping_* → relaxation_*)

--- a/mfgarchon/config/array_validation.py
+++ b/mfgarchon/config/array_validation.py
@@ -8,19 +8,24 @@ numerical properties, and physical constraints specific to MFG problems.
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 import numpy as np
 
+# NDArray must be imported at runtime (not TYPE_CHECKING) because Pydantic 2.12.5+
+# resolves annotation strings at model build time. Under `from __future__ import
+# annotations`, the `NDArray[np.floating]` field annotation on `MFGArrays` becomes
+# a forward reference that pydantic cannot resolve from a TYPE_CHECKING-only import,
+# raising `PydanticUserError: class-not-fully-defined` at instance construction.
+# See Issue #1010 (B5).
+from numpy.typing import NDArray  # noqa: TC002  (pydantic 2.12.5 needs runtime resolution)
+
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical.integration import trapezoid
 
 logger = get_logger(__name__)
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
 
 
 class ArrayValidationConfig(BaseModel):

--- a/tests/unit/test_config/test_array_validation.py
+++ b/tests/unit/test_config/test_array_validation.py
@@ -11,17 +11,8 @@ import pytest
 from pydantic import ValidationError
 
 import numpy as np
-from numpy.typing import NDArray
 
-# Import NDArray into the module's namespace before importing models
-# This allows Pydantic to resolve the NDArray annotation at runtime
-import mfgarchon.config.array_validation as av_module
-
-# Make NDArray available in the array_validation module's namespace
-av_module.NDArray = NDArray
-
-# Now import the models - order is important for Pydantic+NumPy validation
-from mfgarchon.config.array_validation import (  # noqa: E402
+from mfgarchon.config.array_validation import (
     ArrayValidationConfig,
     CollocationConfig,
     ExperimentConfig,
@@ -29,10 +20,8 @@ from mfgarchon.config.array_validation import (  # noqa: E402
     MFGGridConfig,
 )
 
-# Rebuild Pydantic models after NDArray is available
-MFGArrays.model_rebuild()
-CollocationConfig.model_rebuild()
-ExperimentConfig.model_rebuild()
+# NDArray is imported at module level in mfgarchon/config/array_validation.py
+# (Issue #1010 B5), so `model_rebuild()` is no longer needed at import time.
 
 
 class TestArrayValidationConfig:


### PR DESCRIPTION
Part of #1010 (B5). Surgical fix for a pydantic 2.12.5 regression.

## Root cause

`mfgarchon/config/array_validation.py` imported `NDArray` under `if TYPE_CHECKING:` but used it as a field annotation on `MFGArrays.U_solution` / `M_solution`. With `from __future__ import annotations`, these became string forward references. Pydantic 2.12.5 resolves field annotations at model-build time and rejected the unresolved reference:

```
PydanticUserError: `MFGArrays` is not fully defined; you should
define `NDArray`, then call `MFGArrays.model_rebuild()`.
```

Any instantiation of `ExperimentConfig`, `MFGArrays`, or `CollocationConfig` crashed before this fix.

## Fix

One-line: move `NDArray` import out of `TYPE_CHECKING`. Added `# noqa: TC002` with inline explanation since ruff's "move to TYPE_CHECKING" lint is opinionated but wrong for this case.

## Collateral cleanup

`tests/unit/test_config/test_array_validation.py` previously carried three workarounds for the same bug:
- `import numpy.typing.NDArray` at the test level
- `av_module.NDArray = NDArray` monkey-patch
- `MFGArrays.model_rebuild()` / `ExperimentConfig.model_rebuild()` calls

All three are no longer needed. Removed.

## Test plan

- [x] Smoke test: `ExperimentConfig(...)` instantiates cleanly (previously crashed)
- [x] 146 existing config tests pass (54 in `test_array_validation.py` alone)
- [x] `ruff format` + `ruff check` clean
- [ ] CI green

## Version policy

No version bump in this PR. Per the one-version-per-refactor policy, B5 + B2 + internal cleanup will ship together as v0.19.3. CHANGELOG entry added under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)