### PR TITLE
test: dedicated tests for canonical config modules (B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- **Canonical config module coverage** (Issue #1010 B2):
+  Added dedicated unit tests for `mfgarchon/config/core.py` and
+  `mfgarchon/config/mfg_methods.py`, which previously had only indirect
+  coverage via factory tests and integration tests. Two new files (58 tests):
+  - `tests/unit/test_config/test_core.py` — 23 tests covering
+    `LoggingConfig`, `BackendConfig`, canonical-path `PicardConfig`, and
+    `MFGSolverConfig` (defaults, range validators, `@model_validator` hooks,
+    `save_intermediate`-requires-`output_dir`, `numpy`-cannot-use-`gpu`,
+    `anderson_memory <= max_iterations`, `model_dump` round-trip).
+  - `tests/unit/test_config/test_mfg_methods.py` — 35 tests covering the 14
+    method configs: default instantiation, Literal/enum rejection of
+    invalid values, range-bound enforcement, `@model_validator` hooks
+    (e.g., `wind_dependent_bc` requires `ghost_nodes`, FEM auto-quadrature).
+
 ## [0.19.2] - 2026-04-18
 
 ### Changed — B1.5b series (solver ctor kwargs damping_* → relaxation_*)

--- a/tests/unit/test_config/test_core.py
+++ b/tests/unit/test_config/test_core.py
@@ -1,0 +1,149 @@
+"""Unit tests for `mfgarchon.config.core` (Issue #1010 B2).
+
+Covers the canonical composite/top-level Pydantic configs that form the core of
+MFGArchon's solver configuration:
+- LoggingConfig
+- BackendConfig
+- PicardConfig (defaults + range validators only — alias tests live in
+  test_picard_relaxation_alias.py)
+- MFGSolverConfig
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from mfgarchon.config import (
+    BackendConfig,
+    LoggingConfig,
+    MFGSolverConfig,
+    PicardConfig,
+    SolverConfig,
+)
+
+
+class TestLoggingConfig:
+    def test_defaults(self):
+        c = LoggingConfig()
+        assert c.level == "INFO"
+        assert c.progress_bar is True
+        assert c.save_intermediate is False
+        assert c.output_dir is None
+
+    def test_level_enum(self):
+        for lvl in ("DEBUG", "INFO", "WARNING", "ERROR"):
+            assert LoggingConfig(level=lvl).level == lvl
+
+    def test_invalid_level_rejected(self):
+        with pytest.raises(ValidationError):
+            LoggingConfig(level="TRACE")
+
+    def test_save_intermediate_requires_output_dir(self):
+        with pytest.raises(ValidationError, match="output_dir must be provided"):
+            LoggingConfig(save_intermediate=True)
+
+    def test_save_intermediate_with_output_dir_ok(self):
+        c = LoggingConfig(save_intermediate=True, output_dir="/tmp/results")
+        assert c.save_intermediate is True
+        assert c.output_dir == "/tmp/results"
+
+
+class TestBackendConfig:
+    def test_defaults(self):
+        c = BackendConfig()
+        assert c.type == "numpy"
+        assert c.device == "cpu"
+        assert c.precision == "float64"
+
+    @pytest.mark.parametrize("backend", ["numpy", "jax", "pytorch"])
+    def test_backends_accepted(self, backend):
+        assert BackendConfig(type=backend).type == backend
+
+    def test_numpy_gpu_rejected(self):
+        with pytest.raises(ValidationError, match="NumPy backend does not support GPU"):
+            BackendConfig(type="numpy", device="gpu")
+
+    def test_jax_gpu_accepted(self):
+        c = BackendConfig(type="jax", device="gpu")
+        assert c.device == "gpu"
+
+    def test_invalid_precision_rejected(self):
+        with pytest.raises(ValidationError):
+            BackendConfig(precision="float16")
+
+
+class TestPicardConfigCanonical:
+    """Canonical-path coverage only. Alias coverage in test_picard_relaxation_alias.py."""
+
+    def test_defaults(self):
+        c = PicardConfig()
+        assert c.max_iterations == 100
+        assert c.tolerance == 1e-6
+        assert c.relaxation == 0.5
+        assert c.relaxation_M is None
+        assert c.adaptive_relaxation is False
+        assert c.anderson_memory == 0
+        assert c.verbose is True
+
+    def test_relaxation_range(self):
+        PicardConfig(relaxation=0.01)  # lower bound ok
+        PicardConfig(relaxation=1.0)  # upper bound ok
+        with pytest.raises(ValidationError):
+            PicardConfig(relaxation=0.0)
+        with pytest.raises(ValidationError):
+            PicardConfig(relaxation=1.5)
+
+    def test_anderson_memory_cannot_exceed_max_iterations(self):
+        with pytest.raises(ValidationError, match="anderson_memory cannot exceed"):
+            PicardConfig(max_iterations=10, anderson_memory=20)
+
+    def test_anderson_memory_negative_rejected(self):
+        with pytest.raises(ValidationError):
+            PicardConfig(anderson_memory=-1)
+
+    def test_schedule_enum(self):
+        for s in ("constant", "harmonic", "sqrt", "exponential"):
+            assert PicardConfig(relaxation_schedule=s).relaxation_schedule == s
+
+    def test_invalid_schedule_rejected(self):
+        with pytest.raises(ValidationError):
+            PicardConfig(relaxation_schedule="arithmetic")
+
+
+class TestMFGSolverConfig:
+    def test_default_construction_populates_all_subconfigs(self):
+        c = MFGSolverConfig()
+        # All sub-configs should be non-None after default_factory runs
+        assert c.hjb is not None
+        assert c.fp is not None
+        assert c.picard is not None
+        assert c.backend is not None
+        assert c.logging is not None
+
+    def test_solverconfig_is_alias_for_mfgsolverconfig(self):
+        assert SolverConfig is MFGSolverConfig
+
+    def test_nested_override(self):
+        c = MFGSolverConfig(picard=PicardConfig(max_iterations=50))
+        assert c.picard.max_iterations == 50
+        # Other sub-configs keep defaults
+        assert c.logging.level == "INFO"
+
+    def test_model_dump_roundtrip(self):
+        original = MFGSolverConfig(
+            picard=PicardConfig(relaxation=0.3, max_iterations=200),
+            backend=BackendConfig(type="jax", device="gpu"),
+        )
+        dumped = original.model_dump()
+        rebuilt = MFGSolverConfig(**dumped)
+        assert rebuilt.picard.relaxation == 0.3
+        assert rebuilt.picard.max_iterations == 200
+        assert rebuilt.backend.type == "jax"
+        assert rebuilt.backend.device == "gpu"
+
+    def test_model_dump_yaml_excludes_none(self):
+        c = MFGSolverConfig()
+        dumped = c.model_dump_yaml()
+        # None-valued fields should not appear in YAML output
+        assert "relaxation_M" not in dumped.get("picard", {}) or dumped["picard"].get("relaxation_M") is not None

--- a/tests/unit/test_config/test_mfg_methods.py
+++ b/tests/unit/test_config/test_mfg_methods.py
@@ -1,0 +1,228 @@
+"""Unit tests for `mfgarchon.config.mfg_methods` (Issue #1010 B2).
+
+Covers the 14 leaf method configs + composite HJB/FP configs. Focus on:
+- Default instantiation works for every class
+- Literal/enum fields reject invalid values
+- Range-constrained numeric fields enforce bounds
+- Model-level validators (`@model_validator(mode="after")`) fire correctly
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from mfgarchon.config import (
+    BoundaryAccuracyConfig,
+    DerivativeConfig,
+    FDMConfig,
+    FPConfig,
+    GFDMConfig,
+    HJBConfig,
+    NeighborhoodConfig,
+    NetworkConfig,
+    NewtonConfig,
+    ParticleConfig,
+    QPConfig,
+    SLConfig,
+    WENOConfig,
+)
+
+# FEMConfig lives in mfg_methods but is not re-exported from mfgarchon.config
+from mfgarchon.config.mfg_methods import FEMConfig
+
+
+class TestNewtonConfig:
+    def test_defaults(self):
+        c = NewtonConfig()
+        assert c.max_iterations == 10
+        assert c.tolerance == 1e-6
+        assert c.relaxation == 1.0
+
+    def test_relaxation_range(self):
+        NewtonConfig(relaxation=0.01)
+        NewtonConfig(relaxation=1.0)
+        with pytest.raises(ValidationError):
+            NewtonConfig(relaxation=0.0)
+        with pytest.raises(ValidationError):
+            NewtonConfig(relaxation=1.5)
+
+    def test_tolerance_positive(self):
+        with pytest.raises(ValidationError):
+            NewtonConfig(tolerance=0.0)
+        with pytest.raises(ValidationError):
+            NewtonConfig(tolerance=-1e-6)
+
+
+class TestFDMConfig:
+    def test_defaults(self):
+        c = FDMConfig()
+        assert c.scheme == "upwind"
+        assert c.time_stepping == "implicit"
+
+    @pytest.mark.parametrize("scheme", ["central", "upwind", "lax_friedrichs"])
+    def test_valid_schemes(self, scheme):
+        assert FDMConfig(scheme=scheme).scheme == scheme
+
+    def test_invalid_scheme(self):
+        with pytest.raises(ValidationError):
+            FDMConfig(scheme="godunov")
+
+
+class TestFEMConfig:
+    def test_defaults(self):
+        c = FEMConfig()
+        assert c.element_order == 1
+        assert c.quadrature_order == 2 * 1 + 1
+
+    def test_element_order_auto_quadrature(self):
+        c = FEMConfig(element_order=2)
+        assert c.quadrature_order == 2 * 2 + 1
+
+    def test_element_order_enum(self):
+        with pytest.raises(ValidationError):
+            FEMConfig(element_order=3)
+
+
+class TestQPConfig:
+    def test_defaults(self):
+        c = QPConfig()
+        assert c.optimization_level == "none"
+        assert c.solver == "osqp"
+        assert c.warm_start is True
+        assert c.constraint_mode == "indirect"
+
+    @pytest.mark.parametrize("level", ["none", "auto", "always"])
+    def test_optimization_levels(self, level):
+        assert QPConfig(optimization_level=level).optimization_level == level
+
+
+class TestNeighborhoodConfig:
+    def test_defaults(self):
+        c = NeighborhoodConfig()
+        assert c.mode == "hybrid"
+        assert c.k_neighbors is None
+        assert c.adaptive is False
+        assert c.max_delta_multiplier == 5.0
+
+    def test_max_delta_multiplier_must_exceed_one(self):
+        with pytest.raises(ValidationError):
+            NeighborhoodConfig(max_delta_multiplier=1.0)
+        NeighborhoodConfig(max_delta_multiplier=1.01)
+
+
+class TestDerivativeConfig:
+    def test_defaults(self):
+        c = DerivativeConfig()
+        assert c.method == "taylor"
+        assert c.rbf_kernel == "phs3"
+        assert c.rbf_poly_degree == 2
+
+    def test_poly_degree_non_negative(self):
+        DerivativeConfig(rbf_poly_degree=0)
+        with pytest.raises(ValidationError):
+            DerivativeConfig(rbf_poly_degree=-1)
+
+
+class TestBoundaryAccuracyConfig:
+    def test_defaults(self):
+        c = BoundaryAccuracyConfig()
+        assert c.local_coordinate_rotation is False
+        assert c.ghost_nodes is False
+        assert c.wind_dependent_bc is False
+
+    def test_wind_dependent_bc_requires_ghost_nodes(self):
+        with pytest.raises(ValidationError, match="wind_dependent_bc=True requires ghost_nodes=True"):
+            BoundaryAccuracyConfig(wind_dependent_bc=True, ghost_nodes=False)
+
+    def test_wind_dependent_bc_with_ghost_nodes_ok(self):
+        c = BoundaryAccuracyConfig(wind_dependent_bc=True, ghost_nodes=True)
+        assert c.wind_dependent_bc is True
+
+
+class TestGFDMConfig:
+    def test_defaults(self):
+        c = GFDMConfig()
+        assert c.delta == 0.1
+        assert c.taylor_order == 2
+        assert c.weight_function == "wendland"
+        assert c.congestion_mode == "additive"
+        assert isinstance(c.qp, QPConfig)
+        assert isinstance(c.neighborhood, NeighborhoodConfig)
+        assert isinstance(c.derivative, DerivativeConfig)
+        assert isinstance(c.boundary_accuracy, BoundaryAccuracyConfig)
+
+    def test_taylor_order_bounds(self):
+        GFDMConfig(taylor_order=1)
+        GFDMConfig(taylor_order=2)
+        with pytest.raises(ValidationError):
+            GFDMConfig(taylor_order=0)
+        with pytest.raises(ValidationError):
+            GFDMConfig(taylor_order=3)
+
+    def test_delta_positive(self):
+        with pytest.raises(ValidationError):
+            GFDMConfig(delta=0.0)
+
+
+class TestSLConfig:
+    def test_defaults(self):
+        c = SLConfig()
+        assert c.interpolation_method == "cubic"
+        assert c.rk_order == 2
+        assert c.cfl_number == 0.5
+
+    def test_cfl_range(self):
+        SLConfig(cfl_number=0.01)
+        SLConfig(cfl_number=1.0)
+        with pytest.raises(ValidationError):
+            SLConfig(cfl_number=0.0)
+        with pytest.raises(ValidationError):
+            SLConfig(cfl_number=1.5)
+
+    def test_rk_order_enum(self):
+        for k in (1, 2, 3, 4):
+            assert SLConfig(rk_order=k).rk_order == k
+        with pytest.raises(ValidationError):
+            SLConfig(rk_order=5)
+
+
+class TestWENOConfig:
+    def test_defaults_roundtrip(self):
+        c = WENOConfig()
+        rebuilt = WENOConfig(**c.model_dump())
+        assert rebuilt == c
+
+
+class TestParticleConfig:
+    def test_defaults_and_instantiation(self):
+        c = ParticleConfig()
+        assert c is not None
+        assert type(c).__module__ == "mfgarchon.config.mfg_methods"
+
+
+class TestNetworkConfig:
+    def test_defaults_and_instantiation(self):
+        c = NetworkConfig()
+        assert c is not None
+
+
+class TestHJBConfig:
+    def test_defaults(self):
+        c = HJBConfig()
+        assert c.method in {"fdm", "fem", "gfdm", "sl", "weno"}
+
+    def test_has_expected_shape(self):
+        c = HJBConfig()
+        assert hasattr(c, "method")
+        assert hasattr(c, "newton")
+
+
+class TestFPConfig:
+    def test_defaults(self):
+        c = FPConfig()
+        assert c.method in {"fdm", "fem", "particle", "network"}
+
+    def test_has_expected_shape(self):
+        c = FPConfig()
+        assert hasattr(c, "method")


### PR DESCRIPTION
Part of #1010 (B2). Adds durable test coverage for `mfgarchon/config/core.py` and `mfgarchon/config/mfg_methods.py`, which previously had only indirect coverage via factory and integration tests.

## Why this matters

Before this PR, the canonical Pydantic classes could break silently if a field was renamed, a validator was removed, or an enum literal was dropped. Factory tests often test behavior at a higher level and miss field-level regressions.

## What's covered

### `test_core.py` (23 tests)

- `LoggingConfig`: level enum, `save_intermediate`-requires-`output_dir` validator
- `BackendConfig`: `type`/`device`/`precision` enums, `numpy+gpu` rejection
- `PicardConfig` canonical-only (alias coverage lives in `test_picard_relaxation_alias.py`): defaults, relaxation range, `anderson_memory` bounds, schedule enum
- `MFGSolverConfig`: default sub-config population, `SolverConfig` alias identity, nested override, `model_dump` round-trip, `model_dump_yaml` excludes None

### `test_mfg_methods.py` (35 tests, 14 classes)

Default instantiation + enum/range validators + `@model_validator(mode="after")` hooks:
- `NewtonConfig`: relaxation range, tolerance positive
- `FDMConfig`: scheme enum
- `FEMConfig`: element_order enum, auto-quadrature validator
- `QPConfig`: optimization_level enum
- `NeighborhoodConfig`: `max_delta_multiplier > 1` constraint
- `DerivativeConfig`: `rbf_poly_degree >= 0`
- `BoundaryAccuracyConfig`: `wind_dependent_bc` requires `ghost_nodes`
- `GFDMConfig`: `taylor_order in [1, 2]`, `delta > 0`, sub-configs populated
- `SLConfig`: CFL range, RK order enum
- `WENOConfig`: `model_dump` round-trip
- `ParticleConfig`, `NetworkConfig`, `HJBConfig`, `FPConfig`: instantiation + shape

## Minor finding

`FEMConfig` is not re-exported from `mfgarchon.config`; imported directly from `mfgarchon.config.mfg_methods`. Test file documents this. Could be added to public exports in a follow-up if deemed public API.

## Test plan

- [x] 58 new tests pass (23 + 35)
- [x] `ruff format` + `ruff check` clean
- [ ] CI green

## Version policy

No version bump in this PR. Lands under `[Unreleased]`; ships as v0.19.3 together with B5 (#1017) and the internal cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)