### PR TITLE
chore: create_network_mfg_solver uses canonical relaxation internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal cleanup** (B1.5b follow-up): `create_network_mfg_solver` now
+  forwards the canonical `relaxation` kwarg to `FixedPointIterator` internally
+  instead of the legacy `damping_factor`. The legacy-forwarding was a
+  deliberate temporary measure to keep the B1.5b.3 PR mergeable before B1.5b.1
+  (FixedPointIterator rename) landed. With both now on main, the factory no
+  longer emits a self-generated `DeprecationWarning` from its own codebase.
+
 ### Fixed
 
 - **`ExperimentConfig` forward-ref crash under pydantic 2.12.5** (Issue #1010 B5):

--- a/mfgarchon/alg/numerical/coupling/network_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/network_mfg_solver.py
@@ -103,15 +103,11 @@ def create_network_mfg_solver(
 
     # Create fixed-point iterator
     if solver_type == "fixed_point":
-        # NOTE: uses legacy kwarg `damping_factor` internally so this factory works
-        # whether or not PR #1012 (FixedPointIterator rename) has landed. After #1012
-        # merges, update to `relaxation=relaxation`; the internal DeprecationWarning
-        # will then vanish.
         solver = FixedPointIterator(
             problem=problem,
             hjb_solver=hjb_solver,
             fp_solver=fp_solver,
-            damping_factor=relaxation,
+            relaxation=relaxation,
             **solver_kwargs,
         )
     else:


### PR DESCRIPTION
Part of #1010 (B1.5b follow-up).

## One-line fix

When B1.5b.3 (PR #1014) landed, the internal call site was:

```python
solver = FixedPointIterator(
    ...,
    damping_factor=relaxation,  # legacy kwarg used intentionally
    ...
)
```

This kept #1014 mergeable before B1.5b.1 (PR #1012, `FixedPointIterator` rename) merged. A `TODO` comment flagged the cleanup.

Now that both are on main since v0.19.2, this PR swaps the internal call to use the canonical kwarg:

```python
solver = FixedPointIterator(
    ...,
    relaxation=relaxation,
    ...
)
```

## Why it matters

Before: `create_network_mfg_solver` emitted a `DeprecationWarning` from its own codebase every time a user called it — the codebase warning about its own code. That's a self-inflicted smell.

After: canonical-path clean, zero warnings.

## Test plan

- [x] 15 network tests pass
- [x] 7 equivalence tests from B1.5b.3 still pass
- [ ] CI green

## Version

No bump in this PR. Goes into v0.19.3 alongside B2 (#1018, merged) and B5 (#1017, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)