### PR TITLE
chore: bump to v0.19.3 — config renovation internal consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-04-18
+
 ### Changed
 
 - **Internal cleanup** (B1.5b follow-up): `create_network_mfg_solver` now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.2"  # v0.19.2: B1.5b solver kwarg rename damping_* -> relaxation_* (backward-compat aliasing)
+version = "0.19.3"  # v0.19.3: config renovation internal consolidation (tests, B5 fix, internal cleanup)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
Ceremonial bump closing three small items from #1010. Renames `[Unreleased]` → `[0.19.3]` in CHANGELOG; bumps `pyproject.toml`.

## Release contents (all merged)

| PR | Sub-task | CHANGELOG section |
|---|---|---|
| #1019 | `create_network_mfg_solver` stops self-DeprecationWarning | Changed |
| #1017 | `ExperimentConfig` NDArray forward-ref fix (pydantic 2.12.5 compat) | Fixed |
| #1018 | Canonical config module tests (58 tests for `core.py` / `mfg_methods.py`) | Tests |

## Not in v0.19.3

- **B3** (YAML loader migration from `OmegaConf.structured(schema_cls)` to single `bridge_to_pydantic` crossing) — larger scope, target v0.19.4 or later
- **B4** (delete `structured_schemas.py`, slim `omegaconf_manager.py`) — depends on B3

#1010 remains open until both land.

## Policy

Second application of the one-version-per-refactor pattern (v0.19.2 was the first): three internal sub-PRs accumulate under `[Unreleased]`, then a ceremonial bump PR ships them together as a single user-visible patch.

## Test plan

- [x] All three sub-PRs merged and green
- [x] `pyproject.toml` version matches CHANGELOG top section
- [ ] CI green on this tiny diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)