### PR TITLE
Implement diffusion_method='stochastic' for HJBSemiLagrangianSolver (Carlini-Silva 2014)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -7,13 +7,15 @@ equation in MFG problems. The method follows characteristics backward in time an
 interpolation to compute values at departure points.
 
 The HJB equation solved is:
-    ∂u/∂t + H(x, ∇u, m) - σ²/2 Δu = 0    in [0,T) × Ω
+    -∂u/∂t + H(x, ∇u, m) - σ²/2 Δu = 0    in [0,T) × Ω
     u(T, x) = g(x)                         at t = T
 
-where H is the Hamiltonian and the semi-Lagrangian scheme discretizes this as:
-    (u^{n+1} - û^n) / Δt + H(x, ∇û^n, m^{n+1}) - σ²/2 Δû^n = 0
+equivalently ∂u/∂t = H(x, ∇u, m) - σ²/2 Δu (cost-to-go convention; u flows backward
+in time from terminal data g). The semi-Lagrangian scheme discretizes this as:
+    (u^n - û^{n+1}) / (-Δt) + H(x, ∇û^{n+1}, m^{n+1}) - σ²/2 Δû^{n+1} = 0
+    u^n = û^{n+1} - Δt · H(x, ∇û^{n+1}, m^{n+1}) + ... (diffusion handled by chosen method)
 
-where û^n is the value interpolated at the departure point of the characteristic.
+where û^{n+1} is the value of u^{n+1} at the characteristic departure point.
 """
 
 from __future__ import annotations
@@ -198,6 +200,16 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # Gradient clipping configuration (Issue #583)
         self.gradient_clip_threshold = gradient_clip_threshold
         self.enable_gradient_monitoring = enable_gradient_monitoring
+
+        # Issue #1026: Carlini-Silva stochastic SL requires >=2nd-order interpolation.
+        # Linear interpolation caps global error at O(h), defeating the purpose.
+        if self.diffusion_method == "stochastic" and self.interpolation_method == "linear":
+            raise ValueError(
+                "diffusion_method='stochastic' requires cubic or higher-order "
+                "interpolation. Linear interpolation produces O(h) global error, "
+                "incompatible with the Carlini-Silva 2014 second-order scheme. "
+                "Set interpolation_method='cubic' (or 'quintic' for nD)."
+            )
 
         # Gradient clipping statistics tracking
         self._reset_gradient_stats()
@@ -922,6 +934,10 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         if self._use_dpp:
             return self._solve_timestep_dpp(U_next, M_next, time_idx)
 
+        # Issue #1026: Carlini-Silva stochastic-characteristic SL bypasses splitting
+        if self.diffusion_method == "stochastic":
+            return self._solve_timestep_stochastic_sl(U_next, M_next, time_idx, dt=self.dt)
+
         if self.dimension == 1:
             # 1D solve with operator splitting: characteristics + Crank-Nicolson diffusion
             Nx = len(U_next)
@@ -1123,6 +1139,10 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         if self._use_dpp:
             return self._solve_timestep_dpp(U_next, M_next, time_idx, dt=dt)
 
+        # Issue #1026: Carlini-Silva stochastic-characteristic SL bypasses splitting
+        if self.diffusion_method == "stochastic":
+            return self._solve_timestep_stochastic_sl(U_next, M_next, time_idx, dt=dt)
+
         if self.dimension == 1:
             # 1D solve with operator splitting
             Nx = len(U_next)
@@ -1221,6 +1241,209 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 return U_current_shaped.ravel()
             else:
                 return U_current_shaped
+
+    # === Carlini-Silva stochastic-characteristic SL (Issue #1026) ===
+
+    def _solve_timestep_stochastic_sl(
+        self,
+        U_next: np.ndarray,
+        M_next: np.ndarray,
+        time_idx: int,
+        dt: float | None = None,
+    ) -> np.ndarray:
+        """Carlini-Silva (2014) semi-Lagrangian step with stochastic characteristics.
+
+        The diffusion enters directly through 2*d stochastic departure points
+        (one pair per spatial dimension), eliminating the operator-splitting
+        diffusion solve. For separable convex Lagrangian L(x, a, m) =
+        (1/2)|a|^2 + f(x, m) the optimal control is alpha* = -nabla u^{n+1}
+        and the update is
+
+            U^n_i = (1/(2d)) * sum_{k=1..d} [I[U^{n+1}](y_k^+) + I[U^{n+1}](y_k^-)]
+                    - dt * H(x_i, p_i, m_i^n)
+
+        with y_k^pm = x_i + alpha*_i * dt +/- sigma * sqrt(dt) * e_k.
+
+        Validation: see mfg-research/experiments/crowd_evacuation_2d/minors/archive/
+        exp14_towel_1d_benchmark/subs/exp14e_solver_comparison/, where the
+        decoupled-from-diffusion form (diffusion_method='adi' default) gave
+        O(h) convergence on the 1D Boltzmann-Gibbs equilibrium against the
+        Carlini-Silva theoretical O(h^2). Reproducing the CS rate requires
+        this stochastic-characteristic path.
+
+        References:
+            Carlini, E., & Silva, F. J. (2014). A semi-Lagrangian scheme for a
+            degenerate second order MFG system. Discrete and Continuous
+            Dynamical Systems, 35(9), 4269-4292.
+
+        Args:
+            U_next: Value function at next time step (shape (Nx,) for 1D, or
+                grid shape / flattened for nD).
+            M_next: Density at next time step (matching shape).
+            time_idx: Current time index (used in Hamiltonian evaluation).
+            dt: Time step. Defaults to self.dt; pass explicitly for adaptive
+                substepping.
+
+        Returns:
+            Value function at current time step, same shape as U_next.
+
+        Raises:
+            ValueError: if interpolation_method is "linear" (validated in
+                __init__, but check is also enforced here defensively).
+        """
+        if dt is None:
+            dt = self.dt
+        if self.interpolation_method == "linear":
+            raise ValueError(
+                "Stochastic SL with linear interpolation has O(h) global "
+                "error and is incompatible with the Carlini-Silva 2014 "
+                "scheme. Set interpolation_method='cubic' (or 'quintic')."
+            )
+
+        if self.dimension == 1:
+            return self._stochastic_sl_step_1d(U_next, M_next, time_idx, dt)
+        else:
+            return self._stochastic_sl_step_nd(U_next, M_next, time_idx, dt)
+
+    def _stochastic_sl_step_1d(
+        self,
+        U_next: np.ndarray,
+        M_next: np.ndarray,
+        time_idx: int,
+        dt: float,
+    ) -> np.ndarray:
+        """1D stochastic SL step. See _solve_timestep_stochastic_sl."""
+        from scipy.interpolate import CubicSpline
+
+        Nx = len(U_next)
+        sigma = self.problem.sigma  # SDE volatility (Sigma in mfg_problem.py:39)
+        sqrt_dt = float(np.sqrt(dt))
+        diffusion_offset = sigma * sqrt_dt
+
+        # Optimal control alpha* = -p where p = nabla u^{n+1}
+        # (existing code uses x_dep = x - p*dt, i.e., assumes alpha* = -p)
+        grad_u = self._compute_gradient(U_next, check_cfl=True, t_idx=time_idx, m_density=M_next)
+
+        # Two stochastic departures per node
+        x_drift = self.x_grid - grad_u * dt
+        y_plus = x_drift + diffusion_offset
+        y_minus = x_drift - diffusion_offset
+
+        # Boundary handling - same as the Strang-splitting branch
+        bc = self.get_boundary_conditions()
+        bc_type_str = get_bc_type_string(bc)
+        bc_op = bc_type_to_geometric_operation(bc_type_str)
+        bounds = self.problem.geometry.get_bounds()
+        xmin, xmax = bounds[0][0], bounds[1][0]
+        if bc_op == "reflect":
+            y_plus = np.clip(y_plus, xmin, xmax)
+            y_minus = np.clip(y_minus, xmin, xmax)
+        elif bc_op == "wrap":
+            L = xmax - xmin
+            y_plus = xmin + (y_plus - xmin) % L
+            y_minus = xmin + (y_minus - xmin) % L
+
+        # Cubic spline interpolation at both stochastic departures
+        interp_fn = CubicSpline(self.x_grid, U_next, bc_type="not-a-knot")
+        u_plus = interp_fn(y_plus)
+        u_minus = interp_fn(y_minus)
+
+        # CS update: average over Brownian directions, subtract dt*H
+        u_avg = 0.5 * (u_plus + u_minus)
+
+        x_batch = self.x_grid.reshape(-1, 1)
+        p_batch = grad_u.reshape(-1, 1)
+        H_class = self.problem.hamiltonian_class
+        if H_class is not None:
+            H_values = np.asarray(H_class(x_batch, M_next, p_batch, t=time_idx * dt), dtype=float).ravel()
+        else:
+            H_values = np.zeros(Nx)
+
+        U_current = u_avg - dt * H_values
+
+        # Enforce BC on the result
+        if bc:
+            time = time_idx * dt
+            U_current = self.bc_applicator.enforce_values(
+                U_current, boundary_conditions=bc, spacing=(self.dx,), time=time
+            )
+
+        return U_current
+
+    def _stochastic_sl_step_nd(
+        self,
+        U_next: np.ndarray,
+        M_next: np.ndarray,
+        time_idx: int,
+        dt: float,
+    ) -> np.ndarray:
+        """nD stochastic SL step.
+
+        Uses the existing per-point _interpolate_value path (handles cubic /
+        quintic via RegularGridInterpolator). The Brownian quadrature is over
+        2*d departures (one pair per coordinate axis).
+        """
+        # Reshape to grid form (matches the Strang-splitting nD path)
+        if U_next.ndim == 1:
+            total_points = U_next.size
+            expected_full = int(np.prod(self._grid_shape))
+            if total_points == expected_full:
+                grid_shape = tuple(self._grid_shape)
+            else:
+                grid_shape = tuple(n - 1 for n in self._grid_shape)
+            U_next_shaped = U_next.reshape(grid_shape)
+            M_next_shaped = M_next.reshape(grid_shape)
+        else:
+            U_next_shaped = U_next
+            M_next_shaped = M_next
+            grid_shape = U_next_shaped.shape
+
+        sigma = self.problem.sigma
+        if isinstance(sigma, np.ndarray):
+            # Diagonal volatility: sigma[k] is the volatility along axis k
+            sigma_diag = np.asarray(sigma, dtype=float).ravel()
+            if sigma_diag.size != self.dimension:
+                raise ValueError(
+                    f"Diagonal sigma must have {self.dimension} entries, "
+                    f"got {sigma_diag.size}. Full-tensor sigma not yet "
+                    f"supported by stochastic SL."
+                )
+        else:
+            sigma_diag = np.full(self.dimension, float(sigma))
+        sqrt_dt = float(np.sqrt(dt))
+
+        grad_components = self._compute_gradient(U_next_shaped, check_cfl=True, t_idx=time_idx, m_density=M_next_shaped)
+
+        U_current_shaped = np.zeros_like(U_next_shaped)
+        d = self.dimension
+
+        for multi_idx in np.ndindex(grid_shape):
+            x_current = np.array([self.grid.coordinates[ax][multi_idx[ax]] for ax in range(d)])
+            m_current = M_next_shaped[multi_idx]
+            p_optimal = np.array([grad_components[ax][multi_idx] for ax in range(d)])
+            x_drift = x_current - p_optimal * dt
+
+            # 2d stochastic departures - one pair per axis
+            interp_acc = 0.0
+            for ax in range(d):
+                offset = np.zeros(d)
+                offset[ax] = sigma_diag[ax] * sqrt_dt
+                y_plus = x_drift + offset
+                y_minus = x_drift - offset
+                u_plus = self._interpolate_value(U_next_shaped, y_plus)
+                u_minus = self._interpolate_value(U_next_shaped, y_minus)
+                interp_acc += 0.5 * (u_plus + u_minus)
+            u_avg = interp_acc / d
+
+            H_value = self._evaluate_hamiltonian(x_current, p_optimal, m_current, time_idx)
+            U_current_shaped[multi_idx] = u_avg - dt * H_value
+
+        # Enforce BC on the result
+        U_current_shaped = self._enforce_boundary_conditions(U_current_shaped)
+
+        if U_next.ndim == 1:
+            return U_current_shaped.ravel()
+        return U_current_shaped
 
     # === L-based DPP formulation (Issue #909) ===
 
@@ -1993,11 +2216,16 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             return self._explicit_diffusion_step(U_star, dt)
 
         elif self.diffusion_method == "stochastic":
-            # Stochastic diffusion is handled in characteristic tracing
-            # by adding Brownian noise: X(t-dt) = x - p*dt + σ*√dt*ξ
-            # Here we just return the advected solution since diffusion
-            # was already incorporated in the stochastic characteristic
-            return U_star
+            # Issue #1026: stochastic SL bypasses _apply_diffusion entirely; the
+            # Carlini-Silva update bakes diffusion into the SL averaging step.
+            # Reaching this branch indicates broken dispatch in
+            # _solve_timestep_semi_lagrangian.
+            raise NotImplementedError(
+                "_apply_diffusion should not be called when diffusion_method='stochastic'. "
+                "The Carlini-Silva 2014 SL update incorporates diffusion via 2d "
+                "stochastic departure points, replacing the operator-splitting "
+                "diffusion step. Check dispatch in _solve_timestep_semi_lagrangian."
+            )
 
         else:  # "adi" (default)
             if self.dimension == 1:
@@ -2167,12 +2395,49 @@ if __name__ == "__main__":
     print("Testing HJBSemiLagrangianSolver...")
 
     from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
     from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    def _smoke_components_1d():
+        """MFGComponents for the 1D smoke tests."""
+        return MFGComponents(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+        )
+
+    def _smoke_components_2d():
+        """MFGComponents for the 2D smoke tests."""
+        return MFGComponents(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+        )
 
     # Test 1: Solver initialization
     print("\n1. Testing solver initialization...")
-    geometry_1d = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51])
-    problem = MFGProblem(geometry=geometry_1d, T=1.0, Nt=100, sigma=0.1)
+    geometry_1d = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx_points=[51],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    problem = MFGProblem(
+        geometry=geometry_1d,
+        T=1.0,
+        Nt=100,
+        diffusion=0.5 * 0.1**2,
+        components=_smoke_components_1d(),
+    )
     solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", optimization_method="brent")
 
     assert solver.dimension == 1
@@ -2203,12 +2468,18 @@ if __name__ == "__main__":
     # Test 3: 2D solver initialization with ADI compatibility check
     print("\n3. Testing 2D solver with ADI...")
 
+    geometry_2d = TensorProductGrid(
+        dimension=2,
+        bounds=[(0.0, 1.0), (0.0, 1.0)],
+        Nx_points=[20, 20],
+        boundary_conditions=no_flux_bc(dimension=2),
+    )
     problem_2d = MFGProblem(
-        spatial_bounds=[(0.0, 1.0), (0.0, 1.0)],
-        spatial_discretization=[20, 20],
+        geometry=geometry_2d,
         T=0.5,
         Nt=50,
-        sigma=0.1,
+        diffusion=0.5 * 0.1**2,
+        components=_smoke_components_2d(),
     )
 
     solver_2d = HJBSemiLagrangianSolver(problem_2d, interpolation_method="linear")
@@ -2253,19 +2524,11 @@ if __name__ == "__main__":
     assert mass_error < 0.05, f"Mass error too large: {mass_error}"
     print("   Mass conservation: OK")
 
-    # Test 6: ADI with anisotropic sigma (diagonal tensor)
-    print("\n6. Testing ADI with anisotropic diffusion...")
-    problem_2d_aniso = MFGProblem(
-        spatial_bounds=[(0.0, 1.0), (0.0, 1.0)],
-        spatial_discretization=[20, 20],
-        T=0.5,
-        Nt=50,
-        sigma=np.array([0.15, 0.05]),  # Different sigma in x and y
-    )
-    solver_2d_aniso = HJBSemiLagrangianSolver(problem_2d_aniso)
-    assert solver_2d_aniso._adi_compatible  # Diagonal is ADI compatible
-    print(f"   Anisotropic ADI compatible: {solver_2d_aniso._adi_compatible}")
-    print("   Anisotropic sigma: OK")
+    # Test 6: ADI with anisotropic sigma (diagonal tensor) - SKIPPED
+    # The diagonal-sigma API was changed to require a spatial field (Nx, Ny) or
+    # (Nt, Nx, Ny) rather than a per-axis vector (d,). Restoring this smoke test
+    # requires migrating the volatility-field API; out of scope here.
+    print("\n6. Anisotropic ADI smoke test SKIPPED (volatility-field API change)")
 
     # Test 7: BoundaryHandler protocol compliance (Issue #545)
     print("\n7. Testing BoundaryHandler protocol...")
@@ -2348,5 +2611,141 @@ if __name__ == "__main__":
     print("   No-clip path (threshold=None): OK")
 
     print("   Gradient clipping (Issue #583): OK")
+
+    # Test 9: Carlini-Silva stochastic SL (Issue #1026)
+    print("\n9. Testing Carlini-Silva stochastic SL (Issue #1026)...")
+
+    # 9a: linear + stochastic rejected at __init__
+    try:
+        HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="stochastic")
+        raise AssertionError("Expected ValueError for linear + stochastic")
+    except ValueError:
+        print("   9a: linear + stochastic rejected at __init__: OK")
+
+    # 9b: cubic + stochastic instantiates and dispatches correctly
+    solver_cs = HJBSemiLagrangianSolver(
+        problem,
+        interpolation_method="cubic",
+        diffusion_method="stochastic",
+        check_cfl=False,
+    )
+    assert solver_cs.diffusion_method == "stochastic"
+    print("   9b: cubic + stochastic instantiated: OK")
+
+    # 9c: _apply_diffusion raises NotImplementedError under stochastic
+    try:
+        solver_cs._apply_diffusion(np.zeros(11), 0.01)
+        raise AssertionError("Expected NotImplementedError")
+    except NotImplementedError:
+        print("   9c: _apply_diffusion raises under stochastic: OK")
+
+    # 9d: constant terminal -> constant solution (no-drift, no-curvature sanity)
+    from mfgarchon.core.hamiltonian import HamiltonianBase, OptimizationSense
+
+    class _ZeroH(HamiltonianBase):
+        def __init__(self):
+            super().__init__(sense=OptimizationSense.MINIMIZE)
+
+        def __call__(self, x, m, p, t=0.0):
+            p_arr = np.atleast_1d(np.asarray(p, dtype=float))
+            return np.zeros(p_arr.shape[:-1]) if p_arr.ndim > 0 else 0.0
+
+        def gradient_p(self, x, m, p, t=0.0):
+            return np.zeros_like(np.asarray(p, dtype=float))
+
+        def density_derivative(self, x, m, p, t=0.0):
+            return 0.0
+
+    grid_const = TensorProductGrid(
+        dimension=1,
+        bounds=[(-1.0, 1.0)],
+        Nx_points=[51],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    components_const = MFGComponents(
+        hamiltonian=_ZeroH(),
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 1.0,
+    )
+    problem_const = MFGProblem(
+        geometry=grid_const,
+        T=0.1,
+        Nt=20,
+        diffusion=0.045,
+        components=components_const,
+    )
+    solver_const = HJBSemiLagrangianSolver(
+        problem_const,
+        interpolation_method="cubic",
+        diffusion_method="stochastic",
+        check_cfl=False,
+    )
+    U_T_const = np.ones(51)
+    M_dummy = np.ones((problem_const.Nt + 1, 51))
+    U_const = solver_const.solve_hjb_system(
+        M_density=M_dummy,
+        U_terminal=U_T_const,
+        U_coupling_prev=np.zeros((problem_const.Nt + 1, 51)),
+    )
+    assert np.allclose(U_const[0], 1.0, atol=1e-10), (
+        f"Constant terminal not preserved: U[0] range [{U_const[0].min()}, {U_const[0].max()}]"
+    )
+    print("   9d: constant terminal preserved (H=0, sigma>0): OK")
+
+    # 9e: stochastic and ADI produce numerically equivalent results on H=0
+    #     Gaussian backward heat. Both schemes solve the same equation;
+    #     only their discretization paths differ.
+    sigma_test = 0.3
+    T_test = 0.5
+    beta_T = 1.0
+    N_test, Nt_test = 100, 200
+    grid_g = TensorProductGrid(
+        dimension=1,
+        bounds=[(-5.0, 5.0)],
+        Nx_points=[N_test + 1],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    x_g = grid_g.get_spatial_grid().flatten()
+    components_g = MFGComponents(
+        hamiltonian=_ZeroH(),
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: float(np.exp(-(x[0] ** 2) / (2 * beta_T)) / np.sqrt(2 * np.pi * beta_T)),
+    )
+    problem_g = MFGProblem(
+        geometry=grid_g,
+        T=T_test,
+        Nt=Nt_test,
+        diffusion=sigma_test**2 / 2,
+        components=components_g,
+    )
+    U_T_g = np.exp(-(x_g**2) / (2 * beta_T)) / np.sqrt(2 * np.pi * beta_T)
+    M_dummy_g = np.ones((Nt_test + 1, N_test + 1))
+    solver_st = HJBSemiLagrangianSolver(
+        problem_g,
+        interpolation_method="cubic",
+        diffusion_method="stochastic",
+        check_cfl=False,
+    )
+    solver_adi = HJBSemiLagrangianSolver(
+        problem_g,
+        interpolation_method="cubic",
+        diffusion_method="adi",
+        check_cfl=False,
+    )
+    U_st = solver_st.solve_hjb_system(
+        M_density=M_dummy_g,
+        U_terminal=U_T_g,
+        U_coupling_prev=np.zeros((Nt_test + 1, N_test + 1)),
+    )
+    U_adi = solver_adi.solve_hjb_system(
+        M_density=M_dummy_g,
+        U_terminal=U_T_g,
+        U_coupling_prev=np.zeros((Nt_test + 1, N_test + 1)),
+    )
+    discrepancy = np.max(np.abs(U_st[0] - U_adi[0]))
+    assert discrepancy < 5e-3, f"Stochastic and ADI diverge on H=0 Gaussian: max diff = {discrepancy:.3e}"
+    print(f"   9e: stochastic vs ADI on H=0 Gaussian, max diff = {discrepancy:.3e}: OK")
+
+    print("   Carlini-Silva stochastic SL (Issue #1026): OK")
 
     print("\nAll smoke tests passed!")

--- a/tests/unit/test_alg/test_hjb_semi_lagrangian.py
+++ b/tests/unit/test_alg/test_hjb_semi_lagrangian.py
@@ -721,5 +721,211 @@ class TestEnhancementsIntegration:
         assert rel_error < 0.20  # Within 20% (updated after gradient fix)
 
 
+class TestStochasticCharacteristicSL:
+    """Issue #1026: Carlini-Silva (2014) stochastic-characteristic SL.
+
+    Tests the diffusion_method="stochastic" branch that incorporates the
+    diffusion term into the SL update via 2*d Brownian departure points,
+    instead of the operator-splitting (ADI/Crank-Nicolson) default.
+
+    Validation experiment: mfg-research/experiments/crowd_evacuation_2d/
+    minors/archive/exp14_towel_1d_benchmark/subs/exp14e_solver_comparison/
+    """
+
+    def test_linear_plus_stochastic_rejected(self):
+        """Linear interpolation caps global error at O(h); incompatible with CS."""
+        geometry = TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[51],
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
+
+        with pytest.raises(ValueError, match="cubic or higher-order"):
+            HJBSemiLagrangianSolver(
+                problem,
+                interpolation_method="linear",
+                diffusion_method="stochastic",
+            )
+
+    def test_cubic_plus_stochastic_instantiates(self):
+        """Cubic + stochastic is the supported configuration."""
+        geometry = TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[51],
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
+
+        solver = HJBSemiLagrangianSolver(
+            problem,
+            interpolation_method="cubic",
+            diffusion_method="stochastic",
+            check_cfl=False,
+        )
+
+        assert solver.diffusion_method == "stochastic"
+        assert solver.interpolation_method == "cubic"
+
+    def test_apply_diffusion_raises_under_stochastic(self):
+        """Reaching _apply_diffusion under stochastic dispatch is a programming error."""
+        geometry = TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[51],
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
+        solver = HJBSemiLagrangianSolver(
+            problem,
+            interpolation_method="cubic",
+            diffusion_method="stochastic",
+            check_cfl=False,
+        )
+
+        with pytest.raises(NotImplementedError, match="should not be called"):
+            solver._apply_diffusion(np.zeros(51), 0.01)
+
+    def test_constant_terminal_preserved(self):
+        """H=0 with constant U_T must give constant U[0] (no spurious drift)."""
+        from mfgarchon.core.hamiltonian import HamiltonianBase, OptimizationSense
+
+        class ZeroH(HamiltonianBase):
+            def __init__(self):
+                super().__init__(sense=OptimizationSense.MINIMIZE)
+
+            def __call__(self, x, m, p, t=0.0):
+                p_arr = np.atleast_1d(np.asarray(p, dtype=float))
+                if p_arr.ndim > 0:
+                    return np.zeros(p_arr.shape[:-1])
+                return 0.0
+
+            def gradient_p(self, x, m, p, t=0.0):
+                return np.zeros_like(np.asarray(p, dtype=float))
+
+            def density_derivative(self, x, m, p, t=0.0):
+                return 0.0
+
+        geometry = TensorProductGrid(
+            dimension=1,
+            bounds=[(-1.0, 1.0)],
+            Nx_points=[31],
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
+        components = MFGComponents(
+            hamiltonian=ZeroH(),
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 1.0,
+        )
+        problem = MFGProblem(
+            geometry=geometry,
+            T=0.1,
+            Nt=10,
+            diffusion=0.045,
+            components=components,
+        )
+        solver = HJBSemiLagrangianSolver(
+            problem,
+            interpolation_method="cubic",
+            diffusion_method="stochastic",
+            check_cfl=False,
+        )
+
+        Nx = 31
+        Nt = problem.Nt
+        M_density = np.ones((Nt + 1, Nx))
+        U_terminal = np.ones(Nx)
+
+        U = solver.solve_hjb_system(
+            M_density=M_density,
+            U_terminal=U_terminal,
+            U_coupling_prev=np.zeros((Nt + 1, Nx)),
+        )
+
+        np.testing.assert_allclose(U[0], 1.0, atol=1e-10)
+
+    def test_consistency_with_default_adi(self):
+        """Stochastic and default ADI must converge to the same numerical solution.
+
+        Both schemes solve the same backward HJB; only the discretization
+        path differs (Brownian quadrature vs. operator splitting). On a
+        smooth Gaussian terminal with H=0, the difference should be
+        within a few units of the local truncation error of either scheme.
+        """
+        from mfgarchon.core.hamiltonian import HamiltonianBase, OptimizationSense
+
+        class ZeroH(HamiltonianBase):
+            def __init__(self):
+                super().__init__(sense=OptimizationSense.MINIMIZE)
+
+            def __call__(self, x, m, p, t=0.0):
+                p_arr = np.atleast_1d(np.asarray(p, dtype=float))
+                if p_arr.ndim > 0:
+                    return np.zeros(p_arr.shape[:-1])
+                return 0.0
+
+            def gradient_p(self, x, m, p, t=0.0):
+                return np.zeros_like(np.asarray(p, dtype=float))
+
+            def density_derivative(self, x, m, p, t=0.0):
+                return 0.0
+
+        sigma_test = 0.3
+        T_test = 0.5
+        beta_T = 1.0
+        N, Nt = 100, 200
+
+        geometry = TensorProductGrid(
+            dimension=1,
+            bounds=[(-5.0, 5.0)],
+            Nx_points=[N + 1],
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
+        x_grid = geometry.get_spatial_grid().flatten()
+        components = MFGComponents(
+            hamiltonian=ZeroH(),
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: float(np.exp(-(x[0] ** 2) / (2 * beta_T)) / np.sqrt(2 * np.pi * beta_T)),
+        )
+        problem = MFGProblem(
+            geometry=geometry,
+            T=T_test,
+            Nt=Nt,
+            diffusion=sigma_test**2 / 2,
+            components=components,
+        )
+
+        U_terminal = np.exp(-(x_grid**2) / (2 * beta_T)) / np.sqrt(2 * np.pi * beta_T)
+        M_density = np.ones((Nt + 1, N + 1))
+
+        solver_st = HJBSemiLagrangianSolver(
+            problem,
+            interpolation_method="cubic",
+            diffusion_method="stochastic",
+            check_cfl=False,
+        )
+        solver_adi = HJBSemiLagrangianSolver(
+            problem,
+            interpolation_method="cubic",
+            diffusion_method="adi",
+            check_cfl=False,
+        )
+
+        U_st = solver_st.solve_hjb_system(
+            M_density=M_density,
+            U_terminal=U_terminal,
+            U_coupling_prev=np.zeros((Nt + 1, N + 1)),
+        )
+        U_adi = solver_adi.solve_hjb_system(
+            M_density=M_density,
+            U_terminal=U_terminal,
+            U_coupling_prev=np.zeros((Nt + 1, N + 1)),
+        )
+
+        max_diff = np.max(np.abs(U_st[0] - U_adi[0]))
+        # Both schemes are 2nd-order accurate on smooth Gaussians; their
+        # difference should be a few units of the local truncation error.
+        assert max_diff < 5e-3, f"Stochastic and ADI diverge on smooth Gaussian: max diff = {max_diff:.3e}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Fixes #1026.

## Summary

Implements the Carlini-Silva 2014 stochastic-characteristic semi-Lagrangian path that was documented but inactive in `HJBSemiLagrangianSolver`. The previous `diffusion_method="stochastic"` dispatch was a no-op (line 1995–2000 just returned `U_star`), so selecting it ran SL transport with no diffusion at all.

## Changes

**Implementation** — `mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py`:
- `_solve_timestep_stochastic_sl`: dispatches 1D / nD; baked-in diffusion via 2*d Brownian departure points $y^\pm_k = x_i + a^*_i \Delta t \pm \sigma\sqrt{\Delta t}\, e_k$, no separate diffusion solve.
- `_stochastic_sl_step_1d`: vectorized cubic-spline interpolation, BC handling matches existing 1D path.
- `_stochastic_sl_step_nd`: per-point loop using the existing `_interpolate_value` for cubic / quintic.
- Dispatch hooks in `_solve_timestep_semi_lagrangian` and `_solve_timestep_semi_lagrangian_with_dt`.
- `__init__` validator: rejects `interpolation_method="linear"` with `diffusion_method="stochastic"` (linear caps global error at $O(h)$ regardless of $\Delta t$, defeating the scheme).
- `_apply_diffusion` stochastic branch now raises `NotImplementedError` with a dispatch-bug message — no silent fallback.

**Pre-existing bugs fixed** (surfaced during this work):
- Module docstring HJB sign was wrong: `+∂u/∂t + H - σ²/2 Δu = 0` disagreed with the code's actual implementation. Verified empirically — the solver implements the cost-to-go convention $-\partial_t u + H - \tfrac{\sigma^2}{2}\Delta u = 0$. Docstring corrected.
- Inline smoke tests at lines 2412–2503 used the deprecated `MFGProblem(spatial_bounds=...)` and `TensorProductGrid(...)` without `boundary_conditions=`. Migrated to the geometry-first / `MFGComponents` API. Test 6 (anisotropic-sigma) skipped with an explicit note pending volatility-field API migration.

**Tests** — `tests/unit/test_alg/test_hjb_semi_lagrangian.py`:
- New `TestStochasticCharacteristicSL` class, 5 test cases:
  - `test_linear_plus_stochastic_rejected` — guard at `__init__`
  - `test_cubic_plus_stochastic_instantiates` — happy path
  - `test_apply_diffusion_raises_under_stochastic` — dispatch contract
  - `test_constant_terminal_preserved` — H=0, $\sigma > 0$, constant $U_T$ → constant $U[0]$
  - `test_consistency_with_default_adi` — both schemes converge to the same numerical solution on smooth Gaussian H=0 backward heat (max diff = 5.7e-5 at N=100, Nt=200)

## Test plan

- [x] `pytest tests/unit/test_alg/test_hjb_semi_lagrangian.py -v` — 38 passed, 2 skipped, 2 xfailed (no regressions)
- [x] `python -m mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian` — all inline smoke tests pass (Test 6 anisotropic explicitly skipped)
- [x] `ruff format && ruff check` — clean
- [x] `mypy mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py` — 7 new errors, all in the same union-type / `_grid_shape`-untyped patterns as 80+ pre-existing in this file. No mypy regressions on strict-typing surfaces.
- [ ] **mfg-research validation**: rerun `mfg-research/experiments/crowd_evacuation_2d/minors/archive/exp14_towel_1d_benchmark/subs/exp14e_solver_comparison/` with `diffusion_method="stochastic"` + `interpolation_method="cubic"` to demonstrate the $O(h^2)$ Carlini-Silva rate replacing the $O(h)$ rate from the linear + ADI default. Will append the EOC table here once it lands.

## Naming

After this lands, the paper-side language is **"Carlini-Silva SL with cubic interpolation"** for the new path; the existing default (linear + ADI) is described as "SL with Strang splitting", not as "Carlini-Silva". The default itself is unchanged for backward compatibility — only the new opt-in path claims the Carlini-Silva name.

## Out of scope

- General non-separable Hamiltonians (would require inner minimization over $a$). Current implementation is for separable convex $L = \tfrac{1}{2}|a|^2 + f(x, m)$, the case used by all current MFG-research benchmarks (Boltzmann–Gibbs, Towel-on-Beach, obstacle navigation).
- Anisotropic diagonal $\sigma$ in nD: the existing volatility-field API requires $\sigma$ as a spatial array `(Nx, Ny)` rather than per-axis `(d,)`. Tracked separately; `_stochastic_sl_step_nd` parses both forms but the smoke test for the anisotropic case is skipped pending the broader API migration.