### PR TITLE
Add Wendland C2 kernel option to density_estimation.py (Issue #1028)

### DIFF
--- a/mfgarchon/alg/numerical/density_estimation.py
+++ b/mfgarchon/alg/numerical/density_estimation.py
@@ -39,13 +39,18 @@ def _wendland_c2_normalization_1d(delta: float) -> float:
     inner integral expansion: (1-u)^4 (4u+1) = 1 - 10 u^2 + 20 u^3 - 15 u^4 + 4 u^5,
     so int_0^1 = 1 - 10/3 + 5 - 3 + 4/6 = 1/3.
 
-    Note on naming: this polynomial is Wendland's phi_{3,1}, positive definite
-    in R^d for d <= 3. mfgarchon's GFDM uses the same phi_{3,1} dimension-
-    independently (see WendlandKernel in mfgarchon.utils.numerical.kernels).
+    Polynomial choice: this is Wendland's phi_{3,1}, positive definite in R^d
+    for d <= 3. mfgarchon uses phi_{3,1} dimension-independently throughout:
+    the GFDM WendlandKernel applies the same polynomial in 1D, 2D, and 3D
+    (see mfgarchon.utils.numerical.kernels:426). This KDE follows the same
+    convention deliberately - one polynomial across all dimensions, only the
+    normalization constant Z_d changes per dimension. Z_1 = 2 delta / 3 here;
+    a future nD Wendland KDE would compute Z_d analogously.
+
     The canonical 1D-minimal-degree Wendland C^2 is the different polynomial
-    phi_{1,1} = (1-q)^3 (3q+1), with normalization alpha_1 = 5/(4h). That form
-    is not used here because the goal is kernel-matching with the GFDM
-    weight function, not minimal-degree in 1D.
+    phi_{1,1} = (1-q)^3 (3q+1), with alpha_1 = 5/(4h). That form is NOT used
+    in mfgarchon (neither GFDM nor KDE) — minimal degree in each dimension
+    is sacrificed in favor of one consistent polynomial form.
     """
     return 2.0 * delta / 3.0
 
@@ -77,12 +82,12 @@ def gaussian_kde_gpu(
 
     - "wendland_c2": K_h(r) = (3 / (2 h)) * (1 - |r|/h)_+^4 * (4 |r|/h + 1).
       Compact support [-h, h]; bandwidth h interpreted directly as support
-      radius (NOT multiplied by std). C^2 continuity. This is Wendland's
-      phi_{3,1} polynomial (positive definite in R^d for d <= 3), matching
-      mfgarchon's GFDM WendlandKernel (used dimension-independently). The
-      canonical 1D-minimal-degree Wendland C^2 polynomial phi_{1,1} =
-      (1-q)^3 (3q+1) is NOT used; the choice here is to enable kernel-
-      matching with the GFDM stencil.
+      radius (NOT multiplied by std). C^2 continuity. Uses Wendland's
+      phi_{3,1} polynomial (positive definite in R^d for d <= 3) dimension-
+      independently, matching mfgarchon's GFDM WendlandKernel design choice.
+      The canonical 1D-minimal-degree phi_{1,1} = (1-q)^3 (3q+1) is NOT used:
+      mfgarchon deliberately commits to one polynomial across all dimensions,
+      with only the normalization constant Z_d varying.
 
     GPU Acceleration Strategy:
         - Broadcast particles and grid to form (Nx, N) distance matrix

--- a/mfgarchon/alg/numerical/density_estimation.py
+++ b/mfgarchon/alg/numerical/density_estimation.py
@@ -27,14 +27,25 @@ SUPPORTED_KERNELS = ("gaussian", "wendland_c2")
 
 
 def _wendland_c2_normalization_1d(delta: float) -> float:
-    """1D normalization Z_1 for Wendland C^2 kernel with support radius delta.
+    """1D normalization for the Wendland phi_{3,1} kernel with support radius delta.
 
-    K_unnorm(r) = (1 - |r|/delta)_+^4 (4|r|/delta + 1)
-    Z_1 = int_{-delta}^{delta} K_unnorm(r) dr = 2 * delta * int_0^1 phi(u) du
-        = 2 * delta * 1/3 = 2 delta / 3
+    Polynomial: K_unnorm(r) = (1 - |r|/delta)_+^4 (4|r|/delta + 1).
+    1D integral on [-delta, delta]:
+        Z_1 = int_{-delta}^{delta} K_unnorm(r) dr
+            = 2 * delta * int_0^1 (1-u)^4 (4u + 1) du
+            = 2 * delta * 1/3
+            = 2 delta / 3
 
-    where the inner integral is computed via direct expansion:
-    int_0^1 (1-u)^4 (4u + 1) du = int_0^1 (1 - 10 u^2 + 20 u^3 - 15 u^4 + 4 u^5) du = 1/3.
+    inner integral expansion: (1-u)^4 (4u+1) = 1 - 10 u^2 + 20 u^3 - 15 u^4 + 4 u^5,
+    so int_0^1 = 1 - 10/3 + 5 - 3 + 4/6 = 1/3.
+
+    Note on naming: this polynomial is Wendland's phi_{3,1}, positive definite
+    in R^d for d <= 3. mfgarchon's GFDM uses the same phi_{3,1} dimension-
+    independently (see WendlandKernel in mfgarchon.utils.numerical.kernels).
+    The canonical 1D-minimal-degree Wendland C^2 is the different polynomial
+    phi_{1,1} = (1-q)^3 (3q+1), with normalization alpha_1 = 5/(4h). That form
+    is not used here because the goal is kernel-matching with the GFDM
+    weight function, not minimal-degree in 1D.
     """
     return 2.0 * delta / 3.0
 
@@ -66,8 +77,12 @@ def gaussian_kde_gpu(
 
     - "wendland_c2": K_h(r) = (3 / (2 h)) * (1 - |r|/h)_+^4 * (4 |r|/h + 1).
       Compact support [-h, h]; bandwidth h interpreted directly as support
-      radius (NOT multiplied by std). C^2 continuity. Same kernel form as
-      the GFDM Wendland weights, enabling kernel-matched FP / HJB pipelines.
+      radius (NOT multiplied by std). C^2 continuity. This is Wendland's
+      phi_{3,1} polynomial (positive definite in R^d for d <= 3), matching
+      mfgarchon's GFDM WendlandKernel (used dimension-independently). The
+      canonical 1D-minimal-degree Wendland C^2 polynomial phi_{1,1} =
+      (1-q)^3 (3q+1) is NOT used; the choice here is to enable kernel-
+      matching with the GFDM stencil.
 
     GPU Acceleration Strategy:
         - Broadcast particles and grid to form (Nx, N) distance matrix

--- a/mfgarchon/alg/numerical/density_estimation.py
+++ b/mfgarchon/alg/numerical/density_estimation.py
@@ -22,37 +22,62 @@ except ImportError:
     SCIPY_AVAILABLE = False
 
 
+# Kernel options for kde_gpu (Issue #1028)
+SUPPORTED_KERNELS = ("gaussian", "wendland_c2")
+
+
+def _wendland_c2_normalization_1d(delta: float) -> float:
+    """1D normalization Z_1 for Wendland C^2 kernel with support radius delta.
+
+    K_unnorm(r) = (1 - |r|/delta)_+^4 (4|r|/delta + 1)
+    Z_1 = int_{-delta}^{delta} K_unnorm(r) dr = 2 * delta * int_0^1 phi(u) du
+        = 2 * delta * 1/3 = 2 delta / 3
+
+    where the inner integral is computed via direct expansion:
+    int_0^1 (1-u)^4 (4u + 1) du = int_0^1 (1 - 10 u^2 + 20 u^3 - 15 u^4 + 4 u^5) du = 1/3.
+    """
+    return 2.0 * delta / 3.0
+
+
 def gaussian_kde_gpu(
     particles: np.ndarray,
     grid: np.ndarray,
     bandwidth: float,
     backend: "BaseBackend",
+    kernel: str = "gaussian",
 ) -> np.ndarray:
     """
-    GPU-accelerated Gaussian kernel density estimation.
+    GPU-accelerated 1D kernel density estimation.
 
     Converts N particles to density estimate on Nx grid points using
     vectorized GPU operations. This is the critical bottleneck for
     particle-based MFG solvers (typically 70% of compute time).
 
     Mathematical formulation:
-        ρ(x) = (1/N) Σ_{i=1}^N K_h(x - X_i)
+        rho(x) = (1/N) sum_{i=1}^N K_h(x - X_i)
 
-    where K_h is the Gaussian kernel with bandwidth h:
-        K_h(z) = (1/(h√(2π))) exp(-z²/(2h²))
+    where K_h is the chosen kernel.
 
-    Note: To match scipy.stats.gaussian_kde behavior, this function
-    interprets numeric bandwidth as factor * std(particles).
+    Supported kernels (Issue #1028):
+
+    - "gaussian" (default): K_h(z) = (1/(h * sqrt(2 pi))) exp(-z^2 / (2 h^2)).
+      Infinite support; bandwidth interpreted as factor * std(particles)
+      (scipy.stats.gaussian_kde compatible).
+
+    - "wendland_c2": K_h(r) = (3 / (2 h)) * (1 - |r|/h)_+^4 * (4 |r|/h + 1).
+      Compact support [-h, h]; bandwidth h interpreted directly as support
+      radius (NOT multiplied by std). C^2 continuity. Same kernel form as
+      the GFDM Wendland weights, enabling kernel-matched FP / HJB pipelines.
 
     GPU Acceleration Strategy:
         - Broadcast particles and grid to form (Nx, N) distance matrix
         - Compute all kernel values in parallel
         - Reduce over particles dimension
 
-    Complexity: O(Nx × N) but fully parallelized on GPU
+    Complexity: O(Nx * N) but fully parallelized on GPU
 
-    Expected Speedup:
-        - N=10k:   10-15x vs scipy.stats.gaussian_kde
+    Expected Speedup (Gaussian path, vs scipy.stats.gaussian_kde):
+        - N=10k:   10-15x
         - N=50k:   20-30x
         - N=100k:  30-50x
 
@@ -63,9 +88,12 @@ def gaussian_kde_gpu(
     grid : np.ndarray
         Grid points for density evaluation, shape (Nx,)
     bandwidth : float
-        Bandwidth factor (multiplied by data std), matching scipy behavior
+        For "gaussian": bandwidth factor (multiplied by data std).
+        For "wendland_c2": support radius delta (used directly).
     backend : BaseBackend
         Backend providing tensor operations (PyTorch/JAX)
+    kernel : str
+        One of "gaussian", "wendland_c2". See module-level SUPPORTED_KERNELS.
 
     Returns
     -------
@@ -76,12 +104,21 @@ def gaussian_kde_gpu(
     ----------
     - Silverman, B.W. (1986). Density Estimation for Statistics and Data Analysis
     - Scott, D.W. (2015). Multivariate Density Estimation: Theory, Practice, and Visualization
+    - Wendland, H. (1995). Piecewise polynomial, positive definite and compactly
+      supported radial functions of minimal degree. Adv. Comput. Math. 4, 389-396.
     """
+    if kernel not in SUPPORTED_KERNELS:
+        raise ValueError(f"Unknown kernel '{kernel}'. Supported: {SUPPORTED_KERNELS}")
+
     N = len(particles)
 
-    # Match scipy.stats.gaussian_kde: bandwidth = factor * std
-    data_std = np.std(particles, ddof=1)
-    actual_bandwidth = bandwidth * data_std
+    if kernel == "gaussian":
+        # Match scipy.stats.gaussian_kde: bandwidth = factor * std
+        data_std = np.std(particles, ddof=1)
+        actual_bandwidth = bandwidth * data_std
+    else:  # wendland_c2
+        # Bandwidth IS the support radius; no std multiplication.
+        actual_bandwidth = float(bandwidth)
 
     # Get tensor module (torch or jax.numpy)
     xp = backend.array_module
@@ -108,12 +145,23 @@ def gaussian_kde_gpu(
         particles_2d = particles_tensor[None, :]  # (1, N)
         grid_2d = grid_tensor[:, None]  # (Nx, 1)
 
-    distances = (grid_2d - particles_2d) / actual_bandwidth  # (Nx, N)
-
-    # Gaussian kernel: K(z) = (1/(h√(2π))) exp(-z²/2)
-    kernel_vals = xp.exp(-0.5 * distances**2)
-    normalization = actual_bandwidth * np.sqrt(2 * np.pi)
-    kernel_vals = kernel_vals / normalization
+    if kernel == "gaussian":
+        distances = (grid_2d - particles_2d) / actual_bandwidth  # (Nx, N)
+        # Gaussian kernel: K(z) = (1/(h * sqrt(2 pi))) exp(-z^2 / 2)
+        kernel_vals = xp.exp(-0.5 * distances**2)
+        normalization = actual_bandwidth * np.sqrt(2 * np.pi)
+        kernel_vals = kernel_vals / normalization
+    else:  # wendland_c2
+        # Wendland C^2: K(r) = (3 / (2 delta)) * (1 - |r|/delta)_+^4 * (4 |r|/delta + 1)
+        # Z_1 = 2 delta / 3 (see _wendland_c2_normalization_1d)
+        raw_distances = grid_2d - particles_2d  # (Nx, N), unscaled
+        u = xp.abs(raw_distances) / actual_bandwidth  # (Nx, N), in [0, inf)
+        one_minus_u = 1.0 - u
+        # Compactly supported: zero outside [0, 1]
+        positive_part = xp.maximum(one_minus_u, 0.0)
+        kernel_vals = (positive_part**4) * (4.0 * u + 1.0)
+        normalization = _wendland_c2_normalization_1d(actual_bandwidth)
+        kernel_vals = kernel_vals / normalization
 
     # Sum over particles, normalize by N
     # Check for PyTorch tensor specifically (has 'dim' parameter)
@@ -135,11 +183,12 @@ def gaussian_kde_gpu_internal(
     grid_tensor,
     bandwidth: float,
     backend: "BaseBackend",
+    kernel: str = "gaussian",
 ):
     """
     Internal GPU KDE that accepts GPU tensors directly (Phase 2.1).
 
-    This eliminates GPU↔CPU transfers in the particle evolution loop.
+    This eliminates GPU<->CPU transfers in the particle evolution loop.
     Used by _solve_fp_system_gpu() to keep all data on GPU.
 
     Key difference from gaussian_kde_gpu():
@@ -156,15 +205,21 @@ def gaussian_kde_gpu_internal(
     grid_tensor : backend tensor
         Grid points on GPU, shape (Nx,)
     bandwidth : float
-        Absolute bandwidth (NOT factor * std)
+        For "gaussian": absolute bandwidth (NOT factor * std).
+        For "wendland_c2": support radius delta.
     backend : BaseBackend
         Backend providing tensor operations
+    kernel : str
+        One of "gaussian", "wendland_c2" (Issue #1028).
 
     Returns
     -------
     backend tensor
         Estimated density on grid, shape (Nx,)
     """
+    if kernel not in SUPPORTED_KERNELS:
+        raise ValueError(f"Unknown kernel '{kernel}'. Supported: {SUPPORTED_KERNELS}")
+
     xp = backend.array_module
 
     # Backend compatibility - tensor shape access (Issue #543 acceptable)
@@ -181,13 +236,21 @@ def gaussian_kde_gpu_internal(
         particles_2d = particles_tensor[None, :]  # (1, N)
         grid_2d = grid_tensor[:, None]  # (Nx, 1)
 
-    # Compute distances
-    distances = (grid_2d - particles_2d) / bandwidth  # (Nx, N)
-
-    # Gaussian kernel: K(z) = (1/(h√(2π))) exp(-z²/2)
-    kernel_vals = xp.exp(-0.5 * distances**2)
-    normalization = float(bandwidth * np.sqrt(2 * np.pi))
-    kernel_vals = kernel_vals / normalization
+    if kernel == "gaussian":
+        # Compute distances
+        distances = (grid_2d - particles_2d) / bandwidth  # (Nx, N)
+        # Gaussian kernel: K(z) = (1/(h * sqrt(2 pi))) exp(-z^2 / 2)
+        kernel_vals = xp.exp(-0.5 * distances**2)
+        normalization = float(bandwidth * np.sqrt(2 * np.pi))
+        kernel_vals = kernel_vals / normalization
+    else:  # wendland_c2
+        raw_distances = grid_2d - particles_2d
+        u = xp.abs(raw_distances) / bandwidth  # in [0, inf)
+        one_minus_u = 1.0 - u
+        positive_part = xp.maximum(one_minus_u, 0.0)
+        kernel_vals = (positive_part**4) * (4.0 * u + 1.0)
+        normalization = float(_wendland_c2_normalization_1d(bandwidth))
+        kernel_vals = kernel_vals / normalization
 
     # Sum over particles, normalize by N
     # Check for PyTorch tensor specifically (has 'dim' parameter)

--- a/tests/unit/test_alg/test_density_estimation.py
+++ b/tests/unit/test_alg/test_density_estimation.py
@@ -185,3 +185,109 @@ class TestPerformanceComparison:
         print(f"  GPU (torch): {time_gpu * 1000:.2f} ms")
         if time_cpu > time_gpu:
             print(f"  Speedup: {time_cpu / time_gpu:.2f}x")
+
+
+class TestWendlandC2Kernel:
+    """Issue #1028: Wendland C^2 kernel option in 1D KDE.
+
+    Validates the kernel form, normalization, and the compact-support
+    property that motivates the option (eliminates Gaussian-tail spillover
+    handled today by the measure-restriction operator).
+    """
+
+    def test_invalid_kernel_rejected(self):
+        """Unknown kernel string raises ValueError."""
+        from mfgarchon.alg.numerical.density_estimation import gaussian_kde_gpu
+        from mfgarchon.backends.numpy_backend import NumPyBackend
+
+        with pytest.raises(ValueError, match="Unknown kernel"):
+            gaussian_kde_gpu(
+                np.zeros(10),
+                np.linspace(-1, 1, 5),
+                0.1,
+                NumPyBackend(),
+                kernel="bogus",
+            )
+
+    def test_wendland_normalization_constant(self):
+        """Z_1(delta) = 2*delta/3 by direct integration of phi(u) = (1-u)^4(4u+1)."""
+        from mfgarchon.alg.numerical.density_estimation import (
+            _wendland_c2_normalization_1d,
+        )
+
+        for delta in (0.1, 0.5, 1.0, 2.5):
+            assert np.isclose(_wendland_c2_normalization_1d(delta), 2 * delta / 3)
+
+    def test_wendland_unit_mass_single_particle(self):
+        """Single particle at origin -> integrated density approaches 1.
+
+        With delta = 0.5 and a fine grid covering the support, the
+        Riemann sum approximates the analytic integral of K_h to machine
+        precision (modulo trapezoidal error).
+        """
+        from mfgarchon.alg.numerical.density_estimation import gaussian_kde_gpu
+        from mfgarchon.backends.numpy_backend import NumPyBackend
+
+        backend = NumPyBackend()
+        delta = 0.5
+        grid = np.linspace(-3, 3, 1001)  # very fine
+        dx = grid[1] - grid[0]
+        density = gaussian_kde_gpu(np.array([0.0]), grid, delta, backend, kernel="wendland_c2")
+        mass = np.sum(density) * dx
+        assert 0.99 < mass < 1.01, f"Wendland mass deviates: {mass}"
+
+    def test_wendland_compact_support(self):
+        """Density is exactly zero at points beyond delta from every particle."""
+        from mfgarchon.alg.numerical.density_estimation import gaussian_kde_gpu
+        from mfgarchon.backends.numpy_backend import NumPyBackend
+
+        backend = NumPyBackend()
+        # Particles concentrated near origin
+        particles = np.array([0.0, 0.05, -0.05])
+        delta = 0.3
+        grid = np.linspace(-2.0, 2.0, 401)
+        density = gaussian_kde_gpu(particles, grid, delta, backend, kernel="wendland_c2")
+
+        # Points farther than delta from any particle: density must be 0
+        far_mask = np.array([np.min(np.abs(g - particles)) > delta for g in grid])
+        assert np.all(density[far_mask] == 0.0), (
+            "Wendland kernel must give zero density outside support of any particle"
+        )
+
+    def test_wendland_density_nonnegative_and_finite(self):
+        """Sanity: density is non-negative and finite for arbitrary samples."""
+        from mfgarchon.alg.numerical.density_estimation import gaussian_kde_gpu
+        from mfgarchon.backends.numpy_backend import NumPyBackend
+
+        rng = np.random.default_rng(42)
+        particles = rng.normal(0.0, 1.0, size=2000)
+        grid = np.linspace(-5, 5, 100)
+        density = gaussian_kde_gpu(particles, grid, 0.5, NumPyBackend(), kernel="wendland_c2")
+        assert np.all(density >= 0), "Wendland density must be non-negative"
+        assert np.all(np.isfinite(density)), "Wendland density must be finite"
+
+    def test_wendland_total_mass_preserves(self):
+        """Wendland KDE preserves total mass to within trapezoidal-rule accuracy."""
+        from mfgarchon.alg.numerical.density_estimation import gaussian_kde_gpu
+        from mfgarchon.backends.numpy_backend import NumPyBackend
+
+        rng = np.random.default_rng(0)
+        N = 5000
+        particles = rng.normal(0.0, 1.0, size=N)
+        grid = np.linspace(-5, 5, 1001)
+        dx = grid[1] - grid[0]
+        density = gaussian_kde_gpu(particles, grid, 0.5, NumPyBackend(), kernel="wendland_c2")
+        mass = np.sum(density) * dx
+        assert 0.97 < mass < 1.03, f"Wendland total mass: {mass}"
+
+    def test_gaussian_default_unchanged(self):
+        """Calling without kernel= keeps the Gaussian default behavior."""
+        from mfgarchon.alg.numerical.density_estimation import gaussian_kde_gpu
+        from mfgarchon.backends.numpy_backend import NumPyBackend
+
+        rng = np.random.default_rng(0)
+        particles = rng.normal(0.0, 1.0, size=2000)
+        grid = np.linspace(-3, 3, 200)
+        density_default = gaussian_kde_gpu(particles, grid, 0.1, NumPyBackend())
+        density_explicit = gaussian_kde_gpu(particles, grid, 0.1, NumPyBackend(), kernel="gaussian")
+        np.testing.assert_array_equal(density_default, density_explicit)


### PR DESCRIPTION
Fixes #1028.

## Summary

Adds a `kernel="wendland_c2"` option to `gaussian_kde_gpu` (and the GPU-internal sibling `gaussian_kde_gpu_internal`). Gaussian remains the default; the new option enables kernel-matched FP/HJB pipelines where GFDM stencil construction already uses Wendland $C^2$ weights.

## Kernel form

For support radius $\delta$:

$$K(r) = \frac{3}{2\delta} \left(1 - \frac{|r|}{\delta}\right)_+^4 \left(4 \frac{|r|}{\delta} + 1\right)$$

with $Z_1(\delta) = 2\delta / 3$ (analytic, verified by test).

## Bandwidth semantics

The two kernels interpret the `bandwidth` argument differently:

- `kernel="gaussian"` (default, unchanged): `bandwidth` is factor * std(particles), scipy.stats.gaussian_kde compatible
- `kernel="wendland_c2"`: `bandwidth` is the support radius $\delta$, used directly (no std multiplication)

## Real benefits when matched ships

- **Compact support** $[-\delta, \delta]$ eliminates the Gaussian-tail spillover handled today by the $\mathcal{T}[\mu]$ measure-restriction operator
- **Single-kernel narrative**: one Wendland $C^2$ kernel governs both differential operator approximation (GFDM) and density reconstruction (KDE)

## What this is NOT

- Not "spectral alignment" in any Fourier sense (Wendland has algebraic decay, not Gaussian-exp)
- Not adjoint-consistent with the HJB algebra (no $A_{FP} = A_{HJB}^T$ for hybrid pipelines)

## Test plan

- [x] `pytest tests/unit/test_alg/test_density_estimation.py -v` — 14 passed (7 new + 7 existing). Tests cover: invalid-kernel rejection, $Z_1$ normalization, unit-mass single particle, compact support property, non-negative + finite density, total-mass preservation, Gaussian default unchanged.
- [x] `ruff format` + `ruff check` — clean
- [ ] **mfg-research validation**: matched-vs-mismatched comparison on 1D Boltzmann-Gibbs MFG, sweep $h_{KDE} / \delta_{GFDM} \in \{0.5, 0.75, 1.0, 1.25, 1.5, 2.0\}$. Production decision (paper ships Wendland or Gaussian) follows from the data.

## Out of scope

- Adaptive bandwidth selection for Wendland (Wendland's $\delta$ is naturally the support radius — adaptive selection is a separate research question)
- nD Wendland (`gaussian_kde_gpu_nd`); 1D suffices for the current paper. nD form is straightforward but the dimension-dependent $Z_d$ normalization warrants a separate PR.