### PR TITLE
chore(hjb_gfdm): warn on unspecified monotonicity_scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`HJBGFDMSolver` now emits a `UserWarning` when `monotonicity_scheme` is
+  unspecified** (Issue #1034). The default resolves to `"none"` (no QP
+  correction), producing bare Wendland-Taylor LSQ stencils whose M-matrix
+  structure is not enforced. On long-time-horizon problems (e.g. 1D
+  Towel-on-Beach at T=8) this destabilizes FP-Particle coupling and produces
+  catastrophic boundary oscillation. The warning surfaces the trap and points
+  users to `monotonicity_scheme='joint_socp'` (paper-canonical) or
+  `'qp_m_matrix'` (cheaper). Users intentionally using the bare scheme can
+  pass `monotonicity_scheme='none'` explicitly to suppress the warning.
+  Validated in
+  `mfg-research/.../exp08_towel_2d_validation/_preflight_1d/post_mortem_1d_tob_debug.md`.
+
 ## [0.19.6] - 2026-05-06
 
 ### Fixed

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -437,6 +437,32 @@ class HJBGFDMSolver(BaseHJBSolver):
                 "or qp_optimization_level=. The latter is the deprecated alias (v0.18.0)."
             )
 
+        # Issue #1034: warn when user defaults to "none" (bare Wendland-Taylor LSQ).
+        # This default produces a method whose M-matrix structure is not enforced;
+        # boundary stencils can produce oscillatory derivatives that destabilize
+        # FP-Particle coupling on long-time-horizon problems (e.g., 1D ToB at T=8
+        # with KL=0.098 and 11 spurious modes — see Issue #1034 for full evidence).
+        # Validated in mfg-research/.../exp08_towel_2d_validation/_preflight_1d/
+        # post_mortem_1d_tob_debug.md.
+        if monotonicity_scheme is None and monotonicity_application is None and qp_optimization_level is None:
+            import warnings as _w
+
+            _w.warn(
+                "HJBGFDMSolver: no `monotonicity_scheme` specified; defaulting to "
+                "'none' (no QP correction). This produces bare Wendland-Taylor LSQ "
+                "stencils whose M-matrix structure is not enforced — boundary "
+                "stencils can produce oscillatory derivatives that destabilize "
+                "FP-Particle coupling on long-time-horizon problems. For "
+                "paper-canonical monotone behavior, pass "
+                "`monotonicity_scheme='joint_socp'` (M-matrix + per-edge cone, "
+                "discrete comparison principle) or "
+                "`monotonicity_scheme='qp_m_matrix'` (M-matrix only, cheaper). "
+                "See Issue #1034. Pass `monotonicity_scheme='none'` explicitly "
+                "to suppress this warning if the bare scheme is intentional.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         if monotonicity_scheme is not None or monotonicity_application is not None:
             # New API path
             scheme = monotonicity_scheme if monotonicity_scheme is not None else "none"


### PR DESCRIPTION
## Summary

Fixes #1034.

`HJBGFDMSolver(...)` with no monotonicity-related kwarg silently runs bare Wendland-Taylor LSQ stencils whose M-matrix structure is not enforced — boundary stencils can produce oscillatory derivatives that destabilize FP-Particle coupling on long-time-horizon problems. Add a `UserWarning` at `__init__` to surface this trap.

This is **not** a regression (default has been `"none"` since at least v0.17, confirmed by git archeology). It is a long-standing library design issue not previously caught because existing tests/examples use short measurement windows.

## Behavior

```
HJBGFDMSolver(problem, ..., monotonicity_scheme=...)  # behavior unchanged
                                ↓
                          one of "none" / "qp_m_matrix" / "joint_socp"  → no warning

HJBGFDMSolver(problem, ..., qp_optimization_level=...)  # behavior unchanged
                                ↓
                          legacy alias → no warning

HJBGFDMSolver(problem, ...)  # nothing specified → default to "none"
                                ↓
                          UserWarning fires, suggests joint_socp / qp_m_matrix
                          Behavior unchanged (still resolves to "none")
```

## Test plan

- [x] Manual smoke test: 4 cases (no kwarg, explicit `"none"`, `"joint_socp"`, legacy `qp_optimization_level="auto"`) — only "no kwarg" produces the warning. ✓
- [x] Existing integration tests pass: `tests/integration/test_collocation_gfdm_hjb.py` — 8 passed, 1 skipped. ✓ The warning fires in tests using default kwargs (intentional — surfaces the trap to test authors too; can be silenced per-test if needed).
- [x] `ruff format` applied. ✓
- [x] `ruff check` clean for the touched lines (1 pre-existing SIM401 at line 497 is in legacy mapping code, unrelated). ✓
- [x] CHANGELOG.md `[Unreleased]` entry added. ✓

## Validation reference

- `mfg-research/docs/mfgarchon_gotchas.md` G-011 (research-side gotcha entry)
- `mfg-research/experiments/gfdm_monotonicity_audit/minors/exp08_towel_2d_validation/_preflight_1d/post_mortem_1d_tob_debug.md` (full 5-layer debug history)
- 1D ToB measurement: KL=0.098, 11 extrema, k_best=1 with default `"none"`; KL≈1e-3 with `"joint_socp"` (precompute reports 50/50 SOCP-feasible)
- 2D Stage C measurement: 89.6% SOCP-feasible (455/508), 10.4% Phase-2 fallback — paper-canonical regime engaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)