### PR TITLE
fix(implicit_domain): cache num_spatial_points to fix MC-volume non-determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``domain.signed_distance``. Docstring example added in both
   ``HJBGFDMSolver.__init__`` and ``NeighborhoodBuilder.__init__``.
 
+### Fixed
+
+- **`ImplicitDomain.num_spatial_points` now caches the result** (Issue #1037).
+  Previously the property recomputed from an unseeded Monte-Carlo volume
+  estimate on every call, returning slightly different values across calls
+  within one process. Downstream callers like
+  `MFGComponents._setup_custom_initial_density` that pre-allocate based on
+  the value and then iterate the spatial grid would overrun and surface an
+  unhelpful `IndexError: index N out of bounds for size N` (Issue #1036,
+  obsoleted by this cache fix).
+
 ## [0.19.6] - 2026-05-06
 
 ### Fixed

--- a/mfgarchon/geometry/implicit/implicit_domain.py
+++ b/mfgarchon/geometry/implicit/implicit_domain.py
@@ -113,15 +113,26 @@ class ImplicitDomain(
         representations. This method estimates the number of points by computing
         the volume and assuming a typical mesh spacing of 0.1.
 
+        The result is **cached on first call** (Issue #1037): ``compute_volume``
+        uses Monte-Carlo sampling without a fixed seed, so subsequent calls would
+        return slightly different values. Cached returns guarantee the property
+        is deterministic within one process — required by callers like
+        ``MFGComponents._setup_custom_initial_density`` that pre-allocate based
+        on the value and then iterate the spatial grid.
+
         Note: For actual discretization, use sample_uniform() or meshfree methods.
         """
+        # Issue #1037: cache to avoid MC-volume non-determinism across calls
+        if self._num_spatial_points_cached is not None:
+            return self._num_spatial_points_cached
+
         # Estimate number of points based on volume
         # Assume typical mesh spacing h = 0.1
         try:
             volume = self.compute_volume(n_monte_carlo=10000)
             h = 0.1  # Typical mesh spacing
             n_points = int(volume / (h**self.dimension))
-            return max(n_points, 100)  # Minimum of 100 points
+            result = max(n_points, 100)  # Minimum of 100 points
         except (ValueError, RuntimeError) as e:
             # Issue #547: Volume computation can fail for complex implicit domains
             logger.warning(
@@ -134,7 +145,10 @@ class ImplicitDomain(
             bounds = self.get_bounding_box()
             bbox_volume = np.prod(bounds[:, 1] - bounds[:, 0])
             h = 0.1
-            return max(int(bbox_volume / (h**self.dimension)), 100)
+            result = max(int(bbox_volume / (h**self.dimension)), 100)
+
+        self._num_spatial_points_cached = result
+        return result
 
     def get_spatial_grid(self) -> NDArray[np.float64]:
         """
@@ -826,6 +840,10 @@ class ImplicitDomain(
     # =========================================================================
 
     _regions_dict: dict | None = None  # Lazy-initialized by _regions property
+
+    # Issue #1037: cache for num_spatial_points to prevent MC-volume non-determinism
+    # across calls within one process. None until first computation.
+    _num_spatial_points_cached: int | None = None
 
     @property
     def _regions(self) -> dict:


### PR DESCRIPTION
## Summary

Fixes #1037. Obsoletes #1036.

`ImplicitDomain.num_spatial_points` is computed from an unseeded Monte-Carlo volume estimate. Different calls within the same process return different values, breaking downstream callers that pre-allocate based on the property and then iterate the spatial grid.

Cache the value on first call.

## Why this also obsoletes #1036

#1036 was the surface symptom: `MFGComponents._setup_custom_initial_density` was hitting `IndexError: index N out of bounds for size N` because `m_initial` was preallocated with one MC estimate, then the loop iterated based on a different MC estimate. With the cache, the two queries return the same value — the size mismatch is structurally impossible.

I prototyped a defensive ValueError pre-check in `mfg_components.py` for #1036 and **reverted it** as Ptolemaic per the agent_axiom kernel ("Don't add error handling, fallbacks, or validation for scenarios that can't happen"). The cache fix alone is sufficient. #1036 should be closed as "won't fix — fixed structurally by #1037".

## Repro

```python
import numpy as np
from mfgarchon.geometry.implicit import Hyperrectangle, Hypersphere, DifferenceDomain

box = Hyperrectangle(np.array([[0., 3.5], [0., 3.5]]))
obstacle = Hypersphere(center=np.array([1.4, 1.75]), radius=0.4)
domain = DifferenceDomain(box, obstacle)

# Before: [1172, 1175, 1170, 1180, 1173] (or similar)
# After:  [1175, 1175, 1175, 1175, 1175]
print([domain.num_spatial_points for _ in range(5)])
```

Plus the smoke test that `MFGProblem(geometry=domain, ...)` no longer raises IndexError.

## Test plan

- [x] Smoke test: 5 consecutive `num_spatial_points` calls return the same value (was non-deterministic before).
- [x] `MFGProblem(geometry=DifferenceDomain(...), ...)` succeeds without IndexError (the original failure mode).
- [x] `ruff format` + `ruff check` clean.
- [x] CHANGELOG.md `[Unreleased]` entry added.
- [x] No existing tests touched the affected code paths in a way the cache breaks (cache is transparent for first-call behavior).

## Validation reference

- `mfg-research/docs/mfgarchon_gotchas.md` G-012 (research-side gotcha)
- `mfg-research/experiments/gfdm_monotonicity_audit/minors/exp09_obstacle_navigation_full/_staged_buildup/stageB_one_obstacle.py` (worked around the bug pre-fix by passing `box` instead of `DifferenceDomain` to `MFGProblem`)

## Caveats

The cache is sticky for the lifetime of the `ImplicitDomain` instance. If a user mutates the geometry (e.g., adds/removes regions in a way that changes the underlying volume), the cached value becomes stale. Currently `ImplicitDomain` doesn't have a documented mutation API, so this is a moot concern, but worth a follow-up if such an API is added: invalidate the cache on mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)