### PR TITLE
docs(hjb_gfdm): clarify obstacle_sdf sign convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Validated in
   `mfg-research/.../exp08_towel_2d_validation/_preflight_1d/post_mortem_1d_tob_debug.md`.
 
+### Changed
+
+- **Documented `HJBGFDMSolver.obstacle_sdf` sign convention** (Issue #1038).
+  Convention: ``obstacle_sdf(x) < 0`` means "x is INSIDE the obstacle (to be
+  filtered)". This matches a single-obstacle ``Hypersphere``/``Hyperrectangle``
+  ``.signed_distance`` natively but is **inverted** for a CSG composite like
+  ``DifferenceDomain.signed_distance`` (which uses the standard navigable-region
+  convention). Pass ``obstacle.signed_distance`` directly, not
+  ``domain.signed_distance``. Docstring example added in both
+  ``HJBGFDMSolver.__init__`` and ``NeighborhoodBuilder.__init__``.
+
 ## [0.19.6] - 2026-05-06
 
 ### Fixed

--- a/mfgarchon/alg/numerical/gfdm_components/neighborhood_builder.py
+++ b/mfgarchon/alg/numerical/gfdm_components/neighborhood_builder.py
@@ -179,6 +179,25 @@ class NeighborhoodBuilder:
                 neighbors whose line of sight to the center point passes through the
                 obstacle (SDF < 0) are excluded. This prevents cross-wall stencils in
                 narrow channels between obstacles.
+
+                **Sign convention (Issue #1038)**: ``obstacle_sdf(x) < 0`` must mean
+                "x is INSIDE the obstacle (to be filtered out of stencil
+                line-of-sight)". This matches a single-obstacle ``Hypersphere`` /
+                ``Hyperrectangle`` ``.signed_distance``, but does **NOT** match a
+                ``DifferenceDomain(box, obstacle).signed_distance`` — the latter
+                follows the standard navigable-region convention (sd<0 inside
+                navigable, sd>0 outside), opposite of what is needed here.
+
+                For a single-obstacle problem, pass the obstacle's own
+                ``.signed_distance`` directly::
+
+                    obstacle = Hypersphere(center=..., radius=...)
+                    domain = DifferenceDomain(box, obstacle)
+                    HJBGFDMSolver(...,
+                        obstacle_sdf=obstacle.signed_distance,  # ✓ correct
+                        # NOT domain.signed_distance — that has inverted convention
+                    )
+
             visibility_samples: Number of interior samples along each segment for
                 obstacle intersection testing. Default 10.
             visibility_margin: Safety margin for obstacle proximity. Neighbors with

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -405,6 +405,18 @@ class HJBGFDMSolver(BaseHJBSolver):
                 If provided and implements SupportsPeriodic (e.g., Hyperrectangle with
                 periodic_dims), enables periodic neighbor search for GFDM on torus domains.
                 Example: Hyperrectangle(bounds, periodic_dims=(0, 1)) for 2D torus.
+            obstacle_sdf: Optional callable ``f(x) -> float`` for visibility-based
+                stencil filtering. Convention: ``obstacle_sdf(x) < 0`` means x is INSIDE
+                the obstacle. Pass the obstacle's own ``.signed_distance`` directly
+                (e.g., ``obstacle_sdf=Hypersphere(...).signed_distance``); do NOT pass
+                a ``DifferenceDomain.signed_distance``, which has the opposite convention
+                (sd<0 inside the navigable region). See Issue #1038 and the full
+                docstring on ``NeighborhoodBuilder.obstacle_sdf``.
+            visibility_samples: Number of interior samples along each stencil edge for
+                obstacle intersection testing (default 10). Used only when
+                ``obstacle_sdf`` is provided.
+            visibility_margin: Safety margin for obstacle proximity (default 0.0).
+                Stencil edges passing within this distance of an obstacle are filtered.
         """
         super().__init__(problem)
 


### PR DESCRIPTION
## Summary

Fixes #1038. Docs-only.

`HJBGFDMSolver.obstacle_sdf` expects the convention `sd(x) < 0 ⇔ x is INSIDE the obstacle`. This matches a bare `Hypersphere` / `Hyperrectangle` `.signed_distance` natively. But for a CSG composite — `DifferenceDomain(box, obstacle).signed_distance` — the convention is **inverted**: sd<0 means "inside the navigable region", which is the opposite of what `obstacle_sdf` wants.

A user who naively passes `domain.signed_distance` instead of `obstacle.signed_distance` gets silently wrong filtering — neighbors crossing the navigable region are rejected, neighbors crossing the obstacle are kept.

This PR adds an explicit example and warning in both `NeighborhoodBuilder.__init__` (the docstring location where `obstacle_sdf` was already documented) and `HJBGFDMSolver.__init__` (the public class docstring, which previously didn't mention `obstacle_sdf` at all).

## Why docs-only

A runtime sanity check was considered (evaluate `obstacle_sdf` at a known interior collocation point and warn if the sign disagrees with `collocation_geometry.signed_distance`). It was rejected as Ptolemaic per the agent_axiom kernel: 

- The check has edge cases (e.g., `collocation_points[0]` may be on the boundary, where `geom_sd ≈ 0` and the sign comparison is ambiguous).
- A documented example prevents the trap entirely for users who read the docs (the most common path).
- The trap is rare in practice — most users pass `obstacle.signed_distance` for single-obstacle problems.

If the trap turns out to be common after release, a runtime check can be added in a follow-up — but starting with docs-only avoids defensive validation for a state most users won't reach.

## Test plan

- [x] Docs render correctly (no formatting breaks).
- [x] `ruff format` + `ruff check` clean for the touched lines (only pre-existing SIM401 at line 481, unrelated).
- [x] No code paths changed.
- [x] CHANGELOG.md `[Unreleased]` entry under `Changed`.

## Validation reference

`mfg-research/docs/mfgarchon_gotchas.md` G-004 (research-side gotcha entry, cross-references this issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)