### PR TITLE
fix(geometry/implicit): expose .bounds on CSG composites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`exit_flux_history`, `total_absorbed`). Verified by trajectory storage type
   (now `list` for segment-aware vs `ndarray` for uniform).
 
+- **CSG composite domains (`UnionDomain`, `IntersectionDomain`, `DifferenceDomain`,
+  `ComplementDomain`) now expose `.bounds`** (Issue #1041), mirroring the
+  `Hyperrectangle.bounds` API. Previously they had only `get_bounding_box()`,
+  causing `FPParticleSolver._get_grid_params` to silently fall back to the
+  unit hypercube `[(0, 1)] * d` when reading `geom.bounds`. On non-unit
+  domains (e.g., `[0, 18] × [0, 8]`) particles got reflected/clipped against
+  the wrong domain after every FP step → KDE singular covariance downstream.
+  After the fix, FPParticleSolver reads the actual domain bounds end-to-end.
+  `ComplementDomain.bounds` is a property delegating to `get_bounding_box()`
+  (raises if not manually set, since `ComplementDomain` is unbounded by
+  default — fail-fast is correct here).
+
 ### Added
 
 - **`HJBGFDMSolver` now emits a `UserWarning` when `monotonicity_scheme` is

--- a/mfgarchon/geometry/implicit/csg_operations.py
+++ b/mfgarchon/geometry/implicit/csg_operations.py
@@ -65,6 +65,13 @@ class UnionDomain(ImplicitDomain):
         if not all(d.dimension == self._dimension for d in domains):
             raise ValueError(f"All domains must have same dimension, got dimensions: {[d.dimension for d in domains]}")
 
+        # Issue #1041: expose `.bounds` so callers like
+        # FPParticleSolver._get_grid_params don't silently fall back to the unit
+        # hypercube. Mirrors the Hyperrectangle.bounds attribute (instance attr
+        # form, not @property — Hyperrectangle subclasses store as instance attr,
+        # which would conflict with a base-class @property without a setter).
+        self.bounds: NDArray[np.float64] = self.get_bounding_box()
+
     @property
     def dimension(self) -> int:
         """Spatial dimension."""
@@ -152,6 +159,9 @@ class IntersectionDomain(ImplicitDomain):
         # Verify all domains have same dimension
         if not all(d.dimension == self._dimension for d in domains):
             raise ValueError(f"All domains must have same dimension, got dimensions: {[d.dimension for d in domains]}")
+
+        # Issue #1041: expose `.bounds` (see UnionDomain for rationale).
+        self.bounds: NDArray[np.float64] = self.get_bounding_box()
 
     @property
     def dimension(self) -> int:
@@ -280,6 +290,15 @@ class ComplementDomain(ImplicitDomain):
                 "ComplementDomain is unbounded. Set bounding box manually via:\ncomplement.set_bounding_box(bounds)"
             )
         return self._bounding_box.copy()
+
+    @property
+    def bounds(self) -> NDArray[np.float64]:
+        """Issue #1041: expose `.bounds` for FPParticleSolver compatibility.
+
+        Same constraint as ``get_bounding_box``: requires ``set_bounding_box`` to
+        have been called (ComplementDomain is unbounded by default).
+        """
+        return self.get_bounding_box()
 
     def set_bounding_box(self, bounds: NDArray[np.float64]) -> None:
         """

--- a/mfgarchon/geometry/implicit/implicit_domain.py
+++ b/mfgarchon/geometry/implicit/implicit_domain.py
@@ -207,6 +207,11 @@ class ImplicitDomain(
             >>> bounds  # array([[-1, 1], [-1, 1]])
         """
 
+    # Note: subclasses that don't already maintain a `self.bounds` instance
+    # attribute (Hyperrectangle does) should expose `.bounds` themselves —
+    # see CSG composites (UnionDomain/IntersectionDomain/DifferenceDomain/
+    # ComplementDomain) for the Issue #1041 fix that adds them.
+
     # Note: contains() and sample_uniform() now inherited from ImplicitGeometry
 
     def project_to_domain(


### PR DESCRIPTION
## Summary

Fixes #1041.

CSG composite domains (`UnionDomain`, `IntersectionDomain`, `DifferenceDomain`, `ComplementDomain`) previously had only `get_bounding_box()` and no `.bounds` attribute. `FPParticleSolver._get_grid_params` reads `geom.bounds` and on `AttributeError` silently fell through to `[(0, 1)] * d` — the unit-hypercube fallback. Particles on a `[0, 18] × [0, 8]` domain got clipped/reflected against the unit square instead of the actual domain after every FP step.

The fix is to expose `.bounds` on the CSG types, mirroring `Hyperrectangle.bounds`.

## Verification

```
Before fix: FPParticle _get_grid_params bounds = [(0.0, 1.0), (0.0, 1.0)]   ← wrong
After fix:  FPParticle _get_grid_params bounds = [(0.0, 18.0), (0.0, 8.0)]  ← correct
```

## Implementation note (anti-Ptolemaic discipline)

The issue body originally proposed three fixes:
- (A) Expose `.bounds` on CSG composites — **done in this PR**
- (B) Fail-fast in `_get_grid_params` when `.bounds` is missing
- (C) Warn on `implicit_domain=None` when problem geometry is `DifferenceDomain`

Parts B and C are intentionally **deferred**. Both are defensive code for failure modes I haven't observed in the experiment that motivated the issue; the silent unit-square fallback was reachable specifically because CSG composites lacked `.bounds`. With (A) in place, the path is no longer hit. Per the agent_axiom kernel principle "don't add error handling, fallbacks, or validation for scenarios that can't happen," I'm shipping (A) alone.

If a future user hits the silent fallback via some other geometry class without `.bounds`, that's the trigger to add (B). Until then, it's a defensive epicycle.

## Test plan

- [x] Verify all 5 implicit-geometry types expose `.bounds` correctly: `Hyperrectangle` (existing instance attr), `Hypersphere` (via `get_bounding_box()`), `UnionDomain`, `IntersectionDomain`, `DifferenceDomain`. `ComplementDomain.bounds` raises when unset (correct fail-fast for unbounded by default).
- [x] End-to-end test: `FPParticleSolver._get_grid_params(...)` returns actual domain bounds, not unit-square fallback.
- [x] `ruff format` + `ruff check` clean.
- [x] CHANGELOG.md `[Unreleased]` entry added under `### Fixed`.

## Caveat

The CSG `.bounds` API isn't perfectly uniform — `Hyperrectangle`/`UnionDomain`/`IntersectionDomain`/`DifferenceDomain` use instance attribute (always set after `__init__`), while `ComplementDomain` uses a `@property` (raises when unset). The asymmetry is intentional: `ComplementDomain` is genuinely unbounded by default (`ℝ^d \ D`); requiring explicit `set_bounding_box()` before `.bounds` access is correct fail-fast behavior, not a bug.

## Validation reference

`mfg-research/docs/mfgarchon_gotchas.md` G-005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)