### PR TITLE
fix(hjb_sl): SL stochastic step trio — PCHIP interp + reflect not clip + linear allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`HJBSemiLagrangianSolver._stochastic_sl_step_1d` trio of fixes** (Issues
+  #1033, #1048, #1049):
+  1. **#1033**: replace `scipy.interpolate.CubicSpline` (non-monotone, blew up
+     on stiff problems with `max|∇u|` exponential growth 6 → 100 → 10⁶ → NaN
+     on 1D Towel-on-Beach in 17 Picard iters) with `PchipInterpolator`
+     (monotone Hermite). Linear interpolation now uses `np.interp` directly
+     when `interpolation_method="linear"`.
+  2. **#1048**: replace `np.clip(y, xmin, xmax)` boundary handling with
+     iterated mirror reflection `xmin + |((y − xmin) mod 2L) − L|`. Clamping
+     collapsed all out-of-bounds characteristic feet onto the boundary node,
+     biasing toward wall values and breaking upwind property near reflective
+     boundaries. Reflection matches the underlying SDE's behavior for Neumann.
+  3. **#1049**: remove the validation that **rejected** `interpolation_method
+     ="linear"` with `diffusion_method="stochastic"` — that combination IS the
+     proven-stable Carlini-Silva 2014 canonical scheme; the previously-required
+     `cubic` is non-monotone and outside the stability proof. Now `linear` is
+     the unwarned default for stochastic; cubic/quintic emit a `UserWarning`
+     pointing to the proof status.
+
+  See `mfg-research/docs/mfgarchon_gotchas.md` G-008 / G-009 / G-010 for the
+  research-side audit. The dim-agnostic refactor (unifying `_stochastic_sl_step_1d`
+  and `_stochastic_sl_step_nd` per the project's "dimension as parameter, not
+  constraint" principle) is tracked separately as Issue #1050; this PR fixes
+  the 1D path only.
+
 - **`FPParticleSolver._solve_fp_system_callable_drift` now honors segment-aware
   Dirichlet absorbing boundary conditions** (Issue #1042). Previously the
   callable-drift path always routed through `_apply_boundary_conditions_nd`

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -201,14 +201,28 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         self.gradient_clip_threshold = gradient_clip_threshold
         self.enable_gradient_monitoring = enable_gradient_monitoring
 
-        # Issue #1026: Carlini-Silva stochastic SL requires >=2nd-order interpolation.
-        # Linear interpolation caps global error at O(h), defeating the purpose.
-        if self.diffusion_method == "stochastic" and self.interpolation_method == "linear":
-            raise ValueError(
-                "diffusion_method='stochastic' requires cubic or higher-order "
-                "interpolation. Linear interpolation produces O(h) global error, "
-                "incompatible with the Carlini-Silva 2014 second-order scheme. "
-                "Set interpolation_method='cubic' (or 'quintic' for nD)."
+        # Issue #1049: Carlini-Silva 2014 prove unconditional stability of the
+        # deterministic 2-direction averaging SL scheme (here: diffusion_method=
+        # "stochastic") **specifically for Q1 (linear, monotone) interpolation**.
+        # Cubic interpolation is not covered by the CS 2014 proof and is non-monotone
+        # (Issue #1033 documents the exponential blow-up on Towel-on-Beach).
+        # The previous validation actively rejected the proof-applicable combination.
+        # Now: warn (don't reject) when cubic+stochastic is selected, since that
+        # combination violates the monotone-scheme requirement of CS 2014.
+        if self.diffusion_method == "stochastic" and self.interpolation_method in ("cubic", "quintic"):
+            import warnings
+
+            warnings.warn(
+                f"diffusion_method='stochastic' with interpolation_method='{self.interpolation_method}' "
+                "is NOT covered by the Carlini-Silva 2014 stability proof, which "
+                "requires monotone (Q1/linear) interpolation. Cubic/quintic can "
+                "violate the monotone-scheme requirement of Barles-Souganidis and "
+                "produce exponential blow-up on stiff problems (see Issue #1033). "
+                "Recommended: interpolation_method='linear'. mfgarchon's cubic "
+                "path now uses `PchipInterpolator` (monotonic Hermite) which is "
+                "more stable than `CubicSpline` but still outside the formal proof.",
+                UserWarning,
+                stacklevel=2,
             )
 
         # Gradient clipping statistics tracking
@@ -1287,18 +1301,14 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         Returns:
             Value function at current time step, same shape as U_next.
 
-        Raises:
-            ValueError: if interpolation_method is "linear" (validated in
-                __init__, but check is also enforced here defensively).
+        Notes:
+            Issue #1049: previously rejected interpolation_method="linear" here,
+            inverted from CS 2014's stability requirement. The "linear" path is
+            now allowed; warning issued at __init__ when cubic/quintic is used
+            with stochastic (the unproven combination).
         """
         if dt is None:
             dt = self.dt
-        if self.interpolation_method == "linear":
-            raise ValueError(
-                "Stochastic SL with linear interpolation has O(h) global "
-                "error and is incompatible with the Carlini-Silva 2014 "
-                "scheme. Set interpolation_method='cubic' (or 'quintic')."
-            )
 
         if self.dimension == 1:
             return self._stochastic_sl_step_1d(U_next, M_next, time_idx, dt)
@@ -1313,8 +1323,6 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         dt: float,
     ) -> np.ndarray:
         """1D stochastic SL step. See _solve_timestep_stochastic_sl."""
-        from scipy.interpolate import CubicSpline
-
         Nx = len(U_next)
         sigma = self.problem.sigma  # SDE volatility (Sigma in mfg_problem.py:39)
         sqrt_dt = float(np.sqrt(dt))
@@ -1329,24 +1337,48 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         y_plus = x_drift + diffusion_offset
         y_minus = x_drift - diffusion_offset
 
-        # Boundary handling - same as the Strang-splitting branch
+        # Boundary handling — Issue #1048 fix: properly REFLECT characteristic feet
+        # for Neumann BC instead of clamping. Clamping collapsed all out-of-bounds
+        # feet onto the boundary node, biasing toward the wall value and breaking
+        # upwind property near the boundary.
         bc = self.get_boundary_conditions()
         bc_type_str = get_bc_type_string(bc)
         bc_op = bc_type_to_geometric_operation(bc_type_str)
         bounds = self.problem.geometry.get_bounds()
         xmin, xmax = bounds[0][0], bounds[1][0]
         if bc_op == "reflect":
-            y_plus = np.clip(y_plus, xmin, xmax)
-            y_minus = np.clip(y_minus, xmin, xmax)
+            # Iterated mirror reflection via modular arithmetic:
+            #   y' = xmin + |((y − xmin) mod 2L) − L|   where L = xmax − xmin
+            # Maps any y ∈ ℝ to [xmin, xmax] via reflections at xmin and xmax.
+            # Handles arbitrary numbers of bounces in a single expression.
+            L = xmax - xmin
+            y_plus = xmin + np.abs(((y_plus - xmin) % (2 * L)) - L)
+            y_minus = xmin + np.abs(((y_minus - xmin) % (2 * L)) - L)
         elif bc_op == "wrap":
             L = xmax - xmin
             y_plus = xmin + (y_plus - xmin) % L
             y_minus = xmin + (y_minus - xmin) % L
 
-        # Cubic spline interpolation at both stochastic departures
-        interp_fn = CubicSpline(self.x_grid, U_next, bc_type="not-a-knot")
-        u_plus = interp_fn(y_plus)
-        u_minus = interp_fn(y_minus)
+        # Issue #1033 + #1049: dispatch interpolation by configured method.
+        # - "linear": canonical Carlini-Silva 2014 (Q1, monotone, proof applies)
+        # - "cubic":  monotone-preserving Hermite (PchipInterpolator) — replaces
+        #             non-monotone CubicSpline that blew up on stiff problems
+        # - "quintic": fall back to PchipInterpolator (cubic, monotone) here in 1D;
+        #             user gets the warning at __init__ that this is outside the proof.
+        if self.interpolation_method == "linear":
+            u_plus = np.interp(y_plus, self.x_grid, U_next)
+            u_minus = np.interp(y_minus, self.x_grid, U_next)
+        else:
+            # Issue #1033 fix: PchipInterpolator (monotone Hermite) replaces
+            # CubicSpline (non-monotone, blew up on stiff problems). The reflect/
+            # wrap branch above keeps all feet inside [xmin, xmax], so disabling
+            # extrapolation is safe — any out-of-range query indicates a real bug
+            # upstream and should propagate as nan, not be silently masked.
+            from scipy.interpolate import PchipInterpolator
+
+            interp_fn = PchipInterpolator(self.x_grid, U_next, extrapolate=False)
+            u_plus = interp_fn(y_plus)
+            u_minus = interp_fn(y_minus)
 
         # CS update: average over Brownian directions, subtract dt*H
         u_avg = 0.5 * (u_plus + u_minus)

--- a/tests/unit/test_alg/test_hjb_semi_lagrangian.py
+++ b/tests/unit/test_alg/test_hjb_semi_lagrangian.py
@@ -732,8 +732,15 @@ class TestStochasticCharacteristicSL:
     minors/archive/exp14_towel_1d_benchmark/subs/exp14e_solver_comparison/
     """
 
-    def test_linear_plus_stochastic_rejected(self):
-        """Linear interpolation caps global error at O(h); incompatible with CS."""
+    def test_linear_plus_stochastic_accepted(self):
+        """Issue #1049: linear+stochastic IS the canonical Carlini-Silva 2014 scheme.
+
+        Previously rejected by validation (`test_linear_plus_stochastic_rejected`).
+        That validation was inverted from CS 2014's stability requirement: the
+        rejected combination IS the proven-stable canonical scheme, while the
+        forced cubic combination is non-monotone (Issue #1033). Test renamed and
+        inverted to assert the corrected behavior.
+        """
         geometry = TensorProductGrid(
             bounds=[(0.0, 1.0)],
             Nx_points=[51],
@@ -741,29 +748,37 @@ class TestStochasticCharacteristicSL:
         )
         problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
 
-        with pytest.raises(ValueError, match="cubic or higher-order"):
-            HJBSemiLagrangianSolver(
-                problem,
-                interpolation_method="linear",
-                diffusion_method="stochastic",
-            )
-
-    def test_cubic_plus_stochastic_instantiates(self):
-        """Cubic + stochastic is the supported configuration."""
-        geometry = TensorProductGrid(
-            bounds=[(0.0, 1.0)],
-            Nx_points=[51],
-            boundary_conditions=no_flux_bc(dimension=1),
-        )
-        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
-
+        # Should NOT raise — linear+stochastic is now allowed and recommended.
         solver = HJBSemiLagrangianSolver(
             problem,
-            interpolation_method="cubic",
+            interpolation_method="linear",
             diffusion_method="stochastic",
-            check_cfl=False,
         )
+        assert solver.diffusion_method == "stochastic"
+        assert solver.interpolation_method == "linear"
 
+    def test_cubic_plus_stochastic_warns(self):
+        """Issue #1049: cubic+stochastic emits a UserWarning (CS 2014 proof doesn't apply)."""
+        import warnings as _w
+
+        geometry = TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[51],
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
+
+        with _w.catch_warnings(record=True) as caught:
+            _w.simplefilter("always")
+            solver = HJBSemiLagrangianSolver(
+                problem,
+                interpolation_method="cubic",
+                diffusion_method="stochastic",
+                check_cfl=False,
+            )
+            cs_warnings = [m for m in caught if "Carlini-Silva" in str(m.message)]
+
+        assert len(cs_warnings) == 1, f"expected 1 CS UserWarning, got {len(cs_warnings)}"
         assert solver.diffusion_method == "stochastic"
         assert solver.interpolation_method == "cubic"
 


### PR DESCRIPTION
## Summary

Fixes #1033, #1048, #1049 — three bugs in `HJBSemiLagrangianSolver._stochastic_sl_step_1d` (1D Carlini-Silva 2014 stochastic SL path), plus inverts the broken validation in `__init__`.

## What was wrong

| # | Location | Bug |
|---|---|---|
| 1033 | `_stochastic_sl_step_1d` line 1316/1347 (pre-fix) | hardcoded `scipy.interpolate.CubicSpline(bc_type="not-a-knot")` is **non-monotone**, ignored `interpolation_method`, blew up on stiff problems (`max\|∇u\|`: 6 → 100 → 10⁶ → NaN in 17 Picard iters on 1D ToB at σ=0.2) |
| 1048 | `_stochastic_sl_step_1d` lines 1339-1340 (pre-fix) | `np.clip(y_plus, xmin, xmax)` — comment said "reflect" but code was a **clamp**, collapsing all out-of-bounds characteristic feet onto the boundary node, biasing toward wall values and breaking upwind property |
| 1049 | `__init__` lines 206-212 + `_solve_timestep_stochastic_sl` lines 1296-1301 (pre-fix) | validation that **rejected** `interpolation_method="linear"` with `diffusion_method="stochastic"` — but linear+stochastic IS the proven-stable Carlini-Silva 2014 canonical scheme; the forced `cubic` is non-monotone and outside the proof |

## What this PR does

1. **Replace CubicSpline with PchipInterpolator** in the cubic/quintic path. PCHIP is monotone Hermite, matches the Issue #583 pattern already in `hjb_sl_interpolation.py`. Linear path now uses `np.interp` directly.

2. **Reflect, don't clamp** at `bc_op == "reflect"` boundaries. Use the iterated reflection formula `xmin + |((y − xmin) mod 2L) − L|` which correctly handles arbitrary numbers of bounces in one expression.

3. **Invert the validation**: linear+stochastic is now the unwarned canonical path. cubic/quintic+stochastic emits a `UserWarning` pointing to the CS 2014 proof gap. Drops the `ValueError` in both `__init__` and `_solve_timestep_stochastic_sl`.

## Test plan

- [x] Smoke test (linear constructs without error, cubic warns, reflection handles excursions): all pass
- [x] `tests/unit/test_alg/test_hjb_semi_lagrangian.py`: **38 passed, 2 skipped, 2 xfailed** (1 test renamed and inverted to match the corrected policy: `test_linear_plus_stochastic_rejected` → `test_linear_plus_stochastic_accepted`; `test_cubic_plus_stochastic_instantiates` → `test_cubic_plus_stochastic_warns`)
- [x] `ruff format` + `ruff check` clean

## Scope deferred (filed as #1050)

The dim-agnostic refactor — unifying `_stochastic_sl_step_1d` and `_stochastic_sl_step_nd` per the project's "**Dimension should be a parameter, not a constraint**" principle (per Joplin Dev `Dimension-Agnostic MFG Solver Landscape`) — is out of scope here. This PR fixes the 1D path only. The nD path may still have analogous issues (does `_interpolate_value` use a monotone interpolant? does its BC handling clamp or reflect?) — that's separate review.

## Validation reference

`mfg-research/docs/mfgarchon_gotchas.md` G-008 / G-009 / G-010.

## Anti-Ptolemaic discipline

Initial draft included a `np.nan_to_num` fallback in the cubic interpolation branch ("for safety against PchipInterpolator returning NaN on out-of-range queries"). The reflect/wrap above keeps all feet inside, so any NaN here is a real upstream bug, not a state to mask. Removed the fallback: NaNs propagate cleanly to surface bugs at the point they originate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)