### PR TITLE
chore: minor cleanup batch — CFL log spam + fail-fast + sign-convention docs + lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CFL diagnostic logging now emits at INFO once per solver instance**, then
+  DEBUG on subsequent calls (Issue #1052). Previously every Picard iteration
+  emitted the same "CFL diagnostic" line at INFO, spamming user logs and
+  causing researchers to blanket-suppress warnings (which masked unrelated
+  DeprecationWarnings — the Tier-C silent-semantic-shift bugs in #1043 went
+  unnoticed for weeks partially for this reason). Applies to `HJBFDMSolver`
+  and `FPFDMSolver`.
+
+- **`SeparableHamiltonian.potential` docstring** now explicitly documents the
+  "potential as reward" sign convention (Issue #1057, gotcha G-001). For an
+  attractive potential at `x_c`, write `V(x, t) = -0.5*C*(x-x_c)**2`
+  (inverted parabola, peak at `x_c`); for repulsive, write `+0.5*C*(x-x_c)**2`
+  (bowl). This is opposite to standard MFG literature where V is "cost to
+  avoid"; mfgarchon's convention is reward, agents concentrate at V_max.
+
 ### Fixed
 
 - **`HJBSemiLagrangianSolver._stochastic_sl_step_1d` trio of fixes** (Issues
@@ -33,7 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `_stochastic_sl_step_nd` per the project's "dimension as parameter, not
   constraint" principle) is tracked separately as Issue #1050; this PR fixes
   the 1D path only.
-
+- **`FPParticleSolver._get_grid_params` now fails fast on geometries that
+  expose neither `.bounds`, `.xmin`/`.xmax`, nor `.coordinates`** (Issue #1053).
+  Previously fell through to a silent `[(0.0, 1.0)] * dimension` fallback
+  (the unit hypercube), which corrupted FP particle simulation on any
+  non-standard geometry without a clear error. Now raises `TypeError` with
+  a diagnostic pointing at the missing API.
 - **`FPParticleSolver._solve_fp_system_callable_drift` now honors segment-aware
   Dirichlet absorbing boundary conditions** (Issue #1042). Previously the
   callable-drift path always routed through `_apply_boundary_conditions_nd`

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -233,14 +233,19 @@ class FPFDMSolver(BaseFPSolver):
     # _detect_dimension() inherited from BaseNumericalSolver (Issue #633)
 
     def _log_cfl_diagnostic(self, volatility_field: float | None = None) -> None:
-        """Log CFL diagnostic for accuracy/convergence guidance (Issue #882)."""
+        """Log CFL diagnostic for accuracy/convergence guidance (Issue #882, #1052).
+
+        Issue #1052: log once at INFO per solver instance, subsequent calls at
+        DEBUG. CFL parameters are static across Picard iterations.
+        """
         try:
             dt = self.problem.dt
             dx = self.problem.geometry.get_grid_spacing()[0]
             sigma = volatility_field if isinstance(volatility_field, (int, float)) else self.problem.sigma
             cfl_diffusive = sigma**2 * dt / dx**2
             if cfl_diffusive > 0.5:
-                logger.info(
+                log_fn = logger.debug if getattr(self, "_cfl_logged", False) else logger.info
+                log_fn(
                     "CFL diagnostic (FP FDM): diffusive=%.2f (sigma=%.3g, dt=%.3g, dx=%.3g). "
                     "Implicit scheme is stable but accuracy may degrade for CFL >> 1.",
                     cfl_diffusive,
@@ -248,6 +253,7 @@ class FPFDMSolver(BaseFPSolver):
                     dt,
                     dx,
                 )
+                self._cfl_logged = True
         except (AttributeError, IndexError, TypeError):
             pass  # Not enough info to compute CFL — skip silently
 

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -46,7 +46,7 @@ from .particle_result import FPParticleResult
 logger = get_logger(__name__)
 
 
-class KDENormalization(str, Enum):
+class KDENormalization(StrEnum):
     """KDE normalization strategy for particle-based FP solvers."""
 
     NONE = "none"  # No normalization (raw KDE output)
@@ -54,7 +54,7 @@ class KDENormalization(str, Enum):
     ALL = "all"  # Normalize at every time step (default)
 
 
-class KDEMethod(str, Enum):
+class KDEMethod(StrEnum):
     """Density estimation method from particles (Issue #709).
 
     Different methods handle boundary bias differently:
@@ -318,9 +318,23 @@ class FPParticleSolver(BaseFPSolver):
                         if len(geom.coordinates) > 0:
                             bounds = [(coords[0], coords[-1]) for coords in geom.coordinates]
                         else:
-                            bounds = [(0.0, 1.0)] * dimension
-                    except AttributeError:
-                        bounds = [(0.0, 1.0)] * dimension
+                            # Issue #1053: fail-fast instead of silent unit-cube
+                            # fallback. Empty coordinates on a non-Hyperrectangle
+                            # geometry means we genuinely cannot derive bounds.
+                            raise TypeError(
+                                f"FPParticleSolver._get_grid_params: cannot derive simulation bounds "
+                                f"from {type(geom).__name__} (geom.bounds, geom.xmin/.xmax, and "
+                                f"geom.coordinates all absent or empty). Implement one of these on "
+                                f"your geometry class, or wrap with a Hyperrectangle bbox."
+                            )
+                    except AttributeError as _e:
+                        # Issue #1053: same fail-fast for the AttributeError branch.
+                        raise TypeError(
+                            f"FPParticleSolver._get_grid_params: cannot derive simulation bounds "
+                            f"from {type(geom).__name__} (tried geom.bounds, geom.xmin/.xmax, "
+                            f"geom.coordinates — all raised AttributeError). Implement one of "
+                            f"these on your geometry class, or wrap with a Hyperrectangle bbox."
+                        ) from _e
 
             # Get spacing per dimension
             # For implicit geometry (e.g., Hyperrectangle), get_grid_spacing() returns None

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -321,14 +321,21 @@ class HJBFDMSolver(BaseHJBSolver):
         return self._laplacian_op
 
     def _log_cfl_diagnostic(self, volatility_field: float | None = None) -> None:
-        """Log CFL diagnostic for accuracy/convergence guidance (Issue #882)."""
+        """Log CFL diagnostic for accuracy/convergence guidance (Issue #882, #1052).
+
+        Issue #1052: log once at INFO per solver instance, subsequent calls at
+        DEBUG. The CFL parameters don't change between Picard iterations, so
+        emitting INFO every iter spammed user output and caused researchers to
+        blanket-suppress warnings — masking unrelated DeprecationWarnings.
+        """
         try:
             dt = self.problem.dt
             dx = self.problem.geometry.get_grid_spacing()[0]
             sigma = volatility_field if isinstance(volatility_field, (int, float)) else self.problem.sigma
             cfl_diffusive = sigma**2 * dt / dx**2
             if cfl_diffusive > 0.5:
-                logger.info(
+                log_fn = logger.debug if getattr(self, "_cfl_logged", False) else logger.info
+                log_fn(
                     "CFL diagnostic (HJB FDM): diffusive=%.2f (sigma=%.3g, dt=%.3g, dx=%.3g). "
                     "Implicit scheme is stable but accuracy may degrade for CFL >> 1.",
                     cfl_diffusive,
@@ -336,6 +343,7 @@ class HJBFDMSolver(BaseHJBSolver):
                     dt,
                     dx,
                 )
+                self._cfl_logged = True
         except (AttributeError, IndexError, TypeError):
             pass  # Not enough info to compute CFL — skip silently
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -504,11 +504,8 @@ class HJBGFDMSolver(BaseHJBSolver):
                 "always": ("qp_m_matrix", "always"),
                 "precompute": ("qp_m_matrix", "precompute"),
             }
-            if legacy in mapping:
-                scheme, application = mapping[legacy]
-            else:
-                # Unknown legacy value — pass through for solver-internal handling
-                scheme, application = "qp_m_matrix", legacy
+            # Unknown legacy value passes through for solver-internal handling.
+            scheme, application = mapping.get(legacy, ("qp_m_matrix", legacy))
 
         # Canonical storage
         self.monotonicity_scheme = scheme

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -1938,19 +1938,42 @@ class SeparableHamiltonian(HamiltonianBase):
 
     This is the most common form in MFG, where:
     - H_control(p): Control cost (from ControlCostBase)
-    - V(x, t): Potential energy / state cost
+    - V(x, t): Potential energy / state cost (see sign-convention note below)
     - f(m): Density coupling term
 
     The separability allows efficient computation and analytic derivatives.
+
+    Sign convention (Issue #1057, gotcha G-001)
+    -------------------------------------------
+    `potential` enters the Hamiltonian as ``H = H_control(p) + V(x, t) + f(m)``.
+    The class also accepts ``sense=OptimizationSense.MINIMIZE`` (default) which
+    flips the sign on ``H_control``'s Legendre-transform direction — but ``V`` is
+    currently added to ``H`` **without** a corresponding sense-flip. Empirically,
+    research code attracts density to ``x_c`` by writing ``V(x, t) = -C * (x - x_c)**2``
+    (inverted parabola, peak at ``x_c``), not the bowl shape that standard MFG
+    literature would suggest. This is the de-facto "potential as reward"
+    convention.
+
+    The API gap (V not interacting with ``sense``) is tracked as Issue #1060;
+    until that lands, the practical guidance is:
+
+    - **Attractive** potential at ``x_c``: ``V(x, t) = -0.5 * C * (x - x_c)**2``
+      (inverted parabola, peak at ``x_c``).
+    - **Repulsive** potential at ``x_c``: ``V(x, t) = +0.5 * C * (x - x_c)**2``
+      (bowl, minimum at ``x_c``).
+
+    Verified by exp08/09 Stage A/B/C runners — they attract density to ``x_c``
+    using ``-C₁ * (x - x_c)**2``.
 
     Parameters
     ----------
     control_cost : ControlCostBase
         Control cost specification (quadratic, L1, bounded, etc.)
     potential : Callable[[NDArray, float], float] | None
-        Potential function V(x, t). If None, V = 0.
+        Potential V(x, t) added to H. If None, V = 0. See "Sign convention" above —
+        write inverted parabola (peak at x_c) for attractive.
     coupling : Callable[[float | NDArray], float | NDArray] | None
-        Density coupling f(m). If None, f = 0.
+        Density coupling f(m). If None, f = 0. Same "added to H" convention.
     coupling_dm : Callable[[float | NDArray], float | NDArray] | None
         Derivative df/dm. If None, computed via finite differences.
 


### PR DESCRIPTION
## Summary

Bundle of low-risk cleanups in one PR, single CI pass. Closes:

- #1052 — CFL diagnostic log spam (INFO every iter → INFO once per instance, DEBUG after)
- #1053 — `_get_grid_params` silent unit-cube fallback → TypeError fail-fast
- #1057 — `SeparableHamiltonian.potential` sign-convention docstring (de-facto convention documented; #1060 tracks deferred refactor)
- Lint: SIM401 at `hjb_gfdm.py:507`, UP042 at `fp_particle.py:49`

## Why bundled

Each is small (~5-50 LOC). Filing 5 separate PRs would mean 5 separate CI runs; bundling = 1 CI run. Per maintainer guidance.

## Per-issue breakdown

### #1052 — CFL log spam

`HJBFDMSolver._log_cfl_diagnostic` and `FPFDMSolver._log_cfl_diagnostic` emit identical CFL info every Picard iter. Demote to DEBUG after first INFO emission per solver instance (`self._cfl_logged` flag).

### #1053 — Silent unit-cube fallback

`FPParticleSolver._get_grid_params` had a final `bounds = [(0.0, 1.0)] * dimension` fallback for any geometry without `.bounds` / `.xmin`-`.xmax` / `.coordinates`. Per CLAUDE.md "NO silent fallbacks": replaced with `raise TypeError(...)` carrying a diagnostic message about which APIs were tried.

### #1057 — Sign convention docs

`SeparableHamiltonian.potential` docstring now explicitly documents the "potential as reward" convention (write inverted parabola for attractive). Cross-references #1060 for the deferred refactor (potential should interact with `OptimizationSense.MINIMIZE`/`MAXIMIZE`).

### Lint

- SIM401: `if legacy in mapping: scheme, application = mapping[legacy]; else: scheme, application = "qp_m_matrix", legacy` → `scheme, application = mapping.get(legacy, ("qp_m_matrix", legacy))`. Single-line refactor.
- UP042: `class KDENormalization(str, Enum)` → `class KDENormalization(StrEnum)`. `pyproject.toml` requires-python is `>=3.12`, so `StrEnum` (added in 3.11) is safe.

## Test plan

- [x] `tests/unit/test_alg/`: **698 passed, 2 skipped, 2 xfailed**, no regressions
- [x] Smoke test: `_get_grid_params` source inspected, TypeError present, silent unit-cube branch removed
- [x] `ruff format` + `ruff check` clean across all 5 touched files
- [x] CHANGELOG.md `[Unreleased]` entries under `### Changed` and `### Fixed`

## Anti-Ptolemaic

Filed #1060 separately for the bigger convention refactor (`SeparableHamiltonian.potential` should interact with `OptimizationSense`). That's tracked as deferred (per maintainer note: don't break in-flight research code mid-paper). This PR ships only the docstring documentation of the de-facto convention; behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)