### PR TITLE
fix(hjb_sl): apply 1D stochastic SL trio fixes to _stochastic_sl_step_nd (#1054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`HJBSemiLagrangianSolver._stochastic_sl_step_nd` companion fixes**
+  (Issue #1054): apply the analogous trio of correctness fixes to the nD
+  stochastic SL path:
+  1. **Monotone interpolation**: when `interpolation_method ∈ {"cubic",
+     "quintic"}`, route through `RegularGridInterpolator(method="pchip")`
+     (tensor-product monotone Hermite, scipy ≥ 1.10) instead of the
+     non-monotone tensor-product cubic. Mirrors 1D Issue #1033.
+  2. **Per-axis BC handling on Brownian feet**: apply iterated mirror
+     reflection (`reflect`) or modular wrap (`wrap`) per axis to
+     `y_plus`/`y_minus` before interpolation. Previously the nD path
+     silently extrapolated via `bounds_error=False, fill_value=None`,
+     producing values dependent on the nearest interior cell rather than
+     respecting the SDE's reflection/periodicity. Mirrors 1D Issue #1048.
+  3. **Vectorized batch interpolation**: replace per-(node, axis)
+     `_interpolate_value` calls (which rebuilt the interpolator each call)
+     with a single `RegularGridInterpolator` built once and queried on the
+     full `(2*d*N_total, d)` departure batch. Linear interpolation
+     continues to work alongside stochastic dispatch (Issue #1049 carries
+     through).
+
 - **`HJBSemiLagrangianSolver._stochastic_sl_step_1d` trio of fixes** (Issues
   #1033, #1048, #1049):
   1. **#1033**: replace `scipy.interpolate.CubicSpline` (non-monotone, blew up

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1409,12 +1409,19 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         time_idx: int,
         dt: float,
     ) -> np.ndarray:
-        """nD stochastic SL step.
+        """nD stochastic SL step (Carlini-Silva 2014, axis-aligned Brownian).
 
-        Uses the existing per-point _interpolate_value path (handles cubic /
-        quintic via RegularGridInterpolator). The Brownian quadrature is over
-        2*d departures (one pair per coordinate axis).
+        Brownian quadrature: 2*d departures per node (one pair per axis).
+        Mirrors the 1D path's three correctness fixes:
+          - Issue #1033: monotone-preserving cubic — RegularGridInterpolator
+            method="cubic" / "quintic" is non-monotone; route through "pchip"
+            (scipy ≥ 1.10 monotone Hermite, tensor-product) for stochastic.
+          - Issue #1048: reflect/wrap characteristic feet at Neumann/periodic
+            boundaries (per-axis), not silent extrapolation by RGI.
+          - Issue #1049: linear is allowed alongside stochastic (canonical CS).
         """
+        from scipy.interpolate import RegularGridInterpolator
+
         # Reshape to grid form (matches the Strang-splitting nD path)
         if U_next.ndim == 1:
             total_points = U_next.size
@@ -1432,7 +1439,6 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
 
         sigma = self.problem.sigma
         if isinstance(sigma, np.ndarray):
-            # Diagonal volatility: sigma[k] is the volatility along axis k
             sigma_diag = np.asarray(sigma, dtype=float).ravel()
             if sigma_diag.size != self.dimension:
                 raise ValueError(
@@ -1443,32 +1449,76 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         else:
             sigma_diag = np.full(self.dimension, float(sigma))
         sqrt_dt = float(np.sqrt(dt))
+        d = self.dimension
 
         grad_components = self._compute_gradient(U_next_shaped, check_cfl=True, t_idx=time_idx, m_density=M_next_shaped)
 
-        U_current_shaped = np.zeros_like(U_next_shaped)
-        d = self.dimension
+        # Issue #1054 fix: build interpolator once, dispatch monotone method.
+        # "cubic"/"quintic" → "pchip" (monotone Hermite, tensor-product).
+        # "linear" → "linear" (canonical Carlini-Silva, monotone).
+        if self.interpolation_method == "linear":
+            interp_method = "linear"
+        elif self.interpolation_method in ("cubic", "quintic"):
+            interp_method = "pchip"
+        else:
+            interp_method = "linear"
 
+        grid_coords = tuple(self.grid.coordinates)
+        interp_fn = RegularGridInterpolator(
+            grid_coords,
+            U_next_shaped,
+            method=interp_method,
+            bounds_error=False,
+            fill_value=None,
+        )
+
+        # Issue #1054 fix: per-axis BC handling (reflect/wrap) on Brownian feet.
+        bc = self.get_boundary_conditions()
+        bc_type_str = get_bc_type_string(bc)
+        bc_op = bc_type_to_geometric_operation(bc_type_str)
+        bounds = self.problem.geometry.get_bounds()
+        x_min = np.asarray(bounds[0], dtype=float)
+        x_max = np.asarray(bounds[1], dtype=float)
+        L_axis = x_max - x_min
+
+        # Pre-build all departure points (2*d per node), batch-interpolate.
+        n_total = int(np.prod(grid_shape))
+        # x_drift_flat[i, ax] = x_current[ax] − dt * p[ax] for node i
+        mesh = np.meshgrid(*grid_coords, indexing="ij")
+        x_drift_flat = np.stack([mesh[ax].ravel() for ax in range(d)], axis=1)
+        for ax in range(d):
+            x_drift_flat[:, ax] -= grad_components[ax].ravel() * dt
+
+        # Build (2*d*N_total, d) departure array
+        all_departures = np.empty((2 * d * n_total, d), dtype=float)
+        for ax in range(d):
+            offset = np.zeros(d)
+            offset[ax] = sigma_diag[ax] * sqrt_dt
+            block_start = 2 * ax * n_total
+            all_departures[block_start : block_start + n_total] = x_drift_flat + offset[None, :]
+            all_departures[block_start + n_total : block_start + 2 * n_total] = x_drift_flat - offset[None, :]
+
+        # Apply BC vectorized (per-axis broadcast)
+        if bc_op == "reflect":
+            all_departures = x_min + np.abs(((all_departures - x_min) % (2 * L_axis)) - L_axis)
+        elif bc_op == "wrap":
+            all_departures = x_min + (all_departures - x_min) % L_axis
+
+        # Single batch interpolation
+        all_u = interp_fn(all_departures)
+
+        # u_avg per node = mean over 2*d departures (factor 1/(2d), matches the
+        # original loop's `interp_acc / d` after the inner `0.5 * (u_plus + u_minus)`)
+        u_avg = all_u.reshape(2 * d, n_total).mean(axis=0).reshape(grid_shape)
+
+        # Hamiltonian — kept per-point (matches existing implementation)
+        U_current_shaped = np.zeros_like(U_next_shaped)
         for multi_idx in np.ndindex(grid_shape):
-            x_current = np.array([self.grid.coordinates[ax][multi_idx[ax]] for ax in range(d)])
+            x_current = np.array([grid_coords[ax][multi_idx[ax]] for ax in range(d)])
             m_current = M_next_shaped[multi_idx]
             p_optimal = np.array([grad_components[ax][multi_idx] for ax in range(d)])
-            x_drift = x_current - p_optimal * dt
-
-            # 2d stochastic departures - one pair per axis
-            interp_acc = 0.0
-            for ax in range(d):
-                offset = np.zeros(d)
-                offset[ax] = sigma_diag[ax] * sqrt_dt
-                y_plus = x_drift + offset
-                y_minus = x_drift - offset
-                u_plus = self._interpolate_value(U_next_shaped, y_plus)
-                u_minus = self._interpolate_value(U_next_shaped, y_minus)
-                interp_acc += 0.5 * (u_plus + u_minus)
-            u_avg = interp_acc / d
-
             H_value = self._evaluate_hamiltonian(x_current, p_optimal, m_current, time_idx)
-            U_current_shaped[multi_idx] = u_avg - dt * H_value
+            U_current_shaped[multi_idx] = u_avg[multi_idx] - dt * H_value
 
         # Enforce BC on the result
         U_current_shaped = self._enforce_boundary_conditions(U_current_shaped)

--- a/tests/unit/test_alg/test_hjb_semi_lagrangian.py
+++ b/tests/unit/test_alg/test_hjb_semi_lagrangian.py
@@ -942,5 +942,92 @@ class TestStochasticCharacteristicSL:
         assert max_diff < 5e-3, f"Stochastic and ADI diverge on smooth Gaussian: max diff = {max_diff:.3e}"
 
 
+class TestStochasticCharacteristicSL_nD:
+    """Issue #1054: nD stochastic SL companion fixes (analogous to 1D #1033/#1048/#1049)."""
+
+    def _make_2d_problem(self, sigma=0.3, T=0.1, Nt=4, N=15):
+        from mfgarchon.core.hamiltonian import HamiltonianBase, OptimizationSense
+
+        class ZeroH(HamiltonianBase):
+            def __init__(self):
+                super().__init__(sense=OptimizationSense.MINIMIZE)
+
+            def __call__(self, x, m, p, t=0.0):
+                p_arr = np.atleast_1d(np.asarray(p, dtype=float))
+                if p_arr.ndim > 0:
+                    return np.zeros(p_arr.shape[:-1])
+                return 0.0
+
+            def gradient_p(self, x, m, p, t=0.0):
+                return np.zeros_like(np.asarray(p, dtype=float))
+
+            def density_derivative(self, x, m, p, t=0.0):
+                return 0.0
+
+        bc = no_flux_bc(dimension=2)
+        grid = TensorProductGrid(
+            dimension=2, bounds=[(0.0, 1.0), (0.0, 1.0)],
+            Nx_points=[N, N], boundary_conditions=bc,
+        )
+
+        def m0(x):
+            return np.exp(-10.0 * ((x[..., 0] - 0.5) ** 2 + (x[..., 1] - 0.5) ** 2))
+
+        components = MFGComponents(
+            hamiltonian=ZeroH(),
+            m_initial=m0,
+            u_terminal=lambda x: 1.0,
+        )
+        return MFGProblem(
+            geometry=grid, T=T, Nt=Nt, sigma=sigma,
+            components=components, boundary_conditions=bc,
+        ), grid, m0
+
+    def test_2d_linear_stochastic_finite(self):
+        """Issue #1054: linear+stochastic on 2D no-flux must produce finite output."""
+        problem, grid, m0 = self._make_2d_problem()
+        solver = HJBSemiLagrangianSolver(
+            problem, diffusion_method="stochastic",
+            interpolation_method="linear", check_cfl=False,
+        )
+        U_terminal = np.zeros(tuple(grid.Nx_points))
+        M_init = m0(np.stack(np.meshgrid(*grid.coordinates, indexing="ij"), axis=-1))
+        U_step = solver._stochastic_sl_step_nd(U_terminal, M_init, time_idx=problem.Nt - 1, dt=0.025)
+        assert U_step.shape == tuple(grid.Nx_points)
+        assert np.isfinite(U_step).all()
+
+    def test_2d_cubic_stochastic_uses_pchip(self):
+        """Issue #1054: cubic+stochastic in nD routes through monotone PCHIP (no NaN)."""
+        problem, grid, m0 = self._make_2d_problem()
+        with __import__("warnings").catch_warnings():
+            __import__("warnings").simplefilter("ignore")
+            solver = HJBSemiLagrangianSolver(
+                problem, diffusion_method="stochastic",
+                interpolation_method="cubic", check_cfl=False,
+            )
+        U_terminal = np.zeros(tuple(grid.Nx_points))
+        M_init = m0(np.stack(np.meshgrid(*grid.coordinates, indexing="ij"), axis=-1))
+        U_step = solver._stochastic_sl_step_nd(U_terminal, M_init, time_idx=problem.Nt - 1, dt=0.025)
+        assert np.isfinite(U_step).all()
+
+    def test_2d_reflect_bc_no_extrapolation(self):
+        """Issue #1054: high-curvature U near walls must not produce NaN under no-flux."""
+        problem, grid, m0 = self._make_2d_problem()
+        solver = HJBSemiLagrangianSolver(
+            problem, diffusion_method="stochastic",
+            interpolation_method="linear", check_cfl=False,
+        )
+        # Stress-test: bowl U_T peaking near walls — Brownian feet would otherwise
+        # extrapolate (silent fill_value=None) and produce nonsense values.
+        Nx = grid.Nx_points[0]
+        U_terminal = np.fromfunction(
+            lambda i, j: ((i / (Nx - 1) - 0.5) ** 2 + (j / (Nx - 1) - 0.5) ** 2),
+            (Nx, Nx),
+        ).astype(float)
+        M_init = m0(np.stack(np.meshgrid(*grid.coordinates, indexing="ij"), axis=-1))
+        U_step = solver._stochastic_sl_step_nd(U_terminal, M_init, time_idx=problem.Nt - 1, dt=0.025)
+        assert np.isfinite(U_step).all()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary

Companion to PR #1051. Applies the analogous trio of correctness fixes to `_stochastic_sl_step_nd`:

| 1D fix | nD analog |
|---|---|
| #1033: `CubicSpline` → `PchipInterpolator` | RGI `method="cubic"` → `method="pchip"` |
| #1048: `np.clip` → iterated mirror reflection | extrapolation → per-axis reflect/wrap |
| #1049: `linear+stochastic` accepted | (carries through; nD never had the gate) |

Plus a perf cleanup: previous code rebuilt `RegularGridInterpolator` per `_interpolate_value` call (2·d·N_total times per step). Now builds it once and batch-interpolates the full departure array.

Closes #1054. Out of scope: dim-agnostic unification (#1050).

## Test plan

- [x] 3 new tests in `TestStochasticCharacteristicSL_nD`:
  - `test_2d_linear_stochastic_finite` — linear+stochastic 2D no-flux
  - `test_2d_cubic_stochastic_uses_pchip` — cubic→PCHIP routing finite
  - `test_2d_reflect_bc_no_extrapolation` — high-curvature U near walls, no NaN
- [x] All 41 existing SL tests still pass (`pytest tests/unit/test_alg/test_hjb_semi_lagrangian.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)