### PR TITLE
fix(fp_particle): enforce_obstacle_boundary skips outer-bbox violations (#1064)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`enforce_obstacle_boundary` no longer captures particles past the outer
+  bounding box** (Issue #1064). When `FPParticleSolver` is configured with
+  both `implicit_domain` (for obstacle reflection) and a `BoundaryConditions`
+  containing a Dirichlet (absorbing) segment on the outer boundary,
+  `enforce_obstacle_boundary` was projecting **all** particles outside the
+  navigable region back inside — including those that had crossed the
+  Dirichlet exit segment. The segment-aware BC then never saw them, so
+  `total_absorbed` stayed at 0 and absorbing exits were silently disabled.
+
+  The fix discriminates by bounding-box membership: only particles **inside
+  the outer bbox** but in an obstacle interior get re-projected. Particles
+  **past the outer bbox** are an outer-boundary concern and are left for
+  the caller's segment-aware BC (which handles reflect / absorb / wrap per
+  segment). Composes correctly with #1042 (callable-drift segment-aware
+  routing).
+
 - **`HJBSemiLagrangianSolver._stochastic_sl_step_nd` companion fixes**
   (Issue #1054): apply the analogous trio of correctness fixes to the nD
   stochastic SL path:

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle_bc.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle_bc.py
@@ -299,8 +299,19 @@ def enforce_obstacle_boundary(
     Enforce obstacle boundaries via implicit domain geometry (dimension-agnostic).
 
     If an implicit domain with obstacles is defined, particles that have
-    entered obstacle regions (domain.contains() returns False) are projected
-    back to the valid domain using domain.project_to_domain().
+    entered obstacle regions (domain.contains() returns False AND inside outer
+    bbox) are projected back to the valid domain using domain.project_to_domain().
+
+    Issue #1064: particles past the outer bounding box are NOT projected here —
+    they are an outer-boundary concern handled by the caller's
+    BoundaryConditions (segment-aware reflect/absorb/wrap). Re-projecting
+    outer-boundary violations preempts segment-aware Dirichlet absorption.
+
+    The discriminator:
+    - inside bbox + ~contains  →  obstacle interior  →  project here
+    - outside bbox + ~contains →  outer-boundary    →  leave for outer BC
+    - outside bbox + contains  →  impossible (contains implies inside bbox)
+    - inside bbox + contains   →  navigable region  →  no-op
 
     Parameters
     ----------
@@ -332,17 +343,27 @@ def enforce_obstacle_boundary(
     if is_1d_flat:
         particles = particles[:, np.newaxis]
 
-    # Check which particles are outside the valid domain (inside obstacles)
+    # Check which particles are outside the valid domain (inside obstacles
+    # OR past the outer boundary).
     inside_valid = implicit_domain.contains(particles)
 
     # Handle scalar return (single particle case)
     if np.isscalar(inside_valid):
         inside_valid = np.array([inside_valid])
 
-    # Project invalid particles back to domain
+    # Issue #1064: discriminate obstacle-interior violations (we project) from
+    # outer-boundary violations (caller's segment-aware BC handles these).
     if not np.all(inside_valid):
-        outside_indices = np.where(~inside_valid)[0]
-        particles[outside_indices] = implicit_domain.project_to_domain(particles[outside_indices])
+        bounds = implicit_domain.get_bounding_box()  # shape (d, 2)
+        in_bbox = np.all(
+            (particles >= bounds[:, 0]) & (particles <= bounds[:, 1]),
+            axis=1,
+        )
+        # Project only particles inside the outer bbox but in an obstacle.
+        in_obstacle = in_bbox & (~inside_valid)
+        if np.any(in_obstacle):
+            obs_idx = np.where(in_obstacle)[0]
+            particles[obs_idx] = implicit_domain.project_to_domain(particles[obs_idx])
 
     # Convert back to 1D if input was 1D
     if is_1d_flat:

--- a/tests/unit/test_alg/test_fp_particle_solver.py
+++ b/tests/unit/test_alg/test_fp_particle_solver.py
@@ -776,5 +776,69 @@ class TestFPParticleSolverCallableDrift:
         assert np.all(M >= -1e-10)
 
 
+class TestEnforceObstacleBoundary:
+    """Issue #1064: enforce_obstacle_boundary must respect outer-boundary
+    handling — only project obstacle-interior violations, leave outer-boundary
+    violations for the caller's segment-aware BC."""
+
+    def _make_diff_domain(self):
+        """Box [0,1]² minus circular obstacle, off-center to avoid degenerate projection."""
+        from mfgarchon.geometry.implicit import (
+            DifferenceDomain, Hyperrectangle, Hypersphere,
+        )
+        box = Hyperrectangle(np.array([[0.0, 1.0], [0.0, 1.0]]))
+        # Obstacle off bbox center so project_to_domain has a non-degenerate direction
+        obstacle = Hypersphere(center=np.array([0.3, 0.5]), radius=0.15)
+        return DifferenceDomain(box, obstacle)
+
+    def test_obstacle_interior_projected(self):
+        """Particle inside obstacle is projected back to navigable region."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        domain = self._make_diff_domain()
+        particles = np.array([[0.3, 0.5]])  # obstacle center
+        result = enforce_obstacle_boundary(particles.copy(), domain)
+        assert not np.allclose(result, particles), \
+            "Particle inside obstacle should have been projected out"
+        assert domain.contains(result).all()
+
+    def test_outer_bbox_violation_left_alone(self):
+        """Issue #1064: Particle past outer bbox is NOT touched — caller's BC handles it."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        domain = self._make_diff_domain()
+        particles = np.array([[1.5, 0.5]])  # past right wall x=1.5 > bbox max 1.0
+        result = enforce_obstacle_boundary(particles.copy(), domain)
+        np.testing.assert_array_equal(result, particles)
+
+    def test_navigable_particles_untouched(self):
+        """Particles in navigable region are unchanged."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        domain = self._make_diff_domain()
+        particles = np.array([[0.1, 0.1], [0.9, 0.5], [0.3, 0.7]])
+        result = enforce_obstacle_boundary(particles.copy(), domain)
+        np.testing.assert_array_equal(result, particles)
+
+    def test_mixed_obstacle_and_outer_violations(self):
+        """Mix: one in obstacle (project), one past bbox (leave), one valid (untouched)."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        domain = self._make_diff_domain()
+        particles = np.array([
+            [0.3, 0.5],   # inside obstacle → should be projected
+            [1.5, 0.5],   # past right wall → should be left alone (Issue #1064)
+            [0.1, 0.1],   # navigable → untouched
+        ])
+        result = enforce_obstacle_boundary(particles.copy(), domain)
+        assert not np.allclose(result[0], particles[0])
+        assert domain.contains(result[0:1]).all()
+        np.testing.assert_array_equal(result[1], particles[1])
+        np.testing.assert_array_equal(result[2], particles[2])
+
+    def test_none_implicit_domain_passthrough(self):
+        """No implicit_domain → no-op."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        particles = np.array([[10.0, 10.0]])
+        result = enforce_obstacle_boundary(particles.copy(), None)
+        np.testing.assert_array_equal(result, particles)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary

`enforce_obstacle_boundary` was capturing particles that crossed the outer domain boundary (including Dirichlet exit segments) and re-projecting them into the navigable region, **silently disabling absorbing exits** when used with `implicit_domain=DifferenceDomain(box, obstacle)`.

Closes #1064.

## Root cause

For `DifferenceDomain(box, obstacle)`, `.contains()` returns False for two distinct violations:
- Particle past outer box boundary (Dirichlet exit, NO_FLUX wall, etc.)
- Particle inside an obstacle

Both were being re-projected. Segment-aware BC (which runs *after* `_enforce_obstacle_boundary` in the FP step loop) never saw the first class.

## Fix

Discriminate by bounding-box membership. Only project particles **inside the outer bbox** but in an obstacle interior. Particles **past the outer bbox** are outer-boundary concerns left for segment-aware BC.

| Particle | `~inside_valid` | `inside_bbox` | Old | New |
|---|---|---|---|---|
| Crossed Dirichlet exit | True | False | Re-projected | **Left for segment BC** → absorbed ✓ |
| Crossed NO_FLUX wall | True | False | Re-projected | **Left for segment BC** → reflected ✓ |
| Inside obstacle | True | True | Re-projected | Re-projected ✓ (unchanged) |
| In navigable | False | True | Untouched | Untouched ✓ |

## Test plan

- [x] 5 new tests in `TestEnforceObstacleBoundary` covering each quadrant
- [x] All 46 existing `test_fp_particle_solver` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)