### PR TITLE
fix(coupling): Picard NaN/Inf diagnostic identifies HJB vs FP source (#1078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Same trap pattern as Issue #811 (`MFGProblem(diffusion=...)` vs
   `sigma=`); cross-references same docstring at `core/mfg_problem.py:1306-1317`.
-
+- **Picard NaN/Inf diagnostic now identifies HJB vs FP source** (Issue #1078).
+  Previously `fixed_point_iterator.py:804` (Issue #688 fix) emitted a generic
+  "NaN/Inf detected" warning when terminating early on non-finite iterates,
+  with no indication of which side blew up. Now examines `U_new` / `M_new`
+  (still in scope from earlier in the loop iteration) and labels the source
+  as `HJB (Newton divergence)`, `FP (density blow-up)`, `both`, or
+  `post-damping (likely Anderson acceleration)`. Five-line change, no new
+  control flow.
 - **`enforce_obstacle_boundary` no longer captures particles past the outer
   bounding box** (Issue #1064). When `FPParticleSolver` is configured with
   both `implicit_domain` (for obstacle reflection) and a `BoundaryConditions`

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -801,11 +801,23 @@ class FixedPointIterator(BaseCouplingIterator):
                     measure_field.add_snapshot(mu_k, self.U.copy())
 
                 # Issue #688: Early termination on NaN/Inf (runtime safety)
+                # Issue #1078: identify HJB vs FP source for triage
                 if not np.all(np.isfinite(self.U)) or not np.all(np.isfinite(self.M)):
+                    hjb_bad = not np.all(np.isfinite(U_new))
+                    fp_bad = not np.all(np.isfinite(M_new))
+                    if hjb_bad and not fp_bad:
+                        source = "HJB (Newton divergence)"
+                    elif fp_bad and not hjb_bad:
+                        source = "FP (density blow-up)"
+                    elif hjb_bad and fp_bad:
+                        source = "both HJB and FP"
+                    else:
+                        source = "post-damping (likely Anderson acceleration)"
                     convergence_reason = "diverged_nan"
                     logger.warning(
-                        "NaN/Inf detected in iteration %d. Terminating early.",
+                        "NaN/Inf detected in iteration %d (source: %s). Terminating early.",
                         iiter + 1,
+                        source,
                     )
                     self.iterations_run = iiter + 1
                     break


### PR DESCRIPTION
Closes #1078. 5-line addition to existing line-804 NaN check (Issue #688) that examines `U_new` / `M_new` to label the source as HJB / FP / both / post-damping. No new control flow.