### PR TITLE
fix(gfdm,sampling): np.linalg.inv() → np.linalg.solve() in 2 hot paths (#1066)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and returns the bounds list when at least one segment is `NO_FLUX` /
   `REFLECTING` / `NEUMANN`. Per-axis disambiguation is deferred until BC
   framework exposes segment→axis mapping.- **`enforce_obstacle_boundary` no longer captures particles past the outer
-  bounding box** (Issue #1064). When `FPParticleSolver` is configured with
+- **`np.linalg.inv()` → `np.linalg.solve()` in 2 hot paths** (Issue #1066,
+  partial — neighborhood_builder cache deferred). `joint_socp.py:193`
+  computed `ATA_inv` then matmul'd with `e_grad[d]` in a Python loop;
+  now uses a single `solve(ATA, [e_lap|e_grad].T)` (kills Python loop +
+  squares fewer condition numbers). `sampling.py:736` Mahalanobis used
+  `inv(cov)` (silently wrong for cond > 1e10); now uses `solve(cov, ...)`
+  + `einsum`. Third site `neighborhood_builder.py:744` deferred
+  (long-lived cache needs `lu_factor`/`lu_solve`).- **`enforce_obstacle_boundary` no longer captures particles past the outer  bounding box** (Issue #1064). When `FPParticleSolver` is configured with
   both `implicit_domain` (for obstacle reflection) and a `BoundaryConditions`
   containing a Dirichlet (absorbing) segment on the outer boundary,
   `enforce_obstacle_boundary` was projecting **all** particles outside the

--- a/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
+++ b/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
@@ -190,11 +190,14 @@ def solve_joint_socp_at_stencil(
         try:
             W_diag = np.diag(np.asarray(wendland_w, dtype=float))
             ATA = A.T @ W_diag @ A
-            ATA_inv = np.linalg.inv(ATA)
-            L_lsq = W_diag @ A @ ATA_inv @ e_lap
-            D_lsq = np.zeros((dimension, n))
-            for d in range(dimension):
-                D_lsq[d] = W_diag @ A @ ATA_inv @ e_grad[d]
+            # Issue #1066: use solve() instead of inv() — squares condition number
+            # and would silently break SOCP feasibility on marginal stencils.
+            # Solve once for [e_lap, e_grad[0], ..., e_grad[d-1]] as columns.
+            rhs = np.column_stack([e_lap, *e_grad])  # shape (k, 1+dimension)
+            sol = np.linalg.solve(ATA, rhs)          # shape (k, 1+dimension)
+            WA = W_diag @ A
+            L_lsq = WA @ sol[:, 0]
+            D_lsq = (WA @ sol[:, 1:]).T              # shape (dimension, n)
 
             # Check feasibility
             L_off = np.delete(L_lsq, center_idx)

--- a/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
+++ b/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
@@ -194,10 +194,10 @@ def solve_joint_socp_at_stencil(
             # and would silently break SOCP feasibility on marginal stencils.
             # Solve once for [e_lap, e_grad[0], ..., e_grad[d-1]] as columns.
             rhs = np.column_stack([e_lap, *e_grad])  # shape (k, 1+dimension)
-            sol = np.linalg.solve(ATA, rhs)          # shape (k, 1+dimension)
+            sol = np.linalg.solve(ATA, rhs)  # shape (k, 1+dimension)
             WA = W_diag @ A
             L_lsq = WA @ sol[:, 0]
-            D_lsq = (WA @ sol[:, 1:]).T              # shape (dimension, n)
+            D_lsq = (WA @ sol[:, 1:]).T  # shape (dimension, n)
 
             # Check feasibility
             L_off = np.delete(L_lsq, center_idx)

--- a/mfgarchon/utils/numerical/particle/sampling.py
+++ b/mfgarchon/utils/numerical/particle/sampling.py
@@ -731,9 +731,13 @@ def integrate_gaussian_quadrature_mc(
     domain = list(zip(lower_bounds.tolist(), upper_bounds.tolist(), strict=True))
 
     # Gaussian importance function
+    # Issue #1066: use solve() not inv() — for high-dim cov with cond > 1e10,
+    # inv()-based Mahalanobis silently returns wrong values. solve() is stable.
     def gaussian_importance(x):
         diff = x - mean
-        return np.exp(-0.5 * np.sum(diff @ np.linalg.inv(cov) * diff, axis=1))
+        # cov is symmetric → diff @ cov^{-1} = solve(cov, diff.T).T
+        sol = np.linalg.solve(cov, diff.T).T
+        return np.exp(-0.5 * np.einsum("ij,ij->i", sol, diff))
 
     config = MCConfig(num_samples=num_samples, sampling_method="importance", importance_function=gaussian_importance)
 


### PR DESCRIPTION
Closes #1066 (partial). Two of three sites fixed:\n\n- `joint_socp.py:193`: `solve(ATA, [e_lap|e_grad].T)` replaces `inv(ATA)` + per-d Python loop\n- `sampling.py:736`: Mahalanobis via `solve(cov, diff.T).T` + einsum\n\nThird site (`neighborhood_builder.py:744` long-lived cache) deferred — needs lu_factor/lu_solve refactor to preserve cache pattern.