### PR TITLE
fix(tensor_grid): validate Nx_points >= 1 + finite/ordered bounds (#1077 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `inv(cov)` (silently wrong for cond > 1e10); now uses `solve(cov, ...)`
   + `einsum`. Third site `neighborhood_builder.py:744` deferred
   (long-lived cache needs `lu_factor`/`lu_solve`).- **`enforce_obstacle_boundary` no longer captures particles past the outer  bounding box** (Issue #1064). When `FPParticleSolver` is configured with
-  both `implicit_domain` (for obstacle reflection) and a `BoundaryConditions`
+- **`TensorProductGrid` validates `Nx_points >= 1` + finite/ordered bounds**
+  (Issue #1077, partial). `Nx_points=[10, 0, 5]` and `bounds=[[1, 0]]` (lo > hi)
+  now raise `ValueError`. N=1 (single-point grid, zero spacing) preserved.
+  Other input-validation cases in #1077 deferred.- **`enforce_obstacle_boundary` no longer captures particles past the outer  bounding box** (Issue #1064). When `FPParticleSolver` is configured with  both `implicit_domain` (for obstacle reflection) and a `BoundaryConditions`
   containing a Dirichlet (absorbing) segment on the outer boundary,
   `enforce_obstacle_boundary` was projecting **all** particles outside the
   navigable region back inside — including those that had crossed the

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -251,8 +251,7 @@ class TensorProductGrid(
         for i, n in enumerate(self._Nx_points):
             if n < 1:
                 raise ValueError(
-                    f"Nx_points[{i}] = {n} requires N >= 1 grid points per axis. "
-                    f"Got Nx_points = {self._Nx_points}."
+                    f"Nx_points[{i}] = {n} requires N >= 1 grid points per axis. Got Nx_points = {self._Nx_points}."
                 )
 
         # Issue #1077: validate bounds (lo < hi, finite). Inverted or infinite bounds
@@ -264,9 +263,7 @@ class TensorProductGrid(
                     f"Inverted/degenerate bounds produce negative grid spacing."
                 )
             if not (np.isfinite(lo) and np.isfinite(hi)):
-                raise ValueError(
-                    f"bounds[{i}] = ({lo}, {hi}) must be finite."
-                )
+                raise ValueError(f"bounds[{i}] = ({lo}, {hi}) must be finite.")
 
         self._dimension = dimension
         self.bounds = list(bounds)

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -245,6 +245,29 @@ class TensorProductGrid(
         if len(self._Nx_points) != dimension:
             raise ValueError(f"Nx/Nx_points must have length {dimension} (matching bounds), got {len(self._Nx_points)}")
 
+        # Issue #1077: validate Nx_points[i] >= 1 — N=0 makes np.linspace(...,0) empty
+        # array; downstream silently breaks. N=1 is supported (single-point grid with
+        # zero spacing — see test_single_point_grid).
+        for i, n in enumerate(self._Nx_points):
+            if n < 1:
+                raise ValueError(
+                    f"Nx_points[{i}] = {n} requires N >= 1 grid points per axis. "
+                    f"Got Nx_points = {self._Nx_points}."
+                )
+
+        # Issue #1077: validate bounds (lo < hi, finite). Inverted or infinite bounds
+        # produce descending linspace / NaN propagation downstream.
+        for i, (lo, hi) in enumerate(bounds):
+            if not (lo < hi):
+                raise ValueError(
+                    f"bounds[{i}] = ({lo}, {hi}) requires lo < hi. "
+                    f"Inverted/degenerate bounds produce negative grid spacing."
+                )
+            if not (np.isfinite(lo) and np.isfinite(hi)):
+                raise ValueError(
+                    f"bounds[{i}] = ({lo}, {hi}) must be finite."
+                )
+
         self._dimension = dimension
         self.bounds = list(bounds)
         self.spacing_type = spacing_type


### PR DESCRIPTION
Closes #1077 (partial). `Nx_points=[10, 0, 5]` and `bounds=[[1, 0]]` now raise `ValueError` with diagnostic. N=1 (single-point) preserved per existing `test_single_point_grid`. Other input-validation cases in #1077 (sigma=0, Hypersphere(radius=inf), DifferenceDomain empty intersection) deferred.