### PR TITLE
refactor(jax_backend): JIT cache uses None-init pattern (#1068 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (bowl). This is opposite to standard MFG literature where V is "cost to
   avoid"; mfgarchon's convention is reward, agents concentrate at V_max.
 
+### Changed
+
+- **`JAXBackend` JIT cache uses explicit None-init pattern** (Issue #1068, partial).
+  Replaced 4 `hasattr(self, "_jit_*")` duck-typing checks with explicit
+  `is None` initialization in `__init__`. Per CLAUDE.md "Object Shape
+  Stability". Other #1068 hasattr clusters (core/mfg_components, types/protocols)
+  deferred — those need Protocol/ABC design.
+
 ### Fixed
 
 - **`HJBGFDMSolver` diffusion-term arithmetic in `scheme="none"` path**

--- a/mfgarchon/backends/jax_backend.py
+++ b/mfgarchon/backends/jax_backend.py
@@ -7,6 +7,7 @@ and JIT compilation.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -68,10 +69,10 @@ class JAXBackend(BaseBackend):
         # Issue #1068: explicit None-init for JIT cache slots — replaces hasattr
         # duck-typing per CLAUDE.md "Object Shape Stability". Also helps Numba/JAX
         # static analyzers track the Optional[Callable] type.
-        self._jit_hjb_step: "Callable | None" = None
-        self._jit_fpk_step: "Callable | None" = None
-        self._jit_hamiltonian: "Callable | None" = None
-        self._jit_optimal_control: "Callable | None" = None
+        self._jit_hjb_step: Callable | None = None
+        self._jit_fpk_step: Callable | None = None
+        self._jit_hamiltonian: Callable | None = None
+        self._jit_optimal_control: Callable | None = None
         super().__init__(device=device, precision=precision, **kwargs)
 
     def _setup_backend(self):

--- a/mfgarchon/backends/jax_backend.py
+++ b/mfgarchon/backends/jax_backend.py
@@ -65,6 +65,13 @@ class JAXBackend(BaseBackend):
             )
 
         self.jit_compile = jit_compile
+        # Issue #1068: explicit None-init for JIT cache slots — replaces hasattr
+        # duck-typing per CLAUDE.md "Object Shape Stability". Also helps Numba/JAX
+        # static analyzers track the Optional[Callable] type.
+        self._jit_hjb_step: "Callable | None" = None
+        self._jit_fpk_step: "Callable | None" = None
+        self._jit_hamiltonian: "Callable | None" = None
+        self._jit_optimal_control: "Callable | None" = None
         super().__init__(device=device, precision=precision, **kwargs)
 
     def _setup_backend(self):
@@ -191,13 +198,13 @@ class JAXBackend(BaseBackend):
         return -p
 
     def compute_hamiltonian(self, x, p, m, problem_params):
-        if self.jit_compile and hasattr(self, "_jit_hamiltonian"):
+        if self.jit_compile and self._jit_hamiltonian is not None:
             return self._jit_hamiltonian(x, p, m, problem_params)
         else:
             return self._hamiltonian_impl(x, p, m, problem_params)
 
     def compute_optimal_control(self, x, p, m, problem_params):
-        if self.jit_compile and hasattr(self, "_jit_optimal_control"):
+        if self.jit_compile and self._jit_optimal_control is not None:
             return self._jit_optimal_control(x, p, m, problem_params)
         else:
             return self._optimal_control_impl(x, p, m, problem_params)
@@ -261,14 +268,14 @@ class JAXBackend(BaseBackend):
 
     def hjb_step(self, U, M, dt, dx, problem_params):
         x_grid = problem_params.get("x_grid", jnp.linspace(0, 1, len(U)))
-        if self.jit_compile and hasattr(self, "_jit_hjb_step"):
+        if self.jit_compile and self._jit_hjb_step is not None:
             return self._jit_hjb_step(U, M, dt, dx, x_grid, problem_params)
         else:
             return self._hjb_step_impl(U, M, dt, dx, x_grid, problem_params)
 
     def fpk_step(self, M, U, dt, dx, problem_params):
         x_grid = problem_params.get("x_grid", jnp.linspace(0, 1, len(M)))
-        if self.jit_compile and hasattr(self, "_jit_fpk_step"):
+        if self.jit_compile and self._jit_fpk_step is not None:
             return self._jit_fpk_step(M, U, dt, dx, x_grid, problem_params)
         else:
             return self._fpk_step_impl(M, U, dt, dx, x_grid, problem_params)


### PR DESCRIPTION
Closes #1068 partially (jax_backend cluster). 4 `hasattr(self, '_jit_*')` checks replaced with explicit `Callable | None = None` init in `__init__` + `is None` checks at use sites. Per CLAUDE.md "Object Shape Stability". Other hasattr clusters in #1068 (core/mfg_components, types/protocols) deferred — need Protocol/ABC design.