### PR TITLE
fix(coupling): warn on HJB-FP volatility mismatch (#1082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HJB-FP volatility consistency check in `FixedPointIterator`** (Issue #1082).
+  Warns when `volatility_field=X` is passed AND `problem.sigma=Y` with
+  `X != Y` (scalar case). HJB sees Y, FP sees X — Picard fixed point not
+  a coherent MFG. Same trap pattern as #811. Silent for callable / matched.
+
 - **Empirical per-stencil M-matrix verification tests for joint_socp**
   (Issue #1074, partial). New `tests/unit/test_alg/test_socp_m_matrix_property.py`
   verifies the 4 stencil-level invariants the paper claim depends on, across

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -154,6 +154,35 @@ class FixedPointIterator(BaseCouplingIterator):
         self.volatility_field = volatility_field
         self.drift_field = drift_field
 
+        # Issue #1082: warn on HJB-FP volatility mismatch when both are scalars.
+        # If user passes `volatility_field=X` here AND `problem.sigma=Y` with
+        # X != Y, HJB sees Y and FP sees X — Picard fixed point corresponds
+        # to neither original nor (X, Y)-augmented MFG. Same trap pattern as
+        # Issue #811 (`MFGProblem.diffusion` vs `.sigma`). For non-scalar /
+        # callable cases, can't compare cheaply — silently allow (research
+        # code with augmented diffusion intentionally desyncs these).
+        problem_sigma = getattr(problem, "sigma", None)
+        if (
+            volatility_field is not None
+            and problem_sigma is not None
+            and isinstance(volatility_field, (int, float))
+            and isinstance(problem_sigma, (int, float))
+            and abs(float(volatility_field) - float(problem_sigma)) > 1e-12
+        ):
+            import warnings as _warnings
+
+            _warnings.warn(
+                f"FixedPointIterator: volatility_field={volatility_field} differs "
+                f"from problem.sigma={problem_sigma}. HJB will use problem.sigma, "
+                f"FP will use volatility_field. The Picard fixed point may "
+                f"correspond to neither the original nor the augmented MFG. "
+                f"For LLF/regularization-augmented FP, suppress this warning "
+                f"intentionally; for unintentional desync, set both to the "
+                f"same scalar.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Anderson acceleration support
         self.use_anderson = use_anderson
         self.anderson_accelerator = None

--- a/tests/unit/test_alg/test_fixed_point_sigma_consistency.py
+++ b/tests/unit/test_alg/test_fixed_point_sigma_consistency.py
@@ -1,0 +1,103 @@
+"""Issue #1082: FixedPointIterator warns on HJB-FP volatility mismatch.
+
+When user passes `volatility_field=X` to FixedPointIterator AND
+`problem.sigma=Y` with `X != Y`, HJB sees Y, FP sees X. Picard fixed point
+corresponds to neither the original nor a coherent augmented MFG. Same
+trap pattern as Issue #811.
+
+This validates that the warning fires for scalar mismatch (the simplest
+case) and stays silent for non-scalar / callable / matched cases.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from mfgarchon.alg.numerical.coupling import FixedPointIterator
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+
+
+def _make_problem(sigma=0.3):
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(Nx=11, xmin=0.0, xmax=1.0, T=0.2, Nt=5, sigma=sigma, components=components)
+
+
+def test_warns_on_scalar_mismatch():
+    """Issue #1082: scalar volatility_field != problem.sigma warns."""
+    problem = _make_problem(sigma=0.3)
+    hjb = HJBFDMSolver(problem)
+    fp = FPFDMSolver(problem)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        FixedPointIterator(problem, hjb, fp, volatility_field=0.5)  # mismatch!
+        sigma_warns = [x for x in w if "volatility_field" in str(x.message)]
+
+    assert len(sigma_warns) == 1, f"expected 1 mismatch warning, got {len(sigma_warns)}"
+    assert "0.5" in str(sigma_warns[0].message)
+    assert "0.3" in str(sigma_warns[0].message)
+
+
+def test_silent_when_matched():
+    """No warning when volatility_field equals problem.sigma."""
+    problem = _make_problem(sigma=0.3)
+    hjb = HJBFDMSolver(problem)
+    fp = FPFDMSolver(problem)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        FixedPointIterator(problem, hjb, fp, volatility_field=0.3)
+        sigma_warns = [x for x in w if "volatility_field" in str(x.message)]
+
+    assert len(sigma_warns) == 0
+
+
+def test_silent_when_volatility_field_none():
+    """No warning when volatility_field is None (default — uses problem.sigma)."""
+    problem = _make_problem(sigma=0.3)
+    hjb = HJBFDMSolver(problem)
+    fp = FPFDMSolver(problem)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        FixedPointIterator(problem, hjb, fp, volatility_field=None)
+        sigma_warns = [x for x in w if "volatility_field" in str(x.message)]
+
+    assert len(sigma_warns) == 0
+
+
+def test_silent_when_callable():
+    """No warning when volatility_field is a callable (intentional override,
+    e.g., LLF augmentation). User opting in to non-scalar volatility."""
+    problem = _make_problem(sigma=0.3)
+    hjb = HJBFDMSolver(problem)
+    fp = FPFDMSolver(problem)
+
+    callable_vol = lambda t, x, m: 0.5
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        FixedPointIterator(problem, hjb, fp, volatility_field=callable_vol)
+        sigma_warns = [x for x in w if "volatility_field" in str(x.message)]
+
+    # Callable case: silent (LLF / regularization is the intended use)
+    assert len(sigma_warns) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Closes #1082. `FixedPointIterator` now warns when `volatility_field=X` is passed AND `problem.sigma=Y` with `X != Y` (scalar case only). HJB uses Y, FP uses X → Picard fixed point doesn't correspond to a coherent MFG. Same trap pattern as #811. Silent for callable volatility (intentional LLF/regularization override) and for matched scalars. 4 new tests pass.