### PR TITLE
refactor: silent-skip → raise in BC boundary_handler degenerate paths

### DIFF
--- a/mfgarchon/alg/numerical/gfdm_components/boundary_handler.py
+++ b/mfgarchon/alg/numerical/gfdm_components/boundary_handler.py
@@ -349,7 +349,16 @@ class BoundaryHandler:
         for i in self.boundary_indices:
             weights_data = self._gfdm_operator.get_derivative_weights(i)
             if weights_data is None:
-                continue
+                raise ValueError(
+                    f"build_neumann_bc_weights: operator returned None for "
+                    f"boundary point {int(i)} at "
+                    f"{self.collocation_points[int(i)].tolist()}. Cannot enforce "
+                    f"Neumann BC without derivative weights. Likely degenerate "
+                    f"stencil (collocation generator gave a point with no "
+                    f"valid neighbors) or operator construction failure. "
+                    f"Silent skip would leave this point with no BC; raising "
+                    f"per #547 / Issue #1113."
+                )
 
             neighbor_indices = weights_data["neighbor_indices"]
             grad_weights = weights_data["grad_weights"]  # shape: (d, n_neighbors)
@@ -497,9 +506,21 @@ class BoundaryHandler:
         for i in boundary_set:
             normal = self.compute_outward_normal(i)
 
-            # Skip if normal is zero
+            # Defense: zero normal means BC classifier returned no face for
+            # this point. After PR #1097 + #1111 this should never happen
+            # (closed-inequality tolerance + face-derived ±1 normal). Raise
+            # rather than silent-skip per #547 policy (Issue #1113): a
+            # silent-skipped LCR point falls back to plain (non-rotated)
+            # Taylor LSQ, which may degrade boundary-stencil conditioning
+            # in ways that aren't visible until Newton convergence fails.
             if np.linalg.norm(normal) < 1e-10:
-                continue
+                raise ValueError(
+                    f"apply_local_coordinate_rotation: zero outward normal at "
+                    f"boundary point {int(i)} ({self.collocation_points[int(i)].tolist()}). "
+                    f"Indicates BC classifier failure — point not assigned to "
+                    f"any face. Check tolerance settings and BoundaryConditions "
+                    f"segment coverage. Raising per #547 / Issue #1113."
+                )
 
             # Build rotation matrix
             R = self.build_rotation_matrix(normal)
@@ -618,7 +639,25 @@ class BoundaryHandler:
         interior_indices = neighbor_indices[interior_mask]
 
         if len(interior_points) == 0:
-            return np.zeros((0, self.dimension)), np.array([]), np.array([])
+            # No neighbor lies strictly inside the half-space defined by the
+            # outward normal — geometric edge case (e.g. degenerate one-sided
+            # stencil where every neighbor sits along the wall plane). Cannot
+            # build reflection ghosts. Raising rather than returning empty
+            # per #547 / Issue #1113: silent zero-ghost return would let the
+            # broader ghost augmentation continue with no ghost neighbors for
+            # this point, indistinguishable from a successfully ghosted point
+            # at the call site.
+            raise ValueError(
+                f"create_ghost_neighbors: no interior-side neighbor at "
+                f"boundary point {int(point_idx)} "
+                f"({self.collocation_points[int(point_idx)].tolist()}); "
+                f"normal={normal.tolist()}. Stencil has {len(neighbor_indices)} "
+                f"neighbors but all lie on the boundary plane "
+                f"(offsets @ normal >= -1e-10). Cannot build reflection "
+                f"ghosts. Likely an extremely degenerate collocation; "
+                f"consider densifying interior near this boundary. Raising "
+                f"per #547 / Issue #1113."
+            )
 
         # Create ghost points by reflection (delegated to geometry utility)
         ghost_points = create_reflection_ghost_points(center, interior_points, normal)
@@ -701,13 +740,13 @@ class BoundaryHandler:
             neighbor_points = neighborhood["points"]
             neighbor_indices = neighborhood["indices"]
 
-            # Create ghost neighbors
+            # Create ghost neighbors. After the silent-skip → raise sweep
+            # (#1113), create_ghost_neighbors raises on the empty-interior
+            # geometric edge case rather than returning empty arrays.
+            # Reaching here always yields a non-empty ghost set.
             ghost_points, ghost_indices, mirror_indices = self.create_ghost_neighbors(
                 i, neighbor_points, neighbor_indices
             )
-
-            if len(ghost_points) == 0:
-                continue
 
             # Augment neighborhood
             augmented_points = np.vstack([neighbor_points, ghost_points])

--- a/tests/unit/test_alg/test_ghost_nodes_mixed_bc.py
+++ b/tests/unit/test_alg/test_ghost_nodes_mixed_bc.py
@@ -344,30 +344,41 @@ def test_apply_ghost_nodes_legacy_uniform_neumann_still_works():
         dimension=2,
         default_bc=BCType.NO_FLUX,
     )
+    # Build realistic neighborhoods (each boundary point has nearby interior
+    # neighbors), so create_ghost_neighbors can actually reflect them.
+    from scipy.spatial import cKDTree
+
+    tree = cKDTree(pts)
+    _, idxs = tree.query(pts, k=8)
+    neighborhoods = {
+        int(i): {
+            "indices": idxs[int(i)],
+            "points": pts[idxs[int(i)]],
+            "distances": np.linalg.norm(pts[idxs[int(i)]] - pts[int(i)], axis=1),
+            "size": len(idxs[int(i)]),
+        }
+        for i in range(len(pts))
+    }
     handler = BoundaryHandler(
         collocation_points=pts,
         dimension=2,
         domain_bounds=np.array([[0.0, LX], [0.0, LY]]),
         boundary_indices=bdry_idx,
-        neighborhoods={
-            int(i): {
-                "indices": np.array([int(i)]),
-                "points": pts[int(i) : int(i) + 1],
-                "distances": np.zeros(1),
-                "size": 1,
-            }
-            for i in bdry_idx
-        },
+        neighborhoods=neighborhoods,
         boundary_conditions=bc,
         use_ghost_nodes=True,
         use_wind_dependent_bc=False,
         gfdm_operator=None,
         bc_property_getter=lambda prop, default=None: "no_flux" if prop == "type" else default,
     )
-    # Legacy call with no bc_type_for_point — should still work via the
-    # bc_property_getter returning "no_flux"
+    # Legacy call with no bc_type_for_point — falls back to the bc_property_
+    # getter returning "no_flux" globally. Realistic neighborhood lets the
+    # reflection proceed without hitting the post-#1113 raise for empty
+    # interior-side neighbors.
     handler.apply_ghost_nodes_to_neighborhoods()
-    # With only single self-neighbor per point, no interior-side points exist
-    # to reflect; expect zero ghosts but no crash. The contract being tested
-    # is "function runs without early-exit on mixed-BC global check".
-    assert True  # reached without exception
+    n_ghosted = sum(
+        1
+        for i in bdry_idx
+        if handler.neighborhoods[int(i)].get("has_ghost", False)
+    )
+    assert n_ghosted > 0, "Legacy uniform-NEUMANN call must trigger ghost augmentation"


### PR DESCRIPTION
Fixes #1113

## Summary

Three defensive ``continue``/return-empty paths in ``BoundaryHandler`` converted to explicit ``raise ValueError`` per #547 'no silent fallbacks' policy. Surfaced by the PR #1111 audit when fixing upstream tolerance bugs: the silent skips were the proximate mechanism by which the tolerance bug silently disabled LCR / ghost / Neumann weights for 37/175 boundary points on stageC v3.

## Sites changed

1. ``build_neumann_bc_weights:351`` — ``weights_data is None`` → raise
2. ``apply_local_coordinate_rotation:501`` — ``norm(normal) < 1e-10`` → raise
3. ``create_ghost_neighbors:620`` — ``len(interior_points) == 0`` → raise

Companion: ``apply_ghost_nodes_to_neighborhoods:748`` ``len(ghost_points)
== 0: continue`` removed (unreachable post-raise).

## Sites intentionally NOT changed

- ``_build_derivative_matrices:1519`` (interior points may legitimately
  return None; would break setups silently tolerating per-point degeneracy
  — separate audit)
- ``build_rotation_matrix:448, 450`` (already-aligned fast-path, not silent
  fallback)
- ``create_bc_config:309`` (documented contract: caller checks None)

## Test changes

One existing test (``test_apply_ghost_nodes_legacy_uniform_neumann_still_works``)
relied on silent-skip behavior under deliberately-degenerate self-
neighbor cloud. Updated to use realistic k-NN neighborhoods so the
reflection actually generates ghosts, and changed ``assert True`` to a
positive ``has_ghost=True`` check.

## CI / regression

- 88 passed, 2 skipped on ghost / bc / joint_socp / mixed_bc / integration
  filter.
- No new bug surface; this PR catches regressions earlier instead of
  letting them masquerade as silent feature inactivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)