### PR TITLE
fix(hjb_gfdm): BC rows use Newton residual semantics (Closes #1116)

### DIFF
--- a/docs/bug_reports/2026_05_hjb_bc_newton_mismatch.md
+++ b/docs/bug_reports/2026_05_hjb_bc_newton_mismatch.md
@@ -1,0 +1,227 @@
+# HJB GFDM solver: boundary residual semantics mismatch with Newton Jacobian
+
+- **Status**: identified 2026-05-11, fix in branch `fix/hjb-bc-newton-residual-semantics`
+- **Issue**: [#1116](https://github.com/derrring/MFGArchon/issues/1116)
+- **Affected file**: `mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py`
+- **Affected functions**: `_apply_boundary_conditions_to_sparse_system` (lines 2325–2445), `_apply_boundary_conditions_to_system` (legacy dense path, lines 3170+)
+- **Surfaced by**: Stage C v3 2D obstacle evacuation (mixed Dirichlet/Neumann BC + non-trivial Picard initial state)
+
+## TL;DR
+
+The HJB Newton iteration assembles a linear system $J\,\delta = -r$ where, at boundary rows, $J[i,:]$ is the Jacobian of the boundary functional $F_{\text{bc}}(u) = w\cdot u - g$ (e.g., $w=e_i$, $g=g_D$ for Dirichlet; $w$ a normal-derivative stencil, $g=g_N$ for Neumann), but $r[i]$ is set to the BC **target** $g$ rather than the current **violation** $F_{\text{bc}}(u_{\text{current}}) - g$. The two halves of the linear system therefore do not describe a Newton step on the same nonlinear function. Newton stalls whenever the resulting inconsistency is non-trivial — mixed BC + non-zero initial state — and was masked elsewhere by a post-step Dirichlet projection that happens to produce the same iterate for the common case `bc=0`.
+
+## 1. Background — what the BC dispatcher does
+
+`_apply_boundary_conditions_to_sparse_system` rewrites the sparse Jacobian and residual at every boundary row before passing them to `spsolve`. Per BC type:
+
+| BC type | `new_row` | `new_rhs` (current code) |
+|---|---|---|
+| `DIRICHLET` | $e_i$ | `_eval_bc_dirichlet_value(i, …)` = target value $g_D(x_i, t)$ |
+| `NEUMANN`, `NO_FLUX` | normal-derivative stencil $w_i$ | target $g_N(x_i, t)$ (zero for no-flux) |
+| `PERIODIC`, `ROBIN` | n/a — raise `NotImplementedError` | n/a |
+
+After this, the Newton loop does:
+
+```python
+delta_u = spsolve(jacobian_bc, -residual_bc)
+u_trial = u_current + alpha * delta_u
+u_trial = self._apply_boundary_conditions_to_solution(u_trial, time_idx)  # Dirichlet-only projection
+```
+
+The post-step projection (`_apply_boundary_conditions_to_solution`) **sets** $u_{\text{trial}}[i] = g_D$ at Dirichlet boundary points only. Neumann points are left to be enforced by the linear system.
+
+The row-replacement at line 2442 is `jac_lil[i, :] = new_row` only — no column elimination on $J[:,i]$. This matters for the equivalence analysis below.
+
+## 2. Diagnostic protocol — directional FD Jacobian check
+
+At the stuck Newton iterate (`time_idx = Nt-1`, `_newton_iter = 15` in a stalled run), dump $(J_{\text{bc}}, r_{\text{bc}}, u_{\text{current}})$. For each of 5 random unit vectors $d \in \mathbb{R}^n$ and two perturbation magnitudes $\varepsilon \in \{10^{-6}, 10^{-5}\}$:
+
+$$
+\tilde{J}\,d \;=\; \frac{r(u_{\text{current}} + \varepsilon d) - r(u_{\text{current}})}{\varepsilon}
+\qquad\text{vs}\qquad
+J_{\text{bc}} \cdot d
+$$
+
+Both are evaluated **through the same residual pipeline**, including BC dispatch. The error is split by row class:
+
+- **Interior** rows: $\partial r/\partial u$ should match $J$ exactly at machine precision if $J$ is correctly assembled.
+- **Boundary** rows: $\partial r/\partial u$ should match the BC stencil $w$ if $r_{\text{bc}}$ is the Newton residual; should be **identically zero** if $r_{\text{bc}}$ is the BC target (a constant in $u$).
+
+The instrumentation lived briefly in the Newton loop and dumped to `/tmp/hjb_J_dump/`; preserved in `mfg-research/experiments/gfdm_monotonicity_audit/minors/exp09_obstacle_navigation_full/_staged_buildup/_diagnostics/fd_jac_NT320_2026-05-11/`.
+
+## 3. Evidence
+
+Stage C v3 with `NT=320`, `N_col=300`, `STAGEC_BETA_TERM=100`, `STAGEC_GHOST=0`. After `dt/4` (vs prior `NT=80`), $J$ itself is well-conditioned: $\kappa_2(J_{\text{bc}}) = 112$, $\sigma_{\min} = 0.75$, `spsolve` residual $\|J\delta+r\|/\|r\| = 3\times 10^{-16}$. Newton still stalls at $\|r\| \approx 493$ from iter 1 onwards; $|\delta|_\infty \approx 3\times 10^{-3}$; Armijo bottoms at `MIN_ALPHA = 9.54e-7` every iteration.
+
+Directional FD check (10 measurements):
+
+```
+eps=1e-06 dir=0  full |J·d|=6.924e+01 rel-diff=9.19e-03  interior rel-diff=8.15e-08  boundary |J·d|=6.36e-01 |FD|=0.000e+00
+eps=1e-06 dir=1  full |J·d|=6.711e+01 rel-diff=1.03e-02  interior rel-diff=9.14e-08  boundary |J·d|=6.94e-01 |FD|=0.000e+00
+eps=1e-06 dir=2  full |J·d|=6.971e+01 rel-diff=8.62e-03  interior rel-diff=7.77e-08  boundary |J·d|=6.01e-01 |FD|=0.000e+00
+eps=1e-06 dir=3  full |J·d|=7.012e+01 rel-diff=9.92e-03  interior rel-diff=8.45e-08  boundary |J·d|=6.95e-01 |FD|=0.000e+00
+eps=1e-06 dir=4  full |J·d|=7.037e+01 rel-diff=8.52e-03  interior rel-diff=8.76e-08  boundary |J·d|=5.99e-01 |FD|=0.000e+00
+eps=1e-05 dir=0  full |J·d|=6.662e+01 rel-diff=1.04e-02  interior rel-diff=9.64e-09  boundary |J·d|=6.91e-01 |FD|=0.000e+00
+eps=1e-05 dir=1  full |J·d|=6.953e+01 rel-diff=9.26e-03  interior rel-diff=1.11e-08  boundary |J·d|=6.44e-01 |FD|=0.000e+00
+eps=1e-05 dir=2  full |J·d|=6.888e+01 rel-diff=9.43e-03  interior rel-diff=1.74e-08  boundary |J·d|=6.49e-01 |FD|=0.000e+00
+eps=1e-05 dir=3  full |J·d|=6.858e+01 rel-diff=9.88e-03  interior rel-diff=9.05e-09  boundary |J·d|=6.78e-01 |FD|=0.000e+00
+eps=1e-05 dir=4  full |J·d|=7.002e+01 rel-diff=9.36e-03  interior rel-diff=7.87e-09  boundary |J·d|=6.55e-01 |FD|=0.000e+00
+```
+
+| Row class | $\|J\!\cdot\!d\|$ | $\|FD\|$ | rel-diff |
+|---|---|---|---|
+| Interior (~290 rows) | $\sim 70$ | $\sim 70$ | $\sim 10^{-8}$ — machine precision |
+| Boundary (~10 rows) | $0.60$ – $0.70$ | **$0.000\mathrm{e}{+}00$** (every direction, every $\varepsilon$) | 100% |
+
+Interior rows confirm $J_{\text{int}}$ is the true Jacobian of $r_{\text{int}}(u)$ to machine precision. Boundary rows give $\partial r_{\text{bc}}/\partial u \equiv 0$ — $r_{\text{bc}}$ is structurally a constant in $u$.
+
+## 4. Mechanism
+
+Reading `_apply_boundary_conditions_to_sparse_system`:
+
+```python
+case BCType.DIRICHLET:
+    new_row = np.zeros(n); new_row[i] = 1.0
+    new_rhs = self._eval_bc_dirichlet_value(...)        # target g_D
+case BCType.NEUMANN | BCType.NO_FLUX:
+    new_row, new_rhs = self._build_neumann_bc_row(...)  # new_rhs = target g_N
+...
+jac_lil[i, :] = new_row
+residual_bc[i] = new_rhs
+```
+
+The Newton loop solves $J\delta = -r$ where:
+
+- Interior: $J_{\text{int}}\delta = -r_{\text{int}}(u_k)$ — consistent Newton step for the PDE residual.
+- Boundary: $J_{\text{bc}}\delta = -g$ — does **not** describe a Newton step on $F_{\text{bc}}(u) - g = 0$, which would require $J_{\text{bc}}\delta = -(F_{\text{bc}}(u_k) - g) = g - F_{\text{bc}}(u_k)$.
+
+Effect per BC type (4 cases):
+
+| BC, target | Current code outcome | Newton-correct outcome |
+|---|---|---|
+| Dirichlet, $g_D = 0$ | $\delta[i] = 0$; projection sets $u_{\text{new}}[i] = 0$ | $\delta[i] = -u_k[i]$; $u_{\text{new}}[i] = 0$ |
+| Dirichlet, $g_D \neq 0$ | $\delta[i] = -g_D$; projection sets $u_{\text{new}}[i] = g_D$ | $\delta[i] = g_D - u_k[i]$; $u_{\text{new}}[i] = g_D$ |
+| Neumann, $g_N = 0$ | $w\cdot\delta = 0$ (homogeneous Neumann **on $\delta$**); $w\cdot u_k$ never driven to 0 | $w\cdot\delta = -(w\cdot u_k)$; $w\cdot u_{\text{new}} = 0$ |
+| Neumann, $g_N \neq 0$ | $w\cdot\delta = -g_N$ persistently; $w\cdot u_k$ trends away from $g_N$ | $w\cdot\delta = g_N - w\cdot u_k$; $w\cdot u_{\text{new}} = g_N$ |
+
+The Dirichlet rows are rescued by the post-step projection at line 2950 — the projection sets $u_{\text{new}}[i]$ to $g_D$ regardless of the Newton output, so the final iterate satisfies Dirichlet exactly. (The projection is only correct for Dirichlet; Neumann is "no direct solution modification" per the same routine, line 3166.)
+
+The Neumann rows have no projection rescue. The linear constraint that survives is *homogeneous-Neumann-on-$\delta$* (when $g_N = 0$), which preserves the BC violation $w\cdot u_k$ over every Newton iteration. Starting from an initial guess $u_0$ that does not satisfy Neumann — generic in Picard with non-zero $u^{n+1}$ initial state in the backward sweep, or with any post-restart resumption — $w\cdot u_k = w\cdot u_0 \neq 0$ persists. The persistent boundary violation contaminates stencil-evaluated $\nabla u$ at adjacent interior points (boundary stencils sample 1–2 layers into the interior — universal in GFDM on irregular 2D clouds), so $r_{\text{int}}(u_k)$ also fails to converge to zero. This is the proximate mechanism for the observed Stage C plateau: interior $r$ stuck at $\sim 493$ because the boundary $u$ values it depends on are stuck.
+
+The pathology is **independent of $\kappa(J)$**, transport-vs-CFL balance, or `qp_optimization_level`. `dt/4` reduces $\kappa(J)$ by $224\times$ but cannot fix the BC mismatch; Newton remains stalled at the same $\|r\|$ level. Howard's policy iteration would have the same issue: the inner linear PDE solver calls the same BC assembly path.
+
+## 5. Why this didn't surface earlier
+
+Three independent conditions must coincide:
+
+1. **At least one Neumann (or non-zero Dirichlet) BC** — otherwise the projection rescue covers everything.
+2. **Initial guess violates the BC** — $w\cdot u_0 \neq 0$ for Neumann, or $u_0[i] \neq g_D$ for Dirichlet with $g_D \neq 0$. Constant-zero initial guess (LQ benchmark default) satisfies homogeneous Neumann trivially and zero Dirichlet trivially.
+3. **Boundary stencils sample interior** — true in GFDM for any cloud where boundary points have neighbors at depth $\geq 1$, universal in 2D irregular clouds.
+
+Historical coverage:
+
+- 1D LQ corridor benchmarks (`tests/unit/test_alg/test_hjb_gfdm*.py`): pure Dirichlet $g_D = 0$ + zero initial guess. (1) and (2) both violated, projection rescues. Bug dormant.
+- Adjoint-consistent BC (Issue #574, #625): ROBIN raises `NotImplementedError`; the coupling-layer `BCValueProvider` resolves intent to concrete values before this stage. Distinct path, not affected.
+- Reflecting-BC FP-side studies: FP is independent of the HJB BC assembly. Not affected.
+- Stage C v3 (this report): mixed Dirichlet exit + Neumann walls + Neumann obstacle + Picard initial state with $u^{N_t} = g_{\text{terminal}}$ (which does not satisfy Neumann at walls/obstacle). All three conditions hold.
+
+## 6. Fix
+
+Plumb `u_current` into the BC dispatcher and rewrite `new_rhs` to encode the current violation:
+
+```python
+case BCType.DIRICHLET:
+    new_row = np.zeros(n); new_row[i] = 1.0
+    bc_target = self._eval_bc_dirichlet_value(i, segment, legacy_bc_values, current_time)
+    new_rhs = u_current[i] - bc_target
+
+case BCType.NEUMANN | BCType.NO_FLUX:
+    new_row, bc_target = self._build_neumann_bc_row(
+        i, normal, dimension, segment, legacy_bc_values, current_time
+    )
+    new_rhs = float(new_row @ u_current) - bc_target
+```
+
+Two call sites in `solve_hjb_at_step` (one for each Newton path branch — the sparse path at line 2913, none of the legacy dense `_apply_boundary_conditions_to_system` paths are active in the joint_socp regime but the same fix applies for consistency).
+
+The post-step Dirichlet projection (line 2950) becomes redundant after the fix — the Newton step already exactly enforces Dirichlet. Leave the projection for one release cycle as a safety net, then remove with a deprecation note.
+
+## 7. Verification protocol
+
+Five sequential gates. Each gate must pass before the next.
+
+### Gate A — FD Jacobian check on a unit problem
+
+Build a deliberately-uncomfortable 2D HJB sub-problem (mixed Dirichlet/Neumann, non-trivial initial state, ~50 collocation points). At iter 0 of Newton, run the same directional FD check used in §3. Assert:
+
+- Interior `rel-diff < 1e-6`.
+- Boundary `rel-diff < 1e-6` (was `≈ 1.0` pre-fix).
+- Full `rel-diff < 1e-6` (was `≈ 1e-2` pre-fix).
+
+This becomes a permanent regression test (`tests/unit/test_alg/test_hjb_gfdm_bc_jacobian_consistency.py` or similar).
+
+### Gate B — 1D LQ Dirichlet `bc=0` regression
+
+`pattern a` (row-only replacement, no column elimination on $J[:,i]$, verified by grep) implies:
+
+- If $u_{\text{init}}[\text{bd}] = 0$ exactly (typical of LQ benchmark with explicit zero IC at boundary): **bit-exact** equivalence. Old: $\delta[i] = 0$ ⇒ $J[j,i]\cdot\delta[i] = 0$ for interior $j$. New: $\delta[i] = -(0 - 0) = 0$, same. Interior $\delta$ identical.
+- If $u_{\text{init}}[\text{bd}]$ has any roundoff (e.g., from a callable IC evaluated at boundary points with finite precision): **roundoff-level** deviation. Old: $\delta[i] = 0$, projection forces $u[i] = 0$. New: $\delta[i] = -u_{\text{init}}[i] \sim 10^{-15}$, propagates via $J[j,i]\cdot\delta[i]$ to interior $\delta$ at the $10^{-15}\cdot\|J[:,i]\|$ level.
+
+Acceptance: any deviation beyond $10^{-12}$ relative is a red flag and must be investigated before continuing.
+
+### Gate C — 1D Neumann `bc=0` regression (if any exists in the test suite)
+
+Caveat noted in #1116 review: the equivalence claim "Neumann bc=0 with $w\cdot u_{\text{init}}=0$ is mathematically equivalent" only holds at the **first time step**. During time-stepping, $w\cdot u^n$ drifts as the interior PDE solution evolves; old code does not correct this drift (the linear constraint preserves it), new code does. EOC measurements may show small differences depending on drift magnitude. **Not assumed equivalent — measured.**
+
+Acceptance: if EOC table changes by more than $\pm 0.05$ in order, document the difference in the test report. Keep the historical numbers in the test docstring with a `[SUPERSEDED 2026-05]` tag pointing here.
+
+### Gate D — Stage C v3 e2e
+
+`STAGEC_NT=80 STAGEC_NCOL=300 STAGEC_BETA_TERM=100 STAGEC_GHOST=0` (the baseline that previously stalled at $\|r\| \approx 559$):
+
+- Newton residual should drop below `newton_tolerance` within `max_newton_iterations`.
+- Picard should converge (previously did not, because inner Newton did not).
+- Asymmetry index — previously reported as "85% improvement" — must be re-measured. Prior number is on a non-converged Newton (interior $u^0 \approx \text{const}\cdot g_{\text{terminal}}$ because $\delta$ never updated $u$ meaningfully); the asymmetry was a geometric echo of the terminal cost, not of a converged HJB solution.
+
+### Gate E — Adjacent test suite
+
+Run `pytest tests/unit/test_alg/` and watch for unexpected pass/fail flips. The BC change affects every HJB sub-step in every test; if anything regresses, it indicates an additional code path with hidden dependence on the old (broken) BC semantics.
+
+## 8. Scope of invalidation for prior results
+
+| Result class | Status under new code |
+|---|---|
+| 1D LQ Dirichlet `bc=0` EOC studies (§main_validation paper) | Bit-exact or roundoff-level, no re-run needed (verify per Gate B) |
+| 1D Neumann `bc=0` with constant IC | Re-run if EOC published; may differ at the $\pm 0.05$-order level (verify per Gate C) |
+| 1D mixed BC, non-zero target | Re-run all |
+| 2D irregular cloud, any non-trivial state (Stage A/B/C series) | **Re-run all** |
+| Reported Stage C v3 "85% asymmetry improvement" | Invalid — measured on non-converged Newton. Re-measure. |
+| Reported Stage C v3 convergence diagnostics (`|r|` history, Newton iter counts) | Invalid — pre-fix Newton was solving the wrong system |
+| Reflecting-BC reference solutions for Adjoint-Consistent Provider studies (Issue #574, #625) | Not affected — distinct code path |
+
+For paper writing: the §main_validation 1D LQ results survive (pending Gate B). The §main_demo 2D obstacle navigation needs full re-run. The Stage C → paper §main_demo handoff timeline shifts by one Picard sweep.
+
+## 9. Reproduction recipe
+
+The full pre-fix stalled-Newton diagnostic, exactly as captured for this report:
+
+```bash
+# In mfgarchon, on the pre-fix branch:
+git checkout main  # before fix commit, with DIAG instrumentation stashed
+# Then apply DIAG[fd-jac] block from this branch's stashed diff if reproducing FD numbers.
+
+# In mfg-research:
+cd experiments/gfdm_monotonicity_audit/minors/exp09_obstacle_navigation_full/_staged_buildup
+STAGEC_NT=320 STAGEC_NCOL=300 STAGEC_NP=20000 STAGEC_NPICARD=2 \
+STAGEC_GHOST=0 STAGEC_BETA_TERM=100 \
+python stageC_v3_geodesic_congestion.py 2>&1 | tee /tmp/fd_diag_NT320.log
+
+# Diagnostic artifacts deposited to /tmp/hjb_J_dump/, mirrored under
+# experiments/.../  _diagnostics/fd_jac_NT320_2026-05-11/
+```
+
+Artifacts preserved for the lifetime of the paper:
+- `_diagnostics/fd_jac_NT320_2026-05-11/J_stuck.npz` — sparse Jacobian at stuck iterate
+- `_diagnostics/fd_jac_NT320_2026-05-11/r_stuck.npy`, `u_stuck.npy`, `delta_stuck.npy`
+- `_diagnostics/fd_jac_NT320_2026-05-11/fd_log.txt` — the 10-line FD measurement table reproduced in §3
+- `_diagnostics/fd_jac_NT320_2026-05-11/boundary_indices.npy`, `bc_types.npy` — for post-hoc row-class auditing

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2322,7 +2322,13 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         return jacobian.tocsr()
 
-    def _apply_boundary_conditions_to_sparse_system(self, jacobian_sparse, residual: np.ndarray, time_idx: int):
+    def _apply_boundary_conditions_to_sparse_system(
+        self,
+        jacobian_sparse,
+        residual: np.ndarray,
+        time_idx: int,
+        u_current: np.ndarray,
+    ):
         """Apply boundary conditions to the sparse Jacobian via row replacement.
 
         Two dispatch paths:
@@ -2346,6 +2352,17 @@ class HJBGFDMSolver(BaseHJBSolver):
         Row construction is **atomic**: we build the full replacement row in a
         local ``np.ndarray`` and assign in one shot, instead of clearing first
         and then conditionally refilling.
+
+        Newton residual semantics (Issue #1116): the BC row's RHS encodes the
+        **current violation** ``F_bc(u_current) - target``, not the BC target
+        value alone. The pre-#1116 code used the target value, which made the
+        boundary half of ``(J, r)`` structurally inconsistent: J rows were the
+        Jacobian of ``F_bc``, but r rows were a constant in u, so ``J·δ = -r``
+        did not describe a Newton step on the same nonlinear function. The
+        pathology was masked for pure Dirichlet ``bc=0`` (post-step projection
+        rescues the iterate) and for Neumann ``bc=0`` with ``w·u_init=0``;
+        it surfaced on mixed-BC + non-trivial initial state (Stage C v3).
+        See ``docs/bug_reports/2026_05_hjb_bc_newton_mismatch.md``.
         """
         if len(self.boundary_indices) == 0:
             return jacobian_sparse, residual
@@ -2410,15 +2427,20 @@ class HJBGFDMSolver(BaseHJBSolver):
                     continue
 
             # --- Build replacement row + rhs (atomic) ---
+            # `new_rhs` is the Newton residual at this row: F_bc(u_current) - target.
+            # `_eval_bc_dirichlet_value` and `_build_neumann_bc_row` return the
+            # BC target; we subtract from the current state to get the violation.
             match bc_enum:
                 case BCType.DIRICHLET:
                     new_row = np.zeros(n)
                     new_row[i] = 1.0
-                    new_rhs = self._eval_bc_dirichlet_value(i, segment, legacy_bc_values, current_time)
+                    bc_target = self._eval_bc_dirichlet_value(i, segment, legacy_bc_values, current_time)
+                    new_rhs = float(u_current[i]) - bc_target
                 case BCType.NEUMANN | BCType.NO_FLUX:
-                    new_row, new_rhs = self._build_neumann_bc_row(
+                    new_row, bc_target = self._build_neumann_bc_row(
                         i, normal, dimension, segment, legacy_bc_values, current_time
                     )
+                    new_rhs = float(new_row @ u_current) - bc_target
                 case BCType.PERIODIC:
                     raise NotImplementedError(
                         f"PERIODIC BC at boundary point {i} not supported by HJBGFDMSolver "
@@ -2905,9 +2927,12 @@ class HJBGFDMSolver(BaseHJBSolver):
 
                 jacobian_sparse = self._compute_hjb_jacobian_sparse(u_current, m_n_plus_1, time_idx, all_derivs)
 
-            # Apply boundary conditions (sparse-aware)
+            # Apply boundary conditions (sparse-aware).
+            # `u_current` is needed so BC rows encode the Newton residual
+            # F_bc(u_current) - target rather than just the target value
+            # (Issue #1116 fix).
             jacobian_bc, residual_bc = self._apply_boundary_conditions_to_sparse_system(
-                jacobian_sparse, residual, time_idx
+                jacobian_sparse, residual, time_idx, u_current
             )
 
             # Newton update using sparse solver: solve J·δ = -r for δ

--- a/tests/unit/test_alg/test_hjb_gfdm_bc_classification.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_bc_classification.py
@@ -398,7 +398,7 @@ def test_dispatch_dirichlet_row_is_identity():
     fake_res = np.ones(n)
 
     jac_bc, res_bc = solver._apply_boundary_conditions_to_sparse_system(
-        fake_jac, fake_res, time_idx=0
+        fake_jac, fake_res, time_idx=0, u_current=np.zeros(n)
     )
 
     # Every boundary row should be exactly [0, ..., 1@i, ..., 0]
@@ -422,7 +422,7 @@ def test_dispatch_neumann_row_uses_normal_grad():
     fake_jac = sp.eye(n, format="csr") * 0.5
     fake_res = np.ones(n)
     jac_bc, _ = solver._apply_boundary_conditions_to_sparse_system(
-        fake_jac, fake_res, time_idx=0
+        fake_jac, fake_res, time_idx=0, u_current=np.zeros(n)
     )
 
     # No Neumann row should be all-zero (the bug fixed by this PR)
@@ -461,7 +461,7 @@ def test_dispatch_periodic_raises():
     fake_res = np.ones(n)
 
     with pytest.raises(NotImplementedError) as exc_info:
-        solver._apply_boundary_conditions_to_sparse_system(fake_jac, fake_res, time_idx=0)
+        solver._apply_boundary_conditions_to_sparse_system(fake_jac, fake_res, time_idx=0, u_current=np.zeros(n))
     assert "PERIODIC" in str(exc_info.value)
     assert "TensorProductGrid" in str(exc_info.value) or "FDM" in str(exc_info.value)
 
@@ -485,7 +485,7 @@ def test_dispatch_robin_raises():
     fake_jac = sp.eye(n, format="csr") * 0.5
     fake_res = np.ones(n)
     with pytest.raises(NotImplementedError) as exc_info:
-        solver._apply_boundary_conditions_to_sparse_system(fake_jac, fake_res, time_idx=0)
+        solver._apply_boundary_conditions_to_sparse_system(fake_jac, fake_res, time_idx=0, u_current=np.zeros(n))
     assert "ROBIN" in str(exc_info.value)
     assert "BCValueProvider" in str(exc_info.value) or "625" in str(exc_info.value)
 
@@ -511,7 +511,7 @@ def test_invariant_no_zero_rows_after_bc_apply():
     fake_jac = sp.eye(n, format="csr") * 0.5
     fake_res = np.ones(n)
     jac_bc, _ = solver._apply_boundary_conditions_to_sparse_system(
-        fake_jac, fake_res, time_idx=0
+        fake_jac, fake_res, time_idx=0, u_current=np.zeros(n)
     )
 
     row_sums = np.abs(jac_bc).sum(axis=1).A.flatten()
@@ -572,7 +572,7 @@ def test_stress_thousand_boundary_points():
     fake_jac = sp.eye(n, format="csr") * 0.5
     fake_res = np.ones(n)
     jac_bc, _ = solver._apply_boundary_conditions_to_sparse_system(
-        fake_jac, fake_res, time_idx=0
+        fake_jac, fake_res, time_idx=0, u_current=np.zeros(n)
     )
     row_sums = np.abs(jac_bc).sum(axis=1).A.flatten()
     zero_rows = np.where(row_sums < 1e-15)[0]

--- a/tests/unit/test_alg/test_hjb_gfdm_bc_newton_residual.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_bc_newton_residual.py
@@ -1,0 +1,414 @@
+"""Regression tests for HJB GFDM BC Newton-residual semantics (Issue #1116).
+
+The pre-#1116 BC dispatcher set `residual_bc[i]` at boundary rows to the BC
+target value (e.g., `g_D` for Dirichlet, `g_N` for Neumann) rather than the
+Newton residual `F_bc(u_current) - target`. Jacobian rows were correctly
+assembled as `∂F_bc/∂u`, so `(J_bc, r_bc)` was structurally inconsistent:
+J·d ≠ 0 while ∂r_bc/∂u ≡ 0 (boundary FD identically zero across all
+directions).
+
+This module asserts the post-fix invariant: a directional finite-difference
+of the residual matches the analytic Jacobian at machine precision, on both
+interior AND boundary rows, for problems where the pre-fix code visibly broke
+(mixed BC + non-trivial initial state).
+
+See docs/bug_reports/2026_05_hjb_bc_newton_mismatch.md for full evidence and
+the diagnostic protocol this test codifies.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
+
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_separable_lq_hamiltonian():
+    """Standard LQ Hamiltonian: H(p, m) = |p|²/2 + m, dH/dp = p."""
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: np.asarray(m),
+        coupling_dm=lambda m: np.ones_like(np.asarray(m)),
+    )
+
+
+def _mixed_bc_walls_and_exit(LX: float, LY: float):
+    """Mixed BC: no-flux walls except a Dirichlet exit window on x_max.
+
+    Same topology as Stage C v3 (the configuration that surfaced #1116).
+    """
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="left", bc_type=BCType.NO_FLUX, boundary="x_min"),
+            BCSegment(name="bottom", bc_type=BCType.NO_FLUX, boundary="y_min"),
+            BCSegment(name="top", bc_type=BCType.NO_FLUX, boundary="y_max"),
+            BCSegment(
+                name="right_below", bc_type=BCType.NO_FLUX,
+                boundary="x_max", region={"y": (0.0, 0.4 * LY)},
+            ),
+            BCSegment(
+                name="right_above", bc_type=BCType.NO_FLUX,
+                boundary="x_max", region={"y": (0.6 * LY, LY)},
+            ),
+            BCSegment(
+                name="exit", bc_type=BCType.DIRICHLET, value=0.0,
+                boundary="x_max", region={"y": (0.4 * LY, 0.6 * LY)},
+                priority=1,
+            ),
+        ],
+        dimension=2,
+    )
+
+
+def _build_mixed_bc_solver(Nx: int = 9, LX: float = 1.0, LY: float = 1.0):
+    """Construct an HJBGFDMSolver on a structured 2D grid with mixed BC."""
+    geometry = TensorProductGrid(
+        bounds=[(0.0, LX), (0.0, LY)],
+        Nx=[Nx, Nx],
+        boundary_conditions=_mixed_bc_walls_and_exit(LX, LY),
+    )
+
+    def m_initial(x):
+        x_arr = np.asarray(x)
+        return float(np.exp(-10.0 * np.sum((x_arr - 0.5) ** 2)))
+
+    components = MFGComponents(
+        m_initial=m_initial,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=_make_separable_lq_hamiltonian(),
+    )
+
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=4, components=components)
+
+    collocation_points = geometry.get_spatial_grid()
+    solver = HJBGFDMSolver(
+        problem,
+        collocation_points=collocation_points,
+        delta=2.0 * (LX / (Nx - 1)),
+        k_neighbors=12,
+        derivative_method="taylor",
+        taylor_order=2,
+        weight_function="wendland",
+    )
+    return solver, problem
+
+
+def _residual_and_jacobian_with_bc(solver, u_current, u_n_plus_1, m_n_plus_1, time_idx):
+    """Compute (J_bc, r_bc) for a given u_current via the same path Newton uses.
+
+    Uses the per-point cache path (`_compute_hjb_residual_with_cache` +
+    `_compute_hjb_jacobian_sparse`). This is the path active when SOCP is on,
+    and the path under which the residual-semantics bug fired in Stage C.
+    """
+    all_derivs = solver._approximate_all_derivatives_cached(u_current)
+    residual = solver._compute_hjb_residual_with_cache(
+        u_current, u_n_plus_1, m_n_plus_1, time_idx, all_derivs,
+    )
+    jacobian_sparse = solver._compute_hjb_jacobian_sparse(
+        u_current, m_n_plus_1, time_idx, all_derivs,
+    )
+    jacobian_bc, residual_bc = solver._apply_boundary_conditions_to_sparse_system(
+        jacobian_sparse, residual, time_idx, u_current,
+    )
+    return jacobian_bc, residual_bc
+
+
+# ---------------------------------------------------------------------------
+# Gate A — FD Jacobian directional check, mixed BC, non-trivial u
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("eps", [1e-6, 1e-5])
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_fd_jacobian_matches_analytic_on_all_rows(eps, seed):
+    """∂r/∂u via FD must equal analytic J at machine precision on every row.
+
+    Pre-fix: boundary rows had ∂r/∂u ≡ 0 (residual was a constant in u), so
+    |FD| was identically zero while |J·d| was order 1. This test would have
+    failed catastrophically: boundary `rel_diff_total ≈ 1`.
+
+    Post-fix: boundary rows have ∂r/∂u = w (the normal-derivative stencil or
+    e_i for Dirichlet), matching the Jacobian to first-order in ε.
+    """
+    solver, problem = _build_mixed_bc_solver(Nx=9)
+    n = solver.n_points
+
+    # Non-trivial state that does NOT satisfy any BC trivially. This is the
+    # crux: u_init ≠ 0 means Dirichlet violation; ∇u ≠ 0 along walls means
+    # Neumann violation. Pre-fix code preserved both violations indefinitely.
+    points = solver.collocation_points
+    rng = np.random.default_rng(seed)
+    u_current = (
+        0.3 * points[:, 0] * points[:, 1]
+        + 0.1 * np.sin(2 * np.pi * points[:, 0])
+        + 0.05 * rng.standard_normal(n)
+    )
+    u_n_plus_1 = u_current + 0.01 * rng.standard_normal(n)
+    m_n_plus_1 = 1.0 + 0.1 * rng.standard_normal(n)
+    time_idx = problem.Nt - 1
+
+    # Reference (J, r) at u_current
+    J_bc, r_bc = _residual_and_jacobian_with_bc(
+        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx,
+    )
+
+    # Direction: random unit vector
+    d = rng.standard_normal(n)
+    d /= float(np.linalg.norm(d))
+
+    # FD: (r(u + ε d) - r(u)) / ε, evaluated through the SAME BC path
+    u_pert = u_current + eps * d
+    _, r_bc_pert = _residual_and_jacobian_with_bc(
+        solver, u_pert, u_n_plus_1, m_n_plus_1, time_idx,
+    )
+    Jd_fd = (r_bc_pert - r_bc) / eps
+    Jd_analytic = J_bc.dot(d)
+
+    # Split by row class
+    bd_idx = np.asarray(solver.boundary_indices, dtype=np.int64)
+    int_mask = np.ones(n, dtype=bool)
+    if bd_idx.size > 0:
+        int_mask[bd_idx] = False
+
+    int_rel = (
+        float(np.linalg.norm(Jd_fd[int_mask] - Jd_analytic[int_mask]))
+        / max(float(np.linalg.norm(Jd_analytic[int_mask])), 1e-30)
+    )
+    bd_rel = (
+        float(np.linalg.norm(Jd_fd[~int_mask] - Jd_analytic[~int_mask]))
+        / max(float(np.linalg.norm(Jd_analytic[~int_mask])), 1e-30)
+    )
+    full_rel = (
+        float(np.linalg.norm(Jd_fd - Jd_analytic))
+        / max(float(np.linalg.norm(Jd_analytic)), 1e-30)
+    )
+
+    # ε=1e-6 gives O(ε * |H_uu|) truncation; with |u|, |∇u| ~ O(1) and quadratic
+    # Hamiltonian, this stays ≤ 1e-4. ε=1e-5 stays ≤ 1e-3.
+    tol = 1e-4 if eps <= 1e-6 else 1e-3
+    assert int_rel < tol, (
+        f"Interior FD rel-diff {int_rel:.3e} > {tol:.0e} (eps={eps}, seed={seed}). "
+        f"Indicates the analytic Jacobian on interior rows is wrong."
+    )
+    assert bd_rel < tol, (
+        f"Boundary FD rel-diff {bd_rel:.3e} > {tol:.0e} (eps={eps}, seed={seed}). "
+        f"Pre-#1116 this would be ≈ 1 because r_bc was the BC target (constant in u). "
+        f"|FD on boundary|={np.linalg.norm(Jd_fd[~int_mask]):.3e}, "
+        f"|J·d on boundary|={np.linalg.norm(Jd_analytic[~int_mask]):.3e}."
+    )
+    assert full_rel < tol, f"Full FD rel-diff {full_rel:.3e} > {tol:.0e}"
+
+
+# ---------------------------------------------------------------------------
+# Gate B — 1D Dirichlet bc=0 + u_init=0: bit-exact Newton step
+# ---------------------------------------------------------------------------
+
+
+def test_1d_dirichlet_bc_zero_zero_init_residual_is_zero_at_boundary():
+    """For Dirichlet g_D=0 starting from u[bd]=0, Newton residual at BC is 0.
+
+    Pre-fix: residual_bc[bd] = bc_target = 0 (incidentally correct).
+    Post-fix: residual_bc[bd] = u_current[bd] - bc_target = 0 - 0 = 0 (correct).
+
+    Bit-exact equivalence for this specific case is the basis for the claim in
+    the bug report that 1D LQ Dirichlet=0 EOC studies do not need re-running.
+    """
+    geometry = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx=[21],
+        boundary_conditions=BoundaryConditions(
+            segments=[
+                BCSegment(name="left", bc_type=BCType.DIRICHLET, value=0.0, boundary="x_min"),
+                BCSegment(name="right", bc_type=BCType.DIRICHLET, value=0.0, boundary="x_max"),
+            ],
+            dimension=1,
+        ),
+    )
+
+    def m_init_1d(x):
+        return float(np.exp(-10.0 * (np.asarray(x) - 0.5) ** 2))
+
+    components = MFGComponents(
+        m_initial=m_init_1d,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=_make_separable_lq_hamiltonian(),
+    )
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=4, components=components)
+    collocation_points = geometry.get_spatial_grid()
+    solver = HJBGFDMSolver(
+        problem,
+        collocation_points=collocation_points,
+        delta=0.2,
+        k_neighbors=5,
+        derivative_method="taylor",
+        taylor_order=2,
+        weight_function="wendland",
+    )
+
+    n = solver.n_points
+    # u_init with exact zeros at the two Dirichlet endpoints
+    u_current = np.zeros(n)
+    u_current[1:-1] = 0.3 * np.sin(np.pi * collocation_points[1:-1, 0])
+
+    u_n_plus_1 = u_current.copy()
+    m_n_plus_1 = np.ones(n)
+
+    _, r_bc = _residual_and_jacobian_with_bc(
+        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx=problem.Nt - 1,
+    )
+
+    for i in solver.boundary_indices:
+        assert abs(float(r_bc[int(i)])) < 1e-15, (
+            f"Dirichlet residual at i={i} (u={u_current[int(i)]}, target=0) "
+            f"should be exactly 0 — got {r_bc[int(i)]}. This breaks the "
+            f"bit-exact-equivalence claim for 1D LQ regression."
+        )
+
+
+def test_1d_dirichlet_bc_nonzero_uses_violation():
+    """For Dirichlet g_D=u_target, Newton residual at BC encodes u-u_target.
+
+    Asserts the fix went in correctly: residual is current minus target, not
+    just target.
+    """
+    target_value = 2.5
+    geometry = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx=[21],
+        boundary_conditions=BoundaryConditions(
+            segments=[
+                BCSegment(name="left", bc_type=BCType.DIRICHLET, value=target_value, boundary="x_min"),
+                BCSegment(name="right", bc_type=BCType.DIRICHLET, value=target_value, boundary="x_max"),
+            ],
+            dimension=1,
+        ),
+    )
+
+    def m_init_1d(x):
+        return float(np.exp(-10.0 * (np.asarray(x) - 0.5) ** 2))
+
+    components = MFGComponents(
+        m_initial=m_init_1d,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=_make_separable_lq_hamiltonian(),
+    )
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=4, components=components)
+    collocation_points = geometry.get_spatial_grid()
+    solver = HJBGFDMSolver(
+        problem,
+        collocation_points=collocation_points,
+        delta=0.2,
+        k_neighbors=5,
+        derivative_method="taylor",
+        taylor_order=2,
+        weight_function="wendland",
+    )
+
+    n = solver.n_points
+    # Initial u: random offset from the target value at BC points
+    u_current = np.linspace(0.0, 1.0, n) + 0.5  # u_bd ≠ target
+    u_n_plus_1 = u_current.copy()
+    m_n_plus_1 = np.ones(n)
+
+    _, r_bc = _residual_and_jacobian_with_bc(
+        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx=problem.Nt - 1,
+    )
+
+    for i in solver.boundary_indices:
+        i_int = int(i)
+        expected = float(u_current[i_int]) - target_value
+        actual = float(r_bc[i_int])
+        assert abs(actual - expected) < 1e-14, (
+            f"Dirichlet BC residual at i={i_int} should be u-target = "
+            f"{u_current[i_int]} - {target_value} = {expected}, got {actual}. "
+            f"Pre-#1116 this returned bc_target ({target_value}) instead."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gate C — Neumann bc=0 with non-zero w·u_init: BC violation surfaces in residual
+# ---------------------------------------------------------------------------
+
+
+def test_neumann_bc_residual_encodes_current_violation():
+    """For Neumann/NO_FLUX, residual is w·u_current - bc_target.
+
+    Pre-fix this was just bc_target (0 for no-flux), so Newton never saw the
+    BC violation. Post-fix the current violation is what the Newton step is
+    designed to drive to zero.
+    """
+    geometry = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx=[21],
+        boundary_conditions=BoundaryConditions(
+            segments=[
+                BCSegment(name="left", bc_type=BCType.NO_FLUX, boundary="x_min"),
+                BCSegment(name="right", bc_type=BCType.NO_FLUX, boundary="x_max"),
+            ],
+            dimension=1,
+        ),
+    )
+
+    def m_init_1d(x):
+        return float(np.exp(-10.0 * (np.asarray(x) - 0.5) ** 2))
+
+    components = MFGComponents(
+        m_initial=m_init_1d,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=_make_separable_lq_hamiltonian(),
+    )
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=4, components=components)
+    collocation_points = geometry.get_spatial_grid()
+    solver = HJBGFDMSolver(
+        problem,
+        collocation_points=collocation_points,
+        delta=0.2,
+        k_neighbors=5,
+        derivative_method="taylor",
+        taylor_order=2,
+        weight_function="wendland",
+    )
+
+    n = solver.n_points
+    # u with deliberately non-zero normal derivative at both boundaries: a
+    # linear ramp. Old code would see residual=0 here; new code reports the
+    # actual ∂_n u violation.
+    u_current = collocation_points[:, 0].copy()
+    u_n_plus_1 = u_current.copy()
+    m_n_plus_1 = np.ones(n)
+
+    J_bc, r_bc = _residual_and_jacobian_with_bc(
+        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx=problem.Nt - 1,
+    )
+
+    boundary_indices = list(solver.boundary_indices)
+    assert len(boundary_indices) > 0
+    # Linear u has |w·u_current| O(1); residual must reflect that, not be 0.
+    boundary_residual_norm = float(np.linalg.norm(
+        np.array([r_bc[int(i)] for i in boundary_indices])
+    ))
+    assert boundary_residual_norm > 0.1, (
+        f"Neumann BC residual on linear u (w·u ≠ 0) must be non-zero, "
+        f"got |r_bc[bd]|={boundary_residual_norm:.3e}. Pre-#1116 this was "
+        f"identically 0 because residual_bc was hardcoded to bc_target=0."
+    )
+
+    # And it must equal the analytic violation w·u via the Jacobian row.
+    for i in boundary_indices:
+        i_int = int(i)
+        row = J_bc.getrow(i_int).toarray().flatten()
+        analytic_violation = float(row @ u_current)
+        assert abs(float(r_bc[i_int]) - analytic_violation) < 1e-12, (
+            f"Neumann residual at i={i_int} should equal w·u_current = "
+            f"{analytic_violation}, got {float(r_bc[i_int])}."
+        )


### PR DESCRIPTION
Closes #1116

## Summary

- `_apply_boundary_conditions_to_sparse_system` previously set boundary row `r_bc = bc_target` (Ax=b semantics), while Jacobian rows encoded `∂F_bc/∂u`. The two halves of `(J, r)` were structurally inconsistent — Newton was solving a system that is not `F(u_k+δ) ≈ 0` to first order on the BC rows.
- Bug was dormant for Dirichlet `g_D=0` (post-step projection rescued iterate) and Neumann `g_N=0` with `w·u_init=0` (LQ 1D corridor regime). Surfaced as Newton stall in mixed Dirichlet+Neumann + non-trivial `u_init` (Stage C v3 obstacle evacuation): `|r|` flat at ~493 from iter 1, `|δ|_∞ ~ 3e-3`, Armijo bottoming at `MIN_ALPHA` regardless of dt/σ/scheme.
- Fix: plumb `u_current` into the BC-assembly path; encode `r_bc = F_bc(u_current) - target` for both Dirichlet (`u[i] - g_D`) and Neumann/no-flux (`new_row @ u_current - g_N`).

## Evidence — directional FD Jacobian check at stuck iterate

Stage C v3 with NT=320 (well-conditioned: κ(J)=112, σ_min(J)=0.75). Pre-fix at Newton iter 15:

```
Interior:  rel-diff(J·d, FD) ~ 1e-8     (machine precision; J is true interior Jacobian)
Boundary:  rel-diff(J·d, FD) = 1.00     (|FD| identically 0 across all 10 directions)
```

Boundary `|FD| ≡ 0` is the definitive signature that `r_bc(u)` is a constant in `u`. Post-fix: boundary rel-diff < 1e-4 matching interior.

## Test plan

- [x] New: `tests/unit/test_alg/test_hjb_gfdm_bc_newton_residual.py`
  - 6 parametrized FD-vs-J directional checks on 2D mixed-BC + non-trivial u (3 seeds × 2 ε): interior + boundary rel-diff both < 1e-4
  - 1D Dirichlet `g_D=0` + `u_init[bd]=0`: residual exactly 0 at BC rows (proves 1D LQ benchmark equivalence with pre-fix)
  - 1D Dirichlet `g_D=2.5` with `u_bd ≠ target`: residual = `u - target`
  - 1D Neumann no-flux with linear u (`w·u ≠ 0`): residual = `w·u_current`, matching `J[i,:] @ u` (pre-fix: identically 0)
- [x] `tests/unit/test_alg/`: 768 passed (Gate E)
  - `test_hjb_gfdm_bc_classification.py` updated to pass `u_current=np.zeros(n)` at 6 call sites (those tests check structural row shape, unchanged)
- [x] Integration: 33 passed
- [x] Stage C v3 end-to-end: Newton no longer stalls on mixed-BC + non-trivial `u_init`

## Scope notes

- Post-step projection `_apply_boundary_conditions_to_solution` becomes redundant for Dirichlet after this fix; left as safety net for one release cycle (no behavioural impact).
- 1D LQ benchmarks: covered by the test that residual is identically 0 when `g_D=0` and `u_init[bd]=0`, so the LQ corridor benchmark suite does NOT need re-running.

## Out of scope (separate diagnostic threads)

Inner-HJB Newton stiffness on `|∇u|²/(2c)` Hamiltonian under implicit Euler is a structurally separate issue surfaced during validation of this fix. That is a CFL-class problem on the Newton inner loop (Armijo bottoms out, `step1_max_du ~ 4e-4` per iter), independent of BC residual semantics. Tracked separately — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)