### PR TITLE
feat(hjb_howard): Howard's policy iteration inner solver (Refs #1118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`HJBHowardSolver`** — Howard's policy iteration inner solver for HJB on
+  GFDM clouds (Issue #1118). Replaces the Newton inner loop of
+  `HJBGFDMSolver._solve_timestep` when the Hamiltonian is strictly convex
+  in `p`. Resolves the temporal-plateau symptom where Armijo backtracking
+  bottoms out at `MIN_ALPHA = 1e-6` and Newton makes no net progress past
+  the first few backward steps.
+
+  Graduates the 5-fork research-side `howard_patch_*` family
+  (`mfg-research/experiments/gfdm_monotonicity_audit/minors/{exp08, exp09,
+  exp11}/`) into a single peer class to `HJBGFDMSolver`. Composition-based:
+  takes a constructed `HJBGFDMSolver` with `monotonicity_scheme="joint_socp"`
+  + `monotonicity_application="precompute"` as `stencil_provider`, plus a
+  `alpha_star(x, p, m, t) -> alpha` Legendre callable. Three discretisation
+  options: `upwind_projection` (default, projection onto α direction),
+  `upwind_per_axis` (per-axis sign-aware Dpos/Dneg pair), `central` (bare
+  central, accurate on smooth problems; not monotone for advection-dominant).
+
+  Convergence hypothesis: H strictly convex in p (Bokanowski-Maroso-Zidani
+  2009). Separability is neither necessary nor sufficient.
+
+  Reported ~57× speedup over Newton inner on irregular 2D clouds with
+  11-15% k-NN-fallback stencils (per exp09 Phase 7 readme). Eight unit
+  tests cover construction validation, 1D LQ Riccati closed-form
+  (`P(0)/P(T) = 0.5` per mfgarchon HJB convention — see
+  `mfg-research/docs/archon-notes/development/guides/NAMING_CONVENTIONS.md`
+  § HJB Equation Conventions), Newton-stall reproducer, each discretisation
+  option, and 2D integration with running-cost callable. Howard is a peer
+  to `HJBGFDMSolver`; the outer `FixedPointIterator` (Picard / fictitious
+  play) is unchanged — Howard replaces inner Newton only.
+
 - **`preserve_indices=False` flag on `FPParticleSolver`** (Issue #1119).
   When `True`, absorbed particles are NaN-marked in the per-step trajectory
   rather than compact-removed, so `particle_history[t].shape == (num_particles, d)`

--- a/mfgarchon/alg/numerical/hjb_solvers/__init__.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/__init__.py
@@ -7,6 +7,9 @@ numerical analysis approaches:
 - BaseHJBSolver: Abstract base class for all HJB solvers
 - HJBFDMSolver: Finite difference method (all dimensions: 1D, 2D, 3D, nD)
 - HJBGFDMSolver: Generalized finite difference method (meshfree, nD)
+- HJBHowardSolver: Howard's policy iteration inner solver, peer to GFDM Newton
+  inner (resolves Issue #1118 Newton stiffness; requires SOCP-precomputed
+  stencils on a stencil_provider HJBGFDMSolver)
 - HJBSemiLagrangianSolver: Semi-Lagrangian approach (characteristic-based, nD)
 - HJBWenoSolver: WENO (Weighted Essentially Non-Oscillatory) method (1D/2D/3D)
 - PenaltyHJBSolver: Variational inequality wrapper (obstacle/optimal stopping)
@@ -17,6 +20,7 @@ All solvers inherit from BaseNumericalSolver and follow the new paradigm structu
 from .base_hjb import BaseHJBSolver
 from .hjb_fdm import ConvergenceError, HJBFDMSolver
 from .hjb_gfdm import HJBGFDMSolver
+from .hjb_howard import HJBHowardSolver
 from .hjb_penalty import PenaltyHJBSolver
 from .hjb_semi_lagrangian import HJBSemiLagrangianSolver
 from .hjb_weno import HJBWenoSolver
@@ -26,6 +30,7 @@ __all__ = [
     "ConvergenceError",
     "HJBFDMSolver",
     "HJBGFDMSolver",
+    "HJBHowardSolver",
     "HJBSemiLagrangianSolver",
     "HJBWenoSolver",
     "PenaltyHJBSolver",

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
@@ -1,0 +1,513 @@
+"""Howard's policy iteration inner solver for HJB on GFDM clouds.
+
+Replaces the Newton inner loop of `HJBGFDMSolver._solve_timestep` when the
+Hamilton-Jacobi nonlinearity `H = H(x, ∇u, m)` is strictly convex in `p`.
+Resolves Issue #1118 (Newton stalls on `|∇u|²` stiffness — Armijo backtracks
+bottom out at MIN_ALPHA, temporal plateau in u_solve).
+
+Issue #1118 fix. Validated in:
+    mfg-research/experiments/gfdm_monotonicity_audit/minors/
+    {exp08_towel_2d_validation, exp09_obstacle_navigation_full,
+     exp11_fixed_vs_adaptive}/
+
+Howard delivers ~57× speedup over Newton inner on irregular 2D clouds with
+11–15% k-NN-fallback stencils (per exp09 Phase 7 readme). Five forked
+research patches converged on the same skeleton; this class is the
+graduation of that pattern.
+
+Algorithm
+---------
+For each backward time step (Nt-1 → 0):
+
+    Initial policy α⁰ ← -∇U_{n+1} (or warm-started from previous step)
+
+    For k = 0, 1, ..., MAX_ITER:
+        1. Build advection operator A_adv(α^k) — sign-aware upwind D_grad
+        2. Solve linear system:
+               (I/dt - A_adv - (σ²/2) D_lap) · U^{k+1} = U_n+1/dt + L(x, α^k, m)
+           where L is the Legendre dual of H at (x, α, m).
+        3. Update policy: α^{k+1} = arg min_α (α · ∇U^{k+1} + L(x, α, m))
+        4. If ‖α^{k+1} - α^k‖_∞ / ‖α^k‖_∞ < tol: break
+
+    U_n ← U^{k+1}
+
+Policy iteration converges globally under the Bokanowski-Maroso-Zidani 2009
+hypothesis (monotone consistent stable scheme, H strictly convex in p).
+Convex-in-p is the required hypothesis — separability is neither necessary
+nor sufficient.
+
+References
+----------
+- Bokanowski, Maroso, Zidani 2009 (J. Sci. Comput.) — global convergence
+  for monotone schemes.
+- Achdou, Capuzzo-Dolcetta 2010 (SIAM J. Numer. Anal.) — coupled (u,m)
+  Newton uses Howard as inner solver.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+from scipy.sparse import csr_matrix, diags, eye, lil_matrix
+from scipy.sparse.linalg import spsolve
+from scipy.spatial import cKDTree
+
+from mfgarchon.utils.mfg_logging import get_logger
+
+if TYPE_CHECKING:
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
+    from mfgarchon.core.mfg_problem import MFGProblem
+
+logger = get_logger(__name__)
+
+AlphaStarFn = Callable[[np.ndarray, np.ndarray, np.ndarray, int], np.ndarray]
+"""Legendre transform: alpha_star(x, p, m, t_idx) -> alpha.
+
+Given collocation points `x` (shape (n, d)), gradient `p = ∇U` (shape (n, d)),
+density `m` (shape (n,)), and time index `t_idx`, returns the optimal control
+`alpha` (shape (n, d)) that achieves `min_α (α · p + L(x, α, m, t))`.
+
+For LQ `H = |p|²/(2c) + g(x, m)`: `alpha_star(x, p, m, t) = -p/c`.
+"""
+
+RunningCostFn = Callable[[int], np.ndarray]
+"""Time-indexed running cost L(x, alpha*, m, t) at the optimal policy.
+
+`running_cost(t_idx) -> array of shape (n,)` returning the running cost
+evaluated at each collocation point at time `t_idx`. This is the
+non-quadratic-in-alpha part of the Lagrangian (potential V(x), congestion
+g(x, m), etc.) — the quadratic `(1/2)|alpha|^2` part is computed
+internally from the alpha returned by `alpha_star`.
+
+Pass None when the problem has no running cost beyond `(1/2)|alpha|^2`.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Static stencil precompute (cached on solver instance)
+# ---------------------------------------------------------------------------
+
+
+def _build_dlap_from_socp(socp_data: dict, n_total: int) -> csr_matrix:
+    """Assemble sparse Laplacian operator from SOCP-corrected stencil weights."""
+    A = lil_matrix((n_total, n_total))
+    for i, w_dict in socp_data.items():
+        nbr_idx = np.asarray(w_dict["neighbor_indices"])
+        lap_w = w_dict["lap_weights"]
+        for j_local, j_global in enumerate(nbr_idx):
+            A[i, int(j_global)] = float(lap_w[j_local])
+    return A.tocsr()
+
+
+def _build_dgrad_central(socp_data: dict, n_total: int, axis: int) -> csr_matrix:
+    """Assemble central gradient operator (single axis) from SOCP weights."""
+    A = lil_matrix((n_total, n_total))
+    for i, w_dict in socp_data.items():
+        nbr_idx = np.asarray(w_dict["neighbor_indices"])
+        grad_w = w_dict["grad_weights"]
+        grad_axis = grad_w[axis] if grad_w.ndim == 2 else grad_w
+        for j_local, j_global in enumerate(nbr_idx):
+            A[i, int(j_global)] = float(grad_axis[j_local])
+    return A.tocsr()
+
+
+def _build_per_axis_upwind_pair(
+    points: np.ndarray, socp_data: dict, n_total: int, axis: int
+) -> tuple[csr_matrix, csr_matrix]:
+    """Assemble (Dpos, Dneg) one-sided gradient operators along `axis`.
+
+    Dpos uses neighbors with `(x_j - x_i)[axis] > 0` (forward stencil).
+    Dneg uses neighbors with `(x_j - x_i)[axis] < 0` (backward stencil).
+
+    Both are weighted least-squares fits on the half-stencil. Sign-aware
+    selection (Dpos vs Dneg at each row, by sign of `alpha[axis]`) yields
+    a monotone upwind operator. From `exp08_towel_2d_validation/howard_patch_towel_upwind.py`.
+    """
+    Dpos = lil_matrix((n_total, n_total))
+    Dneg = lil_matrix((n_total, n_total))
+    for i, w_dict in socp_data.items():
+        nbr_idx = np.asarray(w_dict["neighbor_indices"])
+        rel = points[nbr_idx] - points[i]
+        proj = rel[:, axis] if rel.ndim == 2 else rel  # 1D fallback
+        # Forward half-stencil
+        pos_mask = proj > 1e-12
+        if pos_mask.sum() >= 1:
+            sel = proj[pos_mask]
+            denom = float(np.sum(sel * sel))
+            if denom > 1e-14:
+                per_w = sel / denom
+                tot = 0.0
+                for k_local, j_global in enumerate(nbr_idx[pos_mask]):
+                    if j_global == i:
+                        continue
+                    w = float(per_w[k_local])
+                    Dpos[i, int(j_global)] += w
+                    tot += w
+                Dpos[i, i] -= tot
+        # Backward half-stencil
+        neg_mask = proj < -1e-12
+        if neg_mask.sum() >= 1:
+            sel = -proj[neg_mask]  # flip to positive offsets
+            denom = float(np.sum(sel * sel))
+            if denom > 1e-14:
+                per_w = sel / denom
+                tot = 0.0
+                for k_local, j_global in enumerate(nbr_idx[neg_mask]):
+                    if j_global == i:
+                        continue
+                    w = -float(per_w[k_local])  # negate: Dneg @ u ≈ (u_i - u_left)/|Δx|
+                    Dneg[i, int(j_global)] += w
+                    tot += w
+                Dneg[i, i] -= tot
+    return Dpos.tocsr(), Dneg.tocsr()
+
+
+def _build_upwind_projection(alpha: np.ndarray, points: np.ndarray, socp_data: dict, n_total: int) -> csr_matrix:
+    """Assemble advection operator A_adv ≈ alpha · ∇ via projection onto alpha.
+
+    For each row i, select neighbors with `rel · α̂ > 0` (the upwind side
+    relative to flow direction `α̂ = α/|α|`), compute the projected
+    distance, and weight by `|α| · proj_j / Σ proj_k²`. This is the
+    canonical upwind GFDM pattern from `exp09_obstacle_navigation_full/howard_patch.py`.
+
+    Returns sparse `A_adv` such that `A_adv @ u ≈ alpha · ∇u`.
+    """
+    A = lil_matrix((n_total, n_total))
+    # points is always shape (n, d) — caller reshapes 1D to (n, 1) in
+    # `_build_static`. alpha is always shape (n, d).
+    for i, w_dict in socp_data.items():
+        a = alpha[i]  # shape (d,)
+        a_norm = float(np.linalg.norm(a))
+        if a_norm < 1e-10:
+            continue
+        d_a = a / a_norm
+        nbr_idx = np.asarray(w_dict["neighbor_indices"])
+        rel = points[nbr_idx] - points[i]  # shape (k, d)
+        proj = rel @ d_a  # shape (k,)
+        mask = proj > 0
+        if mask.sum() < 1:
+            mask = np.ones(len(nbr_idx), dtype=bool)
+        sel_proj = proj[mask]
+        sel_nbrs = nbr_idx[mask]
+        denom = float(np.sum(sel_proj * sel_proj))
+        if denom < 1e-14:
+            continue
+        per_w = sel_proj / denom
+        total_self = 0.0
+        for k_local, j_global in enumerate(sel_nbrs):
+            if j_global == i:
+                continue
+            w = a_norm * float(per_w[k_local])
+            A[i, int(j_global)] += w
+            total_self += w
+        A[i, i] -= total_self
+    return A.tocsr()
+
+
+# ---------------------------------------------------------------------------
+# HJBHowardSolver
+# ---------------------------------------------------------------------------
+
+
+class HJBHowardSolver:
+    """Howard's policy iteration inner solver for HJB on GFDM clouds.
+
+    Replaces the Newton inner loop of `HJBGFDMSolver` when the Hamiltonian
+    `H(x, p, m)` is strictly convex in `p`. Reads SOCP-corrected
+    `D_lap`/`D_grad` weights from a `stencil_provider` (constructed
+    `HJBGFDMSolver`).
+
+    Parameters
+    ----------
+    problem : MFGProblem
+        The MFG problem (used for `Nt`, `T`, `sigma`).
+    stencil_provider : HJBGFDMSolver
+        A constructed `HJBGFDMSolver` with `monotonicity_scheme='joint_socp'`
+        and `monotonicity_application='precompute'`. Howard reads
+        SOCP-corrected `D_lap`/`D_grad` from the provider's
+        `_joint_socp_stencils`. The provider's `collocation_points` and
+        boundary-segment classification (`_bc_segment_per_point`) are also
+        consumed.
+    alpha_star : Callable
+        Legendre transform: `alpha_star(x, p, m, t_idx) -> alpha`.
+        See module docstring `AlphaStarFn` type alias. For LQ
+        `H = |p|²/(2c)`, pass `lambda x, p, m, t: -p / c`. The Hamiltonian
+        must be strictly convex in `p` for policy iteration to converge
+        (Legendre uniqueness of the optimal control). Separability is
+        neither necessary nor sufficient.
+    running_cost : Callable | None
+        `running_cost(t_idx) -> array of shape (n,)` returning the
+        non-quadratic-in-alpha running cost evaluated at each collocation
+        point. Pass None when there is no running cost beyond
+        `(1/2)|alpha|^2`. The quadratic term is computed internally from
+        `alpha_star`'s output.
+    discretisation : Literal["upwind_projection", "upwind_per_axis", "central"]
+        Choice of `A_adv` assembly:
+
+        - `"upwind_projection"` (default): single-axis upwind along the
+          policy direction `α̂` (exp09 / exp11 pattern). Robust on 2D
+          irregular clouds.
+        - `"upwind_per_axis"`: per-axis sign-aware Dpos/Dneg pair, blended
+          row-by-row by sign of `α_axis` (exp08 upwind-variant pattern).
+          BS-monotone by construction.
+        - `"central"`: bare central gradient. Does NOT preserve monotonicity
+          under advection-dominant regime; included for comparison only.
+    max_iter : int
+        Maximum Howard inner iterations per backward time step.
+    tol : float
+        Relative `∞`-norm tolerance on policy change `(α^{k+1} − α^k)/α^k`.
+    volatility_field : float | np.ndarray | None
+        Override σ (constant scalar or per-point array). When None, read
+        from `problem` via `stencil_provider._get_sigma_value(None)`.
+
+    Raises
+    ------
+    RuntimeError
+        If `stencil_provider` does not have `_joint_socp_stencils`
+        populated (missing SOCP precompute).
+    """
+
+    def __init__(
+        self,
+        problem: MFGProblem,
+        stencil_provider: HJBGFDMSolver,
+        alpha_star: AlphaStarFn,
+        running_cost: RunningCostFn | None = None,
+        discretisation: Literal["upwind_projection", "upwind_per_axis", "central"] = "upwind_projection",
+        max_iter: int = 20,
+        tol: float = 1e-4,
+        volatility_field: float | np.ndarray | None = None,
+    ):
+        if getattr(stencil_provider, "_joint_socp_stencils", None) is None:
+            raise RuntimeError(
+                "HJBHowardSolver: stencil_provider has no _joint_socp_stencils. "
+                "Construct the provider with "
+                "monotonicity_scheme='joint_socp' and "
+                "monotonicity_application='precompute'."
+            )
+        if discretisation not in ("upwind_projection", "upwind_per_axis", "central"):
+            raise ValueError(
+                f"discretisation must be one of {{upwind_projection, upwind_per_axis, central}}, got {discretisation!r}"
+            )
+
+        self.problem = problem
+        self.stencil_provider = stencil_provider
+        self.alpha_star = alpha_star
+        self.running_cost = running_cost
+        self.discretisation = discretisation
+        self.max_iter = int(max_iter)
+        self.tol = float(tol)
+        self._volatility_field_override = volatility_field
+
+        self._static: dict | None = None  # lazy-built on first solve
+
+    # ---- Static precompute (lazy) -------------------------------------
+
+    def _build_static(self) -> dict:
+        """Build SOCP-stencil-derived operators and BC masks once."""
+        s = self.stencil_provider
+        pts = np.asarray(s.collocation_points)
+        if pts.ndim == 1:
+            pts = pts.reshape(-1, 1)
+        n = pts.shape[0]
+        dimension = pts.shape[1]
+
+        socp_obj = s._joint_socp_stencils
+        socp_data = {i: socp_obj.get_weights_dict(i) for i in range(n) if socp_obj.has_stencil(i)}
+
+        D_lap = _build_dlap_from_socp(socp_data, n)
+        D_grad_central = [_build_dgrad_central(socp_data, n, d) for d in range(dimension)]
+
+        per_axis_upwind: list[tuple[csr_matrix, csr_matrix]] | None = None
+        if self.discretisation == "upwind_per_axis":
+            per_axis_upwind = [_build_per_axis_upwind_pair(pts, socp_data, n, d) for d in range(dimension)]
+
+        interior_mask = np.zeros(n, dtype=bool)
+        for i in socp_data:
+            interior_mask[i] = True
+        boundary_idx = np.where(~interior_mask)[0]
+
+        # BC type per boundary point. Reads optional segment classification
+        # from the stencil provider; defaults to Neumann-by-extension if
+        # the provider hasn't pre-classified.
+        is_dirichlet = np.zeros(n, dtype=bool)
+        per_pt = getattr(s, "_bc_segment_per_point", None)
+        if per_pt is not None:
+            for i in boundary_idx:
+                seg = per_pt.get(int(i))
+                if seg is not None and "DIRICHLET" in str(getattr(seg, "bc_type", "")).upper():
+                    is_dirichlet[i] = True
+
+        # Nearest interior point for Neumann-by-extension BC rows.
+        int_pts_idx = np.where(interior_mask)[0]
+        nearest_int = np.zeros(n, dtype=int)
+        if len(boundary_idx) > 0 and len(int_pts_idx) > 0:
+            int_tree = cKDTree(pts[int_pts_idx])
+            for i in boundary_idx:
+                _, j_local = int_tree.query(pts[i], k=1)
+                nearest_int[i] = int_pts_idx[j_local]
+
+        return {
+            "pts": pts,
+            "n": n,
+            "dimension": dimension,
+            "socp_data": socp_data,
+            "D_lap": D_lap,
+            "D_grad_central": D_grad_central,
+            "per_axis_upwind": per_axis_upwind,
+            "boundary_idx": boundary_idx,
+            "is_dirichlet": is_dirichlet,
+            "nearest_int": nearest_int,
+        }
+
+    # ---- A_adv assembly -----------------------------------------------
+
+    def _build_A_adv(self, alpha: np.ndarray, static: dict) -> csr_matrix:
+        """Assemble the advection operator A_adv such that A_adv @ u ≈ α·∇u."""
+        if self.discretisation == "central":
+            n = static["n"]
+            A = csr_matrix((n, n))
+            for d in range(static["dimension"]):
+                A = A + diags(alpha[:, d]) @ static["D_grad_central"][d]
+            return A
+        if self.discretisation == "upwind_per_axis":
+            n = static["n"]
+            A = csr_matrix((n, n))
+            for d in range(static["dimension"]):
+                Dpos, Dneg = static["per_axis_upwind"][d]
+                pos_mask = (alpha[:, d] > 0).astype(float)
+                D_sel = diags(pos_mask) @ Dpos + diags(1.0 - pos_mask) @ Dneg
+                A = A + diags(alpha[:, d]) @ D_sel
+            return A
+        # upwind_projection
+        return _build_upwind_projection(alpha, static["pts"], static["socp_data"], static["n"])
+
+    # ---- One backward step --------------------------------------------
+
+    def _howard_step(
+        self,
+        u_next: np.ndarray,
+        m_n: np.ndarray,
+        t_idx: int,
+        sigma: float,
+        dt: float,
+        static: dict,
+        alpha_init: np.ndarray | None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """One backward time step. Returns (U_n, alpha_at_convergence)."""
+        n = static["n"]
+        dimension = static["dimension"]
+        pts = static["pts"]
+        D_lap = static["D_lap"]
+        boundary_idx = static["boundary_idx"]
+        is_dirichlet = static["is_dirichlet"]
+        nearest_int = static["nearest_int"]
+
+        # Initial policy: from previous time step's policy (warm start) or
+        # from central gradient of u_next.
+        if alpha_init is not None:
+            alpha = alpha_init.copy()
+        else:
+            p = np.zeros((n, dimension))
+            for d in range(dimension):
+                p[:, d] = static["D_grad_central"][d] @ u_next
+            alpha = self.alpha_star(pts, p, m_n, t_idx)
+
+        rc_t = self.running_cost(t_idx) if self.running_cost is not None else None
+        u_new = u_next.copy()
+
+        for _ in range(self.max_iter):
+            A_adv = self._build_A_adv(alpha, static)
+            A = eye(n, format="csr") / dt - A_adv - 0.5 * sigma * sigma * D_lap
+
+            # RHS: u_next/dt + (1/2)|alpha|^2 + running_cost
+            alpha_sq = np.sum(alpha * alpha, axis=1)
+            b = u_next / dt + 0.5 * alpha_sq
+            if rc_t is not None:
+                b = b + rc_t
+
+            # Apply BC rows in-place on A.
+            A_lil = A.tolil()
+            for i in boundary_idx:
+                A_lil[i, :] = 0
+                if is_dirichlet[i]:
+                    A_lil[i, i] = 1.0
+                    b[i] = 0.0
+                else:
+                    A_lil[i, i] = -1.0
+                    A_lil[i, int(nearest_int[i])] = 1.0
+                    b[i] = 0.0
+
+            u_new = spsolve(A_lil.tocsr(), b)
+            if not np.all(np.isfinite(u_new)):
+                logger.warning("HJBHowardSolver: non-finite u after spsolve; returning u_next")
+                return u_next.copy(), alpha
+
+            # Policy update.
+            p_new = np.zeros((n, dimension))
+            for d in range(dimension):
+                p_new[:, d] = static["D_grad_central"][d] @ u_new
+            alpha_new = self.alpha_star(pts, p_new, m_n, t_idx)
+
+            # Convergence on policy.
+            denom = max(float(np.linalg.norm(alpha, ord=np.inf)), 1e-10)
+            rel = float(np.linalg.norm(alpha_new - alpha, ord=np.inf)) / denom
+            alpha = alpha_new
+            if rel < self.tol:
+                break
+
+        return u_new, alpha
+
+    # ---- Public solve --------------------------------------------------
+
+    def solve_hjb_system(
+        self,
+        M_density: np.ndarray | None,
+        U_terminal: np.ndarray,
+        **_unused,
+    ) -> np.ndarray:
+        """Backward sweep using Howard inner.
+
+        Parameters
+        ----------
+        M_density : np.ndarray | None
+            Density field at every time step, shape `(Nt+1, n)`. When None,
+            treated as zero (no MFG coupling).
+        U_terminal : np.ndarray
+            Terminal condition `U(T, x)`, shape `(n,)`.
+
+        Returns
+        -------
+        np.ndarray
+            Value function `U(t, x)`, shape `(Nt+1, n)`. `U[Nt] == U_terminal`.
+        """
+        if self._static is None:
+            self._static = self._build_static()
+        static = self._static
+        n = static["n"]
+
+        Nt = int(self.problem.Nt)
+        T_final = float(self.problem.T)
+        dt = T_final / Nt
+
+        if self._volatility_field_override is None:
+            sigma = float(self.stencil_provider._get_sigma_value(None))
+        elif np.isscalar(self._volatility_field_override):
+            sigma = float(self._volatility_field_override)
+        else:
+            sigma = float(np.asarray(self._volatility_field_override).flat[0])
+
+        U = np.zeros((Nt + 1, n))
+        U[Nt] = U_terminal.copy()
+
+        alpha_carry: np.ndarray | None = None
+        for nt in range(Nt - 1, -1, -1):
+            m_n = np.asarray(M_density[nt]) if M_density is not None else np.zeros(n)
+            U[nt], alpha_carry = self._howard_step(U[nt + 1], m_n, nt, sigma, dt, static, alpha_carry)
+
+        return U
+
+
+__all__ = ["HJBHowardSolver", "AlphaStarFn", "RunningCostFn"]

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -1,0 +1,369 @@
+"""Direct unit tests for HJBHowardSolver.
+
+HJBHowardSolver graduates the research-side howard_patch.py family
+(exp08 1D/2D, exp09, exp11) into mfgarchon proper. Replaces the Newton
+inner loop of HJBGFDMSolver._solve_timestep when the Hamiltonian is
+strictly convex in p. Resolves Issue #1118 (Newton stalls on |∇u|²
+stiffness).
+
+Suite covers:
+
+1. Construction validation: requires SOCP-precomputed stencil_provider.
+2. Discretisation enum validation.
+3. 1D LQ closed-form: backward sweep reproduces the analytical Riccati
+   profile for pure LQ (single-agent, no MFG coupling, no potential).
+4. Newton-stall reproducer (Issue #1118): pure LQ regime where Newton
+   inner bottoms out at Armijo MIN_ALPHA — Howard converges.
+5. Each discretisation option runs to completion (upwind_projection,
+   upwind_per_axis, central).
+6. 2D smoke test on irregular cloud.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+pytest.importorskip("cvxpy")
+
+from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import HJBHowardSolver
+from mfgarchon.geometry import Hyperrectangle
+from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
+
+# ---------------------------------------------------------------------------
+# Minimal mock problem (mirrors test_joint_socp_mirror_symmetry pattern)
+# ---------------------------------------------------------------------------
+
+
+class _MockProblem:
+    def __init__(self, geometry, sigma=0.3, T=1.0, Nt=10, dimension=2):
+        self.geometry = geometry
+        self.dimension = dimension
+        self.Nx = 9
+        self.Nt = Nt
+        self.Dx = 0.1
+        self.Dt = T / Nt
+        self.sigma = sigma
+        self.T = T
+        self.lambda_ = 1.0
+        self.is_custom = False
+        self.hamiltonian_class = None
+        self.f_potential = None
+
+    def H(self, x_idx, m_at_x, p_values, t_idx):
+        return 0.5 * sum(v**2 for v in p_values.values() if isinstance(v, (int, float)))
+
+    def get_hjb_hamiltonian_jacobian_contrib(self, *a, **kw):
+        return None
+
+    def get_hjb_residual_m_coupling_term(self, *a, **kw):
+        return None
+
+    def dH_dp(self, *a, **kw):
+        return None
+
+
+def _make_2d_cloud(LX=4.0, LY=4.0, nx=5, ny=5, seed=0):
+    rng = np.random.default_rng(seed)
+    xs = np.linspace(0.0, LX, nx)
+    ys = np.linspace(0.0, LY, ny)
+    interior = []
+    for ix, x in enumerate(xs):
+        for iy, y in enumerate(ys):
+            if 0 < ix < nx - 1 and 0 < iy < ny - 1:
+                interior.append([x + rng.uniform(-0.05, 0.05), y + rng.uniform(-0.05, 0.05)])
+    interior = np.asarray(interior)
+    eps = 1e-7
+    boundary = []
+    for x in xs:
+        boundary.append([x, eps])
+        boundary.append([x, LY - eps])
+    for y in ys:
+        boundary.append([eps, y])
+        boundary.append([LX - eps, y])
+    boundary = np.asarray(boundary)
+    pts = np.vstack([interior, boundary])
+    bdry_idx = np.arange(len(interior), len(pts))
+    geom = Hyperrectangle(np.array([[0.0, LX], [0.0, LY]]))
+    return pts, bdry_idx, geom
+
+
+def _make_1d_cloud(LX=2.0, n_int=11):
+    interior = np.linspace(0.2, LX - 0.2, n_int).reshape(-1, 1)
+    boundary = np.array([[1e-7], [LX - 1e-7]])
+    pts = np.vstack([interior, boundary])
+    bdry_idx = np.arange(len(interior), len(pts))
+    geom = Hyperrectangle(np.array([[0.0, LX]]))
+    return pts, bdry_idx, geom
+
+
+def _make_gfdm_solver(pts, bdry, geom, problem, scheme="joint_socp", k_neighbors=12):
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name=f"side_{d}_{end}", bc_type=BCType.NO_FLUX, boundary=f"{ax}_{end}")
+            for d in range(problem.dimension)
+            for ax in (["x", "y", "z"][d],)
+            for end in ("min", "max")
+        ],
+        dimension=problem.dimension,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return HJBGFDMSolver(
+            problem,
+            collocation_points=pts,
+            boundary_indices=bdry,
+            delta=1.5,
+            k_neighbors=k_neighbors,
+            derivative_method="taylor",
+            taylor_order=2,
+            weight_function="wendland",
+            collocation_geometry=geom,
+            adaptive_neighborhoods=False,
+            boundary_conditions=bc,
+            monotonicity_scheme=scheme,
+            monotonicity_application="precompute",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1. Construction validation
+# ---------------------------------------------------------------------------
+
+
+def test_construction_requires_joint_socp_stencils():
+    """stencil_provider without _joint_socp_stencils raises."""
+    _pts, _bdry, geom = _make_2d_cloud()
+    problem = _MockProblem(geom)
+
+    class _StubProvider:
+        _joint_socp_stencils = None
+
+    with pytest.raises(RuntimeError, match="_joint_socp_stencils"):
+        HJBHowardSolver(
+            problem,
+            stencil_provider=_StubProvider(),
+            alpha_star=lambda x, p, m, t: -p,
+        )
+
+
+def test_construction_rejects_unknown_discretisation():
+    pts, bdry, geom = _make_2d_cloud()
+    problem = _MockProblem(geom)
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem)
+    with pytest.raises(ValueError, match="discretisation must be one of"):
+        HJBHowardSolver(
+            problem,
+            stencil_provider=gfdm,
+            alpha_star=lambda x, p, m, t: -p,
+            discretisation="not_a_real_scheme",  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. 1D LQ closed-form (Riccati profile)
+# ---------------------------------------------------------------------------
+
+
+def test_1d_lq_closed_form_riccati():
+    """Pure LQ in 1D, mfgarchon convention.
+
+    HJB residual form is `-u_t + H - (σ²/2)Δu = 0` (NAMING_CONVENTIONS.md
+    § HJB Equation Conventions). With u(T, x) = 0.5(x - x_c)² (so terminal
+    coefficient P(T) = 0.5), σ = 0, the Riccati ODE reads P'(t) = 2 P².
+    Closed form for T = 1: P(t) = 1 / (4 - 2t), so P(0) = 0.25.
+
+    Analytic ratio at off-centre probe ``|x - x_c| = 1``:
+        u(0)/u(T) = P(0)/P(T) = 0.25 / 0.5 = 0.5
+
+    See NAMING_CONVENTIONS.md § HJB Equation Conventions § Worked example
+    for the full derivation. Probe MUST be off-centre (at centre, the
+    quadratic vanishes and the test is uninformative for any P(t)).
+
+    Tolerance is loose (~30%) because:
+    - SOCP-corrected D_grad on boundary-buffer interior nodes is
+      LSQ-fitted, not exact FD.
+    - n_int=11 is a coarse 1D grid.
+    - No-flux Neumann-by-extension BC introduces a small wall artifact.
+
+    The load-bearing check is Riccati ordering + coefficient ballpark,
+    not high-precision quadrature.
+    """
+    LX = 4.0
+    pts, bdry, geom = _make_1d_cloud(LX=LX, n_int=11)
+    problem = _MockProblem(geom, sigma=0.0, T=1.0, Nt=20, dimension=1)
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5)
+
+    # Terminal: U(T, x) = 0.5 * x² → G_s = 0.5
+    x_pts = pts[:, 0]
+    x_c = LX / 2
+    U_T = 0.5 * (x_pts - x_c) ** 2
+
+    # Use central D_grad: validates linear-algebra under canonical convention,
+    # not the upwind-builder accuracy. Default upwind_projection is first-order
+    # LSQ with bias `(1/2)·Σh_j³/Σh_j² · u''`. On this coarse 1D grid
+    # (n_int=11, h≈0.36), that bias ≈ 0.6·u'' is comparable to |u'|=1.08,
+    # so upwind loses fidelity. On 2D irregular clouds with k=12 averaging
+    # over multiple directions + σ>0 diffusion (the regime Howard graduated
+    # from per Issue #1118), the bias mitigates and upwind works — that
+    # regime is covered by test_each_discretisation_completes and the 2D
+    # smoke test below. See `hjb_howard.py` module docstring for the
+    # convergence hypothesis (Bokanowski-Maroso-Zidani 2009).
+    howard = HJBHowardSolver(
+        problem,
+        stencil_provider=gfdm,
+        alpha_star=lambda x, p, m, t: -p,  # H = |p|²/2 → α* = -p
+        discretisation="central",
+        max_iter=30,
+        tol=1e-6,
+        volatility_field=0.0,
+    )
+    U = howard.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+    # Check Riccati at an OFF-center probe. The quadratic vanishes at x_c,
+    # so probing the center would always give 0 regardless of P(t). Pick a
+    # point with non-zero (x-x_c)² so the Riccati coefficient is observable.
+    assert np.all(np.isfinite(U)), "Howard produced non-finite U"
+    # Probe at x ≈ x_c - 1.0 (interior, off-center): (x-x_c)² = 1.0
+    probe_offset = 1.0
+    probe_idx = int(np.argmin(np.abs(x_pts - (x_c - probe_offset))))
+    U_T_probe = float(U_T[probe_idx])
+    U_0_probe = float(U[0, probe_idx])
+    assert U_T_probe > 0.1, f"Test fixture broken: probe at x={x_pts[probe_idx]:.3f} sees U_T={U_T_probe:.4f}"
+    # Analytical ratio P(0)/P(T) = 0.25 / 0.5 = 0.5 under mfgarchon's HJB
+    # convention `-u_t + H - σ²Δu/2 = 0`. Probe at |x-x_c|=1, T=1, G_s=0.5.
+    # See NAMING_CONVENTIONS.md § HJB Equation Conventions § Worked example.
+    # Loose bound 0.3-0.85: coarse 1D grid + Neumann-by-extension wall artifact.
+    ratio = U_0_probe / U_T_probe
+    assert 0.3 < ratio < 0.85, (
+        f"Riccati ordering broken: U(0)/U(T) at probe x={x_pts[probe_idx]:.3f} = {ratio:.3f}, "
+        f"expected ~0.5 for mfgarchon LQ convention (P(0)/P(T) = 0.25/0.5). "
+        f"See NAMING_CONVENTIONS.md § HJB Equation Conventions."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Newton-stall reproducer (Issue #1118)
+# ---------------------------------------------------------------------------
+
+
+def test_howard_advances_where_newton_would_stall():
+    """The temporal-plateau symptom of Issue #1118 manifests as U(t, x) ≈
+    U(T, x) for all t after stall. Howard must produce U that varies
+    monotonically backward in time.
+
+    Pure LQ regime, single backward sweep.
+    """
+    LX = 4.0
+    pts, bdry, geom = _make_1d_cloud(LX=LX, n_int=15)
+    problem = _MockProblem(geom, sigma=0.0, T=1.0, Nt=10, dimension=1)
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5)
+
+    x_pts = pts[:, 0]
+    U_T = (x_pts - LX / 2) ** 2  # quadratic terminal cost
+
+    # Use central discretisation for 1D smooth-LQ validation (see the
+    # Riccati test docstring for why upwind builders bias on coarse 1D
+    # grids; the upwind regime is exercised by the 2D smoke test).
+    howard = HJBHowardSolver(
+        problem,
+        stencil_provider=gfdm,
+        alpha_star=lambda x, p, m, t: -p,
+        discretisation="central",
+        volatility_field=0.0,
+    )
+    U = howard.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+    # Temporal monotonicity at an OFF-center probe: U[Nt] > U[Nt-1] > ... > U[0].
+    # The quadratic vanishes at x_c so center-probe would be trivially zero
+    # and fail to distinguish plateau from convergence.
+    probe_offset = 1.0
+    probe_idx = int(np.argmin(np.abs(x_pts - (LX / 2 - probe_offset))))
+    profile = np.array([float(U[nt, probe_idx]) for nt in range(problem.Nt + 1)])
+
+    # Strictly decreasing backward (allowing tiny rounding).
+    diffs = np.diff(profile)
+    assert np.all(diffs >= -1e-6), (
+        f"Temporal-plateau or non-monotone profile detected. diffs = {diffs}; profile = {profile}"
+    )
+    # And total cost-to-go shrinkage is non-trivial (NOT a plateau).
+    assert profile[-1] - profile[0] > 0.1 * profile[-1], (
+        f"Temporal plateau: U(0) ≈ U(T) ({profile[0]:.4f} vs {profile[-1]:.4f}). "
+        f"This is the Issue #1118 symptom Howard must fix."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Each discretisation option runs to completion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("discretisation", ["upwind_projection", "upwind_per_axis", "central"])
+def test_each_discretisation_completes(discretisation):
+    """All three A_adv assembly options produce finite U on a small 2D cloud.
+
+    `central` is included for comparison only and may not converge on
+    advection-dominant regimes, but should run without crashing.
+    """
+    pts, bdry, geom = _make_2d_cloud(nx=5, ny=5)
+    problem = _MockProblem(geom, sigma=0.3, T=1.0, Nt=5, dimension=2)
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem)
+
+    x_c = np.array([2.0, 2.0])
+    U_T = 0.5 * np.sum((pts - x_c[None, :]) ** 2, axis=1)
+
+    howard = HJBHowardSolver(
+        problem,
+        stencil_provider=gfdm,
+        alpha_star=lambda x, p, m, t: -p,
+        discretisation=discretisation,
+        max_iter=15,
+    )
+    U = howard.solve_hjb_system(M_density=None, U_terminal=U_T)
+    assert np.all(np.isfinite(U)), f"discretisation={discretisation} produced NaN/Inf"
+    assert U.shape == (problem.Nt + 1, len(pts))
+    # Terminal preserved bit-for-bit.
+    assert np.allclose(U[problem.Nt], U_T)
+
+
+# ---------------------------------------------------------------------------
+# 5. 2D smoke + running_cost callable
+# ---------------------------------------------------------------------------
+
+
+def test_2d_smoke_with_running_cost_callable():
+    """Running cost callable correctly enters the RHS. Use a constant
+    running cost: U is shifted by `T · const` relative to the no-cost case.
+    Just check that supplying running_cost produces a different result.
+    """
+    pts, bdry, geom = _make_2d_cloud(nx=4, ny=4)
+    problem = _MockProblem(geom, sigma=0.2, T=1.0, Nt=5, dimension=2)
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem)
+
+    x_c = np.array([2.0, 2.0])
+    U_T = 0.5 * np.sum((pts - x_c[None, :]) ** 2, axis=1)
+
+    base = HJBHowardSolver(
+        problem,
+        stencil_provider=gfdm,
+        alpha_star=lambda x, p, m, t: -p,
+    ).solve_hjb_system(M_density=None, U_terminal=U_T)
+
+    n = len(pts)
+    rc_const = 0.5
+    with_rc = HJBHowardSolver(
+        problem,
+        stencil_provider=gfdm,
+        alpha_star=lambda x, p, m, t: -p,
+        running_cost=lambda t_idx: rc_const * np.ones(n),
+    ).solve_hjb_system(M_density=None, U_terminal=U_T)
+
+    # Adding a positive running cost shifts U(t<T, x) upward.
+    interior_idx = np.array([i for i in range(n) if np.linalg.norm(pts[i] - x_c) < 0.7])
+    if len(interior_idx) > 0:
+        diff_at_t0 = float(np.mean(with_rc[0, interior_idx]) - np.mean(base[0, interior_idx]))
+        assert diff_at_t0 > 0, f"Constant running cost did not increase U(0) at center; diff={diff_at_t0:.4f}"


### PR DESCRIPTION
## Summary

Adds `HJBHowardSolver` as a peer class to `HJBGFDMSolver`. Replaces the inner Newton loop with policy iteration when the Hamiltonian is strictly convex in `p` (Bokanowski-Maroso-Zidani 2009). Graduates the 5-fork research-side `howard_patch_*` family (exp08 1D/2D-hybrid/2D-upwind/2D-central, exp09, exp11) into a single, dimension-agnostic, dispatcher class.

Resolves the structural fix path for #1118 (the issue itself notes Howard's policy iteration as Option 1 — canonical replacement with low risk).

## Why this is structural, not a parameter tweak

`HJBGFDMSolver._solve_timestep` runs Newton on residuals of `r = -u_t + H - (σ²/2)Δu`. The Jacobian eigenstructure is dominated by `(1/c)·diag(∇u)·D_grad` on advection-dominated regions (per #1118 instrumentation: `|∇u|/h ≈ 34` vs diagonal `1/dt + (σ²/2)/h² ≈ 2.7`). `spsolve(J, -r)` produces large δ pointing along advection eigenmodes; the trust-region radius set by Taylor truncation of `|∇u|²` is `~10⁻³`, smaller than Armijo's `MIN_ALPHA = 1e-6`. Newton bottoms out within ~3-6 backward steps of the terminal.

Howard's policy iteration breaks this trust-region trap by freezing `α^k` and solving a linear LQ system per Howard inner step — no Taylor truncation of `|∇u|²` needed. Convergence is **global** under the BMZ 2009 hypothesis (monotone consistent stable scheme, H strictly convex in p).

Per `[[feedback_newton_vs_howard_hjb]]`: Howard replaces the **inner** Newton (given m, solve HJB). It does NOT replace the outer Picard / fictitious play / damped iteration. `FixedPointIterator` stays unchanged.

## API (composition, not subclassing)

Per audit A.2 (audit `2026-05-10`) recommendation \"extract composables, not subclass proliferation\":

\`\`\`python
from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver, HJBHowardSolver

# Constructed stencil provider — must use joint_socp + precompute
gfdm = HJBGFDMSolver(problem, ...,
                    monotonicity_scheme='joint_socp',
                    monotonicity_application='precompute')

howard = HJBHowardSolver(
    problem,
    stencil_provider=gfdm,                       # source of SOCP-corrected D_lap, D_grad
    alpha_star=lambda x, p, m, t: -p / lambda_,  # Legendre transform (LQ)
    running_cost=...,                            # optional, time-indexed (n,)-array callable
    discretisation='upwind_projection',          # or 'upwind_per_axis' / 'central'
    max_iter=20, tol=1e-4,
)
U = howard.solve_hjb_system(M_density, U_terminal)
\`\`\`

## Three discretisation options

| Option | Source | Stability | Accuracy |
|---|---|---|---|
| `upwind_projection` (default) | exp09 / exp11 pattern; project to α direction, forward-side LSQ | M-matrix preserving | First-order |
| `upwind_per_axis` | exp08 upwind-variant; per-axis sign-aware Dpos/Dneg pair | BS-monotone by construction | First-order |
| `central` | SOCP's central D_grad directly | Not monotone for advection-dominant | Second-order |

`central` is the most accurate on smooth problems (the 1D LQ test uses it) but does not preserve discrete maximum principle. `upwind_projection` is recommended for paper-grade obstacle/evacuation runs.

## What this PR does NOT do

Per `[[bundled_pr_invalidation_chain]]` — single-purpose:

- **No migration of research patches.** The 5 forked `howard_patch_*.py` files in mfg-research stay as-is for this PR. A follow-up PR will convert them to thin shims over `HJBHowardSolver` and archive duplicates.
- **No `inner_solver=` option on HJBGFDMSolver.** The peer-class API is intentional. A future convenience wrapper can be added when v1.0 freezes; per CLAUDE.md \"no premature convenience\".
- **No Carlini-Silva semi-Lagrangian** (#1058). Separate parallel implementation path; Howard handles the bulk of #1118.

## Test plan

- [x] 8 dedicated tests in `tests/unit/test_alg/test_hjb_howard_solver.py`:
  - Construction validation (×2): `stencil_provider` missing `_joint_socp_stencils` raises; unknown discretisation rejected
  - 1D LQ closed-form Riccati: `P(0)/P(T) = 0.5` at off-centre probe (cites `NAMING_CONVENTIONS.md § HJB Equation Conventions § Worked example`)
  - Newton-stall reproducer: temporal monotonicity at off-centre probe; rejects the #1118 plateau symptom
  - Each discretisation completes (×3 parametrise)
  - 2D smoke with running-cost callable
- [x] 779 existing `tests/unit/test_alg/` pass (1 pre-existing `numpy.trapezoid` failure unrelated, deselected)
- [x] `ruff check` + `ruff format --check` clean
- [ ] **Pending: real-workload validation on Stage C v3 cloud** (1200-pt obstacle navigation). The research patches' ~57× speedup vs Newton is referenced from exp09 Phase 7 readme but not yet reproduced through the graduated class.
- [ ] **Pending: 2-3 day backlog** — migrate `howard_patch_*` research forks to use this class; archive duplicates; rerun §main_demo with HJBHowardSolver as the inner solver.

Closure of #1118 contingent on the two pending items.

## Convention codification

Two convention drifts surfaced during implementation, codified before this PR landed:

1. **HJB sign convention** — `mfg-research/docs/archon-notes/development/guides/NAMING_CONVENTIONS.md` § HJB Equation Conventions (new section). Worked LQ Riccati example with `P(0)/P(T) = 0.5` for the canonical mfgarchon convention `-u_t + H - σ²Δu/2 = 0`. Joplin `[Principle] HJB Sign Conventions`.

2. **OptimizationSense → α* sign**: `α* = -∂H/∂p` (MINIMIZE default). Codified in the new section above, retiring the gotcha-only documentation of G-001/G-002/G-003.

## Refs

- Refs #1118 (this is the canonical structural fix path the issue itself proposes; closure pending real-workload validation per `[[feedback_premature_issue_closure]]`)
- Companion to #1121 (PrecomputedMonotoneStencils `neighborhoods=` fix; independent)
- Future follow-up: research-side patch migration to thin shims over `HJBHowardSolver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)