### PR TITLE
feat(geometry): cloud geodesic distance via Dijkstra (Closes #1093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `HJBGFDMSolver`; the outer `FixedPointIterator` (Picard / fictitious
   play) is unchanged — Howard replaces inner Newton only.
 
+- **`compute_geodesic_distance` and `build_geodesic_field`** in
+  `mfgarchon/geometry/cloud_geodesic.py` (Issue #1093). Geodesic distance
+  on meshfree clouds via Dijkstra on a k-NN graph with segment-sample
+  obstacle filtering, companion to the structured-grid Eikonal solvers
+  at `mfgarchon/geometry/level_set/eikonal/`.
+
+  Graduates `mfg-research/experiments/gfdm_monotonicity_audit/minors/exp09_obstacle_navigation_full/geodesic_distance.py`
+  to library status. Two functions:
+
+  - `compute_geodesic_distance(points, sources_idx, obstacles_sdf=None, k_neighbors=25, ...)`
+    returns `(N,)` geodesic distances. Edges crossing obstacles are
+    excluded via `n_segment_samples` SDF samples per edge. `obstacles_sdf`
+    follows the mfgarchon SDF convention (`sd <= 0` inside obstacle, see
+    NAMING_CONVENTIONS.md § Geometry SDF Convention). `np.inf` for points
+    unreachable through navigable region. `O(N · k)` graph build +
+    `O((N + E) log N)` Dijkstra.
+  - `build_geodesic_field(points, d_geodesic, unreachable_penalty=1.5)`
+    wraps per-point distances into a callable `g(x)` via
+    `LinearNDInterpolator` with `NearestNDInterpolator` fallback for
+    out-of-hull queries. Unreachable points (`np.inf`) are substituted
+    with `unreachable_penalty × max(finite d)` so the field stays finite
+    for downstream HJB use.
+
+  Primary use case: terminal cost `u(T, x) = 0.5 · G_s · g(x)²` for
+  obstacle-navigation problems. Bakes routing into `g(x)` so the HJB
+  solver does not need visibility-aware gradient operators or soft-wall
+  potentials to encode it.
+
+  12 unit tests cover obstacle-free correctness (Euclidean within 15%
+  for k=24), triangle inequality on the graph, multiple sources →
+  `min_s d(., s)`, obstacle inflates geodesic above Euclidean,
+  unreachable points return `np.inf`, argument validation, and
+  field-builder round-trip + out-of-hull fallback + penalty substitution.
+
 - **`preserve_indices=False` flag on `FPParticleSolver`** (Issue #1119).
   When `True`, absorbed particles are NaN-marked in the per-step trajectory
   rather than compact-removed, so `particle_history[t].shape == (num_particles, d)`

--- a/mfgarchon/geometry/__init__.py
+++ b/mfgarchon/geometry/__init__.py
@@ -50,6 +50,7 @@ from .boundary import (
     periodic_bc,
     robin_bc,
 )
+from .cloud_geodesic import build_geodesic_field, compute_geodesic_distance
 
 # Collocation point generation
 from .collocation import (
@@ -190,6 +191,9 @@ __all__ = [
     "AMRNotImplementedError",
     "create_amr_grid",
     "is_adaptive",
+    # Cloud geodesic distance (Issue #1093)
+    "compute_geodesic_distance",
+    "build_geodesic_field",
     # Boundary-aware protocol
     "BoundaryAwareProtocol",
     "BoundaryType",

--- a/mfgarchon/geometry/cloud_geodesic.py
+++ b/mfgarchon/geometry/cloud_geodesic.py
@@ -1,0 +1,266 @@
+"""Geodesic distance on meshfree clouds with obstacle-aware edge filtering.
+
+Computes geodesic distance from each cloud point to the nearest source via
+Dijkstra on a k-NN graph where edges crossing obstacles are excluded
+(segment-sample SDF check). The companion `build_geodesic_field` wraps the
+per-point distances into a callable for off-grid evaluation (terminal cost
+fields, coefficients, etc.).
+
+Companion to the structured-grid Eikonal solvers at
+`mfgarchon/geometry/level_set/eikonal/` — same problem (distance to source
+set, optionally with obstacle constraints), different geometry primitive:
+FMM/FSM on `TensorProductGrid` vs Dijkstra on cloud + k-NN connectivity for
+`ImplicitDomain`-flavoured meshfree setups.
+
+Issue #1093. Validated in:
+    mfg-research/experiments/gfdm_monotonicity_audit/minors/
+        exp09_obstacle_navigation_full/geodesic_distance.py
+
+SDF convention (mfgarchon, see NAMING_CONVENTIONS.md § Geometry SDF
+Convention): `obstacles_sdf(x) <= 0` means **inside obstacle**;
+`obstacles_sdf(x) > 0` means **outside obstacle (navigable)**.
+
+References
+----------
+- Sethian (1996) ``A Fast Marching Level Set Method for Monotonically
+  Advancing Fronts'' (Proc. Natl. Acad. Sci. USA 93) — the structured-grid
+  analogue at `mfgarchon/geometry/level_set/eikonal/`.
+- Dijkstra (1959) ``A Note on Two Problems in Connexion with Graphs''
+  (Numer. Math. 1) — the graph-shortest-path algorithm used here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import dijkstra
+from scipy.spatial import cKDTree
+
+from mfgarchon.utils.mfg_logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def compute_geodesic_distance(
+    points: np.ndarray,
+    sources_idx: np.ndarray | int,
+    obstacles_sdf: Callable[[np.ndarray], np.ndarray] | None = None,
+    k_neighbors: int = 25,
+    n_segment_samples: int = 8,
+    max_edge_length: float | None = None,
+) -> np.ndarray:
+    """Compute geodesic distance from each cloud point to the nearest source.
+
+    Builds a k-nearest-neighbor graph on the cloud, optionally filters
+    edges whose segments pass through an obstacle (sampled SDF check),
+    then runs Dijkstra from the source set.
+
+    Parameters
+    ----------
+    points : np.ndarray, shape (N, d)
+        Cloud point positions. Caller must guarantee all points are in
+        the navigable region (`obstacles_sdf(points) > 0` if obstacles
+        are provided); points inside obstacles are not filtered out.
+    sources_idx : np.ndarray or int
+        Index or indices of points with `d_geodesic = 0`. The output
+        is `min_{s ∈ sources_idx} d(., s)`.
+    obstacles_sdf : callable or None
+        `obstacles_sdf(P) -> SDF` for `P` shape `(M, d)`. Following the
+        mfgarchon SDF convention, `SDF <= 0` means **inside obstacle**.
+        Edges whose mid-segment samples cross into an obstacle (any
+        sample with `SDF <= 0`) are excluded from the graph. When None,
+        no edge filtering is performed (pure k-NN Dijkstra; geodesic
+        equals Euclidean modulo k-NN connectivity approximation).
+    k_neighbors : int, default 25
+        Connectivity of the k-NN graph. Higher k = more edges = better
+        geodesic approximation but slower precompute. The research-side
+        validation used k=25.
+    n_segment_samples : int, default 8
+        Number of samples per edge for the obstacle-crossing test.
+        Sample positions are equispaced in `[0.05, 0.95]`; endpoints are
+        skipped because cloud points are in the navigable region by
+        construction.
+    max_edge_length : float or None
+        Upper bound on edge length (Euclidean). Edges longer than this
+        are dropped. When None, uses `3 × mean(nearest-neighbor distance)`.
+
+    Returns
+    -------
+    np.ndarray, shape (N,)
+        Geodesic distance from each cloud point to the nearest source.
+        `np.inf` for points unreachable through the navigable region.
+
+    Notes
+    -----
+    Complexity: `O(N · k_neighbors)` edge constructions + `O((N + E) log N)`
+    Dijkstra. For `N = 1200`, `k = 25` (the validated regime), precompute
+    is ~1 s on a typical workstation.
+
+    Examples
+    --------
+    >>> points = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    >>> d = compute_geodesic_distance(points, sources_idx=0)  # no obstacles
+    >>> d[0]
+    0.0
+    >>> # d_geodesic ≈ Euclidean for obstacle-free quadrilateral
+    """
+    pts = np.asarray(points)
+    if pts.ndim != 2 or pts.shape[0] == 0:
+        raise ValueError(f"points must have shape (N, d) with N >= 1; got shape {pts.shape}")
+    if k_neighbors < 1:
+        raise ValueError(f"k_neighbors must be >= 1; got {k_neighbors}")
+    if n_segment_samples < 1:
+        raise ValueError(f"n_segment_samples must be >= 1; got {n_segment_samples}")
+
+    n = pts.shape[0]
+    sources = np.atleast_1d(np.asarray(sources_idx, dtype=int))
+    if sources.ndim != 1 or sources.size == 0:
+        raise ValueError(f"sources_idx must be a non-empty 1D index array; got {sources}")
+    if int(sources.max()) >= n or int(sources.min()) < 0:
+        raise ValueError(f"sources_idx out of bounds for {n} points: range = [{sources.min()}, {sources.max()}]")
+
+    # k-NN connectivity. Query k+1 to skip self-edge at distance 0.
+    effective_k = min(k_neighbors + 1, n)
+    tree = cKDTree(pts)
+    distances, indices = tree.query(pts, k=effective_k)
+
+    if max_edge_length is None:
+        # Index 1 is the closest non-self neighbour. Use 3× mean for headroom.
+        if effective_k >= 2:
+            max_edge_length = 3.0 * float(np.mean(distances[:, 1]))
+        else:
+            max_edge_length = np.inf
+
+    s_lin = np.linspace(0.05, 0.95, n_segment_samples)
+
+    rows: list[int] = []
+    cols: list[int] = []
+    data: list[float] = []
+    n_filtered_obstacle = 0
+    n_filtered_length = 0
+
+    for i in range(n):
+        for k in range(1, effective_k):
+            j = int(indices[i, k])
+            d_ij = float(distances[i, k])
+            if d_ij > max_edge_length:
+                n_filtered_length += 1
+                continue
+            if obstacles_sdf is not None:
+                seg = pts[i][None, :] + s_lin[:, None] * (pts[j] - pts[i])[None, :]
+                sd = np.asarray(obstacles_sdf(seg))
+                if (sd <= 0.0).any():
+                    n_filtered_obstacle += 1
+                    continue
+            rows.append(i)
+            cols.append(j)
+            data.append(d_ij)
+
+    logger.info(
+        "cloud_geodesic: %d edges kept (filtered %d for obstacle crossing, %d for length cap %.3f)",
+        len(data),
+        n_filtered_obstacle,
+        n_filtered_length,
+        max_edge_length,
+    )
+
+    graph = csr_matrix((data, (rows, cols)), shape=(n, n))
+    # Symmetrise: undirected geodesic graph.
+    graph = graph.maximum(graph.T)
+
+    d_geodesic = dijkstra(graph, indices=sources, return_predecessors=False, min_only=True)
+
+    n_unreachable = int(np.sum(~np.isfinite(d_geodesic)))
+    if n_unreachable > 0:
+        logger.warning(
+            "cloud_geodesic: %d/%d points unreachable from sources through navigable region",
+            n_unreachable,
+            n,
+        )
+    return d_geodesic
+
+
+def build_geodesic_field(
+    points: np.ndarray,
+    d_geodesic: np.ndarray,
+    *,
+    unreachable_penalty: float = 1.5,
+) -> Callable[[np.ndarray], np.ndarray]:
+    """Wrap per-point geodesic distances into a callable for off-grid eval.
+
+    Uses scipy `LinearNDInterpolator` on Delaunay triangulation
+    (piecewise-linear on the convex hull) with `NearestNDInterpolator`
+    fallback for queries outside the hull (rare but possible for HJB ghost
+    points near obstacle corners). No RBF overshoot at medial-axis kinks
+    where two geodesic trajectories meet.
+
+    Parameters
+    ----------
+    points : np.ndarray, shape (N, d)
+        Cloud point positions (same as fed to `compute_geodesic_distance`).
+    d_geodesic : np.ndarray, shape (N,)
+        Per-point geodesic distances from `compute_geodesic_distance`.
+        Unreachable points (`np.inf` entries) are replaced by
+        `unreachable_penalty * max(finite distances)` before interpolation
+        so the field stays finite — a strict penalty for "would have to
+        go far" rather than an interpolation discontinuity at `inf`.
+    unreachable_penalty : float, default 1.5
+        Multiplier applied to `max(finite d_geodesic)` for unreachable
+        points before interpolation.
+
+    Returns
+    -------
+    callable
+        `g(x)` accepting a single point (shape `(d,)`) or array
+        (shape `(M, d)`). Returns a scalar or `(M,)` array respectively.
+
+    Notes
+    -----
+    Use case: terminal cost `u(T, x) = 0.5 * G_s * g(x) ** 2` where `g`
+    is built from `compute_geodesic_distance(..., sources_idx=exit_points)`.
+    Bakes obstacle routing into the terminal cost so the HJB solver does
+    not need visibility-aware gradient operators or wall potentials to
+    encode it (Strategy 3 in exp09_obstacle_navigation_full).
+    """
+    pts = np.asarray(points)
+    d = np.asarray(d_geodesic, dtype=float).copy()
+    finite_mask = np.isfinite(d)
+    if not finite_mask.all():
+        if not finite_mask.any():
+            raise ValueError(
+                "build_geodesic_field: all d_geodesic entries are non-finite; no source is reachable from any point."
+            )
+        d_max = float(d[finite_mask].max())
+        d = np.where(finite_mask, d, d_max * unreachable_penalty)
+        logger.info(
+            "cloud_geodesic: substituted %d unreachable points with %.3f × d_max = %.3f",
+            int((~finite_mask).sum()),
+            unreachable_penalty,
+            d_max * unreachable_penalty,
+        )
+
+    linear_interp = LinearNDInterpolator(pts, d, fill_value=np.nan)
+    nearest_interp = NearestNDInterpolator(pts, d)
+
+    def g_func(x: np.ndarray) -> np.ndarray:
+        x_arr = np.asarray(x)
+        single = x_arr.ndim == 1
+        if single:
+            x_arr = x_arr.reshape(1, -1)
+        v = linear_interp(x_arr)
+        # Fallback to nearest for any out-of-hull queries.
+        nan_mask = np.isnan(v)
+        if nan_mask.any():
+            v[nan_mask] = nearest_interp(x_arr[nan_mask])
+        return float(v[0]) if single else v
+
+    return g_func
+
+
+__all__ = ["compute_geodesic_distance", "build_geodesic_field"]

--- a/tests/unit/test_geometry/test_cloud_geodesic.py
+++ b/tests/unit/test_geometry/test_cloud_geodesic.py
@@ -1,0 +1,263 @@
+"""Unit tests for cloud-geodesic distance computation (Issue #1093).
+
+Graduates the research-side implementation at
+``mfg-research/experiments/gfdm_monotonicity_audit/minors/exp09_obstacle_navigation_full/geodesic_distance.py``.
+
+Test coverage:
+
+1. Basic correctness: single source, obstacle-free 2D grid → geodesic ≈
+   Euclidean (within k-NN approximation tolerance).
+2. Triangle inequality: ``d(a, c) <= d(a, b) + d(b, c)`` for arbitrary
+   triples on the graph.
+3. Multiple sources: returns ``min_s d(., s)``.
+4. Obstacle blocks straight path: a "wall" between source and target
+   increases geodesic above Euclidean.
+5. Unreachable points: enclosed-by-obstacle points return ``np.inf``.
+6. Argument validation: bad ``points`` / ``k_neighbors`` / ``sources_idx`` raise.
+7. ``build_geodesic_field`` round-trip: evaluating at cloud points returns
+   the input distances; out-of-hull queries fall through to nearest.
+8. ``build_geodesic_field`` with unreachable points: substitutes the
+   ``unreachable_penalty × d_max`` fill, no `nan` leaks out.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry import build_geodesic_field, compute_geodesic_distance
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _grid_2d(n: int, lx: float = 4.0, ly: float = 4.0) -> np.ndarray:
+    xs = np.linspace(0.0, lx, n)
+    ys = np.linspace(0.0, ly, n)
+    return np.array([[x, y] for x in xs for y in ys])
+
+
+# A vertical wall obstacle at x ≈ 2.0, spanning y ∈ [1.0, 3.0].
+# SDF convention (mfgarchon): sd <= 0 means INSIDE obstacle.
+def _wall_sdf_factory(x_wall: float = 2.0, thickness: float = 0.2, y_lo: float = 1.0, y_hi: float = 3.0):
+    half = thickness / 2.0
+
+    def sdf(p: np.ndarray) -> np.ndarray:
+        p = np.asarray(p)
+        # Distance to wall in x-direction (negative inside).
+        dx = np.abs(p[..., 0] - x_wall) - half
+        # Distance to wall in y-direction (negative inside [y_lo, y_hi]).
+        dy = np.maximum(y_lo - p[..., 1], p[..., 1] - y_hi)
+        # 2D AABB SDF: max of per-axis SDFs (negative when both are negative).
+        return np.maximum(dx, dy)
+
+    return sdf
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic correctness on obstacle-free grid
+# ---------------------------------------------------------------------------
+
+
+def test_obstacle_free_geodesic_matches_euclidean():
+    """No obstacles → geodesic == Euclidean modulo k-NN graph approximation.
+
+    On a 7x7 grid with k=24 neighbours, the graph is dense enough that the
+    geodesic should match Euclidean within a few percent. Stronger bounds
+    require denser cloud or larger k.
+    """
+    pts = _grid_2d(7)
+    # Source at corner (0, 0); first point in the array.
+    d = compute_geodesic_distance(pts, sources_idx=0, k_neighbors=24)
+    assert d[0] == 0.0
+    euclid = np.linalg.norm(pts - pts[0], axis=1)
+    # Geodesic is an upper bound; should be within ~10% of Euclidean.
+    assert np.all(d >= euclid - 1e-9)
+    # Tight enough to catch sign errors / wrong source handling.
+    rel = (d - euclid) / np.maximum(euclid, 1e-6)
+    assert rel.max() < 0.15, f"Max relative excess over Euclidean = {rel.max():.4f}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Triangle inequality
+# ---------------------------------------------------------------------------
+
+
+def test_triangle_inequality_holds_on_graph():
+    """For any triple (a, b, c) on the cloud: d_geo(a, c) <= d(a, b) + d(b, c).
+
+    Computed by running Dijkstra from b (source), then triangle inequality
+    must hold against pre-computed d(a, ·) and d(c, ·).
+    """
+    pts = _grid_2d(6)
+    src_a, src_b, src_c = 0, 17, 35  # arbitrary cloud indices
+    d_a = compute_geodesic_distance(pts, sources_idx=src_a, k_neighbors=15)
+    d_b = compute_geodesic_distance(pts, sources_idx=src_b, k_neighbors=15)
+    # Triangle: d(a, c) <= d(a, b) + d(b, c)
+    lhs = d_a[src_c]
+    rhs = d_a[src_b] + d_b[src_c]
+    assert np.isfinite(lhs)
+    assert np.isfinite(rhs)
+    # Tolerance for symmetrisation rounding.
+    assert lhs <= rhs + 1e-9, f"Triangle ineq violated: d(a,c)={lhs:.4f} > d(a,b)+d(b,c)={rhs:.4f}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Multiple sources
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_sources_returns_min_over_sources():
+    """For sources `S`, output is `min_{s ∈ S} d(., s)`."""
+    pts = _grid_2d(5)
+    sources = np.array([0, 24])  # corners
+    d_multi = compute_geodesic_distance(pts, sources_idx=sources, k_neighbors=15)
+    d_one = compute_geodesic_distance(pts, sources_idx=0, k_neighbors=15)
+    d_two = compute_geodesic_distance(pts, sources_idx=24, k_neighbors=15)
+    expected = np.minimum(d_one, d_two)
+    np.testing.assert_allclose(d_multi, expected, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 4. Obstacle blocks straight path
+# ---------------------------------------------------------------------------
+
+
+def test_obstacle_inflates_geodesic_above_euclidean():
+    """A vertical wall between source and target → geodesic > Euclidean.
+
+    Wall at x ∈ [1.9, 2.1] × y ∈ [1.0, 3.0]. Source at (0.5, 2.0). Target
+    at (3.5, 2.0) sits directly across the wall; Euclidean distance 3.0,
+    but the geodesic must route around (over y=3.0 or under y=1.0).
+    """
+    pts = _grid_2d(7)
+    # Source ≈ (0.667, 2.0); target ≈ (3.333, 2.0)
+    src_idx = int(np.argmin(np.linalg.norm(pts - np.array([0.667, 2.0]), axis=1)))
+    tgt_idx = int(np.argmin(np.linalg.norm(pts - np.array([3.333, 2.0]), axis=1)))
+    euclid = float(np.linalg.norm(pts[tgt_idx] - pts[src_idx]))
+
+    d_no_obstacle = compute_geodesic_distance(pts, sources_idx=src_idx, k_neighbors=24)[tgt_idx]
+    d_with_wall = compute_geodesic_distance(
+        pts, sources_idx=src_idx, obstacles_sdf=_wall_sdf_factory(), k_neighbors=24
+    )[tgt_idx]
+
+    assert np.isfinite(d_with_wall), "Geodesic with wall should remain finite (routing exists)"
+    assert d_with_wall > d_no_obstacle + 0.5, (
+        f"Wall failed to inflate geodesic: no-obstacle={d_no_obstacle:.3f} vs with-wall={d_with_wall:.3f}"
+    )
+    assert d_with_wall > euclid * 1.1, f"Wall inflation only {d_with_wall / euclid:.3f}× Euclidean; expected >1.1×"
+
+
+# ---------------------------------------------------------------------------
+# 5. Unreachable points
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_points_return_inf():
+    """Source on one side of a full vertical wall → cloud on the other side
+    is unreachable through navigable region.
+    """
+    # Wall spans the full y range so no routing exists.
+    full_wall_sdf = _wall_sdf_factory(x_wall=2.0, thickness=0.2, y_lo=-10.0, y_hi=10.0)
+    # Cloud strictly outside the wall (navigable on both sides).
+    pts_left = np.array([[0.5 + 0.5 * i, 1.0 + 0.5 * j] for i in range(3) for j in range(5)])
+    pts_right = np.array([[2.5 + 0.5 * i, 1.0 + 0.5 * j] for i in range(3) for j in range(5)])
+    pts = np.vstack([pts_left, pts_right])
+    # max_edge_length must be short enough that no edge can hop over the wall
+    # (the wall is 0.2 wide; max_edge_length=1.0 still might miss segments
+    # whose samples all fall in [0.05, 0.95]·edge length on the same side).
+    # Use a tight cap: at most ~0.7 (the y-step is 0.5).
+    d = compute_geodesic_distance(
+        pts,
+        sources_idx=0,
+        obstacles_sdf=full_wall_sdf,
+        k_neighbors=15,
+        max_edge_length=0.75,
+    )
+    # Source at idx 0 is on the LEFT side. RIGHT side (idx 15-29) is unreachable.
+    assert d[0] == 0.0
+    assert np.all(np.isfinite(d[:15])), "Left side should be reachable"
+    assert np.all(np.isinf(d[15:])), "Right side should be unreachable"
+
+
+# ---------------------------------------------------------------------------
+# 6. Argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_compute_validates_points_shape():
+    with pytest.raises(ValueError, match=r"points must have shape"):
+        compute_geodesic_distance(np.array([]), sources_idx=0)
+
+
+def test_compute_validates_k_neighbors():
+    pts = _grid_2d(3)
+    with pytest.raises(ValueError, match=r"k_neighbors must be"):
+        compute_geodesic_distance(pts, sources_idx=0, k_neighbors=0)
+
+
+def test_compute_validates_sources_in_bounds():
+    pts = _grid_2d(3)
+    with pytest.raises(ValueError, match=r"sources_idx out of bounds"):
+        compute_geodesic_distance(pts, sources_idx=999)
+
+
+# ---------------------------------------------------------------------------
+# 7. build_geodesic_field round-trip + out-of-hull fallback
+# ---------------------------------------------------------------------------
+
+
+def test_field_evaluates_to_input_at_cloud_points():
+    """Interpolant at cloud points returns the precomputed d_geodesic."""
+    pts = _grid_2d(5)
+    d = compute_geodesic_distance(pts, sources_idx=0, k_neighbors=20)
+    g = build_geodesic_field(pts, d)
+    # Interior cloud points should match exactly (linear interp is exact at nodes).
+    interior_mask = np.array([0 < p[0] < 4.0 and 0 < p[1] < 4.0 for p in pts])
+    cloud_vals = g(pts[interior_mask])
+    np.testing.assert_allclose(cloud_vals, d[interior_mask], atol=1e-9)
+
+
+def test_field_uses_nearest_outside_convex_hull():
+    """Queries outside the Delaunay hull fall back to NearestNDInterpolator,
+    not NaN.
+    """
+    pts = _grid_2d(4)
+    d = compute_geodesic_distance(pts, sources_idx=0, k_neighbors=12)
+    g = build_geodesic_field(pts, d)
+    # Far outside the hull [0, 4]^2:
+    far_point = np.array([10.0, 10.0])
+    val = g(far_point)
+    # Hull corner (3.33..., 3.33...) is nearest among the 4x4 grid; its d ≈ Euclidean.
+    expected_nearest = float(d[np.argmin(np.linalg.norm(pts - far_point, axis=1))])
+    assert np.isfinite(val)
+    assert abs(val - expected_nearest) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 8. Unreachable points → penalty substitution
+# ---------------------------------------------------------------------------
+
+
+def test_field_replaces_inf_with_penalty_max():
+    """build_geodesic_field substitutes np.inf entries with
+    `unreachable_penalty × max(finite distances)`.
+    """
+    # Construct a tiny scenario by hand: 3 reachable + 1 unreachable.
+    pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [5.0, 5.0]])
+    d = np.array([0.0, 1.0, 1.0, np.inf])
+    g = build_geodesic_field(pts, d, unreachable_penalty=2.0)
+    # Evaluate at the unreachable point: expect penalty * max(finite) = 2 * 1 = 2.0
+    val = g(pts[3])
+    assert np.isfinite(val)
+    assert abs(val - 2.0) < 1e-9
+
+
+def test_field_raises_when_all_unreachable():
+    """If every cloud point is unreachable, building a field is meaningless."""
+    pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    d = np.array([np.inf, np.inf, np.inf])
+    with pytest.raises(ValueError, match=r"all d_geodesic entries are non-finite"):
+        build_geodesic_field(pts, d)


### PR DESCRIPTION
## Summary

Graduates `mfg-research/experiments/gfdm_monotonicity_audit/minors/exp09_obstacle_navigation_full/geodesic_distance.py` to library status. Adds `mfgarchon/geometry/cloud_geodesic.py` with two functions:

- `compute_geodesic_distance(points, sources_idx, obstacles_sdf=None, k_neighbors=25, ...)` — Dijkstra on a k-NN graph of cloud points with segment-sample SDF filtering on edges. Returns per-point distance to nearest source; `np.inf` for unreachable points.
- `build_geodesic_field(points, d_geodesic, unreachable_penalty=1.5)` — wraps per-point distances into a callable `g(x)` for off-grid evaluation (HJB terminal cost, coefficient fields).

Companion to the structured-grid Eikonal solvers at `mfgarchon/geometry/level_set/eikonal/` — same problem (distance to source set, optionally with obstacle constraints), different geometry primitive.

## Why this belongs in geometry

Per the issue, geodesic distance depends only on cloud / grid points, obstacle SDF, connectivity. It does NOT depend on Hamiltonian / control cost / coupling. Putting it in `geometry/` follows the existing eikonal pattern. Cost-design code (terminal cost in `MFGProblem.components`, running cost, soft penalties) just queries the result.

## Primary use case

`u(T, x) = 0.5 · G_s · g(x)²` terminal cost for obstacle-navigation problems. Bakes routing around obstacles into `g(x)` so the HJB solver does not need visibility-aware gradient operators or soft-wall potentials to encode it. This was Strategy 3 in exp09.

## Changes from the research-side reference

| Change | Why |
|---|---|
| `print()` → `mfgarchon.utils.mfg_logging.get_logger()` with INFO / WARNING | Mfgarchon logging convention |
| `obstacles_sdf` optional (`None` → no edge filtering) | Use case: pure k-NN Dijkstra on non-convex obstacle-free domains |
| Explicit argument validation (`points` shape, `sources_idx` bounds, `k_neighbors > 0`) | Fail-fast per CLAUDE.md; replace silent garbage with clear errors |
| Type hints under `TYPE_CHECKING` | ruff `TC003` |
| `unreachable_penalty` as named parameter (was hard-coded 1.5) | Caller may want a stricter or looser routing penalty for HJB terminal cost design |
| `ValueError` when all `d_geodesic` are non-finite | Was silent return; fail-fast at edge |

## What this PR does NOT do

Per `[[bundled_pr_invalidation_chain]]` — single-purpose:

- **No unified `compute_geodesic_distance(geometry, ...)` dispatcher** (#1093 marked optional). When/if we need a cross-geometry-type API, that goes in a follow-up. Per CLAUDE.md "no premature convenience".
- **No migration of `exp09/geodesic_distance.py`** to import from mfgarchon. Separate follow-up after this PR merges.
- **No coupling into `MFGProblem.components`**. The `terminal_cost` callable can already accept any function; this PR just provides one helper for building such a function.

## Test plan

- [x] 12 dedicated tests in `tests/unit/test_geometry/test_cloud_geodesic.py`:
  - Obstacle-free correctness: geodesic ≈ Euclidean within 15% for k=24
  - Triangle inequality: `d(a,c) <= d(a,b) + d(b,c)` on the graph
  - Multiple sources: returns `min_s d(., s)`
  - Obstacle inflates geodesic above Euclidean (vertical wall test)
  - Unreachable points return `np.inf` (full-wall test, no routing)
  - Argument validation: bad `points` shape / `k_neighbors=0` / out-of-bounds `sources_idx` raise
  - `build_geodesic_field` evaluates to input at cloud nodes
  - Out-of-hull query falls through to `NearestNDInterpolator`
  - Unreachable points → `penalty · d_max` substitution
  - All-unreachable input raises `ValueError`
- [x] 709 existing `tests/unit/test_geometry/` pass (1 pre-existing failure in `test_geometry_projection.py::test_grid_to_grid_1d_conservation` is unrelated to this PR)
- [x] `ruff check` + `ruff format --check` clean
- [x] Smoke: `from mfgarchon.geometry import compute_geodesic_distance, build_geodesic_field` works

## Refs

- Closes #1093
- Independent of PR #1121 (precompute neighborhoods) and PR #1122 (Howard inner solver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)