### PR TITLE
fix(monotonicity_enforcer): solve() instead of inv() at local QR-fallback (Refs #1066)

### DIFF
--- a/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
+++ b/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
@@ -752,9 +752,11 @@ class MonotonicityEnforcer:
             A = taylor_data["A"]
             W = taylor_data["W"]
             try:
-                # Compute (A^T W A)^{-1} A^T W and extract row
-                AtWA_inv = np.linalg.inv(A.T @ W @ A)
-                weights_matrix = AtWA_inv @ A.T @ W
+                # Issue #1066: solve(AtWA, AtW) directly instead of inv(AtWA) @ AtW.
+                # Squares condition number; on marginal stencils the inv path can
+                # silently produce weights that violate M-matrix off-diag positivity.
+                AtW = A.T @ W
+                weights_matrix = np.linalg.solve(A.T @ W @ A, AtW)
                 weights = weights_matrix[derivative_idx, :]
                 return weights
             except np.linalg.LinAlgError:


### PR DESCRIPTION
## Summary

Replaces `np.linalg.inv(A.T @ W @ A) @ A.T @ W` with `np.linalg.solve(A.T @ W @ A, A.T @ W)` at `monotonicity_enforcer.py:756`. Same numerical content; `solve` avoids squaring the condition number, which on marginal stencils can silently produce weights that violate the M-matrix off-diagonal positivity constraint.

## Why this is partial #1066

#1066 lists three `inv()` → `solve()` conversion sites:

| Site | Status |
|---|---|
| `gfdm_components/joint_socp.py:193` | Done in #1099 (`ATA_inv = ...` → `np.linalg.solve(ATA, rhs)`) |
| `utils/numerical/particle/sampling.py:739` | Already uses `solve()` (separate commit) |
| `gfdm_components/monotonicity_enforcer.py:756` | This PR |

## What's NOT in this PR

The fourth `inv()` site at `gfdm_components/neighborhood_builder.py:744` STORES `AtWA_inv` in a cached dict consumed by 4 sites across `monotonicity_enforcer.py` (lines 344, 763) and `hjb_gfdm.py:1748`. A drop-in `solve(AtWA, b)` at each consumer would be O(n³) per HJB iteration (re-factorise each call) vs the current O(n²) via stored inverse. The proper fix stores LU factors via `scipy.linalg.lu_factor` and calls `lu_solve` at each consumer — same O(n²) per call, no condition-number squaring.

That refactor touches 4 files and is filed separately as **#1125**. Deferred from this PR to keep single-purpose scope. `Refs #1066` (not `Closes`) until #1125 also lands.

## Test plan

- [x] `ruff check` clean on touched file
- [x] 137 affected tests pass (`pytest tests/unit/test_alg/ -k 'socp or m_matrix or monotonicity or gfdm'`)
- [x] No regression in the QR-fallback path the local change touches

## Refs

- Refs #1066 (parent)
- Filed #1125 to track the remaining storage refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)