### PR TITLE
refactor(precompute): require neighborhoods/points/delta, drop legacy op fallback (Closes #1102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PR — that cluster requires migrating ~20 mfg-research scripts that pass
   `qp_optimization_level=` directly.
 
+- **`PrecomputedMonotoneStencils` / `PrecomputedJointSocpStencils` legacy
+  ctor signature** (Issue #1102, dual-source stencil bug class). The
+  `operator: TaylorOperator` parameter is removed; `neighborhoods=`,
+  `points=`, `delta=` (for `PrecomputedMonotoneStencils`) and
+  `neighborhoods=` (for `PrecomputedJointSocpStencils`) are now required
+  kwargs. The legacy fallback path that read pre-adaptive
+  `op.get_derivative_weights()` / `op.get_neighborhood()` is deleted.
+
+  Motivation: the bug class recurred twice (#1099 → JointSocp,
+  #1102/#1121 → Monotone). Both incidents were the same shape: stencil
+  weights computed against pre-adaptive `op.neighborhoods`, contracted at
+  runtime against `b = u_neighbors - u_center` built from post-adaptive
+  `NeighborhoodBuilder.neighborhoods`, raising
+  `ValueError: matmul: size N is different from K` at corner buffer
+  points where adaptive-δ enlargement modified the stencil. After this
+  change the bug class is statically impossible: there is no way to
+  construct a stencil object that silently drifts from runtime
+  neighborhoods.
+
+  Migration (production callers — already done in
+  `HJBGFDMSolver.__init__` lines 920, 978):
+  ```python
+  # before (v0.24)
+  PrecomputedMonotoneStencils(operator=op, is_boundary=mask, ...)
+  PrecomputedJointSocpStencils(operator=op, points=pts, interior_indices=..., delta=δ, ...)
+
+  # after (v0.25.0)
+  PrecomputedMonotoneStencils(is_boundary=mask, neighborhoods=nh, points=pts, delta=δ)
+  PrecomputedJointSocpStencils(points=pts, interior_indices=..., delta=δ, neighborhoods=nh, ...)
+  ```
+
+  Tests at `tests/unit/test_alg/test_precomputed_monotone_stencils.py`
+  rewritten: legacy-path test deleted, TypeError gates added for each
+  required kwarg, matched + enlarged paths kept, integration regression
+  unchanged. 7/7 pass.
+
 ### Fixed
 
 - **`PrecomputedMonotoneStencils` accepts `neighborhoods=` parameter**

--- a/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
+++ b/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
@@ -460,8 +460,6 @@ class PrecomputedJointSocpStencils:
 
     Parameters
     ----------
-    operator : TaylorOperator
-        GFDM operator with computed stencil neighborhoods.
     points : np.ndarray
         Collocation points, shape (n_total, dimension).
     interior_indices : np.ndarray
@@ -472,6 +470,11 @@ class PrecomputedJointSocpStencils:
     delta : float
         Wendland kernel support radius. Used for distance-weighted SOCP
         objective via `wendland_stencil_weights`.
+    neighborhoods : dict
+        Post-filter stencil dict (typically ``HJBGFDMSolver.neighborhoods``
+        built by ``NeighborhoodBuilder``). Single source of truth: stencils
+        always trace to these indices (Issue #1102 dual-source bug class —
+        legacy fallback to ``op.get_derivative_weights()`` removed in v0.25.0).
     cone_constant_C : float
         Per-edge cone bound: ||D_{ij}||_2 <= C * h_i * L_{ij}. Default 1.0
         (within the paper's $C_\\star \\in [0.5, 1]$ feasibility range for
@@ -490,13 +493,12 @@ class PrecomputedJointSocpStencils:
 
     def __init__(
         self,
-        operator,
         points: np.ndarray,
         interior_indices: np.ndarray,
         delta: float,
+        neighborhoods: dict,
         cone_constant_C: float = 1.0,
         eps_pos: float = 0.0,
-        neighborhoods: dict | None = None,
         cone_constant_C_max: float | None = None,
         cone_constant_C_growth: float = 2.0,
         use_relaxed_fallback: bool = False,
@@ -505,15 +507,21 @@ class PrecomputedJointSocpStencils:
     ):
         if not _CVXPY_AVAILABLE:
             raise ImportError("cvxpy is required for joint SOCP. Install with: pip install cvxpy")
-        self._operator = operator
+        # Single source of truth: neighborhoods + points + delta. With the
+        # legacy `op.get_derivative_weights()` fallback removed in v0.25.0,
+        # the TaylorOperator reference is unused; constructor no longer takes one.
         self._points = np.asarray(points)
         self._interior_indices = np.asarray(interior_indices)
         self._delta = float(delta)
         self._C = float(cone_constant_C)
         self._eps_pos = float(eps_pos)
-        # Post-filter neighborhoods (after visibility filter, ghost nodes, LCR).
-        # See class docstring for why this is required for correctness on
-        # irregular clouds where the visibility filter modifies stencils.
+        # Single source of truth: stencils always trace to the supplied
+        # post-filter neighborhoods (after visibility filter, ghost nodes,
+        # adaptive δ-enlargement). The legacy fallback to
+        # `op.get_derivative_weights()` was removed in v0.25.0 — it silently
+        # produced wrong results on irregular clouds where the visibility
+        # filter / adaptive enlargement modified runtime stencils
+        # (Issue #1102 dual-source bug class).
         self._neighborhoods = neighborhoods
         # Per-stencil C-bisection cap. None disables bisection.
         # When set, infeasible stencils retry with C *= cone_constant_C_growth
@@ -555,27 +563,16 @@ class PrecomputedJointSocpStencils:
 
         for i in self._interior_indices:
             i = int(i)
-            if self._neighborhoods is not None:
-                # Use post-filter neighborhood (matches runtime exactly).
-                nh = self._neighborhoods.get(int(i))
-                if nh is None:
-                    continue
-                nbr = np.asarray(nh["indices"])
-                # Locate center index `i` within the neighbor list (post-filter
-                # neighborhoods include the center as one of the entries — this
-                # is the convention of `NeighborhoodBuilder`).
-                center_match = np.where(nbr == int(i))[0]
-                if len(center_match) == 0:
-                    continue
-                center_in_nbr = int(center_match[0])
-            else:
-                dw = self._operator.get_derivative_weights(i)
-                if dw is None:
-                    continue
-                nbr = dw["neighbor_indices"]
-                center_in_nbr = dw["center_idx_in_neighbors"]
-                if center_in_nbr < 0:
-                    continue
+            # Post-filter neighborhood (matches runtime exactly).
+            # NeighborhoodBuilder convention: center index is one of the entries.
+            nh = self._neighborhoods.get(int(i))
+            if nh is None:
+                continue
+            nbr = np.asarray(nh["indices"])
+            center_match = np.where(nbr == int(i))[0]
+            if len(center_match) == 0:
+                continue
+            center_in_nbr = int(center_match[0])
 
             offsets = self._points[nbr] - self._points[i]
             offsets_for_taylor = offsets.reshape(-1) if self._dimension == 1 and offsets.ndim == 2 else offsets

--- a/mfgarchon/alg/numerical/gfdm_components/precomputed_stencils.py
+++ b/mfgarchon/alg/numerical/gfdm_components/precomputed_stencils.py
@@ -132,8 +132,7 @@ class PrecomputedMonotoneStencils:
         self._dimension = self._points.shape[1] if self._points.ndim == 2 else 1
         if self._dimension not in (1, 2):
             raise ValueError(
-                f"PrecomputedMonotoneStencils currently supports 1D or 2D, "
-                f"got dimension {self._dimension}"
+                f"PrecomputedMonotoneStencils currently supports 1D or 2D, got dimension {self._dimension}"
             )
 
         self.stencils: dict[int, MonotoneStencilData] = {}

--- a/mfgarchon/alg/numerical/gfdm_components/precomputed_stencils.py
+++ b/mfgarchon/alg/numerical/gfdm_components/precomputed_stencils.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 import time
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -42,9 +41,6 @@ from mfgarchon.alg.numerical.gfdm_components.joint_socp import (
     build_taylor_matrix_2d,
     wendland_stencil_weights,
 )
-
-if TYPE_CHECKING:
-    from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import TaylorOperator
 
 # Optional: OSQP for fast QP solving
 try:
@@ -84,27 +80,21 @@ class PrecomputedMonotoneStencils:
 
     Parameters
     ----------
-    operator : TaylorOperator
-        GFDM operator with precomputed Taylor matrices. Used when ``neighborhoods``
-        is None (legacy path); read for pre-adaptive ``op.get_derivative_weights(i)``.
     is_boundary : np.ndarray
         Boolean array indicating boundary points
+    neighborhoods : dict
+        Post-filter stencil dict (typically ``HJBGFDMSolver.neighborhoods`` built
+        by ``NeighborhoodBuilder``). Stencils are built on
+        ``neighborhoods[i]["indices"]``. Required for correctness on irregular
+        clouds where ``adaptive_neighborhoods=True`` enlarges boundary stencils
+        (Issue #1102 dual-source bug class — legacy fallback removed in v0.25.0).
+    points : np.ndarray
+        Collocation points, shape (n_total, dimension).
+    delta : float
+        Wendland kernel support radius. Sets the LSQ weighting used to compute
+        unconstrained Laplacian weights on the supplied stencil.
     tolerance : float
         Numerical tolerance for M-matrix check (default: 1e-6)
-    neighborhoods : dict | None
-        Post-filter stencil dict (typically ``HJBGFDMSolver.neighborhoods`` built
-        by ``NeighborhoodBuilder``). When provided, stencils are built on
-        post-adaptive ``neighborhoods[i]["indices"]`` rather than the pre-adaptive
-        ``op.get_derivative_weights(i)``. Requires ``points`` and ``delta``.
-        Issue #1102: required for correctness on irregular clouds where
-        ``adaptive_neighborhoods=True`` enlarges boundary stencils.
-    points : np.ndarray | None
-        Collocation points, shape (n_total, dimension). Required when
-        ``neighborhoods`` is provided.
-    delta : float | None
-        Wendland kernel support radius. Required when ``neighborhoods`` is
-        provided. Sets the LSQ weighting used to recompute unconstrained
-        Laplacian weights on the enlarged stencil.
 
     Attributes
     ----------
@@ -115,48 +105,36 @@ class PrecomputedMonotoneStencils:
 
     Example
     -------
-    >>> stencils = PrecomputedMonotoneStencils(operator, is_boundary)
-    >>> print(f"Precomputed {stencils.stats['n_monotonized']} stencils in {stencils.stats['time_ms']:.1f}ms")
+    >>> stencils = PrecomputedMonotoneStencils(is_boundary, neighborhoods, points, delta)
     >>> lap_weights, neighbors = stencils.get_laplacian_weights(boundary_point_idx)
     """
 
     def __init__(
         self,
-        operator: TaylorOperator,
         is_boundary: np.ndarray,
+        neighborhoods: dict,
+        points: np.ndarray,
+        delta: float,
         tolerance: float = 1e-6,
-        neighborhoods: dict | None = None,
-        points: np.ndarray | None = None,
-        delta: float | None = None,
     ):
-        self._operator = operator
+        # Single source of truth: stencils are always computed against the
+        # explicitly-supplied post-filter neighborhoods (after visibility
+        # filter, ghost nodes, adaptive δ-enlargement). The legacy fallback
+        # to `op.get_derivative_weights()` (pre-adaptive op.neighborhoods)
+        # was removed in v0.25.0 — it silently produced wrong results when
+        # adaptive_neighborhoods modified the runtime stencils (Issue #1102
+        # dual-source bug class).
         self._is_boundary = np.asarray(is_boundary)
         self._tolerance = tolerance
-        # Post-filter neighborhoods (after visibility filter, ghost nodes,
-        # adaptive δ-enlargement). Issue #1102: when None, fall back to
-        # pre-adaptive op.get_derivative_weights() (legacy path that crashes
-        # if adaptive enlargement modified self.neighborhoods).
         self._neighborhoods = neighborhoods
-        if neighborhoods is not None:
-            if points is None or delta is None:
-                raise ValueError(
-                    "PrecomputedMonotoneStencils: when neighborhoods= is provided, "
-                    "points= and delta= are also required (used to recompute "
-                    "unconstrained Wendland-LSQ Laplacian weights on the enlarged "
-                    "stencil)."
-                )
-            self._points = np.asarray(points)
-            self._delta = float(delta)
-            self._dimension = self._points.shape[1] if self._points.ndim == 2 else 1
-            if self._dimension not in (1, 2):
-                raise ValueError(
-                    f"PrecomputedMonotoneStencils with neighborhoods= currently "
-                    f"supports 1D or 2D, got dimension {self._dimension}"
-                )
-        else:
-            self._points = None
-            self._delta = None
-            self._dimension = None
+        self._points = np.asarray(points)
+        self._delta = float(delta)
+        self._dimension = self._points.shape[1] if self._points.ndim == 2 else 1
+        if self._dimension not in (1, 2):
+            raise ValueError(
+                f"PrecomputedMonotoneStencils currently supports 1D or 2D, "
+                f"got dimension {self._dimension}"
+            )
 
         self.stencils: dict[int, MonotoneStencilData] = {}
         self.stats = {
@@ -180,24 +158,7 @@ class PrecomputedMonotoneStencils:
 
         for i in boundary_indices:
             i = int(i)
-            if self._neighborhoods is not None:
-                # Post-adaptive path (Issue #1102): use runtime stencil indices
-                # so L_w aligns with `b = u_neighbors - u_center` built from
-                # the same neighborhoods at the override site in
-                # HJBGFDMSolver.approximate_derivatives.
-                stencil = self._compute_unconstrained_from_neighborhoods(i)
-            else:
-                # Legacy path: pre-adaptive op weights. Crashes at the override
-                # site if adaptive_neighborhoods modified self.neighborhoods
-                # (see Issue #1102 for the dual-source bug class).
-                weights_data = self._operator.get_derivative_weights(i)
-                if weights_data is None:
-                    continue
-                stencil = (
-                    weights_data["lap_weights"].copy(),
-                    weights_data["neighbor_indices"].copy(),
-                )
-
+            stencil = self._compute_unconstrained_from_neighborhoods(i)
             if stencil is None:
                 continue
             lap_weights, neighbor_indices = stencil

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -918,19 +918,12 @@ class HJBGFDMSolver(BaseHJBSolver):
 
             interior_indices = np.setdiff1d(np.arange(self.n_points), self.boundary_indices)
             self._joint_socp_stencils = PrecomputedJointSocpStencils(
-                operator=self._gfdm_operator,
                 points=self.collocation_points,
                 interior_indices=interior_indices,
                 delta=delta,
+                neighborhoods=self.neighborhoods,
                 cone_constant_C=8.0,  # higher C → cone less binding, picks fast-path Wendland-LSQ where M-matrix holds
                 eps_pos=0.0,
-                # Pass post-filter neighborhoods so SOCP weights are defined on
-                # the same stencil runtime uses to build `b` at the override
-                # site (`approximate_derivatives` line ~1675). Required to make
-                # the override correct on irregular clouds where the visibility
-                # filter (or ghost-node augmentation) modifies stencil indices
-                # between operator and `self.neighborhoods`.
-                neighborhoods=self.neighborhoods,
                 # C-bisection: retry infeasible stencils with progressively
                 # larger C up to C_max. Most marginally infeasible stencils
                 # become feasible at C ∈ (1, 8].
@@ -983,18 +976,11 @@ class HJBGFDMSolver(BaseHJBSolver):
             is_buffer = np.zeros(self.n_points, dtype=bool)
             is_buffer[self.boundary_indices] = True
             self._precomputed_stencils = PrecomputedMonotoneStencils(
-                operator=self._gfdm_operator,
                 is_boundary=is_buffer,
-                tolerance=1e-6,
-                # Issue #1102: pass post-filter neighborhoods so the M-matrix
-                # QP runs on the same stencil indices the override site sees
-                # at runtime. Without this, adaptive_neighborhoods=True (or
-                # ghost-node augmentation) silently desynchronises L_w
-                # (pre-adaptive, from op) from b = u_neighbors - u_center
-                # (post-adaptive, from self.neighborhoods).
                 neighborhoods=self.neighborhoods,
                 points=self.collocation_points,
                 delta=delta,
+                tolerance=1e-6,
             )
             logger.info(
                 f"Precomputed monotone stencils: {self._precomputed_stencils.stats['n_monotonized']}/{self._precomputed_stencils.stats['n_boundary']} "

--- a/tests/unit/test_alg/test_precomputed_monotone_stencils.py
+++ b/tests/unit/test_alg/test_precomputed_monotone_stencils.py
@@ -8,19 +8,22 @@ enlarged the runtime neighborhood (e.g. 53 → 522 at corner buffer points
 on a 1200-point Stage C cloud), the two stencils diverged and
 ``L_w @ b`` raised ``ValueError: matmul: size N is different from K``.
 
-Audit 2026-05-10 D.1 flagged this class as having no dedicated tests. The
-suite below closes that gap and locks in the post-fix invariants:
+v0.25.0 closed the bug class statically: ``neighborhoods``, ``points``,
+``delta`` are required ctor kwargs; the legacy fallback to
+``op.get_derivative_weights()`` was deleted. There is no longer a way to
+construct a stencil object that silently drifts from runtime neighborhoods.
 
-1. Legacy path (neighborhoods=None) reproduces pre-fix behaviour.
-2. Required-arg validation: neighborhoods= without points/delta raises.
-3. Matched-indices path: neighborhoods= with same indices as op produces
-   equivalent stencils to the legacy path (M-matrix property preserved).
-4. Enlarged-stencil path: neighborhoods= with strictly larger index sets
-   produces L_w whose length matches the enlarged stencil. This is the
-   load-bearing property that resolves #1102.
-5. Integration regression: HJBGFDMSolver with adaptive_neighborhoods=True
-   and monotonicity_scheme="qp_m_matrix" completes construction without
-   the precompute-vs-runtime shape mismatch firing.
+This suite locks in the v0.25.0 invariants:
+
+1. Required-arg gate: missing ``neighborhoods=`` / ``points=`` / ``delta=``
+   raises ``TypeError`` at construction (no silent legacy fallback).
+2. Matched-indices path: stencils built on op-equivalent indices produce
+   M-matrix-compliant weights.
+3. Enlarged-stencil path: ``neighborhoods[i]`` strictly larger than the
+   op default produces ``L_w`` of the enlarged length (load-bearing #1102
+   invariant).
+4. Integration regression: HJBGFDMSolver with ``adaptive_neighborhoods=True``
+   and ``monotonicity_scheme="qp_m_matrix"`` constructs end-to-end.
 """
 
 from __future__ import annotations
@@ -35,184 +38,109 @@ from mfgarchon.alg.numerical.gfdm_components.precomputed_stencils import (
     PrecomputedMonotoneStencils,
 )
 
-# ---------------------------------------------------------------------------
-# Minimal mock TaylorOperator — enough to drive _precompute legacy path.
-# Mirrors the dict shape returned by TaylorOperator.get_derivative_weights.
-# ---------------------------------------------------------------------------
-
-
-class _MockTaylorOperator:
-    def __init__(self, points: np.ndarray, neighborhoods: dict, delta: float):
-        """Build a stand-in operator with Wendland-LSQ unconstrained weights
-        at each point, matching the post-filter neighborhoods.
-        """
-        from mfgarchon.alg.numerical.gfdm_components.joint_socp import (
-            build_taylor_matrix_1d,
-            build_taylor_matrix_2d,
-            wendland_stencil_weights,
-        )
-
-        self.points = points
-        self.dimension = points.shape[1] if points.ndim == 2 else 1
-        self._weights_cache: dict[int, dict] = {}
-        for i, nh in neighborhoods.items():
-            nbr = np.asarray(nh["indices"])
-            offsets = points[nbr] - points[i]
-            if self.dimension == 1:
-                offsets_1d = offsets.reshape(-1)
-                A, _ = build_taylor_matrix_1d(offsets_1d)
-                w = wendland_stencil_weights(offsets_1d, delta)
-                e_lap = np.array([0.0, 0.0, 1.0])
-            else:
-                A, _ = build_taylor_matrix_2d(offsets)
-                w = wendland_stencil_weights(offsets, delta)
-                e_lap = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 1.0])
-            W = np.diag(w)
-            ATA = A.T @ W @ A
-            try:
-                coeffs = np.linalg.solve(ATA, e_lap)
-                lap = (W @ A) @ coeffs
-            except np.linalg.LinAlgError:
-                lap = np.zeros(len(nbr))
-            center_in = int(np.where(nbr == i)[0][0]) if i in nbr.tolist() else -1
-            self._weights_cache[int(i)] = {
-                "neighbor_indices": nbr,
-                "lap_weights": lap,
-                "center_idx_in_neighbors": center_in,
-            }
-
-    def get_derivative_weights(self, point_idx: int) -> dict | None:
-        return self._weights_cache.get(int(point_idx))
-
 
 def _build_2d_grid_with_neighborhoods(nx: int = 5, ny: int = 5, delta: float = 1.5):
     """Construct a small 2D Cartesian cloud with k-NN-like neighborhoods.
 
     All boundary points share the same fixed neighbor count, simulating
-    the pre-adaptive op state. Returns (points, op_neighborhoods, boundary_mask).
+    the pre-adaptive op state. Returns (points, neighborhoods, boundary_mask).
     """
+    from scipy.spatial import cKDTree
+
     xs = np.linspace(0.0, float(nx - 1), nx)
     ys = np.linspace(0.0, float(ny - 1), ny)
     pts = np.array([[x, y] for x in xs for y in ys])
     n = len(pts)
-    # k-NN with k=8 — every point has 8 closest neighbors plus itself.
-    from scipy.spatial import cKDTree
-
     tree = cKDTree(pts)
-    op_nh: dict[int, dict] = {}
+    nh: dict[int, dict] = {}
     for i in range(n):
         _, idx = tree.query(pts[i], k=9)  # includes self
-        op_nh[i] = {"indices": np.asarray(idx, dtype=int)}
-    # Boundary mask: outermost ring
+        nh[i] = {"indices": np.asarray(idx, dtype=int)}
     is_boundary = np.zeros(n, dtype=bool)
     for i, p in enumerate(pts):
         if p[0] in (xs[0], xs[-1]) or p[1] in (ys[0], ys[-1]):
             is_boundary[i] = True
-    return pts, op_nh, is_boundary
+    return pts, nh, is_boundary
 
 
 # ---------------------------------------------------------------------------
-# 1. Legacy path is unchanged
+# 1. Required-arg gate
 # ---------------------------------------------------------------------------
 
 
-def test_legacy_path_unchanged_no_neighborhoods():
-    """neighborhoods=None falls back to op.get_derivative_weights() (pre-#1102)."""
-    pts, op_nh, is_b = _build_2d_grid_with_neighborhoods()
-    op = _MockTaylorOperator(pts, op_nh, delta=1.5)
+def test_missing_neighborhoods_raises_type_error():
+    _, _, is_b = _build_2d_grid_with_neighborhoods()
+    with pytest.raises(TypeError):
+        PrecomputedMonotoneStencils(is_boundary=is_b)  # type: ignore[call-arg]
 
-    precomp = PrecomputedMonotoneStencils(operator=op, is_boundary=is_b, tolerance=1e-6)
+
+def test_missing_points_raises_type_error():
+    _, nh, is_b = _build_2d_grid_with_neighborhoods()
+    with pytest.raises(TypeError):
+        PrecomputedMonotoneStencils(is_boundary=is_b, neighborhoods=nh)  # type: ignore[call-arg]
+
+
+def test_missing_delta_raises_type_error():
+    pts, nh, is_b = _build_2d_grid_with_neighborhoods()
+    with pytest.raises(TypeError):
+        PrecomputedMonotoneStencils(is_boundary=is_b, neighborhoods=nh, points=pts)  # type: ignore[call-arg]
+
+
+def test_dimension_3d_rejected():
+    pts = np.random.default_rng(0).uniform(size=(20, 3))
+    is_b = np.zeros(20, dtype=bool)
+    is_b[:5] = True
+    nh = {i: {"indices": np.arange(20, dtype=int)} for i in range(20)}
+    with pytest.raises(ValueError, match="1D or 2D"):
+        PrecomputedMonotoneStencils(
+            is_boundary=is_b, neighborhoods=nh, points=pts, delta=1.5
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Matched-indices path: M-matrix property on op-equivalent stencil
+# ---------------------------------------------------------------------------
+
+
+def test_matched_neighborhoods_produces_m_matrix_compliant_stencils():
+    """neighborhoods matching the op's k-NN indices produces stencils
+    that are M-matrix compliant after QP (off-diagonals non-negative,
+    weights sum to zero modulo tolerance).
+    """
+    pts, nh, is_b = _build_2d_grid_with_neighborhoods()
+
+    precomp = PrecomputedMonotoneStencils(
+        is_boundary=is_b, neighborhoods=nh, points=pts, delta=1.5
+    )
 
     assert precomp.stats["n_boundary"] == int(is_b.sum())
     for i in np.where(is_b)[0]:
-        sd = precomp.stencils.get(int(i))
-        assert sd is not None, f"Missing stencil at boundary point {i}"
-        # Legacy stencil indices come from op directly.
-        assert np.array_equal(sd.neighbor_indices, op_nh[int(i)]["indices"])
+        i = int(i)
+        sd = precomp.stencils.get(i)
+        assert sd is not None, f"missing stencil at boundary point {i}"
+        # Same indices as the supplied neighborhoods.
+        assert np.array_equal(sd.neighbor_indices, nh[i]["indices"])
+        # M-matrix invariants.
+        if sd.center_in_neighbors is not None:
+            off = np.delete(sd.weights, sd.center_in_neighbors)
+            assert np.all(off >= -1e-6), f"point {i}: off-diagonal weights negative"
+            assert abs(np.sum(sd.weights)) < 1e-6, f"point {i}: weights do not sum to zero"
 
 
 # ---------------------------------------------------------------------------
-# 2. Required-arg validation
-# ---------------------------------------------------------------------------
-
-
-def test_neighborhoods_without_points_raises():
-    pts, op_nh, is_b = _build_2d_grid_with_neighborhoods()
-    op = _MockTaylorOperator(pts, op_nh, delta=1.5)
-    with pytest.raises(ValueError, match="points= and delta= are also required"):
-        PrecomputedMonotoneStencils(operator=op, is_boundary=is_b, neighborhoods=op_nh)
-
-
-def test_neighborhoods_without_delta_raises():
-    pts, op_nh, is_b = _build_2d_grid_with_neighborhoods()
-    op = _MockTaylorOperator(pts, op_nh, delta=1.5)
-    with pytest.raises(ValueError, match="points= and delta= are also required"):
-        PrecomputedMonotoneStencils(operator=op, is_boundary=is_b, neighborhoods=op_nh, points=pts)
-
-
-# ---------------------------------------------------------------------------
-# 3. Matched-indices: neighborhoods= with same indices as op produces
-#    M-matrix-compliant stencils on the same indices.
-# ---------------------------------------------------------------------------
-
-
-def test_matched_neighborhoods_produces_equivalent_stencils():
-    """When neighborhoods== matches op's indices, both paths produce stencils
-    on the same indices and both satisfy the M-matrix property after QP.
-
-    Bit-exact equality is not asserted: the Wendland-LSQ recomputation in
-    the new path may differ from op's stored unconstrained weights by the
-    LSQ-conditioning of the operator (different SVD truncation/conditioning
-    paths). The load-bearing invariant is: same indices, M-matrix-compliant.
-    """
-    pts, op_nh, is_b = _build_2d_grid_with_neighborhoods()
-    op = _MockTaylorOperator(pts, op_nh, delta=1.5)
-
-    legacy = PrecomputedMonotoneStencils(operator=op, is_boundary=is_b)
-    fresh = PrecomputedMonotoneStencils(
-        operator=op,
-        is_boundary=is_b,
-        neighborhoods=op_nh,
-        points=pts,
-        delta=1.5,
-    )
-
-    assert legacy.stats["n_boundary"] == fresh.stats["n_boundary"]
-    for i in np.where(is_b)[0]:
-        sd_l = legacy.stencils.get(int(i))
-        sd_f = fresh.stencils.get(int(i))
-        assert sd_l is not None
-        assert sd_f is not None
-        # Same stencil indices.
-        assert np.array_equal(sd_l.neighbor_indices, sd_f.neighbor_indices), (
-            f"point {i}: indices differ between legacy and fresh path"
-        )
-        # M-matrix property holds in fresh path (sum-to-zero and off-diagonal
-        # non-negative — modulo tolerance).
-        if sd_f.center_in_neighbors is not None:
-            off = np.delete(sd_f.weights, sd_f.center_in_neighbors)
-            assert np.all(off >= -1e-6), f"point {i}: fresh path off-diagonal weights have negative entries"
-            assert abs(np.sum(sd_f.weights)) < 1e-6, f"point {i}: fresh path weights do not sum to zero"
-
-
-# ---------------------------------------------------------------------------
-# 4. Enlarged stencil: post-adaptive indices strictly larger than op
+# 3. Enlarged stencil: post-adaptive indices strictly larger than k-NN
 # ---------------------------------------------------------------------------
 
 
 def test_enlarged_neighborhoods_produces_correct_length_weights():
-    """When neighborhoods[i] has strictly more indices than op (simulating
-    adaptive δ-enlargement), L_w must have the enlarged length and remain
-    M-matrix compliant after QP. This is the property that fails pre-#1102.
+    """When neighborhoods[i] has strictly more indices than the k-NN default
+    (simulating adaptive δ-enlargement), L_w must have the enlarged length
+    and remain M-matrix compliant after QP. This is the load-bearing #1102
+    invariant: precomp L_w aligns with runtime b = u_neighbors - u_center.
     """
-    pts, op_nh, is_b = _build_2d_grid_with_neighborhoods()
-    op = _MockTaylorOperator(pts, op_nh, delta=1.5)
-
-    # Simulate adaptive enlargement: at each boundary point, take all points
-    # within radius 2.5*delta instead of k=8. Strictly enlarges every
-    # boundary stencil for this small grid.
     from scipy.spatial import cKDTree
 
+    pts, base_nh, is_b = _build_2d_grid_with_neighborhoods()
     tree = cKDTree(pts)
     enlarged_nh: dict[int, dict] = {}
     for i in range(len(pts)):
@@ -220,38 +148,32 @@ def test_enlarged_neighborhoods_produces_correct_length_weights():
         enlarged_nh[i] = {"indices": idx}
 
     precomp = PrecomputedMonotoneStencils(
-        operator=op,
-        is_boundary=is_b,
-        neighborhoods=enlarged_nh,
-        points=pts,
-        delta=1.5,
+        is_boundary=is_b, neighborhoods=enlarged_nh, points=pts, delta=1.5
     )
 
     for i in np.where(is_b)[0]:
         i = int(i)
         sd = precomp.stencils.get(i)
-        assert sd is not None, f"Missing stencil at boundary point {i}"
+        assert sd is not None, f"missing stencil at boundary point {i}"
         n_enlarged = len(enlarged_nh[i]["indices"])
-        n_legacy = len(op_nh[i]["indices"])
-        # Sanity check on the test fixture: enlargement must actually enlarge.
-        assert n_enlarged > n_legacy, (
-            f"Test fixture broken at point {i}: r=3 not larger than k=8 ({n_enlarged} <= {n_legacy})"
+        n_base = len(base_nh[i]["indices"])
+        assert n_enlarged > n_base, (
+            f"test fixture broken at point {i}: r=3 not larger than k=8 "
+            f"({n_enlarged} <= {n_base})"
         )
-        # The fix: weights and indices share the enlarged length.
         assert len(sd.weights) == n_enlarged, (
             f"point {i}: L_w length {len(sd.weights)} != enlarged stencil "
-            f"length {n_enlarged}. This is the #1102 shape-mismatch invariant."
+            f"length {n_enlarged}. #1102 invariant violated."
         )
         assert len(sd.neighbor_indices) == n_enlarged
-        # M-matrix invariants still hold on the enlarged stencil.
         if sd.center_in_neighbors is not None:
             off = np.delete(sd.weights, sd.center_in_neighbors)
-            assert np.all(off >= -1e-6), f"point {i}: enlarged-stencil weights violate M-matrix off-diagonal"
-            assert abs(np.sum(sd.weights)) < 1e-6, f"point {i}: enlarged-stencil weights do not sum to zero"
+            assert np.all(off >= -1e-6), f"point {i}: enlarged off-diagonals negative"
+            assert abs(np.sum(sd.weights)) < 1e-6, f"point {i}: enlarged weights do not sum to zero"
 
 
 # ---------------------------------------------------------------------------
-# 5. Integration regression — HJBGFDMSolver path
+# 4. Integration regression — HJBGFDMSolver path
 # ---------------------------------------------------------------------------
 
 
@@ -286,22 +208,14 @@ class _MockProblem:
 def test_solver_constructs_with_adaptive_neighborhoods_and_qp_m_matrix():
     """HJBGFDMSolver(adaptive_neighborhoods=True, monotonicity_scheme="qp_m_matrix")
     must complete construction including the PrecomputedMonotoneStencils
-    initialisation, without runtime/precomp size mismatch.
-
-    The crash mode pre-#1102 is at the runtime override site
-    (``approximate_derivatives``); the fix here ensures L_w is built on
-    the same stencil the runtime sees, removing the shape mismatch by
-    construction. This test exercises the construction path; the
-    runtime contraction is exercised by the call from ``_make_solver``
-    setting up Taylor matrices end-to-end.
+    initialisation, without runtime/precomp size mismatch. Locks in the
+    end-to-end #1102 fix.
     """
     from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
     from mfgarchon.geometry import Hyperrectangle
     from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
 
     LX, LY = 6.0, 6.0
-    # Irregular cloud: small jitter to make adaptive enlargement bite at
-    # some corner buffer points without being too pathological.
     rng = np.random.default_rng(0)
     nx, ny = 7, 7
     xs = np.linspace(0.0, LX, nx)
@@ -353,10 +267,6 @@ def test_solver_constructs_with_adaptive_neighborhoods_and_qp_m_matrix():
             monotonicity_application="precompute",
         )
 
-    # Construction succeeded. Now verify the load-bearing invariant: for
-    # every precomputed stencil, the stored weights length matches the
-    # runtime neighborhood length. Pre-#1102 these diverged at adaptive-
-    # enlarged points and the runtime override would raise.
     precomp = s._precomputed_stencils
     assert precomp is not None, "qp_m_matrix + precompute should build stencils"
     for i, sd in precomp.stencils.items():


### PR DESCRIPTION
Closes #1102

## Architectural change

Eliminates the recurring dual-source stencil bug class **statically**. The `Precomputed*` constructor signatures used to admit a silent fallback path that drifted from runtime `NeighborhoodBuilder.neighborhoods`; this PR makes that path impossible to construct.

## Diagnosis (why this matters beyond #1102 itself)

Same bug class fired twice in ~one week:

- **#1099**: `PrecomputedJointSocpStencils` — pre-adaptive stencil contracted against post-adaptive `b` at runtime override site → `ValueError: matmul: size N is different from K`.
- **#1102/#1121**: `PrecomputedMonotoneStencils` — same symptom, same root cause, different class.

Each was patched by adding a `neighborhoods=` kwarg (default `None`) and branching in `_precompute`. The silent fallback was left in place. Memory `feedback_mfgarchon_dual_stencil_bug.md` recorded the pattern but no architectural fix landed.

## Fix

Both `Precomputed*` classes:

- `neighborhoods`, `points`, `delta` are now **required** kwargs (no `None` default).
- `operator: TaylorOperator` parameter removed — it was only consulted in the legacy fallback path; now unused.
- Legacy `op.get_derivative_weights()` / `op.get_neighborhood()` branches deleted from `_precompute`.

Production callers (HJBGFDMSolver lines 920, 978) updated. The dual-source bug class is statically impossible: there is no way to construct a stencil object that silently drifts from the supplied neighborhoods.

## Test plan

- `tests/unit/test_alg/test_precomputed_monotone_stencils.py` rewritten:
  - Legacy-fallback test deleted (path no longer exists).
  - **TypeError gates** added for each required kwarg (`neighborhoods`, `points`, `delta`).
  - Matched-indices path retained (M-matrix invariants on op-equivalent stencil).
  - Enlarged-stencil path retained (load-bearing #1102 invariant: `L_w` length equals enlarged stencil length).
  - End-to-end integration regression retained (`adaptive_neighborhoods=True` + `monotonicity_scheme=\"qp_m_matrix\"` constructs cleanly).
- 7/7 pass.
- Full mfgarchon suite: **818 passed, 3 skipped, 2 xfailed** (135s).

## What this does NOT do

The deeper unification — making `op.neighborhoods` itself post-adaptive so `FPGFDMSolver` (which reads `op.neighborhoods[i]` directly at `fp_gfdm.py:289`) stops being silently inconsistent with HJB under `adaptive_neighborhoods=True` — is deferred. That's a wider architectural change (NeighborhoodBuilder write-back contract, sparse-matrix invalidation, FPGFDMSolver lifecycle). Tracked separately.

This PR is the surgical first step: eliminate the silent fallback within the `Precomputed*` family.

## Breaking change

Constructor signatures change. Internal classes (used via `HJBGFDMSolver` in 100% of mfg-research scripts I've audited); no mfg-research direct callers found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)