### PR TITLE
refactor(fem): WeakFormDiscretization protocol + FEM backend (Phase 1 of #1131)

### DIFF
--- a/mfgarchon/alg/numerical/fem/__init__.py
+++ b/mfgarchon/alg/numerical/fem/__init__.py
@@ -23,6 +23,7 @@ from mfgarchon.alg.numerical.fem.assembly import (
     assemble_stiffness,
     create_basis,
 )
+from mfgarchon.alg.numerical.fem.discretization import FEMDiscretization
 from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
 from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
 from mfgarchon.alg.numerical.fem.mesh_adapter import (
@@ -33,6 +34,7 @@ from mfgarchon.alg.numerical.fem.mesh_adapter import (
 __all__ = [
     "HJBFEMSolver",
     "FPFEMSolver",
+    "FEMDiscretization",
     "create_basis",
     "assemble_stiffness",
     "assemble_mass",

--- a/mfgarchon/alg/numerical/fem/discretization.py
+++ b/mfgarchon/alg/numerical/fem/discretization.py
@@ -1,0 +1,90 @@
+"""
+Finite-element (mesh + Lagrange) backend for the weak-form discretization
+protocol. Assembly is implemented with scikit-fem, but that is an internal
+detail; the backend is named for the method, not the library.
+
+``FEMDiscretization`` adapts the ``fem.assembly`` free functions to the
+``WeakFormDiscretization`` protocol so weak-form solvers can be written against
+the protocol rather than against ``skfem.Basis`` directly. It is a thin adapter:
+each method delegates to the corresponding ``assemble_*`` function, so behavior
+is identical to calling them directly.
+
+Issue #1131 Phase 1.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .assembly import (
+    assemble_advection,
+    assemble_gradient_projection,
+    assemble_mass,
+    assemble_stiffness,
+)
+
+if TYPE_CHECKING:
+    import skfem
+
+    from numpy.typing import NDArray
+    from scipy import sparse
+
+
+class FEMDiscretization:
+    """Mesh + Lagrange finite-element implementation of ``WeakFormDiscretization``.
+
+    Assembly backend: scikit-fem (internal detail).
+    """
+
+    def __init__(self, basis: skfem.Basis) -> None:
+        self._basis = basis
+
+    @property
+    def n_dof(self) -> int:
+        return int(self._basis.N)
+
+    @property
+    def dim(self) -> int:
+        return int(self._basis.mesh.dim())
+
+    def stiffness(self) -> sparse.csr_matrix:
+        return assemble_stiffness(self._basis)
+
+    def mass(self) -> sparse.csr_matrix:
+        return assemble_mass(self._basis)
+
+    def advection(self, velocity: NDArray) -> sparse.csr_matrix:
+        return assemble_advection(self._basis, velocity)
+
+    def gradient_projection(self) -> list[sparse.csr_matrix]:
+        return assemble_gradient_projection(self._basis)
+
+
+if __name__ == "__main__":
+    """Equivalence smoke test: the adapter must reproduce the free functions."""
+    import skfem
+
+    import numpy as np
+    from scipy.sparse import linalg as sla
+
+    from mfgarchon.alg.numerical.weak_form_discretization import WeakFormDiscretization
+
+    from .assembly import create_basis
+
+    mesh = skfem.MeshTri.init_sqsymmetric()
+    basis = create_basis(mesh, order=1)
+    disc: WeakFormDiscretization = FEMDiscretization(basis)
+
+    assert isinstance(disc, WeakFormDiscretization), "protocol conformance failed"
+    assert disc.n_dof == basis.N
+    assert disc.dim == basis.mesh.dim()
+
+    # Each operator must equal the free-function result exactly.
+    assert sla.norm(disc.stiffness() - assemble_stiffness(basis)) == 0.0
+    assert sla.norm(disc.mass() - assemble_mass(basis)) == 0.0
+    for Rd, Rd_free in zip(disc.gradient_projection(), assemble_gradient_projection(basis), strict=True):
+        assert sla.norm(Rd - Rd_free) == 0.0
+    v = np.ones((mesh.dim(), basis.N))
+    assert sla.norm(disc.advection(v) - assemble_advection(basis, v)) == 0.0
+
+    print("FEMDiscretization equivalence smoke test passed.")

--- a/mfgarchon/alg/numerical/fem/fp_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/fp_fem_solver.py
@@ -24,6 +24,7 @@ from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
 from mfgarchon.utils.mfg_logging import get_logger
 
 from .assembly import assemble_mass, assemble_stiffness, create_basis
+from .discretization import FEMDiscretization
 from .mesh_adapter import meshdata_to_skfem
 
 if TYPE_CHECKING:
@@ -62,10 +63,11 @@ class FPFEMSolver(BaseFPSolver):
 
         self._skfem_mesh = meshdata_to_skfem(mesh_data)
         self._basis = create_basis(self._skfem_mesh, order=order)
+        self._disc = FEMDiscretization(self._basis)  # Issue #1131: assembly backend
         self._n_dof = self._basis.N
 
-        self._K = assemble_stiffness(self._basis)
-        self._M = assemble_mass(self._basis)
+        self._K = self._disc.stiffness()
+        self._M = self._disc.mass()
 
         # BC from problem geometry (same framework as FDM/GFDM)
         self._bc = getattr(problem.geometry, "boundary_conditions", None)

--- a/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
@@ -23,7 +23,8 @@ from scipy.sparse.linalg import spsolve
 from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
 from mfgarchon.utils.mfg_logging import get_logger
 
-from .assembly import assemble_gradient_projection, assemble_mass, assemble_stiffness, create_basis
+from .assembly import assemble_mass, assemble_stiffness, create_basis
+from .discretization import FEMDiscretization
 from .mesh_adapter import meshdata_to_skfem
 
 if TYPE_CHECKING:
@@ -71,14 +72,15 @@ class HJBFEMSolver(BaseHJBSolver):
 
         self._skfem_mesh = meshdata_to_skfem(mesh_data)
         self._basis = create_basis(self._skfem_mesh, order=order)
+        self._disc = FEMDiscretization(self._basis)  # Issue #1131: assembly backend
         self._n_dof = self._basis.N
 
         # Pre-assemble constant matrices
-        self._K = assemble_stiffness(self._basis)  # Stiffness (Laplacian)
-        self._M = assemble_mass(self._basis)  # Mass
+        self._K = self._disc.stiffness()  # Stiffness (Laplacian)
+        self._M = self._disc.mass()  # Mass
 
         # Gradient projection matrices for Newton iteration (lazy-built)
-        self._R_grad = assemble_gradient_projection(self._basis)
+        self._R_grad = self._disc.gradient_projection()
         self._G_grad: list[sparse.csr_matrix] | None = None
         self._M_lumped_inv: NDArray | None = None
 

--- a/mfgarchon/alg/numerical/weak_form_discretization.py
+++ b/mfgarchon/alg/numerical/weak_form_discretization.py
@@ -1,0 +1,71 @@
+"""
+Backend-agnostic weak-form discretization protocol.
+
+A weak-form HJB/FP solver depends only on the assembled sparse operators, not on
+how they are built. Finite elements (mesh + Lagrange, via scikit-fem) and
+meshfree Galerkin (point cloud + Moving Least Squares) produce the same operators
+from the same bilinear forms; only the shape-function evaluation differs.
+Decoupling the solver from the assembly backend is the purpose of this protocol.
+
+Implementations:
+- ``FEMDiscretization`` (``fem/discretization.py``) -- mesh + Lagrange.
+- ``MeshlessGalerkinDiscretization`` -- point cloud + MLS (Phase 2).
+
+Issue #1131.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+    from scipy import sparse
+
+
+@runtime_checkable
+class WeakFormDiscretization(Protocol):
+    """Assembled weak-form operators a solver needs, independent of backend.
+
+    All operators are returned as ``scipy`` sparse matrices of shape
+    ``(n_dof, n_dof)`` (the gradient projection as one such matrix per spatial
+    dimension), matching the coupling layer's expectations
+    (``FixedPointIterator``, adjoint operators).
+    """
+
+    @property
+    def n_dof(self) -> int:
+        """Number of degrees of freedom (rows/cols of every operator)."""
+        ...
+
+    @property
+    def dim(self) -> int:
+        """Spatial dimension."""
+        ...
+
+    def stiffness(self) -> sparse.csr_matrix:
+        r"""Stiffness matrix $K_{ij} = \int_\Omega \nabla\phi_i \cdot \nabla\phi_j \, dx$.
+
+        Symmetric. Discretizes $-\Delta$; scale by the diffusion coefficient.
+        """
+        ...
+
+    def mass(self) -> sparse.csr_matrix:
+        r"""Mass matrix $M_{ij} = \int_\Omega \phi_i \phi_j \, dx$. Symmetric PD."""
+        ...
+
+    def advection(self, velocity: NDArray) -> sparse.csr_matrix:
+        r"""Advection matrix $C_{ij} = \int_\Omega (v \cdot \nabla\phi_j) \phi_i \, dx$.
+
+        Not symmetric in general. ``velocity`` is the field at the degrees of
+        freedom, shape ``(dim, n_dof)`` (or ``(n_dof,)`` in 1D).
+        """
+        ...
+
+    def gradient_projection(self) -> list[sparse.csr_matrix]:
+        r"""Gradient-projection operators $[R_0, \dots, R_{d-1}]$.
+
+        $R_d$ maps nodal values to the weak-form $d$-th partial derivative,
+        used to build the Hamiltonian Jacobian in Newton iteration.
+        """
+        ...


### PR DESCRIPTION
## Summary

Phase 1 of #1131. Introduces the backend-agnostic `WeakFormDiscretization` protocol and moves FEM assembly behind it, so weak-form solvers depend on the protocol rather than on `skfem.Basis` directly. **No behavior change.**

## Changes
- **New** `alg/numerical/weak_form_discretization.py` — `WeakFormDiscretization` protocol (`stiffness` / `mass` / `advection` / `gradient_projection` → scipy sparse).
- **New** `alg/numerical/fem/discretization.py` — `FEMDiscretization`, a thin adapter over the existing `assemble_*` functions. scikit-fem is an internal implementation detail, deliberately not in the name (the backend is named for the method, not the library).
- `HJBFEMSolver` / `FPFEMSolver` now assemble via `self._disc = FEMDiscretization(basis)` instead of the free functions.
- Export `FEMDiscretization` from `fem/__init__`.

## Why
This is the assembly-backend abstraction. It sets up the meshless-Galerkin (MLS) backend (Phase 2) to drop in as a second implementation of the same protocol, so finite elements (mesh + Lagrange) and meshfree Galerkin (point cloud + MLS) share one weak-form solver. Background: #580 (adjoint-aware solver pairing), #704 / #706 (the transpose deprecation — invalid for strong-form, valid for the Galerkin assembled operator).

## Verification
- **Equivalence smoke test** (`discretization.py` `__main__`): `FEMDiscretization` operators are byte-identical to the free `assemble_*` functions (`scipy.sparse.linalg.norm(diff) == 0`).
- **FEM integration suite**: 12/12 pass, unchanged from the pre-change baseline.
- Ruff clean on new files.

## Scope
Part of #1131 (Phases 2–3 — MLS backend + basis-agnostic weak-form solvers + `MESHLESS_GALERKIN` scheme — remain; this PR does not close the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
