### PR TITLE
feat(meshless): MeshlessGalerkinDiscretization weak-form backend (Phase 2 of #1131)

### DIFF
--- a/mfgarchon/alg/numerical/meshless_galerkin/__init__.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/__init__.py
@@ -1,0 +1,24 @@
+"""
+Meshless Galerkin (Moving Least Squares) weak-form backend.
+
+Provides ``MeshlessGalerkinDiscretization``, a meshfree implementation of the
+``WeakFormDiscretization`` protocol: weak-form operators are assembled by local
+quadrature against MLS shape functions on a scattered point cloud, with no mesh.
+
+The MLS shape-function derivatives have two interchangeable backends:
+- ``"numpy"`` (default): analytic derivatives, core dependencies only.
+- ``"jax"`` (optional): autodiff; requires jax. No silent fallback -- an
+  explicit error is raised if jax is requested but unavailable.
+
+Issue #1131 Phase 2.
+"""
+
+from mfgarchon.alg.numerical.meshless_galerkin.discretization import (
+    MeshlessGalerkinDiscretization,
+)
+from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
+
+__all__ = [
+    "MeshlessGalerkinDiscretization",
+    "tensor_gauss",
+]

--- a/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
@@ -64,9 +64,7 @@ class MeshlessGalerkinDiscretization:
             np.asarray(quad_points, dtype=np.float64), self._nodes, self._rho, exps, backend
         )
         # gradients at the nodes for the gradient-projection operators: (N, N, dim)
-        _, self._grad_nodes = shape_functions_and_grads(
-            self._nodes, self._nodes, self._rho, exps, backend
-        )
+        _, self._grad_nodes = shape_functions_and_grads(self._nodes, self._nodes, self._rho, exps, backend)
 
     @property
     def n_dof(self) -> int:
@@ -129,9 +127,7 @@ if __name__ == "__main__":
         # gradient projection of linear field u = x_e reproduces delta_{ec}.
         R = [r.toarray() for r in disc.gradient_projection()]
         grad_err = max(
-            float(np.max(np.abs(R[e] @ nodes[:, c] - (1.0 if e == c else 0.0))))
-            for e in range(d)
-            for c in range(d)
+            float(np.max(np.abs(R[e] @ nodes[:, c] - (1.0 if e == c else 0.0)))) for e in range(d) for c in range(d)
         )
         alpha = -np.asarray(pts).T  # velocity at dofs is (dim, N); use nodes-consistent shape
         v = -nodes.T  # (dim, N): drift -x at dofs (potential MFG, Psi=|x|^2/2)

--- a/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
@@ -1,0 +1,152 @@
+"""
+Meshless Galerkin (MLS) implementation of the weak-form discretization protocol.
+
+``MeshlessGalerkinDiscretization`` assembles the weak-form operators on a
+scattered point cloud by local quadrature against MLS shape functions, with no
+mesh. It is the meshfree counterpart of ``FEMDiscretization``; both satisfy
+``WeakFormDiscretization`` so a weak-form solver consumes either.
+
+Shape functions and gradients are evaluated once at the quadrature points (for
+stiffness/mass/advection) and once at the nodes (for the gradient projection);
+operators are then contractions over the cached arrays. Dimension enters only
+through the contracted index.
+
+Issue #1131 Phase 2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy import sparse
+
+from mfgarchon.alg.numerical.meshless_galerkin.mls_basis import (
+    monomial_exponents,
+    shape_functions_and_grads,
+)
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+class MeshlessGalerkinDiscretization:
+    """Point cloud + MLS implementation of ``WeakFormDiscretization``.
+
+    Args:
+        nodes: collocation/test centers, shape ``(n_dof, dim)``.
+        rho: MLS support radius.
+        degree: MLS polynomial degree ``k``.
+        quad_points: integration points, shape ``(Q, dim)``.
+        quad_weights: integration weights, shape ``(Q,)``.
+        backend: ``"numpy"`` (analytic, default) or ``"jax"`` (autodiff).
+    """
+
+    def __init__(
+        self,
+        nodes: NDArray,
+        rho: float,
+        degree: int,
+        quad_points: NDArray,
+        quad_weights: NDArray,
+        backend: str = "numpy",
+    ) -> None:
+        self._nodes = np.asarray(nodes, dtype=np.float64)
+        self._n_dof = int(self._nodes.shape[0])
+        self._dim = int(self._nodes.shape[1])
+        self._rho = float(rho)
+        self._backend = backend
+        self._w = np.asarray(quad_weights, dtype=np.float64)
+        exps = monomial_exponents(self._dim, degree)
+
+        # (phi, grad) at quadrature points: (Q, N), (Q, N, dim)
+        self._phi, self._grad = shape_functions_and_grads(
+            np.asarray(quad_points, dtype=np.float64), self._nodes, self._rho, exps, backend
+        )
+        # gradients at the nodes for the gradient-projection operators: (N, N, dim)
+        _, self._grad_nodes = shape_functions_and_grads(
+            self._nodes, self._nodes, self._rho, exps, backend
+        )
+
+    @property
+    def n_dof(self) -> int:
+        return self._n_dof
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def stiffness(self) -> sparse.csr_matrix:
+        K = np.einsum("q,qid,qjd->ij", self._w, self._grad, self._grad)
+        return sparse.csr_matrix(K)
+
+    def mass(self) -> sparse.csr_matrix:
+        M = np.einsum("q,qi,qj->ij", self._w, self._phi, self._phi)
+        return sparse.csr_matrix(M)
+
+    def advection(self, velocity: NDArray) -> sparse.csr_matrix:
+        # velocity at dofs (dim, n_dof) or (n_dof,); interpolate to quad points
+        # via the MLS shape functions: alpha(xi_q) = sum_j phi_j(xi_q) v_j.
+        velocity = np.asarray(velocity, dtype=np.float64)
+        if velocity.ndim == 1:
+            velocity = velocity[None, :]
+        alpha_q = np.einsum("qj,dj->qd", self._phi, velocity)  # (Q, dim)
+        a = np.einsum("qd,qjd->qj", alpha_q, self._grad)  # (Q, N): alpha . grad phi_j
+        C = np.einsum("q,qi,qj->ij", self._w, self._phi, a)
+        return sparse.csr_matrix(C)
+
+    def gradient_projection(self) -> list[sparse.csr_matrix]:
+        # R_d[i, j] = d phi_j / d x_d evaluated at node x_i.
+        return [sparse.csr_matrix(self._grad_nodes[:, :, d]) for d in range(self._dim)]
+
+
+if __name__ == "__main__":
+    """Smoke test: numpy/jax backends agree; protocol invariants hold (1D, 2D)."""
+    from scipy.sparse import linalg as sla
+
+    from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
+    from mfgarchon.alg.numerical.weak_form_discretization import WeakFormDiscretization
+
+    def grid(d, n):
+        ax = np.linspace(0.0, 1.0, n)
+        mesh = np.meshgrid(*([ax] * d), indexing="ij")
+        return np.stack([m.ravel() for m in mesh], axis=1)
+
+    for d in (1, 2):
+        n_per = 11 if d == 1 else 7
+        nodes = grid(d, n_per)
+        h = 1.0 / (n_per - 1)
+        rho = 3.5 * h if d == 1 else 2.6 * h
+        pts, wts = tensor_gauss([(0.0, 1.0)] * d, n_cells=n_per - 1, n_gauss=4)
+
+        disc = MeshlessGalerkinDiscretization(nodes, rho, 2, pts, wts, backend="numpy")
+        assert isinstance(disc, WeakFormDiscretization), "protocol conformance failed"
+
+        K = disc.stiffness().toarray()
+        one = np.ones(disc.n_dof)
+        K_sym = np.linalg.norm(K - K.T) / np.linalg.norm(K)
+        K_one = np.max(np.abs(K @ one))
+        # gradient projection of linear field u = x_e reproduces delta_{ec}.
+        R = [r.toarray() for r in disc.gradient_projection()]
+        grad_err = max(
+            float(np.max(np.abs(R[e] @ nodes[:, c] - (1.0 if e == c else 0.0))))
+            for e in range(d)
+            for c in range(d)
+        )
+        alpha = -np.asarray(pts).T  # velocity at dofs is (dim, N); use nodes-consistent shape
+        v = -nodes.T  # (dim, N): drift -x at dofs (potential MFG, Psi=|x|^2/2)
+        A_one = np.max(np.abs((0.05 * disc.stiffness() + disc.advection(v)) @ one))
+
+        # numpy vs jax agreement (skip cleanly if jax absent).
+        try:
+            disc_j = MeshlessGalerkinDiscretization(nodes, rho, 2, pts, wts, backend="jax")
+            backend_diff = sla.norm(disc.stiffness() - disc_j.stiffness()) / np.linalg.norm(K)
+            jax_note = f"{backend_diff:.2e}"
+        except ImportError:
+            jax_note = "jax not installed (skipped)"
+
+        print(f"d={d}: N={disc.n_dof}")
+        print(f"   ||K-K^T||/||K|| = {K_sym:.2e}   ||K@1|| = {K_one:.2e}")
+        print(f"   grad-projection err = {grad_err:.2e}   ||(nuK+C)@1|| = {A_one:.2e}")
+        print(f"   numpy-vs-jax stiffness rel diff = {jax_note}")
+    print("MeshlessGalerkinDiscretization smoke test complete.")

--- a/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
@@ -132,9 +132,7 @@ def shape_functions_and_grads_jax(
         import jax
         import jax.numpy as jnp
     except ImportError:
-        raise ImportError(
-            "backend='jax' requires jax. Install jax, or use backend='numpy'."
-        ) from None
+        raise ImportError("backend='jax' requires jax. Install jax, or use backend='numpy'.") from None
 
     jax.config.update("jax_enable_x64", True)
     nodes_j = jnp.asarray(nodes, dtype=jnp.float64)

--- a/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
@@ -1,0 +1,172 @@
+"""
+Dimension-agnostic Moving Least Squares (MLS) shape functions with full
+derivatives. Two interchangeable derivative backends:
+
+- ``"numpy"`` (default): analytic derivatives, core dependencies only.
+- ``"jax"`` (optional): autodiff through the moment matrix; requires jax.
+
+Both compute the *full* MLS derivative (differentiating through M(x)), not the
+diffuse derivative, and must agree to rounding. Dimension enters only through the
+multi-index monomial basis; nothing branches on it.
+
+Issue #1131 Phase 2.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def monomial_exponents(d: int, k: int) -> NDArray:
+    """Exponent multi-indices for the total-degree-<= k space in d variables.
+
+    Returns an integer array of shape ``(m, d)``, ``m = C(d+k, k)``, ordered by
+    total degree then lexicographically. Row ``alpha`` encodes the monomial
+    ``prod_l x_l**alpha_l``.
+    """
+    exps = [e for e in product(range(k + 1), repeat=d) if sum(e) <= k]
+    exps.sort(key=lambda e: (sum(e), e))
+    return np.array(exps, dtype=np.int64)
+
+
+# --- Wendland C^2 weight (radial; dimension enters only via ||x - x_j||) -------
+def _wendland_c2(r: NDArray) -> NDArray:
+    return np.where(r < 1.0, (1.0 - r) ** 4 * (4.0 * r + 1.0), 0.0)
+
+
+def _wendland_c2_deriv(r: NDArray) -> NDArray:
+    return np.where(r < 1.0, -20.0 * r * (1.0 - r) ** 3, 0.0)
+
+
+# --- monomial basis and its gradient (numpy) -----------------------------------
+def _poly_batch(pts: NDArray, exponents: NDArray) -> NDArray:
+    """Monomial basis at many points. pts (P,d), exponents (m,d) -> (P,m)."""
+    return np.prod(pts[:, None, :] ** exponents[None, :, :], axis=2)
+
+
+def _poly_grad_batch(pts: NDArray, exponents: NDArray) -> NDArray:
+    """Gradient of the monomial basis. pts (P,d), exponents (m,d) -> (P,m,d).
+
+    d(prod x_e^a_e)/dx_c = a_c x_c^{a_c-1} prod_{e!=c} x_e^{a_e}. The a_c factor
+    zeroes terms with a_c=0, so the reduced exponent is clamped at 0 to avoid
+    x_c^{-1} (the term is multiplied by 0 anyway).
+    """
+    P, d = pts.shape
+    m = exponents.shape[0]
+    out = np.zeros((P, m, d))
+    for c in range(d):
+        reduced = exponents.copy()
+        reduced[:, c] = np.maximum(reduced[:, c] - 1, 0)
+        term = np.prod(pts[:, None, :] ** reduced[None, :, :], axis=2)  # (P,m)
+        out[:, :, c] = exponents[:, c][None, :] * term
+    return out
+
+
+def shape_functions_and_grads_numpy(
+    x_eval: NDArray, nodes: NDArray, rho: float, exponents: NDArray
+) -> tuple[NDArray, NDArray]:
+    r"""MLS shape functions and full gradients via analytic differentiation.
+
+    phi_j(x) = omega_j(x) p(x)^T M(x)^{-1} p(x_j),  M(x) = sum_l omega_l p_l p_l^T.
+
+    Using gamma = M^{-1} p, s_j = (P gamma)_j, the full gradient is
+        d_c phi_j = (d_c omega_j) s_j + omega_j (P (beta_c - w_c))_j,
+    with beta_c = M^{-1} (d_c p), w_c = M^{-1} (d_c M) gamma, and
+    d(M^{-1}) = -M^{-1} (d M) M^{-1}.
+
+    x_eval (Q,d) -> phi (Q,N), grad (Q,N,d).
+    """
+    x_eval = np.asarray(x_eval, dtype=np.float64)
+    nodes = np.asarray(nodes, dtype=np.float64)
+    Q, d = x_eval.shape
+
+    diffs = x_eval[:, None, :] - nodes[None, :, :]  # (Q,N,d), x - x_l
+    dist = np.linalg.norm(diffs, axis=2)  # (Q,N)
+    r = dist / rho
+    omega = _wendland_c2(r)  # (Q,N)
+    wprime = _wendland_c2_deriv(r)  # (Q,N)
+
+    P = _poly_batch(nodes, exponents)  # (N,m)
+    p = _poly_batch(x_eval, exponents)  # (Q,m)
+    dp = _poly_grad_batch(x_eval, exponents)  # (Q,m,d)
+
+    M = np.einsum("qn,ni,nj->qij", omega, P, P)  # (Q,m,m)
+    # numpy>=2.0: a (Q,m,m) with b (Q,m) is read as a single matrix RHS; pass an
+    # explicit (Q,m,1) column stack and squeeze to get batched vector solves.
+    gamma = np.linalg.solve(M, p[..., None])[..., 0]  # (Q,m)
+    s = np.einsum("qm,nm->qn", gamma, P)  # (Q,N)
+    phi = omega * s
+
+    # weight gradient: d omega_l/dx_c = w'(r_l) (x - x_l)_c / (rho * dist_l).
+    # dist_l = 0 only when x hits a node, where w'(0) = 0, so the row is 0;
+    # the safe denominator just avoids 0/0.
+    safe = np.where(dist == 0.0, 1.0, dist)
+    domega = (wprime / (rho * safe))[..., None] * diffs  # (Q,N,d)
+
+    grad = np.empty((Q, P.shape[0], d))
+    for c in range(d):
+        dM = np.einsum("qn,ni,nj->qij", domega[:, :, c], P, P)  # (Q,m,m)
+        beta = np.linalg.solve(M, dp[:, :, c][..., None])[..., 0]  # (Q,m)
+        u = np.einsum("qij,qj->qi", dM, gamma)  # (Q,m)
+        w_c = np.linalg.solve(M, u[..., None])[..., 0]  # (Q,m)
+        ds = np.einsum("qm,nm->qn", beta - w_c, P)  # (Q,N)
+        grad[:, :, c] = domega[:, :, c] * s + omega * ds
+    return phi, grad
+
+
+def shape_functions_and_grads_jax(
+    x_eval: NDArray, nodes: NDArray, rho: float, exponents: NDArray
+) -> tuple[NDArray, NDArray]:
+    """MLS shape functions and full gradients via JAX autodiff (optional backend).
+
+    Same signature/result as the numpy backend. Raises ImportError if jax is
+    unavailable -- no silent fallback (Issue #1072).
+    """
+    try:
+        import jax
+        import jax.numpy as jnp
+    except ImportError:
+        raise ImportError(
+            "backend='jax' requires jax. Install jax, or use backend='numpy'."
+        ) from None
+
+    jax.config.update("jax_enable_x64", True)
+    nodes_j = jnp.asarray(nodes, dtype=jnp.float64)
+    exps_j = jnp.asarray(exponents)
+    P = jnp.prod(nodes_j[:, None, :] ** exps_j[None, :, :], axis=2)  # (N,m)
+
+    def phi_at(x):  # x (d,) -> (N,)
+        sq = jnp.sum((nodes_j - x[None, :]) ** 2, axis=1)
+        is_zero = sq == 0.0
+        dist = jnp.where(is_zero, 0.0, jnp.sqrt(jnp.where(is_zero, 1.0, sq)))
+        r = dist / rho
+        w = jnp.where(r < 1.0, (1.0 - r) ** 4 * (4.0 * r + 1.0), 0.0)
+        p = jnp.prod(x[None, :] ** exps_j, axis=1)  # (m,)
+        M = jnp.einsum("n,ni,nj->ij", w, P, P)
+        return (P @ jnp.linalg.solve(M, p)) * w
+
+    x_eval_j = jnp.asarray(x_eval, dtype=jnp.float64)
+    phi = jax.vmap(phi_at)(x_eval_j)
+    grad = jax.vmap(jax.jacobian(phi_at))(x_eval_j)
+    return np.asarray(phi), np.asarray(grad)
+
+
+def shape_functions_and_grads(
+    x_eval: NDArray,
+    nodes: NDArray,
+    rho: float,
+    exponents: NDArray,
+    backend: str = "numpy",
+) -> tuple[NDArray, NDArray]:
+    """Dispatch to the numpy (default) or jax MLS derivative backend."""
+    if backend == "numpy":
+        return shape_functions_and_grads_numpy(x_eval, nodes, rho, exponents)
+    if backend == "jax":
+        return shape_functions_and_grads_jax(x_eval, nodes, rho, exponents)
+    raise ValueError(f"Unknown backend {backend!r}; expected 'numpy' or 'jax'.")

--- a/mfgarchon/alg/numerical/meshless_galerkin/quadrature.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/quadrature.py
@@ -1,0 +1,59 @@
+"""
+Dimension-agnostic interior quadrature for meshless Galerkin assembly.
+
+Tensor-product Gauss-Legendre on a background grid over the domain bounding box.
+This is the dimension-agnostic "interior" rule. Boundary-clipped supports
+(B(x_i, rho) intersect Omega) are the only per-dimension concern and are handled
+separately (not yet implemented). For interior-dominated clouds this rule
+suffices to assemble the operators and exhibits the exact Galerkin symmetry
+K = K^T, which holds for any quadrature.
+
+Issue #1131 Phase 2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def tensor_gauss(
+    bounds: list[tuple[float, float]],
+    n_cells: int,
+    n_gauss: int,
+) -> tuple[NDArray, NDArray]:
+    r"""Tensor-product Gauss-Legendre quadrature over an axis-aligned box.
+
+    Args:
+        bounds: ``(a, b)`` per dimension; ``len(bounds)`` is the dimension ``d``.
+        n_cells: cells per dimension (the background grid).
+        n_gauss: Gauss-Legendre points per cell per dimension.
+
+    Returns:
+        ``(points, weights)`` with ``points`` of shape ``(Q, d)`` and ``weights``
+        of shape ``(Q,)``, ``Q = (n_cells * n_gauss) ** d``. Exact for tensor
+        polynomials of per-dimension degree ``<= 2*n_gauss - 1`` on each cell.
+    """
+    xi, wi = np.polynomial.legendre.leggauss(n_gauss)  # reference [-1, 1]
+
+    per_dim_pts, per_dim_wts = [], []
+    for a, b in bounds:
+        edges = np.linspace(a, b, n_cells + 1)
+        pts, wts = [], []
+        for c in range(n_cells):
+            mid = 0.5 * (edges[c] + edges[c + 1])
+            half = 0.5 * (edges[c + 1] - edges[c])
+            pts.append(mid + half * xi)
+            wts.append(half * wi)
+        per_dim_pts.append(np.concatenate(pts))
+        per_dim_wts.append(np.concatenate(wts))
+
+    pts_mesh = np.meshgrid(*per_dim_pts, indexing="ij")
+    points = np.stack([m.ravel() for m in pts_mesh], axis=1)
+    wts_mesh = np.meshgrid(*per_dim_wts, indexing="ij")
+    weights = np.prod(np.stack([m.ravel() for m in wts_mesh], axis=1), axis=1)
+    return points, weights


### PR DESCRIPTION
## Summary

Phase 2 (backend) of #1131. Adds `MeshlessGalerkinDiscretization`, a meshfree Galerkin (Moving Least Squares) implementation of the `WeakFormDiscretization` protocol from #1132. Weak-form operators are assembled by local quadrature against MLS shape functions on a scattered point cloud — **no mesh**. It is the meshfree peer of `FEMDiscretization`; both satisfy the same protocol, so a weak-form solver consumes either.

## New package `mfgarchon/alg/numerical/meshless_galerkin/`
- `mls_basis.py` — dimension-general MLS shape functions with a **dual derivative backend**:
  - `"numpy"` (default) — analytic full MLS derivative, core dependencies only.
  - `"jax"` (optional) — autodiff; lazy-imported, raises an explicit error if requested but unavailable (no silent fallback, per #1072).
- `quadrature.py` — dimension-agnostic interior tensor-Gauss.
- `discretization.py` — `MeshlessGalerkinDiscretization` implementing the protocol.

## Validation (smoke test, 1D and 2D)
| invariant | result |
|---|---|
| `‖K − Kᵀ‖/‖K‖` | ~1e-16 (Galerkin symmetry; holds for any quadrature) |
| `‖K·1‖∞`, `‖(νK+C)·1‖∞` | ~1e-13 (consistency on constants; `1ᵀAᵀ = 0`, the mass-conservation precondition) |
| gradient-projection operators | reproduce exact partials to ~1e-12 |
| **numpy ↔ jax stiffness** | agree to ~1e-12 — the analytic derivative is validated against autodiff, so the default backend needs no jax |

## Design notes
- Dimension is carried only by the multi-index monomial basis; nothing branches on it. The single dimension-dispatched concern (boundary-clipped quadrature) is deferred — it affects near-`∂Ω` accuracy, not symmetry.
- Backend policy follows the repo convention: numpy default, jax opt-in, no silent fallback.

## Scope
Part of #1131. **Does not close it** — follow-up: basis-agnostic `WeakFormHJBSolver`/`WeakFormFPSolver` consuming the protocol, and registering `MESHLESS_GALERKIN` in `NumericalScheme`/`SchemeFamily` + `_create_meshless_galerkin_pair`. Existing FEM integration suite unaffected (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
