### PR TITLE
fix(coupling,particle): #1081 residuals — issue-ref + dead silent sigma default

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -162,7 +162,7 @@ class FixedPointIterator(BaseCouplingIterator):
         self.volatility_field = volatility_field
         self.drift_field = drift_field
 
-        # Issue #1082: warn on HJB-FP volatility mismatch when both are scalars.
+        # Issue #1081: warn on HJB-FP volatility mismatch when both are scalars.
         # If user passes `volatility_field=X` here AND `problem.sigma=Y` with
         # X != Y, HJB sees Y and FP sees X — Picard fixed point corresponds
         # to neither original nor (X, Y)-augmented MFG. Same trap pattern as

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -383,7 +383,10 @@ class FPParticleSolver(BaseFPSolver):
             if self.problem.dt is not None
             else (self.problem.T / self.problem.Nt if self.problem.Nt > 0 else 0.0)
         )
-        sigma = self.problem.sigma if self.problem.sigma is not None else 0.1
+        # Issue #1081: problem.sigma is typed float and resolved in the MFGProblem
+        # constructor, so it is never None here; the prior `else 0.1` silent
+        # default was dead defensive code masking a malformed problem.
+        sigma = self.problem.sigma
         coupling_coefficient = (
             self.problem.coupling_coefficient if self.problem.coupling_coefficient is not None else 1.0
         )


### PR DESCRIPTION
## Summary

Addresses the residual items of #1081. The main ask — HJB-FP σ-consistency enforcement — turned out to be **already implemented** in `FixedPointIterator` (a scalar-mismatch guard), so this PR does not re-add it. Two genuine residuals are fixed.

## Changes
1. **Correct a mis-cited issue reference.** The existing volatility-mismatch guard (`fixed_point_iterator.py:165`) cited "Issue #1082" — which is actually an unrelated common-noise-MFG naming issue (closed). The guard's concern is #1081; comment corrected.
2. **Remove a dead silent default** (`fp_particle.py:386`). `sigma = self.problem.sigma if self.problem.sigma is not None else 0.1` silently substituted `0.1`. But `MFGProblem.sigma` is typed `float` and resolved in the constructor — never `None` here — so the `else` was dead defensive code masking a malformed problem. Replaced with `sigma = self.problem.sigma` (fail-fast / no-silent-fallback, per the repo conventions).

## Design note
The σ-mismatch guard is intentionally a **warning, not a raise**: augmented-diffusion FP (e.g. LLF regularization) legitimately runs HJB and FP at different volatility, so a hard raise would be wrong. This PR keeps that design.

## Validation
Particle + coupled HJB-FP tests: **17 passed, 2 skipped**. Ruff check + format clean.

## Scope
**Refs #1081 — does not close it.** The issue's secondary item (a `newton_tol < picard_tol` ordering check) is intentionally deferred: the defaults already align (both 1e-6), so it is low-value, and it can be picked up separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
