### PR TITLE
feat(meshless): MeshlessGalerkinHJBSolver/FPSolver + MESHLESS_GALERKIN scheme (closes #1131)

### DIFF
--- a/mfgarchon/alg/base_solver.py
+++ b/mfgarchon/alg/base_solver.py
@@ -111,7 +111,8 @@ class SchemeFamily(Enum):
     SL = "semi_lagrangian"  # Semi-Lagrangian
     FVM = "fvm"  # Finite Volume (future)
     FEM = "fem"  # Finite Element Methods (Issue #773)
-    GFDM = "gfdm"  # Meshfree GFDM
+    GFDM = "gfdm"  # Meshfree GFDM (strong-form, Type B)
+    MESHLESS_GALERKIN = "meshless_galerkin"  # Meshfree Galerkin / MLS (weak-form, Type A; Issue #1131)
     PINN = "pinn"  # Physics-Informed Neural Network (future)
     GENERIC = "generic"  # Unknown/custom solvers
 

--- a/mfgarchon/alg/numerical/meshless_galerkin/__init__.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/__init__.py
@@ -15,10 +15,16 @@ Issue #1131 Phase 2.
 
 from mfgarchon.alg.numerical.meshless_galerkin.discretization import (
     MeshlessGalerkinDiscretization,
+    discretization_from_cloud,
 )
+from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
 from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
 
 __all__ = [
     "MeshlessGalerkinDiscretization",
+    "MeshlessGalerkinHJBSolver",
+    "MeshlessGalerkinFPSolver",
+    "discretization_from_cloud",
     "tensor_gauss",
 ]

--- a/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
@@ -102,6 +102,31 @@ class MeshlessGalerkinDiscretization:
         return [sparse.csr_matrix(self._grad_nodes[:, :, d]) for d in range(self._dim)]
 
 
+def discretization_from_cloud(
+    collocation_points: NDArray,
+    delta: float,
+    degree: int = 2,
+    n_gauss: int = 4,
+    backend: str = "numpy",
+) -> MeshlessGalerkinDiscretization:
+    """Build a discretization from a point cloud with interior tensor-Gauss quadrature.
+
+    The background-grid resolution is ~ one cell per node per dimension (assumes a
+    quasi-uniform cloud). ``delta`` is the MLS support radius; ``backend`` selects
+    the numpy (default) or jax derivative engine.
+    """
+    from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
+
+    nodes = np.asarray(collocation_points, dtype=np.float64)
+    if nodes.ndim == 1:
+        nodes = nodes[:, None]
+    n, d = nodes.shape
+    n_per = max(2, round(n ** (1.0 / d)))
+    bounds = [(float(nodes[:, k].min()), float(nodes[:, k].max())) for k in range(d)]
+    pts, wts = tensor_gauss(bounds, n_cells=n_per - 1, n_gauss=n_gauss)
+    return MeshlessGalerkinDiscretization(nodes, delta, degree, pts, wts, backend=backend)
+
+
 if __name__ == "__main__":
     """Smoke test: numpy/jax backends agree; protocol invariants hold (1D, 2D)."""
     from scipy.sparse import linalg as sla

--- a/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
@@ -1,0 +1,87 @@
+"""
+Meshless Galerkin (MLS) Fokker-Planck solver.
+
+Thin subclass over ``WeakFormFPSolver`` on a scattered collocation cloud. Forward
+time stepping and mass-conserving structure are inherited; this class supplies the
+discretization, Neumann BC, and the advection matrix.
+
+Advection follows the current weak-form-family convention (option b, drift = U):
+the velocity v = -coupling * grad(U) is recovered at the nodes via the
+mass-lumped gradient projection and assembled with the protocol's advection.
+(Convention alignment to drift = v = -grad_p H is tracked under #1043.)
+
+Issue #1131 Phase 2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy import sparse
+
+from mfgarchon.alg.base_solver import SchemeFamily
+from mfgarchon.alg.numerical.meshless_galerkin.discretization import discretization_from_cloud
+from mfgarchon.alg.numerical.weak_form_fp_solver import WeakFormFPSolver
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from mfgarchon.core.mfg_problem import MFGProblem
+
+
+class MeshlessGalerkinFPSolver(WeakFormFPSolver):
+    """Fokker-Planck on a scattered point cloud via Galerkin MLS (Type-A discrete duality)."""
+
+    _scheme_family = SchemeFamily.MESHLESS_GALERKIN
+
+    def __init__(
+        self,
+        problem: MFGProblem,
+        collocation_points: NDArray,
+        delta: float = 0.1,
+        degree: int = 2,
+        n_gauss: int = 4,
+        backend: str = "numpy",
+    ) -> None:
+        disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend)
+        super().__init__(problem, disc)
+        self._G_grad: list[sparse.csr_matrix] | None = None
+
+    def _gradient_operators(self) -> list[sparse.csr_matrix]:
+        # G_d = diag(1/M_lumped) @ R_d : mass-lumped L2 projection of d/dx_d.
+        if self._G_grad is None:
+            M_lumped = np.array(self._M.sum(axis=1)).ravel()
+            M_lumped[M_lumped < 1e-15] = 1e-15
+            inv = 1.0 / M_lumped
+            self._G_grad = [(sparse.diags(inv) @ R_d).tocsr() for R_d in self._disc.gradient_projection()]
+        return self._G_grad
+
+    def _is_pure_neumann(self) -> bool:
+        from mfgarchon.alg.numerical.fem.bc_adapter import is_pure_neumann
+
+        return is_pure_neumann(self._bc)
+
+    def _dirichlet_dofs_and_values(self):
+        raise NotImplementedError(
+            "MeshlessGalerkinFPSolver supports Neumann/no-flux BC only; Dirichlet (Nitsche) deferred (#1131)."
+        )
+
+    def _apply_bc_to_system(self, matrix, rhs):
+        raise NotImplementedError(
+            "MeshlessGalerkinFPSolver supports Neumann/no-flux BC only; Dirichlet (Nitsche) deferred (#1131)."
+        )
+
+    def _build_advection(self, U_n: NDArray) -> sparse.csr_matrix:
+        coupling = getattr(self.problem, "coupling_coefficient", 0.5)
+        G = self._gradient_operators()
+        grad_U = np.column_stack([G_d @ U_n for G_d in G])  # (N, dim)
+        velocity = (-coupling * grad_U).T  # (dim, N): v = -coupling * grad(U)
+        # FP weak form (Neumann, integrate by parts): the advection contributes
+        # -C_b^T to the implicit operator (M/dt + D K - C_b^T), where
+        # C_b[i,j] = integral(phi_i (b . grad phi_j)). The TRANSPOSE is the
+        # adjoint-consistency identity A_FP = A_HJB^T and makes the test-function
+        # gradient sum to zero (sum_i grad phi_i = 0), so column sums vanish and
+        # integral(m) is conserved without renormalization. The MINUS comes from
+        # the divergence integration by parts. Issue #1131.
+        return (-self._disc.advection(velocity).T).tocsr()

--- a/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
@@ -1,0 +1,61 @@
+"""
+Meshless Galerkin (MLS) HJB solver.
+
+Thin subclass over the backend-agnostic ``WeakFormHJBSolver``: builds a
+``MeshlessGalerkinDiscretization`` from a scattered collocation cloud + support
+radius ``delta`` (mirroring the ``HJBGFDMSolver(problem, collocation_points,
+delta, ...)`` constructor), with interior tensor-Gauss quadrature. Time stepping,
+Picard, and Newton are inherited.
+
+Boundary conditions: Neumann / no-flux only for now (the weak form's natural BC,
+and the reflecting-wall MFG setting). Dirichlet via Nitsche is deferred (#1131).
+
+Issue #1131 Phase 2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mfgarchon.alg.base_solver import SchemeFamily
+from mfgarchon.alg.numerical.meshless_galerkin.discretization import discretization_from_cloud
+from mfgarchon.alg.numerical.weak_form_hjb_solver import WeakFormHJBSolver
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from mfgarchon.core.mfg_problem import MFGProblem
+
+
+class MeshlessGalerkinHJBSolver(WeakFormHJBSolver):
+    """HJB on a scattered point cloud via Galerkin MLS (Type-A discrete duality)."""
+
+    _scheme_family = SchemeFamily.MESHLESS_GALERKIN
+
+    def __init__(
+        self,
+        problem: MFGProblem,
+        collocation_points: NDArray,
+        delta: float = 0.1,
+        degree: int = 2,
+        n_gauss: int = 4,
+        backend: str = "numpy",
+    ) -> None:
+        disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend)
+        super().__init__(problem, disc)
+        self.hjb_method_name = "MeshlessGalerkin"
+
+    def _is_pure_neumann(self) -> bool:
+        from mfgarchon.alg.numerical.fem.bc_adapter import is_pure_neumann
+
+        return is_pure_neumann(self._bc)
+
+    def _dirichlet_dofs_and_values(self):
+        raise NotImplementedError(
+            "MeshlessGalerkinHJBSolver supports Neumann/no-flux BC only; Dirichlet (Nitsche) deferred (#1131)."
+        )
+
+    def _apply_bc_to_system(self, matrix, rhs):
+        raise NotImplementedError(
+            "MeshlessGalerkinHJBSolver supports Neumann/no-flux BC only; Dirichlet (Nitsche) deferred (#1131)."
+        )

--- a/mfgarchon/factory/scheme_factory.py
+++ b/mfgarchon/factory/scheme_factory.py
@@ -100,6 +100,9 @@ def create_paired_solvers(
     elif scheme in (NumericalScheme.FEM_P1, NumericalScheme.FEM_P2):
         hjb_solver, fp_solver = _create_fem_pair(problem, scheme, hjb_config, fp_config)
 
+    elif scheme == NumericalScheme.MESHLESS_GALERKIN:
+        hjb_solver, fp_solver = _create_meshless_galerkin_pair(problem, hjb_config, fp_config)
+
     else:
         raise NotImplementedError(
             f"Scheme {scheme.value} is defined but not yet implemented in factory. "
@@ -260,6 +263,34 @@ def _create_gfdm_pair(
     hjb_solver = HJBGFDMSolver(problem, **hjb_config)
     fp_solver = FPGFDMSolver(problem, **fp_config)
 
+    return hjb_solver, fp_solver
+
+
+def _create_meshless_galerkin_pair(
+    problem: MFGProblem,
+    hjb_config: dict[str, Any],
+    fp_config: dict[str, Any],
+) -> tuple[BaseHJBSolver, BaseFPSolver]:
+    """Create the meshless Galerkin (MLS) HJB-FP solver pair.
+
+    Discrete duality (Type A): the FP operator is the exact transpose of the
+    Galerkin HJB operator, so no renormalization is needed. Requires
+    ``collocation_points`` (and typically ``delta``) in the configs; these are
+    threaded across HJB/FP for consistency, mirroring the GFDM pair.
+    """
+    from mfgarchon.alg.numerical.meshless_galerkin import (
+        MeshlessGalerkinFPSolver,
+        MeshlessGalerkinHJBSolver,
+    )
+
+    for key in ("delta", "collocation_points", "degree", "n_gauss", "backend"):
+        if key in hjb_config and key not in fp_config:
+            fp_config[key] = hjb_config[key]
+        elif key in fp_config and key not in hjb_config:
+            hjb_config[key] = fp_config[key]
+
+    hjb_solver = MeshlessGalerkinHJBSolver(problem, **hjb_config)
+    fp_solver = MeshlessGalerkinFPSolver(problem, **fp_config)
     return hjb_solver, fp_solver
 
 

--- a/mfgarchon/types/schemes.py
+++ b/mfgarchon/types/schemes.py
@@ -161,6 +161,9 @@ class NumericalScheme(Enum):
     # Type B: Continuous duality schemes (asymptotic adjoint)
     GFDM = "gfdm"
 
+    # Type A (meshfree): discrete duality via Galerkin weak form on MLS (Issue #1131)
+    MESHLESS_GALERKIN = "meshless_galerkin"
+
     def __str__(self) -> str:
         """Human-readable string representation."""
         return self.value
@@ -185,6 +188,7 @@ class NumericalScheme(Enum):
             self.SL_CUBIC,
             self.FEM_P1,
             self.FEM_P2,
+            self.MESHLESS_GALERKIN,
         }
 
     def requires_renormalization(self) -> bool:

--- a/mfgarchon/utils/adjoint_validation.py
+++ b/mfgarchon/utils/adjoint_validation.py
@@ -227,8 +227,14 @@ def check_solver_duality(
         )
 
     # Case 4: Same family → Check duality type
-    # Type A families: Discrete transpose (exact)
-    discrete_families = {SchemeFamily.FDM, SchemeFamily.SL, SchemeFamily.FVM}
+    # Type A families: Discrete transpose (exact). MESHLESS_GALERKIN is the
+    # meshfree Type-A member (Galerkin MLS, A_FP = A_HJB^T exact; Issue #1131).
+    discrete_families = {
+        SchemeFamily.FDM,
+        SchemeFamily.SL,
+        SchemeFamily.FVM,
+        SchemeFamily.MESHLESS_GALERKIN,
+    }
 
     if hjb_family in discrete_families:
         return DualityValidationResult(

--- a/tests/integration/test_meshless_galerkin_mfg.py
+++ b/tests/integration/test_meshless_galerkin_mfg.py
@@ -1,0 +1,94 @@
+"""
+Integration tests for the meshless Galerkin (MLS) solver pair (Issue #1131).
+
+Validates the meshfree weak-form path end-to-end: scheme registration + duality,
+the adjoint-consistent mass-conserving FP advection (FP = HJB^T), and a finite
+HJB backward solve. 1D Neumann LQ-MFG.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mfgarchon import MFGProblem
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents
+from mfgarchon.factory.scheme_factory import create_paired_solvers
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.types.schemes import NumericalScheme
+
+
+def _problem(n=21, T=0.5, nt=20, sigma=0.3):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: -(m**2),
+        coupling_dm=lambda m: -2 * m,
+    )
+    comp = MFGComponents(
+        hamiltonian=H,
+        m_initial=lambda x: np.exp(-40 * (x - 0.35) ** 2),
+        u_terminal=lambda x: 0.5 * (x - 0.5) ** 2,
+    )
+    return MFGProblem(geometry=grid, components=comp, T=T, Nt=nt, sigma=sigma, coupling_coefficient=0.5)
+
+
+def _pair(problem, n=21):
+    cloud = np.linspace(0.0, 1.0, n)[:, None]
+    delta = 3.5 / (n - 1)
+    return create_paired_solvers(
+        problem,
+        NumericalScheme.MESHLESS_GALERKIN,
+        hjb_config={"collocation_points": cloud, "delta": delta},
+    )
+
+
+@pytest.mark.integration
+class TestMeshlessGalerkinMFG:
+    def test_scheme_is_discrete_dual(self):
+        assert NumericalScheme.MESHLESS_GALERKIN.is_discrete_dual()
+        assert not NumericalScheme.MESHLESS_GALERKIN.requires_renormalization()
+
+    def test_pair_creation_and_duality(self):
+        # create_paired_solvers raises if the pair is not a validated dual.
+        hjb, fp = _pair(_problem())
+        assert type(hjb).__name__ == "MeshlessGalerkinHJBSolver"
+        assert type(fp).__name__ == "MeshlessGalerkinFPSolver"
+
+    def test_fp_pure_diffusion_conserves_mass(self):
+        problem = _problem()
+        _, fp = _pair(problem)
+        M_mat = fp._M
+        x = fp._disc.dof_coordinates[:, 0]
+        m0 = np.exp(-40 * (x - 0.5) ** 2)
+        m0 /= float((M_mat @ m0).sum())
+        traj = fp.solve_fp_system(m0, drift_field=None)  # pure diffusion
+        mass = np.array([float((M_mat @ traj[n]).sum()) for n in range(problem.Nt + 1)])
+        # No advection, no clipping needed: mass conserved structurally.
+        assert np.max(np.abs(mass - 1.0)) < 1e-8
+
+    def test_fp_with_drift_conserves_mass_no_blowup(self):
+        problem = _problem()
+        _, fp = _pair(problem)
+        M_mat = fp._M
+        x = fp._disc.dof_coordinates[:, 0]
+        m0 = np.exp(-40 * (x - 0.35) ** 2)
+        m0 /= float((M_mat @ m0).sum())
+        U = np.tile(0.5 * (x - 0.5) ** 2, (problem.Nt + 1, 1))
+        traj = fp.solve_fp_system(m0, drift_field=U)
+        mass = np.array([float((M_mat @ traj[n]).sum()) for n in range(problem.Nt + 1)])
+        assert np.all(np.isfinite(traj)), "FP blew up"
+        # Adjoint-consistent transpose advection conserves mass; residual is the
+        # positivity clip (Galerkin is not an M-matrix), bounded well below O(1).
+        assert np.max(np.abs(mass - 1.0)) < 1e-2
+
+    def test_hjb_solve_finite(self):
+        problem = _problem()
+        hjb, _ = _pair(problem)
+        x = hjb._disc.dof_coordinates[:, 0]
+        m = np.ones((problem.Nt + 1, hjb.n_dof)) / hjb.n_dof
+        U = hjb.solve_hjb_system(M_density=m, U_terminal=0.5 * (x - 0.5) ** 2)
+        assert U.shape == (problem.Nt + 1, hjb.n_dof)
+        assert np.all(np.isfinite(U))

--- a/tests/unit/test_alg/test_scheme_family.py
+++ b/tests/unit/test_alg/test_scheme_family.py
@@ -17,7 +17,9 @@ class TestSchemeFamilyEnum:
         assert hasattr(SchemeFamily, "FDM")
         assert hasattr(SchemeFamily, "SL")
         assert hasattr(SchemeFamily, "FVM")
+        assert hasattr(SchemeFamily, "FEM")
         assert hasattr(SchemeFamily, "GFDM")
+        assert hasattr(SchemeFamily, "MESHLESS_GALERKIN")
         assert hasattr(SchemeFamily, "PINN")
         assert hasattr(SchemeFamily, "GENERIC")
 
@@ -26,7 +28,9 @@ class TestSchemeFamilyEnum:
         assert SchemeFamily.FDM.value == "fdm"
         assert SchemeFamily.SL.value == "semi_lagrangian"
         assert SchemeFamily.FVM.value == "fvm"
+        assert SchemeFamily.FEM.value == "fem"
         assert SchemeFamily.GFDM.value == "gfdm"
+        assert SchemeFamily.MESHLESS_GALERKIN.value == "meshless_galerkin"
         assert SchemeFamily.PINN.value == "pinn"
         assert SchemeFamily.GENERIC.value == "generic"
 
@@ -43,9 +47,10 @@ class TestSchemeFamilyEnum:
     def test_enum_iteration(self):
         """Test that enum can be iterated."""
         families = list(SchemeFamily)
-        assert len(families) == 7
+        assert len(families) == 8
         assert SchemeFamily.FDM in families
         assert SchemeFamily.FEM in families
+        assert SchemeFamily.MESHLESS_GALERKIN in families
         assert SchemeFamily.GENERIC in families
 
 

--- a/tests/unit/test_types/test_schemes.py
+++ b/tests/unit/test_types/test_schemes.py
@@ -40,10 +40,11 @@ class TestNumericalSchemeEnum:
     def test_enum_iteration(self):
         """Test that enum can be iterated."""
         schemes = list(NumericalScheme)
-        assert len(schemes) == 7
+        assert len(schemes) == 8
         assert NumericalScheme.FDM_UPWIND in schemes
         assert NumericalScheme.FEM_P1 in schemes
         assert NumericalScheme.GFDM in schemes
+        assert NumericalScheme.MESHLESS_GALERKIN in schemes
 
 
 class TestDiscreteDuality:
@@ -63,10 +64,14 @@ class TestDiscreteDuality:
         """Test that GFDM has only continuous duality (Type B)."""
         assert not NumericalScheme.GFDM.is_discrete_dual()
 
+    def test_meshless_galerkin_has_discrete_duality(self):
+        """Test that meshless Galerkin (MLS) has discrete duality (Type A; Issue #1131)."""
+        assert NumericalScheme.MESHLESS_GALERKIN.is_discrete_dual()
+
     def test_discrete_dual_count(self):
-        """Test that exactly 6 schemes have discrete duality (FDM, SL, FEM)."""
+        """Test that exactly 7 schemes have discrete duality (FDM, SL, FEM, MESHLESS_GALERKIN)."""
         discrete_schemes = [s for s in NumericalScheme if s.is_discrete_dual()]
-        assert len(discrete_schemes) == 6
+        assert len(discrete_schemes) == 7
 
     def test_continuous_dual_count(self):
         """Test that exactly 1 scheme has continuous duality."""
@@ -196,7 +201,7 @@ class TestEnumUsagePatterns:
     def test_enum_list_comprehension(self):
         """Test enum usage in list comprehension."""
         production_schemes = [s for s in NumericalScheme if not s.is_experimental]
-        assert len(production_schemes) == 6
+        assert len(production_schemes) == 7
         assert NumericalScheme.SL_CUBIC not in production_schemes
 
 


### PR DESCRIPTION
## Summary

Completes #1131. The meshfree weak-form (Galerkin MLS) MFG path now runs **end-to-end** and is a first-class scheme. `MeshlessGalerkinHJBSolver`/`FPSolver` are thin subclasses over the `WeakFormHJBSolver`/`WeakFormFPSolver` bases (from #1135/#1136), on a scattered collocation cloud.

## Changes
- **Solvers** (`meshless_galerkin/{hjb,fp}_solver.py`): cloud + `delta` in → `MeshlessGalerkinDiscretization` with interior tensor-Gauss quadrature on the bounding box. Neumann/no-flux BC; Dirichlet (Nitsche) deferred. `discretization_from_cloud` helper.
- **Scheme registration**: `MESHLESS_GALERKIN` in `NumericalScheme` (`is_discrete_dual()=True`, `requires_renormalization()=False`), `SchemeFamily`, the duality validator's `discrete_families` set, and `_create_meshless_galerkin_pair`.

## The adjoint-consistency payoff (and a bug the end-to-end run caught)
The mass-conserving FP advection is the **transpose** of the HJB advection, entering with a minus from the divergence integration-by-parts:
```
(M/dt + D·K − C_bᵀ) mⁿ⁺¹ = (M/dt) mⁿ,   C_b[i,j] = ∫ φ_i (b·∇φ_j)
```
Column sums vanish (`Σ_i ∇φ_i = 0`), so `∫m` is conserved **without renormalization** — the `A_FP = A_HJBᵀ` identity. The first cut (non-transpose `C`) lost ~93% mass; `+Cᵀ` blew up; only `−Cᵀ` is stable and conservative. All caught by the validation.

## Validation (`tests/integration/test_meshless_galerkin_mfg.py`, 5 tests)
- Pair creation + duality validated (`DISCRETE_DUAL`).
- Pure-diffusion mass conserved to ~1e-8.
- With-drift mass conserved to <1e-2 (residual = positivity clip; Galerkin is not an M-matrix), no blow-up.
- Finite HJB backward solve.

`test_schemes.py` enum counts updated for the new member; FEM tests unaffected.

## Deferred to follow-ups (out of #1131 scope)
- **Dirichlet BC via Nitsche** (Neumann/no-flux only for now — the reflecting-wall MFG regime).
- **Boundary-clipped quadrature** (interior tensor-Gauss only; affects near-∂Ω accuracy, not symmetry/mass).
- **Drift convention** `drift_field = v = −∇_p H` alignment for the whole weak-form FP family — tracked in **#1043**.

Closes #1131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
