### PR TITLE
feat(meshless): SCNI discretization (Stage 1) — smoothed-gradient operators lift the MLS quadrature floor

### DIFF
--- a/mfgarchon/alg/numerical/meshless_galerkin/scni_discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/scni_discretization.py
@@ -1,0 +1,159 @@
+"""
+SCNI (stabilized conforming nodal integration) discretization for the meshless-Galerkin
+weak form -- an alternative to the Gauss-quadrature ``MeshlessGalerkinDiscretization`` that
+lifts the accuracy floor caused by inexact Gauss quadrature of the rational MLS integrands.
+
+Per node ``x_a`` with clipped Voronoi cell ``Omega_a`` (area ``V_a``, boundary edges ``e`` with
+outward unit normal ``n_e``), the SMOOTHED nodal gradient is the divergence-theorem identity
+
+    grad~_d phi_j(x_a) = (1/V_a) * sum_e n_{e,d} * integral_e phi_j ds,
+
+the edge integral by a short Gauss-Legendre rule. The operators are then assembled by a single
+nodal sum (no interior quadrature of the rational integrand):
+
+- stiffness   K = sum_d B~_d^T diag(V) B~_d                       (symmetric)
+- mass        M = diag(V)                                         (lumped; sum = |Omega|)
+- gradient_projection  R_d = diag(V) B~_d   so the solver's G_d = diag(1/M_lumped) R_d = B~_d
+- advection   C[i,j] = sum_a V_a phi_i(x_a) (alpha(x_a) . B~[a,j])  (only the TRIAL phi_j smoothed)
+
+Mass conservation / `K@1=0` follow from the per-cell CLOSURE invariant ``sum_e n_e L_e = 0``
+(asserted in ``voronoi_cells``) plus MLS reproduction of constants; the edge-integral PoU then
+makes ``sum_j B~_d[a,j] = 0`` exactly, independent of the edge-Gauss order.
+
+Plain SCNI is LINEARLY consistent (reproduces constant gradients exactly); quadratic-exactness
+needs NSNI (an extra moment) -- a follow-up. 2D only. Reuses ``SchemeFamily.MESHLESS_GALERKIN``
+(Type-A discrete-dual; ``K`` symmetric + FP advection = ``-C^T``). Issue #1139.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy import sparse
+
+from mfgarchon.alg.numerical.meshless_galerkin.mls_basis import monomial_exponents, shape_functions_and_grads
+from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voronoi_cells
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+
+class MeshlessSCNIDiscretization:
+    """Point cloud + MLS + SCNI implementation of ``WeakFormDiscretization`` (2D)."""
+
+    def __init__(
+        self,
+        nodes: NDArray,
+        rho: float,
+        degree: int,
+        bounds: list[tuple[float, float]],
+        sdf: Callable[[NDArray], NDArray] | None = None,
+        backend: str = "numpy",
+        n_edge_gauss: int = 3,
+    ) -> None:
+        self._nodes = np.asarray(nodes, dtype=np.float64)
+        self._n_dof = int(self._nodes.shape[0])
+        self._dim = int(self._nodes.shape[1])
+        if self._dim != 2:
+            raise NotImplementedError("MeshlessSCNIDiscretization supports 2D only (#1139).")
+        self._rho = float(rho)
+        self._degree = int(degree)
+        self._backend = backend
+        self._exps = monomial_exponents(self._dim, degree)
+
+        cells = clipped_voronoi_cells(self._nodes, bounds, sdf)
+        self._V = np.array([c.area for c in cells], dtype=np.float64)  # (N,)
+        # phi at the nodes (un-smoothed MLS values), Phi[a, i] = phi_i(x_a); used by advection.
+        self._phi_nodes, _ = shape_functions_and_grads(self._nodes, self._nodes, self._rho, self._exps, backend)
+
+        # Smoothed nodal gradients B~_d, shape (N, N), via batched edge quadrature.
+        self._Btilde = self._build_smoothed_gradients(cells, n_edge_gauss)
+
+    # --- smoothed nodal gradient ---------------------------------------------
+    def _build_smoothed_gradients(self, cells, n_edge_gauss):
+        xi, wi = np.polynomial.legendre.leggauss(n_edge_gauss)  # [-1, 1]
+        t = 0.5 * (xi + 1.0)  # edge parameter in [0, 1]
+        pts, cell_idx, nw = [], [], []  # quad points, owning cell, outward-normal * edge weight
+        for a, cell in enumerate(cells):
+            poly = cell.polygon
+            m = len(poly)
+            for i in range(m):
+                v0, v1 = poly[i], poly[(i + 1) % m]
+                d = v1 - v0
+                length = float(np.linalg.norm(d))
+                if length < 1e-14:
+                    continue
+                normal = np.array([d[1], -d[0]]) / length  # outward for a CCW polygon
+                gpts = v0[None, :] + t[:, None] * d[None, :]  # (nq, 2)
+                gw = 0.5 * length * wi  # leggauss weight scaled to the edge
+                pts.append(gpts)
+                cell_idx.append(np.full(gpts.shape[0], a))
+                nw.append(gw[:, None] * normal[None, :])  # (nq, 2)
+        pts = np.vstack(pts)
+        cell_idx = np.concatenate(cell_idx)
+        nw = np.vstack(nw)
+        phi_q, _ = shape_functions_and_grads(pts, self._nodes, self._rho, self._exps, self._backend)  # (Q, N)
+
+        Btilde = []
+        for dd in range(self._dim):
+            acc = np.zeros((self._n_dof, self._n_dof))
+            np.add.at(acc, cell_idx, nw[:, dd][:, None] * phi_q)  # sum_{q in cell a} nw_d phi_j
+            acc /= self._V[:, None]  # divide by V_a
+            Btilde.append(sparse.csr_matrix(acc))
+        return Btilde
+
+    # --- WeakFormDiscretization protocol -------------------------------------
+    @property
+    def n_dof(self) -> int:
+        return self._n_dof
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def dof_coordinates(self) -> NDArray:
+        return self._nodes
+
+    @property
+    def rho(self) -> float:
+        return self._rho
+
+    def smoothed_gradient(self) -> list[sparse.csr_matrix]:
+        """The SCNI smoothed nodal gradient operators ``[B~_0, B~_1]`` (each ``(N, N)``)."""
+        return self._Btilde
+
+    def stiffness(self) -> sparse.csr_matrix:
+        Vdiag = sparse.diags(self._V)
+        K = sum((B.T @ Vdiag @ B) for B in self._Btilde)
+        return K.tocsr()
+
+    def mass(self) -> sparse.csr_matrix:
+        return sparse.diags(self._V).tocsr()  # lumped nodal volumes
+
+    def gradient_projection(self) -> list[sparse.csr_matrix]:
+        # R_d = diag(V) B~_d, so the solver's G_d = diag(1/M_lumped) R_d = B~_d.
+        Vdiag = sparse.diags(self._V)
+        return [(Vdiag @ B).tocsr() for B in self._Btilde]
+
+    def advection(self, velocity: NDArray) -> sparse.csr_matrix:
+        # C[i,j] = sum_a V_a phi_i(x_a) (alpha(x_a) . B~[a,j]); only the trial phi_j is smoothed.
+        velocity = np.asarray(velocity, dtype=np.float64)
+        if velocity.ndim == 1:
+            velocity = velocity[None, :]
+        G = sparse.csr_matrix((self._n_dof, self._n_dof))
+        for dd in range(self._dim):
+            G = G + sparse.diags(velocity[dd]) @ self._Btilde[dd]  # (alpha_d at node a) * B~_d[a,j]
+        Phi = sparse.csr_matrix(self._phi_nodes)  # Phi[a, i] = phi_i(x_a)
+        return (Phi.T @ sparse.diags(self._V) @ G).tocsr()
+
+    def boundary_shape_data(self, x_b: NDArray, normals: NDArray) -> tuple[NDArray, NDArray]:
+        """MLS phi and normal-projected grad at boundary points (Nitsche is SCNI-independent)."""
+        x_b = np.asarray(x_b, dtype=np.float64)
+        normals = np.asarray(normals, dtype=np.float64)
+        phi_b, grad_b = shape_functions_and_grads(x_b, self._nodes, self._rho, self._exps, self._backend)
+        gn_b = np.einsum("qjd,qd->qj", grad_b, normals)
+        return phi_b, gn_b

--- a/mfgarchon/alg/numerical/meshless_galerkin/voronoi_cells.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/voronoi_cells.py
@@ -1,0 +1,194 @@
+"""
+Clipped-Voronoi nodal cells for SCNI (stabilized conforming nodal integration) of the
+meshless-Galerkin operators.
+
+For node ``x_a`` the Voronoi cell is the intersection of bisector half-planes
+``{x : n_b . (x - m_ab) <= 0}`` (``n_b = x_b - x_a``, ``m_ab = (x_a + x_b)/2``), one per
+Voronoi neighbour ``x_b``. Boundary cells are unbounded, so we clip to a slightly inflated
+bounding box (Sutherland-Hodgman) and optionally to the domain ``Omega = {sdf <= 0}``.
+
+SCNI needs, per cell: the area ``V_a`` and, per boundary edge ``e``, the outward unit normal
+``n_e`` and length ``L_e`` (plus the edge segment, to integrate ``phi`` along it). The defining
+SCNI invariant is cell CLOSURE ``sum_e n_e * L_e = 0`` (a closed polygon) -- this is exactly
+what makes the smoothed nodal gradient reproduce constant gradients and conserve mass. It is
+asserted per cell (fail-fast: an open polygon, e.g. from a bad sdf clip, would silently break
+the integration constraint).
+
+2D only (3D marching-cubes-style cells deferred). Issue #1139 (SCNI accuracy lever).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.spatial import Voronoi
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+
+@dataclass
+class CellGeometry:
+    """A clipped Voronoi cell: CCW polygon, area, and boundary-edge normals/lengths/midpoints."""
+
+    polygon: NDArray  # (V, 2) CCW vertices
+    area: float  # |Omega_a|
+    edge_midpoints: NDArray  # (E, 2)
+    edge_normals: NDArray  # (E, 2) outward unit normals
+    edge_lengths: NDArray  # (E,)
+
+
+def _clip_halfplane(poly: NDArray, n: NDArray, c: float, eps: float = 1e-12) -> NDArray:
+    """Sutherland-Hodgman: keep the part of polygon ``poly`` with ``n . x <= c``."""
+    if len(poly) == 0:
+        return poly
+    out = []
+    m = len(poly)
+    for i in range(m):
+        a, b = poly[i], poly[(i + 1) % m]
+        da, db = float(n @ a - c), float(n @ b - c)
+        a_in, b_in = da <= eps, db <= eps
+        if a_in:
+            out.append(a)
+        if a_in != b_in:  # edge crosses the line
+            t = da / (da - db)
+            out.append(a + t * (b - a))
+    return np.array(out) if out else np.empty((0, 2))
+
+
+def _clip_sdf(poly: NDArray, sdf: Callable[[NDArray], NDArray], eps: float = 1e-12) -> NDArray:
+    """Clip ``poly`` to ``{sdf <= 0}`` (boundary arc approximated by chords between crossings)."""
+    s = np.asarray(sdf(poly), dtype=np.float64).ravel()
+    out = []
+    m = len(poly)
+    for i in range(m):
+        a, b = poly[i], poly[(i + 1) % m]
+        sa, sb = float(s[i]), float(s[(i + 1) % m])
+        a_in, b_in = sa <= eps, sb <= eps
+        if a_in:
+            out.append(a)
+        if a_in != b_in:
+            t = sa / (sa - sb)
+            out.append(a + t * (b - a))
+    return np.array(out) if out else np.empty((0, 2))
+
+
+def _polygon_area_ccw(poly: NDArray) -> float:
+    """Signed shoelace area (positive if CCW)."""
+    if len(poly) < 3:
+        return 0.0
+    x, y = poly[:, 0], poly[:, 1]
+    return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+
+
+def _cell_edges(poly: NDArray):
+    """Outward unit normals, lengths, midpoints of a CCW polygon's edges.
+
+    For a CCW polygon the outward normal of edge direction ``(dx, dy)`` is ``(dy, -dx)``.
+    """
+    v0 = poly
+    v1 = np.roll(poly, -1, axis=0)
+    diff = v1 - v0
+    lengths = np.linalg.norm(diff, axis=1)
+    keep = lengths > 1e-14
+    normals = np.stack([diff[:, 1], -diff[:, 0]], axis=1)
+    normals[keep] /= lengths[keep, None]
+    mids = 0.5 * (v0 + v1)
+    return mids[keep], normals[keep], lengths[keep]
+
+
+def clipped_voronoi_cells(
+    nodes: NDArray,
+    bounds: list[tuple[float, float]],
+    sdf: Callable[[NDArray], NDArray] | None = None,
+) -> list[CellGeometry]:
+    """Per-node clipped Voronoi cells for SCNI (2D).
+
+    The cells are clipped to the rectangular domain ``bounds`` (which bounds the otherwise
+    unbounded boundary cells and IS the domain when there is no ``sdf``); with ``sdf`` they are
+    further clipped to ``Omega = {sdf <= 0}``. Either way the cells tile the domain, so
+    ``sum_a V_a`` equals the domain area.
+
+    Args:
+        nodes: ``(N, 2)`` cloud points (must lie within ``bounds``).
+        bounds: ``[(a0, b0), (a1, b1)]`` the rectangular domain / bounding box.
+        sdf: optional domain SDF ``(M, 2) -> (M,)``, ``<= 0`` inside ``Omega``.
+
+    Returns:
+        ``list[CellGeometry]`` aligned with ``nodes``.
+
+    Raises:
+        ValueError: a node has an empty/degenerate cell, or a cell fails the closure invariant.
+    """
+    nodes = np.asarray(nodes, dtype=np.float64)
+    n_nodes, dim = nodes.shape
+    if dim != 2:
+        raise NotImplementedError("clipped_voronoi_cells supports 2D only (SCNI 3D deferred, #1139).")
+    (ax0, bx0), (ax1, bx1) = bounds
+    bbox_poly = np.array([[ax0, ax1], [bx0, ax1], [bx0, bx1], [ax0, bx1]])  # CCW, the actual domain box
+
+    vor = Voronoi(nodes, qhull_options="Qbb Qc Qz")
+    neighbours: list[list[int]] = [[] for _ in range(n_nodes)]
+    for i, j in vor.ridge_points:
+        neighbours[i].append(j)
+        neighbours[j].append(i)
+
+    cells: list[CellGeometry] = []
+    for a in range(n_nodes):
+        poly = bbox_poly.copy()
+        xa = nodes[a]
+        for b in neighbours[a]:
+            normal = nodes[b] - xa
+            poly = _clip_halfplane(poly, normal, float(normal @ (0.5 * (xa + nodes[b]))))
+            if len(poly) == 0:
+                break
+        if sdf is not None and len(poly) >= 3:
+            poly = _clip_sdf(poly, sdf)
+
+        area = _polygon_area_ccw(poly)
+        if area < 0:
+            poly = poly[::-1]
+            area = -area
+        if len(poly) < 3 or area <= 1e-14:
+            raise ValueError(
+                f"SCNI: node {a} at {np.round(xa, 4).tolist()} has an empty/degenerate Voronoi cell "
+                f"(area={area:.2e}); check the cloud / bounds / domain (#1139)."
+            )
+        mids, normals, lengths = _cell_edges(poly)
+        closure = float(np.abs((normals * lengths[:, None]).sum(axis=0)).max())
+        if closure > 1e-9:
+            raise ValueError(
+                f"SCNI: node {a} cell is not closed (||sum_e n_e L_e|| = {closure:.2e}); an open "
+                "polygon breaks the SCNI integration constraint (mass conservation) (#1139)."
+            )
+        cells.append(CellGeometry(poly, area, mids, normals, lengths))
+    return cells
+
+
+if __name__ == "__main__":
+    """Smoke test: tiling (sum of cell areas = domain area) + closure invariant."""
+
+    def grid(n):
+        ax = np.linspace(0.0, 1.0, n)
+        return np.stack([m.ravel() for m in np.meshgrid(ax, ax, indexing="ij")], axis=1)
+
+    nodes = grid(15)
+    cells = clipped_voronoi_cells(nodes, [(0.0, 1.0), (0.0, 1.0)])
+    total = sum(c.area for c in cells)
+    max_closure = max(float(np.abs((c.edge_normals * c.edge_lengths[:, None]).sum(axis=0)).max()) for c in cells)
+    print(f"rect 15x15: N={len(cells)} sum(V_a)={total:.6f} (bbox area 1.0)  max_closure={max_closure:.2e}")
+    assert abs(total - 1.0) < 1e-9, "cells must tile the bounding box"
+
+    # disk sdf
+    C, R = np.array([0.5, 0.5]), 0.4
+    in_disk = lambda P: np.linalg.norm(np.atleast_2d(P) - C, axis=1) - R  # noqa: E731
+    dnodes = nodes[in_disk(nodes) <= 0]
+    dcells = clipped_voronoi_cells(dnodes, [(0.1, 0.9), (0.1, 0.9)], sdf=in_disk)
+    darea = sum(c.area for c in dcells)
+    print(f"disk:      N={len(dcells)} sum(V_a)={darea:.6f} (pi R^2 = {np.pi * R**2:.6f})")
+    assert abs(darea - np.pi * R**2) < 5e-3, "disk cells must tile Omega"
+    print("voronoi_cells smoke test passed.")

--- a/tests/unit/test_alg/test_meshless_scni.py
+++ b/tests/unit/test_alg/test_meshless_scni.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for the SCNI (stabilized conforming nodal integration) meshless discretization (#1139).
+
+The decisive property is BC-free: plain SCNI is LINEARLY consistent, so the smoothed nodal
+gradient reproduces constant gradients EXACTLY (`grad~(a + b.x) = b`) — unlike Gauss quadrature
+of the rational MLS integrands, whose patch error floors at ~5e-2. From `grad~ 1 = 0` (partition
+of unity + per-cell closure) follow `K@1 = 0` and `advection@1 = 0` (mass conservation). These
+need no Dirichlet solve, so they don't depend on the Nitsche chain (#1140-#1142).
+
+(Quadratic-exactness needs NSNI — a follow-up; not tested here.)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.meshless_galerkin.scni_discretization import MeshlessSCNIDiscretization
+from mfgarchon.alg.numerical.weak_form_discretization import WeakFormDiscretization
+
+BOUNDS = [(0.0, 1.0), (0.0, 1.0)]
+
+
+def _grid(n):
+    ax = np.linspace(0.0, 1.0, n)
+    return np.stack([m.ravel() for m in np.meshgrid(ax, ax, indexing="ij")], axis=1)
+
+
+def _disc(n=15):
+    nodes = _grid(n)
+    return nodes, MeshlessSCNIDiscretization(nodes, rho=3.0 / (n - 1), degree=2, bounds=BOUNDS)
+
+
+class TestSCNIDiscretization:
+    def test_protocol_conformance(self):
+        _nodes, disc = _disc(11)
+        assert isinstance(disc, WeakFormDiscretization)
+
+    def test_smoothed_gradient_reproduces_linear(self):
+        # DECISIVE: grad~ reproduces constant gradients exactly (the Gauss version floors ~5e-2).
+        nodes, disc = _disc(15)
+        B0, B1 = disc.smoothed_gradient()
+        one = np.ones(len(nodes))
+        x, y = nodes[:, 0], nodes[:, 1]
+        assert np.max(np.abs(B0 @ one)) < 1e-10  # grad~ of a constant = 0
+        assert np.max(np.abs(B1 @ one)) < 1e-10
+        assert np.max(np.abs(B0 @ x - 1.0)) < 1e-9  # d/dx (x) = 1
+        assert np.max(np.abs(B0 @ y)) < 1e-9  # d/dx (y) = 0
+        assert np.max(np.abs(B1 @ x)) < 1e-9
+        assert np.max(np.abs(B1 @ y - 1.0)) < 1e-9
+
+    def test_stiffness_symmetric_and_constant_nullspace(self):
+        nodes, disc = _disc(15)
+        K = disc.stiffness().toarray()
+        assert np.linalg.norm(K - K.T) / max(np.linalg.norm(K), 1e-30) < 1e-12
+        assert np.max(np.abs(K @ np.ones(len(nodes)))) < 1e-9  # constants in the nullspace
+
+    def test_mass_lumped_tiles_domain(self):
+        _nodes, disc = _disc(15)
+        M = disc.mass()
+        assert M.nnz == disc.n_dof  # diagonal (lumped)
+        assert abs(float(M.sum()) - 1.0) < 1e-9  # nodal volumes tile [0,1]^2
+
+    def test_advection_conserves_mass(self):
+        nodes, disc = _disc(15)
+        v = np.tile(np.array([0.7, -0.3]), (len(nodes), 1)).T
+        C = disc.advection(v).toarray()
+        # C@1 = 0 (from grad~ 1 = 0) => FP operator -C^T has zero column sums => mass conserved
+        assert np.max(np.abs(C @ np.ones(len(nodes)))) < 1e-9
+
+    def test_lloyd_cloud_linear_reproduction(self):
+        # SCNI on a realistic scattered (Lloyd/CVT) cloud, not a structured grid.
+        from mfgarchon.geometry.collocation import ImplicitDomainCollocation
+        from mfgarchon.geometry.implicit import Hyperrectangle
+
+        nodes = ImplicitDomainCollocation(Hyperrectangle(bounds=BOUNDS)).sample_interior(220, method="lloyd", seed=0)
+        h = 1.0 / np.sqrt(len(nodes))
+        disc = MeshlessSCNIDiscretization(nodes, rho=3.0 * h, degree=2, bounds=BOUNDS)
+        B0, B1 = disc.smoothed_gradient()
+        err = np.abs(B0 @ nodes[:, 0] - 1.0)
+        # Linear reproduction is machine-exact at well-conditioned nodes (median ~1e-13); a few
+        # near-boundary nodes degrade to ~1e-4 due to ill-conditioned MLS moment matrices on a
+        # scattered cloud (the cloud-quality effect -- Lloyd >> Poisson, but still not a grid).
+        assert np.median(err) < 1e-9
+        assert err.max() < 1e-3
+        assert np.max(np.abs(B1 @ np.ones(len(nodes)))) < 1e-8  # closure ~machine, tiny boundary outlier

--- a/tests/unit/test_alg/test_meshless_scni.py
+++ b/tests/unit/test_alg/test_meshless_scni.py
@@ -83,3 +83,23 @@ class TestSCNIDiscretization:
         assert np.median(err) < 1e-9
         assert err.max() < 1e-3
         assert np.max(np.abs(B1 @ np.ones(len(nodes)))) < 1e-8  # closure ~machine, tiny boundary outlier
+
+    def test_lipschitz_disk_sdf_clip(self):
+        # SCNI on a non-rectangular (disk) domain via the sdf-clip: linear-exact + conservative,
+        # i.e. the core holds on the actual Lipschitz target (BC-free; Nitsche is separate).
+        C, R = np.array([0.5, 0.5]), 0.4
+        sdf = lambda P: np.linalg.norm(np.atleast_2d(P) - C, axis=1) - R  # noqa: E731
+        ax = np.linspace(0.1, 0.9, 19)
+        grid = np.stack([m.ravel() for m in np.meshgrid(ax, ax, indexing="ij")], axis=1)
+        nodes = grid[sdf(grid) <= 0]
+        disc = MeshlessSCNIDiscretization(nodes, rho=3.0 * 0.8 / 18, degree=2, bounds=[(0.1, 0.9), (0.1, 0.9)], sdf=sdf)
+        B0, _B1 = disc.smoothed_gradient()
+        one = np.ones(len(nodes))
+        err = np.abs(B0 @ nodes[:, 0] - 1.0)
+        assert np.median(err) < 1e-9  # linear reproduction holds on the curved (sdf-clipped) domain
+        assert err.max() < 1e-6
+        assert np.max(np.abs(B0 @ one)) < 1e-8
+        assert abs(float(disc.mass().sum()) - np.pi * R**2) < 5e-3  # cells tile the disk (chord approx)
+        K = disc.stiffness().toarray()
+        assert np.linalg.norm(K - K.T) / np.linalg.norm(K) < 1e-12
+        assert np.max(np.abs(K @ one)) < 1e-8


### PR DESCRIPTION
Refs #1139 (the accuracy lever; does not close it). **Independent of the #1140→#1141→#1142 Nitsche chain** — uses only #1131's MLS basis + the `WeakFormDiscretization` protocol, so it branches off `main` and can merge on its own.

## Why
The meshless-Galerkin accuracy is floored by inexact Gauss quadrature of the **rational** MLS integrands (harmonic-quadratic patch ~5e-2 even on a perfect grid + exact domain, dropping only ~1/n_gauss). Boundary clipping (§4a) can't fix an interior floor. **SCNI** replaces interior Gauss quadrature with **smoothed nodal gradients** — divergence-theorem boundary integrals over each node's (clipped) Voronoi cell — making the discrete integration-by-parts exact.

## What
- `voronoi_cells.py::clipped_voronoi_cells` — per-node Voronoi cell clipped to the domain (Sutherland–Hodgman vs bisector + bbox half-planes; optional `sdf` clip), area, edge normals/lengths. Asserts the **closure invariant** `‖Σ_e n_e L_e‖ < 1e-9` per cell (the make-or-break for conservation).
- `scni_discretization.py::MeshlessSCNIDiscretization` — `grad̃_d φⱼ(x_a) = (1/V_a) Σ_e n_{e,d} ∫_e φⱼ ds`; `stiffness K = Σ_d B̃_dᵀ diag(V) B̃_d` (symmetric); lumped `mass diag(V)`; `gradient_projection R_d = diag(V) B̃_d` (so the solver's `G_d = B̃_d`); `advection` smooths only the trial `φⱼ` (test `φᵢ` un-smoothed) so FP's `−Cᵀ` conserves + transposes. Reuses `SchemeFamily.MESHLESS_GALERKIN` (Type-A); Nitsche/`boundary_shape_data` unchanged.

## Validated (decisive, BC-free)
Smoothed gradient **reproduces constant gradients exactly** (machine on a grid; median ~1e-13 on a Lloyd cloud) — the Gauss 5e-2 floor is gone for the linear part. `K=Kᵀ`, `K@1=0`, mass tiles `|Ω|`, advection `C@1=0` (mass conservation). Geometry smoke test: rectangle tiles exactly, closure machine-zero, disk tiles to πR². Existing meshless + FEM suites unaffected.

## Scope (honest — remain in #1139)
- Plain SCNI is **linearly** consistent; quadratic-exactness needs **NSNI** (extra moment) — a follow-up.
- **Cloud quality**: a few near-boundary nodes on a *scattered* cloud degrade to ~1e-4 (ill-conditioned MLS) — use **Lloyd**, not Poisson.
- **2D only.** **Stage 2** (solver wiring via `integration="scni"` + patch-test-via-Nitsche + EOC vs the Gauss floor) and **Stage 3** (Lipschitz `sdf`-clip) build on the #1140–#1142 chain and follow once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)