### PR TITLE
feat(meshless): clipped quadrature for non-rectangular (Lipschitz) domains

### DIFF
--- a/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
@@ -131,12 +131,28 @@ def discretization_from_cloud(
     degree: int = 2,
     n_gauss: int = 4,
     backend: str = "numpy",
+    domain: object | None = None,
 ) -> MeshlessGalerkinDiscretization:
     """Build a discretization from a point cloud with interior tensor-Gauss quadrature.
 
     The background-grid resolution is ~ one cell per node per dimension (assumes a
     quasi-uniform cloud). ``delta`` is the MLS support radius; ``backend`` selects
     the numpy (default) or jax derivative engine.
+
+    ``domain`` is an optional point predicate ``(N, d) -> bool`` (``True`` = inside
+    Omega), composable with ``mfgarchon.geometry.predicates`` (``sphere_region``,
+    ``sdf_region``, ...). When given, the background tensor-Gauss is **masked to
+    Omega**, so the Galerkin operators integrate over a non-rectangular (Lipschitz)
+    domain rather than the cloud bounding box. Default ``None`` keeps the full
+    bounding box (rectangular Omega).
+
+    Masking is *required* for well-posedness on a non-rectangular Omega: unclipped
+    quadrature points fall outside the node cloud where the MLS moment matrix is
+    singular. The cloud must therefore **cover** Omega; if near-boundary points lack
+    node support the MLS solve raises ``LinAlgError`` (fail-fast, no silent fallback).
+    The structural identities (``K = K^T``, mass conservation, ``A_FP = A_HJB^T``) are
+    algebraic and hold for any quadrature, so masking preserves them; only boundary
+    accuracy is affected (crude mask is ~O(h^1.5); high-order moment-fitting is #1139).
     """
     from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
 
@@ -147,6 +163,11 @@ def discretization_from_cloud(
     n_per = max(2, round(n ** (1.0 / d)))
     bounds = [(float(nodes[:, k].min()), float(nodes[:, k].max())) for k in range(d)]
     pts, wts = tensor_gauss(bounds, n_cells=n_per - 1, n_gauss=n_gauss)
+    if domain is not None:
+        mask = np.asarray(domain(pts), dtype=bool)
+        if not mask.any():
+            raise ValueError("domain predicate excluded every quadrature point; check the cloud and domain.")
+        pts, wts = pts[mask], wts[mask]
     return MeshlessGalerkinDiscretization(nodes, delta, degree, pts, wts, backend=backend)
 
 

--- a/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
@@ -52,9 +52,10 @@ class MeshlessGalerkinFPSolver(WeakFormFPSolver):
         degree: int = 2,
         n_gauss: int = 4,
         backend: str = "numpy",
+        domain: object | None = None,
         nitsche_penalty: float = 20.0,
     ) -> None:
-        disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend)
+        disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend, domain=domain)
         super().__init__(problem, disc)
         self._G_grad: list[sparse.csr_matrix] | None = None
         self._n_gauss = n_gauss

--- a/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
@@ -43,9 +43,10 @@ class MeshlessGalerkinHJBSolver(WeakFormHJBSolver):
         degree: int = 2,
         n_gauss: int = 4,
         backend: str = "numpy",
+        domain: object | None = None,
         nitsche_penalty: float = 20.0,
     ) -> None:
-        disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend)
+        disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend, domain=domain)
         super().__init__(problem, disc)
         self.hjb_method_name = "MeshlessGalerkin"
         self._n_gauss = n_gauss

--- a/mfgarchon/factory/scheme_factory.py
+++ b/mfgarchon/factory/scheme_factory.py
@@ -283,7 +283,10 @@ def _create_meshless_galerkin_pair(
         MeshlessGalerkinHJBSolver,
     )
 
-    for key in ("delta", "collocation_points", "degree", "n_gauss", "backend"):
+    # Thread shared keys across HJB/FP so the pair builds the SAME operators.
+    # domain (#1139) and nitsche_penalty (#1138) MUST match too, or the clipped /
+    # Nitsche blocks differ between HJB and FP and the Type-A transpose identity breaks.
+    for key in ("delta", "collocation_points", "degree", "n_gauss", "backend", "domain", "nitsche_penalty"):
         if key in hjb_config and key not in fp_config:
             fp_config[key] = hjb_config[key]
         elif key in fp_config and key not in hjb_config:

--- a/tests/integration/test_meshless_galerkin_mfg.py
+++ b/tests/integration/test_meshless_galerkin_mfg.py
@@ -201,3 +201,30 @@ class TestMeshlessGalerkinNitsche:
         eps = 1e-6
         fd = (residual(U0 + eps * e) - residual(U0 - eps * e)) / (2 * eps)
         assert np.linalg.norm(fd - J @ e) / np.linalg.norm(J @ e) < 1e-7
+
+
+@pytest.mark.integration
+class TestMeshlessGalerkinDomainClipping:
+    """Quadrature clipping to a non-rectangular Omega threads to BOTH pair members (#1139)."""
+
+    def test_domain_threads_to_both_solvers(self):
+        # A `domain` in hjb_config must reach the FP solver too, or the pair clips
+        # differently and A_FP = A_HJB^T breaks. The factory threads it like delta/cloud.
+        from mfgarchon.alg.numerical.meshless_galerkin.discretization import discretization_from_cloud
+
+        n = 9
+        ax = np.linspace(0.0, 1.0, n)
+        cloud = np.stack([m.ravel() for m in np.meshgrid(ax, ax, indexing="ij")], axis=1)  # 2D grid cloud
+
+        def domain(P):  # keep the left 70% of the box -> a non-bounding-box Omega
+            return P[:, 0] <= 0.7
+
+        problem = _problem(n=n)
+        cfg = {"collocation_points": cloud, "delta": 0.35, "n_gauss": 2, "domain": domain}
+        hjb, fp = create_paired_solvers(problem, NumericalScheme.MESHLESS_GALERKIN, hjb_config=cfg)
+        # both discretizations were assembled from the SAME masked quadrature
+        assert hjb._disc._phi.shape == fp._disc._phi.shape
+        assert np.allclose(hjb._disc.stiffness().toarray(), fp._disc.stiffness().toarray())
+        # and the mask actually dropped the x > 0.7 quadrature points
+        unmasked = discretization_from_cloud(cloud, 0.35, n_gauss=2)
+        assert hjb._disc._phi.shape[0] < unmasked._phi.shape[0]

--- a/tests/unit/test_alg/test_meshless_domain_clipping.py
+++ b/tests/unit/test_alg/test_meshless_domain_clipping.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for meshless-Galerkin quadrature clipping to a non-rectangular domain (#1139).
+
+Masking the background tensor-Gauss to Omega (via a `domain` point predicate, e.g.
+`geometry.predicates.sphere_region`) makes the assembly well-posed on a Lipschitz /
+irregular domain. The structural identities are algebraic (quadrature-independent),
+so masking preserves K=K^T, mass conservation, and A_FP=A_HJB^T; only boundary
+accuracy is affected. Unclipped quadrature on a non-rectangular Omega is ill-posed
+(MLS moment matrix singular at points outside the cloud) and must fail fast.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+from scipy.sparse.linalg import spsolve
+
+from mfgarchon.alg.numerical.meshless_galerkin.discretization import discretization_from_cloud
+from mfgarchon.geometry.predicates import sphere_region
+
+CENTER = np.array([0.5, 0.5])
+R = 0.4
+N_PER = 21
+H = 2 * R / (N_PER - 1)
+RHO = 3.0 * H
+in_disk = sphere_region(CENTER, R)
+
+
+def _disk_cloud():
+    ax = np.linspace(CENTER[0] - R, CENTER[0] + R, N_PER)
+    X = np.stack([m.ravel() for m in np.meshgrid(ax, ax, indexing="ij")], axis=1)
+    return X[in_disk(X)]
+
+
+class TestDomainClipping:
+    def test_clipping_preserves_structure(self):
+        nodes = _disk_cloud()
+        disc = discretization_from_cloud(nodes, delta=RHO, degree=2, n_gauss=4, domain=in_disk)
+        K = disc.stiffness().toarray()
+        one = np.ones(nodes.shape[0])
+        v = np.tile(np.array([1.0, -0.5]), (nodes.shape[0], 1)).T
+        C = disc.advection(v).toarray()
+        assert np.all(np.isfinite(K))
+        assert np.linalg.norm(K - K.T) / np.linalg.norm(K) < 1e-12  # symmetric for ANY quadrature
+        assert np.max(np.abs(K @ one)) < 1e-8  # constants in the stiffness nullspace
+        assert np.max(np.abs(C @ one)) < 1e-8  # gradient partition-of-unity -> mass conservation
+
+    def test_unclipped_on_nonrect_domain_is_singular(self):
+        # Without masking, bounding-box quad points land in the corners outside the disk
+        # cloud, where the MLS moment matrix is singular -> fail fast, no silent fallback.
+        nodes = _disk_cloud()
+        with pytest.raises(np.linalg.LinAlgError):
+            discretization_from_cloud(nodes, delta=RHO, degree=2, n_gauss=4)  # domain=None
+
+    def test_domain_excluding_all_points_raises(self):
+        nodes = _disk_cloud()
+        with pytest.raises(ValueError):
+            discretization_from_cloud(nodes, delta=RHO, domain=lambda P: np.zeros(len(P), dtype=bool))
+
+    def test_fp_neumann_mass_conserved_on_disk(self):
+        nodes = _disk_cloud()
+        disc = discretization_from_cloud(nodes, delta=RHO, degree=2, n_gauss=4, domain=in_disk)
+        M = disc.mass()
+        K = disc.stiffness()
+        D, dt = 0.1, 0.01
+        A = (M / dt + D * K).tocsc()
+        m = np.exp(-30 * np.sum((nodes - CENTER) ** 2, axis=1))
+        m /= (M @ m).sum()
+        mass0 = (M @ m).sum()
+        for _ in range(20):
+            m = spsolve(A, (M / dt) @ m)
+        assert abs((M @ m).sum() - mass0) < 1e-10  # Neumann mass conserved under clipped quadrature
+
+    def test_clipping_reduces_quadrature_to_omega(self):
+        nodes = _disk_cloud()
+        disc = discretization_from_cloud(nodes, delta=RHO, degree=2, n_gauss=4, domain=in_disk)
+        # every retained quadrature point lies inside Omega
+        # (phi cached at quad points; recover their count from the cached array)
+        assert disc._phi.shape[0] > 0
+        # area recovered by the clipped weights approximates the disk, not the bounding box
+        area = float(disc._w.sum())
+        assert abs(area - np.pi * R**2) < 5e-3
+        assert area < (2 * R) ** 2  # strictly less than the bounding-box area


### PR DESCRIPTION
Refs #1139. **Replaces #1141**, which GitHub auto-closed when the parent #1140's branch was deleted on merge (stacked-PR + --delete-branch hazard); identical content, now based on `main`.

Adds the optional `domain` boolean predicate that masks the background tensor-Gauss to a non-rectangular Ω through `discretization_from_cloud` + both meshless solver constructors + the factory shared-key threading (also threads `nitsche_penalty`). Required for well-posedness on a non-rectangular Ω (unclipped quad is singular outside the cloud); structural identities preserved; FP Neumann mass conserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)