### PR TITLE
fix(meshless): gradient_projection returns weak form, not strong derivative (#1145)

### DIFF
--- a/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
@@ -64,8 +64,6 @@ class MeshlessGalerkinDiscretization:
         self._phi, self._grad = shape_functions_and_grads(
             np.asarray(quad_points, dtype=np.float64), self._nodes, self._rho, self._exps, backend
         )
-        # gradients at the nodes for the gradient-projection operators: (N, N, dim)
-        _, self._grad_nodes = shape_functions_and_grads(self._nodes, self._nodes, self._rho, self._exps, backend)
 
     @property
     def n_dof(self) -> int:
@@ -121,8 +119,15 @@ class MeshlessGalerkinDiscretization:
         return sparse.csr_matrix(C)
 
     def gradient_projection(self) -> list[sparse.csr_matrix]:
-        # R_d[i, j] = d phi_j / d x_d evaluated at node x_i.
-        return [sparse.csr_matrix(self._grad_nodes[:, :, d]) for d in range(self._dim)]
+        # Weak-form derivative R_d[i, j] = int phi_i (d phi_j / d x_d) dx (the
+        # WeakFormDiscretization protocol contract): the solver recovers the nodal
+        # gradient via the mass-lumped projection G_d = M_lumped^{-1} R_d. Returning
+        # the strong pointwise derivative d phi_j / d x_d(x_i) here makes that
+        # M_lumped^{-1} a spurious second factor (~1/dx blow-up). Issue #1145.
+        return [
+            sparse.csr_matrix(np.einsum("q,qi,qj->ij", self._w, self._phi, self._grad[:, :, d]))
+            for d in range(self._dim)
+        ]
 
 
 def discretization_from_cloud(
@@ -197,10 +202,13 @@ if __name__ == "__main__":
         one = np.ones(disc.n_dof)
         K_sym = np.linalg.norm(K - K.T) / np.linalg.norm(K)
         K_one = np.max(np.abs(K @ one))
-        # gradient projection of linear field u = x_e reproduces delta_{ec}.
-        R = [r.toarray() for r in disc.gradient_projection()]
+        # gradient projection is the weak-form R_d (Issue #1145); the solver recovers
+        # the nodal gradient via G_d = M_lumped^{-1} R_d, which on a linear field
+        # u = x_e reproduces delta_{ec}.
+        M_lumped_inv = 1.0 / disc.mass().toarray().sum(axis=1)
+        G = [M_lumped_inv[:, None] * r.toarray() for r in disc.gradient_projection()]
         grad_err = max(
-            float(np.max(np.abs(R[e] @ nodes[:, c] - (1.0 if e == c else 0.0)))) for e in range(d) for c in range(d)
+            float(np.max(np.abs(G[e] @ nodes[:, c] - (1.0 if e == c else 0.0)))) for e in range(d) for c in range(d)
         )
         alpha = -np.asarray(pts).T  # velocity at dofs is (dim, N); use nodes-consistent shape
         v = -nodes.T  # (dim, N): drift -x at dofs (potential MFG, Psi=|x|^2/2)

--- a/tests/unit/test_alg/test_meshless_gradient_projection.py
+++ b/tests/unit/test_alg/test_meshless_gradient_projection.py
@@ -1,0 +1,62 @@
+"""Issue #1145 (Bug A): ``MeshlessGalerkinDiscretization.gradient_projection`` must
+return the WEAK-form derivative ``R_d[i,j] = int phi_i (d phi_j / d x_d) dx`` mandated
+by the ``WeakFormDiscretization`` protocol -- NOT the strong pointwise derivative
+``d phi_j / d x_d (x_i)``.
+
+The solver recovers the nodal gradient via the mass-lumped projection
+``G_d = M_lumped^{-1} R_d`` (``weak_form_hjb_solver.py``, ``meshless_galerkin/fp_solver.py``).
+Returning the strong form made that ``M_lumped^{-1}`` a spurious second factor, scaling
+the recovered gradient by ~``1/dx`` (20x at h=1/20) -- which inflated the FP advection
+velocity and blew up the coupled MFG solve.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.meshless_galerkin.discretization import MeshlessGalerkinDiscretization
+from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
+
+
+def _disc(d: int, n_per: int):
+    ax = np.linspace(0.0, 1.0, n_per)
+    mesh = np.meshgrid(*([ax] * d), indexing="ij")
+    nodes = np.stack([m.ravel() for m in mesh], axis=1)
+    h = 1.0 / (n_per - 1)
+    rho = 3.5 * h if d == 1 else 2.6 * h
+    pts, wts = tensor_gauss([(0.0, 1.0)] * d, n_cells=n_per - 1, n_gauss=4)
+    return MeshlessGalerkinDiscretization(nodes, rho, 2, pts, wts, backend="numpy"), nodes
+
+
+def _nodal_gradient_operators(disc):
+    """Mirror the solver: G_d = M_lumped^{-1} R_d (weak_form_hjb_solver.py:90)."""
+    m_lumped_inv = 1.0 / disc.mass().toarray().sum(axis=1)
+    return [m_lumped_inv[:, None] * r.toarray() for r in disc.gradient_projection()]
+
+
+@pytest.mark.parametrize(("d", "n_per"), [(1, 11), (2, 7)])
+def test_nodal_gradient_reproduces_linear_field(d, n_per):
+    """M_lumped^{-1} R_d applied to u = x_e reproduces delta_{ec} (linear-exact)."""
+    disc, nodes = _disc(d, n_per)
+    grad_ops = _nodal_gradient_operators(disc)
+    for e in range(d):
+        for c in range(d):
+            grad = grad_ops[e] @ nodes[:, c]
+            err = np.max(np.abs(grad - (1.0 if e == c else 0.0)))
+            assert err < 1e-9, f"d/dx_{e} of x_{c}: max err {err:.2e}"
+
+
+def test_gradient_projection_is_weak_form_not_strong():
+    """Regression for #1145. The raw operator R_0 is the WEAK form, so
+    R_0 @ (x) = int phi_i (d x / dx) = int phi_i = the consistent-mass row sums
+    (which are O(h)), NOT the strong-form delta = 1 it would be if R_0 returned the
+    pointwise nodal derivative."""
+    disc, nodes = _disc(1, 11)
+    r0 = disc.gradient_projection()[0].toarray()
+    m_lumped = disc.mass().toarray().sum(axis=1)
+    raw = r0 @ nodes[:, 0]  # int phi_i d/dx (x) = int phi_i = M_lumped_i
+    np.testing.assert_allclose(raw, m_lumped, rtol=1e-9, atol=1e-12)
+    # ... which is O(h), nowhere near the strong-form 1.0 (the #1145 bug).
+    assert np.max(np.abs(raw)) < 0.5


### PR DESCRIPTION
## Summary

Bug A of #1145. `MeshlessGalerkinDiscretization.gradient_projection()` returned the **strong** pointwise nodal derivative `∂φⱼ/∂x_d(xᵢ)`, but the `WeakFormDiscretization` protocol specifies `R_d` as the **weak-form** derivative `∫φᵢ ∂_d φⱼ dx` — the solver recovers the nodal gradient via the mass-lumped projection `G_d = M_lumped⁻¹ R_d` (`weak_form_hjb_solver.py:90`, `meshless_galerkin/fp_solver.py:72`). Returning the strong form made that `M_lumped⁻¹` a **spurious second factor**, scaling the recovered gradient by `~1/dx` (20× at h=1/20, confirmed to scale under refinement). That inflated the FP advection velocity `v=−coupling·∇U` and is the first defect that blows up the coupled meshless-Galerkin MFG solve.

`FEMDiscretization` (`assemble_gradient_projection`) and `MeshlessSCNIDiscretization` (`diag(V)·B̃`) both already return the weak form; this aligns the Gauss meshless discretization with the protocol and its consumers.

## Changes

- `discretization.py`: `gradient_projection` returns `∫φᵢ ∂_d φⱼ` (same einsum style as `stiffness`/`mass`/`advection`); drop the now-dead `_grad_nodes`.
- Fix the in-file smoke test, which validated `gradient_projection` against the **strong-form** expectation (`R@u = grad`) **without** the solver's `M⁻¹` step — the reinforced-wrong-contract that let the bug ship. Now applies `M_lumped⁻¹ R` and reports `grad-projection err ~6e-13`.
- New unit test `test_meshless_gradient_projection.py`: `M_lumped⁻¹ R_d` reproduces linear-field gradients (1D/2D); `R_d` itself is the weak (mass-weighted) form (`R₀@x = ∫φᵢ = mass row-sums`, ~h), not the strong `δ`.

## Verification

- New test: 3 passed.
- Full meshless suite (unit + integration, 37 tests): passed — no regression.
- ruff check/format clean.
- Validated in `mfg-research/scripts/{prove_meshless_fix,isolate_under_patch}.py`.

## Scope

**Refs #1145 (Bug A only). Does not close it** — Bug B (FP central-Galerkin undershoot × positivity clip; HJB explicit-Hamiltonian self-amplification) and robust coupled convergence remain open and are tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)