### PR TITLE
fix(weak-form-fp): warn when the positivity clip injects mass (fail-loud)

### DIFF
--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -110,6 +110,7 @@ class WeakFormFPSolver(BaseFPSolver):
             A_base = A_base + A_extra
         pure_neumann = self._is_pure_neumann()
 
+        clip_warned = False
         for n in range(Nt):
             rhs = (self._M / dt) @ M[n]
 
@@ -132,6 +133,23 @@ class WeakFormFPSolver(BaseFPSolver):
                 M[n + 1, interior] = spsolve(A_bc, rhs_bc)
                 M[n + 1, d_dofs] = d_vals
 
+            # Positivity clip. The Galerkin/MLS advection is not an M-matrix, so the
+            # solve can produce density undershoots; the clip deletes them, which INJECTS
+            # mass and violates conservation. Surface it once per solve rather than failing
+            # silently (kernel fail-fast). Streamline diffusion suppresses the undershoots
+            # at the source (meshless ``streamline_diffusion_scale > 0``, Issue #1145).
+            if not clip_warned:
+                injected = -float((self._M @ np.minimum(M[n + 1], 0.0)).sum())
+                total = float((self._M @ np.maximum(M[n + 1], 0.0)).sum())
+                if injected > 1e-6 * max(total, 1e-300):
+                    logger.warning(
+                        "FP positivity clip injected mass %.2e (%.1f%% of total) at step %d: the "
+                        "Galerkin advection is not monotone; consider stabilization.",
+                        injected,
+                        100.0 * injected / max(total, 1e-300),
+                        n,
+                    )
+                    clip_warned = True
             M[n + 1] = np.maximum(M[n + 1], 0.0)
 
         return M

--- a/tests/unit/test_alg/test_weak_form_fp_clip.py
+++ b/tests/unit/test_alg/test_weak_form_fp_clip.py
@@ -1,0 +1,87 @@
+"""The weak-form FP positivity clip is fail-LOUD, not fail-silent.
+
+``WeakFormFPSolver.solve_fp_system`` clips negative density (``np.maximum(M, 0)``)
+because the Galerkin/MLS advection is not an M-matrix. That clip deletes negative
+mass and therefore INJECTS probability, silently violating conservation. The solver
+now emits one warning per solve when the injected mass exceeds a relative threshold,
+so the M-matrix violation is visible instead of hidden (kernel fail-fast). Shared by
+FEM and meshless; the warning is behaviour-additive (no path changes).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+_CLIP_LOGGER = "mfgarchon.alg.numerical.weak_form_fp_solver"
+
+
+def _capture_warnings(logger_name):
+    """Attach a record-collecting handler (mfgarchon loggers do not propagate to caplog)."""
+    records: list[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    logger = logging.getLogger(logger_name)
+    handler = _Collector()
+    logger.addHandler(handler)
+    prev_level = logger.level
+    logger.setLevel(logging.WARNING)
+    return records, logger, handler, prev_level
+
+
+def _meshless_fp(n=21):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(hamiltonian=H, m_initial=lambda x: np.ones_like(x), u_terminal=lambda x: x * 0)
+    problem = MFGProblem(geometry=grid, components=comp, T=0.5, Nt=20, sigma=0.3, coupling_coefficient=0.5)
+    cloud = np.linspace(0.0, 1.0, n)[:, None]
+    return MeshlessGalerkinFPSolver(problem, collocation_points=cloud, delta=3.5 / (n - 1))
+
+
+def test_clip_warns_when_it_injects_mass():
+    """A steep drift makes the central Galerkin advection undershoot; the clip then
+    injects mass and the solver warns (once)."""
+    fp = _meshless_fp()
+    x = fp._disc.dof_coordinates[:, 0]
+    m0 = np.exp(-40 * (x - 0.5) ** 2)
+    m0 /= float((fp._M @ m0).sum())
+    steep_drift = np.tile(10.0 * (x - 0.5) ** 2, (fp.problem.Nt + 1, 1))  # large gradient -> large velocity
+
+    records, logger, handler, prev = _capture_warnings(_CLIP_LOGGER)
+    try:
+        fp.solve_fp_system(m0, drift_field=steep_drift)
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev)
+
+    msgs = [r.getMessage() for r in records]
+    assert any("positivity clip injected mass" in m for m in msgs), f"expected a clip warning, got {msgs}"
+
+
+def test_no_clip_warning_on_pure_diffusion():
+    """Pure diffusion (no drift) does not undershoot, so the clip never injects mass and
+    no warning is emitted -- the warning is a real signal, not noise."""
+    fp = _meshless_fp()
+    x = fp._disc.dof_coordinates[:, 0]
+    m0 = np.exp(-40 * (x - 0.5) ** 2)
+    m0 /= float((fp._M @ m0).sum())
+
+    records, logger, handler, prev = _capture_warnings(_CLIP_LOGGER)
+    try:
+        fp.solve_fp_system(m0, drift_field=None)
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev)
+
+    assert not any("positivity clip injected mass" in r.getMessage() for r in records)


### PR DESCRIPTION
## Summary

`WeakFormFPSolver.solve_fp_system` clips negative density (`np.maximum(M, 0)`) because the Galerkin/MLS advection is **not an M-matrix**. That clip deletes negative density and therefore **injects probability mass**, silently violating conservation — a fail-silent fallback contrary to the repo's fail-fast stance.

It now measures the mass the clip removes and emits **one warning per solve** when it exceeds `1e-6` of the total, so the M-matrix violation is visible instead of hidden.

## Why this is safe across schemes

- **Behaviour-additive**: the clip itself is unchanged, so FEM and meshless paths are byte-identical except for the diagnostic line.
- **No noise**: pure-diffusion / mass-conserving solves never undershoot → no warning (covered by `test_no_clip_warning_on_pure_diffusion`).

## The real fix is elsewhere

This only *surfaces* the symptom. The proper cure for the meshless scheme is streamline-diffusion stabilization, which suppresses the undershoots at the source (Issue #1145, Bug B — separate PR).

## Tests

`tests/unit/test_alg/test_weak_form_fp_clip.py`: the warning fires on a steep-drift undershoot and stays silent on pure diffusion. Full FEM + meshless FP regression passes.

**Refs #1145** (the shared-base clip hardening, split out of the Bug-B recipe PR for single-purpose-PR discipline). Does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)