### PR TITLE
feat(meshless): opt-in Newton-inner + streamline-diffusion stabilization (#1145 Bug B)

### DIFF
--- a/mfgarchon/alg/numerical/fem/fp_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/fp_fem_solver.py
@@ -77,8 +77,11 @@ class FPFEMSolver(WeakFormFPSolver):
         return apply_bc_to_fem_system(matrix, rhs, self._basis, self._bc)
 
     # --- advection from drift via exact quadrature-point gradient of U --------
-    def _build_advection(self, U_n: NDArray) -> sparse.csr_matrix:
-        r"""Assemble $\int (v \cdot \nabla\phi_j)\,\phi_i\,dx$ with $v = -\text{coupling}\cdot\nabla U_n$."""
+    def _build_advection(self, U_n: NDArray, D: float = 0.0) -> sparse.csr_matrix:
+        r"""Assemble $\int (v \cdot \nabla\phi_j)\,\phi_i\,dx$ with $v = -\text{coupling}\cdot\nabla U_n$.
+
+        ``D`` (the current diffusion coefficient) is part of the base contract but unused by
+        FEM, which adds no diffusion-scaled stabilization term."""
         import skfem
         from skfem import BilinearForm
 

--- a/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
@@ -118,6 +118,37 @@ class MeshlessGalerkinDiscretization:
         C = np.einsum("q,qi,qj->ij", self._w, self._phi, a)
         return sparse.csr_matrix(C)
 
+    def streamline_diffusion(self, velocity: NDArray, diffusion: float, c_scale: float = 1.0) -> sparse.csr_matrix:
+        r"""Symmetric SUPG streamline-diffusion operator for an advection ``velocity``.
+
+        ``S[i,j] = sum_q w_q tau_q (b.grad phi_i)(b.grad phi_j)`` with the SUPG parameter
+        ``tau = c_scale * (delta/2|b|)(coth Pe - 1/Pe)``, ``Pe = |b| delta/(2 diffusion)``,
+        length scale ``delta`` = the MLS support radius. ``b`` (``(dim, n_dof)`` or
+        ``(n_dof,)``) is interpolated to the quadrature points through the shape functions,
+        exactly as ``advection`` interpolates its velocity.
+
+        ``S`` is **symmetric** (an outer product of ``b.grad phi_i`` with itself) and
+        ``S @ 1 = 0`` (partition of unity ``sum_j grad phi_j = 0``). Added IDENTICALLY to
+        the FP advection block and the HJB Newton Jacobian, the former preserves the
+        Type-A duality ``A_FP = A_HJB^T`` and the latter keeps the FP mass-conserving.
+        ``diffusion`` MUST be the same ``D = sigma^2/2`` used on the other operator, or
+        the duality breaks. ``c_scale == 0`` returns the zero matrix. Issue #1145 (Bug B).
+        """
+        if c_scale == 0.0:
+            return sparse.csr_matrix((self._n_dof, self._n_dof))
+        velocity = np.asarray(velocity, dtype=np.float64)
+        if velocity.ndim == 1:
+            velocity = velocity[None, :]
+        delta = self._rho  # single global MLS support radius (a scalar)
+        b_q = np.einsum("qj,dj->qd", self._phi, velocity)  # (Q, dim): velocity at quad points
+        b_norm = np.sqrt((b_q**2).sum(axis=1))  # (Q,)
+        pe = b_norm * delta / (2.0 * diffusion)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            xi = 1.0 / np.tanh(pe) - 1.0 / pe  # coth(Pe) - 1/Pe -> 0 as Pe -> 0
+            tau = np.where(b_norm > 1e-12, c_scale * (delta / (2.0 * b_norm)) * xi, 0.0)
+        b_grad = np.einsum("qd,qid->qi", b_q, self._grad)  # (Q, N): b . grad phi_i
+        return sparse.csr_matrix(np.einsum("q,q,qi,qj->ij", self._w, tau, b_grad, b_grad))
+
     def gradient_projection(self) -> list[sparse.csr_matrix]:
         # Weak-form derivative R_d[i, j] = int phi_i (d phi_j / d x_d) dx (the
         # WeakFormDiscretization protocol contract): the solver recovers the nodal

--- a/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
@@ -54,6 +54,7 @@ class MeshlessGalerkinFPSolver(WeakFormFPSolver):
         backend: str = "numpy",
         domain: object | None = None,
         nitsche_penalty: float = 20.0,
+        streamline_diffusion_scale: float = 0.0,
     ) -> None:
         disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend, domain=domain)
         super().__init__(problem, disc)
@@ -62,6 +63,10 @@ class MeshlessGalerkinFPSolver(WeakFormFPSolver):
         self._nitsche_penalty = nitsche_penalty
         self._nitsche_cache: tuple | None = None
         self._nitsche_cache_D: float | None = None
+        # SUPG streamline-diffusion strength on the advection (Issue #1145, Bug B); 0 = off
+        # (default), 1 = canonical SUPG. MUST match the paired HJB solver's value or
+        # A_FP = A_HJB^T breaks (the factory threads it across the pair).
+        self._sd_scale = float(streamline_diffusion_scale)
 
     def _gradient_operators(self) -> list[sparse.csr_matrix]:
         # G_d = diag(1/M_lumped) @ R_d : mass-lumped L2 projection of d/dx_d.
@@ -109,8 +114,8 @@ class MeshlessGalerkinFPSolver(WeakFormFPSolver):
             "not nodal condensation. Reaching this hook means an unsupported BC type."
         )
 
-    def _build_advection(self, U_n: NDArray) -> sparse.csr_matrix:
-        coupling = getattr(self.problem, "coupling_coefficient", 0.5)
+    def _build_advection(self, U_n: NDArray, D: float) -> sparse.csr_matrix:
+        coupling = self.problem.coupling_coefficient
         G = self._gradient_operators()
         grad_U = np.column_stack([G_d @ U_n for G_d in G])  # (N, dim)
         velocity = (-coupling * grad_U).T  # (dim, N): v = -coupling * grad(U)
@@ -121,4 +126,11 @@ class MeshlessGalerkinFPSolver(WeakFormFPSolver):
         # gradient sum to zero (sum_i grad phi_i = 0), so column sums vanish and
         # integral(m) is conserved without renormalization. The MINUS comes from
         # the divergence integration by parts. Issue #1131.
-        return (-self._disc.advection(velocity).T).tocsr()
+        block = -self._disc.advection(velocity).T
+        if self._sd_scale > 0.0:
+            # Add the symmetric streamline-diffusion block (Issue #1145, Bug B). It is the
+            # IDENTICAL matrix the paired HJB Newton Jacobian adds (same velocity, same D,
+            # same scale), so A_FP = A_HJB^T is preserved; S @ 1 = 0 keeps the FP
+            # mass-conserving. D is the current solve's (volatility-aware) diffusion.
+            block = block + self._disc.streamline_diffusion(velocity, D, c_scale=self._sd_scale)
+        return block.tocsr()

--- a/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.meshless_galerkin.discretization import discretization_from_cloud
 from mfgarchon.alg.numerical.weak_form_hjb_solver import WeakFormHJBSolver
@@ -45,6 +47,8 @@ class MeshlessGalerkinHJBSolver(WeakFormHJBSolver):
         backend: str = "numpy",
         domain: object | None = None,
         nitsche_penalty: float = 20.0,
+        use_newton: bool = False,
+        streamline_diffusion_scale: float = 0.0,
     ) -> None:
         disc = discretization_from_cloud(collocation_points, delta, degree, n_gauss, backend, domain=domain)
         super().__init__(problem, disc)
@@ -53,6 +57,47 @@ class MeshlessGalerkinHJBSolver(WeakFormHJBSolver):
         self._nitsche_penalty = nitsche_penalty
         self._nitsche_cache: tuple | None = None
         self._nitsche_cache_D: float | None = None
+        # Bug-B recipe (Issue #1145), opt-in. Default Picard / no stabilization keeps
+        # behaviour byte-identical; a coupled solve that converges needs BOTH enabled:
+        # the Picard path treats the quadratic Hamiltonian explicitly and self-amplifies
+        # (use Newton), and the central-Galerkin FP advection blows up undamped (use SD).
+        # Inner-Newton iteration limits/tolerance come from solve_hjb_system's args (and,
+        # ultimately, NewtonConfig) -- not duplicated here.
+        # streamline_diffusion_scale is the SUPG strength c: 0 = off (default), 1 = canonical
+        # SUPG, >1 over-diffuses (smears the density), <1 under-stabilises.
+        self._use_newton_default = use_newton
+        self._sd_scale = float(streamline_diffusion_scale)
+        # streamline_diffusion_scale and use_newton are duality-coupled: the SD block S is
+        # added to the HJB only via the Newton Jacobian, so stabilising with Picard would
+        # leave the HJB without S while the paired FP carries it -> A_FP = A_HJB^T breaks
+        # (and Picard's explicit Hamiltonian self-amplifies anyway). Fail fast.
+        if self._sd_scale > 0.0 and not self._use_newton_default:
+            raise ValueError(
+                "MeshlessGalerkinHJBSolver: streamline_diffusion_scale > 0 requires use_newton=True. "
+                "Streamline diffusion enters only the Newton Jacobian; with Picard the HJB block "
+                "omits S and the Type-A duality A_FP = A_HJB^T is lost."
+            )
+
+    def solve_hjb_system(self, *args, use_newton: bool | None = None, **kwargs):
+        """Default the inner solver to the constructor's ``use_newton`` (default False =
+        Picard, honouring the documented stiff-LQ finding); pass ``use_newton`` explicitly
+        to force a path. Newton iteration limits/tolerance pass through unchanged. Delegates
+        to ``WeakFormHJBSolver.solve_hjb_system``."""
+        if use_newton is None:
+            use_newton = self._use_newton_default
+        return super().solve_hjb_system(*args, use_newton=use_newton, **kwargs)
+
+    def _stabilization_terms(self, u: NDArray, D: float):
+        """Streamline-diffusion block ``S`` for the HJB Newton path (added to residual and
+        Jacobian of ``-u_t + H - (sigma^2/2) Delta u = 0``). Velocity is the FP drift
+        ``b = -coupling * grad(u)`` so ``S`` is the SAME symmetric matrix added to the FP
+        advection (``A_FP = A_HJB^T`` preserved). ``None`` when stabilization is off."""
+        if self._sd_scale <= 0.0:
+            return None
+        self._build_gradient_operators()
+        coupling = self.problem.coupling_coefficient  # same read as the paired FP (duality)
+        velocity = (-coupling * np.column_stack([G_d @ u for G_d in self._G_grad])).T
+        return self._disc.streamline_diffusion(velocity, D, c_scale=self._sd_scale)
 
     def _is_pure_neumann(self) -> bool:
         from mfgarchon.alg.numerical.fem.bc_adapter import is_pure_neumann

--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -75,8 +75,12 @@ class WeakFormFPSolver(BaseFPSolver):
         return None, None
 
     # --- Advection from drift (subclass-supplied) -----------------------------
-    def _build_advection(self, U_n: NDArray) -> sparse.csr_matrix:
-        r"""Advection matrix for drift $v = -\text{coupling}\cdot\nabla U_n$ in divergence form."""
+    def _build_advection(self, U_n: NDArray, D: float) -> sparse.csr_matrix:
+        r"""Advection matrix for drift $v = -\text{coupling}\cdot\nabla U_n$ in divergence form.
+
+        ``D`` is the diffusion coefficient of the CURRENT solve (``_diffusion_coefficient``,
+        volatility-aware), passed so a subclass that adds a diffusion-scaled stabilization
+        term (e.g. meshless streamline diffusion) uses the same ``D`` as the stiffness block."""
         raise NotImplementedError
 
     def _diffusion_coefficient(self, volatility_field) -> float:
@@ -115,7 +119,7 @@ class WeakFormFPSolver(BaseFPSolver):
 
             if drift_field is not None:
                 U_n = drift_field[n] if drift_field.ndim > 1 else drift_field
-                A_system = A_base + self._build_advection(U_n)
+                A_system = A_base + self._build_advection(U_n, D)
             else:
                 A_system = A_base
 

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -80,6 +80,16 @@ class WeakFormHJBSolver(BaseHJBSolver):
         terms (its MLS basis is non-interpolatory, so condensation is invalid)."""
         return None, None
 
+    def _stabilization_terms(self, u: NDArray, D: float):
+        """Optional symmetric stabilization operator added to BOTH the Newton residual
+        (as ``S @ u``) and the Newton Jacobian (as ``S``), recomputed each Newton iterate.
+
+        Returns a symmetric sparse matrix ``S`` or ``None``. Default no-op (FEM is
+        unaffected and byte-identical). Meshless Galerkin overrides this to return the
+        streamline-diffusion block; because the SAME symmetric ``S`` is added to the FP
+        advection operator, ``A_FP = A_HJB^T`` is preserved (Issue #1145, Bug B)."""
+        return None
+
     # --- Gradient recovery: mass-lumped L2 projection grad_d(u) = G_d @ u -----
     def _build_gradient_operators(self) -> None:
         if self._G_grad is not None:
@@ -153,7 +163,17 @@ class WeakFormHJBSolver(BaseHJBSolver):
                 if rhs_extra is not None:
                     residual = residual - rhs_extra
 
+            # Optional symmetric stabilization (e.g. streamline diffusion) for the
+            # canonical HJB residual -u_t + H - (sigma^2/2) Delta u = 0; recomputed each
+            # iterate (depends on the current gradient). The same S is added to the FP
+            # advection block, preserving A_FP = A_HJB^T (default None -> FEM unaffected).
+            S_stab = self._stabilization_terms(U_current, D)
+            if S_stab is not None:
+                residual = residual + S_stab @ U_current
+
             J = J_fixed.copy()
+            if S_stab is not None:
+                J = J + S_stab
             for d in range(dim):
                 J = J + self._M @ sparse.diags(dH_dp[:, d]) @ self._G_grad[d]
 

--- a/mfgarchon/factory/scheme_factory.py
+++ b/mfgarchon/factory/scheme_factory.py
@@ -286,7 +286,16 @@ def _create_meshless_galerkin_pair(
     # Thread shared keys across HJB/FP so the pair builds the SAME operators.
     # domain (#1139) and nitsche_penalty (#1138) MUST match too, or the clipped /
     # Nitsche blocks differ between HJB and FP and the Type-A transpose identity breaks.
-    for key in ("delta", "collocation_points", "degree", "n_gauss", "backend", "domain", "nitsche_penalty"):
+    for key in (
+        "delta",
+        "collocation_points",
+        "degree",
+        "n_gauss",
+        "backend",
+        "domain",
+        "nitsche_penalty",
+        "streamline_diffusion_scale",
+    ):
         if key in hjb_config and key not in fp_config:
             fp_config[key] = hjb_config[key]
         elif key in fp_config and key not in hjb_config:

--- a/tests/unit/test_alg/test_meshless_stabilization.py
+++ b/tests/unit/test_alg/test_meshless_stabilization.py
@@ -1,0 +1,240 @@
+"""Issue #1145 (Bug B): opt-in streamline-diffusion stabilization + Newton-inner for the
+meshless-Galerkin scheme.
+
+The central (Bubnov-)Galerkin FP advection is not an M-matrix, so undamped it produces
+negative density undershoots that the positivity clip rectifies into injected mass and
+blows up the coupled solve; and the Picard inner path treats the quadratic Hamiltonian
+explicitly and self-amplifies. The recipe adds (opt-in) a symmetric streamline-diffusion
+block to BOTH operators (preserving A_FP = A_HJB^T) and an opt-in Newton inner solver.
+Both default OFF, so existing behaviour is byte-identical.
+
+Validated end-to-end in mfg-research/scripts/{prototype_tight,decoupled_lq_anchor}.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.meshless_galerkin.discretization import MeshlessGalerkinDiscretization
+from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
+from mfgarchon.alg.numerical.weak_form_hjb_solver import WeakFormHJBSolver
+
+
+def _disc(d: int, n_per: int):
+    ax = np.linspace(0.0, 1.0, n_per)
+    mesh = np.meshgrid(*([ax] * d), indexing="ij")
+    nodes = np.stack([m.ravel() for m in mesh], axis=1)
+    h = 1.0 / (n_per - 1)
+    rho = 3.5 * h if d == 1 else 2.6 * h
+    pts, wts = tensor_gauss([(0.0, 1.0)] * d, n_cells=n_per - 1, n_gauss=4)
+    return MeshlessGalerkinDiscretization(nodes, rho, 2, pts, wts, backend="numpy"), nodes
+
+
+# --- streamline-diffusion operator invariants --------------------------------
+@pytest.mark.parametrize(("d", "n_per"), [(1, 11), (2, 7)])
+def test_streamline_diffusion_symmetric_psd_mass_conserving(d, n_per):
+    """S is symmetric (=> preserves A_FP=A_HJB^T when added to both), PSD (SUPG tau>=0),
+    and S@1=0 (=> keeps the FP mass-conserving)."""
+    disc, _ = _disc(d, n_per)
+    velocity = np.ones((d, disc.n_dof))  # constant unit drift
+    s = disc.streamline_diffusion(velocity, diffusion=0.045).toarray()
+    assert np.max(np.abs(s - s.T)) < 1e-12
+    assert np.max(np.abs(s @ np.ones(disc.n_dof))) < 1e-10
+    assert np.linalg.eigvalsh(0.5 * (s + s.T)).min() > -1e-10
+
+
+def test_streamline_diffusion_vanishes_without_drift_or_strength():
+    disc, _ = _disc(1, 11)
+    assert disc.streamline_diffusion(np.zeros((1, disc.n_dof)), 0.045).nnz == 0
+    assert disc.streamline_diffusion(np.ones((1, disc.n_dof)), 0.045, c_scale=0.0).nnz == 0
+
+
+# --- the SD block is added IDENTICALLY to FP and HJB (duality preservation) ----
+def _meshless_pair(n=21, sd_scale=1.0):
+    import numpy as _np
+
+    from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents
+    from mfgarchon.factory.scheme_factory import create_paired_solvers
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+    from mfgarchon.types.schemes import NumericalScheme
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 0.0 * m + 1.0
+    )
+    comp = MFGComponents(
+        hamiltonian=H, m_initial=lambda x: _np.exp(-40 * (x - 0.35) ** 2), u_terminal=lambda x: 0.5 * (x - 0.5) ** 2
+    )
+    problem = MFGProblem(geometry=grid, components=comp, T=0.5, Nt=20, sigma=0.3, coupling_coefficient=0.5)
+    cloud = _np.linspace(0.0, 1.0, n)[:, None]
+    return create_paired_solvers(
+        problem,
+        NumericalScheme.MESHLESS_GALERKIN,
+        hjb_config={
+            "collocation_points": cloud,
+            "delta": 3.5 / (n - 1),
+            "streamline_diffusion_scale": sd_scale,
+            "use_newton": True,
+        },
+    )
+
+
+def test_sd_block_identical_in_fp_and_hjb():
+    """The SD matrix the FP advection adds equals the one the HJB Newton Jacobian adds
+    (same velocity b=-coupling*grad(U), same D), so A_FP = A_HJB^T survives stabilization.
+    Uses a D that is NOT 0.5*sigma^2 to confirm the diffusion coefficient is THREADED into
+    the FP SD (volatility-aware), not hardcoded -- otherwise the duality breaks when a
+    volatility_field != sigma is supplied."""
+    hjb, fp = _meshless_pair(n=21, sd_scale=1.0)
+    x = hjb._disc.dof_coordinates[:, 0]
+    u = 0.5 * (x - 0.5) ** 2
+    d_test = 0.1  # deliberately != 0.5 * sigma^2 (= 0.045)
+    s_hjb = hjb._stabilization_terms(u, d_test).toarray()
+
+    with_sd = fp._build_advection(u, d_test).toarray()
+    fp._sd_scale = 0.0
+    without_sd = fp._build_advection(u, d_test).toarray()
+    fp._sd_scale = 1.0
+    s_fp = with_sd - without_sd
+
+    assert np.max(np.abs(s_hjb - s_fp)) < 1e-12, "FP and HJB must add the SAME S (duality)"
+    assert np.max(np.abs(s_fp - s_fp.T)) < 1e-12
+
+
+def test_stabilization_requires_newton_fails_fast():
+    """streamline_diffusion_scale > 0 with use_newton=False is rejected at construction: S
+    enters only the HJB Newton Jacobian, so with Picard the HJB omits S while the FP carries
+    it (duality break). The two knobs are duality-coupled and must not be set independently."""
+    import numpy as _np
+
+    from mfgarchon import MFGProblem
+    from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(hamiltonian=H, m_initial=lambda x: _np.ones_like(x), u_terminal=lambda x: x * 0)
+    problem = MFGProblem(geometry=grid, components=comp, T=0.5, Nt=5, sigma=0.3)
+    cloud = _np.linspace(0.0, 1.0, 11)[:, None]
+    with pytest.raises(ValueError, match="streamline_diffusion_scale > 0 requires use_newton=True"):
+        MeshlessGalerkinHJBSolver(
+            problem, collocation_points=cloud, delta=0.35, streamline_diffusion_scale=1.0, use_newton=False
+        )
+
+
+def test_factory_threads_sd_scale_to_both():
+    """streamline_diffusion_scale passed only in hjb_config propagates to the FP solver, so
+    the pair cannot be half-stabilized (which would break the duality)."""
+    hjb, fp = _meshless_pair(n=15, sd_scale=1.0)  # _meshless_pair sets the scale only in hjb_config
+    assert hjb._sd_scale == 1.0
+    assert fp._sd_scale == 1.0
+
+
+def test_recipe_defaults_off_byte_identical():
+    """A DEFAULT meshless pair (no recipe kwargs) has streamline_diffusion_scale=0 and
+    use_newton off, so existing behaviour is byte-identical."""
+    import numpy as _np
+
+    from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents
+    from mfgarchon.factory.scheme_factory import create_paired_solvers
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+    from mfgarchon.types.schemes import NumericalScheme
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[15], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(hamiltonian=H, m_initial=lambda x: _np.ones_like(x), u_terminal=lambda x: x * 0)
+    problem = MFGProblem(geometry=grid, components=comp, T=0.5, Nt=10, sigma=0.3)
+    cloud = _np.linspace(0.0, 1.0, 15)[:, None]
+    hjb, fp = create_paired_solvers(
+        problem, NumericalScheme.MESHLESS_GALERKIN, hjb_config={"collocation_points": cloud, "delta": 3.5 / 14}
+    )
+    assert fp._sd_scale == 0.0
+    assert hjb._sd_scale == 0.0
+    assert hjb._use_newton_default is False
+    assert hjb._stabilization_terms(np.zeros(hjb.n_dof), 0.045) is None
+
+
+def test_base_stabilization_hook_is_noop():
+    """The base hook returns None so FEM (which inherits it) adds no SD -- byte-identical."""
+
+    class _Dummy(WeakFormHJBSolver):
+        def __init__(self):
+            pass
+
+    assert _Dummy()._stabilization_terms(np.zeros(3), 0.1) is None
+
+
+# --- end-to-end: the recipe converges and matches a conservative reference -----
+@pytest.mark.integration
+def test_recipe_coupled_matches_fdm_on_wellposed_problem():
+    """On a decoupled (unique) LQ problem all schemes must agree. The meshless recipe
+    (Newton + SD) must converge and track FDM-upwind (the mass-conserving reference)."""
+    import numpy as _np
+
+    from mfgarchon import MFGProblem
+    from mfgarchon.config import MFGSolverConfig
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents
+    from mfgarchon.factory.scheme_factory import create_paired_solvers
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+    from mfgarchon.types.schemes import NumericalScheme
+
+    def mk():
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            potential=lambda x, t: 0.5 * 4.0 * (x[0] - 0.5) ** 2,
+            coupling=None,
+        )
+        comp = MFGComponents(
+            hamiltonian=H, m_initial=lambda x: _np.exp(-40 * (x - 0.35) ** 2), u_terminal=lambda x: 0.5 * (x - 0.5) ** 2
+        )
+        return MFGProblem(geometry=grid, components=comp, T=0.5, Nt=20, sigma=0.3, coupling_coefficient=0.5)
+
+    x = _np.linspace(0.0, 1.0, 21)
+    dx = x[1] - x[0]
+
+    def mean_std(row):
+        m = _np.maximum(row, 0.0)
+        mass = m.sum() * dx
+        mean = (x * m).sum() * dx / mass
+        return mean, _np.sqrt(((x - mean) ** 2 * m).sum() * dx / mass)
+
+    ref = _np.asarray(
+        mk().solve(scheme=NumericalScheme.FDM_UPWIND, max_iterations=200, tolerance=1e-6, verbose=False).M
+    )
+    ref_mean, ref_std = mean_std(ref[-1])
+
+    prob = mk()
+    cloud = x[:, None].copy()
+    hjb, fp = create_paired_solvers(
+        prob,
+        NumericalScheme.MESHLESS_GALERKIN,
+        hjb_config={
+            "collocation_points": cloud,
+            "delta": 3.5 / 20,
+            "use_newton": True,
+            "streamline_diffusion_scale": 1.0,
+        },
+    )
+    res = prob.solve(
+        hjb_solver=hjb, fp_solver=fp, config=MFGSolverConfig(), max_iterations=200, tolerance=1e-6, verbose=False
+    )
+    M = _np.asarray(res.M)
+    assert _np.all(_np.isfinite(M)), "recipe blew up"
+    assert M[-1].min() > -1e-9, "density positive (SD suppresses undershoots)"
+    mean, std = mean_std(M[-1])
+    assert abs(mean - ref_mean) < 2e-2, f"mean {mean:.4f} vs FDM {ref_mean:.4f}"
+    assert abs(std - ref_std) < 2e-2, f"std {std:.4f} vs FDM {ref_std:.4f}"


### PR DESCRIPTION
## Summary

The coupled meshless-Galerkin MFG diverges (Issue #1145, **Bug B**) from two causes: the **Picard** inner solver treats the quadratic Hamiltonian explicitly and self-amplifies, and the central-Galerkin FP advection is not an M-matrix so it produces density undershoots the positivity clip rectifies into injected mass. This adds the validated recipe as **two opt-in knobs, both default OFF** (every existing path byte-identical):

- **`use_newton: bool`** — Newton inner solver for the meshless HJB. Picard stays the default. HJB-only (not factory-threaded).
- **`streamline_diffusion_scale: float = 0.0`** — SUPG strength `c` (0=off, 1=canonical). Threaded across the HJB/FP pair by the factory.

> ⚠️ **Stacked on #1146** (base = `fix/meshless-gradient-projection-weak-form`, the Bug-A gradient fix this depends on). Retarget to `main` once #1146 merges.

## Design

- SD is a new operator-assembly **method** `MeshlessGalerkinDiscretization.streamline_diffusion(velocity, diffusion, c_scale)` (peer of `advection`, Layer-1) — not a free function reaching into discretization internals.
- The symmetric block `S = Σ_q w_q τ_q (b·∇φᵢ)(b·∇φⱼ)` is added **identically** to the FP advection and the HJB Newton Jacobian/residual via a new default-no-op base hook `WeakFormHJBSolver._stabilization_terms` (mirrors `_weak_bc_terms`; **FEM inherits the no-op unchanged → byte-identical**). `S=Sᵀ` and `S@1=0`, so the same `S` on both preserves `A_FP=A_HJB^T` and keeps the FP mass-conserving.

## Duality guards (from a Dev-folder re-audit)

- `streamline_diffusion_scale > 0` **requires** `use_newton=True` (raises): `S` enters only the Newton Jacobian, so stabilising with Picard would leave the HJB without `S` while the FP carries it.
- The FP SD uses the current solve's **volatility-aware D** (threaded through `_build_advection(U_n, D)`), matching the HJB SD's `D` — previously the FP hardcoded `0.5·σ²`, breaking duality when `volatility_field ≠ σ`. The base `_build_advection` gains the `D` parameter (FEM ignores it, byte-identical).

## Open judgment calls flagged for review

- **`use_newton` constructor kwarg + `solve_hjb_system` override**: kept because the `FixedPointIterator` never forwards `use_newton`, so the constructor default is the only way to opt into Newton on the coupled path.
- **`streamline_diffusion` not on the `WeakFormDiscretization` Protocol**: adding it would break FEM/SCNI `@runtime_checkable` conformance; the design is self-consistent (only meshless overrides the hook *and* defines the method).

## Tests

`tests/unit/test_alg/test_meshless_stabilization.py`: `S` symmetry/PSD/`S@1=0`, vanish-without-drift, FP-and-HJB add the **same** `S` (with `D ≠ σ²`), the scale>0-requires-Newton guard, factory threads the scale to both, defaults-off byte-identical, base-hook-noop, and an end-to-end coupled-vs-FDM convergence anchor on the well-posed decoupled LQ. Full meshless + FEM suites pass; ruff clean.

Validated in `mfg-research/scripts/{prototype_tight,decoupled_lq_anchor,monotone_coupled}.py`. **Refs #1145** (Bug B). Does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)