### PR TITLE
fix(fp-fdm): divergence_centered conserves mass at no-flux walls (completes #1149)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -30,10 +30,10 @@ if TYPE_CHECKING:
 # - pde_form: "gradient" (v·∇m) or "divergence" (∇·(vm))
 # - spatial_scheme: "centered" or "upwind"
 AdvectionScheme = Literal[
-    "gradient_centered",  # Non-conservative, oscillates for Peclet > 2
-    "gradient_upwind",  # Conservative (row sums), stable [DEFAULT]
-    "divergence_centered",  # Conservative (telescoping), oscillates for Peclet > 2
-    "divergence_upwind",  # Conservative (telescoping), stable
+    "gradient_centered",  # NON-conservative (v.grad m), oscillates for Peclet > 2
+    "gradient_upwind",  # NON-conservative at no-flux walls (row sums=1/dt is not mass cons.), stable
+    "divergence_centered",  # Conservative (telescoping flux), oscillates for Peclet > 2
+    "divergence_upwind",  # Conservative (telescoping flux), stable [factory DEFAULT for FDM]
     # Legacy aliases (DEPRECATED, will be removed in v1.0.0)
     "centered",  # -> gradient_centered
     "upwind",  # -> gradient_upwind
@@ -61,8 +61,10 @@ class FPFDMSolver(BaseFPSolver):
             Use to demonstrate why conservative schemes are needed.
 
         **gradient_upwind**: Non-conservative form with upwind differences.
-            Mass-conservative via row sums = 1/dt. Stable but first-order.
-            WARNING: Has boundary flux bug when flow crosses boundaries.
+            Row sums = 1/dt, which is NOT mass conservation: column sums are
+            unbalanced at no-flux walls, so mass leaks (up to ~99.8% when the
+            drift is wall-directed). Stable but first-order. Use divergence_* for
+            no-flux FP; the factory routes FDM_UPWIND to divergence_upwind (#382).
 
         **divergence_centered**: Conservative form with centered flux averaging.
             Mass-conservative via flux telescoping. Oscillates for Peclet > 2.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_centered.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_centered.py
@@ -362,8 +362,17 @@ def add_boundary_no_flux_entries_divergence_centered(
             col_indices.append(flat_idx_plus)
             data_values.append(-D / dx_sq)
 
-            # Velocity at node 1 (one-sided)
-            v_plus = -coupling_coefficient * (u_plus - u_center) / dx
+            # Velocity at node 1 for the shared face F_{1/2}. It MUST use the same central
+            # stencil the interior handler uses for node 1 (whose neighbors 0 and 2 exist),
+            # or F_{1/2} is double-valued, the fluxes do not telescope, and mass leaks at
+            # the wall (Issue #1149). One-sided only when node 2 is absent (n <= 2).
+            multi_idx_plus2 = list(multi_idx)
+            multi_idx_plus2[d] = 2
+            if multi_idx_plus2[d] < shape[d]:
+                u_plus2 = u_flat[grid.get_index(tuple(multi_idx_plus2))]
+                v_plus = -coupling_coefficient * (u_plus2 - u_center) / (2 * dx)
+            else:
+                v_plus = -coupling_coefficient * (u_plus - u_center) / dx
 
             # Centered flux at right face only: F_{1/2} = (v_1*m_1 + v_0*m_0)/2
             # But F_{-1/2} = 0, so divergence = F_{1/2} / dx
@@ -395,8 +404,17 @@ def add_boundary_no_flux_entries_divergence_centered(
             col_indices.append(flat_idx_minus)
             data_values.append(-D / dx_sq)
 
-            # Velocity at node N-1 (one-sided)
-            v_minus = -coupling_coefficient * (u_center - u_minus) / dx
+            # Velocity at node N-2 for the shared face F_{N-1/2}. Use the same central
+            # stencil the interior handler uses for node N-2 (whose neighbors N-3 and N-1
+            # exist), or F_{N-1/2} is double-valued and mass leaks at the wall (Issue #1149).
+            # One-sided only when node N-3 is absent (n <= 2).
+            multi_idx_minus2 = list(multi_idx)
+            multi_idx_minus2[d] = shape[d] - 3
+            if multi_idx_minus2[d] >= 0:
+                u_minus2 = u_flat[grid.get_index(tuple(multi_idx_minus2))]
+                v_minus = -coupling_coefficient * (u_center - u_minus2) / (2 * dx)
+            else:
+                v_minus = -coupling_coefficient * (u_center - u_minus) / dx
 
             # Centered flux at left face only: -F_{N-1/2} = -(v_N*m_N + v_{N-1}*m_{N-1})/2
             # Contribution: -v_minus * m_minus / (2*dx) - v_center * m_center / (2*dx)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
@@ -1,9 +1,14 @@
 """Gradient form with upwind differences for FP advection term.
 
 This module implements the advective (gradient) form FDM discretization
-using upwind differences for the advection term. This is the standard
-mass-conservative scheme that achieves discrete conservation through
-row sums = 1/dt property.
+using upwind differences for the advection term.
+
+WARNING: this scheme is NOT mass-conservative at no-flux boundaries. The
+advective (v.grad(m)) form conserves ROW sums = 1/dt, but mass conservation of
+an implicit FP step requires COLUMN sums = 1/dt; the column sums are unbalanced
+at the walls, so probability mass leaks out (measured: up to ~99.8% loss when
+the drift is wall-directed). Use divergence_upwind (or divergence_centered) for
+no-flux FP. See Issue #382; factory routes FDM_UPWIND to divergence_upwind.
 
 Mathematical Formulation:
     Advection term: -div(m * v) ≈ -v · grad(m)  (advective/gradient form)
@@ -13,7 +18,8 @@ Mathematical Formulation:
     - If v < 0 (flow to left): use forward difference dm/dx ≈ (m_{i+1} - m_i) / dx
 
     This ensures:
-    - Mass conservation: row sums = 1/dt (discrete conservation)
+    - Row sums = 1/dt -- this is NOT mass conservation (column sums are
+      unbalanced at no-flux walls; mass leaks). Use divergence_* for no-flux FP.
     - Unconditional stability (no Peclet number restriction)
     - First-order accuracy O(dx)
     - Some numerical diffusion (upwind dissipation)
@@ -64,10 +70,11 @@ def add_interior_entries_gradient_upwind(
     Upwind discretization for advection:
         - Uses ppart/npart to select upwind direction based on velocity
         - ppart(x) = max(0, x), npart(x) = max(0, -x)
-        - Row sums = 1/dt guarantees discrete mass conservation
+        - Row sums = 1/dt (NOT mass conservation: column sums are unbalanced at
+          no-flux walls, so mass leaks; use divergence_* for no-flux FP)
 
     This discretization:
-    - IS mass-conservative (row sums = 1/dt)
+    - Has row sums = 1/dt but is NOT mass-conservative at no-flux boundaries
     - Is unconditionally stable (no Peclet restriction)
     - Has first-order accuracy O(dx)
     - Adds numerical diffusion (upwind dissipation)

--- a/tests/integration/test_fdm_centered_conservation.py
+++ b/tests/integration/test_fdm_centered_conservation.py
@@ -40,22 +40,26 @@ def test_fdm_centered_routes_to_conservative_divergence_centered():
 
 
 def test_fdm_centered_conserves_mass_under_no_flux():
-    """An FP solve with a non-trivial drift on a no-flux domain conserves mass to machine
-    precision (Issue #1149: gradient_centered leaked through the walls)."""
+    """An FP solve conserves mass to machine precision on a no-flux domain (Issue #1149).
+
+    The density is placed AT the wall (columns 0-2) and the drift pushes toward it, so the
+    boundary-face flux is exercised. The boundary handler previously evaluated that face
+    velocity one-sided while the interior used a central stencil -> double-valued face flux
+    -> leak; a mid-domain density (as an earlier version of this test used) is blind to it."""
     n, nt = 41, 40
     prob = _problem(n=n, nt=nt)
     _, fp = create_paired_solvers(prob, NumericalScheme.FDM_CENTERED)
     x = np.linspace(0.0, 1.0, n)
     dx = x[1] - x[0]
-    drift = np.tile(0.5 * (x - 0.5) ** 2, (nt + 1, 1))  # steady confining drift toward 0.5
-    m0 = np.exp(-40 * (x - 0.35) ** 2)
+    drift = np.tile(4.0 * (x - 0.7) ** 2, (nt + 1, 1))  # pushes mass toward the left wall
+    m0 = np.exp(-200 * (x - 0.05) ** 2)  # bump AT the left wall (columns 0-2)
     m0 /= m0.sum() * dx
 
     traj = fp.solve_fp_system(m0, drift_field=drift)
     mass = np.array([traj[k].sum() * dx for k in range(nt + 1)])
     assert np.all(np.isfinite(traj))
-    assert np.max(np.abs(mass - mass[0])) < 1e-9, (
-        f"mass drift {np.max(np.abs(mass - mass[0])):.2e} (no-flux must conserve)"
+    assert np.max(np.abs(mass - mass[0])) < 1e-12, (
+        f"mass drift {np.max(np.abs(mass - mass[0])):.2e} (no-flux must conserve to machine precision)"
     )
 
 
@@ -87,9 +91,6 @@ def test_fdm_centered_coupled_solve_conserves_mass():
     x = np.linspace(0.0, 1.0, 31)
     dx = x[1] - x[0]
     assert np.all(np.isfinite(M))
-    # The #1149 bug leaked ~57% (terminal mass ~0.43); the conservative form keeps it
-    # near 1 (residual is the centered scheme's mild boundary inexactness under the strong
-    # coupled drift, ~0.5%, not a wall leak). A 2% bound catches a regression to the leak.
-    assert abs(M[-1].sum() * dx - 1.0) < 2e-2, (
-        f"terminal mass {M[-1].sum() * dx:.4f} (centered must not leak; bug was 0.43)"
-    )
+    # The #1149 bug leaked ~57% (terminal mass ~0.43). With the conservative scheme AND the
+    # boundary-flux fix the coupled solve conserves mass to ~machine precision.
+    assert abs(M[-1].sum() * dx - 1.0) < 1e-9, f"terminal mass {M[-1].sum() * dx:.8f} (centered must conserve)"


### PR DESCRIPTION
## Summary

#1150 re-routed `FDM_CENTERED` to `divergence_centered`, but a library audit found that scheme **also leaks mass at no-flux walls** — 0.3% (1D), 3–4% (2D corners), 0.5% coupled (far less than the 57% it replaced, but still a leak contradicting its "fluxes telescope" docstring).

**Root cause:** the no-flux boundary handler evaluates the velocity at the first interior node (node 1 / N-2) **one-sided** for the shared face `F_{1/2}`, while the interior handler evaluates that same node **central** → the shared face flux is double-valued and doesn't telescope (+2.0 column-sum defect at columns 1 and N-2; corners stack in 2D).

**Fix:** the boundary handler now uses the same central stencil for that shared-face velocity (one-sided only when the `i±2` neighbor is absent, `n≤2`).

## Verification
- 1D wall-bump mass drift **1.8e-15** (was 3e-3); 2D corner **7.8e-16** (was 3–4e-2); coupled `FDM_CENTERED` terminal mass **1.00000000** (was 1.005).
- Strengthened the conservation test to place density **at** the wall columns (the earlier mid-domain bump was blind to the defect) and tightened it + the coupled test to machine precision. FDM suite: 92 passed.

Also corrects false "mass-conservative (row sums = 1/dt)" claims in the `gradient_upwind` docs + `AdvectionScheme` table — row-sums=1/dt is **not** mass conservation (an audit measured up to 99.8% loss when drift is wall-directed). `gradient_upwind` isn't factory-reachable but is user-selectable.

**Refs #1149** (completes the conservation fix the #1150 re-routing started).

🤖 Generated with [Claude Code](https://claude.com/claude-code)