### PR TITLE
fix(weak-form): volatility_field is sigma -> D=sigma^2/2, not D directly

### DIFF
--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -84,11 +84,15 @@ class WeakFormFPSolver(BaseFPSolver):
         raise NotImplementedError
 
     def _diffusion_coefficient(self, volatility_field) -> float:
+        # volatility_field is the SDE volatility sigma (codebase-wide convention); the PDE
+        # diffusion coefficient is D = sigma^2 / 2 (Conventions Index; Issue #811). The
+        # scalar/array branches previously returned the input as D, skipping the conversion
+        # the None branch and solve_fp_step_adjoint_mode already apply.
         if volatility_field is None:
             return 0.5 * self.problem.sigma**2
         if isinstance(volatility_field, (int, float)):
-            return float(volatility_field)
-        return float(np.mean(volatility_field))
+            return 0.5 * float(volatility_field) ** 2
+        return 0.5 * float(np.mean(volatility_field)) ** 2
 
     def solve_fp_system(
         self,

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -232,12 +232,14 @@ class WeakFormHJBSolver(BaseHJBSolver):
         if M_density.ndim == 1:
             M_density = np.tile(M_density, (Nt + 1, 1))
 
+        # volatility_field is the SDE volatility sigma; the PDE diffusion is D = sigma^2 / 2
+        # (Conventions Index; Issue #811) -- matches the FP _diffusion_coefficient and adjoint mode.
         if volatility_field is None:
             D = 0.5 * self.problem.sigma**2
         elif isinstance(volatility_field, (int, float)):
-            D = float(volatility_field)
+            D = 0.5 * float(volatility_field) ** 2
         else:
-            D = float(np.mean(volatility_field))
+            D = 0.5 * float(np.mean(volatility_field)) ** 2
 
         U = np.zeros((Nt + 1, N))
         U[Nt] = U_terminal

--- a/tests/unit/test_alg/test_weak_form_volatility.py
+++ b/tests/unit/test_alg/test_weak_form_volatility.py
@@ -1,0 +1,70 @@
+"""The weak-form FP/HJB solvers must treat `volatility_field` as the SDE volatility
+`sigma`, converting to the PDE diffusion `D = sigma^2 / 2` (Conventions Index; Issue #811).
+
+Previously the scalar/array branches of `_diffusion_coefficient` (FP) and the HJB D
+computation returned the input directly as D, skipping the conversion that the `None`
+branch, `solve_fp_step_adjoint_mode`, and every other solver (FDM, particle, GFDM) apply
+-- so a passed volatility was used with the wrong (squared-too-large) diffusion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem(sigma, n=15):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H, m_initial=lambda x: np.exp(-20 * (x - 0.5) ** 2), u_terminal=lambda x: 0.5 * (x - 0.5) ** 2
+    )
+    return MFGProblem(geometry=grid, components=comp, T=0.5, Nt=10, sigma=sigma, coupling_coefficient=0.5)
+
+
+def _cloud(n=15):
+    return np.linspace(0.0, 1.0, n)[:, None]
+
+
+def test_diffusion_coefficient_converts_sigma_to_D():
+    """volatility_field (scalar or array) is sigma -> D = sigma^2 / 2."""
+    fp = MeshlessGalerkinFPSolver(_problem(sigma=0.5), collocation_points=_cloud(), delta=3.5 / 14)
+    assert fp._diffusion_coefficient(None) == pytest.approx(0.5 * 0.5**2)  # uses problem.sigma
+    assert fp._diffusion_coefficient(0.3) == pytest.approx(0.5 * 0.3**2)  # NOT 0.3
+    assert fp._diffusion_coefficient(np.full(fp.n_dof, 0.3)) == pytest.approx(0.5 * 0.3**2)
+
+
+def test_fp_volatility_override_equals_problem_with_that_sigma():
+    """An FP solve with volatility_field=s must match a problem built with sigma=s
+    (the equivalence the sigma->D convention guarantees)."""
+    x = np.linspace(0.0, 1.0, 15)
+    m0 = np.exp(-20 * (x - 0.5) ** 2)
+    drift = np.tile(0.5 * (x - 0.5) ** 2, (11, 1))
+
+    fp_override = MeshlessGalerkinFPSolver(_problem(sigma=0.9), collocation_points=_cloud(), delta=3.5 / 14)
+    fp_native = MeshlessGalerkinFPSolver(_problem(sigma=0.3), collocation_points=_cloud(), delta=3.5 / 14)
+    traj_override = fp_override.solve_fp_system(m0, drift_field=drift, volatility_field=0.3)
+    traj_native = fp_native.solve_fp_system(m0, drift_field=drift, volatility_field=None)
+    assert np.allclose(traj_override, traj_native, atol=1e-12)
+
+
+def test_hjb_volatility_override_equals_problem_with_that_sigma():
+    """An HJB solve with volatility_field=s must match a problem built with sigma=s."""
+    x = np.linspace(0.0, 1.0, 15)
+    m = np.ones((11, 15)) / 15
+    u_T = 0.5 * (x - 0.5) ** 2
+
+    hjb_override = MeshlessGalerkinHJBSolver(_problem(sigma=0.9), collocation_points=_cloud(), delta=3.5 / 14)
+    hjb_native = MeshlessGalerkinHJBSolver(_problem(sigma=0.3), collocation_points=_cloud(), delta=3.5 / 14)
+    U_override = hjb_override.solve_hjb_system(M_density=m, U_terminal=u_T, volatility_field=0.3)
+    U_native = hjb_native.solve_hjb_system(M_density=m, U_terminal=u_T, volatility_field=None)
+    assert np.allclose(U_override, U_native, atol=1e-12)


### PR DESCRIPTION
## Summary

The weak-form FP `_diffusion_coefficient` and the weak-form HJB diffusion computation treated a scalar/array `volatility_field` as the PDE diffusion `D` **directly**, while the `None` branch, `solve_fp_step_adjoint_mode`, and every other solver family (FDM, particle, GFDM) correctly treat it as the SDE volatility `sigma` and convert via `D = sigma²/2` (Conventions Index; Issue #811).

So a user passing `volatility_field=0.3` to a FEM or meshless solve got `D=0.3` instead of `D=0.045` — a ~6.7× too-large diffusion, **silently**, wrong physics.

**Fix:** the scalar/array branches now apply `0.5·sigma²`, matching the `None` and adjoint-mode paths.

## Test
`tests/unit/test_alg/test_weak_form_volatility.py`: `_diffusion_coefficient` returns `0.5·sigma²` for scalar/array, and (the decisive check) an FP/HJB solve with `volatility_field=s` is bit-identical to a problem built with `sigma=s`. FEM + meshless suites pass.

Found in a library-wide audit. **Refs #811** (sigma-vs-diffusion convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)