### PR TITLE
fix(core): solve() fails loud when config.hjb/config.fp can't be honored

### DIFF
--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -2436,8 +2436,12 @@ See: docs/migration/HAMILTONIAN_API.md"""
             tolerance: Convergence tolerance (default: from config or 1e-6)
             verbose: Show solver progress (default: from config or True)
             config: Optional MFGSolverConfig for advanced configuration.
-                If config is provided, its values are used as defaults.
-                Explicit parameters (max_iterations, tolerance, verbose) override config.
+                Only ``config.picard`` is applied in Safe/Auto mode (explicit
+                max_iterations/tolerance/verbose override it). ``config.hjb`` /
+                ``config.fp`` are NOT yet threaded into factory-built solvers
+                (Issue #1155); passing non-default hjb/fp values raises rather than
+                silently ignoring them. Use Expert Mode (hjb_solver/fp_solver) for
+                full HJB/FP control.
             scheme: NumericalScheme for Safe Mode (FDM_UPWIND, SL_LINEAR, GFDM, etc.)
             hjb_solver: Pre-initialized HJB solver for Expert Mode
             fp_solver: Pre-initialized FP solver for Expert Mode
@@ -2526,6 +2530,31 @@ See: docs/migration/HAMILTONIAN_API.md"""
                 "  • Expert Mode: problem.solve(hjb_solver=hjb, fp_solver=fp)\n"
                 "  • Auto Mode: problem.solve() [no scheme/solver params]"
             )
+
+        # config.hjb / config.fp are not yet threaded into factory-built solvers
+        # (Issue #1155): the composite HJB/FP configs do not map cleanly to the
+        # per-solver constructor kwargs. Fail loud rather than silently ignore a
+        # user-supplied hjb/fp config in the factory paths (Safe/Auto mode). Expert
+        # Mode builds the solvers directly, so config.hjb/.fp are irrelevant there.
+        if not expert_mode:
+            from mfgarchon.config.mfg_methods import FPConfig, HJBConfig
+
+            unhonored = [
+                name
+                for name, sub, default in (
+                    ("config.hjb", config.hjb, HJBConfig()),
+                    ("config.fp", config.fp, FPConfig()),
+                )
+                if sub != default
+            ]
+            if unhonored:
+                raise NotImplementedError(
+                    f"{' and '.join(unhonored)} cannot be applied in "
+                    f"{'Safe' if safe_mode else 'Auto'} mode yet: the composite HJB/FP config "
+                    "does not map to the factory's per-solver settings (Issue #1155). Only "
+                    "config.picard is honored here. For full HJB/FP control now, use Expert "
+                    "Mode: solve(hjb_solver=..., fp_solver=...)."
+                )
 
         # ─────────────────────────────────────────────────────────────────────
         # Safe Mode: Automatic dual pairing via scheme selection

--- a/tests/unit/test_core/test_solve_config_hjb_fp_guard.py
+++ b/tests/unit/test_core/test_solve_config_hjb_fp_guard.py
@@ -1,0 +1,72 @@
+"""solve(config=...) fails LOUD when config.hjb / config.fp can't be honored.
+
+In Safe/Auto mode, ``MFGProblem.solve`` builds solvers via ``create_paired_solvers``
+and currently only applies ``config.picard``. The composite ``config.hjb`` /
+``config.fp`` subtrees are not yet threaded into the factory (Issue #1155). Rather
+than silently ignore a user-supplied hjb/fp config (wrong-config-ignored), solve()
+raises ``NotImplementedError`` when a non-default hjb/fp config reaches the factory
+paths. Expert Mode (explicit hjb_solver/fp_solver) bypasses the guard, and a
+picard-only or fully-default config solves normally.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.config import FPConfig, HJBConfig, MFGSolverConfig, PicardConfig
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.types import NumericalScheme
+
+
+def _problem(n=11, nt=4):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(hamiltonian=H, m_initial=lambda x: np.ones_like(x), u_terminal=lambda x: 0.5 * (x - 0.5) ** 2)
+    return MFGProblem(geometry=grid, components=comp, T=0.5, Nt=nt, sigma=0.3, coupling_coefficient=0.5)
+
+
+def test_nondefault_hjb_config_raises_in_safe_mode():
+    cfg = MFGSolverConfig(hjb=HJBConfig(method="gfdm"))
+    with pytest.raises(NotImplementedError, match=r"config\.hjb.*#1155"):
+        _problem().solve(scheme=NumericalScheme.FDM_UPWIND, config=cfg)
+
+
+def test_nondefault_fp_config_raises_in_auto_mode():
+    cfg = MFGSolverConfig(fp=FPConfig(method="fdm"))
+    with pytest.raises(NotImplementedError, match=r"config\.fp.*#1155"):
+        _problem().solve(config=cfg)  # auto mode (no scheme/solvers)
+
+
+def test_both_nondefault_named_in_message():
+    cfg = MFGSolverConfig(hjb=HJBConfig(method="gfdm"), fp=FPConfig(method="fdm"))
+    with pytest.raises(NotImplementedError) as exc:
+        _problem().solve(scheme=NumericalScheme.FDM_UPWIND, config=cfg)
+    msg = str(exc.value)
+    assert "config.hjb" in msg
+    assert "config.fp" in msg
+
+
+def test_picard_only_config_does_not_raise():
+    """A non-default picard config (the honored subtree) solves normally."""
+    cfg = MFGSolverConfig(picard=PicardConfig(max_iterations=2, tolerance=1e-3))
+    _problem().solve(scheme=NumericalScheme.FDM_UPWIND, config=cfg)  # no NotImplementedError
+
+
+def test_default_config_does_not_raise():
+    _problem().solve(scheme=NumericalScheme.FDM_UPWIND, config=MFGSolverConfig(), max_iterations=2)
+
+
+def test_expert_mode_bypasses_the_guard():
+    """Expert Mode builds solvers directly, so config.hjb/.fp are legitimately ignored."""
+    from mfgarchon.factory import create_paired_solvers
+
+    prob = _problem()
+    hjb, fp = create_paired_solvers(prob, NumericalScheme.FDM_UPWIND)
+    cfg = MFGSolverConfig(hjb=HJBConfig(method="gfdm"))  # non-default but irrelevant in Expert Mode
+    prob.solve(hjb_solver=hjb, fp_solver=fp, config=cfg, max_iterations=2)  # no NotImplementedError


### PR DESCRIPTION
## Summary

`MFGProblem.solve(config=...)` consumed only `config.picard`. In Safe/Auto mode it called `create_paired_solvers()` **without** `hjb_config`/`fp_config`, so a user-supplied `config.hjb`/`config.fp` was **silently dropped** — and the docstring's *"values are used as defaults"* was false for those subtrees.

Actually honoring them is design-first (tracked in **#1155**): the composite `HJBConfig`/`FPConfig` (marked *"for backward compatibility"*) don't map cleanly to the factory's per-solver kwargs — a `method` selector redundant with `scheme=`, no clean field→kwarg correspondence (`FDMConfig.time_stepping` has no kwarg; `NewtonConfig.max_iterations` → two candidate kwargs mid-deprecation).

## Interim fix (this PR)
Fail **loud** instead of silently ignoring: raise `NotImplementedError` when a non-default `config.hjb`/`config.fp` reaches the Safe/Auto factory paths, naming the subtree(s) and pointing at #1155 + Expert Mode. 
- **Expert Mode** (explicit `hjb_solver`/`fp_solver`) bypasses the guard — those configs are legitimately irrelevant there.
- **picard-only** or **default** config is unaffected.
- **Blast radius zero**: no caller in the repo passes `config=` to `solve()` with a non-default hjb/fp. Docstring corrected.

## Test
`tests/unit/test_core/test_solve_config_hjb_fp_guard.py`: non-default hjb→raises (Safe); non-default fp→raises (Auto); both named; picard-only solves; default solves; Expert Mode bypasses. `test_core`: 482 passed; ruff clean.

**Refs #1155** (the full `MFGSolverConfig → factory` translator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)