### PR TITLE
fix(duality): stop claiming the default FDM pair is a bit-exact transpose

### DIFF
--- a/mfgarchon/factory/scheme_factory.py
+++ b/mfgarchon/factory/scheme_factory.py
@@ -141,7 +141,14 @@ def _create_fdm_pair(
     """
     Create FDM HJB-FP solver pair.
 
-    Discrete duality (Type A): L_FP = L_HJB^T exactly.
+    Discrete duality (Type A): the default pairing (gradient_upwind HJB +
+    divergence_upwind FP) is structure-preserving -- both are mass-conservative
+    and consistent with the continuous adjoint -- but the FP operator is assembled
+    independently and is NOT a bit-exact transpose of the HJB operator in general
+    (the two candidate HJB operators, the velocity advection and the linearized
+    Jacobian, are themselves different). The exact discrete transpose L_FP = L_HJB^T
+    is obtained on demand via the iterator's ``adjoint_mode="jacobian_transpose"``,
+    which assembles the FP step as the transpose of the HJB Jacobian.
 
     Args:
         problem: MFG problem

--- a/mfgarchon/utils/adjoint_validation.py
+++ b/mfgarchon/utils/adjoint_validation.py
@@ -237,11 +237,26 @@ def check_solver_duality(
     }
 
     if hjb_family in discrete_families:
+        # FDM: the default upwind pairing (gradient_upwind HJB + divergence_upwind FP) is
+        # structure-preserving (both mass-conservative, consistent) but the FP operator is
+        # assembled independently and is NOT a bit-exact transpose in general; the exact
+        # L_FP = L_HJB^T is opt-in via the iterator's adjoint_mode="jacobian_transpose".
+        # SL (splatting = transpose of interpolation, #708) and MESHLESS_GALERKIN (Galerkin
+        # MLS, #1131) are exact transposes by construction.
+        # NOTE: this check matches only the _scheme_family enum, not the actual advection
+        # scheme pairing, so it does not detect a mismatched same-family pair.
+        if hjb_family == SchemeFamily.FDM:
+            message = (
+                "Valid discrete dual pair: FDM schemes (structure-preserving; exact "
+                "L_FP = L_HJB^T is opt-in via adjoint_mode='jacobian_transpose')"
+            )
+        else:
+            message = f"Valid discrete dual pair: {hjb_family.value} schemes (L_FP = L_HJB^T)"
         return DualityValidationResult(
             status=DualityStatus.DISCRETE_DUAL,
             hjb_family=hjb_family,
             fp_family=fp_family,
-            message=f"Valid discrete dual pair: {hjb_family.value} schemes (L_FP = L_HJB^T)",
+            message=message,
             recommendation=None,  # No action needed
         )
 

--- a/tests/unit/test_utils/test_duality_claim_honesty.py
+++ b/tests/unit/test_utils/test_duality_claim_honesty.py
@@ -1,0 +1,62 @@
+"""check_solver_duality reports the FDM dual pairing honestly.
+
+The default FDM factory pair (gradient_upwind HJB + divergence_upwind FP) is
+structure-preserving (both mass-conservative, consistent with the continuous
+adjoint) but the FP operator is assembled independently and is NOT a bit-exact
+discrete transpose of the HJB operator -- there isn't even a single ``L_HJB``
+(the velocity-advection and the linearized-Jacobian operators differ). The exact
+``L_FP = L_HJB^T`` is opt-in via the iterator's ``adjoint_mode="jacobian_transpose"``.
+SL (splatting = transpose of interpolation, #708) and MESHLESS_GALERKIN (Galerkin
+MLS, #1131) are exact transposes by construction, so their message is unchanged.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents
+from mfgarchon.factory.scheme_factory import create_paired_solvers
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.types.schemes import NumericalScheme
+from mfgarchon.utils import check_solver_duality
+
+
+def _problem(n=21):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(hamiltonian=H, m_initial=lambda x: np.ones_like(x), u_terminal=lambda x: 0.5 * (x - 0.5) ** 2)
+    return MFGProblem(geometry=grid, components=comp, T=0.5, Nt=8, sigma=0.3, coupling_coefficient=0.5)
+
+
+def test_fdm_duality_message_does_not_claim_bare_exact_transpose():
+    """FDM: still a valid discrete dual pair, but the message must flag that exactness is
+    opt-in, not assert an unconditional exact transpose."""
+    prob = _problem()
+    hjb, fp = create_paired_solvers(prob, NumericalScheme.FDM_UPWIND)
+    result = check_solver_duality(hjb, fp, warn_on_mismatch=False)
+    msg = result.message
+    assert "adjoint_mode" in msg, f"FDM message should flag the opt-in exact mode: {msg!r}"
+    assert "jacobian_transpose" in msg, f"FDM message should name the exact mode: {msg!r}"
+    # It must not present a bare, unconditional 'L_FP = L_HJB^T' with no caveat.
+    assert "structure-preserving" in msg, f"FDM message should say structure-preserving: {msg!r}"
+
+
+def test_sl_duality_message_keeps_exact_transpose_claim():
+    """SL splatting is the exact transpose of interpolation (#708); its message is unchanged."""
+    prob = _problem()
+    hjb, fp = create_paired_solvers(prob, NumericalScheme.SL_LINEAR)
+    result = check_solver_duality(hjb, fp, warn_on_mismatch=False)
+    assert "L_FP = L_HJB^T" in result.message, f"SL message should keep the exact claim: {result.message!r}"
+
+
+def test_factory_fdm_docstring_is_honest():
+    """The _create_fdm_pair docstring no longer claims an unconditional exact transpose."""
+    from mfgarchon.factory import scheme_factory
+
+    doc = scheme_factory._create_fdm_pair.__doc__
+    assert "L_FP = L_HJB^T exactly" not in doc
+    assert "adjoint_mode" in doc
+    assert "structure-preserving" in doc


### PR DESCRIPTION
## Summary

The factory `_create_fdm_pair` docstring and `check_solver_duality` both asserted **`L_FP = L_HJB^T` exactly** for the FDM family. That is misleading for the **default** pairing (`gradient_upwind` HJB + `divergence_upwind` FP):

- The FP operator is assembled **independently** and is not a bit-exact transpose of the HJB operator.
- There isn't even a single `L_HJB`: the velocity-advection matrix and the linearized Jacobian differ by O(1) — `||A_jac - A_adv||_inf = 9.5` on a 21-node LQ test — and **both** transposes are valid conservative FP operators (zero column sums).
- The exact discrete transpose is **opt-in** via the iterator's `adjoint_mode="jacobian_transpose"`.

## Change (message/docstring only — no behavior change)
- `_create_fdm_pair` docstring: default pairing described as **structure-preserving** (mass-conservative, consistent with the continuous adjoint); exact `L_FP = L_HJB^T` available via `adjoint_mode="jacobian_transpose"`.
- `check_solver_duality`: FDM message says structure-preserving + names the opt-in exact mode. **SL** (splatting = transpose of interpolation, #708) and **MESHLESS_GALERKIN** (Galerkin MLS, #1131) keep the exact-transpose wording — true by construction. `DISCRETE_DUAL` status unchanged (no renormalization impact).
- Added a NOTE that the check matches only the `_scheme_family` enum, not the actual advection-scheme pairing — a mismatched same-family pair isn't detected (a separate `validate_scheme_pairing` enhancement, not done here).

## Test
`tests/unit/test_utils/test_duality_claim_honesty.py`: FDM message flags the opt-in (no bare exact claim); SL keeps the exact claim; factory docstring no longer says "exactly". 3 passed; duality/factory regression 142 passed; ruff clean.

Found in a library audit. The audit's cited evidence (`test_true_adjoint`) actually compared two *HJB* matrices, not HJB-vs-FP — so the claim was re-verified directly here before changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)