### PR TITLE
test(hjb-sl): fix stale smoke test 9a to match #1049 (linear+stochastic accepted)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -2697,12 +2697,24 @@ if __name__ == "__main__":
     # Test 9: Carlini-Silva stochastic SL (Issue #1026)
     print("\n9. Testing Carlini-Silva stochastic SL (Issue #1026)...")
 
-    # 9a: linear + stochastic rejected at __init__
-    try:
-        HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="stochastic")
-        raise AssertionError("Expected ValueError for linear + stochastic")
-    except ValueError:
-        print("   9a: linear + stochastic rejected at __init__: OK")
+    # 9a: linear + stochastic is the canonical Carlini-Silva 2014 combo — accepted (Issue #1049)
+    solver_linear_cs = HJBSemiLagrangianSolver(
+        problem, interpolation_method="linear", diffusion_method="stochastic", check_cfl=False
+    )
+    assert solver_linear_cs.interpolation_method == "linear"
+    assert solver_linear_cs.diffusion_method == "stochastic"
+    print("   9a: linear + stochastic accepted (canonical CS 2014, Issue #1049): OK")
+
+    # 9a': cubic + stochastic is outside the CS 2014 monotone proof — warns, not rejected (Issue #1049/#1033)
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as _w:
+        _warnings.simplefilter("always")
+        HJBSemiLagrangianSolver(problem, interpolation_method="cubic", diffusion_method="stochastic", check_cfl=False)
+    assert any(issubclass(rec.category, UserWarning) for rec in _w), (
+        "Expected UserWarning for cubic + stochastic (outside CS 2014 proof)"
+    )
+    print("   9a': cubic + stochastic warns (outside CS 2014 proof): OK")
 
     # 9b: cubic + stochastic instantiates and dispatches correctly
     solver_cs = HJBSemiLagrangianSolver(


### PR DESCRIPTION
## Summary
The `#1049` production fix (PR #1051) changed the `HJBSemiLagrangianSolver` constructor to **allow** `linear + stochastic` (the canonical Carlini–Silva 2014 monotone combo) and to **warn** — not raise — for `cubic`/`quintic + stochastic`. The colocated `if __name__ == "__main__"` smoke **Test 9a** was never updated: it still asserts the removed `ValueError`, so a manual smoke run (`python mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py`) would crash on an uncaught `AssertionError`.

This was discovered while auditing the issue board: `#1049`'s code fix landed but the issue stayed open, and its migration was incomplete (CLAUDE.md *Deprecation Policy* → "Complete migration: update ALL call sites… tests").

## Change
- `9a` now asserts `linear + stochastic` constructs and reports the canonical-combo acceptance.
- New `9a'` asserts `cubic + stochastic` emits a `UserWarning` (outside the CS-2014 proof, #1033).

## Verification
- `python -m py_compile` OK; `ruff check` + `ruff format --check` clean.
- CI unit tests `test_linear_plus_stochastic_accepted` / `test_cubic_plus_stochastic_warns` already encode this behavior and pass — this PR only realigns the leftover inline smoke test. **No production behavior change.**

Closes #1049