### PR TITLE
fix(geometry): Hypersphere fails fast on non-finite radius (#1077 case 6)

### DIFF
--- a/mfgarchon/geometry/implicit/hypersphere.py
+++ b/mfgarchon/geometry/implicit/hypersphere.py
@@ -63,7 +63,7 @@ class Hypersphere(ImplicitDomain):
             radius: Radius (must be positive)
 
         Raises:
-            ValueError: If radius <= 0
+            ValueError: If radius is not a positive, finite scalar
 
         Example:
             >>> # 2D circle at (1, 2) with radius 0.5
@@ -77,6 +77,12 @@ class Hypersphere(ImplicitDomain):
 
         if self.radius <= 0:
             raise ValueError(f"Radius must be positive, got {radius}")
+
+        # Issue #1077: radius=inf/nan slips past the `<= 0` check (inf/nan comparisons are
+        # False), then yields an infinite bounding box -> np.random.uniform(-inf, inf) -> NaN
+        # in rejection sampling. Fail fast.
+        if not np.isfinite(self.radius):
+            raise ValueError(f"Radius must be finite, got {radius}")
 
         if self.center.ndim != 1:
             raise ValueError(f"Center must be 1D array, got shape {self.center.shape}")

--- a/tests/unit/test_geometry/test_geometry.py
+++ b/tests/unit/test_geometry/test_geometry.py
@@ -70,6 +70,17 @@ class TestHypersphere:
         assert domain.contains(np.array([0.5, 0]))  # Interior
         assert not domain.contains(np.array([2, 0]))  # Exterior
 
+    def test_radius_must_be_positive_and_finite(self):
+        """Issue #1077: a non-positive or non-finite radius must fail fast. inf/nan slip
+        past the `<= 0` check and would otherwise yield inf bounding boxes -> NaN in
+        rejection sampling."""
+        for bad in (0.0, -1.0):
+            with pytest.raises(ValueError, match="positive"):
+                Hypersphere(center=[0, 0], radius=bad)
+        for bad in (float("inf"), float("nan")):
+            with pytest.raises(ValueError, match="finite"):
+                Hypersphere(center=[0, 0], radius=bad)
+
     def test_4d_hypersphere(self):
         """Test 4D hypersphere."""
         domain = Hypersphere(center=[0] * 4, radius=1.0)


### PR DESCRIPTION
## Summary
`Hypersphere(radius=inf)` / `radius=nan` slipped past the existing `radius <= 0` check (inf/nan comparisons are False), producing an infinite bounding box → `np.random.uniform(-inf, inf)` → NaN in rejection sampling. Adds an `isfinite` guard + test. One case of #1077.

## #1077 disposition (verify-by-artifact audit of all 7 cases)
| Case | Status |
|---|---|
| 1. `Nx_points >= 1` | **Already landed** — and deliberately `>=1` (single-point grids, `test_single_point_grid`), not the issue's proposed `>=2`. |
| 2. bounds `lo<hi`, finite | **Already landed** (`tensor_grid.py:257-266`). |
| 6. Hypersphere finite radius | **This PR.** |
| 3. `sigma > 0` | **Risky — not done.** Deterministic problems store `self.sigma = 0.0` (`sigma=None` input → `vola=0.0`), so a blanket `sigma<=0` raise would break legitimate deterministic *reconstruction* (`MFGProblem(sigma=other.sigma)`). Needs a reconstruction-safe approach. |
| 4. `T > 0` | Implementable, but the guard must be placed carefully in `MFGProblem`'s multi-path constructor; deferred to keep this PR clean. |
| 5. `Nt >= 1` | **Conflicts** with intentional behavior: `test_mfg_problem.py:648` ("handles Nt=0 gracefully": `Nt==0, dt==0.0, len(tSpace)==1`), `test_unified_mfg_problem.py:504`, `test_fp_fdm_solver.py:151`. A guard would break these — maintainer decision needed (change the tests, or keep Nt=0 graceful). |
| 7. `DifferenceDomain` non-empty | **Deferred** — `obstacle.volume >= domain.volume` is necessary-not-sufficient and runs on approximate SDF volume; an over-broad guard risks false rejections. |

## Verification
`ruff check`/`format` clean; `TestHypersphere` (6 tests incl. new) passes.

Refs #1077