### PR TITLE
fix(coupling): warn when HJB Newton tolerance is looser than Picard tolerance (#1081 part 3)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -579,6 +579,28 @@ class FixedPointIterator(BaseCouplingIterator):
 
             verbose = should_show_progress()
 
+        # Issue #1081: Picard cannot converge below the inner Newton-solve floor. When the
+        # HJB Newton tolerance is looser than the Picard tolerance, each inner solve injects
+        # a ~newton_tolerance residual, so the outer Picard residual plateaus there and the
+        # run reports "max iterations reached" without ever converging. Warn (strictly
+        # looser; equal default tolerances of 1e-6 are fine).
+        _newton_tol = getattr(self.hjb_solver, "newton_tolerance", None)
+        if (
+            isinstance(_newton_tol, (int, float))
+            and isinstance(final_tolerance, (int, float))
+            and _newton_tol > final_tolerance
+        ):
+            import warnings as _warnings
+
+            _warnings.warn(
+                f"HJB newton_tolerance ({_newton_tol:.1e}) is looser than the Picard "
+                f"tolerance ({final_tolerance:.1e}); the outer Picard residual cannot drop "
+                f"below the inner Newton floor and may report 'max iterations reached' "
+                f"without converging. Set newton_tolerance <= picard tolerance.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Get problem dimensions - handle both old 1D and new nD interfaces
         num_time_steps = self.problem.Nt + 1  # Renamed from Nt
 

--- a/tests/unit/test_alg/test_fixed_point_sigma_consistency.py
+++ b/tests/unit/test_alg/test_fixed_point_sigma_consistency.py
@@ -99,5 +99,39 @@ def test_silent_when_callable():
     assert len(sigma_warns) == 0
 
 
+def test_warns_when_newton_tolerance_looser_than_picard():
+    """Issue #1081: a Newton tolerance looser than the Picard tolerance is a convergence
+    floor — each inner HJB solve injects a ~newton_tolerance residual, so Picard cannot
+    drop below it and reports 'max iterations' without converging. Warn at solve()."""
+    problem = _make_problem(sigma=0.3)
+    hjb = HJBFDMSolver(problem, newton_tolerance=1e-4)
+    fp = FPFDMSolver(problem)
+    iterator = FixedPointIterator(problem, hjb, fp)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        iterator.solve(max_iterations=1, tolerance=1e-8)
+        tol_warns = [x for x in w if "newton_tolerance" in str(x.message)]
+
+    assert len(tol_warns) == 1, f"expected 1 tolerance-floor warning, got {len(tol_warns)}"
+    assert "looser" in str(tol_warns[0].message)
+
+
+def test_silent_when_newton_tolerance_tight_enough():
+    """No tolerance-floor warning when newton_tolerance <= picard tolerance (the equal
+    1e-6 defaults are fine; a tighter Newton tolerance is also fine)."""
+    problem = _make_problem(sigma=0.3)
+    hjb = HJBFDMSolver(problem, newton_tolerance=1e-8)
+    fp = FPFDMSolver(problem)
+    iterator = FixedPointIterator(problem, hjb, fp)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        iterator.solve(max_iterations=1, tolerance=1e-6)
+        tol_warns = [x for x in w if "newton_tolerance" in str(x.message)]
+
+    assert len(tol_warns) == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary
Completes the last open part of #1081 (HJB-FP self-consistency fail-loud). Verify-by-artifact shows the first two parts already landed:
- **Part 1** (silent `sigma=0.1` default in `fp_particle`): removed — `fp_particle.py:387-389` now uses `self.problem.sigma` and even comments out the prior `else 0.1`.
- **Part 2** (HJB-FP volatility-consistency warning): implemented at `fixed_point_iterator.py:165-193` (tagged `Issue #1081`); warns on scalar `volatility_field != problem.sigma`, silent for callable/`None` (LLF/augmented-diffusion escape hatch).
- **Part 3** (this PR): the Newton-vs-Picard tolerance floor.

## Part 3
When `newton_tolerance > picard tolerance`, each inner HJB solve injects a `~newton_tolerance` residual, so the outer Picard residual plateaus at that floor and the run reports "max iterations reached" without ever converging — with no diagnostic. This adds a warning at `solve()` entry (where the Picard tolerance is resolved):
- **Strictly** looser only — equal `1e-6` defaults are fine, so the default config never warns.
- `getattr(self.hjb_solver, "newton_tolerance", None)` + isinstance guard → silently skips SL/Howard solvers that expose no Newton tolerance.

## Tests
Added to `test_fixed_point_sigma_consistency.py`: warns when `newton_tolerance=1e-4` vs `picard=1e-8`; silent when `newton <= picard`. Full file (6 tests) passes; `fixed_point_iterator.py` ruff-clean.

Closes #1081