### PR TITLE
feat(hjb-gfdm): add inner_solver='howard' policy-iteration path (#1118 PR1)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -247,6 +247,13 @@ class HJBGFDMSolver(BaseHJBSolver):
         weight_scale: float = 1.0,
         max_newton_iterations: int | None = None,
         newton_tolerance: float | None = None,
+        # Inner HJB solver selector (Issue #1118). 'newton' (default): the existing
+        # per-timestep Newton + Armijo line search. 'howard': delegate the backward
+        # sweep to HJBHowardSolver (policy iteration; no line search, so it avoids the
+        # MIN_ALPHA stall that freezes Newton on advection-dominant / no-flux-BC regimes).
+        # 'howard' requires monotonicity_scheme='joint_socp' + monotonicity_application=
+        # 'precompute', unit control cost, and a no-flux/Dirichlet BC (validated in solve).
+        inner_solver: str = "newton",
         # Deprecated parameters for backward compatibility
         NiterNewton: int | None = None,
         l2errBoundNewton: float | None = None,
@@ -581,6 +588,11 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Newton parameters (store with new names)
         self.max_newton_iterations = max_newton_iterations
         self.newton_tolerance = newton_tolerance
+
+        # Issue #1118: inner-solver selector (Newton default; Howard policy iteration opt-in)
+        if inner_solver not in ("newton", "howard"):
+            raise ValueError(f"inner_solver must be 'newton' or 'howard', got {inner_solver!r}")
+        self.inner_solver = inner_solver
 
         # Keep old names for backward compatibility (without warnings when accessed)
         self.NiterNewton = max_newton_iterations
@@ -2731,29 +2743,38 @@ class HJBGFDMSolver(BaseHJBSolver):
             # Set final condition at t=T (last time index = n_time_points - 1)
             U_solution_collocation[n_time_points - 1, :] = self._mapper.map_grid_to_collocation(U_terminal.flatten())
 
-        # Backward time stepping: Nt steps from index (n_time_points-2) down to 0
-        # This covers all Nt intervals in the backward direction (Issue #587 Protocol pattern)
-        from mfgarchon.utils.progress import create_progress_bar, should_show_progress
+        if self.inner_solver == "howard":
+            # Issue #1118: delegate the backward sweep to Howard's policy iteration (no
+            # Armijo line search -> no MIN_ALPHA stall). Howard owns the full Nt loop and
+            # works in collocation space; the grid<->collocation mapping above and below is
+            # unchanged. Validation + alpha* synthesis live in the helper.
+            U_solution_collocation = self._solve_backward_howard(
+                M_collocation, U_solution_collocation[n_time_points - 1, :]
+            )
+        else:
+            # Backward time stepping: Nt steps from index (n_time_points-2) down to 0
+            # This covers all Nt intervals in the backward direction (Issue #587 Protocol pattern)
+            from mfgarchon.utils.progress import create_progress_bar, should_show_progress
 
-        timestep_range = create_progress_bar(
-            range(n_time_points - 2, -1, -1),
-            verbose=should_show_progress(show_progress),
-            desc="HJB (backward)",
-        )
-
-        for n in timestep_range:
-            rc_n = self._running_cost_fn(n) if self._running_cost_fn is not None else None
-
-            U_solution_collocation[n, :] = self._solve_timestep(
-                U_solution_collocation[n + 1, :],
-                M_collocation[n, :],  # FIXED: Use m^n, not m^{n+1} (same-time coupling)
-                n,
-                running_cost=rc_n,
+            timestep_range = create_progress_bar(
+                range(n_time_points - 2, -1, -1),
+                verbose=should_show_progress(show_progress),
+                desc="HJB (backward)",
             )
 
-            # Update progress bar with QP statistics if available (Issue #587 Protocol - no hasattr needed)
-            if self.qp_optimization_level in ["auto", "always"]:
-                timestep_range.update_metrics(qp_solves=self.qp_stats.get("total_qp_solves", 0))
+            for n in timestep_range:
+                rc_n = self._running_cost_fn(n) if self._running_cost_fn is not None else None
+
+                U_solution_collocation[n, :] = self._solve_timestep(
+                    U_solution_collocation[n + 1, :],
+                    M_collocation[n, :],  # FIXED: Use m^n, not m^{n+1} (same-time coupling)
+                    n,
+                    running_cost=rc_n,
+                )
+
+                # Update progress bar with QP statistics if available (Issue #587 Protocol - no hasattr needed)
+                if self.qp_optimization_level in ["auto", "always"]:
+                    timestep_range.update_metrics(qp_solves=self.qp_stats.get("total_qp_solves", 0))
 
         # Return format depends on input mode
         if is_meshfree_input:
@@ -2763,6 +2784,82 @@ class HJBGFDMSolver(BaseHJBSolver):
             # Hybrid mode: map back to grid
             U_solution = self._mapper.map_collocation_to_grid_batch(U_solution_collocation)
             return U_solution
+
+    def _solve_backward_howard(self, M_collocation: np.ndarray, U_terminal_colloc: np.ndarray) -> np.ndarray:
+        """Issue #1118: backward HJB sweep via Howard's policy iteration (inner_solver='howard').
+
+        Howard has no Armijo line search, so it avoids the MIN_ALPHA stall the per-point Newton
+        path hits on advection-dominant / no-flux-BC regimes (#1118). Operates in collocation
+        space; the caller handles grid<->collocation mapping. PR1 scope: requires joint_socp+
+        precompute stencils, a Hamiltonian exposing dp(), unit control cost, and a no-flux/
+        Neumann/Dirichlet BC. Robin/mixed BC and non-unit control cost are deferred to PR2.
+        """
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import HJBHowardSolver
+
+        if getattr(self, "_joint_socp_stencils", None) is None:
+            raise ValueError(
+                "inner_solver='howard' requires SOCP-precomputed stencils. Construct the solver with "
+                "monotonicity_scheme='joint_socp', monotonicity_application='precompute'."
+            )
+        H_class = getattr(self.problem, "hamiltonian_class", None)
+        if H_class is None:
+            raise ValueError(
+                "inner_solver='howard' requires problem.hamiltonian_class to derive the optimal "
+                "control alpha* = -dH/dp; the legacy no-Hamiltonian LQ path is unsupported."
+            )
+        lambda_val = self._get_lambda_value()
+        if abs(lambda_val - 1.0) > 1e-12:
+            raise NotImplementedError(
+                f"inner_solver='howard' currently assumes unit control cost (lambda_=1), got {lambda_val}. "
+                "Howard's policy-evaluation Lagrangian is hardcoded to (1/2)|alpha|^2; non-unit control cost "
+                "needs a running-cost correction (deferred, Issue #1118 PR2)."
+            )
+        # BC-parity restriction (Issue #1118 PR2 deferral): Howard's BC handling is a
+        # self-contained Neumann-by-nearest-interior + Dirichlet-identity scheme — it does not
+        # honor Robin or coupling providers (e.g. AdjointConsistentProvider). Inspect segments
+        # directly: for a mixed BC, `boundary_conditions.type` raises and `_bc_config["type"]`
+        # is a meaningless 'periodic' fallback, so neither is a reliable indicator.
+        allowed_bc = {"no_flux", "neumann", "dirichlet"}
+        segments = getattr(self.boundary_conditions, "segments", None)
+        if segments:
+            for seg in segments:
+                seg_type = seg.bc_type.value if hasattr(seg.bc_type, "value") else str(seg.bc_type)
+                if seg_type not in allowed_bc:
+                    raise NotImplementedError(
+                        f"inner_solver='howard' supports no-flux/Neumann/Dirichlet BC only; segment "
+                        f"{getattr(seg, 'name', '?')!r} is {seg_type!r}. Robin/periodic/mixed BC parity "
+                        f"is deferred (Issue #1118 PR2)."
+                    )
+                if callable(getattr(getattr(seg, "value", None), "compute", None)):
+                    raise NotImplementedError(
+                        "inner_solver='howard' does not honor a BCValueProvider (e.g. "
+                        "AdjointConsistentProvider); deferred (Issue #1118 PR2)."
+                    )
+        else:
+            try:
+                uniform_type = self.boundary_conditions.type
+            except Exception:
+                uniform_type = None
+            if uniform_type is not None and uniform_type not in allowed_bc:
+                raise NotImplementedError(
+                    f"inner_solver='howard' supports no-flux/Neumann/Dirichlet BC only, got "
+                    f"{uniform_type!r}. Robin/periodic BC parity is deferred (Issue #1118 PR2)."
+                )
+
+        dt = float(self.problem.T) / int(self.problem.Nt)
+
+        def alpha_star(x_pts, p, m, t_idx):
+            # Optimal feedback control alpha* = -dH/dp (the same dp() the Newton Jacobian reads).
+            return -np.asarray(H_class.dp(x_pts, m, p, t=t_idx * dt), dtype=float)
+
+        howard = HJBHowardSolver(
+            self.problem,
+            stencil_provider=self,
+            alpha_star=alpha_star,
+            running_cost=self._running_cost_fn,
+            discretisation="central" if self.dimension == 1 else "upwind_projection",
+        )
+        return howard.solve_hjb_system(M_collocation, U_terminal_colloc)
 
     def _solve_timestep(
         self,

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -101,7 +101,7 @@ def _make_1d_cloud(LX=2.0, n_int=11):
     return pts, bdry_idx, geom
 
 
-def _make_gfdm_solver(pts, bdry, geom, problem, scheme="joint_socp", k_neighbors=12):
+def _make_gfdm_solver(pts, bdry, geom, problem, scheme="joint_socp", k_neighbors=12, inner_solver="newton"):
     bc = BoundaryConditions(
         segments=[
             BCSegment(name=f"side_{d}_{end}", bc_type=BCType.NO_FLUX, boundary=f"{ax}_{end}")
@@ -127,7 +127,20 @@ def _make_gfdm_solver(pts, bdry, geom, problem, scheme="joint_socp", k_neighbors
             boundary_conditions=bc,
             monotonicity_scheme=scheme,
             monotonicity_application="precompute",
+            inner_solver=inner_solver,
         )
+
+
+class _LQHam:
+    """Minimal LQ Hamiltonian H = |p|²/2 exposing dp(x, m, p, t) = p (so α* = -dp = -p).
+
+    Used to validate the integrated `inner_solver='howard'` path, which derives α* from
+    `problem.hamiltonian_class.dp` (Issue #1118). Matches the explicit `lambda x,p,m,t: -p`
+    the standalone Howard tests pass.
+    """
+
+    def dp(self, x, m, p, t=0.0):
+        return np.asarray(p, dtype=float)
 
 
 # ---------------------------------------------------------------------------
@@ -367,3 +380,65 @@ def test_2d_smoke_with_running_cost_callable():
     if len(interior_idx) > 0:
         diff_at_t0 = float(np.mean(with_rc[0, interior_idx]) - np.mean(base[0, interior_idx]))
         assert diff_at_t0 > 0, f"Constant running cost did not increase U(0) at center; diff={diff_at_t0:.4f}"
+
+
+# ---------------------------------------------------------------------------
+# 7. Integrated path: HJBGFDMSolver(inner_solver='howard') (Issue #1118 PR1)
+# ---------------------------------------------------------------------------
+
+
+def test_integrated_howard_inner_solver_lq_1d():
+    """inner_solver='howard' wired into HJBGFDMSolver.solve_hjb_system reproduces the 1D LQ
+    Riccati profile — proving the integrated path derives alpha* = -hamiltonian_class.dp,
+    delegates the backward sweep to Howard, and round-trips the collocation output. Same
+    fixture and loose bound as test_1d_lq_closed_form_riccati (the standalone solver)."""
+    LX = 4.0
+    pts, bdry, geom = _make_1d_cloud(LX=LX, n_int=11)
+    problem = _MockProblem(geom, sigma=0.0, T=1.0, Nt=20, dimension=1)
+    problem.hamiltonian_class = _LQHam()  # H = |p|²/2 → dp = p → α* = -p
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5, inner_solver="howard")
+
+    x_pts = pts[:, 0]
+    x_c = LX / 2
+    U_T = 0.5 * (x_pts - x_c) ** 2
+
+    U = gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)  # delegates to Howard internally
+
+    assert np.all(np.isfinite(U)), "integrated Howard path produced non-finite U"
+    probe_idx = int(np.argmin(np.abs(x_pts - (x_c - 1.0))))
+    U_T_probe = float(U_T[probe_idx])
+    assert U_T_probe > 0.1, "fixture broken: probe is at the quadratic's vertex"
+    ratio = float(U[0, probe_idx]) / U_T_probe
+    assert 0.3 < ratio < 0.85, (
+        f"integrated inner_solver='howard' Riccati ratio U(0)/U(T)={ratio:.3f}, expected ~0.5 "
+        f"(matches the standalone test_1d_lq_closed_form_riccati)."
+    )
+
+
+def test_inner_solver_rejects_unknown_value():
+    """An unknown inner_solver value fails fast at construction."""
+    pts, bdry, geom = _make_1d_cloud()
+    problem = _MockProblem(geom, dimension=1)
+    with pytest.raises(ValueError, match="inner_solver must be"):
+        _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5, inner_solver="bogus")
+
+
+def test_integrated_howard_requires_joint_socp_stencils():
+    """inner_solver='howard' on a non-SOCP scheme raises at solve time (no _joint_socp_stencils)."""
+    pts, bdry, geom = _make_1d_cloud()
+    problem = _MockProblem(geom, sigma=0.0, T=1.0, Nt=5, dimension=1)
+    problem.hamiltonian_class = _LQHam()
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem, scheme="none", k_neighbors=5, inner_solver="howard")
+    U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
+    with pytest.raises(ValueError, match="SOCP-precomputed"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_integrated_howard_requires_hamiltonian_class():
+    """inner_solver='howard' without problem.hamiltonian_class raises (cannot derive α*)."""
+    pts, bdry, geom = _make_1d_cloud()
+    problem = _MockProblem(geom, sigma=0.0, T=1.0, Nt=5, dimension=1)  # hamiltonian_class=None
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5, inner_solver="howard")
+    U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
+    with pytest.raises(ValueError, match="hamiltonian_class"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)


### PR DESCRIPTION
## What & why
Wires the existing, tested `HJBHowardSolver` in as an **opt-in inner solver** for `HJBGFDMSolver`, fixing the #1118 stall (Newton's Armijo line search bottoming at `MIN_ALPHA=1e-6` and applying a silent no-op step). Howard uses policy iteration with **no line search**, so the collapse cannot occur.

**Verified diagnosis** (full repro on the issue): the stall reproduces (~2.6× off the LQ closed form) but is driven by the **no-flux Neumann boundary rows, not interior `|∇u|²` stiffness** (Dirichlet BC converges the interior to 3.5e-8; Jacobian is correct to 4e-10), and the ~2.6× is partly a discretization artifact. `HJBHowardSolver` already existed ("Refs #1118", 8/8 tests) but was **never reached** by `solve_hjb_system`.

## PR1 — wiring, not reimplementation
- `inner_solver: 'newton' | 'howard'` constructor param (default `'newton'`, existing path **byte-identical** — the Newton loop is unchanged, just nested under an `else`).
- `solve_hjb_system` delegates the backward sweep to `HJBHowardSolver` when `'howard'`; `α* = -problem.hamiltonian_class.dp` (the same `dp` the Newton Jacobian reads), running cost from the solver's running-cost fn, `discretisation='central'` (1D) / `'upwind_projection'` (≥2D); collocation output round-trips through the existing grid↔collocation mapper.
- **Fail-loud guards**: requires `joint_socp`+`precompute` stencils and a `hamiltonian_class`; restricts to no-flux/Neumann/Dirichlet BC by **inspecting segments** (mixed-BC `_bc_config['type']` is an unreliable `'periodic'` fallback) and rejects `BCValueProvider`s; `NotImplementedError` for non-unit control cost (Howard's Lagrangian is hardcoded `(1/2)|α|²`).

## Tests / verification
- New: integrated LQ Riccati ratio through `inner_solver='howard'` (matches the standalone `test_1d_lq_closed_form_riccati`) + 3 guard tests. **Howard suite 12/12**, **GFDM suite 65 pass / 1 pre-existing skip**, factory + ruff clean.

## Deferred to PR2 (separate)
BC-row parity — refactor Howard's self-contained Neumann-by-nearest/Dirichlet-identity BC handling to reuse `HJBGFDMSolver`'s BC builders (Robin / `AdjointConsistentProvider` / ghost-node / LCR). This is the load-bearing follow-up since the verified stall is BC-row-driven. Not `Closes` until then.

Refs #1118