### PR TITLE
fix(workflow): make ParameterSweep picklable for ProcessPoolExecutor on macOS spawn (#1080)

### DIFF
--- a/mfgarchon/workflow/parameter_sweep.py
+++ b/mfgarchon/workflow/parameter_sweep.py
@@ -106,6 +106,19 @@ class ParameterSweep:
 
         self.logger.info(f"Initialized parameter sweep with {self.total_combinations} combinations")
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Issue #1080: the logger holds a non-picklable ``threading.Lock``, so pickling the
+        instance to a ``ProcessPoolExecutor`` worker fails under the macOS/Windows ``spawn``
+        start method (Linux ``fork`` inherits memory without pickling, masking it). Drop the
+        logger here; ``__setstate__`` re-initializes it in the worker."""
+        state = self.__dict__.copy()
+        state.pop("logger", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.logger = self._setup_logging()
+
     def _generate_combinations(self) -> list[dict[str, Any]]:
         """Generate all parameter combinations."""
         param_names = []
@@ -233,6 +246,24 @@ class ParameterSweep:
 
     def _execute_parallel_processes(self, function: Callable, **kwargs) -> list[dict[str, Any]]:
         """Execute parameter sweep using process pool."""
+        # Issue #1080: under macOS/Windows 'spawn', worker args are pickled. Fail fast with an
+        # actionable message instead of a cryptic deep-pickle TypeError when the sweep function
+        # (or its captured state) is non-picklable — typically a lambda/closure. (Linux 'fork'
+        # inherits memory without pickling, so this only bites on spawn platforms.)
+        if self.parameter_combinations:
+            probe = (self, function, self.parameter_combinations[0], 0, kwargs)
+            try:
+                pickle.dumps(probe)
+            except (TypeError, AttributeError, pickle.PicklingError) as e:
+                raise ValueError(
+                    f"ParameterSweep parallel-process worker args are not picklable ({e}). Under "
+                    "the macOS/Windows 'spawn' start method the sweep `function` and any captured "
+                    "objects must be picklable: use a module-level/named function rather than a "
+                    "lambda or closure, keep `MFGComponents` callables module-level, and avoid "
+                    "passing live file handles/locks. Or set execution_mode='parallel_threads' "
+                    "(or 'sequential') to sweep in-process without pickling."
+                ) from e
+
         with ProcessPoolExecutor(max_workers=self.config.max_workers) as executor:
             # Prepare arguments for each worker — include self for pickling
             worker_args = [(self, function, params, i, kwargs) for i, params in enumerate(self.parameter_combinations)]

--- a/tests/unit/test_workflow/test_parameter_sweep.py
+++ b/tests/unit/test_workflow/test_parameter_sweep.py
@@ -5,6 +5,7 @@ Tests parameter space exploration including combination generation,
 execution modes, result collection, and error handling.
 """
 
+import pickle
 import tempfile
 from pathlib import Path
 
@@ -578,3 +579,32 @@ def test_results_persist_after_execution():
     assert len(sweep.results) == 3
     # Check we can access results multiple times
     assert len(sweep.results) == 3
+
+
+# ============================================================================
+# Test: Issue #1080 — picklability for ProcessPoolExecutor under macOS spawn
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_parameter_sweep_is_picklable_issue_1080():
+    """ParameterSweep must pickle (for ProcessPoolExecutor under macOS/Windows 'spawn')
+    despite its logger holding a non-picklable threading.Lock. __getstate__ drops the
+    logger; __setstate__ re-initializes it in the worker."""
+    sweep = ParameterSweep({"x": [1, 2], "y": [3, 4]})
+    restored = pickle.loads(pickle.dumps(sweep))
+    assert restored.total_combinations == sweep.total_combinations
+    assert restored.parameters == sweep.parameters
+    assert restored.logger is not None
+    restored.logger.info("worker logger re-initialized OK")  # must not raise
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_parallel_processes_fails_loud_on_unpicklable_function_issue_1080():
+    """A non-picklable sweep function (lambda/closure) must raise an actionable ValueError at
+    the call site, not a cryptic deep-pickle TypeError inside a worker (macOS/Windows spawn)."""
+    sweep = ParameterSweep({"x": [1, 2]})
+    with pytest.raises(ValueError, match="not picklable"):
+        sweep._execute_parallel_processes(lambda x: x)


### PR DESCRIPTION
## Problem
Under the macOS/Windows **`spawn`** start method, `_execute_parallel_processes` pickles the whole `ParameterSweep` instance to each worker (`parameter_sweep.py:238`). That fails because `self.logger` holds a `threading.Lock` — the **universal blocker**: *every* macOS process-sweep crashes regardless of the sweep function. Linux `fork` inherits memory without pickling, masking it.

## Fix
- **`__getstate__`/`__setstate__`** drop + re-initialize the logger so the instance crosses the worker boundary (fixes the `Lock` crash).
- **Fail-loud pre-flight**: pickle-probe the worker args before submitting. A non-picklable `function` (lambda/closure) or captured state now raises an actionable `ValueError` at the call site (use a module-level/named function, or `execution_mode='parallel_threads'`) instead of a cryptic deep-pickle `TypeError` inside a worker.

## Tests
`ParameterSweep` round-trips through `pickle` (logger re-initialized); `parallel_processes` fails loud on a lambda. **38/38** sweep tests pass; ruff clean. No new dependency.

## Deferred (follow-ups, need a dep / wider refactor)
- Full lambda/closure **support** via `cloudpickle`/`loky` (#1080 option 1) — neither is currently a dependency.
- Per-solver `__getstate__` for live file handles / `_boundary_handler` lambdas (#1080 option 3).

Refs #1080