### PR TITLE
docs(hjb-fdm): strengthen non-diagonal-tensor warning to state O(1) severity (#1079)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -891,8 +891,12 @@ class HJBFDMSolver(BaseHJBSolver):
                     import warnings
 
                     warnings.warn(
-                        "Non-diagonal tensor diffusion detected. "
-                        "Using diagonal approximation (ignoring off-diagonal terms).",
+                        "Non-diagonal tensor diffusion detected: dropping the off-diagonal "
+                        "sigma_ij terms (diagonal approximation). This is an O(1) error on the "
+                        "cross-derivative operator 2*sum_{i<j} D_ij d2u/dx_i dx_j -- NOT a small "
+                        "correction (Issue #1079). The result is only meaningful when the "
+                        "off-diagonals are physically negligible; pass a scalar or diagonal "
+                        "sigma to avoid the approximation.",
                         UserWarning,
                         stacklevel=3,
                     )
@@ -902,8 +906,12 @@ class HJBFDMSolver(BaseHJBSolver):
                     import warnings
 
                     warnings.warn(
-                        "Non-diagonal tensor diffusion detected. "
-                        "Using diagonal approximation (ignoring off-diagonal terms).",
+                        "Non-diagonal tensor diffusion detected: dropping the off-diagonal "
+                        "sigma_ij terms (diagonal approximation). This is an O(1) error on the "
+                        "cross-derivative operator 2*sum_{i<j} D_ij d2u/dx_i dx_j -- NOT a small "
+                        "correction (Issue #1079). The result is only meaningful when the "
+                        "off-diagonals are physically negligible; pass a scalar or diagonal "
+                        "sigma to avoid the approximation.",
                         UserWarning,
                         stacklevel=3,
                     )

--- a/tests/unit/test_alg/test_hjb_fdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_fdm_solver.py
@@ -552,6 +552,12 @@ class TestHJBFDMSolverDiagonalTensor:
             # Check that warning was raised
             tensor_warnings = [warning for warning in w if "non-diagonal" in str(warning.message).lower()]
             assert len(tensor_warnings) > 0, "Should warn for non-diagonal tensor"
+            # Issue #1079: the warning must convey the O(1) severity (dropping off-diagonal
+            # sigma_ij is not a small correction), not merely "using diagonal approximation".
+            assert any(
+                "o(1)" in str(warning.message).lower() or "1079" in str(warning.message)
+                for warning in tensor_warnings
+            ), "Warning should state the off-diagonal drop is an O(1) error (Issue #1079)"
 
         # Solution should still be computed (fallback to diagonal)
         assert U_solution.shape == (Nt_points, Nx, Ny)


### PR DESCRIPTION
## Decision
Full-tensor anisotropic σ is handled by `HJBFDMSolver` via a **deliberate, tested** diagonal approximation (`test_non_diagonal_tensor_warning` asserts the warning + a successful "fallback to diagonal" solve). We keep that design (no breaking change) — but the warning **understated the cost**.

## Change
The old message — "Using diagonal approximation (ignoring off-diagonal terms)" — reads like a minor correction. Dropping the off-diagonal `σ_ij` is an **O(1) error** on the cross-derivative operator `2·Σ_{i<j} D_ij ∂²u/∂x_i∂x_j`. Strengthen the message to say so, and assert the severity wording in the test (preserving the existing "non-diagonal" keyword). **No behavior change.**

## Remaining #1079 sites (kept open)
- **GFDM / `joint_socp` (Site 3):** the `e_lap` target zeros the cross-derivative column → a full tensor is silently reduced to the trace, with **no warning at all**.
- **HJB-SL-ADI (Site 4):** diagonal (`σ²/2`) vs off-diagonal (`2·σ²`) conventions are mutually inconsistent; needs a documented assert.
- Fail-loud (issue Option 1) vs the tested diagonal-approximation remains a maintainer decision.

Refs #1079