### PR TITLE
fix(core): MFGProblem rejects non-positive T (#1077 case 4)

### DIFF
--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -526,6 +526,12 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             # No physical parameter specified — deterministic (sigma = 0)
             vola_value = 0.0
 
+        # Issue #1077: T <= 0 is a degenerate (zero/inverted) time horizon — dt = T/Nt = 0
+        # silently produces all-zero integration. Fail fast, consistent with MFGGridConfig's
+        # T-positive validation. (Nt=0 is intentionally graceful — see test_mfg_problem_zero_nt.)
+        if T is not None and T <= 0:
+            raise ValueError(f"T (time horizon) must be > 0, got {T}.")
+
         # Set defaults for T, Nt if not provided
         if T is None:
             T = 1.0

--- a/tests/unit/test_core/test_mfg_problem.py
+++ b/tests/unit/test_core/test_mfg_problem.py
@@ -653,6 +653,16 @@ def test_mfg_problem_zero_nt():
     assert len(problem.tSpace) == 1
 
 
+@pytest.mark.unit
+def test_mfg_problem_rejects_nonpositive_T():
+    """Issue #1077: T <= 0 is a degenerate time horizon (dt = T/Nt = 0 -> all-zero
+    integration) and must fail fast, consistent with MFGGridConfig's T-positive validation.
+    (Nt=0 stays intentionally graceful, above.)"""
+    for bad_T in (0.0, -1.0):
+        with pytest.raises(ValueError, match=r"T .*must be > 0"):
+            create_test_problem(T=bad_T)
+
+
 # ===================================================================
 # Test Module Exports
 # ===================================================================


### PR DESCRIPTION
## Change
`T <= 0` is a degenerate time horizon — `dt = T/Nt = 0` silently produces all-zero integration. Add a fail-fast guard at the **common `__init__` point** (before the `T`-default, so it covers both the 1D-legacy and nD construction paths). This is **consistent with existing precedent**: `MFGGridConfig` already rejects `T=0.0` (`test_validation_T_positive`, "T must be positive").

## Scope (verify-by-artifact)
- **`Nt=0` stays graceful** — `test_mfg_problem_zero_nt` codifies it as intended, so case 5 is deliberately *not* guarded.
- **`sigma<=0` (case 3) deferred** — a blanket guard risks breaking deterministic reconstruction (`self.sigma` is stored as `0.0`); needs an input-path-only / reconstruction-safe formulation.
- 55 MFGProblem tests pass (incl. `Nt=0`-graceful and `T=None`-default); ruff clean.

Part of #1077 (cases 1/2/6 already landed; this is case 4). Refs #1077.