### PR TITLE
refactor(hjb-gfdm): extract _bc_row_for_point shared BC-row helper (#1118 PR2 foundation)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2336,6 +2336,55 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         return jacobian.tocsr()
 
+    def _bc_row_for_point(
+        self,
+        i: int,
+        bc_enum,
+        segment,
+        normal,
+        dimension: int,
+        n: int,
+        legacy_bc_values,
+        current_time: float,
+    ) -> tuple[np.ndarray, float]:
+        """Build the value-form BC row (coefficients + target) for boundary point ``i``.
+
+        Returns ``(row_coeffs, bc_target)`` WITHOUT any residual subtraction, so it is the
+        single coefficient source shared by both BC application paths (Issue #1118 PR2):
+        - the Newton path forms the #1116 residual RHS ``row_coeffs @ u_current - bc_target``;
+        - the Howard value-form path uses ``bc_target`` as the RHS directly.
+        Keeping one source prevents the two paths from drifting (the recurring dual-source BC
+        bug class). Raises for BC types with no row builder (PERIODIC/ROBIN).
+        """
+        match bc_enum:
+            case BCType.DIRICHLET:
+                new_row = np.zeros(n)
+                new_row[i] = 1.0
+                bc_target = self._eval_bc_dirichlet_value(i, segment, legacy_bc_values, current_time)
+            case BCType.NEUMANN | BCType.NO_FLUX:
+                new_row, bc_target = self._build_neumann_bc_row(
+                    i, normal, dimension, segment, legacy_bc_values, current_time
+                )
+            case BCType.PERIODIC:
+                raise NotImplementedError(
+                    f"PERIODIC BC at boundary point {i} not supported by HJBGFDMSolver "
+                    f"via row replacement. Use TensorProductGrid + FDM for periodic "
+                    f"geometries, or rephrase as paired Dirichlet/Neumann segments."
+                )
+            case BCType.ROBIN:
+                raise NotImplementedError(
+                    f"ROBIN BC at boundary point {i} not supported by HJBGFDMSolver "
+                    f"via row replacement. Use the BCValueProvider pattern in the "
+                    f"coupling layer (Issue #625, see AdjointConsistentProvider)."
+                )
+            case _:
+                raise ValueError(
+                    f"Unhandled BCType {bc_enum!r} at boundary point {i}. "
+                    f"This indicates a new BCType value not yet wired into HJBGFDMSolver "
+                    f"BC row construction."
+                )
+        return new_row, float(bc_target)
+
     def _apply_boundary_conditions_to_sparse_system(
         self,
         jacobian_sparse,
@@ -2440,39 +2489,15 @@ class HJBGFDMSolver(BaseHJBSolver):
                     # Symmetric ghost stencils enforce BC structurally; leave row.
                     continue
 
-            # --- Build replacement row + rhs (atomic) ---
-            # `new_rhs` is the Newton residual at this row: F_bc(u_current) - target.
-            # `_eval_bc_dirichlet_value` and `_build_neumann_bc_row` return the
-            # BC target; we subtract from the current state to get the violation.
-            match bc_enum:
-                case BCType.DIRICHLET:
-                    new_row = np.zeros(n)
-                    new_row[i] = 1.0
-                    bc_target = self._eval_bc_dirichlet_value(i, segment, legacy_bc_values, current_time)
-                    new_rhs = float(u_current[i]) - bc_target
-                case BCType.NEUMANN | BCType.NO_FLUX:
-                    new_row, bc_target = self._build_neumann_bc_row(
-                        i, normal, dimension, segment, legacy_bc_values, current_time
-                    )
-                    new_rhs = float(new_row @ u_current) - bc_target
-                case BCType.PERIODIC:
-                    raise NotImplementedError(
-                        f"PERIODIC BC at boundary point {i} not supported by HJBGFDMSolver "
-                        f"via row replacement. Use TensorProductGrid + FDM for periodic "
-                        f"geometries, or rephrase as paired Dirichlet/Neumann segments."
-                    )
-                case BCType.ROBIN:
-                    raise NotImplementedError(
-                        f"ROBIN BC at boundary point {i} not supported by HJBGFDMSolver "
-                        f"via row replacement. Use the BCValueProvider pattern in the "
-                        f"coupling layer (Issue #625, see AdjointConsistentProvider)."
-                    )
-                case _:
-                    raise ValueError(
-                        f"Unhandled BCType {bc_enum!r} at boundary point {i}. "
-                        f"This indicates a new BCType value not yet wired into "
-                        f"HJBGFDMSolver._apply_boundary_conditions_to_sparse_system."
-                    )
+            # --- Build replacement row + value-form target, then form the Newton residual. ---
+            # `_bc_row_for_point` returns (row coefficients, BC target) WITHOUT the residual
+            # subtraction, so the Howard value-form path (Issue #1118 PR2) reuses the SAME
+            # coefficient source. Here we form the #1116 residual: F_bc(u_current) - target.
+            # (Dirichlet's row is e_i, so `new_row @ u_current == u_current[i]` — unchanged.)
+            new_row, bc_target = self._bc_row_for_point(
+                i, bc_enum, segment, normal, dimension, n, legacy_bc_values, current_time
+            )
+            new_rhs = float(new_row @ u_current) - bc_target
 
             # --- Atomic row replacement ---
             jac_lil[i, :] = new_row


### PR DESCRIPTION
## What
Extracts per-point BC-row construction out of the Newton-path `_apply_boundary_conditions_to_sparse_system` into **`_bc_row_for_point(...) -> (row_coeffs, bc_target)`** — returning the coefficients + target **without** the residual subtraction.

- Newton path forms its #1116 residual RHS `row @ u_current - bc_target` at the caller — **byte-equivalent** (Dirichlet's row is `e_i`, so `row @ u_current == u_current[i]`, the prior expression).
- This is the **single coefficient source** the Howard value-form inner solver (#1118) will consume (`bc_target` as its value-form RHS), so the two BC paths share one builder instead of drifting — the recurring dual-source BC bug class.

## Why (design)
A design workflow established that value-form (Howard) and residual-form (Newton, #1116) BC rows are **identical at the coefficient level** (no 1/dt scaling, full-row overwrite both) — only the RHS convention differs. Extracting the shared coefficient source is the foundation that lets Howard reuse the *consistent* Newton BC stencils instead of its current self-contained nearest-interior approximation.

## Verification
**No behavior change.** 85 tests pass unchanged across the BC-touching suites: Newton residual-BC (#1116), GFDM BC-classification, GFDM solver, Howard, FDM-conservation. ruff clean.

## Follow-ups (the value-delivering increments, scoped + saved)
- **PR2a:** wire Howard to `_bc_row_for_point` for **Dirichlet-value parity** — fix the uniform-Dirichlet misclassification (`_bc_segment_per_point` is empty for uniform BC) + write `b=bc_target` instead of hardcoded 0 + lift the guard for `dirichlet`. Chief risk: a guard-lift outrunning the row fix → silent-wrong BC, so classification-fix + `b=target` land together.
- **PR2b:** nonzero-Neumann (Howard's nearest-interior copy → the real normal·grad stencil) then Robin/AdjointConsistent (net-new builder, >1000×-impact regime).

Refs #1118