### PR TITLE
fix(gfdm): re-read geometry BC per solve so resolved providers reach the solver (#1118 PR2b/1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`HJBGFDMSolver` now re-reads geometry boundary conditions per solve** when
+  the BC was sourced from the geometry (Issue #1118). GFDM previously snapshotted
+  the BC and its preclassified per-point segment map at construction, so the
+  coupling layer's per-Picard `using_resolved_bc` swap of
+  `geometry.boundary_conditions` never reached the solver — freezing any resolved
+  value (e.g. `AdjointConsistentProvider`'s `g = -sigma^2/2 * d ln(m)/dn`) at its
+  construction-time value, a silent error in the boundary-stall regime. FDM
+  already re-read BC each solve; GFDM now matches via
+  `_refresh_boundary_conditions_if_changed()` at the top of `solve_hjb_system`.
+  No-op for explicitly-passed `boundary_conditions=` (static) and for
+  provider-free BC (object identity unchanged). Prerequisite for the
+  Robin/adjoint-consistent Howard inner-solver support that follows.
+
 ## [0.19.7] - 2026-06-03
 
 ### Added

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -608,12 +608,18 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Get BC from parameter, or from problem geometry (Issue #542 fix, Issue #527 centralized BC)
         if boundary_conditions is not None:
             self.boundary_conditions = boundary_conditions
+            # Explicit param is the caller's authoritative static choice; never
+            # re-read from geometry at solve time (Issue #1118 BC refresh).
+            self._bc_from_geometry = False
         else:
             # Use centralized BC resolution from BaseMFGSolver (Issue #527)
             # Checks: cached _boundary_conditions, geometry.boundary_conditions,
             # geometry.get_boundary_conditions(), problem.boundary_conditions,
             # problem.get_boundary_conditions()
             self.boundary_conditions = self.get_boundary_conditions()
+            # Geometry-sourced BC may be re-resolved per Picard iteration by the
+            # coupling layer (using_resolved_bc); refresh at solve time (Issue #1118).
+            self._bc_from_geometry = True
         self.interior_indices = np.setdiff1d(np.arange(self.n_points), self.boundary_indices)
 
         # Monotonicity scheme (single source of truth) — already set above (v0.18.0 rename)
@@ -1150,10 +1156,44 @@ class HJBGFDMSolver(BaseHJBSolver):
             )
         return bc_type
 
+    def _refresh_boundary_conditions_if_changed(self) -> None:
+        """Re-sync BC-derived state from geometry if it changed since construction.
+
+        GFDM snapshots ``self.boundary_conditions`` and the preclassified
+        ``_bc_segment_per_point`` map at ``__init__``; FDM instead re-reads
+        ``get_boundary_conditions()`` every solve (hjb_fdm.py:319). When the
+        coupling layer resolves a provider per Picard iteration via
+        ``problem.using_resolved_bc`` (Issue #625), it swaps
+        ``geometry.boundary_conditions`` for a new object whose segments carry
+        the resolved scalar value (e.g. AdjointConsistentProvider's
+        ``g = -sigma^2/2 * d ln(m)/dn``). Without this refresh the GFDM/Howard
+        path would solve every iteration against the construction-time BC,
+        silently freezing the adjoint coupling in the >1000x-impact regime.
+
+        No-op when:
+        - BC came from an explicit constructor argument (static, never resolved);
+        - the live geometry BC is the same object as the cached snapshot
+          (``with_resolved_providers`` fast-paths ``return self`` for
+          provider-free BC, so the object is unchanged).
+        """
+        if not self._bc_from_geometry:
+            return
+        live_bc = self.get_boundary_conditions()
+        if live_bc is None or live_bc is self.boundary_conditions:
+            return
+        self.boundary_conditions = live_bc
+        # Keep the handler's BC reference consistent (its default_bc fallback in
+        # create_bc_config reads it); normals are geometry-only and unaffected.
+        self._boundary_handler.boundary_conditions = live_bc
+        self._bc_config = self._boundary_handler.create_bc_config()
+        self._preclassify_boundary_points()
+
     def _preclassify_boundary_points(self) -> None:
         """Pre-classify every boundary collocation point to a BCSegment + face + normal.
 
-        Called once at __init__ time. Populates three companion maps:
+        Called at __init__ time and re-run by ``_refresh_boundary_conditions_if_changed``
+        when the geometry BC is resolved per Picard iteration. Populates three
+        companion maps:
 
         - ``self._bc_face_per_point[i]``: BoundaryFace the point lies on.
         - ``self._bc_segment_per_point[i]``: BCSegment that applies to ``i``.
@@ -2766,6 +2806,10 @@ class HJBGFDMSolver(BaseHJBSolver):
             if U_coupling_prev is not None:
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
             U_coupling_prev = U_from_prev_picard
+
+        # Pick up any per-Picard resolved BC the coupling layer installed on the
+        # geometry since construction (Issue #1118; matches FDM's per-solve re-read).
+        self._refresh_boundary_conditions_if_changed()
 
         # Validate required parameters
         if U_terminal is None:

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -506,3 +506,119 @@ def test_integrated_howard_rejects_robin_bc():
     U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
     with pytest.raises(NotImplementedError, match=r"ROBIN|PERIODIC"):
         gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+# ---------------------------------------------------------------------------
+# 8. Part 1: per-solve BC refresh (Issue #1118)
+#
+# GFDM snapshots boundary conditions + the preclassified segment map at
+# __init__; the coupling layer resolves providers per Picard iteration by
+# swapping geometry.boundary_conditions (FDM re-reads it each solve, GFDM did
+# not). Without the refresh the adjoint coupling value would freeze at the
+# construction-time BC — silent-wrong in the >1000x-impact regime.
+# ---------------------------------------------------------------------------
+
+
+def _neumann_per_face_1d(value):
+    """Mixed (per-face) Neumann BC so the value flows through _bc_segment_per_point."""
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="x_min", bc_type=BCType.NEUMANN, value=value, boundary="x_min"),
+            BCSegment(name="x_max", bc_type=BCType.NEUMANN, value=value, boundary="x_max"),
+        ],
+        dimension=1,
+    )
+
+
+def _make_geom_sourced_gfdm_1d(bc, inner_solver="howard"):
+    """Construct a 1D GFDM solver that reads BC from geometry (no explicit param).
+
+    Returns (gfdm, geom, pts, bdry). Mutating geom.boundary_conditions then calling
+    a solve (or _refresh_boundary_conditions_if_changed) mimics the coupling layer's
+    per-iteration using_resolved_bc swap.
+    """
+    pts, bdry, geom = _make_1d_cloud()
+    geom.boundary_conditions = bc
+    problem = _MockProblem(geom, dimension=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        gfdm = HJBGFDMSolver(
+            problem,
+            collocation_points=pts,
+            boundary_indices=bdry,
+            delta=1.5,
+            k_neighbors=8,
+            derivative_method="taylor",
+            taylor_order=2,
+            weight_function="wendland",
+            collocation_geometry=geom,
+            adaptive_neighborhoods=False,
+            monotonicity_scheme="joint_socp",
+            monotonicity_application="precompute",
+            inner_solver=inner_solver,
+        )
+    return gfdm, geom, pts, bdry
+
+
+def test_gfdm_refreshes_geometry_bc_per_solve():
+    """Geometry-sourced BC: a value swapped after construction must reach the value-form
+    BC rows (Howard path). This FAILS on the pre-#1118 snapshot (frozen at construction)."""
+    gfdm, geom, _pts, bdry = _make_geom_sourced_gfdm_1d(_neumann_per_face_1d(0.3))
+    assert gfdm._bc_from_geometry is True
+    bi = int(bdry[0])
+    assert gfdm._bc_segment_per_point[bi].value == pytest.approx(0.3)
+    assert gfdm._value_form_bc_rows(0)[bi][1] == pytest.approx(0.3)
+
+    # Coupling layer swaps the geometry BC (resolved-per-Picard analogue).
+    geom.boundary_conditions = _neumann_per_face_1d(0.9)
+    gfdm._refresh_boundary_conditions_if_changed()
+
+    assert gfdm.boundary_conditions is geom.boundary_conditions
+    assert gfdm._bc_segment_per_point[bi].value == pytest.approx(0.9)
+    assert gfdm._value_form_bc_rows(0)[bi][1] == pytest.approx(0.9), (
+        "value-form BC target did not track the resolved geometry BC — stale snapshot."
+    )
+
+
+def test_gfdm_explicit_param_bc_not_refreshed():
+    """An explicit boundary_conditions= argument is the caller's static choice and must
+    NOT be overridden by the geometry, even if the geometry BC changes."""
+    pts, bdry, geom = _make_1d_cloud()
+    geom.boundary_conditions = _neumann_per_face_1d(0.3)
+    problem = _MockProblem(geom, dimension=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        gfdm = HJBGFDMSolver(
+            problem,
+            collocation_points=pts,
+            boundary_indices=bdry,
+            delta=1.5,
+            k_neighbors=8,
+            derivative_method="taylor",
+            taylor_order=2,
+            weight_function="wendland",
+            collocation_geometry=geom,
+            adaptive_neighborhoods=False,
+            monotonicity_scheme="joint_socp",
+            monotonicity_application="precompute",
+            inner_solver="howard",
+            boundary_conditions=_neumann_per_face_1d(0.5),
+        )
+    assert gfdm._bc_from_geometry is False
+    bi = int(bdry[0])
+    assert gfdm._bc_segment_per_point[bi].value == pytest.approx(0.5)
+
+    geom.boundary_conditions = _neumann_per_face_1d(0.9)
+    gfdm._refresh_boundary_conditions_if_changed()
+
+    assert gfdm._bc_segment_per_point[bi].value == pytest.approx(0.5), (
+        "explicit-param BC was wrongly overridden by the geometry on refresh."
+    )
+
+
+def test_gfdm_refresh_noop_when_bc_unchanged():
+    """No provider / no swap: refresh leaves the snapshot object identity intact (no churn)."""
+    gfdm, _geom, _pts, _bdry = _make_geom_sourced_gfdm_1d(_neumann_per_face_1d(0.3))
+    snapshot = gfdm.boundary_conditions
+    gfdm._refresh_boundary_conditions_if_changed()
+    assert gfdm.boundary_conditions is snapshot


### PR DESCRIPTION
## Summary

Part 1 of the #1118 PR2b series (Robin / adjoint-consistent support for the Howard inner solver). This PR fixes a **latent staleness bug** that must land before the Robin guard can be safely lifted.

`HJBGFDMSolver` snapshotted `boundary_conditions` and the preclassified `_bc_segment_per_point` map at `__init__` and never refreshed them. The coupling layer (`FixedPointIterator`) resolves BC value providers **per Picard iteration** by swapping `geometry.boundary_conditions` inside `problem.using_resolved_bc(...)`. FDM re-reads `get_boundary_conditions()` every solve (`hjb_fdm.py:319`); **GFDM did not**. So a resolved scalar — e.g. `AdjointConsistentProvider`'s `g = -sigma^2/2 * d ln(m)/dn` — never reached the GFDM/Howard value-form BC rows; it stayed frozen at the construction-time value. Silent-wrong in the documented >1000x-impact boundary-stall regime (no exception, converges to the wrong equilibrium).

## Change

`_refresh_boundary_conditions_if_changed()`, called at the top of `solve_hjb_system` (before BC validation, mirroring FDM):

- Re-reads `self.get_boundary_conditions()` (geometry-aware).
- If the live BC object differs from the cached snapshot, re-assigns it, rebuilds `_bc_config` (`create_bc_config()` reads the BC live via the GFDM closure getter), and re-runs `_preclassify_boundary_points()` (which rebuilds `_bc_segment_per_point` with the resolved `.value`).
- Gated by a new `_bc_from_geometry` flag set in `__init__`: an explicit `boundary_conditions=` argument is the caller's static choice and is **never** overridden.
- No-op for provider-free BC: `with_resolved_providers` fast-paths `return self`, so the geometry BC object is unchanged → identity check skips re-preclassification.

## Verification

```
tests/unit/test_alg/test_hjb_howard_solver.py  17 passed
GFDM solver + BC classification + Newton-residual suites  65 passed, 1 skipped
ruff check (source + tests)  clean
```

New tests:
- `test_gfdm_refreshes_geometry_bc_per_solve` — **load-bearing**: a geometry BC value swapped after construction reaches `_value_form_bc_rows` (the Howard path). Fails on the pre-fix snapshot (frozen value).
- `test_gfdm_explicit_param_bc_not_refreshed` — explicit-param BC is not overridden by the geometry on refresh.
- `test_gfdm_refresh_noop_when_bc_unchanged` — refresh leaves snapshot identity intact when nothing changed.

## Scope / what's NOT here

This PR does **not** lift the Howard ROBIN guard or add the Robin BC row — `test_integrated_howard_rejects_robin_bc` still asserts ROBIN raises. Those land in the follow-up (Parts 2+3), at which point the resolved adjoint value is guaranteed to reach the solver per-iteration thanks to this refresh.

Refs #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)