### PR TITLE
feat(gfdm): adjoint-consistent Robin BC for the Howard inner solver (#1118 PR2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`HJBGFDMSolver(inner_solver='howard')` now supports adjoint-consistent Robin BC**
+  (Issue #1118 PR2b). `BCType.ROBIN(alpha=0, beta=1)` — the `AdjointConsistentProvider`
+  pattern whose resolved scalar is `g = -sigma^2/2 * d ln(m)/dn` — is routed through the
+  shared `_build_neumann_bc_row` (the equation reduces to `n.grad u = g`), so both the
+  Newton and Howard inner solvers honor it from a single coefficient source. The Howard
+  guard admits `"robin"`; the alpha/beta check lives only in the row builder. Combined
+  with the per-solve BC refresh, the per-Picard resolved value now reaches the Howard
+  value-form rows. Reachable-but-unsupported forms fail loud: `ROBIN(alpha != 0)` and
+  `ROBIN(beta != 1)` raise `NotImplementedError` (the normal-derivative row cannot
+  represent `alpha*u` and does not apply a `1/beta` scaling); an unresolved
+  `BCValueProvider` reaching the solver raises `AssertionError` (the coupling layer must
+  resolve it via `using_resolved_bc` first).
+
 ### Fixed
 
 - **`HJBGFDMSolver` now re-reads geometry boundary conditions per solve** when

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2445,10 +2445,34 @@ class HJBGFDMSolver(BaseHJBSolver):
                     f"geometries, or rephrase as paired Dirichlet/Neumann segments."
                 )
             case BCType.ROBIN:
-                raise NotImplementedError(
-                    f"ROBIN BC at boundary point {i} not supported by HJBGFDMSolver "
-                    f"via row replacement. Use the BCValueProvider pattern in the "
-                    f"coupling layer (Issue #625, see AdjointConsistentProvider)."
+                # Issue #1118 PR2b: the adjoint-consistent BC is ROBIN(alpha=0, beta=1),
+                # whose equation beta*(n.grad u) = g reduces to n.grad u = g — exactly the
+                # Neumann normal-derivative row with RHS = the resolved scalar g (segment.value
+                # is a plain float after with_resolved_providers). Delegate to the SAME builder
+                # the NEUMANN/NO_FLUX arm uses: single coefficient source, no second ROBIN
+                # stencil (the dual-source BC bug class). General Robin (alpha != 0) adds an
+                # alpha*u term the normal-derivative row cannot represent, and beta != 1 would
+                # need a 1/beta scaling the builder does not apply — both are reachable via the
+                # BCSegment API and would be silently mis-solved, so fail loud instead.
+                alpha = getattr(segment, "alpha", 1.0) if segment is not None else 1.0
+                beta = getattr(segment, "beta", 0.0) if segment is not None else 0.0
+                if abs(alpha) > 0.0:
+                    raise NotImplementedError(
+                        f"ROBIN BC with alpha={alpha!r} at boundary point {i} is not supported "
+                        f"by HJBGFDMSolver: the normal-derivative row encodes only "
+                        f"beta*(n.grad u) = g and cannot represent the alpha*u term. Only the "
+                        f"adjoint-consistent ROBIN(alpha=0, beta=1) case is supported "
+                        f"(Issue #1118 PR2b; see AdjointConsistentProvider)."
+                    )
+                if abs(beta - 1.0) > 0.0:
+                    raise NotImplementedError(
+                        f"ROBIN BC with beta={beta!r} at boundary point {i} is not supported: "
+                        f"the delegated Neumann row assumes coefficient 1 on n.grad u and does "
+                        f"not apply a 1/beta scaling. Only beta=1 (the adjoint-consistent case) "
+                        f"is supported (Issue #1118 PR2b)."
+                    )
+                new_row, bc_target = self._build_neumann_bc_row(
+                    i, normal, dimension, segment, legacy_bc_values, current_time
                 )
             case _:
                 raise ValueError(
@@ -2943,21 +2967,34 @@ class HJBGFDMSolver(BaseHJBSolver):
         # either path) and BCValueProvider coupling (e.g. AdjointConsistentProvider). Inspect
         # segments directly: for a mixed BC, `boundary_conditions.type` raises and
         # `_bc_config["type"]` is a meaningless 'periodic' fallback, so neither is reliable.
-        allowed_bc = {"no_flux", "neumann", "dirichlet"}
+        # Issue #1118 PR2b: ROBIN is now consumable by the value-form row builder, but only
+        # the adjoint-consistent ROBIN(alpha=0, beta=1) case (n.grad u = g). The alpha/beta
+        # check lives in exactly one place — _bc_row_for_point fail-louds on ROBIN(alpha != 0)
+        # or beta != 1 — so we add "robin" here and let the row builder be the gate.
+        allowed_bc = {"no_flux", "neumann", "dirichlet", "robin"}
         segments = getattr(self.boundary_conditions, "segments", None)
         if segments:
             for seg in segments:
                 seg_type = seg.bc_type.value if hasattr(seg.bc_type, "value") else str(seg.bc_type)
                 if seg_type not in allowed_bc:
                     raise NotImplementedError(
-                        f"inner_solver='howard' supports no-flux/Neumann/Dirichlet BC; segment "
-                        f"{getattr(seg, 'name', '?')!r} is {seg_type!r}. ROBIN/PERIODIC parity is "
-                        f"deferred (Issue #1118 PR2b)."
+                        f"inner_solver='howard' supports no-flux/Neumann/Dirichlet/Robin BC; "
+                        f"segment {getattr(seg, 'name', '?')!r} is {seg_type!r}. PERIODIC parity "
+                        f"is deferred (Issue #1118 PR2b)."
                     )
                 if callable(getattr(getattr(seg, "value", None), "compute", None)):
-                    raise NotImplementedError(
-                        "inner_solver='howard' does not honor a BCValueProvider (e.g. "
-                        "AdjointConsistentProvider); deferred (Issue #1118 PR2)."
+                    # Providers are resolved UPSTREAM by the coupling layer
+                    # (problem.using_resolved_bc -> with_resolved_providers swaps in a float,
+                    # keeping bc_type=ROBIN) and Part 1's per-solve refresh transports that float
+                    # into the solver. By the time Howard runs, no segment should still carry a
+                    # callable .compute; if one does, the coupling layer failed to resolve it (or
+                    # a static BC carries a raw provider) — a real bug, not a deferred feature.
+                    raise AssertionError(
+                        f"inner_solver='howard': segment {getattr(seg, 'name', '?')!r} still "
+                        f"carries an unresolved BCValueProvider (callable .compute) at solve "
+                        f"time. Providers must be resolved by the coupling layer "
+                        f"(using_resolved_bc / with_resolved_providers) before reaching the "
+                        f"solver (Issue #1118 PR2b)."
                     )
         else:
             try:
@@ -2966,8 +3003,8 @@ class HJBGFDMSolver(BaseHJBSolver):
                 uniform_type = None
             if uniform_type is not None and uniform_type not in allowed_bc:
                 raise NotImplementedError(
-                    f"inner_solver='howard' supports no-flux/Neumann/Dirichlet BC, got "
-                    f"{uniform_type!r}. ROBIN/PERIODIC parity is deferred (Issue #1118 PR2b)."
+                    f"inner_solver='howard' supports no-flux/Neumann/Dirichlet/Robin BC, got "
+                    f"{uniform_type!r}. PERIODIC parity is deferred (Issue #1118 PR2b)."
                 )
 
         dt = float(self.problem.T) / int(self.problem.Nt)

--- a/tests/unit/test_alg/test_hjb_gfdm_bc_classification.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_bc_classification.py
@@ -466,8 +466,10 @@ def test_dispatch_periodic_raises():
     assert "TensorProductGrid" in str(exc_info.value) or "FDM" in str(exc_info.value)
 
 
-def test_dispatch_robin_raises():
-    """ROBIN BC type at a boundary point raises NotImplementedError pointing at provider."""
+def test_dispatch_robin_nonzero_alpha_raises():
+    """ROBIN with alpha != 0 has no normal-derivative row representation (the alpha*u term
+    cannot be expressed), so it raises NotImplementedError naming alpha — on the Newton path
+    too (Issue #1118 PR2b enabled only the adjoint-consistent ROBIN(alpha=0, beta=1) case)."""
     LX, LY = 10.0, 10.0
     geom = Hyperrectangle(np.array([[0.0, LX], [0.0, LY]]))
     points, boundary_idx = _grid_with_boundary(LX, LY, n_in=4, eps=1e-7)
@@ -487,7 +489,45 @@ def test_dispatch_robin_raises():
     with pytest.raises(NotImplementedError) as exc_info:
         solver._apply_boundary_conditions_to_sparse_system(fake_jac, fake_res, time_idx=0, u_current=np.zeros(n))
     assert "ROBIN" in str(exc_info.value)
-    assert "BCValueProvider" in str(exc_info.value) or "625" in str(exc_info.value)
+    assert "alpha" in str(exc_info.value)
+
+
+def test_dispatch_robin_zero_alpha_builds_neumann_row():
+    """ROBIN(alpha=0, beta=1) is the adjoint-consistent case: its row equals the Neumann
+    normal-derivative row with RHS = the resolved scalar g (Issue #1118 PR2b). Verify on the
+    Newton path that ROBIN(alpha=0, beta=1, value=g) produces a Jacobian row byte-identical to
+    NEUMANN(value=g) — same single coefficient source (_build_neumann_bc_row), no second
+    stencil. This is the path Part 1 unfroze for AdjointConsistentProvider on Newton."""
+    LX, LY = 10.0, 10.0
+    geom = Hyperrectangle(np.array([[0.0, LX], [0.0, LY]]))
+    points, boundary_idx = _grid_with_boundary(LX, LY, n_in=4, eps=1e-7)
+    g = 0.5
+
+    def _bc(left_type):
+        segs = [BCSegment(name="bottom", bc_type=BCType.NO_FLUX, boundary="y_min"),
+                BCSegment(name="top", bc_type=BCType.NO_FLUX, boundary="y_max"),
+                BCSegment(name="right", bc_type=BCType.NO_FLUX, boundary="x_max")]
+        if left_type == "robin":
+            segs.insert(0, BCSegment(name="left", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0, value=g, boundary="x_min"))
+        else:
+            segs.insert(0, BCSegment(name="left", bc_type=BCType.NEUMANN, value=g, boundary="x_min"))
+        return BoundaryConditions(segments=segs, dimension=2)
+
+    n = len(points)
+
+    def _apply(left_type):
+        solver = _build_solver(points, boundary_idx, _bc(left_type), geom)
+        jac = sp.eye(n, format="csr") * 0.5
+        res = np.ones(n)
+        jac_out, res_out = solver._apply_boundary_conditions_to_sparse_system(
+            jac, res, time_idx=0, u_current=np.zeros(n)
+        )
+        return np.asarray(jac_out.todense()), np.asarray(res_out)
+
+    jac_robin, res_robin = _apply("robin")  # must NOT raise
+    jac_neumann, res_neumann = _apply("neumann")
+    assert np.allclose(jac_robin, jac_neumann), "ROBIN(alpha=0,beta=1) row != Neumann row"
+    assert np.allclose(res_robin, res_neumann), "ROBIN(alpha=0,beta=1) RHS != Neumann RHS"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -493,18 +493,21 @@ def test_integrated_howard_dirichlet_value():
     )
 
 
-def test_integrated_howard_rejects_robin_bc():
-    """ROBIN stays guarded under inner_solver='howard' (no row builder on either path; #1118 PR2b)."""
+def test_integrated_howard_rejects_robin_nonzero_alpha():
+    """ROBIN with alpha != 0 has no normal-derivative row representation (it would drop the
+    alpha*u term); it must keep raising even after #1118 PR2b enabled ROBIN(alpha=0). The
+    Howard guard now admits 'robin', so the fail-loud comes from _bc_row_for_point during
+    the solve, with a message naming alpha."""
     bc = BoundaryConditions(
         segments=[
-            BCSegment(name="x_min", bc_type=BCType.ROBIN, value=0.0, boundary="x_min"),
-            BCSegment(name="x_max", bc_type=BCType.ROBIN, value=0.0, boundary="x_max"),
+            BCSegment(name="x_min", bc_type=BCType.ROBIN, alpha=1.0, beta=1.0, value=0.0, boundary="x_min"),
+            BCSegment(name="x_max", bc_type=BCType.ROBIN, alpha=1.0, beta=1.0, value=0.0, boundary="x_max"),
         ],
         dimension=1,
     )
     gfdm, pts, _ = _make_howard_gfdm_with_bc(bc)
     U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
-    with pytest.raises(NotImplementedError, match=r"ROBIN|PERIODIC"):
+    with pytest.raises(NotImplementedError, match=r"alpha"):
         gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
 
 
@@ -622,3 +625,165 @@ def test_gfdm_refresh_noop_when_bc_unchanged():
     snapshot = gfdm.boundary_conditions
     gfdm._refresh_boundary_conditions_if_changed()
     assert gfdm.boundary_conditions is snapshot
+
+
+# ---------------------------------------------------------------------------
+# 9. ROBIN / adjoint-consistent BC for inner_solver='howard' (Issue #1118 PR2b)
+#
+# The adjoint-consistent BC is ROBIN(alpha=0, beta=1) whose resolved scalar is
+# g = -sigma^2/2 * d ln(m)/dn. PR2b routes it through _build_neumann_bc_row
+# (n.grad u = g), lifts the Howard guard for "robin", and fail-louds on the
+# unsupported-but-reachable forms (alpha != 0, beta != 1, unresolved provider).
+# Part 1's per-solve refresh transports the per-Picard resolved float in.
+# ---------------------------------------------------------------------------
+
+_AC_SIGMA = 0.3
+_AC_DX = 0.1
+_AC_REG = 1e-10
+
+
+class _ProviderGeom:
+    """Minimal geometry carrying only the grid spacing the provider state needs.
+
+    Decouples the provider's density-array spacing (_AC_DX) from the GFDM cloud
+    spacing: the provider indexes the density array, not the collocation cloud.
+    """
+
+    dimension = 1
+
+    def get_grid_spacing(self):
+        return [_AC_DX]
+
+
+def _adjoint_robin_bc(sigma=_AC_SIGMA):
+    from mfgarchon.geometry.boundary.providers import AdjointConsistentProvider
+
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="left_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
+                      value=AdjointConsistentProvider(side="left", diffusion=sigma), boundary="x_min"),
+            BCSegment(name="right_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
+                      value=AdjointConsistentProvider(side="right", diffusion=sigma), boundary="x_max"),
+        ],
+        dimension=1,
+    )
+
+
+def _expected_g(m, sigma=_AC_SIGMA):
+    """Closed-form adjoint value g = -sigma^2/2 * d ln(m)/dn at each face (outward normal)."""
+    ln = np.log(m + _AC_REG)
+    g_left = -(sigma**2) / 2.0 * (-(ln[1] - ln[0]) / _AC_DX)
+    g_right = -(sigma**2) / 2.0 * ((ln[-1] - ln[-2]) / _AC_DX)
+    return g_left, g_right
+
+
+def test_howard_robin_row_target_tracks_resolved_adjoint_g():
+    """LOAD-BEARING: two DIFFERENT FP densities -> resolve the AdjointConsistentProvider ->
+    Part-1 refresh -> read the value-form BC target from _value_form_bc_rows. The target MUST
+    move between the two densities AND equal the hand-computed closed form each time. FAILS if
+    g were frozen (refresh/row-builder stale): a frozen g gives g_iter2 == g_iter1, which the
+    `!=` assertion rejects. A happy-path 'it ran' test would pass even with a frozen g."""
+    prov_geom = _ProviderGeom()
+    bc = _adjoint_robin_bc()
+    gfdm, geom, _pts, bdry = _make_geom_sourced_gfdm_1d(bc, inner_solver="howard")
+    assert gfdm._bc_from_geometry is True
+    bi_left, bi_right = int(bdry[0]), int(bdry[1])  # lower 1e-7 -> x_min, upper -> x_max
+
+    def resolve_refresh_and_read(m):
+        resolved = bc.with_resolved_providers(
+            {"m_current": m, "geometry": prov_geom, "diffusion": _AC_SIGMA}
+        )
+        assert resolved is not bc  # new object -> Part-1 refresh fires
+        assert resolved.segments[0].bc_type is BCType.ROBIN  # stays ROBIN, value -> float
+        geom.boundary_conditions = resolved
+        gfdm._refresh_boundary_conditions_if_changed()
+        assert gfdm.boundary_conditions is geom.boundary_conditions
+        rows = gfdm._value_form_bc_rows(0)
+        return rows[bi_left][1], rows[bi_right][1]
+
+    m1 = np.array([1.0, 0.8, 0.6, 0.5, 0.4, 0.35, 0.3, 0.28, 0.26, 0.25])
+    m2 = m1[::-1].copy()  # reversed slope -> g flips on both faces
+
+    g1_left, g1_right = resolve_refresh_and_read(m1)
+    e1_left, e1_right = _expected_g(m1)
+    assert g1_left == pytest.approx(e1_left, abs=1e-9), (g1_left, e1_left)
+    assert g1_right == pytest.approx(e1_right, abs=1e-9), (g1_right, e1_right)
+
+    g2_left, g2_right = resolve_refresh_and_read(m2)
+    e2_left, e2_right = _expected_g(m2)
+    assert g2_left == pytest.approx(e2_left, abs=1e-9), (g2_left, e2_left)
+    assert g2_right == pytest.approx(e2_right, abs=1e-9), (g2_right, e2_right)
+
+    assert g2_left != g1_left, "g_left frozen across iterations (refresh/row-builder stale)"
+    assert g2_right != g1_right, "g_right frozen across iterations (refresh/row-builder stale)"
+
+
+def test_howard_robin_nonzero_beta_rejected():
+    """ROBIN(alpha=0, beta!=1) needs a 1/beta scaling the delegated Neumann row does not apply;
+    it is reachable via the BCSegment API, so it must fail loud, not be silently mis-solved."""
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="x_min", bc_type=BCType.ROBIN, alpha=0.0, beta=2.0, value=0.0, boundary="x_min"),
+            BCSegment(name="x_max", bc_type=BCType.ROBIN, alpha=0.0, beta=2.0, value=0.0, boundary="x_max"),
+        ],
+        dimension=1,
+    )
+    gfdm, pts, _ = _make_howard_gfdm_with_bc(bc)
+    U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
+    with pytest.raises(NotImplementedError, match=r"beta"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_howard_unresolved_provider_fails_loud():
+    """A raw (unresolved) AdjointConsistentProvider reaching Howard means the coupling layer
+    failed to resolve it; the converted guard must fail loud (AssertionError), not silently
+    solve against a meaningless provider object."""
+    from mfgarchon.geometry.boundary.providers import AdjointConsistentProvider
+
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="left_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
+                      value=AdjointConsistentProvider(side="left", diffusion=0.3), boundary="x_min"),
+            BCSegment(name="right_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
+                      value=AdjointConsistentProvider(side="right", diffusion=0.3), boundary="x_max"),
+        ],
+        dimension=1,
+    )
+    gfdm, pts, _ = _make_howard_gfdm_with_bc(bc)  # explicit BC, providers NOT resolved
+    U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
+    with pytest.raises(AssertionError, match=r"unresolved BCValueProvider"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_howard_honors_resolved_robin_in_solution():
+    """Howard must HONOR the resolved Robin row in the solved value function, not just build it:
+    the value-form boundary equation row @ U == g holds at the solved (non-terminal) slices.
+    Complements the load-bearing test (which checks the row is BUILT correctly). Verifies the
+    value-form RHS=target is consumed by the inner solve (Constraint c) without depending on the
+    Newton path (whose stall on this regime is the very motivation for Howard, #1118)."""
+    from mfgarchon.geometry.boundary.providers import AdjointConsistentProvider
+
+    sigma = _AC_SIGMA
+    m = np.linspace(1.0, 0.25, 10)
+    state = {"m_current": m, "geometry": _ProviderGeom(), "diffusion": sigma}
+    g_left = AdjointConsistentProvider(side="left", diffusion=sigma).compute(state)
+    g_right = AdjointConsistentProvider(side="right", diffusion=sigma).compute(state)
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="x_min", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0, value=float(g_left), boundary="x_min"),
+            BCSegment(name="x_max", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0, value=float(g_right), boundary="x_max"),
+        ],
+        dimension=1,
+    )
+    gfdm, pts, bdry = _make_howard_gfdm_with_bc(bc, sigma=sigma)
+    U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
+    U = gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+    assert np.all(np.isfinite(U))
+
+    bi_left, bi_right = int(bdry[0]), int(bdry[1])
+    rows = gfdm._value_form_bc_rows(0)
+    row_l, tgt_l = rows[bi_left]
+    row_r, tgt_r = rows[bi_right]
+    u0 = np.asarray(U[0]).ravel()  # solved initial-time slice (terminal slice U[-1] is imposed)
+    assert row_l @ u0 == pytest.approx(tgt_l, abs=1e-8), "Howard did not honor the left Robin row"
+    assert row_r @ u0 == pytest.approx(tgt_r, abs=1e-8), "Howard did not honor the right Robin row"


### PR DESCRIPTION
## Summary

Completes the #1118 Howard inner-solver BC-parity series: PR1 wired `inner_solver='howard'`, PR2a (#1172) added Dirichlet/Neumann **value** parity, #1173 (Part 1) made GFDM re-read resolved geometry BC per solve, and **this PR enables adjoint-consistent Robin BC** — `BCType.ROBIN(alpha=0, beta=1)`, the `AdjointConsistentProvider` pattern whose resolved scalar is `g = -sigma^2/2 * d ln(m)/dn`.

Design + every silent-wrong risk were ground and adversarially verified against the post-Part-1 working tree (0/6 live risks) before implementation.

## Change

**Part 2 — `_bc_row_for_point` ROBIN arm.** The adjoint equation `beta*(n.grad u) = g` reduces to `n.grad u = g`: exactly the Neumann normal-derivative row with RHS = the resolved scalar `g`. Delegate to the **same** `_build_neumann_bc_row` the NEUMANN/NO_FLUX arm uses — single coefficient source, no second ROBIN stencil (avoids the dual-source BC bug class). Reachable-but-unsupported forms **fail loud** instead of being silently mis-solved:
- `alpha != 0` → `NotImplementedError` (the normal-derivative row cannot represent `alpha*u`).
- `beta != 1` → `NotImplementedError` (the builder applies no `1/beta` scaling).

**Part 3 — `_solve_backward_howard` guard.** Add `"robin"` to `allowed_bc` (the alpha/beta check lives only in the row builder). **Convert** the provider-`.compute` guard from `NotImplementedError` (deferred-feature) to `AssertionError` (invariant-violation): after Part 1's per-solve refresh, the coupling layer must have resolved any provider to a float before the solve, so a callable `.compute` reaching Howard is a real bug. Stale `"ROBIN/PERIODIC"` deferral messages → `"PERIODIC"`.

**Part 5 — sign.** No runtime assertion: the provider's outward-normal `g` and the GFDM outward normal (`outward_normal_for_face`: left=−1/right=+1) compose without a double flip; the load-bearing test pins it by asserting `g` against the closed form **per face**. (A runtime `sign(g)` check would be a false invariant — `g`'s sign also depends on the density gradient.)

This also benefits the **Newton** GFDM path: `ROBIN(alpha=0)` now builds the same row there — the path #1173 already unfroze for `AdjointConsistentProvider`.

## Verification

```
test_hjb_howard_solver.py            21 passed
test_hjb_gfdm_bc_classification.py   28 passed, 1 skipped
GFDM solver + Newton-residual + geometry suites   no regression (775 passed)
coupling / adjoint / provider (incl. integration) 214 passed
ruff (source + howard test) clean; source mypy adds no errors
```

New / updated tests:
- **Load-bearing** `test_howard_robin_row_target_tracks_resolved_adjoint_g`: two different `m` → resolve provider → Part-1 refresh → read `_value_form_bc_rows` target; asserts `g` **changes** AND equals the closed form to 1e-9 each time. Fails if `g` were frozen (a happy-path "it ran" test would pass) — drives resolution directly, no full FP/Picard solver.
- `test_howard_robin_nonzero_beta_rejected`, `test_integrated_howard_rejects_robin_nonzero_alpha` (renamed from the old robin-reject), `test_howard_unresolved_provider_fails_loud` (AssertionError).
- `test_howard_honors_resolved_robin_in_solution`: after Howard solves, `row @ U == g` to 1e-8 (value-form row is *honored*, not just built) — Howard-only, no dependence on the stall-prone Newton path.
- `test_hjb_gfdm_bc_classification.py`: `ROBIN(alpha != 0)` raises on the Newton path (names alpha); `ROBIN(alpha=0, beta=1)` row is byte-identical to `NEUMANN(value=g)`.

## On closing #1118

`Refs #1118` (not auto-close). This completes the *planned* Howard BC-parity series, but Howard is an opt-in alternative — the Newton path still stalls on this regime (bypassed, not fixed). Leaving #1118 open for you to decide: close it as "resolved via the Howard inner solver", or keep it tracking the Newton-stall limitation itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)