### PR TITLE
fix(coupling): thread cross-density Hamiltonian into multi-population HJB (#1157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Multi-population HJB now sees cross-population densities** (Issue #1157).
+  `MultiPopulationIterator` computed the cross-density bound Hamiltonian but never
+  passed it to `solve_hjb_system`, so each population's HJB solved against the
+  uncoupled `problem.hamiltonian_class` — the coupling reached the FP drift but not
+  the value function, a silently wrong half-coupled equilibrium. `solve_hjb_system`
+  now accepts a `hamiltonian_override`; `HJBFDMSolver` threads it through the batch
+  Hamiltonian path (forcing `backend=None`, which is numerically equivalent to the
+  per-point path) so the stacked density field reaches the Hamiltonian. The
+  iterator sends the override only to backends that honor it (FDM) and **fails loud**
+  for K>1 on backends that do not, rather than silently decoupling; single-population
+  (K==1) runs are byte-identical (no override is sent). `BoundHamiltonian` now
+  time-indexes a `(Nt+1, K*N)` density trajectory by the evaluation time
+  `t -> n = round(t/dt)`, so each backward step sees the cross-density at that step.
+
 - **`HJBGFDMSolver` now re-reads geometry boundary conditions per solve** when
   the BC was sourced from the geometry (Issue #1118). GFDM previously snapshotted
   the BC and its preclassified per-point segment map at construction, so the

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -139,12 +139,34 @@ class MultiPopulationIterator:
             for k in range(K):
                 prob_k = self.multi_problem.get_population(k)
                 H_k = prob_k.hamiltonian_class
+                solver_k = self.hjb_solvers[k]
 
-                # Bind cross-population density (no mutation of H_k)
-                H_bound = H_k.bind_cross_density(m_all) if hasattr(H_k, "bind_cross_density") else H_k
+                # Bind cross-population density so the HJB sees other populations' densities
+                # (Issue #1157). dt lets BoundHamiltonian map the solve-time t to the trajectory
+                # row n=round(t/dt); the FDM solver routes the bound H through the batch
+                # Hamiltonian path that consumes the stacked density field.
+                H_bound = H_k.bind_cross_density(m_all, dt=prob_k.dt) if hasattr(H_k, "bind_cross_density") else H_k
 
                 U_terminal_k = U[k][-1]
-                U[k] = self.hjb_solvers[k].solve_hjb_system(M[k], U_terminal_k, U[k])
+                # Only HJBFDMSolver threads the cross-density override into the HJB solve today
+                # (Issue #1157). Other backends would silently decouple (their solve reads the
+                # uncoupled problem.hamiltonian_class), so fail loud for K>1 rather than pass an
+                # override they ignore. K==1 has no cross-coupling: a standalone solve is correct
+                # and byte-identical, so no override is sent regardless of backend.
+                honors_override = getattr(solver_k, "_honors_multipop_hamiltonian_override", False)
+                if K > 1 and not honors_override:
+                    raise NotImplementedError(
+                        f"Multi-population cross-coupling requires HJBFDMSolver for the HJB step "
+                        f"(Issue #1157); population {k} uses {type(solver_k).__name__}, which does "
+                        "not thread the cross-density bound Hamiltonian into solve_hjb_system and "
+                        "would silently decouple. Use HJBFDMSolver for multi-population MFG."
+                    )
+                if honors_override:
+                    U[k] = solver_k.solve_hjb_system(
+                        M[k], U_terminal_k, U[k], hamiltonian_override=(None if K == 1 else H_bound)
+                    )
+                else:
+                    U[k] = solver_k.solve_hjb_system(M[k], U_terminal_k, U[k])
 
             # Step 2: Solve K FP equations with drift from H_k
             for k in range(K):
@@ -152,8 +174,10 @@ class MultiPopulationIterator:
                 m0_k = M[k][0]
                 H_k = prob_k.hamiltonian_class
 
-                # Use bound H for velocity computation (sees cross-pop density)
-                H_bound = H_k.bind_cross_density(m_all) if hasattr(H_k, "bind_cross_density") else H_k
+                # Use bound H for velocity computation (sees cross-pop density). dt is required
+                # because _compute_velocity_field calls optimal_control per timestep with t=n*dt,
+                # which BoundHamiltonian maps to trajectory row n (Issue #1157).
+                H_bound = H_k.bind_cross_density(m_all, dt=prob_k.dt) if hasattr(H_k, "bind_cross_density") else H_k
                 velocity = self._compute_velocity_field(U[k], M[k], H_bound, prob_k)
 
                 M_new_k = self.fp_solvers[k].solve_fp_system(m0_k, drift_field=velocity, show_progress=False)

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -548,6 +548,7 @@ def compute_hjb_residual(
     current_time: float = 0.0,  # Current time for time-dependent BCs
     bc_values: dict[str, float] | None = None,  # Issue #574: Per-boundary BC values
     source_term: np.ndarray | None = None,  # MMS verification: pre-evaluated S(t, x)
+    active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H (None => problem's own)
 ) -> np.ndarray:
     Nx = problem.geometry.get_grid_shape()[0]
     dx = problem.geometry.get_grid_spacing()[0]
@@ -631,7 +632,16 @@ def compute_hjb_residual(
 
     # Issue #789: Batch Hamiltonian path — single H_class() call replaces per-point loop
     # Conditions: precomputed_grad available (BC-aware), no backend (NumPy), H_class exists
-    H_class = problem.hamiltonian_class
+    # Issue #1157: a multi-population bound Hamiltonian (active_hamiltonian) is honored
+    # only on this batch path; the per-point fallback below calls problem.H() (the
+    # uncoupled Hamiltonian), which would silently drop the cross-density coupling.
+    H_class = active_hamiltonian if active_hamiltonian is not None else problem.hamiltonian_class
+    if active_hamiltonian is not None and not (precomputed_grad is not None and backend is None):
+        raise NotImplementedError(
+            "Multi-population Hamiltonian override requires the batch Hamiltonian path "
+            "(precomputed_grad available, backend=None); the per-point problem.H() fallback "
+            "cannot honor the cross-density coupling and would silently decouple (Issue #1157)."
+        )
     if precomputed_grad is not None and backend is None and H_class is not None:
         # Build batch arrays
         x_grid = problem.geometry.get_spatial_grid()  # (Nx, 1)
@@ -709,6 +719,7 @@ def compute_hjb_jacobian(
     bc: BoundaryConditions | None = None,  # Boundary conditions (Issue #542 fix)
     domain_bounds: np.ndarray | None = None,  # Domain bounds for BC
     current_time: float = 0.0,  # Current time for time-dependent BCs
+    active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H (None => problem's own)
 ) -> sparse.csr_matrix:
     Nx = problem.geometry.get_grid_shape()[0]
     dx = problem.geometry.get_grid_spacing()[0]
@@ -758,7 +769,15 @@ def compute_hjb_jacobian(
 
     # Hamiltonian part: analytical Jacobian via chain rule (Issue #789)
     # dΦ/dU_j = (dH/dp)_i * (dp_i/dU_j), where dp/dU comes from the gradient stencil.
-    H_class = problem.hamiltonian_class
+    # Issue #1157: the multi-pop bound Hamiltonian is honored only on the batch dp() path;
+    # the per-point problem.H() fallback below would silently drop the cross-density coupling.
+    H_class = active_hamiltonian if active_hamiltonian is not None else problem.hamiltonian_class
+    if active_hamiltonian is not None and not (backend is None and H_class is not None and abs(dx) > 1e-14 and Nx > 1):
+        raise NotImplementedError(
+            "Multi-population Hamiltonian override requires the batch Jacobian path "
+            "(backend=None, Nx>1); the per-point problem.H() fallback cannot honor the "
+            "cross-density coupling and would silently decouple (Issue #1157)."
+        )
     if backend is None and H_class is not None and abs(dx) > 1e-14 and Nx > 1:
         # Compute BC-aware gradient for stencil direction
         precomputed_grad = _compute_gradient_array_1d(U_n_np, dx, bc=bc, upwind=use_upwind, time=current_time)
@@ -931,6 +950,7 @@ def newton_hjb_step(
     current_time: float = 0.0,  # Current time for time-dependent BCs
     bc_values: dict[str, float] | None = None,  # Issue #574
     source_term: np.ndarray | None = None,  # MMS verification
+    active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H
 ) -> tuple[np.ndarray, float]:
     dx = problem.geometry.get_grid_spacing()[0]
     dx_norm = dx if abs(dx) > 1e-12 else 1.0
@@ -952,6 +972,7 @@ def newton_hjb_step(
         current_time=current_time,
         bc_values=bc_values,  # Issue #574
         source_term=source_term,
+        active_hamiltonian=active_hamiltonian,  # Issue #1157
     )
     if has_nan_or_inf(residual_F_U, backend):
         return U_n_current_newton_iterate, np.inf
@@ -969,6 +990,7 @@ def newton_hjb_step(
         bc=bc,
         domain_bounds=domain_bounds,
         current_time=current_time,
+        active_hamiltonian=active_hamiltonian,  # Issue #1157
     )
     if np.any(np.isnan(jacobian_J_U.data)) or np.any(np.isinf(jacobian_J_U.data)):
         return U_n_current_newton_iterate, np.inf
@@ -1043,6 +1065,7 @@ def solve_hjb_timestep_newton(
     current_time: float = 0.0,  # Current time for time-dependent BCs
     bc_values: dict[str, float] | None = None,  # Issue #574: Per-boundary BC values
     source_term: np.ndarray | None = None,  # MMS verification
+    active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H
 ) -> np.ndarray:
     """
     Solve HJB timestep using Newton's method.
@@ -1104,6 +1127,7 @@ def solve_hjb_timestep_newton(
             current_time=current_time,
             bc_values=bc_values,  # Issue #574
             source_term=source_term,
+            active_hamiltonian=active_hamiltonian,  # Issue #1157
         )
 
         if has_nan_or_inf(U_n_next_newton_iterate, backend):
@@ -1248,6 +1272,7 @@ def solve_hjb_system_backward(
     domain_bounds: np.ndarray | None = None,  # Domain bounds for BC
     bc_values: dict[str, float] | None = None,  # Issue #574: Per-boundary BC values
     source_term: Callable | None = None,  # MMS verification: S(t, x_grid) -> values
+    active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H
 ) -> np.ndarray:
     """
     Solve HJB system backward in time using Newton's method.
@@ -1358,6 +1383,7 @@ def solve_hjb_system_backward(
             current_time=current_time,
             bc_values=bc_values,  # Issue #574: Per-boundary BC values
             source_term=source_at_n,
+            active_hamiltonian=active_hamiltonian,  # Issue #1157
         )
         backend_aware_assign(U_solution_this_picard_iter, (n_idx_hjb, slice(None)), U_new_n, backend)
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -129,6 +129,11 @@ class HJBFDMSolver(BaseHJBSolver):
 
     _scheme_family = SchemeFamily.FDM
 
+    # Issue #1157: this backend threads the multi-population cross-density bound Hamiltonian
+    # (hamiltonian_override) into the HJB solve. MultiPopulationIterator checks this flag and
+    # fails loud for K>1 on backends that lack it rather than silently decoupling the HJB.
+    _honors_multipop_hamiltonian_override = True
+
     @deprecated_parameter(
         param_name="NiterNewton",
         since="v0.16.0",
@@ -400,6 +405,8 @@ class HJBFDMSolver(BaseHJBSolver):
         U_from_prev_picard: NDArray | None = None,
         M_density_evolution: NDArray | None = None,
         U_final_condition: NDArray | None = None,
+        *,
+        hamiltonian_override=None,  # Issue #1157: multi-population cross-density bound H
     ) -> NDArray:
         """
         Solve HJB system backward in time.
@@ -454,6 +461,15 @@ class HJBFDMSolver(BaseHJBSolver):
             raise ValueError("U_terminal is required")
         if U_coupling_prev is None:
             raise ValueError("U_coupling_prev is required")
+        # Issue #1157: a multi-population bound Hamiltonian carries the stacked cross-density
+        # field, which only the batch Hamiltonian path (compute_hjb_residual at backend=None)
+        # can consume; the nD path's per-timestep evaluation is not yet validated for it.
+        if hamiltonian_override is not None and self.dimension != 1:
+            raise NotImplementedError(
+                "Multi-population Hamiltonian override (Issue #1157) is currently validated "
+                f"only for the 1D FDM path; got dimension={self.dimension}. Run multi-population "
+                "MFG in 1D, or extend and validate the nD batch Hamiltonian path first."
+            )
         # Issue #889: merge tensor_volatility_field into volatility_field
         # Deprecation warning issued by @deprecated_parameter decorator
         if tensor_volatility_field is not None:
@@ -492,6 +508,13 @@ class HJBFDMSolver(BaseHJBSolver):
                 with suppress(AttributeError):
                     logger.debug(f"[DEBUG Issue #542] BC has {len(bc.segments)} segments")
 
+            # Issue #1157: when a cross-density bound Hamiltonian is supplied, force the batch
+            # Hamiltonian path (backend=None) — the per-point problem.H() fallback receives only
+            # a scalar own-population density and cannot express cross-population coupling. The
+            # batch path is numerically equivalent to the per-point path (Issue #789), so this
+            # changes nothing for single-population solves (override None => self.backend).
+            effective_backend = None if hamiltonian_override is not None else self.backend
+
             # Use optimized 1D solver with BC-aware computation (Issue #542 fix)
             U_solution = base_hjb.solve_hjb_system_backward(
                 M_density_from_prev_picard=M_density,
@@ -500,12 +523,13 @@ class HJBFDMSolver(BaseHJBSolver):
                 problem=self.problem,
                 max_newton_iterations=self.max_newton_iterations,
                 newton_tolerance=self.newton_tolerance,
-                backend=self.backend,
+                backend=effective_backend,
                 volatility_field=volatility_field,
                 use_upwind=self.use_upwind,
                 bc=bc,  # Uses Robin BC from geometry; providers resolved by iterator (Issue #625)
                 domain_bounds=domain_bounds,
                 source_term=source_term,
+                active_hamiltonian=hamiltonian_override,  # Issue #1157
             )
 
             # Apply variational inequality constraint via projection (Issue #591)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
@@ -483,6 +483,7 @@ class HJBHowardSolver:
         self,
         M_density: np.ndarray | None,
         U_terminal: np.ndarray,
+        hamiltonian_override=None,
         **_unused,
     ) -> np.ndarray:
         """Backward sweep using Howard inner.
@@ -500,6 +501,14 @@ class HJBHowardSolver:
         np.ndarray
             Value function `U(t, x)`, shape `(Nt+1, n)`. `U[Nt] == U_terminal`.
         """
+        # Issue #1157: named explicitly (not swallowed by **_unused) so a multi-population
+        # cross-density override fails loud here rather than silently decoupling — the bound
+        # Hamiltonian would never reach Howard's policy-iteration evaluation.
+        if hamiltonian_override is not None:
+            raise NotImplementedError(
+                "HJBHowardSolver does not support the multi-population Hamiltonian override "
+                "(Issue #1157). Use HJBFDMSolver for multi-population MFG."
+            )
         if self._static is None:
             self._static = self._build_static()
         static = self._static

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -209,9 +209,18 @@ class WeakFormHJBSolver(BaseHJBSolver):
         M_density_evolution_from_FP: NDArray | None = None,
         U_final_condition_at_T: NDArray | None = None,
         U_from_prev_picard: NDArray | None = None,
+        hamiltonian_override=None,
         **kwargs,
     ) -> NDArray:
         """Solve the HJB system backward in time on the weak-form operators."""
+        # Issue #1157: named explicitly (not swallowed by **kwargs) so a multi-population
+        # cross-density override fails loud rather than silently decoupling. Covers the
+        # meshless-Galerkin solver, which forwards **kwargs here.
+        if hamiltonian_override is not None:
+            raise NotImplementedError(
+                "WeakFormHJBSolver does not support the multi-population Hamiltonian override "
+                "(Issue #1157). Use HJBFDMSolver for multi-population MFG."
+            )
         if M_density is None and M_density_evolution_from_FP is not None:
             M_density = M_density_evolution_from_FP
         if U_terminal is None and U_final_condition_at_T is not None:

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -994,7 +994,7 @@ class HamiltonianBase(MFGOperatorBase):
 
     # === Multi-population support ===
 
-    def bind_cross_density(self, m_all: np.ndarray) -> BoundHamiltonian:
+    def bind_cross_density(self, m_all: np.ndarray, dt: float | None = None) -> BoundHamiltonian:
         """Return a wrapper that binds cross-population density.
 
         The wrapper delegates all methods to this Hamiltonian. When called,
@@ -1008,13 +1008,18 @@ class HamiltonianBase(MFGOperatorBase):
         m_all : np.ndarray
             Stacked density from all K populations.
             Shape (K*N,) per timestep, or (Nt+1, K*N) for full trajectory.
+        dt : float, optional
+            Time step. Required when ``m_all`` is a full trajectory ``(Nt+1, K*N)``
+            so the wrapper can map the Hamiltonian's evaluation time ``t`` to the
+            trajectory row ``n = round(t/dt)`` (Issue #1157). Ignored for a
+            per-timestep ``(K*N,)`` ``m_all``.
 
         Returns
         -------
         BoundHamiltonian
             Wrapper with bound cross-population density.
         """
-        return BoundHamiltonian(self, m_all)
+        return BoundHamiltonian(self, m_all, dt=dt)
 
     def optimal_control(
         self,
@@ -1293,32 +1298,70 @@ class BoundHamiltonian:
     """Lightweight wrapper binding cross-population density to a HamiltonianBase.
 
     Created by HamiltonianBase.bind_cross_density(m_all). Delegates all
-    methods to the inner Hamiltonian. __call__ passes m_all instead of
-    single-population m — enabling cross-population coupling.
+    methods to the inner Hamiltonian, substituting the stacked K-population
+    density ``m_all`` for the single-population ``m`` the solver supplies —
+    enabling cross-population coupling (Issue #1157).
+
+    ``m_all`` may be supplied as a single per-timestep vector ``(K*N,)`` or as
+    a full backward trajectory ``(Nt+1, K*N)``. The HJB residual evaluates the
+    Hamiltonian one timestep at a time, calling with ``m = M_k[n]`` (shape
+    ``(N,)``) and ``t = n * dt`` (base_hjb.py:1315/1336). A whole trajectory
+    therefore cannot be passed wholesale to the inner Hamiltonian's batch call
+    — it must be indexed to the row for the current timestep. When ``m_all`` is
+    a trajectory, ``dt`` is required so that ``t`` resolves to row
+    ``n = round(t / dt)``; the inner Hamiltonian then sees the cross-density at
+    exactly the timestep the single-population solver would have used for its
+    own ``M_k[n]``. A 1D ``m_all`` is treated as already-per-timestep and used
+    as-is (the index is ignored).
 
     No mutation of the original Hamiltonian. Thread-safe.
     """
 
-    def __init__(self, inner: HamiltonianBase, m_all: np.ndarray):
+    def __init__(self, inner: HamiltonianBase, m_all: np.ndarray, dt: float | None = None):
         self._inner = inner
-        self._m_all = m_all
+        self._m_all = np.asarray(m_all)
+        self._dt = dt
+
+    def _m_at(self, t: float) -> np.ndarray:
+        """Cross-density at time ``t``: the trajectory row for ``n = round(t/dt)``.
+
+        A per-timestep (1D) ``m_all`` is returned unchanged. A trajectory (2D)
+        ``m_all`` is indexed by timestep; ``dt`` must have been supplied, and the
+        resolved row index must lie within the trajectory — both fail loud rather
+        than silently returning the wrong timestep's density.
+        """
+        if self._m_all.ndim < 2:
+            return self._m_all
+        if self._dt is None:
+            raise ValueError(
+                "BoundHamiltonian was given a trajectory m_all (ndim=2) but no dt; "
+                "cannot map the Hamiltonian's time t to a trajectory row. Pass dt to "
+                "bind_cross_density (Issue #1157)."
+            )
+        n = round(t / self._dt)
+        if not 0 <= n < self._m_all.shape[0]:
+            raise IndexError(
+                f"BoundHamiltonian: time t={t} -> row n={n} is outside the "
+                f"cross-density trajectory of length {self._m_all.shape[0]} (dt={self._dt})."
+            )
+        return self._m_all[n]
 
     def __call__(self, x, m, p, t=0.0):
-        """Evaluate H with cross-population density m_all."""
-        return self._inner(x, self._m_all, p, t)
+        """Evaluate H with cross-population density at the current timestep."""
+        return self._inner(x, self._m_at(t), p, t)
 
     def optimal_control(self, x, m, p, t=0.0):
-        """Compute α* using m_all for cross-coupling."""
-        return self._inner.optimal_control(x, self._m_all, p, t)
+        """Compute α* using the cross-population density at the current timestep."""
+        return self._inner.optimal_control(x, self._m_at(t), p, t)
 
     def dp(self, x, m, p, t=0.0):
-        return self._inner.dp(x, m, p, t)
+        return self._inner.dp(x, self._m_at(t), p, t)
 
     def dm(self, x, m, p, t=0.0):
-        return self._inner.dm(x, self._m_all, p, t)
+        return self._inner.dm(x, self._m_at(t), p, t)
 
     def dx(self, x, m, p, t=0.0):
-        return self._inner.dx(x, m, p, t)
+        return self._inner.dx(x, self._m_at(t), p, t)
 
     def is_smooth(self):
         return self._inner.is_smooth()

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -1297,6 +1297,16 @@ class HamiltonianBase(MFGOperatorBase):
 class BoundHamiltonian:
     """Lightweight wrapper binding cross-population density to a HamiltonianBase.
 
+    [PROVISIONAL — SUPERSEDED-BY: Issue #1071] This is the tactical adapter for
+    multi-population cross-coupling (Issue #1157): it transports the stacked density,
+    discards the solver-supplied ``m``, and infers the timestep from ``t`` via
+    ``round(t/dt)``. Those two smells (a dead ``m`` argument; a time index reverse-
+    engineered from a float) signal the missing abstraction — multi-population should
+    be first-class *state* on the Hamiltonian, folded into the #1071 ``evaluate(state)``
+    redesign rather than wrapped at call time. Deferred on purpose: revisit when
+    multi-population MFG is in real use, so the design trade-offs are judged from
+    experience instead of guessed up front.
+
     Created by HamiltonianBase.bind_cross_density(m_all). Delegates all
     methods to the inner Hamiltonian, substituting the stacked K-population
     density ``m_all`` for the single-population ``m`` the solver supplies —

--- a/tests/integration/test_multi_population_cross_coupling.py
+++ b/tests/integration/test_multi_population_cross_coupling.py
@@ -1,0 +1,115 @@
+"""Multi-population HJB cross-coupling (Issue #1157).
+
+Before the fix, `MultiPopulationIterator` computed the cross-population-bound
+Hamiltonian but never passed it to `solve_hjb_system`, so each population's HJB
+solved against the uncoupled `problem.hamiltonian_class` — the cross-density
+coupling reached the FP drift but not the value function (a silently wrong,
+half-coupled equilibrium). These tests pin the fix:
+
+- the HJB now responds to the other population's density (coupled != decoupled);
+- a single-population run is byte-identical (the override is not sent for K==1);
+- a backend that does not thread the override fails loud rather than silently
+  decoupling.
+
+The cross-coupling here enters EXCLUSIVELY through the HJB Hamiltonian term:
+``SeparableHamiltonian.optimal_control`` is momentum-only, so the FP drift never
+sees the bound density. That isolates the HJB-coupling path being fixed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.coupling.multi_population_iterator import MultiPopulationIterator
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.multi_population import MultiPopulationProblem
+
+_NX, _NT, _T, _SIG = 20, 8, 1.0, 0.15
+
+
+def _make_problem(k, cross, K):
+    """Population-k problem whose coupling f_k(m) = cross * (other population's density).
+
+    The coupling distinguishes the stacked cross-density (length K*grid) from a
+    single-population density and is scalar-safe (so MFGComponents validation passes).
+    """
+
+    def coupling(m, pop_idx=k, cross=cross, K=K):
+        m = np.asarray(m, float)
+        if m.ndim >= 1 and m.shape[-1] % K == 0 and m.shape[-1] >= 2 * K:
+            grid = m.shape[-1] // K
+            return cross * m.reshape(*m.shape[:-1], K, grid)[..., 1 - pop_idx, :]
+        return np.zeros_like(m)
+
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=coupling,
+        coupling_dm=lambda m: np.zeros_like(np.asarray(m, float)),
+        population_index=k,
+    )
+    comps = MFGComponents(
+        m_initial=lambda xx, kk=k: np.exp(-((np.asarray(xx) - (0.3 + 0.4 * kk)) ** 2) / 0.02),
+        u_terminal=lambda xx: np.asarray(xx) * 0.0,
+        hamiltonian=H,
+    )
+    return MFGProblem(Nx=[_NX], Nt=_NT, T=_T, sigma=_SIG, components=comps)
+
+
+def _solve(K, cross, max_iterations=6):
+    probs = [_make_problem(k, cross, K) for k in range(K)]
+    multi = MultiPopulationProblem(populations=probs, population_names=[f"P{k}" for k in range(K)])
+    it = MultiPopulationIterator(
+        multi,
+        [HJBFDMSolver(p) for p in probs],
+        [FPFDMSolver(p) for p in probs],
+        relaxation=0.5,
+    )
+    return it.solve(max_iterations=max_iterations, tolerance=1e-10)
+
+
+def test_hjb_sees_cross_density_bug_1157():
+    """LOAD-BEARING: a genuinely cross-coupled 2-population MFG must differ from the
+    decoupled (cross=0) solve. FAILS on the pre-#1157 code (coupled == decoupled bit-for-bit,
+    because the bound Hamiltonian never reached the HJB)."""
+    K = 2
+    coupled = _solve(K, cross=2.0)
+    decoupled = _solve(K, cross=0.0)
+    dU = max(np.max(np.abs(np.asarray(coupled.U[k]) - np.asarray(decoupled.U[k]))) for k in range(K))
+    assert dU > 1e-6, f"cross-coupling had no effect on the HJB value function (bug #1157): dU={dU:.3e}"
+
+
+def test_single_population_byte_identical():
+    """K==1 has no cross-coupling: the iterator must not send an override, so the solve is
+    byte-identical regardless of the (irrelevant) coupling strength."""
+    c = _solve(1, cross=2.0, max_iterations=4)
+    d = _solve(1, cross=0.0, max_iterations=4)
+    assert np.array_equal(np.asarray(c.U[0]), np.asarray(d.U[0]))
+    assert np.array_equal(np.asarray(c.M[0]), np.asarray(d.M[0]))
+
+
+def test_nonfdm_backend_multipop_fails_loud():
+    """A K>1 run on an HJB backend that does not thread the cross-density override must fail
+    loud (the half-coupled silent-wrong equilibrium is the bug), not run silently."""
+
+    class _StubHJB:
+        # Deliberately lacks _honors_multipop_hamiltonian_override.
+        def solve_hjb_system(self, *args, **kwargs):  # pragma: no cover - must not be reached
+            raise AssertionError("solve_hjb_system should not be called; iterator must fail loud first")
+
+    K = 2
+    probs = [_make_problem(k, 2.0, K) for k in range(K)]
+    multi = MultiPopulationProblem(populations=probs, population_names=["A", "B"])
+    it = MultiPopulationIterator(
+        multi,
+        [_StubHJB() for _ in range(K)],
+        [FPFDMSolver(p) for p in probs],
+        relaxation=0.5,
+    )
+    with pytest.raises(NotImplementedError, match="1157"):
+        it.solve(max_iterations=2, tolerance=1e-10)

--- a/tests/unit/test_core/test_hamiltonian_classes.py
+++ b/tests/unit/test_core/test_hamiltonian_classes.py
@@ -1063,3 +1063,71 @@ class TestLagrangianBaseNumerical:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ---------------------------------------------------------------------------
+# BoundHamiltonian time-indexing (Issue #1157)
+# ---------------------------------------------------------------------------
+
+
+def _otherblock_coupling(K, N):
+    """Coupling that returns 3 * (other population's density block) from a stacked (K*N,) m."""
+
+    def coupling(m):
+        m = np.asarray(m, float)
+        if m.ndim >= 1 and m.shape[-1] == K * N:
+            return 3.0 * m.reshape(*m.shape[:-1], K, N)[..., 1, :]
+        return np.zeros_like(m)
+
+    return coupling
+
+
+def test_bound_hamiltonian_time_indexes_trajectory():
+    """A (Nt+1, K*N) cross-density trajectory must be indexed to the row for the
+    Hamiltonian's evaluation time t (n = round(t/dt)), so each backward timestep sees the
+    cross-density at exactly that step (Issue #1157)."""
+    K, N, Ntp, dt = 2, 4, 5, 0.25
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=_otherblock_coupling(K, N),
+        coupling_dm=lambda m: np.zeros_like(np.asarray(m, float)),
+    )
+    m_all = np.arange(Ntp * K * N, dtype=float).reshape(Ntp, K * N)
+    Hb = H.bind_cross_density(m_all, dt=dt)
+    x = np.linspace(0.0, 1.0, N).reshape(-1, 1)
+    p = np.zeros((N, 1))  # control cost at p=0 is 0, so H == coupling
+    for n in range(Ntp):
+        val = np.asarray(Hb(x, np.ones(N), p, t=n * dt)).ravel()
+        expected = 3.0 * m_all[n].reshape(K, N)[1]
+        assert np.allclose(val, expected), (n, val, expected)
+
+
+def test_bound_hamiltonian_per_timestep_vector_is_backcompat():
+    """A 1D per-timestep m_all is used as-is, independent of t and without dt (back-compat)."""
+    K, N = 2, 4
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=_otherblock_coupling(K, N),
+        coupling_dm=lambda m: np.zeros_like(np.asarray(m, float)),
+    )
+    m_row = np.arange(K * N, dtype=float)
+    Hb = H.bind_cross_density(m_row, dt=None)
+    x = np.linspace(0.0, 1.0, N).reshape(-1, 1)
+    p = np.zeros((N, 1))
+    val = np.asarray(Hb(x, np.ones(N), p, t=123.0)).ravel()  # arbitrary t ignored
+    assert np.allclose(val, 3.0 * m_row.reshape(K, N)[1])
+
+
+def test_bound_hamiltonian_trajectory_without_dt_fails_loud():
+    """A 2D trajectory cannot map t to a row without dt: fail loud rather than guess."""
+    K, N, Ntp = 2, 4, 5
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=_otherblock_coupling(K, N),
+        coupling_dm=lambda m: np.zeros_like(np.asarray(m, float)),
+    )
+    m_all = np.zeros((Ntp, K * N))
+    Hb = H.bind_cross_density(m_all, dt=None)
+    x = np.linspace(0.0, 1.0, N).reshape(-1, 1)
+    with pytest.raises(ValueError, match="dt"):
+        Hb(x, np.ones(N), np.zeros((N, 1)), t=0.5)


### PR DESCRIPTION
## Summary

`MultiPopulationIterator._run` computed the cross-population-bound Hamiltonian (`H_k.bind_cross_density(m_all)`) but passed it only to the FP velocity step — **never to `solve_hjb_system`**. Each population's HJB therefore solved against the uncoupled `problem.hamiltonian_class`: the cross-density coupling reached the FP drift but **not the value function**, a silently wrong half-coupled equilibrium whenever the Hamiltonian genuinely couples across populations.

Grounded + adversarially verified via a design workflow (Joplin Dev coupling notes confirm the intent: "pass it through the problem's Hamiltonian"), then **tracing the actual pipeline overturned the design's premise** and shaped the fix.

## Mechanism (verify-by-artifact)

The FDM HJB residual evaluates `H` per backward timestep with the **own** population's density `M_k[n]` (shape `(Nx,)`) at `t = n·dt`. Two routes exist:
- **Per-point** `problem.H(x_idx, m_at_x, ...)` — receives only a **scalar** own-density per point; cannot express cross-population coupling.
- **Batch** `H_class(x_grid, m_grid, p_grid, t)` — passes the full density field, so a bound `H` can slice cross-population blocks.

Default FDM uses the **per-point** route (it passes a `NumPyBackend`, and the batch path requires `backend is None`). So the fix **forces `backend=None`** when an override is active — which is numerically equivalent to the per-point path (Issue #789; verified `max|dU| ~ 1e-10`).

## Changes

- **`BoundHamiltonian`** (`core/hamiltonian.py`): time-index a `(Nt+1, K·N)` trajectory by the evaluation time, `t → n = round(t/dt)`, so each backward step sees the cross-density *at that step*. `dt` required for a trajectory (fail loud otherwise); a 1D per-timestep `m_all` is used as-is (back-compat). The off-by-one is pinned: `base_hjb` uses `M[n]` with `t = n·dt`, so `round(t/dt) = n` exactly.
- **`base_hjb.py`**: thread `active_hamiltonian=None` through `compute_hjb_residual`/`compute_hjb_jacobian`/`newton_hjb_step`/`solve_hjb_timestep_newton`/`solve_hjb_system_backward` into the batch path; **fail loud** if an override would fall into the per-point `problem.H()` fallback (it cannot honor it).
- **`hjb_fdm.py`**: `solve_hjb_system` gains `hamiltonian_override=`; honors it on the **1D** path (forcing `backend=None`), raises for nD (not yet validated); class flag `_honors_multipop_hamiltonian_override=True`.
- **`multi_population_iterator.py`**: bind with `dt`; send the override **only** to backends that honor it (FDM); **fail loud** for `K>1` on backends that don't (no silent decouple); `K==1` sends no override (byte-identical single-population path).
- **`hjb_howard.py` / `weak_form_hjb_solver.py`**: name `hamiltonian_override` explicitly (it was being swallowed by `**_unused` / `**kwargs`) and fail loud — no silent swallow on direct calls.

## Scope

1D FDM **honors** the override (the realistically-wired multi-pop backend); nD FDM and all other backends **fail loud** rather than silently decouple. Single-population and all non-multi-pop solves are **byte-identical** (override defaults to `None` → `problem.hamiltonian_class`).

## Verification

```
tests/integration/test_multi_population_cross_coupling.py   3 passed
  - coupled != decoupled (LOAD-BEARING; bit-identical pre-fix -> dU=79.6 after)
  - K==1 byte-identical
  - non-FDM K>1 fails loud
tests/unit/test_core/test_hamiltonian_classes.py            3 BoundHamiltonian tests
no-regression: 591 passed across FDM/HJB/multipop/weakform/meshless/MMS
ruff clean (source + tests); single-pop MMS unchanged
```

## On closing #1157

`Refs #1157` (not auto-close). The **silent-decoupling bug is fixed** — every backend either honors the override (FDM 1D) or fails loud. The issue's broader Option-1 aspiration (all backends, nD) is intentionally gated as fail-loud follow-up. Leaving closure to you: close as resolved-for-the-realistic-path, or keep open tracking nD / other-backend support as enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)