### PR TITLE
chore(release): v0.19.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.8] - 2026-06-04
+
 ### Added
 
 - **Coupled-MFG-vs-reference MMS test** (`tests/integration/test_coupled_mfg_mms.py`).
@@ -34,7 +36,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BCValueProvider` reaching the solver raises `AssertionError` (the coupling layer must
   resolve it via `using_resolved_bc` first).
 
+- **`HJBGFDMSolver(inner_solver='howard')` honors prescribed Dirichlet values and the
+  real Neumann normal-derivative stencil** (Issue #1118 PR2a). The Howard inner solver
+  previously hardcoded the Dirichlet RHS to 0 and approximated Neumann by a
+  nearest-interior copy; both now flow through the shared `_value_form_bc_rows` /
+  `_bc_row_for_point` single coefficient source, so a nonzero `g_D` and the true
+  `n.grad u = g` stencil are applied (and the Newton/Howard paths share one BC-row builder).
+
+### Changed
+
+- **`MFGProblem` rejects non-positive `T`** (Issue #1077 case 4). `T <= 0` previously
+  produced a degenerate time grid silently; it now raises at construction.
+
+- **Anisotropic non-diagonal σ-tensor warning strengthened** (Issue #1079). The warning
+  now states the dropped off-diagonal cross-derivatives are an O(1) error (not
+  higher-order) in the affected HJB-FDM path. The diagonal-approximation behavior is
+  unchanged (deliberate, codified by `test_non_diagonal_tensor_warning`).
+
 ### Fixed
+
+- **Parameter sweep no longer crashes on macOS `spawn`** (Issue #1080). `ParameterSweep`
+  carried a `threading.Lock` (via its logger) into the pickled payload for
+  `ProcessPoolExecutor`; `__getstate__`/`__setstate__` now drop the logger, and a
+  pre-flight `pickle.dumps` probe fails loud with a clear message instead of an opaque
+  spawn error.
 
 - **Multi-population HJB now sees cross-population densities** (Issue #1157).
   `MultiPopulationIterator` computed the cross-density bound Hamiltonian but never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.19.7"  # v0.19.7: fail-loud/conservation batch + Howard inner solver (#1118)
+version = "0.19.8"  # v0.19.8: Howard BC parity (#1118 PR2) + multi-pop HJB coupling (#1157) + coupled-MMS test
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
Release v0.19.8 — versions the batch merged since v0.19.7 and backfills the missing CHANGELOG entries (audit item G).

## Contents (since v0.19.7)

**Added**
- Coupled-MFG-vs-reference MMS test (#1176) — closes the verification gap that let the σ→D (#1152) and wall-leak (#1151) bugs ship.
- `HJBGFDMSolver(inner_solver='howard')` adjoint-consistent Robin BC (#1118 PR2b) + Dirichlet/Neumann value parity (#1118 PR2a) — completing the Howard inner-solver BC parity.

**Changed**
- `MFGProblem` rejects non-positive `T` (#1077 case 4).
- Anisotropic non-diagonal σ-tensor warning strengthened to state O(1) severity (#1079).

**Fixed**
- Multi-population HJB now sees cross-population densities (#1157).
- `HJBGFDMSolver` re-reads geometry BC per solve so per-Picard resolved providers reach the solver (#1118).
- Parameter sweep no longer crashes on macOS `spawn` (#1080).

## Checklist
- `pyproject.toml:11` 0.19.7 → 0.19.8 (+ inline comment).
- CHANGELOG `[Unreleased]` → `[0.19.8] - 2026-06-04`, empty `[Unreleased]` re-added; backfilled #1080/#1077/#1079/#1118-PR2a (audit G).
- Sanity grep: only `pyproject.toml:11` changed (subpackage `__version__` lines untouched by design).

Tag `v0.19.8` + GitHub Release to follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)