### PR TITLE
fix(hjb-sl): nD ADI diffusion applies the full prescribed diffusion (#1178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **nD ADI diffusion now applies the full prescribed diffusion** (Issue #1178). The
+  semi-Lagrangian `adi_diffusion_step` split the time step across dimensions
+  (`dt/dimension` per directional Crank-Nicolson sweep), applying only `1/dimension`
+  of the diffusion — a silent 2x under-diffusion in 2D, 3x in 3D — on the default
+  `diffusion_method='adi'` path for 2D/3D SL HJB and the SL-adjoint FP. Sequential
+  (Lie) splitting requires the full `dt` per directional solve (the directional
+  Laplacians commute on a tensor grid). Fixed to full `dt`; added a magnitude-pinning
+  regression test (cosine-mode decay vs analytic, 2D + 3D) — no prior test constrained
+  the diffusion magnitude, which is how it shipped.
+
 ## [0.19.8] - 2026-06-04
 
 ### Added

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -181,14 +181,21 @@ def adi_diffusion_step(
     """
     Apply ADI (Alternating Direction Implicit) diffusion for nD grids.
 
-    Uses Peaceman-Rachford splitting for unconditional stability:
-    - For each dimension d, solve implicit diffusion in that direction
-    - Each direction is a set of independent 1D tridiagonal solves
+    Uses sequential (Lie) dimensional splitting with an implicit Crank-Nicolson
+    solve in each direction, each over the FULL dt:
+    - For each dimension d, solve implicit 1D diffusion in that direction over dt
+    - Each direction is a set of independent 1D tridiagonal solves (unconditionally
+      stable)
     - For full tensor diffusion, cross-derivative terms are added explicitly
 
-    For 2D with isotropic σ²:
-        Half-step x: (I - θα L_x) u^{1/2} = (I + θα L_y) u*
-        Half-step y: (I - θα L_y) u^{n}   = (I + θα L_x) u^{1/2}
+    The per-direction Laplacians commute on a tensor grid (constant-coefficient,
+    separable), so for isotropic diffusion the split is exact up to CN time
+    truncation; each directional solve must carry the full dt (NOT dt/dimension,
+    which would apply only 1/dimension of the prescribed diffusion).
+
+    For 2D with isotropic σ² (α = (σ²/2) dt / dx²):
+        Sweep x: (I - θα L_x) u^{1/2} = (I + (1-θ)α L_x) u^{n}
+        Sweep y: (I - θα L_y) u^{n+1} = (I + (1-θ)α L_y) u^{1/2}
 
     For full tensor diffusion (σ_ij):
         ADI handles diagonal terms implicitly, cross terms explicitly:
@@ -235,17 +242,19 @@ def adi_diffusion_step(
     if sigma_tensor is not None:
         U_shaped = apply_cross_diffusion_explicit(U_shaped, sigma_tensor, dt, spacing)
 
-    # Peaceman-Rachford ADI: cycle through dimensions
-    # Split dt evenly across dimensions for symmetric treatment
-    dt_per_dim = dt / dimension
-
+    # Sequential (Lie) dimensional splitting: solve the implicit 1D diffusion in
+    # each direction over the FULL dt. The per-direction Laplacians commute on a
+    # tensor grid (constant-coefficient, separable), so exp(dt L_x) exp(dt L_y) =
+    # exp(dt (L_x + L_y)) exactly — each directional solve MUST carry the full dt.
+    # Using dt/dimension here applied only 1/dimension of the prescribed diffusion
+    # (a 2x under-diffusion in 2D, 3x in 3D), silently wrong (no exception).
     U_current = U_shaped
 
     for d in range(dimension):
-        # Solve implicit diffusion in dimension d
+        # Solve implicit diffusion in dimension d over the full dt.
         # α_d = (σ_d²/2) * dt / dx_d²
         dx_d = spacing[d]
-        alpha_d = 0.5 * sigma_vec[d] ** 2 * dt_per_dim / dx_d**2
+        alpha_d = 0.5 * sigma_vec[d] ** 2 * dt / dx_d**2
         theta = 0.5  # Crank-Nicolson parameter
 
         # Apply implicit solve along dimension d

--- a/tests/unit/test_alg/test_hjb_semi_lagrangian.py
+++ b/tests/unit/test_alg/test_hjb_semi_lagrangian.py
@@ -1029,5 +1029,61 @@ class TestStochasticCharacteristicSL_nD:
         assert np.isfinite(U_step).all()
 
 
+class TestADIDiffusionMagnitude:
+    """Regression: the nD ADI diffusion step must apply the FULL prescribed diffusion.
+
+    A cosine eigenmode of the Laplacian decays analytically as
+    ``exp(-D (sum_d k_d^2) t)`` with ``D = sigma^2/2``. The sequential (Lie) ADI split
+    is exact for this separable mode up to Crank-Nicolson time truncation, so the ADI
+    decay must match the analytic decay. The pre-fix code used ``dt/dimension`` per
+    directional sweep, applying only ``1/dimension`` of the diffusion (2x under in 2D,
+    3x in 3D) — a silent magnitude error no prior test caught (they asserted only
+    finiteness / loose mass). These tests fail on that bug and pass on the full-dt fix.
+    """
+
+    @staticmethod
+    def _decay_relerr(adi_fac, analytic_fac):
+        # relative error in the (small) decay increment, robust near fac~1
+        return abs(adi_fac - analytic_fac) / abs(1.0 - analytic_fac)
+
+    def test_adi_2d_diffusion_matches_analytic(self):
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+
+        N, L, sigma, dt = 81, 1.0, 1.0, 1e-3
+        D = 0.5 * sigma**2
+        x = np.linspace(0.0, L, N)
+        X, Y = np.meshgrid(x, x, indexing="ij")
+        k = np.pi
+        u0 = np.cos(k * X) * np.cos(k * Y)
+        dx = L / (N - 1)
+        u1 = adi_diffusion_step(u0.copy(), dt, sigma, np.array([dx, dx]), (N, N), "neumann")
+        i, j = N // 3, N // 4
+        adi_fac = u1[i, j] / u0[i, j]
+        analytic_fac = np.exp(-D * (2 * k**2) * dt)  # full 2D decay
+        # pre-fix this would be exp(-D*k^2*dt) (half exponent) -> rel error ~1.0
+        assert self._decay_relerr(adi_fac, analytic_fac) < 0.02, (
+            f"ADI 2D under/over-diffuses: factor {adi_fac:.6f} vs analytic {analytic_fac:.6f}"
+        )
+
+    def test_adi_3d_diffusion_matches_analytic(self):
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+
+        N, L, sigma, dt = 31, 1.0, 1.0, 5e-4
+        D = 0.5 * sigma**2
+        x = np.linspace(0.0, L, N)
+        X, Y, Z = np.meshgrid(x, x, x, indexing="ij")
+        k = np.pi
+        u0 = np.cos(k * X) * np.cos(k * Y) * np.cos(k * Z)
+        dx = L / (N - 1)
+        u1 = adi_diffusion_step(u0.copy(), dt, sigma, np.array([dx, dx, dx]), (N, N, N), "neumann")
+        i = N // 3
+        adi_fac = u1[i, i, i] / u0[i, i, i]
+        analytic_fac = np.exp(-D * (3 * k**2) * dt)  # full 3D decay
+        # pre-fix this would be exp(-D*k^2*dt) (one-third exponent) -> rel error ~2.0
+        assert self._decay_relerr(adi_fac, analytic_fac) < 0.03, (
+            f"ADI 3D under/over-diffuses: factor {adi_fac:.6f} vs analytic {analytic_fac:.6f}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary

`adi_diffusion_step` applied only **1/dimension** of the prescribed diffusion — a silent **2× under-diffusion in 2D, 3× in 3D** — because it split the time step across dimensions (`dt_per_dim = dt/dimension`) and did a sequential Crank-Nicolson solve per direction. Sequential (Lie) splitting of `u_t = D(L_x+L_y)u` requires the **full `dt`** per directional solve (the directional Laplacians commute on a tensor grid → exact split up to CN truncation).

Reachable on the **default** path: `diffusion_method='adi'` is the SL default (`hjb_semi_lagrangian.py:115`), and the SL-adjoint FP also calls it (`fp_semi_lagrangian_adjoint.py:534`) — both the nD value function and density were under-diffused (effective volatility wrong).

## Evidence

2D cosine eigenmode, `sigma=1`, `dt=2e-4`:
```
ADI decay   = 0.999014  (one dimension's worth, = exp(-D·k²·dt))
analytic 2D = 0.998028  (= exp(-D·2k²·dt))
defect ratio = 1.999 ≈ dimension
```
After the fix: 2D and 3D ADI decay match analytic to ~1e-4.

## Change

- Full `dt` per directional sweep (delete `dt/dimension`).
- Corrected the docstring (it claimed Peaceman-Rachford; the code is sequential implicit-only CN = Lie splitting).
- **Regression test** `TestADIDiffusionMagnitude` (cosine-mode decay vs analytic, 2D + 3D) — fails on the bug, passes on the fix. No prior test pinned the diffusion magnitude, which is why it shipped (same blind spot as #1152 σ→D / #1151 wall-leak).

## Verification
- New ADI tests: 2 passed.
- No regression: 159 passed across SL / adjoint / WENO suites; ruff clean (the one N801 is a pre-existing class name, untouched).

Found via a calibrated silent-bug audit (adversarially verified + numerically reproduced).

Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)