### PR TITLE
fix(fp): explicit-drift FP advection honors boundary conditions, not periodic default (#1181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Callable/tensor explicit-drift FP advection now honors the domain boundary conditions**
+  (Issue #1181). `solve_timestep_explicit_with_drift` and `solve_timestep_tensor_explicit`
+  called `compute_advection_from_drift_nd` without `bc=`, so on a no-flux domain the
+  advection defaulted to periodic and mass exiting one wall silently re-entered at the
+  opposite wall (a #1151-class wall leak; the U-derived sibling already passed the BC).
+  Reachable via `solve_fp_system(drift_field=<callable>)` or any tensor/anisotropic
+  `volatility_field`. Fixed to pass the in-scope `boundary_conditions`; regression test
+  asserts a leftward drift on a no-flux domain leaves the far-right (near-wall) region empty.
+
+### Fixed
+
 - **nD ADI diffusion now applies the full prescribed diffusion** (Issue #1178). The
   semi-Lagrangian `adi_diffusion_step` split the time step across dimensions
   (`dt/dimension` per directional Crank-Nicolson sweep), applying only `1/dimension`

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -504,8 +504,10 @@ def solve_timestep_explicit_with_drift(
     # Solve implicit diffusion
     M_star = sparse.linalg.spsolve(A_diffusion, b_rhs).reshape(shape)
 
-    # Step 2: Explicit advection using direct drift
-    advection_term = compute_advection_from_drift_nd(M_star, drift, spacing, ndim)
+    # Step 2: Explicit advection using direct drift.
+    # Issue #1181: pass boundary_conditions so a no-flux domain does not default to
+    # periodic (AdvectionOperator bc=None == periodic), which silently wraps wall mass.
+    advection_term = compute_advection_from_drift_nd(M_star, drift, spacing, ndim, bc=boundary_conditions)
     M_next = M_star - dt * advection_term
 
     # Step 3: Add source term (MMS verification)
@@ -984,8 +986,10 @@ def solve_timestep_tensor_explicit(
     # Compute advection term: div(alpha * m)
     # Use upwind scheme from fp_fdm_advection module
     if drift is not None:
-        # Direct drift provided (standalone FP mode)
-        advection_term = compute_advection_from_drift_nd(M_current, drift, spacing, ndim)
+        # Direct drift provided (standalone FP mode).
+        # Issue #1181: pass boundary_conditions (the U-derived branch below already does)
+        # so a no-flux domain does not default to periodic and wrap wall mass.
+        advection_term = compute_advection_from_drift_nd(M_current, drift, spacing, ndim, bc=boundary_conditions)
     else:
         # MFG coupled mode: derive drift from U
         advection_term = compute_advection_term_nd(

--- a/tests/integration/test_fdm_centered_conservation.py
+++ b/tests/integration/test_fdm_centered_conservation.py
@@ -139,3 +139,45 @@ def test_fdm_centered_coupled_solve_conserves_mass():
     # The #1149 bug leaked ~57% (terminal mass ~0.43). With the conservative scheme AND the
     # boundary-flux fix the coupled solve conserves mass to ~machine precision.
     assert abs(M[-1].sum() * dx - 1.0) < 1e-9, f"terminal mass {M[-1].sum() * dx:.8f} (centered must conserve)"
+
+
+@pytest.mark.integration
+def test_callable_drift_explicit_path_respects_no_flux_no_periodic_wrap():
+    """Issue #1181: the callable-drift explicit FP path must use the domain's no-flux BC,
+    not the periodic default. With a constant leftward drift on a no-flux domain, mass piles
+    at the LEFT wall and must NOT appear at the RIGHT wall. Pre-fix the advection omitted the
+    BC argument -> periodic default -> mass exiting the left wall re-entered at the right wall
+    (right-edge mass ~0.19); the fix passes boundary_conditions so the right half stays empty.
+    """
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+
+    n, nt, T = 81, 50, 0.5
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: np.asarray(m) * 0.0,
+        coupling_dm=lambda m: np.asarray(m) * 0.0,
+    )
+    comps = MFGComponents(
+        m_initial=lambda x: np.exp(-((np.asarray(x) - 0.5) ** 2) / 0.01),
+        u_terminal=lambda x: np.asarray(x) * 0.0,
+        hamiltonian=H,
+    )
+    prob = MFGProblem(geometry=grid, T=T, Nt=nt, sigma=0.05, components=comps)
+    x = np.linspace(0.0, 1.0, n)
+    dx = x[1] - x[0]
+    m0 = np.exp(-((x - 0.5) ** 2) / 0.01)
+    m0 /= m0.sum() * dx
+    # callable drift signature is (t, grid, density); constant leftward velocity toward x=0
+    M = FPFDMSolver(prob).solve_fp_system(m0.copy(), drift_field=lambda t, g, m: np.full(n, -0.3))
+    assert np.all(np.isfinite(M))
+    # No periodic wrap: the leftward drift moves the bump to x ~ 0.39, so the far-right region
+    # (x >= 0.7, well clear of the bump tail) must be empty. Pre-#1181 the periodic default
+    # re-entered mass exiting the left wall at the RIGHT wall, giving O(0.1) here.
+    far_right_mass = M[-1, int(0.7 * n) :].sum() * dx
+    assert far_right_mass < 1e-5, (
+        f"mass wrapped through the no-flux wall: far-right (x>=0.7) mass {far_right_mass:.3e} "
+        f"(pre-#1181 the periodic default gave O(0.1) here)"
+    )
+    # Mass should pile toward the LEFT wall (where the leftward drift transports it).
+    assert M[-1, 0] > M[-1, -1], "leftward drift did not pile mass at the left wall"


### PR DESCRIPTION
## Summary

`solve_timestep_explicit_with_drift` (`fp_fdm_time_stepping.py:508`) and `solve_timestep_tensor_explicit` (`:988`) called `compute_advection_from_drift_nd` **without** `bc=`, so `AdvectionOperator` defaulted to `bc=None` == **periodic**. On a no-flux domain (the default) the wall flux is non-zero and mass reaching a wall **wrapped to the opposite wall** — a silent #1151-class leak. The U-derived sibling in the same file (`compute_advection_term_nd(..., boundary_conditions)`) already passes the BC, proving the direct-drift omission was an oversight.

Reachable via `FPFDMSolver.solve_fp_system(drift_field=<callable>)` or any tensor/anisotropic `volatility_field` (both route to the explicit path).

## Evidence

Leftward constant drift, no-flux domain:
```
pre-fix (periodic default):  mass wraps to the RIGHT wall (right-edge ~0.19)
post-fix (no-flux):          far-right region ~5e-12; mass piles at the LEFT wall ✓
```

## Change
Pass the in-scope `boundary_conditions` at both call sites (`compute_advection_from_drift_nd` already accepts `bc=`).

## Verification
- New `test_callable_drift_explicit_path_respects_no_flux_no_periodic_wrap` (leftward drift on no-flux → far-right near-wall region empty; fails pre-fix).
- FP suites: 67 passed (test_fp_fdm_solver 45, test_fp_matrix_conservation 14, test_fdm_centered_conservation 8). No regression.

## Separate finding (NOT introduced here — flagged for a follow-up)
Under **strong** drift into a no-flux wall, the explicit upwind advection is not strictly mass-conserving (~5% growth at `drift=-0.3`; pure diffusion conserves exactly). That is a #1151-sibling in the explicit-drift advection's no-flux boundary handling. This PR only switches the BC from wrong (periodic) to correct (no-flux); the conservation error was previously *masked* by the wrap, not caused by this change. I'll file it separately.

Found via a calibrated silent-bug audit (adversarially verified + reproduced).

Closes #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)