### PR TITLE
fix(fp): warn on mean-collapse of spatially varying sigma in explicit/adjoint FP paths (#1183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Spatially varying volatility on the explicit-drift / strict-adjoint FP paths now warns**
+  instead of silently approximating (Issue #1183). Those paths use a constant-coefficient
+  diffusion (scalar `D = mean(sigma)^2/2`), so a genuinely non-uniform `volatility_field`
+  silently solved a different PDE than the per-point implicit path. They now emit a
+  `UserWarning` when a non-uniform array sigma is collapsed (uniform arrays collapse exactly
+  and do not warn). The full per-point variable-coefficient diffusion on these paths remains
+  tracked in #1183 (it needs an operator that matches the existing conservative no-flux
+  discretization).
+
 ### Fixed
 
 - **Callable/tensor explicit-drift FP advection now honors the domain boundary conditions**

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -704,8 +704,20 @@ class FPFDMSolver(BaseFPSolver):
 
         # Compute diffusion coefficient
         if isinstance(sigma_val, np.ndarray):
-            # For spatially varying diffusion, use mean (approximation)
-            # TODO: Support full spatially varying in matrix form
+            # Issue #1183: the strict-adjoint FP step uses a scalar D; a spatially varying
+            # sigma is collapsed to its mean. For a genuinely non-uniform sigma this silently
+            # solves a different PDE. Fail loud rather than silently approximate; the per-point
+            # variable-coefficient diffusion (matrix form) is tracked in #1183.
+            if float(np.ptp(sigma_val)) > 1e-12:
+                import warnings
+
+                warnings.warn(
+                    "Spatially varying volatility in strict-adjoint FP mode is approximated by "
+                    "its spatial mean (Issue #1183): the per-point matrix form is not yet "
+                    "implemented. Results differ from a true per-point diffusion.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             D = 0.5 * float(np.mean(sigma_val)) ** 2
         else:
             D = 0.5 * float(sigma_val) ** 2

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -467,6 +467,22 @@ def solve_timestep_explicit_with_drift(
     """
     # Get diffusion coefficient
     if isinstance(sigma, np.ndarray):
+        # Issue #1183: the explicit-drift path uses a constant-coefficient LaplacianOperator,
+        # so a spatially varying sigma is collapsed to its mean (a scalar D). For a genuinely
+        # non-uniform sigma this silently solves a different PDE than the per-point implicit
+        # path (solve_timestep_full_nd). Fail loud rather than silently approximate; a true
+        # per-point variable-coefficient diffusion on this path is tracked in #1183.
+        if float(np.ptp(sigma)) > 1e-12:
+            import warnings
+
+            warnings.warn(
+                "Spatially varying volatility on the explicit-drift FP path is approximated by "
+                "its spatial mean (Issue #1183): the per-point variable-coefficient diffusion is "
+                "not yet implemented here. Results differ from the per-point implicit path. Use an "
+                "array drift_field (implicit path) for per-point sigma fidelity.",
+                UserWarning,
+                stacklevel=2,
+            )
         # For spatially varying, use scalar approximation (mean)
         sigma_val = float(np.mean(sigma))
     else:

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -6,6 +6,8 @@ Tests the Finite Difference Method (FDM) solver for Fokker-Planck equations
 with different boundary conditions (periodic, Dirichlet, no-flux).
 """
 
+import warnings
+
 import pytest
 
 import numpy as np
@@ -1136,6 +1138,52 @@ class TestFPFDMSolverCallableDrift:
         assert M.shape == (problem.Nt + 1, Nx, Ny)
         assert np.all(np.isfinite(M))
         assert np.all(M >= -1e-10)
+
+
+class TestVaryingSigmaExplicitDriftWarning:
+    """Issue #1183: the explicit-drift FP path collapses a spatially varying volatility to its
+    mean (scalar D). It must fail loud (warn) for a genuinely non-uniform sigma rather than
+    silently solve a different PDE than the per-point implicit path; a uniform array sigma
+    collapses exactly and must NOT warn."""
+
+    @staticmethod
+    def _solve(sigma_field):
+        n, nt = 41, 30
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: np.asarray(m) * 0.0,
+            coupling_dm=lambda m: np.asarray(m) * 0.0,
+        )
+        comps = MFGComponents(
+            m_initial=lambda x: np.exp(-((np.asarray(x) - 0.5) ** 2) / 0.02),
+            u_terminal=lambda x: np.asarray(x) * 0.0,
+            hamiltonian=H,
+        )
+        prob = MFGProblem(geometry=grid, T=0.3, Nt=nt, sigma=0.1, components=comps)
+        x = np.linspace(0.0, 1.0, n)
+        dx = x[1] - x[0]
+        m0 = np.exp(-((x - 0.5) ** 2) / 0.02)
+        m0 /= m0.sum() * dx
+        # callable drift routes through the explicit path (signature (t, grid, density))
+        FPFDMSolver(prob).solve_fp_system(m0, drift_field=lambda t, g, m: np.zeros(n), volatility_field=sigma_field)
+
+    def test_non_uniform_sigma_warns(self):
+        n = 41
+        x = np.linspace(0.0, 1.0, n)
+        sigma_field = np.where(x < 0.5, 0.05, 0.30)  # genuinely non-uniform
+        with pytest.warns(UserWarning, match="1183"):
+            self._solve(sigma_field)
+
+    def test_uniform_array_sigma_does_not_warn(self):
+        n = 41
+        sigma_field = np.full(n, 0.1)  # uniform array: mean-collapse is exact
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._solve(sigma_field)
+        assert not [w for w in caught if "1183" in str(w.message)], (
+            "uniform array sigma collapses exactly and must not raise the #1183 warning"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The explicit-drift FP path (`solve_timestep_explicit_with_drift`) and the strict-adjoint FP step (`solve_fp_step_adjoint_mode`) build a **constant-coefficient** diffusion (scalar `D = 0.5·mean(sigma)²` via a plain `LaplacianOperator`). For a genuinely non-uniform `volatility_field` this silently solved a *different PDE* than the per-point implicit path (`solve_timestep_full_nd` uses `sigma_local` per grid point) — reproduced as a ~21% final-time L2 difference for a two-level sigma.

## Why warning-interim, not the full fix

A true per-point variable-coefficient diffusion on these paths needs an operator that **reproduces the existing conservative no-flux discretization**. The available `DiffusionOperator`:
- has **no** `as_scipy_sparse` (the explicit path assembles a sparse matrix), and
- its `∇·(D∇)` boundary handling **does not match** `LaplacianOperator` — verified: `max|diff| = 18` at the wall for constant sigma.

Swapping it in would change the diffusion discretization for *all* users and risk a #1151-class conservation defect. Building the matching variable-coefficient matrix is a focused operator task — kept open in **#1183**.

## Interim (this PR)
Emit a `UserWarning` when a **non-uniform** array sigma is collapsed to its mean, converting the silent-wrong into a loud signal. A **uniform** array sigma collapses exactly and does not warn.

## Verification
- `TestVaryingSigmaExplicitDriftWarning`: non-uniform sigma warns (`match="1183"`); uniform array sigma does not.
- ruff clean; FP suites unaffected.

`Refs #1183` (warning-interim; the per-point variable-coefficient diffusion remains the open work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)