### PR TITLE
feat(utils): canonical diffusion_from_volatility converter — single source for D=σ²/2 (retrospect rec #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (a halved magnitude gives relerr 0.46 vs the 0.03 threshold). Covers ADI (1D/2D/3D, tier1)
   and the FP-FDM explicit + implicit paths (tier2). HJB-solver diffusion isolation (past the
   Hamiltonian advection) is a documented follow-up.
+- **Canonical `diffusion_from_volatility(sigma, *, kind=None)` converter**
+  (`mfgarchon/utils/pde_coefficients.py`, Issue #811). Single source of truth for the
+  SDE-volatility -> PDE-diffusion conversion `D = (1/2) Sigma Sigma^T` (scalar `sigma^2/2`),
+  per NAMING_CONVENTIONS "Volatility vs Diffusion": tensor-first (volatility is a tensor in
+  general), `Sigma Sigma^T` not `Sigma^T Sigma`. Fail-loud, no silent guess: a scalar `sigma`
+  is unambiguous, but an array requires `kind` (`"field"` = isotropic per-point `sigma^2/2`
+  elementwise; `"tensor"` = trailing `(d,k)` is Sigma, `D = 0.5*Sigma@Sigma.T`, `ndim>=2`) —
+  an array with `kind=None` raises rather than guessing `(d,d)`-tensor vs `(Nx,Ny)`-field.
+  Replaces the dominant silent-convention bug class (#1152/#1178/#1183) at the root by making
+  `D` come from one place. First consumer: `hjb_sl_adi.py`; remaining ~36 ad-hoc
+  `0.5*sigma**2` sites tracked in #1189 (byte-identical migration).
 
 ### Changed
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 import numpy as np
 from scipy.linalg import solve_banded
 
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
 
 def solve_crank_nicolson_diffusion_1d(
     U_star: np.ndarray,
@@ -61,8 +63,8 @@ def solve_crank_nicolson_diffusion_1d(
     Nx = len(U_star)
     dx = x_grid[1] - x_grid[0]
 
-    # Diffusion coefficient: alpha = sigma^2/2 * dt/dx^2
-    alpha = 0.5 * sigma**2 * dt / dx**2
+    # Diffusion coefficient: alpha = D * dt/dx^2, D = sigma^2/2 (Issue #811, single source).
+    alpha = diffusion_from_volatility(sigma) * dt / dx**2
     theta = 0.5  # Crank-Nicolson parameter
 
     if bc_type == "periodic":
@@ -252,9 +254,9 @@ def adi_diffusion_step(
 
     for d in range(dimension):
         # Solve implicit diffusion in dimension d over the full dt.
-        # α_d = (σ_d²/2) * dt / dx_d²
+        # α_d = D_d * dt / dx_d², D_d = σ_d²/2 (Issue #811, single source).
         dx_d = spacing[d]
-        alpha_d = 0.5 * sigma_vec[d] ** 2 * dt / dx_d**2
+        alpha_d = diffusion_from_volatility(sigma_vec[d]) * dt / dx_d**2
         theta = 0.5  # Crank-Nicolson parameter
 
         # Apply implicit solve along dimension d

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -20,6 +20,52 @@ if TYPE_CHECKING:
     from mfgarchon.core.mfg_problem import MFGProblem
 
 
+def diffusion_from_volatility(
+    sigma: float | np.ndarray,
+    dimension: int | None = None,
+) -> float | np.ndarray:
+    r"""Canonical PDE diffusion coefficient ``D`` from SDE volatility ``sigma`` (Issue #811).
+
+    Single source of truth for the volatility -> diffusion conversion documented in
+    ``NAMING_CONVENTIONS.md`` "Volatility vs Diffusion". Volatility is a tensor in general
+    (the noise matrix :math:`\Sigma`, shape ``(d, k)``); the scalar :math:`\sigma` is the
+    isotropic special case. The diffusion coefficient is
+
+    .. math::  D = \tfrac{1}{2}\,\Sigma\Sigma^\top
+
+    i.e. half the noise covariance :math:`\Sigma\Sigma^\top` (Oksendal, Karatzas-Shreve) --
+    **not** :math:`\Sigma^\top\Sigma`; only :math:`\Sigma\Sigma^\top` has the correct ``(d, d)``
+    shape for a ``(d, k)`` volatility. For a square symmetric :math:`\Sigma` they coincide.
+
+    Shapes:
+
+    - scalar (0-d)               -> ``D = sigma**2 / 2``                  (isotropic scalar)
+    - ``(*spatial,)`` field       -> ``D = sigma**2 / 2`` elementwise       (isotropic per-point)
+    - ``(d, k)`` matrix Sigma      -> ``D = 0.5 * Sigma @ Sigma.T``          (``(d, d)`` symmetric PSD)
+    - ``(*spatial, d, k)`` field   -> per-point ``0.5 * Sigma @ Sigma.T``
+
+    ``dimension`` disambiguates a 2-D array: it is a Sigma tensor when its leading axis
+    equals ``dimension`` (shape ``(d, k)``), otherwise a ``(Nx, Ny, ...)`` spatial field.
+    Without ``dimension`` a 2-D array is treated as a Sigma tensor (volatility is tensor by
+    default); pass ``dimension`` when a 2-D *spatial* field could be mistaken for a tensor.
+    Arrays of ``ndim >= 3`` are always ``(*spatial, d, k)`` tensor fields.
+
+    For scalar / field inputs this is byte-identical to the literal ``0.5 * sigma**2`` it
+    replaces (IEEE-754: ``0.5 * x == x / 2``).
+    """
+    arr = np.asarray(sigma, dtype=float)
+    if arr.ndim == 0:
+        return 0.5 * float(arr) ** 2
+    # Treat the trailing two axes as a noise matrix Sigma (d, k) when:
+    #   - ndim >= 3: always a (*spatial, d, k) tensor field, or
+    #   - ndim == 2 and (no dimension hint => default-tensor, or leading axis == d).
+    is_tensor = arr.ndim >= 3 or (arr.ndim == 2 and (dimension is None or arr.shape[0] == dimension))
+    if is_tensor:
+        return 0.5 * np.matmul(arr, np.swapaxes(arr, -1, -2))
+    # Otherwise: scalar volatility on a (*spatial,) grid -> isotropic per-point D.
+    return 0.5 * arr**2
+
+
 class CoefficientMode(Enum):
     """
     Specifies which variables a callable coefficient depends on.

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 
 def diffusion_from_volatility(
     sigma: float | np.ndarray,
-    dimension: int | None = None,
+    *,
+    kind: str | None = None,
 ) -> float | np.ndarray:
     r"""Canonical PDE diffusion coefficient ``D`` from SDE volatility ``sigma`` (Issue #811).
 
@@ -37,33 +38,40 @@ def diffusion_from_volatility(
     **not** :math:`\Sigma^\top\Sigma`; only :math:`\Sigma\Sigma^\top` has the correct ``(d, d)``
     shape for a ``(d, k)`` volatility. For a square symmetric :math:`\Sigma` they coincide.
 
-    Shapes:
+    A **scalar** ``sigma`` is unambiguous: ``D = sigma**2 / 2``. For an **array** ``sigma``
+    the shape alone cannot distinguish a ``(d, d)`` noise tensor from an ``(Nx, Ny)`` spatial
+    field, so ``kind`` is **required** -- the converter refuses to guess (fail-loud, the same
+    silent-convention class this single-source converter exists to eliminate):
 
-    - scalar (0-d)               -> ``D = sigma**2 / 2``                  (isotropic scalar)
-    - ``(*spatial,)`` field       -> ``D = sigma**2 / 2`` elementwise       (isotropic per-point)
-    - ``(d, k)`` matrix Sigma      -> ``D = 0.5 * Sigma @ Sigma.T``          (``(d, d)`` symmetric PSD)
-    - ``(*spatial, d, k)`` field   -> per-point ``0.5 * Sigma @ Sigma.T``
+    - ``kind="field"``  -> isotropic per-point volatility; ``D = sigma**2 / 2`` elementwise
+      (any spatial shape). Byte-identical to the literal ``0.5 * sigma**2`` (IEEE: ``0.5*x == x/2``).
+    - ``kind="tensor"`` -> the trailing two axes are the noise matrix :math:`\Sigma` ``(d, k)``;
+      ``D = 0.5 * Sigma @ Sigma.T`` over the last two axes (any leading axes are spatial).
+      Requires ``ndim >= 2``. A diagonal-anisotropic volatility is passed as a ``(d, d)``
+      diagonal matrix here, not a ``(d,)`` vector.
 
-    ``dimension`` disambiguates a 2-D array: it is a Sigma tensor when its leading axis
-    equals ``dimension`` (shape ``(d, k)``), otherwise a ``(Nx, Ny, ...)`` spatial field.
-    Without ``dimension`` a 2-D array is treated as a Sigma tensor (volatility is tensor by
-    default); pass ``dimension`` when a 2-D *spatial* field could be mistaken for a tensor.
-    Arrays of ``ndim >= 3`` are always ``(*spatial, d, k)`` tensor fields.
-
-    For scalar / field inputs this is byte-identical to the literal ``0.5 * sigma**2`` it
-    replaces (IEEE-754: ``0.5 * x == x / 2``).
+    Raises ``ValueError`` for an array with ``kind is None`` (ambiguous), an unknown ``kind``,
+    or ``kind="tensor"`` with ``ndim < 2``.
     """
     arr = np.asarray(sigma, dtype=float)
     if arr.ndim == 0:
-        return 0.5 * float(arr) ** 2
-    # Treat the trailing two axes as a noise matrix Sigma (d, k) when:
-    #   - ndim >= 3: always a (*spatial, d, k) tensor field, or
-    #   - ndim == 2 and (no dimension hint => default-tensor, or leading axis == d).
-    is_tensor = arr.ndim >= 3 or (arr.ndim == 2 and (dimension is None or arr.shape[0] == dimension))
-    if is_tensor:
+        return 0.5 * float(arr) ** 2  # scalar isotropic: unambiguous, kind not needed
+    if kind is None:
+        raise ValueError(
+            "array volatility is ambiguous: pass kind='field' (isotropic per-point sigma, "
+            "D = sigma^2/2 elementwise) or kind='tensor' (trailing (d,k) is the noise matrix "
+            "Sigma, D = 1/2 Sigma Sigma^T). Refusing to guess a (d,d) tensor vs a spatial "
+            "field (Issue #811)."
+        )
+    if kind == "field":
+        return 0.5 * arr**2
+    if kind == "tensor":
+        if arr.ndim < 2:
+            raise ValueError(
+                f"kind='tensor' needs a (d,k) or (*spatial,d,k) noise matrix (ndim>=2), got ndim={arr.ndim}."
+            )
         return 0.5 * np.matmul(arr, np.swapaxes(arr, -1, -2))
-    # Otherwise: scalar volatility on a (*spatial,) grid -> isotropic per-point D.
-    return 0.5 * arr**2
+    raise ValueError(f"kind must be 'field' or 'tensor' (or None for scalar sigma), got {kind!r}.")
 
 
 class CoefficientMode(Enum):

--- a/tests/unit/test_utils/test_diffusion_from_volatility.py
+++ b/tests/unit/test_utils/test_diffusion_from_volatility.py
@@ -1,0 +1,75 @@
+"""Tests for the canonical volatility -> diffusion converter (Issue #811).
+
+``diffusion_from_volatility`` is the single source of truth for ``D = (1/2) Sigma Sigma^T``
+(scalar: ``D = sigma^2/2``), replacing ~38 ad-hoc literal ``0.5 * sigma**2`` sites. These
+tests pin the contract documented in NAMING_CONVENTIONS.md "Volatility vs Diffusion":
+tensor-first, ``Sigma Sigma^T`` (NOT ``Sigma^T Sigma``), and byte-identity for the scalar /
+field cases it replaces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+
+class TestScalarAndField:
+    def test_scalar_is_half_sigma_squared(self):
+        assert diffusion_from_volatility(0.5) == pytest.approx(0.125)  # 0.5^2/2
+
+    def test_scalar_byte_identical_to_literal(self):
+        # the literal it replaces is `0.5 * sigma**2`; IEEE-754: 0.5*x == x/2 exactly
+        for sigma in (0.3, 0.05, 1.0, 0.123456789):
+            assert diffusion_from_volatility(sigma) == 0.5 * sigma**2
+
+    def test_spatial_field_is_elementwise(self):
+        sigma = np.array([0.05, 0.1, 0.2, 0.3])  # (*spatial,) isotropic per-point
+        D = diffusion_from_volatility(sigma)
+        assert np.array_equal(D, 0.5 * sigma**2)
+        assert D.shape == sigma.shape
+
+    def test_2d_spatial_field_with_dimension_is_elementwise(self):
+        # a (Nx, Ny) spatial field for a 2D problem: pass dimension so it is NOT read as a tensor
+        sigma = np.linspace(0.05, 0.3, 35).reshape(5, 7)
+        D = diffusion_from_volatility(sigma, dimension=2)  # shape[0]=5 != 2 -> field
+        assert np.array_equal(D, 0.5 * sigma**2)
+
+
+class TestTensor:
+    def test_symmetric_tensor(self):
+        Sigma = np.array([[0.3, 0.1], [0.1, 0.2]])  # symmetric
+        D = diffusion_from_volatility(Sigma)
+        assert np.allclose(D, 0.5 * Sigma @ Sigma.T)
+        assert np.allclose(D, D.T)  # D is symmetric PSD
+
+    def test_uses_sigma_sigmaT_not_sigmaT_sigma(self):
+        # LOAD-BEARING: non-symmetric Sigma distinguishes Sigma@Sigma.T from Sigma.T@Sigma
+        Sigma = np.array([[1.0, 2.0], [0.0, 1.0]])
+        D = diffusion_from_volatility(Sigma)
+        assert np.allclose(D, 0.5 * Sigma @ Sigma.T), "must use Sigma @ Sigma.T"
+        assert not np.allclose(D, 0.5 * Sigma.T @ Sigma), "must NOT use Sigma.T @ Sigma"
+
+    def test_nonsquare_dk_matrix_gives_dxd(self):
+        # (d, k) = (2, 3) volatility -> (d, d) = (2, 2) diffusion via Sigma @ Sigma.T
+        Sigma = np.array([[0.2, 0.1, 0.05], [0.0, 0.3, 0.1]])  # (2, 3)
+        D = diffusion_from_volatility(Sigma, dimension=2)
+        assert D.shape == (2, 2)
+        assert np.allclose(D, 0.5 * Sigma @ Sigma.T)
+
+    def test_default_treats_square_2d_as_tensor(self):
+        # without a dimension hint a square 2-D array is a Sigma tensor (volatility is tensor by default)
+        Sigma = np.array([[0.4, 0.0], [0.2, 0.3]])
+        assert np.allclose(diffusion_from_volatility(Sigma), 0.5 * Sigma @ Sigma.T)
+
+    def test_spatially_varying_tensor_field(self):
+        # (*spatial, d, k) -> per-point 0.5 * Sigma Sigma^T over the trailing axes
+        nx, d = 4, 2
+        rng = np.random.default_rng(0)
+        Sig = rng.uniform(0.05, 0.3, size=(nx, d, d))
+        D = diffusion_from_volatility(Sig)
+        assert D.shape == (nx, d, d)
+        for i in range(nx):
+            assert np.allclose(D[i], 0.5 * Sig[i] @ Sig[i].T)

--- a/tests/unit/test_utils/test_diffusion_from_volatility.py
+++ b/tests/unit/test_utils/test_diffusion_from_volatility.py
@@ -3,8 +3,9 @@
 ``diffusion_from_volatility`` is the single source of truth for ``D = (1/2) Sigma Sigma^T``
 (scalar: ``D = sigma^2/2``), replacing ~38 ad-hoc literal ``0.5 * sigma**2`` sites. These
 tests pin the contract documented in NAMING_CONVENTIONS.md "Volatility vs Diffusion":
-tensor-first, ``Sigma Sigma^T`` (NOT ``Sigma^T Sigma``), and byte-identity for the scalar /
-field cases it replaces.
+tensor-first, ``Sigma Sigma^T`` (NOT ``Sigma^T Sigma``), byte-identity for the scalar / field
+cases it replaces, and FAIL-LOUD on ambiguous array inputs (no silent (d,d)-tensor-vs-field
+guess -- the same silent-convention class the converter exists to eliminate).
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ import numpy as np
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 
-class TestScalarAndField:
+class TestScalar:
     def test_scalar_is_half_sigma_squared(self):
         assert diffusion_from_volatility(0.5) == pytest.approx(0.125)  # 0.5^2/2
 
@@ -25,51 +26,70 @@ class TestScalarAndField:
         for sigma in (0.3, 0.05, 1.0, 0.123456789):
             assert diffusion_from_volatility(sigma) == 0.5 * sigma**2
 
-    def test_spatial_field_is_elementwise(self):
-        sigma = np.array([0.05, 0.1, 0.2, 0.3])  # (*spatial,) isotropic per-point
-        D = diffusion_from_volatility(sigma)
+    def test_scalar_needs_no_kind(self):
+        # scalar is unambiguous (isotropic); kind is not required
+        assert diffusion_from_volatility(0.2) == pytest.approx(0.02)
+
+
+class TestField:
+    def test_1d_field_is_elementwise(self):
+        sigma = np.array([0.05, 0.1, 0.2, 0.3])  # isotropic per-point
+        D = diffusion_from_volatility(sigma, kind="field")
         assert np.array_equal(D, 0.5 * sigma**2)
         assert D.shape == sigma.shape
 
-    def test_2d_spatial_field_with_dimension_is_elementwise(self):
-        # a (Nx, Ny) spatial field for a 2D problem: pass dimension so it is NOT read as a tensor
-        sigma = np.linspace(0.05, 0.3, 35).reshape(5, 7)
-        D = diffusion_from_volatility(sigma, dimension=2)  # shape[0]=5 != 2 -> field
+    def test_2d_field_is_elementwise(self):
+        sigma = np.linspace(0.05, 0.3, 35).reshape(5, 7)  # (Nx, Ny) spatial field, 2D problem
+        D = diffusion_from_volatility(sigma, kind="field")
         assert np.array_equal(D, 0.5 * sigma**2)
 
 
 class TestTensor:
     def test_symmetric_tensor(self):
         Sigma = np.array([[0.3, 0.1], [0.1, 0.2]])  # symmetric
-        D = diffusion_from_volatility(Sigma)
+        D = diffusion_from_volatility(Sigma, kind="tensor")
         assert np.allclose(D, 0.5 * Sigma @ Sigma.T)
         assert np.allclose(D, D.T)  # D is symmetric PSD
 
     def test_uses_sigma_sigmaT_not_sigmaT_sigma(self):
         # LOAD-BEARING: non-symmetric Sigma distinguishes Sigma@Sigma.T from Sigma.T@Sigma
         Sigma = np.array([[1.0, 2.0], [0.0, 1.0]])
-        D = diffusion_from_volatility(Sigma)
+        D = diffusion_from_volatility(Sigma, kind="tensor")
         assert np.allclose(D, 0.5 * Sigma @ Sigma.T), "must use Sigma @ Sigma.T"
         assert not np.allclose(D, 0.5 * Sigma.T @ Sigma), "must NOT use Sigma.T @ Sigma"
 
     def test_nonsquare_dk_matrix_gives_dxd(self):
         # (d, k) = (2, 3) volatility -> (d, d) = (2, 2) diffusion via Sigma @ Sigma.T
         Sigma = np.array([[0.2, 0.1, 0.05], [0.0, 0.3, 0.1]])  # (2, 3)
-        D = diffusion_from_volatility(Sigma, dimension=2)
+        D = diffusion_from_volatility(Sigma, kind="tensor")
         assert D.shape == (2, 2)
         assert np.allclose(D, 0.5 * Sigma @ Sigma.T)
-
-    def test_default_treats_square_2d_as_tensor(self):
-        # without a dimension hint a square 2-D array is a Sigma tensor (volatility is tensor by default)
-        Sigma = np.array([[0.4, 0.0], [0.2, 0.3]])
-        assert np.allclose(diffusion_from_volatility(Sigma), 0.5 * Sigma @ Sigma.T)
 
     def test_spatially_varying_tensor_field(self):
         # (*spatial, d, k) -> per-point 0.5 * Sigma Sigma^T over the trailing axes
         nx, d = 4, 2
         rng = np.random.default_rng(0)
         Sig = rng.uniform(0.05, 0.3, size=(nx, d, d))
-        D = diffusion_from_volatility(Sig)
+        D = diffusion_from_volatility(Sig, kind="tensor")
         assert D.shape == (nx, d, d)
         for i in range(nx):
             assert np.allclose(D[i], 0.5 * Sig[i] @ Sig[i].T)
+
+
+class TestFailLoudOnAmbiguousArrays:
+    def test_array_without_kind_raises(self):
+        # a (d,d) tensor and a (Nx,Ny) field share the shape -> refuse to guess
+        with pytest.raises(ValueError, match=r"ambiguous|kind"):
+            diffusion_from_volatility(np.array([[0.3, 0.1], [0.0, 0.2]]))
+
+    def test_1d_array_without_kind_raises(self):
+        with pytest.raises(ValueError, match=r"ambiguous|kind"):
+            diffusion_from_volatility(np.array([0.1, 0.2, 0.3]))
+
+    def test_tensor_kind_on_1d_raises(self):
+        with pytest.raises(ValueError, match="ndim"):
+            diffusion_from_volatility(np.array([0.1, 0.2]), kind="tensor")
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError, match="kind"):
+            diffusion_from_volatility(np.array([0.1, 0.2]), kind="diagonal")


### PR DESCRIPTION
## Summary

Retrospect **recommendation #2** — attack the dominant silent-convention bug class (#1152 σ→D, #1178 ADI dt/dimension, #1183 σ→mean) **at the root**: make the volatility→diffusion conversion come from **one** place, so a factor error becomes *unrepresentable*, not merely caught downstream.

Adds `mfgarchon/utils/pde_coefficients.diffusion_from_volatility(sigma, *, kind=None)` implementing the `NAMING_CONVENTIONS.md` "Volatility vs Diffusion" contract (Issue #811):

- volatility is a **tensor** in general (Σ, d×k); diffusion is `D = ½ΣΣᵀ` (scalar special case `σ²/2`)
- uses `Σ @ Σ.T`, **not** `Σ.T @ Σ` (Øksendal / Karatzas-Shreve — only `ΣΣᵀ` gives the correct d×d shape for a d×k Σ)
- **fail-loud, no silent guess**: a scalar `sigma` is unambiguous (`D=σ²/2`, no `kind` needed), but an **array**'s shape cannot distinguish a `(d,d)` noise tensor from an `(Nx,Ny)` spatial field, so `kind` is **required**:
  - `kind="field"` → isotropic per-point; `D = σ²/2` elementwise (byte-identical to the `0.5*σ²` literal it replaces)
  - `kind="tensor"` → trailing `(d,k)` axes are Σ; `D = 0.5*Σ@Σ.T` over the last two axes (`ndim≥2`)
  - array + `kind=None` → `ValueError` (ambiguous); `kind="tensor"` + `ndim<2` → `ValueError`; unknown `kind` → `ValueError`

This removes the one place the single-source converter could *itself* re-introduce a silent-convention divergence — the exact bug class it exists to eliminate.

## First consumer + scope

`hjb_sl_adi.py` (the #1178 file) — both `D` computations call the converter on **scalar** σ, **byte-identical** and unaffected by the stricter array policy (the ADI magnitude tests + SL suite confirm no behavior change). The remaining ~36 ad-hoc sites are migrated in test-gated follow-up batches — tracked in **#1189**, guarded by the diffusion-magnitude gate (#1188) + the FP/HJB suites.

## Tests (13, pinning the contract)
- **scalar**: `σ²/2`, byte-identical to `0.5*σ²`, no `kind` needed
- **field**: 1D/2D elementwise with `kind="field"`
- **tensor**: symmetric Σ; the **load-bearing non-symmetric-Σ check** that it's `Σ@Σ.T` not `Σ.T@Σ`; `(d,k)→(d,d)`; spatially-varying `(*spatial,d,k)` field
- **fail-loud**: array-without-`kind` raises, 1D-array-without-`kind` raises, `kind="tensor"` on 1D raises (ndim), unknown `kind` raises

`Refs #1189, #811`

🤖 Generated with [Claude Code](https://claude.com/claude-code)