### PR TITLE
refactor: route numerical-core diffusion through diffusion_from_volatility (#1189 sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **~30 numerical-core diffusion sites now route through `diffusion_from_volatility`**
+  (Issue #1189, the sweep follow-up to the #1190 converter). The literal `0.5*sigma**2`
+  / `sigma**2/2` is replaced by the single-source converter across the problem core
+  (`mfg_problem._volatility_to_diffusion` now delegates its scalar/diagonal/tensor shape
+  dispatch; `.diffusion` property routes through it), all 8 FP solvers, 5 HJB solvers
+  (`base_hjb`/`hjb_fdm` use `kind="field"` for their array-capable sigma; the 7 gfdm,
+  3 weno, 1 SL sites are scalar), and the adjoint ADI/BC-coupling builders. Byte-identical
+  (verified against the diffusion-magnitude gate + the FP/HJB suites). The wrong-coefficient
+  bug class (#1152/#1178) is now unrepresentable in these paths, not merely caught downstream.
+  Out of scope (documented): the PINN/torch-backend sites (torch tensors, not numpy), the
+  code-generation template, and `flux_diagnostics`.
 - **Spatially varying volatility on the explicit-drift / strict-adjoint FP paths now warns**
   instead of silently approximating (Issue #1183). Those paths use a constant-coefficient
   diffusion (scalar `D = mean(sigma)^2/2`), so a genuinely non-uniform `volatility_field`

--- a/mfgarchon/alg/numerical/adjoint/bc_coupling.py
+++ b/mfgarchon/alg/numerical/adjoint/bc_coupling.py
@@ -56,6 +56,7 @@ import numpy as np
 # Import BC types from geometry submodules directly for clarity
 from mfgarchon.geometry.boundary.conditions import BoundaryConditions
 from mfgarchon.geometry.boundary.types import BCSegment, BCType
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -168,7 +169,7 @@ def create_adjoint_consistent_bc_1d(
     )
 
     # Robin BC values: g = -σ²/2 · ∂ln(m)/∂n
-    diffusion_coeff = sigma**2 / 2
+    diffusion_coeff = diffusion_from_volatility(sigma)
     value_left = -diffusion_coeff * grad_ln_m_left
     value_right = -diffusion_coeff * grad_ln_m_right
 

--- a/mfgarchon/alg/numerical/adjoint/operators.py
+++ b/mfgarchon/alg/numerical/adjoint/operators.py
@@ -40,6 +40,8 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 import numpy as np
 from scipy import sparse
 
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
@@ -151,7 +153,7 @@ def build_diffusion_matrix(
     for d in range(ndim):
         # Build 1D Laplacian for dimension d
         Nd = grid_shape[d]
-        alpha_d = 0.5 * sigma**2 * dt / dx[d] ** 2
+        alpha_d = diffusion_from_volatility(sigma) * dt / dx[d] ** 2
 
         # 1D Laplacian: L = [-1, 2, -1] / dx²
         # For (I - θ·α·L), we need to add θ·α times the Laplacian contribution
@@ -275,7 +277,7 @@ def build_diffusion_matrix_1d(
         For Dirichlet BC with zero values, the matrix is also symmetric.
         For periodic BC, the matrix is symmetric (circulant structure).
     """
-    alpha = 0.5 * sigma**2 * dt / dx**2
+    alpha = diffusion_from_volatility(sigma) * dt / dx**2
 
     # Main diagonal
     main = np.ones(Nx) * (1.0 + 2.0 * theta * alpha)
@@ -342,8 +344,8 @@ def build_diffusion_matrix_2d(
     else:
         dx_x, dx_y = dx
 
-    alpha_x = 0.5 * sigma**2 * dt / dx_x**2
-    alpha_y = 0.5 * sigma**2 * dt / dx_y**2
+    alpha_x = diffusion_from_volatility(sigma) * dt / dx_x**2
+    alpha_y = diffusion_from_volatility(sigma) * dt / dx_y**2
 
     # Build sparse matrix
     A = sparse.lil_matrix((N, N))

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_centered.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_centered.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -103,7 +105,7 @@ def add_interior_entries_divergence_centered(
     diagonal_value = 1.0 / dt
 
     # Diffusion coefficient D = sigma^2/2
-    D = sigma**2 / 2.0
+    D = diffusion_from_volatility(sigma)
 
     # Check for periodic BC
     # Issue #543 Phase 2: Replace hasattr with try/except
@@ -278,7 +280,7 @@ def add_boundary_no_flux_entries_divergence_centered(
     diagonal_value = 1.0 / dt
 
     # Diffusion coefficient D = sigma^2/2
-    D = sigma**2 / 2.0
+    D = diffusion_from_volatility(sigma)
 
     for d in range(ndim):
         dx = spacing[d]

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_upwind.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_upwind.py
@@ -36,6 +36,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -84,7 +86,7 @@ def add_interior_entries_divergence_upwind(
     diagonal_value = 1.0 / dt
 
     # Diffusion coefficient D = sigma^2/2
-    D = sigma**2 / 2.0
+    D = diffusion_from_volatility(sigma)
 
     # For each dimension, add flux-based advection + diffusion contributions
     for d in range(ndim):

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from mfgarchon.utils.aux_func import npart, ppart
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
     import numpy as np
@@ -225,7 +226,7 @@ def add_boundary_no_flux_entries_gradient_upwind(
     diagonal_value = 1.0 / dt
 
     # Diffusion coefficient D = σ²/2
-    D = sigma**2 / 2.0
+    D = diffusion_from_volatility(sigma)
 
     # For each dimension, check if we're at a boundary in that dimension
     for d in range(ndim):

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_bc.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_bc.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from mfgarchon.utils.aux_func import npart, ppart
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
     import numpy as np
@@ -71,7 +72,7 @@ def add_boundary_no_flux_entries(
     diagonal_value = 1.0 / dt
 
     # Diffusion coefficient D = sigma^2/2
-    D = sigma**2 / 2.0
+    D = diffusion_from_volatility(sigma)
 
     # For each dimension, check if we're at a boundary in that dimension
     for d in range(ndim):
@@ -248,7 +249,7 @@ def add_boundary_no_flux_entries_conservative(
     diagonal_value = 1.0 / dt
 
     # Diffusion coefficient D = sigma^2/2
-    D = sigma**2 / 2.0
+    D = diffusion_from_volatility(sigma)
 
     # For each dimension, check if we're at a boundary in that dimension
     for d in range(ndim):

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -66,7 +66,7 @@ from mfgarchon.geometry.boundary.applicator_base import (
     LinearConstraint,
 )
 from mfgarchon.geometry.boundary.types import BoundaryFace
-from mfgarchon.utils.pde_coefficients import CoefficientField, _DriftDispatcher
+from mfgarchon.utils.pde_coefficients import CoefficientField, _DriftDispatcher, diffusion_from_volatility
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -488,7 +488,7 @@ def solve_timestep_explicit_with_drift(
     else:
         sigma_val = float(sigma)
 
-    D = 0.5 * sigma_val**2  # Diffusion coefficient
+    D = diffusion_from_volatility(sigma_val)  # Diffusion coefficient
     shape = M_current.shape
 
     # Set default boundary conditions

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -30,6 +30,7 @@ import numpy as np
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
 from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import TaylorOperator
 from mfgarchon.utils.deprecation import deprecated_parameter
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -460,7 +461,7 @@ class FPGFDMSolver(BaseFPSolver):
         else:
             raise NotImplementedError("Only scalar volatility currently supported")
 
-        diffusion_coeff = 0.5 * sigma**2
+        diffusion_coeff = diffusion_from_volatility(sigma)
 
         # Validate inputs
         m_init = np.asarray(m_initial_condition).ravel()

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -44,6 +44,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
 from mfgarchon.operators.stencils.finite_difference import laplacian_with_bc
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 from .base_fp import BaseFPSolver
 
@@ -457,7 +458,7 @@ class FPSLJacobianSolver(BaseFPSolver):
 
         # Step 2: Diffusion via Crank-Nicolson
         # ====================================
-        D = sigma**2 / 2
+        D = diffusion_from_volatility(sigma)
         r = D * dt / (self.dx**2)
 
         # Build RHS: (I + r/2 * L) * m_advected

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -40,6 +40,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
 )
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 from .base_fp import BaseFPSolver
 from .fp_sl_splatting import splat_1d, splat_nd
@@ -416,7 +417,7 @@ class FPSLSolver(BaseFPSolver):
         # This gives boundary stencil: L[0] = (m[1] - m[0])/dx^2
         # The resulting matrix has column sums = 0, ensuring mass conservation.
         #
-        D = sigma**2 / 2
+        D = diffusion_from_volatility(sigma)
         r = D * dt / (self.dx**2)
 
         # Build RHS: (I + r/2 * L_fv) * m_star

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -10,6 +10,7 @@ from mfgarchon.alg.base_solver import BaseNumericalSolver, SchemeFamily
 from mfgarchon.backends.compat import backend_aware_assign, backend_aware_copy, has_nan_or_inf
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -616,7 +617,7 @@ def compute_hjb_residual(
 
         # Apply diffusion term (NumPy broadcasts scalar automatically)
         # Works for both constant σ (scalar) and σ(x,t) (array)
-        Phi_U += -(sigma**2 / 2.0) * U_xx
+        Phi_U += -diffusion_from_volatility(sigma, kind="field") * U_xx
 
     # Precompute BC-aware gradient for entire array (Issue #542 fix)
     # This avoids repeated per-point computation with wrong BC

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -20,7 +20,7 @@ from mfgarchon.geometry.base import CartesianGrid  # nD FDM needs structured gri
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical import FixedPointSolver, NewtonSolver
-from mfgarchon.utils.pde_coefficients import CoefficientField
+from mfgarchon.utils.pde_coefficients import CoefficientField, diffusion_from_volatility
 
 from . import base_hjb
 from .base_hjb import BaseHJBSolver
@@ -969,7 +969,7 @@ class HJBFDMSolver(BaseHJBSolver):
             # Follows 1D pattern in base_hjb.py:774-803
             sigma = sigma_at_n if sigma_at_n is not None else self.problem.sigma
             lap_u = self._get_laplacian_op()(U).ravel()
-            H_values_flat = H_convective - 0.5 * sigma**2 * lap_u
+            H_values_flat = H_convective - diffusion_from_volatility(sigma, kind="field") * lap_u
 
         return H_values_flat.reshape(self.shape)
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -29,6 +29,7 @@ from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
 from mfgarchon.utils.deprecation import deprecated_parameter, deprecated_value
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical.qp_utils import QPCache, QPSolver
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 from .base_hjb import (
     DEFAULT_NEWTON_MAX_ITERATIONS,
@@ -2045,7 +2046,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
         # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
         sigma = self._get_sigma_value(None)
-        diffusion_term = 0.5 * sigma**2 * lap_u
+        diffusion_term = diffusion_from_volatility(sigma) * lap_u
 
         # HJB residual: -u_t + H - diffusion = 0
         residual = -u_t + H_total - diffusion_term
@@ -2099,7 +2100,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
         # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
         sigma = self._get_sigma_value(None)
-        diffusion_term = 0.5 * sigma**2 * lap_u
+        diffusion_term = diffusion_from_volatility(sigma) * lap_u
 
         # HJB residual: -u_t + H - diffusion = 0
         return -u_t + H_total - diffusion_term
@@ -2150,7 +2151,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         jacobian = (1.0 / dt) * eye(n, format="csr")
         for dim in range(d):
             jacobian = jacobian + diags(dH_dp[:, dim], format="csr") @ self._D_grad[dim]
-        jacobian = jacobian - 0.5 * sigma**2 * self._D_lap
+        jacobian = jacobian - diffusion_from_volatility(sigma) * self._D_lap
 
         return jacobian
 
@@ -2239,7 +2240,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                 H = H + running_cost[i]
 
             sigma_val = self._get_sigma_value(i)
-            diffusion_term = 0.5 * sigma_val**2 * laplacian
+            diffusion_term = diffusion_from_volatility(sigma_val) * laplacian
             residual[i] = -u_t[i] + H - diffusion_term
 
         return residual
@@ -2276,7 +2277,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
         # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
         sigma = self._get_sigma_value(None)
-        diffusion_coeff = 0.5 * sigma**2
+        diffusion_coeff = diffusion_from_volatility(sigma)
 
         # Time derivative term: (1/dt) * I
         jacobian = (1.0 / dt) * eye(n, format="csr")
@@ -2359,7 +2360,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                 dH_dp = self._compute_dH_dp_fd(i, m_n_plus_1[i], p_derivs, time_idx)
 
             sigma_val = self._get_sigma_value(i)
-            diffusion_coeff = 0.5 * sigma_val**2
+            diffusion_coeff = diffusion_from_volatility(sigma_val)
 
             # Neighbor contributions
             for k, j in enumerate(neighbor_indices):
@@ -3333,7 +3334,7 @@ class HJBGFDMSolver(BaseHJBSolver):
 
             # Get sigma for diffusion term
             sigma_val = self._get_sigma_value(i)
-            diffusion_coeff = 0.5 * sigma_val**2
+            diffusion_coeff = diffusion_from_volatility(sigma_val)
 
             # Build row i of Jacobian
             # For neighbors: use GFDM weights directly

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -34,7 +34,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
 )
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
-from mfgarchon.utils.pde_coefficients import check_adi_compatibility
+from mfgarchon.utils.pde_coefficients import check_adi_compatibility, diffusion_from_volatility
 
 from .base_hjb import BaseHJBSolver
 from .hjb_sl_adi import (
@@ -2333,7 +2333,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             Solution after explicit diffusion step
         """
         sigma = self.problem.sigma
-        sigma_sq_half = 0.5 * sigma**2
+        sigma_sq_half = diffusion_from_volatility(sigma)
 
         if self.dimension == 1:
             dx = self.dx

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -45,6 +45,7 @@ from mfgarchon.core.derivatives import DerivativeTensors, to_multi_index_dict
 from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
 from mfgarchon.geometry.boundary.conditions import neumann_bc
 from mfgarchon.utils.deprecation import deprecated_parameter
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 from .base_hjb import BaseHJBSolver
 
@@ -737,7 +738,7 @@ class HJBWenoSolver(BaseHJBSolver):
             hamiltonian = self._evaluate_hamiltonian(i, m[i], u_x[i], direction=(1,))
 
             # RHS = -H + diffusion
-            rhs[i] = -hamiltonian + (self.problem.sigma**2 / 2) * u_xx[i]
+            rhs[i] = -hamiltonian + diffusion_from_volatility(self.problem.sigma) * u_xx[i]
 
         return rhs
 
@@ -1301,7 +1302,7 @@ class HJBWenoSolver(BaseHJBSolver):
         # Hamiltonian evaluation for Y-direction (direction (0,1) = y-derivative)
         for i in range(n):
             hamiltonian = self._evaluate_hamiltonian(i, m[i], u_y[i], direction=(0, 1))
-            rhs[i] = -hamiltonian + (self.problem.sigma**2 / 2) * u_yy[i]
+            rhs[i] = -hamiltonian + diffusion_from_volatility(self.problem.sigma) * u_yy[i]
 
         return rhs
 
@@ -1426,7 +1427,7 @@ class HJBWenoSolver(BaseHJBSolver):
         # Hamiltonian evaluation for Z-direction (direction (0,0,1) = z-derivative)
         for i in range(n):
             hamiltonian = self._evaluate_hamiltonian(i, m[i], u_z[i], direction=(0, 0, 1))
-            rhs[i] = -hamiltonian + (self.problem.sigma**2 / 2) * u_zz[i]
+            rhs[i] = -hamiltonian + diffusion_from_volatility(self.problem.sigma) * u_zz[i]
 
         return rhs
 

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -98,17 +98,21 @@ def _volatility_to_diffusion(
     Returns:
         PDE diffusion coefficient D.
     """
+    # Single source for the conversion (Issue #811): delegate the shape dispatch
+    # to the canonical converter. Byte-identical: scalar -> sigma^2/2, 1D diagonal
+    # -> sigma_i^2/2 elementwise (kind="field"), 2D -> 0.5 Sigma Sigma^T (kind="tensor").
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
     if isinstance(sigma, (int, float)):
-        return float(sigma) ** 2 / 2.0
+        return diffusion_from_volatility(float(sigma))
 
     sigma_arr = np.asarray(sigma, dtype=float)
     if sigma_arr.ndim == 0:
-        return float(sigma_arr) ** 2 / 2.0
+        return diffusion_from_volatility(sigma_arr)
     if sigma_arr.ndim == 1:
-        return sigma_arr**2 / 2.0
+        return diffusion_from_volatility(sigma_arr, kind="field")
     if sigma_arr.ndim == 2:
-        # Full matrix: D = (1/2) Sigma Sigma^T
-        return 0.5 * (sigma_arr @ sigma_arr.T)
+        return diffusion_from_volatility(sigma_arr, kind="tensor")
 
     raise ValueError(f"Unsupported volatility shape: {sigma_arr.shape}")
 
@@ -1325,7 +1329,7 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         state-dependent diffusion, evaluate ``self.volatility_field`` and
         apply the conversion ``D = sigma^2/2`` as needed.
         """
-        return self.sigma**2 / 2.0
+        return _volatility_to_diffusion(self.sigma)
 
     @property
     def diffusion_field(self):

--- a/mfgarchon/geometry/boundary/bc_coupling.py
+++ b/mfgarchon/geometry/boundary/bc_coupling.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from mfgarchon.utils.deprecation import deprecated
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 # Import from submodules directly (deprecated module, see Issue #704)
 from .conditions import BoundaryConditions
@@ -81,7 +82,7 @@ def create_adjoint_consistent_bc_1d(
     grad_ln_m_left = -(ln_m[1] - ln_m[0]) / dx
     grad_ln_m_right = (ln_m[-1] - ln_m[-2]) / dx
 
-    diffusion_coeff = sigma**2 / 2
+    diffusion_coeff = diffusion_from_volatility(sigma)
     value_left = -diffusion_coeff * grad_ln_m_left
     value_right = -diffusion_coeff * grad_ln_m_right
 


### PR DESCRIPTION
## Summary

The sweep follow-up to **#1190** (the canonical `diffusion_from_volatility` converter, retrospect rec ②). Replaces ~30 ad-hoc `0.5*sigma**2` / `sigma**2/2` literals across the numerical core with the single-source converter, so the **wrong-coefficient bug class** (#1152 σ→D, #1178 ADI dt/dimension) becomes *unrepresentable* in these paths rather than merely caught downstream by the magnitude gate.

Every change is **byte-identical** — verified against the diffusion-magnitude gate (#1188/#1191) + the FP/HJB suites.

## Commits (subsystem-grouped, each verified)

| Commit | Sites | Verification |
|---|---|---|
| core | `mfg_problem._volatility_to_diffusion` (a **full duplicate** conversion → now delegates scalar/diagonal/tensor shape dispatch) + `.diffusion` property | 221 tests; scalar/0d/1D/2D byte-identical, ndim≥3 still raises |
| FP | 10 sites across 8 FP solvers (all scalar — constant-coeff builders, SL step, gfdm scalar-guard, #1183 collapsed mean) | 250 FP tests + gate FP explicit/implicit |
| HJB | 13 sites across 5 HJB solvers | 444 HJB tests + gate **GFDM slow** (exercises the migrated joint_socp path) + ADI 1/2/3D |
| adjoint/boundary | 6 scalar sites (ADI alpha builders, AC-BC density couplings) | 503 tests |

## `kind="field"` sites

Two HJB sites take **array-capable** sigma (`σ(x,t)` / `sigma_at_n`): `base_hjb.py:619`, `hjb_fdm.py:972`. They pass `kind="field"`, which is **byte-identical for scalar too** — the converter returns at `ndim==0` *before* inspecting `kind`. Everything else is scalar (`_get_sigma_value -> float`, collapsed means, scalar params) → direct calls.

## Out of scope (documented, not silently dropped)

8 sites remain, all in non-core / non-numpy categories the converter cannot serve: the **PINN solvers** + **`torch_backend.py`** (torch tensors, not numpy — need a torch-native conversion), **`code_generation.py`** (emits a code template), **`flux_diagnostics.py`**, and the `hjb_sl.py:2812` smoke test.

`Refs #1189` (core done; torch/PINN residual tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)