### PR TITLE
test: upgrade plumbing-only tests to run-and-compare (retrospect rec ③)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Upgraded two "plumbing-only" tests to run-and-compare (retrospect rec ③).**
+  `test_qp_optimization_levels` only asserted constructor *labels* (`hjb_method_name`) — it
+  would pass even if a QP monotonicity level corrupted the solution; added
+  `test_qp_optimization_levels_agree_on_smooth_problem`, which solves at all three levels on
+  a smooth problem and asserts they agree to <1e-4 (a real regression guard). And
+  `test_fp_matrix_conservation`'s `TestFPMatrixConservation` asserted column-sum=1/dt on a
+  *test-local re-implementation* of the FP matrix (a shadow that passed even if the production
+  assembly diverged); replaced by `TestFPProductionConservation`, which runs the real
+  `FPFDMSolver` and asserts machine-precision (<1e-12) mass conservation — the tight signal a
+  wrong boundary stencil would break. Removed a no-op placeholder test.
 - **~30 numerical-core diffusion sites now route through `diffusion_from_volatility`**
   (Issue #1189, the sweep follow-up to the #1190 converter). The literal `0.5*sigma**2`
   / `sigma**2/2` is replaced by the single-source converter across the problem core

--- a/tests/unit/test_alg/test_fp_matrix_conservation.py
+++ b/tests/unit/test_alg/test_fp_matrix_conservation.py
@@ -1,18 +1,18 @@
-"""
-Tests for FP FDM matrix conservation properties.
+"""Conservation tests for the FP FDM solver.
 
-Phase 2a of Issue #486: Verify that FP transition matrices satisfy conservation
-(column sums = 1/dt for implicit scheme, ensuring mass conservation).
+Verifies the production Fokker-Planck implicit assembly conserves mass and stays
+positive -- the linear-algebraic root of MFG mass conservation (Achdou &
+Capuzzo-Dolcetta 2010, Issue #486).
 
-For the implicit FP scheme: A * m^{n+1} = b
-where A = I/dt + L (spatial discretization operator)
-
-Conservation requirement: sum_i A_{ij} = 1/dt for all j
-This ensures that total mass is preserved: sum_i m_i^{n+1} = sum_i m_i^n
-
-References:
-    - Achdou & Capuzzo-Dolcetta (2010): Mean field games: numerical methods
-    - Issue #486: BC Unification
+History: an earlier ``TestFPMatrixConservation`` asserted column-sum = 1/dt on a
+*test-local re-implementation* of the matrix (a shadow that could pass even if the
+production ``FPFDMSolver`` assembly diverged) and a no-op placeholder test. Those are
+replaced by ``TestFPProductionConservation``, which runs the real solver: the
+machine-precision mass invariant is the signal a wrong boundary stencil (the
+retrospect's non-conservation-at-boundary bug class) would break, and the loose
+``rtol=0.1`` end-to-end checks in ``test_fp_fdm_solver.py`` would miss.
+``TestLinearConstraintMatrixAssembly`` below already points at production
+(``_build_diffusion_matrix_with_bc``) and is unchanged.
 """
 
 from __future__ import annotations
@@ -22,388 +22,59 @@ import pytest
 import numpy as np
 import scipy.sparse as sparse
 
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.geometry import TensorProductGrid
-
-
-class TestFPMatrixConservation:
-    """Test matrix conservation properties for FP FDM solver."""
-
-    @pytest.fixture
-    def simple_1d_problem(self):
-        """Create a simple 1D problem for testing."""
-
-        class SimpleProblem:
-            """Minimal problem for matrix tests."""
-
-            def __init__(self):
-                self.T = 1.0
-                self.Nt = 10
-                self.sigma = 0.5
-                self.lambda_coupling = 1.0
-                self.geometry = TensorProductGrid(
-                    bounds=[[0.0, 1.0]],
-                    num_points=[21],
-                )
-
-        return SimpleProblem()
-
-    def _build_fp_matrix_1d(
-        self,
-        Nx: int,
-        dx: float,
-        dt: float,
-        sigma: float,
-        coupling_coeff: float,
-        u: np.ndarray,
-        bc_type: str = "no_flux",
-    ) -> sparse.csr_matrix:
-        """
-        Build FP transition matrix for testing.
-
-        This replicates the matrix construction from FPFDMSolver to verify
-        column sums.
-
-        Args:
-            Nx: Number of grid points
-            dx: Grid spacing
-            dt: Time step
-            sigma: Diffusion coefficient
-            coupling_coeff: Coupling coefficient (lambda)
-            u: Value function gradient field
-            bc_type: Boundary condition type
-
-        Returns:
-            Sparse CSR matrix for FP transition
-        """
-        from mfgarchon.utils.aux_func import npart, ppart
-
-        row_indices = []
-        col_indices = []
-        data_values = []
-
-        D = sigma**2 / 2.0  # Diffusion coefficient
-
-        for i in range(Nx):
-            # Diagonal term
-            diagonal = 1.0 / dt
-
-            if bc_type == "periodic":
-                # Periodic BC: use modular indexing
-                ip1 = (i + 1) % Nx
-                im1 = (i - 1 + Nx) % Nx
-
-                # Diffusion contribution to diagonal
-                diagonal += sigma**2 / dx**2
-
-                # Advection contribution to diagonal (outflow)
-                diagonal += coupling_coeff * (npart(u[ip1] - u[i]) + ppart(u[i] - u[im1])) / dx**2
-
-                row_indices.append(i)
-                col_indices.append(i)
-                data_values.append(diagonal)
-
-                # Off-diagonal: i-1 neighbor
-                val_im1 = -(sigma**2) / (2 * dx**2)
-                val_im1 += -coupling_coeff * npart(u[i] - u[im1]) / dx**2
-                row_indices.append(i)
-                col_indices.append(im1)
-                data_values.append(val_im1)
-
-                # Off-diagonal: i+1 neighbor
-                val_ip1 = -(sigma**2) / (2 * dx**2)
-                val_ip1 += -coupling_coeff * ppart(u[ip1] - u[i]) / dx**2
-                row_indices.append(i)
-                col_indices.append(ip1)
-                data_values.append(val_ip1)
-
-            elif bc_type == "no_flux":
-                # No-flux BC: J·n = 0 at boundary where J = v*m - D*grad(m)
-                # For conservation: column sums must equal 1/dt
-                #
-                # Key insight: Interior cells have advection terms that pull/push
-                # from boundary cells. Boundary cells must have matching terms
-                # to maintain column sum conservation.
-                if i == 0:
-                    # Left boundary
-                    ip1 = i + 1
-
-                    # Diffusion: one-sided (ghost = interior for no-flux)
-                    diagonal += D / dx**2
-                    val_ip1 = -D / dx**2
-
-                    # Advection: use upwind scheme with no-flux at boundary face
-                    # The interior face (between cell 0 and cell 1) has normal flux
-                    grad_U = (u[ip1] - u[i]) / dx
-                    alpha = -coupling_coeff * grad_U  # velocity = -lambda * grad(U)
-
-                    # Upwind advection for interior face (0, 1):
-                    # If alpha > 0 (flow to right), upwind from left (cell 0)
-                    # If alpha < 0 (flow to left), upwind from right (cell 1)
-                    if alpha >= 0:
-                        # Flow to right: mass leaves cell 0, enters cell 1
-                        diagonal += alpha / dx  # cell 0 loses
-                        val_ip1 += -alpha / dx  # (not needed, ip1 gains)
-                    else:
-                        # Flow to left: mass leaves cell 1, enters cell 0
-                        # For cell 0 equation: gain from cell 1
-                        diagonal += 0  # cell 0 doesn't lose from left flow
-                        val_ip1 += alpha / dx  # alpha < 0, so this is negative (cell 0 gains)
-
-                    row_indices.append(i)
-                    col_indices.append(i)
-                    data_values.append(diagonal)
-
-                    row_indices.append(i)
-                    col_indices.append(ip1)
-                    data_values.append(val_ip1)
-
-                elif i == Nx - 1:
-                    # Right boundary
-                    im1 = i - 1
-
-                    # Diffusion: one-sided (ghost = interior for no-flux)
-                    diagonal += D / dx**2
-                    val_im1 = -D / dx**2
-
-                    # Advection: upwind with interior face flux
-                    grad_U = (u[i] - u[im1]) / dx
-                    alpha = -coupling_coeff * grad_U
-
-                    if alpha >= 0:
-                        # Flow to right: mass enters cell N-1 from cell N-2
-                        val_im1 += -alpha / dx  # cell N-1 gains from cell N-2
-                    else:
-                        # Flow to left: mass leaves cell N-1 toward cell N-2
-                        diagonal += -alpha / dx  # cell N-1 loses (alpha < 0)
-                        val_im1 += alpha / dx  # (not relevant for conservation)
-
-                    row_indices.append(i)
-                    col_indices.append(i)
-                    data_values.append(diagonal)
-
-                    row_indices.append(i)
-                    col_indices.append(im1)
-                    data_values.append(val_im1)
-
-                else:
-                    # Interior point
-                    ip1 = i + 1
-                    im1 = i - 1
-
-                    # Diffusion
-                    diagonal += sigma**2 / dx**2
-
-                    # Advection (upwind)
-                    diagonal += coupling_coeff * (npart(u[ip1] - u[i]) + ppart(u[i] - u[im1])) / dx**2
-
-                    row_indices.append(i)
-                    col_indices.append(i)
-                    data_values.append(diagonal)
-
-                    # Off-diagonal: i-1
-                    val_im1 = -(sigma**2) / (2 * dx**2)
-                    val_im1 += -coupling_coeff * npart(u[i] - u[im1]) / dx**2
-                    row_indices.append(i)
-                    col_indices.append(im1)
-                    data_values.append(val_im1)
-
-                    # Off-diagonal: i+1
-                    val_ip1 = -(sigma**2) / (2 * dx**2)
-                    val_ip1 += -coupling_coeff * ppart(u[ip1] - u[i]) / dx**2
-                    row_indices.append(i)
-                    col_indices.append(ip1)
-                    data_values.append(val_ip1)
-
-        return sparse.coo_matrix((data_values, (row_indices, col_indices)), shape=(Nx, Nx)).tocsr()
-
-    def test_column_sums_periodic_zero_drift(self):
-        """Test column sums = 1/dt for periodic BC with zero drift."""
-        Nx = 21
-        dx = 1.0 / (Nx - 1)
-        dt = 0.01
-        sigma = 0.5
-        coupling_coeff = 1.0
-
-        # Zero drift (constant u)
-        u = np.zeros(Nx)
-
-        A = self._build_fp_matrix_1d(Nx, dx, dt, sigma, coupling_coeff, u, "periodic")
-
-        # Check column sums
-        col_sums = np.array(A.sum(axis=0)).flatten()
-        expected = 1.0 / dt
-
-        np.testing.assert_allclose(
-            col_sums,
-            expected,
-            rtol=1e-10,
-            err_msg=f"Column sums should be {expected}, got {col_sums}",
-        )
-
-    def test_column_sums_periodic_nonzero_drift(self):
-        """Test column sums = 1/dt for periodic BC with nonzero drift."""
-        Nx = 21
-        dx = 1.0 / (Nx - 1)
-        dt = 0.01
-        sigma = 0.5
-        coupling_coeff = 1.0
-
-        # Nonzero drift (linear u)
-        x = np.linspace(0, 1, Nx)
-        u = 0.5 * x
-
-        A = self._build_fp_matrix_1d(Nx, dx, dt, sigma, coupling_coeff, u, "periodic")
-
-        # Check column sums
-        col_sums = np.array(A.sum(axis=0)).flatten()
-        expected = 1.0 / dt
-
-        np.testing.assert_allclose(
-            col_sums,
-            expected,
-            rtol=1e-10,
-            err_msg="Column sums should be 1/dt for conservation",
-        )
-
-    def test_column_sums_no_flux_zero_drift(self):
-        """Test column sums = 1/dt for no-flux BC with zero drift."""
-        Nx = 21
-        dx = 1.0 / (Nx - 1)
-        dt = 0.01
-        sigma = 0.5
-        coupling_coeff = 1.0
-
-        # Zero drift
-        u = np.zeros(Nx)
-
-        A = self._build_fp_matrix_1d(Nx, dx, dt, sigma, coupling_coeff, u, "no_flux")
-
-        # Check column sums
-        col_sums = np.array(A.sum(axis=0)).flatten()
-        expected = 1.0 / dt
-
-        np.testing.assert_allclose(
-            col_sums,
-            expected,
-            rtol=1e-10,
-            err_msg="Column sums should be 1/dt for no-flux BC",
-        )
-
-    def test_column_sums_no_flux_nonzero_drift(self):
-        """Test column sums for no-flux BC with nonzero drift.
-
-        Note: With nonzero drift and upwind scheme, boundary cells may have
-        slightly different column sums due to one-sided stencils. This is
-        a known limitation of the upwind scheme at boundaries.
-
-        The key conservation property is that TOTAL mass is preserved,
-        which is verified in test_mass_conservation_via_matrix.
-        """
-        Nx = 21
-        dx = 1.0 / (Nx - 1)
-        dt = 0.01
-        sigma = 0.5
-        coupling_coeff = 1.0
-
-        # Nonzero drift (quadratic u -> nonzero velocity)
-        x = np.linspace(0, 1, Nx)
-        u = 0.5 * (x - 0.5) ** 2
-
-        A = self._build_fp_matrix_1d(Nx, dx, dt, sigma, coupling_coeff, u, "no_flux")
-
-        # Check column sums for interior points only (boundary handling varies)
-        col_sums = np.array(A.sum(axis=0)).flatten()
-        expected = 1.0 / dt
-
-        # Interior columns should have exact conservation
-        np.testing.assert_allclose(
-            col_sums[2:-2],  # Exclude boundary-adjacent cells
-            expected,
-            rtol=1e-10,
-            err_msg="Interior column sums should be 1/dt",
-        )
-
-        # Boundary columns should be close but may have small deviations
-        # due to one-sided stencils
-        np.testing.assert_allclose(
-            col_sums[[0, -1]],
-            expected,
-            rtol=0.15,
-            err_msg="Boundary column sums should be approximately 1/dt",
-        )
-
-    def test_mass_conservation_via_matrix(self):
-        """Test that matrix multiplication preserves total mass."""
-        Nx = 21
-        dx = 1.0 / (Nx - 1)
-        dt = 0.01
-        sigma = 0.5
-        coupling_coeff = 1.0
-
-        # Initial density (normalized)
-        x = np.linspace(0, 1, Nx)
-        m0 = np.exp(-((x - 0.5) ** 2) / 0.1)
-        m0 = m0 / (np.sum(m0) * dx)  # Normalize
-
-        # Zero drift
-        u = np.zeros(Nx)
-
-        A = self._build_fp_matrix_1d(Nx, dx, dt, sigma, coupling_coeff, u, "periodic")
-
-        # RHS for implicit scheme
-        b = m0 / dt
-
-        # Solve A * m1 = b
-        m1 = sparse.linalg.spsolve(A, b)
-
-        # Check mass conservation
-        mass0 = np.sum(m0) * dx
-        mass1 = np.sum(m1) * dx
-
-        np.testing.assert_allclose(
-            mass1,
-            mass0,
-            rtol=1e-10,
-            err_msg="Mass should be conserved",
-        )
-
-    def test_positivity_preservation(self):
-        """Test that positive initial data stays positive (M-matrix property)."""
-        Nx = 21
-        dx = 1.0 / (Nx - 1)
-        dt = 0.001  # Small timestep for M-matrix property
-        sigma = 0.5
-        coupling_coeff = 1.0
-
-        # Positive initial density
-        x = np.linspace(0, 1, Nx)
-        m0 = np.exp(-((x - 0.5) ** 2) / 0.1)
-        m0 = m0 / (np.sum(m0) * dx)
-
-        # Zero drift
-        u = np.zeros(Nx)
-
-        A = self._build_fp_matrix_1d(Nx, dx, dt, sigma, coupling_coeff, u, "periodic")
-
-        # Multiple timesteps
-        m = m0.copy()
-        for _ in range(10):
-            b = m / dt
-            m = sparse.linalg.spsolve(A, b)
-
-        # Check positivity
-        assert np.all(m >= -1e-10), "Solution should remain non-negative"
-
-
-class TestFPMatrixDivergenceSchemes:
-    """Test matrix properties for divergence-form schemes."""
-
-    def test_divergence_upwind_telescoping(self):
-        """Test that divergence_upwind has telescoping flux property."""
-        # The divergence form ensures:
-        # sum_j (F_{j+1/2} - F_{j-1/2}) = F_{N+1/2} - F_{1/2} = 0 (for no-flux BC)
-        # This is a different conservation mechanism than column sums
-        # Placeholder for future implementation
+from mfgarchon.geometry.boundary import no_flux_bc, periodic_bc
+
+
+def _zero_drift_density_evolution(bc, n=41, nt=40, T=0.2, sigma=0.5):
+    """Evolve m = 1 + 0.4 cos(2 pi x) under the production FP implicit step, zero drift.
+
+    Zero drift isolates pure diffusion, where every conservative scheme must preserve
+    total mass exactly (no advective boundary subtlety). Returns the full M history.
+    """
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=bc)
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: 0.0 * np.asarray(m),
+        coupling_dm=lambda m: 0.0 * np.asarray(m),
+    )
+    x = np.linspace(0.0, 1.0, n)
+    comps = MFGComponents(
+        m_initial=lambda xx: 1.0 + 0.4 * np.cos(2 * np.pi * np.asarray(xx)),
+        u_terminal=lambda xx: 0.0 * np.asarray(xx),
+        hamiltonian=H,
+    )
+    prob = MFGProblem(geometry=grid, T=T, Nt=nt, sigma=sigma, components=comps)
+    solver = FPFDMSolver(prob)
+    m0 = 1.0 + 0.4 * np.cos(2 * np.pi * x)
+    # drift_field as an (nt+1, n) array routes through the implicit per-point assembly
+    M = solver.solve_fp_system(m0.copy(), drift_field=np.zeros((nt + 1, n)), volatility_field=sigma)
+    return M, 1.0 / (n - 1)
+
+
+class TestFPProductionConservation:
+    """Mass + positivity of the real FPFDMSolver implicit step (not a shadow matrix)."""
+
+    def test_mass_conserved_periodic_zero_drift(self):
+        M, dx = _zero_drift_density_evolution(periodic_bc(dimension=1))
+        mass = M.sum(axis=1) * dx
+        relerr = abs(mass[-1] - mass[0]) / mass[0]
+        assert relerr < 1e-12, f"periodic zero-drift mass not conserved: relerr {relerr:.2e}"
+
+    def test_mass_conserved_no_flux_zero_drift(self):
+        M, dx = _zero_drift_density_evolution(no_flux_bc(dimension=1))
+        mass = M.sum(axis=1) * dx
+        relerr = abs(mass[-1] - mass[0]) / mass[0]
+        assert relerr < 1e-12, f"no-flux zero-drift mass not conserved: relerr {relerr:.2e}"
+
+    def test_density_stays_positive(self):
+        # an M-matrix implicit step keeps a positive initial density positive
+        M, _ = _zero_drift_density_evolution(periodic_bc(dimension=1))
+        assert np.all(M[-1] > -1e-12), "production FP step produced a negative density"
 
 
 class TestLinearConstraintMatrixAssembly:

--- a/tests/unit/test_alg/test_hjb_gfdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_solver.py
@@ -131,6 +131,61 @@ class TestHJBGFDMSolverInitialization:
             if application is not None:
                 assert solver.monotonicity_application == application
 
+    @pytest.mark.slow
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+    def test_qp_optimization_levels_agree_on_smooth_problem(self):
+        """Behavioral guard: the monotonicity levels must actually SOLVE consistently.
+
+        The sibling ``test_qp_optimization_levels`` only checks constructor labels --
+        it would pass even if a QP level corrupted the solution. On a smooth problem
+        whose unconstrained solution is already monotone, the QP M-matrix enforcement
+        must not change the answer, so all three levels must converge to the same field.
+        Measured agreement vs ``none``: adaptive ~1e-6, always ~7e-6 (threshold 1e-4).
+
+        (filterwarnings: the ``always`` config solves a QP per point per iteration; its
+        scipy backend emits a ``polish``/``raise_error`` deprecation per solve -- library
+        noise, not a solver issue, suppressed so it does not flood the log.)
+        """
+        n = 15
+        grid = TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1)
+        )
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: 0.0 * np.asarray(m),
+            coupling_dm=lambda m: 0.0 * np.asarray(m),
+        )
+        x = np.linspace(0.0, 1.0, n)
+        comps = MFGComponents(
+            m_initial=lambda xx: np.ones_like(np.asarray(xx, dtype=float)),
+            u_terminal=lambda xx: np.cos(np.pi * np.asarray(xx, dtype=float)),
+            hamiltonian=H,
+        )
+        problem = MFGProblem(geometry=grid, T=0.05, Nt=10, sigma=0.5, components=comps)
+        cp = x.reshape(-1, 1)
+        M_density = np.ones((problem.Nt + 1, n))
+        U_terminal = np.cos(np.pi * x)
+
+        configs = [("none", None), ("qp_m_matrix", "adaptive"), ("qp_m_matrix", "always")]
+        sols = {}
+        for scheme, application in configs:
+            solver = HJBGFDMSolver(
+                problem, cp, delta=0.3,
+                monotonicity_scheme=scheme, monotonicity_application=application,
+            )
+            U = solver.solve_hjb_system(M_density=M_density, U_terminal=U_terminal, show_progress=False)
+            assert np.all(np.isfinite(U)), f"{scheme}/{application} produced non-finite U"
+            sols[(scheme, application)] = U
+
+        base = sols[("none", None)]
+        for key, U in sols.items():
+            relerr = float(np.linalg.norm(U - base) / np.linalg.norm(base))
+            assert relerr < 1e-4, (
+                f"QP level {key} disagrees with 'none' by {relerr:.2e} (>1e-4): "
+                "monotonicity enforcement corrupted the smooth solution"
+            )
+
 
 class TestHJBGFDMSolverNeighborhoods:
     """Test neighborhood structure building."""


### PR DESCRIPTION
## Summary

Retrospect **recommendation ③**: two tests asserted *structure* (labels / a re-implemented matrix) rather than *behavior*, so they'd pass even while production was wrong — false confidence. Both now run real solvers and compare.

## 1. `test_qp_optimization_levels` — labels → behavior

The existing test only asserted constructor labels (`solver.hjb_method_name == "GFDM-QP"`); it never solved, so a QP monotonicity level that corrupted the result would still pass. Kept as-is (labels are a valid fast check) and **added** `test_qp_optimization_levels_agree_on_smooth_problem`:

- solves at all three levels (`none`, `qp_m_matrix`+`adaptive`, `qp_m_matrix`+`always`) on a smooth problem whose unconstrained solution is already monotone
- asserts all finite **and** agreement with `none` to **<1e-4** — measured: adaptive ~1e-6, always ~7e-6
- the guard: QP M-matrix enforcement must not change the answer when it isn't needed; if it did, `always` would diverge from `none`
- `slow`/`tier3`, ~56 s. `filterwarnings` suppresses the per-QP-solve scipy `polish`/`raise_error` deprecation (library noise — the `always` config solves a QP per point per iteration; surfaced separately)

## 2. `test_fp_matrix_conservation` — shadow → production

`TestFPMatrixConservation` asserted column-sum=1/dt on a **test-local re-implementation** of the FP matrix (`_build_fp_matrix_1d`, whose own docstring said *"replicates the matrix construction from FPFDMSolver"*) — a shadow that passes even if the production assembly diverges. Replaced by `TestFPProductionConservation`:

- runs the real `FPFDMSolver` implicit step (zero drift, periodic + no-flux)
- asserts **machine-precision (<1e-12)** mass conservation + positivity — measured ~1e-14
- this is the tight algebraic-conservation signal a wrong boundary stencil (the retrospect's *non-conservation-at-boundary* bug class) would break, and that the loose `rtol=0.1` end-to-end tests in `test_fp_fdm_solver.py` miss

Also removed the no-op `TestFPMatrixDivergenceSchemes` placeholder (empty body, always passed). Kept `TestLinearConstraintMatrixAssembly` unchanged — it already points at production (`_build_diffusion_matrix_with_bc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)