### PR TITLE
fix(core): Legendre dual returns sup under MAXIMIZE (#1185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`DualHamiltonian`/`DualLagrangian` Legendre transform now returns the supremum under
+  `OptimizationSense.MAXIMIZE`** (Issue #1185). The 1-D `__call__` flipped to the *infimum*
+  for MAXIMIZE (the value at a control bound), disagreeing with its own `dp` argmax and the
+  d>1 scipy branch — e.g. `L=½·2·α²`, `p=1` returned `-110.0` instead of the correct
+  `sup_α{p·α−L}=0.25`. The convex conjugate is a supremum by definition, independent of
+  optimization sense; the 1-D branch now always takes the `sup` (matching the d>1 branch).
+  Reachable via a non-separable `LagrangianBase` with `sense=MAXIMIZE` passed to
+  `MFGComponents(lagrangian=...)`.
 - **Callable/tensor explicit-drift FP advection now honors the domain boundary conditions**
   (Issue #1181). `solve_timestep_explicit_with_drift` and `solve_timestep_tensor_explicit`
   called `compute_advection_from_drift_nd` without `bc=`, so on a no-flux domain the

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -1714,10 +1714,10 @@ class DualHamiltonian(HamiltonianBase):
                 [float(p_flat[0]) * a - float(self.lagrangian(x, np.array([a]), m, t)) for a in alpha_grid]
             )
 
-            if self.sense == OptimizationSense.MINIMIZE:
-                return float(np.max(values))  # sup for minimization
-            else:
-                return float(np.min(values))  # inf for maximization
+            # H is the convex conjugate L*(p) = sup_alpha { p.alpha - L(alpha) },
+            # independent of OptimizationSense (matches the d>1 branch below, the
+            # always-sup ControlCostBase.evaluate, and dp's argmax). Issue #1185.
+            return float(np.max(values))
 
         # For higher dimensions, use scipy if available
         try:
@@ -1872,10 +1872,10 @@ class DualLagrangian(LagrangianBase):
                 [float(p) * float(alpha_flat[0]) - float(self.hamiltonian(x, m, np.array([p]), t)) for p in p_grid]
             )
 
-            if self.sense == OptimizationSense.MINIMIZE:
-                return float(np.max(values))
-            else:
-                return float(np.min(values))
+            # L is the convex conjugate H*(alpha) = sup_p { p.alpha - H(p) },
+            # independent of OptimizationSense (matches the d>1 branch below and
+            # d_alpha's argmax). Issue #1185.
+            return float(np.max(values))
 
         # For higher dimensions, use scipy if available
         try:

--- a/tests/unit/test_core/test_hamiltonian_classes.py
+++ b/tests/unit/test_core/test_hamiltonian_classes.py
@@ -274,6 +274,48 @@ class TestLegendreDuality:
         # Should recover original within numerical tolerance
         assert abs(L_recovered_val - L_orig_val) < 0.2
 
+    def test_dual_hamiltonian_maximize_returns_sup_not_inf(self):
+        """Issue #1185: the Legendre conjugate H = L*(p) = sup_a {p.a - L(a)} is a
+        supremum by definition, independent of OptimizationSense. Pre-fix the 1D
+        ``DualHamiltonian.__call__`` returned the *infimum* under MAXIMIZE (the value at
+        a control bound), disagreeing with its own ``dp`` argmax and the d>1 scipy branch.
+        """
+
+        class _QuadL(LagrangianBase):
+            def __init__(self, lam, sense):
+                super().__init__(sense=sense)
+                self.lam = lam
+
+            def __call__(self, x, alpha, m, t=0.0):
+                return 0.5 * self.lam * np.sum(np.atleast_1d(alpha) ** 2)
+
+        x, m, p, t = np.array([0.5]), 0.3, np.array([1.0]), 0.0
+        H_min = _QuadL(2.0, OptimizationSense.MINIMIZE).legendre_transform()
+        H_max = _QuadL(2.0, OptimizationSense.MAXIMIZE).legendre_transform()
+
+        # H = sup_a {p a - 0.5 lam a^2} = p^2/(2 lam) = 0.25 (lam=2, p=1); NOT the
+        # bound infimum -110 the pre-fix MAXIMIZE branch returned.
+        assert abs(H_max(x, m, p, t) - 0.25) < 0.05
+        # sense must not change the conjugate value
+        assert abs(H_max(x, m, p, t) - H_min(x, m, p, t)) < 1e-9
+        # 1D must agree with the d>1 branch under MAXIMIZE: H([1,1]) = |p|^2/(2 lam) = 0.5
+        assert abs(H_max(x, m, np.array([1.0, 1.0]), t) - 0.5) < 0.05
+        # envelope consistency: H(p) == p.alpha* - L(alpha*), alpha* = dp
+        a = float(H_max.dp(x, m, p, t)[0])
+        assert abs(H_max(x, m, p, t) - (1.0 * a - 0.5 * 2.0 * a**2)) < 1e-2
+
+    def test_dual_lagrangian_maximize_returns_sup_not_inf(self):
+        """Issue #1185: the symmetric DualLagrangian L = H*(a) = sup_p {p.a - H(p)} must
+        also be the supremum under MAXIMIZE (not the infimum)."""
+        x, alpha, m, t = np.array([0.5]), np.array([1.0]), 0.3, 0.0
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=2.0),
+            sense=OptimizationSense.MAXIMIZE,
+        )
+        L = H.legendre_transform()  # DualLagrangian(sense=MAXIMIZE)
+        # L = H*(alpha) = 0.5 lam alpha^2 = 1.0 at lam=2, alpha=1
+        assert abs(L(x, alpha, m, t) - 1.0) < 0.1
+
 
 class TestQuadraticMFGHamiltonian:
     """Tests for QuadraticMFGHamiltonian."""


### PR DESCRIPTION
## Bug (audit-found, adversarially verified + independently reproduced)

`DualHamiltonian.__call__` (`hamiltonian.py:1717`) and the symmetric `DualLagrangian.__call__` (`:1875`) compute the Legendre transform over the control, but the 1-D branch returned the **infimum** under `OptimizationSense.MAXIMIZE` — the value at a control bound, not the required supremum.

Reproduced (verifier, independently): `L=½·λ·α²` (λ=2), `p=1` → correct `H = sup_α{p·α − L} = p²/2λ = 0.25`; pre-fix MAXIMIZE returned **−110.0** (the infimum at the bound α=−10), a ~440× internal self-contradiction with the same object's `dp` (which gives α*=0.505, envelope value 0.24997).

## Fix

The convex conjugate is a supremum **by definition**, independent of optimization sense. The 1-D branch now always takes `np.max(values)` — aligning it with the always-sup d>1 scipy branch, `ControlCostBase.evaluate`, and `dp`'s argmax. Byte-identical for MINIMIZE (already `max`); fixes MAXIMIZE.

## Tests

Added `test_dual_hamiltonian_maximize_returns_sup_not_inf` + `test_dual_lagrangian_maximize_returns_sup_not_inf` (envelope-consistency + 1D-vs-dD agreement + sense-invariance). **Pass with the fix, fail without it** (verified by reverting).

`Closes #1185`

🤖 Generated with [Claude Code](https://claude.com/claude-code)