### PR TITLE
fix(operators): backend-aware roll so torch stencils work (#1194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Roll-based finite-difference stencils now work on the torch backend** (Issue #1194).
+  `finite_difference.py` and `tensor_calculus.py` called `xp.roll(u, k, axis=...)`, but
+  `torch.roll` uses `dims=` not `axis=`, so every roll-based stencil (gradient/laplacian/
+  divergence/hessian) raised `TypeError` on the torch backend (e.g.
+  `test_particle_gpu_pipeline::test_boundary_conditions_gpu`). Added a backend-aware `_roll`
+  shim (`dims=` for torch, `axis=` for numpy/cupy); the numpy/cupy path is byte-identical.
 - **`DualHamiltonian`/`DualLagrangian` Legendre transform now returns the supremum under
   `OptimizationSense.MAXIMIZE`** (Issue #1185). The 1-D `__call__` flipped to the *infimum*
   for MAXIMIZE (the value at a control bound), disagreeing with its own `dp` argmax and the

--- a/mfgarchon/operators/stencils/finite_difference.py
+++ b/mfgarchon/operators/stencils/finite_difference.py
@@ -50,6 +50,18 @@ if TYPE_CHECKING:
     from mfgarchon.geometry.boundary import BoundaryConditions
 
 
+def _roll(xp: type, u: NDArray, shift: int, axis: int) -> NDArray:
+    """Backend-aware periodic shift.
+
+    ``numpy``/``cupy`` use the ``axis=`` keyword; ``torch.roll`` uses ``dims=``.
+    Detecting the module by name keeps the numpy/cupy path byte-identical
+    while routing torch tensors to the correct keyword (Issue #1194).
+    """
+    if xp.__name__ == "torch":
+        return xp.roll(u, shift, dims=axis)
+    return xp.roll(u, shift, axis=axis)
+
+
 # =============================================================================
 # First-Order Derivative Stencils
 # =============================================================================
@@ -80,7 +92,7 @@ def gradient_central(u: NDArray, axis: int, h: float, xp: type = np) -> NDArray:
         Uses periodic wrapping via np.roll. For non-periodic boundaries,
         use fix_boundaries_one_sided() or the LinearOperator classes.
     """
-    return (xp.roll(u, -1, axis=axis) - xp.roll(u, 1, axis=axis)) / (2 * h)
+    return (_roll(xp, u, -1, axis) - _roll(xp, u, 1, axis)) / (2 * h)
 
 
 def gradient_forward(u: NDArray, axis: int, h: float, xp: type = np) -> NDArray:
@@ -104,7 +116,7 @@ def gradient_forward(u: NDArray, axis: int, h: float, xp: type = np) -> NDArray:
     Returns:
         Approximation of ∂u/∂x with same shape as u
     """
-    return (xp.roll(u, -1, axis=axis) - u) / h
+    return (_roll(xp, u, -1, axis) - u) / h
 
 
 def gradient_backward(u: NDArray, axis: int, h: float, xp: type = np) -> NDArray:
@@ -128,7 +140,7 @@ def gradient_backward(u: NDArray, axis: int, h: float, xp: type = np) -> NDArray
     Returns:
         Approximation of ∂u/∂x with same shape as u
     """
-    return (u - xp.roll(u, 1, axis=axis)) / h
+    return (u - _roll(xp, u, 1, axis)) / h
 
 
 def gradient_upwind(u: NDArray, axis: int, h: float, xp: type = np) -> NDArray:
@@ -263,7 +275,7 @@ def laplacian_stencil_nd(u: NDArray, spacings: list[float] | tuple[float, ...], 
     """
     result = xp.zeros_like(u)
     for axis, h in enumerate(spacings):
-        result += (xp.roll(u, -1, axis=axis) - 2 * u + xp.roll(u, 1, axis=axis)) / (h * h)
+        result += (_roll(xp, u, -1, axis) - 2 * u + _roll(xp, u, 1, axis)) / (h * h)
     return result
 
 
@@ -292,7 +304,7 @@ def weighted_laplacian_stencil_nd(
     """
     result = xp.zeros_like(u)
     for axis, (h, w) in enumerate(zip(spacings, axis_weights, strict=True)):
-        result += w * (xp.roll(u, -1, axis=axis) - 2 * u + xp.roll(u, 1, axis=axis)) / (h * h)
+        result += w * (_roll(xp, u, -1, axis) - 2 * u + _roll(xp, u, 1, axis)) / (h * h)
     return result
 
 

--- a/mfgarchon/utils/numerical/tensor_calculus.py
+++ b/mfgarchon/utils/numerical/tensor_calculus.py
@@ -70,6 +70,18 @@ AdvectionScheme = Literal["gradient", "divergence"]
 AdvectionMethod = Literal["centered", "upwind"]
 
 
+def _roll(xp: type, u: NDArray, shift: int, axis: int) -> NDArray:
+    """Backend-aware periodic shift.
+
+    ``numpy``/``cupy`` use the ``axis=`` keyword; ``torch.roll`` uses ``dims=``.
+    Detecting the module by name keeps the numpy/cupy path byte-identical
+    while routing torch tensors to the correct keyword (Issue #1194).
+    """
+    if xp.__name__ == "torch":
+        return xp.roll(u, shift, dims=axis)
+    return xp.roll(u, shift, axis=axis)
+
+
 # =============================================================================
 # First-Order Operators: Gradient
 # =============================================================================
@@ -257,7 +269,7 @@ def divergence(
             F_d_work = F_d
 
         # Central difference for divergence: ∂F_d/∂x_d
-        dF_d = (xp.roll(F_d_work, -1, axis=d) - xp.roll(F_d_work, 1, axis=d)) / (2 * h)
+        dF_d = (_roll(xp, F_d_work, -1, d) - _roll(xp, F_d_work, 1, d)) / (2 * h)
 
         # Extract interior if ghost cells were added
         if bc is not None:
@@ -323,7 +335,7 @@ def laplacian(
     for d in range(u.ndim):
         h = spacings[d]
         if h > 1e-14:
-            lap += (xp.roll(u_work, -1, axis=d) - 2 * u_work + xp.roll(u_work, 1, axis=d)) / (h * h)
+            lap += (_roll(xp, u_work, -1, d) - 2 * u_work + _roll(xp, u_work, 1, d)) / (h * h)
 
     # Extract interior if ghost cells were added
     if bc is not None:
@@ -398,15 +410,15 @@ def hessian(
 
             if i == j:
                 # Diagonal: ∂²u/∂xᵢ²
-                d2u = (xp.roll(u_work, -1, axis=i) - 2 * u_work + xp.roll(u_work, 1, axis=i)) / (hi * hi)
+                d2u = (_roll(xp, u_work, -1, i) - 2 * u_work + _roll(xp, u_work, 1, i)) / (hi * hi)
             else:
                 # Off-diagonal: ∂²u/∂xᵢ∂xⱼ (mixed derivative)
                 # Use central differences in both directions
                 d2u = (
-                    xp.roll(xp.roll(u_work, -1, axis=i), -1, axis=j)
-                    - xp.roll(xp.roll(u_work, -1, axis=i), 1, axis=j)
-                    - xp.roll(xp.roll(u_work, 1, axis=i), -1, axis=j)
-                    + xp.roll(xp.roll(u_work, 1, axis=i), 1, axis=j)
+                    _roll(xp, _roll(xp, u_work, -1, i), -1, j)
+                    - _roll(xp, _roll(xp, u_work, -1, i), 1, j)
+                    - _roll(xp, _roll(xp, u_work, 1, i), -1, j)
+                    + _roll(xp, _roll(xp, u_work, 1, i), 1, j)
                 ) / (4 * hi * hj)
 
             # Extract interior if ghost cells were added
@@ -667,17 +679,17 @@ def advection(
 
 def _gradient_central(u: NDArray, axis: int, h: float, xp: type) -> NDArray:
     """Central difference: (u[i+1] - u[i-1]) / (2h)."""
-    return (xp.roll(u, -1, axis=axis) - xp.roll(u, 1, axis=axis)) / (2 * h)
+    return (_roll(xp, u, -1, axis) - _roll(xp, u, 1, axis)) / (2 * h)
 
 
 def _gradient_forward(u: NDArray, axis: int, h: float, xp: type) -> NDArray:
     """Forward difference: (u[i+1] - u[i]) / h."""
-    return (xp.roll(u, -1, axis=axis) - u) / h
+    return (_roll(xp, u, -1, axis) - u) / h
 
 
 def _gradient_backward(u: NDArray, axis: int, h: float, xp: type) -> NDArray:
     """Backward difference: (u[i] - u[i-1]) / h."""
-    return (u - xp.roll(u, 1, axis=axis)) / h
+    return (u - _roll(xp, u, 1, axis)) / h
 
 
 def _gradient_upwind(u: NDArray, axis: int, h: float, xp: type) -> NDArray:
@@ -752,17 +764,17 @@ def _divergence_upwind(
             v_d_work = v_d
 
         # Upwind flux at faces
-        F_forward = xp.roll(F_d, -1, axis=d)
+        F_forward = _roll(xp, F_d, -1, d)
         F_backward = F_d
 
         # Face velocity (average)
-        v_face = 0.5 * (v_d_work + xp.roll(v_d_work, -1, axis=d))
+        v_face = 0.5 * (v_d_work + _roll(xp, v_d_work, -1, d))
 
         # Select upwind flux
         F_face_right = xp.where(v_face >= 0, F_backward, F_forward)
 
-        F_backward_left = xp.roll(F_d, 1, axis=d)
-        v_face_left = 0.5 * (xp.roll(v_d_work, 1, axis=d) + v_d_work)
+        F_backward_left = _roll(xp, F_d, 1, d)
+        v_face_left = 0.5 * (_roll(xp, v_d_work, 1, d) + v_d_work)
         F_face_left = xp.where(v_face_left >= 0, F_backward_left, F_d)
 
         # Divergence

--- a/tests/unit/test_operators/test_stencils.py
+++ b/tests/unit/test_operators/test_stencils.py
@@ -392,5 +392,39 @@ class TestLaplacianWithBC:
         np.testing.assert_allclose(Lu_bc, Lu_stencil, atol=1e-14)
 
 
+class TestBackendRollEquivalence:
+    """Issue #1194: roll-based stencils must work on the torch backend (torch.roll
+    takes dims=, not numpy's axis=) and match the numpy result exactly. Pre-fix the
+    torch path raised TypeError; the numpy path is unchanged (byte-identical)."""
+
+    def test_stencils_torch_backend_match_numpy(self):
+        torch = pytest.importorskip("torch")  # noqa: F841
+        from mfgarchon.backends.torch_backend import TorchBackend
+        from mfgarchon.utils.numerical.tensor_calculus import divergence, hessian, laplacian
+
+        rng = np.random.RandomState(0)
+        a = rng.rand(6, 5)
+        sp = [0.2, 0.3]
+        be = TorchBackend(device="cpu")
+        t = be.array_module.tensor(a, dtype=be.array_module.float64)
+
+        # tensor_calculus operators (backend=) -- pre-fix raised TypeError on roll(axis=)
+        assert np.allclose(laplacian(t, sp, backend=be).numpy(), laplacian(a, sp))
+        assert np.allclose(
+            divergence([t, t * 2], sp, backend=be).numpy(), divergence([a, a * 2], sp)
+        )
+        assert np.allclose(hessian(t, sp, backend=be).numpy(), hessian(a, sp))
+
+        # stencil module (xp = torch module directly), the path the GPU particle solver hits
+        g_t = gradient_central(t, axis=1, h=0.1, xp=be.array_module)
+        assert np.allclose(g_t.numpy(), gradient_central(a, axis=1, h=0.1, xp=np))
+        assert all(
+            np.allclose(x.numpy(), y)
+            for x, y in zip(
+                gradient_nd(t, sp, xp=be.array_module), gradient_nd(a, sp, xp=np), strict=True
+            )
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Bug (audit-found, adversarially verified + independently reproduced)

`finite_difference.py` (gradient/laplacian stencils) and `tensor_calculus.py` (gradient/divergence/laplacian/hessian/upwind) call `xp.roll(u, k, axis=...)`. numpy's `roll` takes `axis=`, but **`torch.roll` takes `dim=`/`dims=`** — so on the torch backend every roll-based stencil raises `TypeError: roll() got an unexpected keyword argument 'axis'`. Reproduced (torch 2.10.0) via `test_particle_gpu_pipeline::test_boundary_conditions_gpu`.

## Fix

A small backend-aware `_roll(xp, u, shift, axis)` shim: `torch.roll(..., dims=axis)` for torch, `xp.roll(..., axis=axis)` for numpy/cupy (detected by module name). All `xp.roll(..., axis=)` call sites route through it. The numpy/cupy path is **byte-identical** (40 stencil/tensor tests + 222 gradient/laplacian/divergence tests unchanged).

## Test

`TestBackendRollEquivalence` asserts torch results equal numpy for laplacian/divergence/hessian/gradient_central/gradient_nd. **Passes with the fix, `TypeError`s without it** (verified by reverting). `pytest.importorskip("torch")` so it skips where torch is absent.

`Closes #1194`

🤖 Generated with [Claude Code](https://claude.com/claude-code)