### PR TITLE
fix(perf): use OSQP 1.0 polishing=/raise_error= kwargs (#1196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   divergence/hessian) raised `TypeError` on the torch backend (e.g.
   `test_particle_gpu_pipeline::test_boundary_conditions_gpu`). Added a backend-aware `_roll`
   shim (`dims=` for torch, `axis=` for numpy/cupy); the numpy/cupy path is byte-identical.
+- **GFDM QP monotonicity path no longer emits deprecated OSQP kwargs** (Issue #1196). The
+  `qp_m_matrix` schemes solve an OSQP problem per collocation point per Newton iteration via
+  `polish=False` + bare `prob.solve()`; OSQP 1.0 renamed `polish`→`polishing` and warns
+  `raise_error`-default-change on every solve (tens of thousands per run, log-flooding, and a
+  latent break when `polish` is removed). Switched to `polishing=False` + explicit
+  `raise_error=False` (byte-identical: same fail-soft fallback on non-`solved` status); bumped
+  the floor to `osqp>=1.0`.
 - **`DualHamiltonian`/`DualLagrangian` Legendre transform now returns the supremum under
   `OptimizationSense.MAXIMIZE`** (Issue #1185). The 1-D `__call__` flipped to the *infimum*
   for MAXIMIZE (the value at a control bound), disagreeing with its own `dp` argmax and the

--- a/mfgarchon/utils/numerical/qp_utils.py
+++ b/mfgarchon/utils/numerical/qp_utils.py
@@ -468,7 +468,7 @@ class QPSolver:
             eps_abs=1e-6,
             eps_rel=1e-6,
             max_iter=10000,
-            polish=False,
+            polishing=False,  # OSQP 1.0+ name; "polish" deprecated (warns per QP solve)
         )
 
         # Apply warm-start if available
@@ -482,8 +482,9 @@ class QPSolver:
         else:
             self.stats["cold_starts"] += 1
 
-        # Solve
-        result = prob.solve()
+        # Solve. raise_error=False is the current default but explicit here to silence the
+        # OSQP 1.x PendingDeprecationWarning; failures are handled below via the status check.
+        result = prob.solve(raise_error=False)
 
         if result.info.status == "solved":
             self.stats["successes"] += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "meshio>=5.3",             # Mesh I/O (Gmsh, VTK)
 
     # GFDM monotone stencils (used by HJBGFDMSolver)
-    "osqp>=0.6",               # QP solver for monotonicity enforcement
+    "osqp>=1.0",               # QP solver for monotonicity enforcement (1.0+: polishing=/raise_error= kwargs)
 
     # Network MFG (used by NetworkGeometry)
     "igraph>=0.10.0",          # Graph backend (C-based, fast)

--- a/tests/unit/test_alg/test_hjb_gfdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_solver.py
@@ -143,9 +143,10 @@ class TestHJBGFDMSolverInitialization:
         must not change the answer, so all three levels must converge to the same field.
         Measured agreement vs ``none``: adaptive ~1e-6, always ~7e-6 (threshold 1e-4).
 
-        (filterwarnings: the ``always`` config solves a QP per point per iteration; its
-        scipy backend emits a ``polish``/``raise_error`` deprecation per solve -- library
-        noise, not a solver issue, suppressed so it does not flood the log.)
+        (filterwarnings: defensive — the ``always`` config solves a QP per point per
+        iteration; its OSQP backend previously emitted a ``polish``/``raise_error``
+        deprecation per solve, fixed in #1196. Kept to absorb any other per-solve library
+        noise so it cannot flood the log.)
         """
         n = 15
         grid = TensorProductGrid(
@@ -185,6 +186,48 @@ class TestHJBGFDMSolverInitialization:
                 f"QP level {key} disagrees with 'none' by {relerr:.2e} (>1e-4): "
                 "monotonicity enforcement corrupted the smooth solution"
             )
+
+    @pytest.mark.slow
+    def test_qp_osqp_emits_no_polish_deprecation(self):
+        """Issue #1196: the qp_m_matrix OSQP path solves a QP per point per Newton
+        iteration; the deprecated ``polish=`` kwarg (and implicit ``raise_error``) warned
+        on every solve -- flooding logs and a latent break when OSQP removes ``polish``.
+        This must NOT be suppressed by filterwarnings (it captures and inspects), so it
+        regresses loudly if the deprecated kwargs return.
+        """
+        import warnings
+
+        n = 11
+        grid = TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1)
+        )
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: 0.0 * np.asarray(m),
+            coupling_dm=lambda m: 0.0 * np.asarray(m),
+        )
+        x = np.linspace(0.0, 1.0, n)
+        comps = MFGComponents(
+            m_initial=lambda xx: np.ones_like(np.asarray(xx, dtype=float)),
+            u_terminal=lambda xx: np.cos(np.pi * np.asarray(xx, dtype=float)),
+            hamiltonian=H,
+        )
+        problem = MFGProblem(geometry=grid, T=0.02, Nt=4, sigma=0.5, components=comps)
+        solver = HJBGFDMSolver(
+            problem, x.reshape(-1, 1), delta=0.3,
+            monotonicity_scheme="qp_m_matrix", monotonicity_application="always",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            solver.solve_hjb_system(
+                M_density=np.ones((problem.Nt + 1, n)),
+                U_terminal=np.cos(np.pi * x), show_progress=False,
+            )
+        offenders = [
+            str(w.message) for w in caught
+            if "polish" in str(w.message).lower() or "raise_error" in str(w.message).lower()
+        ]
+        assert not offenders, f"OSQP polish/raise_error deprecation leaked: {offenders[:3]}"
 
 
 class TestHJBGFDMSolverNeighborhoods:


### PR DESCRIPTION
## Bug (surfaced + independently reproduced)

The GFDM `qp_m_matrix` monotonicity path (`qp_utils.py`) solves an OSQP problem **per collocation point per Newton iteration** via `polish=False` + bare `prob.solve()`. OSQP 1.0 renamed `polish`→`polishing` and warns about the `raise_error` default change on **every solve** — 66,600 `DeprecationWarning`/`PendingDeprecationWarning` on a 15-point smoke problem. Two harms: log-flooding (the #1195 QP test had to `filterwarnings` around it), and `polish=` is a **latent hard break** when OSQP removes the alias.

## Fix

`polish=False`→`polishing=False`, `prob.solve()`→`prob.solve(raise_error=False)`. **Byte-identical**: `polishing=False == polish=False`, and `raise_error=False` is the current default — the existing fail-soft fallback (`status != "solved"` → return `x0`) is unchanged. Bumped `osqp>=0.6`→`osqp>=1.0` (the new kwargs are 1.0+; 1.1.1 installed). Corrected the #1195 test docstring (it's OSQP, not scipy).

## Test

`test_qp_osqp_emits_no_polish_deprecation` runs the `qp_m_matrix`/`always` path under `warnings.catch_warnings` (no suppression) and asserts no `polish`/`raise_error` warning. **Passes with the fix; fails without it** (verified by reverting → `'polish' is deprecated` + `raise_error will change` leak). `slow` (full GFDM solve).

`Closes #1196`

🤖 Generated with [Claude Code](https://claude.com/claude-code)