### PR TITLE
fix(operators): column-conservative no-flux Laplacian for the FP diffusion solve (#1184 diffusion half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Conservative no-flux Laplacian for the implicit FP diffusion solve** (Issue #1184, diffusion
+  half). `LaplacianOperator.as_scipy_sparse()` no-flux branch had zero *row* sums (2nd-order
+  Neumann accuracy) but nonzero *column* sums at the walls (`≈1/h²`); the implicit FP system
+  `(I/dt − D·L)` conserves mass iff `1ᵀL = 0`, so it leaked at no-flux walls (a wall-touching
+  density lost ~0.84% per solve even at zero drift). Added `LaplacianOperator(mass_conservative=…)`
+  (default `False` keeps the byte-identical 2nd-order stencil for HJB/elliptic matvec consumers);
+  the explicit-drift FP diffusion path now requests the finite-volume zero-flux stencil
+  (`mass_conservative=True`, both row- and column-conservative), so pure diffusion at no-flux walls
+  conserves mass to machine precision (was 0.84% → 1.9e-15). The explicit *advection* sub-step's
+  non-conservation under strong drift is a separate follow-up (#1184 step 4); `Refs #1184`.
 - **WENO HJB now sub-steps each backward interval to cover the full `dt`** (Issue #1180). The
   1D/2D/3D/nD backward sweeps advanced only one CFL/diffusion-stable `dt_stable` per interval
   (often `dt_stable << dt`) while recording it as a full `dt` step, so in the common

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -504,7 +504,11 @@ def solve_timestep_explicit_with_drift(
     else:
         from mfgarchon.operators.differential.laplacian import LaplacianOperator
 
-        L_op = LaplacianOperator(spacings=list(spacing), field_shape=shape, bc=boundary_conditions)
+        # mass_conservative=True: the implicit FP diffusion solve needs a column-conservative
+        # (1ᵀL = 0) no-flux stencil, else mass leaks at the walls (Issue #1184).
+        L_op = LaplacianOperator(
+            spacings=list(spacing), field_shape=shape, bc=boundary_conditions, mass_conservative=True
+        )
         L_matrix = L_op.as_scipy_sparse()
 
     # Build implicit system matrix: (I/dt - D*Δ) m^{k+1} = m^k/dt
@@ -768,7 +772,11 @@ def solve_fp_nd_full_system(
         try:
             from mfgarchon.operators.differential.laplacian import LaplacianOperator
 
-            _L_op = LaplacianOperator(spacings=list(spacing), field_shape=shape, bc=boundary_conditions)
+            # mass_conservative=True: cached implicit-FP diffusion matrix must conserve mass
+            # at no-flux walls (column-conservative stencil; Issue #1184).
+            _L_op = LaplacianOperator(
+                spacings=list(spacing), field_shape=shape, bc=boundary_conditions, mass_conservative=True
+            )
             _cached_laplacian = _L_op.as_scipy_sparse()
         except (ValueError, AttributeError):
             _cached_laplacian = None  # Fallback: rebuild each step

--- a/mfgarchon/operators/differential/laplacian.py
+++ b/mfgarchon/operators/differential/laplacian.py
@@ -93,6 +93,7 @@ class LaplacianOperator(LinearOperator):
         bc: BoundaryConditions | None = None,
         order: int = 2,
         time: float = 0.0,
+        mass_conservative: bool = False,
     ):
         """
         Initialize Laplacian operator.
@@ -103,6 +104,15 @@ class LaplacianOperator(LinearOperator):
             bc: Boundary conditions (None for periodic/wrap)
             order: Discretization order (currently only order=2 supported)
             time: Time for time-dependent BCs (default 0.0)
+            mass_conservative: Affects ONLY ``as_scipy_sparse()`` under a no-flux/Neumann BC
+                (Issue #1184). Default ``False`` keeps the 2nd-order-accurate ghost-mirror
+                stencil (diag ``-2/h²``, wall neighbor ``+2/h²``; row-conservative but NOT
+                column-conservative -- it leaks mass when used as the implicit FP system
+                matrix, because ``1ᵀL ≠ 0``). ``True`` emits the finite-volume zero-flux
+                stencil (wall diag ``-1/h²``, neighbor ``+1/h²``), which is BOTH row- and
+                column-conservative (``1ᵀL = 0``), so the implicit diffusion solve conserves
+                mass exactly -- at the cost of 1st-order wall accuracy. The FP mass path sets
+                this; HJB/elliptic consumers (matvec, accuracy-critical) leave it ``False``.
 
         Raises:
             ValueError: If order != 2 (higher orders not yet implemented)
@@ -118,6 +128,7 @@ class LaplacianOperator(LinearOperator):
         self.bc = bc
         self.order = order
         self.time = time
+        self.mass_conservative = mass_conservative
 
         # Validate
         if len(self.spacings) != len(self.field_shape):
@@ -274,7 +285,39 @@ class LaplacianOperator(LinearOperator):
             at_max = i_d == n_d - 1
             interior = ~at_min & ~at_max
 
-            if bc_type in ("neumann", "no_flux"):
+            if bc_type in ("neumann", "no_flux") and self.mass_conservative:
+                # Finite-volume zero-flux stencil (Issue #1184): omit the ghost face at the
+                # wall so each cell's row telescopes against its neighbors' columns. Wall cells
+                # lose one face in dimension d -> diag -1/h² (this dim); interior -2/h². The
+                # single interior neighbor of a wall cell gets +1/h² (NOT the +2/h² ghost
+                # mirror). This is BOTH row- and column-conservative (1ᵀL = 0), so the implicit
+                # FP diffusion solve conserves mass; it is 1st-order accurate at the wall.
+                rows_list.append(all_idx[interior])
+                cols_list.append(all_idx[interior])
+                vals_list.append(np.full(int(interior.sum()), -2.0 / h2))
+
+                wall = at_min | at_max
+                rows_list.append(all_idx[wall])
+                cols_list.append(all_idx[wall])
+                vals_list.append(np.full(int(wall.sum()), -1.0 / h2))
+
+                # Interior: both neighbors +1/h²
+                rows_list.append(all_idx[interior])
+                cols_list.append(all_idx[interior] - stride)
+                vals_list.append(np.full(int(interior.sum()), 1.0 / h2))
+                rows_list.append(all_idx[interior])
+                cols_list.append(all_idx[interior] + stride)
+                vals_list.append(np.full(int(interior.sum()), 1.0 / h2))
+
+                # Wall: single interior neighbor +1/h² (zero-flux: no ghost contribution)
+                rows_list.append(all_idx[at_min])
+                cols_list.append(all_idx[at_min] + stride)
+                vals_list.append(np.full(int(at_min.sum()), 1.0 / h2))
+                rows_list.append(all_idx[at_max])
+                cols_list.append(all_idx[at_max] - stride)
+                vals_list.append(np.full(int(at_max.sum()), 1.0 / h2))
+
+            elif bc_type in ("neumann", "no_flux"):
                 # ALL points get diagonal -2/h² (interior and boundary)
                 rows_list.append(all_idx)
                 cols_list.append(all_idx)

--- a/tests/integration/test_mass_conservation_1d.py
+++ b/tests/integration/test_mass_conservation_1d.py
@@ -358,5 +358,45 @@ class TestMassConservation1D:
             assert max_error < 0.1, f"Mass conservation failed for {name}: {max_error:.6e}"
 
 
+class TestExplicitDriftNoFluxDiffusionConservation:
+    """Issue #1184: the explicit-drift FP path's implicit DIFFUSION sub-step must conserve
+    mass at no-flux walls. The diffusion matrix is `LaplacianOperator.as_scipy_sparse()`; with
+    the column-conservative (mass_conservative=True) no-flux stencil, pure diffusion of a
+    wall-touching density conserves mass to machine precision (was ~0.84% leak from the
+    column-sum defect). The advection sub-step's non-conservation under drift is a separate
+    follow-up (#1184 step 4)."""
+
+    def test_pure_diffusion_no_flux_conserves_mass(self):
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+
+        n, nt, T, sigma = 51, 50, 0.5, 0.3
+        grid = TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1)
+        )
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: 0.0 * np.asarray(m),
+            coupling_dm=lambda m: 0.0 * np.asarray(m),
+        )
+        x = np.linspace(0.0, 1.0, n)
+        comps = MFGComponents(
+            m_initial=lambda xx: np.exp(-30 * (np.asarray(xx) - 0.5) ** 2),
+            u_terminal=lambda xx: 0.0 * np.asarray(xx),
+            hamiltonian=H,
+        )
+        prob = MFGProblem(geometry=grid, T=T, Nt=nt, sigma=sigma, components=comps)
+        solver = FPFDMSolver(prob)
+        dx = 1.0 / (n - 1)
+        m0 = np.exp(-30 * (x - 0.5) ** 2)
+        m0 /= m0.sum() * dx
+        # callable (zero) drift routes through the explicit-drift path; pure diffusion
+        M = solver.solve_fp_system(
+            m0.copy(), drift_field=lambda t, g, m: np.zeros(n), volatility_field=sigma
+        )
+        mass = M.sum(axis=1) * dx
+        rel = abs(mass[-1] - mass[0]) / mass[0]
+        assert rel < 1e-12, f"explicit-drift pure-diffusion no-flux mass leak {rel:.2e} (was ~0.84%)"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/unit/test_operators/test_laplacian.py
+++ b/tests/unit/test_operators/test_laplacian.py
@@ -353,5 +353,50 @@ class TestLaplacianValidation:
         assert "order=2" in r
 
 
+class TestLaplacianMassConservative:
+    """Issue #1184: the no-flux sparse Laplacian used as the implicit FP system matrix must
+    be COLUMN-conservative (1ᵀL = 0) or the diffusion solve leaks mass at the walls."""
+
+    @staticmethod
+    def _sums(L):
+        A = L.as_scipy_sparse()
+        A = A.toarray() if hasattr(A, "toarray") else np.asarray(A)
+        return float(np.max(np.abs(A.sum(axis=1)))), float(np.max(np.abs(A.sum(axis=0)))), A
+
+    def test_default_noflux_is_row_but_not_column_conservative(self):
+        """The default (2nd-order ghost-mirror) stencil has zero row sums but NONZERO column
+        sums at the walls -- this is the leak the flag exists to fix."""
+        n, h = 51, 1.0 / 50
+        rmax, cmax, _ = self._sums(LaplacianOperator([h], (n,), bc=no_flux_bc(dimension=1)))
+        assert rmax < 1e-9, f"default row sums should be 0, got {rmax:.2e}"
+        assert cmax > 1.0 / h**2 / 2, f"default must show the column-sum defect, got {cmax:.2e}"
+
+    @pytest.mark.parametrize("dim", [1, 2])
+    def test_conservative_noflux_row_and_column_sums_zero(self, dim):
+        """mass_conservative=True emits the FV zero-flux stencil: BOTH row and column sums
+        vanish, so the implicit FP diffusion solve conserves mass exactly."""
+        n = 41 if dim == 1 else 11
+        h = 1.0 / (n - 1)
+        bc = no_flux_bc(dimension=dim)
+        L = LaplacianOperator([h] * dim, (n,) * dim, bc=bc, mass_conservative=True)
+        rmax, cmax, A = self._sums(L)
+        assert rmax < 1e-10, f"{dim}D conservative row sums must be 0, got {rmax:.2e}"
+        assert cmax < 1e-10, f"{dim}D conservative column sums must be 0, got {cmax:.2e}"
+        assert np.allclose(A, A.T), "FV no-flux Laplacian must be symmetric"
+
+    def test_default_unchanged_by_flag_off(self):
+        """mass_conservative=False (default) is byte-identical to the pre-#1184 stencil:
+        diag -2/h², wall interior-neighbor +2/h² (regression-lock)."""
+        n, h = 7, 0.25
+        A = LaplacianOperator([h], (n,), bc=no_flux_bc(dimension=1)).as_scipy_sparse().toarray()
+        h2 = h**2
+        assert A[0, 0] == pytest.approx(-2.0 / h2)
+        assert A[0, 1] == pytest.approx(2.0 / h2)  # ghost-mirror, not the FV +1/h²
+        assert A[-1, -1] == pytest.approx(-2.0 / h2)
+        assert A[-1, -2] == pytest.approx(2.0 / h2)
+        assert A[3, 3] == pytest.approx(-2.0 / h2)  # interior unchanged
+        assert A[3, 2] == pytest.approx(1.0 / h2)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Bug (rec④ design + re-derived numbers)

The real root cause of #1184's wall mass loss, verified by reading + reproducing: `LaplacianOperator.as_scipy_sparse()` no-flux/Neumann branch uses the 2nd-order ghost-mirror stencil (diag `−2/h²`, wall neighbor `+2/h²`) which has **zero row sums** (Neumann accuracy) but **nonzero column sums** at the walls (`≈1/h²`). The implicit FP diffusion system `(I/dt − D·L) m* = m^k/dt` conserves total mass **iff `1ᵀL = 0`** (zero *column* sums) — so it leaks at no-flux walls.

Measured (explicit-drift FP, no-flux, wall-touching Gaussian):

| drift | leak (before) |
|---|---|
| **0.0 (pure diffusion)** | **0.84%** |
| −0.3 | 3.66% |
| −1.0 | 49.1% |

Even pure diffusion leaks 0.84% — the column-sum defect. (This corrects the issue's original advection-only framing; the diffusion matrix is the dominant leak.)

## Fix

`LaplacianOperator(mass_conservative=False)` (name chosen to avoid the poisoned Issue #616 `conservative=`). Default `False` keeps the **byte-identical** 2nd-order stencil — HJB/elliptic matvec consumers (`hjb_fdm`, `implicit_heat`) depend on its wall accuracy. `True` emits the finite-volume zero-flux stencil (wall diag `−1/h²`, neighbor `+1/h²`), which is **both row- and column-conservative** (`1ᵀL = 0`, symmetric), at 1st-order wall accuracy. Affects only `as_scipy_sparse`; the matvec is untouched. The explicit-drift FP diffusion path (inline + cached build) requests `mass_conservative=True`.

**Result:** pure-diffusion no-flux leak **0.84% → 1.9e-15**.

## Scope (`Refs`, not `Closes`)

This fixes the **diffusion** half. The explicit **advection** sub-step (`compute_advection_from_drift_nd`, Godunov node-based, non-conservative at flux extrema + nonzero wall flux) remains — that's **step 4** of #1184, which you chose to defer. Note: with diffusion now conservative, the strong-drift *total* leak is dominated by (and shows undiluted) that advection sub-step; a follow-up FV-advection PR closes it.

## Tests
- `TestLaplacianMassConservative`: conservative branch row+col sums ~0 (1D/2D, symmetric); default shows the column defect; default byte-identical regression-lock.
- `test_pure_diffusion_no_flux_conserves_mass`: explicit-drift pure-diffusion <1e-12 — **fails pre-fix at 0.84%**.
- 348 FP/laplacian/conservation tests pass (no regression).

`Refs #1184`

🤖 Generated with [Claude Code](https://claude.com/claude-code)