### PR TITLE
refactor(hjb): single-source batch Hamiltonian evaluation (#1071 Layer A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Single-source batch Hamiltonian evaluation** (`hjb_solvers/h_eval.py`, Issue #1071 Layer A).
+  Every HJB solver inlined the same `np.asarray(H_class(x, m, p, t=t), dtype=float)` batch call
+  (6 value + 5 `dp` sites across `base_hjb`/`hjb_fdm`/`hjb_gfdm`/`hjb_semi_lagrangian`); these now
+  route through `eval_H_batch` / `eval_dH_dp_batch`, so a change to the batch contract (dtype,
+  shape, NaN policy) happens in one place. **Byte-identical** — callers keep their own `.ravel()`
+  / reshape / `alpha* = -dp` sign conventions and discrete operators (369 HJB tests unchanged).
+  Foundation for the residual/Jacobian assembly harness (Layer B); the hardcoded-LQ-default
+  elimination (steps 4-5) is deferred (it is not byte-identical and could shift paper EOC numbers).
 - **Upgraded two "plumbing-only" tests to run-and-compare (retrospect rec ③).**
   `test_qp_optimization_levels` only asserted constructor *labels* (`hjb_method_name`) — it
   would pass even if a QP monotonicity level corrupted the solution; added

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -7,6 +7,7 @@ import numpy as np
 import scipy.sparse as sparse
 
 from mfgarchon.alg.base_solver import BaseNumericalSolver, SchemeFamily
+from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
 from mfgarchon.backends.compat import backend_aware_assign, backend_aware_copy, has_nan_or_inf
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
@@ -650,7 +651,7 @@ def compute_hjb_residual(
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
 
         # Single batch call — eliminates per-point problem.H() overhead
-        H_values = np.asarray(H_class(x_grid, m_grid, p_grid, t=current_time), dtype=float).ravel()
+        H_values = eval_H_batch(H_class, x_grid, m_grid, p_grid, current_time).ravel()
 
         # Mask: propagate NaN from existing Phi_U or from NaN gradients
         nan_mask = np.isnan(Phi_U) | np.isnan(precomputed_grad) | ~np.isfinite(H_values)
@@ -789,9 +790,7 @@ def compute_hjb_jacobian(
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
 
         # Single batch call: dH/dp at all grid points
-        dH_dp = np.asarray(
-            H_class.dp(x_grid, m_grid, p_grid, t=current_time), dtype=float
-        ).ravel()  # (Nx,) — squeeze the 1D momentum dimension
+        dH_dp = eval_dH_dp_batch(H_class, x_grid, m_grid, p_grid, current_time).ravel()  # (Nx,) — squeeze the 1D momentum dimension
 
         # Stencil coefficients: dp_i/dU_j depends on upwind direction
         # Godunov upwind: p >= 0 uses backward (U_i - U_{i-1})/dx,

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -790,7 +790,9 @@ def compute_hjb_jacobian(
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
 
         # Single batch call: dH/dp at all grid points
-        dH_dp = eval_dH_dp_batch(H_class, x_grid, m_grid, p_grid, current_time).ravel()  # (Nx,) — squeeze the 1D momentum dimension
+        dH_dp = eval_dH_dp_batch(
+            H_class, x_grid, m_grid, p_grid, current_time
+        ).ravel()  # (Nx,) — squeeze the 1D momentum dimension
 
         # Stencil coefficients: dp_i/dU_j depends on upwind direction
         # Godunov upwind: p >= 0 uses backward (U_i - U_{i-1})/dx,

--- a/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
@@ -1,0 +1,45 @@
+"""Single-source batch Hamiltonian evaluation for HJB solvers (re-scope of Issue #1071).
+
+The Hamiltonian *value* and its *gradient* are already single-source (``HamiltonianBase``
+in ``core/hamiltonian.py``, reached via ``problem.hamiltonian_class``). What was duplicated
+is the per-solver *evaluation glue* -- every HJB solver inlined the same
+``np.asarray(H_class(x, m, p, t=t), dtype=float)`` batch call. This module is the one home
+for that call, so a future change to the batch contract (dtype, shape handling, NaN policy)
+happens in exactly one place.
+
+These are byte-identical extractions of the inline expressions they replace: the callers
+still own their own ``.ravel()`` / reshape / sign conventions (e.g. ``alpha* = -dp``) and the
+discrete operators (gradient, Laplacian) they feed in. This is Layer A of #1071; the
+residual/Jacobian *assembly* harness is Layer B.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from mfgarchon.core.hamiltonian import HamiltonianBase
+
+
+def eval_H_batch(H_class: HamiltonianBase, x: NDArray, m: NDArray, p: NDArray, t: float) -> NDArray:
+    """Evaluate the Hamiltonian value ``H(x, m, p, t)`` over a batch of points.
+
+    Returns a float ``ndarray`` shaped as ``H_class`` returns it (callers ``.ravel()`` or
+    reshape as their assembly needs). Byte-identical to the inline
+    ``np.asarray(H_class(x, m, p, t=t), dtype=float)`` it replaces.
+    """
+    return np.asarray(H_class(x, m, p, t=t), dtype=float)
+
+
+def eval_dH_dp_batch(H_class: HamiltonianBase, x: NDArray, m: NDArray, p: NDArray, t: float) -> NDArray:
+    """Evaluate the Hamiltonian gradient ``∂H/∂p(x, m, p, t)`` over a batch of points.
+
+    Returns a float ``ndarray`` as ``H_class.dp`` returns it. Callers keep their own sign
+    convention (the FP drift is ``alpha* = -∂H/∂p``, so several callers negate the result).
+    Byte-identical to the inline ``np.asarray(H_class.dp(x, m, p, t=t), dtype=float)``.
+    """
+    return np.asarray(H_class.dp(x, m, p, t=t), dtype=float)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
+from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
 from mfgarchon.geometry.base import CartesianGrid  # nD FDM needs structured grid ABC
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
@@ -946,7 +947,7 @@ class HJBFDMSolver(BaseHJBSolver):
 
             # Convective Hamiltonian via H_class (same pattern as scalar path)
             H_class = self.problem.hamiltonian_class
-            H_convective = np.asarray(H_class(x_grid, m_grid, p_grid, t=time), dtype=float)
+            H_convective = eval_H_batch(H_class, x_grid, m_grid, p_grid, time)
 
             # Anisotropic diffusion: -(1/2) * sum_d sigma_d^2 * d^2u/dx_d^2
             from mfgarchon.operators.stencils.finite_difference import weighted_laplacian_with_bc
@@ -963,7 +964,7 @@ class HJBFDMSolver(BaseHJBSolver):
             # Scalar diffusion mode — batch HamiltonianBase (Issue #784)
             # hamiltonian_class is guaranteed by MFGComponents (Issue #670)
             H_class = self.problem.hamiltonian_class
-            H_convective = np.asarray(H_class(x_grid, m_grid, p_grid, t=time), dtype=float)
+            H_convective = eval_H_batch(H_class, x_grid, m_grid, p_grid, time)
 
             # Diffusion term: -(sigma^2/2) * Laplacian(U) (Issue #787)
             # Follows 1D pattern in base_hjb.py:774-803
@@ -1282,7 +1283,7 @@ class HJBFDMSolver(BaseHJBSolver):
         # Evaluate dH/dp at all grid points
         x_grid = self.problem.geometry.get_spatial_grid()  # (Nx, 1)
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
-        dH_dp = np.asarray(H_class.dp(x_grid, M_flat, p_grid, t=time), dtype=float).ravel()  # (Nx,)
+        dH_dp = eval_dH_dp_batch(H_class, x_grid, M_flat, p_grid, time).ravel()  # (Nx,)
 
         # Stencil coefficients: dp_i/dU_j depends on Godunov upwind direction
         # p >= 0: backward stencil (U_i - U_{i-1})/dx
@@ -1340,7 +1341,7 @@ class HJBFDMSolver(BaseHJBSolver):
         p_grid = np.column_stack([gradients[d].ravel() for d in range(self.dimension)])
 
         # Evaluate dH/dp: returns (N_total, dim) -- one component per dimension
-        dH_dp_all = np.asarray(H_class.dp(x_grid, M_flat, p_grid, t=time), dtype=float)
+        dH_dp_all = eval_dH_dp_batch(H_class, x_grid, M_flat, p_grid, time)
         if dH_dp_all.ndim == 1:
             dH_dp_all = dH_dp_all.reshape(-1, 1)
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -24,6 +24,7 @@ from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import (
     TaylorOperator,
     create_operator,
 )
+from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
 from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
 from mfgarchon.utils.deprecation import deprecated_parameter, deprecated_value
@@ -2087,7 +2088,7 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         # Batch Hamiltonian evaluation: H(x, m, p, t) -> (N,)
         x = self.collocation_points  # (N, d)
-        H_total = np.asarray(H_class(x, m_n_plus_1, grad_u, t=current_time), dtype=float)
+        H_total = eval_H_batch(H_class, x, m_n_plus_1, grad_u, current_time)
 
         # Running cost L(x) at this timestep (passed explicitly from backward loop)
         if running_cost is not None:
@@ -2145,7 +2146,7 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         # Batch dH/dp: shape (N, d)
         x = self.collocation_points
-        dH_dp = np.asarray(H_class.dp(x, m_n_plus_1, grad_u, t=current_time), dtype=float)
+        dH_dp = eval_dH_dp_batch(H_class, x, m_n_plus_1, grad_u, current_time)
 
         # J = (1/dt)I + sum_d diag(dH/dp_d) @ D_grad[d] - (sigma^2/2) D_lap
         jacobian = (1.0 / dt) * eye(n, format="csr")
@@ -3012,7 +3013,7 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         def alpha_star(x_pts, p, m, t_idx):
             # Optimal feedback control alpha* = -dH/dp (the same dp() the Newton Jacobian reads).
-            return -np.asarray(H_class.dp(x_pts, m, p, t=t_idx * dt), dtype=float)
+            return -eval_dH_dp_batch(H_class, x_pts, m, p, t_idx * dt)
 
         howard = HJBHowardSolver(
             self.problem,

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.optimize import minimize, minimize_scalar
 
+from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_H_batch
 from mfgarchon.geometry.boundary.applicator_fdm import FDMApplicator
 from mfgarchon.geometry.boundary.applicator_interpolation import InterpolationApplicator
 from mfgarchon.geometry.boundary.bc_utils import (
@@ -995,7 +996,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 p_batch = grad_u.reshape(-1, 1)  # (Nx, 1)
                 H_class = self.problem.hamiltonian_class
                 if H_class is not None:
-                    H_values = np.asarray(H_class(x_batch, M_next, p_batch, t=time_idx * self.dt), dtype=float).ravel()
+                    H_values = eval_H_batch(H_class, x_batch, M_next, p_batch, time_idx * self.dt).ravel()
                 else:
                     H_values = np.zeros(Nx)
 
@@ -1387,7 +1388,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         p_batch = grad_u.reshape(-1, 1)
         H_class = self.problem.hamiltonian_class
         if H_class is not None:
-            H_values = np.asarray(H_class(x_batch, M_next, p_batch, t=time_idx * dt), dtype=float).ravel()
+            H_values = eval_H_batch(H_class, x_batch, M_next, p_batch, time_idx * dt).ravel()
         else:
             H_values = np.zeros(Nx)
 

--- a/tests/unit/test_alg/test_h_eval.py
+++ b/tests/unit/test_alg/test_h_eval.py
@@ -1,0 +1,55 @@
+"""Contract tests for the single-source batch Hamiltonian evaluation (Issue #1071, Layer A).
+
+``eval_H_batch`` / ``eval_dH_dp_batch`` are byte-identical extractions of the inline
+``np.asarray(H_class(...), dtype=float)`` calls every HJB solver used to duplicate. These
+pin that contract so a future change to the helper cannot silently diverge from the form the
+solvers relied on.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+
+
+def _batch(n=7, d=1):
+    rng = np.random.default_rng(0)
+    x = np.linspace(0.0, 1.0, n).reshape(-1, 1) if d == 1 else rng.uniform(size=(n, d))
+    m = rng.uniform(0.1, 1.0, size=n)
+    p = rng.uniform(-1.0, 1.0, size=(n, d))
+    return x, m, p
+
+
+def test_eval_H_batch_is_byte_identical_to_inline():
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0))
+    x, m, p, t = *_batch(), 0.3
+    out = eval_H_batch(H, x, m, p, t)
+    ref = np.asarray(H(x, m, p, t=t), dtype=float)
+    assert out.dtype == np.float64
+    assert np.array_equal(out, ref)
+
+
+def test_eval_dH_dp_batch_is_byte_identical_to_inline():
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0))
+    x, m, p, t = *_batch(), 0.3
+    out = eval_dH_dp_batch(H, x, m, p, t)
+    ref = np.asarray(H.dp(x, m, p, t=t), dtype=float)
+    assert out.dtype == np.float64
+    assert np.array_equal(out, ref)
+
+
+def test_eval_batch_passes_through_non_lq_coupling():
+    """The helper must call through to whatever H_class computes (not assume the LQ form):
+    a non-LQ congestion coupling f(m)=m**3 changes the value, and the helper reflects it."""
+    H_lq = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0))
+    H_cong = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=2.0),
+        coupling=lambda m: m**3,
+        coupling_dm=lambda m: 3.0 * m**2,
+    )
+    x, m, p, t = *_batch(), 0.0
+    assert np.array_equal(eval_H_batch(H_cong, x, m, p, t), np.asarray(H_cong(x, m, p, t=t), dtype=float))
+    # the congestion term must actually change the value (helper is not LQ-hardcoded)
+    assert not np.allclose(eval_H_batch(H_cong, x, m, p, t), eval_H_batch(H_lq, x, m, p, t))


### PR DESCRIPTION
## rec④ #1071 — Layer A (byte-identical)

The design analysis (+ adversarial critique) confirmed: the Hamiltonian **value/gradient** are already single-source (`HamiltonianBase`). What's duplicated is the per-solver **evaluation glue** — every HJB solver inlined the same `np.asarray(H_class(x, m, p, t=t), dtype=float)` batch call (**6 value + 5 `dp` sites** across `base_hjb`/`hjb_fdm`/`hjb_gfdm`/`hjb_semi_lagrangian`).

Added `hjb_solvers/h_eval.py` with `eval_H_batch` / `eval_dH_dp_batch` and routed every batch site through them, so a change to the batch contract (dtype, shape, NaN policy) happens in **one** place.

**Byte-identical**: the helpers return exactly `np.asarray(H_class(...), dtype=float)`; callers keep their own `.ravel()`/reshape and sign conventions (the FP drift `α* = -∂H/∂p`, so several callers negate). **369 HJB solver tests pass unchanged.** New `test_h_eval.py` pins byte-identity + non-LQ pass-through.

## Scope

This is the safe foundation (the critique's "~70% of benefit, ~30% of risk"). Per your decision, the **hardcoded-LQ-default elimination** (steps 4-5 — the actual convention-divergence fix) is **deferred**: it requires synthesizing a default `QuadraticHamiltonian` for components-less problems, is **not** byte-identical (FP-summation order), and could shift the EOC/convergence numbers in mfg-research paper experiments. Layer B (residual/Jacobian assembly harness) follows as a separate PR.

`Refs #1071`

🤖 Generated with [Claude Code](https://claude.com/claude-code)