### PR TITLE
refactor(hjb): single-source HJB residual/Jacobian assembly (#1071 Layer B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Single-source HJB residual/Jacobian assembly** (`hjb_solvers/h_eval.py`, Issue #1071 Layer B).
+  Added `assemble_hjb_residual` (`-u_t + H(+running_cost) - D·lap_u`) and
+  `assemble_hjb_jacobian_diag` (`(1/dt)I + Σ_d diag(∂H/∂p_d)@D_grad[d] - D·D_lap`), so the
+  diffusion-term convention (`D = σ²/2`, #1073/#811) and the assembly skeleton live in one place;
+  callers supply their own discrete operators (`D_grad`, `D_lap`) and time-derivative. Folded
+  `hjb_gfdm`'s `_compute_hjb_residual_hamiltonian` + `_compute_hjb_jacobian_hamiltonian` onto them,
+  **byte-identical** (112 gfdm tests unchanged). Scoped to the gfdm implicit-residual framing; the
+  `base_hjb` (`Phi_U += -D·U_xx`) and WENO (explicit `-H + D·Δu`) framings are intentionally not
+  folded (irreducibly different). Most of the diffusion-convention centralization value was already
+  delivered by the #1189 converter sweep + Layer A.
 - **Single-source batch Hamiltonian evaluation** (`hjb_solvers/h_eval.py`, Issue #1071 Layer A).
   Every HJB solver inlined the same `np.asarray(H_class(x, m, p, t=t), dtype=float)` batch call
   (6 value + 5 `dp` sites across `base_hjb`/`hjb_fdm`/`hjb_gfdm`/`hjb_semi_lagrangian`); these now

--- a/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
@@ -19,8 +19,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+    from scipy.sparse import spmatrix
 
     from mfgarchon.core.hamiltonian import HamiltonianBase
 
@@ -43,3 +46,59 @@ def eval_dH_dp_batch(H_class: HamiltonianBase, x: NDArray, m: NDArray, p: NDArra
     Byte-identical to the inline ``np.asarray(H_class.dp(x, m, p, t=t), dtype=float)``.
     """
     return np.asarray(H_class.dp(x, m, p, t=t), dtype=float)
+
+
+def assemble_hjb_residual(
+    *,
+    H_class: HamiltonianBase,
+    x: NDArray,
+    m: NDArray,
+    p: NDArray,
+    lap_u: NDArray,
+    sigma: float | NDArray,
+    t: float,
+    u_t: NDArray,
+    running_cost: NDArray | None = None,
+) -> NDArray:
+    r"""Assemble the implicit-backward-Euler HJB residual (Layer B of #1071).
+
+    Returns ``-u_t + H(+running_cost) - D·lap_u`` with ``D = diffusion_from_volatility(sigma)``,
+    so the diffusion-term convention (Issue #1073/#811: ``D = σ²/2``) lives in one place. The
+    caller supplies its own discrete operators (gradient ``p``, Laplacian ``lap_u``) and the
+    time-derivative ``u_t = (u^{n+1}-u^n)/dt``; it owns its own framing -- this is the implicit
+    residual ``-u_t + H - D·lap``, NOT the WENO explicit-RHS framing ``-H + D·Δu``. Byte-identical
+    to the inline gfdm expression it replaces.
+    """
+    H = eval_H_batch(H_class, x, m, p, t)
+    if running_cost is not None:
+        H = H + running_cost
+    return -u_t + H - diffusion_from_volatility(sigma) * lap_u
+
+
+def assemble_hjb_jacobian_diag(
+    *,
+    H_class: HamiltonianBase,
+    x: NDArray,
+    m: NDArray,
+    p: NDArray,
+    sigma: float | NDArray,
+    t: float,
+    dt: float,
+    D_grad: list,
+    D_lap: spmatrix,
+) -> spmatrix:
+    r"""Assemble the sparse HJB Newton Jacobian for the implicit residual (Layer B of #1071).
+
+    Returns ``(1/dt)I + Σ_d diag(∂H/∂p_d) @ D_grad[d] - D·D_lap`` with
+    ``D = diffusion_from_volatility(sigma)``. ``D_grad`` (per-dimension first-derivative
+    matrices) and ``D_lap`` (Laplacian matrix) are the caller's discrete operators -- scattered
+    GFDM stencils, structured FDM matrices, etc. Byte-identical to the inline gfdm assembly.
+    """
+    from scipy.sparse import diags, eye
+
+    dH_dp = eval_dH_dp_batch(H_class, x, m, p, t)
+    n = D_lap.shape[0]
+    jacobian = (1.0 / dt) * eye(n, format="csr")
+    for dim in range(dH_dp.shape[1]):
+        jacobian = jacobian + diags(dH_dp[:, dim], format="csr") @ D_grad[dim]
+    return jacobian - diffusion_from_volatility(sigma) * D_lap

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -24,7 +24,11 @@ from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import (
     TaylorOperator,
     create_operator,
 )
-from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
+from mfgarchon.alg.numerical.hjb_solvers.h_eval import (
+    assemble_hjb_jacobian_diag,
+    assemble_hjb_residual,
+    eval_dH_dp_batch,
+)
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
 from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
 from mfgarchon.utils.deprecation import deprecated_parameter, deprecated_value
@@ -2085,26 +2089,19 @@ class HJBGFDMSolver(BaseHJBSolver):
         """
         dt = self.problem.T / self.problem.Nt
         u_t = (u_n_plus_1 - u_current) / dt
-
-        # Batch Hamiltonian evaluation: H(x, m, p, t) -> (N,)
-        x = self.collocation_points  # (N, d)
-        H_total = eval_H_batch(H_class, x, m_n_plus_1, grad_u, current_time)
-
-        # Running cost L(x) at this timestep (passed explicitly from backward loop)
-        if running_cost is not None:
-            H_total = H_total + running_cost
-
-        # Diffusion term: (sigma^2 / 2) * Laplacian
-        # Issue #1073: use _get_sigma_value (returns σ) instead of confusing
-        # `getattr(problem, "diffusion") or getattr(problem, "sigma")` chain.
-        # `problem.diffusion` returns σ²/2 (PDE coefficient D), so the old chain
-        # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
-        # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
+        # _get_sigma_value returns σ (not D); the harness applies D = σ²/2 (#1073/#811).
         sigma = self._get_sigma_value(None)
-        diffusion_term = diffusion_from_volatility(sigma) * lap_u
-
-        # HJB residual: -u_t + H - diffusion = 0
-        return -u_t + H_total - diffusion_term
+        return assemble_hjb_residual(
+            H_class=H_class,
+            x=self.collocation_points,
+            m=m_n_plus_1,
+            p=grad_u,
+            lap_u=lap_u,
+            sigma=sigma,
+            t=current_time,
+            u_t=u_t,
+            running_cost=running_cost,
+        )
 
     def _compute_hjb_jacobian_hamiltonian(
         self,
@@ -2128,33 +2125,24 @@ class HJBGFDMSolver(BaseHJBSolver):
         Returns:
             Sparse Jacobian matrix in CSR format
         """
-        from scipy.sparse import diags, eye
-
         # Lazy initialization of differentiation matrices
         if self._D_grad is None:
             self._build_differentiation_matrices()
 
-        n = self.n_points
-        d = self.dimension
         dt = self.problem.T / self.problem.Nt
-        # Issue #1073: use _get_sigma_value (returns σ) instead of confusing
-        # `getattr(problem, "diffusion") or getattr(problem, "sigma")` chain.
-        # `problem.diffusion` returns σ²/2 (PDE coefficient D), so the old chain
-        # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
-        # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
+        # _get_sigma_value returns σ (not D); the harness applies D = σ²/2 (#1073/#811).
         sigma = self._get_sigma_value(None)
-
-        # Batch dH/dp: shape (N, d)
-        x = self.collocation_points
-        dH_dp = eval_dH_dp_batch(H_class, x, m_n_plus_1, grad_u, current_time)
-
-        # J = (1/dt)I + sum_d diag(dH/dp_d) @ D_grad[d] - (sigma^2/2) D_lap
-        jacobian = (1.0 / dt) * eye(n, format="csr")
-        for dim in range(d):
-            jacobian = jacobian + diags(dH_dp[:, dim], format="csr") @ self._D_grad[dim]
-        jacobian = jacobian - diffusion_from_volatility(sigma) * self._D_lap
-
-        return jacobian
+        return assemble_hjb_jacobian_diag(
+            H_class=H_class,
+            x=self.collocation_points,
+            m=m_n_plus_1,
+            p=grad_u,
+            sigma=sigma,
+            t=current_time,
+            dt=dt,
+            D_grad=self._D_grad,
+            D_lap=self._D_lap,
+        )
 
     def _interpolate_potential_to_collocation(self) -> np.ndarray:
         """

--- a/tests/unit/test_alg/test_h_eval.py
+++ b/tests/unit/test_alg/test_h_eval.py
@@ -53,3 +53,42 @@ def test_eval_batch_passes_through_non_lq_coupling():
     assert np.array_equal(eval_H_batch(H_cong, x, m, p, t), np.asarray(H_cong(x, m, p, t=t), dtype=float))
     # the congestion term must actually change the value (helper is not LQ-hardcoded)
     assert not np.allclose(eval_H_batch(H_cong, x, m, p, t), eval_H_batch(H_lq, x, m, p, t))
+
+
+def test_assemble_hjb_residual_byte_identical():
+    """Layer B: assemble_hjb_residual == -u_t + H(+running_cost) - D*lap_u (D = sigma^2/2)."""
+    from mfgarchon.alg.numerical.hjb_solvers.h_eval import assemble_hjb_residual
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0))
+    x, m, p = _batch()
+    n = m.shape[0]
+    lap_u = np.linspace(-1.0, 1.0, n)
+    u_t = np.linspace(0.0, 0.5, n)
+    rc = np.full(n, 0.05)
+    sigma, t = 0.3, 0.1
+    out = assemble_hjb_residual(H_class=H, x=x, m=m, p=p, lap_u=lap_u, sigma=sigma, t=t, u_t=u_t, running_cost=rc)
+    ref = -u_t + (np.asarray(H(x, m, p, t=t), dtype=float) + rc) - diffusion_from_volatility(sigma) * lap_u
+    assert np.array_equal(out, ref)
+
+
+def test_assemble_hjb_jacobian_diag_byte_identical():
+    """Layer B: assemble_hjb_jacobian_diag == (1/dt)I + sum_d diag(dH/dp_d)@D_grad[d] - D*D_lap."""
+    from scipy.sparse import diags, eye
+
+    from mfgarchon.alg.numerical.hjb_solvers.h_eval import assemble_hjb_jacobian_diag, eval_dH_dp_batch
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0))
+    x, m, p = _batch()
+    n, d = m.shape[0], p.shape[1]
+    sigma, t, dt = 0.3, 0.1, 0.05
+    D_grad = [eye(n, format="csr") for _ in range(d)]
+    D_lap = (diags(-2.0 * np.ones(n)) + diags(np.ones(n - 1), 1) + diags(np.ones(n - 1), -1)).tocsr()
+    out = assemble_hjb_jacobian_diag(H_class=H, x=x, m=m, p=p, sigma=sigma, t=t, dt=dt, D_grad=D_grad, D_lap=D_lap)
+    dH_dp = eval_dH_dp_batch(H, x, m, p, t)
+    ref = (1.0 / dt) * eye(n, format="csr")
+    for dim in range(d):
+        ref = ref + diags(dH_dp[:, dim], format="csr") @ D_grad[dim]
+    ref = ref - diffusion_from_volatility(sigma) * D_lap
+    assert np.allclose(out.toarray(), ref.toarray())


### PR DESCRIPTION
## rec④ #1071 — Layer B (byte-identical, gfdm-scoped)

Builds on Layer A (#1203). Added two assemblers to `h_eval.py`:
- `assemble_hjb_residual` → `-u_t + H(+running_cost) - D·lap_u`
- `assemble_hjb_jacobian_diag` → `(1/dt)I + Σ_d diag(∂H/∂p_d)@D_grad[d] - D·D_lap`

with `D = diffusion_from_volatility(sigma)`, so the diffusion-term convention (#1073/#811) + the assembly skeleton live in one place. Callers supply their own discrete operators (`D_grad`, `D_lap`) and `u_t`.

Folded `hjb_gfdm`'s `_compute_hjb_residual_hamiltonian` + `_compute_hjb_jacobian_hamiltonian` onto them — **byte-identical** (112 gfdm tests unchanged; new contract tests pin the assembled expressions exactly).

## Scope (honest)

Per the design risk note, this is **gfdm-scoped**: `base_hjb` (`Phi_U += -D·U_xx`) and WENO (explicit `-H + D·Δu`) are **irreducibly different framings** and are intentionally not folded. Most of the diffusion-convention-centralization value was already delivered by the **#1189 converter sweep + Layer A**, so Layer B is a modest skeleton-fold. The hardcoded-LQ-default elimination (steps 4-5) stays **deferred** (not byte-identical; EOC/paper-number risk).

`Refs #1071`

🤖 Generated with [Claude Code](https://claude.com/claude-code)