### PR TITLE
refactor(fp): canonical drift contract — trait + weak-form potential_field rename (#1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Canonical FP drift contract: explicit `_drift_convention` trait + weak-form `potential_field`
+  rename** (Issue #1043). The FP equation only ever sees the advective velocity `α` in
+  `div(α m)`; most solvers (FDM, GFDM) take that velocity as `drift_field`, but the weak-form
+  family (`WeakFormFPSolver` + FEM/meshless) and the network/SL solvers take the value function
+  `U` and recover `α = -coupling·∇U` internally. Added a `DriftConvention` enum + a
+  `_drift_convention` class trait (default `VELOCITY`) so this distinction is explicit and
+  machine-readable, and set `VALUE_FUNCTION` on the U-taking solvers. Renamed the weak-form
+  family's misnamed `drift_field` U-input to **`potential_field`** (the name the SL solvers +
+  couplers already prefer, #919), with a `drift_field` deprecation alias (byte-identical;
+  equivalence + fail-loud-on-both tests added). **Deferred** (paper-number risk, like #1071
+  steps 4-5): the coupler trait-dispatch that would *enforce* the contract (the smooth-H common
+  case currently passes raw `U` and the solver differentiates it on its own grid — moving that
+  into the coupler changes where the gradient is taken → not byte-identical), and the
+  `FPNetworkSolver`/`FPParticleSolver` param renames (network is internally inconsistent; particle
+  is bivalent via a flag). `Refs #1043`.
 - **Single-source HJB residual/Jacobian assembly** (`hjb_solvers/h_eval.py`, Issue #1071 Layer B).
   Added `assemble_hjb_residual` (`-u_t + H(+running_cost) - D·lap_u`) and
   `assemble_hjb_jacobian_diag` (`(1/dt)I + Σ_d diag(∂H/∂p_d)@D_grad[d] - D·D_lap`), so the

--- a/mfgarchon/alg/numerical/fp_solvers/base_fp.py
+++ b/mfgarchon/alg/numerical/fp_solvers/base_fp.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from mfgarchon.alg.base_solver import BaseNumericalSolver, SchemeFamily
+
+
+class DriftConvention(Enum):
+    """What an FP solver's drift input MEANS (Issue #1043).
+
+    The FP equation only ever sees the advective velocity ``α`` in ``div(α m)``. Most solvers
+    take that velocity directly; a few take the value function ``U`` and recover
+    ``α = -coupling·∇U`` internally (e.g. weak-form/FEM/meshless, which differentiate ``U`` on
+    their own quadrature/MLS basis rather than on a possibly-coarse FP grid). This trait makes
+    that distinction explicit and machine-readable so a coupler can dispatch the right object to
+    each solver instead of guessing from the parameter name.
+    """
+
+    VELOCITY = "velocity"  # input is α* = -∂_p H (consumed as flux = m·α)
+    VALUE_FUNCTION = "value_function"  # input is U; the solver computes α = -coupling·∇U itself
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -56,6 +73,12 @@ class BaseFPSolver(BaseNumericalSolver):
 
     # Scheme family trait for duality validation (Issue #580)
     _scheme_family = SchemeFamily.GENERIC
+
+    # Drift-input convention trait (Issue #1043). Default VELOCITY: the canonical contract is
+    # drift_field = advective velocity α*. Solvers that take the value function U instead set
+    # this to VALUE_FUNCTION. Metadata only today; a future coupler dispatch reads it (the
+    # signature-sniffing it would replace carries paper-number risk, deferred).
+    _drift_convention: DriftConvention = DriftConvention.VELOCITY
 
     def __init__(self, problem: MFGProblem, config: BaseConfig | None = None) -> None:
         """

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -46,7 +46,7 @@ from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
-from .base_fp import BaseFPSolver
+from .base_fp import BaseFPSolver, DriftConvention
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -94,6 +94,7 @@ class FPSLJacobianSolver(BaseFPSolver):
     from mfgarchon.alg.base_solver import SchemeFamily
 
     _scheme_family = SchemeFamily.SL
+    _drift_convention = DriftConvention.VALUE_FUNCTION  # Issue #1043: takes U via potential_field
 
     @deprecated(since="v0.17.6", replacement="FPSLSolver")
     def __init__(

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -42,7 +42,7 @@ from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
-from .base_fp import BaseFPSolver
+from .base_fp import BaseFPSolver, DriftConvention
 from .fp_sl_splatting import splat_1d, splat_nd
 
 if TYPE_CHECKING:
@@ -94,6 +94,7 @@ class FPSLSolver(BaseFPSolver):
     from mfgarchon.alg.base_solver import SchemeFamily
 
     _scheme_family = SchemeFamily.SL  # Forward SL (adjoint of HJB Backward SL)
+    _drift_convention = DriftConvention.VALUE_FUNCTION  # Issue #1043: takes U via potential_field
 
     def __init__(
         self,

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -29,7 +29,7 @@ import numpy as np
 import scipy.sparse as sp
 from scipy.sparse.linalg import spsolve
 
-from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
 
 
 class FPNetworkSolver(BaseFPSolver):
+    # Issue #1043: consumes the value function U (via the still-misnamed `drift_field` param,
+    # rename deferred — its body differentiates U); marked VALUE_FUNCTION for the contract trait.
+    _drift_convention = DriftConvention.VALUE_FUNCTION
     """
     Fokker-Planck solver for Mean Field Games on networks.
 

--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -22,7 +22,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from scipy.sparse.linalg import spsolve
 
-from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
 if TYPE_CHECKING:
@@ -37,6 +38,10 @@ logger = get_logger(__name__)
 
 class WeakFormFPSolver(BaseFPSolver):
     """FP solver on assembled weak-form operators; BC + advection are subclass hooks."""
+
+    # Issue #1043: this family takes the value function U and recovers α = -coupling·∇U on its
+    # own quadrature/MLS basis (a genuine feature: avoids differentiating U on a coarse FP grid).
+    _drift_convention = DriftConvention.VALUE_FUNCTION
 
     def __init__(self, problem: MFGProblem, discretization: WeakFormDiscretization) -> None:
         super().__init__(problem)
@@ -94,14 +99,28 @@ class WeakFormFPSolver(BaseFPSolver):
             return 0.5 * float(volatility_field) ** 2
         return 0.5 * float(np.mean(volatility_field)) ** 2
 
+    @deprecated_parameter(param_name="drift_field", since="v0.20.0", replacement="potential_field")
     def solve_fp_system(
         self,
         m_initial: NDArray,
-        drift_field: NDArray | None = None,
+        potential_field: NDArray | None = None,
         volatility_field: float | NDArray | None = None,
+        drift_field: NDArray | None = None,  # DEPRECATED alias for potential_field (Issue #1043)
         **kwargs,
     ) -> NDArray:
-        """Solve the FP equation forward in time on the weak-form operators."""
+        """Solve the FP equation forward in time on the weak-form operators.
+
+        ``potential_field`` is the value function ``U(t,x)`` (Issue #1043); this solver recovers
+        the advective velocity ``α = -coupling·∇U`` on its own quadrature/MLS basis. It was
+        historically -- and misleadingly -- named ``drift_field``, but on this solver that input
+        always meant ``U``, never the velocity; ``drift_field`` is kept as a deprecated alias.
+        """
+        # Issue #1043: drift_field is the deprecated name for the U (potential) input here.
+        if drift_field is not None:
+            if potential_field is not None:
+                raise ValueError("Pass only potential_field; drift_field is its deprecated alias (Issue #1043).")
+            potential_field = drift_field
+
         Nt = self.problem.Nt
         dt = self.problem.dt
         N = self._n_dof
@@ -122,8 +141,8 @@ class WeakFormFPSolver(BaseFPSolver):
         for n in range(Nt):
             rhs = (self._M / dt) @ M[n]
 
-            if drift_field is not None:
-                U_n = drift_field[n] if drift_field.ndim > 1 else drift_field
+            if potential_field is not None:
+                U_n = potential_field[n] if potential_field.ndim > 1 else potential_field
                 A_system = A_base + self._build_advection(U_n, D)
             else:
                 A_system = A_base

--- a/tests/unit/test_alg/test_drift_contract.py
+++ b/tests/unit/test_alg/test_drift_contract.py
@@ -1,0 +1,69 @@
+"""Tests for the canonical FP drift contract (Issue #1043).
+
+`drift_field` MEANS the advective velocity α* everywhere; solvers that instead take the value
+function U expose it through `potential_field` and carry `_drift_convention == VALUE_FUNCTION`.
+The weak-form family historically (mis)named its U input `drift_field`; it is renamed to
+`potential_field` with a deprecation alias, which the Deprecation Policy requires be proven
+equivalent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.base_fp import DriftConvention
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+from mfgarchon.alg.numerical.network_solvers.fp_network import FPNetworkSolver
+from mfgarchon.alg.numerical.weak_form_fp_solver import WeakFormFPSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def test_drift_convention_trait_values():
+    """The velocity-taking solvers keep the VELOCITY default; the U-taking solvers are
+    explicitly VALUE_FUNCTION (machine-readable contract for a future coupler dispatch)."""
+    assert FPFDMSolver._drift_convention is DriftConvention.VELOCITY
+    assert FPGFDMSolver._drift_convention is DriftConvention.VELOCITY
+    for cls in (WeakFormFPSolver, MeshlessGalerkinFPSolver, FPSLJacobianSolver, FPSLSolver, FPNetworkSolver):
+        assert cls._drift_convention is DriftConvention.VALUE_FUNCTION, cls.__name__
+
+
+def _problem(sigma=0.3, n=15):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H, m_initial=lambda x: np.exp(-20 * (x - 0.5) ** 2), u_terminal=lambda x: 0.5 * (x - 0.5) ** 2
+    )
+    return MFGProblem(geometry=grid, components=comp, T=0.5, Nt=10, sigma=sigma, coupling_coefficient=0.5)
+
+
+def test_weak_form_drift_field_alias_equivalent_to_potential_field():
+    """Issue #1043 rename: passing the value function via the deprecated `drift_field` must warn
+    and give byte-identical results to the canonical `potential_field` (Deprecation Policy)."""
+    x = np.linspace(0.0, 1.0, 15)
+    m0 = np.exp(-20 * (x - 0.5) ** 2)
+    U = np.tile(0.5 * (x - 0.5) ** 2, (11, 1))  # (Nt+1, n) value function
+
+    fp = MeshlessGalerkinFPSolver(_problem(), collocation_points=x[:, None], delta=3.5 / 14)
+    traj_new = fp.solve_fp_system(m0, potential_field=U)
+    with pytest.warns(DeprecationWarning, match="drift_field"):
+        traj_old = fp.solve_fp_system(m0, drift_field=U)
+    assert np.array_equal(traj_new, traj_old)
+
+
+def test_weak_form_rejects_both_potential_and_drift():
+    """Passing both the canonical and deprecated U inputs is a fail-loud error."""
+    x = np.linspace(0.0, 1.0, 15)
+    m0 = np.exp(-20 * (x - 0.5) ** 2)
+    U = np.tile(0.5 * (x - 0.5) ** 2, (11, 1))
+    fp = MeshlessGalerkinFPSolver(_problem(), collocation_points=x[:, None], delta=3.5 / 14)
+    with pytest.warns(DeprecationWarning, match="drift_field"), pytest.raises(ValueError, match="potential_field"):
+        fp.solve_fp_system(m0, potential_field=U, drift_field=U)


### PR DESCRIPTION
## rec④ #1043 — the safe, byte-identical core (coupler dispatch deferred)

A workflow mapped every FP solver's drift-param semantics + every coupler's dispatch (cited to file:line). Findings:
- **Already velocity-correct** (no change): FPFDM, FPGFDM.
- **Already take U via `potential_field`** (no rename, just the trait): the two SL solvers.
- **Misnamed `drift_field` = U**: WeakForm/FEM/Meshless (clean), FPNetwork (internally inconsistent), FPParticle (bivalent via a flag).

## This PR (byte-identical)

1. **`DriftConvention` enum + `_drift_convention` trait** on `BaseFPSolver` (default `VELOCITY`). Set `VALUE_FUNCTION` on the U-taking solvers (weak-form/FEM/meshless, SL×2, network). Makes the contract explicit + machine-readable.
2. **Weak-form rename**: `WeakFormFPSolver.solve_fp_system`'s misnamed `drift_field` U-input → **`potential_field`** (the name the SL solvers + couplers already prefer, #919), with a `drift_field` deprecation alias (`@deprecated_parameter` + body redirect, fail-loud if both given).

**Byte-identical**: 209 weak-form/meshless/FEM/SL/network/coupling tests pass; the couplers now pass the preferred `potential_field`. New tests pin the trait values, the `drift_field`≡`potential_field` equivalence (Deprecation Policy), and the both-given error.

## ⚠️ Deferred — paper-number risk (consistent with #1071 steps 4-5)

The map flagged the coupler **trait-dispatch** (the part that would *enforce* the contract) as **HIGH paper-number risk**: the smooth-H common case (LQ/paper baseline) currently passes **raw U**, and the FP solver computes `−coupling·∇U` **on its own grid**; moving that velocity computation into the coupler changes *where the gradient is taken* → **not byte-identical** → could shift mfg-research EOC. Also deferred: `FPNetwork`/`FPParticle` param renames (network is internally inconsistent; particle is bivalent). All are marked via the trait for the future dispatch.

`Refs #1043`

🤖 Generated with [Claude Code](https://claude.com/claude-code)