### PR TITLE
test(meshless): coupled meshless-Galerkin-vs-FDM regression guard (#1145 acceptance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Coupled meshless-Galerkin-vs-FDM regression test** (Issue #1145 acceptance gap). The
+  meshless MFG fixed point previously diverged to NaN and had *no* coupled-vs-reference test —
+  only isolated-piece tests. `TestMeshlessGalerkinCoupled` runs the full HJB↔FP Picard with the
+  opt-in stabilization recipe (`use_newton=True`, streamline-diffusion) and asserts it stays
+  finite (the #1145 NaN regression), mass-bounded, and its terminal mean tracks `FDM_UPWIND`
+  within 0.05 (slow/integration). The *unstabilized default still NaNs*, so #1145 stays open for
+  that (default-stabilization decision) + the clip-limited convergence.
 - **Diffusion-magnitude invariant CI gate** (`tests/integration/test_diffusion_magnitude_gate.py`).
   A standing parametrized gate that pins every diffusion-carrying solver to the correct
   magnitude `D = sigma^2/2` (Issue #811) via cosine-eigenmode decay (`exp(-D*sum k^2*T)`).

--- a/tests/integration/test_meshless_galerkin_mfg.py
+++ b/tests/integration/test_meshless_galerkin_mfg.py
@@ -228,3 +228,55 @@ class TestMeshlessGalerkinDomainClipping:
         # and the mask actually dropped the x > 0.7 quadrature points
         unmasked = discretization_from_cloud(cloud, 0.35, n_gauss=2)
         assert hjb._disc._phi.shape[0] < unmasked._phi.shape[0]
+
+
+@pytest.mark.integration
+class TestMeshlessGalerkinCoupled:
+    """Issue #1145: the COUPLED meshless-Galerkin MFG fixed point — the path that was missing
+    a regression guard. Before Bug-A (gradient_projection) + Bug-B (streamline-diffusion /
+    Newton-inner), the unstabilized coupled solve diverged to NaN at outer-iter ~6 (mass →
+    5.9e4, singular matrix + overflow). With the opt-in stabilization recipe it stays finite,
+    mass-bounded, and its terminal mean position tracks the FDM_UPWIND reference."""
+
+    @pytest.mark.slow
+    def test_coupled_meshless_stabilized_is_finite_and_tracks_fdm(self):
+        """Stabilized (`use_newton=True`, streamline_diffusion_scale>0) coupled meshless MFG
+        must NOT diverge (the #1145 regression) and must match the FDM reference's terminal
+        mean within tolerance. The Galerkin positivity clip is not an M-matrix, so this pins
+        stability + reference-proximity, not tight Picard convergence."""
+        from mfgarchon.alg.numerical.coupling import FixedPointIterator
+
+        x = np.linspace(0.0, 1.0, 21)
+        dx = 1.0 / 20
+
+        p_ml = _problem()
+        hjb_ml, fp_ml = create_paired_solvers(
+            p_ml,
+            NumericalScheme.MESHLESS_GALERKIN,
+            hjb_config={
+                "collocation_points": x[:, None],
+                "delta": 3.5 / 20,
+                "use_newton": True,
+                "streamline_diffusion_scale": 1.0,
+            },
+        )
+        res_ml = FixedPointIterator(p_ml, hjb_solver=hjb_ml, fp_solver=fp_ml, relaxation=0.5).solve(
+            max_iterations=120, tolerance=1e-5, verbose=False
+        )
+        M_ml = np.asarray(res_ml.M)
+        assert np.all(np.isfinite(M_ml)), "coupled meshless diverged to NaN (Issue #1145 regression)"
+        mass_T = float(M_ml[-1].sum() * dx)
+        assert abs(mass_T - 1.0) < 0.05, f"coupled meshless mass not bounded: {mass_T:.4f}"
+        mean_ml = float((M_ml[-1] * x).sum() / M_ml[-1].sum())
+
+        # FDM reference (fast, converges) — the trusted equilibrium.
+        p_fdm = _problem()
+        hjb_f, fp_f = create_paired_solvers(p_fdm, NumericalScheme.FDM_UPWIND)
+        res_f = FixedPointIterator(p_fdm, hjb_solver=hjb_f, fp_solver=fp_f, relaxation=0.5).solve(
+            max_iterations=120, tolerance=1e-5, verbose=False
+        )
+        M_f = np.asarray(res_f.M)
+        mean_fdm = float((M_f[-1] * x).sum() / M_f[-1].sum())
+        assert abs(mean_ml - mean_fdm) < 0.05, (
+            f"coupled meshless terminal mean {mean_ml:.4f} far from FDM reference {mean_fdm:.4f}"
+        )


### PR DESCRIPTION
## #1145 acceptance gap — closed (the test), residuals documented

#1145's stated acceptance — *"a test that runs the HJB↔FP fixed point to a converged equilibrium against a reference"* — was **never added**; the repo's meshless tests all exercise pieces in **isolation**. Worse, **verify-by-artifact shows the coupled solve still diverges to NaN by default** (converged=False, iter ~6, singular matrix + overflow — the exact #1145 symptoms), because Bug-B's fix (#1148 streamline-diffusion + Newton-inner) is **opt-in** (default off).

| | FDM_UPWIND | meshless (unstabilized, default) | meshless (stabilized recipe) |
|---|---|---|---|
| outcome | converged | **NaN at iter ~6** | finite |
| mass(T) | 1.000 | → 5.9e4 → NaN | 1.034 |
| mean X(T) | 0.418 | — | 0.441 |

## This PR

`TestMeshlessGalerkinCoupled` runs the full Picard with the stabilization recipe (`use_newton=True`, `streamline_diffusion_scale=1.0`) and asserts: **finite** (the NaN regression — the unstabilized path fails this), **mass-bounded** (`|mass−1|<0.05`), and **terminal mean within 0.05 of the FDM reference**. The Galerkin positivity clip isn't an M-matrix, so it pins *stability + reference-proximity*, not tight Picard convergence. `slow`/`integration`, ~34s.

## #1145 stays OPEN

Two residuals the test surfaced: the **unstabilized default still NaNs** (should the coupled meshless default enable stabilization?) and convergence is **clip-limited**. I'll update #1145 with this verified status.

`Refs #1145`

🤖 Generated with [Claude Code](https://claude.com/claude-code)