### PR TITLE
fix(weno): Osher-Shu HJ-WENO5 derivatives + Lax-Friedrichs numerical Hamiltonian (#1200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **WENO HJB spatial scheme rebuilt: correct gradient + Lax-Friedrichs numerical Hamiltonian**
+  (Issue #1200). The previous scheme reconstructed WENO interface *values* and then took a bogus
+  central difference `(u_right − u_left)/(2·dx)`, so the nodal gradient fed to the Hamiltonian was
+  `≈ −0.25 · du/dx` (wrong sign **and** magnitude) — the solver had never computed a correct
+  gradient in any dimension, and the 2D/3D off-axis sweeps were `np.gradient` placeholders. With no
+  numerical Hamiltonian, oscillatory terminal data amplified high-frequency modes and blew up
+  (`1e26+`), CFL-independent; the whole WENO suite only asserted `isfinite`/shape so this was never
+  caught. Replaced with the Osher–Shu HJ-WENO5 one-sided nodal derivatives `p_minus`/`p_plus`
+  (undivided-difference stencils, ghost depth 2→3) and a global Lax-Friedrichs numerical Hamiltonian
+  `Ĥ = H((p_minus+p_plus)/2) − (α/2)(p_plus−p_minus)`, `α = max|∂_pH|`, whose viscosity damps the
+  unstable modes while staying O(h⁵) on smooth data (measured EOC ≈ 6, polynomial-exact to degree 3).
+  All dimensions now route through a single vectorized axis operator (`_compute_hjb_rhs_axis`); the
+  duplicated/placeholder 2D/3D direction methods are removed (−232 lines net). New tests assert the
+  gradient sign/magnitude, polynomial exactness, convergence order, bounded oscillatory solve, and 2D
+  axis-symmetry; the `#1200` `xfail` is removed. `Fixes #1200`.
+- **High-order ghost extrapolation fixed at the high boundary** (`PreallocatedGhostBuffer`, surfaced
+  by #1200). `_extrapolate_boundary_1d` paired the nearest-first `x_interior = [-dx, -2dx, ...]` with
+  `interior_indices` ordered farthest-first at the high boundary, so the Vandermonde fit produced
+  badly wrong order>2 ghosts there (the low boundary, where both orderings coincide, was correct).
+  Latent because WENO5 is the only order-5 consumer and nothing had consumed the high-boundary ghost
+  derivative correctly before; the prior order-5 test checked the low boundary only. Now ordered
+  nearest-first to match; smooth high-boundary ghosts recover machine-level accuracy (a `cos(pi x)`
+  ghost went from ~1.6e-1 error to ~1e-9), with a both-boundaries regression test added.
 - **Conservative no-flux Laplacian for the implicit FP diffusion solve** (Issue #1184, diffusion
   half). `LaplacianOperator.as_scipy_sparse()` no-flux branch had zero *row* sums (2nd-order
   Neumann accuracy) but nonzero *column* sums at the walls (`≈1/h²`); the implicit FP system

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -289,8 +289,9 @@ class HJBWenoSolver(BaseHJBSolver):
         """
         Setup ghost cell buffer for boundary handling with high-order accuracy.
 
-        WENO5 requires:
-        - ghost_depth=2: 2 ghost cells on each side for 5-point stencil (i-2 to i+2)
+        HJ-WENO5 requires:
+        - ghost_depth=3: 3 ghost cells on each side for the one-sided derivative
+          stencils p_minus / p_plus (undivided differences over i-3 to i+3, #1200)
         - order=5: High-order polynomial extrapolation for O(h^5) boundary accuracy
 
         Issue #576: Unified ghost node architecture enables WENO5 to achieve
@@ -299,8 +300,12 @@ class HJBWenoSolver(BaseHJBSolver):
         Uses composition pattern: the solver holds a PreallocatedGhostBuffer
         component rather than inheriting from a BoundaryAwareSolver base class.
         """
-        # Ghost depth for WENO5: 2 cells on each side for 5-point stencil
-        self.ghost_depth = 2
+        # Ghost depth for the Osher-Shu HJ-WENO5 one-sided derivative stencil.
+        # Reconstructing p_minus / p_plus at an interior node needs the undivided
+        # differences spanning u_{i-3} .. u_{i+3} (Issue #1200), i.e. 3 ghost cells
+        # per side -- not 2. (2 sufficed only for the previous, incorrect, value-
+        # interface reconstruction.)
+        self.ghost_depth = 3
 
         # Reconstruction order: 5th-order accuracy at boundaries
         # Issue #576: Uses polynomial extrapolation (not simple reflection)
@@ -312,24 +317,17 @@ class HJBWenoSolver(BaseHJBSolver):
         # Build domain bounds from grid information
         domain_bounds = self._get_domain_bounds()
 
-        # Create ghost buffer for each dimension
-        # For 1D, interior_shape is (num_points,)
-        # For nD, we create per-dimension buffers for dimensional splitting
-        if self.dimension == 1:
-            interior_shape = (self.num_grid_points_x,)
-            self.ghost_buffer = PreallocatedGhostBuffer(
-                interior_shape=interior_shape,
-                boundary_conditions=bc,
-                domain_bounds=domain_bounds,
-                ghost_depth=self.ghost_depth,
-                order=self.ghost_order,  # High-order ghost cells for WENO5
-            )
-        else:
-            # For multi-D with dimensional splitting, we create 1D buffers on demand
-            # Store BC and bounds for later use
-            self._bc = bc
-            self._domain_bounds = domain_bounds
-            self.ghost_buffer = None  # Created per-sweep in multi-D
+        # Single nD ghost buffer for every dimension. update_ghosts() fills ghosts
+        # on all axes; each directional sweep reads the BC-correct line along its
+        # axis from the padded buffer (Issue #1200 -- replaces the former
+        # per-dimension special-casing and the multi-D None placeholder).
+        self.ghost_buffer = PreallocatedGhostBuffer(
+            interior_shape=tuple(self.num_grid_points),
+            boundary_conditions=bc,
+            domain_bounds=domain_bounds,
+            ghost_depth=self.ghost_depth,
+            order=self.ghost_order,  # High-order ghost cells for WENO5
+        )
 
     def _get_boundary_conditions(self):
         """
@@ -611,7 +609,10 @@ class HJBWenoSolver(BaseHJBSolver):
 
     def solve_hjb_step(self, u_current: np.ndarray, m_current: np.ndarray, dt: float) -> np.ndarray:
         """
-        Solve one time step of the HJB equation using selected WENO variant.
+        Solve one 1D backward time step of the HJB equation (axis 0).
+
+        Multi-dimensional sweeps call ``_solve_hjb_step_axis`` directly with the
+        target axis; this is the public 1D entry point.
 
         Args:
             u_current: Current value function
@@ -621,33 +622,31 @@ class HJBWenoSolver(BaseHJBSolver):
         Returns:
             u_new: Updated value function after one time step
         """
+        return self._solve_hjb_step_axis(u_current, m_current, dt, axis=0)
+
+    def _solve_hjb_step_axis(self, u: np.ndarray, m: np.ndarray, dt: float, axis: int) -> np.ndarray:
+        """One backward time step of the 1D HJB operator along ``axis``.
+
+        The spatial discretisation (HJ-WENO5 derivatives + Lax-Friedrichs
+        numerical Hamiltonian + central diffusion) is supplied by
+        ``_compute_hjb_rhs_axis``; this method only advances it in time. Used for
+        the 1D solve (axis 0) and for every direction of the multi-D
+        dimensional split.
+        """
         if self.time_integration == "tvd_rk3":
-            return self._solve_hjb_tvd_rk3(u_current, m_current, dt)
+            # Stage 1
+            k1 = self._compute_hjb_rhs_axis(u, m, axis)
+            u1 = u + dt * k1
+            # Stage 2
+            k2 = self._compute_hjb_rhs_axis(u1, m, axis)
+            u2 = (3 / 4) * u + (1 / 4) * u1 + (1 / 4) * dt * k2
+            # Stage 3
+            k3 = self._compute_hjb_rhs_axis(u2, m, axis)
+            return (1 / 3) * u + (2 / 3) * u2 + (2 / 3) * dt * k3
         elif self.time_integration == "explicit_euler":
-            return self._solve_hjb_explicit_euler(u_current, m_current, dt)
+            return u + dt * self._compute_hjb_rhs_axis(u, m, axis)
         else:
             raise ValueError(f"Unknown time integration: {self.time_integration}")
-
-    def _solve_hjb_explicit_euler(self, u_current: np.ndarray, m_current: np.ndarray, dt: float) -> np.ndarray:
-        """Explicit Euler time step with WENO spatial discretization."""
-        rhs = self._compute_hjb_rhs(u_current, m_current)
-        return u_current + dt * rhs
-
-    def _solve_hjb_tvd_rk3(self, u_current: np.ndarray, m_current: np.ndarray, dt: float) -> np.ndarray:
-        """TVD-RK3 time step with WENO spatial discretization."""
-        # Stage 1
-        k1 = self._compute_hjb_rhs(u_current, m_current)
-        u1 = u_current + dt * k1
-
-        # Stage 2
-        k2 = self._compute_hjb_rhs(u1, m_current)
-        u2 = (3 / 4) * u_current + (1 / 4) * u1 + (1 / 4) * dt * k2
-
-        # Stage 3
-        k3 = self._compute_hjb_rhs(u2, m_current)
-        u_new = (1 / 3) * u_current + (2 / 3) * u2 + (2 / 3) * dt * k3
-
-        return u_new
 
     def _evaluate_hamiltonian(self, x_idx: int, m_val: float, grad: float, direction: tuple[int, ...] = (1,)) -> float:
         """
@@ -698,128 +697,159 @@ class HJBWenoSolver(BaseHJBSolver):
         # For 1D partial: H = (1/2)|∂u/∂x_i|² + m * ∂u/∂x_i
         return 0.5 * grad**2 + m_val * grad
 
-    def _compute_hjb_rhs(self, u: np.ndarray, m: np.ndarray) -> np.ndarray:
+    def _compute_hjb_rhs_axis(self, u: np.ndarray, m: np.ndarray, axis: int) -> np.ndarray:
+        """Right-hand side of the HJB equation along a single ``axis``.
+
+        Implements the monotone Hamilton-Jacobi discretisation (Issue #1200):
+
+            RHS = -Hhat(p_minus, p_plus) + D * d^2u/dx_axis^2
+
+        where ``p_minus`` / ``p_plus`` are the Osher-Shu HJ-WENO5 one-sided nodal
+        derivatives along ``axis`` and ``Hhat`` is the global Lax-Friedrichs
+        numerical Hamiltonian
+
+            Hhat = H((p_minus + p_plus)/2) - (alpha/2) * (p_plus - p_minus),
+            alpha = max |dH/dp|.
+
+        The LF viscosity (proportional to ``p_plus - p_minus ~ dx * u_xx``) damps
+        the high-frequency modes the previous central-difference scheme amplified,
+        while staying O(h^5) where the field is smooth. ``D = sigma^2/2``. Works in
+        any dimension: the field is padded on every axis and differentiated along
+        ``axis`` only, so this single operator serves both the 1D solve and each
+        direction of the multi-D dimensional split.
         """
-        Compute right-hand side of HJB equation using WENO discretization.
+        dx = self.grid_spacing[axis]
+        g = self.ghost_depth
 
-        RHS = -H(x, ∇u, m) + (σ²/2)Δu
-
-        Uses ghost cells for full 5th-order accuracy at boundaries.
-        """
-        n = len(u)
-        rhs = np.zeros(n)
-        dx = self.grid_spacing_x
-        g = self.ghost_depth  # 2 for WENO5
-
-        # Apply boundary conditions via ghost buffer
-        # This gives us a padded array with ghost cells on each side
+        # BC-aware ghost padding on every axis; the line along `axis` is then exact.
         self.ghost_buffer.interior[:] = u
         self.ghost_buffer.update_ghosts()
-        u_padded = self.ghost_buffer.padded  # Shape: (n + 2*g,)
+        u_padded = self.ghost_buffer.padded
 
-        # Compute spatial derivatives using WENO reconstruction on padded array
-        # Now we can use full WENO stencil at ALL interior points
-        u_x = np.zeros(n)
+        # One-sided HJ-WENO5 derivatives along `axis`.
+        p_minus, p_plus = self._weno5_hj_derivatives(u_padded, axis, dx)
 
-        for i in range(n):  # All interior points
-            # Index in padded array
-            i_pad = i + g
+        # Central second derivative along `axis` (ghost cells make it valid everywhere).
+        # Restrict non-swept axes to interior so u_aa is interior-shaped on all axes.
+        interior = [slice(g, -g)] * u_padded.ndim
+        interior[axis] = slice(None)
+        ua = np.moveaxis(u_padded[tuple(interior)], axis, -1)
+        n = ua.shape[-1] - 2 * g
+        u_aa = (ua[..., g + 1 : g + 1 + n] - 2.0 * ua[..., g : g + n] + ua[..., g - 1 : g - 1 + n]) / dx**2
+        u_aa = np.moveaxis(u_aa, -1, axis)
 
-            # WENO reconstruction for derivative approximation
-            # Now uses full stencil without clamping at boundaries
-            u_left, u_right = self._weno_reconstruction_padded(u_padded, i_pad)
+        # Per-direction Hamiltonian value at the averaged momentum + LF dissipation.
+        p_mid = 0.5 * (p_minus + p_plus)
+        direction = tuple(1 if d == axis else 0 for d in range(self.dimension))
+        h_mid, alpha = self._directional_hamiltonian_and_speed(m, p_mid, direction, axis)
+        h_hat = h_mid - 0.5 * alpha * (p_plus - p_minus)
 
-            # High-order central difference for first derivative
-            u_x[i] = (u_right - u_left) / (2 * dx)
+        diffusion = diffusion_from_volatility(self.problem.sigma)
+        return -h_hat + diffusion * u_aa
 
-        # Compute second derivative using central differences on padded array
-        # With ghost cells, we can use standard central diff at all points
-        u_xx = np.zeros(n)
-        for i in range(n):
-            i_pad = i + g
-            u_xx[i] = (u_padded[i_pad + 1] - 2 * u_padded[i_pad] + u_padded[i_pad - 1]) / dx**2
+    def _weno5_hj_derivatives(self, u_padded: np.ndarray, axis: int, dx: float) -> tuple[np.ndarray, np.ndarray]:
+        """Osher-Shu HJ-WENO5 one-sided nodal derivatives along ``axis``.
 
-        # Compute Hamiltonian and assemble RHS
-        for i in range(n):
-            # Evaluate Hamiltonian using problem interface (direction (1,) = x-derivative)
-            hamiltonian = self._evaluate_hamiltonian(i, m[i], u_x[i], direction=(1,))
-
-            # RHS = -H + diffusion
-            rhs[i] = -hamiltonian + diffusion_from_volatility(self.problem.sigma) * u_xx[i]
-
-        return rhs
-
-    def _weno_reconstruction_padded(self, u_padded: np.ndarray, i: int) -> tuple[float, float]:
+        Returns ``(p_minus, p_plus)`` -- the left- and right-biased fifth-order
+        WENO reconstructions of ``du/dx_axis`` at every interior node, shaped like
+        the interior field. Both are O(h^5) where the field is smooth and degrade
+        gracefully (no Gibbs growth) near kinks. Requires ``ghost_depth >= 3``: the
+        stencils span the undivided differences over ``u_{i-3} .. u_{i+3}``.
         """
-        WENO reconstruction on padded array (no boundary clamping needed).
+        g = self.ghost_depth
+        # Keep ghosts on the swept axis (the derivative needs them); restrict every
+        # other axis to its interior so the result is interior-shaped on all axes.
+        interior = [slice(g, -g)] * u_padded.ndim
+        interior[axis] = slice(None)
+        ua = np.moveaxis(u_padded[tuple(interior)], axis, -1)
+        # Undivided differences D[k] = (u[k+1] - u[k]) / dx, living at k+1/2.
+        diffs = np.diff(ua, axis=-1) / dx
+        n = ua.shape[-1] - 2 * g
 
-        Args:
-            u_padded: Padded array with ghost cells
-            i: Index in padded array (must have valid stencil i-2 to i+2)
+        # Left-biased stencil:  v_minus = [D[i],   D[i+1], D[i+2], D[i+3], D[i+4]]
+        vm = np.stack([diffs[..., k : k + n] for k in range(5)], axis=-1)
+        # Right-biased stencil: v_plus  = [D[i+5], D[i+4], D[i+3], D[i+2], D[i+1]]
+        vp = np.stack([diffs[..., (5 - k) : (5 - k) + n] for k in range(5)], axis=-1)
 
-        Returns:
-            (u_left, u_right): Reconstructed values at interface
+        p_minus = self._weno5_reconstruct_derivative(vm)
+        p_plus = self._weno5_reconstruct_derivative(vp)
+        return np.moveaxis(p_minus, -1, axis), np.moveaxis(p_plus, -1, axis)
+
+    def _weno5_reconstruct_derivative(self, v: np.ndarray) -> np.ndarray:
+        """Fifth-order WENO combination of three candidate derivative stencils.
+
+        ``v`` has shape ``(..., 5)`` and holds the five undivided differences,
+        ordered so the smooth (optimal-weight) combination approximates the nodal
+        derivative. Honours the selected WENO variant via the nonlinear weights.
+        Each candidate's coefficients sum to one, so on a constant-gradient field
+        the reconstruction is exact.
         """
-        # Get WENO weights using selected variant
-        w_plus, w_minus = self._compute_weno_weights_padded(u_padded, i)
+        beta = self._weno5_smoothness(v)
+        w = self._weno5_nonlinear_weights(beta)
+        v1, v2, v3, v4, v5 = (v[..., k] for k in range(5))
+        # Candidate third-order derivative reconstructions (Osher-Shu / Jiang-Peng).
+        q0 = v1 / 3.0 - 7.0 * v2 / 6.0 + 11.0 * v3 / 6.0
+        q1 = -v2 / 6.0 + 5.0 * v3 / 6.0 + v4 / 3.0
+        q2 = v3 / 3.0 + 5.0 * v4 / 6.0 - v5 / 6.0
+        return w[..., 0] * q0 + w[..., 1] * q1 + w[..., 2] * q2
 
-        # Extract 5-point stencil (no clamping - ghost cells ensure validity)
-        u = u_padded[i - 2 : i + 3]
+    @staticmethod
+    def _weno5_smoothness(v: np.ndarray) -> np.ndarray:
+        """Vectorised WENO5 smoothness indicators from stacked differences ``v`` (..., 5)."""
+        v1, v2, v3, v4, v5 = (v[..., k] for k in range(5))
+        b0 = (13.0 / 12.0) * (v1 - 2.0 * v2 + v3) ** 2 + 0.25 * (v1 - 4.0 * v2 + 3.0 * v3) ** 2
+        b1 = (13.0 / 12.0) * (v2 - 2.0 * v3 + v4) ** 2 + 0.25 * (v2 - v4) ** 2
+        b2 = (13.0 / 12.0) * (v3 - 2.0 * v4 + v5) ** 2 + 0.25 * (3.0 * v3 - 4.0 * v4 + v5) ** 2
+        return np.stack([b0, b1, b2], axis=-1)
 
-        # Reconstruct using weighted combination of sub-stencil polynomials
-        u_left = 0.0
-        u_right = 0.0
+    def _weno5_nonlinear_weights(self, beta: np.ndarray) -> np.ndarray:
+        """Vectorised nonlinear weights for the HJ derivative reconstruction.
 
-        for k in range(3):
-            # Left reconstruction (positive direction)
-            u_left += w_plus[k] * np.dot(self.c_plus[k], u[k : k + 3])
-
-            # Right reconstruction (negative direction)
-            if k == 0:
-                u_vals = u[2::-1]  # [u2, u1, u0]
-            elif k == 1:
-                u_vals = u[3:0:-1]  # [u3, u2, u1]
-            else:  # k == 2
-                u_vals = u[4:1:-1]  # [u4, u3, u2]
-
-            u_right += w_minus[k] * np.dot(self.c_minus[k], u_vals)
-
-        return u_left, u_right
-
-    def _compute_weno_weights_padded(self, u_padded: np.ndarray, i: int) -> tuple[np.ndarray, np.ndarray]:
+        Optimal linear weights for the one-sided derivative are ``(0.1, 0.6, 0.3)``.
+        ``weno5`` / ``weno-js`` use the classic Jiang-Shu weights; ``weno-z`` adds
+        the global smoothness measure ``tau_5 = |beta_0 - beta_2|``; ``weno-m``
+        applies the Henrick mapping toward the optimal weights.
         """
-        Compute WENO weights on padded array (no boundary clamping).
+        eps = self.weno_epsilon
+        d = np.array([0.1, 0.6, 0.3])
 
-        Args:
-            u_padded: Padded array with ghost cells
-            i: Index in padded array
-
-        Returns:
-            (w_plus, w_minus): WENO weights for upwind and downwind reconstruction
-        """
-        # Extract 5-point stencil directly (ghost cells ensure validity)
-        u = u_padded[i - 2 : i + 3]
-
-        # Compute smoothness indicators (same for all variants)
-        beta = self._compute_smoothness_indicators(u)
-
-        # Select weight calculation based on variant
-        if self.weno_variant == "weno5" or self.weno_variant == "weno-js":
-            w_plus = self._compute_classic_weights(beta, self.d_plus)
-            w_minus = self._compute_classic_weights(beta[::-1], self.d_minus)
-        elif self.weno_variant == "weno-z":
-            tau = self._compute_tau_indicator(u)
-            w_plus = self._compute_z_weights(beta, tau, self.d_plus)
-            w_minus = self._compute_z_weights(beta[::-1], tau, self.d_minus)
+        if self.weno_variant == "weno-z":
+            tau5 = np.abs(beta[..., 0:1] - beta[..., 2:3])
+            alpha = d * (1.0 + (tau5 / (eps + beta)) ** self.weno_z_parameter)
         elif self.weno_variant == "weno-m":
-            w_plus = self._compute_mapped_weights(beta, self.d_plus)
-            w_minus = self._compute_mapped_weights(beta[::-1], self.d_minus)
-        else:
-            # Fallback to classic
-            w_plus = self._compute_classic_weights(beta, self.d_plus)
-            w_minus = self._compute_classic_weights(beta[::-1], self.d_minus)
+            alpha0 = d / (eps + beta) ** 2
+            w0 = alpha0 / np.sum(alpha0, axis=-1, keepdims=True)
+            # Henrick et al. (2005) mapping toward the optimal linear weights.
+            alpha = w0 * (d + d * d - 3.0 * d * w0 + w0 * w0) / (d * d + w0 * (1.0 - 2.0 * d))
+        else:  # weno5 / weno-js (classic Jiang-Shu)
+            alpha = d / (eps + beta) ** 2
 
-        return w_plus, w_minus
+        return alpha / np.sum(alpha, axis=-1, keepdims=True)
+
+    def _directional_hamiltonian_and_speed(
+        self, m: np.ndarray, p_mid: np.ndarray, direction: tuple[int, ...], axis: int
+    ) -> tuple[np.ndarray, float]:
+        """Per-node Hamiltonian ``H(p_mid)`` and global LF speed ``alpha = max|dH/dp|``.
+
+        Reuses ``_evaluate_hamiltonian`` (dimensional-splitting convention: only the
+        derivative along ``axis`` is non-zero). ``alpha`` is estimated by a central
+        finite difference of ``H`` in ``p``; over-estimating it only adds
+        dissipation, so the bound is safe. ``x_idx`` is the index along the swept
+        axis, matching the pre-#1200 per-direction operators.
+        """
+        h_mid = np.empty_like(p_mid)
+        speed = np.empty_like(p_mid)
+        eps = 1e-7
+        for idx in np.ndindex(p_mid.shape):
+            x_idx = idx[axis]
+            m_val = float(m[idx])
+            p = float(p_mid[idx])
+            h_mid[idx] = self._evaluate_hamiltonian(x_idx, m_val, p, direction=direction)
+            h_plus = self._evaluate_hamiltonian(x_idx, m_val, p + eps, direction=direction)
+            h_minus = self._evaluate_hamiltonian(x_idx, m_val, p - eps, direction=direction)
+            speed[idx] = abs((h_plus - h_minus) / (2.0 * eps))
+        alpha = float(np.max(speed)) if speed.size else 0.0
+        return h_mid, alpha
 
     def _compute_dt_stable_1d(self, u: np.ndarray, m: np.ndarray) -> float:
         """Compute stable time step based on CFL and diffusion stability."""
@@ -935,38 +965,31 @@ class HJBWenoSolver(BaseHJBSolver):
 
     def _step_2d_split(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
         """One 2D dimensional-split step of size ``dt`` (Strang or Godunov)."""
-        if self.splitting_method == "strang":
-            u_half = self._solve_hjb_step_2d_x_direction(u, m, dt / 2)
-            u_full = self._solve_hjb_step_2d_y_direction(u_half, m, dt)
-            return self._solve_hjb_step_2d_x_direction(u_full, m, dt / 2)
-        u_half = self._solve_hjb_step_2d_x_direction(u, m, dt)
-        return self._solve_hjb_step_2d_y_direction(u_half, m, dt)
+        return self._step_nd_split(u, m, dt)
 
     def _step_3d_split(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
         """One 3D dimensional-split step of size ``dt`` (Strang or Godunov)."""
-        if self.splitting_method == "strang":
-            u1 = self._solve_hjb_step_3d_x_direction(u, m, dt / 2)
-            u2 = self._solve_hjb_step_3d_y_direction(u1, m, dt / 2)
-            u3 = self._solve_hjb_step_3d_z_direction(u2, m, dt)
-            u4 = self._solve_hjb_step_3d_y_direction(u3, m, dt / 2)
-            return self._solve_hjb_step_3d_x_direction(u4, m, dt / 2)
-        u1 = self._solve_hjb_step_3d_x_direction(u, m, dt)
-        u2 = self._solve_hjb_step_3d_y_direction(u1, m, dt)
-        return self._solve_hjb_step_3d_z_direction(u2, m, dt)
+        return self._step_nd_split(u, m, dt)
 
     def _step_nd_split(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """One nD dimensional-split step of size ``dt`` (Strang or Godunov)."""
+        """One dimensional-split step of size ``dt`` (Strang or Godunov), any dim.
+
+        Each axis is advanced by the single unified operator ``_solve_hjb_step_axis``
+        (Issue #1200). Strang splitting sweeps axes ``0..d-2`` at half step, the last
+        axis ``d-1`` at full step, then ``0..d-2`` again at half step (second-order in
+        time); Godunov sweeps each axis once at full step (first-order).
+        """
         if self.splitting_method == "strang":
             u_temp = u.copy()
             for dim_idx in range(self.dimension - 1):
-                u_temp = self._solve_hjb_step_direction_nd(u_temp, m, dt / 2, dim_idx)
-            u_temp = self._solve_hjb_step_direction_nd(u_temp, m, dt, self.dimension - 1)
+                u_temp = self._solve_hjb_step_axis(u_temp, m, dt / 2, dim_idx)
+            u_temp = self._solve_hjb_step_axis(u_temp, m, dt, self.dimension - 1)
             for dim_idx in range(self.dimension - 2, -1, -1):
-                u_temp = self._solve_hjb_step_direction_nd(u_temp, m, dt / 2, dim_idx)
+                u_temp = self._solve_hjb_step_axis(u_temp, m, dt / 2, dim_idx)
             return u_temp
         u_new = u.copy()
         for dim_idx in range(self.dimension):
-            u_new = self._solve_hjb_step_direction_nd(u_new, m, dt, dim_idx)
+            u_new = self._solve_hjb_step_axis(u_new, m, dt, dim_idx)
         return u_new
 
     def _solve_hjb_system_1d(
@@ -1126,74 +1149,6 @@ class HJBWenoSolver(BaseHJBSolver):
 
         return U_solved
 
-    def _solve_hjb_step_direction_nd(self, u: np.ndarray, m: np.ndarray, dt: float, axis: int) -> np.ndarray:
-        """
-        Apply WENO reconstruction along a specific axis for nD problems.
-
-        This is the dimension-agnostic directional solver that works for any dimension.
-
-        Args:
-            u: Value function array (shape: [n0, n1, ..., nd])
-            m: Density array (shape: [n0, n1, ..., nd])
-            dt: Time step
-            axis: Axis index to apply WENO (0 = first spatial dimension, etc.)
-
-        Returns:
-            u_new: Updated value function after WENO step along specified axis
-        """
-        u_new = u.copy()
-
-        # Move target axis to the end for easier slicing
-        u_transposed = np.moveaxis(u, axis, -1)
-        m_transposed = np.moveaxis(m, axis, -1)
-        u_new_transposed = np.moveaxis(u_new, axis, -1)
-
-        # Get shape of all dimensions except the target axis
-        shape_except_axis = u_transposed.shape[:-1]
-
-        # Iterate over all slices perpendicular to the target axis
-        for idx in np.ndindex(shape_except_axis):
-            u_slice = u_transposed[idx]
-            m_slice = m_transposed[idx]
-
-            # Apply 1D WENO step adapted for this direction
-            u_new_transposed[idx] = self._solve_hjb_step_1d_direction_adapted(u_slice, m_slice, dt, axis)
-
-        # Move axis back to original position
-        u_new = np.moveaxis(u_new_transposed, -1, axis)
-
-        return u_new
-
-    def _solve_hjb_step_1d_direction_adapted(
-        self, u_1d: np.ndarray, m_1d: np.ndarray, dt: float, axis: int
-    ) -> np.ndarray:
-        """
-        Apply 1D WENO step adapted for a specific direction with appropriate grid spacing.
-
-        Args:
-            u_1d: 1D slice of value function
-            m_1d: 1D slice of density
-            dt: Time step
-            axis: Axis index (0, 1, 2, ...) to determine grid spacing
-
-        Returns:
-            u_new: Updated 1D slice
-        """
-        # Save current grid spacing and temporarily replace with axis-specific spacing
-        original_spacing = self.grid_spacing_x
-        self.grid_spacing_x = self.grid_spacing[axis]
-
-        # Apply 1D WENO solver
-        if self.time_integration == "tvd_rk3":
-            u_new = self._solve_hjb_tvd_rk3(u_1d, m_1d, dt)
-        else:
-            u_new = self._solve_hjb_explicit_euler(u_1d, m_1d, dt)
-
-        # Restore original spacing
-        self.grid_spacing_x = original_spacing
-
-        return u_new
-
     def _compute_dt_stable_nd(self, u: np.ndarray, m: np.ndarray) -> float:
         """
         Compute stable time step for nD problem based on CFL and diffusion stability.
@@ -1251,99 +1206,6 @@ class HJBWenoSolver(BaseHJBSolver):
 
         return max(dt_stable, 1e-10)  # Ensure positive time step
 
-    def _solve_hjb_step_2d_x_direction(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """Apply WENO reconstruction in X-direction for 2D problem."""
-        u_new = u.copy()
-
-        # Apply 1D WENO reconstruction in X-direction for each Y-slice
-        for j in range(self.num_grid_points_y):
-            u_slice = u[:, j]
-            m_slice = m[:, j]
-
-            # Use existing 1D WENO step
-            u_new[:, j] = self.solve_hjb_step(u_slice, m_slice, dt)
-
-        return u_new
-
-    def _solve_hjb_step_2d_y_direction(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """Apply WENO reconstruction in Y-direction for 2D problem."""
-        u_new = u.copy()
-
-        # Apply 1D WENO reconstruction in Y-direction for each X-slice
-        # This requires adapting the 1D solver to work on transposed arrays
-        for i in range(self.num_grid_points_x):
-            u_slice = u[i, :]
-            m_slice = m[i, :]
-
-            # Apply 1D WENO step (would need adaptation for different grid spacing)
-            # For now, use simplified approach
-            u_new[i, :] = self._solve_hjb_step_1d_y_adapted(u_slice, m_slice, dt)
-
-        return u_new
-
-    def _solve_hjb_step_1d_y_adapted(self, u_1d: np.ndarray, m_1d: np.ndarray, dt: float) -> np.ndarray:
-        """Apply 1D WENO step adapted for Y-direction with appropriate grid spacing."""
-        # This is a simplified adaptation - in full implementation would properly
-        # handle different grid spacing and coordinate systems
-
-        # Use existing WENO reconstruction logic but with Y-direction spacing
-        if self.time_integration == "tvd_rk3":
-            return self._solve_hjb_tvd_rk3_y_adapted(u_1d, m_1d, dt)
-        else:
-            return self._solve_hjb_explicit_euler_y_adapted(u_1d, m_1d, dt)
-
-    def _solve_hjb_tvd_rk3_y_adapted(self, u_current: np.ndarray, m_current: np.ndarray, dt: float) -> np.ndarray:
-        """TVD-RK3 time stepping adapted for Y-direction."""
-        # Stage 1
-        L1 = self._compute_spatial_operator_y_adapted(u_current, m_current)
-        u1 = u_current + dt * L1
-
-        # Stage 2
-        L2 = self._compute_spatial_operator_y_adapted(u1, m_current)
-        u2 = 0.75 * u_current + 0.25 * u1 + 0.25 * dt * L2
-
-        # Stage 3
-        L3 = self._compute_spatial_operator_y_adapted(u2, m_current)
-        u_new = (1.0 / 3.0) * u_current + (2.0 / 3.0) * u2 + (2.0 / 3.0) * dt * L3
-
-        return u_new
-
-    def _solve_hjb_explicit_euler_y_adapted(
-        self, u_current: np.ndarray, m_current: np.ndarray, dt: float
-    ) -> np.ndarray:
-        """Explicit Euler time stepping adapted for Y-direction."""
-        L = self._compute_spatial_operator_y_adapted(u_current, m_current)
-        return u_current + dt * L
-
-    def _compute_spatial_operator_y_adapted(self, u: np.ndarray, m: np.ndarray) -> np.ndarray:
-        """Compute spatial operator for Y-direction with adapted grid spacing."""
-        # This is a placeholder - full implementation would properly handle
-        # Y-direction WENO reconstruction with self.grid_spacing_y spacing
-        n = len(u)
-        rhs = np.zeros(n)
-
-        # Compute derivatives using Y-direction spacing
-        u_y = self._weno_reconstruction_y_adapted(u)
-
-        # Second derivative (central differences with Y spacing)
-        u_yy = np.zeros(n)
-        u_yy[1:-1] = (u[:-2] - 2 * u[1:-1] + u[2:]) / (self.grid_spacing_y**2)
-        u_yy[0] = u_yy[1]
-        u_yy[-1] = u_yy[-2]
-
-        # Hamiltonian evaluation for Y-direction (direction (0,1) = y-derivative)
-        for i in range(n):
-            hamiltonian = self._evaluate_hamiltonian(i, m[i], u_y[i], direction=(0, 1))
-            rhs[i] = -hamiltonian + diffusion_from_volatility(self.problem.sigma) * u_yy[i]
-
-        return rhs
-
-    def _weno_reconstruction_y_adapted(self, u: np.ndarray) -> np.ndarray:
-        """WENO reconstruction adapted for Y-direction with proper grid spacing."""
-        # This would use the same WENO logic but with Dy spacing
-        # For now, use standard gradient as placeholder
-        return np.gradient(u, self.grid_spacing_y)
-
     def _compute_dt_stable_3d(self, u: np.ndarray, m: np.ndarray) -> float:
         """Compute stable time step for 3D problem based on CFL and diffusion stability."""
         # Compute gradients for stability analysis
@@ -1374,100 +1236,6 @@ class HJBWenoSolver(BaseHJBSolver):
         dt_diffusion = min(dt_diffusion_x, dt_diffusion_y, dt_diffusion_z)
 
         return min(dt_cfl, dt_diffusion)
-
-    def _solve_hjb_step_3d_x_direction(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """Apply WENO reconstruction in X-direction for 3D problem."""
-        u_new = u.copy()
-        # Apply 1D WENO reconstruction in X-direction for each (Y,Z)-slice
-        for j in range(self.num_grid_points_y):
-            for k in range(self.num_grid_points_z):
-                u_slice = u[:, j, k]
-                m_slice = m[:, j, k]
-                # Apply 1D WENO step
-                u_new[:, j, k] = self._solve_hjb_step_1d_adapted(u_slice, m_slice, dt)
-        return u_new
-
-    def _solve_hjb_step_3d_y_direction(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """Apply WENO reconstruction in Y-direction for 3D problem."""
-        u_new = u.copy()
-        # Apply 1D WENO reconstruction in Y-direction for each (X,Z)-slice
-        for i in range(self.num_grid_points_x):
-            for k in range(self.num_grid_points_z):
-                u_slice = u[i, :, k]
-                m_slice = m[i, :, k]
-                # Apply 1D WENO step adapted for Y-direction
-                u_new[i, :, k] = self._solve_hjb_step_1d_y_adapted(u_slice, m_slice, dt)
-        return u_new
-
-    def _solve_hjb_step_3d_z_direction(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """Apply WENO reconstruction in Z-direction for 3D problem."""
-        u_new = u.copy()
-        # Apply 1D WENO reconstruction in Z-direction for each (X,Y)-slice
-        for i in range(self.num_grid_points_x):
-            for j in range(self.num_grid_points_y):
-                u_slice = u[i, j, :]
-                m_slice = m[i, j, :]
-                # Apply 1D WENO step adapted for Z-direction
-                u_new[i, j, :] = self._solve_hjb_step_1d_z_adapted(u_slice, m_slice, dt)
-        return u_new
-
-    def _solve_hjb_step_1d_z_adapted(self, u_1d: np.ndarray, m_1d: np.ndarray, dt: float) -> np.ndarray:
-        """Apply 1D WENO step adapted for Z-direction with appropriate grid spacing."""
-        # Use existing WENO reconstruction logic but with Z-direction spacing
-        if self.time_integration == "tvd_rk3":
-            return self._solve_hjb_tvd_rk3_z_adapted(u_1d, m_1d, dt)
-        else:
-            return self._solve_hjb_explicit_euler_z_adapted(u_1d, m_1d, dt)
-
-    def _solve_hjb_tvd_rk3_z_adapted(self, u_current: np.ndarray, m_current: np.ndarray, dt: float) -> np.ndarray:
-        """TVD-RK3 time stepping adapted for Z-direction."""
-        # Stage 1
-        L1 = self._compute_spatial_operator_z_adapted(u_current, m_current)
-        u1 = u_current + dt * L1
-
-        # Stage 2
-        L2 = self._compute_spatial_operator_z_adapted(u1, m_current)
-        u2 = 0.75 * u_current + 0.25 * u1 + 0.25 * dt * L2
-
-        # Stage 3
-        L3 = self._compute_spatial_operator_z_adapted(u2, m_current)
-        u_new = (1.0 / 3.0) * u_current + (2.0 / 3.0) * u2 + (2.0 / 3.0) * dt * L3
-
-        return u_new
-
-    def _solve_hjb_explicit_euler_z_adapted(
-        self, u_current: np.ndarray, m_current: np.ndarray, dt: float
-    ) -> np.ndarray:
-        """Explicit Euler time stepping adapted for Z-direction."""
-        L = self._compute_spatial_operator_z_adapted(u_current, m_current)
-        return u_current + dt * L
-
-    def _compute_spatial_operator_z_adapted(self, u: np.ndarray, m: np.ndarray) -> np.ndarray:
-        """Compute spatial operator for Z-direction with adapted grid spacing."""
-        n = len(u)
-        rhs = np.zeros(n)
-
-        # Compute derivatives using Z-direction spacing
-        u_z = self._weno_reconstruction_z_adapted(u)
-
-        # Second derivative (central differences with Z spacing)
-        u_zz = np.zeros(n)
-        u_zz[1:-1] = (u[:-2] - 2 * u[1:-1] + u[2:]) / (self.grid_spacing_z**2)
-        u_zz[0] = u_zz[1]
-        u_zz[-1] = u_zz[-2]
-
-        # Hamiltonian evaluation for Z-direction (direction (0,0,1) = z-derivative)
-        for i in range(n):
-            hamiltonian = self._evaluate_hamiltonian(i, m[i], u_z[i], direction=(0, 0, 1))
-            rhs[i] = -hamiltonian + diffusion_from_volatility(self.problem.sigma) * u_zz[i]
-
-        return rhs
-
-    def _weno_reconstruction_z_adapted(self, u: np.ndarray) -> np.ndarray:
-        """WENO reconstruction adapted for Z-direction with proper grid spacing."""
-        # This would use the same WENO logic but with Dz spacing
-        # For now, use standard gradient as placeholder
-        return np.gradient(u, self.grid_spacing_z)
 
     def get_variant_info(self) -> dict[str, str]:
         """

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -1194,9 +1194,14 @@ class PreallocatedGhostBuffer:
             interior_indices = list(range(g + 1, g + 1 + n_stencil))
         else:
             # Ghost points: indices -g to -1 (i.e., -g, -g+1, ..., -1)
-            # Interior stencil: indices -g-n_stencil-1 to -g-1 (skip boundary at -g-1)
+            # Interior stencil: indices -g-n_stencil-1 to -g-1 (skip boundary at -g-1).
+            # Order nearest-boundary first so the pairing matches ``x_interior`` below
+            # ([-dx, -2dx, ...], also nearest-first). Without the reversal the Vandermonde
+            # rows pair x=-dx with the farthest interior value, fitting a garbage polynomial
+            # -> badly wrong high-boundary ghosts (Issue #1200: latent until HJ-WENO5 became
+            # the first high-order scheme to consume the high-boundary ghost derivative).
             ghost_indices = list(range(n_total - g, n_total))
-            interior_indices = list(range(n_total - g - n_stencil - 1, n_total - g - 1))
+            interior_indices = list(range(n_total - g - n_stencil - 1, n_total - g - 1))[::-1]
 
         # Compute polynomial coefficients once, then apply to all slices
         # Build Vandermonde matrix and solve for extrapolation weights

--- a/tests/unit/test_alg/test_weno_family.py
+++ b/tests/unit/test_alg/test_weno_family.py
@@ -445,15 +445,16 @@ class TestWenoSolverIntegration:
         assert np.all(np.isfinite(U_solution))
         assert U_solution.shape == (Nt, Nx)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="WENO HJB is spatially unstable for oscillatory terminal data (sin(2*pi*x), "
-        "sigma=0.1): it amplifies high-frequency modes independent of dt -- see #1200. "
-        "Pre-#1180 this passed only because the solver under-integrated (near-frozen at the "
-        "bounded terminal) and never reached the blow-up. Remove the xfail when #1200 lands.",
-    )
     def test_solution_finiteness(self, integration_problem):
-        """Test that solution remains finite throughout (oscillatory terminal: #1200 instability)."""
+        """Oscillatory terminal data stays bounded (Issue #1200 regression).
+
+        ``sin(2*pi*x)`` at ``sigma=0.1`` previously triggered a CFL-independent
+        high-frequency blow-up (1e26+ by a handful of intervals) because the scheme
+        used a central derivative with no numerical viscosity. With the Osher-Shu
+        HJ-WENO5 derivatives + Lax-Friedrichs numerical Hamiltonian the solution
+        stays smooth and O(1). A finiteness check alone is too weak (it would pass
+        on a slowly-growing instability), so we also bound the magnitude.
+        """
         solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
@@ -467,8 +468,12 @@ class TestWenoSolverIntegration:
 
         U_solution = solver.solve_hjb_system(M_density, U_final, U_prev)
 
-        # All values should be finite
         assert np.all(np.isfinite(U_solution))
+        # No high-frequency amplification: the value function never exceeds a small
+        # multiple of the terminal amplitude (the unstable scheme reached 1e26+).
+        assert np.max(np.abs(U_solution)) < 10.0, (
+            f"oscillatory terminal amplified (#1200 regression): max|U|={np.max(np.abs(U_solution)):.3e}"
+        )
 
     def test_different_cfl_numbers(self, integration_problem):
         """Test solver with different CFL numbers."""
@@ -515,9 +520,7 @@ class TestWenoTimeSubstepping:
             u_terminal=lambda x: 0.5 * (x - 0.5) ** 2,
             hamiltonian=ham,
         )
-        dom = TensorProductGrid(
-            bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1)
-        )
+        dom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1))
         return MFGProblem(geometry=dom, T=T, Nt=Nt, sigma=sigma, components=comps)
 
     @pytest.mark.slow
@@ -579,6 +582,214 @@ class TestWenoTimeSubstepping:
         with pytest.raises(ValueError, match="max_substeps"):
             # 3 substeps of 0.01 cover 0.03 << dt=1.0 -> uncovered -> raise
             solver._advance_full_interval(u, m, 1.0, lambda uu, mm: 0.01, lambda uu, mm, dd: uu)
+
+
+class TestWenoHJDerivativeCorrectness:
+    """Numerical-correctness guards for the HJ-WENO5 spatial scheme (Issue #1200).
+
+    The pre-#1200 scheme reconstructed *interface values* and then took a bogus
+    central difference, so the nodal gradient it fed the Hamiltonian was
+    ``~ -0.25 * du/dx`` (wrong sign AND magnitude). The whole WENO test suite only
+    asserted ``isfinite`` / shape, so this never surfaced. These tests assert the
+    gradient and the scheme order directly.
+    """
+
+    def _solver(self, n, variant="weno5"):
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        )
+        comp = MFGComponents(m_initial=lambda x: np.ones_like(x), u_terminal=lambda x: 0.0, hamiltonian=H)
+        dom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+        prob = MFGProblem(geometry=dom, T=1.0, Nt=30, sigma=0.1, components=comp)
+        return HJBWenoSolver(prob, weno_variant=variant)
+
+    def _derivatives(self, solver, u):
+        solver.ghost_buffer.interior[:] = u
+        solver.ghost_buffer.update_ghosts()
+        padded = solver.ghost_buffer.padded
+        return solver._weno5_hj_derivatives(padded, 0, solver.grid_spacing[0])
+
+    def test_ghost_depth_is_three(self):
+        """HJ-WENO5 one-sided derivative needs a 3-cell ghost layer (u_{i-3}..u_{i+3})."""
+        assert self._solver(41).ghost_depth == 3
+
+    def test_gradient_sign_and_magnitude(self):
+        """p_minus, p_plus recover du/dx on the new reconstruction path.
+
+        The pre-#1200 code computed ``~ -0.25 * du/dx`` (wrong sign and magnitude); this
+        is a strong guard on the replacement (it flags a sign flip or a 0.25x scale by
+        ~3900x). (It exercises ``_weno5_hj_derivatives``, which did not exist before the
+        fix, so it guards the new code path rather than literally re-running the old one.)
+        """
+        solver = self._solver(41)
+        x = np.linspace(0.0, 1.0, 41)
+        interior = slice(6, 41 - 6)
+        for u, du in [(x**2, 2 * x), (np.sin(2 * np.pi * x), 2 * np.pi * np.cos(2 * np.pi * x))]:
+            p_minus, p_plus = self._derivatives(solver, u)
+            for p in (p_minus, p_plus):
+                np.testing.assert_allclose(p[interior], du[interior], rtol=2e-3, atol=2e-3)
+
+    def test_gradient_accurate_at_boundary_nodes(self):
+        """Gradient is accurate AT the boundary nodes, not just the deep interior.
+
+        The boundary nodes are exactly those whose WENO stencils consume the
+        ghost-extrapolated cells; the other accuracy tests slice the boundary band out.
+        Uses ``cos(pi x)`` (du/dn = 0 at both ends, Neumann-compatible). Both endpoints
+        must be accurate -- this also guards the high-boundary ghost-extrapolation fix
+        (Issue #1200): before it, the last node's gradient was off by ~0.19."""
+        n = 81
+        solver = self._solver(n)
+        x = np.linspace(0.0, 1.0, n)
+        u = np.cos(np.pi * x)
+        d_true = -np.pi * np.sin(np.pi * x)
+        p_minus, p_plus = self._derivatives(solver, u)
+        p_mid = 0.5 * (p_minus + p_plus)
+        # Whole domain INCLUDING both boundary nodes (no interior slicing).
+        np.testing.assert_allclose(p_mid, d_true, atol=1e-5)
+        # The two endpoints specifically (the ghost-consuming nodes).
+        assert abs(p_mid[0] - d_true[0]) < 1e-6
+        assert abs(p_mid[-1] - d_true[-1]) < 1e-6
+
+    def test_polynomial_exactness(self):
+        """WENO5 derivative is exact (machine precision) for polynomials up to degree 3."""
+        n = 61
+        solver = self._solver(n)
+        x = np.linspace(0.0, 1.0, n)
+        interior = slice(8, n - 8)
+        for deg in (1, 2, 3):
+            p_minus, p_plus = self._derivatives(solver, x**deg)
+            d_true = deg * x ** (deg - 1)
+            assert np.max(np.abs(p_minus[interior] - d_true[interior])) < 1e-10
+            assert np.max(np.abs(p_plus[interior] - d_true[interior])) < 1e-10
+
+    def test_high_order_convergence(self):
+        """Smooth-data derivative converges at >=4th order (design order 5)."""
+        prev_err = None
+        rates = []
+        for n in (21, 41, 81, 161):
+            solver = self._solver(n)
+            x = np.linspace(0.0, 1.0, n)
+            p_minus, p_plus = self._derivatives(solver, np.sin(2 * np.pi * x))
+            d_true = 2 * np.pi * np.cos(2 * np.pi * x)
+            interior = slice(8, n - 8)
+            err = np.max(np.abs(0.5 * (p_minus + p_plus)[interior] - d_true[interior]))
+            if prev_err is not None:
+                rates.append(np.log(prev_err / err) / np.log(2))
+            prev_err = err
+        assert min(rates) > 4.0, f"WENO5 derivative convergence too low: rates={rates}"
+
+    @pytest.mark.parametrize("variant", ["weno5", "weno-z", "weno-m", "weno-js"])
+    def test_all_variants_recover_gradient(self, variant):
+        """Every WENO variant reconstructs the gradient (not just weno5)."""
+        solver = self._solver(41, variant=variant)
+        x = np.linspace(0.0, 1.0, 41)
+        p_minus, p_plus = self._derivatives(solver, np.sin(2 * np.pi * x))
+        d_true = 2 * np.pi * np.cos(2 * np.pi * x)
+        interior = slice(6, 41 - 6)
+        np.testing.assert_allclose(0.5 * (p_minus + p_plus)[interior], d_true[interior], rtol=5e-3, atol=5e-3)
+
+
+class TestWeno2DSolve:
+    """The dimensional-split multi-D path is now a real WENO5 sweep, not the former
+    ``np.gradient`` placeholder (Issue #1200)."""
+
+    def _problem_2d(self, n):
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        )
+        comp = MFGComponents(m_initial=lambda x: np.ones_like(x[..., 0]), u_terminal=lambda x: 0.0, hamiltonian=H)
+        dom = TensorProductGrid(
+            bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[n, n], boundary_conditions=no_flux_bc(dimension=2)
+        )
+        return MFGProblem(geometry=dom, T=0.2, Nt=10, sigma=0.2, components=comp)
+
+    def test_2d_solve_finite_and_bounded(self):
+        """A 2D HJB solve with oscillatory terminal data stays finite and bounded."""
+        n = 21
+        prob = self._problem_2d(n)
+        solver = HJBWenoSolver(prob, weno_variant="weno5")
+        Nt = prob.Nt + 1
+        x = np.linspace(0.0, 1.0, n)
+        xx, yy = np.meshgrid(x, x, indexing="ij")
+        U_terminal = np.sin(2 * np.pi * xx) * np.sin(2 * np.pi * yy)
+        M_density = np.ones((Nt, n, n)) * 0.5
+        U_prev = np.zeros((Nt, n, n))
+
+        U = solver.solve_hjb_system(M_density, U_terminal, U_prev)
+
+        assert U.shape == (Nt, n, n)
+        assert np.all(np.isfinite(U))
+        assert np.max(np.abs(U)) < 10.0
+
+    def test_2d_split_symmetry(self):
+        """An x<->y symmetric problem yields a near-symmetric value function: both
+        axes are now advanced by the *same* WENO5 operator. The former placeholder
+        (x = WENO, y = np.gradient) produced an O(1) directional bias; here the only
+        asymmetry is the Strang-split axis-swap error, O(dt^2) ~ 3e-4 here. We assert
+        the relative asymmetry is well below 1% (a placeholder-class bug would be
+        comparable to the field amplitude)."""
+        n = 21
+        prob = self._problem_2d(n)
+        solver = HJBWenoSolver(prob, weno_variant="weno5")
+        Nt = prob.Nt + 1
+        x = np.linspace(0.0, 1.0, n)
+        xx, yy = np.meshgrid(x, x, indexing="ij")
+        # Symmetric under (x, y) -> (y, x).
+        U_terminal = np.cos(np.pi * xx) * np.cos(np.pi * yy)
+        M_density = np.ones((Nt, n, n)) * 0.5
+        U_prev = np.zeros((Nt, n, n))
+
+        U = solver.solve_hjb_system(M_density, U_terminal, U_prev)
+        asymmetry = np.max(np.abs(U[0] - U[0].T))
+        assert asymmetry < 1e-2 * np.max(np.abs(U[0])), (
+            f"value function not axis-symmetric (directional-bias regression): "
+            f"asymmetry={asymmetry:.3e}, max|U|={np.max(np.abs(U[0])):.3e}"
+        )
+
+    @staticmethod
+    def _rect_problem(bounds, npts):
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        )
+        comp = MFGComponents(m_initial=lambda x: np.ones_like(x[..., 0]), u_terminal=lambda x: 0.0, hamiltonian=H)
+        dom = TensorProductGrid(bounds=bounds, Nx_points=npts, boundary_conditions=no_flux_bc(dimension=2))
+        return MFGProblem(geometry=dom, T=0.2, Nt=10, sigma=0.2, components=comp)
+
+    def test_2d_anisotropic_transpose_invariance(self):
+        """Per-axis grid spacing is honoured (Issue #1200). On a SQUARE grid a
+        grid_spacing[axis] mix-up is invisible (dx_x == dx_y), so the square symmetry
+        test cannot guard it -- the exact area the deleted placeholder warned about
+        ('would need adaptation for different grid spacing'). Here problem B is problem A
+        with both axes swapped (domain, grid, and terminal data all transposed). Because
+        the Hamiltonian/diffusion are isotropic, the correct solver must satisfy
+        U_B = U_A.T up to the O(dt^2) Strang axis-swap error. A spacing mix-up (e.g. the
+        y-sweep using dx_x) breaks this by O(1) -- it shifts U by ~50% of its amplitude
+        on this 1-vs-2 aspect-ratio grid."""
+        nx, ny = 21, 31
+        # A: x in [0,1] (fine), y in [0,2] (coarse); B: axes swapped.
+        probA = self._rect_problem([(0.0, 1.0), (0.0, 2.0)], [nx, ny])
+        probB = self._rect_problem([(0.0, 2.0), (0.0, 1.0)], [ny, nx])
+        solA = HJBWenoSolver(probA, weno_variant="weno5")
+        solB = HJBWenoSolver(probB, weno_variant="weno5")
+        Nt = probA.Nt + 1
+        xa = np.linspace(0.0, 1.0, nx)
+        ya = np.linspace(0.0, 2.0, ny)
+        xxa, yya = np.meshgrid(xa, ya, indexing="ij")
+        # Neumann-compatible (du/dn = 0 on all four edges).
+        U_T_A = np.cos(np.pi * xxa) * np.cos(np.pi * yya / 2.0)
+        U_A = solA.solve_hjb_system(np.ones((Nt, nx, ny)) * 0.5, U_T_A, np.zeros((Nt, nx, ny)))
+        U_B = solB.solve_hjb_system(np.ones((Nt, ny, nx)) * 0.5, U_T_A.T, np.zeros((Nt, ny, nx)))
+
+        diff = np.max(np.abs(U_B[0] - U_A[0].T))
+        amp = np.max(np.abs(U_A[0]))
+        # O(dt^2) Strang asymmetry only; a per-axis-spacing bug would be ~0.5*amp.
+        assert diff < 5e-2 * amp, f"per-axis spacing not honoured: diff={diff:.3e}, amp={amp:.3e}"
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_alg/test_weno_ghost_order.py
+++ b/tests/unit/test_alg/test_weno_ghost_order.py
@@ -51,12 +51,15 @@ def test_weno_uses_high_order_ghosts():
     # Create WENO solver
     solver = HJBWenoSolver(problem)
 
-    # Check that ghost buffer was created with correct parameters
+    # Check that ghost buffer was created with correct parameters.
+    # Issue #1200: the Osher-Shu HJ-WENO5 one-sided derivative stencil spans
+    # u_{i-3}..u_{i+3}, so WENO5 needs 3 ghost cells per side (was 2 for the old,
+    # incorrect, value-interface reconstruction).
     assert solver.ghost_buffer is not None, "WENO should create ghost buffer in 1D"
-    assert solver.ghost_depth == 2, "WENO5 needs 2 ghost cells per side"
+    assert solver.ghost_depth == 3, "HJ-WENO5 needs 3 ghost cells per side (#1200)"
     assert solver.ghost_order == 5, "WENO5 should use order=5 for high-order accuracy"
     assert solver.ghost_buffer._order == 5, "Ghost buffer should have order=5"
-    assert solver.ghost_buffer._ghost_depth == 2, "Ghost buffer should have depth=2"
+    assert solver.ghost_buffer._ghost_depth == 3, "Ghost buffer should have depth=3"
 
     print(f"✓ WENO ghost buffer: depth={solver.ghost_depth}, order={solver.ghost_order}")
 
@@ -88,40 +91,26 @@ def test_weno_ghost_cells_work():
     solver.ghost_buffer.interior[:] = u
     solver.ghost_buffer.update_ghosts(time=0.0)
 
-    # Check that ghost cells were filled with reasonable values
-    ghost_0 = solver.ghost_buffer.padded[0]
-    ghost_1 = solver.ghost_buffer.padded[1]
-
-    # For x^3 with Neumann BC at x=0 (du/dx = 0), ghosts should be negative of interior
-    # due to reflection about the zero-derivative point
+    # Ghost cell ordering (depth g): padded[0] is furthest from the boundary
+    # (x = -g*dx), padded[g-1] is nearest (x = -dx). Extrapolation error grows with
+    # distance, so the nearest ghost is the tight accuracy gate; the farther ones
+    # only need to stay bounded (Issue #1200 bumped the depth 2 -> 3).
+    g = solver.ghost_depth
     dx = 1.0 / (solver.num_grid_points_x - 1)
 
-    # Ghost cells should not be NaN or infinite
-    assert not np.isnan(ghost_0), "Ghost cell 0 should be valid"
-    assert not np.isnan(ghost_1), "Ghost cell 1 should be valid"
-    assert not np.isinf(ghost_0), "Ghost cell 0 should be finite"
-    assert not np.isinf(ghost_1), "Ghost cell 1 should be finite"
+    ghosts = [solver.ghost_buffer.padded[k] for k in range(g)]
+    assert np.all(np.isfinite(ghosts)), f"ghost cells must be finite, got {ghosts}"
 
-    # Check that ghost values are reasonable (should be close to extrapolated values)
-    # For cubic with zero derivative at x=0:
-    # Ghost cell ordering: ghost[0] is furthest from boundary, ghost[1] is nearest
-    # ghost[0] at x=-2*dx, ghost[1] at x=-dx
-    x_ghost_0 = -2 * dx  # Furthest ghost cell
-    x_ghost_1 = -dx  # Nearest ghost cell
-    u_exact_ghost_0 = x_ghost_0**3
-    u_exact_ghost_1 = x_ghost_1**3
-
-    # Order-5 extrapolation should be reasonably accurate for cubics
-    error_0 = np.abs(ghost_0 - u_exact_ghost_0)
-    error_1 = np.abs(ghost_1 - u_exact_ghost_1)
-
-    print(f"  Ghost[0] @ x={x_ghost_0:.6f}: computed={ghost_0:.6f}, exact={u_exact_ghost_0:.6f}, error={error_0:.6e}")
-    print(f"  Ghost[1] @ x={x_ghost_1:.6f}: computed={ghost_1:.6f}, exact={u_exact_ghost_1:.6f}, error={error_1:.6e}")
-
-    # Should be reasonably accurate (allow for some extrapolation error)
-    # For a cubic function, order-5 extrapolation should give good accuracy
-    assert error_0 < 1e-4, f"Ghost 0 error too large: {error_0}"
-    assert error_1 < 1e-4, f"Ghost 1 error too large: {error_1}"
+    # The data is a cubic and the ghost scheme is a degree-5 polynomial extrapolation
+    # (n_stencil=order=5 interior points + p'(0)=0), so x^3 is reproduced EXACTLY at every
+    # ghost regardless of distance -- a true machine-precision guard (a distance-scaled
+    # tolerance would let a real boundary-extrapolation regression pass silently).
+    for k in range(g):
+        x_ghost = -(g - k) * dx  # padded[k] sits at this coordinate
+        u_exact = x_ghost**3
+        error = np.abs(ghosts[k] - u_exact)
+        print(f"  Ghost[{k}] @ x={x_ghost:.6f}: computed={ghosts[k]:.6f}, exact={u_exact:.6f}, error={error:.6e}")
+        assert error < 1e-10, f"Ghost {k} (x={x_ghost:.4f}) error too large: {error}"
 
     print("✓ WENO high-order ghost cells work correctly")
 

--- a/tests/unit/test_geometry/test_poly_extrapolation.py
+++ b/tests/unit/test_geometry/test_poly_extrapolation.py
@@ -135,6 +135,44 @@ def test_order_5_neumann_1d():
     print("✓ Order 5 Neumann 1D: 3 ghost cells filled with high accuracy")
 
 
+def test_order_5_neumann_both_boundaries_accurate():
+    """High-order ghosts must be accurate at BOTH boundaries (Issue #1200 regression).
+
+    The high-boundary Vandermonde fit previously paired ``x_interior=[-dx,-2dx,...]``
+    (nearest-first) with ``interior_indices`` ordered farthest-first, so the high-boundary
+    ghosts were badly wrong (the low boundary, where both orderings agree, was fine). The
+    bug stayed latent because the only order-5 test checked the low boundary only. Here we
+    use ``cos(pi x)`` -- Neumann-compatible (du/dx=0) at both x=0 and x=1 -- and require the
+    high-boundary ghosts to be reconstructed as accurately as the low-boundary ghosts.
+    """
+    nx = 41
+    x = np.linspace(0.0, 1.0, nx)
+    dx = 1.0 / (nx - 1)
+    u_exact = np.cos(np.pi * x)
+
+    buffer = PreallocatedGhostBuffer(
+        interior_shape=(nx,),
+        boundary_conditions=neumann_bc(dimension=1),
+        domain_bounds=np.array([[0.0, 1.0]]),
+        order=5,
+        ghost_depth=3,
+    )
+    buffer.interior[:] = u_exact
+    buffer.update_ghosts(time=0.0)
+
+    g = 3
+    # Low ghosts: padded[0..g-1] at x = -g*dx .. -dx (padded[0] farthest).
+    low_err = max(abs(buffer.padded[k] - np.cos(np.pi * (-(g - k) * dx))) for k in range(g))
+    # High ghosts: padded[-g..-1] at x = 1+dx .. 1+g*dx (padded[-1] farthest).
+    high_err = max(abs(buffer.padded[-g + k] - np.cos(np.pi * (1.0 + (k + 1) * dx))) for k in range(g))
+
+    # Both boundaries must be accurate (order-5 extrapolation of a smooth function).
+    assert low_err < 1e-3, f"low-boundary ghost error too large: {low_err}"
+    assert high_err < 1e-3, f"high-boundary ghost error too large (#1200): {high_err}"
+    # And symmetric to within an order of magnitude (the bug made high ~1e5x worse).
+    assert high_err < 100 * low_err, f"high/low ghost asymmetry: high={high_err}, low={low_err}"
+
+
 def test_order_3_neumann_2d():
     """Test order=3 polynomial extrapolation in 2D."""
     nx, ny = 10, 12


### PR DESCRIPTION
## Summary

Fixes the WENO-HJB spatial instability (#1200) — but the root cause was deeper than "missing dissipation". Tracing the scheme showed it reconstructed WENO interface **values** then took a bogus central difference `(u_right − u_left)/(2·dx)`, so the nodal gradient fed to the Hamiltonian was `≈ −0.25 · du/dx` (**wrong sign and magnitude**). The solver had never computed a correct gradient in any dimension; the 2D/3D off-axis sweeps were `np.gradient` placeholders (no WENO). With no numerical Hamiltonian, oscillatory terminal data amplified high-frequency modes → `1e26+` blow-up, CFL-independent. None of it was caught because the whole WENO suite only asserted `isfinite`/shape.

A pure "damp the blow-up with LF on the existing gradient" would have passed the finiteness `xfail` while still computing numerically **wrong** answers (fail-silent), so the fix necessarily rebuilds the gradient.

## What changed

- **Osher–Shu HJ-WENO5 one-sided nodal derivatives** `p_minus`/`p_plus` from undivided-difference stencils (ghost depth **2→3**, needed for the `u_{i-3}..u_{i+3}` span).
- **Global Lax-Friedrichs numerical Hamiltonian** `Ĥ = H((p⁻+p⁺)/2) − (α/2)(p⁺−p⁻)`, `α = max|∂_pH|`. The viscosity (`∝ p⁺−p⁻ ∼ dx·u_xx`) damps the unstable modes while staying O(h⁵) on smooth data.
- **All dimensions through one vectorized axis operator** (`_compute_hjb_rhs_axis`); the duplicated/placeholder 2D/3D direction methods (`_weno_reconstruction_y/z_adapted`, `_solve_hjb_step_2d/3d_*`, …) are removed — **−232 lines net** in `hjb_weno.py`.
- **Geometry fix (boundary half):** `PreallocatedGhostBuffer._extrapolate_boundary_1d` paired nearest-first `x_interior` with farthest-first `interior_indices` at the **high** boundary, producing badly wrong order>2 ghost cells there (the low boundary, where both orderings coincide, was fine). Latent because WENO5 is the only order-5 consumer and nothing had consumed the high-boundary ghost derivative correctly; the sole order-5 test checked the low boundary only. Now ordered nearest-first to match.

## Validation

| check | result |
|---|---|
| nodal gradient vs truth | ratio **1.0000** (was −0.25×) |
| polynomial exactness | exact to degree 3 (machine precision) |
| EOC (smooth) | **≈ 6** interior, **≈ 5** including boundaries |
| oscillatory solve `sin(2πx)`, σ=0.1 | bounded, `max|U|≈1.5` (was `1e26+`) |
| high-boundary ghost (`cos`) | `1.6e-1 → 1e-9` error |

New tests assert gradient sign/magnitude, polynomial exactness, convergence order, **boundary-node** accuracy, bounded oscillatory solve, 2D axis-symmetry, and **anisotropic per-axis-spacing** invariance; the #1200 `xfail` is removed. A both-boundaries ghost regression test is added.

- Suites: **897** alg + **812** geometry/WENO unit tests pass, 0 regressions; `ruff format`/`check` clean.
- **5-lens adversarial review** (math / LF-sign via von-Neumann symbol analysis / nD byte-identity / boundary / test adequacy): all substantive lenses **PASS**; the test-adequacy CONCERNS (square-grid symmetry couldn't guard per-axis spacing; cubic ghost tolerance guarded nothing) are both addressed in this PR.

## Known non-blockers (documented, not patched)

- `α` is sampled at `p_mid` only; the global max over the field compensates and the review could not construct a blow-up. The strictly-safe LLF would sample `{p⁻, p⁺}` endpoints — left as a noted optional robustness item.
- `dt_stable` uses a `max|∇u|` advection proxy and doesn't explicitly fold the LF viscosity; ≈ α within 3% for the separable-quadratic case. Pre-existing.
- `meta/optimization_meta.py:339` references a non-existent `_solve_hjb_step` (always wrong; the public method is `solve_hjb_step`). Pre-existing, out of scope.

Fixes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
