### PR TITLE
fix(fp): conservative finite-volume advection at no-flux walls (#1184 advection half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`mass_conservative=True`, both row- and column-conservative), so pure diffusion at no-flux walls
   conserves mass to machine precision (was 0.84% → 1.9e-15). The explicit *advection* sub-step's
   non-conservation under strong drift is a separate follow-up (#1184 step 4); `Refs #1184`.
+- **Conservative finite-volume advection at no-flux walls** (Issue #1184, advection half). The
+  divergence-form upwind advection applied a *node-based* `gradient_upwind` to the flux `v·m`,
+  which telescopes in the interior but leaks `±(v·m)` through a no-flux wall — under strong drift
+  into a wall the explicit-drift FP solve lost mass catastrophically (a density piled against the
+  wall reached mass `0.79` at drift −0.3 and went **negative** (`−0.57`) at drift −0.8). Added
+  `AdvectionOperator(mass_conservative=…)` (opt-in; mirrors `LaplacianOperator`): a finite-volume
+  flux-difference with velocity-upwinded face fluxes and **zero flux through no-flux/periodic
+  boundary faces**, so `1ᵀA = 0` exactly (column-conservative). The explicit-drift FP paths
+  (`solve_timestep_explicit_with_drift`, `solve_timestep_tensor_explicit`) opt in: mass is now
+  conserved to machine precision under arbitrary wall-directed drift, with no negative densities;
+  the scheme self-converges (L1 rate ≈ 1.2–1.6). Default `False` keeps the byte-identical
+  node-based divergence for all other consumers (verified bit-for-bit over 19 cases), so there is
+  no change to the HJB/geometry advection paths. `Fixes #1184`.
 - **WENO HJB now sub-steps each backward interval to cover the full `dt`** (Issue #1180). The
   1D/2D/3D/nD backward sweeps advanced only one CFL/diffusion-stable `dt_stable` per interval
   (often `dt_stable << dt`) while recording it as a full `dt` step, so in the common

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_advection.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_advection.py
@@ -194,6 +194,7 @@ def compute_advection_from_drift_nd(
     ndim: int,
     scheme: str = "upwind",
     bc: Any | None = None,
+    mass_conservative: bool = False,
 ) -> np.ndarray:
     """
     Compute advection term div(alpha * m) with drift alpha provided directly.
@@ -216,6 +217,11 @@ def compute_advection_from_drift_nd(
         Advection scheme: "upwind" (default) or "centered"
     bc : BoundaryConditions, optional
         Boundary conditions. If None, uses periodic.
+    mass_conservative : bool, optional
+        If True (upwind only), use the discretely-conservative finite-volume divergence
+        that zeroes the advective flux through no-flux walls, so a density driven against
+        a wall by strong drift does not leak mass (Issue #1184). Default False keeps the
+        byte-identical node-based divergence.
 
     Returns
     -------
@@ -264,6 +270,7 @@ def compute_advection_from_drift_nd(
         scheme=scheme,
         form="divergence",  # Conservative form: ∇·(vm)
         bc=bc,
+        mass_conservative=mass_conservative,
     )
 
     # Apply operator

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -527,7 +527,11 @@ def solve_timestep_explicit_with_drift(
     # Step 2: Explicit advection using direct drift.
     # Issue #1181: pass boundary_conditions so a no-flux domain does not default to
     # periodic (AdvectionOperator bc=None == periodic), which silently wraps wall mass.
-    advection_term = compute_advection_from_drift_nd(M_star, drift, spacing, ndim, bc=boundary_conditions)
+    # Issue #1184: conservative FV divergence so mass driven against a no-flux wall by
+    # strong drift does not leak (the explicit upwind advection was non-conservative there).
+    advection_term = compute_advection_from_drift_nd(
+        M_star, drift, spacing, ndim, bc=boundary_conditions, mass_conservative=True
+    )
     M_next = M_star - dt * advection_term
 
     # Step 3: Add source term (MMS verification)
@@ -1013,7 +1017,10 @@ def solve_timestep_tensor_explicit(
         # Direct drift provided (standalone FP mode).
         # Issue #1181: pass boundary_conditions (the U-derived branch below already does)
         # so a no-flux domain does not default to periodic and wrap wall mass.
-        advection_term = compute_advection_from_drift_nd(M_current, drift, spacing, ndim, bc=boundary_conditions)
+        # Issue #1184: conservative FV divergence (zero advective flux through no-flux walls).
+        advection_term = compute_advection_from_drift_nd(
+            M_current, drift, spacing, ndim, bc=boundary_conditions, mass_conservative=True
+        )
     else:
         # MFG coupled mode: derive drift from U
         advection_term = compute_advection_term_nd(

--- a/mfgarchon/operators/differential/advection.py
+++ b/mfgarchon/operators/differential/advection.py
@@ -146,6 +146,7 @@ class AdvectionOperator(LinearOperator):
         form: Literal["gradient", "divergence"] = "divergence",
         bc: BoundaryConditions | None = None,
         time: float = 0.0,
+        mass_conservative: bool = False,
     ):
         """
         Initialize advection operator.
@@ -162,6 +163,15 @@ class AdvectionOperator(LinearOperator):
                 - "divergence": ∇·(vm) (conservative, for FP)
             bc: Boundary conditions (None for periodic/wrap)
             time: Time for time-dependent BCs (default 0.0)
+            mass_conservative: If True (only for ``form="divergence"``, ``scheme="upwind"``),
+                use a finite-volume flux-difference discretisation that is discretely
+                mass-conservative at no-flux walls — the advective flux through a no-flux
+                boundary face is set to zero, so ``1ᵀA = 0`` (column-conservative) and a
+                density piled against a wall by strong drift does not leak (Issue #1184).
+                Default ``False`` keeps the node-based ``gradient_upwind`` divergence
+                (byte-identical), which is conservative in the interior but leaks
+                ``±(v·m)`` at no-flux walls. Mirrors ``LaplacianOperator.mass_conservative``
+                (Issue #1184 diffusion half / #1202).
 
         Raises:
             ValueError: If scheme or form invalid
@@ -188,6 +198,12 @@ class AdvectionOperator(LinearOperator):
         if form not in ("gradient", "divergence"):
             raise ValueError(f"Unknown form: {form}. Use 'gradient' or 'divergence'.")
 
+        if mass_conservative and not (form == "divergence" and scheme == "upwind"):
+            raise ValueError(
+                "mass_conservative=True is only supported for form='divergence' with "
+                f"scheme='upwind' (got form={form!r}, scheme={scheme!r})."
+            )
+
         self.velocity_field = velocity_field
         self.spacings = list(spacings)
         self.field_shape = field_shape
@@ -195,6 +211,7 @@ class AdvectionOperator(LinearOperator):
         self.form = form
         self.bc = bc
         self.time = time
+        self.mass_conservative = mass_conservative
         self.dimension = len(field_shape)
 
         # Validate
@@ -232,6 +249,10 @@ class AdvectionOperator(LinearOperator):
 
         # Reshape to field
         m = m_flat.reshape(self.field_shape)
+
+        # Issue #1184: opt-in discretely-conservative finite-volume divergence.
+        if self.mass_conservative:
+            return self._divergence_upwind_conservative(m).ravel()
 
         # Apply ghost cell padding if BC provided (for non-periodic)
         if self.bc is not None:
@@ -275,6 +296,56 @@ class AdvectionOperator(LinearOperator):
 
         # Return flattened
         return adv_m.ravel()
+
+    def _divergence_upwind_conservative(self, m: NDArray) -> NDArray:
+        """Discretely-conservative finite-volume upwind divergence ``∇·(vm)`` (Issue #1184).
+
+        Per axis, builds the upwind flux at each interior cell face
+        ``F_{i+1/2} = v_{i+1/2} m_i`` if ``v_{i+1/2} >= 0`` else ``v_{i+1/2} m_{i+1}``
+        (``v_{i+1/2}`` = node-average), then ``div_i = (F_{i+1/2} - F_{i-1/2}) / h``. The
+        flux telescopes, so the column sum equals the net boundary-face flux:
+
+        - **No-flux BC**: the two wall faces are set to zero flux -> ``1ᵀA = 0`` exactly
+          (mass conserved even when strong drift piles density against the wall).
+        - **Periodic (bc=None)**: the wrap face closes the telescope -> ``1ᵀA = 0``.
+
+        Only no-flux / Neumann / reflecting / periodic boundaries are supported here (the
+        FP use case); other BCs would need an inflow flux and should not opt in.
+        """
+        from mfgarchon.geometry.boundary import BCType, BoundaryConditions
+
+        periodic = self.bc is None
+        if not periodic:
+            ok = isinstance(self.bc, BoundaryConditions) and self.bc.is_uniform
+            seg_type = self.bc.segments[0].bc_type if ok else None
+            if seg_type not in (BCType.NO_FLUX, BCType.NEUMANN, BCType.REFLECTING):
+                raise NotImplementedError(
+                    "mass_conservative divergence supports only no-flux/Neumann/reflecting "
+                    f"(zero wall flux) or periodic boundaries; got {self.bc!r}."
+                )
+
+        div = np.zeros_like(m, dtype=np.float64)
+        for d in range(self.dimension):
+            h = self.spacings[d]
+            md = np.moveaxis(m, d, -1)
+            vd = np.moveaxis(self.velocity_field[d], d, -1)
+            # Upwind flux on interior faces i+1/2 (i = 0 .. N-2), velocity averaged to the face.
+            v_face = 0.5 * (vd[..., :-1] + vd[..., 1:])
+            flux = np.where(v_face >= 0.0, v_face * md[..., :-1], v_face * md[..., 1:])
+            dvar = np.empty_like(md)
+            if periodic:
+                v_wrap = 0.5 * (vd[..., -1] + vd[..., 0])
+                flux_wrap = np.where(v_wrap >= 0.0, v_wrap * md[..., -1], v_wrap * md[..., 0])
+                dvar[..., 0] = (flux[..., 0] - flux_wrap) / h
+                dvar[..., 1:-1] = (flux[..., 1:] - flux[..., :-1]) / h
+                dvar[..., -1] = (flux_wrap - flux[..., -1]) / h
+            else:
+                # No-flux walls: zero flux through both boundary faces.
+                dvar[..., 0] = flux[..., 0] / h
+                dvar[..., 1:-1] = (flux[..., 1:] - flux[..., :-1]) / h
+                dvar[..., -1] = -flux[..., -1] / h
+            div += np.moveaxis(dvar, -1, d)
+        return div
 
     def __call__(self, m: NDArray) -> NDArray:
         """

--- a/tests/integration/test_fdm_centered_conservation.py
+++ b/tests/integration/test_fdm_centered_conservation.py
@@ -171,13 +171,19 @@ def test_callable_drift_explicit_path_respects_no_flux_no_periodic_wrap():
     # callable drift signature is (t, grid, density); constant leftward velocity toward x=0
     M = FPFDMSolver(prob).solve_fp_system(m0.copy(), drift_field=lambda t, g, m: np.full(n, -0.3))
     assert np.all(np.isfinite(M))
-    # No periodic wrap: the leftward drift moves the bump to x ~ 0.39, so the far-right region
-    # (x >= 0.7, well clear of the bump tail) must be empty. Pre-#1181 the periodic default
-    # re-entered mass exiting the left wall at the RIGHT wall, giving O(0.1) here.
+    # No periodic wrap: a periodic default re-enters mass exiting the LEFT wall AT the RIGHT
+    # wall, giving O(0.1) there. The direct wrap signal is the right-wall value itself.
+    assert M[-1, -1] < 1e-6, f"mass wrapped to the right wall (no-flux violated): M[-1,-1]={M[-1, -1]:.3e}"
+    # The far-right region stays a smooth, negligible diffusion tail. The conservative FV advection
+    # (#1184) retains the mass the old scheme leaked and is slightly more diffusive, so the tail
+    # (~4e-5) is fatter than the pre-#1184 leaking scheme (<1e-5) but still ~1e4x below the O(0.1)
+    # periodic-wrap level this test guards against.
     far_right_mass = M[-1, int(0.7 * n) :].sum() * dx
-    assert far_right_mass < 1e-5, (
+    assert far_right_mass < 1e-3, (
         f"mass wrapped through the no-flux wall: far-right (x>=0.7) mass {far_right_mass:.3e} "
-        f"(pre-#1181 the periodic default gave O(0.1) here)"
+        f"(periodic default gives O(0.1); a diffusion tail is ~4e-5)"
     )
+    # Conservative FV advection (#1184) conserves mass exactly even under strong wall-directed drift.
+    assert abs(M[-1].sum() * dx - 1.0) < 1e-9, f"mass not conserved: {M[-1].sum() * dx:.8f}"
     # Mass should pile toward the LEFT wall (where the leftward drift transports it).
     assert M[-1, 0] > M[-1, -1], "leftward drift did not pile mass at the left wall"

--- a/tests/unit/test_alg/test_fp_matrix_conservation.py
+++ b/tests/unit/test_alg/test_fp_matrix_conservation.py
@@ -77,6 +77,159 @@ class TestFPProductionConservation:
         assert np.all(M[-1] > -1e-12), "production FP step produced a negative density"
 
 
+class TestConservativeAdvection:
+    """Conservative finite-volume divergence at no-flux walls (Issue #1184).
+
+    The default node-based upwind divergence is conservative in the interior but leaks
+    +-(v*m) through no-flux walls; under strong drift into a wall the explicit-drift FP
+    solve loses (or even negates) mass. The opt-in ``mass_conservative=True`` FV
+    flux-difference zeroes the wall flux so the assembled operator is column-conservative.
+    """
+
+    @staticmethod
+    def _adv_matrix(drift_val, n, conservative, bc):
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm_advection import compute_advection_from_drift_nd
+
+        dx = 1.0 / (n - 1)
+        drift = np.full(n, drift_val)
+        cols = []
+        for j in range(n):
+            e = np.zeros(n)
+            e[j] = 1.0
+            cols.append(compute_advection_from_drift_nd(e, drift, (dx,), 1, bc=bc, mass_conservative=conservative))
+        return np.array(cols).T, dx
+
+    def test_conservative_operator_column_sum_zero_no_flux(self):
+        """1^T A = 0 (mass conserved) for the conservative operator at no-flux walls."""
+        for drift_val in (0.3, 0.8):
+            A, dx = self._adv_matrix(drift_val, 41, conservative=True, bc=no_flux_bc(dimension=1))
+            col_sums = A.sum(axis=0) * dx
+            assert np.max(np.abs(col_sums)) < 1e-12, (
+                f"conservative operator leaks at drift={drift_val}: max|colsum|={np.max(np.abs(col_sums)):.2e}"
+            )
+
+    def test_conservative_operator_column_sum_zero_periodic(self):
+        """1^T A = 0 for the conservative operator under periodic wrap."""
+        A, dx = self._adv_matrix(0.5, 41, conservative=True, bc=None)
+        assert np.max(np.abs(A.sum(axis=0))) * dx < 1e-12
+
+    def test_default_leaks_but_conservative_holds_at_wall(self):
+        """Direct contrast in a pure-advection wall-piling loop: the default node-based
+        upwind divergence loses mass at the no-flux wall, the conservative FV form does not.
+        (The default is state-dependent/non-linear, so it is exercised in a real solve loop
+        rather than via a meaningless basis-vector matrix probe.)"""
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm_advection import compute_advection_from_drift_nd
+
+        n = 51
+        x = np.linspace(0.0, 1.0, n)
+        dx = x[1] - x[0]
+        bc = no_flux_bc(dimension=1)
+        drift = np.full(n, -0.8)
+        dt = 0.2 * dx / 0.8  # CFL-stable for pure explicit advection
+
+        def run(conservative):
+            M = np.exp(-200.0 * (x - 0.18) ** 2)
+            M /= M.sum() * dx
+            for _ in range(400):
+                M = M - dt * compute_advection_from_drift_nd(M, drift, (dx,), 1, bc=bc, mass_conservative=conservative)
+            return float(M.sum() * dx)
+
+        mass_default = run(False)
+        mass_conservative = run(True)
+        assert abs(mass_default - 1.0) > 1e-3, f"expected default to leak at wall, got mass={mass_default:.6f}"
+        assert abs(mass_conservative - 1.0) < 1e-12, (
+            f"conservative form must preserve mass, got {mass_conservative:.8f}"
+        )
+
+    def test_explicit_drift_fp_conserves_mass_into_wall(self):
+        """The explicit-drift FP step keeps mass=1 and density>=0 when strong drift piles
+        density against a no-flux wall (pre-fix this leaked to negative mass)."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_explicit_with_drift
+
+        n = 51
+        x = np.linspace(0.0, 1.0, n)
+        dx = x[1] - x[0]
+        dt = 5e-4
+        bc = no_flux_bc(dimension=1)
+        M = np.exp(-200.0 * (x - 0.18) ** 2)
+        M /= M.sum() * dx
+        drift = np.full(n, -0.8)  # strong drift into the left wall
+        for _ in range(800):
+            M = solve_timestep_explicit_with_drift(M, drift, dt, 0.1, (dx,), 1, boundary_conditions=bc)
+        mass = float(M.sum() * dx)
+        assert abs(mass - 1.0) < 1e-9, f"explicit-drift FP leaked mass at wall: mass={mass:.8f}"
+        assert M.min() > -1e-12, f"explicit-drift FP produced negative density: min={M.min():.2e}"
+
+    def test_mass_conservative_requires_upwind_divergence(self):
+        """mass_conservative is only valid for form='divergence', scheme='upwind'."""
+        from mfgarchon.operators import AdvectionOperator
+
+        v = np.zeros((1, 5))
+        with pytest.raises(ValueError, match="mass_conservative"):
+            AdvectionOperator(v, [0.25], (5,), scheme="centered", form="divergence", mass_conservative=True)
+        with pytest.raises(ValueError, match="mass_conservative"):
+            AdvectionOperator(v, [0.25], (5,), scheme="upwind", form="gradient", mass_conservative=True)
+
+    def test_conservative_rejects_unsupported_bc(self):
+        """The conservative path supports only no-flux/Neumann/reflecting/periodic (zero wall
+        flux); other BCs (e.g. Dirichlet inflow) raise rather than silently mishandling the wall."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm_advection import compute_advection_from_drift_nd
+        from mfgarchon.geometry.boundary import dirichlet_bc
+
+        m = np.ones(11)
+        drift = np.full(11, 0.4)
+        with pytest.raises(NotImplementedError, match="conservative"):
+            compute_advection_from_drift_nd(
+                m, drift, (0.1,), 1, bc=dirichlet_bc(value=0.0, dimension=1), mass_conservative=True
+            )
+
+    def test_default_path_byte_identical_golden(self):
+        """Pin the DEFAULT (mass_conservative=False) divergence to frozen values, so a future
+        change to the node-based path is caught. The opt-in EOC-safety story depends on the
+        default staying byte-identical for HJB/geometry/non-opted-in consumers (Issue #1184)."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm_advection import compute_advection_from_drift_nd
+
+        x = np.linspace(0.0, 1.0, 11)
+        m = np.exp(-10.0 * (x - 0.5) ** 2)
+        drift = np.full(11, 0.4)
+        r = compute_advection_from_drift_nd(m, drift, (x[1] - x[0],), 1, bc=no_flux_bc(dimension=1))
+        expected = np.array([0.0, 0.818693, 0.938069, -0.938069, -0.818693, 0.0])
+        np.testing.assert_allclose(r[::2], expected, atol=1e-6)
+
+    def test_tensor_explicit_path_conserves_at_wall(self):
+        """The second opted-in production site (solve_timestep_tensor_explicit, tensor-diffusion
+        explicit path) also conserves mass when strong drift piles density against a no-flux wall."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_tensor_explicit
+
+        n = 51
+        x = np.linspace(0.0, 1.0, n)
+        dx = x[1] - x[0]
+        bc = no_flux_bc(dimension=1)
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=bc)
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: 0.0 * np.asarray(m),
+            coupling_dm=lambda m: 0.0 * np.asarray(m),
+        )
+        comps = MFGComponents(
+            m_initial=lambda xx: np.exp(-((np.asarray(xx) - 0.18) ** 2) / 0.005),
+            u_terminal=lambda xx: 0.0 * np.asarray(xx),
+            hamiltonian=H,
+        )
+        prob = MFGProblem(geometry=grid, T=0.4, Nt=50, sigma=0.05, components=comps)
+        M = np.exp(-200.0 * (x - 0.18) ** 2)
+        M /= M.sum() * dx
+        tensor = np.array([[0.05**2]])  # 1x1 diffusion tensor
+        drift = np.full(n, -0.8)  # strong drift into the left wall
+        for k in range(800):
+            M = solve_timestep_tensor_explicit(
+                M, None, prob, 5e-4, tensor, 1.0, (dx,), grid, 1, (n,), bc, k, drift=drift
+            )
+        mass = float(M.sum() * dx)
+        assert abs(mass - 1.0) < 1e-9, f"tensor-explicit path leaked mass at wall: mass={mass:.8f}"
+        assert M.min() > -1e-12, f"tensor-explicit path produced negative density: min={M.min():.2e}"
+
+
 class TestLinearConstraintMatrixAssembly:
     """
     Test LinearConstraint-based matrix assembly.


### PR DESCRIPTION
## Summary

Completes #1184 (the advection half; the diffusion half shipped as #1202). The divergence-form FP advection applied a **node-based** `gradient_upwind` to the flux `v·m`, which telescopes in the interior but leaks `±(v·m)` through a no-flux wall. Under strong drift into a wall the explicit-drift FP solve lost mass **catastrophically** — a density piled against the wall reached mass `0.79` at drift −0.3 and went **negative (−0.57)** at drift −0.8.

## Fix (EOC-safe, opt-in)

Added `AdvectionOperator(mass_conservative=…)` (mirrors `LaplacianOperator.mass_conservative` from the diffusion half): a finite-volume flux-difference with **velocity-upwinded face fluxes** and **zero flux through no-flux / periodic boundary faces**, so `div_i = (F_{i+1/2} − F_{i−1/2})/h` telescopes to `1ᵀA = 0` (column-conservative) exactly.

- **Default `False` → byte-identical** node-based path for every other consumer (HJB advection, `tensor_grid`, geometry wrappers, the coupled-MFG drift path) — verified bit-for-bit over 19 cases, so no EOC shift for them.
- The explicit-drift FP paths (`solve_timestep_explicit_with_drift`, `solve_timestep_tensor_explicit`) **opt in**.

## Validation (regression-baseline workflow)

Baseline captured on `main` first, then compared:

| check | result |
|---|---|
| default path (mass_conservative=False) | **0 diff** over 19 cases (1D/2D, no-flux/periodic, upwind/centered, gradient/divergence) |
| conservative operator column-sum (no-flux + periodic) | `0` (machine precision) |
| wall-piling FP solve, drift −0.3 / −0.8 | mass `1.00000000`, density ≥ 0 (was `0.79` / `−0.57`) |
| new scheme self-convergence | L1 rate ≈ 1.2–1.6 (valid first-order scheme), mass = 1 at every resolution |

New tests in `TestConservativeAdvection`: column-sum=0 (no-flux + periodic), default-leaks-vs-conservative contrast, explicit-drift FP wall conservation, and the `mass_conservative` validation guard. Updated the #1181 wrap test to discriminate periodic-wrap (O(0.1), checked at the right wall) from the conservative scheme's slightly fatter — but mass-conserving — diffusion tail (~4e-5). **310 FP/operator/integration tests pass; ruff clean.** Verified by a 3-lens adversarial review (FV math/sign, byte-identical default + scope, test adequacy).

## EOC note (the accepted risk)

The opt-in FP path's *interior* changes from the old non-physical flux-gradient upwind to the standard conservative velocity-upwind FV (Linf ~0.1–0.3 vs old at finite resolution). This is a **correctness improvement** — the old scheme leaked mass to negative density — and the new scheme self-converges. The explicit-drift path is **not** the paper EOC path (the paper uses implicit/GFDM), and all broad consumers are byte-identical, so paper-relevant EOC is unaffected.

Fixes #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
