### PR TITLE
fix(geometry): honor nonzero Neumann flux in high-order ghost extrapolation (#1186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   derivative correctly before; the prior order-5 test checked the low boundary only. Now ordered
   nearest-first to match; smooth high-boundary ghosts recover machine-level accuracy (a `cos(pi x)`
   ghost went from ~1.6e-1 error to ~1e-9), with a both-boundaries regression test added.
+- **High-order ghost extrapolation honours a nonzero Neumann flux** (Issue #1186). The order>2
+  ghost BC row hardcoded `p'(0) = 0`, so a `neumann_bc(value=g)` with `g != 0` was silently
+  dropped (WENO5 HJB is the order-5 consumer). The row now encodes the prescribed `du/dn = g`
+  with the outward-normal sign (`p'(0) = -g` at the low boundary, `+g` at the high boundary,
+  matching the Robin branch); `NO_FLUX`/`REFLECTING` stay zero-flux. A quadratic with `du/dn = g`
+  at both ends is now reproduced to machine precision (regression test added). The order<=2 linear
+  reflection path (shared by FDM/SL) still zeroes nonzero Neumann flux — tracked separately.
 - **Conservative no-flux Laplacian for the implicit FP diffusion solve** (Issue #1184, diffusion
   half). `LaplacianOperator.as_scipy_sparse()` no-flux branch had zero *row* sums (2nd-order
   Neumann accuracy) but nonzero *column* sums at the walls (`≈1/h²`); the implicit FP system

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -1232,14 +1232,21 @@ class PreallocatedGhostBuffer:
 
         # Last row: BC constraint at x=0
         if bc_type in [BCType.NEUMANN, BCType.NO_FLUX, BCType.REFLECTING]:
-            # Neumann: p'(0) = 0
-            # p'(x) = sum_j j * a_j * x^{j-1}
-            # p'(0) = a_1 (only linear term survives)
+            # Derivative constraint p'(0) = a_1 (only the linear term survives at x=0).
             V[n_stencil, 0] = 0.0  # a_0 doesn't contribute to derivative
             V[n_stencil, 1] = 1.0  # a_1 coefficient
             for j in range(2, n_poly + 1):
                 V[n_stencil, j] = 0.0  # Higher terms vanish at x=0
-            rhs[n_stencil] = 0.0  # Zero derivative
+            # Issue #1186: encode the prescribed flux du/dn = bc_value, not a hardcoded 0.
+            # The local poly coordinate has x>0 pointing INTO the domain at the low boundary
+            # (outward normal = -x_local -> p'(0) = -g) and OUT of the domain at the high
+            # boundary (outward normal = +x_local -> p'(0) = +g); g = du/dn (outward), matching
+            # the Robin branch's sign convention above. NO_FLUX / REFLECTING are definitionally
+            # zero-flux and keep p'(0) = 0 regardless of any stray value.
+            if bc_type == BCType.NEUMANN:
+                rhs[n_stencil] = -bc_value if is_low else bc_value
+            else:
+                rhs[n_stencil] = 0.0
 
         elif bc_type == BCType.DIRICHLET:
             # Dirichlet: p(0) = bc_value

--- a/tests/unit/test_geometry/test_poly_extrapolation.py
+++ b/tests/unit/test_geometry/test_poly_extrapolation.py
@@ -173,6 +173,44 @@ def test_order_5_neumann_both_boundaries_accurate():
     assert high_err < 100 * low_err, f"high/low ghost asymmetry: high={high_err}, low={low_err}"
 
 
+def test_order_5_nonzero_neumann_flux():
+    """A nonzero Neumann flux is honoured, not silently zeroed (Issue #1186).
+
+    The high-order ghost BC row previously hardcoded du/dn = 0, so a ``neumann_bc(value=g)``
+    with g != 0 was dropped (WENO5 is the order-5 consumer). Uses ``u = (g/L) x^2 - g x + c``,
+    whose outward-normal derivative is exactly ``g`` at BOTH boundaries (consistent with a
+    uniform ``neumann_bc(value=g)``). Degree-5 extrapolation reproduces this quadratic
+    exactly, so the ghosts must equal ``u(x_ghost)`` to machine precision at both ends --
+    which holds only if the constraint encodes ``p'(0) = -g`` (low) / ``+g`` (high).
+    """
+    n, gd = 41, 3
+    length = 1.0
+    dx = length / (n - 1)
+    g_flux = 0.7
+    c = 2.0
+    x = np.linspace(0.0, length, n)
+
+    def u_exact(xq):
+        return (g_flux / length) * xq**2 - g_flux * xq + c
+
+    buffer = PreallocatedGhostBuffer(
+        interior_shape=(n,),
+        boundary_conditions=neumann_bc(dimension=1, value=g_flux),
+        domain_bounds=np.array([[0.0, length]]),
+        order=5,
+        ghost_depth=gd,
+    )
+    buffer.interior[:] = u_exact(x)
+    buffer.update_ghosts(time=0.0)
+
+    # Low ghosts padded[0..gd-1] at x = -gd*dx .. -dx; high ghosts padded[-gd..-1] at L+dx .. L+gd*dx.
+    for k in range(gd):
+        assert abs(buffer.padded[k] - u_exact(-(gd - k) * dx)) < 1e-9, f"low ghost {k} dropped flux g={g_flux}"
+        assert abs(buffer.padded[-gd + k] - u_exact(length + (k + 1) * dx)) < 1e-9, (
+            f"high ghost {k} dropped flux g={g_flux}"
+        )
+
+
 def test_order_3_neumann_2d():
     """Test order=3 polynomial extrapolation in 2D."""
     nx, ny = 10, 12


### PR DESCRIPTION
## Summary

(Re-opened against `main` — the original PR #1208 was auto-closed when its stacked base branch was deleted on #1207's merge. #1207 is now merged, so this targets `main` directly.)

`PreallocatedGhostBuffer._extrapolate_boundary_1d` (the order>2 polynomial ghost path used by WENO5 HJB) hardcoded the boundary derivative constraint to `p'(0) = 0`, so a `neumann_bc(value=g)` with `g != 0` was **silently dropped**.

## Fix

The BC row now encodes `du/dn = g` with the outward-normal sign (`p'(0) = -g` low, `+g` high), matching the Robin branch. `NO_FLUX`/`REFLECTING` stay zero-flux.

## Validation

A quadratic with `du/dn = g` at both ends is reproduced to machine precision; analytic `p'(0) = g` exactly at both boundaries (g ∈ {0.7, −1.3}); g=0 and NO_FLUX unchanged. Regression test `test_order_5_nonzero_neumann_flux` added; 130 geometry+WENO tests pass.

Depends on the high-boundary stencil-ordering fix already merged in #1207 (same function).

Fixes #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)
