### PR TITLE
fix(fp): per-point spatially-varying volatility on explicit-drift & strict-adjoint FP (#1183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Per-point spatially-varying volatility on the explicit-drift & strict-adjoint FP paths**
+  (Issue #1183). Both paths collapsed a non-uniform `volatility_field` to its spatial **mean**
+  (a scalar `D`), silently solving a different PDE than the per-point implicit path (a low-σ
+  region was over-diffused, a high-σ region under-diffused — ~14–21% L2 error). Added a
+  variable-coefficient mode to `LaplacianOperator` (`coefficient_field=`): the conservative
+  finite-volume no-flux stencil now bakes in the **face-averaged** diffusion
+  `D_{i+1/2} = ½(D_i + D_{i+1})`, so `∇·(D(x)∇·)` stays column-conservative (`1ᵀL = 0`) even
+  for varying `D` — a point-value `D_i·Δ` would leak. The explicit-drift
+  (`solve_timestep_explicit_with_drift`) and strict-adjoint (`solve_fp_step_adjoint_mode`) FP
+  steps now build this per-point matrix for an array σ (replacing the mean-collapse + the interim
+  warning), so a non-uniform σ is honored per point **and** mass is conserved; low-σ regions
+  correctly under-diffuse. Scalar (and uniform-array) σ takes the existing scalar path unchanged
+  — **byte-identical**, so no EOC change for the common case. `coefficient_field=None` leaves
+  `LaplacianOperator` byte-identical for all other consumers. (The point-value implicit reference
+  `solve_timestep_full_nd` is itself non-conservative for varying σ, and the strict-adjoint
+  *scalar* path is not yet mass-conservative — both tracked as a follow-up.) `Fixes #1183`.
 - **Nonzero Neumann flux in the linear-reflection ghost path** (Issue #1186 sibling, FDM/SL).
   `PreallocatedGhostBuffer._apply_linear_reflection` (the order<=2 ghost path used by FDM/SL)
   filled Neumann/no-flux ghosts with a pure mirror, silently dropping a nonzero

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -699,33 +699,31 @@ class FPFDMSolver(BaseFPSolver):
         spacing = list(self.problem.geometry.get_grid_spacing())
         bc = self.boundary_conditions
 
-        L_op = LaplacianOperator(spacings=spacing, field_shape=shape, bc=bc)
-        L_matrix = L_op.as_scipy_sparse()
+        sigma_arr = np.asarray(sigma_val)
+        varying_sigma = sigma_arr.ndim > 0 and float(np.ptp(sigma_arr)) > 1e-12
 
-        # Compute diffusion coefficient
-        if isinstance(sigma_val, np.ndarray):
-            # Issue #1183: the strict-adjoint FP step uses a scalar D; a spatially varying
-            # sigma is collapsed to its mean. For a genuinely non-uniform sigma this silently
-            # solves a different PDE. Fail loud rather than silently approximate; the per-point
-            # variable-coefficient diffusion (matrix form) is tracked in #1183.
-            if float(np.ptp(sigma_val)) > 1e-12:
-                import warnings
+        # Build the diffusion matrix.
+        if varying_sigma:
+            # Issue #1183: per-point variable-coefficient diffusion -- bake the field
+            # D(x) = sigma(x)^2/2 into a conservative finite-volume Laplacian (face-averaged
+            # D_{i+1/2}, mass-conserving) rather than collapsing sigma to its mean.
+            from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
-                warnings.warn(
-                    "Spatially varying volatility in strict-adjoint FP mode is approximated by "
-                    "its spatial mean (Issue #1183): the per-point matrix form is not yet "
-                    "implemented. Results differ from a true per-point diffusion.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            D = 0.5 * float(np.mean(sigma_val)) ** 2
+            d_field = diffusion_from_volatility(sigma_arr, kind="field")
+            diffusion_matrix = LaplacianOperator(
+                spacings=spacing, field_shape=shape, bc=bc, mass_conservative=True, coefficient_field=d_field
+            ).as_scipy_sparse()
         else:
-            D = 0.5 * float(sigma_val) ** 2
+            # Scalar (or uniform-array) sigma: scalar D times the (existing) Laplacian.
+            scalar_sigma = float(sigma_arr.reshape(-1)[0]) if sigma_arr.ndim > 0 else float(sigma_val)
+            D = 0.5 * scalar_sigma**2
+            L_matrix = LaplacianOperator(spacings=spacing, field_shape=shape, bc=bc).as_scipy_sparse()
+            diffusion_matrix = D * L_matrix
 
-        # Build full system matrix: (I/dt + A_advection_T - D*Laplacian)
-        # Note: Laplacian has negative diagonal, so we SUBTRACT D*L
+        # Build full system matrix: (I/dt + A_advection_T - diffusion). The Laplacian has a
+        # negative diagonal, so the diffusion matrix is SUBTRACTED.
         identity = sparse.eye(N_total)
-        A_system = identity / dt + A_advection_T - D * L_matrix
+        A_system = identity / dt + A_advection_T - diffusion_matrix
 
         # Right-hand side
         b_rhs = M_current.ravel() / dt

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -465,31 +465,10 @@ def solve_timestep_explicit_with_drift(
     For full FP no-flux BCs with advection, use no_flux_bc() which properly
     handles mass conservation at boundaries.
     """
-    # Get diffusion coefficient
-    if isinstance(sigma, np.ndarray):
-        # Issue #1183: the explicit-drift path uses a constant-coefficient LaplacianOperator,
-        # so a spatially varying sigma is collapsed to its mean (a scalar D). For a genuinely
-        # non-uniform sigma this silently solves a different PDE than the per-point implicit
-        # path (solve_timestep_full_nd). Fail loud rather than silently approximate; a true
-        # per-point variable-coefficient diffusion on this path is tracked in #1183.
-        if float(np.ptp(sigma)) > 1e-12:
-            import warnings
+    from mfgarchon.operators.differential.laplacian import LaplacianOperator
 
-            warnings.warn(
-                "Spatially varying volatility on the explicit-drift FP path is approximated by "
-                "its spatial mean (Issue #1183): the per-point variable-coefficient diffusion is "
-                "not yet implemented here. Results differ from the per-point implicit path. Use an "
-                "array drift_field (implicit path) for per-point sigma fidelity.",
-                UserWarning,
-                stacklevel=2,
-            )
-        # For spatially varying, use scalar approximation (mean)
-        sigma_val = float(np.mean(sigma))
-    else:
-        sigma_val = float(sigma)
-
-    D = diffusion_from_volatility(sigma_val)  # Diffusion coefficient
     shape = M_current.shape
+    N_total = int(np.prod(shape))
 
     # Set default boundary conditions
     if boundary_conditions is None:
@@ -497,25 +476,35 @@ def solve_timestep_explicit_with_drift(
 
         boundary_conditions = no_flux_bc(dimension=ndim)
 
-    # Step 1: Implicit diffusion using LaplacianOperator (Issue #597 Milestone 2B)
-    # Issue #927: Use cached Laplacian if available (constant sigma across time steps)
-    if cached_laplacian is not None:
-        L_matrix = cached_laplacian
+    sigma_arr = np.asarray(sigma)
+    varying_sigma = sigma_arr.ndim > 0 and float(np.ptp(sigma_arr)) > 1e-12
+
+    # Step 1: implicit diffusion (I/dt - L_D) m* = m^k/dt, mass-conservative no-flux stencil.
+    if varying_sigma:
+        # Issue #1183: per-point variable-coefficient diffusion. Bake the field D(x)=sigma(x)^2/2
+        # into a conservative finite-volume Laplacian (face-averaged D_{i+1/2}, 1ᵀL=0 preserved),
+        # so a non-uniform sigma is honored per point instead of collapsed to its mean.
+        d_field = diffusion_from_volatility(sigma_arr, kind="field")
+        L_matrix = LaplacianOperator(
+            spacings=list(spacing),
+            field_shape=shape,
+            bc=boundary_conditions,
+            mass_conservative=True,
+            coefficient_field=d_field,
+        ).as_scipy_sparse()
+        A_diffusion = sparse.eye(N_total) / dt - L_matrix
     else:
-        from mfgarchon.operators.differential.laplacian import LaplacianOperator
-
-        # mass_conservative=True: the implicit FP diffusion solve needs a column-conservative
-        # (1ᵀL = 0) no-flux stencil, else mass leaks at the walls (Issue #1184).
-        L_op = LaplacianOperator(
-            spacings=list(spacing), field_shape=shape, bc=boundary_conditions, mass_conservative=True
-        )
-        L_matrix = L_op.as_scipy_sparse()
-
-    # Build implicit system matrix: (I/dt - D*Δ) m^{k+1} = m^k/dt
-    # Note: Laplacian has NEGATIVE diagonal, so we SUBTRACT
-    N_total = int(np.prod(shape))
-    identity = sparse.eye(N_total)
-    A_diffusion = identity / dt - D * L_matrix
+        # Scalar (or uniform-array) sigma: unit mass-conservative Laplacian scaled by the scalar D.
+        scalar_sigma = float(sigma_arr.reshape(-1)[0]) if sigma_arr.ndim > 0 else float(sigma)
+        D = diffusion_from_volatility(scalar_sigma)
+        # Issue #927: reuse the cached unit Laplacian (constant sigma across time steps) if given.
+        if cached_laplacian is not None:
+            L_matrix = cached_laplacian
+        else:
+            L_matrix = LaplacianOperator(
+                spacings=list(spacing), field_shape=shape, bc=boundary_conditions, mass_conservative=True
+            ).as_scipy_sparse()
+        A_diffusion = sparse.eye(N_total) / dt - D * L_matrix
 
     # RHS: m^k / dt
     # Note: No b_bc term needed - BCs are incorporated into L_matrix

--- a/mfgarchon/operators/differential/laplacian.py
+++ b/mfgarchon/operators/differential/laplacian.py
@@ -94,6 +94,7 @@ class LaplacianOperator(LinearOperator):
         order: int = 2,
         time: float = 0.0,
         mass_conservative: bool = False,
+        coefficient_field: NDArray | None = None,
     ):
         """
         Initialize Laplacian operator.
@@ -113,6 +114,12 @@ class LaplacianOperator(LinearOperator):
                 column-conservative (``1ᵀL = 0``), so the implicit diffusion solve conserves
                 mass exactly -- at the cost of 1st-order wall accuracy. The FP mass path sets
                 this; HJB/elliptic consumers (matvec, accuracy-critical) leave it ``False``.
+            coefficient_field: Optional per-point diffusion field ``D(x)`` (same shape as the
+                field) for a spatially-varying ``∇·(D∇·)`` (Issue #1183). Only honored by
+                ``as_scipy_sparse()`` with ``mass_conservative=True``: the stencil uses the
+                face-averaged ``D_{i+1/2} = ½(D_i + D_{i+1})``, so the flux telescopes and
+                ``1ᵀL = 0`` holds even for varying ``D`` (a *point-value* ``D_i·Δ`` would leak).
+                ``None`` (default) builds the unit Laplacian (caller multiplies by a scalar ``D``).
 
         Raises:
             ValueError: If order != 2 (higher orders not yet implemented)
@@ -129,6 +136,7 @@ class LaplacianOperator(LinearOperator):
         self.order = order
         self.time = time
         self.mass_conservative = mass_conservative
+        self.coefficient_field = None if coefficient_field is None else np.asarray(coefficient_field, dtype=np.float64)
 
         # Validate
         if len(self.spacings) != len(self.field_shape):
@@ -136,6 +144,17 @@ class LaplacianOperator(LinearOperator):
 
         if order != 2:
             raise ValueError(f"Only order=2 currently supported, got {order}")
+
+        if self.coefficient_field is not None:
+            if self.coefficient_field.shape != self.field_shape:
+                raise ValueError(
+                    f"coefficient_field shape {self.coefficient_field.shape} != field_shape {self.field_shape}"
+                )
+            if not mass_conservative:
+                raise ValueError(
+                    "coefficient_field requires mass_conservative=True (variable-coefficient diffusion "
+                    "is only assembled in the conservative finite-volume branch; Issue #1183)."
+                )
 
         # Compute operator shape
         N = int(np.prod(field_shape))
@@ -287,35 +306,50 @@ class LaplacianOperator(LinearOperator):
 
             if bc_type in ("neumann", "no_flux") and self.mass_conservative:
                 # Finite-volume zero-flux stencil (Issue #1184): omit the ghost face at the
-                # wall so each cell's row telescopes against its neighbors' columns. Wall cells
-                # lose one face in dimension d -> diag -1/h² (this dim); interior -2/h². The
-                # single interior neighbor of a wall cell gets +1/h² (NOT the +2/h² ghost
-                # mirror). This is BOTH row- and column-conservative (1ᵀL = 0), so the implicit
-                # FP diffusion solve conserves mass; it is 1st-order accurate at the wall.
-                rows_list.append(all_idx[interior])
-                cols_list.append(all_idx[interior])
-                vals_list.append(np.full(int(interior.sum()), -2.0 / h2))
+                # wall so each cell's row telescopes against its neighbors' columns -> BOTH
+                # row- and column-conservative (1ᵀL = 0), 1st-order accurate at the wall.
+                # Each face carries the face-averaged diffusion D_{i+1/2} = ½(D_i + D_{i+1})
+                # (Issue #1183); with no coefficient_field every face coefficient is 1 (the
+                # caller multiplies the unit Laplacian by a scalar D -> byte-identical).
+                d_flat = None if self.coefficient_field is None else self.coefficient_field.ravel()
+                ii = all_idx[interior]
+                amin = all_idx[at_min]
+                amax = all_idx[at_max]
+                if d_flat is None:
+                    f_lo_i = np.ones(ii.size)
+                    f_hi_i = np.ones(ii.size)
+                    f_hi_min = np.ones(amin.size)
+                    f_lo_max = np.ones(amax.size)
+                else:
+                    f_lo_i = 0.5 * (d_flat[ii] + d_flat[ii - stride])  # face i-1/2
+                    f_hi_i = 0.5 * (d_flat[ii] + d_flat[ii + stride])  # face i+1/2
+                    f_hi_min = 0.5 * (d_flat[amin] + d_flat[amin + stride])
+                    f_lo_max = 0.5 * (d_flat[amax] + d_flat[amax - stride])
 
-                wall = at_min | at_max
-                rows_list.append(all_idx[wall])
-                cols_list.append(all_idx[wall])
-                vals_list.append(np.full(int(wall.sum()), -1.0 / h2))
+                # Interior cell: diag -(f_lo+f_hi)/h², neighbors +f/h²
+                rows_list.append(ii)
+                cols_list.append(ii)
+                vals_list.append(-(f_lo_i + f_hi_i) / h2)
+                rows_list.append(ii)
+                cols_list.append(ii - stride)
+                vals_list.append(f_lo_i / h2)
+                rows_list.append(ii)
+                cols_list.append(ii + stride)
+                vals_list.append(f_hi_i / h2)
 
-                # Interior: both neighbors +1/h²
-                rows_list.append(all_idx[interior])
-                cols_list.append(all_idx[interior] - stride)
-                vals_list.append(np.full(int(interior.sum()), 1.0 / h2))
-                rows_list.append(all_idx[interior])
-                cols_list.append(all_idx[interior] + stride)
-                vals_list.append(np.full(int(interior.sum()), 1.0 / h2))
-
-                # Wall: single interior neighbor +1/h² (zero-flux: no ghost contribution)
-                rows_list.append(all_idx[at_min])
-                cols_list.append(all_idx[at_min] + stride)
-                vals_list.append(np.full(int(at_min.sum()), 1.0 / h2))
-                rows_list.append(all_idx[at_max])
-                cols_list.append(all_idx[at_max] - stride)
-                vals_list.append(np.full(int(at_max.sum()), 1.0 / h2))
+                # Wall cells: only the single interior-facing face (zero flux through the wall)
+                rows_list.append(amin)
+                cols_list.append(amin)
+                vals_list.append(-f_hi_min / h2)
+                rows_list.append(amin)
+                cols_list.append(amin + stride)
+                vals_list.append(f_hi_min / h2)
+                rows_list.append(amax)
+                cols_list.append(amax)
+                vals_list.append(-f_lo_max / h2)
+                rows_list.append(amax)
+                cols_list.append(amax - stride)
+                vals_list.append(f_lo_max / h2)
 
             elif bc_type in ("neumann", "no_flux"):
                 # ALL points get diagonal -2/h² (interior and boundary)

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -1140,14 +1140,15 @@ class TestFPFDMSolverCallableDrift:
         assert np.all(M >= -1e-10)
 
 
-class TestVaryingSigmaExplicitDriftWarning:
-    """Issue #1183: the explicit-drift FP path collapses a spatially varying volatility to its
-    mean (scalar D). It must fail loud (warn) for a genuinely non-uniform sigma rather than
-    silently solve a different PDE than the per-point implicit path; a uniform array sigma
-    collapses exactly and must NOT warn."""
+class TestVaryingSigmaExplicitDriftPerPoint:
+    """Issue #1183: the explicit-drift FP path now solves a per-point variable-coefficient
+    diffusion (face-averaged D(x)=sigma(x)^2/2 in a conservative FV Laplacian) instead of
+    collapsing a spatially varying volatility to its mean. A non-uniform sigma is honored per
+    point (low-sigma regions under-diffuse) AND mass is conserved -- no warning. A uniform
+    array sigma uses the scalar path unchanged (also no warning)."""
 
     @staticmethod
-    def _solve(sigma_field):
+    def _solve(sigma_field, bump_center=0.25):
         n, nt = 41, 30
         grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
         H = SeparableHamiltonian(
@@ -1155,35 +1156,51 @@ class TestVaryingSigmaExplicitDriftWarning:
             coupling=lambda m: np.asarray(m) * 0.0,
             coupling_dm=lambda m: np.asarray(m) * 0.0,
         )
-        comps = MFGComponents(
-            m_initial=lambda x: np.exp(-((np.asarray(x) - 0.5) ** 2) / 0.02),
-            u_terminal=lambda x: np.asarray(x) * 0.0,
-            hamiltonian=H,
-        )
-        prob = MFGProblem(geometry=grid, T=0.3, Nt=nt, sigma=0.1, components=comps)
         x = np.linspace(0.0, 1.0, n)
         dx = x[1] - x[0]
-        m0 = np.exp(-((x - 0.5) ** 2) / 0.02)
+
+        def m_init(xx):
+            return np.exp(-((np.asarray(xx) - bump_center) ** 2) / 0.01)
+
+        comps = MFGComponents(m_initial=m_init, u_terminal=lambda xx: np.asarray(xx) * 0.0, hamiltonian=H)
+        prob = MFGProblem(geometry=grid, T=0.3, Nt=nt, sigma=0.1, components=comps)
+        m0 = m_init(x)
         m0 /= m0.sum() * dx
         # callable drift routes through the explicit path (signature (t, grid, density))
-        FPFDMSolver(prob).solve_fp_system(m0, drift_field=lambda t, g, m: np.zeros(n), volatility_field=sigma_field)
+        traj = FPFDMSolver(prob).solve_fp_system(
+            m0, drift_field=lambda t, g, m: np.zeros(n), volatility_field=sigma_field
+        )
+        return np.asarray(traj)[-1], dx
 
-    def test_non_uniform_sigma_warns(self):
+    def test_non_uniform_sigma_per_point_not_mean(self):
+        """A bump in the LOW-sigma region under-diffuses (stays more peaked) vs the mean-collapse,
+        and mass is conserved -- the per-point fidelity #1183 asks for. No interim warning."""
         n = 41
         x = np.linspace(0.0, 1.0, n)
-        sigma_field = np.where(x < 0.5, 0.05, 0.30)  # genuinely non-uniform
-        with pytest.warns(UserWarning, match="1183"):
-            self._solve(sigma_field)
-
-    def test_uniform_array_sigma_does_not_warn(self):
-        n = 41
-        sigma_field = np.full(n, 0.1)  # uniform array: mean-collapse is exact
+        sigma_field = np.where(x < 0.5, 0.05, 0.30)  # low-sigma left (the bump sits here), high-sigma right
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            self._solve(sigma_field)
+            m_perpoint, dx = self._solve(sigma_field, bump_center=0.25)
         assert not [w for w in caught if "1183" in str(w.message)], (
-            "uniform array sigma collapses exactly and must not raise the #1183 warning"
+            "the interim #1183 mean-collapse warning must be gone"
         )
+        m_meancollapse, _ = self._solve(float(np.mean(sigma_field)), bump_center=0.25)
+
+        assert abs(m_perpoint.sum() * dx - 1.0) < 1e-9, f"per-point diffusion leaked mass: {m_perpoint.sum() * dx:.8f}"
+        assert np.all(m_perpoint >= -1e-12), "per-point diffusion produced a negative density"
+        # The low-sigma bump diffuses LESS than the mean would -> a higher retained peak.
+        assert m_perpoint.max() > m_meancollapse.max() * 1.02, (
+            f"per-point did not under-diffuse the low-sigma bump: peak {m_perpoint.max():.4f} "
+            f"vs mean-collapse {m_meancollapse.max():.4f}"
+        )
+
+    def test_uniform_array_sigma_unchanged(self):
+        """A uniform array sigma uses the scalar path (no #1183 warning, mass conserved)."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            m, dx = self._solve(np.full(41, 0.1))
+        assert not [w for w in caught if "1183" in str(w.message)]
+        assert abs(m.sum() * dx - 1.0) < 1e-9
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_alg/test_fp_matrix_conservation.py
+++ b/tests/unit/test_alg/test_fp_matrix_conservation.py
@@ -545,5 +545,52 @@ class TestLinearConstraintMatrixAssembly:
         assert abs(c_neum.bias - (-0.1)) < 1e-10
 
 
+class TestStrictAdjointPerPointSigma:
+    """Issue #1183: the strict-adjoint FP step honors a per-point sigma (conservative
+    variable-coefficient diffusion) instead of collapsing it to the mean."""
+
+    @staticmethod
+    def _solver(n):
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: 0.0 * np.asarray(m),
+            coupling_dm=lambda m: 0.0 * np.asarray(m),
+        )
+        comps = MFGComponents(
+            m_initial=lambda x: np.exp(-((np.asarray(x) - 0.25) ** 2) / 0.01),
+            u_terminal=lambda x: 0.0 * np.asarray(x),
+            hamiltonian=H,
+        )
+        prob = MFGProblem(geometry=grid, T=0.3, Nt=30, sigma=0.1, components=comps)
+        return FPFDMSolver(prob)
+
+    def test_array_sigma_conserves_and_per_point(self):
+        """Pure-diffusion strict-adjoint step (zero advection matrix) with a non-uniform sigma:
+        mass conserved, density non-negative, and the low-sigma region retains a higher peak than
+        the mean-collapse would (the per-point fidelity the issue asks for)."""
+        n = 41
+        x = np.linspace(0.0, 1.0, n)
+        dx = x[1] - x[0]
+        solver = self._solver(n)
+        a_t_zero = sparse.csr_matrix((n, n))  # no advection -> isolate diffusion
+        m0 = np.exp(-((x - 0.25) ** 2) / 0.01)
+        m0 /= m0.sum() * dx
+        sigma_field = np.where(x < 0.5, 0.05, 0.30)  # bump sits in the low-sigma region
+
+        m_pp = m0.copy()
+        for _ in range(30):
+            m_pp = solver.solve_fp_step_adjoint_mode(m_pp, a_t_zero, sigma=sigma_field)
+        m_mc = m0.copy()
+        for _ in range(30):
+            m_mc = solver.solve_fp_step_adjoint_mode(m_mc, a_t_zero, sigma=float(np.mean(sigma_field)))
+
+        assert abs(m_pp.sum() * dx - 1.0) < 1e-9, f"per-point strict-adjoint leaked mass: {m_pp.sum() * dx:.8f}"
+        assert np.all(m_pp >= -1e-12), "per-point strict-adjoint produced a negative density"
+        assert m_pp.max() > m_mc.max() * 1.02, (
+            f"per-point did not under-diffuse the low-sigma bump: {m_pp.max():.4f} vs mean {m_mc.max():.4f}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_operators/test_laplacian.py
+++ b/tests/unit/test_operators/test_laplacian.py
@@ -398,5 +398,70 @@ class TestLaplacianMassConservative:
         assert A[3, 2] == pytest.approx(1.0 / h2)
 
 
+class TestLaplacianVariableCoefficient:
+    """Variable-coefficient diffusion via coefficient_field (Issue #1183): face-averaged
+    D_{i+1/2} baked into the conservative FV stencil, so ∇·(D(x)∇·) is column-conservative
+    even for varying D (a point-value D_i·Δ would leak)."""
+
+    def test_none_is_byte_identical_unit(self):
+        """coefficient_field=None reproduces the unit mass-conservative Laplacian exactly."""
+        n, h = 21, 1.0 / 20
+        bc = no_flux_bc(dimension=1)
+        unit = LaplacianOperator([h], (n,), bc=bc, mass_conservative=True).as_scipy_sparse().toarray()
+        again = (
+            LaplacianOperator([h], (n,), bc=bc, mass_conservative=True, coefficient_field=None)
+            .as_scipy_sparse()
+            .toarray()
+        )
+        np.testing.assert_array_equal(again, unit)
+
+    def test_constant_field_equals_scalar_times_unit(self):
+        """A constant coefficient_field D0 equals D0 * (unit Laplacian), bit-for-bit."""
+        n, h, d0 = 21, 1.0 / 20, 0.5
+        bc = no_flux_bc(dimension=1)
+        unit = LaplacianOperator([h], (n,), bc=bc, mass_conservative=True).as_scipy_sparse().toarray()
+        baked = (
+            LaplacianOperator([h], (n,), bc=bc, mass_conservative=True, coefficient_field=np.full(n, d0))
+            .as_scipy_sparse()
+            .toarray()
+        )
+        np.testing.assert_allclose(baked, d0 * unit, atol=1e-14)
+
+    def test_varying_field_is_column_conservative(self):
+        """1ᵀL = 0 for a spatially varying D (a point-value scheme would have colsum != 0)."""
+        n, h = 41, 1.0 / 40
+        x = np.linspace(0.0, 1.0, n)
+        d_field = np.where(x < 0.5, 0.02**2 / 2, 0.30**2 / 2)
+        A = (
+            LaplacianOperator([h], (n,), bc=no_flux_bc(dimension=1), mass_conservative=True, coefficient_field=d_field)
+            .as_scipy_sparse()
+            .toarray()
+        )
+        assert np.max(np.abs(A.sum(axis=0))) < 1e-12
+
+    def test_varying_field_2d_column_conservative(self):
+        n, h = 11, 1.0 / 10
+        d_field = np.outer(0.1 + np.linspace(0, 1, n), np.ones(n))
+        A = (
+            LaplacianOperator(
+                [h, h], (n, n), bc=no_flux_bc(dimension=2), mass_conservative=True, coefficient_field=d_field
+            )
+            .as_scipy_sparse()
+            .toarray()
+        )
+        assert np.max(np.abs(A.sum(axis=0))) < 1e-11
+
+    def test_coefficient_field_requires_mass_conservative(self):
+        """coefficient_field is only assembled in the conservative branch -> reject otherwise."""
+        with pytest.raises(ValueError, match="mass_conservative"):
+            LaplacianOperator([0.1], (5,), bc=no_flux_bc(dimension=1), coefficient_field=np.ones(5))
+
+    def test_coefficient_field_shape_validated(self):
+        with pytest.raises(ValueError, match="coefficient_field shape"):
+            LaplacianOperator(
+                [0.1], (5,), bc=no_flux_bc(dimension=1), mass_conservative=True, coefficient_field=np.ones(7)
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The explicit-drift (`solve_timestep_explicit_with_drift`) and strict-adjoint (`solve_fp_step_adjoint_mode`) FP paths collapsed a non-uniform `volatility_field` to its spatial **mean** (scalar `D`) — silently solving a different PDE than the per-point implicit path (a low-σ region over-diffused, a high-σ region under-diffused; ~14–21% L2 error), with only an interim warning.

## Fix (conservative variable-coefficient diffusion)

Added `coefficient_field=` to `LaplacianOperator`: the conservative finite-volume no-flux stencil bakes in the **face-averaged** diffusion `D_{i+1/2} = ½(D_i + D_{i+1})`, so `∇·(D(x)∇·)` stays **column-conservative** (`1ᵀL = 0`) even for varying `D` (a point-value `D_i·Δ` would leak). Both FP steps build this per-point matrix for an array σ (replacing the mean-collapse + warning).

## Validation (EOC-safe, baseline-gated)

Captured a scalar-σ byte-identical baseline on `main` first, then verified the change touches only the array-σ branch:

| check | result |
|---|---|
| scalar σ (0.1, 0.3), explicit-drift | **bit-for-bit identical** to baseline (EOC-safe) |
| `LaplacianOperator(coefficient_field=None)` | `== ` unit Laplacian (all other consumers unchanged) |
| constant field `D₀` | `== D₀ × unit`, bit-for-bit |
| varying field, 1D & 2D | column-sum `< 1e-11` (conservative) |
| array σ (0.05 left / 0.30 right), explicit-drift | mass `1.0`, density ≥ 0, **low-σ bump retains a higher peak** than mean-collapse |
| array σ, strict-adjoint (pure diffusion) | mass `1.0`, per-point fidelity |

New tests: `TestLaplacianVariableCoefficient` (None-identical / const=D×unit / varying-conservative 1D+2D / validation guards), `TestVaryingSigmaExplicitDriftPerPoint` (replaces the obsolete interim-warning test), `TestStrictAdjointPerPointSigma`. **117 FP/operator tests pass; ruff clean.**

## Scope / follow-up (#1213)

This fixes the two explicit FP paths #1183 names. Two related conservation gaps are filed separately in **#1213**: the *point-value* implicit reference (`solve_timestep_full_nd`) is itself non-conservative for varying σ, and the strict-adjoint **scalar** path is not yet mass-conservative (#1184-class). Both are EOC-risky and need their own baseline; the paper paths use constant σ + the conservative defaults, so they're low priority.

Fixes #1183
Refs #1184, #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
