### PR TITLE
chore(deprecation): remove dead fdm_bc_1d BC factory functions (deprecated v0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracked in #1183 (it needs an operator that matches the existing conservative no-flux
   discretization).
 
+### Removed (BREAKING)
+
+- **Deprecated `fdm_bc_1d` 1D BC factory functions** `periodic_bc`, `dirichlet_bc`, `neumann_bc`,
+  `no_flux_bc`, `robin_bc` (deprecated since v0.14.0 — past the 3-minor-version removal window at
+  v0.19.8). They were dead code: every live import resolves the same names from the geometry-first
+  `conditions.py` (re-exported by `mfgarchon.geometry` / `…geometry.boundary`); nothing imported the
+  factories from `fdm_bc_1d` (only its `BoundaryConditions` dataclass is still used). Use
+  `from mfgarchon.geometry import periodic_bc; bc = periodic_bc(dimension=1)` (the documented
+  replacement). The legacy `fdm_bc_1d.BoundaryConditions` dataclass is unchanged (still imported by
+  the FDM/applicator layer; itself deprecated since v0.14.0 and kept until its consumers migrate).
+
 ### Fixed
 
 - **Per-point spatially-varying volatility on the explicit-drift & strict-adjoint FP paths**

--- a/mfgarchon/geometry/boundary/fdm_bc_1d.py
+++ b/mfgarchon/geometry/boundary/fdm_bc_1d.py
@@ -5,9 +5,8 @@
     This module is deprecated. Use the unified boundary condition API instead:
 
     **Old (deprecated):**
-        from mfgarchon.geometry.boundary.fdm_bc_1d import BoundaryConditions, periodic_bc
+        from mfgarchon.geometry.boundary.fdm_bc_1d import BoundaryConditions
         bc = BoundaryConditions(type="periodic")
-        bc = periodic_bc()
 
     **New (recommended):**
         from mfgarchon.geometry import periodic_bc
@@ -26,8 +25,6 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
-
-from mfgarchon.utils.deprecation import deprecated
 
 
 @dataclass
@@ -171,84 +168,3 @@ class BoundaryConditions:
             )
         else:
             return f"Unknown({self.type})"
-
-
-# Convenience functions for common boundary condition types
-@deprecated(
-    since="v0.14.0",
-    replacement="Use from mfgarchon.geometry import periodic_bc; bc = periodic_bc(dimension=1).",
-)
-def periodic_bc() -> BoundaryConditions:
-    """Create periodic boundary conditions.
-
-    .. deprecated:: 0.14.0
-        Use ``from mfgarchon.geometry import periodic_bc; bc = periodic_bc(dimension=1)``
-    """
-    return BoundaryConditions(type="periodic")
-
-
-@deprecated(
-    since="v0.14.0",
-    replacement="Use from mfgarchon.geometry import dirichlet_bc; bc = dirichlet_bc(value=..., dimension=1).",
-)
-def dirichlet_bc(left_value: float, right_value: float) -> BoundaryConditions:
-    """Create Dirichlet boundary conditions.
-
-    .. deprecated:: 0.14.0
-        Use ``from mfgarchon.geometry import dirichlet_bc; bc = dirichlet_bc(value=..., dimension=1)``
-    """
-    return BoundaryConditions(type="dirichlet", left_value=left_value, right_value=right_value)
-
-
-@deprecated(
-    since="v0.14.0",
-    replacement="Use from mfgarchon.geometry import neumann_bc; bc = neumann_bc(value=..., dimension=1).",
-)
-def neumann_bc(left_gradient: float, right_gradient: float) -> BoundaryConditions:
-    """Create Neumann boundary conditions.
-
-    .. deprecated:: 0.14.0
-        Use ``from mfgarchon.geometry import neumann_bc; bc = neumann_bc(value=..., dimension=1)``
-    """
-    return BoundaryConditions(type="neumann", left_value=left_gradient, right_value=right_gradient)
-
-
-@deprecated(
-    since="v0.14.0",
-    replacement="Use from mfgarchon.geometry import no_flux_bc; bc = no_flux_bc(dimension=1).",
-)
-def no_flux_bc() -> BoundaryConditions:
-    """Create no-flux boundary conditions.
-
-    .. deprecated:: 0.14.0
-        Use ``from mfgarchon.geometry import no_flux_bc; bc = no_flux_bc(dimension=1)``
-    """
-    return BoundaryConditions(type="no_flux")
-
-
-@deprecated(
-    since="v0.14.0",
-    replacement="Use from mfgarchon.geometry import robin_bc; bc = robin_bc(alpha=..., beta=..., dimension=1).",
-)
-def robin_bc(
-    left_alpha: float,
-    left_beta: float,
-    left_value: float,
-    right_alpha: float,
-    right_beta: float,
-    right_value: float,
-) -> BoundaryConditions:
-    """Create Robin boundary conditions.
-
-    .. deprecated:: 0.14.0
-        Use ``from mfgarchon.geometry import robin_bc; bc = robin_bc(alpha=..., beta=..., dimension=1)``
-    """
-    return BoundaryConditions(
-        type="robin",
-        left_alpha=left_alpha,
-        left_beta=left_beta,
-        left_value=left_value,
-        right_alpha=right_alpha,
-        right_beta=right_beta,
-        right_value=right_value,
-    )


### PR DESCRIPTION
## Summary

Removes 5 dead deprecated BC factory functions from `mfgarchon/geometry/boundary/fdm_bc_1d.py` — `periodic_bc`, `dirichlet_bc`, `neumann_bc`, `no_flux_bc`, `robin_bc`. Deprecated since **v0.14.0**, past the 3-minor-version removal window (policy: 3 minor versions **or** 6 months; current v0.19.8).

**Why it's safe (dead code, not just past-window):** every live import of these names resolves the geometry-first `conditions.py` versions (re-exported by `mfgarchon.geometry` and `…geometry.boundary`). Nothing imports the factories *from* `fdm_bc_1d` — only its `BoundaryConditions` dataclass is still consumed (by the FDM/applicator layer). So the shadowed factories were unreachable.

## Changes
- Delete the 5 `@deprecated` factory functions + the now-unused `@deprecated` import + refresh the module-docstring example.
- `fdm_bc_1d.BoundaryConditions` (the dataclass) is **untouched** — still imported by 8 modules; itself deprecated since v0.14.0 but kept until its consumers migrate.

## Validation
- Zero references to the removed factories across `mfgarchon/`, `tests/`, `examples/`, `benchmarks/` (verified by grep).
- **716 geometry tests pass**; ruff clean.

Found via a deprecation-utility audit (4-lens workflow). This is the one unambiguously-safe cleanse; the rest of the audit (blocked removals needing migration, ad-hoc-warn → decorator unification, and deprecation-infrastructure gaps) is reported separately for prioritization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
