### PR TITLE
fix: correct HJB-SL reflecting-BC characteristic-foot fold (single-source it)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HJB-SL reflecting-BC characteristic-foot fold was wrong on asymmetric domains**
+  (Issues #1161, #1048, #1054). Three sibling code paths in `hjb_semi_lagrangian.py` folded
+  out-of-bounds characteristic feet for no-flux/Neumann BC, each with a private copy of the
+  rule: the deterministic explicit/rk2 fast path used `np.clip` (clamping feet onto the wall
+  node, biasing toward the wall value — #1161), while the stochastic 1D (#1048) and nD (#1054)
+  paths used `xmin + |((x-xmin) mod 2L) - L|`, which is a point-inversion about the domain
+  *center* (`x -> xmin+xmax-x`), **not** a boundary reflection — it displaced even in-bounds
+  feet. All three shipped because their tests used a symmetric `[0,1]` domain/data where the
+  center-flip is a symmetry of the solution (silent divergence). Replaced all three (plus the
+  duplicated formula) with a single vectorized `reflect_into_domain(x, xmin, xmax)` helper in
+  `hjb_sl_characteristics.py`, the closed-form triangle wave `xmin + L - |((x-xmin) mod 2L) - L|`
+  verified equal to the trusted iterated scalar `apply_boundary_conditions_1d` on asymmetric
+  domains and identity in-bounds. Numerics are unchanged on symmetric-domain runs and on the
+  paper EOC paths (FDM / GFDM, not SL); asymmetric-domain reflecting-BC SL runs now reflect
+  correctly. Added `TestReflectIntoDomain` (asymmetric-domain reflected-value tests — the
+  coverage gap that let the bug ship).
+
 - **Polymorphic reads of the non-uniform `.bounds` geometry attribute** (Issue #1056). The ad-hoc
   `.bounds` attribute returns four incompatible shapes across geometry classes (`(d,2)` ndarray,
   `(min,max)` tuple, `list[(min,max)]`, or absent), while `get_bounds() -> (mins, maxs)` is the

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -45,6 +45,7 @@ from .hjb_sl_adi import (
 from .hjb_sl_characteristics import (
     apply_boundary_conditions_1d,
     apply_boundary_conditions_nd,
+    reflect_into_domain,
     trace_characteristic_backward_1d,
     trace_characteristic_backward_nd,
 )
@@ -974,8 +975,9 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 bounds = self.problem.geometry.get_bounds()
                 xmin, xmax = bounds[0][0], bounds[1][0]
                 if bc_op == "reflect":
-                    # Reflect: fold back into domain
-                    x_departures = np.clip(x_departures, xmin, xmax)
+                    # Issue #1161: mirror-reflect out-of-bounds feet (no-flux/Neumann),
+                    # not np.clip — clamping collapsed them onto the wall node.
+                    x_departures = reflect_into_domain(x_departures, xmin, xmax)
                 elif bc_op == "wrap":
                     # Periodic: wrap around
                     L = xmax - xmin
@@ -1348,13 +1350,11 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         bounds = self.problem.geometry.get_bounds()
         xmin, xmax = bounds[0][0], bounds[1][0]
         if bc_op == "reflect":
-            # Iterated mirror reflection via modular arithmetic:
-            #   y' = xmin + |((y − xmin) mod 2L) − L|   where L = xmax − xmin
-            # Maps any y ∈ ℝ to [xmin, xmax] via reflections at xmin and xmax.
-            # Handles arbitrary numbers of bounces in a single expression.
-            L = xmax - xmin
-            y_plus = xmin + np.abs(((y_plus - xmin) % (2 * L)) - L)
-            y_minus = xmin + np.abs(((y_minus - xmin) % (2 * L)) - L)
+            # Issue #1048 fix used a center-flip (missing the leading "L -"), which
+            # mirrored every foot about the domain midpoint; reflect_into_domain is the
+            # correct boundary fold (identity in-bounds).
+            y_plus = reflect_into_domain(y_plus, xmin, xmax)
+            y_minus = reflect_into_domain(y_minus, xmin, xmax)
         elif bc_op == "wrap":
             L = xmax - xmin
             y_plus = xmin + (y_plus - xmin) % L
@@ -1501,7 +1501,9 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
 
         # Apply BC vectorized (per-axis broadcast)
         if bc_op == "reflect":
-            all_departures = x_min + np.abs(((all_departures - x_min) % (2 * L_axis)) - L_axis)
+            # Issue #1054: same center-flip bug as #1048 (missing "L -"); use the
+            # correct per-axis boundary fold.
+            all_departures = reflect_into_domain(all_departures, x_min, x_max)
         elif bc_op == "wrap":
             all_departures = x_min + (all_departures - x_min) % L_axis
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_characteristics.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_characteristics.py
@@ -222,6 +222,34 @@ def apply_boundary_conditions_1d(
     return float(np.clip(x, xmin, xmax))
 
 
+def reflect_into_domain(
+    x: np.ndarray,
+    xmin: float | np.ndarray,
+    xmax: float | np.ndarray,
+) -> np.ndarray:
+    r"""
+    Vectorized mirror-reflection of points into ``[xmin, xmax]`` (no-flux / Neumann fold).
+
+    Closed-form triangle wave, equivalent to the iterated scalar reflection in
+    :func:`apply_boundary_conditions_1d` (apply ``2*xmin - x`` / ``2*xmax - x`` until in
+    bounds):
+
+    .. math::
+        x' = x_{\min} + L - \bigl|\,((x - x_{\min}) \bmod 2L) - L\,\bigr|,
+        \qquad L = x_{\max} - x_{\min}.
+
+    Identity for in-bounds ``x``; resolves arbitrarily many bounces in one pass. ``xmin`` /
+    ``xmax`` may be scalars (1D) or per-axis arrays broadcastable against ``x`` (nD).
+
+    The leading ``L -`` is load-bearing: the variant ``xmin + |((x - xmin) mod 2L) - L|``
+    (without it) is a point-inversion about the domain *center* (``x -> xmin + xmax - x``),
+    not a boundary reflection — it displaces even in-bounds points and is correct only on
+    domains/data symmetric about the midpoint.
+    """
+    span = xmax - xmin
+    return xmin + span - np.abs(((x - xmin) % (2.0 * span)) - span)
+
+
 def apply_boundary_conditions_nd(
     x: np.ndarray,
     bounds: list[tuple[float, float]],

--- a/tests/unit/test_alg/test_hjb_semi_lagrangian.py
+++ b/tests/unit/test_alg/test_hjb_semi_lagrangian.py
@@ -966,8 +966,10 @@ class TestStochasticCharacteristicSL_nD:
 
         bc = no_flux_bc(dimension=2)
         grid = TensorProductGrid(
-            dimension=2, bounds=[(0.0, 1.0), (0.0, 1.0)],
-            Nx_points=[N, N], boundary_conditions=bc,
+            dimension=2,
+            bounds=[(0.0, 1.0), (0.0, 1.0)],
+            Nx_points=[N, N],
+            boundary_conditions=bc,
         )
 
         def m0(x):
@@ -978,17 +980,27 @@ class TestStochasticCharacteristicSL_nD:
             m_initial=m0,
             u_terminal=lambda x: 1.0,
         )
-        return MFGProblem(
-            geometry=grid, T=T, Nt=Nt, sigma=sigma,
-            components=components, boundary_conditions=bc,
-        ), grid, m0
+        return (
+            MFGProblem(
+                geometry=grid,
+                T=T,
+                Nt=Nt,
+                sigma=sigma,
+                components=components,
+                boundary_conditions=bc,
+            ),
+            grid,
+            m0,
+        )
 
     def test_2d_linear_stochastic_finite(self):
         """Issue #1054: linear+stochastic on 2D no-flux must produce finite output."""
         problem, grid, m0 = self._make_2d_problem()
         solver = HJBSemiLagrangianSolver(
-            problem, diffusion_method="stochastic",
-            interpolation_method="linear", check_cfl=False,
+            problem,
+            diffusion_method="stochastic",
+            interpolation_method="linear",
+            check_cfl=False,
         )
         U_terminal = np.zeros(tuple(grid.Nx_points))
         M_init = m0(np.stack(np.meshgrid(*grid.coordinates, indexing="ij"), axis=-1))
@@ -1002,8 +1014,10 @@ class TestStochasticCharacteristicSL_nD:
         with __import__("warnings").catch_warnings():
             __import__("warnings").simplefilter("ignore")
             solver = HJBSemiLagrangianSolver(
-                problem, diffusion_method="stochastic",
-                interpolation_method="cubic", check_cfl=False,
+                problem,
+                diffusion_method="stochastic",
+                interpolation_method="cubic",
+                check_cfl=False,
             )
         U_terminal = np.zeros(tuple(grid.Nx_points))
         M_init = m0(np.stack(np.meshgrid(*grid.coordinates, indexing="ij"), axis=-1))
@@ -1014,14 +1028,16 @@ class TestStochasticCharacteristicSL_nD:
         """Issue #1054: high-curvature U near walls must not produce NaN under no-flux."""
         problem, grid, m0 = self._make_2d_problem()
         solver = HJBSemiLagrangianSolver(
-            problem, diffusion_method="stochastic",
-            interpolation_method="linear", check_cfl=False,
+            problem,
+            diffusion_method="stochastic",
+            interpolation_method="linear",
+            check_cfl=False,
         )
         # Stress-test: bowl U_T peaking near walls — Brownian feet would otherwise
         # extrapolate (silent fill_value=None) and produce nonsense values.
         Nx = grid.Nx_points[0]
         U_terminal = np.fromfunction(
-            lambda i, j: ((i / (Nx - 1) - 0.5) ** 2 + (j / (Nx - 1) - 0.5) ** 2),
+            lambda i, j: (i / (Nx - 1) - 0.5) ** 2 + (j / (Nx - 1) - 0.5) ** 2,
             (Nx, Nx),
         ).astype(float)
         M_init = m0(np.stack(np.meshgrid(*grid.coordinates, indexing="ij"), axis=-1))
@@ -1083,6 +1099,65 @@ class TestADIDiffusionMagnitude:
         assert self._decay_relerr(adi_fac, analytic_fac) < 0.03, (
             f"ADI 3D under/over-diffuses: factor {adi_fac:.6f} vs analytic {analytic_fac:.6f}"
         )
+
+
+class TestReflectIntoDomain:
+    """Regression guard for the reflecting-BC characteristic-foot fold (Issues #1161/#1048/#1054).
+
+    The vectorized fold must equal the trusted iterated scalar reflection
+    (``apply_boundary_conditions_1d``) on ASYMMETRIC domains. The bug that shipped used
+    ``xmin + |((x-xmin) % 2L) - L|`` (a center-flip about the midpoint), which is correct only
+    on domains symmetric about their center — exactly why the prior [0,1]-only tests missed it.
+    """
+
+    def test_matches_trusted_scalar_reference_asymmetric(self):
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import (
+            apply_boundary_conditions_1d,
+            reflect_into_domain,
+        )
+
+        xmin, xmax = 2.0, 5.0  # asymmetric, off-origin: center-flip != reflection here
+        pts = np.array([2.5, 1.8, 1.0, 5.0, 2.0, 3.5, 6.2, -1.0, 8.3, 4.99])
+        new = reflect_into_domain(pts, xmin, xmax)
+        ref = np.array([apply_boundary_conditions_1d(float(x), xmin, xmax, "reflect") for x in pts])
+        np.testing.assert_allclose(new, ref, atol=1e-12)
+
+    def test_in_bounds_is_identity(self):
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import reflect_into_domain
+
+        xmin, xmax = 2.0, 5.0
+        interior = np.array([2.0, 2.5, 3.5, 4.99, 5.0])
+        np.testing.assert_allclose(reflect_into_domain(interior, xmin, xmax), interior, atol=1e-12)
+
+    def test_single_and_multi_bounce(self):
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import reflect_into_domain
+
+        xmin, xmax = 2.0, 5.0  # L = 3
+        # 6.2 over by 1.2 -> 3.8 (one bounce); 8.3 -> two bounces -> 2.3; -1.0 -> 5.0
+        out = reflect_into_domain(np.array([6.2, 8.3, -1.0]), xmin, xmax)
+        np.testing.assert_allclose(out, [3.8, 2.3, 5.0], atol=1e-12)
+        assert np.all((out >= xmin - 1e-12) & (out <= xmax + 1e-12))
+
+    def test_not_center_flip(self):
+        """The specific bug: an interior point must NOT be mirrored about the midpoint."""
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import reflect_into_domain
+
+        xmin, xmax = 2.0, 5.0
+        x = 2.5
+        flipped = xmin + xmax - x  # 4.5 — what the broken formula produced
+        out = reflect_into_domain(np.array([x]), xmin, xmax)[0]
+        assert out == pytest.approx(x)
+        assert out != pytest.approx(flipped)
+
+    def test_per_axis_broadcast_nd(self):
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import reflect_into_domain
+
+        xmn = np.array([0.0, 2.0])
+        xmx = np.array([1.0, 5.0])
+        pts = np.array([[0.3, 2.5], [1.2, 6.2], [-0.3, 1.0]])
+        out = reflect_into_domain(pts, xmn, xmx)
+        np.testing.assert_allclose(out, [[0.3, 2.5], [0.8, 3.8], [0.3, 3.0]], atol=1e-12)
+        assert np.all((out >= xmn - 1e-9) & (out <= xmx + 1e-9))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three sibling paths in `hjb_semi_lagrangian.py` fold out-of-bounds characteristic feet for no-flux / Neumann (reflecting) BC, each carrying a **private, differently-wrong copy** of the rule — the repo's canonical bug class (parallel paths, private convention copies, no single source):

| Path | Site | Old behavior | Bug |
|---|---|---|---|
| deterministic explicit/rk2 | `:978` | `np.clip(x, xmin, xmax)` | clamps feet onto the wall node (biases toward wall value, breaks upwind near boundary) — **#1161** |
| stochastic 1D | `:1356-1357` | `xmin + \|((x-xmin) mod 2L) - L\|` | point-inversion about the domain **center** (`x → xmin+xmax-x`), not a reflection — displaces even in-bounds feet — **#1048** |
| stochastic nD | `:1504` | same center-flip (per-axis) | same — **#1054** |

All three shipped because their tests use a symmetric `[0,1]` domain/data, where the center-flip is a **symmetry of the solution** → silent divergence. On any asymmetric domain (e.g. `[2,5]`): `2.5 → 4.5` under the old stochastic formula, should be `2.5`.

## Fix

One vectorized helper in `hjb_sl_characteristics.py`, co-located with the trusted iterated scalar reflection it generalizes:

```python
def reflect_into_domain(x, xmin, xmax):
    span = xmax - xmin
    return xmin + span - np.abs(((x - xmin) % (2.0 * span)) - span)
```

The closed-form triangle wave (note the load-bearing leading `span -`). Verified **equal to `apply_boundary_conditions_1d`** (the trusted `2·xmin−x` / `2·xmax−x` iterated reference) on an asymmetric battery, **identity in-bounds**, and supports scalar (1D) and per-axis-array (nD) bounds via broadcasting. All three call sites route through it; the duplicated inline formulas are gone.

## EOC / numerics impact

- SL is **off both paper EOC paths** (1D LQ FDM, 2D scattered GFDM).
- **Symmetric-domain runs unchanged** at the solution level (the flip was a symmetry; clip→fold is identity for in-bounds feet).
- **Asymmetric-domain reflecting-BC SL runs now reflect correctly** — this is a numerics change to the previously-merged #1048/#1054 stochastic paths. Flagged for review.

## Tests

`TestReflectIntoDomain`: matches the trusted scalar reference on `[2,5]`, in-bounds identity, single/multi-bounce, the specific "not a center-flip" assertion, and nD broadcast. These are the asymmetric-domain reflected-value checks whose absence let the bug ship. Existing SL suite (63 tests) still passes; repo-wide grep confirms no other copies of the broken fold remain.

Closes #1161; repairs #1048 / #1054 propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)