### PR TITLE
fix: stop collocation.py SDF fallbacks from swallowing real TypeErrors (#1069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`geometry/collocation.py` silently swallowed real `TypeError`s in SDF fallbacks**
+  (Issue #1069). Nine `except (AttributeError, TypeError): pass` blocks guard optional
+  `geometry.signed_distance(...)` calls in the mesh-optimization / interior-filter paths.
+  Catching `AttributeError` is the correct optional-capability signal (TensorProductGrid /
+  network geometries legitimately lack `signed_distance`), but also catching `TypeError`
+  masked genuine dtype/shape bugs inside geometries that *do* implement it. Narrowed all nine
+  to `except AttributeError` so the optional-capability fallback is preserved while real
+  failures surface (fail-fast). The four `_select_strategy` capability probes (already
+  `except AttributeError` + terminal `raise ValueError`) and the analytic→FD gradient fallback
+  are correct idiom and untouched.
+
 - **`@deprecated_parameter` false-positive warning + dead removal-readiness lister**. The
   decorator called `bound.apply_defaults()` and warned whenever the resolved value was
   non-`None`, so any deprecated parameter with a **non-`None` default** emitted a deprecation

--- a/mfgarchon/geometry/collocation.py
+++ b/mfgarchon/geometry/collocation.py
@@ -1066,7 +1066,7 @@ def _optimize_mesh_ratio_interior(
         try:
             sdf = geometry.signed_distance(test_points)
             test_points = test_points[sdf < 0]
-        except (AttributeError, TypeError):
+        except AttributeError:
             pass
 
         if len(test_points) > 0:
@@ -1275,7 +1275,7 @@ def _lloyd_relaxation_interior_only(
                 boundary_dist = max(np.abs(sdf[i]), 1e-10)
                 force_mag = boundary_strength / (boundary_dist**2)
                 forces[i] -= grad_sdf[i] * force_mag * np.sign(sdf[i])
-        except (AttributeError, TypeError):
+        except AttributeError:
             # Box boundary fallback
             for dim in range(d):
                 lo, hi = bounds[dim]
@@ -1312,7 +1312,7 @@ def _lloyd_relaxation_interior_only(
                 grad_norm = np.maximum(grad_norm, 1e-10)
                 push_dist = 0.02 * target_spacing
                 current[outside] -= (sdf_new[outside, np.newaxis] + push_dist) * grad / grad_norm
-        except (AttributeError, TypeError):
+        except AttributeError:
             pass
 
         # Clamp to bounds
@@ -1391,7 +1391,7 @@ def _optimize_mesh_ratio(
         try:
             sdf = geometry.signed_distance(test_points)
             test_points = test_points[sdf < 0]
-        except (AttributeError, TypeError):
+        except AttributeError:
             pass
 
         if len(test_points) > 0:
@@ -1499,7 +1499,7 @@ def _lloyd_relaxation_pass(
                 boundary_dist = max(np.abs(sdf[i]), 1e-10)
                 force_mag = boundary_strength / (boundary_dist**2)
                 forces[i] -= grad_sdf[i] * force_mag * np.sign(sdf[i])
-        except (AttributeError, TypeError):
+        except AttributeError:
             # No SDF, use box boundary repulsion
             for dim in range(d):
                 lo, hi = bounds[dim]
@@ -1537,7 +1537,7 @@ def _lloyd_relaxation_pass(
                 grad_norm = np.maximum(grad_norm, 1e-10)
                 push_dist = 0.02 * target_spacing
                 current[outside] -= (sdf_new[outside, np.newaxis] + push_dist) * grad / grad_norm
-        except (AttributeError, TypeError):
+        except AttributeError:
             pass
 
         # Clamp to bounds
@@ -1591,7 +1591,7 @@ def _find_coverage_gaps(
         sdf = geometry.signed_distance(test_points)
         interior_mask = sdf < 0
         test_points = test_points[interior_mask]
-    except (AttributeError, TypeError):
+    except AttributeError:
         pass  # No SDF, use all test points
 
     if len(test_points) == 0:
@@ -1710,7 +1710,7 @@ def _enforce_max_fill_distance(
                 sdf = geometry.signed_distance(candidate.reshape(1, -1))[0]
                 if sdf >= -min_separation / 2:  # Too close to or outside boundary
                     continue
-            except (AttributeError, TypeError):
+            except AttributeError:
                 pass
 
             new_points.append(candidate)
@@ -1816,7 +1816,7 @@ def _enforce_separation(
                 logger.debug(
                     f"Removed {np.sum(too_close_mask)} interior points within {boundary_margin} of domain boundary"
                 )
-        except (AttributeError, TypeError):
+        except AttributeError:
             # Geometry doesn't support SDF, skip this step
             pass
 


### PR DESCRIPTION
## Summary

`geometry/collocation.py` has **nine** `except (AttributeError, TypeError): pass` blocks guarding optional `geometry.signed_distance(...)` calls in the mesh-optimization and interior-filter paths.

- `AttributeError` is the **correct** optional-capability signal — `TensorProductGrid` / network geometries legitimately lack `signed_distance`, and these paths must fall back to the bounding box / all-points.
- Also catching `TypeError` **masked real bugs**: a dtype/shape error inside a geometry that *does* implement `signed_distance` was silently swallowed, leaving the fallback to run on a broken state (the repo's fail-fast violation).

Narrowed all nine to `except AttributeError`, so the optional-capability fallback is preserved while genuine `TypeError`s surface.

## Scope (verified, not the issue's literal ask)

The triage that flagged this initially identified 5 sites; reading the file showed **9** of the same pattern (1069, 1278, 1315, 1394, 1502, 1540, 1594, 1713, 1819) — all narrowed. **Left untouched** (correct idiom, not silent failures):
- the four `_select_strategy` capability probes — already `except AttributeError` and terminate in a `raise ValueError` dispatch-exhaustion error;
- the analytic→finite-difference gradient fallback in `_compute_sdf_gradient`.

The issue body's "proposed audit format" example (`get_lipschitz_constant() → h_box=1.0`, a `GeometryCapabilityNotSupported` class) matches **no code in the repo** and was not implemented; the larger ask (new exception class, hoist-to-construction Protocol checks) is declined.

## Tests

716 geometry unit tests + 17 collocation integration tests pass; ruff check + format clean.

Closes #1069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)