### PR TITLE
fix: warn when FDM averages a spatially-varying diffusion tensor to constant (#1079 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Silent collapse of a spatially-varying diffusion tensor to a constant in the FDM tensor
+  path** (Issue #1079, partial). When `HJBFDMSolver` is given a spatially-varying *diagonal*
+  tensor `volatility_field` (shape `(*grid, d, d)`), it extracts the per-axis diagonal and
+  averages it to a single constant per axis — discretizing a constant-coefficient Laplacian and
+  silently dropping the spatial variation of `D(x)`. The existing #1169 warning only fired for
+  *non-diagonal* tensors, so this varying-diagonal reduction was silent. Added a warning that
+  fires only when the diagonal is actually spatially-varying; scalar / constant-tensor inputs
+  (incl. the paper EOC paths) are byte-identical (no new warning). The two other #1079 sub-sites
+  are **not** addressed here: the GFDM "tensor → trace" drop does not reproduce (`MFGProblem`
+  rejects an array `sigma` at construction, and a callable `sigma` is not trace-reduced), and the
+  `hjb_sl_adi` diagonal-vs-off-diagonal scaling mismatch needs a `sigma`-vs-`D` convention
+  decision — so #1079 stays open for the ADI convention item.
+
 - **`geometry/collocation.py` silently swallowed real `TypeError`s in SDF fallbacks**
   (Issue #1069). Nine `except (AttributeError, TypeError): pass` blocks guard optional
   `geometry.signed_distance(...)` calls in the mesh-optimization / interior-filter paths.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -943,6 +943,18 @@ class HJBFDMSolver(BaseHJBSolver):
                 # Spatially-varying: extract diagonal, average to constant weights
                 sigma_diag = np.diagonal(Sigma_at_n, axis1=-2, axis2=-1)
                 if sigma_diag.ndim > 1:
+                    import warnings
+
+                    warnings.warn(
+                        "Spatially-varying diffusion tensor averaged to constant per-axis "
+                        "weights (grid mean): the FDM tensor path discretizes a "
+                        "constant-coefficient Laplacian, so spatial variation in D(x) is dropped "
+                        "(Issue #1079). Pass a scalar/constant sigma, or use a "
+                        "variable-coefficient FP path, if the variation is physically "
+                        "significant.",
+                        UserWarning,
+                        stacklevel=3,
+                    )
                     sigma_diag = sigma_diag.reshape(-1, self.dimension).mean(axis=0)
 
             # Convective Hamiltonian via H_class (same pattern as scalar path)

--- a/tests/unit/test_alg/test_hjb_fdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_fdm_solver.py
@@ -555,13 +555,46 @@ class TestHJBFDMSolverDiagonalTensor:
             # Issue #1079: the warning must convey the O(1) severity (dropping off-diagonal
             # sigma_ij is not a small correction), not merely "using diagonal approximation".
             assert any(
-                "o(1)" in str(warning.message).lower() or "1079" in str(warning.message)
-                for warning in tensor_warnings
+                "o(1)" in str(warning.message).lower() or "1079" in str(warning.message) for warning in tensor_warnings
             ), "Warning should state the off-diagonal drop is an O(1) error (Issue #1079)"
 
         # Solution should still be computed (fallback to diagonal)
         assert U_solution.shape == (Nt_points, Nx, Ny)
         assert not np.any(np.isnan(U_solution))
+
+    def test_spatially_varying_tensor_averaging_warning(self):
+        """Issue #1079: a spatially-varying *diagonal* tensor is averaged to constant per-axis
+        weights — previously silent. Must warn (and must NOT raise the non-diagonal warning)."""
+        domain = TensorProductGrid(
+            bounds=[(0.0, 1.0), (0.0, 0.6)], Nx_points=[12, 9], boundary_conditions=no_flux_bc(dimension=2)
+        )
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=4, sigma=0.1, components=_default_components_2d())
+        solver = HJBFDMSolver(problem, solver_type="newton")
+
+        Nx, Ny = domain.get_grid_shape()
+        Nt_points = problem.Nt_points
+        M_density = np.ones((Nt_points, Nx, Ny)) * 0.5
+        U_final = np.zeros((Nx, Ny))
+        U_prev = np.zeros((Nt_points, Nx, Ny))
+
+        # Spatially-varying DIAGONAL tensor field (Nx, Ny, 2, 2); off-diagonals zero,
+        # diagonal varies in x → forces the "average to constant" reduction.
+        field = np.zeros((Nx, Ny, 2, 2))
+        field[..., 0, 0] = 0.05 + 0.1 * np.linspace(0.0, 1.0, Nx)[:, None]
+        field[..., 1, 1] = 0.05
+
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            solver.solve_hjb_system(M_density, U_final, U_prev, tensor_volatility_field=field)
+
+            averaging = [x for x in w if "averaged to constant" in str(x.message)]
+            assert len(averaging) > 0, "Should warn that a spatially-varying tensor is averaged to constant"
+            assert any("1079" in str(x.message) for x in averaging)
+            # The field is diagonal, so the non-diagonal-drop warning must NOT fire.
+            non_diag = [x for x in w if "non-diagonal" in str(x.message).lower()]
+            assert len(non_diag) == 0, "Diagonal field must not trigger the off-diagonal warning"
 
     def test_diagonal_tensor_is_diagonal_helper(self):
         """Test is_diagonal_tensor helper function."""


### PR DESCRIPTION
## Summary

When `HJBFDMSolver` is given a spatially-varying **diagonal** tensor `volatility_field` (shape `(*grid, d, d)`), it extracts the per-axis diagonal and **averages it to a single constant per axis** — discretizing a constant-coefficient Laplacian and silently dropping the spatial variation of `D(x)`. The existing #1169 warning only fires for **non-diagonal** tensors, so this varying-diagonal reduction was silent (the repo's silent-divergence bug class).

Added a warning that fires **only** when the diagonal is genuinely spatially-varying (`sigma_diag.ndim > 1`). Scalar / constant-tensor inputs are byte-identical — verified: a scalar σ run emits **zero** #1079 warnings.

## Scope — verify-by-artifact narrowed the triage's 3 sites to 1

The triage flagged three silent-drop sites; reading the actual code resolved them:

| Sub-site | Disposition |
|---|---|
| **Site 2** non-diagonal constant tensor | already warns (#1169) — no change |
| **Site 1** varying diagonal → constant | **this PR** |
| **Site 3** GFDM tensor → trace | **does not reproduce** — `MFGProblem` rejects an array `sigma` at construction (treated as a mis-shaped field), and a callable `sigma` is not trace-reduced. No speculative guard added. |
| **Site 4** `hjb_sl_adi` diag (`D=Σ/2`) vs off-diag (`2·Σ_ij`) scaling mismatch | needs a `sigma`-vs-`D` convention decision; **deferred** |

Because Site 4 remains, this is **`Refs #1079`**, not `Closes` — the issue stays open for the ADI convention item.

## Tests

`TestHJBFDMSolverDiagonalTensor.test_spatially_varying_tensor_averaging_warning`: a varying diagonal field warns (and the non-diagonal warning correctly does **not** fire). 48 `hjb_fdm` tests pass; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)