### PR TITLE
test: cross-path convention-agreement guards (σ→D, get_bounds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cross-path convention-agreement guards** (`tests/unit/test_convention_agreement.py`). The
+  dominant bug class here is the same convention implemented along parallel code paths with
+  private copies and silent divergence. These tests pin the conventions that have *converged*
+  so a future private-copy drift fails loudly: (1) `sigma -> D` resolution agrees across the
+  canonical converter, `MFGProblem.diffusion`, the GFDM `_get_sigma_value` path, and the backend
+  literal `0.5*sigma**2` (Issue #811/#1192); (2) `get_bounds()` is the one uniform bounds
+  accessor across `TensorProductGrid` / `Hyperrectangle` / `Hypersphere` / CSG composites
+  (the `.bounds` / `get_bounding_box` non-uniformity itself stays tracked in #1056).
+
 - **6-month removal criterion + `deprecated_on` date** for the deprecation policy (CLAUDE.md
   "3 minor versions OR 6 months"). Only the version criterion was implemented; the time
   criterion is now wired through a single source of truth, `_removable_by_policy(since,

--- a/tests/unit/test_convention_agreement.py
+++ b/tests/unit/test_convention_agreement.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Cross-path convention-agreement guards.
+
+The dominant bug class in this library is the *same* convention implemented along several
+parallel code paths, each carrying a private copy, with no single owning abstraction — and the
+divergence is silent (no exception / NaN). These tests pin the conventions that have *converged*
+to a single value across their parallel implementations, so a future private-copy drift fails
+loudly instead of silently.
+
+Scope note (verified once via a probe, not re-run here as brittle permanent assertions): the
+``sigma -> D`` convention was additionally checked by *recovering* D from the assembled FP-FDM
+upwind/divergence matrices, the ADI Crank-Nicolson operator, and the weak-form FP coefficient —
+all 66 (sigma x path) combinations agreed to <= 1e-14. The behavioral magnitude guard for the
+solver dynamics lives separately in ``tests/integration/test_diffusion_magnitude_gate.py``
+(Issue #1188); this file guards the *resolution* layer (the converter + the touchpoints solvers
+read) so the two are complementary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+SIGMAS = [0.1, 0.7, 1.0, np.sqrt(2.0), 2.5, 3.0]
+
+
+class TestSigmaToDiffusionAgreement:
+    """Issue #811 / #1192: every path resolves the SDE volatility to D = sigma**2 / 2."""
+
+    @pytest.mark.parametrize("sigma", SIGMAS)
+    def test_converter_and_problem_property_agree(self, sigma):
+        """The canonical converter and the MFGProblem.diffusion property (which the solvers
+        read) must both yield D = sigma**2 / 2 — i.e. the property delegates to the single
+        source, not a private copy."""
+        from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+        from mfgarchon.core.mfg_components import MFGComponents
+        from mfgarchon.core.mfg_problem import MFGProblem
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc
+
+        d_reference = 0.5 * sigma * sigma
+
+        components = MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        )
+        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(geometry=geometry, T=0.1, Nt=5, sigma=sigma, components=components)
+
+        assert diffusion_from_volatility(sigma) == pytest.approx(d_reference, rel=1e-12)
+        assert float(problem.diffusion) == pytest.approx(d_reference, rel=1e-12)
+
+    @pytest.mark.parametrize("sigma", SIGMAS)
+    def test_gfdm_sigma_resolution_agrees(self, sigma):
+        """The 2D scattered-cloud GFDM HJB path resolves sigma via _get_sigma_value, then applies
+        the canonical converter (hjb_gfdm.py:2053-2054 etc.). It must agree with the converter."""
+        from types import SimpleNamespace
+
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
+
+        stub = SimpleNamespace(problem=SimpleNamespace(sigma=sigma))
+        resolved = HJBGFDMSolver._get_sigma_value(stub, None)
+        assert diffusion_from_volatility(resolved) == pytest.approx(0.5 * sigma * sigma, rel=1e-12)
+
+    @pytest.mark.parametrize("sigma", SIGMAS)
+    def test_backend_literal_equals_single_source(self, sigma):
+        """Several backends apply D via the literal ``0.5 * sigma**2`` rather than the converter
+        (numpy/jax/numba/torch). Pin that the literal is bit-equal to the single source so a
+        backend edit that drifts from sigma**2/2 fails here."""
+        assert 0.5 * sigma**2 == diffusion_from_volatility(sigma)
+
+
+class TestGeometryBoundsAccessor:
+    """Issue #1056: the .bounds / get_bounding_box accessors are non-uniform across geometry
+    classes, but get_bounds() is the one accessor present on ALL of them (the Geometry ABC
+    contract). Pin that uniform contract so it is not eroded; the .bounds non-uniformity itself
+    remains tracked in #1056."""
+
+    @staticmethod
+    def _geometries():
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc
+        from mfgarchon.geometry.implicit.csg_operations import (
+            DifferenceDomain,
+            IntersectionDomain,
+            UnionDomain,
+        )
+        from mfgarchon.geometry.implicit.hyperrectangle import Hyperrectangle
+        from mfgarchon.geometry.implicit.hypersphere import Hypersphere
+
+        box = Hyperrectangle(bounds=[(0.0, 1.0), (0.0, 1.0)])
+        ball = Hypersphere(center=[0.5, 0.5], radius=0.4)
+        return [
+            (
+                "TensorProductGrid",
+                TensorProductGrid(
+                    bounds=[(0.0, 1.0), (0.0, 2.0)], Nx_points=[5, 6], boundary_conditions=no_flux_bc(dimension=2)
+                ),
+            ),
+            ("Hyperrectangle", box),
+            ("Hypersphere", ball),
+            ("UnionDomain", UnionDomain([box, ball])),
+            ("IntersectionDomain", IntersectionDomain([box, ball])),
+            ("DifferenceDomain", DifferenceDomain(box, ball)),
+        ]
+
+    def test_get_bounds_uniform_contract(self):
+        """Every geometry exposes get_bounds() -> (mins, maxs), each length d, mins <= maxs."""
+        for name, geom in self._geometries():
+            result = geom.get_bounds()
+            assert isinstance(result, tuple), f"{name}: get_bounds must return a tuple"
+            assert len(result) == 2, f"{name}: get_bounds must return (mins, maxs)"
+            mins, maxs = np.asarray(result[0], dtype=float), np.asarray(result[1], dtype=float)
+            assert mins.shape == maxs.shape, f"{name}: mins/maxs shape mismatch"
+            assert np.all(mins <= maxs), f"{name}: mins must be <= maxs, got {mins} / {maxs}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The dominant verified bug class in this library is the **same convention implemented along parallel code paths**, each with a private copy, no single owner — and the divergence is **silent** (no exception/NaN). Recent examples: σ→D (#1152/#1178/#1183), the reflecting-BC fold (#1218: 4 copies, 3 broken differently), FP drift (#1043).

This adds a **detection layer** — tests that pin the conventions a probe verified have *converged*, so the next private-copy drift fails loudly instead of silently. Built from a fan-out that constructed and **ran** agreement probes across each convention's parallel implementations.

## Guards (both green)

1. **`TestSigmaToDiffusionAgreement`** (#811/#1192) — `D = σ²/2` agrees across the canonical `diffusion_from_volatility`, the `MFGProblem.diffusion` property, the GFDM `_get_sigma_value` resolution (2D scattered EOC path), and the backend literal `0.5*σ²`. The probe additionally recovered D from the FP-FDM upwind/divergence matrices, the ADI operator, and the weak-form coefficient — all 66 (σ × path) combos agreed to ≤ 1e-14 (documented in the file's scope note; not re-run as brittle permanent assertions). Complements the behavioral magnitude gate (#1188) by guarding the **resolution** layer.

2. **`TestGeometryBoundsAccessor`** (#1056) — `get_bounds()` is the one accessor uniform across `TensorProductGrid` / `Hyperrectangle` / `Hypersphere` / CSG `Union`/`Intersection`/`Difference`, returning `(mins, maxs)` with `mins ≤ maxs`. The `.bounds` / `get_bounding_box` non-uniformity itself (3-way return-type split; absent on Hypersphere/PointCloud) stays tracked in #1056.

## Divergences the probe found (NOT in this PR — reported for triage)

These need design decisions, so they're reported rather than shipped as speculative xfail contracts:

- **#1043 (fresh)** — `FPParticleSolver._drift_convention` declares `VELOCITY` (inherited default) but its body behaves `VALUE_FUNCTION` (behavioral probe: `d⟨x⟩=+0.001` vs `+0.17` for true velocity solvers); and `test_drift_contract.py` *silently omits* the particle from both assertion lists, so the mismatch is unguarded. Bivalent via `drift_is_precomputed` → matches the #1043 deferral, but the silent omission is a tracker-honesty gap.
- **#1101/#1114** — boundary on-wall classification: 6/10 battery points diverge across 4 classifiers (tolerance ladder 1e-10/1e-8/1e-6, `<` vs `<=`); `outward_normal` vs obstacle-SDF normal misfire reproduced (21.8° apart).

## Tests

19 tests pass; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)