### PR TITLE
fix: make FPParticleSolver._drift_convention trait honest (#1043 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`FPParticleSolver._drift_convention` trait was dishonest** (Issue #1043). It inherited the
+  base `VELOCITY` default, but the solver body is `VALUE_FUNCTION` by default — the 1D path always
+  takes the value function `U` via `drift_field` and computes `alpha = -coupling*grad(U)`, and the
+  nD default does the same (`drift_is_precomputed=True`, nD only, flips it to `VELOCITY`). Set the
+  class trait to `VALUE_FUNCTION` to match the default behavior, documenting the per-call
+  precomputed exception. Pure metadata: nothing dispatches on `_drift_convention` (verified — the
+  only readers are the contract test), so this is byte-identical on every path. Also added
+  `FPParticleSolver` to `test_drift_contract.py`, which previously silently omitted it from both
+  assertion lists — the one bivalent solver was the only untested one.
+
 - **Silent collapse of a spatially-varying diffusion tensor to a constant in the FDM tensor
   path** (Issue #1079, partial). When `HJBFDMSolver` is given a spatially-varying *diagonal*
   tensor `volatility_field` (shape `(*grid, d, d)`), it extracts the per-axis diagonal and

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -34,7 +34,7 @@ from mfgarchon.utils.numerical.particle import (
     sample_from_density,
 )
 
-from .base_fp import BaseFPSolver
+from .base_fp import BaseFPSolver, DriftConvention
 from .fp_particle_bc import apply_boundary_conditions as _apply_bc
 from .fp_particle_bc import enforce_obstacle_boundary as _enforce_obstacle
 from .fp_particle_bc import get_topology_per_dimension as _get_topology
@@ -115,6 +115,14 @@ class FPParticleSolver(BaseFPSolver):
     from mfgarchon.alg.base_solver import SchemeFamily
 
     _scheme_family = SchemeFamily.GENERIC  # Particle methods don't fit standard families
+
+    # Issue #1043: the default body is VALUE_FUNCTION — it takes the value function U via
+    # `drift_field` and computes alpha = -coupling * grad(U) (see _solve_fp_system_cpu_1d/_nd).
+    # The 1D path is always VALUE_FUNCTION; `drift_is_precomputed=True` flips ONLY the nD path to
+    # VELOCITY (interpolate a precomputed alpha). The class trait records the default; the
+    # per-call exception lives in the drift_is_precomputed parameter. Previously this inherited
+    # the base VELOCITY default, which mislabeled the solver.
+    _drift_convention = DriftConvention.VALUE_FUNCTION
 
     @deprecated_parameter(param_name="mode", since="v0.17.0", replacement="density_mode")
     @deprecated_parameter(param_name="external_particles", since="v0.17.0", replacement="num_particles")

--- a/tests/unit/test_alg/test_drift_contract.py
+++ b/tests/unit/test_alg/test_drift_contract.py
@@ -16,6 +16,7 @@ import numpy as np
 from mfgarchon.alg.numerical.fp_solvers.base_fp import DriftConvention
 from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
 from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
@@ -29,10 +30,22 @@ from mfgarchon.geometry.boundary import no_flux_bc
 
 def test_drift_convention_trait_values():
     """The velocity-taking solvers keep the VELOCITY default; the U-taking solvers are
-    explicitly VALUE_FUNCTION (machine-readable contract for a future coupler dispatch)."""
+    explicitly VALUE_FUNCTION (machine-readable contract for a future coupler dispatch).
+
+    FPParticleSolver is VALUE_FUNCTION by default: its 1D path always takes U via `drift_field`
+    and computes alpha = -coupling*grad(U), and the nD default does the same; only the per-call
+    `drift_is_precomputed=True` (nD) flips it to VELOCITY. The class trait records the default
+    (Issue #1043). Previously it silently inherited the base VELOCITY default and was untested."""
     assert FPFDMSolver._drift_convention is DriftConvention.VELOCITY
     assert FPGFDMSolver._drift_convention is DriftConvention.VELOCITY
-    for cls in (WeakFormFPSolver, MeshlessGalerkinFPSolver, FPSLJacobianSolver, FPSLSolver, FPNetworkSolver):
+    for cls in (
+        WeakFormFPSolver,
+        MeshlessGalerkinFPSolver,
+        FPSLJacobianSolver,
+        FPSLSolver,
+        FPNetworkSolver,
+        FPParticleSolver,
+    ):
         assert cls._drift_convention is DriftConvention.VALUE_FUNCTION, cls.__name__
 
 


### PR DESCRIPTION
## Summary

`FPParticleSolver` inherited the base `VELOCITY` default for `_drift_convention`, but its body is **`VALUE_FUNCTION` by default** — the 1D path always takes the value function `U` via `drift_field` and computes `α = -coupling·∇U`, and the nD default does the same; only the per-call `drift_is_precomputed=True` (nD only) flips it to `VELOCITY`. The trait *lied* about the solver's behavior.

A cross-path probe surfaced this: a behavioral discriminator (constant `drift_field`, measure d⟨x⟩) gave `d⟨x⟩=+0.001` for the particle solver (value-function behavior) vs `+0.17` for the genuinely velocity-taking FDM/GFDM solvers, while the declared trait said `VELOCITY`.

## Fix

Set `FPParticleSolver._drift_convention = DriftConvention.VALUE_FUNCTION` to match the default body, with a comment documenting the `drift_is_precomputed=True` (nD) → `VELOCITY` exception.

**Byte-identical on every path.** Nothing dispatches on `_drift_convention` — verified by grep: the only readers are the contract test itself; the coupler selects FP kwargs by parameter-name signature, not the trait. The paper EOC solvers (`FPFDMSolver`/`FPGFDMSolver`) keep `VELOCITY` and are untouched.

## Test coverage gap closed

`test_drift_contract.py` previously **silently omitted** `FPParticleSolver` from *both* the `VELOCITY` and `VALUE_FUNCTION` assertion lists — the one bivalent solver was the only untested one. Added it to the `VALUE_FUNCTION` list with a docstring note on the bivalence.

## Scope

`Refs #1043`, not `Closes` — this is the trait-honesty slice only. The broader #1043 unification (wiring the coupler to *dispatch* on the trait; the `FPNetwork`/`FPParticle` `drift_field`→`potential_field` renames) remains deferred per the issue's EOC-risk notes (that dispatch would make the trait numerically load-bearing and is not byte-identical).

## Tests

159 particle tests + 3 drift-contract tests pass; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)