### PR TITLE
fix: unify geometry bounds reads on get_bounds() (#1056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Polymorphic reads of the non-uniform `.bounds` geometry attribute** (Issue #1056). The ad-hoc
+  `.bounds` attribute returns four incompatible shapes across geometry classes (`(d,2)` ndarray,
+  `(min,max)` tuple, `list[(min,max)]`, or absent), while `get_bounds() -> (mins, maxs)` is the
+  uniform `Geometry` ABC accessor present on every class. Migrated the eight cross-type `.bounds`
+  readers to `get_bounds()` (`projection`, `hjb_weno`, `gfdm_strategies` periodic, three
+  `hjb_semi_lagrangian` sites, `fp_particle`, `base_pinn`). Paper paths already consumed
+  `get_bounds()` and are untouched (byte-identical). The migration also fixes four latent bugs the
+  shape-divergence caused: `hjb_semi_lagrangian` nD clip (`bounds[0][d]` mis-indexed for `d>=1`),
+  `fp_particle` PointCloud bounds transpose, `projection` tuple/ndarray mismatch, and `base_pinn`
+  reading a nonexistent `self.problem.domain` (so it always fell back to default bounds).
+  1177 affected-suite tests pass. The per-class `.bounds` attributes remain as internal detail
+  (deprecating/uniformizing them is optional follow-up); `get_bounds()` is now the canonical
+  cross-geometry accessor, pinned by `tests/unit/test_convention_agreement.py`.
+
 - **`FPParticleSolver._drift_convention` trait was dishonest** (Issue #1043). It inherited the
   base `VELOCITY` default, but the solver body is `VALUE_FUNCTION` by default — the 1D path always
   takes the value function `U` via `drift_field` and computes `alpha = -coupling*grad(U)`, and the

--- a/mfgarchon/alg/neural/pinn_solvers/base_pinn.py
+++ b/mfgarchon/alg/neural/pinn_solvers/base_pinn.py
@@ -921,8 +921,11 @@ class PINNBase(BaseNeuralSolver, ABC):
         upper_bounds = torch.tensor([1.0, 1.0], device=self.device, dtype=self.dtype)
 
         # Try to get bounds from problem if available
+        # Issue #1056: use the uniform get_bounds() accessor on .geometry (every other site in
+        # this class uses self.problem.geometry; .domain does not exist, so the prior code always
+        # fell through to the default bounds).
         try:
-            bounds = self.problem.domain.bounds
+            bounds = self.problem.geometry.get_bounds()
             if isinstance(bounds, list | tuple) and len(bounds) == 2:
                 lower_bounds = torch.tensor(bounds[0], device=self.device, dtype=self.dtype)
                 upper_bounds = torch.tensor(bounds[1], device=self.device, dtype=self.dtype)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -313,17 +313,11 @@ class FPParticleSolver(BaseFPSolver):
             # Get bounds per dimension (with fallback chain for legacy interfaces)
             # NOTE: bounds needed before spacing for implicit geometry fallback
             try:
-                geom_bounds = geom.bounds
-                if geom_bounds is None:
-                    raise AttributeError("bounds is None")
-                # Handle Hyperrectangle: bounds is np.ndarray of shape (d, 2)
-                # Convert to list of tuples: [(xmin, xmax), (ymin, ymax), ...]
-                if isinstance(geom_bounds, np.ndarray) and geom_bounds.ndim == 2:
-                    # Numpy array format: bounds[d, 0] = min, bounds[d, 1] = max
-                    bounds = [(float(geom_bounds[d, 0]), float(geom_bounds[d, 1])) for d in range(geom_bounds.shape[0])]
-                else:
-                    # List/tuple format - convert to list of tuples
-                    bounds = [(float(b[0]), float(b[1])) for b in geom_bounds]
+                # Issue #1056: uniform get_bounds() -> (min_coords, max_coords); build per-axis
+                # (min, max). Replaces ad-hoc .bounds shape-sniffing, which transposed the
+                # PointCloud (min_coords, max_coords) form into [(min0, min1), (max0, max1)].
+                min_coords, max_coords = geom.get_bounds()
+                bounds = [(float(min_coords[d]), float(max_coords[d])) for d in range(len(min_coords))]
             except AttributeError:
                 try:
                     # Legacy 1D geometry

--- a/mfgarchon/alg/numerical/gfdm_components/gfdm_strategies.py
+++ b/mfgarchon/alg/numerical/gfdm_components/gfdm_strategies.py
@@ -494,7 +494,9 @@ class TaylorOperator(DifferentialOperator):
         # Geometry provides protocol info (bounds, periodic_dims), utility does work
         from mfgarchon.geometry.boundary.periodic import create_periodic_ghost_points
 
-        bounds = self._geometry.bounds
+        # Issue #1056: uniform get_bounds() accessor; create_periodic_ghost_points takes the
+        # (d, 2) form, so rebuild it from (mins, maxs).
+        bounds = np.column_stack(self._geometry.get_bounds())
         periodic_dims = self._geometry.periodic_dimensions
         return create_periodic_ghost_points(self._points, bounds, periodic_dims)
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1668,11 +1668,14 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 x_current = np.array([self.grid.coordinates[d][multi_idx[d]] for d in range(self.dimension)])
                 m_current = M_next_shaped[multi_idx]
 
-                def dpp_cost_nd(alpha_vec, _xc=x_current, _mc=m_current):
+                _bnd_min, _bnd_max = self.grid.get_bounds()  # Issue #1056: uniform accessor
+
+                def dpp_cost_nd(alpha_vec, _xc=x_current, _mc=m_current, _lo=_bnd_min, _hi=_bnd_max):
                     x_next = _xc + alpha_vec * dt
-                    # Clip to domain bounds
+                    # Clip to domain bounds (per-axis; the prior self.grid.bounds[0][d] mis-indexed
+                    # the ad-hoc .bounds shape for d>=1 -- latent nD bug, Issue #1056).
                     for d in range(self.dimension):
-                        x_next[d] = np.clip(x_next[d], self.grid.bounds[0][d], self.grid.bounds[1][d])
+                        x_next[d] = np.clip(x_next[d], _lo[d], _hi[d])
                     u_next = self._interpolate_value(U_next_shaped, x_next)
                     L_val = float(L_class(_xc, alpha_vec, _mc, t_value))
                     return dt * L_val + u_next
@@ -1909,7 +1912,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
 
             return apply_boundary_conditions_nd(
                 x_departure,
-                bounds=self.grid.bounds,
+                bounds=np.column_stack(self.grid.get_bounds()),  # Issue #1056: uniform accessor
                 bc_type=bc_op,
             )
 
@@ -2174,23 +2177,15 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         Returns:
             Grid index (int for 1D, tuple for nD)
         """
-        # Get bounds from geometry (preferred) or legacy xmin/xmax
-        # Issue #545: Use try/except instead of hasattr
-        try:
-            bounds = self.problem.geometry.bounds if self.problem.geometry is not None else None
-        except AttributeError:
-            bounds = None
-        grid_shape = self.problem.geometry.get_grid_shape() if bounds is not None else None
+        # Issue #1056: uniform get_bounds() accessor (was a polymorphic .bounds-primary path with a
+        # get_bounds() fallback; get_bounds() gives the same mins, so this is byte-identical).
+        mins, _maxs = self.problem.geometry.get_bounds()
+        grid_shape = self.problem.geometry.get_grid_shape()
 
         if self.dimension == 1:
             x_scalar = float(x) if np.ndim(x) > 0 else x
-            if bounds is not None:
-                xmin = bounds[0][0]
-                Nx = grid_shape[0] - 1
-            else:
-                geom_bounds = self.problem.geometry.get_bounds()
-                xmin = geom_bounds[0][0]
-                Nx = self.problem.geometry.get_grid_shape()[0] - 1
+            xmin = mins[0]
+            Nx = grid_shape[0] - 1
             # dx is scalar for 1D
             dx = self.dx if np.isscalar(self.dx) else self.dx[0]
             x_idx = int((x_scalar - xmin) / dx)
@@ -2199,13 +2194,8 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             x_vec = np.atleast_1d(x)
             indices = []
             for i in range(self.dimension):
-                if bounds is not None:
-                    xmin_i = bounds[i][0]
-                    Nx_i = grid_shape[i] - 1
-                else:
-                    geom_bounds = self.problem.geometry.get_bounds()
-                    xmin_i = geom_bounds[0][i]
-                    Nx_i = self.problem.geometry.get_grid_shape()[i] - 1
+                xmin_i = mins[i]
+                Nx_i = grid_shape[i] - 1
                 # dx is array for nD
                 dx_i = self.dx[i]
                 idx = int((x_vec[i] - xmin_i) / dx_i)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -379,9 +379,12 @@ class HJBWenoSolver(BaseHJBSolver):
 
     def _get_domain_bounds(self) -> np.ndarray:
         """Get domain bounds from problem/geometry (NO hasattr per CLAUDE.md)."""
-        # Priority 1: Try CartesianGrid geometry bounds attribute
+        # Priority 1: uniform get_bounds() accessor (Issue #1056). Returns (mins, maxs); rebuild
+        # the (d, 2) ndarray contract this method promises. np.array(geometry.bounds) gave the
+        # same (d, 2) for grid/rectangle but raised for geometries lacking the ad-hoc .bounds.
         try:
-            return np.array(self.problem.geometry.bounds)
+            mins, maxs = self.problem.geometry.get_bounds()
+            return np.column_stack([mins, maxs])
         except AttributeError:
             pass
 

--- a/mfgarchon/operators/interpolation/projection.py
+++ b/mfgarchon/operators/interpolation/projection.py
@@ -503,8 +503,9 @@ class GeometryProjector:
 
         Fast fallback for nD particle → grid projection.
         """
-        # Get grid bounds
-        bounds = self.hjb_geometry.bounds  # (min_coords, max_coords)
+        # Get grid bounds (Issue #1056: get_bounds() is the uniform accessor; the downstream
+        # indexing bounds[0][i]/bounds[1][i] expects exactly its (min_coords, max_coords) form).
+        bounds = self.hjb_geometry.get_bounds()  # (min_coords, max_coords)
 
         dimension = len(grid_shape)
 

--- a/tests/unit/test_convention_agreement.py
+++ b/tests/unit/test_convention_agreement.py
@@ -123,6 +123,29 @@ class TestGeometryBoundsAccessor:
             assert mins.shape == maxs.shape, f"{name}: mins/maxs shape mismatch"
             assert np.all(mins <= maxs), f"{name}: mins must be <= maxs, got {mins} / {maxs}"
 
+    def test_get_bounding_box_is_derived_view_of_get_bounds(self):
+        """For the implicit family, get_bounding_box() is the (d, 2) view of the same source:
+        column_stack(get_bounds()) == get_bounding_box() (Issue #1056)."""
+        from mfgarchon.geometry.implicit.csg_operations import (
+            DifferenceDomain,
+            IntersectionDomain,
+            UnionDomain,
+        )
+        from mfgarchon.geometry.implicit.hyperrectangle import Hyperrectangle
+        from mfgarchon.geometry.implicit.hypersphere import Hypersphere
+
+        box = Hyperrectangle(bounds=[(0.0, 1.0), (0.0, 1.0)])
+        ball = Hypersphere(center=[0.5, 0.5], radius=0.4)
+        for name, geom in [
+            ("Hyperrectangle", box),
+            ("Hypersphere", ball),
+            ("UnionDomain", UnionDomain([box, ball])),
+            ("IntersectionDomain", IntersectionDomain([box, ball])),
+            ("DifferenceDomain", DifferenceDomain(box, ball)),
+        ]:
+            mins, maxs = geom.get_bounds()
+            np.testing.assert_allclose(np.column_stack([mins, maxs]), geom.get_bounding_box(), atol=1e-12, err_msg=name)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The ad-hoc `.bounds` geometry attribute returns **four incompatible shapes** across classes — `(d,2)` ndarray (Hyperrectangle/CSG), `(min,max)` tuple (PointCloud/Mesh), `list[(min,max)]` (TensorProductGrid), or absent (Hypersphere/Network) — while `get_bounds() -> (mins, maxs)` is the uniform `Geometry` ABC accessor present on **every** class and is what both paper paths already consume.

This is the #1056 unification, **Option B**: canonicalize `get_bounds()` and migrate the cross-type `.bounds` *readers* to it. (Option A — making `.bounds` a base property and renaming the divergent instance attributes — was rejected: it touches `Hyperrectangle.signed_distance` on the GFDM paper path and hits a `property`-vs-instance-attribute conflict, for the same public outcome.)

## Changes

Migrated the **eight** cross-type `.bounds` readers to `get_bounds()`: `projection`, `hjb_weno._get_domain_bounds`, `gfdm_strategies` (periodic), three `hjb_semi_lagrangian` sites, `fp_particle`, `base_pinn`. Paper-path consumers (`hjb_fdm`, `fp_fdm`, `hjb_gfdm`) already used `get_bounds()` and are **untouched → byte-identical**.

### Latent bugs fixed as a side effect of the shape-unification

| Site | Bug |
|---|---|
| `hjb_semi_lagrangian` nD clip | `bounds[0][d]` mis-indexed the `.bounds` shape for `d>=1` (wrong clip bounds in nD) |
| `fp_particle` | PointCloud `(min,max)` form transposed into `[(min0,min1),(max0,max1)]` |
| `projection` | downstream expects the tuple form, but `.bounds` is `(d,2)` for most geometries |
| `base_pinn` | read nonexistent `self.problem.domain` → the `try` always excepted → always used default bounds |

None is a paper configuration; the **1177-test** affected-suite sweep (SL, particle, weno, projection, pinn, gfdm, geometry) passes, confirming nothing relied on the buggy behavior.

## Tests

`tests/unit/test_convention_agreement.py`: existing `get_bounds()` uniform-contract guard + a new assertion that `column_stack(get_bounds()) == get_bounding_box()` for the implicit family (proves `get_bounding_box` is the derived `(d,2)` view of the single source). ruff check + format clean.

## Scope

`Refs #1056`, not `Closes` — the per-class `.bounds` *attributes* still exist (now internal-only, no longer read polymorphically). Deprecating/uniformizing the `.bounds` attribute itself is an optional follow-up; if you consider the polymorphic-divergence resolved, close #1056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)