### PR TITLE
refactor: single-source boundary on-wall tolerances (#1101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Single-sourced boundary on-wall tolerances** (Issue #1101). The scattered `1e-6` / `1e-8` /
+  `1e-10` / `1e-12` magic literals across the boundary / geometry on-wall classifiers are now
+  named, documented, tunable constants in `mfgarchon/geometry/boundary/tolerances.py`
+  (`BOUNDARY_TOL=1e-6`, `ONWALL_TOL=1e-10`, `SDF_BOUNDARY_TOL=1e-8`, `BOUNDARY_REL_TOL=1e-12`).
+  Routed ~25 sites across `conditions`, `base`, `types`, `point_cloud`, `implicit_domain`,
+  `tensor_grid`, `network_geometry`, GFDM `boundary_handler` and `hjb_gfdm`. **Byte-identical**:
+  each literal maps to a same-valued constant, so every path (incl. the GFDM `1e-6` paper path
+  and the analytic-geometry `1e-10` exact-membership path) is unchanged — verified by the full
+  geometry + GFDM suites (764 tests). The distinct values are preserved on purpose (grid-exact
+  `1e-10` vs scattered-cloud `1e-6` vs SDF `1e-8` are different *measures*); they are **not**
+  collapsed to one (that would loosen analytic boundary detection by four orders of magnitude).
+  Non-on-wall `1e-X` (FD-step `eps`, degenerate-normal guards, iterative-projection convergence,
+  Lipschitz validation, point-equality, QP active-set) were left untouched. `protocol.py`'s
+  `typing.Protocol` stub defaults are also left as literals (not executed; concrete impls route
+  through the constants). Pinned by `tests/unit/test_convention_agreement.py`.
+
 - **Canonical FP drift contract: explicit `_drift_convention` trait + weak-form `potential_field`
   rename** (Issue #1043). The FP equation only ever sees the advective velocity `α` in
   `div(α m)`; most solvers (FDM, GFDM) take that velocity as `drift_field`, but the weak-form

--- a/mfgarchon/alg/numerical/gfdm_components/boundary_handler.py
+++ b/mfgarchon/alg/numerical/gfdm_components/boundary_handler.py
@@ -26,6 +26,7 @@ from mfgarchon.geometry.boundary.ghost import (
     compute_normal_from_bounds,
     create_reflection_ghost_points,
 )
+from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -161,7 +162,7 @@ class BoundaryHandler:
         # Wind BC hyperviscosity parameter
         self._wind_bc_hyperviscosity: float = 0.0
 
-    def compute_outward_normal(self, point_idx: int, tolerance: float = 1e-6) -> np.ndarray:
+    def compute_outward_normal(self, point_idx: int, tolerance: float = BOUNDARY_TOL) -> np.ndarray:
         """Compute outward normal vector at a single boundary point.
 
         Routes through ``BoundaryConditions.identify_boundary_face`` +
@@ -216,7 +217,7 @@ class BoundaryHandler:
         # Legacy fallback for setups with no BC object attached.
         return compute_normal_from_bounds(point, self.domain_bounds)
 
-    def compute_boundary_normals(self, tolerance: float = 1e-6) -> np.ndarray | None:
+    def compute_boundary_normals(self, tolerance: float = BOUNDARY_TOL) -> np.ndarray | None:
         """Compute outward normal vectors for all boundary points.
 
         Resolution order:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -30,6 +30,7 @@ from mfgarchon.alg.numerical.hjb_solvers.h_eval import (
     eval_dH_dp_batch,
 )
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
+from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL
 from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
 from mfgarchon.utils.deprecation import deprecated_parameter, deprecated_value
 from mfgarchon.utils.mfg_logging import get_logger
@@ -1239,7 +1240,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # generators (e.g. SDF-clipped boundary points placed at micron
         # distance from the wall). Users with looser collocation can override
         # via a future kwarg; current default is conservative.
-        tol = 1e-6
+        tol = BOUNDARY_TOL
         unmatched: list[tuple[int, np.ndarray, BoundaryFace | None, str]] = []
 
         for i in self.boundary_indices:
@@ -1315,7 +1316,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         if bounds is None or len(bounds) == 0:
             return np.array([], dtype=int)
 
-        tol = 1e-6
+        tol = BOUNDARY_TOL
         boundary_mask = np.zeros(len(collocation_points), dtype=bool)
 
         for d, (d_min, d_max) in enumerate(bounds):
@@ -1411,7 +1412,9 @@ class HJBGFDMSolver(BaseHJBSolver):
             return None
         return np.array(bounds_list, dtype=float)
 
-    def _infer_boundary_id(self, point: np.ndarray, domain_bounds: np.ndarray | None, tol: float = 1e-6) -> str | None:
+    def _infer_boundary_id(
+        self, point: np.ndarray, domain_bounds: np.ndarray | None, tol: float = BOUNDARY_TOL
+    ) -> str | None:
         """Infer boundary identifier for a point on rectangular domain boundary.
 
         This is optional - BCSegment.matches_point() can work without boundary_id

--- a/mfgarchon/geometry/base.py
+++ b/mfgarchon/geometry/base.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
+from .boundary.tolerances import ONWALL_TOL
 from .meshes.mesh_data import MeshVisualizationMode
 from .protocol import GeometryType
 from .traits import BoundaryDef, ConnectivityType, StructureType
@@ -425,7 +426,7 @@ class Geometry(ABC):
     def is_on_boundary(
         self,
         points: NDArray,
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> NDArray:
         """
         Check if points are on the domain boundary.
@@ -495,7 +496,7 @@ class Geometry(ABC):
             return normals
 
         min_coords, max_coords = bounds_result
-        tolerance = 1e-10
+        tolerance = ONWALL_TOL
 
         # Detect which boundaries each point is on (n, d) for min and max
         near_min = np.abs(points - min_coords) < tolerance
@@ -554,7 +555,7 @@ class Geometry(ABC):
     def is_near_corner(
         self,
         points: NDArray,
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> NDArray:
         """
         Check if points are near domain corners (where multiple boundaries meet).
@@ -591,7 +592,7 @@ class Geometry(ABC):
     def get_boundary_faces_at_point(
         self,
         point: NDArray,
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> list[tuple[int, str]]:
         """
         Get list of boundary faces that a point lies on.
@@ -738,7 +739,7 @@ class Geometry(ABC):
     def get_boundary_indices(
         self,
         points: NDArray,
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> NDArray:
         """
         Get indices of points that lie on the domain boundary.
@@ -768,7 +769,7 @@ class Geometry(ABC):
     def get_boundary_info(
         self,
         points: NDArray,
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> tuple[NDArray, NDArray]:
         """
         Get boundary indices and outward normals in one call.
@@ -1248,7 +1249,7 @@ class UnstructuredMesh(Geometry):
         # Placeholder: fall back to base class axis-aligned implementation
         return super().project_to_boundary(points)
 
-    def is_on_boundary(self, points: NDArray, tolerance: float = 1e-10) -> NDArray:
+    def is_on_boundary(self, points: NDArray, tolerance: float = ONWALL_TOL) -> NDArray:
         """
         Check if points are on the mesh boundary.
 

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -36,6 +36,7 @@ import numpy as np
 from mfgarchon.geometry.protocols import SupportsRegionMarking
 from mfgarchon.utils.deprecation import deprecated
 
+from .tolerances import BOUNDARY_REL_TOL, BOUNDARY_TOL, SDF_BOUNDARY_TOL
 from .types import BCSegment, BCType, BoundaryFace, _compute_sdf_gradient
 
 if TYPE_CHECKING:
@@ -289,7 +290,7 @@ class BoundaryConditions:
         self,
         point: np.ndarray,
         boundary_id: str | None = None,
-        tolerance: float = 1e-8,
+        tolerance: float = SDF_BOUNDARY_TOL,
         axis_names: dict[int, str] | None = None,
         geometry=None,  # Type: SupportsRegionMarking | None (Issue #596 Phase 2.5)
     ) -> BCSegment:
@@ -414,7 +415,7 @@ class BoundaryConditions:
     def identify_boundary_face(
         self,
         point: np.ndarray,
-        tolerance: float = 1e-6,
+        tolerance: float = BOUNDARY_TOL,
         domain_bounds: np.ndarray | None = None,
     ) -> BoundaryFace | None:
         """
@@ -461,8 +462,8 @@ class BoundaryConditions:
             bounds = np.asarray(bounds, dtype=float)
             for axis_idx in range(dimension):
                 low, high = bounds[axis_idx, 0], bounds[axis_idx, 1]
-                tol_low = tolerance + abs(low) * 1e-12
-                tol_high = tolerance + abs(high) * 1e-12
+                tol_low = tolerance + abs(low) * BOUNDARY_REL_TOL
+                tol_high = tolerance + abs(high) * BOUNDARY_REL_TOL
                 if abs(point[axis_idx] - low) <= tol_low:
                     return BoundaryFace(axis_idx, "min")
                 if abs(point[axis_idx] - high) <= tol_high:
@@ -522,7 +523,7 @@ class BoundaryConditions:
         normal[face.axis] = 1.0 if face.side == "max" else -1.0
         return normal
 
-    def identify_boundary_id(self, point: np.ndarray, tolerance: float = 1e-6) -> str | None:
+    def identify_boundary_id(self, point: np.ndarray, tolerance: float = BOUNDARY_TOL) -> str | None:
         """
         Identify which boundary a point lies on (legacy string interface).
 
@@ -548,7 +549,7 @@ class BoundaryConditions:
         side = "max" if normal[dominant_axis] > 0 else "min"
         return BoundaryFace(dominant_axis, side).to_string()
 
-    def is_on_boundary(self, point: np.ndarray, tolerance: float = 1e-8) -> bool:
+    def is_on_boundary(self, point: np.ndarray, tolerance: float = SDF_BOUNDARY_TOL) -> bool:
         """
         Check if a point is on the domain boundary.
 

--- a/mfgarchon/geometry/boundary/tolerances.py
+++ b/mfgarchon/geometry/boundary/tolerances.py
@@ -1,0 +1,31 @@
+"""Single-source boundary-detection tolerances (Issue #1101).
+
+These values were previously scattered as magic literals across the boundary / geometry
+on-wall classifiers. They are intentionally **not** a single number: the "is this point on the
+wall" judgment has genuinely different scales depending on how membership is measured.
+
+- ``BOUNDARY_TOL`` (1e-6): bounds-comparison on-wall band for scattered / collocation geometries,
+  where boundary points are *placed* at ~1e-6 of the wall (GFDM). Used with a closed ``<=``
+  comparison; this is the value the 2D scattered-cloud GFDM path uses.
+- ``ONWALL_TOL`` (1e-10): tight exact-membership band for analytic / grid geometries, where a
+  point is "on the wall" only at ~machine precision for O(1) coordinates (strict ``<``).
+- ``SDF_BOUNDARY_TOL`` (1e-8): signed-distance band (``|phi(x)| < tol``), and the
+  ``conditions.py`` bounds-comparison variant that shares this scale.
+- ``BOUNDARY_REL_TOL`` (1e-12): relative-coordinate augmentation factor added to an absolute
+  band to absorb floating-point subtraction error at large coordinates
+  (``tol + |bound| * BOUNDARY_REL_TOL``).
+
+Each is a **tunable default**: pass an explicit ``tolerance=`` to override per call, or retune
+globally here. The values are unchanged from the prior scattered literals (byte-identical
+single-sourcing); they do NOT collapse the distinct on-wall scales into one (that would loosen
+analytic-geometry detection by four orders of magnitude — see Issue #1101 discussion).
+"""
+
+from __future__ import annotations
+
+BOUNDARY_TOL: float = 1e-6
+ONWALL_TOL: float = 1e-10
+SDF_BOUNDARY_TOL: float = 1e-8
+BOUNDARY_REL_TOL: float = 1e-12
+
+__all__ = ["BOUNDARY_TOL", "ONWALL_TOL", "SDF_BOUNDARY_TOL", "BOUNDARY_REL_TOL"]

--- a/mfgarchon/geometry/boundary/types.py
+++ b/mfgarchon/geometry/boundary/types.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from mfgarchon.geometry.boundary.tolerances import SDF_BOUNDARY_TOL
 from mfgarchon.geometry.protocols import SupportsRegionMarking
 from mfgarchon.utils.deprecation import deprecated
 
@@ -487,7 +488,7 @@ class BCSegment:
         point: np.ndarray,
         boundary_id: str | None,
         domain_bounds: np.ndarray | None,
-        tolerance: float = 1e-8,
+        tolerance: float = SDF_BOUNDARY_TOL,
         axis_names: dict[int, str] | None = None,
         domain_sdf: Callable[[np.ndarray], float] | None = None,
         geometry: SupportsRegionMarking | None = None,

--- a/mfgarchon/geometry/graph/network_geometry.py
+++ b/mfgarchon/geometry/graph/network_geometry.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 # Import base geometry class
 from mfgarchon.geometry.base import GraphGeometry
+from mfgarchon.geometry.boundary.tolerances import ONWALL_TOL
 
 # Import geometry protocol
 from mfgarchon.geometry.protocol import GeometryType
@@ -776,7 +777,7 @@ class NetworkGeometry(GraphGeometry):
     def is_on_boundary(
         self,
         points: np.ndarray,
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> np.ndarray:
         """
         Check if points are on the network boundary.
@@ -834,7 +835,7 @@ class NetworkGeometry(GraphGeometry):
 
         min_coords, max_coords = bounds
         normals = np.zeros_like(points)
-        tolerance = 1e-10
+        tolerance = ONWALL_TOL
 
         for i, p in enumerate(points):
             for d in range(len(min_coords)):

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from mfgarchon.geometry.base import CartesianGrid
+from mfgarchon.geometry.boundary.tolerances import ONWALL_TOL
 from mfgarchon.geometry.protocol import GeometryType
 from mfgarchon.geometry.protocols import (
     SupportsAdvection,
@@ -987,7 +988,7 @@ class TensorProductGrid(
                 raise ValueError(f"Unknown side: {side}. Expected 'min' or 'max'")
         else:
             # Infer boundary from point location
-            tolerance = 1e-10
+            tolerance = ONWALL_TOL
             min_coords, max_coords = self.get_bounds()
 
             for i, point in enumerate(points):
@@ -1098,7 +1099,7 @@ class TensorProductGrid(
     def project_to_interior(
         self,
         points: NDArray,
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> NDArray:
         """
         Project points from outside domain into interior.

--- a/mfgarchon/geometry/implicit/implicit_domain.py
+++ b/mfgarchon/geometry/implicit/implicit_domain.py
@@ -25,6 +25,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from mfgarchon.geometry.base import ImplicitGeometry
+from mfgarchon.geometry.boundary.tolerances import SDF_BOUNDARY_TOL
 from mfgarchon.geometry.protocol import GeometryType
 from mfgarchon.geometry.protocols import (
     SupportsBoundaryDistance,
@@ -503,7 +504,7 @@ class ImplicitDomain(
 
         return x_proj[0] if is_single else x_proj
 
-    def is_on_boundary(self, x: NDArray[np.float64], tol: float = 1e-8) -> bool | NDArray[np.bool_]:
+    def is_on_boundary(self, x: NDArray[np.float64], tol: float = SDF_BOUNDARY_TOL) -> bool | NDArray[np.bool_]:
         """
         Check if point(s) are on the domain boundary using SDF.
 

--- a/mfgarchon/geometry/implicit/point_cloud.py
+++ b/mfgarchon/geometry/implicit/point_cloud.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from mfgarchon.geometry.boundary.tolerances import ONWALL_TOL
 from mfgarchon.geometry.protocol import GeometryProtocol, GeometryType
 
 if TYPE_CHECKING:
@@ -147,7 +148,7 @@ class PointCloudGeometry:
     def is_on_boundary(
         self,
         points: NDArray[np.floating],
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> NDArray[np.bool_]:
         """Check if points are on the bounding box boundary."""
         points = np.atleast_2d(points)
@@ -170,7 +171,7 @@ class PointCloudGeometry:
         points = np.atleast_2d(points)
         normals = np.zeros_like(points)
         min_coords, max_coords = self.bounds
-        tolerance = 1e-10
+        tolerance = ONWALL_TOL
 
         for i, p in enumerate(points):
             for d in range(self.dimension):
@@ -261,7 +262,7 @@ class PointCloudGeometry:
     def get_boundary_indices(
         self,
         points: NDArray[np.floating],
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> NDArray[np.intp]:
         """Get indices of boundary points (default implementation)."""
         on_boundary = self.is_on_boundary(points, tolerance)
@@ -270,7 +271,7 @@ class PointCloudGeometry:
     def get_boundary_info(
         self,
         points: NDArray[np.floating],
-        tolerance: float = 1e-10,
+        tolerance: float = ONWALL_TOL,
     ) -> tuple[NDArray[np.intp], NDArray[np.floating]]:
         """Get boundary indices and normals (default implementation)."""
         boundary_indices = self.get_boundary_indices(points, tolerance)

--- a/tests/unit/test_convention_agreement.py
+++ b/tests/unit/test_convention_agreement.py
@@ -147,5 +147,35 @@ class TestGeometryBoundsAccessor:
             np.testing.assert_allclose(np.column_stack([mins, maxs]), geom.get_bounding_box(), atol=1e-12, err_msg=name)
 
 
+class TestBoundaryToleranceSingleSource:
+    """Issue #1101: boundary on-wall tolerances are single-sourced in
+    geometry/boundary/tolerances.py. Pin the values (a future edit cannot silently shift them)
+    and pin that the key classifier defaults reference the constants — so the scattered magic
+    literals do not regrow. The values are intentionally distinct (grid-exact vs scattered vs SDF)
+    and are NOT collapsed to one (that would loosen analytic boundary detection 4 decades)."""
+
+    def test_constant_values_pinned(self):
+        from mfgarchon.geometry.boundary import tolerances as tol
+
+        assert tol.BOUNDARY_TOL == 1e-6
+        assert tol.ONWALL_TOL == 1e-10
+        assert tol.SDF_BOUNDARY_TOL == 1e-8
+        assert tol.BOUNDARY_REL_TOL == 1e-12
+
+    def test_classifier_defaults_reference_single_source(self):
+        """The paper-path GFDM classifier defaults to BOUNDARY_TOL (1e-6) and the analytic
+        Geometry on-wall defaults to ONWALL_TOL (1e-10) — byte-identical to the prior literals."""
+        import inspect
+
+        from mfgarchon.geometry.base import Geometry
+        from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+        from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL, ONWALL_TOL
+
+        face_default = inspect.signature(BoundaryConditions.identify_boundary_face).parameters["tolerance"].default
+        assert face_default == BOUNDARY_TOL == 1e-6
+        onwall_default = inspect.signature(Geometry.is_on_boundary).parameters["tolerance"].default
+        assert onwall_default == ONWALL_TOL == 1e-10
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The "is this point on the wall" tolerance was scattered as `1e-6` / `1e-8` / `1e-10` / `1e-12` **magic literals across ~25 sites**, each an independent copy — Issue #1101's "5 sites compute the same point-on-wall judgment with different tolerances."

Introduced `mfgarchon/geometry/boundary/tolerances.py` with named, documented, **tunable** constants and routed every on-wall site through them:

| Constant | Value | Purpose |
|---|---|---|
| `BOUNDARY_TOL` | `1e-6` | scattered / GFDM bounds on-wall (closed `<=`) — the value the GFDM paper path uses |
| `ONWALL_TOL` | `1e-10` | analytic / grid exact membership (strict `<`) |
| `SDF_BOUNDARY_TOL` | `1e-8` | signed-distance band (`\|φ\|<tol`) + the conditions.py bounds variant |
| `BOUNDARY_REL_TOL` | `1e-12` | relative-coordinate augmentation |

Routed: `conditions`, `base`, `types`, `point_cloud`, `implicit_domain`, `tensor_grid`, `network_geometry`, GFDM `boundary_handler`, `hjb_gfdm`.

## Byte-identical (the design you chose: Option A — name + preserve)

Each literal maps to a **same-valued** constant, so every path is unchanged — including the GFDM `1e-6` paper path and the analytic-geometry `1e-10` exact-membership path. Verified by the full geometry + GFDM suites (**764 tests pass**). No separate baseline-pickle gate is needed: with values unchanged, byte-identical is structural.

The distinct values are **preserved on purpose** — grid-exact `1e-10`, scattered-cloud `1e-6`, and SDF `1e-8` are different *measures* of membership. They are **not** collapsed to one tolerance (Option B), which would have loosened analytic boundary detection by four orders of magnitude. Each constant is a tunable default (override per call, or retune globally here).

## Precision (what was left untouched)

Only genuine on-wall tolerances were routed. Left as literals: FD-step `eps` (normal computation), degenerate-normal guards (`normal_norm < 1e-12`), iterative-projection convergence (`project_to_boundary`/`project_to_interior`), Lipschitz-regularity validation, point-equality (`is_same_pointset`), QP active-set; and `protocol.py`'s `typing.Protocol` stub defaults (not executed — concrete implementations route through the constants; importing a `boundary/` module into that foundational file would also risk a circular import).

## Tests

`tests/unit/test_convention_agreement.py::TestBoundaryToleranceSingleSource` pins the constant values and that the GFDM/analytic classifier defaults reference them. ruff check + format clean.

## Scope

`Refs #1101` — the residual #1114 (outward-normal source: face-derived vs SDF-gradient) is a separate item, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)