### PR TITLE
fix: unify outward-normal sources; fix obstacle-SDF misfire on outer walls (#1114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`BoundaryConditions.get_outward_normal` mis-fired on outer walls of Difference-style domains**
+  (Issue #1114). It checked `domain_sdf` *first*, so for a domain that is an outer box minus an
+  obstacle (both `domain_bounds` and `domain_sdf` set), a point on the outer wall received the
+  *obstacle's* SDF gradient — pointing toward the obstacle, tens of degrees off the wall normal —
+  instead of the axis-aligned wall normal. Unified the two normal sources into one classifier:
+  an axis-aligned outer-box wall now returns the exact face normal (via `outward_normal_for_face`),
+  and the SDF gradient is used only for genuinely curved boundaries (the obstacle surface, or a
+  pure-SDF domain). The box-wall branch is guarded by an explicit axis-bound match (not
+  `identify_boundary_face`, whose SDF Method-2 also classifies curved points) so obstacle-surface
+  normals keep the SDF gradient. The GFDM paper path was unaffected either way (it uses the
+  `identify_boundary_face` + `outward_normal_for_face` Path-1, with `get_outward_normal` only a
+  legacy fallback). Added `TestOutwardNormalSourceAgreement`.
+
 - **HJB-SL reflecting-BC characteristic-foot fold was wrong on asymmetric domains**
   (Issues #1161, #1048, #1054). Three sibling code paths in `hjb_semi_lagrangian.py` folded
   out-of-bounds characteristic feet for no-flux/Neumann BC, each with a private copy of the

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -583,6 +583,14 @@ class BoundaryConditions:
         """
         Get the outward normal at a boundary point.
 
+        Single classifier (Issue #1114): the exact axis-aligned face normal is preferred for
+        points on an outer-box wall, and the SDF gradient is used only for genuinely curved
+        boundaries (or pure-SDF domains with no box). The prior ordering checked ``domain_sdf``
+        first, which mis-fired on Difference-style domains where ``domain_sdf`` is the *obstacle's*
+        SDF: a point on the outer wall received the obstacle-pointing gradient (off by tens of
+        degrees) instead of the wall normal. Routing the face case through
+        :meth:`outward_normal_for_face` unifies the two normal sources.
+
         Args:
             point: Spatial coordinates on the boundary
             epsilon: Finite difference step for SDF gradient
@@ -593,23 +601,25 @@ class BoundaryConditions:
         dimension = self._require_dimension("get_outward_normal")
         point = np.asarray(point, dtype=float)
 
-        # SDF domain: use gradient
+        # Outer-box wall: exact face-derived normal (the canonical source). Checked first so an
+        # obstacle SDF cannot override the wall normal on a Difference-style domain. Only an
+        # axis-aligned bound match counts — NOT identify_boundary_face, whose SDF Method-2 also
+        # classifies curved obstacle-surface points (those must keep the SDF gradient below).
+        if self.domain_bounds is not None:
+            face = self.identify_boundary_face(point)
+            if face is not None:
+                low, high = self.domain_bounds[face.axis]
+                bound = high if face.side == "max" else low
+                if abs(float(point[face.axis]) - bound) <= BOUNDARY_TOL + abs(bound) * BOUNDARY_REL_TOL:
+                    return self.outward_normal_for_face(face, dimension=dimension)
+
+        # Curved / SDF boundary (e.g. the obstacle surface, or a pure-SDF domain): use gradient.
         if self.domain_sdf is not None:
             normal = _compute_sdf_gradient(point, self.domain_sdf, epsilon=epsilon)
             normal_norm = np.linalg.norm(normal)
             if normal_norm > 1e-12:
                 return normal / normal_norm
             return None
-
-        # Rectangular domain: compute based on boundary face
-        if self.domain_bounds is not None:
-            face = self.identify_boundary_face(point)
-            if face is None:
-                return None
-
-            normal = np.zeros(dimension)
-            normal[face.axis] = 1.0 if face.side == "max" else -1.0
-            return normal
 
         return None
 

--- a/tests/unit/test_convention_agreement.py
+++ b/tests/unit/test_convention_agreement.py
@@ -177,5 +177,48 @@ class TestBoundaryToleranceSingleSource:
         assert onwall_default == ONWALL_TOL == 1e-10
 
 
+class TestOutwardNormalSourceAgreement:
+    """Issue #1114: the two outward-normal sources (face-derived vs SDF-gradient) must agree on
+    outer-box walls. `get_outward_normal` returns the exact face normal there — NOT the obstacle
+    SDF gradient — for Difference-style domains (outer box + obstacle SDF); the SDF gradient is
+    used only for genuinely curved boundaries."""
+
+    @staticmethod
+    def _difference_bc():
+        from mfgarchon.geometry.boundary.conditions import BCSegment, BCType, BoundaryConditions
+
+        def obstacle_sdf(p):
+            p = np.asarray(p, dtype=float)
+            return 0.2 - np.linalg.norm(p - np.array([0.5, 0.5]))
+
+        bc = BoundaryConditions(segments=[BCSegment(name="w", bc_type=BCType.NO_FLUX, boundary="x_min")], dimension=2)
+        bc.domain_bounds = np.array([[0.0, 1.0], [0.0, 1.0]])
+        bc.domain_sdf = obstacle_sdf
+        return bc
+
+    def test_outer_wall_uses_face_normal_not_obstacle_sdf(self):
+        bc = self._difference_bc()
+        point = np.array([0.0, 0.5])  # on the outer left wall
+        normal = bc.get_outward_normal(point)
+        # exact face normal, not the obstacle-pointing SDF gradient (the #1114 misfire)
+        np.testing.assert_allclose(normal, [-1.0, 0.0], atol=1e-12)
+        # and it agrees with the canonical face-derived source
+        face = bc.identify_boundary_face(point)
+        np.testing.assert_allclose(normal, bc.outward_normal_for_face(face, dimension=2), atol=1e-12)
+
+    def test_curved_boundary_still_uses_sdf_gradient(self):
+        bc = self._difference_bc()
+        # A point on the obstacle surface at a DIAGONAL (interior to the box, not on any outer
+        # wall). A face normal could only be axis-aligned, so a diagonal result proves the SDF
+        # gradient path is used — not snapped to an axis face.
+        d = 0.2 / np.sqrt(2.0)
+        point = np.array([0.5 + d, 0.5 + d])  # on the r=0.2 obstacle circle, 45 degrees
+        normal = bc.get_outward_normal(point)
+        assert normal is not None
+        np.testing.assert_allclose(np.linalg.norm(normal), 1.0, atol=1e-9)
+        # diagonal => both components non-trivial (an axis face normal would have a zero component)
+        assert abs(normal[0]) > 0.1 and abs(normal[1]) > 0.1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`BoundaryConditions.get_outward_normal` checked `domain_sdf` **first**, so on a **Difference-style domain** (outer box minus an obstacle — both `domain_bounds` and `domain_sdf` set), a point on the **outer wall** received the *obstacle's* SDF gradient (pointing toward the obstacle, ~22° off the true wall normal) instead of the axis-aligned wall normal. A cross-source probe reproduced the misfire: face-derived vs obstacle-SDF normal diverged 21.8° on the outer wall.

## Fix — one classifier (Issue #1114)

`get_outward_normal` now routes:
- **axis-aligned outer-box wall** → exact face normal via `outward_normal_for_face` (the canonical source);
- **genuinely curved boundary** (obstacle surface, or pure-SDF domain) → SDF gradient.

The box-wall branch is guarded by an **explicit axis-bound match**, not `identify_boundary_face` — whose SDF Method-2 *also* classifies curved obstacle-surface points, which must keep the SDF gradient. So:

| Point | Before | After |
|---|---|---|
| outer wall (box + obstacle SDF) | obstacle gradient (22° off) ❌ | exact face normal ✅ |
| obstacle surface | SDF gradient ✅ | SDF gradient ✅ (unchanged) |
| pure-SDF domain boundary | SDF gradient ✅ | SDF gradient ✅ (unchanged) |
| box wall, no obstacle SDF | face normal ✅ | face normal ✅ (unchanged) |

The only behavior change is the previously-wrong misfire case.

## EOC-safe

The GFDM paper path uses the `identify_boundary_face` + `outward_normal_for_face` **Path-1** (in `boundary_handler`); `get_outward_normal` is only its legacy Path-2 fallback. So the paper path is unaffected. 463 boundary/geometry/GFDM tests pass; ruff clean.

## Tests

`TestOutwardNormalSourceAgreement`: outer-wall normal equals `outward_normal_for_face` (not the obstacle gradient); a **diagonal** obstacle-surface point keeps the SDF gradient (a face normal could only be axis-aligned, so the diagonal result proves the SDF path is used).

Closes #1114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)