### PR TITLE
fix(fem): mass-conserving FP advection + factory wiring + gmsh-free mesh path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FEM solver path was broken at three seams** (FEM-readiness audit; Issues #773, #580). (1) The
+  FP advection operator was assembled as the raw convective form `+C` (`C[i,j]=∫φ_i(v·∇φ_j)`),
+  which is **not** mass-conserving — column sums `≈∫v·∇φ_j≠0`, giving ~20%+ mass drift on a
+  non-divergence-free drift. Now assembled as `-C^T` (integration-by-parts form, zero column
+  sums since `Σφ_i=1`), matching the meshless-Galerkin sibling and the adjoint identity
+  `A_FP=A_HJB^T` (verified: `max|col sum|≈6e-17`). (2) `HJBFEMSolver`/`FPFEMSolver` inherited
+  `_scheme_family=GENERIC`, so the documented factory entry point `create_paired_solvers(..., FEM_P1)`
+  **raised** (duality VALIDATION_SKIPPED); both now carry `SchemeFamily.FEM`, which is registered as
+  a Type-A (exact-discrete-transpose) Galerkin family in the duality validator. (3) `Mesh2D`/`Mesh3D`
+  `generate_mesh()` now returns a pre-populated `mesh_data` as-is — a gmsh-free path for callers
+  that inject a mesh (e.g. via `skfem_to_meshdata`), since gmsh is not in the default install. Added
+  `tests/integration/test_fem_solver_path.py` exercising the real solver classes (the prior
+  `test_fem_coupled_mfg.py` hand-rolled raw `K`/`M` and never touched them). NOTE: coupled FEM
+  *through* `FixedPointIterator` still cannot run — the iterator requires a `CartesianGrid` while
+  FEM requires an unstructured mesh, and `fem/bc_adapter` expects a `BoundaryConditions` object
+  where the solver receives a `dict`; those two seams are the remaining coupled-FEM prerequisites.
+
 - **`BoundaryConditions.get_outward_normal` mis-fired on outer walls of Difference-style domains**
   (Issue #1114). It checked `domain_sdf` *first*, so for a domain that is an outer box minus an
   obstacle (both `domain_bounds` and `domain_sdf` set), a point on the outer wall received the

--- a/mfgarchon/alg/numerical/fem/fp_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/fp_fem_solver.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.weak_form_fp_solver import WeakFormFPSolver
 from mfgarchon.utils.mfg_logging import get_logger
 
@@ -33,14 +34,19 @@ logger = get_logger(__name__)
 class FPFEMSolver(WeakFormFPSolver):
     """FEM (mesh + Lagrange) Fokker-Planck solver.
 
-    Mass conservation is guaranteed by the Galerkin weak form (the test space
-    contains constants). Forward time stepping is inherited from ``WeakFormFPSolver``.
+    Mass conservation holds because the assembled operator has zero column sums: the
+    diffusion stiffness already does (``sum_i K[i,j] = integral(grad(sum_i phi_i) . grad phi_j)
+    = 0`` since ``sum_i phi_i = 1``), and the advection block is assembled as ``-C^T`` (see
+    :meth:`_build_advection`) so its column sums vanish too. Forward time stepping is inherited
+    from ``WeakFormFPSolver``.
 
     Example:
         >>> from mfgarchon.alg.numerical.fem import FPFEMSolver
         >>> solver = FPFEMSolver(problem)
         >>> M = solver.solve_fp_system(m_initial, U_solution)
     """
+
+    _scheme_family = SchemeFamily.FEM
 
     def __init__(self, problem: MFGProblem, order: int = 1) -> None:
         mesh_data = problem.geometry.mesh_data
@@ -78,7 +84,17 @@ class FPFEMSolver(WeakFormFPSolver):
 
     # --- advection from drift via exact quadrature-point gradient of U --------
     def _build_advection(self, U_n: NDArray, D: float = 0.0) -> sparse.csr_matrix:
-        r"""Assemble $\int (v \cdot \nabla\phi_j)\,\phi_i\,dx$ with $v = -\text{coupling}\cdot\nabla U_n$.
+        r"""Assemble the mass-conserving FP advection block for drift $v = -\text{coupling}\cdot\nabla U_n$.
+
+        The raw convective form $C_{ij} = \int \phi_i\,(v\cdot\nabla\phi_j)\,dx$ (gradient on the
+        TRIAL function) does NOT conserve mass: its column sums are
+        $\sum_i C_{ij} = \int (v\cdot\nabla\phi_j)\,dx \ne 0$. Integrating $\text{div}(v\,m)$ by
+        parts moves the gradient onto the test function, giving the operator $-C^{\top}$, whose
+        column sums vanish ($\sum_i (-C^\top)_{ij} = -\int (v\cdot\nabla\phi_j)\sum_i\phi_i = 0$
+        since $\sum_i \phi_i = 1$). $-C^\top$ is also the adjoint-consistency identity
+        $A_{FP} = A_{HJB}^\top$, matching the meshless-Galerkin sibling (Issue #1131). Before this
+        fix (Issue #1114-adjacent / FEM survey) FEM returned the un-transposed $+C$, giving ~20%+
+        mass drift on a non-divergence-free drift.
 
         ``D`` (the current diffusion coefficient) is part of the base contract but unused by
         FEM, which adds no diffusion-scaled stabilization term."""
@@ -86,7 +102,7 @@ class FPFEMSolver(WeakFormFPSolver):
         from skfem import BilinearForm
 
         dim = self._skfem_mesh.p.shape[0]
-        coupling = getattr(self.problem, "coupling_coefficient", 0.5)
+        coupling = self.problem.coupling_coefficient
         du = self._basis.interpolate(U_n)
 
         @BilinearForm
@@ -97,7 +113,8 @@ class FPFEMSolver(WeakFormFPSolver):
                 result += v_d * u.grad[d]
             return result * v.value
 
-        return skfem.asm(advection_form, self._basis)
+        c_matrix = skfem.asm(advection_form, self._basis)
+        return (-c_matrix.T).tocsr()
 
 
 if __name__ == "__main__":

--- a/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.weak_form_hjb_solver import WeakFormHJBSolver
 from mfgarchon.utils.mfg_logging import get_logger
 
@@ -40,6 +41,8 @@ class HJBFEMSolver(WeakFormHJBSolver):
         >>> U = solver.solve_hjb_system(M_density, U_terminal, U_coupling_prev)
         >>> U = solver.solve_hjb_system(M_density, U_terminal, use_newton=True)
     """
+
+    _scheme_family = SchemeFamily.FEM
 
     def __init__(self, problem: MFGProblem, order: int = 1) -> None:
         mesh_data = problem.geometry.mesh_data

--- a/mfgarchon/geometry/meshes/mesh_2d.py
+++ b/mfgarchon/geometry/meshes/mesh_2d.py
@@ -281,7 +281,14 @@ class Mesh2D(_MeshGeneratorBase):
             warnings.warn(f"Hole creation failed: {e}. Continuing with domain without holes.", stacklevel=2)
 
     def generate_mesh(self) -> MeshData:
-        """Generate 2D triangular mesh using Gmsh → Meshio pipeline."""
+        """Generate 2D triangular mesh using Gmsh → Meshio pipeline.
+
+        If ``self.mesh_data`` is already populated (e.g. injected from a pre-built mesh via
+        ``mfgarchon.alg.numerical.fem.mesh_adapter.skfem_to_meshdata``), it is returned as-is —
+        a gmsh-free path for callers that supply their own mesh, and idempotent memoization
+        otherwise."""
+        if self.mesh_data is not None:
+            return self.mesh_data
         try:
             import gmsh
             import meshio  # noqa: F401

--- a/mfgarchon/geometry/meshes/mesh_3d.py
+++ b/mfgarchon/geometry/meshes/mesh_3d.py
@@ -366,7 +366,12 @@ class Mesh3D(_MeshGeneratorBase):
             gmsh.model.occ.synchronize()
 
     def generate_mesh(self) -> MeshData:
-        """Generate 3D tetrahedral mesh."""
+        """Generate 3D tetrahedral mesh.
+
+        Returns a pre-populated ``self.mesh_data`` as-is if present (gmsh-free injected-mesh
+        path / idempotent memoization)."""
+        if self.mesh_data is not None:
+            return self.mesh_data
         try:
             import gmsh
             import meshio  # noqa: F401

--- a/mfgarchon/utils/adjoint_validation.py
+++ b/mfgarchon/utils/adjoint_validation.py
@@ -227,13 +227,16 @@ def check_solver_duality(
         )
 
     # Case 4: Same family → Check duality type
-    # Type A families: Discrete transpose (exact). MESHLESS_GALERKIN is the
-    # meshfree Type-A member (Galerkin MLS, A_FP = A_HJB^T exact; Issue #1131).
+    # Type A families: Discrete transpose (exact). MESHLESS_GALERKIN is the meshfree Type-A
+    # member (Galerkin MLS, A_FP = A_HJB^T exact; Issue #1131); FEM is its mesh-based sibling
+    # (Galerkin Lagrange, exact transpose: the FP advection block is assembled as -C^T of the
+    # HJB convective form, and mass/stiffness are symmetric).
     discrete_families = {
         SchemeFamily.FDM,
         SchemeFamily.SL,
         SchemeFamily.FVM,
         SchemeFamily.MESHLESS_GALERKIN,
+        SchemeFamily.FEM,
     }
 
     if hjb_family in discrete_families:

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -1,0 +1,103 @@
+"""Integration tests for the FEM solver *classes* (not raw assembly).
+
+Before these, no test instantiated ``HJBFEMSolver`` / ``FPFEMSolver`` — ``test_fem_coupled_mfg.py``
+hand-rolls a driftless Picard loop on raw ``K``/``M`` and never touches the solver classes, so the
+FEM solver path was unverified. These tests pin the three things the FEM-readiness survey found
+broken and that this change fixes:
+
+1. the factory can build a FEM pair (the ``_scheme_family``/duality wiring),
+2. the FP advection operator is mass-conserving (the ``-C^T`` fix),
+3. a pre-built mesh can be injected without gmsh (the ``generate_mesh`` memoization).
+
+Coupled FEM *through ``FixedPointIterator``* is NOT exercised here: the iterator currently requires
+a ``CartesianGrid`` geometry, while the FEM solvers require an unstructured mesh, and the
+``fem.bc_adapter`` expects a ``BoundaryConditions`` object where the solver receives a ``dict`` —
+those two seams must be closed before an end-to-end coupled-FEM test is possible.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required for FEM tests")
+
+
+def _fem_problem(refine: int = 2):
+    """A gmsh-free 2D FEM MFG problem: a skfem built-in mesh injected as MeshData."""
+    from mfgarchon.alg.numerical.fem.mesh_adapter import skfem_to_meshdata
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry.boundary import no_flux_bc
+    from mfgarchon.geometry.meshes.mesh_2d import Mesh2D
+
+    mesh = skfem.MeshTri.init_sqsymmetric().refined(refine)
+    geom = Mesh2D(domain_type="rectangle", bounds=(0.0, 1.0, 0.0, 1.0))
+    geom.mesh_data = skfem_to_meshdata(mesh)
+    components = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    problem = MFGProblem(
+        geometry=geom,
+        T=0.2,
+        Nt=5,
+        sigma=0.3,
+        components=components,
+        coupling_coefficient=0.5,
+        boundary_conditions=no_flux_bc(dimension=2),
+    )
+    return problem, mesh
+
+
+@pytest.mark.integration
+class TestFEMSolverPath:
+    def test_factory_creates_fem_pair_with_traits(self):
+        """Issue #773 / #580: the documented factory entry point must build a FEM pair. It used to
+        raise (HJB/FP inherited ``_scheme_family=GENERIC`` → duality VALIDATION_SKIPPED → factory
+        raised). Both solvers now carry ``SchemeFamily.FEM`` and the pair validates as Type-A."""
+        from mfgarchon.alg.base_solver import SchemeFamily
+        from mfgarchon.factory.scheme_factory import NumericalScheme, create_paired_solvers
+
+        problem, _ = _fem_problem()
+        hjb, fp = create_paired_solvers(problem, NumericalScheme.FEM_P1)
+        assert type(hjb).__name__ == "HJBFEMSolver"
+        assert type(fp).__name__ == "FPFEMSolver"
+        assert hjb._scheme_family is SchemeFamily.FEM
+        assert fp._scheme_family is SchemeFamily.FEM
+
+    def test_fp_advection_is_mass_conserving(self):
+        """The FP advection operator must have zero column sums (mass conservation). The raw
+        convective form ``C[i,j] = ∫ φ_i (v·∇φ_j)`` does NOT (column sums ≈ ∫ v·∇φ_j); the
+        operator is assembled as ``-C^T`` whose column sums vanish since ``Σ_i φ_i = 1``. A random
+        value function gives a non-divergence-free drift, so this fails on the prior ``+C``."""
+        from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+
+        problem, _ = _fem_problem()
+        fp = FPFEMSolver(problem)
+        u_n = np.random.RandomState(0).rand(fp._basis.N)
+        advection = fp._build_advection(u_n)
+        max_col_sum = float(np.abs(np.asarray(advection.sum(axis=0)).ravel()).max())
+        assert max_col_sum < 1e-12, f"FP advection not mass-conserving: max|col sum|={max_col_sum:.2e}"
+
+    def test_gmsh_free_mesh_injection_is_returned_as_is(self):
+        """generate_mesh() returns a pre-populated mesh_data unchanged (gmsh-free injected-mesh
+        path / idempotent memoization) — gmsh is not importable in the default install."""
+        from mfgarchon.alg.numerical.fem.mesh_adapter import skfem_to_meshdata
+        from mfgarchon.geometry.meshes.mesh_2d import Mesh2D
+
+        mesh_data = skfem_to_meshdata(skfem.MeshTri.init_sqsymmetric().refined(1))
+        geom = Mesh2D(domain_type="rectangle", bounds=(0.0, 1.0, 0.0, 1.0))
+        geom.mesh_data = mesh_data
+        assert geom.generate_mesh() is mesh_data
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The FEM-readiness audit found the FEM solver *path* broken at three seams (the architecture from #1131 is sound, but the path itself was unverified — no test instantiated `HJBFEMSolver`/`FPFEMSolver`). This is **Tier 0** of the "make FEM correct + tested" prep, fixing what's self-contained.

### 1. FP advection was not mass-conserving (the load-bearing bug)
`FPFEMSolver._build_advection` returned the raw convective form `+C` (`C[i,j]=∫φ_i(v·∇φ_j)`), whose column sums are `≈∫v·∇φ_j ≠ 0` → **~20%+ mass drift** on a non-divergence-free drift (the docstring's "mass conservation guaranteed by the Galerkin weak form" was false for advection). Now assembled as `-Cᵀ` (the integration-by-parts form): zero column sums since `Σ_iφ_i=1`, matching the meshless-Galerkin sibling and the adjoint identity `A_FP=A_HJBᵀ`. **Verified `max|col sum| ≈ 6e-17`.** Also dropped the `getattr(problem,'coupling_coefficient',0.5)` duck-typing default.

### 2. The documented factory entry point raised
`HJBFEMSolver`/`FPFEMSolver` inherited `_scheme_family=GENERIC`, so `create_paired_solvers(..., FEM_P1)` **raised** (duality `VALIDATION_SKIPPED`). Both now carry `SchemeFamily.FEM`, registered as a **Type-A** (exact discrete transpose) Galerkin family in `adjoint_validation` alongside `MESHLESS_GALERKIN` — correct, since Galerkin FEM with `-Cᵀ` advection + symmetric mass/stiffness is an exact transpose.

### 3. gmsh-free mesh path
`Mesh2D`/`Mesh3D.generate_mesh()` now returns a pre-populated `mesh_data` as-is (idempotent memoization) — a gmsh-free path for callers injecting a mesh via `skfem_to_meshdata`, since gmsh is **not** in the default install (the entire FEM entry path was otherwise unavailable).

## Tests
`tests/integration/test_fem_solver_path.py` — the first tests to drive the **real** solver classes: factory builds the FEM pair with correct traits; FP advection is mass-conserving (fails on the prior `+C`); gmsh-free mesh injection round-trips. 343 adjoint/FEM/mesh/factory tests pass; ruff clean.

## ⚠️ Reported, not fixed — the remaining coupled-FEM prerequisites
Coupled FEM **through `FixedPointIterator` still cannot run**, blocked at two seams the audit under-weighted:
- **`FixedPointIterator` is grid-only** — it requires a `CartesianGrid` (`get_grid_shape()`/`get_grid_spacing()`), but FEM requires an unstructured mesh. (Meshless "cheats" by using a grid-geometry problem; FEM can't.)
- **`fem/bc_adapter` type mismatch** — `is_pure_neumann`/the BC strategy expect a `BoundaryConditions` object, but the solver receives a `dict` from `get_boundary_conditions()` → `AttributeError: 'dict' has no attribute 'segments'`.

These two are the genuine "coupled FEM end-to-end" blockers and should be closed before extending FEM (element families, etc.). EOC-safe throughout: FEM is off the paper EOC path; the `adjoint_validation` change only reclassifies FEM/FEM pairs.

Refs #773, #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)