### PR TITLE
refactor: single-source σ→D in the weak-form/FEM family (#811/#1192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Single-sourced the σ→D conversion in the weak-form / FEM family** (Issue #811 / #1192; FEM
+  audit). The weak-form HJB and FP solvers had three inline `0.5 * sigma**2` copies
+  (`weak_form_fp_solver._diffusion_coefficient`, `solve_fp_step_adjoint_mode`, and
+  `weak_form_hjb_solver.solve_hjb_system`) that bypassed the canonical `diffusion_from_volatility`
+  and had already diverged for an array volatility (silently collapsing the field to a scalar
+  mean). Added one `scalar_diffusion_from_volatility(volatility_field, fallback_sigma)` helper in
+  `pde_coefficients` that all three delegate to; it routes the formula through the single source
+  and makes the scalar-D field-collapse **loud** (warns that a spatially-varying field is reduced
+  to its mean, since these solvers assemble `D * K` with one scalar `D`). Byte-identical to the
+  prior copies (`None→0.5σ²`, `scalar→0.5v²`, `array→0.5·mean(v)²`); also dedups the
+  `solve_fp_step_adjoint_mode` copy onto `_diffusion_coefficient`. EOC-safe (weak-form/FEM is off
+  the paper EOC path; scalar paths bit-identical).
+
 - **Single-sourced boundary on-wall tolerances** (Issue #1101). The scattered `1e-6` / `1e-8` /
   `1e-10` / `1e-12` magic literals across the boundary / geometry on-wall classifiers are now
   named, documented, tunable constants in `mfgarchon/geometry/boundary/tolerances.py`

--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -25,6 +25,7 @@ from scipy.sparse.linalg import spsolve
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import scalar_diffusion_from_volatility
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -89,15 +90,9 @@ class WeakFormFPSolver(BaseFPSolver):
         raise NotImplementedError
 
     def _diffusion_coefficient(self, volatility_field) -> float:
-        # volatility_field is the SDE volatility sigma (codebase-wide convention); the PDE
-        # diffusion coefficient is D = sigma^2 / 2 (Conventions Index; Issue #811). The
-        # scalar/array branches previously returned the input as D, skipping the conversion
-        # the None branch and solve_fp_step_adjoint_mode already apply.
-        if volatility_field is None:
-            return 0.5 * self.problem.sigma**2
-        if isinstance(volatility_field, (int, float)):
-            return 0.5 * float(volatility_field) ** 2
-        return 0.5 * float(np.mean(volatility_field)) ** 2
+        # D = sigma^2 / 2 via the single-source converter (Issue #811). A spatially-varying field
+        # is collapsed to its mean with a warning (this scalar-D solver cannot represent it).
+        return scalar_diffusion_from_volatility(volatility_field, self.problem.sigma)
 
     @deprecated_parameter(param_name="drift_field", since="v0.20.0", replacement="potential_field")
     def solve_fp_system(
@@ -194,12 +189,7 @@ class WeakFormFPSolver(BaseFPSolver):
         e.g. as the transpose of the assembled HJB operator.
         """
         dt = self.problem.dt
-        if sigma is None:
-            D = 0.5 * self.problem.sigma**2
-        elif isinstance(sigma, (int, float)):
-            D = 0.5 * float(sigma) ** 2
-        else:
-            D = 0.5 * float(np.mean(sigma)) ** 2
+        D = self._diffusion_coefficient(sigma)
 
         A_system = self._M / dt + A_advection_T + D * self._K
         rhs = (self._M / dt) @ M_current.ravel()

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -25,6 +25,7 @@ from scipy.sparse.linalg import spsolve
 
 from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import scalar_diffusion_from_volatility
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -241,14 +242,9 @@ class WeakFormHJBSolver(BaseHJBSolver):
         if M_density.ndim == 1:
             M_density = np.tile(M_density, (Nt + 1, 1))
 
-        # volatility_field is the SDE volatility sigma; the PDE diffusion is D = sigma^2 / 2
-        # (Conventions Index; Issue #811) -- matches the FP _diffusion_coefficient and adjoint mode.
-        if volatility_field is None:
-            D = 0.5 * self.problem.sigma**2
-        elif isinstance(volatility_field, (int, float)):
-            D = 0.5 * float(volatility_field) ** 2
-        else:
-            D = 0.5 * float(np.mean(volatility_field)) ** 2
+        # D = sigma^2 / 2 via the single-source converter (Issue #811) -- matches the FP
+        # _diffusion_coefficient / adjoint mode. Array field collapses to its mean (with a warning).
+        D = scalar_diffusion_from_volatility(volatility_field, self.problem.sigma)
 
         U = np.zeros((Nt + 1, N))
         U[Nt] = U_terminal

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -74,6 +74,39 @@ def diffusion_from_volatility(
     raise ValueError(f"kind must be 'field' or 'tensor' (or None for scalar sigma), got {kind!r}.")
 
 
+def scalar_diffusion_from_volatility(volatility_field: Any, fallback_sigma: Any) -> float:
+    """Single scalar PDE diffusion ``D`` for solvers that assemble ``D * K`` with a scalar ``D``
+    (the weak-form / FEM family).
+
+    Routes the SDE-volatility -> PDE-diffusion conversion through the single source
+    :func:`diffusion_from_volatility` (``D = sigma^2 / 2``; Issue #811) so the ``0.5 * sigma**2``
+    formula is not re-copied per solver:
+
+    - ``volatility_field is None`` -> ``D`` from ``fallback_sigma`` (the problem's ``sigma``);
+    - scalar ``volatility_field`` -> ``D`` from that scalar;
+    - array ``volatility_field`` -> ``D`` from ``mean(volatility_field)``, with a warning. These
+      solvers cannot represent a spatially-varying field (``D`` multiplies the assembled stiffness
+      as one scalar), so the field is collapsed to its mean -- made loud here rather than silent
+      (Issue #1079-adjacent). Use an FDM/GFDM path with ``coefficient_field`` for true varying ``D``.
+
+    Byte-identical to the prior inline ``0.5 * sigma**2`` / ``0.5 * mean(sigma)**2`` copies.
+    """
+    if volatility_field is None:
+        return float(diffusion_from_volatility(fallback_sigma))
+    if np.ndim(volatility_field) == 0:
+        return float(diffusion_from_volatility(float(volatility_field)))
+    import warnings
+
+    warnings.warn(
+        "Weak-form/FEM solver uses a single scalar diffusion D; the spatially-varying volatility "
+        "field is collapsed to its mean (D = mean(sigma)^2 / 2). For a true varying-coefficient "
+        "diffusion use an FDM/GFDM FP path with coefficient_field (Issue #1079).",
+        UserWarning,
+        stacklevel=2,
+    )
+    return float(diffusion_from_volatility(float(np.mean(volatility_field))))
+
+
 class CoefficientMode(Enum):
     """
     Specifies which variables a callable coefficient depends on.

--- a/tests/unit/test_core/test_pde_coefficients.py
+++ b/tests/unit/test_core/test_pde_coefficients.py
@@ -436,3 +436,30 @@ class TestCoefficientFieldEdgeCases:
 
         with pytest.raises(ValueError, match="my_custom_field"):
             field.evaluate_at(timestep_idx=0, grid=grid, density=density, dt=0.01)
+
+
+class TestScalarDiffusionFromVolatility:
+    """Issue #811 / FEM survey: the weak-form / FEM family's single scalar D = sigma^2/2,
+    single-sourced via diffusion_from_volatility. Byte-identical to the prior inline copies
+    (None -> 0.5*sigma^2, scalar -> 0.5*v^2, array -> 0.5*mean(v)^2); the array case warns
+    because a scalar-D solver cannot represent a spatially-varying field."""
+
+    def test_none_uses_fallback_sigma(self):
+        from mfgarchon.utils.pde_coefficients import scalar_diffusion_from_volatility
+
+        assert scalar_diffusion_from_volatility(None, 0.3) == pytest.approx(0.5 * 0.3**2, rel=1e-12)
+
+    def test_scalar_is_converted(self):
+        from mfgarchon.utils.pde_coefficients import scalar_diffusion_from_volatility
+
+        for v in (0.1, 0.7, 2.5):
+            assert scalar_diffusion_from_volatility(v, 0.3) == pytest.approx(0.5 * v**2, rel=1e-12)
+
+    def test_array_collapses_to_mean_with_warning(self):
+        from mfgarchon.utils.pde_coefficients import scalar_diffusion_from_volatility
+
+        arr = np.array([0.2, 0.4, 0.6])
+        with pytest.warns(UserWarning, match="collapsed to its mean"):
+            d = scalar_diffusion_from_volatility(arr, 0.3)
+        # byte-identical to the prior inline `0.5 * mean(arr)**2`
+        assert d == pytest.approx(0.5 * float(np.mean(arr)) ** 2, rel=1e-12)


### PR DESCRIPTION
## Summary

**Tier 1** of the FEM-prep batch. The weak-form HJB and FP solvers carried **three inline `0.5 * sigma**2` copies** of the σ→D conversion (`weak_form_fp_solver._diffusion_coefficient`, `solve_fp_step_adjoint_mode`, `weak_form_hjb_solver.solve_hjb_system`) that bypassed the canonical `diffusion_from_volatility` — the repo's dominant "private convention copy" bug class, and **already diverged**: for an array volatility they silently did `0.5*mean(σ)²`, collapsing the field to a scalar mean with no signal.

## Fix

One helper — `scalar_diffusion_from_volatility(volatility_field, fallback_sigma)` in `pde_coefficients` — that all three delegate to. It:
- routes the `D = σ²/2` formula through the single source `diffusion_from_volatility`;
- makes the scalar-D field-collapse **loud** (warns that a spatially-varying field is reduced to its mean — these solvers assemble `D * K` with one scalar `D` and cannot represent a varying field; use an FDM/GFDM `coefficient_field` path for that, Issue #1079).

**Byte-identical** to the prior copies: `None→0.5σ²`, `scalar→0.5v²`, `array→0.5·mean(v)²` (the array form equals `diffusion_from_volatility(mean(σ))`). Also dedups the `solve_fp_step_adjoint_mode` copy onto `_diffusion_coefficient`.

## Tests
`TestScalarDiffusionFromVolatility` (None/scalar byte-identical; array collapses to mean **with warning**). 206 weak-form/meshless + 30 pde-coefficient tests pass; ruff clean.

EOC-safe: weak-form/FEM is off the paper EOC path, and the scalar paths are bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)