### PR TITLE
fix(fem): tag axis-aligned named boundary facets so BCSegment resolves (#607, coupled-FEM seam 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FEM named-region BC silently unresolved: no facet boundary tags** (Issue #607; coupled-FEM
+  chain, seam 2). `meshdata_to_skfem` produced a skfem mesh with `mesh.boundaries = None`, so a
+  `BCSegment(boundary="x_min")` could not be resolved — the FEM `bc_adapter` either crashed
+  (`argument of type 'NoneType' is not iterable`) or fell back to the *entire* boundary. Now
+  `meshdata_to_skfem` tags axis-aligned wall facets as named boundaries (`x_min`/`x_max`/`y_min`/…,
+  matching `BoundaryFace.to_string()` / `BCSegment.boundary`) via skfem `with_boundaries`, keyed off
+  the mesh bounding box with `BOUNDARY_TOL`. A Dirichlet segment now resolves to exactly its wall's
+  DOFs (verified: `x_min` → only `x=xmin` DOFs, a strict subset of the boundary), and an FP solve
+  with a Dirichlet BC runs. `_find_segment_dofs` also guards `mesh.boundaries is None` (untagged
+  meshes fall back cleanly instead of raising). Curved/SDF region markers remain out of scope. The
+  last coupled-FEM seam is `FixedPointIterator` mesh-geometry support. Refs #607.
+
 - **`UnstructuredMesh.get_boundary_conditions()` returned boundary-handler metadata, not a
   `BoundaryConditions`** (coupled-FEM chain, seam 1). It returned `get_boundary_handler()` — e.g.
   `{"type": "unstructured_mesh", "boundary_faces": None}` — which, as the higher-priority accessor

--- a/mfgarchon/alg/numerical/fem/bc_adapter.py
+++ b/mfgarchon/alg/numerical/fem/bc_adapter.py
@@ -158,7 +158,10 @@ def _find_segment_dofs(
     """
     boundary_name = getattr(segment, "boundary", None)
 
-    if boundary_name and boundary_name in mesh.boundaries:
+    # mesh.boundaries is None when no named regions were tagged (mesh_adapter tags axis-aligned
+    # walls x_min/x_max/... for box domains; #607). Guard it so an untagged mesh falls back
+    # cleanly instead of raising "argument of type 'NoneType' is not iterable".
+    if boundary_name and mesh.boundaries and boundary_name in mesh.boundaries:
         # Named boundary region
         facets = mesh.boundaries[boundary_name]
         dofs = basis.get_dofs(facets)

--- a/mfgarchon/alg/numerical/fem/mesh_adapter.py
+++ b/mfgarchon/alg/numerical/fem/mesh_adapter.py
@@ -67,11 +67,39 @@ def meshdata_to_skfem(mesh_data: MeshData) -> skfem.Mesh:
 
     mesh = mesh_cls(nodes, elements)
 
-    # Transfer boundary tags if available
+    # Transfer boundary tags if available (gmsh physical-group path)
     if mesh_data.boundary_faces is not None and len(mesh_data.boundary_faces) > 0:
         _apply_boundary_tags(mesh, mesh_data)
 
+    # Issue #607: tag axis-aligned wall facets as named boundaries (x_min/x_max/...) matching the
+    # BoundaryFace naming, so a BCSegment(boundary="x_min") resolves to the right facet set. This
+    # is the unified segment->facet specification for axis-aligned (box) mesh domains; without it
+    # mesh.boundaries is None and the FEM bc_adapter falls back to the entire boundary.
+    mesh = _tag_axis_aligned_boundaries(mesh)
+
     return mesh
+
+
+def _tag_axis_aligned_boundaries(mesh: skfem.Mesh) -> skfem.Mesh:
+    """Return ``mesh`` with named axis-aligned wall boundaries (``x_min``/``x_max``/``y_min``/...).
+
+    A facet is on wall ``<axis>_<side>`` when its coordinate on that axis is within ``BOUNDARY_TOL``
+    of the mesh bounding-box bound. Names follow ``BoundaryFace.to_string()`` (axis 0->x, 1->y,
+    2->z), matching ``BCSegment.boundary``. For non-box domains these tag only the facets touching
+    the bounding box on each axis; SDF/region-based markers for curved domains are out of scope here.
+    """
+    from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL
+
+    dim = mesh.p.shape[0]
+    mins = mesh.p.min(axis=1)
+    maxs = mesh.p.max(axis=1)
+    axis_names = "xyz"
+    predicates: dict = {}
+    for d in range(dim):
+        name = axis_names[d] if d < len(axis_names) else f"axis{d}"
+        predicates[f"{name}_min"] = lambda x, d=d, b=mins[d]: np.isclose(x[d], b, atol=BOUNDARY_TOL)
+        predicates[f"{name}_max"] = lambda x, d=d, b=maxs[d]: np.isclose(x[d], b, atol=BOUNDARY_TOL)
+    return mesh.with_boundaries(predicates)
 
 
 def skfem_to_meshdata(mesh: skfem.Mesh) -> MeshData:

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -9,10 +9,11 @@ broken and that this change fixes:
 2. the FP advection operator is mass-conserving (the ``-C^T`` fix),
 3. a pre-built mesh can be injected without gmsh (the ``generate_mesh`` memoization).
 
-Coupled FEM *through ``FixedPointIterator``* is NOT exercised here: the iterator currently requires
-a ``CartesianGrid`` geometry, while the FEM solvers require an unstructured mesh, and the
-``fem.bc_adapter`` expects a ``BoundaryConditions`` object where the solver receives a ``dict`` —
-those two seams must be closed before an end-to-end coupled-FEM test is possible.
+Coupled FEM *through ``FixedPointIterator``* is still NOT exercised here: the iterator requires a
+``CartesianGrid`` geometry while the FEM solvers require an unstructured mesh (the last seam of the
+coupled-FEM chain). The other two seams are now closed — the BC accessor returns a real
+``BoundaryConditions`` (seam 1) and ``meshdata_to_skfem`` tags axis-aligned named walls so Dirichlet
+segments resolve (seam 2, #607) — so coupled FEM is exercised via a manual Picard loop below.
 """
 
 from __future__ import annotations
@@ -158,6 +159,65 @@ class TestFEMBoundaryConditionResolution:
         masses = [float((mass_matrix @ m_sol[t]).sum()) for t in range(n_t + 1)]
         drift = abs(masses[-1] - masses[0]) / masses[0]
         assert drift < 1e-3, f"no-flux FEM mass drift {drift:.2%} (advection not conservative?)"
+
+
+@pytest.mark.integration
+class TestFEMFacetBoundaryTags:
+    """Seam 2 of the coupled-FEM chain (#607): meshdata_to_skfem tags axis-aligned wall facets as
+    named boundaries (x_min/x_max/...), so a BCSegment(boundary="x_min") resolves to the correct
+    facet set. Before this, mesh.boundaries was None and the Dirichlet path crashed with
+    "argument of type 'NoneType' is not iterable"."""
+
+    def test_named_axis_walls_are_tagged(self):
+        from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+
+        problem, _ = _fem_problem()
+        fp = FPFEMSolver(problem)
+        assert set(fp._skfem_mesh.boundaries) == {"x_min", "x_max", "y_min", "y_max"}
+
+    def test_dirichlet_segment_resolves_to_correct_wall_dofs(self):
+        from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+        from mfgarchon.alg.numerical.fem.mesh_adapter import skfem_to_meshdata
+        from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+        from mfgarchon.core.mfg_components import MFGComponents
+        from mfgarchon.core.mfg_problem import MFGProblem
+        from mfgarchon.geometry.boundary.conditions import BCSegment, BCType, BoundaryConditions
+        from mfgarchon.geometry.meshes.mesh_2d import Mesh2D
+
+        geom = Mesh2D(domain_type="rectangle", bounds=(0.0, 1.0, 0.0, 1.0))
+        geom.mesh_data = skfem_to_meshdata(skfem.MeshTri.init_sqsymmetric().refined(2))
+        geom.boundary_conditions = BoundaryConditions(
+            segments=[BCSegment(name="inlet", bc_type=BCType.DIRICHLET, boundary="x_min", value=0.0)],
+            dimension=2,
+        )
+        components = MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+            ),
+        )
+        problem = MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=components, coupling_coefficient=0.5)
+        fp = FPFEMSolver(problem)
+        dofs, _vals = fp._dirichlet_dofs_and_values()  # previously raised NoneType-not-iterable
+        assert len(dofs) > 0
+        # every constrained dof is on the x_min wall, not the whole boundary
+        assert np.allclose(fp._skfem_mesh.p[0, dofs], 0.0)
+        assert len(dofs) < len(fp._skfem_mesh.boundary_nodes())  # a wall, not all boundary
+
+    def test_untagged_mesh_falls_back_without_crashing(self):
+        """If mesh.boundaries is None (no tagging), _find_segment_dofs must fall back to all
+        boundary nodes, not raise."""
+        from mfgarchon.alg.numerical.fem.assembly import create_basis
+        from mfgarchon.alg.numerical.fem.bc_adapter import _find_segment_dofs
+        from mfgarchon.geometry.boundary.conditions import BCSegment, BCType
+
+        mesh = skfem.MeshTri.init_sqsymmetric().refined(1)  # raw skfem mesh: boundaries is None
+        assert mesh.boundaries is None
+        basis = create_basis(mesh, order=1)
+        seg = BCSegment(name="d", bc_type=BCType.DIRICHLET, boundary="x_min", value=0.0)
+        dofs = _find_segment_dofs(mesh, basis, seg)  # must not raise
+        assert len(dofs) == len(mesh.boundary_nodes())  # fell back to all boundary nodes
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Seam 2** of the coupled-FEM chain (#607). `meshdata_to_skfem` produced a skfem mesh with `mesh.boundaries = None`, so a `BCSegment(boundary="x_min")` could not be resolved — the FEM `bc_adapter` crashed (`argument of type 'NoneType' is not iterable`) or fell back to the **entire** boundary.

## Fix

`meshdata_to_skfem` now tags axis-aligned wall facets as **named boundaries** (`x_min`/`x_max`/`y_min`/… matching `BoundaryFace.to_string()` / `BCSegment.boundary`) via skfem `with_boundaries`, keyed off the mesh bounding box with the single-source `BOUNDARY_TOL`. `_find_segment_dofs` also guards `mesh.boundaries is None` (untagged meshes fall back to all boundary nodes instead of raising).

**Verified:** a Dirichlet segment on `"x_min"` resolves to exactly that wall's DOFs (all at `x=xmin`, a strict subset of the boundary — not the whole boundary), and an FP solve with a Dirichlet BC runs (was the `NoneType` crash).

## Scope

Axis-aligned (box) domains — the common FEM case and what `BCSegment.boundary` names. Curved/SDF region markers are out of scope. The gmsh physical-group path (`_apply_boundary_tags`) is unchanged (untestable without gmsh).

## Tests
`TestFEMFacetBoundaryTags`: named walls tagged (`{x_min,x_max,y_min,y_max}`); Dirichlet segment → correct wall DOFs (subset, not whole boundary); untagged mesh falls back without crashing. 204 FEM/mesh/geometry tests pass; ruff clean.

## Chain status
- ✅ seam 1 (#1229, merged): FEM solver gets a real `BoundaryConditions`.
- ✅ seam 2 (this PR): named facet tags → Dirichlet segments resolve.
- ⏭ seam 3: `FixedPointIterator` mesh-geometry support (EOC-sensitive shared layer — will be baseline-gated).

`Refs #607`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)