### PR TITLE
chore: ruff format 11 pre-existing-drift test files

### DIFF
--- a/tests/integration/test_diffusion_magnitude_gate.py
+++ b/tests/integration/test_diffusion_magnitude_gate.py
@@ -145,9 +145,16 @@ def test_fp_fdm_diffusion_magnitude(path):
 _PI = np.pi  # cos(pi x) is a no-flux Laplacian eigenmode on [0,1]
 
 
-def _gfdm_diffusion_field_relerr(sigma: float, D_reference: float, n_x: int = 41,
-                                 T: float = 0.05, nt: int = 50, amp: float = 1e-3,
-                                 lam: float = 1.0, delta: float = 0.3) -> float:
+def _gfdm_diffusion_field_relerr(
+    sigma: float,
+    D_reference: float,
+    n_x: int = 41,
+    T: float = 0.05,
+    nt: int = 50,
+    amp: float = 1e-3,
+    lam: float = 1.0,
+    delta: float = 0.3,
+) -> float:
     """L2 error between the GFDM-recovered field and the analytic backward eigenmode.
 
     The solver applies its own ``D = sigma^2/2`` (the path under test); the analytic
@@ -159,8 +166,7 @@ def _gfdm_diffusion_field_relerr(sigma: float, D_reference: float, n_x: int = 41
     ``L^n[i] = -H(grad u*^n)``; ``amp`` is kept small so the residual cancellation is
     clean (diffusion O(amp) dominates the O(amp^2) Hamiltonian remnant).
     """
-    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n_x],
-                             boundary_conditions=no_flux_bc(dimension=1))
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n_x], boundary_conditions=no_flux_bc(dimension=1))
     H = SeparableHamiltonian(
         control_cost=QuadraticControlCost(control_cost=lam),
         coupling=lambda m: 0.0 * np.asarray(m),
@@ -173,8 +179,9 @@ def _gfdm_diffusion_field_relerr(sigma: float, D_reference: float, n_x: int = 41
         hamiltonian=H,
     )
     prob = MFGProblem(geometry=grid, T=T, Nt=nt, sigma=sigma, components=comps)
-    solver = HJBGFDMSolver(prob, x.reshape(-1, 1), delta=delta,
-                           monotonicity_scheme="joint_socp", monotonicity_application="precompute")
+    solver = HJBGFDMSolver(
+        prob, x.reshape(-1, 1), delta=delta, monotonicity_scheme="joint_socp", monotonicity_application="precompute"
+    )
     tspace = np.linspace(0.0, T, nt + 1)
 
     def running_cost_fn(n):  # L^n[i] = -H(grad u*^n) on the analytic field

--- a/tests/integration/test_mass_conservation_1d.py
+++ b/tests/integration/test_mass_conservation_1d.py
@@ -370,9 +370,7 @@ class TestExplicitDriftNoFluxDiffusionConservation:
         from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 
         n, nt, T, sigma = 51, 50, 0.5, 0.3
-        grid = TensorProductGrid(
-            bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1)
-        )
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
         H = SeparableHamiltonian(
             control_cost=QuadraticControlCost(control_cost=1.0),
             coupling=lambda m: 0.0 * np.asarray(m),
@@ -390,9 +388,7 @@ class TestExplicitDriftNoFluxDiffusionConservation:
         m0 = np.exp(-30 * (x - 0.5) ** 2)
         m0 /= m0.sum() * dx
         # callable (zero) drift routes through the explicit-drift path; pure diffusion
-        M = solver.solve_fp_system(
-            m0.copy(), drift_field=lambda t, g, m: np.zeros(n), volatility_field=sigma
-        )
+        M = solver.solve_fp_system(m0.copy(), drift_field=lambda t, g, m: np.zeros(n), volatility_field=sigma)
         mass = M.sum(axis=1) * dx
         rel = abs(mass[-1] - mass[0]) / mass[0]
         assert rel < 1e-12, f"explicit-drift pure-diffusion no-flux mass leak {rel:.2e} (was ~0.84%)"

--- a/tests/unit/test_alg/test_fp_particle_solver.py
+++ b/tests/unit/test_alg/test_fp_particle_solver.py
@@ -788,6 +788,7 @@ class TestEnforceObstacleBoundary:
             Hyperrectangle,
             Hypersphere,
         )
+
         box = Hyperrectangle(np.array([[0.0, 1.0], [0.0, 1.0]]))
         # Obstacle off bbox center so project_to_domain has a non-degenerate direction
         obstacle = Hypersphere(center=np.array([0.3, 0.5]), radius=0.15)
@@ -796,16 +797,17 @@ class TestEnforceObstacleBoundary:
     def test_obstacle_interior_projected(self):
         """Particle inside obstacle is projected back to navigable region."""
         from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+
         domain = self._make_diff_domain()
         particles = np.array([[0.3, 0.5]])  # obstacle center
         result = enforce_obstacle_boundary(particles.copy(), domain)
-        assert not np.allclose(result, particles), \
-            "Particle inside obstacle should have been projected out"
+        assert not np.allclose(result, particles), "Particle inside obstacle should have been projected out"
         assert domain.contains(result).all()
 
     def test_outer_bbox_violation_left_alone(self):
         """Issue #1064: Particle past outer bbox is NOT touched — caller's BC handles it."""
         from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+
         domain = self._make_diff_domain()
         particles = np.array([[1.5, 0.5]])  # past right wall x=1.5 > bbox max 1.0
         result = enforce_obstacle_boundary(particles.copy(), domain)
@@ -814,6 +816,7 @@ class TestEnforceObstacleBoundary:
     def test_navigable_particles_untouched(self):
         """Particles in navigable region are unchanged."""
         from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+
         domain = self._make_diff_domain()
         particles = np.array([[0.1, 0.1], [0.9, 0.5], [0.3, 0.7]])
         result = enforce_obstacle_boundary(particles.copy(), domain)
@@ -822,12 +825,15 @@ class TestEnforceObstacleBoundary:
     def test_mixed_obstacle_and_outer_violations(self):
         """Mix: one in obstacle (project), one past bbox (leave), one valid (untouched)."""
         from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+
         domain = self._make_diff_domain()
-        particles = np.array([
-            [0.3, 0.5],   # inside obstacle → should be projected
-            [1.5, 0.5],   # past right wall → should be left alone (Issue #1064)
-            [0.1, 0.1],   # navigable → untouched
-        ])
+        particles = np.array(
+            [
+                [0.3, 0.5],  # inside obstacle → should be projected
+                [1.5, 0.5],  # past right wall → should be left alone (Issue #1064)
+                [0.1, 0.1],  # navigable → untouched
+            ]
+        )
         result = enforce_obstacle_boundary(particles.copy(), domain)
         assert not np.allclose(result[0], particles[0])
         assert domain.contains(result[0:1]).all()
@@ -837,6 +843,7 @@ class TestEnforceObstacleBoundary:
     def test_none_implicit_domain_passthrough(self):
         """No implicit_domain → no-op."""
         from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+
         particles = np.array([[10.0, 10.0]])
         result = enforce_obstacle_boundary(particles.copy(), None)
         np.testing.assert_array_equal(result, particles)
@@ -849,16 +856,21 @@ class TestFPParticlePreserveIndices:
     def _absorbing_corridor_problem():
         """2D corridor with absorbing right wall, neumann elsewhere."""
         from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
+
         Lx, Ly, Nt, T = 4.0, 2.0, 20, 1.0
-        bc = BoundaryConditions(segments=[
-            BCSegment(name="left",   bc_type=BCType.NEUMANN, value=0.0, boundary="x_min"),
-            BCSegment(name="right",  bc_type=BCType.DIRICHLET, value=0.0, boundary="x_max"),
-            BCSegment(name="bottom", bc_type=BCType.NEUMANN, value=0.0, boundary="y_min"),
-            BCSegment(name="top",    bc_type=BCType.NEUMANN, value=0.0, boundary="y_max"),
-        ], dimension=2)
+        bc = BoundaryConditions(
+            segments=[
+                BCSegment(name="left", bc_type=BCType.NEUMANN, value=0.0, boundary="x_min"),
+                BCSegment(name="right", bc_type=BCType.DIRICHLET, value=0.0, boundary="x_max"),
+                BCSegment(name="bottom", bc_type=BCType.NEUMANN, value=0.0, boundary="y_min"),
+                BCSegment(name="top", bc_type=BCType.NEUMANN, value=0.0, boundary="y_max"),
+            ],
+            dimension=2,
+        )
         grid = TensorProductGrid([(0, Lx), (0, Ly)], Nx_points=[21, 11], boundary_conditions=bc)
-        return MFGProblem(geometry=grid, Nt=Nt, T=T, sigma=0.3,
-                          boundary_conditions=bc, components=_default_components_2d()), bc
+        return MFGProblem(
+            geometry=grid, Nt=Nt, T=T, sigma=0.3, boundary_conditions=bc, components=_default_components_2d()
+        ), bc
 
     @staticmethod
     def _drift_rightward(t, x, m):
@@ -868,13 +880,19 @@ class TestFPParticlePreserveIndices:
         np.random.seed(seed)
         problem, bc = self._absorbing_corridor_problem()
         solver = FPParticleSolver(
-            problem, num_particles=500, density_mode="query_only",
-            boundary_conditions=bc, preserve_indices=preserve_indices,
+            problem,
+            num_particles=500,
+            density_mode="query_only",
+            boundary_conditions=bc,
+            preserve_indices=preserve_indices,
         )
         init = np.random.uniform([0.5, 0.5], [1.5, 1.5], (500, 2))
         return solver.solve_fp_system(
-            initial_particles=init, drift_field=self._drift_rightward,
-            volatility_field=0.3, drift_needs_density=False, show_progress=False,
+            initial_particles=init,
+            drift_field=self._drift_rightward,
+            volatility_field=0.3,
+            drift_needs_density=False,
+            show_progress=False,
         )
 
     def test_default_off_preserves_legacy_behavior(self):
@@ -899,8 +917,8 @@ class TestFPParticlePreserveIndices:
         assert nan_counts[-1] > 0, "Some particles should be absorbed by final t"
         # Monotone non-decreasing (no resurrection)
         for t in range(1, 21):
-            assert nan_counts[t] >= nan_counts[t-1], (
-                f"NaN count decreased at t={t}: {nan_counts[t-1]} -> {nan_counts[t]}"
+            assert nan_counts[t] >= nan_counts[t - 1], (
+                f"NaN count decreased at t={t}: {nan_counts[t - 1]} -> {nan_counts[t]}"
             )
 
     def test_preserve_indices_equivalent_absorbed_count(self):
@@ -910,21 +928,24 @@ class TestFPParticlePreserveIndices:
         absorbed_off = 500 - r_off.get_particles(20).shape[0]
         absorbed_on = int(np.sum(np.isnan(r_on.get_particles(20)[:, 0])))
         # Same RNG → identical physics; absorbed count should match exactly
-        assert absorbed_off == absorbed_on, (
-            f"Absorbed totals differ: off={absorbed_off}, on={absorbed_on}"
-        )
+        assert absorbed_off == absorbed_on, f"Absorbed totals differ: off={absorbed_off}, on={absorbed_on}"
 
     def test_preserve_indices_unsupported_paths_raise(self):
         """preserve_indices not yet supported in non-segment-aware paths."""
         from mfgarchon.geometry.boundary import no_flux_bc
+
         Lx, Ly, Nt, T = 4.0, 2.0, 20, 1.0
         bc = no_flux_bc(dimension=2)
         grid = TensorProductGrid([(0, Lx), (0, Ly)], Nx_points=[21, 11], boundary_conditions=bc)
-        problem = MFGProblem(geometry=grid, Nt=Nt, T=T, sigma=0.3,
-                              boundary_conditions=bc, components=_default_components_2d())
+        problem = MFGProblem(
+            geometry=grid, Nt=Nt, T=T, sigma=0.3, boundary_conditions=bc, components=_default_components_2d()
+        )
         solver = FPParticleSolver(
-            problem, num_particles=500, density_mode="query_only",
-            boundary_conditions=bc, preserve_indices=True,
+            problem,
+            num_particles=500,
+            density_mode="query_only",
+            boundary_conditions=bc,
+            preserve_indices=True,
         )
         np.random.seed(0)
         init = np.random.uniform([0.5, 0.5], [1.5, 1.5], (500, 2))
@@ -932,7 +953,9 @@ class TestFPParticlePreserveIndices:
             solver.solve_fp_system(
                 initial_particles=init,
                 drift_field=lambda t, x, m: np.column_stack([np.full(len(x), 2.0), np.zeros(len(x))]),
-                volatility_field=0.3, drift_needs_density=False, show_progress=False,
+                volatility_field=0.3,
+                drift_needs_density=False,
+                show_progress=False,
             )
 
 

--- a/tests/unit/test_alg/test_ghost_nodes_mixed_bc.py
+++ b/tests/unit/test_alg/test_ghost_nodes_mixed_bc.py
@@ -180,8 +180,7 @@ def test_compute_outward_normal_matches_bulk_method_on_eps_boundary():
             single,
             bulk_normals[local_idx],
             atol=1e-12,
-            err_msg=f"Dual-source mismatch at pt {global_idx}: "
-            f"single={single}, bulk={bulk_normals[local_idx]}",
+            err_msg=f"Dual-source mismatch at pt {global_idx}: single={single}, bulk={bulk_normals[local_idx]}",
         )
 
 
@@ -251,26 +250,14 @@ def test_apply_ghost_nodes_fires_on_mixed_bc_neumann_points():
 
     handler = s._boundary_handler
     # Count points classified as exit (Dirichlet) vs wall (Neumann)
-    n_exit = sum(
-        1
-        for i in bdry_idx
-        if s._bc_segment_per_point[int(i)].bc_type == BCType.DIRICHLET
-    )
-    n_wall = sum(
-        1
-        for i in bdry_idx
-        if s._bc_segment_per_point[int(i)].bc_type in (BCType.NEUMANN, BCType.NO_FLUX)
-    )
+    n_exit = sum(1 for i in bdry_idx if s._bc_segment_per_point[int(i)].bc_type == BCType.DIRICHLET)
+    n_wall = sum(1 for i in bdry_idx if s._bc_segment_per_point[int(i)].bc_type in (BCType.NEUMANN, BCType.NO_FLUX))
     # Setup sanity: at least one of each must exist
     assert n_wall > 0
     assert n_exit > 0
 
     # Ghost augmentation should fire on the n_wall Neumann points
-    n_ghosted = sum(
-        1
-        for i in bdry_idx
-        if handler.neighborhoods.get(int(i), {}).get("has_ghost", False)
-    )
+    n_ghosted = sum(1 for i in bdry_idx if handler.neighborhoods.get(int(i), {}).get("has_ghost", False))
     assert n_ghosted == n_wall, (
         f"Expected {n_wall} ghost-augmented points (one per NO_FLUX boundary pt), "
         f"got {n_ghosted}. Bug A regression: ghost augmentation no longer fires "
@@ -281,9 +268,7 @@ def test_apply_ghost_nodes_fires_on_mixed_bc_neumann_points():
         i = int(i)
         if s._bc_segment_per_point[i].bc_type == BCType.DIRICHLET:
             has_ghost = handler.neighborhoods.get(i, {}).get("has_ghost", False)
-            assert not has_ghost, (
-                f"Exit point pt {i} has ghost augmentation — should be skipped for Dirichlet"
-            )
+            assert not has_ghost, f"Exit point pt {i} has ghost augmentation — should be skipped for Dirichlet"
 
 
 def test_apply_ghost_nodes_skips_when_periodic_default():
@@ -317,14 +302,8 @@ def test_apply_ghost_nodes_skips_when_periodic_default():
             monotonicity_scheme="none",
         )
     handler = s._boundary_handler
-    n_ghosted = sum(
-        1
-        for i in bdry_idx
-        if handler.neighborhoods.get(int(i), {}).get("has_ghost", False)
-    )
-    assert n_ghosted == 0, (
-        f"Periodic BC should not trigger ghost augmentation, got {n_ghosted}"
-    )
+    n_ghosted = sum(1 for i in bdry_idx if handler.neighborhoods.get(int(i), {}).get("has_ghost", False))
+    assert n_ghosted == 0, f"Periodic BC should not trigger ghost augmentation, got {n_ghosted}"
 
 
 def test_apply_ghost_nodes_legacy_uniform_neumann_still_works():
@@ -376,9 +355,5 @@ def test_apply_ghost_nodes_legacy_uniform_neumann_still_works():
     # reflection proceed without hitting the post-#1113 raise for empty
     # interior-side neighbors.
     handler.apply_ghost_nodes_to_neighborhoods()
-    n_ghosted = sum(
-        1
-        for i in bdry_idx
-        if handler.neighborhoods[int(i)].get("has_ghost", False)
-    )
+    n_ghosted = sum(1 for i in bdry_idx if handler.neighborhoods[int(i)].get("has_ghost", False))
     assert n_ghosted > 0, "Legacy uniform-NEUMANN call must trigger ghost augmentation"

--- a/tests/unit/test_alg/test_hjb_gfdm_bc_classification.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_bc_classification.py
@@ -108,13 +108,18 @@ def _mixed_bc_with_exit(LX: float, LY: float, exit_y_lo=0.4, exit_y_hi=0.6):
             BCSegment(name="left", bc_type=BCType.NO_FLUX, boundary="x_min"),
             BCSegment(name="bottom", bc_type=BCType.NO_FLUX, boundary="y_min"),
             BCSegment(name="top", bc_type=BCType.NO_FLUX, boundary="y_max"),
-            BCSegment(name="right_below", bc_type=BCType.NO_FLUX,
-                      boundary="x_max", region={"y": (0.0, exit_y_lo * LY)}),
-            BCSegment(name="right_above", bc_type=BCType.NO_FLUX,
-                      boundary="x_max", region={"y": (exit_y_hi * LY, LY)}),
-            BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=0.0,
-                      boundary="x_max", region={"y": (exit_y_lo * LY, exit_y_hi * LY)},
-                      priority=1),
+            BCSegment(
+                name="right_below", bc_type=BCType.NO_FLUX, boundary="x_max", region={"y": (0.0, exit_y_lo * LY)}
+            ),
+            BCSegment(name="right_above", bc_type=BCType.NO_FLUX, boundary="x_max", region={"y": (exit_y_hi * LY, LY)}),
+            BCSegment(
+                name="exit",
+                bc_type=BCType.DIRICHLET,
+                value=0.0,
+                boundary="x_max",
+                region={"y": (exit_y_lo * LY, exit_y_hi * LY)},
+                priority=1,
+            ),
         ],
         dimension=2,
     )
@@ -147,12 +152,12 @@ def _build_solver(points, boundary_idx, bc, geometry, scheme="none"):
 @pytest.mark.parametrize(
     "LX,LY,eps",
     [
-        (1.0, 1.0, 0.0),       # exactly on wall
-        (1.0, 1.0, 1e-7),      # well inside tol
-        (1.0, 1.0, 1e-6),      # at tol boundary
-        (10.0, 10.0, 1e-6),    # moderate bound + tol-boundary ε
-        (20.0, 10.0, 1e-6),    # the stageC case (FP rounding regime)
-        (100.0, 50.0, 1e-6),   # larger bound, tighter relative
+        (1.0, 1.0, 0.0),  # exactly on wall
+        (1.0, 1.0, 1e-7),  # well inside tol
+        (1.0, 1.0, 1e-6),  # at tol boundary
+        (10.0, 10.0, 1e-6),  # moderate bound + tol-boundary ε
+        (20.0, 10.0, 1e-6),  # the stageC case (FP rounding regime)
+        (100.0, 50.0, 1e-6),  # larger bound, tighter relative
     ],
 )
 def test_preclassify_eps_off_wall(LX, LY, eps):
@@ -232,8 +237,7 @@ def test_identify_face_domain_bounds_override():
     )
     # Override to [0, 1]: point at x=0.9 should now classify as on x_max
     override = np.array([[0.0, 1.0], [0.0, 1.0]])
-    face = bc.identify_boundary_face(np.array([1.0, 0.5]), tolerance=1e-6,
-                                      domain_bounds=override)
+    face = bc.identify_boundary_face(np.array([1.0, 0.5]), tolerance=1e-6, domain_bounds=override)
     assert face is not None
     assert face.axis == 0 and face.side == "max"
 
@@ -254,6 +258,7 @@ def test_identify_face_domain_bounds_override():
 )
 def test_outward_normal_for_face_2d(axis, side, expected):
     from mfgarchon.geometry.boundary.types import BoundaryFace
+
     bc = BoundaryConditions(segments=[], dimension=2)
     normal = bc.outward_normal_for_face(BoundaryFace(axis, side), dimension=2)
     np.testing.assert_array_equal(normal, expected)
@@ -270,6 +275,7 @@ def test_outward_normal_for_face_2d(axis, side, expected):
 )
 def test_outward_normal_for_face_3d(axis, side, expected):
     from mfgarchon.geometry.boundary.types import BoundaryFace
+
     bc = BoundaryConditions(segments=[], dimension=3)
     normal = bc.outward_normal_for_face(BoundaryFace(axis, side), dimension=3)
     np.testing.assert_array_equal(normal, expected)
@@ -296,10 +302,8 @@ def test_preclassify_corner_priority():
     # left has higher priority than bottom
     bc = BoundaryConditions(
         segments=[
-            BCSegment(name="left", bc_type=BCType.DIRICHLET, value=1.0,
-                      boundary="x_min", priority=10),
-            BCSegment(name="bottom", bc_type=BCType.NO_FLUX,
-                      boundary="y_min", priority=1),
+            BCSegment(name="left", bc_type=BCType.DIRICHLET, value=1.0, boundary="x_min", priority=10),
+            BCSegment(name="bottom", bc_type=BCType.NO_FLUX, boundary="y_min", priority=1),
         ],
         dimension=2,
     )
@@ -307,8 +311,7 @@ def test_preclassify_corner_priority():
     # The corner point should be assigned to "left" (higher priority)
     assigned = solver._bc_segment_per_point[int(boundary_idx[0])]
     assert assigned.name == "left", (
-        f"Corner point at (eps, eps) should bind to higher-priority segment 'left', "
-        f"got {assigned.name!r}"
+        f"Corner point at (eps, eps) should bind to higher-priority segment 'left', got {assigned.name!r}"
     )
 
 
@@ -341,9 +344,7 @@ def test_preclassify_unmatched_raises_with_coords():
     assert "pre-classification failed" in msg
     # Coordinate of an unmatched x_max point must appear in message
     # (x ≈ LX = 10.0 with eps offset)
-    assert "9.99" in msg or "10.0" in msg, (
-        "Unmatched right-wall coords should be greppable from the error message"
-    )
+    assert "9.99" in msg or "10.0" in msg, "Unmatched right-wall coords should be greppable from the error message"
     # BoundaryFace info must be in message
     assert "y_min" in msg or "y_max" in msg or "x_max" in msg or "BoundaryFace" in msg
 
@@ -361,12 +362,11 @@ def test_preclassify_uniform_bc_skipped():
 
     # Uniform Dirichlet — not mixed
     from mfgarchon.geometry.boundary import dirichlet_bc
+
     bc = dirichlet_bc(value=0.0, dimension=2)
 
     solver = _build_solver(points, boundary_idx, bc, geom)
-    assert len(solver._bc_segment_per_point) == 0, (
-        "Uniform BC must skip pre-classification (legacy fast path)"
-    )
+    assert len(solver._bc_segment_per_point) == 0, "Uniform BC must skip pre-classification (legacy fast path)"
 
 
 # ---------------------------------------------------------------------------
@@ -504,9 +504,11 @@ def test_dispatch_robin_zero_alpha_builds_neumann_row():
     g = 0.5
 
     def _bc(left_type):
-        segs = [BCSegment(name="bottom", bc_type=BCType.NO_FLUX, boundary="y_min"),
-                BCSegment(name="top", bc_type=BCType.NO_FLUX, boundary="y_max"),
-                BCSegment(name="right", bc_type=BCType.NO_FLUX, boundary="x_max")]
+        segs = [
+            BCSegment(name="bottom", bc_type=BCType.NO_FLUX, boundary="y_min"),
+            BCSegment(name="top", bc_type=BCType.NO_FLUX, boundary="y_max"),
+            BCSegment(name="right", bc_type=BCType.NO_FLUX, boundary="x_max"),
+        ]
         if left_type == "robin":
             segs.insert(0, BCSegment(name="left", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0, value=g, boundary="x_min"))
         else:
@@ -597,6 +599,7 @@ def test_stress_thousand_boundary_points():
     bc = _mixed_bc_with_exit(LX, LY)
 
     import time as _time
+
     t0 = _time.perf_counter()
     solver = _build_solver(points, boundary_idx, bc, geom)
     t_init = _time.perf_counter() - t0

--- a/tests/unit/test_alg/test_hjb_gfdm_bc_newton_residual.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_bc_newton_residual.py
@@ -15,6 +15,7 @@ interior AND boundary rows, for problems where the pre-fix code visibly broke
 See docs/bug_reports/2026_05_hjb_bc_newton_mismatch.md for full evidence and
 the diagnostic protocol this test codifies.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -53,16 +54,23 @@ def _mixed_bc_walls_and_exit(LX: float, LY: float):
             BCSegment(name="bottom", bc_type=BCType.NO_FLUX, boundary="y_min"),
             BCSegment(name="top", bc_type=BCType.NO_FLUX, boundary="y_max"),
             BCSegment(
-                name="right_below", bc_type=BCType.NO_FLUX,
-                boundary="x_max", region={"y": (0.0, 0.4 * LY)},
+                name="right_below",
+                bc_type=BCType.NO_FLUX,
+                boundary="x_max",
+                region={"y": (0.0, 0.4 * LY)},
             ),
             BCSegment(
-                name="right_above", bc_type=BCType.NO_FLUX,
-                boundary="x_max", region={"y": (0.6 * LY, LY)},
+                name="right_above",
+                bc_type=BCType.NO_FLUX,
+                boundary="x_max",
+                region={"y": (0.6 * LY, LY)},
             ),
             BCSegment(
-                name="exit", bc_type=BCType.DIRICHLET, value=0.0,
-                boundary="x_max", region={"y": (0.4 * LY, 0.6 * LY)},
+                name="exit",
+                bc_type=BCType.DIRICHLET,
+                value=0.0,
+                boundary="x_max",
+                region={"y": (0.4 * LY, 0.6 * LY)},
                 priority=1,
             ),
         ],
@@ -112,13 +120,23 @@ def _residual_and_jacobian_with_bc(solver, u_current, u_n_plus_1, m_n_plus_1, ti
     """
     all_derivs = solver._approximate_all_derivatives_cached(u_current)
     residual = solver._compute_hjb_residual_with_cache(
-        u_current, u_n_plus_1, m_n_plus_1, time_idx, all_derivs,
+        u_current,
+        u_n_plus_1,
+        m_n_plus_1,
+        time_idx,
+        all_derivs,
     )
     jacobian_sparse = solver._compute_hjb_jacobian_sparse(
-        u_current, m_n_plus_1, time_idx, all_derivs,
+        u_current,
+        m_n_plus_1,
+        time_idx,
+        all_derivs,
     )
     jacobian_bc, residual_bc = solver._apply_boundary_conditions_to_sparse_system(
-        jacobian_sparse, residual, time_idx, u_current,
+        jacobian_sparse,
+        residual,
+        time_idx,
+        u_current,
     )
     return jacobian_bc, residual_bc
 
@@ -149,9 +167,7 @@ def test_fd_jacobian_matches_analytic_on_all_rows(eps, seed):
     points = solver.collocation_points
     rng = np.random.default_rng(seed)
     u_current = (
-        0.3 * points[:, 0] * points[:, 1]
-        + 0.1 * np.sin(2 * np.pi * points[:, 0])
-        + 0.05 * rng.standard_normal(n)
+        0.3 * points[:, 0] * points[:, 1] + 0.1 * np.sin(2 * np.pi * points[:, 0]) + 0.05 * rng.standard_normal(n)
     )
     u_n_plus_1 = u_current + 0.01 * rng.standard_normal(n)
     m_n_plus_1 = 1.0 + 0.1 * rng.standard_normal(n)
@@ -159,7 +175,11 @@ def test_fd_jacobian_matches_analytic_on_all_rows(eps, seed):
 
     # Reference (J, r) at u_current
     J_bc, r_bc = _residual_and_jacobian_with_bc(
-        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx,
+        solver,
+        u_current,
+        u_n_plus_1,
+        m_n_plus_1,
+        time_idx,
     )
 
     # Direction: random unit vector
@@ -169,7 +189,11 @@ def test_fd_jacobian_matches_analytic_on_all_rows(eps, seed):
     # FD: (r(u + ε d) - r(u)) / ε, evaluated through the SAME BC path
     u_pert = u_current + eps * d
     _, r_bc_pert = _residual_and_jacobian_with_bc(
-        solver, u_pert, u_n_plus_1, m_n_plus_1, time_idx,
+        solver,
+        u_pert,
+        u_n_plus_1,
+        m_n_plus_1,
+        time_idx,
     )
     Jd_fd = (r_bc_pert - r_bc) / eps
     Jd_analytic = J_bc.dot(d)
@@ -180,18 +204,13 @@ def test_fd_jacobian_matches_analytic_on_all_rows(eps, seed):
     if bd_idx.size > 0:
         int_mask[bd_idx] = False
 
-    int_rel = (
-        float(np.linalg.norm(Jd_fd[int_mask] - Jd_analytic[int_mask]))
-        / max(float(np.linalg.norm(Jd_analytic[int_mask])), 1e-30)
+    int_rel = float(np.linalg.norm(Jd_fd[int_mask] - Jd_analytic[int_mask])) / max(
+        float(np.linalg.norm(Jd_analytic[int_mask])), 1e-30
     )
-    bd_rel = (
-        float(np.linalg.norm(Jd_fd[~int_mask] - Jd_analytic[~int_mask]))
-        / max(float(np.linalg.norm(Jd_analytic[~int_mask])), 1e-30)
+    bd_rel = float(np.linalg.norm(Jd_fd[~int_mask] - Jd_analytic[~int_mask])) / max(
+        float(np.linalg.norm(Jd_analytic[~int_mask])), 1e-30
     )
-    full_rel = (
-        float(np.linalg.norm(Jd_fd - Jd_analytic))
-        / max(float(np.linalg.norm(Jd_analytic)), 1e-30)
-    )
+    full_rel = float(np.linalg.norm(Jd_fd - Jd_analytic)) / max(float(np.linalg.norm(Jd_analytic)), 1e-30)
 
     # ε=1e-6 gives O(ε * |H_uu|) truncation; with |u|, |∇u| ~ O(1) and quadratic
     # Hamiltonian, this stays ≤ 1e-4. ε=1e-5 stays ≤ 1e-3.
@@ -264,7 +283,11 @@ def test_1d_dirichlet_bc_zero_zero_init_residual_is_zero_at_boundary():
     m_n_plus_1 = np.ones(n)
 
     _, r_bc = _residual_and_jacobian_with_bc(
-        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx=problem.Nt - 1,
+        solver,
+        u_current,
+        u_n_plus_1,
+        m_n_plus_1,
+        time_idx=problem.Nt - 1,
     )
 
     for i in solver.boundary_indices:
@@ -321,7 +344,11 @@ def test_1d_dirichlet_bc_nonzero_uses_violation():
     m_n_plus_1 = np.ones(n)
 
     _, r_bc = _residual_and_jacobian_with_bc(
-        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx=problem.Nt - 1,
+        solver,
+        u_current,
+        u_n_plus_1,
+        m_n_plus_1,
+        time_idx=problem.Nt - 1,
     )
 
     for i in solver.boundary_indices:
@@ -388,15 +415,17 @@ def test_neumann_bc_residual_encodes_current_violation():
     m_n_plus_1 = np.ones(n)
 
     J_bc, r_bc = _residual_and_jacobian_with_bc(
-        solver, u_current, u_n_plus_1, m_n_plus_1, time_idx=problem.Nt - 1,
+        solver,
+        u_current,
+        u_n_plus_1,
+        m_n_plus_1,
+        time_idx=problem.Nt - 1,
     )
 
     boundary_indices = list(solver.boundary_indices)
     assert len(boundary_indices) > 0
     # Linear u has |w·u_current| O(1); residual must reflect that, not be 0.
-    boundary_residual_norm = float(np.linalg.norm(
-        np.array([r_bc[int(i)] for i in boundary_indices])
-    ))
+    boundary_residual_norm = float(np.linalg.norm(np.array([r_bc[int(i)] for i in boundary_indices])))
     assert boundary_residual_norm > 0.1, (
         f"Neumann BC residual on linear u (w·u ≠ 0) must be non-zero, "
         f"got |r_bc[bd]|={boundary_residual_norm:.3e}. Pre-#1116 this was "
@@ -409,6 +438,5 @@ def test_neumann_bc_residual_encodes_current_violation():
         row = J_bc.getrow(i_int).toarray().flatten()
         analytic_violation = float(row @ u_current)
         assert abs(float(r_bc[i_int]) - analytic_violation) < 1e-12, (
-            f"Neumann residual at i={i_int} should equal w·u_current = "
-            f"{analytic_violation}, got {float(r_bc[i_int])}."
+            f"Neumann residual at i={i_int} should equal w·u_current = {analytic_violation}, got {float(r_bc[i_int])}."
         )

--- a/tests/unit/test_alg/test_hjb_gfdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_solver.py
@@ -122,7 +122,8 @@ class TestHJBGFDMSolverInitialization:
         ]
         for scheme, application, expected_name in configs:
             solver = HJBGFDMSolver(
-                problem, collocation_points,
+                problem,
+                collocation_points,
                 monotonicity_scheme=scheme,
                 monotonicity_application=application,
             )
@@ -149,9 +150,7 @@ class TestHJBGFDMSolverInitialization:
         noise so it cannot flood the log.)
         """
         n = 15
-        grid = TensorProductGrid(
-            bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1)
-        )
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
         H = SeparableHamiltonian(
             control_cost=QuadraticControlCost(control_cost=1.0),
             coupling=lambda m: 0.0 * np.asarray(m),
@@ -172,8 +171,11 @@ class TestHJBGFDMSolverInitialization:
         sols = {}
         for scheme, application in configs:
             solver = HJBGFDMSolver(
-                problem, cp, delta=0.3,
-                monotonicity_scheme=scheme, monotonicity_application=application,
+                problem,
+                cp,
+                delta=0.3,
+                monotonicity_scheme=scheme,
+                monotonicity_application=application,
             )
             U = solver.solve_hjb_system(M_density=M_density, U_terminal=U_terminal, show_progress=False)
             assert np.all(np.isfinite(U)), f"{scheme}/{application} produced non-finite U"
@@ -198,9 +200,7 @@ class TestHJBGFDMSolverInitialization:
         import warnings
 
         n = 11
-        grid = TensorProductGrid(
-            bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1)
-        )
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
         H = SeparableHamiltonian(
             control_cost=QuadraticControlCost(control_cost=1.0),
             coupling=lambda m: 0.0 * np.asarray(m),
@@ -214,17 +214,22 @@ class TestHJBGFDMSolverInitialization:
         )
         problem = MFGProblem(geometry=grid, T=0.02, Nt=4, sigma=0.5, components=comps)
         solver = HJBGFDMSolver(
-            problem, x.reshape(-1, 1), delta=0.3,
-            monotonicity_scheme="qp_m_matrix", monotonicity_application="always",
+            problem,
+            x.reshape(-1, 1),
+            delta=0.3,
+            monotonicity_scheme="qp_m_matrix",
+            monotonicity_application="always",
         )
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             solver.solve_hjb_system(
                 M_density=np.ones((problem.Nt + 1, n)),
-                U_terminal=np.cos(np.pi * x), show_progress=False,
+                U_terminal=np.cos(np.pi * x),
+                show_progress=False,
             )
         offenders = [
-            str(w.message) for w in caught
+            str(w.message)
+            for w in caught
             if "polish" in str(w.message).lower() or "raise_error" in str(w.message).lower()
         ]
         assert not offenders, f"OSQP polish/raise_error deprecation leaked: {offenders[:3]}"
@@ -601,11 +606,15 @@ class TestHJBGFDMSigmaConvention:
 
     def _make_solver(self, sigma):
         domain = TensorProductGrid(
-            bounds=[(0.0, 1.0)], Nx_points=[21],
+            bounds=[(0.0, 1.0)],
+            Nx_points=[21],
             boundary_conditions=no_flux_bc(dimension=1),
         )
         problem = MFGProblem(
-            geometry=domain, T=0.1, Nt=10, sigma=sigma,
+            geometry=domain,
+            T=0.1,
+            Nt=10,
+            sigma=sigma,
             components=_default_components(),
         )
         x_coords = np.linspace(0, 1, 11)
@@ -630,7 +639,7 @@ class TestHJBGFDMSigmaConvention:
         sigma_returned = solver._get_sigma_value(None)
         assert abs(sigma_returned - sigma) < 1e-12, (
             f"_get_sigma_value() returned {sigma_returned}, expected σ = {sigma}. "
-            f"If it returned σ²/2 = {sigma**2/2}, the Issue #1073 regression has returned."
+            f"If it returned σ²/2 = {sigma**2 / 2}, the Issue #1073 regression has returned."
         )
 
     @pytest.mark.parametrize("sigma", [0.3, 0.5, 1.0])
@@ -647,7 +656,7 @@ class TestHJBGFDMSigmaConvention:
         assert abs(diffusion_coeff - expected_D) < 1e-12, (
             f"σ={sigma}: diffusion coefficient = {diffusion_coeff}, "
             f"expected D = σ²/2 = {expected_D}. If diffusion = (σ²/2)²/2 = "
-            f"{(sigma**2/2)**2 / 2}, Issue #1073 regression."
+            f"{(sigma**2 / 2) ** 2 / 2}, Issue #1073 regression."
         )
 
 

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -660,10 +660,22 @@ def _adjoint_robin_bc(sigma=_AC_SIGMA):
 
     return BoundaryConditions(
         segments=[
-            BCSegment(name="left_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
-                      value=AdjointConsistentProvider(side="left", diffusion=sigma), boundary="x_min"),
-            BCSegment(name="right_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
-                      value=AdjointConsistentProvider(side="right", diffusion=sigma), boundary="x_max"),
+            BCSegment(
+                name="left_ac",
+                bc_type=BCType.ROBIN,
+                alpha=0.0,
+                beta=1.0,
+                value=AdjointConsistentProvider(side="left", diffusion=sigma),
+                boundary="x_min",
+            ),
+            BCSegment(
+                name="right_ac",
+                bc_type=BCType.ROBIN,
+                alpha=0.0,
+                beta=1.0,
+                value=AdjointConsistentProvider(side="right", diffusion=sigma),
+                boundary="x_max",
+            ),
         ],
         dimension=1,
     )
@@ -690,9 +702,7 @@ def test_howard_robin_row_target_tracks_resolved_adjoint_g():
     bi_left, bi_right = int(bdry[0]), int(bdry[1])  # lower 1e-7 -> x_min, upper -> x_max
 
     def resolve_refresh_and_read(m):
-        resolved = bc.with_resolved_providers(
-            {"m_current": m, "geometry": prov_geom, "diffusion": _AC_SIGMA}
-        )
+        resolved = bc.with_resolved_providers({"m_current": m, "geometry": prov_geom, "diffusion": _AC_SIGMA})
         assert resolved is not bc  # new object -> Part-1 refresh fires
         assert resolved.segments[0].bc_type is BCType.ROBIN  # stays ROBIN, value -> float
         geom.boundary_conditions = resolved
@@ -742,10 +752,22 @@ def test_howard_unresolved_provider_fails_loud():
 
     bc = BoundaryConditions(
         segments=[
-            BCSegment(name="left_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
-                      value=AdjointConsistentProvider(side="left", diffusion=0.3), boundary="x_min"),
-            BCSegment(name="right_ac", bc_type=BCType.ROBIN, alpha=0.0, beta=1.0,
-                      value=AdjointConsistentProvider(side="right", diffusion=0.3), boundary="x_max"),
+            BCSegment(
+                name="left_ac",
+                bc_type=BCType.ROBIN,
+                alpha=0.0,
+                beta=1.0,
+                value=AdjointConsistentProvider(side="left", diffusion=0.3),
+                boundary="x_min",
+            ),
+            BCSegment(
+                name="right_ac",
+                bc_type=BCType.ROBIN,
+                alpha=0.0,
+                beta=1.0,
+                value=AdjointConsistentProvider(side="right", diffusion=0.3),
+                boundary="x_max",
+            ),
         ],
         dimension=1,
     )

--- a/tests/unit/test_alg/test_precomputed_monotone_stencils.py
+++ b/tests/unit/test_alg/test_precomputed_monotone_stencils.py
@@ -92,9 +92,7 @@ def test_dimension_3d_rejected():
     is_b[:5] = True
     nh = {i: {"indices": np.arange(20, dtype=int)} for i in range(20)}
     with pytest.raises(ValueError, match="1D or 2D"):
-        PrecomputedMonotoneStencils(
-            is_boundary=is_b, neighborhoods=nh, points=pts, delta=1.5
-        )
+        PrecomputedMonotoneStencils(is_boundary=is_b, neighborhoods=nh, points=pts, delta=1.5)
 
 
 # ---------------------------------------------------------------------------
@@ -109,9 +107,7 @@ def test_matched_neighborhoods_produces_m_matrix_compliant_stencils():
     """
     pts, nh, is_b = _build_2d_grid_with_neighborhoods()
 
-    precomp = PrecomputedMonotoneStencils(
-        is_boundary=is_b, neighborhoods=nh, points=pts, delta=1.5
-    )
+    precomp = PrecomputedMonotoneStencils(is_boundary=is_b, neighborhoods=nh, points=pts, delta=1.5)
 
     assert precomp.stats["n_boundary"] == int(is_b.sum())
     for i in np.where(is_b)[0]:
@@ -147,9 +143,7 @@ def test_enlarged_neighborhoods_produces_correct_length_weights():
         idx = np.asarray(tree.query_ball_point(pts[i], r=3.0), dtype=int)
         enlarged_nh[i] = {"indices": idx}
 
-    precomp = PrecomputedMonotoneStencils(
-        is_boundary=is_b, neighborhoods=enlarged_nh, points=pts, delta=1.5
-    )
+    precomp = PrecomputedMonotoneStencils(is_boundary=is_b, neighborhoods=enlarged_nh, points=pts, delta=1.5)
 
     for i in np.where(is_b)[0]:
         i = int(i)
@@ -158,8 +152,7 @@ def test_enlarged_neighborhoods_produces_correct_length_weights():
         n_enlarged = len(enlarged_nh[i]["indices"])
         n_base = len(base_nh[i]["indices"])
         assert n_enlarged > n_base, (
-            f"test fixture broken at point {i}: r=3 not larger than k=8 "
-            f"({n_enlarged} <= {n_base})"
+            f"test fixture broken at point {i}: r=3 not larger than k=8 ({n_enlarged} <= {n_base})"
         )
         assert len(sd.weights) == n_enlarged, (
             f"point {i}: L_w length {len(sd.weights)} != enlarged stencil "

--- a/tests/unit/test_alg/test_socp_m_matrix_property.py
+++ b/tests/unit/test_alg/test_socp_m_matrix_property.py
@@ -36,9 +36,7 @@ except ImportError:
     _HAS_CVXPY = False
 
 
-pytestmark = pytest.mark.skipif(
-    not _HAS_CVXPY, reason="cvxpy not installed; joint_socp tests skipped"
-)
+pytestmark = pytest.mark.skipif(not _HAS_CVXPY, reason="cvxpy not installed; joint_socp tests skipped")
 
 
 def _make_solver(sigma: float, n_x: int = 21):
@@ -62,9 +60,7 @@ def _make_solver(sigma: float, n_x: int = 21):
             coupling_dm=lambda m: np.ones_like(np.asarray(m)),
         ),
     )
-    problem = MFGProblem(
-        geometry=geometry, T=0.5, Nt=10, sigma=sigma, components=components
-    )
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=sigma, components=components)
     bounds = problem.geometry.get_bounds()
     x_coords = np.linspace(bounds[0][0], bounds[1][0], n_x)
     collocation_points = x_coords.reshape(-1, 1)
@@ -106,8 +102,7 @@ def test_socp_stencil_off_diagonal_nonnegative(sigma):
         L_off = np.delete(L, center)
         # Allow tiny SOCP slop (eps_pos default = 0)
         assert np.all(L_off >= -1e-9), (
-            f"point {idx}: min(L_off) = {L_off.min():.3e}, "
-            f"expected >= 0 (M-matrix off-diagonal sign)"
+            f"point {idx}: min(L_off) = {L_off.min():.3e}, expected >= 0 (M-matrix off-diagonal sign)"
         )
 
 
@@ -123,9 +118,7 @@ def test_socp_stencil_center_nonpositive(sigma):
         L = stencil.L
         center = stencil.center_in_neighbors
         L_center = L[center]
-        assert L_center <= 1e-9, (
-            f"point {idx}: L_center = {L_center:.3e}, expected <= 0"
-        )
+        assert L_center <= 1e-9, f"point {idx}: L_center = {L_center:.3e}, expected <= 0"
 
 
 @pytest.mark.parametrize("sigma", [0.5, 1.0, 1.5])
@@ -195,8 +188,7 @@ def test_socp_at_least_some_feasible():
     # At low Pe with σ=1, expect majority feasibility. Stage 1/2 paper
     # baseline reports >85% at N>=75.
     assert n_feasible > 0, (
-        f"sigma=1 low-Pe: 0/{total} stencils SOCP-feasible — "
-        f"joint_socp scheme producing no usable stencils"
+        f"sigma=1 low-Pe: 0/{total} stencils SOCP-feasible — joint_socp scheme producing no usable stencils"
     )
 
 

--- a/tests/unit/test_operators/test_stencils.py
+++ b/tests/unit/test_operators/test_stencils.py
@@ -410,9 +410,7 @@ class TestBackendRollEquivalence:
 
         # tensor_calculus operators (backend=) -- pre-fix raised TypeError on roll(axis=)
         assert np.allclose(laplacian(t, sp, backend=be).numpy(), laplacian(a, sp))
-        assert np.allclose(
-            divergence([t, t * 2], sp, backend=be).numpy(), divergence([a, a * 2], sp)
-        )
+        assert np.allclose(divergence([t, t * 2], sp, backend=be).numpy(), divergence([a, a * 2], sp))
         assert np.allclose(hessian(t, sp, backend=be).numpy(), hessian(a, sp))
 
         # stencil module (xp = torch module directly), the path the GPU particle solver hits
@@ -420,9 +418,7 @@ class TestBackendRollEquivalence:
         assert np.allclose(g_t.numpy(), gradient_central(a, axis=1, h=0.1, xp=np))
         assert all(
             np.allclose(x.numpy(), y)
-            for x, y in zip(
-                gradient_nd(t, sp, xp=be.array_module), gradient_nd(a, sp, xp=np), strict=True
-            )
+            for x, y in zip(gradient_nd(t, sp, xp=be.array_module), gradient_nd(a, sp, xp=np), strict=True)
         )
 
 


### PR DESCRIPTION
## Summary

A codebase-cleanliness check found **11 test files failing `ruff format --check`** — pre-existing format drift (committed without, or with an older, ruff-format). The CI Quick-Validation gate is **diff-scoped**, so it never reformats files a PR doesn't touch; the drift accumulated unnoticed.

Pure formatting (whitespace / line reflow) — **no test logic changed**. All 11 collect cleanly; `ruff format --check tests/` is now fully clean (243 files).

## Files
`test_diffusion_magnitude_gate`, `test_mass_conservation_1d`, `test_fp_particle_solver`, `test_ghost_nodes_mixed_bc`, `test_hjb_gfdm_bc_classification`, `test_hjb_gfdm_bc_newton_residual`, `test_hjb_gfdm_solver`, `test_hjb_howard_solver`, `test_precomputed_monotone_stencils`, `test_socp_m_matrix_property`, `test_stencils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)