### PR TITLE
fix: NewtonMFGSolver diverged ~99.5% from Picard (#1233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`NewtonMFGSolver` diverged ~99.5% from Picard** (Issue #1233). The Newton coupling residual
+  `F = [HJB(M) - U, FP(U) - M]` was inconsistent with the Picard fixed point, so the two solvers
+  converged to different roots. Two causes: **(1) stale FP drift convention** — `MFGResidual`
+  passed the value function as `drift_field`, but the v0.18.6 rename redefined `drift_field` as
+  the *velocity* $\alpha^*$ (the old U-potential entry point became `potential_field`); the
+  Picard `FixedPointIterator` was updated (#896/#919) while `MFGResidual` was not, so
+  `||F_FP(Picard soln)||` was O(10) instead of ~0. The drift/potential resolution is now
+  **single-sourced** in `resolve_fp_drift_kwargs` + `compute_fp_velocity_field`
+  (`fixed_point_utils`), shared by both `FixedPointIterator` and `MFGResidual` — the
+  `FixedPointIterator` FDM path is **byte-identical** (verified `max|Δ|=0` on 1D-LQ `U`/`M`).
+  **(2) basin selection** — even with a consistent residual, a too-short Picard warmup (3) left
+  the iterate in the basin of a spurious near-trivial discrete fixed point; Newton (a local
+  root-finder, line search cannot escape a basin) locked onto it. Documented the warmup-basin
+  requirement; the comparison test now warms up adequately. Also **defaulted
+  `use_jax_autodiff=False`** for `NewtonMFGSolver`: the residual wraps black-box numpy/scipy
+  solvers that JAX cannot trace, so `'auto'` was a guaranteed `TracerArrayConversionError` +
+  FD-fallback warning on every run (the option is retained for a hypothetical jnp-native
+  residual). Added fast, non-`slow` guards (`tests/integration/test_newton_picard_agreement.py`):
+  the realistic-grid comparison is `slow` (skipped on PRs), which is why this stayed red on
+  `main` undetected. (`multi_population_iterator` keeps its own *node*-centered velocity copy —
+  a different convention — and is left as a tracked third copy, not folded in here.)
+
 - **FEM named-region BC silently unresolved: no facet boundary tags** (Issue #607; coupled-FEM
   chain, seam 2). `meshdata_to_skfem` produced a skfem mesh with `mesh.boundaries = None`, so a
   `BCSegment(boundary="x_min")` could not be resolved — the FEM `bc_adapter` either crashed

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -23,9 +23,11 @@ from mfgarchon.utils.solver_result import SolverResult
 from .base_mfg import BaseCouplingIterator
 from .fixed_point_utils import (
     check_convergence_criteria,
+    compute_fp_velocity_field,
     initialize_cold_start,
     preserve_initial_condition,
     preserve_terminal_condition,
+    resolve_fp_drift_kwargs,
 )
 
 logger = get_logger(__name__)
@@ -443,71 +445,11 @@ class FixedPointIterator(BaseCouplingIterator):
     def _compute_velocity_field(self, U, M, H_class):
         """Compute face-centered velocity α* via H.optimal_control.
 
-        Issue #919: evaluates H.optimal_control at cell interfaces (i+1/2),
-        using forward-difference gradient p_{i+1/2} = (U[i+1]-U[i])/dx.
-        This matches the FDM divergence-upwind stencil exactly.
-
-        Returns
-        -------
-        np.ndarray
-            Face-centered velocity α* at cell interfaces.
-            1D: shape (Nt, Nx-1) — velocity at each face (i+1/2).
-            nD: shape (Nt, ndim, *spatial_shape) — node-centered (nD fallback).
+        Issue #1233: single-sourced through
+        :func:`fixed_point_utils.compute_fp_velocity_field` (shared with the Newton
+        ``MFGResidual``). The face-centered convention (Issue #919) is unchanged.
         """
-        geometry = self.problem.geometry
-        grid_spacing = geometry.get_grid_spacing()
-        dt = self.problem.dt
-        Nt = U.shape[0]
-        spatial_shape = U.shape[1:]
-        ndim = len(spatial_shape)
-
-        bounds = geometry.get_bounds()
-
-        if ndim == 1:
-            dx = grid_spacing[0]
-            Nx = spatial_shape[0]
-
-            # Face centers: x_{i+1/2}
-            x_nodes = np.linspace(bounds[0][0], bounds[1][0], Nx)
-            x_faces = 0.5 * (x_nodes[:-1] + x_nodes[1:])  # (Nx-1,)
-
-            # Face gradient: p_{i+1/2} = (U[i+1] - U[i]) / dx
-            p_faces = np.diff(U, axis=-1) / dx  # (Nt, Nx-1)
-
-            # Face density: m_{i+1/2} = (m[i] + m[i+1]) / 2
-            m_faces = 0.5 * (M[:, :-1] + M[:, 1:])  # (Nt, Nx-1)
-
-            alpha_faces = np.zeros((Nt, Nx - 1))
-            x_arr = x_faces.reshape(-1, 1)
-            for n in range(Nt):
-                m_n = m_faces[n] if n < m_faces.shape[0] else m_faces[-1]
-                p_n = p_faces[n].reshape(-1, 1)
-                alpha_faces[n] = H_class.optimal_control(x_arr, m_n, p_n, t=n * dt).ravel()
-
-            return alpha_faces
-        else:
-            # nD: node-centered fallback (face-centered nD deferred)
-            grad_components = []
-            for d in range(ndim):
-                grad_d = np.gradient(U, grid_spacing[d], axis=d + 1)
-                grad_components.append(grad_d)
-
-            coords = [np.linspace(bounds[0][d], bounds[1][d], spatial_shape[d]) for d in range(ndim)]
-            mesh = np.meshgrid(*coords, indexing="ij")
-            x_grid = np.stack(mesh, axis=-1)
-
-            alpha_field = np.zeros((Nt, ndim, *spatial_shape))
-            for n in range(Nt):
-                p_n = np.stack([grad_components[d][n] for d in range(ndim)], axis=-1)
-                m_n = M[n] if n < M.shape[0] else M[-1]
-                alpha_n = H_class.optimal_control(x_grid, m_n, p_n, t=n * dt)
-                if alpha_n.ndim == ndim + 1:
-                    alpha_field[n] = np.moveaxis(alpha_n, -1, 0)
-                else:
-                    for d in range(ndim):
-                        alpha_field[n, d] = alpha_n
-
-            return alpha_field
+        return compute_fp_velocity_field(self.problem, U, M, H_class)
 
     def solve(
         self,
@@ -760,32 +702,18 @@ class FixedPointIterator(BaseCouplingIterator):
                     source_term=fp_source,
                 )
 
-                # Drift/potential logic (FP-specific, not in _build_fp_kwargs)
+                # Drift/potential logic (FP-specific, not in _build_fp_kwargs).
+                # Issue #1233: single-sourced via resolve_fp_drift_kwargs, shared with
+                # the Newton MFGResidual so both coupling paths use one convention.
                 if self._fp_sig_params is not None:
-                    params = self._fp_sig_params
-                    if self.drift_field is not None:
-                        if "drift_field" in params:
-                            kwargs["drift_field"] = self.drift_field
-                    else:
-                        H_class = self.problem.hamiltonian_class
-                        from mfgarchon.core.hamiltonian import SeparableHamiltonian
-
-                        use_velocity = (
-                            H_class is not None
-                            and "drift_field" in params
-                            and not (isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth())
-                        )
-                        if use_velocity:
-                            kwargs["drift_field"] = self._compute_velocity_field(U_new, M_old, H_class)
-                        elif "potential_field" in params:
-                            kwargs["potential_field"] = U_new
-                        elif "drift_field" in params:
-                            kwargs["drift_field"] = U_new
-
-                    if "drift_field" in params or "potential_field" in params:
-                        M_new = self.fp_solver.solve_fp_system(M_initial, **kwargs)
-                    else:
+                    drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
+                        self.problem, self._fp_sig_params, self.drift_field, U_new, M_old
+                    )
+                    kwargs.update(drift_kwargs)
+                    if use_positional_U:
                         M_new = self.fp_solver.solve_fp_system(M_initial, U_new, **kwargs)
+                    else:
+                        M_new = self.fp_solver.solve_fp_system(M_initial, **kwargs)
                 else:
                     M_new = self.fp_solver.solve_fp_system(M_initial, U_new)
 

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -374,3 +374,151 @@ def preserve_terminal_condition(
     """
     U[-1] = U_terminal
     return U
+
+
+def compute_fp_velocity_field(
+    problem: object,
+    U: np.ndarray,
+    M: np.ndarray,
+    H_class: object,
+) -> np.ndarray:
+    """Compute the face-centered FP advection velocity $\\alpha^*$ from the value function.
+
+    Single-source for the velocity convention shared by the Picard
+    ``FixedPointIterator`` and the Newton ``MFGResidual`` (Issue #1233). Evaluates
+    ``H.optimal_control`` at cell interfaces $x_{i+1/2}$ using the forward-difference
+    gradient $p_{i+1/2} = (U_{i+1} - U_i)/\\Delta x$ (Issue #919), which matches the
+    FDM divergence-upwind stencil exactly.
+
+    Args:
+        problem: MFG problem (provides ``geometry`` and ``dt``).
+        U: Value function, shape ``(Nt+1, *spatial_shape)``.
+        M: Density, shape ``(Nt+1, *spatial_shape)`` (only the own-population density).
+        H_class: Hamiltonian exposing ``optimal_control(x, m, p, t)``.
+
+    Returns:
+        Face-centered velocity $\\alpha^*$.
+        1D: shape ``(Nt, Nx-1)`` — velocity at each face $(i+1/2)$.
+        nD: shape ``(Nt, ndim, *spatial_shape)`` — node-centered (nD fallback).
+    """
+    geometry = problem.geometry
+    grid_spacing = geometry.get_grid_spacing()
+    dt = problem.dt
+    Nt = U.shape[0]
+    spatial_shape = U.shape[1:]
+    ndim = len(spatial_shape)
+
+    bounds = geometry.get_bounds()
+
+    if ndim == 1:
+        dx = grid_spacing[0]
+        Nx = spatial_shape[0]
+
+        # Face centers: x_{i+1/2}
+        x_nodes = np.linspace(bounds[0][0], bounds[1][0], Nx)
+        x_faces = 0.5 * (x_nodes[:-1] + x_nodes[1:])  # (Nx-1,)
+
+        # Face gradient: p_{i+1/2} = (U[i+1] - U[i]) / dx
+        p_faces = np.diff(U, axis=-1) / dx  # (Nt, Nx-1)
+
+        # Face density: m_{i+1/2} = (m[i] + m[i+1]) / 2
+        m_faces = 0.5 * (M[:, :-1] + M[:, 1:])  # (Nt, Nx-1)
+
+        alpha_faces = np.zeros((Nt, Nx - 1))
+        x_arr = x_faces.reshape(-1, 1)
+        for n in range(Nt):
+            m_n = m_faces[n] if n < m_faces.shape[0] else m_faces[-1]
+            p_n = p_faces[n].reshape(-1, 1)
+            alpha_faces[n] = H_class.optimal_control(x_arr, m_n, p_n, t=n * dt).ravel()
+
+        return alpha_faces
+    else:
+        # nD: node-centered fallback (face-centered nD deferred)
+        grad_components = []
+        for d in range(ndim):
+            grad_d = np.gradient(U, grid_spacing[d], axis=d + 1)
+            grad_components.append(grad_d)
+
+        coords = [np.linspace(bounds[0][d], bounds[1][d], spatial_shape[d]) for d in range(ndim)]
+        mesh = np.meshgrid(*coords, indexing="ij")
+        x_grid = np.stack(mesh, axis=-1)
+
+        alpha_field = np.zeros((Nt, ndim, *spatial_shape))
+        for n in range(Nt):
+            p_n = np.stack([grad_components[d][n] for d in range(ndim)], axis=-1)
+            m_n = M[n] if n < M.shape[0] else M[-1]
+            alpha_n = H_class.optimal_control(x_grid, m_n, p_n, t=n * dt)
+            if alpha_n.ndim == ndim + 1:
+                alpha_field[n] = np.moveaxis(alpha_n, -1, 0)
+            else:
+                for d in range(ndim):
+                    alpha_field[n, d] = alpha_n
+
+        return alpha_field
+
+
+def resolve_fp_drift_kwargs(
+    problem: object,
+    fp_sig_params: set[str] | None,
+    drift_field_override: object | None,
+    U: np.ndarray,
+    M: np.ndarray,
+) -> tuple[dict, bool]:
+    """Resolve how the value function enters ``solve_fp_system`` (drift vs potential).
+
+    Single-source for the FP drift/potential convention shared by the Picard
+    ``FixedPointIterator`` and the Newton ``MFGResidual`` (Issue #1233). Before this
+    helper existed the two code paths diverged: ``MFGResidual`` still passed the value
+    function as ``drift_field`` (which the v0.18.6 rename redefined as the *velocity*
+    $\\alpha^*$, not the potential), so the Newton residual was inconsistent with the
+    Picard fixed point and the two solvers converged to different roots.
+
+    Resolution rules (matching the FP-solver semantics post-v0.18.6):
+        - Explicit ``drift_field`` override → pass it through verbatim (velocity).
+        - Smooth separable $H$ → pass $U$ as ``potential_field`` (the FP solver derives
+          the velocity internally; ``potential_field`` is the deprecated-but-routing
+          U-potential entry point).
+        - Non-smooth $H$ → pass the face-centered velocity $\\alpha^*$ as ``drift_field``
+          (see :func:`compute_fp_velocity_field`).
+
+    Args:
+        problem: MFG problem (provides ``hamiltonian_class``, ``geometry``, ``dt``).
+        fp_sig_params: Parameter names of ``fp_solver.solve_fp_system`` (or ``None``).
+        drift_field_override: Caller-supplied drift override (array/callable), or ``None``.
+        U: Current value function, shape ``(Nt+1, *spatial_shape)``.
+        M: Current density, shape ``(Nt+1, *spatial_shape)`` (used only for non-smooth $H$).
+
+    Returns:
+        ``(drift_kwargs, use_positional_U)`` where ``drift_kwargs`` is one of ``{}``,
+        ``{"drift_field": ...}`` or ``{"potential_field": ...}`` to merge into the
+        solver kwargs, and ``use_positional_U`` is ``True`` iff the FP solver exposes
+        neither ``drift_field`` nor ``potential_field`` (legacy positional-U interface),
+        in which case the caller passes ``U`` positionally.
+    """
+    if fp_sig_params is None:
+        return {}, True
+
+    params = fp_sig_params
+    drift_kwargs: dict = {}
+
+    if drift_field_override is not None:
+        if "drift_field" in params:
+            drift_kwargs["drift_field"] = drift_field_override
+    else:
+        from mfgarchon.core.hamiltonian import SeparableHamiltonian
+
+        H_class = problem.hamiltonian_class
+        use_velocity = (
+            H_class is not None
+            and "drift_field" in params
+            and not (isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth())
+        )
+        if use_velocity:
+            drift_kwargs["drift_field"] = compute_fp_velocity_field(problem, U, M, H_class)
+        elif "potential_field" in params:
+            drift_kwargs["potential_field"] = U
+        elif "drift_field" in params:
+            drift_kwargs["drift_field"] = U
+
+    use_positional_U = not ("drift_field" in params or "potential_field" in params)
+    return drift_kwargs, use_positional_U

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np  # noqa: TC002
+import numpy as np
 
 if TYPE_CHECKING:
     from mfgarchon.utils.solver_result import SolverResult

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -28,6 +28,8 @@ import numpy as np
 from mfgarchon.geometry.boundary import no_flux_bc
 from mfgarchon.utils.mfg_logging import get_logger
 
+from .fixed_point_utils import resolve_fp_drift_kwargs
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
@@ -176,36 +178,44 @@ class MFGResidual:
 
         return self.hjb_solver.solve_hjb_system(M, self.U_terminal, U_prev, **kwargs)
 
-    def compute_fp_output(self, U: NDArray) -> NDArray:
+    def compute_fp_output(self, U: NDArray, M: NDArray | None = None) -> NDArray:
         """
         Compute FP solver output for given value function.
 
+        Issue #1233: the drift/potential convention is single-sourced through
+        :func:`resolve_fp_drift_kwargs`, identical to the Picard ``FixedPointIterator``.
+        Previously this method always passed the value function as ``drift_field``,
+        which the v0.18.6 rename redefined as the *velocity* — so the Newton residual
+        was inconsistent with the Picard fixed point and the solvers diverged.
+
         Args:
             U: Current value function (Nt+1, *spatial_shape)
+            M: Current density (Nt+1, *spatial_shape), used only for non-smooth $H$ to
+                evaluate the density-dependent velocity. Defaults to the time-broadcast
+                initial density when not supplied.
 
         Returns:
             M_new: Density field from FP solve
         """
-        kwargs: dict[str, Any] = {}
-
-        if self._fp_sig_params is not None:
-            if "show_progress" in self._fp_sig_params:
-                kwargs["show_progress"] = False
-
-            # Determine drift
-            effective_drift = self.drift_field if self.drift_field is not None else U
-
-            if "drift_field" in self._fp_sig_params:
-                kwargs["drift_field"] = effective_drift
-                if "volatility_field" in self._fp_sig_params and self.volatility_field is not None:
-                    kwargs["volatility_field"] = self.volatility_field
-                return self.fp_solver.solve_fp_system(self.M_initial, **kwargs)
-            else:
-                # Legacy interface
-                return self.fp_solver.solve_fp_system(self.M_initial, effective_drift, **kwargs)
-        else:
-            # Basic call
+        if self._fp_sig_params is None:
             return self.fp_solver.solve_fp_system(self.M_initial, U)
+
+        params = self._fp_sig_params
+        kwargs: dict[str, Any] = {}
+        if "show_progress" in params:
+            kwargs["show_progress"] = False
+        if "volatility_field" in params and self.volatility_field is not None:
+            kwargs["volatility_field"] = self.volatility_field
+
+        if M is None:
+            M = np.broadcast_to(self.M_initial, self.solution_shape) if self.M_initial is not None else U
+
+        drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(self.problem, params, self.drift_field, U, M)
+        kwargs.update(drift_kwargs)
+
+        if use_positional_U:
+            return self.fp_solver.solve_fp_system(self.M_initial, U, **kwargs)
+        return self.fp_solver.solve_fp_system(self.M_initial, **kwargs)
 
     def compute_residual(
         self,
@@ -235,7 +245,7 @@ class MFGResidual:
 
         # Compute solver outputs
         U_new = self.compute_hjb_output(M, U)
-        M_new = self.compute_fp_output(U)
+        M_new = self.compute_fp_output(U, M)
 
         # Compute residuals (difference from fixed point)
         F_HJB = U_new - U

--- a/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
@@ -75,11 +75,22 @@ class NewtonMFGSolver(BaseCouplingIterator):
         problem: MFG problem definition
         hjb_solver: HJB solver instance (must be trait-validated)
         fp_solver: FP solver instance (must be trait-validated)
-        picard_warmup: Number of Picard iterations before Newton (default: 3)
+        picard_warmup: Number of Picard iterations before Newton (default: 3). The
+            warmup must bring the iterate into the basin of the physical equilibrium:
+            Newton is a *local* root-finder and (even with line search) cannot escape a
+            basin, so a too-short warmup can converge to a spurious near-trivial fixed
+            point of the discrete MFG map. For stiff couplings increase this until the
+            warmup residual is well past its transient peak (Issue #1233).
         newton_tolerance: Convergence tolerance for Newton (default: 1e-6)
         newton_max_iterations: Maximum Newton iterations (default: 20)
         line_search: Enable backtracking line search (default: True)
-        use_jax_autodiff: Use JAX for Jacobian ('auto', True, False)
+        use_jax_autodiff: Use JAX autodiff for the Jacobian (default: False). The MFG
+            residual wraps the black-box numpy/scipy HJB and FP solvers, which JAX
+            cannot trace — autodiff therefore raises ``TracerArrayConversionError`` and
+            falls back to the finite-difference Jacobian. The FD-Jacobian path is the
+            supported one; ``'auto'``/``True`` are retained only for a hypothetical
+            JAX-traceable residual and will warn-and-fall-back with the standard solvers
+            (Issue #1233).
         volatility_field: Optional diffusion override
         drift_field: Optional drift override
 
@@ -100,7 +111,7 @@ class NewtonMFGSolver(BaseCouplingIterator):
         newton_tolerance: float = 1e-6,
         newton_max_iterations: int = 20,
         line_search: bool = True,
-        use_jax_autodiff: bool | str = "auto",
+        use_jax_autodiff: bool | str = False,
         volatility_field: float | NDArray | Any | None = None,
         drift_field: NDArray | Any | None = None,
     ):
@@ -170,7 +181,7 @@ class NewtonMFGSolver(BaseCouplingIterator):
             U_new = self.mfg_residual.compute_hjb_output(M_old, U_old)
 
             # FP solve: M_new = FP(U_new)
-            M_new = self.mfg_residual.compute_fp_output(U_new)
+            M_new = self.mfg_residual.compute_fp_output(U_new, M_old)
 
             # Apply damping
             U = self.picard_damping * U_new + (1 - self.picard_damping) * U_old

--- a/tests/integration/test_newton_mfg_solver.py
+++ b/tests/integration/test_newton_mfg_solver.py
@@ -218,12 +218,16 @@ class TestNewtonVsPicard:
         hjb_picard = HJBFDMSolver(comparison_problem)
         fp_picard = FPFDMSolver(comparison_problem)
 
-        # Newton solver
+        # Newton solver.
+        # Issue #1233: the warmup must reach the basin of the physical equilibrium —
+        # Newton is a local root-finder and a too-short warmup (e.g. 3) converges to a
+        # spurious near-trivial fixed point of the discrete MFG map. See the fast guards
+        # in test_newton_picard_agreement.py.
         newton_solver = NewtonMFGSolver(
             comparison_problem,
             hjb_newton,
             fp_newton,
-            picard_warmup=3,
+            picard_warmup=15,
             newton_max_iterations=10,
             line_search=True,
         )

--- a/tests/integration/test_newton_picard_agreement.py
+++ b/tests/integration/test_newton_picard_agreement.py
@@ -1,0 +1,116 @@
+"""Fast Newton↔Picard agreement guards for the MFG coupling layer (Issue #1233).
+
+These are the lightweight CI counterparts to ``test_newton_mfg_solver.py`` (which is
+marked ``slow`` because its realistic-grid Newton runs are expensive). The slow suite
+is skipped on PRs, so the drift-convention regression that #1233 fixed went unnoticed
+on ``main``. The tests here run on a tiny grid and stay un-marked so every PR exercises:
+
+1. ``MFGResidual`` evaluates to ~0 at the Picard fixed point — i.e. the Newton residual
+   uses the *same* FP drift/potential convention as the Picard ``FixedPointIterator``.
+   This is the precise guard for the single-sourced ``resolve_fp_drift_kwargs``: a future
+   private re-fork of the drift convention makes ``||F(Picard soln)||`` blow up here.
+2. The full Newton solve converges to the same solution as Picard (with an adequate
+   warmup that lands in the physical basin).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _small_problem():
+    """Tiny 1D LQ-ish MFG: small enough that the O(N) FD-Jacobian Newton runs in seconds."""
+    geometry = TensorProductGrid(bounds=[(0.0, 1.0)], boundary_conditions=no_flux_bc(dimension=1), Nx_points=[6])
+    components = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    return MFGProblem(geometry=geometry, T=0.15, Nt=3, sigma=0.3, components=components)
+
+
+def _picard_solution(problem):
+    picard = FixedPointIterator(
+        problem,
+        hjb_solver=HJBFDMSolver(problem),
+        fp_solver=FPFDMSolver(problem),
+        relaxation=0.5,
+    )
+    result = picard.solve(max_iterations=80, tolerance=1e-6, verbose=False)
+    return result[0], result[1]
+
+
+def test_residual_consistent_with_picard_fixed_point():
+    """The Newton residual must vanish at the Picard fixed point (Issue #1233).
+
+    Before the fix, ``MFGResidual`` passed the value function as ``drift_field`` — which
+    the v0.18.6 rename redefined as the *velocity* — so ``||F_FP(Picard soln)||`` was
+    O(10), the Newton and Picard solvers chased inconsistent roots, and the comparison
+    test failed by ~99.5%. With the drift convention single-sourced, the residual is ~0.
+    """
+    problem = _small_problem()
+    U_picard, M_picard = _picard_solution(problem)
+
+    residual = MFGResidual(problem, HJBFDMSolver(problem), FPFDMSolver(problem))
+    _, F_hjb, F_fp = residual.compute_residual(U_picard, M_picard, return_components=True)
+
+    # HJB residual floor is set by the inner HJB solver tolerance (~1e-6); the FP residual
+    # is the one that regresses on a drift-convention divergence — pin it tightly.
+    assert np.linalg.norm(F_fp) < 1e-4, (
+        f"FP residual does not vanish at the Picard fixed point: ||F_FP||={np.linalg.norm(F_fp):.3e}. "
+        "The Newton MFGResidual FP drift/potential convention has diverged from the Picard "
+        "FixedPointIterator (resolve_fp_drift_kwargs no longer single-sourced)."
+    )
+    assert np.linalg.norm(F_hjb) < 1e-3
+
+
+def test_newton_matches_picard_small():
+    """End-to-end: Newton converges to the Picard solution on a tiny grid (Issue #1233).
+
+    Uses an adequate Picard warmup so the iterate enters the basin of the physical
+    equilibrium before Newton (a local root-finder) takes over.
+    """
+    problem = _small_problem()
+    U_picard, M_picard = _picard_solution(problem)
+
+    newton = NewtonMFGSolver(
+        problem,
+        HJBFDMSolver(problem),
+        FPFDMSolver(problem),
+        picard_warmup=5,
+        newton_max_iterations=3,
+        line_search=True,
+    )
+    U_newton, M_newton, _info = newton.solve(max_iterations=8, tolerance=1e-5, verbose=False)
+
+    u_diff = np.linalg.norm(U_newton - U_picard) / (np.linalg.norm(U_picard) + 1e-10)
+    m_diff = np.linalg.norm(M_newton - M_picard) / (np.linalg.norm(M_picard) + 1e-10)
+    assert u_diff < 0.05, f"Newton U differs from Picard by {u_diff * 100:.1f}%"
+    assert m_diff < 0.05, f"Newton M differs from Picard by {m_diff * 100:.1f}%"
+
+
+def test_default_uses_finite_difference_jacobian():
+    """NewtonMFGSolver defaults to the FD-Jacobian path (Issue #1233).
+
+    The MFG residual wraps black-box numpy/scipy solvers that JAX cannot trace, so the
+    autodiff path is off by default to avoid a guaranteed TracerArrayConversionError +
+    fallback warning on every run.
+    """
+    problem = _small_problem()
+    newton = NewtonMFGSolver(problem, HJBFDMSolver(problem), FPFDMSolver(problem))
+    assert newton.use_jax_autodiff is False


### PR DESCRIPTION
## Problem

`NewtonMFGSolver` and the Picard `FixedPointIterator` converged to **different** solutions (the `@slow` `TestNewtonVsPicard` comparison failed by **99.5%**, red on `main` but skipped in PR CI). The Newton residual `F = [HJB(M) - U, FP(U) - M]` was *inconsistent* with the Picard fixed point.

## Root cause (two layers, diagnosed by artifact)

Decisive probe — evaluate `MFGResidual` at the converged Picard solution:
`‖F_HJB(Up,Mp)‖ = 9e-7` ✓ but `‖F_FP(Up,Mp)‖ = 17.81` ✗.

**(1) Stale FP drift convention.** `MFGResidual.compute_fp_output` passed the value function as `drift_field`. The **v0.18.6 rename** redefined `drift_field` as the *velocity* α* (the old U-potential entry point became `potential_field`), and the Picard `FixedPointIterator` was updated for this (#896/#919) — but `MFGResidual` was not. So it told the FP solver "the value function **is** the velocity" → garbage `M`. The classic *parallel-path / private-convention-copy* bug.

**(2) Basin selection.** Even after fixing (1) so the residual vanishes at the Picard FP (`‖F_FP‖ → 5e-12`), Newton still landed on `‖U‖≈2.34` vs Picard's `‖U‖≈36.46`. A Picard step from Newton's point barely moves it → it's a **genuine spurious near-trivial fixed point**. The 3-iteration warmup left the iterate in its basin; Newton (a *local* root-finder; line search cannot escape a basin) locked onto it. Picard escapes because it is globally damped.

## Fix

- **Single-source the FP drift/potential resolution** — `resolve_fp_drift_kwargs` + `compute_fp_velocity_field` in `fixed_point_utils`, now shared by `FixedPointIterator` and `MFGResidual`. The `FixedPointIterator` FDM path is **byte-identical** (verified `max|Δ| = 0` on 1D-LQ `U`/`M`) — **EOC-safe**.
- **Warmup-basin requirement documented**; the comparison test warms up adequately (warmup ≥ 10 → Newton matches Picard to **0.0%**).
- **`use_jax_autodiff=False` default** for `NewtonMFGSolver`: the residual wraps black-box numpy/scipy HJB/FP solvers JAX cannot trace, so `'auto'` was a guaranteed `TracerArrayConversionError` + FD-fallback warning every run. **Backend-compatible**: the FDM solvers are pure numpy/scipy (never jax-traceable regardless of the selected backend); the option is retained for a hypothetical jnp-native residual.

## Tests
- New **fast, non-`slow`** guards (`tests/integration/test_newton_picard_agreement.py`): residual-consistency at the Picard FP (precise guard for the single-source), end-to-end small-grid agreement, and the JAX default. The realistic-grid comparison is `@slow` (skipped on PRs) — which is why this stayed red on `main` undetected.
- Full coupling/fixed-point/multi-pop sweep: **195 passed**, 0 failed.

## Scope note
`multi_population_iterator` keeps its own *node*-centered velocity copy (a different convention from the #919 face-centered one) and is left as a tracked third copy, not folded in here.

Closes #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)