### PR TITLE
feat(fem): enable Quadrilateral P1+P2 solve path (#470 slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Quadrilateral FEM solve path, P1 + P2** (Issue #470, smallest actionable slice). The FEM
+  `element_map` had `(MeshQuad, 1) → ElementQuad1` but no order-2 entry, so a quad mesh at
+  `order=2` raised `ValueError` even though `ElementQuad2` ships with skfem. Added
+  `(MeshQuad, 2)` / `(MeshQuad1, 2) → ElementQuad2` and corrected the error text (it omitted
+  Quad despite Quad-P1 already working). The mesh-generation layer (`Mesh2D`/`Mesh3D`) still
+  emits only simplex meshes via gmsh — and **gmsh is not an installed dependency** — but the FEM
+  *solve* path is element-family-agnostic, so a quad mesh built gmsh-free via
+  `skfem.MeshQuad.init_tensor` now runs end-to-end (`mesh_adapter` round-trips `element_type='quad'`).
+  New `tests/integration/test_fem_quad_path.py`: quad round-trip + Poisson at P1 and P2 (manufactured
+  solution) + a P2-more-accurate-than-P1 check. gmsh-based Quad/Hex/Prism *generation* remains the
+  large, separately-blocked part of #470. FEM is a distinct scheme — no paper-path (FDM/GFDM) impact.
+
 - **`FixedPointIterator` supports unstructured-mesh geometry** (coupled-FEM chain, seam 3). The
   coupling iterator was grid-only — it required a `CartesianGrid` and used `get_grid_shape()` /
   `get_grid_spacing()`, so a FEM pair (which needs an unstructured mesh) could never run through

--- a/mfgarchon/alg/numerical/fem/assembly.py
+++ b/mfgarchon/alg/numerical/fem/assembly.py
@@ -55,7 +55,9 @@ def create_basis(mesh: skfem.Mesh, order: int = 1) -> skfem.Basis:
         (skfem.MeshTet1, 1): skfem.ElementTetP1,
         (skfem.MeshTet1, 2): skfem.ElementTetP2,
         (skfem.MeshQuad, 1): skfem.ElementQuad1,
+        (skfem.MeshQuad, 2): skfem.ElementQuad2,
         (skfem.MeshQuad1, 1): skfem.ElementQuad1,
+        (skfem.MeshQuad1, 2): skfem.ElementQuad2,
         (skfem.MeshLine, 1): skfem.ElementLineP1,
         (skfem.MeshLine, 2): skfem.ElementLineP2,
         (skfem.MeshLine1, 1): skfem.ElementLineP1,
@@ -71,7 +73,7 @@ def create_basis(mesh: skfem.Mesh, order: int = 1) -> skfem.Basis:
     if element_cls is None:
         raise ValueError(
             f"No element for mesh type {type(mesh).__name__} with order {order}. "
-            f"Supported: P1 (order=1) and P2 (order=2) for Tri/Tet/Line."
+            f"Supported: P1 (order=1) and P2 (order=2) for Tri/Tet/Line/Quad."
         )
 
     return skfem.Basis(mesh, element_cls())

--- a/tests/integration/test_fem_quad_path.py
+++ b/tests/integration/test_fem_quad_path.py
@@ -1,0 +1,101 @@
+"""End-to-end Quadrilateral FEM path — the smallest actionable slice of #470.
+
+The mesh-generation layer (``Mesh2D``/``Mesh3D``) only emits simplex (Tri/Tet) meshes
+via gmsh, and gmsh is not even an installed dependency. But the FEM *solve* path
+(``mesh_adapter`` → ``create_basis`` → assembly) is element-family-agnostic, and skfem
+can build a quad mesh gmsh-free via ``MeshQuad.init_tensor``. This test injects such a
+mesh and drives a full Poisson solve at **both** Quad-P1 and Quad-P2, which:
+
+- exercises the ``element_map`` Quad-P2 entry added for #470 (``(MeshQuad, 2) →
+  ElementQuad2``); before it, ``order=2`` on a quad mesh raised ``ValueError``;
+- confirms a quad ``MeshData`` round-trips through ``mesh_adapter`` (``element_type='quad'``);
+- checks P2 is genuinely more accurate than P1 on the same mesh (not just "it runs").
+
+EOC note: this is a *new FEM scheme* path; it does not touch the byte-identical
+1D-LQ-FDM Picard or 2D-scattered-GFDM paper paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required for FEM tests")
+
+from mfgarchon.alg.numerical.fem.assembly import (  # noqa: E402
+    apply_dirichlet_bc,
+    assemble_mass,
+    assemble_stiffness,
+    create_basis,
+)
+from mfgarchon.alg.numerical.fem.mesh_adapter import meshdata_to_skfem, skfem_to_meshdata  # noqa: E402
+
+
+def _quad_mesh(n: int) -> skfem.Mesh:
+    """gmsh-free quad mesh on the unit square: an (n x n) node tensor grid."""
+    xs = np.linspace(0.0, 1.0, n)
+    return skfem.MeshQuad.init_tensor(xs, xs)
+
+
+def _solve_poisson(mesh: skfem.Mesh, order: int):
+    r"""Solve $-\Delta u = f$ with $u = u_{\text{exact}}$ on $\partial\Omega$ for the
+    manufactured solution $u(x,y) = \sin(\pi x)\sin(\pi y)$ (so $f = 2\pi^2 u$, $u=0$
+    on the unit-square boundary). Returns (max nodal error, n_dofs)."""
+    basis = create_basis(mesh, order=order)
+    coords = basis.doflocs  # (2, N)
+    x, y = coords[0], coords[1]
+    u_exact = np.sin(np.pi * x) * np.sin(np.pi * y)
+    f = 2.0 * np.pi**2 * u_exact
+
+    K = assemble_stiffness(basis)
+    M = assemble_mass(basis)
+    rhs = M @ f  # consistent FEM load vector ∫ f φ_i
+
+    boundary_dofs = np.unique(basis.get_dofs().flatten())
+    K_int, f_int = apply_dirichlet_bc(K, rhs, boundary_dofs, values=u_exact[boundary_dofs])
+
+    from scipy.sparse.linalg import spsolve
+
+    interior = np.setdiff1d(np.arange(basis.N), boundary_dofs)
+    u = u_exact.copy()
+    u[interior] = spsolve(K_int.tocsr(), f_int)
+
+    return float(np.max(np.abs(u - u_exact))), basis.N
+
+
+def test_quad_meshdata_roundtrip():
+    """A quad mesh round-trips through the mesh adapter as ``element_type='quad'``."""
+    mesh = _quad_mesh(5)
+    md = skfem_to_meshdata(mesh)
+    assert md.element_type == "quad"
+    assert md.elements.shape[1] == 4  # 4 nodes per quad
+
+    mesh2 = meshdata_to_skfem(md)
+    assert "Quad" in type(mesh2).__name__
+    assert mesh2.p.shape == mesh.p.shape
+    assert mesh2.t.shape == mesh.t.shape
+
+
+@pytest.mark.parametrize("order", [1, 2])
+def test_quad_poisson_solves(order):
+    """Quad P1 and P2 both assemble and solve Poisson end-to-end (#470 element_map).
+
+    Before the fix, ``order=2`` on a quad mesh raised ``ValueError`` (no
+    ``(MeshQuad, 2)`` entry in ``element_map``).
+    """
+    err, ndof = _solve_poisson(_quad_mesh(9), order=order)
+    assert ndof > 0
+    assert err < 0.05, f"Quad P{order} Poisson nodal error {err:.3e} too large"
+
+
+def test_quad_p2_more_accurate_than_p1():
+    """On the same mesh, Quad-P2 should be markedly more accurate than Quad-P1.
+
+    Distinguishes a genuine P2 solve from a silent fallback to P1.
+    """
+    mesh = _quad_mesh(9)
+    err_p1, n_p1 = _solve_poisson(mesh, order=1)
+    err_p2, n_p2 = _solve_poisson(mesh, order=2)
+    assert n_p2 > n_p1  # P2 adds edge/center dofs
+    assert err_p2 < 0.25 * err_p1, f"P2 error {err_p2:.3e} not better than P1 {err_p1:.3e}"


### PR DESCRIPTION
## Summary

Smallest actionable slice of #470: enable the **Quadrilateral** FEM solve path at both P1 and P2.

The FEM `element_map` (`assembly.create_basis`) had `(MeshQuad, 1) → ElementQuad1` but **no order-2 entry**, so a quad mesh at `order=2` raised `ValueError` — even though `ElementQuad2` ships with skfem (12.0.1). The error text also omitted Quad despite Quad-P1 already working.

## Changes
- `assembly.py`: add `(MeshQuad, 2)` / `(MeshQuad1, 2) → ElementQuad2`; fix the `ValueError` text (`…for Tri/Tet/Line/Quad`).
- New `tests/integration/test_fem_quad_path.py`: quad `MeshData` round-trip through `mesh_adapter` (`element_type='quad'`), Poisson solve at P1 **and** P2 (manufactured `u = sin(πx)sin(πy)`), and a P2-more-accurate-than-P1 check (distinguishes a genuine P2 solve from a silent P1 fallback).

## Why this is the actionable slice
The mesh-*generation* layer (`Mesh2D`/`Mesh3D`) emits only simplex meshes via gmsh, and **gmsh is not an installed dependency** (absent from `pyproject.toml` and the venv). But the FEM *solve* path is element-family-agnostic, so a quad mesh built gmsh-free via `skfem.MeshQuad.init_tensor` runs end-to-end. gmsh-based Quad/Hex/Prism **generation** is the large, separately-blocked part of #470 and stays out of scope.

## Safety
FEM is a distinct scheme — **no impact** on the byte-identical 1D-LQ-FDM Picard or 2D-scattered-GFDM paper paths. 4 new tests pass; `ruff check`/`format` clean.

Refs #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)