### PR TITLE
test(fem): cover P2 in the FP mass-conservation regression (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **FP mass-conservation regression now covers P2** (Issue #470 follow-up). The FEM FP advection
+  operator is assembled as `-C^T`, whose column sums vanish by partition of unity
+  (`Σ_i φ_i = 1`) — an *order-agnostic* property. `test_fp_advection_is_mass_conserving` is now
+  parametrized over P1 and P2, pinning that the P2 path conserves mass exactly (verified
+  `max|col sum| ≈ 1e-16` at P2) so a future P2 assembly change cannot silently break it.
+
 - **Quadrilateral FEM solve path, P1 + P2** (Issue #470, smallest actionable slice). The FEM
   `element_map` had `(MeshQuad, 1) → ElementQuad1` but no order-2 entry, so a quad mesh at
   `order=2` raised `ValueError` even though `ElementQuad2` ships with skfem. Added

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -77,19 +77,24 @@ class TestFEMSolverPath:
         assert hjb._scheme_family is SchemeFamily.FEM
         assert fp._scheme_family is SchemeFamily.FEM
 
-    def test_fp_advection_is_mass_conserving(self):
+    @pytest.mark.parametrize("order", [1, 2])
+    def test_fp_advection_is_mass_conserving(self, order):
         """The FP advection operator must have zero column sums (mass conservation). The raw
         convective form ``C[i,j] = ∫ φ_i (v·∇φ_j)`` does NOT (column sums ≈ ∫ v·∇φ_j); the
         operator is assembled as ``-C^T`` whose column sums vanish since ``Σ_i φ_i = 1``. A random
-        value function gives a non-divergence-free drift, so this fails on the prior ``+C``."""
+        value function gives a non-divergence-free drift, so this fails on the prior ``+C``.
+
+        Parametrized over P1 and P2: the ``-C^T`` mass-conservation property is *order-agnostic*
+        (partition of unity ``Σ_i φ_i = 1`` holds for any Lagrange order), so P2 must conserve
+        mass exactly as P1 does — a regression guard for the P2 FEM path (#470)."""
         from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
 
         problem, _ = _fem_problem()
-        fp = FPFEMSolver(problem)
+        fp = FPFEMSolver(problem, order=order)
         u_n = np.random.RandomState(0).rand(fp._basis.N)
         advection = fp._build_advection(u_n)
         max_col_sum = float(np.abs(np.asarray(advection.sum(axis=0)).ravel()).max())
-        assert max_col_sum < 1e-12, f"FP advection not mass-conserving: max|col sum|={max_col_sum:.2e}"
+        assert max_col_sum < 1e-12, f"FP advection (P{order}) not mass-conserving: max|col sum|={max_col_sum:.2e}"
 
     def test_gmsh_free_mesh_injection_is_returned_as_is(self):
         """generate_mesh() returns a pre-populated mesh_data unchanged (gmsh-free injected-mesh


### PR DESCRIPTION
## Summary

The FEM FP advection operator is assembled as `-C^T`, whose column sums vanish by partition of unity (`Σ_i φ_i = 1`) — an **order-agnostic** property. Now that the Quad/P2 `element_map` work (#1236) makes P2 reachable, this parametrizes `test_fp_advection_is_mass_conserving` over **P1 and P2** so the P2 path is pinned to conserve mass exactly.

Verified: `max|col sum| ≈ 1e-16` at P2 (machine precision), identical to P1.

## Why
A regression guard: a future change to the P2 assembly cannot silently break mass conservation without this test going red.

## Safety
Test-only; FEM is a distinct scheme — no impact on the byte-identical FDM Picard / GFDM paper paths. Both parametrizations pass.

Refs #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)