### PR TITLE
fix(fem): fail loud on Robin/Periodic BC instead of silent Neumann fallback (#1237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Robin / Periodic FEM boundary conditions now fail loud** (Issue #1237). `apply_bc_to_fem_system`
+  previously *warned and silently fell back to natural (Neumann) BC* for `BCType.ROBIN` — a
+  fail-silent anti-pattern that ran the wrong physics quietly — and warn-only (no fallback) for
+  `BCType.PERIODIC`. Both now raise `NotImplementedError` with a pointer to the use-an-FDM/GFDM-solver
+  workaround. A correct Robin FEM BC needs a diffusion-coefficient-scaled `FacetBasis` boundary term
+  threaded through the weak-form assembly (the adapter is coefficient-blind — it only sees the
+  already-assembled matrix); Periodic needs DOF identification across paired boundaries. Both are
+  tracked in #1237. Nothing exercised these stubs through the FEM path, so this only converts a silent
+  wrong-answer into a loud error. New parametrized fail-loud tests in `test_fem_solver_path.py`.
+
 - **Single-sourced the tensor-diffusion operator** (Issue #1228). `∇·(Σ∇u)` was implemented twice:
   `operators/differential/diffusion.py` (`DiffusionOperator` private `_tensor_diffusion_1d/2d/nd`)
   and `utils/numerical/tensor_calculus.py` (`diffusion`) — two independent copies, the repo's

--- a/mfgarchon/alg/numerical/fem/bc_adapter.py
+++ b/mfgarchon/alg/numerical/fem/bc_adapter.py
@@ -8,8 +8,10 @@ Mapping:
     BCType.DIRICHLET → condense() with boundary DOFs and values
     BCType.NEUMANN   → natural BC (default in weak form, no action needed)
     BCType.NO_FLUX   → same as NEUMANN (zero normal derivative)
-    BCType.ROBIN     → boundary integral via FacetBasis (alpha*u + beta*du/dn = g)
-    BCType.PERIODIC  → DOF pairing (not yet implemented for FEM)
+    BCType.ROBIN     → NotImplementedError (needs a D-scaled FacetBasis boundary term threaded
+                       through weak-form assembly; not resolvable in this coefficient-blind
+                       adapter — Issue #1237)
+    BCType.PERIODIC  → NotImplementedError (needs DOF pairing across boundaries — Issue #1237)
 
 Issue #773: BC framework integration for FEM solvers
 """
@@ -40,7 +42,8 @@ def apply_bc_to_fem_system(
 
     For Dirichlet segments: condense the system (eliminate boundary DOFs).
     For Neumann/no-flux: no action (natural BC in weak form).
-    For Robin: add boundary integral terms (future).
+    For Robin/Periodic: raises ``NotImplementedError`` (Issue #1237) — fail loud rather than
+    silently degrade to Neumann.
 
     Args:
         A: System matrix (N_dof, N_dof)
@@ -74,22 +77,21 @@ def apply_bc_to_fem_system(
             pass
 
         elif segment.bc_type == BCType.ROBIN:
-            # Robin BC: alpha*u + beta*du/dn = g
-            # Requires FacetBasis boundary integral — future implementation
-            import warnings
-
-            warnings.warn(
-                f"Robin BC on segment '{segment.name}' not yet implemented for FEM. "
-                "Falling back to natural (Neumann) BC.",
-                stacklevel=2,
+            # Robin BC (alpha*u + beta*du/dn = g) needs a FacetBasis boundary term scaled by the
+            # diffusion coefficient D, which is assembled upstream (weak-form base class) and is
+            # NOT visible to this coefficient-blind adapter. Fail loud rather than silently
+            # degrade to Neumann (which would run the wrong physics quietly). See Issue #1237.
+            raise NotImplementedError(
+                f"Robin BC on segment '{segment.name}' is not implemented for the FEM solver path. "
+                "Correct Robin BC requires threading the diffusion coefficient / time factor into "
+                "the weak-form assembly (Issue #1237). Use Dirichlet or Neumann/no-flux here, or an "
+                "FDM/GFDM solver for Robin/reflecting boundaries."
             )
 
         elif segment.bc_type == BCType.PERIODIC:
-            import warnings
-
-            warnings.warn(
-                f"Periodic BC on segment '{segment.name}' not yet implemented for FEM.",
-                stacklevel=2,
+            raise NotImplementedError(
+                f"Periodic BC on segment '{segment.name}' is not implemented for the FEM solver "
+                "path (needs DOF identification across paired boundaries; see Issue #1237)."
             )
 
     if dirichlet_dofs:

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -138,6 +138,29 @@ class TestFEMBoundaryConditionResolution:
         assert isinstance(fp._bc, BoundaryConditions)
         assert fp._is_pure_neumann()  # no-flux is natural/Neumann
 
+    @pytest.mark.parametrize("bc_type_name", ["ROBIN", "PERIODIC"])
+    def test_robin_periodic_fem_bc_fail_loud(self, bc_type_name):
+        """Robin/Periodic FEM BC must raise, not silently degrade to Neumann (Issue #1237).
+
+        The previous behavior warned and fell back to natural (Neumann) BC — a fail-silent
+        anti-pattern that ran the wrong physics quietly. Correct Robin/Periodic FEM needs a
+        D-scaled FacetBasis term / DOF pairing threaded through weak-form assembly, which the
+        coefficient-blind ``apply_bc_to_fem_system`` cannot do."""
+        from mfgarchon.alg.numerical.fem.assembly import assemble_stiffness, create_basis
+        from mfgarchon.alg.numerical.fem.bc_adapter import apply_bc_to_fem_system
+        from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+        from mfgarchon.geometry.boundary.types import BCSegment, BCType
+
+        mesh = skfem.MeshTri.init_sqsymmetric().refined(1)
+        basis = create_basis(mesh, order=1)
+        A = assemble_stiffness(basis)
+        rhs = np.zeros(basis.N)
+        segment = BCSegment(name="wall", bc_type=getattr(BCType, bc_type_name), alpha=1.0, beta=1.0)
+        bc = BoundaryConditions(dimension=2, segments=[segment])
+
+        with pytest.raises(NotImplementedError, match="Issue #1237"):
+            apply_bc_to_fem_system(A, rhs, basis, bc)
+
     def test_coupled_fem_no_flux_runs_and_conserves_mass(self):
         """First coupled FEM MFG through the real solver classes (manual Picard — the standard
         FixedPointIterator is still grid-only, seam 3). No-flux ⇒ mass conserved, confirming the


### PR DESCRIPTION
## Summary

`apply_bc_to_fem_system` previously **warned and silently fell back to natural (Neumann) BC** for `BCType.ROBIN` — a fail-silent anti-pattern that runs the wrong physics quietly — and warn-only (no fallback) for `BCType.PERIODIC`. Both now raise `NotImplementedError`.

## Why fail-loud (not implement)
A correct Robin FEM BC `α u + β ∂u/∂n = g` needs a boundary term `(Dα/β)∫_∂Ω uv` scaled by the diffusion coefficient `D`, assembled where the stiffness `K` is (so it joins the `M/dt + D·K` implicit step). But `apply_bc_to_fem_system` is **coefficient-blind** — it receives the already-assembled matrix with `D`/time-factor baked in upstream (weak-form base class). So a correct implementation belongs at the solver level, also touches the meshless-Galerkin-shared base classes (#1145), and per repo rules needs a Joplin-Dev consult. That design work is tracked in **#1237**. Shipping a guessed-coefficient Robin would be worse than failing loud.

## Safety
Nothing exercises Robin/Periodic through the FEM path (verified by grep), so this only converts a **silent wrong-answer into a loud error** — aligned with the repo's fail-fast / no-silent-fallback rule. New parametrized fail-loud tests (`test_fem_solver_path.py`); 5 BC-resolution tests pass.

> Stacked on #1238 (base will retarget to `main` once that merges).

Refs #1237, #773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)