### PR TITLE
docs(fem): P2 mass-lumping caveat + quad/hex injection path (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Robin / Periodic FEM boundary conditions now fail loud** (Issue #1237). `apply_bc_to_fem_system`
+  previously *warned and silently fell back to natural (Neumann) BC* for `BCType.ROBIN` — a
+  fail-silent anti-pattern that ran the wrong physics quietly — and warn-only (no fallback) for
+  `BCType.PERIODIC`. Both now raise `NotImplementedError` with a pointer to the use-an-FDM/GFDM-solver
+  workaround. A correct Robin FEM BC needs a diffusion-coefficient-scaled `FacetBasis` boundary term
+  threaded through the weak-form assembly (the adapter is coefficient-blind — it only sees the
+  already-assembled matrix); Periodic needs DOF identification across paired boundaries. Both are
+  tracked in #1237. Nothing exercised these stubs through the FEM path, so this only converts a silent
+  wrong-answer into a loud error. New parametrized fail-loud tests in `test_fem_solver_path.py`.
+
 - **Single-sourced the tensor-diffusion operator** (Issue #1228). `∇·(Σ∇u)` was implemented twice:
   `operators/differential/diffusion.py` (`DiffusionOperator` private `_tensor_diffusion_1d/2d/nd`)
   and `utils/numerical/tensor_calculus.py` (`diffusion`) — two independent copies, the repo's

--- a/mfgarchon/alg/numerical/fem/bc_adapter.py
+++ b/mfgarchon/alg/numerical/fem/bc_adapter.py
@@ -8,8 +8,10 @@ Mapping:
     BCType.DIRICHLET → condense() with boundary DOFs and values
     BCType.NEUMANN   → natural BC (default in weak form, no action needed)
     BCType.NO_FLUX   → same as NEUMANN (zero normal derivative)
-    BCType.ROBIN     → boundary integral via FacetBasis (alpha*u + beta*du/dn = g)
-    BCType.PERIODIC  → DOF pairing (not yet implemented for FEM)
+    BCType.ROBIN     → NotImplementedError (needs a D-scaled FacetBasis boundary term threaded
+                       through weak-form assembly; not resolvable in this coefficient-blind
+                       adapter — Issue #1237)
+    BCType.PERIODIC  → NotImplementedError (needs DOF pairing across boundaries — Issue #1237)
 
 Issue #773: BC framework integration for FEM solvers
 """
@@ -40,7 +42,8 @@ def apply_bc_to_fem_system(
 
     For Dirichlet segments: condense the system (eliminate boundary DOFs).
     For Neumann/no-flux: no action (natural BC in weak form).
-    For Robin: add boundary integral terms (future).
+    For Robin/Periodic: raises ``NotImplementedError`` (Issue #1237) — fail loud rather than
+    silently degrade to Neumann.
 
     Args:
         A: System matrix (N_dof, N_dof)
@@ -74,22 +77,21 @@ def apply_bc_to_fem_system(
             pass
 
         elif segment.bc_type == BCType.ROBIN:
-            # Robin BC: alpha*u + beta*du/dn = g
-            # Requires FacetBasis boundary integral — future implementation
-            import warnings
-
-            warnings.warn(
-                f"Robin BC on segment '{segment.name}' not yet implemented for FEM. "
-                "Falling back to natural (Neumann) BC.",
-                stacklevel=2,
+            # Robin BC (alpha*u + beta*du/dn = g) needs a FacetBasis boundary term scaled by the
+            # diffusion coefficient D, which is assembled upstream (weak-form base class) and is
+            # NOT visible to this coefficient-blind adapter. Fail loud rather than silently
+            # degrade to Neumann (which would run the wrong physics quietly). See Issue #1237.
+            raise NotImplementedError(
+                f"Robin BC on segment '{segment.name}' is not implemented for the FEM solver path. "
+                "Correct Robin BC requires threading the diffusion coefficient / time factor into "
+                "the weak-form assembly (Issue #1237). Use Dirichlet or Neumann/no-flux here, or an "
+                "FDM/GFDM solver for Robin/reflecting boundaries."
             )
 
         elif segment.bc_type == BCType.PERIODIC:
-            import warnings
-
-            warnings.warn(
-                f"Periodic BC on segment '{segment.name}' not yet implemented for FEM.",
-                stacklevel=2,
+            raise NotImplementedError(
+                f"Periodic BC on segment '{segment.name}' is not implemented for the FEM solver "
+                "path (needs DOF identification across paired boundaries; see Issue #1237)."
             )
 
     if dirichlet_dofs:

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -93,6 +93,11 @@ class WeakFormHJBSolver(BaseHJBSolver):
 
     # --- Gradient recovery: mass-lumped L2 projection grad_d(u) = G_d @ u -----
     def _build_gradient_operators(self) -> None:
+        # Accuracy caveat: row-sum mass lumping (M_lumped = M.sum(axis=1)) keeps gradient recovery
+        # cheap and diagonal, and is exact-order for P1. For P2 it is suboptimal — the lumped
+        # projection can cap the recovered gradient below the full consistent-mass O(h^p) rate, so
+        # a P2 HJB solve may not realize the full P2 convergence order here. Replacing this with a
+        # full consistent-mass L2 projection is a deferred accuracy-vs-speed design decision.
         if self._G_grad is not None:
             return
         M_lumped = np.array(self._M.sum(axis=1)).ravel()

--- a/mfgarchon/geometry/meshes/mesh_2d.py
+++ b/mfgarchon/geometry/meshes/mesh_2d.py
@@ -286,7 +286,12 @@ class Mesh2D(_MeshGeneratorBase):
         If ``self.mesh_data`` is already populated (e.g. injected from a pre-built mesh via
         ``mfgarchon.alg.numerical.fem.mesh_adapter.skfem_to_meshdata``), it is returned as-is —
         a gmsh-free path for callers that supply their own mesh, and idempotent memoization
-        otherwise."""
+        otherwise.
+
+        Note: gmsh generation here emits **triangular (simplex)** elements only. The FEM solve
+        path also supports **quadrilateral** meshes (Issue #470), but quad generation is not
+        implemented — inject a pre-built quad mesh instead, e.g. ``skfem.MeshQuad.init_tensor``
+        → ``skfem_to_meshdata`` (gmsh-free)."""
         if self.mesh_data is not None:
             return self.mesh_data
         try:

--- a/mfgarchon/geometry/meshes/mesh_3d.py
+++ b/mfgarchon/geometry/meshes/mesh_3d.py
@@ -369,7 +369,11 @@ class Mesh3D(_MeshGeneratorBase):
         """Generate 3D tetrahedral mesh.
 
         Returns a pre-populated ``self.mesh_data`` as-is if present (gmsh-free injected-mesh
-        path / idempotent memoization)."""
+        path / idempotent memoization).
+
+        Note: gmsh generation here emits **tetrahedral (simplex)** elements only. Non-simplex
+        meshes (e.g. hexahedral) for the FEM solve path (Issue #470) are not generated here —
+        inject a pre-built mesh instead, e.g. ``skfem.MeshHex.init_tensor`` → ``skfem_to_meshdata``."""
         if self.mesh_data is not None:
             return self.mesh_data
         try:

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -138,6 +138,29 @@ class TestFEMBoundaryConditionResolution:
         assert isinstance(fp._bc, BoundaryConditions)
         assert fp._is_pure_neumann()  # no-flux is natural/Neumann
 
+    @pytest.mark.parametrize("bc_type_name", ["ROBIN", "PERIODIC"])
+    def test_robin_periodic_fem_bc_fail_loud(self, bc_type_name):
+        """Robin/Periodic FEM BC must raise, not silently degrade to Neumann (Issue #1237).
+
+        The previous behavior warned and fell back to natural (Neumann) BC — a fail-silent
+        anti-pattern that ran the wrong physics quietly. Correct Robin/Periodic FEM needs a
+        D-scaled FacetBasis term / DOF pairing threaded through weak-form assembly, which the
+        coefficient-blind ``apply_bc_to_fem_system`` cannot do."""
+        from mfgarchon.alg.numerical.fem.assembly import assemble_stiffness, create_basis
+        from mfgarchon.alg.numerical.fem.bc_adapter import apply_bc_to_fem_system
+        from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+        from mfgarchon.geometry.boundary.types import BCSegment, BCType
+
+        mesh = skfem.MeshTri.init_sqsymmetric().refined(1)
+        basis = create_basis(mesh, order=1)
+        A = assemble_stiffness(basis)
+        rhs = np.zeros(basis.N)
+        segment = BCSegment(name="wall", bc_type=getattr(BCType, bc_type_name), alpha=1.0, beta=1.0)
+        bc = BoundaryConditions(dimension=2, segments=[segment])
+
+        with pytest.raises(NotImplementedError, match="Issue #1237"):
+            apply_bc_to_fem_system(A, rhs, basis, bc)
+
     def test_coupled_fem_no_flux_runs_and_conserves_mass(self):
         """First coupled FEM MFG through the real solver classes (manual Picard — the standard
         FixedPointIterator is still grid-only, seam 3). No-flux ⇒ mass conserved, confirming the


### PR DESCRIPTION
## Summary
Two honest known-limitation / usage notes surfaced by the FEM-extension survey (comments/docstrings only — no behavior or API change):

- **`weak_form_hjb_solver._build_gradient_operators`**: note that row-sum mass lumping is exact-order for P1 but **suboptimal for P2** — the lumped projection can cap recovered-gradient accuracy below the full consistent-mass `O(h^p)` rate, so a P2 HJB solve may not realize full P2 order here. Replacing with a consistent-mass L2 projection is a deferred accuracy-vs-speed design decision.
- **`Mesh2D`/`Mesh3D.generate_mesh` docstrings**: gmsh generation emits **simplex (Tri/Tet)** elements only; quad/hex meshes for the FEM path (#470) are not generated — inject a pre-built mesh via `skfem.MeshQuad`/`MeshHex.init_tensor` → `skfem_to_meshdata` (gmsh-free).

Note: the survey also suggested sharpening the FEM adjoint-transpose comment in `adjoint_validation.py`, but that comment is already accurate and nuanced (states the `-C^T` assembled-operator transpose correctly), so it was left untouched.

> Stacked on #1239 → #1238 (base retargets to `main` as those merge).

Refs #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)