### PR TITLE
fix: single-source multi-population FP drift with single-pop (#1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Multi-population FP drift now single-sourced with single-pop** (Issue #1043). The
+  `MultiPopulationIterator` computed its own *node*-centered velocity (`np.gradient`) and always
+  passed it as an explicit `drift_field`, while the single-population `FixedPointIterator`/
+  `MFGResidual` resolve drift through `resolve_fp_drift_kwargs` — *face*-centered velocity (#919,
+  matched to the divergence-upwind stencil) for non-smooth H, or `potential_field=U` for
+  smooth-separable H. Two divergent conventions on parallel paths (the repo's dominant bug class):
+  feeding the *same* U through the same FP solver, the node-centered velocity gave a **~68%**
+  different density, and a **K=1** multi-population solve was **~116%** off the equivalent
+  single-population solve. The iterator now routes its continuous-domain FP drift through the
+  shared `resolve_fp_drift_kwargs` (new `h_class=` param threads the cross-density-bound
+  Hamiltonian so the velocity still sees other populations' density, #1157); the private
+  `_compute_velocity_field` copy is removed and the network branch (`spatial_dimension == 0`) is
+  preserved. K=1 now matches single-pop to **~19%** (residual is the iterators' other non-FP
+  differences — single-pop damps U+M and runs Anderson/source/BC machinery; the multi-pop loop is
+  a leaner Picard — not the drift convention). `resolve_fp_drift_kwargs(h_class=None)` is
+  byte-identical for single-pop. New `test_k1_matches_single_population_fp_convention`; 18 existing
+  multi-pop tests still pass. (`_compute_drift_field`, the separately-deprecated node-centered
+  sibling, keeps its own v0.25.0 removal timeline.)
+
 - **`NewtonMFGSolver` diverged ~99.5% from Picard** (Issue #1233). The Newton coupling residual
   `F = [HJB(M) - U, FP(U) - M]` was inconsistent with the Picard fixed point, so the two solvers
   converged to different roots. Two causes: **(1) stale FP drift convention** — `MFGResidual`

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -463,6 +463,8 @@ def resolve_fp_drift_kwargs(
     drift_field_override: object | None,
     U: np.ndarray,
     M: np.ndarray,
+    *,
+    h_class: object | None = None,
 ) -> tuple[dict, bool]:
     """Resolve how the value function enters ``solve_fp_system`` (drift vs potential).
 
@@ -487,6 +489,10 @@ def resolve_fp_drift_kwargs(
         drift_field_override: Caller-supplied drift override (array/callable), or ``None``.
         U: Current value function, shape ``(Nt+1, *spatial_shape)``.
         M: Current density, shape ``(Nt+1, *spatial_shape)`` (used only for non-smooth $H$).
+        h_class: Hamiltonian to use for the smoothness dispatch and velocity computation,
+            overriding ``problem.hamiltonian_class``. The multi-population iterator passes the
+            cross-density-bound Hamiltonian here (Issue #1043) so K populations resolve drift the
+            same way single-pop does; ``None`` uses ``problem.hamiltonian_class`` (single-pop).
 
     Returns:
         ``(drift_kwargs, use_positional_U)`` where ``drift_kwargs`` is one of ``{}``,
@@ -507,7 +513,7 @@ def resolve_fp_drift_kwargs(
     else:
         from mfgarchon.core.hamiltonian import SeparableHamiltonian
 
-        H_class = problem.hamiltonian_class
+        H_class = h_class if h_class is not None else problem.hamiltonian_class
         use_velocity = (
             H_class is not None
             and "drift_field" in params

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -77,6 +77,17 @@ class MultiPopulationIterator:
         if len(fp_solvers) != K:
             raise ValueError(f"Need {K} FP solvers, got {len(fp_solvers)}")
 
+        # Issue #1043: cache each FP solver's solve_fp_system signature so the drift/potential
+        # convention can be resolved via the shared resolve_fp_drift_kwargs (same as single-pop).
+        import inspect
+
+        self._fp_sig_params: list[set[str] | None] = []
+        for fp in fp_solvers:
+            try:
+                self._fp_sig_params.append(set(inspect.signature(fp.solve_fp_system).parameters))
+            except (AttributeError, ValueError, TypeError):
+                self._fp_sig_params.append(None)
+
     @property
     def damping_factor(self) -> float:
         """Deprecated alias for `relaxation` (v0.19.2+). Removal in v0.25.0."""
@@ -168,19 +179,33 @@ class MultiPopulationIterator:
                 else:
                     U[k] = solver_k.solve_hjb_system(M[k], U_terminal_k, U[k])
 
-            # Step 2: Solve K FP equations with drift from H_k
+            # Step 2: Solve K FP equations. The FP drift/potential convention is single-sourced
+            # through resolve_fp_drift_kwargs (Issue #1043), identical to the single-population
+            # FixedPointIterator — so a K=1 multi-population solve matches single-pop. The
+            # cross-density-bound Hamiltonian is passed as h_class so the velocity (non-smooth H)
+            # sees the other populations' density (its optimal_control maps t→trajectory row n;
+            # Issue #1157). Network problems keep the U-as-drift path (FPNetworkSolver extracts
+            # rates internally).
+            from .fixed_point_utils import resolve_fp_drift_kwargs
+
             for k in range(K):
                 prob_k = self.multi_problem.get_population(k)
                 m0_k = M[k][0]
                 H_k = prob_k.hamiltonian_class
-
-                # Use bound H for velocity computation (sees cross-pop density). dt is required
-                # because _compute_velocity_field calls optimal_control per timestep with t=n*dt,
-                # which BoundHamiltonian maps to trajectory row n (Issue #1157).
                 H_bound = H_k.bind_cross_density(m_all, dt=prob_k.dt) if hasattr(H_k, "bind_cross_density") else H_k
-                velocity = self._compute_velocity_field(U[k], M[k], H_bound, prob_k)
+                fp_k = self.fp_solvers[k]
 
-                M_new_k = self.fp_solvers[k].solve_fp_system(m0_k, drift_field=velocity, show_progress=False)
+                if getattr(prob_k, "spatial_dimension", None) == 0:
+                    M_new_k = fp_k.solve_fp_system(m0_k, drift_field=U[k], show_progress=False)
+                else:
+                    drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
+                        prob_k, self._fp_sig_params[k], None, U[k], M[k], h_class=H_bound
+                    )
+                    if use_positional_U:
+                        M_new_k = fp_k.solve_fp_system(m0_k, U[k], show_progress=False)
+                    else:
+                        M_new_k = fp_k.solve_fp_system(m0_k, show_progress=False, **drift_kwargs)
+
                 M[k] = (1 - self.relaxation) * M_old[k] + self.relaxation * M_new_k
 
             # Check convergence
@@ -207,42 +232,6 @@ class MultiPopulationIterator:
             errors=errors,
             population_names=self.multi_problem.population_names,
         )
-
-    @staticmethod
-    def _compute_velocity_field(U, M, H_class, problem):
-        """Compute velocity α*(t, x) from H.optimal_control.
-
-        M is the own-population density (Nt+1, Nx). H_k accesses
-        cross-population density via _m_all_current (injected by iterator).
-
-        Dispatches on problem type:
-        - Network (spatial_dimension == 0): return U directly (FP network
-          solver handles drift extraction internally via H.optimal_control)
-        - Continuous 1D: compute α* via ∇U → H.optimal_control
-        """
-        spatial_dim = getattr(problem, "spatial_dimension", None)
-        if spatial_dim == 0:
-            # Network: pass U (FPNetworkSolver extracts rates internally)
-            return U
-
-        geometry = problem.geometry
-        grid_spacing = geometry.get_grid_spacing()
-        dx = grid_spacing[0]
-        dt = problem.dt
-        Nt = U.shape[0]
-        Nx = U.shape[-1]
-
-        grad_U = np.gradient(U, dx, axis=-1)
-        bounds = geometry.get_bounds()
-        x_grid = np.linspace(bounds[0][0], bounds[1][0], Nx).reshape(-1, 1)
-
-        alpha_field = np.zeros_like(grad_U)
-        for n in range(Nt):
-            p = grad_U[n]
-            m_n = M[n] if n < M.shape[0] else M[-1]
-            alpha_field[n] = H_class.optimal_control(x_grid, m_n, p.reshape(-1, 1), t=n * dt).ravel()
-
-        return alpha_field
 
     @staticmethod
     def _compute_drift_field(U, M, H_class, problem):

--- a/tests/integration/test_multi_population_cross_coupling.py
+++ b/tests/integration/test_multi_population_cross_coupling.py
@@ -93,6 +93,36 @@ def test_single_population_byte_identical():
     assert np.array_equal(np.asarray(c.M[0]), np.asarray(d.M[0]))
 
 
+def test_k1_matches_single_population_fp_convention():
+    """K=1 multi-pop must resolve FP drift the SAME way the single-pop FixedPointIterator does
+    (Issue #1043).
+
+    The iterator previously computed its own *node*-centered velocity and always passed it as an
+    explicit ``drift_field``, diverging from single-pop, which resolves drift via
+    ``resolve_fp_drift_kwargs`` (``potential_field=U`` for smooth-separable H, face-centered
+    velocity otherwise). For a K=1 LQ problem the resulting density was ~116% off the single-pop
+    solve. Now both route through the shared resolver, so the K=1 density matches single-pop up to
+    the iterators' other (non-FP) differences (single-pop damps U+M and runs Anderson/source/BC
+    machinery; the multi-pop loop is a leaner Picard). The 0.30 threshold sits well below the
+    pre-fix 1.16 (a re-fork to a private velocity convention fails here) and above the post-fix
+    ~0.19 residual."""
+    from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+
+    prob = _make_problem(0, cross=0.0, K=1)
+    sp = FixedPointIterator(prob, hjb_solver=HJBFDMSolver(prob), fp_solver=FPFDMSolver(prob), relaxation=0.5).solve(
+        max_iterations=120, tolerance=1e-6, verbose=False
+    )
+    M_sp = sp[1]
+
+    mp = _solve(1, cross=0.0, max_iterations=200)
+    M_mp = np.asarray(mp.M[0])
+
+    m_diff = np.linalg.norm(M_mp - M_sp) / (np.linalg.norm(M_sp) + 1e-12)
+    assert m_diff < 0.30, f"K=1 multi-pop density {m_diff * 100:.1f}% off single-pop (FP convention re-forked?)"
+    # mass conservation preserved
+    assert np.allclose(M_mp.sum(axis=-1), M_mp[0].sum(), rtol=1e-6)
+
+
 def test_nonfdm_backend_multipop_fails_loud():
     """A K>1 run on an HJB backend that does not thread the cross-density override must fail
     loud (the half-coupled silent-wrong equilibrium is the bug), not run silently."""


### PR DESCRIPTION
## Problem (dominant bug class: parallel paths, private convention copies)

`MultiPopulationIterator` computed its own **node-centered** velocity (`np.gradient`) and always passed it as an explicit `drift_field`. The single-population `FixedPointIterator`/`MFGResidual` instead resolve drift through `resolve_fp_drift_kwargs` — **face-centered** velocity (#919, matched to the divergence-upwind stencil) for non-smooth H, or `potential_field=U` for smooth-separable H. Two divergent conventions for the same physics.

### Measured (verify-by-artifact)
- Same converged `U` → same FP solver: node-centered velocity gives a **67.65%** different density vs face-centered.
- **K=1** multi-pop vs equivalent single-pop: **U 89% / M 116%** off.

## Fix
Route the iterator's continuous-domain FP drift through the shared `resolve_fp_drift_kwargs`. A new `h_class=` param threads the **cross-density-bound** Hamiltonian (so the velocity still sees other populations' density for non-smooth H, #1157). Removed the private `_compute_velocity_field`; **preserved** the network branch (`spatial_dimension == 0` → `U`).

### Result
K=1 multi-pop now matches single-pop to **U 44% / M 19%** (M-diff **116% → 19%**). The residual is the iterators' *other* non-FP differences (single-pop damps U+M and runs Anderson/source/BC machinery; the multi-pop loop is a leaner Picard) — a separate, broader consistency matter, **not** the drift convention, and out of scope here.

## Safety
- `resolve_fp_drift_kwargs(h_class=None)` is **byte-identical** for single-pop (the single-pop callers never pass `h_class`). Verified: the #1233 Newton-Picard agreement + convention-agreement guards pass.
- New `test_k1_matches_single_population_fp_convention` (threshold 0.30: pre-fix 1.16 fails, post-fix 0.19 passes). **18** existing multi-pop tests pass.
- `_compute_drift_field` (the separately-deprecated node-centered sibling, uncalled) keeps its own v0.25.0 removal timeline.

This is one slice of #1043's 5-solver/3-convention umbrella (the multi-pop ↔ single-pop axis); the full all-solver `potential_field`+`drift_field` API unification remains.

Refs #1043, #1157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)