### PR TITLE
feat(gfdm): assembled-matrix DMP verification + runtime guard for joint_socp (#1074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Assembled-matrix DMP verification + runtime guard for joint_socp** (Issue #1074, paper-critical).
+  Per-stencil SOCP feasibility (already tested) does **not** imply the *assembled* HJB iteration
+  matrix `I/Δt − D·L + α·D_grad` is an M-matrix — the paper's discrete-maximum-principle claim.
+  Empirical finding (verify-by-artifact): the assembled interior matrix **is** an M-matrix at zero
+  drift for σ∈{0.3,0.5,1.0} (the SOCP-monotone Laplacian gives the diffusion-part DMP), but the
+  signed `α·D_grad` term **flips an off-diagonal positive** once `|α| > α_crit = D·min_edge(L_ij /
+  ‖D_grad_ij‖)` — a Péclet-like threshold. So **the DMP holds conditionally (diffusion-dominated),
+  not unconditionally**. Crucially this off-diagonal *sign* condition is **dt-independent** (a smaller
+  Δt restores diagonal dominance but not the sign). Added `verify_assembled_m_matrix(J,
+  interior_indices)` and `critical_drift_for_dmp(D_lap, D_grad, D)` to `gfdm_components/
+  monotonicity_enforcer.py`, and an **opt-in** `HJBGFDMSolver(check_dmp=True)` runtime guard that
+  warns once when a solve's drift exceeds `α_crit`. The guard is **numerically inert** — verified the
+  GFDM joint_socp solve is **byte-identical** with `check_dmp` False vs True (`max|Δ|=0`), and it
+  defaults off (zero overhead on the paper path). Characterization tests pin both halves (M-matrix at
+  zero drift; broken under strong drift) so a future unconditional-DMP claim fails loudly. The formal
+  per-stencil→assembled theorem and the paper-claim wording (scope to low-Péclet vs add gradient
+  upwinding) remain open for the author.
+
 - **FP mass-conservation regression now covers P2** (Issue #470 follow-up). The FEM FP advection
   operator is assembled as `-C^T`, whose column sums vanish by partition of unity
   (`Σ_i φ_i = 1`) — an *order-agnostic* property. `test_fp_advection_is_mass_conserving` is now

--- a/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
+++ b/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
@@ -869,3 +869,102 @@ class MonotonicityEnforcer:
                 print(f"  Cache size:             {qp_cache.size} / {qp_cache.max_size}")
 
         print("=" * 80 + "\n")
+
+
+def verify_assembled_m_matrix(
+    matrix: Any,
+    interior_indices: np.ndarray | None = None,
+    atol: float = 1e-9,
+) -> dict[str, Any]:
+    r"""Verify the M-matrix property of the *assembled* HJB iteration matrix (Issue #1074).
+
+    The per-stencil SOCP checks (:meth:`MonotonicityEnforcer.check_m_matrix`) verify the raw
+    Laplacian weights at each collocation point. They do **not** imply that the assembled
+    Newton iteration matrix $J = I/\Delta t - D\,L + \alpha\cdot D_{\mathrm{grad}}$ is an
+    M-matrix: the signed drift term $\alpha\cdot D_{\mathrm{grad}}$ can flip an off-diagonal
+    positive once $|\alpha|$ is large relative to $D$ (a Péclet-like condition; see
+    :func:`critical_drift_for_dmp`). This checks the assembled system directly.
+
+    Args:
+        matrix: Assembled iteration matrix (any scipy sparse format).
+        interior_indices: Restrict the check to these rows. Boundary rows carry BC structure
+            that the solver applies separately and that is not expected to be M-matrix
+            pre-BC, so pass the solver's ``interior_indices`` to test the scheme's claim.
+        atol: Sign/zero tolerance.
+
+    Returns:
+        dict with ``is_m_matrix`` (bool) and the diagnostics ``n_bad_diag`` (non-positive
+        diagonals), ``n_positive_offdiag`` (wrong-sign off-diagonals), ``worst_positive_offdiag``
+        (max wrong-sign off-diagonal magnitude), ``worst_dominance_margin`` (max of
+        $\sum_{j\ne i}|J_{ij}| - J_{ii}$ over checked rows; $\le 0$ means weakly diagonally
+        dominant).
+    """
+    J = matrix.tocsr()
+    n = J.shape[0]
+    rows = np.arange(n) if interior_indices is None else np.asarray(interior_indices)
+
+    n_bad_diag = 0
+    n_positive_offdiag = 0
+    worst_positive_offdiag = 0.0
+    worst_dominance_margin = -np.inf
+    for i in rows:
+        row = J.getrow(i).toarray().ravel()
+        d_i = row[i]
+        off = row.copy()
+        off[i] = 0.0
+        if d_i <= atol:
+            n_bad_diag += 1
+        positive = off[off > atol]
+        if positive.size:
+            n_positive_offdiag += int(positive.size)
+            worst_positive_offdiag = max(worst_positive_offdiag, float(positive.max()))
+        worst_dominance_margin = max(worst_dominance_margin, float(np.abs(off).sum() - d_i))
+
+    is_m_matrix = n_bad_diag == 0 and n_positive_offdiag == 0 and worst_dominance_margin <= atol
+    return {
+        "is_m_matrix": is_m_matrix,
+        "n_bad_diag": n_bad_diag,
+        "n_positive_offdiag": n_positive_offdiag,
+        "worst_positive_offdiag": worst_positive_offdiag,
+        "worst_dominance_margin": worst_dominance_margin,
+    }
+
+
+def critical_drift_for_dmp(
+    d_lap: Any,
+    d_grad: list,
+    diffusion_coeff: float,
+    interior_indices: np.ndarray | None = None,
+    atol: float = 1e-12,
+) -> float:
+    r"""Largest drift magnitude $|\alpha|$ for which the assembled interior matrix keeps its
+    M-matrix off-diagonal sign (Issue #1074).
+
+    For interior off-diagonal $(i, j)$ the assembled entry is
+    $\sum_d \alpha_d (D_{\mathrm{grad}})_{d,ij} - D\,L_{ij}$. With $L_{ij} \ge 0$ (SOCP-monotone
+    Laplacian) the diffusion part is $\le 0$; the worst-case unit-$|\alpha|$ direction makes the
+    drift part $|\alpha|\,\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$ (Cauchy–Schwarz), so the sign
+    holds iff $|\alpha| \le D\,L_{ij}/\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$. The minimum over
+    edges is the critical drift. (The SOCP cone bound $\lVert D_{:,j}\rVert \le (C/h)L_j$ forces
+    the gradient support into the Laplacian support, so every drift-coupled edge has $L_{ij} > 0$
+    and the threshold is strictly positive.)
+
+    Returns ``inf`` when no edge constrains the sign (e.g. a zero gradient operator).
+    """
+    L = d_lap.tocsr()
+    grads = [g.tocsr() for g in d_grad]
+    n = L.shape[0]
+    rows = np.arange(n) if interior_indices is None else np.asarray(interior_indices)
+
+    alpha_crit = np.inf
+    for i in rows:
+        l_row = L.getrow(i).toarray().ravel()
+        g_rows = [g.getrow(i).toarray().ravel() for g in grads]
+        for j in np.nonzero(l_row > atol)[0]:
+            if j == i:
+                continue
+            g_norm = float(np.sqrt(sum(gr[j] ** 2 for gr in g_rows)))
+            if g_norm <= atol:
+                continue
+            alpha_crit = min(alpha_crit, diffusion_coeff * float(l_row[j]) / g_norm)
+    return alpha_crit

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -305,6 +305,11 @@ class HJBGFDMSolver(BaseHJBSolver):
         obstacle_sdf: object | None = None,
         visibility_samples: int = 10,
         visibility_margin: float = 0.0,
+        # DMP runtime guard (Issue #1074): warn when the solved drift exceeds the
+        # assembled-M-matrix threshold for joint_socp. Off by default (zero overhead,
+        # numerically byte-identical) — the assembled discrete-maximum-principle is only
+        # diagnostic, not enforced.
+        check_dmp: bool = False,
     ):
         """
         Initialize the GFDM HJB solver.
@@ -628,6 +633,12 @@ class HJBGFDMSolver(BaseHJBSolver):
             # coupling layer (using_resolved_bc); refresh at solve time (Issue #1118).
             self._bc_from_geometry = True
         self.interior_indices = np.setdiff1d(np.arange(self.n_points), self.boundary_indices)
+
+        # DMP runtime guard state (Issue #1074): lazily-computed critical drift and a
+        # warn-once latch. Active only when check_dmp=True (default off → no overhead).
+        self.check_dmp = check_dmp
+        self._dmp_alpha_crit: float | None = None
+        self._dmp_warned = False
 
         # Monotonicity scheme (single source of truth) — already set above (v0.18.0 rename)
         # self.monotonicity_scheme and self.qp_optimization_level both = resolved monotonicity_scheme
@@ -2285,6 +2296,42 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         return jacobian
 
+    def _maybe_warn_dmp(self, u_current: np.ndarray) -> None:
+        """Warn (once) when the current drift exceeds the assembled-M-matrix threshold (Issue #1074).
+
+        Per-stencil joint_socp feasibility does NOT imply the assembled HJB iteration matrix
+        ``I/dt - D·L + α·D_grad`` is an M-matrix: the signed drift term flips an off-diagonal
+        positive once ``|α| > α_crit = D·min_edge(L_ij/‖D_grad_ij‖)`` (see
+        :func:`critical_drift_for_dmp`). So the discrete maximum principle holds only in the
+        diffusion-dominated regime. This is a *diagnostic* warning (numerically inert); active only
+        when ``check_dmp=True`` and the scheme is ``joint_socp``. The drift is computed from the
+        current iterate via the assembled gradient operator, consistent with the Jacobian.
+        """
+        if not self.check_dmp or self._dmp_warned or self.monotonicity_scheme != "joint_socp":
+            return
+        if self._D_grad is None or self._D_lap is None:
+            return
+        if self._dmp_alpha_crit is None:
+            from mfgarchon.alg.numerical.gfdm_components.monotonicity_enforcer import critical_drift_for_dmp
+
+            diffusion_coeff = diffusion_from_volatility(self._get_sigma_value(None))
+            self._dmp_alpha_crit = critical_drift_for_dmp(
+                self._D_lap, self._D_grad, diffusion_coeff, interior_indices=self.interior_indices
+            )
+        lambda_val = self._get_lambda_value()
+        grad = np.stack([self._D_grad[d] @ u_current for d in range(self.dimension)], axis=1)
+        max_alpha = float(np.max(np.linalg.norm(grad, axis=1)) / lambda_val)
+        if max_alpha > self._dmp_alpha_crit:
+            logger.warning(
+                "DMP not guaranteed (joint_socp, Issue #1074): max|drift| = %.3g exceeds the "
+                "assembled-M-matrix threshold alpha_crit = %.3g. Per-stencil SOCP feasibility does "
+                "not imply an assembled M-matrix once |drift| > alpha_crit (advection-dominated); the "
+                "discrete maximum principle holds only for |drift| <= alpha_crit.",
+                max_alpha,
+                self._dmp_alpha_crit,
+            )
+            self._dmp_warned = True
+
     def _compute_hjb_jacobian_sparse(
         self,
         u_current: np.ndarray,
@@ -3180,6 +3227,9 @@ class HJBGFDMSolver(BaseHJBSolver):
                     break
 
                 jacobian_sparse = self._compute_hjb_jacobian_sparse(u_current, m_n_plus_1, time_idx, all_derivs)
+
+            # Issue #1074: diagnostic DMP guard (no-op unless check_dmp=True). Numerically inert.
+            self._maybe_warn_dmp(u_current)
 
             # Apply boundary conditions (sparse-aware).
             # `u_current` is needed so BC rows encode the Newton residual

--- a/tests/unit/test_alg/test_socp_m_matrix_property.py
+++ b/tests/unit/test_alg/test_socp_m_matrix_property.py
@@ -12,17 +12,23 @@ These are enforced by `solve_joint_socp_at_stencil` constraints (see
 for representative configurations. If the test fails, the paper claim has an
 empirical counter-example.
 
-The full assembled-matrix M-matrix property (Issue #1074 long-term ask)
-requires also bounding the advective contribution `(1/lambda)*D_grad*dt`
-against the diffusive contribution `(sigma**2/2)*L*dt`, which depends on
-the time-step. That's deferred — this test covers the part joint_socp
-itself guarantees.
+The full assembled-matrix M-matrix property (Issue #1074 long-term ask) is now
+also covered (tests at the bottom). Per-stencil SOCP feasibility does NOT imply
+the assembled HJB iteration matrix ``I/dt - D*L + alpha*D_grad`` is an M-matrix:
+the signed drift term flips an off-diagonal positive once
+``|alpha| > alpha_crit = D * min_edge(L_ij / ||D_grad_ij||)`` (a Peclet-like
+condition; ``critical_drift_for_dmp``). Note this off-diagonal *sign* condition is
+**dt-independent** — a smaller dt restores diagonal dominance but not the sign. So
+the discrete maximum principle holds only in the diffusion-dominated regime
+``|alpha| <= alpha_crit``; the runtime ``check_dmp`` guard warns when a solve
+exceeds it.
 """
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
+
+import numpy as np
 
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc
@@ -189,6 +195,120 @@ def test_socp_at_least_some_feasible():
     # baseline reports >85% at N>=75.
     assert n_feasible > 0, (
         f"sigma=1 low-Pe: 0/{total} stencils SOCP-feasible — joint_socp scheme producing no usable stencils"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1074 — ASSEMBLED-matrix M-matrix property (the long-term ask).
+# The per-stencil checks above do NOT imply the assembled HJB iteration matrix
+# (I/dt - D·L + α·D_grad) is an M-matrix. These characterize when it is.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sigma", [0.3, 0.5, 1.0])
+def test_assembled_m_matrix_holds_at_zero_drift(sigma):
+    """Issue #1074: at zero drift the assembled interior matrix (I/dt - D·L) IS an M-matrix.
+
+    This is the positive half — the SOCP-monotone Laplacian gives the diffusion-part discrete
+    maximum principle. (The 2 boundary rows carry BC structure applied separately and are
+    excluded via interior_indices.)"""
+    from mfgarchon.alg.numerical.gfdm_components.monotonicity_enforcer import verify_assembled_m_matrix
+
+    solver = _make_solver(sigma=sigma, n_x=21)
+    grad_u = np.zeros((solver.n_points, 1))
+    J = solver._compute_hjb_jacobian_vectorized(grad_u)
+    report = verify_assembled_m_matrix(J, interior_indices=solver.interior_indices)
+    assert report["is_m_matrix"], f"σ={sigma}: assembled interior matrix not M-matrix at zero drift: {report}"
+
+
+@pytest.mark.parametrize("sigma", [0.3, 0.5, 1.0])
+def test_assembled_m_matrix_breaks_under_strong_drift(sigma):
+    """Issue #1074: per-stencil SOCP feasibility does NOT imply the assembled M-matrix.
+
+    A large enough drift flips an off-diagonal positive via the α·D_grad term (the empirical
+    counter-example to an *unconditional* DMP claim). Pinning this catches a future change that
+    silently claims unconditional DMP. The threshold is predicted by critical_drift_for_dmp."""
+    from mfgarchon.alg.numerical.gfdm_components.monotonicity_enforcer import (
+        critical_drift_for_dmp,
+        verify_assembled_m_matrix,
+    )
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+    solver = _make_solver(sigma=sigma, n_x=21)
+    solver._compute_hjb_jacobian_vectorized(np.zeros((solver.n_points, 1)))  # build operators
+    diffusion_coeff = diffusion_from_volatility(sigma)
+    alpha_crit = critical_drift_for_dmp(
+        solver._D_lap, solver._D_grad, diffusion_coeff, interior_indices=solver.interior_indices
+    )
+    assert alpha_crit > 0.0  # SOCP cone bound keeps the threshold strictly positive
+
+    # λ=1 ⇒ |α| = |grad|. Drift well past α_crit must break the assembled M-matrix.
+    strong = np.full((solver.n_points, 1), 5.0 * alpha_crit)
+    J = solver._compute_hjb_jacobian_vectorized(strong)
+    report = verify_assembled_m_matrix(J, interior_indices=solver.interior_indices)
+    assert not report["is_m_matrix"], f"σ={sigma}: expected M-matrix violation at |drift|=5·α_crit, got {report}"
+    assert report["n_positive_offdiag"] > 0
+
+
+def test_runtime_dmp_guard_warns_only_when_violated():
+    """Issue #1074 runtime guard: check_dmp=True warns when the drift exceeds α_crit; it is
+    silent below the threshold and a no-op when check_dmp=False (the default — numerically inert)."""
+    import logging
+
+    records: list[str] = []
+    handler = logging.Handler()
+    handler.emit = lambda r: records.append(r.getMessage())
+    gfdm_logger = logging.getLogger("mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm")
+    gfdm_logger.addHandler(handler)
+    try:
+        solver = _make_solver_check_dmp(sigma=0.3, check_dmp=True)
+        solver._compute_hjb_jacobian_vectorized(np.zeros((solver.n_points, 1)))  # build operators + α_crit
+        x = np.linspace(0.0, 1.0, solver.n_points)
+
+        records.clear()
+        solver._maybe_warn_dmp(1e-4 * x)  # |drift| ≪ α_crit
+        assert not any("DMP" in m for m in records), "guard warned in the diffusion-dominated regime"
+
+        records.clear()
+        solver._dmp_warned = False
+        solver._maybe_warn_dmp(100.0 * x)  # |drift| ≫ α_crit
+        assert any("Issue #1074" in m for m in records), "guard did not warn under strong drift"
+
+        off = _make_solver_check_dmp(sigma=0.3, check_dmp=False)
+        off._compute_hjb_jacobian_vectorized(np.zeros((off.n_points, 1)))
+        records.clear()
+        off._maybe_warn_dmp(100.0 * x)
+        assert not any("DMP" in m for m in records), "guard fired with check_dmp=False (should be inert)"
+    finally:
+        gfdm_logger.removeHandler(handler)
+
+
+def _make_solver_check_dmp(sigma: float, check_dmp: bool, n_x: int = 21):
+    """`_make_solver` variant exposing the check_dmp flag (Issue #1074 runtime guard)."""
+    from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+
+    geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n_x], boundary_conditions=no_flux_bc(dimension=1))
+    components = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: np.ones_like(np.asarray(m)),
+        ),
+    )
+    problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, sigma=sigma, components=components)
+    x_coords = np.linspace(0.0, 1.0, n_x).reshape(-1, 1)
+    return HJBGFDMSolver(
+        problem,
+        x_coords,
+        delta=0.15,
+        monotonicity_scheme="joint_socp",
+        monotonicity_application="precompute",
+        check_dmp=check_dmp,
     )
 
 


### PR DESCRIPTION
## Paper-critical finding

Per-stencil SOCP feasibility (already tested in `test_socp_m_matrix_property.py`) does **not** imply the **assembled** HJB iteration matrix `I/Δt − D·L + α·D_grad` is an M-matrix — which is the paper's discrete-maximum-principle claim.

**Empirical characterization** (assembled interior matrix, via `_compute_hjb_jacobian_vectorized`, checked with the new `verify_assembled_m_matrix`):

| Regime | Result |
|---|---|
| Zero drift, σ∈{0.3,0.5,1.0} | **M-matrix holds** ✓ (SOCP-monotone Laplacian ⇒ diffusion-part DMP) |
| `\|α\| > α_crit` | **off-diagonal flips positive** (M-matrix lost) |

with `α_crit = D · min_edge(L_ij / ‖D_grad_ij‖)` (matches the empirical break-point tightly; `α_crit/D ≈ 8.8` const for this stencil). **The DMP is conditional (diffusion-dominated), not unconditional.** The off-diagonal *sign* condition is **dt-independent** — a smaller Δt restores *diagonal dominance* but not the sign (the issue's `C·|α|·dt < D` conflated the two).

## Delivered (the issue's short-term verification + long-term runtime-assertion option)
- `verify_assembled_m_matrix(J, interior_indices)` and `critical_drift_for_dmp(D_lap, D_grad, D)` in `gfdm_components/monotonicity_enforcer.py`.
- Opt-in `HJBGFDMSolver(check_dmp=True)` runtime guard: warns once when a solve's drift exceeds `α_crit`.
- Characterization tests: M-matrix at zero drift (positive evidence) + broken under strong drift (counter-example, so a future *unconditional*-DMP claim fails loudly) + guard fires only when violated.

## Safety (EOC)
The guard is **numerically inert**: the joint_socp GFDM solve is **byte-identical** with `check_dmp` False vs True (`max|Δ|=0`), and `check_dmp` defaults **off** (zero overhead on the byte-identical 2D-scattered-GFDM paper path). 52 GFDM/monotonicity/diffusion-gate tests pass.

## Open (author's domain)
The formal per-stencil→assembled **theorem** and the **paper-claim decision** — scope the DMP claim to low-Péclet, or add gradient **upwinding** so the off-diagonal sign survives advection — remain yours. **Refs #1074** (not Closes: paper-claim resolution pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)