### PR TITLE
fix: multi-pop K=1 converged to a non-fixed-point — BoundHamiltonian defeated FP dispatch (#1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Multi-population K=1 converged to a non-fixed-point: BoundHamiltonian defeated the FP drift
+  dispatch** (Issue #1043 follow-up). After the FP-drift single-sourcing below, a K=1 multi-pop
+  solve *still* diverged from single-pop (`||F_FP|| ≈ 6.9`, 19% density / 44% U) — and the
+  multi-pop solution was **not a coupled fixed point** (`||F_HJB|| ≈ 0` but `||F_FP|| = O(1)`; a
+  Picard step from it moved M by 11%). Root cause: the iterator binds `H_bound =
+  H.bind_cross_density(...)`, a `BoundHamiltonian` wrapper that fails
+  `isinstance(SeparableHamiltonian)`, so `resolve_fp_drift_kwargs` took the *velocity* path while
+  single-pop (unbound H) took the *potential* path — two different (self-consistent-but-distinct)
+  fixed points. The wrapper's `optimal_control` delegates to the inner H, so a bound
+  smooth-separable H still has the momentum-only optimal control that makes `potential_field=U`
+  correct (cross-coupling enters via the HJB, not the FP drift). The resolver now unwraps
+  `H._inner` for the smoothness dispatch; K=1 multi-pop now matches single-pop **exactly** (`U`/`M`
+  diff `< 1e-4`, bounded by the Picard tolerance; was 116%/19% across the two stacked bugs).
+  No-op for single-pop (no `_inner` → byte-identical; Newton-Picard + convention guards pass).
+  Tightened `test_k1_matches_single_population_fp_convention` to assert the exact match.
+
 - **Multi-population FP drift now single-sourced with single-pop** (Issue #1043). The
   `MultiPopulationIterator` computed its own *node*-centered velocity (`np.gradient`) and always
   passed it as an explicit `drift_field`, while the single-population `FixedPointIterator`/

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -514,10 +514,19 @@ def resolve_fp_drift_kwargs(
         from mfgarchon.core.hamiltonian import SeparableHamiltonian
 
         H_class = h_class if h_class is not None else problem.hamiltonian_class
+        # Issue #1043: unwrap a cross-density-bound Hamiltonian (BoundHamiltonian, multi-pop) to
+        # its inner H for the smoothness dispatch. The wrapper delegates optimal_control to the
+        # inner H, so a bound smooth-separable H still has the momentum-only optimal control that
+        # makes potential_field=U correct (the cross-coupling enters via the HJB, not the FP
+        # drift). Without this, the wrapper fails `isinstance(SeparableHamiltonian)` and a K=1
+        # multi-population solve takes the velocity path while single-pop takes potential → the
+        # two converge to different fixed points (||F_FP|| ~ O(1)). For single-pop H_class has no
+        # `_inner`, so this is a no-op (byte-identical).
+        H_base = getattr(H_class, "_inner", H_class)
         use_velocity = (
             H_class is not None
             and "drift_field" in params
-            and not (isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth())
+            and not (isinstance(H_base, SeparableHamiltonian) and H_base.control_cost.is_smooth())
         )
         if use_velocity:
             drift_kwargs["drift_field"] = compute_fp_velocity_field(problem, U, M, H_class)

--- a/tests/integration/test_multi_population_cross_coupling.py
+++ b/tests/integration/test_multi_population_cross_coupling.py
@@ -94,31 +94,33 @@ def test_single_population_byte_identical():
 
 
 def test_k1_matches_single_population_fp_convention():
-    """K=1 multi-pop must resolve FP drift the SAME way the single-pop FixedPointIterator does
-    (Issue #1043).
+    """A K=1 multi-pop solve must converge to the SAME fixed point as the single-pop
+    FixedPointIterator (Issue #1043).
 
-    The iterator previously computed its own *node*-centered velocity and always passed it as an
-    explicit ``drift_field``, diverging from single-pop, which resolves drift via
-    ``resolve_fp_drift_kwargs`` (``potential_field=U`` for smooth-separable H, face-centered
-    velocity otherwise). For a K=1 LQ problem the resulting density was ~116% off the single-pop
-    solve. Now both route through the shared resolver, so the K=1 density matches single-pop up to
-    the iterators' other (non-FP) differences (single-pop damps U+M and runs Anderson/source/BC
-    machinery; the multi-pop loop is a leaner Picard). The 0.30 threshold sits well below the
-    pre-fix 1.16 (a re-fork to a private velocity convention fails here) and above the post-fix
-    ~0.19 residual."""
+    Two stacked convention bugs made K=1 diverge from single-pop. (1) The iterator computed its
+    own *node*-centered velocity and always passed it as an explicit ``drift_field`` (~116% off);
+    routing through the shared ``resolve_fp_drift_kwargs`` fixed the convention. (2) The iterator
+    binds ``H_bound = H.bind_cross_density(...)`` — a ``BoundHamiltonian`` wrapper that fails
+    ``isinstance(SeparableHamiltonian)``, so the resolver took the *velocity* path while single-pop
+    (unbound H) took *potential*; the K=1 solve then converged to a point with ``||F_FP|| ~ O(1)``
+    that is **not** a coupled fixed point. Unwrapping the bound H for the smoothness dispatch fixed
+    it. With both fixes K=1 matches single-pop **exactly** (bounded only by the Picard tolerance),
+    so a tight threshold catches any reintroduction of either bug."""
     from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
 
     prob = _make_problem(0, cross=0.0, K=1)
     sp = FixedPointIterator(prob, hjb_solver=HJBFDMSolver(prob), fp_solver=FPFDMSolver(prob), relaxation=0.5).solve(
         max_iterations=120, tolerance=1e-6, verbose=False
     )
-    M_sp = sp[1]
+    U_sp, M_sp = sp[0], sp[1]
 
     mp = _solve(1, cross=0.0, max_iterations=200)
-    M_mp = np.asarray(mp.M[0])
+    U_mp, M_mp = np.asarray(mp.U[0]), np.asarray(mp.M[0])
 
+    u_diff = np.linalg.norm(U_mp - U_sp) / (np.linalg.norm(U_sp) + 1e-12)
     m_diff = np.linalg.norm(M_mp - M_sp) / (np.linalg.norm(M_sp) + 1e-12)
-    assert m_diff < 0.30, f"K=1 multi-pop density {m_diff * 100:.1f}% off single-pop (FP convention re-forked?)"
+    assert u_diff < 1e-4, f"K=1 multi-pop U {u_diff * 100:.3f}% off single-pop (FP convention re-forked?)"
+    assert m_diff < 1e-4, f"K=1 multi-pop density {m_diff * 100:.3f}% off single-pop (FP convention re-forked?)"
     # mass conservation preserved
     assert np.allclose(M_mp.sum(axis=-1), M_mp[0].sum(), rtol=1e-6)
 


### PR DESCRIPTION
## Problem (a real bug, found investigating the #1042 residual)

After the FP-drift single-sourcing (#1242), a **K=1** multi-pop solve *still* diverged from single-pop (19% density / 44% U). Investigation (verify-by-artifact) showed the multi-pop solution is **not a coupled fixed point**:
- `‖F_HJB(multi soln)‖ = 2e-12` (U consistent with M) but `‖F_FP(multi soln)‖ = 6.9` (M **not** consistent with FP(U)).
- A Picard step from the multi-pop solution moves M by **11%**; from the single-pop solution, **0%**.

So multi-pop converged (by its `max|M−M_old|` criterion) to a point that is self-consistent under *its* FP step but not under the canonical one.

## Root cause

The iterator binds `H_bound = H.bind_cross_density(...)` — a **`BoundHamiltonian`** wrapper. It fails `isinstance(H_bound, SeparableHamiltonian)` (verified: `False`, though `control_cost.is_smooth()` is `True`), so `resolve_fp_drift_kwargs` took the **velocity** path for multi-pop while single-pop (unbound H) took the **potential** path → two different self-consistent-but-distinct fixed points. (My earlier "19% = iterator architecture" hand-wave was wrong — this is the actual cause.)

## Fix

`BoundHamiltonian.optimal_control` delegates to the inner H, so a bound smooth-separable H still has the momentum-only optimal control that makes `potential_field=U` correct (the cross-coupling enters via the **HJB**, not the FP drift). `resolve_fp_drift_kwargs` now unwraps `H._inner` for the smoothness dispatch.

- **K=1 multi-pop now matches single-pop exactly** — `U`/`M` diff `< 1e-4` (Picard-tolerance bound); was **116%/19%** across the two stacked bugs.
- Correct for **K>1** too: `optimal_control` is momentum-only regardless of cross-density binding, so the coupling stays in the HJB and `potential_field=U` is right.

## Safety
**No-op for single-pop** (`H_class` has no `_inner` → byte-identical dispatch). Verified: Newton-Picard agreement + convention-agreement guards pass; 4 multi-pop tests pass. Tightened `test_k1_matches_single_population_fp_convention` from `< 0.30` to `< 1e-4`.

Refs #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)