### PR TITLE
fix: regime-switching/graph MFG iterators converged on U only, ignoring M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Regime-switching / graph MFG iterators declared convergence on the value function only**
+  (silent-divergence bug-hunt). `RegimeSwitchingIterator` and `GraphMFGSolver` gated
+  `converged=True` on `max_k|U^k_{n+1} − U^k_n| < tol` with **no density term** — half of the
+  canonical `(u, m)` criterion (`fixed_point_utils.check_convergence_criteria` requires both). When
+  a regime/node's value function stabilizes faster than its density (different timescales across
+  regimes, strong mass-transfer coupling), the iterator returned a solution whose density was still
+  evolving — reproduced for a two-volatility-regime problem: `solve()` reported converged at iter 12
+  with `error_U = 7e-5 < tol` but `error_M = 3.3·tol` (M reached tol only at iter 15). Both now gate
+  on `max(error_U, error_M)` (with an iteration-0 shape guard: the 1D initial density vs the 2D
+  trajectory makes the M-change undefined → treated as not-converged). Verified the fix still
+  converges (both U and M below tol, monotone) and the existing integration tests stay green.
+  Not on any byte-identical paper path (Phase-2 institutional-MFG features). Docstrings corrected
+  (tolerance was documented as U-only).
+
 - **Multi-population K=1 converged to a non-fixed-point: BoundHamiltonian defeated the FP drift
   dispatch** (Issue #1043 follow-up). After the FP-drift single-sourcing below, a K=1 multi-pop
   solve *still* diverged from single-pop (`||F_FP|| ≈ 6.9`, 19% density / 44% U) — and the

--- a/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
@@ -88,7 +88,8 @@ class GraphMFGSolver(BaseCouplingIterator):
     max_iterations : int
         Maximum Picard iterations (default 50).
     tolerance : float
-        Convergence tolerance on max |v^k_{n+1} - v^k_n| (default 1e-5).
+        Convergence tolerance on max over nodes of both the value-function and the
+        density change, max(|v^k_{n+1} - v^k_n|, |m^k_{n+1} - m^k_n|) (default 1e-5).
     damping : float
         Damping factor for Picard update (default 0.5).
 
@@ -218,7 +219,24 @@ class GraphMFGSolver(BaseCouplingIterator):
                         Ms_new[k] = theta * Ms_new[k] + (1 - theta) * Ms_expanded
 
             # --- Convergence check ---
-            error = max(np.max(np.abs(Us_new[k] - Us_full[k])) for k in range(N))
+            # Gate on BOTH the value function AND the density change (the canonical (u, m)
+            # criterion). Previously this checked only U, so a node whose density was still
+            # evolving while its value function had stabilized reported converged=True with a
+            # non-converged density (same one-field defect as RegimeSwitchingIterator).
+            error_U = max(np.max(np.abs(Us_new[k] - Us_full[k])) for k in range(N))
+            m_errors = []
+            m_comparable = True
+            for k in range(N):
+                if Ms_new[k] is None:
+                    m_comparable = False
+                    break
+                Ms_exp = self._expand_density(k, Ms[k])
+                if Ms_new[k].shape != Ms_exp.shape:
+                    m_comparable = False
+                    break
+                m_errors.append(np.max(np.abs(Ms_new[k] - Ms_exp)))
+            error_M = max(m_errors) if (m_comparable and m_errors) else float("inf")
+            error = max(error_U, error_M)
             error_history.append(error)
 
             Us_full = Us_new

--- a/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
@@ -85,7 +85,8 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
     max_iterations : int
         Maximum Picard iterations (default 50).
     tolerance : float
-        Convergence tolerance on max |v^k_{n+1} - v^k_n| (default 1e-5).
+        Convergence tolerance on max over regimes of both the value-function and the
+        density change, max(|v^k_{n+1} - v^k_n|, |m^k_{n+1} - m^k_n|) (default 1e-5).
     damping : float
         Damping factor for Picard update (default 0.5).
     update_scheme : Literal["jacobi", "gauss_seidel"]
@@ -271,7 +272,20 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
                     Ms_new[k] = theta * Ms_new[k] + (1 - theta) * Ms[k]
 
             # --- Convergence check ---
-            error = max(np.max(np.abs(Us_new[k] - Us_full[k])) for k in range(K))
+            # Gate on BOTH the value function AND the density change — the canonical (u, m)
+            # criterion (see fixed_point_utils.check_convergence_criteria). Previously this
+            # checked only U, so a regime whose density was still evolving while its value
+            # function had stabilized (different timescales across regimes) reported
+            # converged=True with a non-converged density (Issue #1043-class one-field defect).
+            error_U = max(np.max(np.abs(Us_new[k] - Us_full[k])) for k in range(K))
+            # On iteration 0 the initial Ms[k] is the 1D m_initial while Ms_new[k] is the 2D
+            # trajectory (the ndim guard above skips iter-0 M-damping), so the M-change is
+            # undefined → treat as not-converged.
+            if all(Ms_new[k] is not None and Ms[k].ndim == Ms_new[k].ndim for k in range(K)):
+                error_M = max(np.max(np.abs(Ms_new[k] - Ms[k])) for k in range(K))
+            else:
+                error_M = float("inf")
+            error = max(error_U, error_M)
             error_history.append(error)
 
             Us_full = Us_new


### PR DESCRIPTION
## Problem (silent-divergence bug-hunt)

`RegimeSwitchingIterator` and `GraphMFGSolver` declared `converged=True` on `max_k |U^k_{n+1} − U^k_n| < tol` with **no density term** — half of the canonical `(u, m)` convergence criterion (`fixed_point_utils.check_convergence_criteria` requires `max(l2distu, l2distm) < tol`).

When a regime/node's value function stabilizes faster than its density (different timescales across regimes, strong mass-transfer coupling), the iterator returns a solution whose **density is still evolving**.

**Reproduced** (two-volatility-regime LQ, σ 0.25/0.08): `solve()` reported `converged=True` at iter 12 with `error_U = 7e-5 < tol=1e-4` but `error_M = 3.3·tol`; M reached tol only at iter 15.

## Fix
Both iterators now gate on `max(error_U, error_M)`, matching `check_convergence_criteria`. Iteration-0 shape guard: the 1D initial density vs the 2D trajectory makes the M-change undefined → treated as not-converged (`GraphMFGSolver` uses `_expand_density` for the per-node comparison).

## Verification
- Fix still **converges** (both U and M below tol, monotone — iter 14 on the repro).
- **16** GraphMFGSolver + **2** regime integration tests pass (incl. `test_error_history`).
- Docstrings corrected (tolerance was documented as U-only).

## Safety
Not on any byte-identical paper path — both are Phase-2 institutional-MFG features; the paper paths (`FixedPointIterator` 1D-LQ-FDM, the GFDM stack) are untouched.

Found by the silent-divergence bug-hunt; one of two confirmed bugs (the FP-particle boundary-drift gradient is a separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)