### PR TITLE
fix: FP-particle drift gradient ignored BC — O(1/h) wrong-sign drift at non-periodic walls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FP-particle drift gradient ignored boundary conditions: O(1/h) wrong-sign drift at
+  non-periodic walls** (silent-divergence bug-hunt). `FPParticleSolver._compute_gradient_nd`
+  computed `∇U` for the drift `α = -∇U/λ` via the **periodic-wrap** central difference
+  (`stencils.gradient_nd`) regardless of BC, while the HJB uses the BC-aware
+  `geometry.get_gradient_operator`. At a non-periodic wall the periodic stencil takes
+  `(U[1] − U[N-1])/(2h)` — wrapping to the *far* wall — giving an **O(1/h) wrong-sign** drift that
+  pushes mass away from the wall (verified: for `U=x²` on `[0,1]` no-flux at N=51, `g[0]=−24.99`
+  vs exact 0; end-to-end ~2.5× wrong wall density, ~15% mass misplaced). It now routes through the
+  same BC-aware operator the HJB uses, unifying the two gradient conventions (ghost-padded /
+  one-sided at non-periodic boundaries; periodic BC reproduces the wrap **byte-identically** —
+  verified `max|Δ|=0`). The GPU/backend path round-trips through host numpy for the operator. Not a
+  byte-identical paper path (those are FP-FDM / FP-GFDM); the precomputed-drift path
+  (`drift_is_precomputed=True`, e.g. the GFDM→particle handoff) bypasses this gradient entirely.
+  **FP-*particle* experiments on non-periodic domains were silently wrong at the boundary and
+  should be re-validated.** Replaced the obsolete `test_compute_gradient_zero_dx` (it pinned the
+  now-advisory passed-spacing behavior) with a boundary-BC-aware refinement regression test.
+
 - **Regime-switching / graph MFG iterators declared convergence on the value function only**
   (silent-divergence bug-hunt). `RegimeSwitchingIterator` and `GraphMFGSolver` gated
   `converged=True` on `max_k|U^k_{n+1} − U^k_n| < tol` with **no density term** — half of the

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -27,7 +27,6 @@ from mfgarchon.geometry.boundary.applicator_particle import ParticleApplicator
 from mfgarchon.geometry.boundary.types import BCType
 
 # Issue #625: Migrated from tensor_calculus to operators/stencils
-from mfgarchon.operators.stencils.finite_difference import gradient_nd
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical.particle import (
     interpolate_grid_to_particles,
@@ -428,16 +427,31 @@ class FPParticleSolver(BaseFPSolver):
         use_backend: bool = False,
     ) -> list:
         """
-        Compute spatial gradient using stencils.
+        Compute the spatial gradient of the value function for the FP drift, BC-aware.
 
-        Uses gradient_nd (central differences, no BC handling).
-        BC handling for particles is done separately in _apply_boundary_conditions_nd.
+        Routes through ``geometry.get_gradient_operator(scheme="central")`` — the SAME BC-aware
+        operator the HJB uses — so non-periodic boundaries get ghost-padded / one-sided stencils.
+        Previously this used the periodic-wrap ``gradient_nd``, which at a non-periodic wall takes
+        ``(U[1] - U[N-1])/(2h)`` (wrapping to the far wall) → an O(1/h) **wrong-sign** drift that
+        pushes mass away from the wall (silent-divergence bug-hunt). Periodic BC reproduces the
+        wrap (results unchanged); the precomputed-drift path (``drift_is_precomputed=True``, e.g.
+        the GFDM→particle handoff) bypasses this gradient entirely.
 
-        Issue #625: Migrated from tensor_calculus.gradient_simple to stencils.gradient_nd
+        The operator uses the geometry's own grid spacing and BC; ``spacings`` is retained only for
+        its length (the spatial dimension) and matches the geometry spacing at every call site.
+
+        Issue #625: migrated tensor_calculus.gradient_simple → stencils.gradient_nd.
+        Bug-hunt: migrated periodic-wrap gradient_nd → BC-aware geometry operator.
         """
-        # Get array module (numpy or backend-specific like cupy)
-        xp = self.backend.array_module if use_backend and self.backend else np
-        return gradient_nd(U_array, spacings, xp=xp)
+        ndim = len(spacings)
+        grad_ops = self.problem.geometry.get_gradient_operator(scheme="central")
+        on_backend = use_backend and self.backend is not None
+        # The geometry operator is numpy; round-trip through host for the backend/GPU path.
+        u_host = self.backend.to_numpy(U_array) if on_backend else np.asarray(U_array)
+        grads = [grad_ops[d](u_host) for d in range(ndim)]
+        if on_backend:
+            grads = [self.backend.from_numpy(g) for g in grads]
+        return grads
 
     # =========================================================================
     # DRY Helper Methods (Issue #635 cleanup)

--- a/tests/unit/test_alg/test_fp_particle_solver.py
+++ b/tests/unit/test_alg/test_fp_particle_solver.py
@@ -542,25 +542,31 @@ class TestFPParticleSolverHelperMethods:
         assert np.all(np.isfinite(gradient))
         assert gradient.shape == U_array.shape
 
-    def test_compute_gradient_zero_dx(self):
-        """Test gradient computation with zero Dx."""
-        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=0.3, Nt=15, components=_default_components())
-        solver = FPParticleSolver(problem, num_particles=500)
+    def test_compute_gradient_bc_aware_at_boundary(self):
+        """The drift gradient must be BC-aware at non-periodic walls (silent-divergence bug-hunt).
 
-        Nx_points = problem.geometry.get_grid_shape()[0]
-        bounds = problem.geometry.get_bounds()
-
-        x_coords = np.linspace(bounds[0][0], bounds[1][0], Nx_points)
-        U_array = x_coords**2
-
-        gradients = solver._compute_gradient_nd(U_array, [0.0], use_backend=False)
-
-        # Should return list of gradient components (one per dimension)
-        assert isinstance(gradients, list)
-        assert len(gradients) == 1  # 1D case
-        # With zero spacing, gradient should be zeros
-        assert np.allclose(gradients[0], 0.0)
+        Previously ``_compute_gradient_nd`` used a periodic-wrap central difference regardless of
+        BC: at a no-flux wall it took ``(U[1] - U[N-1])/(2h)``, wrapping to the far wall — an
+        O(1/h) wrong-sign drift (e.g. ~-25 for U=x² at N=51, blowing up under refinement). It now
+        routes through the geometry's BC-aware operator (the same one the HJB uses), so the
+        boundary gradient is O(1)-bounded and shrinks under refinement, not the periodic garbage.
+        """
+        bounds_diff = []
+        for n_x in (26, 51, 101):
+            geometry = TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[n_x], boundary_conditions=no_flux_bc(dimension=1)
+            )
+            problem = MFGProblem(geometry=geometry, T=0.3, Nt=15, components=_default_components())
+            solver = FPParticleSolver(problem, num_particles=500)
+            dx = problem.geometry.get_grid_spacing()[0]
+            x_coords = np.linspace(0.0, 1.0, n_x)
+            g = solver._compute_gradient_nd(x_coords**2, [dx], use_backend=False)[0]
+            # O(1)-bounded at the wall (the periodic-wrap bug gave |g[0]| ~ 1/(2dx) -> blows up).
+            assert abs(g[0]) < 1.0, f"N={n_x}: |g[0]|={abs(g[0]):.2f} — periodic-wrap O(1/h) drift not fixed?"
+            assert np.all(np.isfinite(g))
+            bounds_diff.append(abs(g[0]))
+        # Boundary error shrinks under refinement (it would GROW ~1/h with the periodic-wrap bug).
+        assert bounds_diff[-1] < bounds_diff[0], f"boundary gradient not converging: {bounds_diff}"
 
     def test_normalize_density_none(self):
         """Test density normalization with NONE strategy."""


### PR DESCRIPTION
## Problem (silent-divergence bug-hunt, verified by repro)

`FPParticleSolver._compute_gradient_nd` computed `∇U` for the particle drift `α = −∇U/λ` via the **periodic-wrap** central difference (`stencils.gradient_nd`) **regardless of BC**, while the HJB uses the BC-aware `geometry.get_gradient_operator`. At a non-periodic wall the periodic stencil takes `(U[1] − U[N-1])/(2h)` — wrapping to the *far* wall — an **O(1/h) wrong-sign** drift that pushes mass away from the wall.

**Verified** (`U=x²` on `[0,1]`, no-flux, N=51): `g[0] = −24.99` (exact 0), `g[-1] = −24.01` (exact 2); `periodic·h = −0.5` const ⇒ O(1/h) blowup under refinement. End-to-end: ~**2.5×** wrong terminal wall density, ~**15%** mass misplaced. Reachable by any plain particle-solver run on a bounded non-periodic domain (`resolve_fp_drift_kwargs` passes `potential_field=U` for smooth-separable H → `drift_is_precomputed=False` → this gradient).

## Fix
Route `_compute_gradient_nd` through `geometry.get_gradient_operator(scheme="central")` — the **same** BC-aware operator the HJB uses (ghost-padded / one-sided at non-periodic boundaries; periodic reproduces the wrap). GPU/backend path round-trips through host numpy. Boundary gradient is now O(1)-bounded and **converges** under refinement (regression test asserts both).

## Safety / impact
- **Not a byte-identical paper path** (paper = FP-FDM / FP-GFDM). **Periodic BC byte-identical** (verified `max|Δ|=0`); the precomputed-drift path (`drift_is_precomputed=True`, GFDM→particle) bypasses this gradient.
- ⚠️ **FP-*particle* experiments on non-periodic domains were silently wrong at the boundary and should be re-validated** (they were wrong before; this corrects them).
- Replaced the obsolete `test_compute_gradient_zero_dx` (pinned the now-advisory passed-spacing behavior) with a boundary-BC-aware refinement regression test. **169** particle tests pass.

Second of the two confirmed silent-divergence bug-hunt findings (the regime/graph U-only convergence was #1245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)