### PR TITLE
fix(howard): fail loud on Hamiltonians inner_solver='howard' cannot model (#1247)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -3000,6 +3000,54 @@ class HJBGFDMSolver(BaseHJBSolver):
                 "Howard's policy-evaluation Lagrangian is hardcoded to (1/2)|alpha|^2; non-unit control cost "
                 "needs a running-cost correction (deferred, Issue #1118 PR2)."
             )
+        # Howard's policy evaluation hardcodes the unit-quadratic Lagrangian (1/2)|alpha|^2 and
+        # consumes ONLY alpha* = -dH/dp, so the backward sweep is faithful solely for a pure
+        # separable LQ Hamiltonian H = (1/2)|p|^2 (MINIMIZE) with no potential V(x, t) and no
+        # density coupling f(m). The pure-LQ test suite sits inside that envelope, which hid
+        # three silent-wrong-physics holes: V/f(m) dropped, running_cost entering with the
+        # opposite sign of the Newton H-additive convention, and the unit-cost gate above
+        # reading problem.lambda_ (never synced with the components Hamiltonian's control cost).
+        # Inspect the actual Hamiltonian components and fail loud on anything Howard does not
+        # model; full support is deferred. Found in the 2026-06-10 library audit; validated by
+        # tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_*.
+        control_cost = getattr(H_class, "control_cost", None)
+        if control_cost is not None:
+            from mfgarchon.core.hamiltonian import QuadraticControlCost
+
+            cc_lambda = getattr(control_cost, "lambda_", 1.0)
+            if not isinstance(control_cost, QuadraticControlCost) or abs(cc_lambda - 1.0) > 1e-12:
+                raise NotImplementedError(
+                    "inner_solver='howard' hardcodes the unit-quadratic Lagrangian (1/2)|alpha|^2, "
+                    f"but the Hamiltonian's control cost is {type(control_cost).__name__}"
+                    f"(lambda_={cc_lambda}). Non-unit / non-quadratic control cost needs "
+                    "control_cost.lagrangian() in the policy-evaluation RHS; use inner_solver='newton' "
+                    "(deferred, Issue #1118 PR2)."
+                )
+            if getattr(control_cost, "sign", 1) != 1:
+                raise NotImplementedError(
+                    "inner_solver='howard' derives alpha* = -dH/dp (MINIMIZE sense); the Hamiltonian "
+                    "uses MAXIMIZE, which needs alpha* = +dH/dp. Use inner_solver='newton' (deferred)."
+                )
+        if getattr(H_class, "_potential", None) is not None:
+            raise NotImplementedError(
+                "inner_solver='howard' ignores the Hamiltonian potential V(x, t): its policy "
+                "evaluation uses only alpha* = -dH/dp, so V never enters the HJB and the value "
+                "function silently decouples from it. Use inner_solver='newton' for problems with a "
+                "potential (deferred)."
+            )
+        if getattr(H_class, "_coupling", None) is not None:
+            raise NotImplementedError(
+                "inner_solver='howard' ignores the density coupling f(m): its policy evaluation "
+                "uses only alpha* = -dH/dp, so f(m) never enters the HJB and the value function "
+                "silently decouples from the density. Use inner_solver='newton' for density-coupled "
+                "problems (deferred)."
+            )
+        if self._running_cost_fn is not None:
+            raise NotImplementedError(
+                "inner_solver='howard' does not yet support a running cost: it would enter Howard's "
+                "Lagrangian-additive slot with the opposite sign of the Newton path's H-additive "
+                "convention (H_total = H + L). Use inner_solver='newton' with running_cost (deferred)."
+            )
         # BC parity (Issue #1118 PR2a): the howard path now consumes the provider's shared
         # value-form BC rows (`_value_form_bc_rows` -> `_bc_row_for_point`), so it honors
         # Dirichlet VALUES and the real Neumann normal·grad stencil (not the legacy

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -31,6 +31,11 @@ pytest.importorskip("cvxpy")
 
 from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import HJBHowardSolver
+from mfgarchon.core.hamiltonian import (
+    OptimizationSense,
+    QuadraticControlCost,
+    SeparableHamiltonian,
+)
 from mfgarchon.geometry import Hyperrectangle
 from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
 
@@ -442,6 +447,82 @@ def test_integrated_howard_requires_hamiltonian_class():
     U_T = 0.5 * (pts[:, 0] - 2.0) ** 2
     with pytest.raises(ValueError, match="hamiltonian_class"):
         gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+# ---------------------------------------------------------------------------
+# 7b. Integrated path: envelope gate fails loud on Hamiltonians Howard cannot
+#     model (2026-06-10 audit). Howard's policy evaluation hardcodes the
+#     unit-quadratic Lagrangian (1/2)|alpha|^2 and uses only alpha* = -dH/dp,
+#     so V(x,t), f(m), non-unit/non-quadratic control cost, and running_cost
+#     were silently dropped/mis-signed. Each must now raise NotImplementedError.
+# ---------------------------------------------------------------------------
+
+
+def _howard_gfdm_with_hamiltonian(hamiltonian_class, *, LX=4.0, Nt=20):
+    pts, bdry, geom = _make_1d_cloud(LX=LX, n_int=11)
+    problem = _MockProblem(geom, sigma=0.0, T=1.0, Nt=Nt, dimension=1)
+    problem.hamiltonian_class = hamiltonian_class
+    gfdm = _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5, inner_solver="howard")
+    U_T = 0.5 * (pts[:, 0] - LX / 2) ** 2
+    return gfdm, U_T
+
+
+def test_integrated_howard_rejects_potential():
+    """A Hamiltonian potential V(x, t) is dropped by Howard's policy evaluation -> fail loud."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(lambda_=1.0),
+        potential=lambda x, t: 0.5 * float(np.sum(np.atleast_1d(x) ** 2)),
+    )
+    gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
+    with pytest.raises(NotImplementedError, match="potential"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_integrated_howard_rejects_coupling():
+    """A density coupling f(m) is dropped by Howard's policy evaluation -> fail loud."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(lambda_=1.0),
+        coupling=lambda m: m,
+    )
+    gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
+    with pytest.raises(NotImplementedError, match="coupling"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_integrated_howard_rejects_nonunit_control_cost():
+    """Non-unit control cost defeats the hardcoded (1/2)|alpha|^2 Lagrangian -> fail loud.
+
+    Regression for the gate reading problem.lambda_ (left at the 1.0 default here) instead of
+    the components Hamiltonian's actual control cost: the old gate passed and Howard solved the
+    wrong effective Hamiltonian; the fixed gate reads control_cost.lambda_ and raises.
+    """
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(lambda_=2.0))
+    gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
+    assert gfdm.problem.lambda_ == 1.0  # the legacy gate's source is unit -> would have passed
+    with pytest.raises(NotImplementedError, match="control cost"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_integrated_howard_rejects_maximize_sense():
+    """MAXIMIZE needs alpha* = +dH/dp; the wrapper hardcodes -dH/dp -> fail loud."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(lambda_=1.0, sense=OptimizationSense.MAXIMIZE),
+    )
+    gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
+    with pytest.raises(NotImplementedError, match="MAXIMIZE"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_integrated_howard_rejects_running_cost():
+    """running_cost enters Howard's Lagrangian slot with the wrong sign vs Newton -> fail loud."""
+    gfdm, U_T = _howard_gfdm_with_hamiltonian(_LQHam())
+    n = U_T.shape[0]
+    with pytest.raises(NotImplementedError, match="running cost"):
+        gfdm.solve_hjb_system(
+            M_density=None,
+            U_terminal=U_T,
+            running_cost=lambda t_idx: 0.1 * np.ones(n),
+        )
 
 
 def _make_howard_gfdm_with_bc(bc, sigma=0.3, Nt=5):


### PR DESCRIPTION
## Summary
The integrated `inner_solver='howard'` path silently solved wrong physics on any non-pure-LQ Hamiltonian (audit finding, 2026-06-10). Howard's policy evaluation hardcodes the unit-quadratic Lagrangian `(1/2)|α|²` and consumes only `α* = -dH/dp`, so it is faithful **only** for `H = (1/2)|p|²` (MINIMIZE) with no potential, no coupling, no running cost. Three holes were hidden by the pure-LQ test suite:

- **Potential `V(x,t)` and coupling `f(m)` dropped** — the HJB silently decoupled from potential/density (`hjb_gfdm.py:3052-3064`).
- **`running_cost` sign-flipped** — it entered Howard's Lagrangian-additive slot with the opposite sign of the Newton path's H-additive convention `H_total = H + L` (`:3060`).
- **Unit-cost gate defeated** — it read `problem.lambda_`, never synced with the components Hamiltonian's `control_cost`, so `QuadraticControlCost(lambda_≠1)` passed and Howard solved the wrong effective Hamiltonian (`:2996-3002`).

## Change
The envelope gate now inspects the actual Hamiltonian components — `control_cost.lambda_`, `control_cost.sign` (MINIMIZE/MAXIMIZE), `_potential`, `_coupling` — and the running cost, raising `NotImplementedError` on anything Howard does not model. Purely additive gating: it can only reject configurations that were previously getting wrong answers. Default `inner_solver='newton'` is byte-identical.

## Verification
- 5 pinning tests (`test_integrated_howard_rejects_{potential,coupling,nonunit_control_cost,maximize_sense,running_cost}`) **fail without the gate** (3 confirmed silently solving / mis-gating) and **pass with it**.
- Full Howard suite: 26 passed. `ruff format --check` + `ruff check` clean.

## Scope
This is the **fail-loud mitigation** — it closes the silent-wrong-physics bug. Actually *supporting* `V` / `f(m)` / running-cost / non-unit control cost in Howard's policy evaluation is a separate enhancement. Recommend keeping #1247 open (or relabelling to track that capability) rather than auto-closing.

Refs #1247

_Found in the 2026-06-10 library audit (baseline f58e8fe9 → d5eb29a8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)