### PR TITLE
fix(regime-switching): correct inverted sign of inter-regime HJB cross-term (#1251)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
@@ -178,7 +178,12 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
                         u_j = Us_full[j]
                     u_k_n = Us_full[k][n] if n < Us_full[k].shape[0] else Us_full[k][-1]
                     u_j_n = u_j[n] if n < u_j.shape[0] else u_j[-1]
-                    s += Q[k, j] * (u_k_n - u_j_n)
+                    # The DPP chain term sum_j Q[k,j](v^k - v^j) sits on the HJB LHS
+                    # (-v^k_t + H^k - (sigma^2/2)Lap + cross = 0). The HJB solver subtracts
+                    # the source (Phi_U -= source_term, base_hjb), so source = -cross. Passing
+                    # +cross flipped the inter-regime coupling sign (2026-06-10 audit, #1251);
+                    # the FP source below already carries the correct +inflow/-outflow sign.
+                    s -= Q[k, j] * (u_k_n - u_j_n)
             return s
 
         return source

--- a/tests/unit/test_alg/test_regime_switching_iterator.py
+++ b/tests/unit/test_alg/test_regime_switching_iterator.py
@@ -234,3 +234,44 @@ class TestRegimeSwitchingGetResults:
         )
         with pytest.raises(RuntimeError, match="No solution computed"):
             iterator.get_results()
+
+
+class TestRegimeSwitchingCrossTermSign:
+    """Inter-regime coupling sign (#1251, 2026-06-10 audit).
+
+    The DPP chain term ``sum_j Q[k,j](v^k - v^j)`` sits on the HJB LHS, and the HJB
+    solver subtracts the source (``Phi_U -= source_term``), so the source must equal
+    ``-cross``. A ``+cross`` source flips the inter-regime value coupling. The FP source
+    (``+inflow Q[j,k]m^j - outflow Q[k,j]m^k``) was already correct and must be unchanged.
+    """
+
+    def _iterator(self):
+        problems, config, hjbs, fps = _make_2regime_system()
+        return (
+            RegimeSwitchingIterator(problems=problems, regime_config=config, hjb_solvers=hjbs, fp_solvers=fps),
+            problems,
+            config.transition_matrix,
+        )
+
+    def test_hjb_source_is_negative_cross_term(self):
+        iterator, problems, Q = self._iterator()
+        Nt, N = problems[0].Nt, 5
+        x = np.linspace(0.0, 1.0, N)
+        v0, v1 = 2.0, 1.0
+        Us_full = [v0 * np.ones((Nt + 1, N)), v1 * np.ones((Nt + 1, N))]
+
+        src0 = iterator._make_hjb_source(0, 2, Q, Us_full, [None, None])
+        np.testing.assert_allclose(src0(0.0, x), -Q[0, 1] * (v0 - v1) * np.ones(N))
+
+        src1 = iterator._make_hjb_source(1, 2, Q, Us_full, [None, None])
+        np.testing.assert_allclose(src1(0.0, x), -Q[1, 0] * (v1 - v0) * np.ones(N))
+
+    def test_fp_source_sign_unchanged(self):
+        iterator, problems, Q = self._iterator()
+        Nt, N = problems[0].Nt, 5
+        x = np.linspace(0.0, 1.0, N)
+        m0, m1 = 0.7, 0.3
+        Ms = [m0 * np.ones((Nt + 1, N)), m1 * np.ones((Nt + 1, N))]
+
+        src0 = iterator._make_fp_source(0, 2, Q, Ms)
+        np.testing.assert_allclose(src0(0.0, x), (Q[1, 0] * m1 - Q[0, 1] * m0) * np.ones(N))


### PR DESCRIPTION
## Summary
The inter-regime HJB cross-term entered with the wrong sign, so any `RegimeSwitchingIterator` solve with a non-trivial transition matrix `Q` and distinct regime value functions solved the wrong coupled PDE (audit finding, 2026-06-10).

## Trace
The DPP chain term sits on the HJB LHS:
```
-v^k_t + H^k - (σ²/2)Δv^k + Σ_j Q[k,j](v^k - v^j) = 0
```
The HJB solver subtracts the source (`Phi_U -= source_term`, `base_hjb.py`), so `source = -cross`. `_make_hjb_source` (`regime_switching_iterator.py:181`) passed `s += Q[k,j](u_k - u_j)` = `+cross`, flipping the coupling. The FP source (`Q[j,k]m^j - Q[k,j]m^k`, `:204-205`) was already correct, so the chain coupling was sign-inconsistent between the two equations.

## Change
Negate the HJB cross-term so `source = -cross`. FP source unchanged.

## Verification
`TestRegimeSwitchingCrossTermSign`:
- `test_hjb_source_is_negative_cross_term` — **fails without the fix** (actual `+0.1` vs desired `-0.1`), passes with it.
- `test_fp_source_sign_unchanged` — passes before and after (pins that FP was/stays correct).
- Full suite: 16 passed. `ruff format --check` + `ruff check` clean.

Fixes #1251

_Found in the 2026-06-10 library audit (baseline f58e8fe9 → d5eb29a8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)