### PR TITLE
fix(geometry): correct low-wall sign for order<=2 nonzero Neumann ghost

### DIFF
--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -1032,9 +1032,14 @@ class PreallocatedGhostBuffer:
             #
             # Issue #1186 sibling: for BCType.NEUMANN with a NONZERO prescribed flux du/dn = v,
             # add the linear flux offset on top of the mirror (the mirror alone silently dropped
-            # it). Sign matches the Robin branch below: -dx*v at the low wall (outward normal -1),
-            # +dx*v at the high wall (+1). v == 0 (and NO_FLUX / REFLECTING, definitionally
-            # zero-flux) leaves the pure mirror -> byte-identical.
+            # it). du/dn = v means du/dx = -v at the low wall (outward normal -x) and du/dx = +v
+            # at the high wall (outward normal +x). Both walls: ghost = interior + dx*v.
+            # Derivation (cell-centred, boundary at x=0):
+            #   du/dx|_0 approx (u_interior - u_ghost)/dx, so ghost = interior - dx*(du/dx)
+            #   Low wall: ghost = interior - dx*(-v) = interior + dx*v  [Issue #1262, 2026-06-10 audit]
+            #   High wall: ghost = interior + dx*v  (outward normal +x, du/dx = v)
+            # v == 0 (and NO_FLUX / REFLECTING, definitionally zero-flux) leaves the pure
+            # mirror -> byte-identical.
             apply_flux = bc_type == BCType.NEUMANN and v != 0.0
             for axis in range(d):
                 dx = self._grid_spacing[axis] if self._grid_spacing is not None else 1.0
@@ -1046,7 +1051,7 @@ class PreallocatedGhostBuffer:
                     lo_interior[axis] = g + k  # Adjacent interior cells from g up
                     buf[tuple(lo_ghost)] = buf[tuple(lo_interior)]
                     if apply_flux:
-                        buf[tuple(lo_ghost)] -= dx * v
+                        buf[tuple(lo_ghost)] += dx * v  # Issue #1262: was -= (du/dx sign), now += (du/dn sign)
 
                 # High boundary: ghost mirrors adjacent interior
                 for k in range(g):

--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -1280,7 +1280,12 @@ class TestLinearReflectionNeumannFlux:
         u = np.sin(np.linspace(0.0, 1.0, 11))
         for v in (0.5, -1.3):
             gh = self._ghosts(neumann_bc(dimension=1, value=v), u, dx=dx)
-            dudn_low = (gh[1] - gh[0]) / dx  # (u_interior - u_ghost)/dx, low outward = -x
+            # du/dn is the OUTWARD-normal derivative: low wall outward = -x, so
+            # du/dn = (u_ghost - u_interior)/dx (Issue #1262, 2026-06-10 audit). The previous
+            # (u_interior - u_ghost)/dx computed -du/dn; that sign error cancelled the old
+            # ghost-sign bug (u_g = u_i - dx*v), so this test passed against incorrect ghosts.
+            # With the corrected ghost (u_g = u_i + dx*v) the low-wall du/dn is +v.
+            dudn_low = (gh[0] - gh[1]) / dx  # (u_ghost - u_interior)/dx, low outward = -x
             dudn_high = (gh[-1] - gh[-2]) / dx  # (u_ghost - u_interior)/dx, high outward = +x
             assert abs(dudn_low - v) < 1e-12, f"low du/dn={dudn_low} != {v}"
             assert abs(dudn_high - v) < 1e-12, f"high du/dn={dudn_high} != {v}"

--- a/tests/unit/test_geometry/test_neumann_low_wall_sign.py
+++ b/tests/unit/test_geometry/test_neumann_low_wall_sign.py
@@ -1,0 +1,131 @@
+"""
+Pinning test for Issue #1262: linear-reflection nonzero-Neumann low-wall sign.
+
+The order<=2 path must encode du/dn = v (outward normal), not du/dx = v.
+At the LOW wall (outward normal -x): ghost = interior + dx*v.
+At the HIGH wall (outward normal +x): ghost = interior + dx*v.
+Both walls agree; both must agree with the order>2 polynomial path.
+"""
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import neumann_bc
+from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
+
+
+def _make_buffer(v: float, order: int, n: int = 10) -> PreallocatedGhostBuffer:
+    """Create a 1D ghost buffer with Neumann BC du/dn = v."""
+    bc = neumann_bc(value=v, dimension=1)
+    buf = PreallocatedGhostBuffer(
+        interior_shape=(n,),
+        boundary_conditions=bc,
+        domain_bounds=np.array([[0.0, 1.0]]),
+        order=order,
+    )
+    return buf
+
+
+class TestNeumannLowWallSign:
+    """Issue #1262 — low-wall ghost must be interior + dx*v, not interior - dx*v."""
+
+    def test_order2_low_ghost_plus_dx_v(self):
+        """
+        For nonzero v, order=2 low-wall ghost = first_interior + dx*v.
+
+        Buggy code: -= dx*v  =>  ghost = interior - dx*v  (FAILS).
+        Fixed code: += dx*v  =>  ghost = interior + dx*v  (PASSES).
+        """
+        v = 2.5
+        buf = _make_buffer(v=v, order=2)
+        buf.interior[:] = np.ones(10) * 3.0
+        buf.update_ghosts(time=0.0)
+
+        n = 10
+        dx = 1.0 / (n - 1)  # domain [0,1], n points
+        first_interior = buf.interior[0]  # 3.0
+        expected_lo = first_interior + dx * v
+        actual_lo = buf.padded[0]
+
+        assert np.isclose(actual_lo, expected_lo), (
+            f"Low ghost = {actual_lo:.6f}, expected {expected_lo:.6f} "
+            f"(interior + dx*v = {first_interior} + {dx}*{v}). "
+            f"Wrong sign would give {first_interior - dx * v:.6f}."
+        )
+
+    def test_order2_high_ghost_plus_dx_v(self):
+        """High-wall ghost = last_interior + dx*v (was already correct, must not regress)."""
+        v = 2.5
+        buf = _make_buffer(v=v, order=2)
+        buf.interior[:] = np.ones(10) * 3.0
+        buf.update_ghosts(time=0.0)
+
+        n = 10
+        dx = 1.0 / (n - 1)
+        last_interior = buf.interior[-1]  # 3.0
+        expected_hi = last_interior + dx * v
+        actual_hi = buf.padded[-1]
+
+        assert np.isclose(actual_hi, expected_hi), f"High ghost = {actual_hi:.6f}, expected {expected_hi:.6f}."
+
+    def test_order2_and_order4_low_ghost_agree(self):
+        """
+        order=2 and order=4 must give the same low-wall ghost for a linear field.
+
+        Linear data u(x) = c + a*x satisfies du/dn = v at the low wall iff
+        du/dx|_{x_lo} = -v (outward normal -x). For such a field polynomial
+        extrapolation is exact, so order=2 and order=4 must agree to machine eps.
+
+        Buggy order=2 (- sign) would give c - dx*v instead of c + dx*v,
+        diverging from the order=4 result.
+        """
+        v = 1.5
+        n = 10
+        dx = 1.0 / (n - 1)
+
+        # Linear field: u(x) = 5.0 - v*x  =>  du/dx = -v  =>  du/dn(low) = +v
+        # Grid points: cell-centred at x = dx/2, 3*dx/2, ...; but order<=2 uses
+        # node-aligned spacing from domain_bounds. Use grid at x = 0, dx, 2*dx, ...
+        x_interior = np.linspace(0.0, 1.0, n)
+        u_interior = 5.0 - v * x_interior  # du/dx = -v => du/dn = +v at low wall
+
+        buf2 = _make_buffer(v=v, order=2)
+        buf4 = _make_buffer(v=v, order=4, n=n)
+
+        buf2.interior[:] = u_interior
+        buf4.interior[:] = u_interior
+
+        buf2.update_ghosts(time=0.0)
+        buf4.update_ghosts(time=0.0)
+
+        lo2 = buf2.padded[0]
+        lo4 = buf4.padded[0]
+
+        assert np.isclose(lo2, lo4, atol=1e-10), (
+            f"order=2 low ghost = {lo2:.8f}, order=4 = {lo4:.8f}. "
+            f"They must agree for a linear field. "
+            f"Wrong sign gives {u_interior[0] - dx * v:.8f} instead of "
+            f"{u_interior[0] + dx * v:.8f}."
+        )
+
+    def test_zero_flux_neumann_unchanged(self):
+        """v=0 must leave ghost identical to the pure mirror (regression guard)."""
+        buf = _make_buffer(v=0.0, order=2)
+        buf.interior[:] = np.arange(1, 11, dtype=np.float64)
+        buf.update_ghosts(time=0.0)
+
+        assert buf.padded[0] == buf.interior[0], "v=0 low ghost must mirror interior[0]"
+        assert buf.padded[-1] == buf.interior[-1], "v=0 high ghost must mirror interior[-1]"
+
+    def test_negative_v_low_ghost(self):
+        """Sign must be consistent for v < 0."""
+        v = -3.0
+        buf = _make_buffer(v=v, order=2)
+        buf.interior[:] = np.ones(10) * 7.0
+        buf.update_ghosts(time=0.0)
+
+        n = 10
+        dx = 1.0 / (n - 1)
+        expected_lo = buf.interior[0] + dx * v  # 7.0 + dx*(-3.0) = 7.0 - 3*dx
+        assert np.isclose(buf.padded[0], expected_lo), (
+            f"Negative-v: low ghost = {buf.padded[0]:.6f}, expected {expected_lo:.6f}."
+        )


### PR DESCRIPTION
## Summary

- `_apply_linear_reflection` (order<=2 Neumann path) had `buf[lo_ghost] -= dx*v` at the low wall, implementing `du/dx = v` instead of the documented `du/dn = v` (outward-normal convention).
- At the low wall (outward normal -x): `du/dn = v` means `du/dx = -v`, so `ghost = interior + dx*v`. The code wrote `interior - dx*v`.
- High wall was already correct (`+= dx*v`). The order>2 polynomial path was also correct. Only the linear-reflection low-wall sign was wrong.
- Fix: one-character change, `-=` → `+=`, plus corrected comment and explicit issue reference.

## Test plan

- `tests/unit/test_geometry/test_neumann_low_wall_sign.py` — 5 new pinning tests:
  - `test_order2_low_ghost_plus_dx_v`: low ghost == interior + dx*v for v>0 (fails on buggy code)
  - `test_order2_high_ghost_plus_dx_v`: high ghost == interior + dx*v, regression guard
  - `test_order2_and_order4_low_ghost_agree`: order=2 and order=4 agree to machine-eps for a linear field (fails on buggy code)
  - `test_zero_flux_neumann_unchanged`: v=0 leaves pure mirror byte-identical
  - `test_negative_v_low_ghost`: sign consistent for v<0 (fails on buggy code)

Buggy run: 3 FAILED / 2 passed. Fixed run: 5 passed.

Fixes #1262

🤖 Generated with [Claude Code](https://claude.com/claude-code)