### PR TITLE
fix(adi): remove erroneous factor-of-2 in ADI cross-diffusion explicit step

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -11,9 +11,9 @@ Methods:
 - 1D: Crank-Nicolson (unconditionally stable)
 - nD: Peaceman-Rachford ADI splitting with optional full tensor support
 
-For full tensor diffusion (non-diagonal σ_ij):
+For full tensor diffusion (non-diagonal σ_ij, with D_ij = σ_ij/2):
     ADI handles diagonal terms implicitly, cross terms explicitly:
-    u^{n+1} = ADI_solve(u^n + dt * Σ_{i≠j} σ_ij ∂²u/∂x_i∂x_j)
+    u^{n+1} = ADI_solve(u^n + dt * Σ_{i<j} σ_ij ∂²u/∂x_i∂x_j)
 
 Module structure per issue #392:
     hjb_sl_adi.py - ADI diffusion methods for semi-Lagrangian solver
@@ -199,9 +199,9 @@ def adi_diffusion_step(
         Sweep x: (I - θα L_x) u^{1/2} = (I + (1-θ)α L_x) u^{n}
         Sweep y: (I - θα L_y) u^{n+1} = (I + (1-θ)α L_y) u^{1/2}
 
-    For full tensor diffusion (σ_ij):
+    For full tensor diffusion (σ_ij covariance, D_ij = σ_ij/2):
         ADI handles diagonal terms implicitly, cross terms explicitly:
-        u^{n+1} = ADI_solve(u^n + dt * Σ_{i≠j} σ_ij ∂²u/∂x_i∂x_j)
+        u^{n+1} = ADI_solve(u^n + dt * Σ_{i<j} σ_ij ∂²u/∂x_i∂x_j)
 
     Args:
         U_star: Intermediate solution after advection step, shape (N1, N2, ..., Nd)
@@ -278,15 +278,27 @@ def apply_cross_diffusion_explicit(
     """
     Apply cross-derivative diffusion terms explicitly.
 
-    For full tensor diffusion with off-diagonal terms σ_ij (i != j),
-    we need to add: dt * Σ_{i<j} 2*σ_ij * ∂²u/∂x_i∂x_j
+    For full tensor diffusion with off-diagonal entries sigma_ij of the covariance
+    matrix (sigma_tensor), the diagonal ADI step handles D_d = sigma_tensor[d,d]/2
+    for each direction d. The full operator expanded by symmetry is:
+
+        sum_{i,j} D_ij d^2u/dx_i dx_j
+        = sum_i (sigma_tensor[i,i]/2) d^2u/dx_i^2
+          + 2 * sum_{i<j} (sigma_tensor[i,j]/2) d^2u/dx_i dx_j
+        = (diagonal, handled by ADI)
+          + sum_{i<j} sigma_tensor[i,j] * d^2u/dx_i dx_j
+
+    So the explicit correction adds dt * sigma_tensor[i,j] * d^2u/dx_i dx_j per
+    off-diagonal pair (i<j). The factor of 2 from the symmetry expansion already
+    cancels the 1/2 from D_ij = sigma_tensor[i,j]/2; no extra factor of 2 here.
+    Issue #1261 fix, 2026-06-10 audit.
 
     Uses central differences for mixed partial derivatives:
-        ∂²u/∂x_i∂x_j ≈ (u_{i+1,j+1} - u_{i+1,j-1} - u_{i-1,j+1} + u_{i-1,j-1}) / (4*dx_i*dx_j)
+        d^2u/dx_i dx_j ~= (u_{+i,+j} - u_{+i,-j} - u_{-i,+j} + u_{-i,-j}) / (4*dx_i*dx_j)
 
     Args:
         U: Solution array, shape (N1, N2, ..., Nd)
-        sigma_tensor: Full diffusion tensor, shape (d, d)
+        sigma_tensor: Covariance (sigma*sigma^T) tensor, shape (d, d). D_ij = sigma_tensor[i,j]/2.
         dt: Time step size
         spacing: Grid spacing in each dimension
 
@@ -298,7 +310,10 @@ def apply_cross_diffusion_explicit(
 
     for i in range(d):
         for j in range(i + 1, d):
-            # Off-diagonal coefficient
+            # Off-diagonal covariance entry; D_ij = sigma_ij/2.
+            # The full-operator symmetry expansion gives coefficient sigma_ij per (i<j) pair
+            # (the factor-of-2 from symmetry and the 1/2 in D_ij cancel exactly).
+            # Issue #1261 fix, 2026-06-10 audit: was erroneously 2.0 * sigma_ij.
             sigma_ij = sigma_tensor[i, j]
             if abs(sigma_ij) < 1e-14:
                 continue
@@ -307,12 +322,10 @@ def apply_cross_diffusion_explicit(
             dx_j = spacing[j]
 
             # Compute mixed partial derivative using central differences
-            # Need to handle boundary carefully
             mixed_deriv = compute_mixed_derivative(U, i, j, dx_i, dx_j)
 
-            # Add explicit contribution: dt * σ_ij * ∂²u/∂x_i∂x_j
-            # Factor of 2 because we only loop over i < j but tensor has both (i,j) and (j,i)
-            U_new += dt * 2.0 * sigma_ij * mixed_deriv
+            # Add explicit contribution: dt * sigma_ij * d^2u/dx_i dx_j
+            U_new += dt * sigma_ij * mixed_deriv
 
     return U_new
 

--- a/tests/unit/test_alg/test_adi_cross_diffusion_factor.py
+++ b/tests/unit/test_alg/test_adi_cross_diffusion_factor.py
@@ -1,0 +1,102 @@
+"""
+Pinning test for Issue #1261: ADI explicit cross-diffusion term was 2x too large.
+
+Convention: sigma_tensor is the covariance matrix. Diagonal ADI uses
+D_d = sigma_tensor[d,d]/2 (via diffusion_from_volatility on sqrt of diagonal).
+The off-diagonal explicit contribution per pair (i<j) must be
+  dt * sigma_tensor[i,j] * d^2u/dx_i dx_j
+NOT dt * 2 * sigma_tensor[i,j] * d^2u/dx_i dx_j.
+
+The factor-of-2 from symmetry (sum over all i!=j = 2*sum_{i<j}) and the 1/2 in
+D_ij = sigma_tensor[i,j]/2 cancel; no residual factor of 2 remains.
+"""
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import apply_cross_diffusion_explicit
+
+
+def _make_quadratic_xy(Nx: int, Ny: int, dx: float, dy: float) -> np.ndarray:
+    """u(x,y) = x * y on a uniform grid.  Mixed derivative d^2u/dx dy = 1 everywhere."""
+    xs = np.arange(Nx) * dx
+    ys = np.arange(Ny) * dy
+    X, Y = np.meshgrid(xs, ys, indexing="ij")
+    return X * Y
+
+
+class TestADICrossDiffusionFactor:
+    """Issue #1261, 2026-06-10 audit: off-diagonal factor must be sigma_ij, not 2*sigma_ij."""
+
+    def test_cross_diffusion_increment_matches_sigma_not_2sigma(self) -> None:
+        """
+        For u(x,y) = x*y the mixed derivative d^2u/dx dy = 1 everywhere (interior).
+        With sigma_tensor = [[a, b], [b, a]] (symmetric, b != 0) and dt=1,
+        the increment at interior points must equal b * 1 = b,
+        NOT 2*b.
+
+        This test FAILS on buggy code (returns 2*b) and PASSES after the fix (returns b).
+        """
+        Nx, Ny = 10, 10
+        dx, dy = 0.1, 0.1
+        dt = 1.0
+
+        a = 1.0  # diagonal; irrelevant to cross term
+        b = 0.5  # off-diagonal
+        sigma_tensor = np.array([[a, b], [b, a]])
+        spacing = np.array([dx, dy])
+
+        U = _make_quadratic_xy(Nx, Ny, dx, dy)
+        U_new = apply_cross_diffusion_explicit(U, sigma_tensor, dt, spacing)
+
+        increment = U_new - U  # should be dt * b * mixed_deriv_approx
+
+        # Interior region: rows/cols 1:-1 (boundary is zero-padded in mixed deriv)
+        interior = increment[1:-1, 1:-1]
+
+        # The exact mixed second derivative of x*y is 1 everywhere.
+        # Central-difference approximation of d^2(xy)/dxdy on a uniform grid = 1 exactly.
+        # So dt * sigma_ij * d^2u/dxdy = 1.0 * 0.5 * 1.0 = 0.5 at every interior point.
+        expected = dt * b * 1.0  # = 0.5
+
+        np.testing.assert_allclose(
+            interior,
+            expected,
+            rtol=1e-10,
+            err_msg=(
+                f"Expected cross-diffusion increment {expected} (= dt*sigma_ij*mixed_deriv), "
+                f"got {interior[0, 0]:.6f}. "
+                "If 2x too large, this is Issue #1261 (factor-of-2 bug)."
+            ),
+        )
+
+    def test_cross_diffusion_coefficient_is_sigma_not_2sigma_parametric(self) -> None:
+        """
+        Parametric sweep over several b values to confirm linearity and correct coefficient.
+        """
+        Nx, Ny = 8, 8
+        dx, dy = 0.2, 0.2
+        dt = 0.5
+        spacing = np.array([dx, dy])
+
+        for b in [0.1, 0.3, 0.7, 1.0]:
+            sigma_tensor = np.array([[1.0, b], [b, 1.0]])
+            U = _make_quadratic_xy(Nx, Ny, dx, dy)
+            U_new = apply_cross_diffusion_explicit(U, sigma_tensor, dt, spacing)
+            interior_increment = (U_new - U)[1:-1, 1:-1]
+            expected = dt * b * 1.0  # d^2(xy)/dxdy = 1
+            np.testing.assert_allclose(
+                interior_increment,
+                expected,
+                rtol=1e-10,
+                err_msg=f"b={b}: expected {expected}, got {interior_increment[0, 0]:.6f}",
+            )
+
+    def test_zero_off_diagonal_no_change(self) -> None:
+        """Diagonal sigma_tensor: cross term is zero, U unchanged."""
+        Nx, Ny = 6, 6
+        dx, dy = 0.1, 0.1
+        sigma_tensor = np.array([[1.0, 0.0], [0.0, 1.0]])
+        spacing = np.array([dx, dy])
+        U = _make_quadratic_xy(Nx, Ny, dx, dy)
+        U_new = apply_cross_diffusion_explicit(U, sigma_tensor, 1.0, spacing)
+        np.testing.assert_array_equal(U_new, U, err_msg="Zero off-diagonal: U must be unchanged.")


### PR DESCRIPTION
## Summary

- `apply_cross_diffusion_explicit` in `hjb_sl_adi.py` used `dt * 2.0 * sigma_ij * mixed_deriv` per off-diagonal pair `(i<j)`.
- Under the diagonal ADI convention `D_d = sigma_tensor[d,d]/2` (set at line 259 via `diffusion_from_volatility(sqrt(sigma_tensor[d,d]))`), the correct off-diagonal explicit contribution is `dt * sigma_tensor[i,j] * d^2u/dx_i dx_j` per pair. The factor-of-2 from the symmetry expansion `2*sum_{i<j}` and the `1/2` in `D_ij = sigma_tensor[i,j]/2` cancel exactly, leaving coefficient `sigma_tensor[i,j]` — no residual factor of 2.
- The bug doubles the off-diagonal diffusion for all 2D+ HJB SL solvers using a full (d,d) sigma with nonzero off-diagonal entries.

## Fix

Removed the `2.0 *` from `hjb_sl_adi.py:315`. Updated docstrings (module header + `adi_diffusion_step` + `apply_cross_diffusion_explicit`) to state the correct formula `sum_{i<j} sigma_ij * d^2u/dx_i dx_j`.

## Test plan

- Pinning test `tests/unit/test_alg/test_adi_cross_diffusion_factor.py`: uses `u(x,y) = x*y` (exact mixed deriv = 1 everywhere), asserts interior increment equals `dt * sigma_ij` not `dt * 2 * sigma_ij`.
- Demonstrated fail-without / pass-with: 2 tests FAIL on buggy code (actual = 2x expected), 3 tests PASS after fix.
- `ruff format` + `ruff check` clean on both changed files.

Fixes #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)