### PR TITLE
fix(fem): fail loud on EXTRAPOLATION BC; fix boundary_tags TypeError on fresh skfem mesh

### DIFF
--- a/mfgarchon/alg/numerical/fem/bc_adapter.py
+++ b/mfgarchon/alg/numerical/fem/bc_adapter.py
@@ -94,6 +94,18 @@ def apply_bc_to_fem_system(
                 "path (needs DOF identification across paired boundaries; see Issue #1237)."
             )
 
+        else:
+            # Issue #1260: EXTRAPOLATION_LINEAR / EXTRAPOLATION_QUADRATIC (and any future BCType
+            # added without a matching branch) must fail loud rather than silently degrade to
+            # natural (Neumann) BC — the same design intent as Robin/Periodic above (#1241).
+            # 2026-06-10 audit.
+            raise NotImplementedError(
+                f"BC type '{segment.bc_type.value}' on segment '{segment.name}' is not implemented "
+                "for the FEM solver path. EXTRAPOLATION_LINEAR/QUADRATIC are ghost-cell FDM concepts "
+                "with no direct FEM counterpart. Use a Dirichlet or Neumann/no-flux BC for FEM, "
+                "or use an FDM/GFDM solver for extrapolation boundaries (Issue #1260)."
+            )
+
     if dirichlet_dofs:
         # Condense: eliminate Dirichlet DOFs from system
         dof_array = np.array(dirichlet_dofs, dtype=int)

--- a/mfgarchon/alg/numerical/fem/mesh_adapter.py
+++ b/mfgarchon/alg/numerical/fem/mesh_adapter.py
@@ -168,13 +168,20 @@ def _apply_boundary_tags(mesh: skfem.Mesh, mesh_data: MeshData) -> None:
     if mesh_data.boundary_tags is None or len(mesh_data.boundary_tags) == 0:
         return
 
+    # Issue #1260: mesh.boundaries is a read-only property backed by mesh._boundaries, which is
+    # None on a freshly constructed MeshTri/MeshLine/MeshTet (skfem 12.0.1).  Item-assignment on
+    # None raises TypeError; initialize the backing field to an empty dict before use.
+    # 2026-06-10 audit.
+    if mesh._boundaries is None:
+        mesh._boundaries = {}
+
     unique_tags = np.unique(mesh_data.boundary_tags)
     for tag in unique_tags:
         if tag == 0:
             continue  # Skip default/untagged
         mask = mesh_data.boundary_tags == tag
         facet_indices = np.where(mask)[0]
-        mesh.boundaries[f"region_{tag}"] = facet_indices
+        mesh._boundaries[f"region_{tag}"] = facet_indices
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_alg/test_fem_adapter_issue1260.py
+++ b/tests/unit/test_alg/test_fem_adapter_issue1260.py
@@ -1,0 +1,146 @@
+"""
+Pinning tests for Issue #1260: two FEM adapter defects.
+
+(A) apply_bc_to_fem_system had no terminal else for unhandled BCTypes, so
+    EXTRAPOLATION_LINEAR/QUADRATIC silently degraded to Neumann BC.
+    Fix: terminal else raises NotImplementedError.
+
+(B) _apply_boundary_tags crashed with TypeError on gmsh-tagged meshes because
+    mesh.boundaries is None on a freshly constructed skfem Mesh.
+    Fix: initialize mesh._boundaries to {} before item-assignment.
+
+Both tests FAIL on the unfixed code and PASS after the fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required")
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _minimal_skfem_basis():
+    """Return a tiny (A, rhs, basis) triple for bc_adapter tests."""
+    from scipy import sparse
+
+    mesh = skfem.MeshTri.init_sqsymmetric()
+    elem = skfem.ElementTriP1()
+    basis = skfem.Basis(mesh, elem)
+    n = basis.N
+    A = sparse.eye(n, format="csr")
+    rhs = np.ones(n)
+    return A, rhs, basis
+
+
+def _extrapolation_bc(dimension: int = 2):
+    """BoundaryConditions with one EXTRAPOLATION_LINEAR segment."""
+    from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+    from mfgarchon.geometry.boundary.types import BCSegment, BCType
+
+    return BoundaryConditions(
+        segments=[
+            BCSegment(
+                name="left_extrap",
+                bc_type=BCType.EXTRAPOLATION_LINEAR,
+                value=0.0,
+                boundary="x_min",
+            )
+        ],
+        dimension=dimension,
+    )
+
+
+def _tagged_meshdata():
+    """MeshData for a 1D line mesh with nonzero boundary_tags."""
+    from mfgarchon.geometry.meshes.mesh_data import MeshData
+
+    # A trivial 1D segment: 3 nodes, 2 line elements, 2 boundary faces
+    vertices = np.array([[0.0], [0.5], [1.0]])
+    elements = np.array([[0, 1], [1, 2]])
+    boundary_faces = np.array([[0], [2]])
+    boundary_tags = np.array([1, 2], dtype=np.int64)  # nonzero tags
+    element_tags = np.zeros(2, dtype=np.int64)
+    return MeshData(
+        vertices=vertices,
+        elements=elements,
+        element_type="line",
+        boundary_tags=boundary_tags,
+        element_tags=element_tags,
+        boundary_faces=boundary_faces,
+        dimension=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (A) EXTRAPOLATION_LINEAR must raise NotImplementedError (Issue #1260)
+# ---------------------------------------------------------------------------
+
+
+def test_extrapolation_linear_raises_not_implemented():
+    """apply_bc_to_fem_system must raise NotImplementedError for EXTRAPOLATION_LINEAR.
+
+    Before the fix: the segment matched no branch in the if/elif chain and the
+    function returned (A, rhs) unchanged — silent Neumann degrade.
+    After the fix: the terminal else raises NotImplementedError.
+    """
+    from mfgarchon.alg.numerical.fem.bc_adapter import apply_bc_to_fem_system
+
+    A, rhs, basis = _minimal_skfem_basis()
+    bc = _extrapolation_bc(dimension=2)
+
+    with pytest.raises(NotImplementedError, match="EXTRAPOLATION"):
+        apply_bc_to_fem_system(A, rhs, basis, bc)
+
+
+def test_extrapolation_quadratic_raises_not_implemented():
+    """apply_bc_to_fem_system must raise NotImplementedError for EXTRAPOLATION_QUADRATIC."""
+    from mfgarchon.alg.numerical.fem.bc_adapter import apply_bc_to_fem_system
+    from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+    from mfgarchon.geometry.boundary.types import BCSegment, BCType
+
+    A, rhs, basis = _minimal_skfem_basis()
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(
+                name="right_extrap",
+                bc_type=BCType.EXTRAPOLATION_QUADRATIC,
+                value=0.0,
+                boundary="x_max",
+            )
+        ],
+        dimension=2,
+    )
+
+    with pytest.raises(NotImplementedError, match="EXTRAPOLATION"):
+        apply_bc_to_fem_system(A, rhs, basis, bc)
+
+
+# ---------------------------------------------------------------------------
+# (B) gmsh-tagged MeshData must not crash (Issue #1260)
+# ---------------------------------------------------------------------------
+
+
+def test_tagged_meshdata_to_skfem_no_crash():
+    """meshdata_to_skfem must not raise TypeError for nonzero boundary_tags.
+
+    Before the fix: _apply_boundary_tags did mesh.boundaries[...] = ... on a
+    None boundaries dict, raising TypeError.
+    After the fix: mesh._boundaries is initialized to {} first.
+    """
+    from mfgarchon.alg.numerical.fem.mesh_adapter import meshdata_to_skfem
+
+    md = _tagged_meshdata()
+    # Must not raise TypeError
+    mesh = meshdata_to_skfem(md)
+
+    # Verify the boundary tags were actually registered
+    assert mesh.boundaries is not None, "boundaries dict must be populated"
+    assert "region_1" in mesh.boundaries, "region_1 must be registered"
+    assert "region_2" in mesh.boundaries, "region_2 must be registered"


### PR DESCRIPTION
## Summary

- **(A) `bc_adapter.py`**: `apply_bc_to_fem_system` had no terminal `else` after its `BCType` dispatch, so `EXTRAPOLATION_LINEAR` / `EXTRAPOLATION_QUADRATIC` segments silently fell through and degraded to natural (Neumann) BC — exactly the silent-wrong-physics pattern that #1241 fixed for Robin/Periodic. Adds a terminal `else: raise NotImplementedError(...)` matching that pattern.
- **(B) `mesh_adapter.py`**: `_apply_boundary_tags` did `mesh.boundaries[...] = ...` on a `None` dict — `mesh.boundaries` is a read-only property (no setter) backed by `mesh._boundaries` which is `None` on any freshly constructed skfem `MeshTri`/`MeshLine`/`MeshTet` (skfem 12.0.1). Any `MeshData` with nonzero `boundary_tags` (gmsh physical-group path) crashed `FPFEMSolver`/`HJBFEMSolver` construction with `TypeError`. Fix initializes `mesh._boundaries = {}` before assignment.

## Pinning tests

`tests/unit/test_alg/test_fem_adapter_issue1260.py` — 3 tests, all confirm fail-without / pass-with:

| Test | Buggy code | Fixed code |
|---|---|---|
| `test_extrapolation_linear_raises_not_implemented` | `Failed: DID NOT RAISE` | PASSED |
| `test_extrapolation_quadratic_raises_not_implemented` | `Failed: DID NOT RAISE` | PASSED |
| `test_tagged_meshdata_to_skfem_no_crash` | `TypeError: 'NoneType'...` | PASSED |

## Test plan

- [x] `python -m pytest tests/unit/test_alg/test_fem_adapter_issue1260.py -q` — 3 passed
- [x] `ruff format` + `ruff check` — clean
- [x] Fail-without demonstrated via `git stash` on source files

Refs #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)