### PR TITLE
fix: route uniform neumann BC to no-flux handler in implicit FP-FDM (Issue #1250)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -1114,6 +1114,20 @@ def solve_timestep_full_nd(
     col_indices: list[int] = []
     data_values: list[float] = []
 
+    # Issue #1250 2026-06-10 audit: pre-validate BC type before the per-point loop.
+    # Uniform 'robin' has no correct implicit stencil here; silently routing it to the
+    # interior handler produces an absorbing wall (ghost-zero, +D/dx² row-sum).  Fail
+    # loud once rather than silently corrupting every boundary row.
+    _bc_is_uniform = getattr(boundary_conditions, "is_uniform", None)
+    if _bc_is_uniform:
+        _bc_type_str = boundary_conditions.type  # safe: is_uniform True → .type won't raise
+        if _bc_type_str == "robin":
+            raise NotImplementedError(
+                "Implicit FDM FP assembly does not support uniform 'robin' boundary conditions; "
+                "the boundary stencil for Robin BC is not implemented on this path. "
+                "Use 'no_flux' or 'neumann' for zero-flux (reflecting) walls. (Issue #1250)"
+            )
+
     # Build matrix by iterating over all grid points
     for flat_idx in range(N_total):
         # Convert flat index to multi-index (i, j, k, ...)
@@ -1130,8 +1144,14 @@ def solve_timestep_full_nd(
         is_boundary = is_boundary_point(multi_idx, shape, ndim)
 
         # Determine BC type (Issue #859: explicit legacy handling, fail on unknown)
+        # Issue #1250 2026-06-10 audit: uniform 'neumann' is homogeneous-Neumann, identical
+        # to 'no_flux' for the FP equation; the operator paths already treat them identically
+        # (laplacian.py:307, advection.py:316).  Route to the same no-flux boundary handler.
         try:
-            is_no_flux = boundary_conditions.is_uniform and boundary_conditions.type == "no_flux"
+            is_no_flux = boundary_conditions.is_uniform and boundary_conditions.type in (
+                "no_flux",
+                "neumann",
+            )
             is_uniform = boundary_conditions.is_uniform
         except AttributeError:
             # Legacy BoundaryConditions1D from fdm_bc_1d: has .type string but no .is_uniform

--- a/tests/unit/test_alg/test_fp_matrix_conservation.py
+++ b/tests/unit/test_alg/test_fp_matrix_conservation.py
@@ -27,7 +27,7 @@ from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.geometry import TensorProductGrid
-from mfgarchon.geometry.boundary import no_flux_bc, periodic_bc
+from mfgarchon.geometry.boundary import neumann_bc, no_flux_bc, periodic_bc, robin_bc
 
 
 def _zero_drift_density_evolution(bc, n=41, nt=40, T=0.2, sigma=0.5):
@@ -75,6 +75,54 @@ class TestFPProductionConservation:
         # an M-matrix implicit step keeps a positive initial density positive
         M, _ = _zero_drift_density_evolution(periodic_bc(dimension=1))
         assert np.all(M[-1] > -1e-12), "production FP step produced a negative density"
+
+
+class TestNeumannBCImplicitFP:
+    """Issue #1250 pinning tests: uniform 'neumann' BC must conserve mass in implicit FDM.
+
+    Before the fix, neumann was routed to the interior handler (is_no_flux=False,
+    is_uniform=True → neither branch of the dispatch), producing a ghost-zero absorbing
+    wall row (+D/dx² diagonal, missing coupling → mass drains 3-7% / 5 steps).
+    After the fix, neumann routes to the same no-flux boundary handler as no_flux.
+    """
+
+    def test_mass_conserved_neumann_zero_value_zero_drift(self):
+        """neumann_bc(0) implicit step must conserve total mass to ~1e-10.
+
+        This is the primary pinning test for Issue #1250.  On the buggy code the
+        boundary rows are assembled as absorbing sinks and mass falls ~3% over 5 steps.
+        """
+        M, dx = _zero_drift_density_evolution(neumann_bc(dimension=1))
+        mass = M.sum(axis=1) * dx
+        relerr = abs(mass[-1] - mass[0]) / mass[0]
+        assert relerr < 1e-10, (
+            f"neumann zero-drift mass not conserved (Issue #1250): relerr {relerr:.2e} "
+            f"(expected <1e-10; >3e-3 indicates the absorbing-wall bug is active)"
+        )
+
+    def test_neumann_matches_no_flux_implicit(self):
+        """neumann_bc(0) and no_flux_bc must produce byte-identical mass histories.
+
+        Both are homogeneous-Neumann; the operator paths already treat them identically
+        (laplacian.py:307, advection.py:316).  After the fix the implicit assembly must
+        as well.
+        """
+        M_nf, _dx = _zero_drift_density_evolution(no_flux_bc(dimension=1))
+        M_ne, _ = _zero_drift_density_evolution(neumann_bc(dimension=1))
+        max_diff = np.max(np.abs(M_nf - M_ne))
+        assert max_diff < 1e-14, (
+            f"neumann and no_flux produce different density histories (Issue #1250): "
+            f"max|diff|={max_diff:.2e} (should be 0 to floating-point)"
+        )
+
+    def test_robin_bc_fails_loud_implicit(self):
+        """Uniform 'robin' BC must raise NotImplementedError (not silently absorb mass).
+
+        Issue #1250: until a correct Robin stencil is implemented, failing loud is
+        correct (fail-fast doctrine); silently assembling an absorbing wall is not.
+        """
+        with pytest.raises(NotImplementedError, match="robin"):
+            _zero_drift_density_evolution(robin_bc(dimension=1))
 
 
 class TestConservativeAdvection:


### PR DESCRIPTION
## Summary

- Uniform `neumann_bc(0)` was silently dispatched to the **interior** handler in `solve_timestep_full_nd` because `is_no_flux` only matched `"no_flux"`, leaving `is_uniform=True` and `is_no_flux=False`. The gate `(is_no_flux or not is_uniform)` evaluated to `False`, so wall rows got the full `2D/dx²` diagonal without the missing-neighbor coupling — equivalent to a ghost node clamped at `m=0` (absorbing wall). Mass drained ~3% over 5 implicit steps.
- Fix: include `"neumann"` in the `is_no_flux` check at line 1134 of `fp_fdm_time_stepping.py`. The operator paths already treat them identically (`laplacian.py:307`, `advection.py:316`).
- Also adds a pre-loop `NotImplementedError` guard for uniform `"robin"` BC, which has no correct stencil on this implicit path (fail-fast, not silent corruption).

## Test plan

- [ ] `TestNeumannBCImplicitFP::test_mass_conserved_neumann_zero_value_zero_drift` — relerr < 1e-10 (was ~3.2% on buggy code)
- [ ] `TestNeumannBCImplicitFP::test_neumann_matches_no_flux_implicit` — byte-identical M histories (was max diff ~0.03 on buggy code)
- [ ] `TestNeumannBCImplicitFP::test_robin_bc_fails_loud_implicit` — `NotImplementedError` raised (was silently producing absorbing wall)
- [ ] All 22 tests in `test_fp_matrix_conservation.py` pass

Pinning test fail-without / pass-with evidence (stash-verified):
- **Without fix**: 2 FAILED (mass not conserved, neumann ≠ no_flux) + 1 FAILED (robin did not raise)
- **With fix**: 3 passed in 0.07s

Fixes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)