### PR TITLE
fix: DMP guard dead on joint_socp solve path; alpha_crit over-estimated on negative-L edges (#1253)

### DIFF
--- a/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
+++ b/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
@@ -941,15 +941,20 @@ def critical_drift_for_dmp(
     M-matrix off-diagonal sign (Issue #1074).
 
     For interior off-diagonal $(i, j)$ the assembled entry is
-    $\sum_d \alpha_d (D_{\mathrm{grad}})_{d,ij} - D\,L_{ij}$. With $L_{ij} \ge 0$ (SOCP-monotone
-    Laplacian) the diffusion part is $\le 0$; the worst-case unit-$|\alpha|$ direction makes the
-    drift part $|\alpha|\,\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$ (Cauchy–Schwarz), so the sign
-    holds iff $|\alpha| \le D\,L_{ij}/\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$. The minimum over
-    edges is the critical drift. (The SOCP cone bound $\lVert D_{:,j}\rVert \le (C/h)L_j$ forces
-    the gradient support into the Laplacian support, so every drift-coupled edge has $L_{ij} > 0$
-    and the threshold is strictly positive.)
+    $\sum_d \alpha_d (D_{\mathrm{grad}})_{d,ij} - D\,L_{ij}$. The worst-case unit-$|\alpha|$
+    direction makes the drift part $|\alpha|\,\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$
+    (Cauchy-Schwarz), so the M-matrix sign holds iff
+    $|\alpha| \le D\,L_{ij}/\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$.
+
+    When $L_{ij} \le 0$ (relaxed-SOCP slack row; Issue #1253) and $\lVert D_{:,j}\rVert > 0$,
+    the right-hand side is $\le 0$: the off-diagonal entry is already non-negative at zero
+    drift, so $\alpha_{\mathrm{crit}}$ collapses to 0 (or below) for that edge. The
+    iteration therefore covers **all** edges with nonzero gradient weight, treating
+    $L_{ij} \le atol$ edges as immediate-violation contributors.
 
     Returns ``inf`` when no edge constrains the sign (e.g. a zero gradient operator).
+    Returns a value $\le 0$ when any assembled off-diagonal is already non-negative at zero
+    drift (assembled matrix non-M regardless of advection).
     """
     L = d_lap.tocsr()
     grads = [g.tocsr() for g in d_grad]
@@ -960,11 +965,15 @@ def critical_drift_for_dmp(
     for i in rows:
         l_row = L.getrow(i).toarray().ravel()
         g_rows = [g.getrow(i).toarray().ravel() for g in grads]
-        for j in np.nonzero(l_row > atol)[0]:
+        # Issue #1253 2026-06-10 audit: iterate over ALL off-diagonal edges with
+        # nonzero gradient weight, not only those with L_ij > atol. A negative L_ij
+        # (relaxed-SOCP slack) means D*L_ij < 0, so the assembled off-diagonal entry
+        # alpha*D_grad_ij - D*L_ij > 0 at zero drift → alpha_crit → 0 or negative.
+        # Iterating only l_row > atol silently drops these edges and over-estimates
+        # alpha_crit (false-negative DMP warning).
+        g_norms = np.sqrt(sum(gr**2 for gr in g_rows))  # vectorized over all n columns
+        for j in np.nonzero(g_norms > atol)[0]:
             if j == i:
                 continue
-            g_norm = float(np.sqrt(sum(gr[j] ** 2 for gr in g_rows)))
-            if g_norm <= atol:
-                continue
-            alpha_crit = min(alpha_crit, diffusion_coeff * float(l_row[j]) / g_norm)
+            alpha_crit = min(alpha_crit, diffusion_coeff * float(l_row[j]) / float(g_norms[j]))
     return alpha_crit

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2309,8 +2309,13 @@ class HJBGFDMSolver(BaseHJBSolver):
         """
         if not self.check_dmp or self._dmp_warned or self.monotonicity_scheme != "joint_socp":
             return
+        # Issue #1253 2026-06-10 audit: _D_grad/_D_lap are built lazily and are
+        # None on the joint_socp per-point Newton path (_compute_hjb_jacobian_sparse
+        # never calls _build_differentiation_matrices). Build them here so the guard
+        # actually runs on the real solve path, not just when the vectorized Jacobian
+        # path happened to pre-build them as a side effect.
         if self._D_grad is None or self._D_lap is None:
-            return
+            self._build_differentiation_matrices()
         if self._dmp_alpha_crit is None:
             from mfgarchon.alg.numerical.gfdm_components.monotonicity_enforcer import critical_drift_for_dmp
 

--- a/tests/unit/test_alg/test_socp_m_matrix_property.py
+++ b/tests/unit/test_alg/test_socp_m_matrix_property.py
@@ -312,5 +312,107 @@ def _make_solver_check_dmp(sigma: float, check_dmp: bool, n_x: int = 21):
     )
 
 
+# ---------------------------------------------------------------------------
+# Issue #1253 — DMP guard dead on joint_socp solve path; alpha_crit over-estimated
+# ---------------------------------------------------------------------------
+
+
+def test_dmp_guard_fires_on_real_solve_path():
+    """Issue #1253 2026-06-10: _maybe_warn_dmp must fire on the normal Newton solve path.
+
+    Before the fix: _D_grad is None on the joint_socp/precompute per-point path because
+    _compute_hjb_jacobian_sparse never calls _build_differentiation_matrices; the guard
+    silently returned. After the fix: _build_differentiation_matrices() is called lazily
+    inside _maybe_warn_dmp so the guard actually runs.
+
+    Pinning condition: a joint_socp solve with check_dmp=True in advection-dominated
+    1D regime (small sigma, steep u_terminal) must emit the DMP warning via
+    solve_hjb_system(), WITHOUT any manual pre-build of _D_grad.
+    """
+    import logging
+
+    records: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Capture()
+    gfdm_logger = logging.getLogger("mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm")
+    gfdm_logger.addHandler(handler)
+    try:
+        # Small sigma → small alpha_crit (D = sigma^2/2 ≈ 0.005).
+        # Steep u_terminal → large grad_u → max_alpha ≫ alpha_crit from first Newton step.
+        n_x = 21
+        solver = _make_solver_check_dmp(sigma=0.1, check_dmp=True, n_x=n_x)
+
+        # Verify operators have NOT been pre-built (this is the bug condition: guard
+        # would silently return without the fix).
+        assert solver._D_grad is None, "_D_grad must be None before solve to test the real path"
+
+        n_pts = solver.n_points
+        x_vals = solver.collocation_points[:, 0]
+        # Steep linear terminal: gradient ≈ 10, far exceeds alpha_crit ≈ D/h ≈ 0.005/0.05 ≈ 0.1
+        u_terminal = 10.0 * x_vals
+
+        m_density = np.ones((solver.problem.Nt + 1, n_pts))  # uniform density, no coupling effect
+
+        # Run through the REAL solve path. _solve_timestep → per-point branch
+        # → _maybe_warn_dmp is called with _D_grad=None (pre-fix: silent return).
+        solver.solve_hjb_system(
+            M_density=m_density,
+            U_terminal=u_terminal,
+        )
+
+        assert any("DMP" in m or "Issue #1074" in m for m in records), (
+            "DMP warning must fire when drift > alpha_crit on the real solve path "
+            "(Issue #1253: guard was silently skipped when _D_grad=None)"
+        )
+    finally:
+        gfdm_logger.removeHandler(handler)
+
+
+def test_critical_drift_includes_negative_lap_edges():
+    """Issue #1253 2026-06-10: critical_drift_for_dmp must include edges where L_ij <= 0
+    but gradient weight is nonzero (relaxed-SOCP slack rows).
+
+    When L_ij < 0 and D_grad_ij ≠ 0, the assembled off-diagonal D*L_ij term is
+    negative → the entry is positive at zero drift → alpha_crit must be ≤ 0.
+    The old code iterated only l_row > atol and returned a positive finite threshold,
+    producing a false-negative DMP warning.
+    """
+    from scipy.sparse import csr_matrix
+
+    from mfgarchon.alg.numerical.gfdm_components.monotonicity_enforcer import critical_drift_for_dmp
+
+    # Hand-crafted 3-point system: interior point i=1, neighbors j=0, j=2.
+    # L[1,0]=−0.1 (negative, relaxed-SOCP slack), L[1,2]=0.5, L[1,1] adjusted for row sum=0.
+    # D_grad[1,0]=1.0, D_grad[1,2]=1.0 (nonzero gradient on both edges).
+    n = 3
+    L_data = np.zeros((n, n))
+    L_data[1, 0] = -0.1  # negative off-diagonal — relaxed SOCP slack
+    L_data[1, 2] = 0.5
+    L_data[1, 1] = -L_data[1, 0] - L_data[1, 2]  # row sum = 0
+
+    G_data = np.zeros((n, n))
+    G_data[1, 0] = 1.0
+    G_data[1, 2] = 1.0
+    G_data[1, 1] = -G_data[1, 0] - G_data[1, 2]
+
+    d_lap = csr_matrix(L_data)
+    d_grad = [csr_matrix(G_data)]
+    diffusion_coeff = 1.0
+    interior = np.array([1])
+
+    alpha_crit = critical_drift_for_dmp(d_lap, d_grad, diffusion_coeff, interior_indices=interior)
+
+    # Before fix: iterates only L_ij > atol → j=2 only → alpha_crit = 1.0*0.5/1.0 = 0.5
+    # After fix: includes j=0 (L_ij=-0.1, g_norm=1.0) → alpha_crit = 1.0*(-0.1)/1.0 = -0.1
+    assert alpha_crit <= 0.0, (
+        f"alpha_crit={alpha_crit:.4f}: negative-L edge (L=-0.1, g=1.0) must drive alpha_crit <= 0; "
+        "old code returned +0.5, masking a pre-existing M-matrix violation (Issue #1253)"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary

- **Primary** (`hjb_gfdm.py:2312`): `_maybe_warn_dmp` silently returned when `_D_grad is None`. On the `joint_socp/precompute` per-point Newton path, `_compute_hjb_jacobian_sparse` never calls `_build_differentiation_matrices()`, so `_D_grad` stays `None` for the entire solve and `check_dmp=True` never warns. Fix: call `_build_differentiation_matrices()` lazily instead of returning, consistent with the existing lazy-init pattern in `_compute_hjb_jacobian_vectorized`.

- **Secondary** (`monotonicity_enforcer.py:963`): `critical_drift_for_dmp` iterated only edges with `L_ij > atol`, dropping relaxed-SOCP rows with `L_ij <= 0` but nonzero gradient weight. For `L_ij < 0` (relaxed-SOCP slack), the assembled off-diagonal `alpha*D_grad_ij - D*L_ij > 0` at zero drift — the function returned a falsely positive `alpha_crit`. Fix: iterate over all off-diagonal entries with nonzero gradient weight; `L_ij < 0` collapses `alpha_crit` to ≤ 0, correctly flagging an already-violated M-matrix.

## Test plan

- [x] `test_dmp_guard_fires_on_real_solve_path`: `joint_socp` solve with `check_dmp=True` + small sigma + steep `u_terminal` emits the DMP warning via `solve_hjb_system()` WITHOUT any manual pre-build of `_D_grad`. **Fails on buggy code** (guard silently skipped), **passes with fix**.
- [x] `test_critical_drift_includes_negative_lap_edges`: hand-crafted 3-point operator with `L[1,0]=-0.1` (negative off-diagonal) and `D_grad[1,0]=1.0` must yield `alpha_crit <= 0`. Old code returned `+0.5`. **Fails on buggy code**, **passes with fix**.
- [x] All 22 existing tests in `test_socp_m_matrix_property.py` still pass.

Note: `inner_solver='howard'` bypass of `_solve_timestep` is a separate gap not addressed here (deferred per issue scope).

Refs #1253 #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)