### PR TITLE
fix: FixedPointIterator silently dropped nonlocal_operator from HJB source

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -29,6 +29,7 @@ from .fixed_point_utils import (
     preserve_terminal_condition,
     resolve_fp_drift_kwargs,
 )
+from .graph_coupling import _get_time_slice
 
 logger = get_logger(__name__)
 
@@ -233,15 +234,21 @@ class FixedPointIterator(BaseCouplingIterator):
         # Cache solver signatures via base class (Issue #934)
         self._init_solver_signatures(self.hjb_solver, self.fp_solver)
 
-    def _compose_hjb_source(self, m_current: np.ndarray) -> Callable | None:
+    def _compose_hjb_source(self, m_current: np.ndarray, u_current: np.ndarray) -> Callable | None:
         """Compose problem-level source terms into a solver-level source_term callable.
 
         Reads source_term_hjb, nonlocal_operator, and obstacle from MFGProblem,
-        binds spatial grid and current density, returns a (v, t) -> array closure
-        compatible with BaseHJBSolver.solve_hjb_system(source_term=...).
+        binds spatial grid, current density, and current value function, returns
+        a (t, x) -> array closure compatible with
+        BaseHJBSolver.solve_hjb_system(source_term=...).
 
         Issue #921/#922: Bridges problem-level signature (x, m, v, t) to
         solver-level signature (t, x) by closure binding.
+        Issue #1259 fix (2026-06-10 audit): nonlocal_operator term was computed
+        in has_nonlocal but never applied inside the closure.  Added explicit
+        branch that extracts the time slice of the previous-iterate value function
+        and applies J[v] with the same sign convention used by graph_mfg_solver
+        (s += nonlocal_operator @ v_t).
 
         Returns:
             Callable or None if no source terms are active.
@@ -256,10 +263,8 @@ class FixedPointIterator(BaseCouplingIterator):
 
         def composed(t: float, x: np.ndarray) -> np.ndarray:
             # Note: HJB solver calls source_term(t, x_grid) -> array.
-            # We need v (current value function) for nonlocal_operator,
-            # but the HJB solver evaluates source_term *before* solving.
-            # For the current time step, we use the previous iterate's U.
-            # This is consistent with explicit treatment of source terms.
+            # The nonlocal and source terms use the previous iterate's U
+            # (explicit treatment), consistent with graph_mfg_solver.py:306.
             terms: list[np.ndarray] = []
             if has_source:
                 terms.append(problem.source_term_hjb(x, m_current, np.zeros_like(m_current), t))
@@ -270,6 +275,12 @@ class FixedPointIterator(BaseCouplingIterator):
                 # Note: this is evaluated with v=0 here; for proper penalty,
                 # PenaltyHJBSolver wrapper (#924) should be used instead.
                 terms.append((1.0 / eps) * np.maximum(0.0, psi.ravel()))
+            if has_nonlocal:
+                # Issue #1259 fix (2026-06-10 audit): apply J[v] using the
+                # previous iterate's value function at time t (explicit
+                # treatment), matching the convention in graph_mfg_solver.py:306.
+                v_t = _get_time_slice(u_current, t, problem.dt)
+                terms.append(problem.nonlocal_operator @ v_t)
             return sum(terms) if terms else np.zeros(x.shape[0])
 
         return composed
@@ -680,7 +691,8 @@ class FixedPointIterator(BaseCouplingIterator):
                 # Issue #614: Use hierarchical subtask for inner solver visibility
                 # Issue #625: Resolve BC providers before HJB solve
                 # Issue #922: Compose source terms from problem fields
-                hjb_source = self._compose_hjb_source(M_old)
+                # Issue #1259: Pass U_old so nonlocal_operator J[v] uses previous iterate
+                hjb_source = self._compose_hjb_source(M_old, U_old)
 
                 # Issue #934: Context routing handles progress automatically —
                 # solver's create_progress_bar detects parent HierarchicalProgress

--- a/tests/unit/test_alg/test_fpi_nonlocal_hjb_source.py
+++ b/tests/unit/test_alg/test_fpi_nonlocal_hjb_source.py
@@ -1,0 +1,125 @@
+"""Issue #1259: FixedPointIterator._compose_hjb_source silently dropped nonlocal_operator.
+
+The `has_nonlocal` flag was computed but never used inside the `composed`
+closure.  This test builds a tiny problem with a known LinearOperator
+nonlocal_operator and asserts that the composed HJB source includes the J[v]
+contribution.  It fails on pre-fix code (source omits nonlocal term) and
+passes after the fix.
+
+2026-06-10 audit.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling import FixedPointIterator
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+
+
+def _make_problem_with_nonlocal(Nx: int = 5, Nt: int = 3) -> MFGProblem:
+    """Minimal 1-D MFG problem with a diagonal nonlocal_operator."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    # nonlocal_operator: 2*I (applied to v_t it returns 2*v_t)
+    nonlocal_op = 2.0 * np.eye(Nx)
+    return MFGProblem(
+        Nx=Nx,
+        xmin=0.0,
+        xmax=1.0,
+        T=0.3,
+        Nt=Nt,
+        sigma=0.2,
+        components=components,
+        nonlocal_operator=nonlocal_op,
+    )
+
+
+def test_nonlocal_term_present_in_hjb_source():
+    """Composed HJB source must include nonlocal_operator @ v_t (Issue #1259).
+
+    Setup: nonlocal_operator = 2*I, so J[v_t] = 2*v_t.
+    For t=0 and a known u_current, the source must equal 2 * v_t[0, :].
+    Pre-fix: source returns zeros (nonlocal branch absent).
+    Post-fix: source returns 2 * v_t.
+    """
+    Nx = 5
+    Nt = 3
+    problem = _make_problem_with_nonlocal(Nx=Nx, Nt=Nt)
+    hjb_solver = HJBFDMSolver(problem)
+    fp_solver = FPFDMSolver(problem)
+    iterator = FixedPointIterator(problem, hjb_solver, fp_solver)
+
+    # Build m_current (flat spatial) and u_current (Nt+1, Nx)
+    m_current = np.ones(Nx) / Nx
+    rng = np.random.default_rng(42)
+    u_current = rng.standard_normal((Nt + 1, Nx))
+
+    # The composed source at t=0 with x_grid irrelevant to the nonlocal term
+    x_grid = np.linspace(0.0, 1.0, Nx).reshape(-1, 1)
+    source_fn = iterator._compose_hjb_source(m_current, u_current)
+
+    assert source_fn is not None, "source_fn must not be None when nonlocal_operator is set"
+
+    result = source_fn(t=0.0, x=x_grid)
+
+    # Expected: nonlocal_operator @ v_t(0) = 2*I @ u_current[0] = 2*u_current[0]
+    expected_nonlocal = 2.0 * u_current[0]
+
+    np.testing.assert_allclose(
+        result,
+        expected_nonlocal,
+        rtol=1e-12,
+        err_msg=(
+            "HJB source did not include nonlocal_operator @ v_t. Pre-fix code returns zeros; post-fix returns 2*v_t."
+        ),
+    )
+
+
+def test_nonlocal_term_present_at_interior_time():
+    """Nonlocal term is correctly extracted at an interior time step.
+
+    Checks that _get_time_slice selects the right row of u_current.
+    """
+    Nx = 5
+    Nt = 4
+    problem = _make_problem_with_nonlocal(Nx=Nx, Nt=Nt)
+    hjb_solver = HJBFDMSolver(problem)
+    fp_solver = FPFDMSolver(problem)
+    iterator = FixedPointIterator(problem, hjb_solver, fp_solver)
+
+    m_current = np.ones(Nx) / Nx
+    rng = np.random.default_rng(7)
+    u_current = rng.standard_normal((Nt + 1, Nx))
+
+    x_grid = np.linspace(0.0, 1.0, Nx).reshape(-1, 1)
+    source_fn = iterator._compose_hjb_source(m_current, u_current)
+
+    # t = T/2 -> time index n = round(t / dt) = round(Nt/2)
+    dt = problem.dt
+    t_half = dt * (Nt // 2)
+    n_half = Nt // 2
+
+    result = source_fn(t=t_half, x=x_grid)
+    expected_nonlocal = 2.0 * u_current[n_half]
+
+    np.testing.assert_allclose(
+        result,
+        expected_nonlocal,
+        rtol=1e-12,
+        err_msg=(
+            f"At t={t_half} (index {n_half}), expected 2*u_current[{n_half}]. nonlocal time-slice extraction failed."
+        ),
+    )


### PR DESCRIPTION
## Summary

`FixedPointIterator._compose_hjb_source` (lines 250-273 pre-fix) computed `has_nonlocal = problem.nonlocal_operator is not None` but the `composed` closure contained **no `if has_nonlocal:` branch** — so `problem.nonlocal_operator` (a documented `MFGProblem` kwarg for integro-differential / Lévy operators $J[v]$) was silently dropped from the HJB source on every Picard iteration.

`GraphMFGSolver._compose_hjb_source` (graph_mfg_solver.py:304-306) correctly applies the operator:

```python
if has_nonlocal:
    v_t = _get_time_slice(Us_full[k], t, dt)
    s = s + p.nonlocal_operator @ v_t
```

`FixedPointIterator` is the primary solver; it had no equivalent branch.

## Fix

- Added `u_current: np.ndarray` parameter to `_compose_hjb_source` (the previous-iterate value function, explicit treatment matching graph solver).
- Imported `_get_time_slice` from `graph_coupling` (already used by graph solver).
- Added `if has_nonlocal:` branch: `v_t = _get_time_slice(u_current, t, problem.dt); terms.append(nonlocal_operator @ v_t)`.
- Updated the call site in `solve()` to pass `U_old`.
- Sign convention: `+nonlocal_operator @ v_t`, matching `graph_mfg_solver.py:306` and the `source_term` sign (appended to HJB source terms, not negated).

## Test

`tests/unit/test_alg/test_fpi_nonlocal_hjb_source.py` — two unit tests:
1. `test_nonlocal_term_present_in_hjb_source`: `nonlocal_operator = 2I`, asserts `source(t=0, x) == 2 * u_current[0]`.
2. `test_nonlocal_term_present_at_interior_time`: same with interior time slice.

**Fail-without (pre-fix):**
```
TypeError: FixedPointIterator._compose_hjb_source() takes 2 positional arguments but 3 were given
```
(signature unchanged; nonlocal branch absent)

**Pass-with (post-fix):** `2 passed in 0.02s`

Fixes #1259