### PR TITLE
fix: FPSLSolver periodic diffusion sub-step uses Neumann stencil instead of periodic CN/ADI

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -30,7 +30,10 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import numpy as np
 from scipy.linalg import solve_banded
 
-from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import (
+    adi_diffusion_step,
+    solve_crank_nicolson_diffusion_1d,
+)
 from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import (
     apply_boundary_conditions_1d,
 )
@@ -221,6 +224,18 @@ class FPSLSolver(BaseFPSolver):
         bc_type = get_bc_type_string(self.boundary_conditions)
         return bc_type_to_geometric_operation(bc_type)
 
+    def _get_diffusion_bc_type(self) -> str:
+        """Return diffusion BC type for CN/ADI: 'periodic' or 'neumann'.
+
+        Issue #1257, 2026-06-10 audit: FP-SL diffusion sub-step must use the
+        same BC type as the advection sub-step so a periodic domain does not
+        acquire a spurious Neumann seam-flux.  Mirrors HJB-SL
+        _get_diffusion_bc_type() (hjb_semi_lagrangian.py:2238).
+        """
+        if self._get_bc_operation_type() == "periodic":
+            return "periodic"
+        return "neumann"
+
     @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
     @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     @deprecated_parameter(param_name="drift_field", since="v0.18.6", replacement="potential_field")
@@ -403,21 +418,22 @@ class FPSLSolver(BaseFPSolver):
         if self.interpolation_method != "linear":
             m_star = self._clip_nonneg(m_star)
 
-        # Step 2: Diffusion via Crank-Nicolson (Finite Volume formulation)
-        # ================================================================
-        # Issue #708: Use zero-flux (finite volume) boundary stencil for mass conservation.
-        #
-        # The standard ghost-point method (m[-1] = m[1]) is Strong Form and breaks
-        # mass conservation. The correct approach is Flux Form (finite volume):
-        #
-        # Physical interpretation:
-        #   - Boundary flux J_{-1/2} = 0 (zero-flux BC)
-        #   - Interior flux J_{i+1/2} = -D * (m[i+1] - m[i]) / dx
-        #   - dm[i]/dt = -(J_{i+1/2} - J_{i-1/2}) / dx
-        #
-        # This gives boundary stencil: L[0] = (m[1] - m[0])/dx^2
-        # The resulting matrix has column sums = 0, ensuring mass conservation.
-        #
+        # Step 2: Diffusion via Crank-Nicolson
+        # =====================================
+        # Issue #1257, 2026-06-10 audit: the diffusion BC must match the advection BC.
+        # On a periodic domain the advection step already wraps mass across the seam;
+        # pairing it with a Neumann/zero-flux diffusion sub-step produces an O(1) seam
+        # flux error every step and breaks adjoint consistency with HJB-SL (which
+        # threads _get_diffusion_bc_type into both its CN and ADI).  Use
+        # solve_crank_nicolson_diffusion_1d from hjb_sl_adi (which has both
+        # 'periodic' and 'neumann' branches) so the periodic case gets the
+        # Sherman-Morrison circulant solve instead of the zero-flux stencil.
+        diff_bc = self._get_diffusion_bc_type()
+        if diff_bc == "periodic":
+            return solve_crank_nicolson_diffusion_1d(m_star, dt, sigma, self.x_grid, bc_type="periodic")
+
+        # Neumann / zero-flux path (preserved from Issue #708: FV stencil for mass
+        # conservation; the standard ghost-point strong-form method breaks ∫m).
         D = diffusion_from_volatility(sigma)
         r = D * dt / (self.dx**2)
 
@@ -532,13 +548,19 @@ class FPSLSolver(BaseFPSolver):
 
         # Step 2: Diffusion via ADI
         # =========================
-        # Reuse the ADI diffusion from HJB-SL module
+        # Reuse the ADI diffusion from HJB-SL module.
+        # Issue #1257, 2026-06-10 audit: pass bc_type so that a periodic domain
+        # uses periodic ADI (Sherman-Morrison per axis) instead of defaulting to
+        # 'neumann', which would impose a zero-flux seam mis-matched to the
+        # periodic advection step above.  Mirrors HJB-SL _adi_diffusion_step
+        # (hjb_semi_lagrangian.py:2263).
         m_new = adi_diffusion_step(
             U_star=m_star,
             dt=dt,
             sigma=sigma,
             spacing=self.spacing,
             grid_shape=self.grid_shape,
+            bc_type=self._get_diffusion_bc_type(),
         )
 
         # Ensure non-negativity

--- a/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
+++ b/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
@@ -1,0 +1,138 @@
+"""Pinning test for Issue #1257: FPSLSolver periodic domain diffusion seam fix.
+
+Bug: _adjoint_sl_step_1d built the CN matrix with zero-flux (Neumann) boundary
+stencils unconditionally; _adjoint_sl_step_nd called adi_diffusion_step without
+bc_type (defaults 'neumann').  On a periodic domain this paired periodic advection
+with Neumann diffusion, producing an O(1) seam-flux error every step.
+
+Fix: _get_diffusion_bc_type() maps 'periodic' -> 'periodic', else 'neumann'.
+_adjoint_sl_step_1d branches to solve_crank_nicolson_diffusion_1d(..., bc_type)
+for periodic; _adjoint_sl_step_nd passes bc_type=self._get_diffusion_bc_type().
+
+Pinning test logic (1D):
+  * Place a unit spike at x=0 (the periodic seam), zero drift.
+  * After one diffusion sub-step the spike MUST spread symmetrically:
+    m_new[1]  (right neighbour) == m_new[-1] (left neighbour, wrap).
+  * With the buggy zero-flux stencil at i=0, L[0] = (m[1]-m[0])/dx^2 only
+    diffuses rightward, so m_new[1] >> m_new[-1].
+  * With the periodic CN (Sherman-Morrison), L[0] wraps m[-1], so
+    m_new[1] == m_new[-1] exactly (by symmetry of the tridiagonal system).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import periodic_bc
+
+
+def _periodic_problem(n: int = 41, nt: int = 10, sigma: float = 0.3) -> MFGProblem:
+    """Minimal MFGProblem with periodic BC for FPSLSolver construction."""
+    bc = periodic_bc(dimension=1)
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=bc)
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: 0.0,
+        coupling_dm=lambda m: 0.0,
+    )
+    comp = MFGComponents(
+        hamiltonian=H,
+        m_initial=lambda x: np.ones_like(x),
+        u_terminal=lambda x: x * 0,
+    )
+    return MFGProblem(geometry=grid, components=comp, T=1.0, Nt=nt, sigma=sigma)
+
+
+def test_periodic_diffusion_seam_symmetry_1d():
+    """After one diffusion sub-step with spike at seam, m_new[1] == m_new[-1].
+
+    This is the direct numerical witness of Issue #1257: the periodic CN must
+    spread mass symmetrically across the seam.  Fails on buggy (Neumann) code
+    because m_new[1] >> m_new[-1]; passes on fixed code.
+    """
+    n = 41
+    prob = _periodic_problem(n=n, sigma=0.3)
+    fp = FPSLSolver(prob)
+
+    # Spike at x=0 (index 0), the periodic seam.  Normalised so sum*dx = 1.
+    x = np.linspace(0.0, 1.0, n)
+    dx = x[1] - x[0]
+    m = np.zeros(n)
+    m[0] = 1.0 / dx  # unit mass at left boundary / seam
+
+    # Zero drift: only the diffusion sub-step acts.
+    alpha = np.zeros(n)
+    dt = prob.dt
+    sigma = prob.sigma
+
+    # Run ONE step.
+    m_new = fp._adjoint_sl_step_1d(m, alpha, dt, sigma)
+
+    # The right neighbour (index 1) and the left-wrap neighbour (index -1) must
+    # receive equal mass — periodic CN wraps through x=-1 == x[N-1].
+    # Tolerance: they must agree to within 1% relative error.
+    ratio = m_new[1] / (m_new[-1] + 1e-300)
+    assert abs(ratio - 1.0) < 0.01, (
+        f"Periodic diffusion seam asymmetry: m_new[1]={m_new[1]:.6f}, "
+        f"m_new[-1]={m_new[-1]:.6f}, ratio={ratio:.4f}.  "
+        "Expected ratio ~1 (periodic CN); got >> 1 means Neumann zero-flux stencil "
+        "is still in use (Issue #1257)."
+    )
+
+
+def test_periodic_diffusion_uses_diffusion_bc_type():
+    """_get_diffusion_bc_type returns 'periodic' for a periodic-domain solver."""
+    prob = _periodic_problem()
+    fp = FPSLSolver(prob)
+    assert fp._get_diffusion_bc_type() == "periodic", (
+        "_get_diffusion_bc_type() must return 'periodic' for a periodic domain (Issue #1257)"
+    )
+
+
+def test_neumann_domain_preserves_zero_flux_stencil():
+    """Neumann (no-flux) domain still uses the FV zero-flux path, not periodic CN.
+
+    Regression guard: ensure the fix does not accidentally route Neumann domains
+    through the periodic solver (which would be wrong for mass conservation).
+    """
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    bc = no_flux_bc(dimension=1)
+    n = 41
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=bc)
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: 0.0,
+        coupling_dm=lambda m: 0.0,
+    )
+    comp = MFGComponents(
+        hamiltonian=H,
+        m_initial=lambda x: np.ones_like(x),
+        u_terminal=lambda x: x * 0,
+    )
+    prob = MFGProblem(geometry=grid, components=comp, T=1.0, Nt=10, sigma=0.3)
+    fp = FPSLSolver(prob)
+
+    assert fp._get_diffusion_bc_type() == "neumann", (
+        "_get_diffusion_bc_type() must return 'neumann' for a no-flux domain (regression guard for Issue #1257 fix)"
+    )
+
+    # Spike at the left boundary — with no-flux/zero-flux the spike is reflected,
+    # so m_new[1] > m_new[-1] (boundary acts as a mirror, not a seam).
+    x = np.linspace(0.0, 1.0, n)
+    dx = x[1] - x[0]
+    m = np.zeros(n)
+    m[0] = 1.0 / dx
+    alpha = np.zeros(n)
+    m_new = fp._adjoint_sl_step_1d(m, alpha, prob.dt, prob.sigma)
+
+    # No-flux left boundary: diffusion only goes rightward, so m_new[1] > m_new[-1].
+    assert m_new[1] > m_new[-1], (
+        "Neumann domain: spike at left boundary should diffuse rightward only, "
+        "so m_new[1] should exceed m_new[-1] (zero-flux stencil)."
+    )


### PR DESCRIPTION
## Summary

- **Bug (Issue #1257)**: `FPSLSolver._adjoint_sl_step_1d` built its Crank-Nicolson matrix with zero-flux (Neumann) finite-volume boundary stencils unconditionally; `_adjoint_sl_step_nd` called `adi_diffusion_step` without `bc_type` (defaulting to `'neumann'`). On a periodic domain, advection correctly wrapped mass across the seam but diffusion imposed a zero-flux boundary there — O(1) seam-flux error per step, and breaks advertised adjoint-consistency with HJB-SL (which threads `_get_diffusion_bc_type` into both CN and ADI).
- **Fix**: Add `_get_diffusion_bc_type()` (returns `'periodic'` or `'neumann'`, mirroring `hjb_semi_lagrangian.py:2238`). `_adjoint_sl_step_1d` now branches to `solve_crank_nicolson_diffusion_1d(..., bc_type='periodic')` for periodic domains; `_adjoint_sl_step_nd` passes `bc_type=self._get_diffusion_bc_type()`. The Neumann FV zero-flux path (Issue #708) is preserved unchanged.
- **Pinning test**: Spike at the periodic seam (`x=0`), zero drift, one step. With the buggy Neumann stencil: `m_new[1]/m_new[-1] = 4e8` (zero-flux blocks wrap). With the fix: `m_new[1] == m_new[-1]` to <1% (Sherman-Morrison circulant CN symmetric spread). Also guards that Neumann domains still get the FV path.

## Test plan

- [x] `test_periodic_diffusion_seam_symmetry_1d` — direct numerical witness (ratio check)
- [x] `test_periodic_diffusion_uses_diffusion_bc_type` — `_get_diffusion_bc_type()` returns `'periodic'`
- [x] `test_neumann_domain_preserves_zero_flux_stencil` — regression guard, FV path unchanged
- [x] `ruff format && ruff check` clean
- [x] All 3 tests **fail** on pre-fix code, **pass** on fixed code (stash-verified)

Refs #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)