### PR TITLE
fix: fail-loud for anisotropic volatility shape and drift_is_precomputed=True on 1D particle path

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -117,10 +117,11 @@ class FPParticleSolver(BaseFPSolver):
 
     # Issue #1043: the default body is VALUE_FUNCTION — it takes the value function U via
     # `drift_field` and computes alpha = -coupling * grad(U) (see _solve_fp_system_cpu_1d/_nd).
-    # The 1D path is always VALUE_FUNCTION; `drift_is_precomputed=True` flips ONLY the nD path to
-    # VELOCITY (interpolate a precomputed alpha). The class trait records the default; the
-    # per-call exception lives in the drift_is_precomputed parameter. Previously this inherited
-    # the base VELOCITY default, which mislabeled the solver.
+    # The nD path honours `drift_is_precomputed=True` (VELOCITY mode: interpolate precomputed α).
+    # The 1D CPU/GPU paths do NOT honour it and raise NotImplementedError if it is set (Issue
+    # #1256 2026-06-10 audit).  The class trait records the default; the per-call exception lives
+    # in the drift_is_precomputed parameter.  Previously this inherited the base VELOCITY default,
+    # which mislabeled the solver.
     _drift_convention = DriftConvention.VALUE_FUNCTION
 
     @deprecated_parameter(param_name="mode", since="v0.17.0", replacement="density_mode")
@@ -1406,6 +1407,19 @@ class FPParticleSolver(BaseFPSolver):
 
             # Route based on dimension
             if dimension == 1:
+                # Issue #1256 2026-06-10 audit: the 1D CPU/GPU paths never read
+                # self._drift_is_precomputed — they always differentiate drift_field
+                # as the value function U.  Fail loud instead of silently wrong drift.
+                if self._drift_is_precomputed:
+                    raise NotImplementedError(
+                        "drift_is_precomputed=True is not supported for dimension=1. "
+                        "The 1D CPU/GPU paths always differentiate drift_field as the "
+                        "value function U; a precomputed velocity array would be "
+                        "silently differentiated producing wrong drift. "
+                        "For precomputed drift with 1D problems use a callable: "
+                        "drift_field=lambda t, x, m: alpha_array[t_index] (callable-drift "
+                        "path). Refs #1256."
+                    )
                 # 1D: Use existing optimized solvers with strategy selection
                 self.current_strategy = self.strategy_selector.select_strategy(
                     backend=self.backend if (self.backend is not None and self.backend.name != "numpy") else None,
@@ -1988,6 +2002,41 @@ class FPParticleSolver(BaseFPSolver):
         # For SDE: dX = drift*dt + σ*dW (volatility_field = σ)
         volatility_is_callable = callable(volatility_field)
         volatility_is_array = isinstance(volatility_field, np.ndarray)
+
+        # Issue #1256 2026-06-10 audit: reject array volatility_field shapes that are
+        # not valid spatial scalar fields.  The increment generator takes a scalar σ per
+        # particle; _interpolate_field_at_particles→interpolate_grid_to_particles has no
+        # shape-vs-grid validation and silently treats a (d,d) matrix as a d×d "grid",
+        # bilinearly smearing the four matrix entries as per-particle σ — silent garbage.
+        # A (d,) per-axis array fails later with a cryptic broadcast error.
+        if volatility_is_array:
+            vf_shape = volatility_field.shape
+            # Check for anisotropic noise matrix: (d,d) or (*grid_shape, d, d)
+            if vf_shape == (dimension, dimension) or (len(vf_shape) >= 3 and vf_shape[-2:] == (dimension, dimension)):
+                raise ValueError(
+                    f"volatility_field has shape {vf_shape}, which looks like an anisotropic "
+                    f"noise matrix Σ (dimension={dimension}). Anisotropic Σ is not supported "
+                    "in the particle path — the increment generator accepts scalar σ only. "
+                    "Pass a scalar float for constant isotropic volatility, a spatial array "
+                    f"of shape matching the grid {grid_shape} for spatially varying isotropic "
+                    "volatility, or a Callable sigma(t,x,m)->float."
+                )
+            # Reject (d,) per-axis array — ambiguous and unsupported
+            if vf_shape == (dimension,):
+                raise ValueError(
+                    f"volatility_field has shape {vf_shape}, which is ambiguous: it matches "
+                    f"neither a scalar σ nor the spatial grid shape {grid_shape}. "
+                    "Pass a scalar float for constant isotropic volatility, a spatial array "
+                    f"of shape {grid_shape} for spatially varying volatility, or a "
+                    "Callable sigma(t,x,m)->float."
+                )
+            # Require exact match with grid shape for spatial scalar fields
+            if vf_shape != grid_shape:
+                raise ValueError(
+                    f"volatility_field has shape {vf_shape} but the spatial grid shape is "
+                    f"{grid_shape}. For a spatially varying isotropic σ field, the array "
+                    "must match the grid shape exactly."
+                )
 
         if volatility_field is None:
             base_sigma = self.problem.sigma

--- a/tests/unit/test_alg/test_issue_1256_particle_volatility_drift.py
+++ b/tests/unit/test_alg/test_issue_1256_particle_volatility_drift.py
@@ -1,0 +1,256 @@
+"""
+Pinning tests for Issue #1256: FPParticleSolver volatile-field shape validation
+and drift_is_precomputed on 1D paths.
+
+(A) Anisotropic (d,d) volatility matrix routed through spatial interpolator -> silent garbage.
+    Fix: validate array shape vs grid; raise ValueError for (d,d), (d,), or shape mismatch.
+(B) drift_is_precomputed=True silently ignored on 1D CPU/GPU paths (always differentiates U).
+    Fix: raise NotImplementedError when drift_is_precomputed=True and dimension==1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers import FPParticleSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import neumann_bc, periodic_bc
+
+
+def _hamiltonian():
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+
+
+def _1d_problem():
+    """Minimal 1D MFGProblem for issue #1256 tests."""
+    geometry = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx_points=[10],
+        boundary_conditions=neumann_bc(dimension=1),
+    )
+    return MFGProblem(
+        geometry=geometry,
+        T=0.1,
+        Nt=5,
+        sigma=0.1,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=_hamiltonian(),
+        ),
+    )
+
+
+def _2d_problem():
+    """Minimal 2D MFGProblem for issue #1256 tests."""
+
+    def m_initial_2d(x):
+        x_arr = np.asarray(x)
+        return np.exp(-10 * np.sum((x_arr - 0.5) ** 2))
+
+    geometry = TensorProductGrid(
+        bounds=[(0.0, 1.0), (0.0, 1.0)],
+        Nx_points=[10, 10],
+        boundary_conditions=periodic_bc(dimension=2),
+    )
+    return MFGProblem(
+        geometry=geometry,
+        T=0.1,
+        Nt=5,
+        sigma=0.1,
+        components=MFGComponents(
+            m_initial=m_initial_2d,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=_hamiltonian(),
+        ),
+    )
+
+
+class TestIssue1256VolatilityShapeValidation:
+    """Bug (A): (d,d) anisotropic Sigma must be rejected with a clear error, not interpolated."""
+
+    def test_2d_diagonal_sigma_matrix_raises_valueerror(self):
+        """
+        Pinning test for Issue #1256 bug A.
+
+        volatility_field=np.diag([s1, s2]) is a (2,2) matrix passed to a 2D problem.
+        Before the fix: silently treated as a 2x2 spatial grid; matrix entries bilinearly
+        smeared as per-particle scalar sigma — silent garbage.
+        After the fix: raises ValueError with a message about anisotropic unsupported.
+        """
+        problem = _2d_problem()
+        assert problem.dimension == 2, "problem must be 2D for this test"
+
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        grid_shape = problem.geometry.get_grid_shape()
+        m0 = np.ones(grid_shape) / np.prod(grid_shape)
+
+        # Callable drift — routes through _solve_fp_system_callable_drift
+        def zero_drift(t, x, m):
+            return np.zeros_like(x)
+
+        anisotropic_sigma = np.diag([0.1, 0.2])  # shape (2,2) — anisotropic noise matrix
+
+        with pytest.raises(ValueError, match="anisotropic"):
+            solver.solve_fp_system(
+                M_initial=m0,
+                drift_field=zero_drift,
+                volatility_field=anisotropic_sigma,
+                show_progress=False,
+            )
+
+    def test_per_axis_sigma_array_raises_valueerror(self):
+        """
+        Per-axis (d,) volatility array must be rejected with a clear message.
+
+        Before the fix: hits a cryptic broadcast error inside the interpolator.
+        After the fix: raises ValueError with a message about ambiguous shape.
+        """
+        problem = _2d_problem()
+        assert problem.dimension == 2, "problem must be 2D for this test"
+
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        grid_shape = problem.geometry.get_grid_shape()
+        m0 = np.ones(grid_shape) / np.prod(grid_shape)
+
+        def zero_drift(t, x, m):
+            return np.zeros_like(x)
+
+        per_axis_sigma = np.array([0.1, 0.2])  # shape (2,) — ambiguous/unsupported
+
+        with pytest.raises(ValueError, match="ambiguous"):
+            solver.solve_fp_system(
+                M_initial=m0,
+                drift_field=zero_drift,
+                volatility_field=per_axis_sigma,
+                show_progress=False,
+            )
+
+    def test_wrong_shape_spatial_sigma_raises_valueerror(self):
+        """
+        Spatial sigma array with shape != grid_shape must be rejected.
+
+        After the fix: raises ValueError with a shape-mismatch message.
+        """
+        problem = _2d_problem()
+        assert problem.dimension == 2, "problem must be 2D for this test"
+
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        grid_shape = problem.geometry.get_grid_shape()
+        m0 = np.ones(grid_shape) / np.prod(grid_shape)
+
+        def zero_drift(t, x, m):
+            return np.zeros_like(x)
+
+        # Wrong spatial shape (5x5 instead of grid_shape=(10,10))
+        wrong_shape_sigma = np.full((5, 5), 0.1)
+
+        with pytest.raises(ValueError, match="grid shape"):
+            solver.solve_fp_system(
+                M_initial=m0,
+                drift_field=zero_drift,
+                volatility_field=wrong_shape_sigma,
+                show_progress=False,
+            )
+
+    def test_valid_spatial_sigma_array_accepted(self):
+        """
+        A spatial sigma array with shape == grid_shape should still be accepted.
+
+        Regression guard: the fix must not break valid usage.
+        """
+        problem = _2d_problem()
+        assert problem.dimension == 2, "problem must be 2D for this test"
+
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        grid_shape = problem.geometry.get_grid_shape()
+        m0 = np.ones(grid_shape) / np.prod(grid_shape)
+
+        def zero_drift(t, x, m):
+            return np.zeros_like(x)
+
+        # sigma field matching grid_shape exactly — should be accepted
+        valid_sigma = np.full(grid_shape, 0.1)
+
+        result = solver.solve_fp_system(
+            M_initial=m0,
+            drift_field=zero_drift,
+            volatility_field=valid_sigma,
+            show_progress=False,
+        )
+        assert result.ndim == 3  # (time, Nx, Ny)
+        assert result.shape[1:] == grid_shape
+        assert np.all(np.isfinite(result))
+
+
+class TestIssue1256DriftIsPrecomputed1D:
+    """Bug (B): drift_is_precomputed=True silently ignored on 1D paths."""
+
+    def test_1d_drift_is_precomputed_raises_not_implemented(self):
+        """
+        Pinning test for Issue #1256 bug B.
+
+        Before the fix: self._drift_is_precomputed is stored but never read in the 1D
+        CPU/GPU paths; they unconditionally differentiate drift_field as U, producing wrong
+        drift or a crash.
+        After the fix: raises NotImplementedError with a message referencing #1256.
+        """
+        problem = _1d_problem()
+        assert problem.dimension == 1, "problem must be 1D for this test"
+
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        Nx = problem.geometry.num_spatial_points
+        Nt = problem.Nt
+
+        m0 = np.ones(Nx) / Nx
+        # Precomputed velocity array alpha(t,x) — zero constant drift
+        alpha_precomputed = np.zeros((Nt, Nx))
+
+        with pytest.raises(NotImplementedError, match="drift_is_precomputed"):
+            solver.solve_fp_system(
+                M_initial=m0,
+                drift_field=alpha_precomputed,
+                drift_is_precomputed=True,
+                show_progress=False,
+            )
+
+    def test_1d_drift_is_precomputed_false_still_works(self):
+        """
+        drift_is_precomputed=False (default) on 1D must still work after the fix.
+
+        Regression guard: the fail-loud check must only fire for True.
+        """
+        problem = _1d_problem()
+        assert problem.dimension == 1, "problem must be 1D for this test"
+
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        Nx = problem.geometry.num_spatial_points
+        Nt = problem.Nt
+
+        m0 = np.ones(Nx) / Nx
+        # Value function U (not precomputed alpha) — default VALUE_FUNCTION path
+        U = np.zeros((Nt, Nx))
+
+        result = solver.solve_fp_system(
+            M_initial=m0,
+            drift_field=U,
+            drift_is_precomputed=False,
+            show_progress=False,
+        )
+        assert result.shape == (Nt + 1, Nx)
+        assert np.all(np.isfinite(result))


### PR DESCRIPTION
## Summary

Two fail-loud mitigations for silent-garbage defects in `FPParticleSolver` (Issue #1256):

- **(A) Volatility shape validation**: `_solve_fp_system_callable_drift` passed any `np.ndarray` `volatility_field` directly to `_interpolate_field_at_particles` with no shape-vs-grid validation. A `(d,d)` anisotropic matrix was treated as a `d×d` spatial grid, bilinearly smearing its four entries as per-particle scalar sigma. A `(d,)` per-axis array hit a cryptic broadcast error rather than a clear rejection. Fix: validate array shape against `grid_shape` before interpolation; raise `ValueError` for `(d,d)`, `(*grid,d,d)`, `(d,)`, or any shape that does not match the spatial grid exactly.

- **(B) drift_is_precomputed=True on 1D**: `solve_fp_system` stored `self._drift_is_precomputed` but the 1D CPU and GPU paths never read it, always differentiating `drift_field` as the value function U. A precomputed velocity array was silently differentiated → wrong drift. Fix: raise `NotImplementedError` before routing to the 1D paths when `drift_is_precomputed=True`, with a message pointing callers to the callable-drift path.

Both halves are fail-loud mitigations, not full honoring of the advertised API. The docstring at `fp_particle.py:1275` and `1949-1950` advertising `(d,d)` anisotropic support, and `1268-1271` advertising 1D `drift_is_precomputed`, remain inaccurate until the features are implemented.

## Test plan

- [ ] `tests/unit/test_alg/test_issue_1256_particle_volatility_drift.py` — 6 new pinning tests (FAIL-without / PASS-with demonstrated in commit)
- [ ] `test_2d_diagonal_sigma_matrix_raises_valueerror` — FAIL on buggy: `DID NOT RAISE`, PASS on fix: `ValueError: anisotropic`
- [ ] `test_per_axis_sigma_array_raises_valueerror` — FAIL on buggy: wrong error message, PASS on fix: `ValueError: ambiguous`
- [ ] `test_wrong_shape_spatial_sigma_raises_valueerror` — FAIL on buggy: `DID NOT RAISE`, PASS on fix: `ValueError: grid shape`
- [ ] `test_valid_spatial_sigma_array_accepted` — regression guard, passes on both
- [ ] `test_1d_drift_is_precomputed_raises_not_implemented` — FAIL on buggy: `DID NOT RAISE`, PASS on fix: `NotImplementedError: drift_is_precomputed`
- [ ] `test_1d_drift_is_precomputed_false_still_works` — regression guard, passes on both

Refs #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)