### PR TITLE
fix(fp-particle): thread solver BC override + implicit geom guard in _compute_gradient_nd; fix uniform Robin ghost alpha/beta (#1255)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -429,26 +429,61 @@ class FPParticleSolver(BaseFPSolver):
         """
         Compute the spatial gradient of the value function for the FP drift, BC-aware.
 
-        Routes through ``geometry.get_gradient_operator(scheme="central")`` — the SAME BC-aware
-        operator the HJB uses — so non-periodic boundaries get ghost-padded / one-sided stencils.
-        Previously this used the periodic-wrap ``gradient_nd``, which at a non-periodic wall takes
-        ``(U[1] - U[N-1])/(2h)`` (wrapping to the far wall) → an O(1/h) **wrong-sign** drift that
-        pushes mass away from the wall (silent-divergence bug-hunt). Periodic BC reproduces the
-        wrap (results unchanged); the precomputed-drift path (``drift_is_precomputed=True``, e.g.
-        the GFDM→particle handoff) bypasses this gradient entirely.
+        For TensorProductGrid geometries, routes through
+        ``geometry.get_gradient_operator(scheme="central", bc=<solver-BCs>)`` — the SAME
+        BC-aware operator the HJB uses — so non-periodic boundaries get ghost-padded /
+        one-sided stencils.  The solver's own ``self.boundary_conditions`` (priority-1 BC
+        source) is threaded into the operator so an override that differs from the
+        geometry's default BCs is respected.  Previously the geometry's built-in BCs were
+        always used, re-introducing the O(1/h) wall-drift error when the solver BCs
+        override differed (Issue #1255 A, 2026-06-10 audit).
 
-        The operator uses the geometry's own grid spacing and BC; ``spacings`` is retained only for
-        its length (the spatial dimension) and matches the geometry spacing at every call site.
+        For implicit geometries (Hyperrectangle, CSG torus, etc.) whose
+        ``get_gradient_operator`` does not accept ``scheme=``, fall back to the
+        periodic-wrap ``gradient_nd``.  For fully-periodic domains (torus) this
+        reproduces the pre-#1246 correct behavior.  For non-periodic implicit domains the
+        periodic wrap is the same fallback as the pre-#1246 path (particle BCs are
+        enforced separately; the grid-gradient is not wall-aware here).
+        (Issue #1255 B, 2026-06-10 audit)
+
+        Previously this used the periodic-wrap ``gradient_nd``, which at a non-periodic
+        wall takes ``(U[1] - U[N-1])/(2h)`` (wrapping to the far wall) → an O(1/h)
+        **wrong-sign** drift that pushes mass away from the wall (silent-divergence
+        bug-hunt). Periodic BC reproduces the wrap (results unchanged); the
+        precomputed-drift path (``drift_is_precomputed=True``, e.g. the GFDM→particle
+        handoff) bypasses this gradient entirely.
 
         Issue #625: migrated tensor_calculus.gradient_simple → stencils.gradient_nd.
         Bug-hunt: migrated periodic-wrap gradient_nd → BC-aware geometry operator.
+        Issue #1255 (A, B): thread solver BCs; guard implicit geometry path.
         """
+        from mfgarchon.geometry.grids.tensor_grid import TensorProductGrid
+
         ndim = len(spacings)
-        grad_ops = self.problem.geometry.get_gradient_operator(scheme="central")
         on_backend = use_backend and self.backend is not None
         # The geometry operator is numpy; round-trip through host for the backend/GPU path.
         u_host = self.backend.to_numpy(U_array) if on_backend else np.asarray(U_array)
-        grads = [grad_ops[d](u_host) for d in range(ndim)]
+
+        geom = self.problem.geometry
+        if isinstance(geom, TensorProductGrid):
+            # BC-aware path: thread the solver's resolved boundary_conditions so an
+            # override that differs from geometry's default BCs is respected.
+            # Issue #1255 (A), 2026-06-10 audit.
+            from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+
+            bc_override = self.boundary_conditions if isinstance(self.boundary_conditions, BoundaryConditions) else None
+            grad_ops = geom.get_gradient_operator(scheme="central", bc=bc_override)
+            grads = [grad_ops[d](u_host) for d in range(ndim)]
+        else:
+            # Implicit / meshfree geometry: get_gradient_operator may not accept
+            # scheme= and its placeholder raises NotImplementedError anyway.  Fall back
+            # to periodic-wrap gradient_nd — correct for torus, pre-#1246 compatible
+            # for other implicit domains.
+            # Issue #1255 (B), 2026-06-10 audit.
+            from mfgarchon.operators.stencils.finite_difference import gradient_nd
+
+            grads = gradient_nd(u_host, spacings)
+
         if on_backend:
             grads = [self.backend.from_numpy(g) for g in grads]
         return grads

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -941,7 +941,10 @@ class PreallocatedGhostBuffer:
 
         if bc.is_uniform:
             seg = bc.segments[0]
-            self._update_ghosts_uniform(seg.bc_type, seg.value, time)
+            # Issue #1255 (C), 2026-06-10 audit: pass seg.alpha/seg.beta so that
+            # uniform Robin(alpha, beta, value) is not silently treated as
+            # Robin(0, 1, value) (pure-Neumann special case).
+            self._update_ghosts_uniform(seg.bc_type, seg.value, time, seg.alpha, seg.beta)
         else:
             # Mixed BC requires more complex per-point updates
             self._update_ghosts_mixed(bc, time)
@@ -951,6 +954,8 @@ class PreallocatedGhostBuffer:
         bc_type: BCType,
         value: float | None,
         time: float,
+        alpha: float = 0.0,
+        beta: float = 1.0,
     ) -> None:
         """
         Update ghost cells for uniform BC (same type on all boundaries).
@@ -958,10 +963,17 @@ class PreallocatedGhostBuffer:
         Dispatches to appropriate reconstruction method based on self._order:
         - order <= 2: Linear reflection (simple mirror)
         - order > 2: Polynomial extrapolation (high-order schemes)
+
+        Args:
+            alpha: Robin coefficient on u  (alpha*u + beta*du/dn = value).
+                   Defaults to 0 (pure Neumann convention).  Issue #1255 (C).
+            beta:  Robin coefficient on du/dn. Defaults to 1. Issue #1255 (C).
         """
         # Dispatch based on order
         if self._order <= 2:
-            self._apply_linear_reflection(bc_type, value, time)
+            # Issue #1255 (C), 2026-06-10 audit: forward alpha/beta so the Robin
+            # branch in _apply_linear_reflection uses the full general formula.
+            self._apply_linear_reflection(bc_type, value, time, alpha, beta)
         else:
             self._apply_poly_extrapolation(bc_type, value, time)
 
@@ -970,12 +982,20 @@ class PreallocatedGhostBuffer:
         bc_type: BCType,
         value: float | None,
         time: float,
+        alpha: float = 0.0,
+        beta: float = 1.0,
     ) -> None:
         """
         Apply linear reflection for order <= 2 ghost cell reconstruction.
 
         This is the original implementation that works for FDM and simple
         Semi-Lagrangian schemes. Provides O(h^2) accuracy.
+
+        Args:
+            alpha: Robin coefficient on u  (alpha*u + beta*du/dn = value).
+                   Used only when bc_type == BCType.ROBIN. Defaults to 0.
+                   Issue #1255 (C), 2026-06-10 audit.
+            beta:  Robin coefficient on du/dn. Defaults to 1. Issue #1255 (C).
         """
         d = self._dimension
         g = self._ghost_depth
@@ -1059,41 +1079,53 @@ class PreallocatedGhostBuffer:
                         buf[tuple(hi_ghost)] += dx * v
 
         elif bc_type == BCType.ROBIN:
-            # Robin: alpha*u + beta*du/dn = g
-            # For uniform BC, we assume alpha=0, beta=1 (Neumann-like with non-zero flux)
-            # Cell-centered grids: ghost and interior are dx apart, not 2*dx.
-            # du/dn = (u_ghost - u_interior)/dx * sign, so:
-            # u_ghost = u_interior + dx*g*sign
-            # Note: For full Robin BC with arbitrary alpha/beta, use mixed BC API.
+            # Robin: alpha*u + beta*du/dn = g (cell-centered ghost formula).
+            # Issue #1255 (C), 2026-06-10 audit: use the same general formula as
+            # _apply_ghost_for_face (mixed-segment path, lines 1549-1582) instead of
+            # the prior hardcoded alpha=0/beta=1 (pure-Neumann special case).
+            #
+            # Cell-centred derivation (boundary at x_b midway between ghost x_g and
+            # interior x_i; spacing dx between cell centres):
+            #   u_b   = (u_g + u_i)/2
+            #   du/dn = (u_g - u_i)/dx * outward_sign
+            # Robin BC: alpha*(u_g+u_i)/2 + beta*(u_g-u_i)/dx*sign = g
+            # => u_g * (alpha/2 + beta*sign/dx) = g - u_i*(alpha/2 - beta*sign/dx)
             for axis in range(d):
-                # Get grid spacing for this axis
-                if self._grid_spacing is not None:
-                    dx = self._grid_spacing[axis]
-                else:
-                    dx = 1.0  # Fallback
+                dx = self._grid_spacing[axis] if self._grid_spacing is not None else 1.0
 
-                # Get adjacent interior values (at index g for low, -g-1 for high)
-                lo_interior = [slice(None)] * d
-                lo_interior[axis] = g  # Adjacent interior cell
-                u_lo_interior = buf[tuple(lo_interior)]
+                # Precompute per-wall (min/max) coefficients.
+                # Low wall: outward_sign = -1
+                coeff_ghost_lo = alpha / 2.0 - beta / dx
+                coeff_int_lo = alpha / 2.0 + beta / dx
+                # High wall: outward_sign = +1
+                coeff_ghost_hi = alpha / 2.0 + beta / dx
+                coeff_int_hi = alpha / 2.0 - beta / dx
 
-                hi_interior = [slice(None)] * d
-                hi_interior[axis] = -g - 1  # Adjacent interior cell
-                u_hi_interior = buf[tuple(hi_interior)]
+                # Get adjacent interior values (first/last interior cell).
+                lo_int_sl = [slice(None)] * d
+                lo_int_sl[axis] = g
+                u_lo_interior = buf[tuple(lo_int_sl)]
+
+                hi_int_sl = [slice(None)] * d
+                hi_int_sl[axis] = -g - 1
+                u_hi_interior = buf[tuple(hi_int_sl)]
 
                 for k in range(g):
-                    # Low boundary (outward normal = -1)
+                    # Low ghost (outward normal = -1)
                     lo_ghost = [slice(None)] * d
-                    lo_ghost[axis] = g - 1 - k  # Ghost cells from g-1 down to 0
-                    # u_ghost = u_interior + dx*g*(-1) = u_interior - dx*v
-                    buf[tuple(lo_ghost)] = u_lo_interior - dx * v
+                    lo_ghost[axis] = g - 1 - k
+                    if abs(coeff_ghost_lo) < 1e-12:
+                        buf[tuple(lo_ghost)] = u_lo_interior  # Degenerate: mirror
+                    else:
+                        buf[tuple(lo_ghost)] = (v - u_lo_interior * coeff_int_lo) / coeff_ghost_lo
 
-                for k in range(g):
-                    # High boundary (outward normal = +1)
+                    # High ghost (outward normal = +1)
                     hi_ghost = [slice(None)] * d
-                    hi_ghost[axis] = -(g - k)  # Ghost cells from -g up to -1
-                    # u_ghost = u_interior + dx*g*(+1) = u_interior + dx*v
-                    buf[tuple(hi_ghost)] = u_hi_interior + dx * v
+                    hi_ghost[axis] = -(g - k)
+                    if abs(coeff_ghost_hi) < 1e-12:
+                        buf[tuple(hi_ghost)] = u_hi_interior  # Degenerate: mirror
+                    else:
+                        buf[tuple(hi_ghost)] = (v - u_hi_interior * coeff_int_hi) / coeff_ghost_hi
 
     def _apply_poly_extrapolation(
         self,

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -1515,6 +1515,7 @@ class TensorProductGrid(
         order: int = 2,
         scheme: str = "central",
         time: float = 0.0,
+        bc: BoundaryConditions | None = None,
     ):
         """
         Return discrete gradient operator(s) for this grid.
@@ -1526,6 +1527,10 @@ class TensorProductGrid(
             order: Discretization order (not used yet, reserved for future)
             scheme: Difference scheme ("central", "upwind", "one_sided")
             time: Time for time-dependent boundary conditions (default 0.0)
+            bc: Boundary conditions to use (None uses grid's default BC).  Mirrors the
+                ``bc=`` parameter of ``get_laplacian_operator`` so callers with a
+                solver-level BC override can thread it in without mutating the grid.
+                Issue #1255 (A), 2026-06-10 audit.
 
         Returns:
             If direction is None:
@@ -1542,8 +1547,10 @@ class TensorProductGrid(
         """
         from mfgarchon.operators import PartialDerivOperator
 
-        # Use grid's BC
-        bc = self.get_boundary_conditions()
+        # Use caller-supplied BC if provided, otherwise fall back to grid's own BC.
+        # Matches the pattern of get_laplacian_operator (tensor_grid.py:1474).
+        # Issue #1255 (A), 2026-06-10 audit.
+        bc = bc if bc is not None else self.get_boundary_conditions()
 
         # Create operator(s)
         if direction is not None:

--- a/tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py
+++ b/tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py
@@ -1,0 +1,359 @@
+"""
+Pinning tests for Issue #1255 — three residual holes in the #1246 FP-particle
+drift-gradient fix.
+
+(A) fp_particle.py: _compute_gradient_nd used the geometry's own BC, ignoring
+    the solver's boundary_conditions override.  With a no-flux geometry BC and a
+    periodic solver override the gradient at the wall was wrong by O(1/h).
+
+(B) fp_particle.py: on implicit geometries (Hyperrectangle/CSG torus),
+    get_gradient_operator(self) accepted no kwargs, so the scheme="central" call
+    raised TypeError — crashing a previously-working torus/zero-drift path.
+
+(C) applicator_fdm.py: _update_ghosts_uniform discarded seg.alpha/seg.beta for
+    uniform ROBIN BCs, silently treating them all as pure Neumann (alpha=0,
+    beta=1).
+
+Each test below FAILS on the buggy code and PASSES after the fix.
+
+2026-06-10 audit — Issue #1255.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+
+def _default_hamiltonian():
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+
+
+def _default_components():
+    from mfgarchon.core.mfg_components import MFGComponents
+
+    return MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=_default_hamiltonian(),
+    )
+
+
+# ===========================================================================
+# (A) Solver boundary_conditions override threads into _compute_gradient_nd
+# ===========================================================================
+
+
+class TestGradientBCOverrideThreaded:
+    """
+    Issue #1255 (A): _compute_gradient_nd must use the solver's
+    boundary_conditions, not the geometry's default BC.
+
+    Setup: TensorProductGrid with NO_FLUX BC; solver created with periodic BC
+    override.  On u = [0, 1, 2, 3, 4] (spacing=1):
+
+      periodic:  ghost_lo = u[4] = 4  →  du/dx|_{x=0} = (u[1]-ghost_lo)/(2h) = (1-4)/2 = -1.5
+      no_flux:   ghost_lo = u[0] = 0  →  du/dx|_{x=0} = (u[1]-ghost_lo)/(2h) = (1-0)/2 = 0.5
+
+    Bug: get_gradient_operator always called self.get_boundary_conditions()
+    (geometry BC), so the override had no effect → gradient = 0.5.
+    Fix: bc_override is forwarded to get_gradient_operator(bc=bc_override).
+    """
+
+    def _make_solver(self):
+        from mfgarchon.alg.numerical.fp_solvers import FPParticleSolver
+        from mfgarchon.core.mfg_problem import MFGProblem
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc, periodic_bc
+
+        # 1-D grid [0,4] with 5 points, spacing = 1.0 — BC is NO_FLUX
+        geom = TensorProductGrid(
+            bounds=[(0.0, 4.0)],
+            Nx_points=[5],
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
+        problem = MFGProblem(
+            geometry=geom,
+            T=1.0,
+            Nt=2,
+            sigma=0.1,
+            coupling_coefficient=0.5,
+            components=_default_components(),
+        )
+        # Solver overrides BC with periodic — priority-1 source per docs
+        solver = FPParticleSolver(
+            problem,
+            num_particles=10,
+            boundary_conditions=periodic_bc(dimension=1),
+        )
+        return solver
+
+    def test_override_bc_is_stored(self):
+        """Solver stores the override BC, not the geometry BC."""
+        from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+        from mfgarchon.geometry.boundary.types import BCType
+
+        solver = self._make_solver()
+        assert isinstance(solver.boundary_conditions, BoundaryConditions)
+        assert solver.boundary_conditions.segments[0].bc_type == BCType.PERIODIC
+
+    def test_gradient_uses_periodic_override_not_noflux_geometry(self):
+        """
+        _compute_gradient_nd must return the periodic-wrap gradient, not the
+        no-flux one.  Fails on buggy code (returns 0.5), passes after fix (-1.5).
+        """
+        solver = self._make_solver()
+        u = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        spacings = [1.0]
+
+        grads = solver._compute_gradient_nd(u, spacings, use_backend=False)
+
+        grad_x = grads[0]
+        # Periodic: at x=0, du/dx = (u[1] - u[4])/(2*1) = (1-4)/2 = -1.5
+        # No-flux: at x=0, du/dx = (u[1] - u[0])/(2*1) = (1-0)/2 = 0.5
+        assert abs(grad_x[0] - (-1.5)) < 1e-9, (
+            f"Expected -1.5 (periodic override), got {grad_x[0]:.4f}. "
+            "Bug: geometry's no-flux BC was used instead of solver's periodic override."
+        )
+
+
+# ===========================================================================
+# (B) Implicit geometry (torus) no longer raises TypeError on scheme=
+# ===========================================================================
+
+
+class TestImplicitGeometryGradientNoTypeError:
+    """
+    Issue #1255 (B): ImplicitGeometry.get_gradient_operator(self) accepts no
+    kwargs, so calling it with scheme="central" raised TypeError — crashing the
+    torus/zero-drift path.
+
+    Fix: _compute_gradient_nd detects non-TensorProductGrid geometry and falls
+    back to gradient_nd (periodic-wrap) instead of calling get_gradient_operator.
+
+    We test with a minimal mock geometry whose get_gradient_operator takes no
+    kwargs (reproducing the ImplicitGeometry signature exactly).
+    """
+
+    class _MockImplicitGeom:
+        """Reproduces the failing ImplicitGeometry.get_gradient_operator signature."""
+
+        dimension = 1
+        periodic_dimensions = (0,)  # Fully periodic → sentinel "periodic" in solver
+
+        def get_boundary_conditions(self):
+            return None
+
+        def get_gradient_operator(self):  # NO kwargs accepted
+            # Placeholder — should never be reached after fix
+            raise NotImplementedError("Meshfree gradient not implemented")
+
+    def _make_solver_with_implicit_geom(self):
+        """Create a minimal FPParticleSolver whose geometry is implicit."""
+        from mfgarchon.alg.numerical.fp_solvers import FPParticleSolver
+
+        geom = self._MockImplicitGeom()
+
+        # Build a minimal mock problem that satisfies FPParticleSolver.__init__
+        # without needing a real MFGProblem.
+        class _MinimalProblem:
+            geometry = geom
+            T = 1.0
+            Nt = 2
+            sigma = 0.1
+            coupling_coefficient = 0.5
+            dimension = 1
+
+            def get_components(self):
+                return None
+
+        problem = _MinimalProblem()
+
+        # FPParticleSolver.__init__ calls super().__init__(problem) which accesses
+        # problem attributes — we bypass __init__ and construct the object directly
+        # so we can set only what _compute_gradient_nd needs.
+        solver = object.__new__(FPParticleSolver)
+        solver.problem = problem
+        solver.backend = None  # No GPU; numpy only
+        solver.boundary_conditions = "periodic"  # Torus sentinel
+        return solver
+
+    def test_zero_drift_on_implicit_geom_does_not_raise_type_error(self):
+        """
+        Calling _compute_gradient_nd on a zero field with implicit geometry must
+        not raise TypeError.  Buggy code: TypeError on scheme= kwarg.
+        """
+        solver = self._make_solver_with_implicit_geom()
+        u = np.zeros(5)
+        spacings = [1.0]
+
+        # Must not raise TypeError
+        grads = solver._compute_gradient_nd(u, spacings, use_backend=False)
+
+        # Zero field → zero gradient in every component
+        assert len(grads) == 1
+        assert np.allclose(grads[0], 0.0), "Expected zero gradient for zero field"
+
+    def test_nonzero_field_falls_back_to_periodic_wrap(self):
+        """
+        For a non-zero field, the fallback path (gradient_nd) uses periodic wrap.
+        This is the pre-#1246 correct behavior for torus geometries.
+        """
+        solver = self._make_solver_with_implicit_geom()
+        u = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        spacings = [1.0]
+
+        grads = solver._compute_gradient_nd(u, spacings, use_backend=False)
+
+        # gradient_nd uses np.roll periodic wrap — same as pre-#1246 behavior.
+        # At x=0: (u[1] - u[-1])/(2h) = (1 - 4)/2 = -1.5
+        assert abs(grads[0][0] - (-1.5)) < 1e-9, f"Expected -1.5 (periodic-wrap fallback), got {grads[0][0]:.4f}"
+
+
+# ===========================================================================
+# (C) Uniform Robin ghost fill uses general alpha/beta formula
+# ===========================================================================
+
+
+class TestUniformRobinGhostAlphaBeta:
+    """
+    Issue #1255 (C): _update_ghosts_uniform discarded seg.alpha/seg.beta for
+    ROBIN, silently using alpha=0/beta=1 (pure Neumann).
+
+    We verify by creating a PreallocatedGhostBuffer with robin_bc(alpha=1,
+    beta=2, value=5.0, dimension=1) and checking that the ghost values match
+    the general Robin formula, not the pure-Neumann one.
+
+    Cell-centred Robin formula (cell centres dx apart, boundary midway):
+        alpha * (u_g + u_i)/2 + beta * (u_g - u_i)/dx * sign = g
+        => u_g = (g - u_i * (alpha/2 - beta*sign/dx)) / (alpha/2 + beta*sign/dx)
+
+    Low wall (sign = -1):
+        coeff_ghost = alpha/2 + beta*(-1)/dx = alpha/2 - beta/dx
+        coeff_int   = alpha/2 - beta*(-1)/dx = alpha/2 + beta/dx
+        u_ghost_lo  = (g - u_i * coeff_int) / coeff_ghost
+
+    High wall (sign = +1):
+        coeff_ghost = alpha/2 + beta*(+1)/dx = alpha/2 + beta/dx
+        coeff_int   = alpha/2 - beta*(+1)/dx = alpha/2 - beta/dx
+        u_ghost_hi  = (g - u_i * coeff_int) / coeff_ghost
+
+    For alpha=1, beta=2, g=5, dx=1, u_lo=u_hi=1.0:
+        Low:  coeff_ghost = 0.5 - 2 = -1.5  coeff_int = 2.5
+              u_ghost_lo  = (5 - 1*2.5)/(-1.5) = -2.5/-1.5 ≈ 1.6667
+        High: coeff_ghost = 0.5 + 2 = 2.5   coeff_int = -1.5
+              u_ghost_hi  = (5 - 1*(-1.5))/2.5 = 6.5/2.5 = 2.6
+
+    Buggy code (alpha=0, beta=1):
+        Low:  u_ghost_lo = u_i - dx*g = 1 - 5 = -4.0
+        High: u_ghost_hi = u_i + dx*g = 1 + 5 = 6.0
+    """
+
+    @pytest.fixture
+    def ghost_buffer(self):
+        from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
+        from mfgarchon.geometry.boundary.conditions import robin_bc
+
+        bc = robin_bc(alpha=1.0, beta=2.0, value=5.0, dimension=1)
+        buf = PreallocatedGhostBuffer(
+            interior_shape=(5,),
+            boundary_conditions=bc,
+            domain_bounds=np.array([[0.0, 4.0]]),  # dx = 4/(5-1) = 1.0
+            ghost_depth=1,
+        )
+        buf.interior[:] = np.array([1.0, 2.0, 3.0, 2.0, 1.0])
+        buf.update_ghosts(time=0.0)
+        return buf
+
+    def test_low_wall_ghost_uses_general_robin_not_neumann(self, ghost_buffer):
+        """
+        Low-wall ghost must use the general Robin formula, not pure Neumann.
+        Buggy value: -4.0 (pure Neumann, alpha=0, beta=1).
+        Fixed value: (5 - 1*2.5)/(-1.5) = -2.5/-1.5 ≈ 1.6667.
+        """
+        u_ghost_lo = ghost_buffer.padded[0]  # index 0 = low ghost
+        expected = (5.0 - 1.0 * 2.5) / (-1.5)  # ≈ 1.6667
+        assert abs(u_ghost_lo - expected) < 1e-9, (
+            f"Low ghost: expected {expected:.4f} (general Robin), "
+            f"got {u_ghost_lo:.4f}. "
+            "Bug: pure-Neumann formula was used (alpha=0, beta=1 hardcoded)."
+        )
+
+    def test_high_wall_ghost_uses_general_robin_not_neumann(self, ghost_buffer):
+        """
+        High-wall ghost must use the general Robin formula, not pure Neumann.
+        Buggy value: 6.0 (pure Neumann).
+        Fixed value: (5 + 1*1.5)/2.5 = 2.6.
+        """
+        u_ghost_hi = ghost_buffer.padded[-1]  # index -1 = high ghost
+        expected = (5.0 - 1.0 * (-1.5)) / 2.5  # = 6.5/2.5 = 2.6
+        assert abs(u_ghost_hi - expected) < 1e-9, (
+            f"High ghost: expected {expected:.4f} (general Robin), "
+            f"got {u_ghost_hi:.4f}. "
+            "Bug: pure-Neumann formula was used (alpha=0, beta=1 hardcoded)."
+        )
+
+    def test_uniform_matches_mixed_segment_path(self):
+        """
+        Cross-check: uniform Robin ghost must equal the mixed-segment path result.
+
+        Create the same Robin BC as a mixed-segment specification (which already
+        used the full formula before #1255).  Both paths must agree.
+        """
+        from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
+        from mfgarchon.geometry.boundary.conditions import BoundaryConditions, robin_bc
+        from mfgarchon.geometry.boundary.types import BCSegment, BCType
+
+        alpha, beta, g_val = 1.0, 2.0, 5.0
+        interior = np.array([1.0, 2.0, 3.0, 2.0, 1.0])
+        shape = (5,)
+        bounds = np.array([[0.0, 4.0]])
+
+        # Uniform path (the one with the bug)
+        bc_uniform = robin_bc(alpha=alpha, beta=beta, value=g_val, dimension=1)
+        buf_uniform = PreallocatedGhostBuffer(shape, bc_uniform, bounds)
+        buf_uniform.interior[:] = interior
+        buf_uniform.update_ghosts(time=0.0)
+
+        # Mixed-segment path (was correct before #1255)
+        bc_mixed = BoundaryConditions(
+            segments=[
+                BCSegment(
+                    name="left",
+                    bc_type=BCType.ROBIN,
+                    alpha=alpha,
+                    beta=beta,
+                    value=g_val,
+                    boundary="x_min",
+                ),
+                BCSegment(
+                    name="right",
+                    bc_type=BCType.ROBIN,
+                    alpha=alpha,
+                    beta=beta,
+                    value=g_val,
+                    boundary="x_max",
+                ),
+            ],
+            dimension=1,
+        )
+        buf_mixed = PreallocatedGhostBuffer(shape, bc_mixed, bounds)
+        buf_mixed.interior[:] = interior
+        buf_mixed.update_ghosts(time=0.0)
+
+        assert np.allclose(buf_uniform.padded, buf_mixed.padded, atol=1e-12), (
+            f"Uniform path padded:\n{buf_uniform.padded}\n"
+            f"Mixed path padded:\n{buf_mixed.padded}\n"
+            "Uniform and mixed Robin paths must produce identical ghost values."
+        )


### PR DESCRIPTION
## Summary

Three residual holes in the #1246 FP-particle drift-gradient fix (Issue #1255).

### (A) Solver BC override not threaded into gradient operator

`_compute_gradient_nd` called `geometry.get_gradient_operator(scheme="central")` which always used `geometry.get_boundary_conditions()`, ignoring the solver's priority-1 `boundary_conditions` override. With a no-flux geometry BC and a periodic solver override the wall gradient was O(1/h) wrong.

**Fix:** Added `bc=` parameter to `TensorProductGrid.get_gradient_operator` (matching the existing `get_laplacian_operator` pattern). `_compute_gradient_nd` now passes the solver's resolved `BoundaryConditions` object when the geometry is a `TensorProductGrid`.

### (B) Implicit geometry crashes on `scheme=` kwarg

`ImplicitGeometry.get_gradient_operator(self)` accepts no kwargs, so `scheme="central"` raised `TypeError`, crashing the torus/zero-drift path that previously worked.

**Fix:** `_compute_gradient_nd` detects non-`TensorProductGrid` geometries and falls back to `gradient_nd` (periodic wrap) — the pre-#1246 correct behavior for torus domains.

### (C) Uniform Robin ghost fill hardcoded alpha=0/beta=1

`_update_ghosts_uniform` discarded `seg.alpha`/`seg.beta`, silently treating all uniform Robin BCs as pure Neumann (alpha=0, beta=1).

**Fix:** Thread `alpha`/`beta` from the segment through `_update_ghosts_uniform` → `_apply_linear_reflection`. Replace the hardcoded Neumann formula with the same general Robin ghost formula used by the (already-correct) mixed-segment path.

## Test plan

- [x] New pinning tests in `tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py` — 6/7 fail on buggy code, 7/7 pass after fix (demonstrated via stash/unstash)
- [x] Existing FP particle tests (65 tests): all pass
- [x] Geometry tests (716 tests): all pass
- [x] `ruff format --check` + `ruff check`: clean

## Pinning test evidence

**Fail (buggy):**
```
FAILED TestGradientBCOverrideThreaded::test_gradient_uses_periodic_override_not_noflux_geometry
FAILED TestImplicitGeometryGradientNoTypeError::test_zero_drift_on_implicit_geom_does_not_raise_type_error
FAILED TestImplicitGeometryGradientNoTypeError::test_nonzero_field_falls_back_to_periodic_wrap
FAILED TestUniformRobinGhostAlphaBeta::test_low_wall_ghost_uses_general_robin_not_neumann
FAILED TestUniformRobinGhostAlphaBeta::test_high_wall_ghost_uses_general_robin_not_neumann
FAILED TestUniformRobinGhostAlphaBeta::test_uniform_matches_mixed_segment_path
6 failed, 1 passed
```

**Pass (fixed):**
```
7 passed
```

Refs #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)