### PR TITLE
fix(fp-fdm): tensor diffusion missing D=(1/2)ΣΣᵀ — ~6.7× overdiffusion (#1249)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -996,9 +996,14 @@ def solve_timestep_tensor_explicit(
     else:
         raise TypeError(f"tensor_field must be np.ndarray or callable, got {type(tensor_field)}")
 
-    # Compute tensor diffusion term: div(Sigma * grad(m))
-    # Issue #625: Migrated from tensor_calculus to operators/differential
-    diffusion_term = apply_diffusion(M_current, Sigma, list(spacing), bc=boundary_conditions)
+    # Compute tensor diffusion term: div(D * grad(m)).
+    # Sigma is the SDE volatility; the diffusion operator needs the PDE diffusion tensor
+    # D = (1/2) Sigma Sigma^T (NAMING_CONVENTIONS "Volatility vs Diffusion", #811). The raw
+    # Sigma was applied as if it were D — e.g. isotropic Sigma = 0.3 I gave effective D = 0.3
+    # instead of D = sigma^2/2 = 0.045 (~6.7x overdiffusion). Route through the single-source
+    # converter so the tensor path matches the scalar path D = sigma^2/2 (2026-06-10 audit, #1249).
+    D_tensor = diffusion_from_volatility(Sigma, kind="tensor")
+    diffusion_term = apply_diffusion(M_current, D_tensor, list(spacing), bc=boundary_conditions)
 
     # Compute advection term: div(alpha * m)
     # Use upwind scheme from fp_fdm_advection module

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -769,6 +769,42 @@ class TestFPFDMSolverTensorDiffusion:
         masses = np.sum(M, axis=(1, 2)) * domain.spacing[0] * domain.spacing[1]
         assert np.allclose(masses, 1.0, atol=0.1)
 
+    def test_isotropic_tensor_matches_scalar_diffusion(self):
+        """Isotropic volatility Sigma = sigma*I must give D = sigma^2/2, like the scalar path.
+
+        Regression for #1249 (2026-06-10 audit): the tensor path applied the raw Sigma as the
+        diffusion tensor (D = sigma instead of D = sigma^2/2), ~6.7x overdiffusion at sigma=0.3.
+        Pure diffusion, zero drift: the tensor run with Sigma = sigma*I and the scalar run with
+        problem.sigma = sigma both encode D = sigma^2/2, so their densities must match within
+        the (small) cross-scheme discretization gap, NOT differ by the 6.7x raw-Sigma factor.
+        """
+        sigma = 0.3
+        domain = TensorProductGrid(
+            bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[26, 26], boundary_conditions=no_flux_bc(dimension=2)
+        )
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=sigma, components=_default_components_2d())
+        solver = FPFDMSolver(problem, boundary_conditions=no_flux_bc(dimension=1))
+
+        Nt = problem.Nt + 1
+        Nx, Ny = domain.num_points[0], domain.num_points[1]
+        x_coords, y_coords = domain.coordinates
+        X, Y = np.meshgrid(x_coords, y_coords, indexing="ij")
+        m0 = np.exp(-((X - 0.5) ** 2 + (Y - 0.5) ** 2) / (2 * 0.1**2))
+        m0 /= np.sum(m0) * domain.spacing[0] * domain.spacing[1]
+        U = np.zeros((Nt, Nx, Ny))
+
+        M_scalar = solver.solve_fp_system(m0, potential_field=U)  # scalar workhorse, D = sigma^2/2
+        M_tensor = solver.solve_fp_system(
+            m0, potential_field=U, tensor_diffusion_field=sigma * np.eye(2)
+        )  # tensor path; D must also be sigma^2/2
+
+        peak = np.max(np.abs(M_scalar[-1]))
+        rel = np.max(np.abs(M_tensor[-1] - M_scalar[-1])) / peak
+        assert rel < 0.1, (
+            f"isotropic tensor diffusion magnitude mismatch rel={rel:.3f}; the raw-Sigma bug "
+            f"applies D=sigma instead of sigma^2/2 (~6.7x overdiffusion -> ~0.5 relative)."
+        )
+
     def test_full_tensor_with_cross_diffusion(self):
         """Test full anisotropic tensor with off-diagonal terms."""
         domain = TensorProductGrid(


### PR DESCRIPTION
## Summary
The FP tensor-diffusion path applied the raw SDE volatility Σ as if it were the PDE diffusion tensor — `div(Σ ∇m)` — skipping the `D = ½ΣΣᵀ` conversion (audit finding, 2026-06-10). An isotropic `Σ = 0.3·I` gave effective `D = 0.3` instead of `D = σ²/2 = 0.045`: **~6.7× overdiffusion**, silently.

## Trace
`solve_timestep_tensor_explicit` (`fp_fdm_time_stepping.py:1001`) called `apply_diffusion(M, Σ, …)`, and `apply_diffusion`/`tensor_calculus.diffusion`'s tensor branch computes `∇·(coeff ∇u)` with `coeff` used **raw**. Every scalar FP path routes through the single-source converter `diffusion_from_volatility(sigma)` (= σ²/2); the tensor path was the **only** site that skipped it (`grep` confirms `diffusion_from_volatility(..., kind="tensor")` was never called on this chain).

## Change
Route the tensor coefficient through the canonical converter before the operator:
```python
D_tensor = diffusion_from_volatility(Sigma, kind="tensor")  # = 0.5 * Sigma @ Sigma.T
diffusion_term = apply_diffusion(M_current, D_tensor, ...)
```
`solve_timestep_tensor_explicit` is the sole tensor-diffusion application site, so this is a single conversion point (no parallel path). Scalar paths untouched.

## Verification
- `test_isotropic_tensor_matches_scalar_diffusion`: isotropic `Σ = σI` now matches the scalar `D = σ²/2` path (`rel < 0.1`); **fails without the fix** (~0.5 relative, the 6.7× signature).
- All 10 `TestFPFDMSolverTensorDiffusion` tests pass (existing shape/mass tests unaffected — they assert no magnitude). `ruff` clean.

Fixes #1249

_Found in the 2026-06-10 library audit (baseline f58e8fe9 → d5eb29a8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)