### PR TITLE
fix(fp-fdm): route problem.volatility_field (array/callable) into the FP solve (#1248)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -533,10 +533,21 @@ class FPFDMSolver(BaseFPSolver):
         # Issue #717: volatility_field is the SDE volatility σ or Σ
         # The solver computes D = σ²/2 (scalar) or D = ΣΣᵀ/2 (matrix) internally
         if volatility_field is None:
-            # Use problem.sigma (backward compatible)
-            effective_sigma = self.problem.sigma
-            is_tensor = False
-        elif isinstance(volatility_field, (int, float)):
+            # Issue #1248 (2026-06-10 audit): with no explicit override, use the problem's
+            # full SDE volatility (scalar / per-point array / callable), routed through the
+            # same detection below. The old `effective_sigma = self.problem.sigma` used the
+            # placeholder scalar that MFGProblem stores for non-scalar volatility (an array is
+            # collapsed to its mean, a callable to 1.0), so problem.solve() / the coupled loop
+            # silently solved a different PDE than the user specified.
+            volatility_field = self.problem.volatility_field
+
+        if volatility_field is None:
+            # Defensive: a problem with neither sigma nor volatility_field is malformed.
+            raise ValueError(
+                "No volatility specified: problem.volatility_field is None and no volatility_field "
+                "override was passed to solve_fp_system."
+            )
+        if isinstance(volatility_field, (int, float)):
             # Constant isotropic volatility
             effective_sigma = float(volatility_field)
             is_tensor = False

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -732,6 +732,42 @@ class TestFPFDMSolverCallableDiffusion:
             solver.solve_fp_system(m_initial, volatility_field=nan_diffusion)
 
 
+class TestFPFDMSolverProblemVolatility:
+    """problem-level non-scalar volatility must reach the solver (#1248, 2026-06-10 audit)."""
+
+    def test_problem_array_sigma_reaches_solver(self):
+        """A per-point problem.sigma array must drive the solve, not its mean.
+
+        MFGProblem stores a placeholder problem.sigma = mean(array) for non-scalar volatility,
+        and the FP solver read that placeholder, so a spatially-varying sigma silently solved
+        the mean PDE. After the fix the no-override path uses problem.volatility_field, so the
+        problem-level solve matches an explicit per-point volatility_field and differs from the
+        mean scalar.
+        """
+        domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1))
+        Nx = domain.num_points[0]
+        sigma_arr = np.linspace(0.1, 0.5, Nx)  # low-left, high-right per-point volatility
+        problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=sigma_arr, components=_default_components())
+        solver = FPFDMSolver(problem, boundary_conditions=no_flux_bc(dimension=1))
+
+        Nt = problem.Nt + 1
+        x = np.linspace(0.0, 1.0, Nx)
+        m0 = np.exp(-((x - 0.5) ** 2) / (2 * 0.08**2))
+        m0 /= np.sum(m0) * domain.spacing[0]
+        U = np.zeros((Nt, Nx))
+
+        M_problem = solver.solve_fp_system(m0, U)  # no override -> must use problem.volatility_field
+        M_explicit = solver.solve_fp_system(m0, U, volatility_field=sigma_arr)
+        M_mean = solver.solve_fp_system(m0, U, volatility_field=float(np.mean(sigma_arr)))
+
+        assert np.allclose(M_problem[-1], M_explicit[-1], atol=1e-12), (
+            "problem-level solve must equal the explicit per-point volatility_field"
+        )
+        assert not np.allclose(M_problem[-1], M_mean[-1], atol=1e-3), (
+            "problem-level solve must NOT collapse the per-point sigma to its mean (#1248 bug)"
+        )
+
+
 class TestFPFDMSolverTensorDiffusion:
     """Test tensor diffusion support (Phase 3.0)."""
 


### PR DESCRIPTION
## Summary
`MFGProblem` stores the true SDE volatility in `problem.volatility_field`, but a **placeholder** in `problem.sigma` — an array collapses to `mean(array)`, a callable to `1.0`. The FP-FDM solver's no-override path read `problem.sigma`, so `problem.solve()` / the coupled `FixedPointIterator` loop silently solved the **mean** (or `σ=1.0`) PDE instead of the spatially-varying / state-dependent one the user specified (audit finding, 2026-06-10).

## Trace
`fp_fdm.py:535-537` (pre-fix): `if volatility_field is None: effective_sigma = self.problem.sigma`. No solver path read `problem.volatility_field` (`grep` confirmed); the designed conduit `get_diffusion_coefficient_field()` had no solver callers.

## Change
When `solve_fp_system` gets no `volatility_field` override, resolve it from `problem.volatility_field` and run it through the **existing** scalar/array/tensor/callable detection — the same path an explicit override already takes — plus a fail-loud guard if neither is set. Scalar problems are unchanged (`problem.volatility_field` is the scalar).

## Verification
- `test_problem_array_sigma_reaches_solver`: a per-point σ array now drives the solve (matches an explicit per-point `volatility_field`, **differs from the mean scalar**); fails without the fix.
- Manually verified the callable case: problem-callable ≡ explicit-callable (`max|Δ|=0`) and differs from the `σ=1.0` placeholder by 1.22. CFL log showing `sigma=1` is cosmetic (the diagnostic can't evaluate a callable); the solve uses it.
- All 48 `test_fp_fdm_solver.py` tests pass. `ruff` clean.

## Scope (Refs, not Fixes)
Covers the **FP-FDM** path (used by `problem.solve()` / the coupled iterator — the demonstrated critical). **Not** covered, remaining under #1248: the same `problem.sigma`-placeholder pattern in the particle / GFDM / SL FP solvers, and the explicit-`volatility_field` drop on the particle ndarray-drift path (C5).

Refs #1248

_Found in the 2026-06-10 library audit (baseline f58e8fe9 → d5eb29a8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)