### PR TITLE
fix(fem): fail loud on P2+ mass-lumped gradient recovery — was silent garbage (#1252)

### DIFF
--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -93,15 +93,27 @@ class WeakFormHJBSolver(BaseHJBSolver):
 
     # --- Gradient recovery: mass-lumped L2 projection grad_d(u) = G_d @ u -----
     def _build_gradient_operators(self) -> None:
-        # Accuracy caveat: row-sum mass lumping (M_lumped = M.sum(axis=1)) keeps gradient recovery
-        # cheap and diagonal, and is exact-order for P1. For P2 it is suboptimal — the lumped
-        # projection can cap the recovered gradient below the full consistent-mass O(h^p) rate, so
-        # a P2 HJB solve may not realize the full P2 convergence order here. Replacing this with a
-        # full consistent-mass L2 projection is a deferred accuracy-vs-speed design decision.
+        # Row-sum mass lumping (M_lumped = M.sum(axis=1)) keeps gradient recovery cheap and
+        # diagonal, and is exact-order for P1 (every row sum is a positive fraction of the element
+        # measure). It is INVALID for P2+ Lagrange: the vertex shape function integrates to ~0 over
+        # a triangle (int lambda(2 lambda - 1) = 0) and to a NEGATIVE value over a tetrahedron, so
+        # the consistent-mass row sum at every vertex DOF is ~0 or < 0. The old clamp
+        # (M_lumped < 1e-15 -> 1e-15) then turned that into 1e-15, and 1/1e-15 = 1e15 multiplied the
+        # recovered vertex gradient into garbage (recovered grad of u = x came out ~1e-3 or ~-6e12
+        # at P2 vertices), silently feeding nonsense into H(grad u). Fail loud instead; a
+        # consistent-mass L2 projection (grad = M^{-1} R) is the fix for P2+ (#1252, 2026-06-10 audit).
         if self._G_grad is not None:
             return
         M_lumped = np.array(self._M.sum(axis=1)).ravel()
-        M_lumped[M_lumped < 1e-15] = 1e-15
+        m_min, m_max = float(M_lumped.min()), float(M_lumped.max())
+        if m_min < 1e-12 * m_max:
+            raise NotImplementedError(
+                "Row-sum mass lumping for nodal gradient recovery requires strictly positive lumped "
+                f"masses, but the minimum row sum is {m_min:.3e} (max {m_max:.3e}). This is the P2+ "
+                "Lagrange case (vertex shape functions integrate to ~0 / negative), where lumping "
+                "yields garbage gradients in H(grad u). Use P1 elements, or implement a "
+                "consistent-mass L2 projection grad = M^{-1} R for higher-order elements (#1252)."
+            )
         self._M_lumped_inv = 1.0 / M_lumped
         self._G_grad = [(sparse.diags(self._M_lumped_inv) @ R_d).tocsr() for R_d in self._R_grad]
 

--- a/tests/unit/test_alg/test_weak_form_hjb_p2_gradient_1252.py
+++ b/tests/unit/test_alg/test_weak_form_hjb_p2_gradient_1252.py
@@ -1,0 +1,58 @@
+"""Issue #1252 (2026-06-10 audit): P2 mass-lumped nodal-gradient recovery is invalid.
+
+Row-sum mass lumping (M_lumped = M.sum(axis=1)) assumes strictly positive lumped masses.
+For P2+ Lagrange the vertex shape function integrates to ~0 over a triangle and to a negative
+value over a tetrahedron, so the consistent-mass row sum at every vertex DOF is ~0 or < 0. The
+old code clamped that to 1e-15 and 1/1e-15 = 1e15 turned the recovered vertex gradient into
+garbage, silently feeding nonsense into H(grad u). _build_gradient_operators must now fail loud
+for P2+ and keep working for P1. The fix exercises the real method via a minimal carrier holding
+genuine skfem-assembled P1/P2 mass matrices.
+"""
+
+import pytest
+
+import numpy as np
+from scipy import sparse
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required for FEM gradient-recovery test")
+
+from mfgarchon.alg.numerical.fem.assembly import assemble_mass, create_basis  # noqa: E402
+from mfgarchon.alg.numerical.weak_form_hjb_solver import WeakFormHJBSolver  # noqa: E402
+
+
+class _GradStub:
+    """Minimal carrier exposing the attributes _build_gradient_operators reads/writes."""
+
+    def __init__(self, M, n):
+        self._M = M
+        # _R_grad is only consumed AFTER the positivity guard; identity placeholders suffice.
+        self._R_grad = [sparse.eye(n, format="csr"), sparse.eye(n, format="csr")]
+        self._G_grad = None
+        self._M_lumped_inv = None
+
+
+def _mass_matrix(order):
+    mesh = skfem.MeshTri.init_sqsymmetric().refined(2)
+    basis = create_basis(mesh, order=order)
+    return assemble_mass(basis), basis.N
+
+
+def test_p2_gradient_lumping_fails_loud():
+    """P2: lumped row sums are pathological (~0/negative) -> must raise NotImplementedError."""
+    M, n = _mass_matrix(order=2)
+    m_lumped = np.asarray(M.sum(axis=1)).ravel()
+    assert m_lumped.min() < 1e-12 * m_lumped.max(), "premise: P2 vertex DOFs should have ~0/negative lumped row sums"
+    stub = _GradStub(M, n)
+    with pytest.raises(NotImplementedError, match="lumping"):
+        WeakFormHJBSolver._build_gradient_operators(stub)
+
+
+def test_p1_gradient_lumping_ok():
+    """P1: all lumped row sums strictly positive -> operators build without raising."""
+    M, n = _mass_matrix(order=1)
+    m_lumped = np.asarray(M.sum(axis=1)).ravel()
+    assert m_lumped.min() > 1e-12 * m_lumped.max(), "P1 lumped row sums must be strictly positive"
+    stub = _GradStub(M, n)
+    WeakFormHJBSolver._build_gradient_operators(stub)  # must not raise
+    assert stub._G_grad is not None
+    assert len(stub._G_grad) == 2


### PR DESCRIPTION
## Summary
P2 HJB-FEM nodal-gradient recovery was silently producing garbage at every vertex DOF (audit finding, 2026-06-10). `_build_gradient_operators` recovers `grad u` via row-sum mass lumping `G_d = diag(1/M.sum(axis=1)) @ R_d`, which assumes strictly positive lumped masses.

## Trace
For P2+ Lagrange the **vertex** shape function integrates to ~0 over a triangle (`∫λ(2λ−1) = 0`) and to a **negative** value over a tetrahedron, so the consistent-mass row sum at every vertex DOF is `~0` or `< 0`. The old clamp `M_lumped[M_lumped < 1e-15] = 1e-15` then made `1/1e-15 = 1e15` multiply the recovered vertex gradient into garbage — recovered `grad` of `u = x` came out `~1e-3` (Tri) or `~−6e12` (Tet) at P2 vertices — silently feeding nonsense into `H(grad u)`.

## Change
Fail loud when the minimum lumped row sum is non-positive relative to the max (`m_min < 1e-12·m_max`) — exactly the P2+ pathology — instead of clamping to garbage. **P1 is unaffected** (all row sums are a positive fraction of the element measure).

## Verification
Pinning test (`test_weak_form_hjb_p2_gradient_1252.py`) drives the **real** `_build_gradient_operators` via a minimal carrier holding genuine skfem-assembled mass matrices:
- P2 → `NotImplementedError` (**fails without the fix** — the clamp path builds garbage with no error).
- P1 → builds operators, no raise (passes before and after).
- FEM integration suite unaffected (21 passed). `ruff` clean.

## Scope (Refs, not Fixes)
This is the **fail-loud mitigation** — it stops silent garbage. The proper fix is a **consistent-mass L2 projection** `grad = M⁻¹R` for P2+, which interacts with the Newton Jacobian (`M @ diag(dH/dp) @ G_d` with `G_d = M⁻¹R_d`) and is a larger change. Recommend keeping #1252 open to track that.

Refs #1252

_Found in the 2026-06-10 library audit (baseline f58e8fe9 → d5eb29a8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)