### PR TITLE
fix(fp-gfdm): default solves continuity div(mα), not transport α·∇m (#1279)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -529,10 +529,16 @@ class FPGFDMSolver(BaseFPSolver):
                 # Use upwind-stabilized divergence
                 advection = self._compute_upwind_divergence(drift, m_current)
             else:
-                # Compute div(m*α) via gradient: div(m*α) = α·∇m + m·div(α)
-                # Simplified: use product rule with gradient operator
-                grad_m = self.gfdm_operator.gradient(m_current)  # (N, d)
-                advection = np.sum(drift * grad_m, axis=1)  # α·∇m (gradient form)
+                # Conservative continuity form: advection = div(m*α) = sum_d d/dx_d (m * α_d).
+                # The previous code computed only `np.sum(drift * grad_m)` = α·∇m (transport form),
+                # silently dropping the m·div(α) term. For any α with nonzero divergence (e.g.
+                # α = -∇U with ΔU != 0, the standard MFG case) that term is O(1), so the default
+                # path returned a wrong-SHAPE density on every call; the renormalization below masks
+                # total-mass drift but not the shape error. Take the divergence of the flux
+                # F = m*α directly via the GFDM gradient — the same conservative flux form the
+                # upwind path (_compute_upwind_divergence) uses. (#1279, 2026-06-11 survey)
+                flux = m_current[:, np.newaxis] * drift  # (N, d): F_d = m * alpha_d
+                advection = sum(self.gfdm_operator.gradient(flux[:, d])[:, d] for d in range(drift.shape[1]))
 
             # Diffusion term: D * Laplacian(m)
             laplacian = self.gfdm_operator.laplacian(m_current)

--- a/tests/unit/test_alg/test_fp_gfdm_continuity_1279.py
+++ b/tests/unit/test_alg/test_fp_gfdm_continuity_1279.py
@@ -1,0 +1,51 @@
+"""Issue #1279 (2026-06-11 survey): FPGFDMSolver default must solve continuity, not transport.
+
+The default `upwind_scheme="none"` path computed only `α·∇m` (transport form), silently dropping
+the `m·div(α)` term of `div(mα)`. With a UNIFORM initial density and a drift whose divergence
+varies in space, the continuity term `m·div(α)` drives the density into a non-uniform profile,
+while the transport form is zero for uniform `m` (∇m = 0) and diffusion of a uniform field is also
+zero — so the buggy path leaves the density uniform.
+"""
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import Hyperrectangle, TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem_2d(sigma=0.1):
+    grid = TensorProductGrid(
+        bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[11, 11], boundary_conditions=no_flux_bc(dimension=2)
+    )
+    comp = MFGComponents(
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+    )
+    return MFGProblem(geometry=grid, components=comp, T=0.1, Nt=5, sigma=sigma)
+
+
+def test_fp_gfdm_default_uses_continuity_not_transport():
+    problem = _problem_2d()
+    domain = Hyperrectangle(np.array([[0.0, 1.0], [0.0, 1.0]]))
+    points = domain.sample_uniform(150, seed=0)
+    solver = FPGFDMSolver(problem, collocation_points=points, delta=0.25)
+    assert solver.upwind_scheme == "none"  # exercise the default (buggy) path
+
+    n = points.shape[0]
+    m0 = np.ones(n) / n  # uniform: transport term and diffusion term both vanish on it
+    # drift alpha(x) = (x^2, 0) -> div(alpha) = 2x varies in space, so m*div(alpha) != 0
+    alpha = np.zeros((problem.Nt + 1, n, 2))
+    alpha[:, :, 0] = (points[:, 0] ** 2)[None, :]
+
+    M = solver.solve_fp_system(m0, drift_field=alpha, show_progress=False)
+    final = M[-1]
+    rel_spread = float(np.std(final) / np.mean(final))
+    assert rel_spread > 1e-2, (
+        f"density stayed ~uniform (rel_spread={rel_spread:.2e}); the m·div(α) continuity term was "
+        f"dropped (transport form α·∇m)."
+    )


### PR DESCRIPTION
## Summary
`FPGFDMSolver`'s **default** advection path (`upwind_scheme="none"`) solved the transport equation `∂m/∂t + α·∇m = DΔm` instead of the continuity equation `∂m/∂t + div(mα) = DΔm` — it dropped the `m·div(α)` term, returning **wrong-shape density on every default call** (audit/survey finding, verified core-path critical, 2026-06-11).

## Trace
`fp_gfdm.py:531-535` computed `advection = np.sum(drift * grad_m, axis=1)` = `α·∇m`, even though the inline comment stated the full identity `div(mα) = α·∇m + m·div(α)`. For standard MFG `α = −∇U`, `div(α) = −ΔU ≠ 0` generically, so the dropped term is O(1). Mass renormalization (`:556-558`) masks total-mass drift but not the shape error. Same non-conservative-gradient-form class as #1149/#1075, here in the GFDM solver.

## Change
Take the divergence of the flux `F = m·α` directly via the GFDM gradient (`advection = Σ_d ∂_d(m·α_d)`) — the conservative flux form the upwind path (`_compute_upwind_divergence`) already uses. The upwind path is unchanged.

## Verification
- `test_fp_gfdm_continuity_1279`: uniform initial density + drift `α=(x²,0)` (so `div(α)=2x`); the continuity term `m·div(α)` makes the density non-uniform (`rel_spread > 1e-2`). **Without the fix** the transport form leaves uniform `m` unchanged (`rel_spread = 5e-16`, fails).
- FPGFDM integration + drift-contract suites: 12 passed. `ruff` clean.

Fixes #1279

_Found in the 2026-06-11 untouched-area survey (verified core-path critical)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)