### PR TITLE
fix: fail-fast sigma ValueError + zero-drift nan guard in upwind divergence

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -310,20 +310,26 @@ class FPGFDMSolver(BaseFPSolver):
                 if r_norm < 1e-12:
                     continue  # Skip coincident points
 
-                # Streamline alignment: cos θ = (α · r) / (||α|| · ||r||)
-                cos_theta = np.dot(drift_i, r_ij) / (drift_norm * r_norm)
-
-                # Upwind weight modification
-                if self.upwind_scheme == "exponential":
-                    # Scharfetter-Gummel style: exp(β cos θ)
-                    # Upstream (cos<0): weight < 1
-                    # Downstream (cos>0): weight > 1
-                    weight_factor = np.exp(self.upwind_strength * cos_theta)
-                elif self.upwind_scheme == "linear":
-                    # Linear bias: 1 + β*cos θ
-                    weight_factor = 1.0 + self.upwind_strength * cos_theta
-                else:
+                # Issue #1286, 2026-06-11 survey: guard zero-drift — when ||α||≈0
+                # the streamline direction is undefined; dividing by drift_norm
+                # produces nan.  Fall back to symmetric (unbiased) weight=1.
+                if drift_norm < 1e-12:
                     weight_factor = 1.0
+                else:
+                    # Streamline alignment: cos θ = (α · r) / (||α|| · ||r||)
+                    cos_theta = np.dot(drift_i, r_ij) / (drift_norm * r_norm)
+
+                    # Upwind weight modification
+                    if self.upwind_scheme == "exponential":
+                        # Scharfetter-Gummel style: exp(β cos θ)
+                        # Upstream (cos<0): weight < 1
+                        # Downstream (cos>0): weight > 1
+                        weight_factor = np.exp(self.upwind_strength * cos_theta)
+                    elif self.upwind_scheme == "linear":
+                        # Linear bias: 1 + β*cos θ
+                        weight_factor = 1.0 + self.upwind_strength * cos_theta
+                    else:
+                        weight_factor = 1.0
 
                 upwind_weights.append(weight_factor)
                 neighbor_points.append(j)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -231,8 +231,17 @@ def adi_diffusion_step(
         sigma_tensor = np.asarray(sigma)
         sigma_vec = np.sqrt(np.diag(sigma_tensor))  # Diagonal part for ADI
     else:
-        # Fallback to scalar
-        sigma_vec = np.full(dimension, 0.1)
+        # Issue #1286, 2026-06-11 survey: fail-fast — never silently default sigma.
+        # A wrong sigma type causes adi_diffusion_step to solve a different PDE.
+        sigma_type = type(sigma).__name__
+        sigma_shape = getattr(sigma, "shape", "N/A")
+        raise ValueError(
+            f"adi_diffusion_step: unsupported sigma type '{sigma_type}' "
+            f"(shape={sigma_shape}). "
+            f"Expected: scalar (int/float), 1-D array of length {dimension} "
+            f"(diagonal per-direction), or 2-D array (full tensor). "
+            f"Silently falling back to sigma=0.1 was removed (Issue #1286)."
+        )
 
     # Ensure U_star is shaped correctly
     if U_star.ndim == 1:

--- a/tests/unit/test_alg/test_issue1286_fail_fast.py
+++ b/tests/unit/test_alg/test_issue1286_fail_fast.py
@@ -1,0 +1,186 @@
+"""
+Pinning tests for Issue #1286 (2026-06-11 survey):
+
+1. adi_diffusion_step with an unrecognised sigma type must raise ValueError,
+   not silently fall back to sigma=0.1.
+2. _compute_upwind_divergence must return finite values (no nan) when the
+   drift field is zero at one or more collocation points.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Bug 1: adi_diffusion_step silently used sigma=0.1 for bad sigma type
+# ---------------------------------------------------------------------------
+
+
+def test_adi_diffusion_step_bad_sigma_type_raises():
+    """Unrecognised sigma type (dict) must raise ValueError (was: silent sigma=0.1)."""
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+
+    U = np.zeros((4, 4))
+    bad_sigma = {"value": 0.5}  # dict -- never a valid sigma type
+
+    with pytest.raises(ValueError, match="unsupported sigma type"):
+        adi_diffusion_step(
+            U_star=U,
+            dt=0.01,
+            sigma=bad_sigma,
+            spacing=np.array([0.25, 0.25]),
+            grid_shape=(4, 4),
+        )
+
+
+def test_adi_diffusion_step_bad_sigma_wrong_ndim_raises():
+    """3-D sigma array (ndim=3) must raise ValueError."""
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+
+    U = np.zeros((4, 4))
+    bad_sigma = np.zeros((2, 2, 2))  # ndim=3 -- not scalar, 1-D, or 2-D
+
+    with pytest.raises(ValueError, match="unsupported sigma type"):
+        adi_diffusion_step(
+            U_star=U,
+            dt=0.01,
+            sigma=bad_sigma,
+            spacing=np.array([0.25, 0.25]),
+            grid_shape=(4, 4),
+        )
+
+
+def test_adi_diffusion_step_bad_sigma_wrong_1d_length_raises():
+    """1-D sigma with wrong length (3 for 2-D grid) must raise ValueError."""
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+
+    U = np.zeros((4, 4))
+    bad_sigma = np.array([0.5, 0.5, 0.5])  # length 3 for a 2-D grid
+
+    with pytest.raises(ValueError, match="unsupported sigma type"):
+        adi_diffusion_step(
+            U_star=U,
+            dt=0.01,
+            sigma=bad_sigma,
+            spacing=np.array([0.25, 0.25]),
+            grid_shape=(4, 4),
+        )
+
+
+def test_adi_diffusion_step_valid_sigma_types_do_not_raise():
+    """Valid sigma types (scalar, 1-D matching dimension, 2-D tensor) must not raise."""
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+
+    U = np.zeros((4, 4))
+    spacing = np.array([0.25, 0.25])
+
+    # scalar
+    adi_diffusion_step(U, dt=0.01, sigma=0.5, spacing=spacing, grid_shape=(4, 4))
+    # 1-D array matching dimension
+    adi_diffusion_step(
+        U,
+        dt=0.01,
+        sigma=np.array([0.5, 0.5]),
+        spacing=spacing,
+        grid_shape=(4, 4),
+    )
+    # 2-D tensor
+    adi_diffusion_step(
+        U,
+        dt=0.01,
+        sigma=np.diag([0.5, 0.5]),
+        spacing=spacing,
+        grid_shape=(4, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: _compute_upwind_divergence produces nan when drift is zero
+# ---------------------------------------------------------------------------
+
+
+def _make_problem():
+    """Build a minimal 1-D MFGProblem for FPGFDMSolver tests."""
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    grid = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx_points=[10],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H,
+        m_initial=lambda x: np.exp(-20 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.5 * (x - 0.5) ** 2,
+    )
+    return MFGProblem(
+        geometry=grid,
+        components=comp,
+        T=0.5,
+        Nt=5,
+        sigma=0.3,
+        coupling_coefficient=0.5,
+    )
+
+
+def _make_fp_gfdm_solver():
+    """Construct FPGFDMSolver on a small 1-D point cloud."""
+    from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+
+    points = np.linspace(0.0, 1.0, 12).reshape(-1, 1)
+    problem = _make_problem()
+    solver = FPGFDMSolver(
+        problem=problem,
+        collocation_points=points,
+        upwind_scheme="exponential",
+        upwind_strength=1.0,
+    )
+    return solver
+
+
+def test_upwind_divergence_zero_drift_no_invalid_float_op():
+    """_compute_upwind_divergence must not produce an invalid float operation
+    (nan/inf in intermediate values) when drift is entirely zero.
+
+    On buggy code: cos_theta = dot(0, r) / (0 * r_norm) raises RuntimeWarning
+    (invalid value encountered in scalar divide).  With errstate(invalid='raise')
+    that becomes FloatingPointError, so the test FAILS on the unfixed code.
+    After fix: zero-drift path bypasses the divide entirely; no warning raised.
+    """
+    solver = _make_fp_gfdm_solver()
+    N = solver.n_points
+
+    drift = np.zeros((N, 1))  # all-zero drift -- triggers division-by-zero bug
+    density = np.ones(N) / N
+
+    with np.errstate(invalid="raise"):
+        result = solver._compute_upwind_divergence(drift_field=drift, density=density)
+
+    assert np.all(np.isfinite(result)), (
+        f"_compute_upwind_divergence returned non-finite values with zero drift: {result}"
+    )
+
+
+def test_upwind_divergence_partial_zero_drift_no_invalid_float_op():
+    """Same invariant when only some points have zero drift."""
+    solver = _make_fp_gfdm_solver()
+    N = solver.n_points
+
+    rng = np.random.default_rng(42)
+    drift = rng.standard_normal((N, 1)) * 0.5
+    drift[::2] = 0.0  # zero drift at every other point
+
+    density = np.ones(N) / N
+
+    with np.errstate(invalid="raise"):
+        result = solver._compute_upwind_divergence(drift_field=drift, density=density)
+
+    assert np.all(np.isfinite(result)), (
+        f"_compute_upwind_divergence returned non-finite values with partial zero drift: {result}"
+    )


### PR DESCRIPTION
## Summary

Two fail-fast bugs fixed in FP/HJB solver paths (Issue #1286, 2026-06-11 survey).

- `hjb_sl_adi.py:adi_diffusion_step`: the `else` branch after the three valid sigma shapes silently assigned `sigma_vec = np.full(dimension, 0.1)`, solving a different PDE with no diagnostic. Replaced with `ValueError` naming the actual type and shape.
- `fp_gfdm.py:_compute_upwind_divergence`: divided by `drift_norm` without guarding the zero-drift case (`drift_norm < 1e-12`). The `0/0` produces `nan` in `cos_theta` which propagates through `weight_factor` and `div_i`. Fix: when `drift_norm < 1e-12` the streamline direction is undefined; fall back to symmetric weight (`weight_factor=1.0`) and skip the divide.

## Pinning tests (`tests/unit/test_alg/test_issue1286_fail_fast.py`)

- **Bug 1 (3 tests)**: assert `ValueError` is raised for dict/3-D array/wrong-length 1-D sigma. FAIL on pre-fix code (DID NOT RAISE), PASS after fix.
- **Bug 2 (2 tests)**: use `np.errstate(invalid='raise')` so the latent `0/0` divide becomes `FloatingPointError` on pre-fix code, passes clean after fix.

## Test plan

- [x] `pytest tests/unit/test_alg/test_issue1286_fail_fast.py` — 6 passed, 0 failed (fixed code)
- [x] Same suite on stashed (pre-fix) code — 5 failed, 1 passed (confirms pinning)
- [x] `ruff format` + `ruff check` — clean

Refs #1286