### PR TITLE
fix: MFGResidual fails loud when source_term_hjb/fp, nonlocal_operator, or obstacle is set

### DIFF
--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -90,6 +90,32 @@ class MFGResidual:
         self.volatility_field = volatility_field
         self.drift_field = drift_field
 
+        # Issue #1285: Newton residual does not compose source_term_hjb,
+        # source_term_fp, nonlocal_operator, or obstacle — it silently solves
+        # a different variational problem than Picard when any of those fields
+        # is set.  Fail loud until these terms are wired.
+        # Use FixedPointIterator instead; it correctly composes all four via
+        # _compose_hjb_source / _compose_fp_source.  Refs #1285 #1043.
+        _unsupported_fields = [
+            name
+            for name, val in [
+                ("source_term_hjb", problem.source_term_hjb),
+                ("source_term_fp", problem.source_term_fp),
+                ("nonlocal_operator", problem.nonlocal_operator),
+                ("obstacle", problem.obstacle),
+            ]
+            if val is not None
+        ]
+        if _unsupported_fields:
+            raise NotImplementedError(
+                f"MFGResidual (Newton path) does not support problem fields: "
+                f"{_unsupported_fields}. "
+                "These terms are silently ignored, causing Newton to converge "
+                "to a wrong equilibrium. "
+                "Use FixedPointIterator instead, which correctly composes "
+                "all four terms. Refs #1285 #1043."
+            )
+
         # Cache problem dimensions
         self.num_time_steps = problem.Nt + 1
         self.spatial_shape = tuple(problem.geometry.get_grid_shape())

--- a/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
+++ b/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
@@ -1,0 +1,244 @@
+"""Pinning tests for Issue #1285 (2026-06-11 survey).
+
+MFGResidual / NewtonMFGSolver silently ignored source_term_hjb,
+source_term_fp, nonlocal_operator, and obstacle, causing Newton to
+converge to a wrong equilibrium whenever any of those problem fields
+is set.
+
+Fix: MFGResidual.__init__ raises NotImplementedError with a clear
+message when any of the four unsupported fields is non-None.
+FixedPointIterator correctly composes all four terms and should be
+used instead.
+
+Each test here asserts that NotImplementedError is raised.
+On unfixed code (no guard in __init__): the object constructs silently
+-- no error -- so pytest.raises(...) catches no exception and the test
+FAILS.  After the fix the guard fires and the tests PASS.
+
+Refs #1285 #1043.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+
+# ---------------------------------------------------------------------------
+# Minimal problem factory
+# ---------------------------------------------------------------------------
+
+
+def _make_plain_problem(Nx: int = 5, Nt: int = 3) -> MFGProblem:
+    """1-D problem without any extended fields."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(Nx=Nx, xmin=0.0, xmax=1.0, T=0.3, Nt=Nt, sigma=0.2, components=comp)
+
+
+def _make_problem_with_nonlocal(Nx: int = 5, Nt: int = 3) -> MFGProblem:
+    """1-D problem with a diagonal nonlocal_operator."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(
+        Nx=Nx,
+        xmin=0.0,
+        xmax=1.0,
+        T=0.3,
+        Nt=Nt,
+        sigma=0.2,
+        components=comp,
+        nonlocal_operator=np.eye(Nx),
+    )
+
+
+def _make_problem_with_source_hjb(Nx: int = 5, Nt: int = 3) -> MFGProblem:
+    """1-D problem with source_term_hjb."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(
+        Nx=Nx,
+        xmin=0.0,
+        xmax=1.0,
+        T=0.3,
+        Nt=Nt,
+        sigma=0.2,
+        components=comp,
+        source_term_hjb=lambda x, m, v, t: np.zeros(len(x)),
+    )
+
+
+def _make_problem_with_source_fp(Nx: int = 5, Nt: int = 3) -> MFGProblem:
+    """1-D problem with source_term_fp."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(
+        Nx=Nx,
+        xmin=0.0,
+        xmax=1.0,
+        T=0.3,
+        Nt=Nt,
+        sigma=0.2,
+        components=comp,
+        source_term_fp=lambda x, m, v, t: np.zeros(len(x)),
+    )
+
+
+def _make_problem_with_obstacle(Nx: int = 5, Nt: int = 3) -> MFGProblem:
+    """1-D problem with obstacle."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: 0.0,
+        m_initial=lambda x: 1.0,
+    )
+    return MFGProblem(
+        Nx=Nx,
+        xmin=0.0,
+        xmax=1.0,
+        T=0.3,
+        Nt=Nt,
+        sigma=0.2,
+        components=comp,
+        obstacle=lambda x: np.zeros(len(x)),
+    )
+
+
+def _make_solvers(problem: MFGProblem):
+    from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+    from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+
+    return HJBFDMSolver(problem), FPFDMSolver(problem)
+
+
+# ---------------------------------------------------------------------------
+# MFGResidual must raise NotImplementedError for each unsupported field
+# ---------------------------------------------------------------------------
+
+
+def test_mfg_residual_raises_on_nonlocal_operator():
+    """MFGResidual must raise NotImplementedError when nonlocal_operator is set.
+
+    Pre-fix: object constructs silently, no exception raised.
+    Post-fix: NotImplementedError is raised with '#1285' in the message.
+    """
+    from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+
+    problem = _make_problem_with_nonlocal()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    with pytest.raises(NotImplementedError, match="#1285"):
+        MFGResidual(problem, hjb_solver, fp_solver)
+
+
+def test_mfg_residual_raises_on_source_term_hjb():
+    """MFGResidual must raise NotImplementedError when source_term_hjb is set."""
+    from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+
+    problem = _make_problem_with_source_hjb()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    with pytest.raises(NotImplementedError, match="#1285"):
+        MFGResidual(problem, hjb_solver, fp_solver)
+
+
+def test_mfg_residual_raises_on_source_term_fp():
+    """MFGResidual must raise NotImplementedError when source_term_fp is set."""
+    from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+
+    problem = _make_problem_with_source_fp()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    with pytest.raises(NotImplementedError, match="#1285"):
+        MFGResidual(problem, hjb_solver, fp_solver)
+
+
+def test_mfg_residual_raises_on_obstacle():
+    """MFGResidual must raise NotImplementedError when obstacle is set."""
+    from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+
+    problem = _make_problem_with_obstacle()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    with pytest.raises(NotImplementedError, match="#1285"):
+        MFGResidual(problem, hjb_solver, fp_solver)
+
+
+# ---------------------------------------------------------------------------
+# NewtonMFGSolver (builds MFGResidual internally) must propagate the error
+# ---------------------------------------------------------------------------
+
+
+def test_newton_solver_raises_on_nonlocal_operator():
+    """NewtonMFGSolver must raise NotImplementedError when nonlocal_operator is set.
+
+    NewtonMFGSolver constructs MFGResidual internally; the guard in
+    MFGResidual.__init__ must propagate through.
+    """
+    from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
+
+    problem = _make_problem_with_nonlocal()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    with pytest.raises(NotImplementedError, match="#1285"):
+        NewtonMFGSolver(problem, hjb_solver, fp_solver)
+
+
+def test_newton_solver_raises_on_source_term_hjb():
+    """NewtonMFGSolver must raise NotImplementedError when source_term_hjb is set."""
+    from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
+
+    problem = _make_problem_with_source_hjb()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    with pytest.raises(NotImplementedError, match="#1285"):
+        NewtonMFGSolver(problem, hjb_solver, fp_solver)
+
+
+# ---------------------------------------------------------------------------
+# Plain problem (no extended fields) must NOT raise
+# ---------------------------------------------------------------------------
+
+
+def test_mfg_residual_plain_problem_does_not_raise():
+    """MFGResidual must construct cleanly for a plain problem with no extended fields."""
+    from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+
+    problem = _make_plain_problem()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    residual = MFGResidual(problem, hjb_solver, fp_solver)
+    # Smoke-check: basic attributes are set
+    assert residual.problem is problem
+    assert residual.num_time_steps == problem.Nt + 1
+
+
+def test_newton_solver_plain_problem_does_not_raise():
+    """NewtonMFGSolver must construct cleanly for a plain problem."""
+    from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
+
+    problem = _make_plain_problem()
+    hjb_solver, fp_solver = _make_solvers(problem)
+
+    solver = NewtonMFGSolver(problem, hjb_solver, fp_solver)
+    assert solver.problem is problem


### PR DESCRIPTION
## Summary

- `MFGResidual.__init__` now raises `NotImplementedError` with a greppable message (`#1285`) when any of `problem.source_term_hjb`, `source_term_fp`, `nonlocal_operator`, or `obstacle` is non-`None`.
- Previously those four fields were silently ignored: Newton converged to a wrong equilibrium (a different variational problem than Picard) with no diagnostic.
- `NewtonMFGSolver` propagates the error automatically because it constructs `MFGResidual` in its `__init__`.
- The error message directs users to `FixedPointIterator`, which correctly composes all four terms via `_compose_hjb_source` / `_compose_fp_source`.

## Scope

Conservative fail-loud guard per repo fail-fast policy.  Full wiring of the four terms into the Newton residual is deferred (convention-sensitive; Refs #1043).

## Test plan

- `tests/unit/test_alg/test_issue1285_newton_fail_loud.py` — 8 tests
  - 4 `MFGResidual` tests (one per unsupported field): FAIL on pre-fix code (DID NOT RAISE), PASS after
  - 2 `NewtonMFGSolver` propagation tests: same pattern
  - 2 plain-problem tests: PASS throughout (guard absent when no field is set)
- `ruff format` + `ruff check` clean on both changed files

Refs #1285 #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)