### PR TITLE
fix: backend robustness — numba diff shape, HybridStrategy TypeError, torch float64 default

### DIFF
--- a/mfgarchon/backends/numba_backend.py
+++ b/mfgarchon/backends/numba_backend.py
@@ -286,12 +286,11 @@ class NumbaBackend(BaseBackend):
             return trapezoid(y, x=x, dx=dx, axis=axis)
 
     def diff(self, a, n=1, axis=-1):
-        if NUMBA_AVAILABLE and n == 1 and axis == -1:
-            # Use optimized finite difference
-            dx = 1.0  # Assume unit spacing
-            return self._finite_diff_1d(a, dx)
-        else:
-            return np.diff(a, n=n, axis=axis)
+        # Issue #1283: _finite_diff_1d is a *derivative* kernel (size-n), not a
+        # discrete difference (size-(n-1)).  Using it here violated the base-class
+        # contract (matching np.diff) and all other backends.  Delegate to np.diff
+        # unconditionally; _finite_diff_1d remains available for gradient use only.
+        return np.diff(a, n=n, axis=axis)
 
     def interp(self, x, xp, fp):
         return np.interp(x, xp, fp)

--- a/mfgarchon/backends/strategies/particle_strategies.py
+++ b/mfgarchon/backends/strategies/particle_strategies.py
@@ -281,7 +281,8 @@ class HybridParticleStrategy(ParticleStrategy):
 
         if num_particles < gpu_threshold:
             # Small problem: Use CPU (avoids GPU transfer overhead)
-            cpu_strategy = CPUParticleStrategy(self.backend)
+            # Issue #1283: CPUParticleStrategy has no __init__; passing args raises TypeError.
+            cpu_strategy = CPUParticleStrategy()
             return cpu_strategy.solve(
                 m_initial,
                 U_drift,
@@ -296,7 +297,8 @@ class HybridParticleStrategy(ParticleStrategy):
             # Large problem: Use full GPU (benefits from parallelism)
             if self.backend is None:
                 # No GPU available, fall back to CPU
-                cpu_strategy = CPUParticleStrategy(None)
+                # Issue #1283: CPUParticleStrategy has no __init__; passing args raises TypeError.
+                cpu_strategy = CPUParticleStrategy()
                 return cpu_strategy.solve(
                     m_initial,
                     U_drift,

--- a/mfgarchon/backends/torch_backend.py
+++ b/mfgarchon/backends/torch_backend.py
@@ -92,7 +92,7 @@ class TorchBackend(BaseBackend):
     - MFG-specific optimized kernels
     """
 
-    def __init__(self, device: str = "auto", precision: str = "float32", **kwargs):
+    def __init__(self, device: str = "auto", precision: str = "float64", **kwargs):
         """
         Initialize PyTorch backend.
 
@@ -121,13 +121,15 @@ class TorchBackend(BaseBackend):
         self.torch_device = self._select_device(self.device)
         self.device_type = self.torch_device.type
 
-        # Set precision
+        # Set precision.
+        # Issue #1283: torch.set_default_dtype() is a process-global side effect —
+        # constructing any TorchBackend would mutate dtype for all subsequent
+        # torch.tensor() calls in the process.  Use self.torch_dtype explicitly
+        # on all tensor construction instead; never touch the global default.
         if self.precision == "float32":
             self.torch_dtype = torch.float32
-            torch.set_default_dtype(torch.float32)
         elif self.precision == "float64":
             self.torch_dtype = torch.float64
-            torch.set_default_dtype(torch.float64)
         else:
             raise ValueError(f"Unsupported precision: {self.precision}")
 

--- a/tests/unit/test_backends/test_issue_1283_backend_robustness.py
+++ b/tests/unit/test_backends/test_issue_1283_backend_robustness.py
@@ -1,0 +1,191 @@
+"""
+Pinning tests for Issue #1283 — backend robustness fixes.
+
+Three bugs:
+  (1) NumbaBackend.diff() returned size-n (derivative) instead of size-(n-1) (np.diff contract).
+  (2) HybridParticleStrategy.solve() passed constructor args to CPUParticleStrategy
+      which accepts none → TypeError on small-N and backend=None fallback paths.
+  (3) TorchBackend defaulted to float32; all other backends default to float64
+      → silent precision drift; also called torch.set_default_dtype() (process-global).
+
+Each test below FAILS on the pre-fix code and PASSES after.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# (1) NumbaBackend.diff() output length
+# ---------------------------------------------------------------------------
+
+
+def test_numba_diff_returns_n_minus_1():
+    """NumbaBackend.diff(a) must return length len(a)-1, matching np.diff contract."""
+    pytest.importorskip("numba")
+    from mfgarchon.backends.numba_backend import NumbaBackend
+
+    backend = NumbaBackend()
+    for n in (5, 10, 100):
+        a = np.arange(n, dtype=np.float64)
+        result = backend.diff(a)
+        assert len(result) == n - 1, (
+            f"NumbaBackend.diff() returned length {len(result)} for input length {n}; "
+            f"expected {n - 1} (np.diff contract). Issue #1283 fix not applied."
+        )
+
+    # Values must also match np.diff exactly
+    a = np.array([1.0, 4.0, 9.0, 16.0])
+    np.testing.assert_array_equal(
+        backend.diff(a),
+        np.diff(a),
+        err_msg="NumbaBackend.diff() values do not match np.diff(). Issue #1283.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# (2) HybridParticleStrategy small-N and backend=None paths do not raise TypeError
+# ---------------------------------------------------------------------------
+
+
+class _MockProblem:
+    """Minimal MFGProblem stand-in for strategy routing tests."""
+
+    T = 1.0
+    Nt = 5
+    Nx = 10
+    xmin = 0.0
+    xmax = 1.0
+    sigma = 0.1
+
+
+def test_hybrid_strategy_small_n_no_typeerror(monkeypatch):
+    """
+    HybridParticleStrategy.solve() with num_particles < 10000 must not raise TypeError.
+
+    Before the fix, CPUParticleStrategy(self.backend) was called, but CPUParticleStrategy
+    has no __init__ and raises TypeError: object.__init__() takes exactly one argument.
+    """
+    from mfgarchon.backends.strategies.particle_strategies import (
+        CPUParticleStrategy,
+        HybridParticleStrategy,
+    )
+
+    # Patch CPUParticleStrategy.solve so we only test the instantiation path
+    captured = {}
+
+    def _fake_solve(self, *args, **kwargs):
+        captured["called"] = True
+        return np.zeros((6, 11))  # shape (Nt+1, Nx+1)
+
+    monkeypatch.setattr(CPUParticleStrategy, "solve", _fake_solve)
+
+    strategy = HybridParticleStrategy(backend=object())  # non-None backend
+    m_initial = np.ones(11) / 11
+    U_drift = np.zeros((6, 11))
+
+    # Must not raise TypeError (pre-fix: CPUParticleStrategy(self.backend) would crash)
+    strategy.solve(
+        m_initial,
+        U_drift,
+        _MockProblem(),
+        num_particles=100,  # < 10000 → small-N path
+        kde_bandwidth="scott",
+        normalize_kde_output=True,
+        boundary_conditions=None,
+        backend=None,
+    )
+    assert captured.get("called"), "CPUParticleStrategy.solve was not called on small-N path"
+
+
+def test_hybrid_strategy_backend_none_fallback_no_typeerror(monkeypatch):
+    """
+    HybridParticleStrategy.solve() with backend=None and large N must not raise TypeError.
+
+    Before the fix, CPUParticleStrategy(None) was called on the fallback path.
+    """
+    from mfgarchon.backends.strategies.particle_strategies import (
+        CPUParticleStrategy,
+        HybridParticleStrategy,
+    )
+
+    captured = {}
+
+    def _fake_solve(self, *args, **kwargs):
+        captured["called"] = True
+        return np.zeros((6, 11))
+
+    monkeypatch.setattr(CPUParticleStrategy, "solve", _fake_solve)
+
+    strategy = HybridParticleStrategy(backend=None)  # backend=None → CPU fallback
+    m_initial = np.ones(11) / 11
+    U_drift = np.zeros((6, 11))
+
+    # Must not raise TypeError (pre-fix: CPUParticleStrategy(None) would crash)
+    strategy.solve(
+        m_initial,
+        U_drift,
+        _MockProblem(),
+        num_particles=50_000,  # ≥ 10000 → large-N path, but backend=None → CPU fallback
+        kde_bandwidth="scott",
+        normalize_kde_output=True,
+        boundary_conditions=None,
+        backend=None,
+    )
+    assert captured.get("called"), "CPUParticleStrategy.solve was not called on backend=None fallback"
+
+
+# ---------------------------------------------------------------------------
+# (3) TorchBackend default dtype is float64, no process-global side effect
+# ---------------------------------------------------------------------------
+
+
+def test_torch_backend_default_precision_is_float64():
+    """
+    TorchBackend() with no precision argument must default to float64,
+    matching numpy/jax/numba backends. Issue #1283 fix: change default from float32.
+    """
+    torch = pytest.importorskip("torch")
+    from mfgarchon.backends.torch_backend import TorchBackend
+
+    backend = TorchBackend(device="cpu")
+    assert backend.precision == "float64", (
+        f"TorchBackend default precision is '{backend.precision}', expected 'float64'. Issue #1283 fix not applied."
+    )
+    assert backend.torch_dtype == torch.float64, (
+        f"TorchBackend.torch_dtype is {backend.torch_dtype}, expected torch.float64. Issue #1283 fix not applied."
+    )
+
+
+def test_torch_backend_does_not_mutate_global_default_dtype():
+    """
+    Constructing a TorchBackend must not call torch.set_default_dtype() and
+    must not change the process-global dtype. Issue #1283 fix: remove global side effect.
+
+    The pre-fix code called torch.set_default_dtype() in _setup_backend, so constructing
+    TorchBackend(precision='float32') after the global was set to float64 would silently
+    mutate it back to float32 — observable by any subsequent torch.tensor([1.0]) call.
+    """
+    torch = pytest.importorskip("torch")
+    from mfgarchon.backends.torch_backend import TorchBackend
+
+    original_dtype = torch.get_default_dtype()
+    try:
+        # Force global to float64 so any float32 mutation is detectable
+        torch.set_default_dtype(torch.float64)
+        pre_dtype = torch.get_default_dtype()
+        assert pre_dtype == torch.float64, "setup failed: could not set global dtype to float64"
+
+        # Construct with float32 — pre-fix code would call
+        # torch.set_default_dtype(torch.float32) and mutate the global back to float32.
+        _backend = TorchBackend(device="cpu", precision="float32")
+        post_construct_dtype = torch.get_default_dtype()
+        assert post_construct_dtype == torch.float64, (
+            f"TorchBackend(precision='float32') mutated process-global dtype from float64 "
+            f"to {post_construct_dtype}. Issue #1283 fix not applied: torch.set_default_dtype() "
+            f"must not be called in _setup_backend."
+        )
+    finally:
+        torch.set_default_dtype(original_dtype)


### PR DESCRIPTION
## Summary

Three backend defects on off-paper-path code (Refs #1283):

- **(1) `NumbaBackend.diff()` returned size-n** (it delegated to `_finite_diff_1d`, a *derivative* kernel that returns `np.zeros_like(u)`, i.e. size-n). Base-class contract and all other backends (`np.diff`, `jnp.diff`) return size-(n-1). Fix: remove the wrong fast path; delegate to `np.diff` unconditionally. `_finite_diff_1d` remains for gradient computation only.

- **(2) `HybridParticleStrategy.solve()` raised `TypeError`** on both the small-N path (`CPUParticleStrategy(self.backend)`) and the `backend=None` fallback path (`CPUParticleStrategy(None)`). `CPUParticleStrategy` defines no `__init__` (inherits `object.__init__`, accepts no args). Fix: instantiate as `CPUParticleStrategy()`.

- **(3) `TorchBackend` defaulted to `float32`** while numpy/jax/numba all default to `float64`, causing silent precision drift on backend switches. `_setup_backend()` also called `torch.set_default_dtype()` — a process-global side effect that mutated dtype for all subsequent `torch.tensor()` calls in the process. Fix: change constructor default to `'float64'`; remove both `torch.set_default_dtype()` calls and rely on `self.torch_dtype` passed explicitly at each tensor construction site.

## Test plan

- [ ] All 5 pinning tests in `tests/unit/test_backends/test_issue_1283_backend_robustness.py` pass on fixed code
- [ ] All 5 pinning tests fail on pre-fix code (verified by `git stash push` + re-run)
- [ ] `ruff format` + `ruff check` clean on all changed files
- [ ] Existing test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)