### PR TITLE
fix(geometry): DifferenceDomain raises on empty navigable region (#1077 case c)

### DIFF
--- a/mfgarchon/geometry/implicit/csg_operations.py
+++ b/mfgarchon/geometry/implicit/csg_operations.py
@@ -346,6 +346,10 @@ class DifferenceDomain(IntersectionDomain):
             domain1: Base domain (what we start with)
             domain2: Domain to subtract (the "hole")
 
+        Raises:
+            ValueError: If the navigable region (domain1 \\ domain2) is empty,
+                detected by sampling domain1 and finding all points inside domain2.
+
         Example:
             >>> # Square with circular obstacle removed
             >>> square = Hyperrectangle(np.array([[0, 1], [0, 1]]))
@@ -363,6 +367,22 @@ class DifferenceDomain(IntersectionDomain):
         # Store originals for repr
         self.domain1 = domain1
         self.domain2 = domain2
+
+        # Issue #1077 (c): detect empty navigable region at construction time.
+        # Sample a small fixed-seed batch from domain1; if ALL points fall inside
+        # domain2, the navigable region has zero measure and downstream rejection
+        # sampling would exhaust attempts without finding valid points.
+        # Using seed=0 makes the check deterministic; 128 samples is cheap and
+        # sufficient for the common case of an obstacle covering the entire base domain.
+        _n_check = 128
+        _check_pts = domain1.sample_uniform(_n_check, seed=0)
+        if np.all(domain2.contains(_check_pts)):
+            raise ValueError(
+                f"DifferenceDomain navigable region is empty: {_n_check} uniform "
+                "samples from the base domain are all inside the subtracted domain; "
+                "domain1 \\ domain2 has zero measure. "
+                "Issue #1077."
+            )
 
     def __repr__(self) -> str:
         """String representation."""

--- a/tests/unit/test_geometry/test_geometry.py
+++ b/tests/unit/test_geometry/test_geometry.py
@@ -378,6 +378,23 @@ class TestCSGOperations:
         # Verify all particles in base domain
         assert np.all((particles >= 0) & (particles <= 1))
 
+    def test_difference_domain_empty_raises(self):
+        """Issue #1077 (c): DifferenceDomain with empty navigable region must fail fast.
+
+        Previously constructed silently; rejection sampling downstream would then
+        exhaust all attempts and raise RuntimeError after wasted work.
+        """
+        # Case 1: rectangular obstacle larger than base domain
+        base = Hyperrectangle(np.array([[0.0, 1.0], [0.0, 1.0]]))
+        obstacle_rect = Hyperrectangle(np.array([[-0.5, 1.5], [-0.5, 1.5]]))
+        with pytest.raises(ValueError, match="empty"):
+            DifferenceDomain(base, obstacle_rect)
+
+        # Case 2: spherical obstacle covering the entire base domain
+        obstacle_sphere = Hypersphere(center=[0.5, 0.5], radius=2.0)
+        with pytest.raises(ValueError, match="empty"):
+            DifferenceDomain(base, obstacle_sphere)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `DifferenceDomain.__init__` now samples 128 seed-0 points from the base domain and raises `ValueError` (greppable: `"navigable region is empty"` + `"Issue #1077"`) if every sampled point is inside the subtracted domain.
- Previously the object constructed silently; the first `sample_uniform` call downstream then exhausted all rejection-sampling attempts and raised a generic `RuntimeError`.
- Pinning test `TestCSGOperations::test_difference_domain_empty_raises` covers both a rectangular and a spherical obstacle that each cover the entire base domain.

## Decision log for all three #1077 cases assigned to this wave

| Case | Action |
|---|---|
| (b) Hypersphere non-finite radius | Already fixed (commit `8ad4116e`, PR #1163); test `test_radius_must_be_positive_and_finite` passes on main. |
| (a) `sigma=0` | Leave unchanged — deterministic problems store `self.sigma = 0.0` legitimately; a blanket guard breaks reconstruction. PR #1287 already guards specific ADI paths that break on zero diffusion. |
| (c) Empty `DifferenceDomain` | **This PR.** Monte Carlo check (128 seed-0 samples from `domain1`): if all are inside `domain2`, raise immediately. |

## Test plan

- [x] `test_difference_domain_empty_raises` FAILS on unpatched code (`DID NOT RAISE`), PASSES with fix
- [x] All 26 existing geometry tests still pass
- [x] `ruff format` + `ruff check` clean

Refs #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)