### PR TITLE
fix: hoist M_initial/U_terminal before warm/cold branch in FP and FictitiousPlay iterators

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -323,6 +323,12 @@ class FictitiousPlayIterator(BaseCouplingIterator):
         grid_spacing = self.problem.geometry.get_grid_spacing()[0]
         time_step = self.problem.dt
 
+        # Issue #1285: M_initial / U_terminal are needed by both the warm-start
+        # and cold-start paths (HJB solve, FP solve, BC preservation).  Hoist
+        # unconditionally so the warm-start branch does not hit NameError.
+        # BlockIterator does the same (block_iterators.py:485).
+        M_initial, U_terminal = self._get_initial_and_terminal_conditions(shape)
+
         # Initialize arrays (cold start or warm start)
         warm_start = self.get_warm_start_data()
         if warm_start is not None:
@@ -335,10 +341,6 @@ class FictitiousPlayIterator(BaseCouplingIterator):
             else:
                 self.U = np.zeros((num_time_steps, *shape))
                 self.M = np.zeros((num_time_steps, *shape))
-
-            # Get initial density and terminal condition
-            # Issue #543 Phase 2: Use centralized helper (eliminates 8 hasattr checks)
-            M_initial, U_terminal = self._get_initial_and_terminal_conditions(shape)
 
             if num_time_steps > 0:
                 if len(shape) == 1:

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -589,6 +589,12 @@ class FixedPointIterator(BaseCouplingIterator):
             )
         time_step = self.problem.dt
 
+        # Issue #1285: M_initial / U_terminal are needed by both the warm-start
+        # and cold-start paths (HJB solve, FP solve, BC preservation).  Hoist
+        # unconditionally so the warm-start branch does not hit NameError.
+        # BlockIterator does the same (block_iterators.py:485).
+        M_initial, U_terminal = self._get_initial_and_terminal_conditions(shape)
+
         # Initialize arrays (cold start or warm start)
         warm_start = self.get_warm_start_data()
         if warm_start is not None:
@@ -601,10 +607,6 @@ class FixedPointIterator(BaseCouplingIterator):
             else:
                 self.U = np.zeros((num_time_steps, *shape))
                 self.M = np.zeros((num_time_steps, *shape))
-
-            # Get initial density and terminal condition
-            # Issue #543 Phase 2: Use centralized helper (eliminates 8 hasattr checks)
-            M_initial, U_terminal = self._get_initial_and_terminal_conditions(shape)
 
             if num_time_steps > 0:
                 # Set boundary conditions
@@ -656,8 +658,6 @@ class FixedPointIterator(BaseCouplingIterator):
         # Main fixed-point iteration loop
         converged = False
         convergence_reason = "Maximum iterations reached"
-        # M_initial already computed above
-
         # Hierarchical progress for Picard iterations (Issue #614)
         from mfgarchon.utils.progress import HierarchicalProgress
 

--- a/tests/integration/test_warm_start_nameerror_1285.py
+++ b/tests/integration/test_warm_start_nameerror_1285.py
@@ -1,0 +1,121 @@
+"""
+Pinning test for Issue #1285 (warm-start NameError sub-bug).
+
+FixedPointIterator.solve() and FictitiousPlayIterator.solve() defined
+M_initial / U_terminal only inside the cold-start else-branch.  On the
+warm-start path both names were referenced but never defined -> NameError.
+
+The fix hoists _get_initial_and_terminal_conditions() unconditionally before
+the warm/cold branch (mirrors BlockIterator, which was already correct).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling import FictitiousPlayIterator, FixedPointIterator
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _make_problem() -> MFGProblem:
+    """Minimal 1D MFG problem with Gaussian initial density."""
+    geometry = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx_points=[11],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    components = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    return MFGProblem(
+        geometry=geometry,
+        T=0.2,
+        Nt=4,
+        sigma=0.2,
+        components=components,
+    )
+
+
+def _warm_arrays(problem: MFGProblem) -> tuple[np.ndarray, np.ndarray]:
+    """Return trivial warm-start arrays of the right shape."""
+    shape = tuple(problem.geometry.get_grid_shape())
+    Nt1 = problem.Nt + 1
+    U_warm = np.zeros((Nt1, *shape))
+    M_warm = np.ones((Nt1, *shape)) / np.prod(shape)
+    return U_warm, M_warm
+
+
+class TestWarmStartNameError1285:
+    """Issue #1285: warm-start path must not raise NameError."""
+
+    def test_fixed_point_iterator_warm_start(self):
+        """FixedPointIterator.solve() must complete without NameError on warm path."""
+        problem = _make_problem()
+        hjb = HJBFDMSolver(problem)
+        fp = FPFDMSolver(problem)
+
+        solver = FixedPointIterator(problem, hjb, fp, relaxation=0.5)
+        U_warm, M_warm = _warm_arrays(problem)
+        solver.set_warm_start_data(U_warm, M_warm)
+
+        # Must not raise NameError; 2 iterations is sufficient to exercise the path.
+        result = solver.solve(max_iterations=2, tolerance=1e-10)
+        assert result.U is not None
+        assert result.M is not None
+        assert result.U.shape[0] == problem.Nt + 1
+        assert result.M.shape[0] == problem.Nt + 1
+        assert np.all(np.isfinite(result.U))
+        assert np.all(np.isfinite(result.M))
+
+    def test_fictitious_play_iterator_warm_start(self):
+        """FictitiousPlayIterator.solve() must complete without NameError on warm path."""
+        problem = _make_problem()
+        hjb = HJBFDMSolver(problem)
+        fp = FPFDMSolver(problem)
+
+        solver = FictitiousPlayIterator(problem, hjb, fp, learning_rate_schedule="harmonic")
+        U_warm, M_warm = _warm_arrays(problem)
+        solver.set_warm_start_data(U_warm, M_warm)
+
+        # Must not raise NameError; 2 iterations is sufficient to exercise the path.
+        result = solver.solve(max_iterations=2, tolerance=1e-10)
+        assert result.U is not None
+        assert result.M is not None
+        assert result.U.shape[0] == problem.Nt + 1
+        assert result.M.shape[0] == problem.Nt + 1
+        assert np.all(np.isfinite(result.U))
+        assert np.all(np.isfinite(result.M))
+
+    def test_cold_start_still_works_fixed_point(self):
+        """Cold-start path must be unaffected by the hoist."""
+        problem = _make_problem()
+        hjb = HJBFDMSolver(problem)
+        fp = FPFDMSolver(problem)
+
+        solver = FixedPointIterator(problem, hjb, fp, relaxation=0.5)
+        result = solver.solve(max_iterations=3, tolerance=1e-10)
+        assert result.U is not None
+        assert np.all(np.isfinite(result.U))
+
+    def test_cold_start_still_works_fictitious_play(self):
+        """Cold-start path must be unaffected by the hoist."""
+        problem = _make_problem()
+        hjb = HJBFDMSolver(problem)
+        fp = FPFDMSolver(problem)
+
+        solver = FictitiousPlayIterator(problem, hjb, fp)
+        result = solver.solve(max_iterations=3, tolerance=1e-10)
+        assert result.U is not None
+        assert np.all(np.isfinite(result.U))


### PR DESCRIPTION
## Summary

- `FixedPointIterator.solve()` and `FictitiousPlayIterator.solve()` defined `M_initial` / `U_terminal` only inside the cold-start `else`-branch.
- Any call via `set_warm_start_data()` + `solve()` skipped that branch and hit `UnboundLocalError` on the first HJB or FP solve — a broken advertised feature.
- Fix: hoist `_get_initial_and_terminal_conditions(shape)` unconditionally before the warm/cold branch in both iterators, mirroring the pattern already used by `BlockIterator` (`block_iterators.py:485`).

## Test plan

- [ ] `test_fixed_point_iterator_warm_start` — passes warm arrays, confirms no `NameError`, result is finite
- [ ] `test_fictitious_play_iterator_warm_start` — same for `FictitiousPlayIterator`
- [ ] `test_cold_start_still_works_fixed_point` — cold-start path unaffected
- [ ] `test_cold_start_still_works_fictitious_play` — cold-start path unaffected

All 4 pass after fix; first 2 fail with `UnboundLocalError` on current main.

Refs #1285 (this closes the warm-start sub-bug; the Newton source-term wiring and `lions_correction` time-slice items remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)