### PR TITLE
refactor: migrate remaining FP sigma**2/2 sites to diffusion_from_volatility (Issue #1189 + Refs #1193)

### DIFF
--- a/mfgarchon/alg/neural/pinn_solvers/fp_pinn_solver.py
+++ b/mfgarchon/alg/neural/pinn_solvers/fp_pinn_solver.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 import numpy as np
 
 from mfgarchon.alg.neural.nn import create_mfg_networks
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch
 
 from .base_pinn import PINNBase, PINNConfig
 
@@ -285,8 +286,8 @@ class FPPINNSolver(PINNBase):
         # Divergence term: div(m * b) = b * ∂m/∂x + m * ∂b/∂x
         divergence_term = drift * m_x + m * drift_x
 
-        # Diffusion term: (σ²/2) * Δm = (σ²/2) * ∂²m/∂x²
-        diffusion_term = (self.sigma**2 / 2) * m_xx
+        # Diffusion term: D * Δm  where D = σ²/2 (Issue #1189: route through single source)
+        diffusion_term = diffusion_from_volatility_torch(self.sigma) * m_xx
 
         # FP equation residual: ∂m/∂t - div(m*b) - (σ²/2)Δm = 0
         fp_residual = m_t - divergence_term - diffusion_term
@@ -392,8 +393,8 @@ class FPPINNSolver(PINNBase):
         u_x = self.get_value_function_gradient(t, x)
         drift = self.compute_drift(u_x, x, m)
 
-        # No-flux condition: j = m*b + (σ²/2)*∂m/∂x = 0
-        flux = m * drift + (self.sigma**2 / 2) * m_x
+        # No-flux condition: j = m*b + D*∂m/∂x = 0  where D = σ²/2 (Issue #1189)
+        flux = m * drift + diffusion_from_volatility_torch(self.sigma) * m_x
 
         boundary_loss = torch.mean(flux**2)
 

--- a/mfgarchon/alg/neural/pinn_solvers/mfg_pinn_solver.py
+++ b/mfgarchon/alg/neural/pinn_solvers/mfg_pinn_solver.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 import numpy as np
 
 from mfgarchon.alg.neural.nn import create_mfg_networks
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch
 
 from .base_pinn import PINNBase, PINNConfig
 
@@ -293,9 +294,9 @@ class MFGPINNSolver(PINNBase):
         # Compute Hamiltonian
         H = self.compute_hamiltonian(u_x, x, m)
 
-        # Viscous term: (sigma^2/2)*u_xx — Issue #1281 fix (2026-06-11 survey)
-        # Convention mirrors FP: fp_residual subtracts (sigma^2/2)*m_xx.
-        viscous_term = (self.sigma**2 / 2) * u_xx
+        # Viscous term: D*u_xx where D = sigma^2/2 — Issue #1281 fix (2026-06-11 survey)
+        # Convention mirrors FP: fp_residual subtracts D*m_xx. Issue #1189: route through D.
+        viscous_term = diffusion_from_volatility_torch(self.sigma) * u_xx
 
         # HJB residual: du/dt + H(grad_u, x, m) - (sigma^2/2)*u_xx = 0
         hjb_residual = u_t + H - viscous_term
@@ -328,8 +329,8 @@ class MFGPINNSolver(PINNBase):
         # Divergence: div(m * b) = b * ∂m/∂x + m * ∂b/∂x
         divergence_term = drift * m_x + m * drift_x
 
-        # Diffusion term
-        diffusion_term = (self.sigma**2 / 2) * m_xx
+        # Diffusion term: D*m_xx where D = sigma^2/2 (Issue #1189: route through D)
+        diffusion_term = diffusion_from_volatility_torch(self.sigma) * m_xx
 
         # FP residual: ∂m/∂t - div(m*b) - (σ²/2)Δm = 0
         fp_residual = m_t - divergence_term - diffusion_term
@@ -399,8 +400,8 @@ class MFGPINNSolver(PINNBase):
         _, m_x, _ = self.compute_derivatives_m(t, x)
         _, u_x_boundary, _u_xx_boundary = self.compute_derivatives_u(t, x)
 
-        # No-flux: m*(-u_x) + (sigma^2/2)*dm/dx = 0
-        flux = m * (-u_x_boundary) + (self.sigma**2 / 2) * m_x
+        # No-flux: m*(-u_x) + D*dm/dx = 0  where D = sigma^2/2 (Issue #1189)
+        flux = m * (-u_x_boundary) + diffusion_from_volatility_torch(self.sigma) * m_x
         m_boundary_loss = torch.mean(flux**2)
 
         return u_boundary_loss + m_boundary_loss

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_centered.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_centered.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -96,6 +98,9 @@ def add_interior_entries_gradient_centered(
     # Diagonal term (accumulates contributions from all dimensions)
     diagonal_value = 1.0 / dt
 
+    # Diffusion coefficient D = sigma^2/2 (Issue #1189: single source)
+    D = diffusion_from_volatility(sigma)
+
     # Check for periodic BC
     # Issue #543 Phase 2: Replace hasattr with try/except
     try:
@@ -142,12 +147,12 @@ def add_interior_entries_gradient_centered(
         velocity_d = -coupling_coefficient * (u_plus - u_minus) / (2 * dx)
 
         # Diffusion contribution (centered differences) - same as upwind
-        # -σ²/(2dx²) * (m_{i+1} - 2m_i + m_{i-1})
-        diagonal_value += sigma**2 / dx_sq
+        # -D * (m_{i+1} - 2m_i + m_{i-1}) / dx^2  where D = sigma^2/2
+        diagonal_value += 2 * D / dx_sq
 
         if has_plus or is_periodic:
-            # Diffusion: coupling to m_{i+1}
-            coeff_plus = -(sigma**2) / (2 * dx_sq)
+            # Diffusion: coupling to m_{i+1}: -D/dx^2
+            coeff_plus = -D / dx_sq
 
             # Advection (CENTERED): v * (m_{i+1} - m_{i-1}) / (2dx)
             # Contribution to m_{i+1}: v / (2dx)
@@ -158,8 +163,8 @@ def add_interior_entries_gradient_centered(
             data_values.append(coeff_plus)
 
         if has_minus or is_periodic:
-            # Diffusion: coupling to m_{i-1}
-            coeff_minus = -(sigma**2) / (2 * dx_sq)
+            # Diffusion: coupling to m_{i-1}: -D/dx^2
+            coeff_minus = -D / dx_sq
 
             # Advection (CENTERED): v * (m_{i+1} - m_{i-1}) / (2dx)
             # Contribution to m_{i-1}: -v / (2dx)
@@ -201,6 +206,9 @@ def add_boundary_no_flux_entries_gradient_centered(
     # Diagonal term
     diagonal_value = 1.0 / dt
 
+    # Diffusion coefficient D = sigma^2/2 (Issue #1189: single source)
+    D = diffusion_from_volatility(sigma)
+
     for d in range(ndim):
         dx = spacing[d]
         dx_sq = dx * dx
@@ -220,9 +228,9 @@ def add_boundary_no_flux_entries_gradient_centered(
 
                 # Diffusion: Neumann BC via ghost point reflection
                 # No-flux: dm/dx = 0 → m_{-1} = m_1, so Laplacian = 2(m_1 - m_0)/dx²
-                # Issue #668 fix: coefficient is σ²/dx², not σ²/(2*dx²)
-                diagonal_value += sigma**2 / dx_sq
-                coeff_plus = -(sigma**2) / dx_sq
+                # Coefficient is 2D/dx² = σ²/dx² (Issue #668 fix; Issue #1189: route through D)
+                diagonal_value += 2 * D / dx_sq
+                coeff_plus = -2 * D / dx_sq
 
                 row_indices.append(flat_idx)
                 col_indices.append(flat_idx_plus)
@@ -236,9 +244,9 @@ def add_boundary_no_flux_entries_gradient_centered(
 
                 # Diffusion: Neumann BC via ghost point reflection
                 # No-flux: dm/dx = 0 → m_{N+1} = m_{N-1}, so Laplacian = 2(m_{N-1} - m_N)/dx²
-                # Issue #668 fix: coefficient is σ²/dx², not σ²/(2*dx²)
-                diagonal_value += sigma**2 / dx_sq
-                coeff_minus = -(sigma**2) / dx_sq
+                # Coefficient is 2D/dx² = σ²/dx² (Issue #668 fix; Issue #1189: route through D)
+                diagonal_value += 2 * D / dx_sq
+                coeff_minus = -2 * D / dx_sq
 
                 row_indices.append(flat_idx)
                 col_indices.append(flat_idx_minus)
@@ -258,11 +266,11 @@ def add_boundary_no_flux_entries_gradient_centered(
 
             velocity_d = -coupling_coefficient * (u_plus - u_minus) / (2 * dx)
 
-            # Diffusion
-            diagonal_value += sigma**2 / dx_sq
+            # Diffusion: -D * (m_{i+1} - 2m_i + m_{i-1}) / dx^2  where D = sigma^2/2
+            diagonal_value += 2 * D / dx_sq
 
-            coeff_plus = -(sigma**2) / (2 * dx_sq) + velocity_d / (2 * dx)
-            coeff_minus = -(sigma**2) / (2 * dx_sq) - velocity_d / (2 * dx)
+            coeff_plus = -D / dx_sq + velocity_d / (2 * dx)
+            coeff_minus = -D / dx_sq - velocity_d / (2 * dx)
 
             row_indices.append(flat_idx)
             col_indices.append(flat_idx_plus)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
@@ -110,6 +110,9 @@ def add_interior_entries_gradient_upwind(
     # Diagonal term (accumulates contributions from all dimensions)
     diagonal_value = 1.0 / dt
 
+    # Diffusion coefficient D = sigma^2/2 (Issue #1189: single source)
+    D = diffusion_from_volatility(sigma)
+
     # For each dimension, add advection + diffusion contributions
     for d in range(ndim):
         dx = spacing[d]
@@ -153,12 +156,12 @@ def add_interior_entries_gradient_upwind(
         u_center = u_flat[flat_idx]
 
         # Diffusion contribution (centered differences)
-        # -σ²/(2dx²) * (m_{i+1} - 2m_i + m_{i-1})
-        diagonal_value += sigma**2 / dx_sq
+        # -D * (m_{i+1} - 2m_i + m_{i-1}) / dx^2  where D = sigma^2/2
+        diagonal_value += 2 * D / dx_sq
 
         if has_plus or is_periodic:
-            # Coupling to m_{i+1,j}
-            coeff_plus = -(sigma**2) / (2 * dx_sq)
+            # Coupling to m_{i+1,j}: diffusion -D/dx^2
+            coeff_plus = -D / dx_sq
 
             # Add advection upwind term
             # For advection: -d/dx(m*v) where v = -coupling_coefficient * dU/dx
@@ -173,8 +176,8 @@ def add_interior_entries_gradient_upwind(
             diagonal_value += float(coupling_coefficient * ppart(u_plus - u_center) / dx_sq)
 
         if has_minus or is_periodic:
-            # Coupling to m_{i-1,j}
-            coeff_minus = -(sigma**2) / (2 * dx_sq)
+            # Coupling to m_{i-1,j}: diffusion -D/dx^2
+            coeff_minus = -D / dx_sq
 
             # Add advection upwind term
             # Upwind: use npart for negative velocity contribution
@@ -251,13 +254,13 @@ def add_boundary_no_flux_entries_gradient_upwind(
             u_minus = u_flat[flat_idx_minus]
             u_center = u_flat[flat_idx]
 
-            # Diffusion: D*(m_{i+1} - 2m_i + m_{i-1}) / dx²
-            diagonal_value += sigma**2 / dx_sq
+            # Diffusion: -D*(m_{i+1} - 2m_i + m_{i-1}) / dx^2  where D = sigma^2/2
+            diagonal_value += 2 * D / dx_sq
 
-            coeff_plus = -(sigma**2) / (2 * dx_sq)
+            coeff_plus = -D / dx_sq
             coeff_plus += float(-coupling_coefficient * ppart(u_plus - u_center) / dx_sq)
 
-            coeff_minus = -(sigma**2) / (2 * dx_sq)
+            coeff_minus = -D / dx_sq
             coeff_minus += float(-coupling_coefficient * npart(u_center - u_minus) / dx_sq)
 
             row_indices.append(flat_idx)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_bc.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_bc.py
@@ -97,13 +97,13 @@ def add_boundary_no_flux_entries(
             u_minus = u_flat[flat_idx_minus]
             u_center = u_flat[flat_idx]
 
-            # Diffusion: D*(m_{i+1} - 2m_i + m_{i-1}) / dx^2
-            diagonal_value += sigma**2 / dx_sq
+            # Diffusion: -D*(m_{i+1} - 2m_i + m_{i-1}) / dx^2  where D = sigma^2/2
+            diagonal_value += 2 * D / dx_sq
 
-            coeff_plus = -(sigma**2) / (2 * dx_sq)
+            coeff_plus = -D / dx_sq
             coeff_plus += float(-coupling_coefficient * ppart(u_plus - u_center) / dx_sq)
 
-            coeff_minus = -(sigma**2) / (2 * dx_sq)
+            coeff_minus = -D / dx_sq
             coeff_minus += float(-coupling_coefficient * npart(u_center - u_minus) / dx_sq)
 
             row_indices.append(flat_idx)

--- a/mfgarchon/backends/torch_backend.py
+++ b/mfgarchon/backends/torch_backend.py
@@ -18,6 +18,7 @@ from typing import Any
 import numpy as np
 
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch
 
 from .base_backend import BaseBackend
 
@@ -448,11 +449,11 @@ class TorchBackend(BaseBackend):
         flux = M_tensor * drift
         div_term = torch.gradient(flux, spacing=dx, dim=-1)[0]
 
-        # Compute diffusion term: (σ²/2) * d²M/dx²
+        # Compute diffusion term: D * d²M/dx²  where D = σ²/2 (Issue #1189: route through D)
         sigma = problem_params.get("diffusion", 0.1)
         M_grad = torch.gradient(M_tensor, spacing=dx, dim=-1)[0]
         M_grad2 = torch.gradient(M_grad, spacing=dx, dim=-1)[0]
-        diffusion_term = 0.5 * sigma**2 * M_grad2
+        diffusion_term = diffusion_from_volatility_torch(sigma) * M_grad2
 
         # Forward Euler step: M^{n+1} = M^n + dt * (div_term + diffusion_term)
         M_new = M_tensor + dt * (div_term + diffusion_term)

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -74,6 +74,35 @@ def diffusion_from_volatility(
     raise ValueError(f"kind must be 'field' or 'tensor' (or None for scalar sigma), got {kind!r}.")
 
 
+def diffusion_from_volatility_torch(sigma: Any) -> Any:
+    r"""Canonical PDE diffusion coefficient ``D`` from SDE volatility ``sigma`` for torch tensors.
+
+    Mirrors the scalar contract of :func:`diffusion_from_volatility` (``D = 0.5 * sigma**2``)
+    but accepts any numeric type — plain Python floats, NumPy scalars, and PyTorch tensors —
+    preserving the autograd computation graph when ``sigma`` is a ``torch.Tensor``.
+
+    Issue #1189/#1193: single source of the sigma->D conversion for torch-based solvers
+    (PINNs, torch_backend).  A pure Python implementation (no explicit torch import) so this
+    module stays importable when PyTorch is absent; torch tensors are handled transparently
+    because ``*`` and ``**`` dispatch to tensor ops automatically.
+
+    :math:`D = \frac{1}{2}\sigma^2` — byte-identical to ``0.5 * sigma**2`` for all
+    IEEE-754 double-precision normal floats; the constant 0.5 is exactly representable,
+    so ``0.5 * x`` and ``x / 2`` coincide at the bit level.
+
+    Parameters
+    ----------
+    sigma : float, numpy scalar, or torch.Tensor
+        Volatility coefficient (SDE noise amplitude).
+
+    Returns
+    -------
+    Same type as input (float, numpy scalar, or torch.Tensor)
+        Diffusion coefficient ``D = 0.5 * sigma**2``.
+    """
+    return 0.5 * sigma**2
+
+
 def scalar_diffusion_from_volatility(volatility_field: Any, fallback_sigma: Any) -> float:
     """Single scalar PDE diffusion ``D`` for solvers that assemble ``D * K`` with a scalar ``D``
     (the weak-form / FEM family).

--- a/tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py
+++ b/tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py
@@ -1,0 +1,374 @@
+"""Pinning test for Issue #1189: sigma->D migration in FP matrix-assembly files.
+
+Verifies byte-identity (np.testing.assert_array_equal) between the original
+inline sigma**2 arithmetic and the canonical diffusion_from_volatility(sigma)
+at each migrated site.
+
+Run BEFORE the refactor: assertions against the ORIGINAL patterns pass.
+Run AFTER the refactor: assertions against the MIGRATED patterns pass.
+
+The structural invariant being tested: for every sigma and dx pair,
+    sigma**2 / (2 * dx**2)   ==  diffusion_from_volatility(sigma) / dx**2
+    sigma**2 / dx**2          ==  2 * diffusion_from_volatility(sigma) / dx**2
+    sigma**2 / dx**2          ==  2 * diffusion_from_volatility(sigma) / dx**2
+
+These are exact IEEE-754 equalities (0.5*x**2 is the same bit pattern as
+x**2/2 due to IEEE multiply-by-0.5 == right-shift-exponent for normal floats).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+import numpy.testing as npt
+
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+# ---------------------------------------------------------------------------
+# Equivalence proofs (dtype-independent, representative sigma/dx values)
+# ---------------------------------------------------------------------------
+
+SIGMA_VALUES = [0.1, 0.2, 0.5, 1.0, 2.0]
+DX_VALUES = [0.01, 0.05, 0.1, 0.5]
+
+
+@pytest.mark.parametrize("sigma", SIGMA_VALUES)
+@pytest.mark.parametrize("dx", DX_VALUES)
+def test_half_sigma_sq_over_dxsq_equals_D_over_dxsq(sigma, dx):
+    """sigma**2/(2*dx**2) == diffusion_from_volatility(sigma)/dx**2.
+
+    This is the core identity for off-diagonal Laplacian coefficients:
+        coeff = -(sigma**2) / (2 * dx**2)   [original]
+              = -D / dx**2                   [refactored]
+    """
+    dx_sq = dx * dx
+    original = sigma**2 / (2 * dx_sq)
+    D = diffusion_from_volatility(sigma)
+    refactored = D / dx_sq
+    npt.assert_array_equal(
+        original,
+        refactored,
+        err_msg=f"sigma={sigma}, dx={dx}: sigma**2/(2*dx**2) != D/dx**2",
+    )
+
+
+@pytest.mark.parametrize("sigma", SIGMA_VALUES)
+@pytest.mark.parametrize("dx", DX_VALUES)
+def test_sigma_sq_over_dxsq_equals_2D_over_dxsq(sigma, dx):
+    """sigma**2/dx**2 == 2*diffusion_from_volatility(sigma)/dx**2.
+
+    This is the identity for diagonal Laplacian coefficients (sum of off-diagonals
+    with both neighbors present, or the ghost-point-reflected boundary term):
+        diagonal += sigma**2 / dx**2   [original]
+                  = 2 * D / dx**2      [refactored]
+    """
+    dx_sq = dx * dx
+    original = sigma**2 / dx_sq
+    D = diffusion_from_volatility(sigma)
+    refactored = 2 * D / dx_sq
+    npt.assert_array_equal(
+        original,
+        refactored,
+        err_msg=f"sigma={sigma}, dx={dx}: sigma**2/dx**2 != 2*D/dx**2",
+    )
+
+
+@pytest.mark.parametrize("sigma", SIGMA_VALUES)
+@pytest.mark.parametrize("dx", DX_VALUES)
+def test_sigma_sq_over_dxsq_equals_negative_2D_boundary(sigma, dx):
+    """-(sigma**2)/dx**2 == -2*diffusion_from_volatility(sigma)/dx**2.
+
+    Ghost-point boundary off-diagonal coefficient (Issue #668 fix pattern):
+        coeff = -(sigma**2) / dx**2   [original]
+              = -2 * D / dx**2        [refactored]
+    """
+    dx_sq = dx * dx
+    original = -(sigma**2) / dx_sq
+    D = diffusion_from_volatility(sigma)
+    refactored = -2 * D / dx_sq
+    npt.assert_array_equal(
+        original,
+        refactored,
+        err_msg=f"sigma={sigma}, dx={dx}: -(sigma**2)/dx**2 != -2*D/dx**2",
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end matrix coefficient tests (validate actual matrix entries)
+# ---------------------------------------------------------------------------
+
+
+class _FakeGrid:
+    """Minimal grid stub for testing matrix-assembly functions."""
+
+    def __init__(self, shape):
+        self.shape = shape
+        self._ndim = len(shape)
+
+    def get_index(self, multi_idx):
+        """Flatten multi-index to flat index (C order)."""
+        flat = 0
+        stride = 1
+        for d in reversed(range(self._ndim)):
+            flat += multi_idx[d] * stride
+            stride *= self.shape[d]
+        return flat
+
+
+class _FakeBC:
+    """Minimal BC stub (non-periodic, non-uniform)."""
+
+    is_uniform = False
+    type = "neumann"
+
+
+def _run_gradient_centered_interior(sigma, dx, dt=0.01, coupling=1.0):
+    """Call add_interior_entries_gradient_centered and return matrix triplets."""
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_alg_gradient_centered import (
+        add_interior_entries_gradient_centered,
+    )
+
+    N = 5
+    shape = (N,)
+    grid = _FakeGrid(shape)
+    # Interior point (not at boundary)
+    flat_idx = 2
+    multi_idx = (2,)
+    u_flat = np.zeros(N)
+    spacing = (dx,)
+
+    row_indices, col_indices, data_values = [], [], []
+    add_interior_entries_gradient_centered(
+        row_indices=row_indices,
+        col_indices=col_indices,
+        data_values=data_values,
+        flat_idx=flat_idx,
+        multi_idx=multi_idx,
+        shape=shape,
+        ndim=1,
+        dt=dt,
+        sigma=sigma,
+        coupling_coefficient=coupling,
+        spacing=spacing,
+        u_flat=u_flat,
+        grid=grid,
+        boundary_conditions=_FakeBC(),
+    )
+    return dict(zip(col_indices, data_values, strict=True))
+
+
+def _run_gradient_upwind_interior(sigma, dx, dt=0.01, coupling=1.0):
+    """Call add_interior_entries_gradient_upwind and return matrix triplets."""
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_alg_gradient_upwind import (
+        add_interior_entries_gradient_upwind,
+    )
+
+    N = 5
+    shape = (N,)
+    grid = _FakeGrid(shape)
+    flat_idx = 2
+    multi_idx = (2,)
+    u_flat = np.zeros(N)
+    spacing = (dx,)
+
+    row_indices, col_indices, data_values = [], [], []
+    add_interior_entries_gradient_upwind(
+        row_indices=row_indices,
+        col_indices=col_indices,
+        data_values=data_values,
+        flat_idx=flat_idx,
+        multi_idx=multi_idx,
+        shape=shape,
+        ndim=1,
+        dt=dt,
+        sigma=sigma,
+        coupling_coefficient=coupling,
+        spacing=spacing,
+        u_flat=u_flat,
+        grid=grid,
+        boundary_conditions=_FakeBC(),
+    )
+    return dict(zip(col_indices, data_values, strict=True))
+
+
+def _run_bc_no_flux_interior(sigma, dx, dt=0.01, coupling=1.0):
+    """Call add_boundary_no_flux_entries with a point at corner(boundary in d=0,interior in d=1 if 2D).
+    For 1D, test the interior-in-d branch by passing a 1D point at index (1,) — boundary only in ndim=1D
+    means all points are potentially boundary, so we use a 2D grid and test a corner point
+    that is interior in the y-dimension.
+    """
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_bc import add_boundary_no_flux_entries
+
+    Nx, Ny = 5, 5
+    shape = (Nx, Ny)
+    grid = _FakeGrid(shape)
+    # Point at (0, 2): at_lower_boundary in d=0, interior in d=1
+    flat_idx = grid.get_index((0, 2))
+    multi_idx = (0, 2)
+    u_flat = np.zeros(Nx * Ny)
+    spacing = (dx, dx)
+
+    row_indices, col_indices, data_values = [], [], []
+    add_boundary_no_flux_entries(
+        row_indices=row_indices,
+        col_indices=col_indices,
+        data_values=data_values,
+        flat_idx=flat_idx,
+        multi_idx=multi_idx,
+        shape=shape,
+        ndim=2,
+        dt=dt,
+        sigma=sigma,
+        coupling_coefficient=coupling,
+        spacing=spacing,
+        u_flat=u_flat,
+        grid=grid,
+    )
+    return dict(zip(col_indices, data_values, strict=True))
+
+
+@pytest.mark.parametrize("sigma", [0.1, 0.3, 0.5])
+@pytest.mark.parametrize("dx", [0.05, 0.1])
+def test_gradient_centered_interior_diagonal_coefficient(sigma, dx):
+    """Diagonal of the interior stencil = 1/dt + 2*D/dx^2 (Issue #1189)."""
+    dt = 0.01
+    entries = _run_gradient_centered_interior(sigma, dx, dt=dt)
+    flat_idx = 2
+    diagonal = entries[flat_idx]
+    D = diffusion_from_volatility(sigma)
+    expected_diag = 1.0 / dt + 2 * D / dx**2
+    npt.assert_allclose(
+        diagonal,
+        expected_diag,
+        rtol=1e-12,
+        err_msg=f"sigma={sigma}, dx={dx}: centered interior diagonal mismatch",
+    )
+
+
+@pytest.mark.parametrize("sigma", [0.1, 0.3, 0.5])
+@pytest.mark.parametrize("dx", [0.05, 0.1])
+def test_gradient_centered_interior_offdiagonal_coefficient(sigma, dx):
+    """Off-diagonal of the interior stencil (zero drift) = -D/dx^2 (Issue #1189)."""
+    dt = 0.01
+    entries = _run_gradient_centered_interior(sigma, dx, dt=dt)
+    D = diffusion_from_volatility(sigma)
+    # With zero U field, off-diagonals are exactly -D/dx^2
+    for idx in [1, 3]:  # neighbors of flat_idx=2
+        npt.assert_allclose(
+            entries[idx],
+            -D / dx**2,
+            rtol=1e-12,
+            err_msg=f"sigma={sigma}, dx={dx}: centered off-diagonal mismatch at col {idx}",
+        )
+
+
+@pytest.mark.parametrize("sigma", [0.1, 0.3, 0.5])
+@pytest.mark.parametrize("dx", [0.05, 0.1])
+def test_gradient_upwind_interior_diagonal_coefficient(sigma, dx):
+    """Diagonal of the upwind interior stencil = 1/dt + 2*D/dx^2 (Issue #1189)."""
+    dt = 0.01
+    entries = _run_gradient_upwind_interior(sigma, dx, dt=dt)
+    flat_idx = 2
+    diagonal = entries[flat_idx]
+    D = diffusion_from_volatility(sigma)
+    expected_diag = 1.0 / dt + 2 * D / dx**2
+    npt.assert_allclose(
+        diagonal,
+        expected_diag,
+        rtol=1e-12,
+        err_msg=f"sigma={sigma}, dx={dx}: upwind interior diagonal mismatch",
+    )
+
+
+@pytest.mark.parametrize("sigma", [0.1, 0.3, 0.5])
+@pytest.mark.parametrize("dx", [0.05, 0.1])
+def test_gradient_upwind_interior_offdiagonal_coefficient(sigma, dx):
+    """Off-diagonal of the upwind interior stencil (zero drift) = -D/dx^2 (Issue #1189)."""
+    dt = 0.01
+    entries = _run_gradient_upwind_interior(sigma, dx, dt=dt)
+    D = diffusion_from_volatility(sigma)
+    for idx in [1, 3]:
+        npt.assert_allclose(
+            entries[idx],
+            -D / dx**2,
+            rtol=1e-12,
+            err_msg=f"sigma={sigma}, dx={dx}: upwind off-diagonal mismatch at col {idx}",
+        )
+
+
+@pytest.mark.parametrize("sigma", [0.1, 0.3, 0.5])
+@pytest.mark.parametrize("dx", [0.05, 0.1])
+def test_bc_no_flux_interior_in_d_coefficients(sigma, dx):
+    """Interior-in-d branch of add_boundary_no_flux_entries uses D correctly (Issue #1189)."""
+    dt = 0.01
+    entries = _run_bc_no_flux_interior(sigma, dx, dt=dt)
+    D = diffusion_from_volatility(sigma)
+    # In d=1, the interior-in-d branch should contribute -D/dx^2 to the y-neighbors
+    # Point (0, 2), Ny=5: y-neighbors are (0,1)=flat_idx_minus and (0,3)=flat_idx_plus
+    grid = _FakeGrid((5, 5))
+    y_plus_flat = grid.get_index((0, 3))
+    y_minus_flat = grid.get_index((0, 1))
+    # Off-diagonal in y: -D/dx^2 base (zero drift, so no advection term)
+    npt.assert_allclose(
+        entries.get(y_plus_flat, 0.0),
+        -D / dx**2,
+        rtol=1e-12,
+        err_msg=f"sigma={sigma}, dx={dx}: bc no-flux interior y+ coefficient mismatch",
+    )
+    npt.assert_allclose(
+        entries.get(y_minus_flat, 0.0),
+        -D / dx**2,
+        rtol=1e-12,
+        err_msg=f"sigma={sigma}, dx={dx}: bc no-flux interior y- coefficient mismatch",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Torch diffusion_from_volatility_torch byte-identity tests
+# ---------------------------------------------------------------------------
+
+
+def test_diffusion_from_volatility_torch_numpy_parity():
+    """diffusion_from_volatility_torch(sigma) == diffusion_from_volatility(sigma) for scalars."""
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch
+
+    for sigma in SIGMA_VALUES:
+        result_torch = diffusion_from_volatility_torch(sigma)
+        result_numpy = diffusion_from_volatility(sigma)
+        npt.assert_array_equal(
+            float(result_torch),
+            float(result_numpy),
+            err_msg=f"sigma={sigma}: diffusion_from_volatility_torch != diffusion_from_volatility",
+        )
+
+
+def test_diffusion_from_volatility_torch_preserves_autograd():
+    """diffusion_from_volatility_torch preserves torch autograd graph."""
+    pytest.importorskip("torch")
+    import torch
+
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch
+
+    sigma = torch.tensor(0.3, requires_grad=True, dtype=torch.float64)
+    D = diffusion_from_volatility_torch(sigma)
+    # d(D)/d(sigma) = d(0.5*sigma^2)/d(sigma) = sigma
+    grad = torch.autograd.grad(D, sigma)[0]
+    npt.assert_allclose(
+        float(grad),
+        float(sigma),
+        rtol=1e-10,
+        err_msg="autograd of diffusion_from_volatility_torch should give sigma",
+    )
+
+
+def test_diffusion_from_volatility_torch_byte_identity_scalar():
+    """diffusion_from_volatility_torch(sigma) == 0.5*sigma**2 for float scalars (byte-equal)."""
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch
+
+    for sigma in SIGMA_VALUES:
+        npt.assert_array_equal(
+            diffusion_from_volatility_torch(sigma),
+            0.5 * sigma**2,
+            err_msg=f"sigma={sigma}: diffusion_from_volatility_torch not byte-identical to 0.5*sigma**2",
+        )


### PR DESCRIPTION
## Summary

- Routes all remaining inline `sigma**2/(2*dx_sq)` / `sigma**2/dx_sq` patterns in FP matrix-assembly files through canonical `diffusion_from_volatility(sigma)` (= `0.5*sigma**2`, the D coefficient). This is the single-source convention established by Issue #811 and partially applied to HJB/SL in prior batches.
- Adds `diffusion_from_volatility_torch(sigma)` to `pde_coefficients.py` — a pure-Python `0.5*sigma**2` function that works with torch tensors (preserves autograd graph) and routes the 6 PINN/torch_backend sigma**2/2 sites through it (Refs #1193).

**Files changed (numpy path, Fixes #1189):**
- `fp_fdm_alg_gradient_centered.py`: add import + `D = diffusion_from_volatility(sigma)` in both functions; 10 inline sites migrated
- `fp_fdm_alg_gradient_upwind.py`: add `D=` in interior function (3 sites); use existing `D=` for 3 interior-in-d sites in boundary function
- `fp_fdm_bc.py`: 3 interior-in-d sites in `add_boundary_no_flux_entries` (D already computed at top)

**Factor-of-2 invariant verified at each site:**
- `sigma**2/(2*dx_sq)` → `-D/dx_sq` (off-diagonal Laplacian)
- `sigma**2/dx_sq` → `2*D/dx_sq` (diagonal, both neighbors present)
- `sigma**2/dx_sq` → `2*D/dx_sq` (ghost-point boundary, Issue #668 factor)

**Files changed (torch/PINN path, Refs #1193):**
- `pde_coefficients.py`: add `diffusion_from_volatility_torch` (no explicit torch import, autograd-safe)
- `fp_pinn_solver.py`: 2 sites
- `mfg_pinn_solver.py`: 3 sites
- `torch_backend.py`: 1 site

## Test plan

- [x] Pinning test: `tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py` — 93 tests
  - Fails before refactor (`diffusion_from_volatility_torch` ImportError); passes after
  - Asserts `np.testing.assert_array_equal` (byte-identity) for all 3 coefficient patterns across 20 sigma/dx pairs
  - Verifies autograd preservation and numpy/torch parity for `diffusion_from_volatility_torch`
- [x] Full `tests/unit/test_alg/` suite: 1092 passed, 3 skipped, 2 xfailed, 0 failures
- [x] `ruff format` + `ruff check` — all clean

Fixes #1189
Refs #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)