### PR TITLE
fix(fem): consistent-mass L2 projection for P2+ nodal gradient recovery (#1252)

### DIFF
--- a/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
@@ -11,7 +11,11 @@ Issue #773 (FEM); Issue #1131 Phase 2 (factored onto WeakFormHJBSolver).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from scipy import sparse
+from scipy.sparse.linalg import factorized
 
 from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.weak_form_hjb_solver import WeakFormHJBSolver
@@ -54,6 +58,10 @@ class HJBFEMSolver(WeakFormHJBSolver):
         from .assembly import create_basis
 
         self._basis = create_basis(self._skfem_mesh, order=order)
+        # P2+ gradient-recovery attributes: set before super().__init__ so that
+        # _build_gradient_operators (called lazily on first solve) sees them defined.
+        self._use_consistent_mass: bool = False
+        self._M_lu: Any | None = None  # scipy factorized(M) callable, P2+ only (#1252)
         super().__init__(problem, FEMDiscretization(self._basis))
         self.hjb_method_name = "FEM"
         self.order = order
@@ -65,6 +73,71 @@ class HJBFEMSolver(WeakFormHJBSolver):
     def basis(self):
         """scikit-fem Basis object."""
         return self._basis
+
+    # --- P2+ consistent-mass gradient recovery (#1252) -----------------------
+    def _build_gradient_operators(self) -> None:
+        """Override: use consistent-mass L2 projection for P2+ Lagrange elements.
+
+        Row-sum mass lumping (``WeakFormHJBSolver._build_gradient_operators``) is exact-
+        order for P1 (all lumped masses strictly positive), but is invalid for P2+: the
+        vertex shape function ``lambda(2 lambda - 1)`` integrates to 0 over a triangle
+        and to a negative value over a tetrahedron, so the consistent-mass row sum at
+        every vertex DOF is ~0 or < 0. The old clamp ``<1e-15 -> 1e-15`` turned invalid
+        masses into 1e-15, yielding 1/1e-15 = 1e15 scale factors that corrupted the
+        recovered vertex gradient (Tri: ~1e-3; Tet: ~-6e12 instead of 1.0).
+
+        Fix (P2+): build a sparse LU factorisation of the consistent mass matrix M and
+        solve ``M g_d = R_d u`` at each gradient evaluation via the precomputed factor.
+        For P1 (all lumped masses positive): fall through to the cheap diagonal path in
+        the base class. The meshless-Galerkin path (P1/MLS bases) is unaffected because
+        it does not call this override.
+        """
+        if self._G_grad is not None:
+            return
+        M_lumped = np.asarray(self._M.sum(axis=1)).ravel()
+        m_min, m_max = float(M_lumped.min()), float(M_lumped.max())
+        if m_min < 1e-12 * m_max:
+            # P2+: build LU once; gradient evaluations will call factorized(M)(R_d @ u).
+            self._M_lu = factorized(self._M.tocsc())
+            # _G_grad must be non-None to signal "operators built" (base-class guard).
+            # Entries are None (sentinels); _apply_gradient_operator uses _M_lu + _R_grad.
+            self._G_grad = [None] * len(self._R_grad)
+            self._use_consistent_mass = True
+            self._M_lumped_inv = None
+            logger.info(
+                "P2+ FEM: consistent-mass L2 projection for nodal gradient recovery "
+                f"(min lumped mass {m_min:.3e}, max {m_max:.3e}; Issue #1252)"
+            )
+        else:
+            super()._build_gradient_operators()
+
+    def _apply_gradient_operator(self, d: int, u: NDArray) -> NDArray:
+        """P2+ override: solve M g_d = R_d u via precomputed LU (#1252).
+
+        For P1 the base-class lumped-diagonal path is used (self._use_consistent_mass
+        is False). The meshless-Galerkin path never calls this override.
+        """
+        if self._use_consistent_mass:
+            return self._M_lu(self._R_grad[d] @ u)
+        return super()._apply_gradient_operator(d, u)
+
+    def _hamiltonian_jacobian_term(self, dH_dp_d: NDArray, d: int) -> sparse.csr_matrix:
+        """P2+ override: inexact Newton Jacobian for the consistent-mass path (#1252).
+
+        The exact Jacobian term is ``M @ diag(dH/dp_d) @ M^{-1} @ R_d``. Forming
+        ``M^{-1} @ R_d`` as a dense matrix is O(N^2) — prohibitive for production meshes.
+
+        Approximation used here: ``diag(dH/dp_d) @ R_d`` (drops the ``M @ ... @ M^{-1}``
+        wrapping). This is an inexact Jacobian; Newton converges to the correct residual-
+        zero solution because the residual ``F(U) = ... + M H(M^{-1} R_d U)`` uses the
+        full consistent-mass gradient. The Jacobian approximation only reduces the
+        convergence rate from quadratic to superlinear (#1252 design note).
+
+        For P1: the base-class exact term ``M @ diag(dH/dp_d) @ G_d`` is used.
+        """
+        if self._use_consistent_mass:
+            return sparse.diags(dH_dp_d) @ self._R_grad[d]
+        return super()._hamiltonian_jacobian_term(dH_dp_d, d)
 
     # --- scikit-fem boundary-condition strategy -------------------------------
     def _is_pure_neumann(self) -> bool:

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -119,7 +119,24 @@ class WeakFormHJBSolver(BaseHJBSolver):
 
     def _nodal_gradient(self, u: NDArray) -> NDArray:
         self._build_gradient_operators()
-        return np.column_stack([G_d @ u for G_d in self._G_grad])
+        return np.column_stack([self._apply_gradient_operator(d, u) for d in range(len(self._R_grad))])
+
+    def _apply_gradient_operator(self, d: int, u: NDArray) -> NDArray:
+        """Apply the d-th gradient operator to u (i.e. compute G_d @ u = grad_d u).
+
+        Default: lumped-mass L2 projection stored in ``self._G_grad[d]``. Subclasses
+        override this for non-lumped recovery (e.g. P2 FEM consistent-mass path, #1252).
+        """
+        return self._G_grad[d] @ u
+
+    def _hamiltonian_jacobian_term(self, dH_dp_d: NDArray, d: int) -> sparse.csr_matrix:
+        """Build the d-th Jacobian term for the Hamiltonian coupling: M @ diag(dH/dp_d) @ G_d.
+
+        Default: exact term using the lumped-mass gradient operator stored in
+        ``self._G_grad[d]``. Subclasses may return an inexact but sparse approximation,
+        as long as the residual F(U) = 0 fixed point is correct (#1252).
+        """
+        return self._M @ sparse.diags(dH_dp_d) @ self._G_grad[d]
 
     def _solve_timestep_newton(
         self,
@@ -166,7 +183,7 @@ class WeakFormHJBSolver(BaseHJBSolver):
 
         delta_norm = np.inf
         for k in range(max_iterations):
-            p_nodal = np.column_stack([G_d @ U_current for G_d in self._G_grad])  # (N, dim)
+            p_nodal = np.column_stack([self._apply_gradient_operator(d, U_current) for d in range(dim)])  # (N, dim)
 
             H_vals = np.asarray(H_class(x_grid, m_n, p_nodal, t=t), dtype=float).ravel()
             dH_dp = np.asarray(H_class.dp(x_grid, m_n, p_nodal, t=t), dtype=float)
@@ -193,7 +210,7 @@ class WeakFormHJBSolver(BaseHJBSolver):
             if S_stab is not None:
                 J = J + S_stab
             for d in range(dim):
-                J = J + self._M @ sparse.diags(dH_dp[:, d]) @ self._G_grad[d]
+                J = J + self._hamiltonian_jacobian_term(dH_dp[:, d], d)
 
             if condense:
                 residual[d_dofs] = 0.0

--- a/tests/unit/test_alg/test_weak_form_hjb_p2_gradient_1252.py
+++ b/tests/unit/test_alg/test_weak_form_hjb_p2_gradient_1252.py
@@ -5,8 +5,15 @@ For P2+ Lagrange the vertex shape function integrates to ~0 over a triangle and 
 value over a tetrahedron, so the consistent-mass row sum at every vertex DOF is ~0 or < 0. The
 old code clamped that to 1e-15 and 1/1e-15 = 1e15 turned the recovered vertex gradient into
 garbage, silently feeding nonsense into H(grad u). _build_gradient_operators must now fail loud
-for P2+ and keep working for P1. The fix exercises the real method via a minimal carrier holding
-genuine skfem-assembled P1/P2 mass matrices.
+for P2+ in the base WeakFormHJBSolver (protecting the meshless-Galerkin path), and
+HJBFEMSolver overrides it to use a consistent-mass L2 projection for P2+ (#1252).
+
+The fix exercises:
+1. WeakFormHJBSolver._build_gradient_operators still fails loud for P2+ (base-class guard,
+   called directly via _GradStub to confirm the meshless path is protected).
+2. HJBFEMSolver._nodal_gradient with order=2 correctly recovers grad(x) = 1 at ALL DOFs
+   (vertex + edge-midpoint) via the consistent-mass M^{-1} R_d solve.
+3. P1 recovery is byte-identical after the refactor (no regression).
 """
 
 import pytest
@@ -37,8 +44,18 @@ def _mass_matrix(order):
     return assemble_mass(basis), basis.N
 
 
+# ---------------------------------------------------------------------------
+# Base-class guards (protect the meshless-Galerkin path)
+# ---------------------------------------------------------------------------
+
+
 def test_p2_gradient_lumping_fails_loud():
-    """P2: lumped row sums are pathological (~0/negative) -> must raise NotImplementedError."""
+    """P2: lumped row sums are pathological (~0/negative) -> base class raises NotImplementedError.
+
+    This verifies the WeakFormHJBSolver guard remains in place after the #1252 fix, so that
+    any non-FEM subclass (e.g. MeshlessGalerkinHJBSolver) that inadvertently receives P2+
+    operators still fails loud rather than silently returning garbage gradients.
+    """
     M, n = _mass_matrix(order=2)
     m_lumped = np.asarray(M.sum(axis=1)).ravel()
     assert m_lumped.min() < 1e-12 * m_lumped.max(), "premise: P2 vertex DOFs should have ~0/negative lumped row sums"
@@ -56,3 +73,117 @@ def test_p1_gradient_lumping_ok():
     WeakFormHJBSolver._build_gradient_operators(stub)  # must not raise
     assert stub._G_grad is not None
     assert len(stub._G_grad) == 2
+
+
+# ---------------------------------------------------------------------------
+# HJBFEMSolver pinning tests for #1252
+# These tests FAIL pre-fix (HJBFEMSolver called base-class _build_gradient_operators
+# which raised NotImplementedError for P2) and PASS after the consistent-mass fix.
+# ---------------------------------------------------------------------------
+
+
+def _make_fem_solver(order: int):
+    """Build a minimal HJBFEMSolver on a unit-square MeshTri for gradient-recovery tests."""
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+    from mfgarchon.alg.numerical.fem.mesh_adapter import skfem_to_meshdata
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry.boundary import no_flux_bc
+    from mfgarchon.geometry.meshes.mesh_2d import Mesh2D
+
+    mesh = skfem.MeshTri.init_sqsymmetric().refined(2)
+    geom = Mesh2D(domain_type="rectangle", bounds=(0.0, 1.0, 0.0, 1.0))
+    geom.mesh_data = skfem_to_meshdata(mesh)
+    geom.boundary_conditions = no_flux_bc(dimension=2)
+    components = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    problem = MFGProblem(
+        geometry=geom,
+        T=0.2,
+        Nt=5,
+        sigma=0.3,
+        components=components,
+        coupling_coefficient=0.5,
+        boundary_conditions=no_flux_bc(dimension=2),
+    )
+    return HJBFEMSolver(problem, order=order)
+
+
+def test_p2_hjb_fem_gradient_recovery_linear_x():
+    """PINNING TEST for #1252 (FAILS pre-fix, PASSES after).
+
+    HJBFEMSolver(order=2)._nodal_gradient(u) with u = x must recover grad_x ~ 1 and
+    grad_y ~ 0 at EVERY DOF (vertex + edge-midpoint nodes) to within 1e-8. Pre-fix this
+    raised NotImplementedError (fail-loud guard in base class). Post-fix HJBFEMSolver
+    overrides _build_gradient_operators to use a consistent-mass L2 projection.
+    """
+    solver = _make_fem_solver(order=2)
+    coords = solver._disc.dof_coordinates  # (N, 2)
+    u_linear = coords[:, 0].copy()  # u = x, so exact grad = (1, 0)
+
+    p_nodal = solver._nodal_gradient(u_linear)  # (N, 2)
+
+    max_err_x = float(np.abs(p_nodal[:, 0] - 1.0).max())
+    max_err_y = float(np.abs(p_nodal[:, 1]).max())
+    assert max_err_x < 1e-8, (
+        f"P2 consistent-mass gradient recovery: grad_x max error {max_err_x:.3e} (expected < 1e-8). "
+        "Pre-fix this path raised NotImplementedError; now it must return 1 at all DOFs."
+    )
+    assert max_err_y < 1e-8, (
+        f"P2 consistent-mass gradient recovery: grad_y max error {max_err_y:.3e} (expected < 1e-8)."
+    )
+
+
+def test_p2_hjb_fem_gradient_recovery_vertex_dofs():
+    """PINNING TEST: vertex DOFs specifically must not collapse to ~0 (the #1252 corruption).
+
+    The issue reported Tri P2 vertex rows with lumped mass ~1.7e-18 yielding grad ~1e-3
+    instead of 1.0. This test extracts vertex-only DOFs from the P2 basis and checks them.
+    """
+    solver = _make_fem_solver(order=2)
+    coords = solver._disc.dof_coordinates  # (N, 2)
+    u_linear = coords[:, 0].copy()  # u = x
+
+    p_nodal = solver._nodal_gradient(u_linear)  # (N, 2)
+
+    # Vertex DOFs are identified by integer coordinates in the mesh (mesh.p columns
+    # are mesh vertices). For a refined MeshTri, vertex DOFs index into basis.doflocs.
+    mesh = solver._skfem_mesh
+    n_vertices = mesh.p.shape[1]
+    # P2 basis: first n_vertices DOFs are vertex nodes; remaining are edge-midpoints.
+    vertex_grad_x = p_nodal[:n_vertices, 0]
+    max_vertex_err = float(np.abs(vertex_grad_x - 1.0).max())
+    assert max_vertex_err < 1e-8, (
+        f"P2 vertex DOF gradient: max error {max_vertex_err:.3e} at vertex nodes "
+        f"(issue #1252 reported ~1e-3 / -6e12 due to lumped-mass corruption). "
+        f"n_vertices={n_vertices}, n_dof={solver._n_dof}"
+    )
+
+
+def test_p1_hjb_fem_gradient_recovery_unchanged():
+    """P1 HJBFEMSolver gradient recovery is byte-identical after the #1252 refactor.
+
+    The new _apply_gradient_operator hook must call the base-class lumped path for P1,
+    producing the same result as the direct G_d @ u computation it replaced.
+    """
+    solver = _make_fem_solver(order=1)
+    coords = solver._disc.dof_coordinates  # (N, 2)
+    u_linear = coords[:, 0].copy()  # u = x
+
+    p_nodal = solver._nodal_gradient(u_linear)  # (N, 2)
+
+    max_err_x = float(np.abs(p_nodal[:, 0] - 1.0).max())
+    max_err_y = float(np.abs(p_nodal[:, 1]).max())
+    assert max_err_x < 1e-8, f"P1 gradient recovery: grad_x max error {max_err_x:.3e}"
+    assert max_err_y < 1e-8, f"P1 gradient recovery: grad_y max error {max_err_y:.3e}"
+    # Also confirm P1 uses lumped path (not consistent-mass)
+    assert not solver._use_consistent_mass, "P1 must use lumped path, not consistent-mass"
+    assert solver._M_lu is None, "P1 must not build LU factorisation"


### PR DESCRIPTION
## Summary

- **Root cause**: `WeakFormHJBSolver._build_gradient_operators` used row-sum mass lumping for P2+ Lagrange elements, where the vertex shape function `lambda(2*lambda-1)` integrates to 0 (Tri) or a negative value (Tet). The previous clamp (`min < 1e-15 -> 1e-15`) silently turned invalid masses into 1e-15, yielding 1/1e-15 = 1e15 scale factors. Recovered vertex gradients: ~1e-3 (TriP2) or ~-6e12 (TetP2) instead of 1.0. PR #1278 replaced the clamp with a fail-loud guard.
- **This PR** implements the real fix: `HJBFEMSolver` overrides `_build_gradient_operators` to use a consistent-mass L2 projection (`M g_d = R_d u` via sparse LU) for P2+, leaving the P1 lumped path and all meshless-Galerkin paths completely unaffected.
- Two new override hooks (`_apply_gradient_operator`, `_hamiltonian_jacobian_term`) added to `WeakFormHJBSolver` so the P2 path does not duplicate the Newton loop. Newton Jacobian for P2 uses an inexact approximation `diag(dH/dp_d) @ R_d` (avoids the O(N^2) dense `M^{-1} R_d`); residual is exact so the fixed point is correct.

## Changed files

- `mfgarchon/alg/numerical/weak_form_hjb_solver.py`: add `_apply_gradient_operator` and `_hamiltonian_jacobian_term` hooks; update `_nodal_gradient` and `_solve_timestep_newton` callers; base-class fail-loud guard preserved.
- `mfgarchon/alg/numerical/fem/hjb_fem_solver.py`: add `_use_consistent_mass`, `_M_lu`; override `_build_gradient_operators` (LU for P2+), `_apply_gradient_operator` (LU solve), `_hamiltonian_jacobian_term` (inexact Jacobian).
- `tests/unit/test_alg/test_weak_form_hjb_p2_gradient_1252.py`: three new pinning tests + updated docstring.

## Test plan

- [ ] `test_p2_hjb_fem_gradient_recovery_linear_x` — FAILED pre-fix (NotImplementedError), PASSES post-fix: `grad_x` of `u=x` is `1.0` at ALL P2 DOFs to < 1e-8.
- [ ] `test_p2_hjb_fem_gradient_recovery_vertex_dofs` — vertex-DOF column specifically, confirming the #1252 O(1) corruption at vertex nodes is fixed.
- [ ] `test_p1_hjb_fem_gradient_recovery_unchanged` — P1 lumped path byte-identical; confirms `_use_consistent_mass=False` and `_M_lu=None` for P1.
- [ ] `test_p2_gradient_lumping_fails_loud` / `test_p1_gradient_lumping_ok` — base-class guards (via `_GradStub`) remain green; meshless path unaffected.
- [ ] Full FEM integration suite (`test_fem_solver_path.py`, `test_fem_mfg_solve.py`, `test_fem_quad_path.py`) — 35 tests green.
- [ ] Full meshless-Galerkin suite (`test_meshless_galerkin_mfg.py`, `test_meshless_gradient_projection.py`, `test_meshless_nitsche.py`, `test_meshless_stabilization.py`, `test_meshless_curved_nitsche.py`) — all green; confirms no regression on the P1/MLS path.

Fixes #1252

🤖 Generated with [Claude Code](https://claude.com/claude-code)