### PR TITLE
chore(alg): remove deprecated HJBGFDMSolver params at v0.25.0 (Issue #1070)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -32,7 +32,7 @@ from mfgarchon.alg.numerical.hjb_solvers.h_eval import (
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
 from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL
 from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
-from mfgarchon.utils.deprecation import deprecated_parameter, deprecated_value
+from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical.qp_utils import QPCache, QPSolver
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
@@ -198,12 +198,21 @@ class HJBGFDMSolver(BaseHJBSolver):
         Returns:
             Configured HJBGFDMSolver instance
         """
+        # Translate QPConfig.optimization_level to the v0.18.0 canonical axes
+        # (qp_optimization_level was removed from __init__ in v0.25.0, Issue #1070).
+        _qp_level_to_scheme: dict[str, tuple[str, str | None]] = {
+            "none": ("none", None),
+            "auto": ("qp_m_matrix", "adaptive"),
+            "always": ("qp_m_matrix", "always"),
+        }
+        _mono_scheme, _mono_app = _qp_level_to_scheme.get(config.qp.optimization_level, ("none", None))
         kwargs: dict[str, Any] = {
             "delta": config.delta,
             "taylor_order": config.taylor_order,
             "weight_function": config.weight_function,
             "weight_scale": config.weight_scale,
-            "qp_optimization_level": config.qp.optimization_level,
+            "monotonicity_scheme": _mono_scheme,
+            "monotonicity_application": _mono_app,
             "qp_solver": config.qp.solver,
             "qp_warm_start": config.qp.warm_start,
             "qp_constraint_mode": config.qp.constraint_mode,
@@ -223,27 +232,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         kwargs.update(extra)
         return cls(problem, collocation_points, **kwargs)
 
-    @deprecated_value(
-        param_name="qp_optimization_level",
-        deprecated_values={"smart": "auto", "tuned": "auto", "basic": "auto"},
-        since="v0.17.0",
-    )
-    @deprecated_parameter(
-        param_name="qp_optimization_level",
-        since="v0.18.0",
-        replacement="monotonicity_scheme",
-        removal_blockers=["internal_usage", "equivalence_test", "migration_docs"],
-    )
-    @deprecated_parameter(
-        param_name="NiterNewton",
-        since="v0.17.0",
-        replacement="max_newton_iterations",
-    )
-    @deprecated_parameter(
-        param_name="l2errBoundNewton",
-        since="v0.17.0",
-        replacement="newton_tolerance",
-    )
     def __init__(
         self,
         problem: MFGProblem,
@@ -261,9 +249,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         # 'howard' requires monotonicity_scheme='joint_socp' + monotonicity_application=
         # 'precompute', unit control cost, and a homogeneous no-flux BC (validated in solve).
         inner_solver: str = "newton",
-        # Deprecated parameters for backward compatibility
-        NiterNewton: int | None = None,
-        l2errBoundNewton: float | None = None,
         boundary_indices: np.ndarray | None = None,
         boundary_conditions: dict | BoundaryConditions | None = None,
         # Monotonicity construction (renamed from qp_optimization_level v0.18.0; Issue #XXXX).
@@ -273,8 +258,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         # See docstring for full semantics.
         monotonicity_scheme: str | None = None,
         monotonicity_application: str | None = None,
-        # Deprecated alias bundling both axes — will be removed v0.25.0
-        qp_optimization_level: str | None = None,
         qp_usage_target: float = 0.1,  # Unused, kept for backward compatibility
         qp_solver: str = "osqp",  # "osqp" or "scipy"
         qp_warm_start: bool = True,  # Enable QP warm-starting
@@ -322,13 +305,9 @@ class HJBGFDMSolver(BaseHJBSolver):
             weight_function: Weight function type ("wendland", "cubic_spline", "gaussian", "inverse_distance", "uniform")
             weight_scale: Scale parameter for weight function
             max_newton_iterations: Maximum Newton iterations (new parameter name)
-            newton_tolerance: Newton convergence tolerance (new parameter name)
-            NiterNewton: DEPRECATED - use max_newton_iterations
-            l2errBoundNewton: DEPRECATED - use newton_tolerance
+            newton_tolerance: Newton convergence tolerance.
             boundary_indices: Indices of boundary collocation points
             boundary_conditions: Dictionary or BoundaryConditions object specifying boundary conditions
-            use_monotone_constraints: DEPRECATED - Use qp_optimization_level instead.
-                If explicitly set to True, will override qp_optimization_level.
             monotonicity_scheme: Which monotonicity construction to enforce on the GFDM
                 Laplacian (and, for joint_socp, the per-edge cone on the gradient stencil):
                 - "none": no constraints (fastest; no monotonicity guarantee).
@@ -337,23 +316,17 @@ class HJBGFDMSolver(BaseHJBSolver):
                 - "joint_socp": (Phase 1B follow-up) joint SOCP — M-matrix on $-\\Delta_h$
                   + per-edge cone $\\|D_{ij}\\|_2 \\leq C h_i L_{ij}$, closing the discrete
                   comparison principle (audit-major contribution).
-                Default: "none".
-                Renamed from `qp_optimization_level` in v0.18.0; legacy bundle still
-                accepted as deprecated alias.
+                Default: "none". (Renamed from qp_optimization_level in v0.18.0.)
             monotonicity_application: When the chosen scheme is enforced (only
                 meaningful for non-"none" schemes):
                 - "adaptive": only at nodes where the unconstrained weights violate
-                  the constraint (= legacy "auto"; recommended for qp_m_matrix).
+                  the constraint (recommended for qp_m_matrix).
                 - "always": at every node, every solve.
                 - "precompute": cache feasible weights at construction; reuse for all
                   Picard iterations / time steps. Recommended for joint_socp.
                 Default (None): use scheme-recommended default — "adaptive" for
                 qp_m_matrix, "precompute" for joint_socp.
-            qp_optimization_level: DEPRECATED alias bundling (scheme + application). Will be
-                removed in v0.25.0. Mappings: "none"→(none, —), "auto"→(qp_m_matrix, adaptive),
-                "always"→(qp_m_matrix, always), "precompute"→(qp_m_matrix, precompute).
-                Pass `monotonicity_scheme=` and `monotonicity_application=` instead.
-            qp_usage_target: Deprecated parameter, kept for backward compatibility
+            qp_usage_target: Unused parameter, kept for backward compatibility
             qp_solver: QP solver backend (default "osqp"):
                 - "osqp": Use OSQP solver (fast convex QP, 5-10× faster than scipy)
                 - "scipy": Use scipy.optimize.minimize (SLSQP or L-BFGS-B)
@@ -469,21 +442,8 @@ class HJBGFDMSolver(BaseHJBSolver):
         #   joint_socp  → "precompute"   (audit-major default; weights cached at construction)
         #   none        → ignored
         #
-        # Legacy `qp_optimization_level` bundles both axes via these mappings:
-        #   "none"       → (none, ignored)
-        #   "auto"       → (qp_m_matrix, adaptive)
-        #   "always"     → (qp_m_matrix, always)
-        #   "precompute" → (qp_m_matrix, precompute)
-        #
-        # Mutual exclusion: pass either the new (scheme + application) or the legacy alias,
-        # not both.
-        if (
-            monotonicity_scheme is not None or monotonicity_application is not None
-        ) and qp_optimization_level is not None:
-            raise ValueError(
-                "Specify at most one of: (monotonicity_scheme=, monotonicity_application=) "
-                "or qp_optimization_level=. The latter is the deprecated alias (v0.18.0)."
-            )
+        # v0.25.0 (Issue #1070): qp_optimization_level= parameter removed; pass
+        # monotonicity_scheme= and monotonicity_application= directly.
 
         # Issue #1034: warn when user defaults to "none" (bare Wendland-Taylor LSQ).
         # This default produces a method whose M-matrix structure is not enforced;
@@ -492,7 +452,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # with KL=0.098 and 11 spurious modes — see Issue #1034 for full evidence).
         # Validated in mfg-research/.../exp08_towel_2d_validation/_preflight_1d/
         # post_mortem_1d_tob_debug.md.
-        if monotonicity_scheme is None and monotonicity_application is None and qp_optimization_level is None:
+        if monotonicity_scheme is None and monotonicity_application is None:
             import warnings as _w
 
             _w.warn(
@@ -512,7 +472,6 @@ class HJBGFDMSolver(BaseHJBSolver):
             )
 
         if monotonicity_scheme is not None or monotonicity_application is not None:
-            # New API path
             scheme = monotonicity_scheme if monotonicity_scheme is not None else "none"
             valid_schemes = ("none", "qp_m_matrix", "joint_socp")
             if scheme not in valid_schemes:
@@ -532,16 +491,9 @@ class HJBGFDMSolver(BaseHJBSolver):
             else:
                 application = monotonicity_application
         else:
-            # Legacy path
-            legacy = qp_optimization_level if qp_optimization_level is not None else "none"
-            mapping = {
-                "none": ("none", "ignored"),
-                "auto": ("qp_m_matrix", "adaptive"),
-                "always": ("qp_m_matrix", "always"),
-                "precompute": ("qp_m_matrix", "precompute"),
-            }
-            # Unknown legacy value passes through for solver-internal handling.
-            scheme, application = mapping.get(legacy, ("qp_m_matrix", legacy))
+            # Default: no monotonicity constraints
+            scheme = "none"
+            application = "ignored"
 
         # Canonical storage
         self.monotonicity_scheme = scheme
@@ -590,15 +542,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         else:
             self.hjb_method_name = f"GFDM-{self.qp_optimization_level}"
 
-        # Handle backward compatibility (warnings issued by @deprecated_parameter decorators)
-        if NiterNewton is not None:
-            if max_newton_iterations is None:
-                max_newton_iterations = NiterNewton
-
-        if l2errBoundNewton is not None:
-            if newton_tolerance is None:
-                newton_tolerance = l2errBoundNewton
-
         # Set defaults if still None
         if max_newton_iterations is None:
             max_newton_iterations = DEFAULT_NEWTON_MAX_ITERATIONS
@@ -614,7 +557,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         self.weight_function = weight_function
         self.weight_scale = weight_scale
 
-        # Newton parameters (store with new names)
+        # Newton parameters (canonical names; v0.25.0 removed NiterNewton/l2errBoundNewton)
         self.max_newton_iterations = max_newton_iterations
         self.newton_tolerance = newton_tolerance
 
@@ -622,10 +565,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         if inner_solver not in ("newton", "howard"):
             raise ValueError(f"inner_solver must be 'newton' or 'howard', got {inner_solver!r}")
         self.inner_solver = inner_solver
-
-        # Keep old names for backward compatibility (without warnings when accessed)
-        self.NiterNewton = max_newton_iterations
-        self.l2errBoundNewton = newton_tolerance
 
         # Boundary condition parameters
         # Auto-detect boundary indices if not provided (Issue #542 fix)

--- a/tests/unit/test_alg/test_hjb_gfdm_monotonicity_scheme_rename.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_monotonicity_scheme_rename.py
@@ -1,24 +1,18 @@
-"""Equivalence tests for v0.18.0 monotonicity_scheme rename.
+"""Tests for monotonicity_scheme / monotonicity_application canonical API.
 
-mfgarchon CLAUDE.md deprecation policy requires:
-  - Immediate redirection: old API calls new API internally
-  - Equivalence test: old API == new API give identical behavior
-
-This module verifies that for each of the four legacy
-`qp_optimization_level` values, the corresponding new
-(`monotonicity_scheme`, `monotonicity_application`) tuple produces
-identical solver state (same scheme/application/method-name and
-same Laplacian/gradient stencil weights).
-
-Issue #XXXX. Removal blocker: equivalence_test → check_internal_deprecation.py.
+v0.18.0 introduced the two-axis API replacing qp_optimization_level=.
+v0.25.0 (Issue #1070) removed qp_optimization_level= from the constructor
+signature; passing it now raises TypeError. These tests verify the canonical
+API works correctly and that the removed parameter is no longer accepted.
 """
 
 from __future__ import annotations
 
 import warnings
 
-import numpy as np
 import pytest
+
+import numpy as np
 
 from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
@@ -60,7 +54,6 @@ def _problem_2d_quasi_uniform():
     if pts.ndim == 1:
         pts = np.atleast_2d(pts).T
     bdry = []
-    n = pts.shape[0]
     for i, p in enumerate(pts):
         if min(p[0], 1.0 - p[0], p[1], 1.0 - p[1]) < 1e-9:
             bdry.append(i)
@@ -90,13 +83,13 @@ def setup():
 
 @pytest.mark.parametrize("legacy_value", list(LEGACY_TO_NEW.keys()))
 def test_scheme_application_match(setup, legacy_value):
-    """For each legacy value, verify new (scheme, application) produces identical
-    self.monotonicity_scheme, self.monotonicity_application, and self.qp_optimization_level."""
+    """For each canonical (scheme, application) pair, verify the solver stores the
+    expected self.monotonicity_scheme, self.monotonicity_application, and the
+    internal self.qp_optimization_level attribute."""
     problem, pts, bdry = setup
     new_scheme, new_app = LEGACY_TO_NEW[legacy_value]
 
-    # New API
-    s_new = HJBGFDMSolver(
+    s = HJBGFDMSolver(
         problem,
         collocation_points=pts,
         boundary_indices=bdry,
@@ -105,37 +98,26 @@ def test_scheme_application_match(setup, legacy_value):
         monotonicity_application=new_app,
     )
 
-    # Legacy API
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        s_old = HJBGFDMSolver(
-            problem,
-            collocation_points=pts,
-            boundary_indices=bdry,
-            delta=0.3,
-            qp_optimization_level=legacy_value,
-        )
-
-    assert s_new.monotonicity_scheme == s_old.monotonicity_scheme, (
-        f"scheme mismatch for legacy={legacy_value}: new={s_new.monotonicity_scheme}, old={s_old.monotonicity_scheme}"
-    )
-    assert s_new.monotonicity_application == s_old.monotonicity_application, (
-        f"application mismatch for legacy={legacy_value}: new={s_new.monotonicity_application}, old={s_old.monotonicity_application}"
-    )
-    assert s_new.qp_optimization_level == s_old.qp_optimization_level, (
-        f"legacy alias mismatch for legacy={legacy_value}"
-    )
-    assert s_new.hjb_method_name == s_old.hjb_method_name, f"method_name mismatch for legacy={legacy_value}"
+    assert s.monotonicity_scheme == new_scheme, f"scheme mismatch for {legacy_value}"
+    # Check internal qp_optimization_level attribute (set from scheme, not from the
+    # removed parameter — this is an internal implementation detail, not public API).
+    if new_scheme == "none":
+        assert s.qp_optimization_level == "none"
+    elif new_scheme == "qp_m_matrix" and new_app == "adaptive":
+        assert s.qp_optimization_level == "auto"
+    elif new_scheme == "qp_m_matrix":
+        assert s.qp_optimization_level == new_app
+    assert s.hjb_method_name is not None, "hjb_method_name should be set"
 
 
 @pytest.mark.parametrize("legacy_value", list(LEGACY_TO_NEW.keys()))
-def test_stencil_weights_identical(setup, legacy_value):
-    """Beyond config equivalence, verify that the actual Laplacian and gradient
-    stencil weights are bit-identical between old and new API."""
+def test_stencil_weights_canonical(setup, legacy_value):
+    """Verify that canonical (scheme, application) constructs a solver with valid
+    stencil weights (behavioral guard for the new API path)."""
     problem, pts, bdry = setup
     new_scheme, new_app = LEGACY_TO_NEW[legacy_value]
 
-    s_new = HJBGFDMSolver(
+    s = HJBGFDMSolver(
         problem,
         collocation_points=pts,
         boundary_indices=bdry,
@@ -143,48 +125,23 @@ def test_stencil_weights_identical(setup, legacy_value):
         monotonicity_scheme=new_scheme,
         monotonicity_application=new_app,
     )
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        s_old = HJBGFDMSolver(
-            problem,
-            collocation_points=pts,
-            boundary_indices=bdry,
-            delta=0.3,
-            qp_optimization_level=legacy_value,
-        )
 
-    op_new = s_new._gfdm_operator
-    op_old = s_old._gfdm_operator
+    op = s._gfdm_operator
     n_pts = pts.shape[0]
     for i in range(n_pts):
-        w_new = op_new.get_derivative_weights(i)
-        w_old = op_old.get_derivative_weights(i)
-        if w_new is None and w_old is None:
+        w = op.get_derivative_weights(i)
+        if w is None:
             continue
-        assert (w_new is None) == (w_old is None), f"mismatch at i={i}: weights None status differs"
-        np.testing.assert_array_equal(
-            w_new["neighbor_indices"],
-            w_old["neighbor_indices"],
-            err_msg=f"neighbor_indices mismatch at i={i} for legacy={legacy_value}",
-        )
-        np.testing.assert_allclose(
-            w_new["lap_weights"],
-            w_old["lap_weights"],
-            rtol=1e-12,
-            err_msg=f"lap_weights mismatch at i={i} for legacy={legacy_value}",
-        )
-        np.testing.assert_allclose(
-            w_new["grad_weights"],
-            w_old["grad_weights"],
-            rtol=1e-12,
-            err_msg=f"grad_weights mismatch at i={i} for legacy={legacy_value}",
-        )
+        assert "neighbor_indices" in w
+        assert "lap_weights" in w
+        assert "grad_weights" in w
 
 
 def test_mutual_exclusion(setup):
-    """Passing both new and legacy params must raise ValueError."""
+    """v0.25.0: qp_optimization_level= no longer in the signature; passing it (even
+    alongside monotonicity_scheme=) raises TypeError (unexpected kwarg)."""
     problem, pts, bdry = setup
-    with pytest.raises(ValueError, match="Specify at most one"):
+    with pytest.raises(TypeError, match="qp_optimization_level"):
         HJBGFDMSolver(
             problem,
             collocation_points=pts,
@@ -240,28 +197,17 @@ def test_default_application_per_scheme(setup):
     assert s.monotonicity_application == "precompute"
 
 
-def test_legacy_emits_deprecation_warning(setup):
-    """Using qp_optimization_level= must emit a DeprecationWarning naming the
-    replacement parameter."""
+def test_removed_qp_optimization_level_raises_type_error(setup):
+    """v0.25.0 removal (Issue #1070): qp_optimization_level= is no longer in the
+    __init__ signature; passing it raises TypeError, not DeprecationWarning."""
     problem, pts, bdry = setup
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with pytest.raises(TypeError, match="qp_optimization_level"):
         HJBGFDMSolver(
             problem,
             collocation_points=pts,
             boundary_indices=bdry,
             delta=0.3,
             qp_optimization_level="auto",
-        )
-        dep = [
-            w
-            for w in caught
-            if issubclass(w.category, DeprecationWarning)
-            and "qp_optimization_level" in str(w.message)
-            and "monotonicity_scheme" in str(w.message)
-        ]
-        assert len(dep) >= 1, (
-            f"Expected DeprecationWarning naming qp_optimization_level + monotonicity_scheme; got: {[str(w.message) for w in caught]}"
         )
 
 
@@ -371,4 +317,4 @@ def test_joint_socp_unsupported_application_warns(setup):
             adaptive_neighborhoods=True,
         )
     fb = [w for w in caught if "joint_socp" in str(w.message) and "precompute" in str(w.message)]
-    assert len(fb) >= 1, f"Expected fallback warning when joint_socp + non-precompute application is requested"
+    assert len(fb) >= 1, "Expected fallback warning when joint_socp + non-precompute application is requested"

--- a/tests/unit/test_alg/test_hjb_gfdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_solver.py
@@ -89,21 +89,23 @@ class TestHJBGFDMSolverInitialization:
         assert solver.max_newton_iterations == 50
         assert solver.newton_tolerance == 1e-8
 
-    def test_deprecated_parameters(self, standard_problem):
-        """Test backward compatibility with deprecated parameter names."""
+    def test_removed_deprecated_parameters_raise(self, standard_problem):
+        """v0.25.0 removal (Issue #1070): NiterNewton= and l2errBoundNewton= no longer
+        exist in the signature — passing them raises TypeError."""
         problem = standard_problem
         bounds = problem.geometry.get_bounds()
         (Nx_points,) = problem.geometry.get_grid_shape()  # 1D spatial grid
         x_coords = np.linspace(bounds[0][0], bounds[1][0], Nx_points)
         collocation_points = x_coords.reshape(-1, 1)
 
-        with pytest.warns(DeprecationWarning, match="Parameter.*deprecated"):
-            solver = HJBGFDMSolver(problem, collocation_points, NiterNewton=40, l2errBoundNewton=1e-5)
+        with pytest.raises(TypeError, match="NiterNewton"):
+            HJBGFDMSolver(problem, collocation_points, NiterNewton=40)
 
-        assert solver.max_newton_iterations == 40
-        assert solver.newton_tolerance == 1e-5
-        assert solver.NiterNewton == 40
-        assert solver.l2errBoundNewton == 1e-5
+        with pytest.raises(TypeError, match="l2errBoundNewton"):
+            HJBGFDMSolver(problem, collocation_points, l2errBoundNewton=1e-5)
+
+        with pytest.raises(TypeError, match="qp_optimization_level"):
+            HJBGFDMSolver(problem, collocation_points, qp_optimization_level="auto")
 
     def test_qp_optimization_levels(self, standard_problem):
         """Test different QP optimization levels."""

--- a/tests/unit/test_alg/test_hjb_gfdm_v025_removal.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_v025_removal.py
@@ -1,0 +1,143 @@
+"""Pinning test: v0.25.0 removal of deprecated HJBGFDMSolver constructor params.
+
+Issue #1070 — Remove deprecated FixedPointIterator damping_* params and
+qp_optimization_level (past the deprecation window).
+
+Cluster B: HJBGFDMSolver three removed params:
+  - NiterNewton          → max_newton_iterations
+  - l2errBoundNewton     → newton_tolerance
+  - qp_optimization_level → monotonicity_scheme + monotonicity_application
+
+PINNING BEHAVIOUR (pre/post fix):
+  - PRE-FIX: passing deprecated kwargs emits DeprecationWarning (they are still in
+    the signature). These tests fail because they assert TypeError is raised.
+  - POST-FIX: deprecated kwargs are no longer in the signature, so Python raises
+    TypeError: __init__() got an unexpected keyword argument. Tests pass.
+
+Canonical kwargs (max_newton_iterations, newton_tolerance, monotonicity_scheme,
+monotonicity_application) must still work correctly and be byte-identical to
+their pre-removal counterparts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _make_problem_and_points(n: int = 11):
+    """Minimal 1D MFG problem + collocation points."""
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: 0.0 * m,
+        coupling_dm=lambda m: 0.0 * m,
+    )
+    comps = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=H,
+    )
+    problem = MFGProblem(geometry=grid, T=0.2, Nt=5, sigma=0.3, components=comps)
+    pts = problem.geometry.get_spatial_grid().reshape(-1, 1)
+    return problem, pts
+
+
+class TestRemovedDeprecatedParams:
+    """Locked-in v0.25.0 removal: NiterNewton, l2errBoundNewton, qp_optimization_level
+    must NOT be accepted by HJBGFDMSolver.__init__ after removal."""
+
+    @pytest.fixture(scope="class")
+    def setup(self):
+        return _make_problem_and_points()
+
+    def test_NiterNewton_raises_type_error(self, setup):
+        """NiterNewton= no longer in signature → TypeError: unexpected kwarg."""
+        problem, pts = setup
+        with pytest.raises(TypeError, match="NiterNewton"):
+            HJBGFDMSolver(problem, pts, NiterNewton=40)
+
+    def test_l2errBoundNewton_raises_type_error(self, setup):
+        """l2errBoundNewton= no longer in signature → TypeError: unexpected kwarg."""
+        problem, pts = setup
+        with pytest.raises(TypeError, match="l2errBoundNewton"):
+            HJBGFDMSolver(problem, pts, l2errBoundNewton=1e-5)
+
+    def test_qp_optimization_level_raises_type_error(self, setup):
+        """qp_optimization_level= no longer in signature → TypeError: unexpected kwarg."""
+        problem, pts = setup
+        with pytest.raises(TypeError, match="qp_optimization_level"):
+            HJBGFDMSolver(problem, pts, monotonicity_scheme="none", qp_optimization_level="auto")
+
+    def test_qp_optimization_level_standalone_raises_type_error(self, setup):
+        """qp_optimization_level= as sole kwarg also raises TypeError."""
+        problem, pts = setup
+        with pytest.raises(TypeError, match="qp_optimization_level"):
+            HJBGFDMSolver(problem, pts, qp_optimization_level="none")
+
+
+class TestCanonicalParamsStillWork:
+    """Canonical replacements for the removed deprecated params must still work
+    correctly and produce solvers with the expected internal state."""
+
+    @pytest.fixture(scope="class")
+    def setup(self):
+        return _make_problem_and_points()
+
+    def test_max_newton_iterations_accepted(self, setup):
+        """max_newton_iterations= (canonical) is accepted and stored correctly."""
+        problem, pts = setup
+        solver = HJBGFDMSolver(problem, pts, max_newton_iterations=40, monotonicity_scheme="none")
+        assert solver.max_newton_iterations == 40
+
+    def test_newton_tolerance_accepted(self, setup):
+        """newton_tolerance= (canonical) is accepted and stored correctly."""
+        problem, pts = setup
+        solver = HJBGFDMSolver(problem, pts, newton_tolerance=1e-5, monotonicity_scheme="none")
+        assert solver.newton_tolerance == 1e-5
+
+    def test_monotonicity_scheme_none_accepted(self, setup):
+        """monotonicity_scheme='none' selects the bare Wendland-Taylor path."""
+        problem, pts = setup
+        solver = HJBGFDMSolver(problem, pts, monotonicity_scheme="none")
+        assert solver.monotonicity_scheme == "none"
+        assert solver.qp_optimization_level == "none"  # internal attribute still present
+
+    def test_monotonicity_scheme_qp_m_matrix_adaptive(self, setup):
+        """monotonicity_scheme='qp_m_matrix' + application='adaptive'."""
+        problem, pts = setup
+        solver = HJBGFDMSolver(problem, pts, monotonicity_scheme="qp_m_matrix", monotonicity_application="adaptive")
+        assert solver.monotonicity_scheme == "qp_m_matrix"
+        assert solver.monotonicity_application == "adaptive"
+        assert solver.qp_optimization_level == "auto"  # internal alias
+
+    def test_monotonicity_scheme_qp_m_matrix_always(self, setup):
+        """monotonicity_scheme='qp_m_matrix' + application='always'."""
+        problem, pts = setup
+        solver = HJBGFDMSolver(problem, pts, monotonicity_scheme="qp_m_matrix", monotonicity_application="always")
+        assert solver.monotonicity_scheme == "qp_m_matrix"
+        assert solver.monotonicity_application == "always"
+
+    def test_legacy_attribute_NiterNewton_gone(self, setup):
+        """After removal, solver instance no longer exposes .NiterNewton attribute."""
+        problem, pts = setup
+        solver = HJBGFDMSolver(problem, pts, max_newton_iterations=30, monotonicity_scheme="none")
+        assert not hasattr(solver, "NiterNewton"), (
+            "solver.NiterNewton attribute still present; remove self.NiterNewton = ... "
+            "assignment from HJBGFDMSolver.__init__"
+        )
+
+    def test_legacy_attribute_l2errBoundNewton_gone(self, setup):
+        """After removal, solver instance no longer exposes .l2errBoundNewton attribute."""
+        problem, pts = setup
+        solver = HJBGFDMSolver(problem, pts, newton_tolerance=1e-7, monotonicity_scheme="none")
+        assert not hasattr(solver, "l2errBoundNewton"), (
+            "solver.l2errBoundNewton attribute still present; remove self.l2errBoundNewton = ... "
+            "assignment from HJBGFDMSolver.__init__"
+        )


### PR DESCRIPTION
## Summary

Hard removal of three deprecated `HJBGFDMSolver` constructor parameters that passed the 3-version / 6-month deprecation window (Issue #1070, Cluster B):

- `NiterNewton=` → canonical `max_newton_iterations=`
- `l2errBoundNewton=` → canonical `newton_tolerance=`
- `qp_optimization_level=` → canonical `monotonicity_scheme=` + `monotonicity_application=`

**Cluster A** (`FixedPointIterator` damping_* params) was already done prior to this PR.

### Key changes

- `hjb_gfdm.py`: removed 3 params from `__init__` signature and all backward-compat body code; `from_config` now translates `QPConfig.optimization_level` to `(monotonicity_scheme, monotonicity_application)` directly via a translation dict.
- `test_hjb_gfdm_v025_removal.py` (new): pinning test — 4 `TypeError` tests lock in the removal, 7 canonical-API tests guard regressions.
- `test_hjb_gfdm_solver.py`: updated `test_deprecated_parameters` → `test_removed_deprecated_parameters_raise` to expect `TypeError`.
- `test_hjb_gfdm_monotonicity_scheme_rename.py`: rewrote dual-constructor comparisons to canonical-only; `test_mutual_exclusion` now expects `TypeError` (not `ValueError`).

### Pinning test evidence

**Pre-fix** (params still in signature → `DeprecationWarning`, no `TypeError`):
```
FAILED test_hjb_gfdm_v025_removal.py::TestRemovedDeprecatedParams::test_NiterNewton_raises_type_error
  - DID NOT RAISE <class 'TypeError'>
```

**Post-fix** (params removed → Python raises `TypeError: unexpected keyword argument`):
```
58 passed in 74.99s
```

Fixes #1070

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>