### PR TITLE
fix(workflow): SweepConfiguration.mp_context + spawn end-to-end test (Fixes #1080)

### DIFF
--- a/mfgarchon/workflow/parameter_sweep.py
+++ b/mfgarchon/workflow/parameter_sweep.py
@@ -42,6 +42,19 @@ class SweepConfiguration:
     timeout_per_run: float | None = None
     retry_failed: bool = True
     max_retries: int = 3
+    mp_context: Any = None
+    """Multiprocessing context passed to ``ProcessPoolExecutor`` for
+    ``parallel_processes`` mode.
+
+    ``None`` (default) uses the platform default start method (fork on
+    Linux, spawn on macOS/Windows).  Pass ``multiprocessing.get_context('spawn')``
+    to force spawn on all platforms — required for deterministic portability
+    testing and for environments that initialize CUDA/JAX before forking.
+
+    Issue #1080: the spawn start method pickles every worker argument, so the
+    sweep function and the ``ParameterSweep`` instance must both be picklable.
+    ``ParameterSweep.__getstate__`` drops the logger for this purpose.
+    """
 
     def __post_init__(self):
         if self.max_workers is None:
@@ -264,7 +277,10 @@ class ParameterSweep:
                     "(or 'sequential') to sweep in-process without pickling."
                 ) from e
 
-        with ProcessPoolExecutor(max_workers=self.config.max_workers) as executor:
+        # Issue #1080: pass the caller-supplied mp_context so users can force
+        # spawn on Linux (e.g. to test portability or avoid CUDA/JAX fork issues)
+        # without changing the system-wide start method.  None → platform default.
+        with ProcessPoolExecutor(max_workers=self.config.max_workers, mp_context=self.config.mp_context) as executor:
             # Prepare arguments for each worker — include self for pickling
             worker_args = [(self, function, params, i, kwargs) for i, params in enumerate(self.parameter_combinations)]
 

--- a/tests/unit/test_workflow/test_parameter_sweep.py
+++ b/tests/unit/test_workflow/test_parameter_sweep.py
@@ -5,6 +5,7 @@ Tests parameter space exploration including combination generation,
 execution modes, result collection, and error handling.
 """
 
+import multiprocessing as mp
 import pickle
 import tempfile
 from pathlib import Path
@@ -12,6 +13,23 @@ from pathlib import Path
 import pytest
 
 from mfgarchon.workflow.parameter_sweep import ParameterSweep, SweepConfiguration
+
+# ---------------------------------------------------------------------------
+# Module-level helper for Issue #1080 spawn-compatibility test.
+#
+# Must be at MODULE level (not inside any function) so that spawned
+# ProcessPoolExecutor workers can import it via the module path
+# tests.unit.test_workflow.test_parameter_sweep._spawn_test_add.
+# spawn inherits sys.path from the parent process (Python multiprocessing
+# copies sys.path into the worker's preparation data), so this module is
+# importable in the worker when pytest has added the project root to sys.path.
+# ---------------------------------------------------------------------------
+
+
+def _spawn_test_add(x, y):
+    """Return {'sum': x + y}. Module-level for spawn-process importability."""
+    return {"sum": x + y}
+
 
 # ============================================================================
 # Test: SweepConfiguration
@@ -608,3 +626,55 @@ def test_parallel_processes_fails_loud_on_unpicklable_function_issue_1080():
     sweep = ParameterSweep({"x": [1, 2]})
     with pytest.raises(ValueError, match="not picklable"):
         sweep._execute_parallel_processes(lambda x: x)
+
+
+@pytest.mark.unit
+def test_spawn_context_end_to_end_issue_1080():
+    """Two-combination sweep runs to completion via the public execute() API using
+    an explicit spawn-context ProcessPoolExecutor.
+
+    This is the canonical end-to-end regression guard for Issue #1080.
+
+    What fails pre-fix (without the SweepConfiguration.mp_context field and its
+    use in _execute_parallel_processes):
+      - SweepConfiguration(**kwargs) raises TypeError (unexpected mp_context arg)
+      - OR ProcessPoolExecutor does not receive the explicit spawn context
+
+    What passes post-fix:
+      - SweepConfiguration accepts mp_context
+      - _execute_parallel_processes passes it to ProcessPoolExecutor
+      - ParameterSweep.__getstate__ drops the logger so the instance stays
+        picklable under spawn (relevant for Python versions where Logger handlers
+        hold non-picklable state)
+      - _spawn_test_add is module-level so spawned workers can import it
+
+    The sweep function ``_spawn_test_add`` is defined at module level in this file
+    (not inside any test function) so spawned workers can import it; Python's
+    multiprocessing copies sys.path into the worker's preparation data (via
+    get_preparation_data → sys_path), making this test module importable in the
+    child process.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = SweepConfiguration(
+            parameters={"x": [1, 2], "y": [3]},
+            execution_mode="parallel_processes",
+            max_workers=2,
+            save_intermediate=False,
+            output_dir=Path(tmpdir),
+            mp_context=mp.get_context("spawn"),  # explicit spawn — tests all platforms
+        )
+        sweep = ParameterSweep({"x": [1, 2], "y": [3]}, config=config)
+
+        # Verify the full worker payload pickles cleanly (critical regression check).
+        for i, params in enumerate(sweep.parameter_combinations):
+            args = (sweep, _spawn_test_add, params, i, {})
+            data = pickle.dumps(args)  # TypeError here if __getstate__ missing
+            pickle.loads(data)  # must round-trip cleanly
+
+        # Run through the public API with explicit spawn context.
+        results = sweep.execute(_spawn_test_add)
+
+    assert len(results) == 2, f"Expected 2 results, got {len(results)}: {sweep.failed_runs}"
+    assert all(r["status"] == "success" for r in results), results
+    sums = {r["sum"] for r in results}
+    assert sums == {1 + 3, 2 + 3}, f"Expected {{4, 5}}, got {sums}"


### PR DESCRIPTION
## Summary

- Add `mp_context: Any = None` field to `SweepConfiguration`; passed directly to `ProcessPoolExecutor(mp_context=...)` in `_execute_parallel_processes`. Default `None` preserves platform-default behaviour (fork on Linux, spawn on macOS/Windows). Users can now force spawn on any platform via `SweepConfiguration(mp_context=mp.get_context('spawn'))`.
- Add `_spawn_test_add` module-level helper + `test_spawn_context_end_to_end_issue_1080` pinning test: runs a 2-combination sweep through `sweep.execute()` with explicit spawn context, verifying pickle round-trip and correct results.

## Fixes

Fixes #1080

## What was already in main (this PR exercises but did not introduce)

- `ParameterSweep.__getstate__` / `__setstate__`: drops logger so the instance is picklable under spawn (Python's `multiprocessing.spawn` copies `sys.path` to workers; logger handlers can hold `_thread.RLock` in some Python versions/configs)
- Fail-fast probe in `_execute_parallel_processes`: raises `ValueError("not picklable")` with an actionable message when `function` is a lambda/closure rather than letting a `BrokenProcessPool` surface deep in the worker
- Module-level `_process_worker`: picklable callable for `ProcessPoolExecutor.submit`

## Stash dance (pinning test fail / pass)

**Pre-fix** (stash `mfgarchon/workflow/parameter_sweep.py` only):
```
FAILED tests/unit/test_workflow/test_parameter_sweep.py::test_spawn_context_end_to_end_issue_1080
TypeError: SweepConfiguration.__init__() got an unexpected keyword argument 'mp_context'
```

**Post-fix** (stash popped):
```
PASSED  tests/unit/test_workflow/test_parameter_sweep.py::test_spawn_context_end_to_end_issue_1080
1 passed in 4.77s
```

## Test plan

- [x] `test_spawn_context_end_to_end_issue_1080` — new end-to-end spawn test
- [x] `test_parameter_sweep_is_picklable_issue_1080` — existing pickle round-trip
- [x] `test_parallel_processes_fails_loud_on_unpicklable_function_issue_1080` — existing fail-fast probe
- [x] Full `tests/unit/test_workflow/` suite: 207 passed, no regressions
- [x] `ruff format` + `ruff check`: all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)