### PR TITLE
feat(alg): add LLF augmented diffusion option to HJBGFDMSolver

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -293,6 +293,16 @@ class HJBGFDMSolver(BaseHJBSolver):
         # numerically byte-identical) — the assembled discrete-maximum-principle is only
         # diagnostic, not enforced.
         check_dmp: bool = False,
+        # LLF (Local Lax-Friedrichs) augmented diffusion (Issue #1059, paper P2 branch).
+        # Adds per-node artificial viscosity nu_i to the diffusion term so that the
+        # local Peclet condition Pe_h(i) = l_H(i)*h_i / (sigma^2 + 2*nu_i) <= 1/(2C)
+        # is satisfied at every node, restoring the discrete comparison principle at
+        # high-Pe nodes where P1 (unaugmented) cannot satisfy the theorem hypothesis.
+        # Default OFF (byte-identical to current main when off).
+        # When on, requires llf_l_H: per-node |dH/dp| Lipschitz bound (fail-loud if None).
+        llf_augmentation: bool = False,
+        llf_cone_constant: float = 0.5,  # C in nu_i = max(0, C*l_H*h - sigma^2/2)
+        llf_l_H: float | np.ndarray | None = None,  # per-node Lipschitz bound |dH/dp|
     ):
         """
         Initialize the GFDM HJB solver.
@@ -409,6 +419,24 @@ class HJBGFDMSolver(BaseHJBSolver):
                 ``obstacle_sdf`` is provided.
             visibility_margin: Safety margin for obstacle proximity (default 0.0).
                 Stencil edges passing within this distance of an obstacle are filtered.
+            llf_augmentation: Enable Local Lax-Friedrichs (LLF) per-node artificial
+                diffusion (Issue #1059, paper P2 branch of thm:discrete_comparison).
+                When True, augments the diffusion coefficient at each node i by
+                ``nu_i = max(0, C * l_H(i) * h_i - sigma^2/2)``, so the effective
+                volatility is ``sigma_eff_i = sqrt(sigma^2 + 2*nu_i)``.  This restores
+                the discrete comparison principle at high-Pe nodes (``l_H(i)*h_i/sigma^2
+                >> 1``) where P1 (unaugmented) cannot satisfy the theorem hypothesis.
+                Default OFF (byte-identical to current main when off).
+                Requires ``llf_l_H`` to be provided (fail-loud otherwise).
+            llf_cone_constant: The constant C in ``nu_i = max(0, C*l_H(i)*h_i -
+                sigma^2/2)`` (default 0.5). Per the mfg-research prototype: C=0.5 gives
+                structural stability; C=1.0 is catastrophic (vicious Picard feedback).
+                See Issue #1059.
+            llf_l_H: Per-node Lipschitz bound ``l_H(i) = |dH/dp|(i)``.  May be a scalar
+                (broadcast to all nodes) or a shape ``(n_points,)`` array.  Design
+                options: (a) cone bound from stencil, (b) from ``dH/dp`` at previous
+                Picard iterate, (c) user-supplied (this parameter).  Fail-loud if
+                ``llf_augmentation=True`` and this is None.
         """
         super().__init__(problem)
 
@@ -595,6 +623,34 @@ class HJBGFDMSolver(BaseHJBSolver):
         self.check_dmp = check_dmp
         self._dmp_alpha_crit: float | None = None
         self._dmp_warned = False
+
+        # LLF augmented diffusion (Issue #1059, paper P2 branch of thm:discrete_comparison).
+        # nu_i = max(0, C * l_H(i) * h_i - sigma^2/2)
+        # sigma_eff_i = sqrt(sigma^2 + 2*nu_i)
+        # Stored attributes (None when llf_augmentation=False → zero overhead):
+        #   self._llf_l_H      : np.ndarray (n_points,) — per-node |dH/dp| Lipschitz bound
+        #   self._llf_sigma_eff: np.ndarray (n_points,) — per-node effective volatility
+        self.llf_augmentation: bool = llf_augmentation
+        self._llf_cone_constant: float = float(llf_cone_constant)
+        if llf_augmentation:
+            if llf_l_H is None:
+                raise ValueError(
+                    "llf_augmentation=True requires llf_l_H: the per-node |dH/dp| "
+                    "Lipschitz bound (scalar float or shape (n_points,) array). "
+                    "Provide llf_l_H=<value> to enable LLF augmented diffusion. "
+                    "See Issue #1059."
+                )
+            l_H_raw = np.asarray(llf_l_H, dtype=float)
+            # Scalar or shape (n_points,) — broadcast to full node array
+            self._llf_l_H: np.ndarray = np.broadcast_to(l_H_raw, (self.n_points,)).copy()
+            if np.any(self._llf_l_H < 0.0):
+                raise ValueError(
+                    f"llf_l_H must be non-negative at every node; got min={float(np.min(self._llf_l_H)):.3g} < 0."
+                )
+            self._llf_sigma_eff: np.ndarray = self._compute_llf_sigma_eff()
+        else:
+            self._llf_l_H = None  # type: ignore[assignment]
+            self._llf_sigma_eff = None  # type: ignore[assignment]
 
         # Monotonicity scheme (single source of truth) — already set above (v0.18.0 rename)
         # self.monotonicity_scheme and self.qp_optimization_level both = resolved monotonicity_scheme
@@ -2020,8 +2076,14 @@ class HJBGFDMSolver(BaseHJBSolver):
         # `problem.diffusion` returns σ²/2 (PDE coefficient D), so the old chain
         # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
         # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
-        sigma = self._get_sigma_value(None)
-        diffusion_term = diffusion_from_volatility(sigma) * lap_u
+        #
+        # Issue #1059 LLF augmentation: use per-node sigma_eff_i when active.
+        if self.llf_augmentation and self._llf_sigma_eff is not None:
+            # Per-node effective diffusion: D_i = sigma_eff_i^2/2 (elementwise)
+            diffusion_term = diffusion_from_volatility(self._llf_sigma_eff, kind="field") * lap_u
+        else:
+            sigma = self._get_sigma_value(None)
+            diffusion_term = diffusion_from_volatility(sigma) * lap_u
 
         # HJB residual: -u_t + H - diffusion = 0
         residual = -u_t + H_total - diffusion_term
@@ -2060,6 +2122,16 @@ class HJBGFDMSolver(BaseHJBSolver):
         dt = self.problem.T / self.problem.Nt
         u_t = (u_n_plus_1 - u_current) / dt
         # _get_sigma_value returns σ (not D); the harness applies D = σ²/2 (#1073/#811).
+        # Issue #1059 LLF: when active, assemble inline with per-node D_i = sigma_eff_i^2/2
+        # (assemble_hjb_residual only accepts scalar sigma; bypass it for the LLF path).
+        if self.llf_augmentation and self._llf_sigma_eff is not None:
+            from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_H_batch
+
+            H = eval_H_batch(H_class, self.collocation_points, m_n_plus_1, grad_u, current_time)
+            if running_cost is not None:
+                H = H + running_cost
+            D_eff = diffusion_from_volatility(self._llf_sigma_eff, kind="field")
+            return -u_t + H - D_eff * lap_u
         sigma = self._get_sigma_value(None)
         return assemble_hjb_residual(
             H_class=H_class,
@@ -2101,6 +2173,20 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         dt = self.problem.T / self.problem.Nt
         # _get_sigma_value returns σ (not D); the harness applies D = σ²/2 (#1073/#811).
+        # Issue #1059 LLF: assemble_hjb_jacobian_diag only accepts scalar sigma;
+        # for the LLF path assemble inline with per-node D_i = sigma_eff_i^2/2.
+        if self.llf_augmentation and self._llf_sigma_eff is not None:
+            from scipy.sparse import diags, eye
+
+            from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch
+
+            dH_dp = eval_dH_dp_batch(H_class, self.collocation_points, m_n_plus_1, grad_u, current_time)
+            n = self._D_lap.shape[0]
+            jacobian = (1.0 / dt) * eye(n, format="csr")
+            for dim in range(dH_dp.shape[1]):
+                jacobian = jacobian + diags(dH_dp[:, dim], format="csr") @ self._D_grad[dim]
+            D_eff = diffusion_from_volatility(self._llf_sigma_eff, kind="field")
+            return jacobian - diags(D_eff, format="csr") @ self._D_lap
         sigma = self._get_sigma_value(None)
         return assemble_hjb_jacobian_diag(
             H_class=H_class,
@@ -2235,8 +2321,13 @@ class HJBGFDMSolver(BaseHJBSolver):
         # `problem.diffusion` returns σ²/2 (PDE coefficient D), so the old chain
         # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
         # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
-        sigma = self._get_sigma_value(None)
-        diffusion_coeff = diffusion_from_volatility(sigma)
+        # Issue #1059 LLF: when active, use per-node D_i = sigma_eff_i^2/2.
+        if self.llf_augmentation and self._llf_sigma_eff is not None:
+            D_eff = diffusion_from_volatility(self._llf_sigma_eff, kind="field")
+        else:
+            sigma = self._get_sigma_value(None)
+            D_eff = None
+            diffusion_coeff = diffusion_from_volatility(sigma)
 
         # Time derivative term: (1/dt) * I
         jacobian = (1.0 / dt) * eye(n, format="csr")
@@ -2247,8 +2338,11 @@ class HJBGFDMSolver(BaseHJBSolver):
             p_d = grad_u[:, dim] / lambda_val  # dH/dp_d = p_d / λ
             jacobian = jacobian + diags(p_d, format="csr") @ self._D_grad[dim]
 
-        # Diffusion term: -(σ²/2) * D_lap
-        jacobian = jacobian - diffusion_coeff * self._D_lap
+        # Diffusion term: -(D_i) * D_lap  [per-node for LLF, scalar otherwise]
+        if D_eff is not None:
+            jacobian = jacobian - diags(D_eff, format="csr") @ self._D_lap
+        else:
+            jacobian = jacobian - diffusion_coeff * self._D_lap
 
         return jacobian
 
@@ -2732,12 +2826,53 @@ class HJBGFDMSolver(BaseHJBSolver):
             )
         return float(lambda_val)
 
+    def _compute_llf_sigma_eff(self) -> np.ndarray:
+        """Compute per-node effective sigma for LLF augmentation (Issue #1059, paper P2).
+
+        For each collocation node i:
+
+            nu_i = max(0, C * l_H(i) * h_i - sigma^2/2)
+            sigma_eff_i = sqrt(sigma^2 + 2 * nu_i)
+
+        where:
+          - sigma = problem volatility (scalar; callable not supported here, evaluated at None)
+          - C = self._llf_cone_constant (paper P2 cone constant, default 0.5)
+          - l_H(i) = self._llf_l_H[i] (user-supplied |dH/dp| Lipschitz bound)
+          - h_i = self.delta (conservative upper bound for local mesh size)
+
+        When nu_i = 0 at node i (Pe already small enough), sigma_eff_i = sigma exactly
+        (no augmentation at that node).  Called once at __init__ and stored in
+        self._llf_sigma_eff; not recomputed per Picard iteration (Issue #1059 stability
+        note: holding nu_i fixed avoids the runaway Picard feedback in the prototype).
+
+        Returns:
+            shape (n_points,) float64 array of per-node effective volatility values.
+        """
+        # Use scalar sigma from problem (callable sigma: evaluated with None, returns 1.0
+        # representative value — callable-sigma + LLF is an uncommon combination).
+        sigma = self._get_sigma_value(None)
+        D_base = 0.5 * sigma**2  # sigma^2/2, the base diffusion coefficient
+
+        # nu_i = max(0, C * l_H(i) * h_i - D_base)
+        # h_i approximated by self.delta (conservative upper bound; actual stencil
+        # distances are <= delta, so this may over-estimate nu_i slightly, never under).
+        nu_i = np.maximum(0.0, self._llf_cone_constant * self._llf_l_H * self.delta - D_base)
+
+        # sigma_eff_i = sqrt(sigma^2 + 2*nu_i)
+        return np.sqrt(sigma**2 + 2.0 * nu_i)
+
     def _get_sigma_value(self, point_idx: int | None = None) -> float:
         """
         Get diffusion coefficient value, handling both numeric and callable sigma.
 
+        When llf_augmentation=True and point_idx is not None, returns the per-node
+        effective sigma sqrt(sigma^2 + 2*nu_i) from LLF augmentation (Issue #1059).
+        When point_idx is None (batch path), returns the base scalar sigma regardless
+        of llf_augmentation (the batch path handles LLF separately via the
+        self._llf_sigma_eff array in _compute_hjb_residual_vectorized and related).
+
         Args:
-            point_idx: Collocation point index (for callable sigma evaluation)
+            point_idx: Collocation point index (for callable sigma evaluation or LLF lookup)
 
         Returns:
             Numeric sigma value
@@ -2747,6 +2882,13 @@ class HJBGFDMSolver(BaseHJBSolver):
         2. problem.sigma is callable → evaluate at collocation point
         3. problem.sigma is numeric → use directly (fallback: 1.0)
         """
+        # LLF per-node override: return sigma_eff_i when augmentation is active (Issue #1059).
+        # Only applies when point_idx is not None (per-point path); the batch path (None)
+        # reads self._llf_sigma_eff directly.
+        if self.llf_augmentation and point_idx is not None and self._llf_sigma_eff is not None:
+            if point_idx < len(self._llf_sigma_eff):
+                return float(self._llf_sigma_eff[point_idx])
+
         # Check for legacy "nu" attribute (optional)
         nu = getattr(self.problem, "nu", None)
         if nu is not None:

--- a/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
@@ -1,0 +1,399 @@
+"""
+Pinning tests for LLF (Local Lax-Friedrichs) augmented diffusion in HJBGFDMSolver.
+
+Issue #1059: paper P2 branch of thm:discrete_comparison — per-node artificial viscosity
+nu_i that restores the discrete comparison principle at high-Pe nodes.
+
+PINNING CONTRACT
+----------------
+Pre-fix (before this PR): ``HJBGFDMSolver.__init__`` has no ``llf_augmentation``
+parameter; constructing with it raises ``TypeError: unexpected keyword argument``.
+
+Post-fix: the parameter exists; the solver stores ``_llf_sigma_eff`` (per-node effective
+sigma), and ``_get_sigma_value(i)`` returns ``sigma_eff_i >= sigma`` for all i when LLF is
+active.  With LLF OFF the result is byte-identical to the baseline (no sigma override).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _hamiltonian():
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+
+
+def _components():
+    return MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=_hamiltonian(),
+    )
+
+
+@pytest.fixture
+def problem_and_pts():
+    """1D MFG problem + 21 uniform collocation points."""
+    sigma = 0.5  # small sigma → high Pe (motivating regime for LLF)
+    domain = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx_points=[21],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    problem = MFGProblem(geometry=domain, T=1.0, Nt=21, sigma=sigma, components=_components())
+    bounds = problem.geometry.get_bounds()
+    (Nx,) = problem.geometry.get_grid_shape()
+    pts = np.linspace(bounds[0][0], bounds[1][0], Nx).reshape(-1, 1)
+    return problem, pts
+
+
+# ---------------------------------------------------------------------------
+# PINNING TEST 1 — core: option accepted + sigma_eff stored correctly
+# ---------------------------------------------------------------------------
+
+
+class TestLLFAugmentationPinning:
+    """Core pinning tests — fail pre-fix, pass post-fix."""
+
+    def test_llf_parameter_accepted(self, problem_and_pts):
+        """PINNING: llf_augmentation parameter accepted without TypeError.
+
+        Pre-fix: TypeError: __init__() got an unexpected keyword argument 'llf_augmentation'.
+        Post-fix: solver constructs cleanly.
+        """
+        problem, pts = problem_and_pts
+        # This raises TypeError on the unpatched code.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_cone_constant=0.5,
+                llf_l_H=10.0,  # large l_H guarantees nu_i > 0 at every node
+            )
+        assert solver.llf_augmentation is True
+
+    def test_llf_sigma_eff_stored(self, problem_and_pts):
+        """PINNING: _llf_sigma_eff is a shape-(n_points,) float array when LLF is on."""
+        problem, pts = problem_and_pts
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_l_H=10.0,
+            )
+        assert solver._llf_sigma_eff is not None
+        assert solver._llf_sigma_eff.shape == (solver.n_points,)
+        assert solver._llf_sigma_eff.dtype == np.float64
+
+    def test_llf_sigma_eff_ge_base(self, problem_and_pts):
+        """PINNING: sigma_eff_i >= sigma everywhere (LLF only adds diffusion)."""
+        problem, pts = problem_and_pts
+        sigma_base = problem.sigma
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_l_H=10.0,
+            )
+        np.testing.assert_array_less(
+            sigma_base - 1e-12,
+            solver._llf_sigma_eff,
+            err_msg="sigma_eff_i must be >= sigma (LLF only stabilises, never de-stabilises)",
+        )
+
+    def test_llf_at_least_one_node_augmented(self, problem_and_pts):
+        """PINNING: with l_H=10 and delta=0.1, nu_i > 0 at every node."""
+        problem, pts = problem_and_pts
+        # nu_i = max(0, C*l_H*delta - sigma^2/2) = max(0, 0.5*10*0.1 - 0.25/2)
+        #       = max(0, 0.5 - 0.125) = 0.375 > 0
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_l_H=10.0,
+            )
+        assert np.all(solver._llf_sigma_eff > problem.sigma + 1e-12), (
+            "Expected all nodes augmented for l_H=10, delta=0.1, sigma=0.5, C=0.5"
+        )
+
+    def test_llf_get_sigma_value_returns_eff(self, problem_and_pts):
+        """PINNING: _get_sigma_value(i) returns sigma_eff_i when LLF is on."""
+        problem, pts = problem_and_pts
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_l_H=10.0,
+            )
+        for i in range(min(5, solver.n_points)):
+            got = solver._get_sigma_value(i)
+            expected = float(solver._llf_sigma_eff[i])
+            assert abs(got - expected) < 1e-12, f"_get_sigma_value({i}) = {got} != sigma_eff[{i}] = {expected}"
+
+    def test_llf_off_get_sigma_value_unchanged(self, problem_and_pts):
+        """PINNING: LLF OFF → _get_sigma_value(i) returns base problem sigma."""
+        problem, pts = problem_and_pts
+        sigma_base = float(problem.sigma)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(problem, pts, monotonicity_scheme="none")
+        for i in range(min(5, solver.n_points)):
+            got = solver._get_sigma_value(i)
+            assert abs(got - sigma_base) < 1e-12, f"LLF OFF: _get_sigma_value({i}) = {got} != sigma = {sigma_base}"
+
+    def test_llf_off_no_sigma_eff(self, problem_and_pts):
+        """PINNING: LLF OFF → _llf_sigma_eff is None (zero overhead)."""
+        problem, pts = problem_and_pts
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(problem, pts, monotonicity_scheme="none")
+        assert solver._llf_sigma_eff is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud validation
+# ---------------------------------------------------------------------------
+
+
+class TestLLFValidation:
+    """Fail-loud validation tests (fail-fast per CLAUDE.md)."""
+
+    def test_missing_l_H_raises(self, problem_and_pts):
+        """llf_augmentation=True without llf_l_H raises ValueError (fail-loud)."""
+        problem, pts = problem_and_pts
+        # Suppress unrelated UserWarning from no monotonicity_scheme; ValueError is what
+        # we're testing, and it fires before the warning in the constructor path.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with pytest.raises(ValueError, match="llf_l_H"):
+                HJBGFDMSolver(problem, pts, monotonicity_scheme="none", llf_augmentation=True)
+
+    def test_negative_l_H_raises(self, problem_and_pts):
+        """Negative l_H values raise ValueError."""
+        problem, pts = problem_and_pts
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with pytest.raises(ValueError, match="non-negative"):
+                HJBGFDMSolver(
+                    problem,
+                    pts,
+                    monotonicity_scheme="none",
+                    llf_augmentation=True,
+                    llf_l_H=-1.0,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Numerical correctness of nu_i computation
+# ---------------------------------------------------------------------------
+
+
+class TestLLFNumerics:
+    """Numerical correctness of sigma_eff_i computation."""
+
+    def test_zero_l_H_gives_base_sigma(self, problem_and_pts):
+        """l_H = 0 → nu_i = 0 → sigma_eff_i = sigma (no augmentation at any node)."""
+        problem, pts = problem_and_pts
+        sigma_base = float(problem.sigma)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_l_H=0.0,
+            )
+        np.testing.assert_allclose(
+            solver._llf_sigma_eff,
+            sigma_base,
+            rtol=1e-12,
+            err_msg="l_H=0 → nu_i=0 → sigma_eff_i must equal sigma exactly",
+        )
+
+    def test_sigma_eff_formula_scalar_l_H(self, problem_and_pts):
+        """Verify sigma_eff_i matches the analytic formula for scalar l_H."""
+        problem, pts = problem_and_pts
+        sigma = float(problem.sigma)
+        C = 0.5
+        l_H = 5.0
+        delta = 0.1  # default
+
+        # Expected: nu_i = max(0, C*l_H*delta - sigma^2/2), same at every node
+        D_base = 0.5 * sigma**2
+        nu_expected = max(0.0, C * l_H * delta - D_base)
+        sigma_eff_expected = np.sqrt(sigma**2 + 2.0 * nu_expected)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_cone_constant=C,
+                llf_l_H=l_H,
+            )
+        np.testing.assert_allclose(
+            solver._llf_sigma_eff,
+            sigma_eff_expected,
+            rtol=1e-12,
+            err_msg="sigma_eff_i must match analytic formula",
+        )
+
+    def test_sigma_eff_formula_per_node_l_H(self, problem_and_pts):
+        """sigma_eff_i computed correctly when l_H is a per-node array."""
+        problem, pts = problem_and_pts
+        sigma = float(problem.sigma)
+        C = 0.5
+        delta = 0.1
+        n = pts.shape[0]
+
+        # Varying l_H: first half high, second half zero
+        l_H_arr = np.zeros(n)
+        l_H_arr[: n // 2] = 20.0  # augmented nodes
+        l_H_arr[n // 2 :] = 0.0  # unaugmented nodes
+
+        D_base = 0.5 * sigma**2
+        nu_expected = np.maximum(0.0, C * l_H_arr * delta - D_base)
+        sigma_eff_expected = np.sqrt(sigma**2 + 2.0 * nu_expected)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_cone_constant=C,
+                llf_l_H=l_H_arr,
+            )
+        np.testing.assert_allclose(
+            solver._llf_sigma_eff,
+            sigma_eff_expected,
+            rtol=1e-12,
+            err_msg="Per-node sigma_eff_i must match element-wise formula",
+        )
+
+    def test_cone_constant_effect(self, problem_and_pts):
+        """Larger C → larger nu_i → larger sigma_eff_i."""
+        problem, pts = problem_and_pts
+        l_H = 8.0
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver_c05 = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_cone_constant=0.5,
+                llf_l_H=l_H,
+            )
+            solver_c10 = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_cone_constant=1.0,
+                llf_l_H=l_H,
+            )
+        # C=1.0 → larger nu_i → larger sigma_eff
+        assert np.all(solver_c10._llf_sigma_eff >= solver_c05._llf_sigma_eff - 1e-12)
+        assert np.any(solver_c10._llf_sigma_eff > solver_c05._llf_sigma_eff + 1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Operator-level test: Jacobian diagonal differs in stabilising direction
+# ---------------------------------------------------------------------------
+
+
+class TestLLFJacobianEffect:
+    """Verify that LLF ON changes the assembled Jacobian in the expected direction."""
+
+    def test_jacobian_diffusion_diagonal_larger_with_llf(self, problem_and_pts):
+        """LLF ON → Jacobian diagonal is larger at interior nodes.
+
+        The (i, i) entry of the vectorized Jacobian contains:
+            (1/dt) - D_i * L_ii + (dH/dp) * G_ii
+        The center Laplacian weight L_ii = -sum_{j!=i}(L_ij) < 0 (M-matrix: off-diagonal
+        weights L_ij >= 0, so center is their negated sum).  Therefore:
+            -D_i * L_ii = D_i * |L_ii| > 0   (positive contribution)
+
+        With LLF, D_i_eff >= D_i, so -D_i_eff * L_ii >= -D_i * L_ii, meaning the
+        diagonal is (algebraically) LARGER when LLF is active.  We verify this at
+        interior nodes with zero gradient (no advection term).
+        """
+        problem, pts = problem_and_pts
+        n = pts.shape[0]
+        grad_u_zero = np.zeros((n, 1))  # zero gradient → no advection term
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver_off = HJBGFDMSolver(problem, pts, monotonicity_scheme="none")
+            solver_on = HJBGFDMSolver(
+                problem,
+                pts,
+                monotonicity_scheme="none",
+                llf_augmentation=True,
+                llf_l_H=10.0,
+            )
+
+        # Build differentiation matrices
+        solver_off._build_differentiation_matrices()
+        solver_on._build_differentiation_matrices()
+
+        # Jacobian at zero gradient (only time + diffusion terms matter)
+        J_off = solver_off._compute_hjb_jacobian_vectorized(grad_u_zero)
+        J_on = solver_on._compute_hjb_jacobian_vectorized(grad_u_zero)
+
+        diag_off = J_off.diagonal()
+        diag_on = J_on.diagonal()
+
+        # LLF adds diffusion → diagonal increases (D_i_eff > D_i, center lap weight < 0,
+        # so -D_i_eff * L_ii > -D_i * L_ii).
+        # Only interior rows are affected by diffusion coefficient change.
+        interior = solver_on.interior_indices
+        assert np.all(diag_on[interior] >= diag_off[interior] - 1e-12), (
+            "LLF ON should produce Jacobian diagonal >= LLF OFF diagonal at interior nodes "
+            "(larger D_i_eff, negative center Laplacian weight → larger positive contribution)"
+        )
+        # At least one interior node must differ strictly
+        assert np.any(diag_on[interior] > diag_off[interior] + 1e-12), (
+            "Expected at least one interior node with strictly larger diagonal "
+            "when LLF is active with l_H=10 (nu_i > 0 at every node)"
+        )


### PR DESCRIPTION
## Summary

- Adds opt-in `llf_augmentation=True` parameter to `HJBGFDMSolver.__init__` (default `False`, byte-identical when off), implementing the **P2 branch** of `thm:discrete_comparison` from the paper.
- At high-Pe nodes where P1 (unaugmented GFDM) cannot satisfy the theorem hypothesis `Pe_h(i) = l_H(i)*h_i/sigma^2 <= 1/(2C)`, the LLF option restores it by adding per-node artificial viscosity: `nu_i = max(0, C*l_H(i)*h_i - sigma^2/2)`, `sigma_eff_i = sqrt(sigma^2 + 2*nu_i)`.
- Motivating regime: sigma=0.5 on Towel-on-Beach (per-node Pe 6–18, well outside 1/(2C)≈0.5 for C=1).

## New parameters

| Parameter | Default | Description |
|---|---|---|
| `llf_augmentation` | `False` | Enable LLF per-node artificial diffusion (byte-identical when False) |
| `llf_cone_constant` | `0.5` | C in nu_i formula (0.5 empirically stable; C=1.0 catastrophic per prototype) |
| `llf_l_H` | `None` | Per-node `|dH/dp|` Lipschitz bound (scalar or `(n_points,)` array). Required when `llf_augmentation=True`; fail-loud otherwise. |

## Design choices

- `h_i` approximated by `delta` (conservative upper bound for stencil radius)
- `nu_i` computed **once at construction**, held fixed across Picard iterations — avoids the runaway feedback in the mfg-research prototype (Issue #1059 stability note)
- Per-node `sigma_eff_i` wired into all three Newton paths (per-point, legacy vectorized, batch Hamiltonian)
- The option for `llf_l_H` to be computed from `dH/dp` at previous Picard iterate (design option b in issue) is deferred: user supplies it as a scalar/array for now

## Partial scope note

`assemble_hjb_residual` / `assemble_hjb_jacobian_diag` in `h_eval.py` accept scalar `sigma` only; the batch Hamiltonian path with LLF active assembles inline (bypasses those helpers). Adding `kind='field'` array support to `h_eval.py` is tracked as a follow-up to avoid widening this PR's scope.

## Test plan

- [x] 14 new tests in `tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py`
- [x] Pinning fail-without / pass-with: pre-fix raises `TypeError: unexpected keyword argument 'llf_augmentation'`; post-fix passes all 14
- [x] Existing HJB GFDM suite: 109 tests green, 0 regressions
- [x] `ruff format --check` + `ruff check` clean

Refs #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)