### PR TITLE
feat(config): thread config.hjb/fp/picard fields to solver constructors

### DIFF
--- a/mfgarchon/config/__init__.py
+++ b/mfgarchon/config/__init__.py
@@ -65,6 +65,16 @@ from .mfg_methods import (
     WENOConfig,
 )
 
+# Config → solver kwargs translator (Issue #1155)
+from .translator import (
+    backend_config_to_kwargs,
+    check_logging_config,
+    fp_config_to_kwargs,
+    hjb_config_to_kwargs,
+    picard_config_to_iterator_kwargs,
+    translate_solver_config,
+)
+
 # =============================================================================
 # OPTIONAL: OmegaConf-based configuration management
 # =============================================================================
@@ -119,6 +129,13 @@ __all__ = [
     "load_solver_config",
     "save_solver_config",
     "validate_yaml_config",
+    # Translator (Issue #1155)
+    "hjb_config_to_kwargs",
+    "fp_config_to_kwargs",
+    "picard_config_to_iterator_kwargs",
+    "backend_config_to_kwargs",
+    "check_logging_config",
+    "translate_solver_config",
     # MFG solver config
     "MFGSolverConfig",
     # Array validation

--- a/mfgarchon/config/translator.py
+++ b/mfgarchon/config/translator.py
@@ -1,0 +1,567 @@
+"""
+Translator: MFGSolverConfig fields -> solver constructor kwargs.
+
+Maps validated config.hjb / config.fp / config.picard fields to the
+corresponding HJB/FP/FixedPointIterator constructor kwargs (Issue #1155).
+
+Rule
+----
+Only pass fields whose value differs from the Pydantic config default.
+If equal to default: skip (let solver use its own default).
+If non-default with a clear mapping: thread it.
+If non-default with no mapping (unsupported or wrong scheme): raise
+  NotImplementedError with "Refs #1155".
+
+This design preserves backward compatibility: existing code that relies on
+solver-level defaults is unaffected unless the user explicitly sets a
+non-default config value.
+
+BackendConfig.type threading
+-----------------------------
+config.backend.type is threaded to solvers that accept a ``backend`` kwarg
+(HJBFDMSolver, FixedPointIterator).  BackendConfig.device and .precision are
+not yet mapped; non-default values raise NotImplementedError (Refs #1155).
+
+LoggingConfig
+-------------
+Non-default values raise NotImplementedError; they are validated by Pydantic
+but have no mapping in the current solver infrastructure (Refs #1155).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mfgarchon.config.core import BackendConfig, LoggingConfig, PicardConfig
+    from mfgarchon.config.mfg_methods import FPConfig, HJBConfig
+    from mfgarchon.types import NumericalScheme
+
+
+# ---------------------------------------------------------------------------
+# HJB translator
+# ---------------------------------------------------------------------------
+
+
+def hjb_config_to_kwargs(
+    hjb_cfg: HJBConfig,
+    scheme: NumericalScheme,
+) -> dict[str, Any]:
+    """Map HJBConfig non-default fields to HJB solver constructor kwargs.
+
+    Parameters
+    ----------
+    hjb_cfg : HJBConfig
+        Validated HJB sub-configuration.
+    scheme : NumericalScheme
+        Active numerical scheme (determines which solver class is created).
+
+    Returns
+    -------
+    dict
+        Kwargs to pass to the HJB solver constructor (or hjb_config dict in
+        create_paired_solvers).
+
+    Raises
+    ------
+    NotImplementedError
+        For non-default fields that cannot be applied to the selected scheme,
+        or that have no current mapping.
+    """
+    from mfgarchon.config.mfg_methods import (
+        FDMConfig,
+        FEMConfig,
+        GFDMConfig,
+        NewtonConfig,
+        SLConfig,
+        WENOConfig,
+    )
+    from mfgarchon.config.mfg_methods import (
+        HJBConfig as _DefaultHJBConfig,
+    )
+    from mfgarchon.types import NumericalScheme
+
+    kwargs: dict[str, Any] = {}
+    default_hjb = _DefaultHJBConfig()
+
+    # ------------------------------------------------------------------
+    # Newton sub-config: tolerance, max_iterations, relaxation
+    # Applies to FDM, GFDM, SL (all Newton-based inner solvers).
+    # ------------------------------------------------------------------
+    newton = hjb_cfg.newton
+    default_newton = NewtonConfig()
+
+    if newton.tolerance != default_newton.tolerance:
+        kwargs["newton_tolerance"] = newton.tolerance
+
+    if newton.max_iterations != default_newton.max_iterations:
+        kwargs["max_newton_iterations"] = newton.max_iterations
+
+    if newton.relaxation != default_newton.relaxation:
+        # `relaxation` is a constructor kwarg for HJBFDMSolver; GFDM / SL
+        # solvers do not expose it at construction time.
+        if scheme in (NumericalScheme.FDM_UPWIND, NumericalScheme.FDM_CENTERED):
+            kwargs["relaxation"] = newton.relaxation
+        else:
+            raise NotImplementedError(
+                f"config.hjb.newton.relaxation is not mapped for "
+                f"scheme={scheme.value} (only FDM HJB solvers accept it). "
+                "Refs #1155."
+            )
+
+    # ------------------------------------------------------------------
+    # Top-level fields: method, accuracy_order, boundary_conditions
+    # ------------------------------------------------------------------
+    if hjb_cfg.method != default_hjb.method:
+        _scheme_method = {
+            NumericalScheme.FDM_UPWIND: "fdm",
+            NumericalScheme.FDM_CENTERED: "fdm",
+            NumericalScheme.SL_LINEAR: "semi_lagrangian",
+            NumericalScheme.SL_CUBIC: "semi_lagrangian",
+            NumericalScheme.GFDM: "gfdm",
+            NumericalScheme.FEM_P1: "fem",
+            NumericalScheme.FEM_P2: "fem",
+        }
+        expected = _scheme_method.get(scheme)
+        if expected is not None and hjb_cfg.method != expected:
+            raise NotImplementedError(
+                f"config.hjb.method={hjb_cfg.method!r} conflicts with "
+                f"scheme={scheme.value} (expected method {expected!r}). "
+                "In Safe/Auto mode the scheme selects the solver class. Refs #1155."
+            )
+
+    if hjb_cfg.accuracy_order != default_hjb.accuracy_order:
+        raise NotImplementedError(
+            f"config.hjb.accuracy_order={hjb_cfg.accuracy_order} is not yet mapped to a solver kwarg. Refs #1155."
+        )
+
+    if hjb_cfg.boundary_conditions != default_hjb.boundary_conditions:
+        raise NotImplementedError(
+            f"config.hjb.boundary_conditions={hjb_cfg.boundary_conditions!r} is "
+            "not yet mapped to HJB solver kwargs. Refs #1155."
+        )
+
+    # ------------------------------------------------------------------
+    # FDM sub-config
+    # ------------------------------------------------------------------
+    is_fdm_scheme = scheme in (NumericalScheme.FDM_UPWIND, NumericalScheme.FDM_CENTERED)
+    if hjb_cfg.fdm is not None:
+        default_fdm = FDMConfig()
+        if hjb_cfg.fdm != default_fdm:
+            if not is_fdm_scheme:
+                raise NotImplementedError(
+                    f"config.hjb.fdm has non-default values but "
+                    f"scheme={scheme.value} does not use a FDM HJB solver. "
+                    "Refs #1155."
+                )
+            _fdm_hjb_map = {"upwind": "gradient_upwind", "central": "gradient_centered"}
+            if hjb_cfg.fdm.scheme != default_fdm.scheme:
+                if hjb_cfg.fdm.scheme in _fdm_hjb_map:
+                    kwargs["advection_scheme"] = _fdm_hjb_map[hjb_cfg.fdm.scheme]
+                else:
+                    raise NotImplementedError(
+                        f"config.hjb.fdm.scheme={hjb_cfg.fdm.scheme!r} has no "
+                        "mapping to HJBFDMSolver advection_scheme. Refs #1155."
+                    )
+            if hjb_cfg.fdm.time_stepping != default_fdm.time_stepping:
+                raise NotImplementedError(
+                    f"config.hjb.fdm.time_stepping={hjb_cfg.fdm.time_stepping!r} is not yet mapped. Refs #1155."
+                )
+
+    # ------------------------------------------------------------------
+    # GFDM sub-config
+    # ------------------------------------------------------------------
+    if hjb_cfg.gfdm is not None:
+        default_gfdm = GFDMConfig()
+        if hjb_cfg.gfdm != default_gfdm:
+            if scheme != NumericalScheme.GFDM:
+                raise NotImplementedError(
+                    f"config.hjb.gfdm has non-default values but "
+                    f"scheme={scheme.value} does not use a GFDM HJB solver. "
+                    "Refs #1155."
+                )
+            _map_gfdm_to_hjb_kwargs(hjb_cfg.gfdm, kwargs)
+
+    # ------------------------------------------------------------------
+    # SL sub-config
+    # ------------------------------------------------------------------
+    is_sl_scheme = scheme in (NumericalScheme.SL_LINEAR, NumericalScheme.SL_CUBIC)
+    if hjb_cfg.sl is not None:
+        default_sl = SLConfig()
+        if hjb_cfg.sl != default_sl:
+            if not is_sl_scheme:
+                raise NotImplementedError(
+                    f"config.hjb.sl has non-default values but "
+                    f"scheme={scheme.value} does not use a SL HJB solver. "
+                    "Refs #1155."
+                )
+            _map_sl_to_hjb_kwargs(hjb_cfg.sl, kwargs)
+
+    # ------------------------------------------------------------------
+    # WENO sub-config — not yet mapped
+    # ------------------------------------------------------------------
+    if hjb_cfg.weno is not None:
+        default_weno = WENOConfig()
+        if hjb_cfg.weno != default_weno:
+            raise NotImplementedError("config.hjb.weno is not yet mapped to HJBWENOSolver kwargs. Refs #1155.")
+
+    # ------------------------------------------------------------------
+    # FEM sub-config — element order comes from scheme, not config
+    # ------------------------------------------------------------------
+    if hjb_cfg.fem is not None:
+        default_fem = FEMConfig()
+        if hjb_cfg.fem != default_fem:
+            raise NotImplementedError(
+                "config.hjb.fem sub-config is not yet mapped to HJBFEMSolver "
+                "kwargs (element order is taken from the NumericalScheme). "
+                "Refs #1155."
+            )
+
+    return kwargs
+
+
+def _map_gfdm_to_hjb_kwargs(gfdm_cfg: Any, kwargs: dict[str, Any]) -> None:
+    """Map GFDMConfig non-default fields to HJBGFDMSolver kwargs (in-place)."""
+    from mfgarchon.config.mfg_methods import GFDMConfig as _Def
+
+    d = _Def()
+
+    if gfdm_cfg.delta != d.delta:
+        kwargs["delta"] = gfdm_cfg.delta
+    if gfdm_cfg.taylor_order != d.taylor_order:
+        kwargs["taylor_order"] = gfdm_cfg.taylor_order
+    if gfdm_cfg.weight_function != d.weight_function:
+        kwargs["weight_function"] = gfdm_cfg.weight_function
+    if gfdm_cfg.weight_scale != d.weight_scale:
+        kwargs["weight_scale"] = gfdm_cfg.weight_scale
+    if gfdm_cfg.congestion_mode != d.congestion_mode:
+        kwargs["congestion_mode"] = gfdm_cfg.congestion_mode
+
+    # QP sub-config
+    _qp_map = {"none": "none", "auto": "qp_m_matrix", "always": "joint_socp"}
+    if gfdm_cfg.qp.optimization_level != d.qp.optimization_level:
+        kwargs["monotonicity_scheme"] = _qp_map[gfdm_cfg.qp.optimization_level]
+    if gfdm_cfg.qp.solver != d.qp.solver:
+        kwargs["qp_solver"] = gfdm_cfg.qp.solver
+    if gfdm_cfg.qp.warm_start != d.qp.warm_start:
+        kwargs["qp_warm_start"] = gfdm_cfg.qp.warm_start
+    if gfdm_cfg.qp.constraint_mode != d.qp.constraint_mode:
+        kwargs["qp_constraint_mode"] = gfdm_cfg.qp.constraint_mode
+
+    # Neighborhood sub-config
+    if gfdm_cfg.neighborhood.mode != d.neighborhood.mode:
+        kwargs["neighborhood_mode"] = gfdm_cfg.neighborhood.mode
+    if gfdm_cfg.neighborhood.k_neighbors != d.neighborhood.k_neighbors:
+        kwargs["k_neighbors"] = gfdm_cfg.neighborhood.k_neighbors
+    if gfdm_cfg.neighborhood.adaptive != d.neighborhood.adaptive:
+        kwargs["adaptive_neighborhoods"] = gfdm_cfg.neighborhood.adaptive
+    if gfdm_cfg.neighborhood.k_min != d.neighborhood.k_min:
+        kwargs["k_min"] = gfdm_cfg.neighborhood.k_min
+    if gfdm_cfg.neighborhood.max_delta_multiplier != d.neighborhood.max_delta_multiplier:
+        kwargs["max_delta_multiplier"] = gfdm_cfg.neighborhood.max_delta_multiplier
+
+    # Derivative sub-config
+    if gfdm_cfg.derivative.method != d.derivative.method:
+        kwargs["derivative_method"] = gfdm_cfg.derivative.method
+    if gfdm_cfg.derivative.rbf_kernel != d.derivative.rbf_kernel:
+        kwargs["rbf_kernel"] = gfdm_cfg.derivative.rbf_kernel
+    if gfdm_cfg.derivative.rbf_poly_degree != d.derivative.rbf_poly_degree:
+        kwargs["rbf_poly_degree"] = gfdm_cfg.derivative.rbf_poly_degree
+
+    # Boundary accuracy sub-config
+    if gfdm_cfg.boundary_accuracy.local_coordinate_rotation != d.boundary_accuracy.local_coordinate_rotation:
+        kwargs["use_local_coordinate_rotation"] = gfdm_cfg.boundary_accuracy.local_coordinate_rotation
+    if gfdm_cfg.boundary_accuracy.ghost_nodes != d.boundary_accuracy.ghost_nodes:
+        kwargs["use_ghost_nodes"] = gfdm_cfg.boundary_accuracy.ghost_nodes
+    if gfdm_cfg.boundary_accuracy.wind_dependent_bc != d.boundary_accuracy.wind_dependent_bc:
+        kwargs["use_wind_dependent_bc"] = gfdm_cfg.boundary_accuracy.wind_dependent_bc
+
+
+def _map_sl_to_hjb_kwargs(sl_cfg: Any, kwargs: dict[str, Any]) -> None:
+    """Map SLConfig non-default fields to HJBSemiLagrangianSolver kwargs (in-place)."""
+    from mfgarchon.config.mfg_methods import SLConfig as _Def
+
+    d = _Def()
+    _rk_map: dict[int, str] = {1: "explicit_euler", 2: "rk2", 4: "rk4"}
+
+    if sl_cfg.interpolation_method != d.interpolation_method:
+        kwargs["interpolation_method"] = sl_cfg.interpolation_method
+
+    if sl_cfg.rk_order != d.rk_order:
+        if sl_cfg.rk_order in _rk_map:
+            kwargs["characteristic_solver"] = _rk_map[sl_cfg.rk_order]
+        else:
+            raise NotImplementedError(
+                f"config.hjb.sl.rk_order={sl_cfg.rk_order} is not in supported "
+                f"values {list(_rk_map.keys())}. Refs #1155."
+            )
+
+    if sl_cfg.cfl_number != d.cfl_number:
+        raise NotImplementedError(
+            f"config.hjb.sl.cfl_number={sl_cfg.cfl_number} is not yet mapped to "
+            "HJBSemiLagrangianSolver params. Refs #1155."
+        )
+
+
+# ---------------------------------------------------------------------------
+# FP translator
+# ---------------------------------------------------------------------------
+
+
+def fp_config_to_kwargs(
+    fp_cfg: FPConfig,
+    scheme: NumericalScheme,
+) -> dict[str, Any]:
+    """Map FPConfig non-default fields to FP solver constructor kwargs.
+
+    Parameters
+    ----------
+    fp_cfg : FPConfig
+        Validated FP sub-configuration.
+    scheme : NumericalScheme
+        Active numerical scheme.
+
+    Returns
+    -------
+    dict
+        Kwargs to pass to the FP solver constructor (or fp_config dict in
+        create_paired_solvers).
+
+    Raises
+    ------
+    NotImplementedError
+        For non-default fields that cannot be applied to the selected scheme.
+    """
+    from mfgarchon.config.mfg_methods import (
+        FDMConfig,
+        FEMConfig,
+        NetworkConfig,
+        ParticleConfig,
+    )
+    from mfgarchon.config.mfg_methods import (
+        FPConfig as _DefaultFPConfig,
+    )
+    from mfgarchon.types import NumericalScheme
+
+    kwargs: dict[str, Any] = {}
+    default_fp = _DefaultFPConfig()
+    is_fdm_scheme = scheme in (NumericalScheme.FDM_UPWIND, NumericalScheme.FDM_CENTERED)
+
+    # ------------------------------------------------------------------
+    # method field: validate scheme consistency
+    # ------------------------------------------------------------------
+    _scheme_fp_method: dict[NumericalScheme, str] = {
+        NumericalScheme.FDM_UPWIND: "fdm",
+        NumericalScheme.FDM_CENTERED: "fdm",
+        NumericalScheme.GFDM: "gfdm",
+        NumericalScheme.FEM_P1: "fem",
+        NumericalScheme.FEM_P2: "fem",
+        # SL → FPSLSolver has no analog in FPConfig.method literals
+    }
+    if fp_cfg.method != default_fp.method:
+        expected = _scheme_fp_method.get(scheme)
+        if expected is not None and fp_cfg.method != expected:
+            raise NotImplementedError(
+                f"config.fp.method={fp_cfg.method!r} conflicts with "
+                f"scheme={scheme.value} (expected method {expected!r}). "
+                "In Safe/Auto mode the scheme selects the FP solver class. Refs #1155."
+            )
+
+    # ------------------------------------------------------------------
+    # FDM sub-config
+    # ------------------------------------------------------------------
+    if fp_cfg.fdm is not None:
+        default_fdm = FDMConfig()
+        if fp_cfg.fdm != default_fdm:
+            if not is_fdm_scheme:
+                raise NotImplementedError(
+                    f"config.fp.fdm has non-default values but "
+                    f"scheme={scheme.value} does not use a FDM FP solver. "
+                    "Refs #1155."
+                )
+            # FP needs divergence (conservative) form; HJB uses gradient form.
+            _fdm_fp_map = {
+                "upwind": "divergence_upwind",
+                "central": "divergence_centered",
+            }
+            if fp_cfg.fdm.scheme != default_fdm.scheme:
+                if fp_cfg.fdm.scheme in _fdm_fp_map:
+                    kwargs["advection_scheme"] = _fdm_fp_map[fp_cfg.fdm.scheme]
+                else:
+                    raise NotImplementedError(
+                        f"config.fp.fdm.scheme={fp_cfg.fdm.scheme!r} has no "
+                        "mapping to FPFDMSolver advection_scheme. Refs #1155."
+                    )
+            if fp_cfg.fdm.time_stepping != default_fdm.time_stepping:
+                raise NotImplementedError(
+                    f"config.fp.fdm.time_stepping={fp_cfg.fdm.time_stepping!r} is not yet mapped. Refs #1155."
+                )
+
+    # ------------------------------------------------------------------
+    # Particle sub-config: no current Safe/Auto scheme creates FPParticleSolver
+    # ------------------------------------------------------------------
+    if fp_cfg.particle is not None:
+        default_particle = ParticleConfig()
+        if fp_cfg.particle != default_particle:
+            raise NotImplementedError(
+                "config.fp.particle has non-default values but no Safe/Auto mode "
+                "scheme creates FPParticleSolver. Use Expert Mode "
+                "(solve(hjb_solver=..., fp_solver=FPParticleSolver(...))) to "
+                "configure particle-based FP solving. Refs #1155."
+            )
+
+    # ------------------------------------------------------------------
+    # GFDM sub-config (FPConfig has no gfdm field; skip if absent)
+    # ------------------------------------------------------------------
+    # Note: FPConfig does not include a gfdm sub-config — GFDM FP params
+    # are threaded via the pair factory's delta/collocation_points syncing.
+    # This gap is tracked in Refs #1155.
+
+    # ------------------------------------------------------------------
+    # Network sub-config — not yet mapped
+    # ------------------------------------------------------------------
+    if fp_cfg.network is not None:
+        default_network = NetworkConfig()
+        if fp_cfg.network != default_network:
+            raise NotImplementedError("config.fp.network is not yet mapped. Refs #1155.")
+
+    # ------------------------------------------------------------------
+    # FEM sub-config — not yet mapped
+    # ------------------------------------------------------------------
+    if fp_cfg.fem is not None:
+        default_fem = FEMConfig()
+        if fp_cfg.fem != default_fem:
+            raise NotImplementedError("config.fp.fem sub-config is not yet mapped to FPFEMSolver kwargs. Refs #1155.")
+
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Picard (FixedPointIterator) extras
+# ---------------------------------------------------------------------------
+
+
+def picard_config_to_iterator_kwargs(picard_cfg: PicardConfig) -> dict[str, Any]:
+    """Map PicardConfig.anderson_memory to FixedPointIterator constructor kwargs.
+
+    Returns an empty dict when anderson_memory==0 (disabled), so callers can
+    safely unpack the result without conditionals.
+
+    Parameters
+    ----------
+    picard_cfg : PicardConfig
+        Validated Picard iteration configuration.
+
+    Returns
+    -------
+    dict
+        ``use_anderson`` and ``anderson_depth`` entries (if anderson_memory > 0).
+    """
+    if picard_cfg.anderson_memory > 0:
+        return {
+            "use_anderson": True,
+            "anderson_depth": picard_cfg.anderson_memory,
+        }
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Backend / Logging extras
+# ---------------------------------------------------------------------------
+
+
+def backend_config_to_kwargs(backend_cfg: BackendConfig) -> dict[str, Any]:
+    """Map BackendConfig to solver constructor kwargs.
+
+    BackendConfig.type is threaded to solvers that accept a ``backend`` kwarg.
+    BackendConfig.device and .precision are not yet mapped; non-default values
+    raise NotImplementedError (Refs #1155).
+
+    Parameters
+    ----------
+    backend_cfg : BackendConfig
+        Validated backend configuration.
+
+    Returns
+    -------
+    dict
+        ``backend`` entry if type is non-default; otherwise empty.
+    """
+    from mfgarchon.config.core import BackendConfig as _Def
+
+    d = _Def()
+    kwargs: dict[str, Any] = {}
+
+    if backend_cfg.type != d.type:
+        kwargs["backend"] = backend_cfg.type
+
+    if backend_cfg.device != d.device:
+        raise NotImplementedError(
+            f"config.backend.device={backend_cfg.device!r} is not yet threaded to solvers. Refs #1155."
+        )
+
+    if backend_cfg.precision != d.precision:
+        raise NotImplementedError(
+            f"config.backend.precision={backend_cfg.precision!r} is not yet threaded to solvers. Refs #1155."
+        )
+
+    return kwargs
+
+
+def check_logging_config(logging_cfg: LoggingConfig) -> None:
+    """Raise NotImplementedError for non-default LoggingConfig fields.
+
+    LoggingConfig is validated by Pydantic but its fields have no mapping in
+    the current solver infrastructure (Refs #1155).  Calling this function
+    ensures users get a clear error rather than silent discard.
+    """
+    from mfgarchon.config.core import LoggingConfig as _Def
+
+    d = _Def()
+    non_default = [
+        f"{name}={getattr(logging_cfg, name)!r}"
+        for name in ("level", "progress_bar", "save_intermediate", "output_dir")
+        if getattr(logging_cfg, name) != getattr(d, name)
+    ]
+    if non_default:
+        raise NotImplementedError(
+            f"config.logging has non-default values ({', '.join(non_default)}) "
+            "that are not yet threaded to solvers. Refs #1155."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: translate a full MFGSolverConfig
+# ---------------------------------------------------------------------------
+
+
+def translate_solver_config(
+    config: Any,
+    scheme: NumericalScheme,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Translate a full MFGSolverConfig into solver constructor kwarg dicts.
+
+    Parameters
+    ----------
+    config : MFGSolverConfig
+        Validated solver configuration.
+    scheme : NumericalScheme
+        Active numerical scheme (determines HJB/FP solver classes).
+
+    Returns
+    -------
+    hjb_kwargs : dict
+        Kwargs for HJB solver constructor.
+    fp_kwargs : dict
+        Kwargs for FP solver constructor.
+    iterator_kwargs : dict
+        Extra kwargs for FixedPointIterator (anderson acceleration).
+    backend_kwargs : dict
+        Backend kwarg for both HJB solver and FixedPointIterator.
+    """
+    hjb_kwargs = hjb_config_to_kwargs(config.hjb, scheme)
+    fp_kwargs = fp_config_to_kwargs(config.fp, scheme)
+    iterator_kwargs = picard_config_to_iterator_kwargs(config.picard)
+    backend_kwargs = backend_config_to_kwargs(config.backend)
+    check_logging_config(config.logging)
+    return hjb_kwargs, fp_kwargs, iterator_kwargs, backend_kwargs

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -2446,12 +2446,12 @@ See: docs/migration/HAMILTONIAN_API.md"""
             tolerance: Convergence tolerance (default: from config or 1e-6)
             verbose: Show solver progress (default: from config or True)
             config: Optional MFGSolverConfig for advanced configuration.
-                Only ``config.picard`` is applied in Safe/Auto mode (explicit
-                max_iterations/tolerance/verbose override it). ``config.hjb`` /
-                ``config.fp`` are NOT yet threaded into factory-built solvers
-                (Issue #1155); passing non-default hjb/fp values raises rather than
-                silently ignoring them. Use Expert Mode (hjb_solver/fp_solver) for
-                full HJB/FP control.
+                ``config.picard`` drives iteration parameters (max_iterations,
+                tolerance, relaxation, anderson_memory).  ``config.hjb`` /
+                ``config.fp`` non-default fields are translated to solver
+                constructor kwargs (Issue #1155).  Fields with no mapping raise
+                NotImplementedError (fail-loud, Refs #1155).  Use Expert Mode
+                (hjb_solver/fp_solver) to bypass the translator entirely.
             scheme: NumericalScheme for Safe Mode (FDM_UPWIND, SL_LINEAR, GFDM, etc.)
             hjb_solver: Pre-initialized HJB solver for Expert Mode
             fp_solver: Pre-initialized FP solver for Expert Mode
@@ -2541,31 +2541,6 @@ See: docs/migration/HAMILTONIAN_API.md"""
                 "  • Auto Mode: problem.solve() [no scheme/solver params]"
             )
 
-        # config.hjb / config.fp are not yet threaded into factory-built solvers
-        # (Issue #1155): the composite HJB/FP configs do not map cleanly to the
-        # per-solver constructor kwargs. Fail loud rather than silently ignore a
-        # user-supplied hjb/fp config in the factory paths (Safe/Auto mode). Expert
-        # Mode builds the solvers directly, so config.hjb/.fp are irrelevant there.
-        if not expert_mode:
-            from mfgarchon.config.mfg_methods import FPConfig, HJBConfig
-
-            unhonored = [
-                name
-                for name, sub, default in (
-                    ("config.hjb", config.hjb, HJBConfig()),
-                    ("config.fp", config.fp, FPConfig()),
-                )
-                if sub != default
-            ]
-            if unhonored:
-                raise NotImplementedError(
-                    f"{' and '.join(unhonored)} cannot be applied in "
-                    f"{'Safe' if safe_mode else 'Auto'} mode yet: the composite HJB/FP config "
-                    "does not map to the factory's per-solver settings (Issue #1155). Only "
-                    "config.picard is honored here. For full HJB/FP control now, use Expert "
-                    "Mode: solve(hjb_solver=..., fp_solver=...)."
-                )
-
         # ─────────────────────────────────────────────────────────────────────
         # Safe Mode: Automatic dual pairing via scheme selection
         # ─────────────────────────────────────────────────────────────────────
@@ -2581,10 +2556,20 @@ See: docs/migration/HAMILTONIAN_API.md"""
                         f"Unknown scheme string: {scheme!r}. Valid schemes: {[s.value for s in NumericalScheme]}"
                     ) from None
 
+            # Issue #1155: translate config.hjb / config.fp to solver kwargs.
+            # Non-default fields that have clear mappings are threaded; unknown /
+            # unsupported non-default fields raise NotImplementedError (fail-loud).
+            from mfgarchon.config.translator import fp_config_to_kwargs, hjb_config_to_kwargs
+
+            _hjb_ctor_kw = hjb_config_to_kwargs(config.hjb, scheme)
+            _fp_ctor_kw = fp_config_to_kwargs(config.fp, scheme)
+
             # Create validated dual pair (Phase 2 factory)
             hjb_solver, fp_solver = create_paired_solvers(
                 problem=self,
                 scheme=scheme,
+                hjb_config=_hjb_ctor_kw,
+                fp_config=_fp_ctor_kw,
                 validate_duality=True,  # Guaranteed dual by construction
             )
 
@@ -2632,9 +2617,17 @@ See: docs/migration/HAMILTONIAN_API.md"""
             # For now, get_recommended_scheme() returns FDM_UPWIND as safe default
             recommended_scheme = get_recommended_scheme(self)
 
+            # Issue #1155: translate config.hjb / config.fp to solver kwargs.
+            from mfgarchon.config.translator import fp_config_to_kwargs, hjb_config_to_kwargs
+
+            _hjb_ctor_kw = hjb_config_to_kwargs(config.hjb, recommended_scheme)
+            _fp_ctor_kw = fp_config_to_kwargs(config.fp, recommended_scheme)
+
             hjb_solver, fp_solver = create_paired_solvers(
                 problem=self,
                 scheme=recommended_scheme,
+                hjb_config=_hjb_ctor_kw,
+                fp_config=_fp_ctor_kw,
                 validate_duality=True,
             )
 
@@ -2654,12 +2647,26 @@ See: docs/migration/HAMILTONIAN_API.md"""
         # solve a different PDE than the user specified. FP-FDM was fixed
         # separately in PR #1277 to fall back to problem.volatility_field when
         # None is passed, but HJB and other solvers still use problem.sigma.
+        #
+        # Issue #1155: thread anderson_memory and backend from config to iterator.
+        from mfgarchon.config.translator import (
+            backend_config_to_kwargs,
+            check_logging_config,
+            picard_config_to_iterator_kwargs,
+        )
+
+        _iterator_extra_kw = picard_config_to_iterator_kwargs(config.picard)
+        _backend_kw = backend_config_to_kwargs(config.backend)
+        check_logging_config(config.logging)
+
         solver = FixedPointIterator(
             problem=self,
             hjb_solver=hjb_solver,
             fp_solver=fp_solver,
             config=config,
             volatility_field=self.volatility_field,
+            **_iterator_extra_kw,
+            **_backend_kw,
         )
 
         return solver.solve(verbose=verbose)

--- a/tests/unit/test_config/test_config_translator.py
+++ b/tests/unit/test_config/test_config_translator.py
@@ -1,0 +1,377 @@
+"""
+Pinning tests for Issue #1155: config.hjb / config.fp / PicardConfig.anderson_memory
+translated to solver constructor kwargs in Safe / Auto mode.
+
+Pre-fix behaviour
+-----------------
+Any non-default config.hjb or config.fp value raises NotImplementedError from the
+guard in mfg_problem.py:solve().  anderson_memory is validated by Pydantic but never
+passed to FixedPointIterator (silently dropped).
+
+Post-fix behaviour
+------------------
+Non-default config.hjb.newton.{tolerance,max_iterations}, config.hjb.fdm.scheme,
+config.fp.fdm.scheme, and config.picard.anderson_memory are threaded to the
+constructed solvers / iterator.  Unknown / unsupported non-default fields continue
+to raise NotImplementedError (fail-loud).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.config import (
+    FPConfig,
+    HJBConfig,
+    MFGSolverConfig,
+    NewtonConfig,
+    PicardConfig,
+    fp_config_to_kwargs,
+    hjb_config_to_kwargs,
+    picard_config_to_iterator_kwargs,
+)
+from mfgarchon.config.mfg_methods import FDMConfig
+from mfgarchon.types import NumericalScheme
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tiny_problem():
+    """Minimal 1-D MFG problem for fast construction."""
+    from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+    )
+    return MFGProblem(Nx=[10], Nt=5, T=0.1, components=components)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: translator functions (no solver construction)
+# ---------------------------------------------------------------------------
+
+
+class TestHJBConfigToKwargs:
+    """Unit tests for hjb_config_to_kwargs."""
+
+    def test_all_defaults_returns_empty(self):
+        """Default HJBConfig produces no kwargs (solvers use their own defaults)."""
+        kw = hjb_config_to_kwargs(HJBConfig(), NumericalScheme.FDM_UPWIND)
+        assert kw == {}
+
+    def test_newton_tolerance_threaded(self):
+        """Non-default newton.tolerance is mapped to newton_tolerance."""
+        cfg = HJBConfig(newton=NewtonConfig(tolerance=1e-10))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["newton_tolerance"] == 1e-10
+
+    def test_newton_max_iterations_threaded(self):
+        """Non-default newton.max_iterations is mapped to max_newton_iterations."""
+        cfg = HJBConfig(newton=NewtonConfig(max_iterations=42))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["max_newton_iterations"] == 42
+
+    def test_newton_relaxation_threaded_for_fdm(self):
+        """newton.relaxation is mapped to relaxation for FDM schemes."""
+        cfg = HJBConfig(newton=NewtonConfig(relaxation=0.5))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["relaxation"] == 0.5
+
+    def test_newton_relaxation_raises_for_gfdm(self):
+        """newton.relaxation raises NotImplementedError for non-FDM schemes."""
+        cfg = HJBConfig(newton=NewtonConfig(relaxation=0.5))
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.GFDM)
+
+    def test_fdm_scheme_central_mapped(self):
+        """config.hjb.fdm.scheme='central' maps to advection_scheme='gradient_centered'."""
+        cfg = HJBConfig(method="fdm", fdm=FDMConfig(scheme="central"))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["advection_scheme"] == "gradient_centered"
+
+    def test_fdm_scheme_default_no_kwarg(self):
+        """Default fdm.scheme='upwind' does not inject advection_scheme kwarg."""
+        cfg = HJBConfig(method="fdm")  # fdm sub-config auto-populated with defaults
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert "advection_scheme" not in kw
+
+    def test_fdm_params_for_wrong_scheme_raises(self):
+        """Non-default fdm sub-config with SL scheme raises NotImplementedError."""
+        cfg = HJBConfig(method="fdm", fdm=FDMConfig(scheme="central"))
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.SL_LINEAR)
+
+    def test_accuracy_order_nondefault_raises(self):
+        """Non-default accuracy_order raises NotImplementedError (unmapped)."""
+        cfg = HJBConfig(accuracy_order=4)
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+
+    def test_sl_interpolation_method_threaded(self):
+        """Non-default sl.interpolation_method is threaded for SL schemes.
+        SLConfig default is interpolation_method='cubic', so 'linear' is non-default.
+        """
+        from mfgarchon.config.mfg_methods import SLConfig
+
+        cfg = HJBConfig(method="semi_lagrangian", sl=SLConfig(interpolation_method="linear"))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.SL_CUBIC)
+        assert kw["interpolation_method"] == "linear"
+
+    def test_sl_rk_order_mapped(self):
+        """sl.rk_order=4 maps to characteristic_solver='rk4'."""
+        from mfgarchon.config.mfg_methods import SLConfig
+
+        cfg = HJBConfig(method="semi_lagrangian", sl=SLConfig(rk_order=4))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.SL_LINEAR)
+        assert kw["characteristic_solver"] == "rk4"
+
+    def test_method_conflict_raises(self):
+        """config.hjb.method='gfdm' with scheme=FDM raises NotImplementedError."""
+        cfg = HJBConfig(method="gfdm")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+
+
+class TestFPConfigToKwargs:
+    """Unit tests for fp_config_to_kwargs."""
+
+    def test_all_defaults_returns_empty(self):
+        """Default FPConfig (method='particle', particle=ParticleConfig()) → no kwargs."""
+        kw = fp_config_to_kwargs(FPConfig(), NumericalScheme.FDM_UPWIND)
+        assert kw == {}
+
+    def test_default_particle_config_no_error(self):
+        """Default particle sub-config is silently skipped (no particle params set)."""
+        # ParticleConfig() is the Pydantic default; num_particles=5000 is the default.
+        # This must NOT raise even though FDM creates FPFDMSolver (not FPParticleSolver).
+        kw = fp_config_to_kwargs(FPConfig(), NumericalScheme.FDM_UPWIND)
+        assert kw == {}
+
+    def test_nondefault_particle_num_particles_raises(self):
+        """Non-default particle.num_particles raises for FDM scheme (no particle solver)."""
+        from mfgarchon.config.mfg_methods import ParticleConfig
+
+        cfg = FPConfig(method="particle", particle=ParticleConfig(num_particles=999))
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            fp_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+
+    def test_fdm_scheme_central_mapped(self):
+        """config.fp.fdm.scheme='central' maps to advection_scheme='divergence_centered'."""
+        cfg = FPConfig(method="fdm", fdm=FDMConfig(scheme="central"))
+        kw = fp_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["advection_scheme"] == "divergence_centered"
+
+    def test_fdm_default_scheme_no_kwarg(self):
+        """config.fp.fdm.scheme='upwind' is the default — translator emits no kwarg.
+        The scheme_factory setdefault handles the divergence_upwind default internally.
+        """
+        # FDMConfig().scheme == "upwind" is the config default; no kwarg emitted.
+        cfg = FPConfig(method="fdm", fdm=FDMConfig(scheme="upwind"))
+        kw = fp_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert "advection_scheme" not in kw
+
+    def test_fdm_params_for_wrong_scheme_raises(self):
+        """Non-default fdm sub-config with SL scheme raises NotImplementedError."""
+        cfg = FPConfig(method="fdm", fdm=FDMConfig(scheme="central"))
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            fp_config_to_kwargs(cfg, NumericalScheme.SL_LINEAR)
+
+    def test_fp_method_conflict_raises(self):
+        """config.fp.method='fem' with GFDM scheme raises NotImplementedError."""
+        cfg = FPConfig(method="fem")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            fp_config_to_kwargs(cfg, NumericalScheme.GFDM)
+
+
+class TestPicardConfigToIteratorKwargs:
+    """Unit tests for picard_config_to_iterator_kwargs."""
+
+    def test_zero_anderson_memory_empty(self):
+        """anderson_memory=0 (default) returns empty dict."""
+        kw = picard_config_to_iterator_kwargs(PicardConfig(anderson_memory=0))
+        assert kw == {}
+
+    def test_nonzero_anderson_memory_threaded(self):
+        """anderson_memory=3 enables Anderson acceleration with depth=3."""
+        kw = picard_config_to_iterator_kwargs(PicardConfig(anderson_memory=3))
+        assert kw["use_anderson"] is True
+        assert kw["anderson_depth"] == 3
+
+    def test_anderson_memory_5(self):
+        """anderson_memory=5 is threaded correctly."""
+        kw = picard_config_to_iterator_kwargs(PicardConfig(anderson_memory=5))
+        assert kw["use_anderson"] is True
+        assert kw["anderson_depth"] == 5
+
+
+# ---------------------------------------------------------------------------
+# PINNING TEST: end-to-end via create_paired_solvers + FixedPointIterator
+#
+# This block proves that:
+#   PRE-FIX:  setting non-default config.hjb field raises NotImplementedError
+#   POST-FIX: the same config is accepted and values reach the constructed solvers
+#
+# Run git stash push mfgarchon/config/translator.py mfgarchon/core/mfg_problem.py
+# to get pre-fix behaviour; pytest -k test_pin_* should FAIL.
+# After git stash pop, pytest -k test_pin_* should PASS.
+# ---------------------------------------------------------------------------
+
+
+class TestPinningConfigThreading:
+    """
+    Pinning tests that FAIL on pre-fix code (NotImplementedError guard) and
+    PASS after the translator is wired in.
+    """
+
+    @pytest.fixture
+    def problem(self):
+        return _tiny_problem()
+
+    def test_pin_newton_tolerance_reaches_hjb_solver(self, problem):
+        """
+        config.hjb.newton.tolerance=1e-10 must reach hjb_solver.newton_tolerance.
+
+        PRE-FIX: raises NotImplementedError (config.hjb non-default).
+        POST-FIX: value threaded; solver has newton_tolerance=1e-10.
+        """
+        from mfgarchon.factory import create_paired_solvers
+
+        cfg = HJBConfig(newton=NewtonConfig(tolerance=1e-10))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["newton_tolerance"] == 1e-10
+
+        hjb_solver, _ = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND, hjb_config=kw)
+        assert hjb_solver.newton_tolerance == 1e-10, (
+            f"Expected newton_tolerance=1e-10, got {hjb_solver.newton_tolerance}"
+        )
+
+    def test_pin_newton_max_iterations_reaches_hjb_solver(self, problem):
+        """
+        config.hjb.newton.max_iterations=42 must reach hjb_solver.max_newton_iterations.
+
+        PRE-FIX: raises NotImplementedError.
+        POST-FIX: value threaded.
+        """
+        from mfgarchon.factory import create_paired_solvers
+
+        cfg = HJBConfig(newton=NewtonConfig(max_iterations=42))
+        kw = hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["max_newton_iterations"] == 42
+
+        hjb_solver, _ = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND, hjb_config=kw)
+        assert hjb_solver.max_newton_iterations == 42
+
+    def test_pin_fp_fdm_scheme_reaches_fp_solver(self, problem):
+        """
+        config.fp.fdm.scheme='central' must produce FP advection_scheme='divergence_centered'.
+
+        PRE-FIX: raises NotImplementedError.
+        POST-FIX: value threaded.
+        """
+        from mfgarchon.factory import create_paired_solvers
+
+        cfg = FPConfig(method="fdm", fdm=FDMConfig(scheme="central"))
+        kw = fp_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
+        assert kw["advection_scheme"] == "divergence_centered"
+
+        _, fp_solver = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND, fp_config=kw)
+        assert fp_solver.advection_scheme == "divergence_centered", (
+            f"Expected 'divergence_centered', got {fp_solver.advection_scheme!r}"
+        )
+
+    def test_pin_anderson_memory_reaches_fixed_point_iterator(self, problem):
+        """
+        config.picard.anderson_memory=3 must enable Anderson acceleration in
+        FixedPointIterator with depth=3.
+
+        PRE-FIX: anderson_memory validated but silently dropped.
+        POST-FIX: use_anderson=True, anderson_accelerator.depth==3.
+        """
+        from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+        from mfgarchon.factory import create_paired_solvers
+
+        picard_cfg = PicardConfig(anderson_memory=3)
+        iter_kw = picard_config_to_iterator_kwargs(picard_cfg)
+        assert iter_kw["use_anderson"] is True
+        assert iter_kw["anderson_depth"] == 3
+
+        hjb_solver, fp_solver = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
+        iterator = FixedPointIterator(
+            problem=problem,
+            hjb_solver=hjb_solver,
+            fp_solver=fp_solver,
+            **iter_kw,
+        )
+        assert iterator.use_anderson is True
+        assert iterator.anderson_accelerator is not None
+        assert iterator.anderson_accelerator.depth == 3
+
+    def test_pin_full_solve_with_nondefault_hjb_config_no_raise(self, problem):
+        """
+        problem.solve(config=..., scheme=FDM_UPWIND) with non-default
+        config.hjb.newton.tolerance must succeed (not raise NotImplementedError).
+
+        PRE-FIX: raises NotImplementedError from the guard.
+        POST-FIX: succeeds.
+        """
+        config = MFGSolverConfig()
+        # Mutate sub-config fields to non-default values
+        config.hjb.newton = NewtonConfig(tolerance=1e-9, max_iterations=5)
+        config.picard = PicardConfig(max_iterations=3, anderson_memory=2)
+
+        # Must not raise
+        result = problem.solve(
+            scheme=NumericalScheme.FDM_UPWIND,
+            config=config,
+            verbose=False,
+        )
+        assert result is not None
+
+    def test_pin_default_config_no_regression(self, problem):
+        """
+        Default config must produce the same result as no config (regression guard).
+        The translator returns empty dicts for default configs → solver defaults used.
+        """
+        # Default config
+        result_with_default = problem.solve(
+            scheme=NumericalScheme.FDM_UPWIND,
+            config=MFGSolverConfig(),
+            max_iterations=3,
+            verbose=False,
+        )
+        # No config at all
+        result_no_config = problem.solve(
+            scheme=NumericalScheme.FDM_UPWIND,
+            max_iterations=3,
+            verbose=False,
+        )
+        assert result_with_default is not None
+        assert result_no_config is not None
+
+    def test_pin_genuinely_unsupported_field_raises(self, problem):
+        """
+        A non-default field with no mapping (accuracy_order) must raise
+        NotImplementedError, not silently drop.  This is the fail-loud contract.
+        """
+        config = MFGSolverConfig()
+        config.hjb.accuracy_order = 4  # non-default, no mapping
+
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            problem.solve(
+                scheme=NumericalScheme.FDM_UPWIND,
+                config=config,
+                verbose=False,
+            )


### PR DESCRIPTION
## Summary

- Implements Issue #1155: `config.hjb` / `config.fp` were validated by Pydantic then silently dropped before reaching solver constructors. `PicardConfig.anderson_memory` was also dropped.
- Builds a translator (`mfgarchon/config/translator.py`) that maps non-default validated config fields to solver constructor kwargs for the Safe/Auto-mode construction paths.
- Removes the `NotImplementedError` guard from #1284 leftover items 3–4 now that the fields are actually threaded.
- Keeps unsupported non-default fields fail-loud with `NotImplementedError('Refs #1155')`.

## Changes

**New file: `mfgarchon/config/translator.py`**
- `hjb_config_to_kwargs`: newton.tolerance/max_iterations/relaxation, fdm.scheme, gfdm.*, sl.interpolation_method/rk_order. Unsupported: accuracy_order, boundary_conditions, weno, fem → `NotImplementedError`.
- `fp_config_to_kwargs`: fdm.scheme ("central" → "divergence_centered"). Particle non-defaults → `NotImplementedError` (no Safe/Auto FPParticleSolver).
- `picard_config_to_iterator_kwargs`: anderson_memory > 0 → `use_anderson=True, anderson_depth=N`.
- `backend_config_to_kwargs`: type threads to `backend` kwarg; device/precision → `NotImplementedError`.
- `check_logging_config`: any non-default → `NotImplementedError`.

**Modified: `mfgarchon/core/mfg_problem.py`**
- Safe mode and Auto mode call the translator before `create_paired_solvers`.
- `FixedPointIterator` now receives anderson_memory + backend kwargs.
- Removes the old `NotImplementedError` guard (prior #1284 placeholder).

**New test file: `tests/unit/test_config/test_config_translator.py`**
- 29 tests: 12 unit tests for `hjb_config_to_kwargs`, 7 for `fp_config_to_kwargs`, 3 for `picard_config_to_iterator_kwargs`, 7 pinning tests.

## Pinning test evidence

**Pre-fix behavior (simulated with old guard):**
```
PRE-FIX: NotImplementedError raised as expected: config.hjb cannot be applied in Safe mode yet...
PRE-FIX: iterator.use_anderson = False  (expected True, got False)
```

**Post-fix behavior:**
```
POST-FIX: iterator.use_anderson = True  (expected True)
POST-FIX: iterator.anderson_accelerator.depth = 3  (expected 3)
POST-FIX: hjb_solver.newton_tolerance = 1e-10  (expected 1e-10)
POST-FIX: hjb_solver.max_newton_iterations = 42  (expected 42)
POST-FIX: fp_solver.advection_scheme = divergence_centered  (expected divergence_centered)
```

## Test plan

- [x] `tests/unit/test_config/test_config_translator.py` — 29 passed
- [x] `tests/unit/test_config/` — 184 passed (existing config suite, no regression)
- [x] `tests/integration/test_three_mode_api.py` — 15 passed, 1 skipped
- [x] `tests/unit/test_issue_1284_config_factory_bugs.py` — 6 passed
- [x] `ruff format` + `ruff check` — all clean

## Caveats / open gaps (Refs #1155)

- `FPConfig` has no `gfdm` field; GFDM FP params must go via the pair factory's delta/collocation_point syncing — tracked as a gap under Refs #1155.
- `BackendConfig.device` and `.precision` have no solver-level mapping yet → fail-loud.
- `LoggingConfig` has no solver-level mapping → fail-loud.
- `HJBConfig.accuracy_order`, `.boundary_conditions`, `.weno`, `.fem` are not yet mapped → fail-loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)