### PR TITLE
refactor(core): route HJB control-cost lambda through the Hamiltonian single source (Refs #1071)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -261,6 +261,71 @@ class BaseHJBSolver(BaseNumericalSolver):
         }
         return type_mapping.get(class_name)
 
+    # === Hamiltonian single source of truth (Issue #1071) ===
+
+    def _hamiltonian_control_cost(self):
+        """Control-cost component of the problem's Hamiltonian -- the #1071 single source.
+
+        The Hamiltonian class (``problem.hamiltonian_class``) is the canonical source of
+        the control-cost weight ``lambda`` and the optimal control ``alpha* = -dH/dp``.
+        This returns its ``ControlCostBase`` component, which exposes ``.lambda_``,
+        ``.optimal_control(p)``, ``.dp(p)`` and ``.evaluate(p)``.
+
+        Fail loud when the problem carries no Hamiltonian class (or a Hamiltonian without a
+        control-cost component): there is then no canonical control cost to read, and a
+        solver must not silently fall back to a scalar placeholder (Issue #1071, the root
+        of the #1247 Howard lambda desync).
+        """
+        H_class = getattr(self.problem, "hamiltonian_class", None)
+        if H_class is None:
+            raise ValueError(
+                f"{type(self).__name__}: problem.hamiltonian_class is None; cannot derive the "
+                "control-cost lambda / optimal control from the Hamiltonian single source "
+                "(Issue #1071)."
+            )
+        control_cost = getattr(H_class, "control_cost", None)
+        if control_cost is None:
+            raise ValueError(
+                f"{type(self).__name__}: the Hamiltonian {type(H_class).__name__} exposes no "
+                "control_cost component; cannot derive lambda / optimal control (Issue #1071)."
+            )
+        return control_cost
+
+    def _control_cost_lambda(self) -> float:
+        """Control-cost weight ``lambda`` from the Hamiltonian single source (Issue #1071).
+
+        Prefers the Hamiltonian's control cost (``hamiltonian_class.control_cost.lambda_``)
+        -- the canonical source of ``alpha* = -p/lambda``. Falls back to ``problem.lambda_``
+        ONLY when the problem carries no Hamiltonian class (the legacy LQ fast path, where
+        ``problem.lambda_`` is then the sole available source).
+
+        This redirect removes the silent desync where a solver read ``problem.lambda_``
+        while the components Hamiltonian's control cost said otherwise -- the root of the
+        #1247 Howard defects. For the matched ``lambda=1`` paper case the two agree, so the
+        golden byte-identity gate is preserved.
+        """
+        H_class = getattr(self.problem, "hamiltonian_class", None)
+        if H_class is not None:
+            control_cost = getattr(H_class, "control_cost", None)
+            if control_cost is not None:
+                lambda_val = float(control_cost.lambda_)
+                if lambda_val <= 0:
+                    raise ValueError(
+                        f"Control cost lambda must be positive, got {lambda_val} from "
+                        f"{type(H_class).__name__}.control_cost (Issue #1071)."
+                    )
+                return lambda_val
+        # Legacy fallback: no Hamiltonian class -- problem.lambda_ is the only source.
+        lambda_val = getattr(self.problem, "lambda_", 1.0)
+        if lambda_val is None:
+            lambda_val = 1.0
+        if lambda_val <= 0:
+            raise ValueError(
+                f"Control cost parameter lambda_ must be positive, got {lambda_val}. "
+                "Set problem.lambda_ to a positive value."
+            )
+        return float(lambda_val)
+
     # Implementation of BaseMFGSolver abstract methods
     def solve(self) -> np.ndarray:
         """

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2027,7 +2027,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Two modes supported:
         # - additive:       H = |p|²/(2λ) + V + γm (standard separable form)
         # - multiplicative: H = (1 + γ|Ω|m)|p|²/(2λ) + V (velocity reduction by congestion)
-        lambda_val = self._get_lambda_value()
+        lambda_val = self._control_cost_lambda()
         gamma_val = getattr(self.problem, "gamma", 0.0)
 
         # |grad_u|^2 for all points
@@ -2315,7 +2315,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         n = self.n_points
         d = self.dimension
         dt = self.problem.T / self.problem.Nt
-        lambda_val = self._get_lambda_value()
+        lambda_val = self._control_cost_lambda()
         # Issue #1073: use _get_sigma_value (returns σ) instead of confusing
         # `getattr(problem, "diffusion") or getattr(problem, "sigma")` chain.
         # `problem.diffusion` returns σ²/2 (PDE coefficient D), so the old chain
@@ -2373,7 +2373,7 @@ class HJBGFDMSolver(BaseHJBSolver):
             self._dmp_alpha_crit = critical_drift_for_dmp(
                 self._D_lap, self._D_grad, diffusion_coeff, interior_indices=self.interior_indices
             )
-        lambda_val = self._get_lambda_value()
+        lambda_val = self._control_cost_lambda()
         grad = np.stack([self._D_grad[d] @ u_current for d in range(self.dimension)], axis=1)
         max_alpha = float(np.max(np.linalg.norm(grad, axis=1)) / lambda_val)
         if max_alpha > self._dmp_alpha_crit:
@@ -2802,30 +2802,6 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         return new_row, rhs
 
-    def _get_lambda_value(self) -> float:
-        """
-        Get control cost parameter lambda with validation.
-
-        Returns:
-            Positive lambda value
-
-        Raises:
-            ValueError: If lambda <= 0
-
-        Notes:
-            Lambda appears in the Hamiltonian as H = |p|²/(2λ) + ...
-            Division by lambda requires λ > 0.
-        """
-        lambda_val = getattr(self.problem, "lambda_", 1.0)
-        if lambda_val is None:
-            lambda_val = 1.0
-        if lambda_val <= 0:
-            raise ValueError(
-                f"Control cost parameter lambda_ must be positive, got {lambda_val}. "
-                f"Set problem.lambda_ to a positive value."
-            )
-        return float(lambda_val)
-
     def _compute_llf_sigma_eff(self) -> np.ndarray:
         """Compute per-node effective sigma for LLF augmentation (Issue #1059, paper P2).
 
@@ -3096,7 +3072,9 @@ class HJBGFDMSolver(BaseHJBSolver):
                 "inner_solver='howard' requires problem.hamiltonian_class to derive the optimal "
                 "control alpha* = -dH/dp; the legacy no-Hamiltonian LQ path is unsupported."
             )
-        lambda_val = self._get_lambda_value()
+        # Issue #1071: derive lambda from the Hamiltonian's control cost (the single source),
+        # NOT from problem.lambda_ — the placeholder read that powered the #1247 desync.
+        lambda_val = self._control_cost_lambda()
         if abs(lambda_val - 1.0) > 1e-12:
             raise NotImplementedError(
                 f"inner_solver='howard' currently assumes unit control cost (lambda_=1), got {lambda_val}. "
@@ -3109,7 +3087,8 @@ class HJBGFDMSolver(BaseHJBSolver):
         # density coupling f(m). The pure-LQ test suite sits inside that envelope, which hid
         # three silent-wrong-physics holes: V/f(m) dropped, running_cost entering with the
         # opposite sign of the Newton H-additive convention, and the unit-cost gate above
-        # reading problem.lambda_ (never synced with the components Hamiltonian's control cost).
+        # reading problem.lambda_ (the #1247 desync, now fixed: the gate derives lambda from
+        # the Hamiltonian's control cost via _control_cost_lambda(), Issue #1071).
         # Inspect the actual Hamiltonian components and fail loud on anything Howard does not
         # model; full support is deferred. Found in the 2026-06-10 library audit; validated by
         # tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_*.

--- a/tests/unit/test_alg/test_hjb_1071_control_cost_lambda.py
+++ b/tests/unit/test_alg/test_hjb_1071_control_cost_lambda.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Issue #1071: the control-cost weight lambda comes from the Hamiltonian single source.
+
+The HJB solvers historically read a scalar placeholder ``problem.lambda_`` (via
+``HJBGFDMSolver._get_lambda_value()``) that was NEVER synced with the components
+Hamiltonian's ``QuadraticControlCost.lambda_`` -- the desync that powered the #1247
+Howard defects. After #1071 the canonical source is ``hamiltonian_class.control_cost``,
+read through ``BaseHJBSolver._control_cost_lambda()`` /
+``BaseHJBSolver._hamiltonian_control_cost()``.
+
+These tests pin:
+1. The fix: with the Hamiltonian carrying lambda=2 and ``problem.lambda_`` left at its
+   default placeholder, the solver now derives lambda=2 (from H), not 1 (the placeholder).
+2. The equivalence (deprecation policy): for the matched lambda=1 case, old and new agree.
+3. The legacy fallback: with NO Hamiltonian class, ``problem.lambda_`` is the sole source.
+4. Fail-loud: the strict accessor raises when there is no Hamiltonian class.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem_with_lambda(control_lambda: float) -> MFGProblem:
+    """1D MFG problem whose Hamiltonian's control cost carries ``control_lambda``.
+
+    ``problem.lambda_`` is deliberately left unset (default), so it stays at the scalar
+    placeholder the old ``_get_lambda_value()`` would have read.
+    """
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    components = MFGComponents(
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(lambda_=control_lambda)),
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+    )
+    return MFGProblem(geometry=grid, T=0.2, Nt=10, sigma=0.3, components=components)
+
+
+def _gfdm_solver(problem: MFGProblem) -> HJBGFDMSolver:
+    pts = np.linspace(0.0, 1.0, 21).reshape(-1, 1)
+    return HJBGFDMSolver(problem, collocation_points=pts, delta=0.2)
+
+
+def test_control_cost_lambda_derived_from_hamiltonian_not_placeholder():
+    """#1247-root fix: lambda is read from the Hamiltonian, not the problem.lambda_ placeholder."""
+    problem = _problem_with_lambda(2.0)
+
+    # The placeholder source the OLD _get_lambda_value() read was getattr(problem, "lambda_", 1.0).
+    # It is NOT 2.0 -- this is exactly the desync #1071 removes.
+    placeholder = getattr(problem, "lambda_", None)
+    assert placeholder in (None, 1.0), f"expected unset/1.0 placeholder, got {placeholder}"
+
+    # The migrated accessor derives lambda from the Hamiltonian single source.
+    solver = _gfdm_solver(problem)
+    assert solver._control_cost_lambda() == 2.0
+    # And the strict accessor exposes the canonical control-cost object.
+    assert solver._hamiltonian_control_cost().lambda_ == 2.0
+
+
+def test_base_helper_is_shared_across_solvers():
+    """The helper lives on BaseHJBSolver, so every HJB solver derives the same lambda from H."""
+    problem = _problem_with_lambda(2.0)
+    fdm = HJBFDMSolver(problem)
+    gfdm = _gfdm_solver(problem)
+    assert fdm._control_cost_lambda() == 2.0
+    assert gfdm._control_cost_lambda() == 2.0
+
+
+def test_matched_case_is_equivalent_to_placeholder():
+    """Deprecation equivalence: for the matched lambda=1 case, H-derived == old placeholder."""
+    problem = _problem_with_lambda(1.0)
+    solver = _gfdm_solver(problem)
+    # Old path: getattr(problem, "lambda_", 1.0) -> 1.0 (None -> 1.0). New path: H.control_cost -> 1.0.
+    old_placeholder = getattr(problem, "lambda_", 1.0)
+    if old_placeholder is None:
+        old_placeholder = 1.0
+    assert solver._control_cost_lambda() == old_placeholder == 1.0
+
+
+class _NoHamProblem:
+    """Stand-in for the legacy LQ fast path: a problem with no Hamiltonian class.
+
+    A real MFGProblem always carries a Hamiltonian (Issue #670 requires components with a
+    hamiltonian for u_terminal), so the no-Hamiltonian branch is exercised with a stand-in
+    -- the same pattern the Howard suite uses (_MockProblem with hamiltonian_class=None).
+    """
+
+    hamiltonian_class = None
+
+    def __init__(self, lambda_: float | None):
+        self.lambda_ = lambda_
+
+
+class _Solver:
+    def __init__(self, problem):
+        self.problem = problem
+
+
+def test_legacy_fallback_without_hamiltonian_class():
+    """No Hamiltonian class -> problem.lambda_ is the sole source (legacy LQ fast path)."""
+    solver = _Solver(_NoHamProblem(lambda_=3.0))
+    assert BaseHJBSolver._control_cost_lambda(solver) == 3.0
+    # Unset lambda_ falls back to 1.0 (matches the old _get_lambda_value default).
+    assert BaseHJBSolver._control_cost_lambda(_Solver(_NoHamProblem(lambda_=None))) == 1.0
+
+
+def test_strict_accessor_fails_loud_without_hamiltonian_class():
+    """The strict accessor raises -- a solver must not invent a control cost (Issue #1071)."""
+    solver = _Solver(_NoHamProblem(lambda_=3.0))
+    with pytest.raises(ValueError, match="hamiltonian_class is None"):
+        BaseHJBSolver._hamiltonian_control_cost(solver)
+
+
+def test_nonpositive_lambda_rejected():
+    """A non-positive control cost is rejected (division by lambda requires lambda > 0)."""
+    with pytest.raises(ValueError, match="must be positive"):
+        QuadraticControlCost(lambda_=-1.0)


### PR DESCRIPTION
## Refs #1071 — Phase 1 (lambda / alpha* surface)

The Hamiltonian class (`problem.hamiltonian_class`) is the true source of the optimal control `alpha* = -dH/dp`, the control-cost weight `lambda`, and the control-cost structure. The HJB solvers historically read a scalar placeholder `problem.lambda_` (via `HJBGFDMSolver._get_lambda_value()` -> `getattr(problem, "lambda_", 1.0)`) that was **never** synced with the components Hamiltonian's `QuadraticControlCost.lambda_`. That desync powered the #1247 Howard defects: the unit-cost gate validated `problem.lambda_` while the real physics lived in `hamiltonian_class.control_cost`.

**Scope note:** `sigma` stays a problem/PDE property (SDE volatility, not a Hamiltonian prop) and is **not** touched — #1071 is about `lambda`/`alpha*`/`H`.

### What changed

- **`BaseHJBSolver._hamiltonian_control_cost()`** — strict accessor returning the Hamiltonian's `control_cost` (exposes `.lambda_` / `.optimal_control(p)` / `.dp(p)` / `.evaluate(p)`); **fail-loud** when `hamiltonian_class` is `None`.
- **`BaseHJBSolver._control_cost_lambda()`** — prefers `hamiltonian_class.control_cost.lambda_` (canonical); falls back to `problem.lambda_` **only** on the legacy no-Hamiltonian LQ path, where it is the sole available source. Shared by every `BaseHJBSolver` subclass.
- **`hjb_gfdm.py`** — removed `_get_lambda_value()`; routed all four call sites (legacy vectorized residual/Jacobian, the DMP diagnostic, and the **Howard unit-cost gate**) through `_control_cost_lambda()`. The Howard gate now derives `lambda` from the Hamiltonian — the **#1247-root fix**.

The small solvers (`fdm`/`howard`/`weno`/`SL`) already route `lambda`/`alpha` through `H_class.dp` / `optimal_control` / `control_cost`; there are **no** `problem.lambda_` / `_get_lambda_value` read-sites there to migrate (verified by grep). All lambda desync was concentrated in `hjb_gfdm`.

### Verification

- **Goldens (byte-identity gate):** 4/4 green — `tests/regression/test_solver_golden_baseline.py` (FDM + GFDM, lambda=1). The batch Hamiltonian path already used `H_class.dp`, so the goldens are unaffected and stay byte-identical.
- **HJB suites:** 265 passed / 3 skipped / 2 xfailed across gfdm/howard/fdm/SL/weno/monotonicity/bc/llf/bug15.
- **Completeness grep:** no `_get_lambda_value` remains anywhere; the only residual `problem.lambda_` code reads are (a) the documented legacy fallback inside `_control_cost_lambda()`, and (b) `_compute_dH_dp_fd`'s legacy closed-form gated on `not is_custom` (no Hamiltonian class to read from — not a desync site).
- **Lambda-correctness (#1247-root proof):** new `tests/unit/test_alg/test_hjb_1071_control_cost_lambda.py` — with the Hamiltonian carrying `lambda=2` and `problem.lambda_` at its default placeholder, the solver now derives `2` (from H), not `1`. Plus equivalence (matched lambda=1), legacy fallback, and fail-loud.
- **Ruff** check + format clean.

### What remains (deferred — this is large; `Refs` not `Fixes`)

- The genuinely no-Hamiltonian legacy LQ closed-form in `_compute_dH_dp_fd` (gated `not is_custom`; there is no `H_class` to route through when it fires).
- The wider `sigma` read surface (out of #1071 scope by design).
- A deeper consolidation of the legacy LQ vectorized path vs. the H-class batch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)