### PR TITLE
fix(config): guard num_particles kwarg when fp.particle is None (#1317)

### DIFF
--- a/mfgarchon/factory/solver_factory.py
+++ b/mfgarchon/factory/solver_factory.py
@@ -132,7 +132,19 @@ class SolverFactory:
 
         # Particle-specific updates
         if "num_particles" in kwargs:
-            updated_config.fp.particle.num_particles = kwargs["num_particles"]
+            # Issue #1317: guard the particle sub-config.
+            # When fp.method != 'particle' (e.g. 'fdm'/'fem'/'network'),
+            # particle is None and accessing .num_particles raises
+            # AttributeError.  Only set num_particles when the particle
+            # sub-config is present.
+            if updated_config.fp.particle is not None:
+                updated_config.fp.particle.num_particles = kwargs["num_particles"]
+            else:
+                logger.warning(
+                    "Ignoring 'num_particles' kwarg: fp.particle sub-config is None "
+                    "(fp.method=%r is not 'particle'). Set fp.method='particle' first.",
+                    updated_config.fp.method,
+                )
         if "delta" in kwargs:
             # Issue #1284 / 2026-06-11 survey: guard the gfdm sub-config.
             # When hjb.method == 'fdm' (the default), gfdm is None and

--- a/tests/unit/test_factory/test_solver_factory.py
+++ b/tests/unit/test_factory/test_solver_factory.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from mfgarchon.config import MFGSolverConfig
+from mfgarchon.config import FPConfig, MFGSolverConfig
 from mfgarchon.factory.solver_factory import (
     SolverFactory,
     SolverFactoryConfig,
@@ -141,6 +141,30 @@ def test_update_config_with_kwargs_particles():
     )
 
     assert updated.fp.particle.num_particles == 8000
+
+
+@pytest.mark.unit
+def test_update_config_with_kwargs_num_particles_non_particle_fp():
+    """Issue #1317: num_particles kwarg must not raise when fp.method has no
+    particle sub-config.
+
+    When ``fp.method`` is e.g. 'fdm'/'fem'/'network', ``fp.particle`` is None.
+    The factory must guard the assignment (mirroring the hjb.gfdm/delta guard)
+    and log a warning instead of raising ``AttributeError``.
+    """
+    base_config = MFGSolverConfig(fp=FPConfig(method="fdm"))
+    # Precondition that triggers the bug: no particle sub-config present.
+    assert base_config.fp.particle is None
+
+    with patch("mfgarchon.factory.solver_factory.logger") as mock_logger:
+        updated = SolverFactory._update_config_with_kwargs(
+            base_config,
+            num_particles=8000,
+        )
+
+    # Did not raise; particle sub-config stays None and a warning is logged.
+    assert updated.fp.particle is None
+    mock_logger.warning.assert_called_once()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

`SolverFactory._update_config_with_kwargs` (`mfgarchon/factory/solver_factory.py:135`) assigned `updated_config.fp.particle.num_particles` without checking that `fp.particle` is not `None`. When `FPConfig(method='fdm'|'fem'|'network')` leaves `fp.particle=None`, passing a `num_particles` kwarg raised `AttributeError: 'NoneType' object has no attribute 'num_particles'`.

## Fix

Guard the assignment exactly like the adjacent `hjb.gfdm`/`delta` guard just below it: set `num_particles` only when `fp.particle is not None`, otherwise `logger.warning(...)` that the kwarg is ignored because `fp.method` has no particle sub-config. Warning wording mirrors the existing delta guard.

## Pinning test

`tests/unit/test_factory/test_solver_factory.py::test_update_config_with_kwargs_num_particles_non_particle_fp`

- Builds `MFGSolverConfig(fp=FPConfig(method="fdm"))` (precondition: `fp.particle is None`).
- Calls `_update_config_with_kwargs(..., num_particles=8000)` and asserts it does **not** raise, that `fp.particle` stays `None`, and that a warning is logged.
- **Fails without the fix**: `AttributeError` at `solver_factory.py:135`.
- **Passes with the fix**.

## Test suites run green

- `tests/unit/test_factory/` — 83 passed
- `tests/unit/test_issue_1284_config_factory_bugs.py` — 6 passed (sibling guard for `hjb.gfdm`/`delta`)
- `ruff format --check` + `ruff check` clean on both changed files.

Fixes #1317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)