### PR TITLE
fix(algorithms): route U via drift-convention dispatcher in regime/graph FP solves

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -7,12 +7,29 @@ These utilities are used by both legacy and config-aware fixed-point iterator im
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 if TYPE_CHECKING:
     from mfgarchon.utils.solver_result import SolverResult
+
+
+def fp_solver_sig_params(fp_solver: object) -> set[str] | None:
+    """Return the parameter names of ``fp_solver.solve_fp_system`` (or ``None``).
+
+    Mirrors :meth:`BaseCouplingIterator._init_solver_signatures` for iterators that hold a
+    *list* of per-subsystem FP solvers (regime-switching, graph MFG) and therefore cache one
+    signature set per solver rather than a single shared one. The cached set is the
+    ``fp_sig_params`` argument of :func:`resolve_fp_drift_kwargs`, which decides whether the
+    value function is routed via ``potential_field`` (smooth separable $H$, FP derives the
+    velocity) or ``drift_field`` (Issue #1315).
+    """
+    try:
+        return set(inspect.signature(fp_solver.solve_fp_system).parameters.keys())
+    except (AttributeError, ValueError):
+        return None
 
 
 def initialize_cold_start(

--- a/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
@@ -26,6 +26,10 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+from mfgarchon.alg.numerical.coupling.fixed_point_utils import (
+    fp_solver_sig_params,
+    resolve_fp_drift_kwargs,
+)
 from mfgarchon.alg.numerical.coupling.graph_coupling import _get_time_slice
 
 if TYPE_CHECKING:
@@ -123,6 +127,11 @@ class GraphMFGSolver(BaseCouplingIterator):
         self._coupling = coupling
         self._hjb = hjb_solvers
         self._fp = fp_solvers
+        # Issue #1315: cache each per-node FP solver's solve_fp_system signature so the FP step
+        # can route the value function through the drift-convention dispatcher
+        # (resolve_fp_drift_kwargs), exactly as the single-solver iterators do via
+        # _init_solver_signatures. One set per node because nodes may use different FP solvers.
+        self._fp_sig_params_k = [fp_solver_sig_params(fp) for fp in fp_solvers]
         self._max_iter = max_iterations
         self._tol = tolerance
         self._damping = damping
@@ -202,11 +211,26 @@ class GraphMFGSolver(BaseCouplingIterator):
                 fp_source = self._compose_fp_source(k, Us_new, Ms_expanded, raw_coupling)
 
                 m0_k = Ms[k][0] if isinstance(Ms[k], np.ndarray) and Ms[k].ndim == 2 else Ms[k]
-                M_k = self._fp[k].solve_fp_system(
-                    m0_k,
-                    drift_field=Us_new[k],
-                    source_term=fp_source,
-                )
+                # Issue #1315 (Refs #1043): route the value function through the
+                # drift-convention dispatcher instead of passing U as drift_field. After the
+                # v0.18.6 rename drift_field is the velocity alpha*, not the U-potential; for a
+                # smooth separable H the FP solver must receive U via potential_field and derive
+                # the velocity internally. Passing drift_field=U is silent-wrong-equilibrium.
+                # Mirrors FixedPointIterator.solve() / fictitious_play (#1299), per-node: each
+                # node has its own problem (Hamiltonian/geometry) and FP solver signature.
+                fp_kwargs: dict[str, Any] = {"source_term": fp_source}
+                fp_sig_params_k = self._fp_sig_params_k[k]
+                if fp_sig_params_k is not None:
+                    drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
+                        self._problems[k], fp_sig_params_k, None, Us_new[k], Ms_expanded[k]
+                    )
+                    fp_kwargs.update(drift_kwargs)
+                    if use_positional_U:
+                        M_k = self._fp[k].solve_fp_system(m0_k, Us_new[k], **fp_kwargs)
+                    else:
+                        M_k = self._fp[k].solve_fp_system(m0_k, **fp_kwargs)
+                else:
+                    M_k = self._fp[k].solve_fp_system(m0_k, Us_new[k], source_term=fp_source)
                 Ms_new[k] = M_k
 
             # --- Damping ---

--- a/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
@@ -26,6 +26,10 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+from mfgarchon.alg.numerical.coupling.fixed_point_utils import (
+    fp_solver_sig_params,
+    resolve_fp_drift_kwargs,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -125,6 +129,12 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
         self._regime = regime_config
         self._hjb = hjb_solvers
         self._fp = fp_solvers
+        # Issue #1315: cache each per-regime FP solver's solve_fp_system signature so the FP
+        # step can route the value function through the drift-convention dispatcher
+        # (resolve_fp_drift_kwargs), exactly as the single-solver iterators do via
+        # _init_solver_signatures. One set per regime k because regimes may use different FP
+        # solver types.
+        self._fp_sig_params_k = [fp_solver_sig_params(fp) for fp in fp_solvers]
         self._max_iter = max_iterations
         self._tol = tolerance
         self._damping = damping
@@ -262,11 +272,26 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
                 fp_source = self._make_fp_source(k, K, Q, Ms)
 
                 m0_k = Ms[k][0] if Ms[k].ndim == 2 else Ms[k]
-                M_k = self._fp[k].solve_fp_system(
-                    m0_k,
-                    drift_field=Us_new[k],  # Use updated value function
-                    source_term=fp_source,
-                )
+                # Issue #1315 (Refs #1043): route the value function through the
+                # drift-convention dispatcher instead of passing U as drift_field. After the
+                # v0.18.6 rename drift_field is the velocity alpha*, not the U-potential; for a
+                # smooth separable H the FP solver must receive U via potential_field and derive
+                # the velocity internally. Passing drift_field=U is silent-wrong-equilibrium.
+                # Mirrors FixedPointIterator.solve() / fictitious_play (#1299), per-regime: each
+                # regime has its own problem (Hamiltonian/geometry) and FP solver signature.
+                fp_kwargs: dict[str, Any] = {"source_term": fp_source}
+                fp_sig_params_k = self._fp_sig_params_k[k]
+                if fp_sig_params_k is not None:
+                    drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
+                        self._problems[k], fp_sig_params_k, None, Us_new[k], Ms[k]
+                    )
+                    fp_kwargs.update(drift_kwargs)
+                    if use_positional_U:
+                        M_k = self._fp[k].solve_fp_system(m0_k, Us_new[k], **fp_kwargs)
+                    else:
+                        M_k = self._fp[k].solve_fp_system(m0_k, **fp_kwargs)
+                else:
+                    M_k = self._fp[k].solve_fp_system(m0_k, Us_new[k], source_term=fp_source)
                 Ms_new[k] = M_k
 
             # --- Damping ---

--- a/tests/integration/test_graph_mfg_solver.py
+++ b/tests/integration/test_graph_mfg_solver.py
@@ -357,3 +357,47 @@ class TestIssue1006Regression:
         composed_val = composed(0.2, x)
         raw_val = raw(0.2, x)
         np.testing.assert_allclose(composed_val - raw_val, -2.0, atol=1e-10)
+
+
+class TestIssue1315FPDriftConvention:
+    """FP drift-convention routing (#1315, Refs #1043).
+
+    After the v0.18.6 rename ``drift_field`` is the velocity ``alpha*``, not the value
+    function. For a smooth separable ``H`` each per-node FP solver must receive ``U`` via
+    ``potential_field`` and derive ``alpha*`` itself; passing ``U`` as ``drift_field`` bypasses
+    ``resolve_fp_drift_kwargs`` and converges to a wrong equilibrium. This pins the per-node FP
+    solve to route ``U`` via ``potential_field``.
+    """
+
+    def test_fp_receives_U_via_potential_field_not_drift(self):
+        problems, coupling, hjbs, fps = _make_3node_system()
+        solver = GraphMFGSolver(
+            problems=problems,
+            coupling=coupling,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=1,
+        )
+
+        captured: list[tuple[int, list[str]]] = []
+        for k, fp in enumerate(fps):
+            original = fp.solve_fp_system
+
+            def spy(*args, _original=original, _k=k, **kwargs):
+                captured.append((_k, sorted(kwargs)))
+                return _original(*args, **kwargs)
+
+            fp.solve_fp_system = spy
+
+        solver.solve()
+
+        assert captured, "FP solver was never called"
+        for k, keys in captured:
+            assert "potential_field" in keys, (
+                f"node {k}: value function not routed via potential_field (kwargs={keys}); "
+                "#1315 drift-convention bypass reopened"
+            )
+            assert "drift_field" not in keys, (
+                f"node {k}: value function wrongly passed as drift_field (velocity alpha*); "
+                "#1315 silent-wrong-equilibrium"
+            )

--- a/tests/unit/test_alg/test_regime_switching_iterator.py
+++ b/tests/unit/test_alg/test_regime_switching_iterator.py
@@ -275,3 +275,48 @@ class TestRegimeSwitchingCrossTermSign:
 
         src0 = iterator._make_fp_source(0, 2, Q, Ms)
         np.testing.assert_allclose(src0(0.0, x), (Q[1, 0] * m1 - Q[0, 1] * m0) * np.ones(N))
+
+
+class TestRegimeFPDriftConvention:
+    """FP drift-convention routing (#1315, Refs #1043).
+
+    After the v0.18.6 rename ``drift_field`` is the velocity ``alpha*``, not the value
+    function. For a smooth separable ``H`` the FP solver must receive ``U`` via
+    ``potential_field`` and derive ``alpha*`` itself; passing ``U`` as ``drift_field`` bypasses
+    ``resolve_fp_drift_kwargs`` and converges to a wrong equilibrium (silent-wrong-physics).
+    This pins the per-regime FP solve to route ``U`` via ``potential_field`` so the bypass
+    cannot silently reopen.
+    """
+
+    def test_fp_receives_U_via_potential_field_not_drift(self):
+        problems, config, hjbs, fps = _make_2regime_system()
+        iterator = RegimeSwitchingIterator(
+            problems=problems,
+            regime_config=config,
+            hjb_solvers=hjbs,
+            fp_solvers=fps,
+            max_iterations=1,
+        )
+
+        captured: list[tuple[int, list[str]]] = []
+        for k, fp in enumerate(fps):
+            original = fp.solve_fp_system
+
+            def spy(*args, _original=original, _k=k, **kwargs):
+                captured.append((_k, sorted(kwargs)))
+                return _original(*args, **kwargs)
+
+            fp.solve_fp_system = spy
+
+        iterator.solve()
+
+        assert captured, "FP solver was never called"
+        for k, keys in captured:
+            assert "potential_field" in keys, (
+                f"regime {k}: value function not routed via potential_field (kwargs={keys}); "
+                "#1315 drift-convention bypass reopened"
+            )
+            assert "drift_field" not in keys, (
+                f"regime {k}: value function wrongly passed as drift_field (velocity alpha*); "
+                "#1315 silent-wrong-equilibrium"
+            )


### PR DESCRIPTION
## Summary

`RegimeSwitchingIterator` (`regime_switching_iterator.py`) and `GraphMFGSolver` (`graph_mfg_solver.py`) called `solve_fp_system(m0_k, drift_field=Us_new[k], source_term=...)`, passing the value function `U` as `drift_field`. After the v0.18.6 rename, `drift_field` is the **velocity** `alpha*` (not the U-potential), so this bypassed the drift-convention dispatcher (`resolve_fp_drift_kwargs`). For a smooth separable `H`, `U` must enter via `potential_field` (the FP solver derives the velocity internally). Passing `drift_field=U` is silent-wrong-equilibrium.

## Fix

Replicate the `#1299` pattern from `fictitious_play.py` / `FixedPointIterator.solve()`, but **per subsystem** since these iterators hold a list of per-k FP solvers:

- New helper `fp_solver_sig_params()` in `fixed_point_utils.py` returns a solver's `solve_fp_system` parameter names (mirrors `BaseCouplingIterator._init_solver_signatures` for the list case).
- Each iterator caches `self._fp_sig_params_k = [fp_solver_sig_params(fp) for fp in fp_solvers]` in `__init__`.
- The FP step resolves drift/potential kwargs via `resolve_fp_drift_kwargs(self._problems[k], fp_sig_params_k, None, Us_new[k], M_old)` and dispatches positionally or by keyword accordingly. `self._problems[k]` (not the base-class representative `problems[0]`) is used so each regime/node resolves against its own Hamiltonian and geometry.
- `source_term` and the `m0_k` positional are preserved. A legacy positional-`U` fallback is kept for solvers whose signature cannot be introspected.

No `drift_field` override attribute exists on these iterators, so `None` is passed for the override.

## Tier-C (wrong→right) note

This changes regime/graph numerical results (intended: wrong→right physics). The existing regime + graph suites do **not** pin the old behavior — all passed unchanged after the fix; none required a justification update.

## Pinning tests

- `tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeFPDriftConvention::test_fp_receives_U_via_potential_field_not_drift`
- `tests/integration/test_graph_mfg_solver.py::TestIssue1315FPDriftConvention::test_fp_receives_U_via_potential_field_not_drift`

Both spy on `solve_fp_system` and assert `U` is routed via `potential_field` (not `drift_field`) for a smooth separable `H`.

- **Fail without fix** (source files stashed): `AssertionError: ... not routed via potential_field (kwargs=['drift_field', 'source_term'])`
- **Pass with fix**: both green.

## Suites run green

- `tests/unit/test_alg/test_regime_switching_iterator.py` + `tests/integration/test_graph_mfg_solver.py` — 34 passed
- `tests/integration/test_phase1_5_validation.py` + `test_fixed_point_iterator_relaxation_alias.py` + `test_fixed_point_sigma_consistency.py` — 36 passed, 1 skipped (regression on `fixed_point_utils` consumers)
- `ruff format --check` + `ruff check` clean on all 5 changed files.

Fixes #1315 (Refs #1043).

🤖 Generated with [Claude Code](https://claude.com/claude-code)