### PR TITLE
fix(alg): consume volatility_field in HJB-GFDM, fail loud in SL/WENO (Fixes #1316)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -624,6 +624,15 @@ class HJBGFDMSolver(BaseHJBSolver):
         self._dmp_alpha_crit: float | None = None
         self._dmp_warned = False
 
+        # Issue #1316: per-solve volatility_field override. None by default (explicit
+        # init for object-shape stability — see CLAUDE.md). When solve_hjb_system is
+        # called with volatility_field != None, this holds the spatial diffusion the
+        # coupling layer / FP solver is using; _get_sigma_value reads it INSTEAD of
+        # problem.sigma so HJB and FP stay convention-consistent. None -> byte-identical
+        # legacy path (problem.sigma). Set BEFORE the LLF block: _compute_llf_sigma_eff()
+        # below calls _get_sigma_value(None), which now reads this attribute.
+        self._volatility_field_override: float | np.ndarray | Callable | None = None
+
         # LLF augmented diffusion (Issue #1059, paper P2 branch of thm:discrete_comparison).
         # nu_i = max(0, C * l_H(i) * h_i - sigma^2/2)
         # sigma_eff_i = sqrt(sigma^2 + 2*nu_i)
@@ -2853,10 +2862,12 @@ class HJBGFDMSolver(BaseHJBSolver):
         Returns:
             Numeric sigma value
 
-        Handles three cases:
-        1. problem.nu exists (legacy attribute)
-        2. problem.sigma is callable → evaluate at collocation point
-        3. problem.sigma is numeric → use directly (fallback: 1.0)
+        Handles, in precedence order:
+        1. LLF per-node augmentation (point_idx given)
+        2. volatility_field override (Issue #1316) — the per-solve spatial diffusion
+        3. problem.nu (legacy attribute)
+        4. problem.sigma is callable → evaluate at the point / center of domain
+        5. problem.sigma is numeric → use directly (fallback: 1.0)
         """
         # LLF per-node override: return sigma_eff_i when augmentation is active (Issue #1059).
         # Only applies when point_idx is not None (per-point path); the batch path (None)
@@ -2865,6 +2876,13 @@ class HJBGFDMSolver(BaseHJBSolver):
             if point_idx < len(self._llf_sigma_eff):
                 return float(self._llf_sigma_eff[point_idx])
 
+        # Issue #1316: the per-solve volatility_field override (the spatial diffusion
+        # the coupling layer / FP solver is using) is the authoritative diffusion source,
+        # replacing problem.sigma so HJB and FP stay convention-consistent. None (the
+        # default) falls through to the byte-identical legacy path below.
+        if self._volatility_field_override is not None:
+            return self._resolve_diffusion_source(self._volatility_field_override, point_idx)
+
         # Check for legacy "nu" attribute (optional)
         nu = getattr(self.problem, "nu", None)
         if nu is not None:
@@ -2872,16 +2890,39 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         sigma = getattr(self.problem, "sigma", None)
         if callable(sigma):
-            # Callable sigma: evaluate at current point if available
-            if point_idx is not None and point_idx < len(self.collocation_points):
-                x = self.collocation_points[point_idx]
-                return float(self.problem.sigma(x))
-            else:
-                # Fallback: use representative value (center of domain)
-                return 1.0
+            # Callable sigma: evaluate at the point (per-point path) or at the center
+            # of the domain (batch path). Issue #1316: the batch path previously returned
+            # a hardcoded 1.0 ("representative value" in name only), silently replacing
+            # callable sigma with sigma=1.0 (~2x diffusion error). Now an actual
+            # center-of-domain evaluation, matching the documented intent.
+            return self._resolve_diffusion_source(sigma, point_idx)
         else:
             # Numeric sigma: use directly (with fallback to default)
             return float(getattr(self.problem, "sigma", 1.0))
+
+    def _resolve_diffusion_source(self, source: float | np.ndarray | Callable, point_idx: int | None) -> float:
+        """Resolve a scalar / callable / per-point-array diffusion source to a scalar sigma.
+
+        - callable: evaluate at the collocation point (``point_idx`` given) or at the
+          domain center (mean of collocation points) on the batch path (``point_idx=None``).
+        - array (ndim >= 1): index by point (``point_idx`` given); on the batch path the
+          GFDM residual applies one global scalar, so collapse to the mean — matching
+          MFGProblem's own array->scalar (sigma = mean) convention.
+        - scalar: returned directly.
+        """
+        if callable(source):
+            if point_idx is not None and point_idx < len(self.collocation_points):
+                x = self.collocation_points[point_idx]
+            else:
+                # Center of domain (mean of collocation points), shape (d,).
+                x = self.collocation_points.mean(axis=0)
+            return float(source(x))
+        arr = np.asarray(source)
+        if arr.ndim >= 1:
+            if point_idx is not None and point_idx < len(arr):
+                return float(arr[point_idx])
+            return float(np.mean(arr))
+        return float(source)
 
     # Note: _check_monotonicity_violation moved to MonotonicityEnforcer component
     # Note: _check_m_matrix_property moved to MonotonicityEnforcer component
@@ -2949,6 +2990,13 @@ class HJBGFDMSolver(BaseHJBSolver):
             if U_coupling_prev is not None:
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
             U_coupling_prev = U_from_prev_picard
+
+        # Issue #1316: install the per-solve volatility_field as the authoritative
+        # diffusion source for _get_sigma_value (consumed below via the residual /
+        # Jacobian / LLF paths). Set every call (not cleared at end) so there is no
+        # stale state and the default volatility_field=None restores the byte-identical
+        # legacy problem.sigma path.
+        self._volatility_field_override = volatility_field
 
         # Pick up any per-Picard resolved BC the coupling layer installed on the
         # geometry since construction (Issue #1118; matches FDM's per-solve re-read).

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -816,6 +816,25 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
             U_coupling_prev = U_from_prev_picard
 
+        # Issue #1316: the semi-Lagrangian solver reads diffusion from problem.sigma at
+        # multiple scattered sites (the advection-diffusion split, ADI, Crank-Nicolson),
+        # with no single sigma chokepoint to redirect. Honoring a volatility_field that
+        # differs from problem.sigma would require threading it through all of them; doing
+        # nothing would silently solve HJB with problem.sigma while FP uses the field,
+        # breaking the Picard correspondence. Fail loud instead of accept-and-ignore. A
+        # scalar field equal to problem.sigma is the iterator's redundant forwarding of
+        # problem.volatility_field (Issue #1248) and is accepted as a no-op.
+        if volatility_field is not None and not (
+            np.isscalar(volatility_field) and float(volatility_field) == float(self.problem.sigma)
+        ):
+            raise NotImplementedError(
+                "HJBSemiLagrangianSolver cannot honor a volatility_field that differs from "
+                "problem.sigma: it reads diffusion from problem.sigma at multiple sites with no "
+                "single chokepoint (Issue #1316). A spatially-varying or mismatched field would "
+                "make HJB solve a different diffusion than FP, breaking the Picard fixed point. "
+                "Use HJBGFDMSolver (which consumes volatility_field) or set problem.sigma to match."
+            )
+
         # Validate required parameters
         if M_density is None:
             raise ValueError("M_density is required")

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -916,6 +916,25 @@ class HJBWenoSolver(BaseHJBSolver):
                 raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
             U_coupling_prev = U_from_prev_picard
 
+        # Issue #1316: the WENO solver reads diffusion from problem.sigma at multiple
+        # scattered sites (the diffusion CFL bound and the diffusion update in each
+        # dimensional sweep), with no single sigma chokepoint to redirect. Honoring a
+        # volatility_field that differs from problem.sigma would require threading it
+        # through all of them; doing nothing would silently solve HJB with problem.sigma
+        # while FP uses the field, breaking the Picard correspondence. Fail loud instead
+        # of accept-and-ignore. A scalar field equal to problem.sigma is the iterator's
+        # redundant forwarding of problem.volatility_field (Issue #1248) and is a no-op.
+        if volatility_field is not None and not (
+            np.isscalar(volatility_field) and float(volatility_field) == float(self.problem.sigma)
+        ):
+            raise NotImplementedError(
+                "HJBWENOSolver cannot honor a volatility_field that differs from problem.sigma: "
+                "it reads diffusion from problem.sigma at multiple sites with no single chokepoint "
+                "(Issue #1316). A spatially-varying or mismatched field would make HJB solve a "
+                "different diffusion than FP, breaking the Picard fixed point. Use HJBGFDMSolver "
+                "(which consumes volatility_field) or set problem.sigma to match."
+            )
+
         # Validate required parameters
         if M_density is None:
             raise ValueError("M_density is required")

--- a/tests/unit/test_alg/test_issue_1316_hjb_volatility_consumption.py
+++ b/tests/unit/test_alg/test_issue_1316_hjb_volatility_consumption.py
@@ -1,0 +1,214 @@
+"""Pinning tests for Issue #1316: HJB solvers accept volatility_field but ignore it.
+
+The coupling iterator forwards ``volatility_field`` to ``solve_hjb_system`` for solvers
+that declare it (signature-gated, ``coupling/base_mfg.py``). Before this fix:
+
+  * ``HJBGFDMSolver`` declared ``volatility_field`` but never consumed it — the body
+    resolved diffusion via ``_get_sigma_value()`` / ``problem.sigma`` only. So a
+    spatially-varying field passed to FP was silently dropped by HJB, breaking the
+    Picard fixed-point correspondence.
+  * ``HJBGFDMSolver._get_sigma_value`` returned a HARDCODED ``1.0`` for a callable
+    ``problem.sigma`` on the batch path (``point_idx=None``), despite the comment
+    "use representative value (center of domain)" — a ~2x diffusion error.
+
+This module pins:
+
+  FIX-B — callable sigma batch path evaluates at the domain center, not 1.0.
+  FIX-A — a volatility_field override is the authoritative diffusion source
+          (replacing problem.sigma) and is wired in by solve_hjb_system.
+  Default (volatility_field=None) path is unchanged (problem.sigma).
+  SL / WENO fail loud (NotImplementedError) on a mismatched volatility_field
+          instead of silently accept-and-ignore.
+
+Refs #1316 (Refs #1248).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import (
+    HJBGFDMSolver,
+    HJBSemiLagrangianSolver,
+    HJBWenoSolver,
+)
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _components():
+    return MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+    )
+
+
+def _problem(sigma=0.3):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=0.2, Nt=10, sigma=sigma, components=_components())
+
+
+def _gfdm_solver(problem):
+    pts = np.linspace(0.0, 1.0, 21).reshape(-1, 1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return HJBGFDMSolver(problem, collocation_points=pts, delta=0.2)
+
+
+# ---------------------------------------------------------------------------
+# FIX-B: callable sigma batch path -> center-of-domain eval (not 1.0)
+# ---------------------------------------------------------------------------
+
+
+def test_callable_sigma_batch_path_is_center_eval_not_one():
+    """Issue #1316 FIX-B — _get_sigma_value(None) for callable sigma(x)=0.5+0.5x must
+    evaluate at the domain center (~0.75 over [0,1]), NOT return the hardcoded 1.0."""
+    solver = _gfdm_solver(_problem())
+    # Make problem.sigma callable; collocation points span [0,1] -> center mean = 0.5.
+    solver.problem.sigma = lambda x: 0.5 + 0.5 * float(np.atleast_1d(x)[0])
+
+    resolved = solver._get_sigma_value(None)
+
+    assert resolved == pytest.approx(0.75, abs=1e-12), (
+        f"callable sigma batch path resolved to {resolved}; expected the center eval 0.75. "
+        f"If it returned 1.0 the Issue #1316 hardcoded fallback has returned."
+    )
+    assert resolved != pytest.approx(1.0, abs=1e-9), "regressed to the hardcoded 1.0 fallback"
+
+
+def test_callable_sigma_per_point_path_unchanged():
+    """Sanity: the per-point path (point_idx given) still evaluates at that point."""
+    solver = _gfdm_solver(_problem())
+    solver.problem.sigma = lambda x: 0.5 + 0.5 * float(np.atleast_1d(x)[0])
+    # Point 0 is x=0 -> 0.5; last point x=1 -> 1.0.
+    assert solver._get_sigma_value(0) == pytest.approx(0.5, abs=1e-12)
+    assert solver._get_sigma_value(solver.n_points - 1) == pytest.approx(1.0, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# FIX-A: volatility_field override is the authoritative diffusion source
+# ---------------------------------------------------------------------------
+
+
+def test_array_override_replaces_problem_sigma():
+    """Issue #1316 FIX-A — a per-point array override is used (not problem.sigma): the
+    batch path collapses to its mean, the per-point path indexes it; both differ from
+    problem.sigma = 0.3."""
+    problem = _problem(sigma=0.3)
+    solver = _gfdm_solver(problem)
+    field = np.full(solver.n_points, 0.8)
+    solver._volatility_field_override = field
+
+    batch = solver._get_sigma_value(None)
+    assert batch == pytest.approx(0.8, abs=1e-12)
+    assert batch != pytest.approx(float(problem.sigma), abs=1e-9), "override ignored; used problem.sigma"
+
+    assert solver._get_sigma_value(5) == pytest.approx(0.8, abs=1e-12)
+
+
+def test_callable_override_replaces_problem_sigma():
+    """Issue #1316 FIX-A — a callable override evaluates at the center on the batch path."""
+    problem = _problem(sigma=0.3)
+    solver = _gfdm_solver(problem)
+    solver._volatility_field_override = lambda x: 0.5 + 0.5 * float(np.atleast_1d(x)[0])
+
+    batch = solver._get_sigma_value(None)
+    assert batch == pytest.approx(0.75, abs=1e-12)
+    assert batch != pytest.approx(float(problem.sigma), abs=1e-9), "override ignored; used problem.sigma"
+
+
+def test_solve_hjb_system_wires_in_override():
+    """Issue #1316 FIX-A — solve_hjb_system stores the volatility_field arg into the
+    override attribute (the wiring that makes _get_sigma_value see it), and a default
+    None solve leaves it None."""
+    problem = _problem(sigma=0.3)
+    solver = _gfdm_solver(problem)
+    U_T = 0.5 * (np.linspace(0.0, 1.0, 21) - 0.5) ** 2
+    M = np.ones((11, 21)) / 21
+    field = np.full(solver.n_points, 0.8)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver.solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=field)
+    assert solver._volatility_field_override is field, "solve_hjb_system did not install the override"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver.solve_hjb_system(M_density=M, U_terminal=U_T)
+    assert solver._volatility_field_override is None, "override not reset on a default (None) solve"
+
+
+def test_scalar_override_equal_to_sigma_is_byte_identical():
+    """Convention agreement — forwarding the scalar problem.sigma as volatility_field
+    (the iterator's redundant Issue #1248 forwarding) is byte-identical to not forwarding."""
+    U_T = 0.5 * (np.linspace(0.0, 1.0, 21) - 0.5) ** 2
+    M = np.ones((11, 21)) / 21
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        u_none = np.asarray(_gfdm_solver(_problem(0.3)).solve_hjb_system(M_density=M, U_terminal=U_T))
+        u_fwd = np.asarray(
+            _gfdm_solver(_problem(0.3)).solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=0.3)
+        )
+    np.testing.assert_array_equal(u_fwd, u_none, err_msg="scalar volatility_field == sigma changed the solution")
+
+
+# ---------------------------------------------------------------------------
+# SL / WENO: fail loud on a mismatched volatility_field (no clean chokepoint)
+# ---------------------------------------------------------------------------
+
+
+def _sl_problem():
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=0.2, Nt=10, sigma=0.3, components=_components())
+
+
+@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWenoSolver])
+def test_sl_weno_fail_loud_on_spatial_volatility(solver_cls):
+    """Issue #1316 — SL/WENO read problem.sigma at scattered sites (no chokepoint); a
+    spatial volatility_field must fail loud, not be silently ignored."""
+    problem = _sl_problem()
+    solver = solver_cls(problem)
+    U_T = np.zeros(21)
+    M = np.ones((11, 21)) / 21
+    field = np.linspace(0.2, 0.8, 21)
+
+    with pytest.raises(NotImplementedError, match="volatility_field"):
+        solver.solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=field)
+
+
+@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWenoSolver])
+def test_sl_weno_fail_loud_on_mismatched_scalar(solver_cls):
+    """Issue #1316 — a scalar volatility_field that differs from problem.sigma also fails
+    loud (HJB would silently solve a different diffusion than FP)."""
+    problem = _sl_problem()
+    solver = solver_cls(problem)
+    U_T = np.zeros(21)
+    M = np.ones((11, 21)) / 21
+
+    with pytest.raises(NotImplementedError, match="volatility_field"):
+        solver.solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=0.9)
+
+
+@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWenoSolver])
+def test_sl_weno_accept_scalar_equal_to_sigma(solver_cls):
+    """Issue #1316 — the iterator's redundant forwarding of a scalar problem.sigma as
+    volatility_field is a no-op and must NOT raise."""
+    problem = _sl_problem()
+    solver = solver_cls(problem)
+    U_T = np.zeros(21)
+    M = np.ones((11, 21)) / 21
+    U_prev = np.zeros((11, 21))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        U = solver.solve_hjb_system(M_density=M, U_terminal=U_T, U_coupling_prev=U_prev, volatility_field=0.3)
+    assert np.asarray(U).shape[0] == 11

--- a/tests/unit/test_convention_agreement.py
+++ b/tests/unit/test_convention_agreement.py
@@ -68,9 +68,15 @@ class TestSigmaToDiffusionAgreement:
         from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
 
         # _get_sigma_value reads self.llf_augmentation / self._llf_sigma_eff (LLF augmentation,
-        # Issue #1059); a real solver always sets both in __init__. LLF off is the default sigma
-        # resolution path this convention guard exercises.
-        stub = SimpleNamespace(problem=SimpleNamespace(sigma=sigma), llf_augmentation=False, _llf_sigma_eff=None)
+        # Issue #1059) and self._volatility_field_override (Issue #1316); a real solver sets all
+        # three in __init__. LLF off + no override is the default sigma resolution path this
+        # convention guard exercises.
+        stub = SimpleNamespace(
+            problem=SimpleNamespace(sigma=sigma),
+            llf_augmentation=False,
+            _llf_sigma_eff=None,
+            _volatility_field_override=None,
+        )
         resolved = HJBGFDMSolver._get_sigma_value(stub, None)
         assert diffusion_from_volatility(resolved) == pytest.approx(0.5 * sigma * sigma, rel=1e-12)
 


### PR DESCRIPTION
## Summary

Fixes #1316 (Refs #1248). The coupling iterator forwards `volatility_field` to `solve_hjb_system` for solvers that declare it (signature-gated, `coupling/base_mfg.py`). The HJB solvers **declared** it but never consumed it, so a spatially-varying `volatility_field` passed to FP was silently dropped by HJB — FP solved with the field while HJB solved with scalar `problem.sigma`, breaking the Picard fixed-point correspondence. Separately, `HJBGFDMSolver._get_sigma_value` returned a hardcoded `1.0` for a callable `problem.sigma` on the batch path (`point_idx=None`), despite the comment "use representative value (center of domain)" (~2x diffusion error).

## Changes

### `HJBGFDMSolver` — full consumption (the primary solver)
- **FIX-A**: `solve_hjb_system` stores `volatility_field` into `self._volatility_field_override` (explicit `None` init in `__init__`, placed **before** the LLF block because `_compute_llf_sigma_eff` calls `_get_sigma_value` during construction). `_get_sigma_value` uses the override as the authoritative diffusion source when set, replacing `problem.sigma`. Default `None` → byte-identical legacy path.
- **FIX-B**: callable `problem.sigma` on the batch path now evaluates at the domain center (mean of collocation points) instead of returning `1.0`.
- New `_resolve_diffusion_source` helper unifies scalar / callable / per-point-array resolution (callable → point or center; array → index per point, or mean on the scalar batch path matching `MFGProblem`'s own array→scalar convention).

### `HJBSemiLagrangianSolver` / `HJBWenoSolver` — fail loud (no clean chokepoint)
Both read `problem.sigma` at multiple scattered sites (advection-diffusion split / ADI / CN; diffusion CFL + per-axis updates) — no single sigma chokepoint to redirect. `solve_hjb_system` now raises `NotImplementedError` when `volatility_field` is not `None` **and** differs from `problem.sigma`. A scalar field equal to `problem.sigma` (the iterator's redundant #1248 forwarding of `problem.volatility_field`) is accepted as a no-op.

### `HJBHowardSolver` — no change
Already consumes `volatility_field` via its **constructor** (Issue #1254) at a single sigma chokepoint; the iterator does not forward to its `solve_hjb_system` (`volatility_field` is not in its signature params, only `**_unused`).

## Pinning test
`tests/unit/test_alg/test_issue_1316_hjb_volatility_consumption.py` (12 cases): callable-sigma center eval (~0.75, not 1.0), array/callable override consumption, `solve_hjb_system` wiring + reset, scalar byte-identity, SL/WENO fail-loud on spatial + mismatched-scalar, SL/WENO accept-scalar-equal-to-sigma.

**fail-without / pass-with**: with the source fixes stashed, 8 of 12 fail (the 4 that pass are invariant cases: per-point path, byte-identity, SL/WENO accept-scalar); with the fixes, all 12 pass.

## Suites run green
- `tests/regression/` (incl. the #1071 GFDM + coupled byte-identity goldens)
- `test_hjb_gfdm*` (solver, llf_augmentation, bc_newton_residual, monotonicity, rotation, v025_removal, monotonicity_scheme_rename, bc_classification, bug15, components, fp_gfdm_continuity)
- `test_hjb_semi_lagrangian`, `test_weno_family`, `test_hjb_howard_solver`
- `test_convention_agreement` (stub updated for the new attr), `test_issue_1248_volatility_forwarding`, `test_fixed_point_sigma_consistency`, `test_issue_1079_anisotropic_sigma`

`ruff format --check` clean; `ruff check` clean on changed source + new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)