### PR TITLE
fix(backends): unify diffusion-coefficient key across 4 backends via resolve_volatility (Fixes #1282)

### DIFF
--- a/mfgarchon/backends/jax_backend.py
+++ b/mfgarchon/backends/jax_backend.py
@@ -42,6 +42,7 @@ else:
 import numpy as np
 
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import resolve_volatility
 
 from .base_backend import BaseBackend
 
@@ -248,14 +249,16 @@ class JAXBackend(BaseBackend):
         div_flux = div_flux.at[0].set((flux[1] - flux[0]) / dx)
         div_flux = div_flux.at[-1].set((flux[-1] - flux[-2]) / dx)
 
-        # Diffusion term
-        sigma_sq = problem_params.get("sigma_sq", 0.01)
+        # Diffusion term.  Issue #1282: read the volatility through the single-source
+        # resolver (canonical "sigma" key; legacy "sigma_sq" holds sigma**2, default
+        # preserves the prior sqrt(0.01)=0.1 no-key behavior), then D = sigma**2/2.
+        sigma = resolve_volatility(problem_params, legacy_key="sigma_sq", legacy_is_squared=True, default=0.1)
         d2M_dx2 = jnp.zeros_like(M)
         d2M_dx2 = d2M_dx2.at[1:-1].set((M[2:] - 2 * M[1:-1] + M[:-2]) / (dx**2))
         d2M_dx2 = d2M_dx2.at[0].set(d2M_dx2[1])
         d2M_dx2 = d2M_dx2.at[-1].set(d2M_dx2[-2])
 
-        diffusion = 0.5 * sigma_sq * d2M_dx2
+        diffusion = 0.5 * sigma * sigma * d2M_dx2
 
         # Time step
         M_new = M + dt * (-div_flux + diffusion)

--- a/mfgarchon/backends/numba_backend.py
+++ b/mfgarchon/backends/numba_backend.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 
 from mfgarchon.utils.numerical.integration import trapezoid
+from mfgarchon.utils.pde_coefficients import resolve_volatility
 
 from .base_backend import BaseBackend
 
@@ -332,7 +333,9 @@ class NumbaBackend(BaseBackend):
     # MFG-Specific Operations
     def compute_hamiltonian(self, x, p, m, problem_params):
         """Compute Hamiltonian using optimized kernel."""
-        sigma = problem_params.get("sigma", 1.0)
+        # Issue #1282: numba already uses the canonical "sigma" key; route through the
+        # single-source resolver (no legacy key) so all four backends share one lookup.
+        sigma = resolve_volatility(problem_params, default=1.0)
 
         if NUMBA_AVAILABLE:
             # Use JIT-compiled kernel for performance
@@ -350,7 +353,9 @@ class NumbaBackend(BaseBackend):
 
     def hjb_step(self, U, M, dt, dx, problem_params):
         """Single Hamilton-Jacobi-Bellman time step."""
-        sigma = problem_params.get("sigma", 1.0)
+        # Issue #1282: numba already uses the canonical "sigma" key; route through the
+        # single-source resolver (no legacy key) so all four backends share one lookup.
+        sigma = resolve_volatility(problem_params, default=1.0)
 
         if NUMBA_AVAILABLE:
             return self._hjb_step_kernel(U, M, dt, dx, sigma)
@@ -372,7 +377,9 @@ class NumbaBackend(BaseBackend):
 
     def fpk_step(self, M, U, dt, dx, problem_params):
         """Single Fokker-Planck-Kolmogorov time step."""
-        sigma = problem_params.get("sigma", 1.0)
+        # Issue #1282: numba already uses the canonical "sigma" key; route through the
+        # single-source resolver (no legacy key) so all four backends share one lookup.
+        sigma = resolve_volatility(problem_params, default=1.0)
 
         if NUMBA_AVAILABLE:
             return self._fpk_step_kernel(M, U, dt, dx, sigma)

--- a/mfgarchon/backends/numpy_backend.py
+++ b/mfgarchon/backends/numpy_backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import numpy as np
 
 from mfgarchon.utils.numerical.integration import trapezoid
+from mfgarchon.utils.pde_coefficients import resolve_volatility
 
 from .base_backend import BaseBackend
 
@@ -182,15 +183,17 @@ class NumPyBackend(BaseBackend):
         div_flux[0] = (flux[1] - flux[0]) / dx
         div_flux[-1] = (flux[-1] - flux[-2]) / dx
 
-        # Diffusion term: σ²/2 * ∇²M
-        sigma_sq = problem_params.get("sigma_sq", 0.01)
+        # Diffusion term: σ²/2 * ∇²M.  Issue #1282: read the volatility through the
+        # single-source resolver (canonical "sigma" key; legacy "sigma_sq" holds sigma**2,
+        # default preserves the prior sqrt(0.01)=0.1 no-key behavior), then D = sigma**2/2.
+        sigma = resolve_volatility(problem_params, legacy_key="sigma_sq", legacy_is_squared=True, default=0.1)
         d2M_dx2 = np.zeros_like(M)
         d2M_dx2[1:-1] = (M[2:] - 2 * M[1:-1] + M[:-2]) / (dx**2)
         # Zero Neumann boundary conditions for diffusion
         d2M_dx2[0] = d2M_dx2[1]
         d2M_dx2[-1] = d2M_dx2[-2]
 
-        diffusion = 0.5 * sigma_sq * d2M_dx2
+        diffusion = 0.5 * sigma * sigma * d2M_dx2
 
         # Time step: M^{n+1} = M^n + dt * (-∇·J + diffusion)
         M_new = M + dt * (-div_flux + diffusion)

--- a/mfgarchon/backends/torch_backend.py
+++ b/mfgarchon/backends/torch_backend.py
@@ -18,7 +18,7 @@ from typing import Any
 import numpy as np
 
 from mfgarchon.utils.mfg_logging import get_logger
-from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility_torch, resolve_volatility
 
 from .base_backend import BaseBackend
 
@@ -449,8 +449,11 @@ class TorchBackend(BaseBackend):
         flux = M_tensor * drift
         div_term = torch.gradient(flux, spacing=dx, dim=-1)[0]
 
-        # Compute diffusion term: D * d²M/dx²  where D = σ²/2 (Issue #1189: route through D)
-        sigma = problem_params.get("diffusion", 0.1)
+        # Compute diffusion term: D * d²M/dx²  where D = σ²/2 (Issue #1189: route through D).
+        # Issue #1282: read the volatility through the single-source resolver (canonical
+        # "sigma" key; legacy "diffusion" key holds the volatility despite the name, default
+        # preserves the prior 0.1 no-key behavior).
+        sigma = resolve_volatility(problem_params, legacy_key="diffusion", legacy_is_squared=False, default=0.1)
         M_grad = torch.gradient(M_tensor, spacing=dx, dim=-1)[0]
         M_grad2 = torch.gradient(M_grad, spacing=dx, dim=-1)[0]
         diffusion_term = diffusion_from_volatility_torch(sigma) * M_grad2

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -7,6 +7,7 @@ eliminating code duplication across HJB, FP, and coupling solvers.
 
 from __future__ import annotations
 
+import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -103,6 +104,80 @@ def diffusion_from_volatility_torch(sigma: Any) -> Any:
     return 0.5 * sigma**2
 
 
+_VOLATILITY_LEGACY_KEY_WARNED: set[str] = set()
+
+
+def resolve_volatility(
+    problem_params: dict[str, Any],
+    *,
+    legacy_key: str | None = None,
+    legacy_is_squared: bool = False,
+    default: float,
+) -> Any:
+    r"""Resolve the SDE volatility ``sigma`` from a backend ``problem_params`` dict.
+
+    Single source for the diffusion-coefficient lookup shared by the four computational
+    backends (numpy / jax / torch / numba). Before this resolver the backends read the
+    coefficient under **three different keys with three different semantics and defaults**
+    -- numba ``"sigma"`` (default 1.0), numpy/jax ``"sigma_sq"`` (``sigma**2``, default 0.01),
+    torch ``"diffusion"`` (the volatility despite the name, default 0.1) -- so a single
+    ``problem_params`` dict could not be ported across backends without remapping
+    (Issue #1282 item 3; coordinate with Issue #1189's ``"sigma"`` canonicalization).
+
+    Resolution order (canonical first):
+
+    1. ``problem_params["sigma"]`` -- the canonical SDE volatility key
+       (``NAMING_CONVENTIONS.md`` "Volatility vs Diffusion"). Returned verbatim; the caller
+       computes ``D = sigma**2 / 2``. No warning.
+    2. ``problem_params[legacy_key]`` -- the backend's historical key, when ``legacy_key`` is
+       given and present. ``legacy_is_squared=True`` means the stored value is ``sigma**2``
+       (the numpy/jax ``"sigma_sq"`` key), so ``sqrt`` is applied; ``legacy_is_squared=False``
+       means the stored value is already ``sigma`` (the torch ``"diffusion"`` key). Emits a
+       **one-time** ``DeprecationWarning`` (per legacy key, per process) naming the canonical
+       ``"sigma"`` key.
+    3. ``default`` -- the backend's historical no-key default, so callers that omit the
+       parameter see no behavior change.
+
+    Returns ``sigma`` (not ``D``); each backend applies its own ``sigma -> D`` conversion
+    (``0.5 * sigma**2`` for numpy/jax/numba, :func:`diffusion_from_volatility_torch` for torch)
+    so the autograd / JIT computation graph is preserved. The square root uses ``value ** 0.5``
+    rather than ``np.sqrt`` so torch tensors and jax tracers pass through their own dispatch
+    unchanged.
+
+    Parameters
+    ----------
+    problem_params : dict
+        Backend problem-parameter dict.
+    legacy_key : str | None
+        The backend's historical dict key, or ``None`` (numba, already canonical).
+    legacy_is_squared : bool
+        ``True`` if ``problem_params[legacy_key]`` stores ``sigma**2`` (numpy/jax ``"sigma_sq"``).
+    default : float
+        Volatility used when neither the canonical nor the legacy key is present. Required
+        (keyword-only) so each backend explicitly preserves its prior no-key default.
+
+    Returns
+    -------
+    sigma : float | torch.Tensor | jax.Array
+        The SDE volatility (same type as the stored value on the legacy/canonical path).
+    """
+    if "sigma" in problem_params:
+        return problem_params["sigma"]
+    if legacy_key is not None and legacy_key in problem_params:
+        if legacy_key not in _VOLATILITY_LEGACY_KEY_WARNED:
+            _VOLATILITY_LEGACY_KEY_WARNED.add(legacy_key)
+            warnings.warn(
+                f"problem_params key {legacy_key!r} is deprecated; use the canonical 'sigma' "
+                f"key holding the SDE volatility (D = sigma**2/2) for cross-backend portability "
+                f"(Issue #1282).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        value = problem_params[legacy_key]
+        return value**0.5 if legacy_is_squared else value
+    return default
+
+
 def scalar_diffusion_from_volatility(volatility_field: Any, fallback_sigma: Any) -> float:
     """Single scalar PDE diffusion ``D`` for solvers that assemble ``D * K`` with a scalar ``D``
     (the weak-form / FEM family).
@@ -124,8 +199,6 @@ def scalar_diffusion_from_volatility(volatility_field: Any, fallback_sigma: Any)
         return float(diffusion_from_volatility(fallback_sigma))
     if np.ndim(volatility_field) == 0:
         return float(diffusion_from_volatility(float(volatility_field)))
-    import warnings
-
     warnings.warn(
         "Weak-form/FEM solver uses a single scalar diffusion D; the spatially-varying volatility "
         "field is collapsed to its mean (D = mean(sigma)^2 / 2). For a true varying-coefficient "

--- a/tests/unit/test_backends/test_issue_1282_diffusion_key.py
+++ b/tests/unit/test_backends/test_issue_1282_diffusion_key.py
@@ -1,0 +1,235 @@
+"""Pinning tests for #1282 item 3: unify the backend diffusion-coefficient key.
+
+Before the fix the four backends read the diffusion coefficient under three
+different ``problem_params`` keys with three different semantics and defaults:
+
+- numba  -> ``"sigma"``     (volatility, default 1.0)              -- canonical
+- numpy  -> ``"sigma_sq"``  (sigma**2,   default 0.01)
+- jax    -> ``"sigma_sq"``  (sigma**2,   default 0.01)
+- torch  -> ``"diffusion"`` (volatility, default 0.1)
+
+so a single ``problem_params`` dict could not be ported across backends. The
+fix routes all four through ``resolve_volatility`` (prefer canonical ``"sigma"``;
+fall back to the backend's legacy key with a one-time ``DeprecationWarning``;
+else the backend's prior default).
+
+Two pinning groups:
+
+(1) Cross-backend portability -- one ``{"sigma": 0.3}`` dict yields the SAME
+    effective ``D = sigma**2/2 = 0.045`` in every backend's ``fpk_step``.
+(2) Backward-compat -- each backend's legacy key still resolves to the same
+    sigma and emits a ``DeprecationWarning`` naming the canonical key.
+
+Each group FAILs on the pre-fix code (legacy keys diverge / canonical ignored)
+and PASSes after the fix.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.utils import pde_coefficients
+from mfgarchon.utils.pde_coefficients import resolve_volatility
+
+# Per-backend (legacy_key, legacy_is_squared, default) — the exact arguments each
+# backend's fpk_step passes to resolve_volatility.
+BACKEND_DIFFUSION_CONFIG = {
+    "numpy": {"legacy_key": "sigma_sq", "legacy_is_squared": True, "default": 0.1},
+    "jax": {"legacy_key": "sigma_sq", "legacy_is_squared": True, "default": 0.1},
+    "torch": {"legacy_key": "diffusion", "legacy_is_squared": False, "default": 0.1},
+    "numba": {"legacy_key": None, "legacy_is_squared": False, "default": 1.0},
+}
+
+SIGMA = 0.3
+EXPECTED_D = 0.5 * SIGMA * SIGMA  # 0.045
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_warning_guard():
+    """resolve_volatility warns only once per legacy key per process; clear the
+    guard before each test so warning assertions are deterministic."""
+    pde_coefficients._VOLATILITY_LEGACY_KEY_WARNED.clear()
+    yield
+    pde_coefficients._VOLATILITY_LEGACY_KEY_WARNED.clear()
+
+
+# ---------------------------------------------------------------------------
+# (1) Cross-backend portability at the resolver level (no backend libs needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend_name", list(BACKEND_DIFFUSION_CONFIG))
+def test_canonical_sigma_gives_same_effective_D_all_backends(backend_name):
+    """A single ``{"sigma": 0.3}`` dict resolves to sigma=0.3 (=> D=0.045) under
+    every backend's resolver configuration."""
+    cfg = BACKEND_DIFFUSION_CONFIG[backend_name]
+    sigma = resolve_volatility({"sigma": SIGMA}, **cfg)
+    assert sigma == SIGMA
+    assert 0.5 * sigma * sigma == pytest.approx(EXPECTED_D)
+
+
+def test_canonical_sigma_preferred_over_legacy_no_warning():
+    """When both keys are present the canonical ``"sigma"`` wins and no
+    DeprecationWarning is emitted."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes an error
+        sigma = resolve_volatility(
+            {"sigma": SIGMA, "sigma_sq": 0.09}, legacy_key="sigma_sq", legacy_is_squared=True, default=0.1
+        )
+    assert sigma == SIGMA
+
+
+@pytest.mark.parametrize("backend_name", list(BACKEND_DIFFUSION_CONFIG))
+def test_no_key_returns_backend_default(backend_name):
+    """With neither canonical nor legacy key, the backend's prior default is
+    returned and no warning is emitted (no behavior change for such callers)."""
+    cfg = BACKEND_DIFFUSION_CONFIG[backend_name]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sigma = resolve_volatility({"unrelated": 1.0}, **cfg)
+    assert sigma == cfg["default"]
+
+
+# ---------------------------------------------------------------------------
+# (2) Backward-compat: legacy keys still resolve + emit DeprecationWarning
+# ---------------------------------------------------------------------------
+
+# (legacy_key, legacy_is_squared, stored_value, expected_sigma)
+LEGACY_CASES = [
+    pytest.param("sigma_sq", True, 0.09, 0.3, id="numpy_jax_sigma_sq"),
+    pytest.param("diffusion", False, 0.3, 0.3, id="torch_diffusion"),
+]
+
+
+@pytest.mark.parametrize(("legacy_key", "legacy_is_squared", "stored", "expected"), LEGACY_CASES)
+def test_legacy_key_resolves_and_warns(legacy_key, legacy_is_squared, stored, expected):
+    """Each legacy key resolves to the same sigma and emits a one-time
+    DeprecationWarning naming the canonical 'sigma' key."""
+    with pytest.warns(DeprecationWarning, match="sigma"):
+        sigma = resolve_volatility(
+            {legacy_key: stored}, legacy_key=legacy_key, legacy_is_squared=legacy_is_squared, default=0.1
+        )
+    assert sigma == pytest.approx(expected)
+
+
+def test_legacy_warning_is_one_time_per_key():
+    """The DeprecationWarning fires once per legacy key per process; a second
+    resolve with the same legacy key is silent."""
+    params = {"sigma_sq": 0.09}
+    with pytest.warns(DeprecationWarning, match="sigma"):
+        resolve_volatility(params, legacy_key="sigma_sq", legacy_is_squared=True, default=0.1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # a second warning would raise
+        sigma = resolve_volatility(params, legacy_key="sigma_sq", legacy_is_squared=True, default=0.1)
+    assert sigma == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# (1') Cross-backend portability through the actual fpk_step code paths.
+#
+# For each available backend, ``fpk_step`` with the canonical ``{"sigma": 0.3}``
+# dict must produce the IDENTICAL density evolution as ``fpk_step`` with that
+# backend's own legacy key encoding sigma=0.3 (same backend, same discretisation,
+# same dtype -> exact agreement).  Pre-fix the canonical key is ignored by
+# numpy/jax/torch (they read sigma_sq/diffusion), so the two outputs diverge.
+# ---------------------------------------------------------------------------
+
+
+def _gaussian_density(nx: int = 41):
+    dx = 1.0 / (nx - 1)
+    x = np.linspace(0.0, 1.0, nx)
+    M = np.exp(-0.5 * ((x - 0.5) / 0.15) ** 2)
+    fn = getattr(np, "trapezoid", None) or np.trapz
+    M = M / fn(M, dx=dx)
+    U = np.zeros_like(x)  # zero drift -> pure diffusion isolates the D term
+    return M, U, dx, x
+
+
+def _to_numpy(arr):
+    if hasattr(arr, "detach"):  # torch
+        return arr.detach().cpu().numpy()
+    return np.asarray(arr)
+
+
+# canonical dict and the legacy-key dict that encodes the SAME sigma=0.3
+_LEGACY_ENCODING = {
+    "numpy": {"sigma_sq": 0.09},
+    "jax": {"sigma_sq": 0.09},
+    "torch": {"diffusion": 0.3},
+    "numba": {"sigma": 0.3},  # numba's canonical key IS its native key
+}
+
+
+def _make_backend(name):
+    if name == "numpy":
+        from mfgarchon.backends.numpy_backend import NumPyBackend
+
+        return NumPyBackend()
+    if name == "numba":
+        pytest.importorskip("numba")
+        from mfgarchon.backends.numba_backend import NumbaBackend
+
+        return NumbaBackend()
+    if name == "jax":
+        pytest.importorskip("jax")
+        from mfgarchon.backends.jax_backend import JAXBackend
+
+        return JAXBackend()
+    if name == "torch":
+        pytest.importorskip("torch")
+        from mfgarchon.backends.torch_backend import TorchBackend
+
+        return TorchBackend()
+    raise AssertionError(name)
+
+
+@pytest.mark.parametrize("backend_name", list(BACKEND_DIFFUSION_CONFIG))
+def test_canonical_sigma_dict_portable_through_fpk_step(backend_name):
+    """``fpk_step({"sigma": 0.3})`` must match ``fpk_step({<legacy enc of 0.3>})``
+    for the SAME backend.  Pre-fix numpy/jax/torch ignore the canonical key and
+    fall to their default D, so the two outputs diverge -> this FAILs without the
+    routing fix.  numba already used the canonical key (its case is the reference)."""
+    backend = _make_backend(backend_name)
+    M, U, dx, x = _gaussian_density()
+    dt = 1e-3
+
+    canonical = {"sigma": SIGMA, "x_grid": x}
+    legacy = dict(_LEGACY_ENCODING[backend_name])
+    legacy["x_grid"] = x
+
+    out_canonical = _to_numpy(backend.fpk_step(M, U, dt, dx, canonical))
+    out_legacy = _to_numpy(backend.fpk_step(M, U, dt, dx, legacy))
+
+    np.testing.assert_allclose(
+        out_canonical,
+        out_legacy,
+        rtol=1e-6,
+        atol=1e-9,
+        err_msg=(
+            f"[{backend_name}] canonical {{'sigma': 0.3}} fpk_step output differs from the "
+            f"legacy-key encoding of the same sigma -> the canonical key is not honored "
+            f"(Issue #1282 item 3)."
+        ),
+    )
+
+
+@pytest.mark.parametrize("backend_name", ["numpy", "jax", "torch"])
+def test_canonical_sigma_changes_diffusion_vs_default(backend_name):
+    """Guard against a resolver that always returns the default: for the backends
+    whose default sigma (0.1) differs from 0.3, the canonical dict must change the
+    diffusion-driven evolution relative to the no-key default."""
+    backend = _make_backend(backend_name)
+    M, U, dx, x = _gaussian_density()
+    dt = 1e-3
+
+    out_sigma = _to_numpy(backend.fpk_step(M, U, dt, dx, {"sigma": SIGMA, "x_grid": x}))
+    out_default = _to_numpy(backend.fpk_step(M, U, dt, dx, {"x_grid": x}))
+
+    assert not np.allclose(out_sigma, out_default, rtol=1e-3), (
+        f"[{backend_name}] canonical sigma=0.3 produced the same output as the no-key "
+        f"default; the diffusion coefficient is not being read from 'sigma'."
+    )


### PR DESCRIPTION
## Summary

Closes the **last open item** of #1282 (item 3; items 1/2 were fixed by #1300). The four computational backends read the diffusion coefficient under **three different `problem_params` keys with different semantics and defaults**, so a single `problem_params` dict could not be ported across backends:

| backend | key | stored value | default | sigma->D |
|--------|-----|--------------|---------|----------|
| numba  | `"sigma"`     | volatility (canonical) | 1.0  | `0.5*sigma**2` |
| numpy  | `"sigma_sq"`  | `sigma**2`             | 0.01 | `0.5*sigma_sq` |
| jax    | `"sigma_sq"`  | `sigma**2`             | 0.01 | `0.5*sigma_sq` |
| torch  | `"diffusion"` | volatility (despite the name) | 0.1 | `diffusion_from_volatility_torch` |

A caller passing only `"sigma"` to numpy/jax/torch silently hit the hardcoded default regardless of the real value; the defaults only coincide near sigma=0.1, masking the bug.

## Fix (single-source + non-breaking)

Add a resolver to `mfgarchon/utils/pde_coefficients.py`:

```python
resolve_volatility(problem_params, *, legacy_key=None, legacy_is_squared=False, default=...)
```

Resolution order: canonical `"sigma"` → the backend's legacy key (sqrt for the squared `"sigma_sq"` key; the torch `"diffusion"` value is already the volatility) emitting a **one-time `DeprecationWarning`** naming the canonical key → the backend's prior `default`. Returns `sigma`; each backend keeps its own `sigma -> D` conversion. The sqrt uses `value ** 0.5` (not `np.sqrt`) so torch tensors and jax tracers pass through their own dispatch unchanged (jax `fpk_step` is JIT-compiled).

All four backends' diffusion reads are routed through it — numba's 3 reads (`compute_hamiltonian` / `hjb_step` / `fpk_step`), and the `fpk_step` reads of numpy / jax / torch.

**Non-breaking**: each backend's existing no-key default is preserved (numba 1.0, torch 0.1, numpy/jax `sqrt(0.01)=0.1`), so callers that omit the parameter see no behavior change. A `problem_params={"sigma": s}` dict now yields the same effective `D = s**2/2` across all four backends.

## Pinning test

`tests/unit/test_backends/test_issue_1282_diffusion_key.py` (19 tests):

- **cross-backend portability** — one `{"sigma": 0.3}` dict gives effective `D = 0.045` in all four backends, both at the resolver level (parametrized over the 4 backend configs) and through the actual `fpk_step` code paths (each backend's canonical-key output must equal its legacy-key-encoding-of-the-same-sigma output; libs skipped when unavailable).
- **backward-compat** — each legacy key still resolves to the same sigma and emits a one-time `DeprecationWarning` naming the canonical `"sigma"` key; canonical key present emits no warning; no-key returns the backend default.

**FAILS-without / PASSES-with**: with the 4 backend files reverted (`git stash`, resolver kept), the canonical key is ignored by numpy/jax/torch and the portability assertions fail (6 failed, numba passes as the reference); with the fix, all 19 pass.

## Test plan

- [x] `tests/unit/test_backends/test_issue_1282_diffusion_key.py` — 19 passed (FAILS-without verified via git stash of the 4 backend files).
- [x] `tests/unit/test_backends/` + `test_core/test_pde_coefficients.py` + `test_utils/test_diffusion_from_volatility.py` + `test_alg/test_issue_1189_fp_sigma_migration.py` — 357 passed, 3 skipped.
- [x] `ruff format --check` clean on changed files; `ruff check` clean on changed lines (one pre-existing TC003 in `jax_backend.py:10` is on `main`, unrelated).

Fixes #1282 (Refs #1189)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
