### PR TITLE
fix(coupling): time-slice density for problem-level source terms (Refs #1285)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -267,7 +267,13 @@ class FixedPointIterator(BaseCouplingIterator):
             # (explicit treatment), consistent with graph_mfg_solver.py:306.
             terms: list[np.ndarray] = []
             if has_source:
-                terms.append(problem.source_term_hjb(x, m_current, np.zeros_like(m_current), t))
+                # Issue #1285: evaluate the problem-level source (delta F / delta m) at the
+                # density SLICE for time t, not the whole (Nt+1, Nx) array. Otherwise a
+                # time-dependent source (e.g. lions_correction F[m]) silently falls back to the
+                # terminal slice m[-1] for every t. Mirrors the nonlocal branch below and
+                # graph_mfg_solver.py (_get_time_slice).
+                m_t = _get_time_slice(m_current, t, problem.dt)
+                terms.append(problem.source_term_hjb(x, m_t, np.zeros_like(m_t), t))
             if has_obstacle:
                 psi = problem.obstacle(x)
                 # Penalty parameter: large but finite, consistent with Rev 4 design
@@ -300,7 +306,10 @@ class FixedPointIterator(BaseCouplingIterator):
             return None
 
         def composed(t: float, x: np.ndarray) -> np.ndarray:
-            return problem.source_term_fp(x, m_current, v_current, t)
+            # Issue #1285: slice density and value function at time t (see _compose_hjb_source).
+            m_t = _get_time_slice(m_current, t, problem.dt)
+            v_t = _get_time_slice(v_current, t, problem.dt)
+            return problem.source_term_fp(x, m_t, v_t, t)
 
         return composed
 

--- a/tests/unit/test_alg/test_issue1285_source_term_time_slice.py
+++ b/tests/unit/test_alg/test_issue1285_source_term_time_slice.py
@@ -1,0 +1,92 @@
+"""Issue #1285 (secondary bug): time-dependent source terms must see the time-t density slice.
+
+``FixedPointIterator._compose_hjb_source`` / ``_compose_fp_source`` bind the current density
+iterate ``M_old`` (full ``(Nt+1, Nx)`` array) into a ``(t, x)`` closure handed to the solver's
+``source_term``. Before this fix the closure passed the WHOLE array to the problem-level
+``source_term_hjb/fp(x, m, v, t)`` without slicing by ``t``, so a time-dependent source — e.g.
+``lions_correction`` ``F[m]`` whose 2-D branch falls back to ``m[-1]`` — silently used the
+terminal density slice for every backward time step. The sibling nonlocal branch already sliced
+the value function via ``_get_time_slice`` (Issue #1259); the source branch did not.
+
+These pins assert the source callback receives the time-``t`` slice (``m[k]``, 1-D), not the full
+2-D array — failing against the pre-fix code and passing after.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+_NX = 5
+_NT = 4
+
+
+class _Stub:
+    """Minimal stand-in carrying only ``.problem`` — the only attribute the compose methods read."""
+
+    def __init__(self, problem: MFGProblem) -> None:
+        self.problem = problem
+
+
+def _problem_with_source(captured: list, *, kind: str) -> MFGProblem:
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_NX], boundary_conditions=no_flux_bc(dimension=1))
+
+    def spy(x, m, v, t):  # problem-level signature (x, m, v, t)
+        captured.append((t, np.asarray(m).copy()))
+        return np.zeros(np.asarray(x).shape[0])
+
+    comps = MFGComponents(
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+    )
+    # source_term_hjb/fp are MFGProblem-level kwargs (mfg_problem.py:568), not MFGComponents fields.
+    source_kw = {"source_term_hjb": spy} if kind == "hjb" else {"source_term_fp": spy}
+    return MFGProblem(geometry=grid, T=0.4, Nt=_NT, sigma=0.3, components=comps, **source_kw)
+
+
+def _row_indexed_field() -> np.ndarray:
+    """(Nt+1, Nx) array whose row k is the constant k — so a slice reveals which time index was used."""
+    return np.arange(_NT + 1, dtype=float)[:, None] * np.ones((_NT + 1, _NX))
+
+
+def test_hjb_source_receives_time_slice_not_full_array():
+    captured: list = []
+    problem = _problem_with_source(captured, kind="hjb")
+    M_full = _row_indexed_field()
+    U_full = np.zeros((_NT + 1, _NX))
+    closure = FixedPointIterator._compose_hjb_source(_Stub(problem), M_full, U_full)
+    assert closure is not None
+    x = np.linspace(0.0, 1.0, _NX)
+    dt = problem.dt
+
+    for k in (0, 2, _NT):  # t = 0, mid, terminal
+        captured.clear()
+        closure(k * dt, x)
+        _, m = captured[-1]
+        assert m.ndim == 1, f"source got the full {m.ndim}-D array, not the time-t slice (Issue #1285)"
+        assert np.allclose(m, k), f"t={k * dt}: expected the k={k} density slice, got {m} (terminal-slice bug)"
+
+
+def test_fp_source_receives_time_slice_not_full_array():
+    captured: list = []
+    problem = _problem_with_source(captured, kind="fp")
+    M_full = _row_indexed_field()
+    V_full = np.zeros((_NT + 1, _NX))
+    closure = FixedPointIterator._compose_fp_source(_Stub(problem), M_full, V_full)
+    assert closure is not None
+    x = np.linspace(0.0, 1.0, _NX)
+    dt = problem.dt
+
+    for k in (0, 2, _NT):
+        captured.clear()
+        closure(k * dt, x)
+        _, m = captured[-1]
+        assert m.ndim == 1, f"FP source got the full {m.ndim}-D array, not the time-t slice (Issue #1285)"
+        assert np.allclose(m, k), f"t={k * dt}: expected the k={k} density slice, got {m}"


### PR DESCRIPTION
## Bug (Issue #1285 secondary — the time-slice defect)

`FixedPointIterator._compose_hjb_source` / `_compose_fp_source` bind the current density iterate `M_old` (full `(Nt+1, Nx)` array) into a `(t, x)` closure handed to the solver's `source_term`, but passed the **whole array** to the problem-level `source_term_hjb/fp(x, m, v, t)` **without slicing by `t`**.

A time-dependent source then silently used the wrong density. Concretely, `lions_correction`'s `δF/δm`, whose 2-D branch falls back to `m[-1]` (`lions_correction.py:122,182`), applied the **terminal** density slice at **every** backward HJB time step.

The sibling branches already did this correctly:
- the **nonlocal** branch one line below: `v_t = _get_time_slice(u_current, t, problem.dt)` (Issue #1259 fix, `fixed_point_iterator.py:282`)
- `graph_mfg_solver.py:327`: `m_t = _get_time_slice(Ms_expanded[k], t, dt)`

Only the source branch (`fixed_point_iterator.py:270`, and the FP analog `:303`) was missed.

## Fix
Slice `m` (and `v` for the FP source) at time `t` via the existing `_get_time_slice` helper before calling the problem-level source, mirroring the nonlocal branch and `graph_mfg_solver`. `_get_time_slice` returns a 1-D input unchanged and clamps the index, so a single-slice density still works.

## Verification
- New pinning test `tests/unit/test_alg/test_issue1285_source_term_time_slice.py`: a spy source over a row-indexed `(Nt+1, Nx)` density asserts the callback receives the **1-D time-`t` slice** `m[k]`, not the full 2-D array. **Fails** against the pre-fix code (gets the 2-D array), **passes** after.
- Regression: `test_fpi_nonlocal_hjb_source`, `test_lions_correction`, `test_source_term_wiring`, `test_issue1285_newton_fail_loud` — 27 passed.

## Scope
This is the **time-slice secondary bug** of #1285; the main path (MFGResidual/Newton silently ignoring source terms) was fail-loud-gated by #1291. Newton/MFGResidual source-term *support* (vs the fail-loud guard) remains separate and deferred. Hence `Refs #1285`, not `Fixes`.