### PR TITLE
fix(alg): implement anisotropic (d,d) volatility Σ in particle FP solver (Refs #1256 Part 1)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -1305,11 +1305,19 @@ class FPParticleSolver(BaseFPSolver):
                                   If False (default), drift_field is treated as value function U(t,x) and
                                   drift is computed as α = -coupling_coefficient * ∇U.
                                   Use True to preserve high-precision gradients from GFDM or other meshfree methods.
-            volatility_field: Volatility specification for SDE noise (optional):
+            volatility_field: Volatility specification for SDE noise (optional). The SDE is
+                dX = v dt + Σ dW with dW ~ N(0, dt·I_d), giving diffusion tensor
+                D = (1/2) Σ Σ^T (matches the FDM tensor-diffusion convention, Issue #1249/#1276);
+                a scalar σ is Σ = σ·I (isotropic D = σ²/2). Supported forms:
                 - None: Use problem.sigma (backward compatible)
-                - float: Constant isotropic volatility σ (SDE: dX = v dt + σ dW)
-                - np.ndarray (d,d): Anisotropic noise matrix Σ (SDE: dX = v dt + Σ dW)
-                - Callable: State-dependent σ(t,x,m) or Σ(t,x,m)
+                - float: Constant isotropic volatility σ
+                - np.ndarray, shape == grid_shape: spatially varying isotropic σ(x)
+                - np.ndarray (d, d): constant anisotropic noise matrix Σ
+                - np.ndarray (*grid_shape, d, d): spatially varying anisotropic Σ(x)
+                - Callable: state-dependent scalar volatility σ(t,x,m) -> per-particle σ
+                The (d, d) and (*grid_shape, d, d) anisotropic matrix forms are implemented on
+                the nD CPU path (drift_field None for pure diffusion, or a callable drift);
+                an anisotropic Σ with an ndarray (grid) drift_field is unsupported and raises.
                 Note: This is the SDE noise coefficient, NOT the PDE diffusion D = σ²/2.
             diffusion_field: DEPRECATED, use volatility_field instead.
             initial_particles: Pre-sampled initial particles, shape (num_particles, dimension).
@@ -1412,6 +1420,20 @@ class FPParticleSolver(BaseFPSolver):
                 # the array to its mean.  For a callable we cannot reduce to a
                 # scalar without evaluation — raise rather than silently drop.
                 if isinstance(volatility_field, np.ndarray):
+                    # Issue #1256: an anisotropic Σ (trailing (d,d)) cannot be carried by
+                    # the grid-drift path, which consumes a single scalar sigma. Mean-
+                    # collapsing a matrix would silently destroy the anisotropy → fail
+                    # loud and route the user to the callable-drift / pure-diffusion path
+                    # (drift_field=None or callable), which applies the full Σ @ dW step.
+                    vf_dim = self._get_grid_params()["dimension"]
+                    if volatility_field.ndim >= 2 and volatility_field.shape[-2:] == (vf_dim, vf_dim):
+                        raise NotImplementedError(
+                            f"Anisotropic volatility matrix Σ (shape {volatility_field.shape}) is "
+                            "not supported with an ndarray drift_field: the grid-drift particle "
+                            "path consumes a scalar sigma. Pass drift_field=None (pure diffusion) "
+                            "or a callable drift_field so the callable-drift path applies the full "
+                            "Σ @ dW increment per particle (Issue #1256 Part 1). Refs #1256."
+                        )
                     import warnings
 
                     warnings.warn(
@@ -2022,10 +2044,14 @@ class FPParticleSolver(BaseFPSolver):
             - m: density at particle positions, shape (N_particles,)
             Returns: drift velocity, shape (N_particles, d) for nD or (N_particles,) for 1D
         volatility_field : float, np.ndarray, Callable, or None
-            Volatility (SDE noise coefficient σ or Σ). Uses problem.sigma if None.
-            - float: Constant isotropic volatility σ
-            - (d,d) array: Anisotropic noise matrix Σ
-            - Callable: State-dependent σ(t,x,m) or Σ(t,x,m)
+            Volatility (SDE noise coefficient). SDE: dX = v dt + Σ dW, dW ~ N(0, dt·I_d),
+            so D = (1/2) Σ Σ^T (Issue #1249/#1276); a scalar σ is Σ = σ·I. Uses
+            problem.sigma if None.
+            - float: constant isotropic volatility σ
+            - (*grid_shape,) array: spatially varying isotropic σ(x)
+            - (d, d) array: constant anisotropic noise matrix Σ
+            - (*grid_shape, d, d) array: spatially varying anisotropic Σ(x)
+            - Callable: state-dependent scalar volatility σ(t, x, m) -> per-particle σ
         show_progress : bool
             Show progress bar
         initial_particles : np.ndarray or None
@@ -2067,40 +2093,57 @@ class FPParticleSolver(BaseFPSolver):
         volatility_is_callable = callable(volatility_field)
         volatility_is_array = isinstance(volatility_field, np.ndarray)
 
-        # Issue #1256 2026-06-10 audit: reject array volatility_field shapes that are
-        # not valid spatial scalar fields.  The increment generator takes a scalar σ per
-        # particle; _interpolate_field_at_particles→interpolate_grid_to_particles has no
-        # shape-vs-grid validation and silently treats a (d,d) matrix as a d×d "grid",
-        # bilinearly smearing the four matrix entries as per-particle σ — silent garbage.
-        # A (d,) per-axis array fails later with a cryptic broadcast error.
+        # Issue #1256: classify the volatility array shape. Four valid array forms:
+        #   (1) spatial scalar field, shape == grid_shape  (isotropic σ(x), existing path);
+        #   (2) constant anisotropic matrix Σ, shape == (d, d);
+        #   (3) spatial anisotropic matrix Σ(x), shape == (*grid_shape, d, d).
+        # SDE convention (matches the FDM tensor-diffusion path, Issue #1249/#1276):
+        #   dX = v dt + Σ dW,  dW ~ N(0, dt·I_d)  =>  diffusion tensor D = (1/2) Σ Σ^T.
+        # A scalar σ (Σ = σ·I) reduces to the existing isotropic D = σ²/2 path exactly.
+        # A (d,) per-axis array is rejected (ambiguous: neither scalar nor grid field).
+        volatility_is_matrix = False
+        matrix_is_spatial = False
         if volatility_is_array:
             vf_shape = volatility_field.shape
-            # Check for anisotropic noise matrix: (d,d) or (*grid_shape, d, d)
-            if vf_shape == (dimension, dimension) or (len(vf_shape) >= 3 and vf_shape[-2:] == (dimension, dimension)):
+            if vf_shape == (dimension, dimension):
+                # Constant anisotropic noise matrix Σ
+                volatility_is_matrix = True
+                matrix_is_spatial = False
+            elif (
+                len(vf_shape) == dimension + 2
+                and vf_shape[:-2] == grid_shape
+                and vf_shape[-2:] == (dimension, dimension)
+            ):
+                # Spatially varying anisotropic noise matrix Σ(x) on the grid
+                volatility_is_matrix = True
+                matrix_is_spatial = True
+            elif len(vf_shape) >= 3 and vf_shape[-2:] == (dimension, dimension):
+                # Matrix-trailing array whose leading dims do not match the grid — unsupported
                 raise ValueError(
-                    f"volatility_field has shape {vf_shape}, which looks like an anisotropic "
-                    f"noise matrix Σ (dimension={dimension}). Anisotropic Σ is not supported "
-                    "in the particle path — the increment generator accepts scalar σ only. "
-                    "Pass a scalar float for constant isotropic volatility, a spatial array "
-                    f"of shape matching the grid {grid_shape} for spatially varying isotropic "
-                    "volatility, or a Callable sigma(t,x,m)->float."
+                    f"volatility_field has shape {vf_shape}: the trailing ({dimension}, {dimension}) "
+                    f"matches an anisotropic Σ, but the leading dims do not match the grid {grid_shape}. "
+                    f"Pass a constant matrix ({dimension}, {dimension}) or a spatial matrix field "
+                    f"of shape {(*grid_shape, dimension, dimension)}."
                 )
-            # Reject (d,) per-axis array — ambiguous and unsupported
-            if vf_shape == (dimension,):
+            elif vf_shape == (dimension,):
+                # Reject (d,) per-axis array — ambiguous and unsupported
                 raise ValueError(
                     f"volatility_field has shape {vf_shape}, which is ambiguous: it matches "
                     f"neither a scalar σ nor the spatial grid shape {grid_shape}. "
                     "Pass a scalar float for constant isotropic volatility, a spatial array "
-                    f"of shape {grid_shape} for spatially varying volatility, or a "
+                    f"of shape {grid_shape} for spatially varying isotropic volatility, a "
+                    f"constant matrix ({dimension}, {dimension}) for anisotropic Σ, or a "
                     "Callable sigma(t,x,m)->float."
                 )
-            # Require exact match with grid shape for spatial scalar fields
-            if vf_shape != grid_shape:
+            elif vf_shape != grid_shape:
+                # Spatial scalar field must match the grid exactly
                 raise ValueError(
                     f"volatility_field has shape {vf_shape} but the spatial grid shape is "
                     f"{grid_shape}. For a spatially varying isotropic σ field, the array "
-                    "must match the grid shape exactly."
+                    f"must match the grid shape exactly; for anisotropic noise pass a "
+                    f"({dimension}, {dimension}) matrix or a {(*grid_shape, dimension, dimension)} field."
                 )
+            # else: vf_shape == grid_shape — spatial scalar field (existing isotropic path)
 
         if volatility_field is None:
             base_sigma = self.problem.sigma
@@ -2265,6 +2308,23 @@ class FPParticleSolver(BaseFPSolver):
             if sigma_sde_constant is not None:
                 # Constant diffusion - use pre-computed value
                 dW = self._generate_brownian_increment_nd(n_particles_t, dimension, Dt, sigma_sde_constant)
+            elif volatility_is_matrix:
+                # Issue #1256: anisotropic noise matrix Σ. Draw a UNIT Brownian
+                # increment dW_p ~ N(0, dt·I_d) (σ=1, no double-application of σ),
+                # then apply the per-particle increment ΔX_diff = Σ(x_p) @ dW_p.
+                # Per-step covariance = dt·Σ Σ^T ⇒ diffusion tensor D = (1/2) Σ Σ^T,
+                # matching the FDM tensor-diffusion convention (Issue #1249/#1276).
+                dW_unit = self._generate_brownian_increment_nd(n_particles_t, dimension, Dt, 1.0)
+                if matrix_is_spatial:
+                    # Σ(x): interpolate each matrix entry to particles (same linear
+                    # grid-to-particle path used for spatial scalar volatility).
+                    sigma_matrix_at_particles = self._interpolate_matrix_field_at_particles(
+                        particles_t, volatility_field, bounds, dimension
+                    )
+                    dW = np.einsum("pij,pj->pi", sigma_matrix_at_particles, dW_unit)
+                else:
+                    # Constant Σ: (Σ @ dW_p^T)^T == dW_unit @ Σ^T
+                    dW = dW_unit @ volatility_field.T
             else:
                 # Spatially varying or callable volatility - evaluate at particle positions
                 if volatility_is_callable:
@@ -2382,6 +2442,46 @@ class FPParticleSolver(BaseFPSolver):
             Field values at particle positions, shape (N_particles,)
         """
         return self._interpolate_grid_to_particles_nd(field, bounds, particles)
+
+    def _interpolate_matrix_field_at_particles(
+        self,
+        particles: np.ndarray,
+        matrix_field: np.ndarray,
+        bounds: list[tuple[float, float]],
+        dimension: int,
+    ) -> np.ndarray:
+        """
+        Interpolate a spatial anisotropic volatility matrix field Σ(x) to particles.
+
+        Each component ``matrix_field[..., i, j]`` is a scalar grid field of shape
+        ``grid_shape``; it is interpolated to particle positions with the same linear
+        grid-to-particle path used for scalar volatility fields (Issue #1256), so that
+        a spatial Σ(x) reuses the existing interpolation rather than a parallel one.
+
+        Parameters
+        ----------
+        particles : np.ndarray
+            Particle positions, shape (N_particles, dimension).
+        matrix_field : np.ndarray
+            Volatility matrix field Σ(x), shape (*grid_shape, dimension, dimension).
+        bounds : list[tuple[float, float]]
+            Domain bounds per dimension.
+        dimension : int
+            Spatial dimension d.
+
+        Returns
+        -------
+        np.ndarray
+            Σ at each particle position, shape (N_particles, dimension, dimension).
+        """
+        n_particles = particles.shape[0]
+        sigma_matrix = np.empty((n_particles, dimension, dimension))
+        for i in range(dimension):
+            for j in range(dimension):
+                sigma_matrix[:, i, j] = self._interpolate_grid_to_particles_nd(
+                    matrix_field[..., i, j], bounds, particles
+                )
+        return sigma_matrix
 
     def _estimate_density_at_particles(
         self,

--- a/tests/unit/test_alg/test_fp_particle_anisotropic_sigma_1256.py
+++ b/tests/unit/test_alg/test_fp_particle_anisotropic_sigma_1256.py
@@ -1,0 +1,162 @@
+"""
+Validation tests for Issue #1256 Part 1: anisotropic (d,d) volatility Σ in the
+meshfree particle FP solver (FPParticleSolver, nD CPU path).
+
+SDE convention (must match the FDM tensor-diffusion path, Issue #1249/#1276):
+
+    dX = v dt + Σ dW,   dW ~ N(0, dt·I_d)   =>   diffusion tensor D = (1/2) Σ Σ^T.
+
+Correctness proof (the gate): a free-diffusion ensemble (drift v = 0) started from a
+single point, evolved for time T under a CONSTANT anisotropic Σ, must have empirical
+particle covariance ≈ Σ Σ^T · T. A wrong apply (Σ Σ^T vs Σ, a transpose Σ^T Σ, or a
+double-σ) fails this. The isotropic reduction Σ = σ I must give Cov ≈ σ² T · I, matching
+the existing scalar-σ path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers import FPParticleSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import neumann_bc
+
+
+def _hamiltonian():
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+
+
+def _free_diffusion_problem(T: float, Nt: int):
+    """Large-domain 2D problem so a tight central cloud never touches the boundary
+    over [0, T] (pure free diffusion, no BC interaction)."""
+    geometry = TensorProductGrid(
+        bounds=[(-3.0, 3.0), (-3.0, 3.0)],
+        Nx_points=[16, 16],
+        boundary_conditions=neumann_bc(dimension=2),
+    )
+    return MFGProblem(
+        geometry=geometry,
+        T=T,
+        Nt=Nt,
+        sigma=0.1,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-np.sum(np.asarray(x) ** 2)),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=_hamiltonian(),
+        ),
+    )
+
+
+def _zero_drift(t, x, m):
+    return np.zeros_like(x)
+
+
+def _final_cloud_covariance(volatility_field, *, T=0.5, Nt=50, num_particles=20000, seed=11):
+    """Run free diffusion from a single point (all particles at the origin) and return
+    the empirical covariance of the final particle cloud.
+
+    Only randomness is the per-step Brownian increment (global np.random seeded);
+    initial particles are deterministic, density_mode='query_only' skips per-step KDE.
+    """
+    problem = _free_diffusion_problem(T, Nt)
+    grid_shape = problem.geometry.get_grid_shape()
+    m0 = np.ones(grid_shape) / np.prod(grid_shape)
+    initial_particles = np.zeros((num_particles, 2))  # all at the origin (tight cloud)
+
+    np.random.seed(seed)
+    solver = FPParticleSolver(problem, num_particles=num_particles, density_mode="query_only")
+    solver.solve_fp_system(
+        M_initial=m0,
+        drift_field=_zero_drift,
+        volatility_field=volatility_field,
+        initial_particles=initial_particles,
+        show_progress=False,
+    )
+    final_cloud = solver.M_particles_trajectory[-1]
+    assert final_cloud.shape == (num_particles, 2)
+    return np.cov(final_cloud.T)
+
+
+class TestAnisotropicCovarianceGate:
+    """The correctness proof: empirical covariance ≈ Σ Σ^T · T."""
+
+    def test_constant_anisotropic_covariance(self):
+        """
+        Σ = [[0.3, 0.1], [0.0, 0.2]] (non-symmetric), drift v=0, point start.
+
+        Asserts Cov(X_T) ≈ Σ Σ^T · T entrywise, AND that it is distinguishable from the
+        transpose-bug target Σ^T Σ · T (which differs in the off-diagonal and (1,1) entry).
+        """
+        T = 0.5
+        Sigma = np.array([[0.3, 0.1], [0.0, 0.2]])
+        emp_cov = _final_cloud_covariance(Sigma, T=T)
+
+        expected = T * (Sigma @ Sigma.T)  # correct: dt·Σ Σ^T accumulated over T
+        transpose_bug = T * (Sigma.T @ Sigma)  # what a dW @ Σ (transpose) apply would give
+
+        # Gate: matches Σ Σ^T · T within Monte-Carlo tolerance (N=20000 ⇒ ~1-2% on entries).
+        assert np.allclose(emp_cov, expected, rtol=0.08, atol=0.0025), (
+            f"empirical cov\n{emp_cov}\nnot ~ Sigma Sigma^T * T\n{expected}"
+        )
+        # Discrimination: a transposed apply would NOT pass the same tolerance.
+        assert not np.allclose(emp_cov, transpose_bug, rtol=0.08, atol=0.0025), (
+            "empirical covariance is indistinguishable from the transpose-bug target; "
+            "the test cannot discriminate Sigma Sigma^T from Sigma^T Sigma."
+        )
+        # The off-diagonal is the sharpest discriminator (0.01 correct vs 0.015 transposed).
+        assert abs(emp_cov[0, 1] - emp_cov[1, 0]) < 1e-12  # covariance is symmetric
+        assert abs(emp_cov[0, 1] - expected[0, 1]) < 0.0025
+
+    def test_isotropic_reduction_matches_scalar(self):
+        """
+        Σ = σ I reduces to the existing isotropic path: Cov ≈ σ² T · I (off-diagonal ≈ 0).
+
+        Also checks the matrix path and the scalar-float path give statistically the same
+        covariance (the (d,d) branch is a strict generalization, not a divergent path).
+        """
+        T = 0.5
+        sigma = 0.25
+        Sigma = sigma * np.eye(2)
+
+        cov_matrix = _final_cloud_covariance(Sigma, T=T, seed=7)
+        cov_scalar = _final_cloud_covariance(float(sigma), T=T, seed=7)
+
+        expected_diag = sigma**2 * T  # = 0.03125
+        # Diagonal matches σ² T; off-diagonal ≈ 0.
+        assert np.allclose(np.diag(cov_matrix), expected_diag, rtol=0.08)
+        assert abs(cov_matrix[0, 1]) < 0.0025
+        # Matrix Σ = σ I and scalar σ agree statistically (same covariance structure).
+        assert np.allclose(cov_matrix, cov_scalar, rtol=0.10, atol=0.0025)
+
+    def test_spatial_anisotropic_field_matches_constant(self):
+        """
+        A spatially CONSTANT Σ supplied as a full (*grid_shape, d, d) field must reproduce
+        the same covariance as the constant (d, d) matrix. Exercises the spatial-matrix
+        interpolation branch (_interpolate_matrix_field_at_particles).
+        """
+        T = 0.5
+        Sigma = np.array([[0.3, 0.1], [0.0, 0.2]])
+        grid_shape = (16, 16)
+        # Broadcast the constant matrix over the whole grid: shape (16, 16, 2, 2).
+        Sigma_field = np.broadcast_to(Sigma, (*grid_shape, 2, 2)).copy()
+
+        cov_field = _final_cloud_covariance(Sigma_field, T=T, seed=11)
+        expected = T * (Sigma @ Sigma.T)
+        assert np.allclose(cov_field, expected, rtol=0.08, atol=0.0025), (
+            f"spatial-field covariance\n{cov_field}\nnot ~ Sigma Sigma^T * T\n{expected}"
+        )
+
+
+if __name__ == "__main__":
+    t = TestAnisotropicCovarianceGate()
+    t.test_constant_anisotropic_covariance()
+    t.test_isotropic_reduction_matches_scalar()
+    t.test_spatial_anisotropic_field_matches_constant()
+    print("All anisotropic-sigma validation tests passed.")

--- a/tests/unit/test_alg/test_issue_1256_particle_volatility_drift.py
+++ b/tests/unit/test_alg/test_issue_1256_particle_volatility_drift.py
@@ -3,9 +3,14 @@ Pinning tests for Issue #1256: FPParticleSolver volatile-field shape validation
 and drift_is_precomputed on 1D paths.
 
 (A) Anisotropic (d,d) volatility matrix routed through spatial interpolator -> silent garbage.
-    Fix: validate array shape vs grid; raise ValueError for (d,d), (d,), or shape mismatch.
+    Part 1 fix (Issue #1256): the nD CPU path now IMPLEMENTS anisotropic Σ via the
+    per-particle increment ΔX = Σ(x_p) @ dW_p (constant (d,d) and spatial (*grid,d,d)).
+    Shape validation still rejects (d,), wrong-grid spatial fields, and mismatched
+    matrix-trailing arrays. Quantitative covariance validation lives in
+    test_fp_particle_anisotropic_sigma_1256.py.
 (B) drift_is_precomputed=True silently ignored on 1D CPU/GPU paths (always differentiates U).
-    Fix: raise NotImplementedError when drift_is_precomputed=True and dimension==1.
+    Still deferred (Refs #1256): raise NotImplementedError when drift_is_precomputed=True
+    and dimension==1.
 """
 
 from __future__ import annotations
@@ -76,16 +81,17 @@ def _2d_problem():
 
 
 class TestIssue1256VolatilityShapeValidation:
-    """Bug (A): (d,d) anisotropic Sigma must be rejected with a clear error, not interpolated."""
+    """Bug (A) Part 1: (d,d) anisotropic Sigma is now SUPPORTED on the nD CPU path;
+    only genuinely-unsupported array shapes still raise."""
 
-    def test_2d_diagonal_sigma_matrix_raises_valueerror(self):
+    def test_2d_diagonal_sigma_matrix_now_supported(self):
         """
-        Pinning test for Issue #1256 bug A.
+        Issue #1256 Part 1: a (d,d) anisotropic Σ on the nD CPU path is implemented.
 
         volatility_field=np.diag([s1, s2]) is a (2,2) matrix passed to a 2D problem.
-        Before the fix: silently treated as a 2x2 spatial grid; matrix entries bilinearly
-        smeared as per-particle scalar sigma — silent garbage.
-        After the fix: raises ValueError with a message about anisotropic unsupported.
+        Before Part 1 (#1274): raised ValueError (fail-loud placeholder).
+        After Part 1: runs the per-particle ΔX = Σ @ dW increment and returns a finite
+        density. (Quantitative covariance correctness is in the dedicated validation file.)
         """
         problem = _2d_problem()
         assert problem.dimension == 2, "problem must be 2D for this test"
@@ -101,11 +107,38 @@ class TestIssue1256VolatilityShapeValidation:
 
         anisotropic_sigma = np.diag([0.1, 0.2])  # shape (2,2) — anisotropic noise matrix
 
-        with pytest.raises(ValueError, match="anisotropic"):
+        result = solver.solve_fp_system(
+            M_initial=m0,
+            drift_field=zero_drift,
+            volatility_field=anisotropic_sigma,
+            show_progress=False,
+        )
+        assert result.ndim == 3  # (time, Nx, Ny)
+        assert result.shape[1:] == grid_shape
+        assert np.all(np.isfinite(result))
+
+    def test_mismatched_matrix_trailing_array_raises_valueerror(self):
+        """
+        A matrix-trailing array whose leading dims do not match the grid is unsupported.
+
+        E.g. (3, 3, 2, 2) on a (10, 10) grid: trailing (2,2) is a Σ matrix but the leading
+        (3,3) is neither the grid nor empty. Must fail loud (not silently interpolated).
+        """
+        problem = _2d_problem()
+        solver = FPParticleSolver(problem, num_particles=50)
+        grid_shape = problem.geometry.get_grid_shape()
+        m0 = np.ones(grid_shape) / np.prod(grid_shape)
+
+        def zero_drift(t, x, m):
+            return np.zeros_like(x)
+
+        bad = np.zeros((3, 3, 2, 2))  # leading (3,3) != grid (10,10)
+
+        with pytest.raises(ValueError, match="leading dims"):
             solver.solve_fp_system(
                 M_initial=m0,
                 drift_field=zero_drift,
-                volatility_field=anisotropic_sigma,
+                volatility_field=bad,
                 show_progress=False,
             )
 


### PR DESCRIPTION
## Summary

Issue #1256 **Part 1**: the meshfree particle FP solver (`fp_particle.py`) previously **fail-loud-rejected** a `(d,d)` or `(*grid_shape, d, d)` anisotropic volatility matrix `Σ` (the placeholder added by #1274). This PR implements real support on the **nD CPU** path (`_solve_fp_system_callable_drift`, reached via pure-diffusion `drift_field=None` or a callable drift).

## SDE convention (must match the rest of the library)

`Σ` is the noise matrix; the particle SDE is

```
dX = v dt + Σ dW,   dW ~ N(0, dt·I_d)   =>   diffusion tensor D = (1/2) Σ Σ^T
```

This matches the FDM tensor-diffusion convention (`_volatility_to_diffusion`: `D = (1/2) Σ Σ^T`, Issue #1249/#1276). A scalar `σ` (i.e. `Σ = σ·I`) reduces to the existing isotropic `D = σ²/2` path **exactly** — the scalar / spatial-scalar paths are untouched and byte-identical.

## Implementation

- **Shape classification** (`_solve_fp_system_callable_drift`): spatial scalar field (`== grid_shape`), constant matrix `(d,d)`, or spatial matrix `(*grid_shape, d, d)`. Still **fail loud** for `(d,)` per-axis arrays, wrong-grid scalar fields, and matrix-trailing arrays whose leading dims ≠ grid.
- **Euler-Maruyama step**: draw a UNIT Brownian increment `dW_p ~ N(0, dt·I_d)` (σ=1, no double-application of σ) then apply `ΔX_diff = Σ(x_p) @ dW_p`:
  - constant `Σ`: `dW_unit @ Σ.T`
  - spatial `Σ(x)`: new `_interpolate_matrix_field_at_particles` interpolates each `Σ[...,i,j]` entry with the **same linear grid-to-particle path** used for scalar volatility, then `einsum("pij,pj->pi", ...)`.
  Drift step unchanged.
- **Grid-drift path** (ndarray drift + matrix `Σ`): now fails loud instead of silently mean-collapsing the matrix.
- Docstrings corrected to document the supported forms + convention (they previously advertised support that wasn't implemented).

## Deferred (still fail-loud, Refs #1256 — not Fixes)

- `drift_is_precomputed=True` on the 1D CPU / GPU paths (unchanged `NotImplementedError`).
- GPU-path anisotropic support (no nD GPU path exists).

## Validation

New `tests/unit/test_alg/test_fp_particle_anisotropic_sigma_1256.py`:

- **Covariance gate**: free-diffusion ensemble (`v=0`) from a point cloud under constant `Σ = [[0.3, 0.1], [0.0, 0.2]]` for time `T` ⇒ empirical particle covariance `≈ Σ Σ^T · T` (entrywise, N=20000), **and** distinguishable from the transpose-bug target `Σ^T Σ · T`. A wrong apply (`ΣΣ^T` vs `Σ`, transpose, or double-σ) fails this.
- **Isotropic reduction**: `Σ = σ I` ⇒ `Cov ≈ σ² T · I` (off-diagonal ≈ 0), and matches the scalar-float path statistically.
- **Spatial-field path**: a spatially-constant `Σ` supplied as a full `(*grid_shape, d, d)` field reproduces the constant-matrix covariance (exercises the interpolation branch).

Fails-without / passes-with: with the production change stashed, all 3 validation tests fail (old code raises on `(d,d)`); restored, all pass.

**Isotropic invariance pinning**: a scalar-σ free-diffusion run (deterministic `initial_particles` + fixed seed) is byte-identical before/after the change (sha256 `551cb74a…`).

## Tests run (green)

- `tests/unit/test_alg/test_fp_particle.py`, `test_fp_particle_solver.py`, `test_fp_particle_gradient_bc_1255.py`, `test_fp_particle_anisotropic_sigma_1256.py` (new), `test_issue_1256_particle_volatility_drift.py` — 85 passed
- `test_drift_contract.py`, `test_issue_1079_anisotropic_sigma.py` — 9 passed
- `ruff format --check` + `ruff check` clean on all changed files

Refs #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)