### PR TITLE
fix(alg): wire V(x)+f(m)+running_cost into Howard inner solver (Refs #1247)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -28,6 +28,7 @@ from mfgarchon.alg.numerical.hjb_solvers.h_eval import (
     assemble_hjb_jacobian_diag,
     assemble_hjb_residual,
     eval_dH_dp_batch,
+    eval_H_batch,
 )
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
 from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL
@@ -3102,10 +3103,15 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         Howard has no Armijo line search, so it avoids the MIN_ALPHA stall the per-point Newton
         path hits on advection-dominant / no-flux-BC regimes (#1118). Operates in collocation
-        space; the caller handles grid<->collocation mapping. PR1 scope: requires joint_socp+
-        precompute stencils, a Hamiltonian exposing dp(), unit control cost, and a HOMOGENEOUS
-        no-flux BC (Howard hardcodes Dirichlet b=0 and approximates Neumann by nearest interior,
-        so nonzero-Dirichlet/Neumann, Robin, and BCValueProviders are deferred to PR2).
+        space; the caller handles grid<->collocation mapping. Requires joint_socp+precompute
+        stencils and a Hamiltonian exposing dp().
+
+        Issue #1247 (#1118 PR2): the separable Hamiltonian's potential V(x, t) and density
+        coupling f(m), plus any caller-supplied running cost, are wired into Howard's
+        running_cost slot (see `running_cost` closure below), so Howard solves the full non-LQ
+        HJB ``-d_t u + (1/2)|grad u|^2 + V(x) + f(m) - (sigma^2/2) Lap u = 0``. Still deferred
+        (fail-loud below): non-unit control cost lambda, non-quadratic control cost, and the
+        MAXIMIZE sense (the Lagrangian-scaling work tracked alongside #1071).
         """
         from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import HJBHowardSolver
 
@@ -3130,16 +3136,12 @@ class HJBGFDMSolver(BaseHJBSolver):
                 "needs a running-cost correction (deferred, Issue #1118 PR2)."
             )
         # Howard's policy evaluation hardcodes the unit-quadratic Lagrangian (1/2)|alpha|^2 and
-        # consumes ONLY alpha* = -dH/dp, so the backward sweep is faithful solely for a pure
-        # separable LQ Hamiltonian H = (1/2)|p|^2 (MINIMIZE) with no potential V(x, t) and no
-        # density coupling f(m). The pure-LQ test suite sits inside that envelope, which hid
-        # three silent-wrong-physics holes: V/f(m) dropped, running_cost entering with the
-        # opposite sign of the Newton H-additive convention, and the unit-cost gate above
-        # reading problem.lambda_ (the #1247 desync, now fixed: the gate derives lambda from
-        # the Hamiltonian's control cost via _control_cost_lambda(), Issue #1071).
-        # Inspect the actual Hamiltonian components and fail loud on anything Howard does not
-        # model; full support is deferred. Found in the 2026-06-10 library audit; validated by
-        # tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_*.
+        # derives alpha* = -dH/dp, so the control term is faithful only for a unit-quadratic
+        # MINIMIZE control cost H_control = (1/2)|p|^2. The potential V(x, t), the density
+        # coupling f(m), and any caller running cost ARE now wired (Issue #1247, below); what
+        # remains unmodelled — non-unit / non-quadratic control cost and the MAXIMIZE sense —
+        # is the Lagrangian-scaling work deferred alongside #1071. Fail loud on those cases;
+        # validated by tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_*.
         control_cost = getattr(H_class, "control_cost", None)
         if control_cost is not None:
             from mfgarchon.core.hamiltonian import QuadraticControlCost
@@ -3158,26 +3160,6 @@ class HJBGFDMSolver(BaseHJBSolver):
                     "inner_solver='howard' derives alpha* = -dH/dp (MINIMIZE sense); the Hamiltonian "
                     "uses MAXIMIZE, which needs alpha* = +dH/dp. Use inner_solver='newton' (deferred)."
                 )
-        if getattr(H_class, "_potential", None) is not None:
-            raise NotImplementedError(
-                "inner_solver='howard' ignores the Hamiltonian potential V(x, t): its policy "
-                "evaluation uses only alpha* = -dH/dp, so V never enters the HJB and the value "
-                "function silently decouples from it. Use inner_solver='newton' for problems with a "
-                "potential (deferred)."
-            )
-        if getattr(H_class, "_coupling", None) is not None:
-            raise NotImplementedError(
-                "inner_solver='howard' ignores the density coupling f(m): its policy evaluation "
-                "uses only alpha* = -dH/dp, so f(m) never enters the HJB and the value function "
-                "silently decouples from the density. Use inner_solver='newton' for density-coupled "
-                "problems (deferred)."
-            )
-        if self._running_cost_fn is not None:
-            raise NotImplementedError(
-                "inner_solver='howard' does not yet support a running cost: it would enter Howard's "
-                "Lagrangian-additive slot with the opposite sign of the Newton path's H-additive "
-                "convention (H_total = H + L). Use inner_solver='newton' with running_cost (deferred)."
-            )
         # BC parity (Issue #1118 PR2a): the howard path now consumes the provider's shared
         # value-form BC rows (`_value_form_bc_rows` -> `_bc_row_for_point`), so it honors
         # Dirichlet VALUES and the real Neumann normal·grad stencil (not the legacy
@@ -3231,11 +3213,56 @@ class HJBGFDMSolver(BaseHJBSolver):
             # Optimal feedback control alpha* = -dH/dp (the same dp() the Newton Jacobian reads).
             return -eval_dH_dp_batch(H_class, x_pts, m, p, t_idx * dt)
 
+        # Issue #1247 (#1118 PR2): route the Hamiltonian's non-quadratic-in-alpha source terms
+        # — potential V(x, t), density coupling f(m^n) — and any caller running cost L_user
+        # into Howard's running_cost slot, so Howard solves the full non-LQ HJB.
+        #
+        #   SIGN of rc_t (load-bearing). Howard's converged policy-evaluation equation is
+        #       (u^n - u^{n+1})/dt + (1/2)|grad u^n|^2 - (sigma^2/2) Lap u^n - rc_t = 0
+        #   (substitute alpha* = -grad u^n into b = u^{n+1}/dt + (1/2)|alpha|^2 + rc_t and the
+        #   advection operator A_adv u = alpha . grad u; see hjb_howard.py:_howard_step). The
+        #   Newton ground truth (h_eval.assemble_hjb_residual, -u_t + H + L_user - D Lap u = 0
+        #   with H = (1/2)|grad u|^2 + V + f(m)) is
+        #       (u^n - u^{n+1})/dt + (1/2)|grad u^n|^2 + V + f(m) + L_user - (sigma^2/2) Lap u^n = 0.
+        #   Matching the two forces rc_t = -(V + f(m) + L_user): Howard's slot is the Legendre
+        #   dual side, which carries the H-additive terms with a FLIPPED sign. Resolved
+        #   EMPIRICALLY (not by reasoning alone) by the Howard-vs-Newton agreement gate
+        #   test_integrated_howard_matches_newton_nonlq: with Newton as ground truth, s=-1 gives
+        #   max-rel-error ~1e-5..5e-4 across V-only / f(m)-only / V+f, while s=+1 gives ~2.0
+        #   (a different, wrong value function). The negated user running cost also corrects the
+        #   #1247 Defect 2 sign flip (it previously entered Howard's slot un-negated).
+        potential = getattr(H_class, "_potential", None)
+        coupling = getattr(H_class, "_coupling", None)
+        user_rc = self._running_cost_fn
+        has_H_extra = potential is not None or coupling is not None
+
+        howard_running_cost = None
+        if has_H_extra or user_rc is not None:
+            colloc_pts = self.collocation_points
+            p_zero = np.zeros((self.n_points, self.dimension))
+
+            def howard_running_cost(t_idx):
+                rc = np.zeros(self.n_points)
+                if has_H_extra:
+                    # V(x, t) + f(m^n) via the SAME eval_H_batch the Newton residual uses
+                    # (single source). At p=0 the gate-enforced unit-quadratic control cost
+                    # gives H_control(0)=0, so eval_H_batch(..., p=0, ...) == V(x, t) + f(m^n).
+                    rc = (
+                        rc
+                        + np.asarray(
+                            eval_H_batch(H_class, colloc_pts, M_collocation[t_idx], p_zero, t_idx * dt),
+                            dtype=float,
+                        ).ravel()
+                    )
+                if user_rc is not None:
+                    rc = rc + np.asarray(user_rc(t_idx), dtype=float).ravel()
+                return -rc  # rc_t = -(V + f(m) + L_user); see SIGN note above.
+
         howard = HJBHowardSolver(
             self.problem,
             stencil_provider=self,
             alpha_star=alpha_star,
-            running_cost=self._running_cost_fn,
+            running_cost=howard_running_cost,
             discretisation="central" if self.dimension == 1 else "upwind_projection",
             use_provider_bc_rows=True,  # Issue #1118 PR2a: shared value-form BC rows
         )

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -450,11 +450,12 @@ def test_integrated_howard_requires_hamiltonian_class():
 
 
 # ---------------------------------------------------------------------------
-# 7b. Integrated path: envelope gate fails loud on Hamiltonians Howard cannot
-#     model (2026-06-10 audit). Howard's policy evaluation hardcodes the
-#     unit-quadratic Lagrangian (1/2)|alpha|^2 and uses only alpha* = -dH/dp,
-#     so V(x,t), f(m), non-unit/non-quadratic control cost, and running_cost
-#     were silently dropped/mis-signed. Each must now raise NotImplementedError.
+# 7b. Integrated path: envelope gate. Issue #1247 (#1118 PR2) wired the
+#     potential V(x, t), density coupling f(m), and caller running_cost into
+#     Howard's running_cost slot (correctness gate in section 7c). What stays
+#     fail-loud is the Lagrangian-scaling work deferred alongside #1071:
+#     non-unit / non-quadratic control cost and the MAXIMIZE sense. Each must
+#     raise NotImplementedError.
 # ---------------------------------------------------------------------------
 
 
@@ -465,28 +466,6 @@ def _howard_gfdm_with_hamiltonian(hamiltonian_class, *, LX=4.0, Nt=20):
     gfdm = _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5, inner_solver="howard")
     U_T = 0.5 * (pts[:, 0] - LX / 2) ** 2
     return gfdm, U_T
-
-
-def test_integrated_howard_rejects_potential():
-    """A Hamiltonian potential V(x, t) is dropped by Howard's policy evaluation -> fail loud."""
-    H = SeparableHamiltonian(
-        control_cost=QuadraticControlCost(lambda_=1.0),
-        potential=lambda x, t: 0.5 * float(np.sum(np.atleast_1d(x) ** 2)),
-    )
-    gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
-    with pytest.raises(NotImplementedError, match="potential"):
-        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
-
-
-def test_integrated_howard_rejects_coupling():
-    """A density coupling f(m) is dropped by Howard's policy evaluation -> fail loud."""
-    H = SeparableHamiltonian(
-        control_cost=QuadraticControlCost(lambda_=1.0),
-        coupling=lambda m: m,
-    )
-    gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
-    with pytest.raises(NotImplementedError, match="coupling"):
-        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
 
 
 def test_integrated_howard_rejects_nonunit_control_cost():
@@ -513,16 +492,116 @@ def test_integrated_howard_rejects_maximize_sense():
         gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
 
 
-def test_integrated_howard_rejects_running_cost():
-    """running_cost enters Howard's Lagrangian slot with the wrong sign vs Newton -> fail loud."""
-    gfdm, U_T = _howard_gfdm_with_hamiltonian(_LQHam())
-    n = U_T.shape[0]
-    with pytest.raises(NotImplementedError, match="running cost"):
-        gfdm.solve_hjb_system(
-            M_density=None,
-            U_terminal=U_T,
-            running_cost=lambda t_idx: 0.1 * np.ones(n),
+# ---------------------------------------------------------------------------
+# 7c. Correctness gate (Issue #1247 / #1118 PR2): Howard MUST agree with Newton
+#     on a non-LQ separable Hamiltonian (potential V(x) and/or density coupling
+#     f(m)). Newton is the ground truth — its per-point residual evaluates the
+#     full H = (1/2)|p|^2 + V + f(m) (problem.H), so a wrong rc_t sign in Howard
+#     makes it converge to a different value function. This is the gate that
+#     RESOLVED the rc_t sign: with s=-1 (rc_t = -(V+f(m))) the max-rel-error is
+#     ~1e-5..5e-4 across all three cases; with the flipped s=+1 it is ~2.0. The
+#     zero terminal cost keeps the pure-LQ baseline exact (Newton==Howard for
+#     V=f=0), so the residual error isolates the V/f wiring, not |grad u|^2
+#     stiffness (the #1118 regime where Newton itself stalls).
+# ---------------------------------------------------------------------------
+
+
+class _SeparableMockProblem(_MockProblem):
+    """Mock whose per-point ``H`` delegates to the SeparableHamiltonian, so the Newton
+    per-point path (``problem.H``) and the Howard path (``hamiltonian_class``) evaluate the
+    IDENTICAL H = (1/2)|p|^2 + V(x) + f(m). Without this, the base ``_MockProblem.H`` drops
+    V and f(m) and could not serve as a non-LQ ground truth."""
+
+    def __init__(self, geometry, hamiltonian, **kw):
+        super().__init__(geometry, **kw)
+        self.hamiltonian_class = hamiltonian
+
+    def H(self, i, m_at_x, derivs=None, x_position=None, t=0.0):
+        p = np.atleast_1d(np.asarray(derivs.grad, dtype=float))
+        x = np.atleast_1d(np.asarray(x_position, dtype=float))
+        return float(self.hamiltonian_class(x, m_at_x, p, t))
+
+
+def _make_nonlq_solver(hamiltonian, inner_solver, *, LX=1.0, n_int=15, sigma=0.4, Nt=12):
+    pts, bdry, geom = _make_1d_cloud(LX=LX, n_int=n_int)
+    problem = _SeparableMockProblem(geom, hamiltonian, sigma=sigma, T=1.0, Nt=Nt, dimension=1)
+    bc = BoundaryConditions(
+        segments=[BCSegment(name=f"x_{end}", bc_type=BCType.NO_FLUX, boundary=f"x_{end}") for end in ("min", "max")],
+        dimension=1,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        gfdm = HJBGFDMSolver(
+            problem,
+            collocation_points=pts,
+            boundary_indices=bdry,
+            delta=1.5,
+            k_neighbors=7,
+            derivative_method="taylor",
+            taylor_order=2,
+            weight_function="wendland",
+            collocation_geometry=geom,
+            adaptive_neighborhoods=False,
+            boundary_conditions=bc,
+            monotonicity_scheme="joint_socp",
+            monotonicity_application="precompute",
+            inner_solver=inner_solver,
         )
+    return gfdm, pts
+
+
+def _v_quadratic(x, t):
+    """Repulsive bowl V(x) = 2(x-0.5)^2 (time-independent: Newton's per-point H call passes no t)."""
+    x = np.asarray(x, dtype=float)
+    return 2.0 * (x[..., 0] - 0.5) ** 2
+
+
+@pytest.mark.parametrize(
+    ("potential", "coupling", "case"),
+    [
+        (_v_quadratic, None, "V-only"),
+        (None, lambda m: 0.5 * np.asarray(m), "f(m)-only"),
+        (_v_quadratic, lambda m: 0.5 * np.asarray(m), "V+f(m)"),
+    ],
+)
+def test_integrated_howard_matches_newton_nonlq(potential, coupling, case):
+    """Issue #1247 correctness gate + rc_t sign resolver.
+
+    Howard (inner_solver='howard') must match Newton (inner_solver='newton') on a non-LQ
+    separable Hamiltonian once V(x)/f(m) are wired into Howard's running_cost slot. The
+    relative tolerance 2e-2 PASSES for the resolved sign rc_t = -(V+f(m)) (observed
+    max-rel-error <~5e-4 for all three cases) and FAILS for the flipped sign rc_t = +(V+f(m))
+    (observed ~2.0). Zero terminal cost makes the pure-LQ baseline exact so the residual is
+    the V/f-wiring error, not |grad u|^2 stiffness."""
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(lambda_=1.0),
+        potential=potential,
+        coupling=coupling,
+    )
+    gfdm_h, pts = _make_nonlq_solver(H, "howard")
+    gfdm_n, _ = _make_nonlq_solver(H, "newton")
+
+    n = pts.shape[0]
+    x = pts[:, 0]
+    x_c = 0.5
+    U_T = np.zeros(n)  # zero terminal cost: pure-LQ baseline is exact (Newton==Howard for V=f=0)
+    Nt = gfdm_h.problem.Nt
+    m_profile = 0.5 + np.exp(-((x - x_c) ** 2) / (2 * 0.15**2))
+    M = np.tile(m_profile, (Nt + 1, 1))
+
+    U_howard = gfdm_h.solve_hjb_system(M_density=M, U_terminal=U_T)
+    U_newton = gfdm_n.solve_hjb_system(M_density=M, U_terminal=U_T)
+
+    assert np.all(np.isfinite(U_howard)), f"[{case}] Howard produced non-finite U"
+    assert np.all(np.isfinite(U_newton)), f"[{case}] Newton produced non-finite U"
+
+    denom = max(float(np.max(np.abs(U_newton))), 1e-12)
+    max_rel_err = float(np.max(np.abs(U_howard - U_newton))) / denom
+    assert max_rel_err < 2e-2, (
+        f"[{case}] Howard disagrees with Newton: max-rel-error={max_rel_err:.4e}. The wired "
+        f"V(x)/f(m) running_cost (rc_t = -(V+f(m))) should match Newton to discretization "
+        f"tolerance; a large error indicates a dropped term or a flipped rc_t sign (Issue #1247)."
+    )
 
 
 def _make_howard_gfdm_with_bc(bc, sigma=0.3, Nt=5):


### PR DESCRIPTION
## Summary

`inner_solver='howard'` (with `monotonicity_scheme='joint_socp'`) previously **fail-louded** on any non-pure-LQ separable Hamiltonian: the GFDM wrapper `_solve_backward_howard` dropped the potential `V(x,t)` and density coupling `f(m)`, and rejected a caller `running_cost` (Issue #1247 Defects 1/2, gated by PR #1263). This PR wires them into Howard's existing `running_cost(t_idx)` slot so Howard solves the full non-LQ HJB:

```
-d_t u + (1/2)|grad u|^2 + V(x) + f(m) - (sigma^2/2) Lap u = 0
```

## What was wired

- **V(x,t)** (`H_class._potential`) and **f(m^n)** (`H_class._coupling`), evaluated jointly via the **same `eval_H_batch`** the Newton residual uses (single source). At `p=0` the gate-enforced unit-quadratic control cost gives `H_control(0)=0`, so `eval_H_batch(..., p=0, ...) == V(x,t) + f(m^n)` exactly.
- The pre-existing problem-level **`running_cost`** (`self._running_cost_fn`), summed with V+f(m) (all are non-quadratic Lagrangian source terms).

## The rc_t sign (resolved empirically, not by reasoning alone)

Matching Howard's converged policy-evaluation equation against the Newton ground-truth residual forces `rc_t = -(V + f(m) + L_user)` — Howard's slot is the Legendre-dual side, carrying the H-additive terms with a **flipped** sign. The Howard-vs-Newton agreement gate confirms (Newton = ground truth):

| case | s = -1 (shipped) | s = +1 (flipped) |
|------|------------------|------------------|
| V-only | **1.98e-4** | 1.97 |
| f(m)-only | **2.33e-4** | 2.00 |
| V+f(m) | **4.52e-6** | 2.00 |

s=+1 converges to a different, wrong value function. The negated user running_cost also corrects the Defect 2 sign flip (it previously entered Howard's slot un-negated).

## Gate test

`tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[V-only / f(m)-only / V+f(m)]` — asserts `max|U_howard - U_newton| / max|U_newton| < 2e-2` (passes for s=-1, fails for s=+1). Zero terminal cost keeps the pure-LQ baseline exact (Newton==Howard for V=f=0), isolating the V/f wiring from the `|grad u|^2` stiffness regime where Newton itself stalls (#1118).

## Still deferred (fail-loud, kept intact)

The Lagrangian-scaling work tracked alongside #1071 — **non-unit control cost lambda**, **non-quadratic control cost**, **MAXIMIZE sense** — still raises `NotImplementedError`; their `test_integrated_howard_rejects_*` tests are unchanged. Hence **Refs #1247**, not Fixes.

## Regression

- Pure-LQ (`V=f=None`, no running_cost) → `running_cost=None`, **byte-identical** to before.
- `tests/unit/test_alg/test_hjb_howard_solver.py`: 28 passed.
- Related GFDM/SOCP/HJB suites (`test_hjb_gfdm_solver`, `test_hjb_1071_control_cost_lambda`, `test_joint_socp_mirror_symmetry`, `test_hjb_gfdm_bc_classification`, `test_hjb_gfdm_monotonicity`): 79 passed, 1 skipped.
- `ruff format --check` + `ruff check` clean.

Refs #1247 / #1118 PR2

🤖 Generated with [Claude Code](https://claude.com/claude-code)