### PR TITLE
feat(viz): VTK export for FEM solutions via meshio (#895)

### DIFF
--- a/mfgarchon/visualization/__init__.py
+++ b/mfgarchon/visualization/__init__.py
@@ -15,8 +15,11 @@ from .convergence_plots import (
     plot_multi_error_history,
     plot_wasserstein_history,
 )
+from .vtk_export import export_mesh_solution_vtk, export_time_series_vtk
 
 __all__ = [
+    "export_mesh_solution_vtk",
+    "export_time_series_vtk",
     "plot_convergence_rate",
     "plot_convergence_summary",
     "plot_distribution_evolution",

--- a/mfgarchon/visualization/vtk_export.py
+++ b/mfgarchon/visualization/vtk_export.py
@@ -1,0 +1,204 @@
+"""
+VTK export for FEM/unstructured-mesh MFG solutions via meshio (Issue #895).
+
+Writes a mesh plus nodal field values (e.g. the value function $u(t,x)$ and the
+density $m(t,x)$) to ParaView-readable ``.vtu`` (XML VTK) files:
+
+- :func:`export_mesh_solution_vtk` — one timestep (mesh + ``{name: array(N,)}``).
+- :func:`export_time_series_vtk` — an MFG solution ``(Nt+1, N)`` as a sequence of
+  ``<stem>_<k>.vtu`` files plus a ParaView ``.pvd`` collection indexing them by
+  time $t_k$.
+
+The mesh argument is the FEM solution's mesh: a MFGarchon :class:`MeshData`
+(``problem.geometry.mesh_data``) or, for convenience, a ``skfem.Mesh`` (converted
+via the existing :func:`skfem_to_meshdata` adapter). Nodal fields must be indexed
+by mesh vertex, so this targets P1 Lagrange / vertex-DOF fields; higher-order DOF
+vectors (P2 edge midpoints) do not match the vertex count and fail loud.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from numpy.typing import NDArray
+
+    from mfgarchon.geometry.meshes.mesh_data import MeshData
+
+# MeshData.element_type -> meshio cell type. MeshData uses "tetrahedron"/"hexahedron"
+# where meshio uses "tetra"/"hexahedron"; the rest coincide.
+_MESHIO_CELL_TYPE: dict[str, str] = {
+    "line": "line",
+    "triangle": "triangle",
+    "quad": "quad",
+    "tetrahedron": "tetra",
+    "hexahedron": "hexahedron",
+}
+
+
+def _import_meshio():
+    """Import meshio with a clear error message (declared dependency)."""
+    try:
+        import meshio
+    except ImportError as err:  # pragma: no cover - meshio is a hard dependency
+        raise ImportError("meshio is required for VTK export. Install with: pip install meshio") from err
+    return meshio
+
+
+def _as_meshdata(mesh) -> MeshData:
+    """Coerce a ``MeshData`` or ``skfem.Mesh`` to ``MeshData`` (fail loud otherwise)."""
+    from mfgarchon.geometry.meshes.mesh_data import MeshData
+
+    if isinstance(mesh, MeshData):
+        return mesh
+
+    try:
+        import skfem
+    except ImportError:
+        skfem = None
+    if skfem is not None and isinstance(mesh, skfem.Mesh):
+        from mfgarchon.alg.numerical.fem.mesh_adapter import skfem_to_meshdata
+
+        return skfem_to_meshdata(mesh)
+
+    raise TypeError(f"mesh must be a MeshData or skfem.Mesh, got {type(mesh).__name__}")
+
+
+def _meshio_mesh(mesh_data: MeshData, fields: Mapping[str, NDArray]):
+    """Build a ``meshio.Mesh`` from ``MeshData`` + nodal fields, validating both."""
+    meshio = _import_meshio()
+
+    cell_type = _MESHIO_CELL_TYPE.get(mesh_data.element_type)
+    if cell_type is None:
+        raise ValueError(
+            f"Unsupported element_type '{mesh_data.element_type}' for VTK export. "
+            f"Supported: {sorted(_MESHIO_CELL_TYPE)}"
+        )
+
+    n_points = mesh_data.num_vertices
+    point_data: dict[str, NDArray] = {}
+    for name, values in fields.items():
+        arr = np.asarray(values)
+        if arr.shape[0] != n_points:
+            raise ValueError(
+                f"Nodal field '{name}' has length {arr.shape[0]} but the mesh has {n_points} "
+                f"vertices. Nodal fields must be indexed by mesh vertex (P1/vertex DOFs); "
+                f"higher-order (e.g. P2 edge-midpoint) DOF vectors are not supported."
+            )
+        point_data[name] = arr
+
+    # VTK is intrinsically 3D; pad 2D/1D coordinates with zero columns so meshio does
+    # not emit an implicit-padding warning and ParaView reads explicit 3D points.
+    points = mesh_data.vertices
+    if points.shape[1] < 3:
+        points = np.column_stack([points, np.zeros((points.shape[0], 3 - points.shape[1]))])
+
+    return meshio.Mesh(
+        points=points,
+        cells=[(cell_type, mesh_data.elements)],
+        point_data=point_data,
+    )
+
+
+def export_mesh_solution_vtk(mesh, fields: Mapping[str, NDArray], path: str | Path) -> Path:
+    """Export one mesh + nodal fields to a ParaView ``.vtu`` file.
+
+    Args:
+        mesh: The solution mesh — a MFGarchon ``MeshData`` (e.g.
+            ``problem.geometry.mesh_data``) or a ``skfem.Mesh``.
+        fields: Nodal fields ``{name: array}``; each array's first axis must have
+            length ``mesh.num_vertices`` (e.g. ``{"U": U[-1], "M": M[-1]}``).
+        path: Output path (``.vtu`` XML VTK recommended).
+
+    Returns:
+        The written file path.
+
+    Raises:
+        ValueError: Unsupported ``element_type`` or a field whose length does not
+            match the vertex count.
+        TypeError: ``mesh`` is neither ``MeshData`` nor ``skfem.Mesh``.
+    """
+    mesh_data = _as_meshdata(mesh)
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    _meshio_mesh(mesh_data, fields).write(out)
+    return out
+
+
+def export_time_series_vtk(
+    mesh,
+    fields: Mapping[str, NDArray],
+    times: Sequence[float] | NDArray,
+    path: str | Path,
+) -> Path:
+    """Export a time-resolved MFG solution as per-timestep ``.vtu`` files + a ``.pvd``.
+
+    For ``Nt+1`` timesteps this writes ``<stem>_<k>.vtu`` (``k = 0 .. Nt``) next to
+    ``path`` and a ParaView ``.pvd`` collection at ``path`` indexing each file by its
+    time $t_k$, so ParaView animates the series.
+
+    Args:
+        mesh: The solution mesh (``MeshData`` or ``skfem.Mesh``).
+        fields: Time-resolved nodal fields ``{name: array(Nt+1, N)}``; the first axis
+            is time (length ``len(times)``), the second is the mesh vertices
+            (e.g. ``{"U": U, "M": M}`` with ``U, M`` of shape ``(Nt+1, N)``).
+        times: The ``Nt+1`` time values $t_k$.
+        path: Output ``.pvd`` path; the per-timestep ``.vtu`` stem is derived from it.
+
+    Returns:
+        The written ``.pvd`` collection path.
+
+    Raises:
+        ValueError: Empty ``fields``, a field that is not ``(n_times, N)``, or a field
+            whose time length disagrees with ``len(times)``.
+    """
+    mesh_data = _as_meshdata(mesh)
+    times = np.asarray(times, dtype=float)
+    n_times = times.shape[0]
+
+    if not fields:
+        raise ValueError("export_time_series_vtk requires at least one field.")
+    for name, values in fields.items():
+        arr = np.asarray(values)
+        if arr.ndim != 2:
+            raise ValueError(f"Time-series field '{name}' must be 2D (n_times, n_vertices), got shape {arr.shape}.")
+        if arr.shape[0] != n_times:
+            raise ValueError(f"Time-series field '{name}' has {arr.shape[0]} timesteps but {n_times} times were given.")
+
+    pvd_path = Path(path)
+    pvd_path.parent.mkdir(parents=True, exist_ok=True)
+    stem = pvd_path.stem
+
+    datasets: list[tuple[float, str]] = []
+    for k in range(n_times):
+        vtu_name = f"{stem}_{k}.vtu"
+        snapshot = {name: np.asarray(values)[k] for name, values in fields.items()}
+        # Per-vertex length validation happens inside _meshio_mesh.
+        _meshio_mesh(mesh_data, snapshot).write(pvd_path.parent / vtu_name)
+        datasets.append((float(times[k]), vtu_name))
+
+    _write_pvd(pvd_path, datasets)
+    return pvd_path
+
+
+def _write_pvd(pvd_path: Path, datasets: Sequence[tuple[float, str]]) -> None:
+    """Write a ParaView ``.pvd`` collection referencing ``(time, vtu_filename)`` pairs.
+
+    File names are stored relative to the ``.pvd`` (same directory), so the collection
+    is relocatable as a unit.
+    """
+    lines = [
+        '<?xml version="1.0"?>',
+        '<VTKFile type="Collection" version="0.1" byte_order="LittleEndian">',
+        "  <Collection>",
+    ]
+    for time, vtu_name in datasets:
+        lines.append(f'    <DataSet timestep="{time}" group="" part="0" file="{vtu_name}"/>')
+    lines.append("  </Collection>")
+    lines.append("</VTKFile>")
+    pvd_path.write_text("\n".join(lines) + "\n")

--- a/tests/unit/test_visualization/test_vtk_export.py
+++ b/tests/unit/test_visualization/test_vtk_export.py
@@ -1,0 +1,253 @@
+"""
+Unit tests for VTK export of FEM/unstructured-mesh MFG solutions (Issue #895).
+
+Covers ``mfgarchon.visualization.vtk_export``:
+
+- Round-trip: export a mesh + nodal fields to ``.vtu``, read back with
+  ``meshio.read``, and assert points / cells / point_data survive.
+- Time series: per-timestep ``.vtu`` + a ParaView ``.pvd`` collection, with each
+  timestep round-tripping its own field.
+- Fail-loud validation: wrong field length and unsupported element types raise.
+- End-to-end smoke: solve a tiny FEM MFG problem and export the result.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import meshio
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.meshes.mesh_data import MeshData
+from mfgarchon.visualization.vtk_export import export_mesh_solution_vtk, export_time_series_vtk
+
+
+def _two_triangle_mesh() -> MeshData:
+    """Unit square split into two triangles: 4 vertices, 2 elements, 2D."""
+    vertices = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    elements = np.array([[0, 1, 2], [1, 3, 2]], dtype=np.int64)
+    return MeshData(
+        vertices=vertices,
+        elements=elements,
+        element_type="triangle",
+        boundary_tags=np.zeros(0, dtype=np.int64),
+        element_tags=np.zeros(2, dtype=np.int64),
+        boundary_faces=np.zeros((0, 2), dtype=np.int64),
+        dimension=2,
+    )
+
+
+def _single_tetra_mesh() -> MeshData:
+    """A single reference tetrahedron: 4 vertices, 1 element, 3D."""
+    vertices = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    elements = np.array([[0, 1, 2, 3]], dtype=np.int64)
+    return MeshData(
+        vertices=vertices,
+        elements=elements,
+        element_type="tetrahedron",
+        boundary_tags=np.zeros(0, dtype=np.int64),
+        element_tags=np.zeros(1, dtype=np.int64),
+        boundary_faces=np.zeros((0, 3), dtype=np.int64),
+        dimension=3,
+    )
+
+
+@pytest.mark.unit
+class TestSingleExportRoundTrip:
+    """(a) export -> meshio.read -> points / cells / point_data match the originals."""
+
+    def test_triangle_vtu_roundtrip(self, tmp_path):
+        md = _two_triangle_mesh()
+        fields = {"U": np.array([1.0, 2.0, 3.0, 4.0]), "M": np.array([0.1, 0.2, 0.3, 0.4])}
+
+        out = export_mesh_solution_vtk(md, fields, tmp_path / "sol.vtu")
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+        back = meshio.read(out)
+
+        # Points: VTK is 3D, so 2D coords are padded with a zero z-column. The (x, y)
+        # block must match exactly; the padded column must be zeros.
+        assert back.points.shape == (4, 3)
+        np.testing.assert_array_equal(back.points[:, :2], md.vertices)
+        np.testing.assert_array_equal(back.points[:, 2], np.zeros(4))
+
+        # Cells: connectivity must survive exactly (integers).
+        np.testing.assert_array_equal(back.cells_dict["triangle"], md.elements)
+
+        # Point data: float fields round-trip (allclose).
+        for name, values in fields.items():
+            np.testing.assert_allclose(back.point_data[name], values)
+
+    def test_tetra_vtu_roundtrip(self, tmp_path):
+        md = _single_tetra_mesh()
+        fields = {"U": np.array([1.0, -2.0, 0.5, 3.0])}
+
+        out = export_mesh_solution_vtk(md, fields, tmp_path / "tet.vtu")
+        back = meshio.read(out)
+
+        np.testing.assert_array_equal(back.points, md.vertices)  # already 3D, no padding
+        np.testing.assert_array_equal(back.cells_dict["tetra"], md.elements)
+        np.testing.assert_allclose(back.point_data["U"], fields["U"])
+
+    def test_accepts_skfem_mesh(self, tmp_path):
+        """The mesh arg also accepts a skfem.Mesh (converted via the existing adapter)."""
+        skfem = pytest.importorskip("skfem", reason="scikit-fem required")
+        mesh = skfem.MeshTri.init_sqsymmetric().refined(1)
+        n = mesh.p.shape[1]
+        fields = {"U": np.arange(n, dtype=float)}
+
+        out = export_mesh_solution_vtk(mesh, fields, tmp_path / "skfem.vtu")
+        back = meshio.read(out)
+
+        np.testing.assert_array_equal(back.points[:, :2], mesh.p.T)
+        np.testing.assert_array_equal(back.cells_dict["triangle"], mesh.t.T)
+        np.testing.assert_allclose(back.point_data["U"], fields["U"])
+
+
+@pytest.mark.unit
+class TestTimeSeries:
+    """(b) time series: a .pvd indexing N per-timestep .vtu files that each round-trip."""
+
+    def test_pvd_references_each_timestep_and_roundtrips(self, tmp_path):
+        md = _two_triangle_mesh()
+        n_t, n = 3, md.num_vertices
+        rng = np.random.RandomState(0)
+        U = rng.rand(n_t, n)
+        M = rng.rand(n_t, n)
+        times = np.array([0.0, 0.5, 1.0])
+
+        pvd = export_time_series_vtk(md, {"U": U, "M": M}, times, tmp_path / "series.pvd")
+        assert pvd.exists()
+
+        # The .pvd must list exactly n_t datasets, each pointing at an existing .vtu,
+        # with the correct timestep attribute.
+        root = ET.parse(pvd).getroot()
+        datasets = root.findall("./Collection/DataSet")
+        assert len(datasets) == n_t
+
+        for k, ds in enumerate(datasets):
+            assert float(ds.attrib["timestep"]) == times[k]
+            vtu = pvd.parent / ds.attrib["file"]
+            assert vtu.exists()
+            assert vtu.stat().st_size > 0
+
+            back = meshio.read(vtu)
+            # Each .vtu carries THAT timestep's slice of every field.
+            np.testing.assert_allclose(back.point_data["U"], U[k])
+            np.testing.assert_allclose(back.point_data["M"], M[k])
+            np.testing.assert_array_equal(back.cells_dict["triangle"], md.elements)
+
+
+@pytest.mark.unit
+class TestFailLoud:
+    """(c) clear, loud failures for malformed inputs (fail-fast convention)."""
+
+    def test_field_length_mismatch_raises(self, tmp_path):
+        md = _two_triangle_mesh()  # 4 vertices
+        with pytest.raises(ValueError, match=r"length 3 but the mesh has 4 vertices"):
+            export_mesh_solution_vtk(md, {"U": np.ones(3)}, tmp_path / "bad.vtu")
+
+    def test_unsupported_element_type_raises(self, tmp_path):
+        md = MeshData(
+            vertices=np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]),
+            elements=np.array([[0, 1, 2]], dtype=np.int64),
+            element_type="polygon",  # not in the meshio cell map
+            boundary_tags=np.zeros(0, dtype=np.int64),
+            element_tags=np.zeros(1, dtype=np.int64),
+            boundary_faces=np.zeros((0, 2), dtype=np.int64),
+            dimension=2,
+        )
+        with pytest.raises(ValueError, match=r"Unsupported element_type 'polygon'.*Supported"):
+            export_mesh_solution_vtk(md, {"U": np.ones(3)}, tmp_path / "bad.vtu")
+
+    def test_non_mesh_argument_raises(self, tmp_path):
+        with pytest.raises(TypeError, match=r"MeshData or skfem.Mesh"):
+            export_mesh_solution_vtk("not a mesh", {"U": np.ones(3)}, tmp_path / "bad.vtu")
+
+    def test_time_series_non_2d_field_raises(self, tmp_path):
+        md = _two_triangle_mesh()
+        with pytest.raises(ValueError, match=r"must be 2D"):
+            export_time_series_vtk(md, {"U": np.ones(4)}, [0.0], tmp_path / "bad.pvd")
+
+    def test_time_series_time_length_mismatch_raises(self, tmp_path):
+        md = _two_triangle_mesh()
+        U = np.ones((3, md.num_vertices))
+        with pytest.raises(ValueError, match=r"3 timesteps but 2 times"):
+            export_time_series_vtk(md, {"U": U}, [0.0, 1.0], tmp_path / "bad.pvd")
+
+
+@pytest.mark.integration
+def test_export_solved_fem_mfg_result(tmp_path):
+    """(d) End-to-end: solve a tiny FEM MFG problem, export the (Nt+1, N) U/M, re-read."""
+    skfem = pytest.importorskip("skfem", reason="scikit-fem required for FEM solve")
+
+    from mfgarchon.alg.numerical.fem.assembly import assemble_mass
+    from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+    from mfgarchon.alg.numerical.fem.mesh_adapter import skfem_to_meshdata
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry.boundary import no_flux_bc
+    from mfgarchon.geometry.meshes.mesh_2d import Mesh2D
+
+    mesh = skfem.MeshTri.init_sqsymmetric().refined(1)
+    geom = Mesh2D(domain_type="rectangle", bounds=(0.0, 1.0, 0.0, 1.0))
+    geom.mesh_data = skfem_to_meshdata(mesh)
+    geom.boundary_conditions = no_flux_bc(dimension=2)
+    components = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    problem = MFGProblem(
+        geometry=geom,
+        T=0.2,
+        Nt=4,
+        sigma=0.3,
+        components=components,
+        coupling_coefficient=0.5,
+        boundary_conditions=no_flux_bc(dimension=2),
+    )
+
+    hjb, fp = HJBFEMSolver(problem), FPFEMSolver(problem)
+    n_dof, n_t = fp._basis.N, problem.Nt
+    mass = assemble_mass(fp._basis)
+    m0 = np.exp(-10 * ((mesh.p[0] - 0.5) ** 2 + (mesh.p[1] - 0.5) ** 2))
+    m0 /= (mass @ m0).sum()
+    u_sol = np.zeros((n_t + 1, n_dof))
+    m_sol = np.tile(m0, (n_t + 1, 1))
+    for _ in range(3):  # a few Picard sweeps: finite, re-readable result (not convergence)
+        u_new = np.asarray(hjb.solve_hjb_system(m_sol, np.zeros(n_dof), u_sol))
+        m_new = np.asarray(fp.solve_fp_system(m0, u_new))
+        u_sol = 0.5 * u_sol + 0.5 * u_new
+        m_sol = 0.5 * m_sol + 0.5 * m_new
+    assert np.all(np.isfinite(u_sol))
+    assert np.all(np.isfinite(m_sol))
+
+    # P1 FEM: n_dof == number of mesh vertices, so nodal fields export directly.
+    assert n_dof == geom.mesh_data.num_vertices
+
+    times = np.linspace(0.0, problem.T, n_t + 1)
+    pvd = export_time_series_vtk(geom.mesh_data, {"U": u_sol, "M": m_sol}, times, tmp_path / "mfg.pvd")
+    assert pvd.exists()
+    assert pvd.stat().st_size > 0
+
+    root = ET.parse(pvd).getroot()
+    datasets = root.findall("./Collection/DataSet")
+    assert len(datasets) == n_t + 1
+    last = meshio.read(pvd.parent / datasets[-1].attrib["file"])
+    assert last.points.shape[0] == n_dof
+    np.testing.assert_allclose(last.point_data["M"], m_sol[-1])
+
+    # Single-snapshot terminal export also re-reads cleanly.
+    vtu = export_mesh_solution_vtk(geom.mesh_data, {"U": u_sol[-1], "M": m_sol[-1]}, tmp_path / "terminal.vtu")
+    assert vtu.stat().st_size > 0
+    assert meshio.read(vtu).points.shape[0] == n_dof


### PR DESCRIPTION
Fixes #895

## Summary

Adds `mfgarchon/visualization/vtk_export.py` — a thin meshio-based VTK export path for FEM / unstructured-mesh MFG solutions (ParaView-readable `.vtu`, plus a `.pvd` time-series collection). Visualization-only; no solver/physics code is touched.

## API

- `export_mesh_solution_vtk(mesh, fields, path) -> Path`
  - `mesh`: `MeshData` (primary — `problem.geometry.mesh_data`) **or** `skfem.Mesh` (converted via the existing `skfem_to_meshdata` adapter).
  - `fields`: `{name: array(N,)}` nodal fields, e.g. `{"U": U[-1], "M": M[-1]}`.
  - Builds a `meshio.Mesh` (points / cells / point_data) and writes the `.vtu`.
- `export_time_series_vtk(mesh, fields, times, path) -> Path`
  - `fields`: `{name: array(Nt+1, N)}`; writes `<stem>_<k>.vtu` per timestep plus a ParaView `.pvd` collection indexing each file by time `t_k` — the natural MFG use-case.

A standalone-function API is used deliberately (no `result.to_vtk` convenience wrapper) per the no-premature-convenience convention.

## Fail-fast validation (no silent fallback)

- Nodal-field length must equal the vertex count — targets P1 / vertex DOFs; P2 edge-midpoint vectors are rejected with a clear message.
- `element_type` must map to a meshio cell type (`line` / `triangle` / `quad` / `tetra` / `hexahedron`); otherwise `ValueError` lists the supported types.
- A non-mesh argument raises `TypeError`.
- 2D/1D points are padded to explicit 3D (VTK is intrinsically 3D), avoiding meshio's implicit-padding warning.

## Tests — `tests/unit/test_visualization/test_vtk_export.py`

- **Round-trip** (`meshio.read` back): asserts points (x,y match, padded z column = 0), exact cell connectivity, and float `point_data` for triangle and tetra `MeshData`, and for a `skfem.Mesh` input.
- **Time series**: asserts the `.pvd` references `N` `.vtu` files, each existing and round-tripping its own timestep's `U`/`M` slice and connectivity.
- **Fail-loud**: wrong field length, unsupported `element_type`, non-mesh argument, and malformed time-series shapes all raise with greppable messages.
- **End-to-end smoke**: solves a tiny FEM MFG problem (`HJBFEMSolver` + `FPFEMSolver`, manual Picard) and exports the `(Nt+1, N)` result as a `.pvd` + terminal `.vtu`, confirming non-empty and re-readable.

All 10 new tests pass; the full `tests/unit/test_visualization/` suite (28) passes. `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)