### PR TITLE
fix(geometry): remove silent PERIODIC default BC; require explicit default_bc (Fixes #1100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed (BREAKING)
 
+- **`BoundaryConditions.default_bc` no longer silently defaults to `PERIODIC`** (Issue #1100).
+  The dataclass field is now `default_bc: BCType | None = None` ("unspecified"). Previously any
+  boundary point that matched no segment (coverage gap, geometric-tolerance edge) silently fell back
+  to periodic wrapping — wrong physics for the non-periodic 2D geometries that dominate real use, and
+  the proximate cause of silent zero-Jacobian rows (#1098). Now, resolving an unmatched point with
+  `default_bc` unset raises a clear `ValueError` ("...matched no BC and default_bc was not specified
+  ...; set default_bc=BCType.NO_FLUX / PERIODIC / DIRICHLET explicitly (Issue #1100)") at the point→BC
+  resolution sites (`BoundaryConditions.get_bc_at_point` / `get_bc_type_at_boundary` via the new
+  `_resolve_default_bc` helper, and the implicit/meshfree applicators, `fp_gfdm`, and
+  `base_solver` constraint/env-config builders). **Migration**: pass `default_bc=BCType.NO_FLUX`
+  (safe, mass-conserving) — or `BCType.PERIODIC` if you genuinely want wrapping — whenever your
+  segments may not cover every boundary point; the `*_bc()` factories (`no_flux_bc`, `periodic_bc`,
+  …) already set `default_bc` explicitly and are unaffected. The `mixed_bc_from_regions` factory's
+  no-`"default"`-segment fallback changed from `PERIODIC` to `NO_FLUX`. Global-property reads
+  (`__str__`, `validate()`, `validate_boundary_conditions`) treat `None` as "not specified" and do
+  not crash. Explicit-BC paths (no-flux / Dirichlet / explicit-periodic) are byte-identical.
+
 - **Deprecated `fdm_bc_1d` 1D BC factory functions** `periodic_bc`, `dirichlet_bc`, `neumann_bc`,
   `no_flux_bc`, `robin_bc` (deprecated since v0.14.0 — past the 3-minor-version removal window at
   v0.19.8). They were dead code: every live import resolves the same names from the geometry-first

--- a/mfgarchon/alg/base_solver.py
+++ b/mfgarchon/alg/base_solver.py
@@ -403,10 +403,14 @@ class BaseOptimizationSolver(BaseMFGSolver):
 
             constraints.append(constraint)
 
-        # If no segments, create constraint from default BC if available
+        # If no segments, create constraint from default BC.
+        # Issue #1100: a unified BoundaryConditions with default_bc unset (None)
+        # is fully unspecified here -> fail loud rather than silently apply a default.
         if not constraints:
-            bc_type = getattr(bc, "default_bc", None)
-            if bc_type is not None:
+            from mfgarchon.geometry.boundary import BoundaryConditions
+
+            if isinstance(bc, BoundaryConditions):
+                bc_type = bc._resolve_default_bc("BaseOptimizationSolver.get_domain_constraints")
                 constraint = {
                     "region": "all",
                     "value": getattr(bc, "value", 0.0),
@@ -414,6 +418,7 @@ class BaseOptimizationSolver(BaseMFGSolver):
                     "type": "eq" if bc_type == BCType.DIRICHLET else "grad",
                 }
                 constraints.append(constraint)
+            # else: legacy/non-unified BC object carries no default constraint
 
         return constraints
 
@@ -576,9 +581,14 @@ class BaseRLSolver(BaseMFGSolver):
         # Map BC type to environment behavior
         bc = self.get_boundary_conditions()
         if bc is not None:
-            from mfgarchon.geometry.boundary import BCType
+            from mfgarchon.geometry.boundary import BCType, BoundaryConditions
 
-            bc_type = getattr(bc, "default_bc", None)
+            # Issue #1100: a unified BoundaryConditions with default_bc unset (None)
+            # would previously map to "wrap" (silent PERIODIC). Fail loud instead.
+            if isinstance(bc, BoundaryConditions):
+                bc_type = bc._resolve_default_bc("BaseRLSolver.get_environment_boundary_config")
+            else:
+                bc_type = getattr(bc, "default_bc", None)
 
             if bc_type == BCType.PERIODIC:
                 config["boundary_mode"] = "wrap"

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -185,7 +185,12 @@ class FPGFDMSolver(BaseFPSolver):
         # Map BoundaryConditions to string for GFDMOperator
         if bc is not None:
             try:
-                default_bc = bc.default_bc
+                # Fails loud (ValueError) if default_bc unset; Issue #1100.
+                # AttributeError only for legacy objects lacking the unified interface.
+                default_bc = bc._resolve_default_bc("FPGFDMSolver._resolve_boundary_type")
+            except AttributeError:
+                default_bc = None
+            if default_bc is not None:
                 if default_bc == BCType.NO_FLUX:
                     return "no_flux"
                 elif default_bc == BCType.NEUMANN:
@@ -194,8 +199,6 @@ class FPGFDMSolver(BaseFPSolver):
                     return "periodic"  # GFDMOperator may support this in future
                 # Other BC types not yet supported by GFDMOperator
                 return None
-            except AttributeError:
-                pass
 
         # Priority: Legacy boundary_type string
         return boundary_type_str

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -538,7 +538,9 @@ if __name__ == "__main__":
     # Create problem with Neumann BC
     left_bc = BCSegment(name="left", bc_type=BCType.NEUMANN, value=0.0, boundary="x_min")
     right_bc = BCSegment(name="right", bc_type=BCType.NEUMANN, value=0.0, boundary="x_max")
-    bc = BoundaryConditions(segments=[left_bc, right_bc])
+    bc = BoundaryConditions(
+        segments=[left_bc, right_bc], default_bc=BCType.NO_FLUX
+    )  # Issue #1100: explicit (was implicit PERIODIC)
 
     domain = TensorProductGrid(bounds=[(X_MIN, X_MAX)], Nx_points=[N + 1], boundary_conditions=bc)
 

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -630,7 +630,9 @@ if __name__ == "__main__":
     # Create problem with Neumann BC
     left_bc = BCSegment(name="left", bc_type=BCType.NEUMANN, value=0.0, boundary="x_min")
     right_bc = BCSegment(name="right", bc_type=BCType.NEUMANN, value=0.0, boundary="x_max")
-    bc = BoundaryConditions(segments=[left_bc, right_bc])
+    bc = BoundaryConditions(
+        segments=[left_bc, right_bc], default_bc=BCType.NO_FLUX
+    )  # Issue #1100: explicit (was implicit PERIODIC)
 
     domain = TensorProductGrid(bounds=[(X_MIN, X_MAX)], Nx_points=[N + 1], boundary_conditions=bc)
 

--- a/mfgarchon/alg/numerical/gfdm_components/boundary_handler.py
+++ b/mfgarchon/alg/numerical/gfdm_components/boundary_handler.py
@@ -308,11 +308,23 @@ class BoundaryHandler:
         bc_type = self._bc_property_getter("type", None)
 
         if bc_type is None:
-            # Try to infer from BC object
-            try:
-                bc_type = self.boundary_conditions.default_bc.value.lower()
-            except AttributeError:
-                # No BC specified - return None
+            # `.type` is undefined for mixed BC (multiple segments), so
+            # _bc_property_getter returned None. Infer a legacy global "type" hint.
+            # Issue #1100: default_bc may now be None (unspecified). Resolution
+            # order: explicit default_bc -> "mixed" sentinel if the BC carries
+            # segments (it IS specified; per-point dispatch enforces each point)
+            # -> None only when there is genuinely no BC at all. The "mixed"
+            # sentinel is never consumed as a uniform type: every enforcement path
+            # routes mixed BC through use_per_point_bc / _get_bc_type_for_point.
+            from mfgarchon.geometry.boundary import BCType
+
+            default_bc = getattr(self.boundary_conditions, "default_bc", None)
+            if isinstance(default_bc, BCType):
+                bc_type = default_bc.value.lower()
+            elif getattr(self.boundary_conditions, "segments", None):
+                bc_type = "mixed"
+            else:
+                # No global type, no explicit default, no segments -> unspecified.
                 return None
 
         if isinstance(bc_type, str):

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -1153,8 +1153,9 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         For mixed BC where the point was *not* pre-classified, this method
         raises ``ValueError`` rather than silently falling back to
-        ``self.boundary_conditions.default_bc`` (which defaults to PERIODIC
-        — historically the source of silent zero Jacobian rows). The
+        ``self.boundary_conditions.default_bc`` (historically defaulted to
+        PERIODIC — the source of silent zero Jacobian rows; Issue #1100 removed
+        that implicit default so it is now ``None``/fail-loud). The
         pre-classification at __init__ already raised on unmatched points
         with full diagnostic; reaching here means the boundary_indices set
         was mutated after __init__, which is a programmer error.
@@ -1241,10 +1242,10 @@ class HJBGFDMSolver(BaseHJBSolver):
           from the face — not from any SDF gradient).
 
         Raises if any boundary point cannot be classified to a face or matched
-        to a segment. This converts a class of latent failures — silent
-        ``default_bc=PERIODIC`` fallback plus zero Jacobian rows discovered
-        80 Newton iterations later — into a loud, diagnosable construction-
-        time error.
+        to a segment. This converts a class of latent failures — the historical
+        silent ``default_bc=PERIODIC`` fallback (removed in Issue #1100) plus
+        zero Jacobian rows discovered 80 Newton iterations later — into a loud,
+        diagnosable construction-time error.
 
         Only runs for mixed-BC setups; uniform BC keeps the global-type fast
         path. Skipped entirely if ``len(self.boundary_indices) == 0``.

--- a/mfgarchon/geometry/boundary/applicator_implicit.py
+++ b/mfgarchon/geometry/boundary/applicator_implicit.py
@@ -133,8 +133,8 @@ class ImplicitApplicator(MeshfreeApplicator):
         boundary_points = points[boundary_mask]
         normals = self._compute_boundary_normals(boundary_points)
 
-        # Apply BC based on type
-        bc_type = boundary_conditions.default_bc
+        # Apply BC based on type (fails loud if default_bc unset; Issue #1100)
+        bc_type = boundary_conditions._resolve_default_bc("ImplicitBoundaryApplicator.apply")
         bc_value = self._resolve_bc_value(boundary_conditions, boundary_points, time)
 
         if bc_type == BCType.DIRICHLET:

--- a/mfgarchon/geometry/boundary/applicator_meshfree.py
+++ b/mfgarchon/geometry/boundary/applicator_meshfree.py
@@ -356,8 +356,8 @@ class MeshfreeApplicator(BaseMeshfreeApplicator):
         if not np.any(on_boundary):
             return field
 
-        # Get BC type (uniform BC for now)
-        bc_type = boundary_conditions.default_bc
+        # Get BC type (uniform BC for now; fails loud if default_bc unset, Issue #1100)
+        bc_type = boundary_conditions._resolve_default_bc("MeshfreeBoundaryApplicator.apply")
 
         if bc_type == BCType.DIRICHLET:
             # Get Dirichlet value
@@ -440,7 +440,8 @@ class MeshfreeApplicator(BaseMeshfreeApplicator):
             >>> bc = neumann_bc(dimension=2)  # Zero-flux = reflecting
             >>> particles_updated = applicator.apply_particles(particles, bc)
         """
-        bc_type = boundary_conditions.default_bc
+        # Fails loud if default_bc unset (Issue #1100)
+        bc_type = boundary_conditions._resolve_default_bc("MeshfreeBoundaryApplicator.apply_particles")
 
         if bc_type == BCType.NEUMANN:
             # Zero-flux Neumann → reflecting BC for particles

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -62,7 +62,12 @@ class BoundaryConditions:
         dimension: Spatial dimension of the problem (1, 2, 3, ...) or None for lazy binding.
             When None, dimension will be inferred when BC is attached to a Geometry.
         segments: List of BC segments (ordered by priority)
-        default_bc: Default BC type when no segment matches
+        default_bc: Fallback BC type for points/segments that match no explicit
+            segment. ``None`` (the default) means *unspecified*: resolving a
+            fall-through point then raises instead of silently applying a default
+            (Issue #1100 — PERIODIC is never applied unless explicitly requested).
+            Set explicitly (e.g. ``BCType.NO_FLUX``) when segments may not cover
+            every boundary point.
         default_value: Default BC value when no segment matches
         domain_bounds: Domain bounds array of shape (dimension, 2) for rectangular domains
         domain_sdf: Signed distance function for general/Lipschitz domains
@@ -91,7 +96,9 @@ class BoundaryConditions:
 
     dimension: int | None = None
     segments: list[BCSegment] = field(default_factory=list)
-    default_bc: BCType = BCType.PERIODIC
+    # Issue #1100: None = "unspecified" (no silent PERIODIC fallback). Resolving a
+    # fall-through point with default_bc is None fails loud via _resolve_default_bc.
+    default_bc: BCType | None = None
     default_value: float = 0.0
 
     # Rectangular domain specification
@@ -286,6 +293,32 @@ class BoundaryConditions:
             raise ValueError("bc_type property only valid for uniform BCs. For mixed BCs, access segments directly.")
         return self.segments[0].bc_type
 
+    def _resolve_default_bc(self, context: str) -> BCType:
+        """Return ``default_bc`` for a fall-through point, or fail loud if unset.
+
+        Issue #1100: ``default_bc`` is ``None`` when the user never specified a
+        fallback. A point/segment that matches no explicit BC segment falls
+        through to ``default_bc``; silently substituting a default (historically
+        ``PERIODIC``) is wrong physics, so resolution raises here instead of
+        guessing. PERIODIC is applied only when the user sets it explicitly.
+
+        Args:
+            context: Caller name, surfaced in the error for debuggability.
+
+        Returns:
+            The explicitly-set default ``BCType``.
+
+        Raises:
+            ValueError: If ``default_bc`` is ``None`` (unspecified).
+        """
+        if self.default_bc is None:
+            raise ValueError(
+                f"{context}: point/segment matched no BC and default_bc was not "
+                "specified on BoundaryConditions; set default_bc=BCType.NO_FLUX / "
+                "PERIODIC / DIRICHLET explicitly (Issue #1100)."
+            )
+        return self.default_bc
+
     def get_bc_at_point(
         self,
         point: np.ndarray,
@@ -329,10 +362,10 @@ class BoundaryConditions:
             ):
                 return segment
 
-        # No match - return default BC as a segment
+        # No match - return default BC as a segment (fails loud if default_bc unset)
         return BCSegment(
             name="default",
-            bc_type=self.default_bc,
+            bc_type=self._resolve_default_bc("get_bc_at_point"),
             value=self.default_value,
             priority=-1,
         )
@@ -376,8 +409,8 @@ class BoundaryConditions:
             if segment.boundary == boundary:
                 return segment.bc_type
 
-        # No match - return default BC type
-        return self.default_bc
+        # No match - return default BC type (fails loud if default_bc unset)
+        return self._resolve_default_bc("get_bc_type_at_boundary")
 
     def get_bc_value_at_boundary(self, boundary: str, time: float = 0.0, point: np.ndarray | None = None) -> float:
         """
@@ -792,18 +825,19 @@ class BoundaryConditions:
                 has_min_coverage = any(_seg_covers_face(seg, target_min) for seg in self.segments)
                 has_max_coverage = any(_seg_covers_face(seg, target_max) for seg in self.segments)
 
-                # If no explicit segment coverage, default BC will be used
+                # If no explicit segment coverage, default BC will be used.
+                # Issue #1100: default_bc may be None (unspecified) -> flag that
+                # resolution will fail loud at those points rather than crashing here.
                 face_label_min = target_min.to_string()
                 face_label_max = target_max.to_string()
+                default_desc = self.default_bc.value if self.default_bc is not None else "unspecified (will raise)"
                 if not has_min_coverage:
                     warnings.append(
-                        f"No explicit BC segment for {face_label_min} boundary. "
-                        f"Default BC ({self.default_bc.value}) will be used."
+                        f"No explicit BC segment for {face_label_min} boundary. Default BC ({default_desc}) will be used."
                     )
                 if not has_max_coverage:
                     warnings.append(
-                        f"No explicit BC segment for {face_label_max} boundary. "
-                        f"Default BC ({self.default_bc.value}) will be used."
+                        f"No explicit BC segment for {face_label_max} boundary. Default BC ({default_desc}) will be used."
                     )
 
         is_valid = len(warnings) == 0
@@ -821,7 +855,9 @@ class BoundaryConditions:
         lines = [f"BoundaryConditions({dim_str}, mixed, {domain_type}):"]
         for segment in self.segments:
             lines.append(f"  - {segment}")
-        lines.append(f"  - Default: {self.default_bc.value} = {self.default_value}")
+        # Issue #1100: default_bc may be None (unspecified) -> guard .value access.
+        default_desc = self.default_bc.value if self.default_bc is not None else "unspecified"
+        lines.append(f"  - Default: {default_desc} = {self.default_value}")
         if self.corner_strategy != "priority":
             lines.append(f"  - Corner handling: {self.corner_strategy}")
         return "\n".join(lines)
@@ -1093,11 +1129,15 @@ def mixed_bc_from_regions(
     bounds = getattr(geometry, "bounds", None)
     domain_bounds = np.array(bounds) if bounds is not None else None
 
-    # Create BoundaryConditions object
+    # Create BoundaryConditions object.
+    # Issue #1100: when no explicit "default" segment is supplied, fall back to
+    # NO_FLUX (safe, mass-conserving, non-surprising) rather than the historical
+    # PERIODIC. PERIODIC is applied only when the caller passes a default segment
+    # whose bc_type is PERIODIC (the explicit path below).
     return BoundaryConditions(
         dimension=dimension,
         segments=segments,
-        default_bc=default_segment.bc_type if default_segment else BCType.PERIODIC,
+        default_bc=default_segment.bc_type if default_segment else BCType.NO_FLUX,
         default_value=default_segment.value if default_segment else 0.0,
         domain_bounds=domain_bounds,
     )

--- a/mfgarchon/geometry/boundary/resolution.py
+++ b/mfgarchon/geometry/boundary/resolution.py
@@ -429,7 +429,10 @@ def to_boundary_conditions(
         )
         segments.append(seg)
 
-    return BoundaryConditions(segments=segments, dimension=dimension)
+    # Issue #1100: explicit NO_FLUX fallback for any boundary the resolved
+    # segments do not cover (matches the empty-resolved no_flux_bc default above);
+    # avoids the removed implicit PERIODIC default.
+    return BoundaryConditions(segments=segments, dimension=dimension, default_bc=BCType.NO_FLUX)
 
 
 # =============================================================================

--- a/tests/unit/test_geometry/test_default_bc_explicit_1100.py
+++ b/tests/unit/test_geometry/test_default_bc_explicit_1100.py
@@ -1,0 +1,164 @@
+"""
+Regression tests for Issue #1100: remove the silent PERIODIC default BC.
+
+``BoundaryConditions.default_bc`` no longer defaults to ``BCType.PERIODIC``.
+It is ``None`` ("unspecified") unless set explicitly. The contract:
+
+(a) Resolving a point/segment that matches no explicit BC segment, when
+    ``default_bc`` is unset, fails loud with a clear ValueError (no silent
+    PERIODIC wrapping).
+(b) Setting ``default_bc=BCType.PERIODIC`` explicitly still resolves
+    fall-through points to PERIODIC, exactly as the old implicit default did
+    (equivalence — the explicit path is unchanged).
+(c) Global-property reads (``__str__``/``__repr__``, ``validate()``,
+    ``validate_boundary_conditions`` has_periodic) on a ``default_bc=None``
+    object do not crash; None is treated as "not specified / no periodic
+    default".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry import BCSegment, BCType, BoundaryConditions
+
+
+def _bounds_2d() -> np.ndarray:
+    return np.array([[0.0, 1.0], [0.0, 1.0]])
+
+
+# =============================================================================
+# (a) Unspecified default + unmatched point -> fail loud
+# =============================================================================
+
+
+class TestUnspecifiedDefaultFailsLoud:
+    def test_default_bc_is_none_when_unset(self):
+        """The dataclass field defaults to None, not PERIODIC (Issue #1100)."""
+        bc = BoundaryConditions(segments=[], dimension=2, domain_bounds=_bounds_2d())
+        assert bc.default_bc is None
+
+    def test_get_bc_type_at_boundary_unmatched_raises(self):
+        """A coverage gap (segment only on x_min) must raise on the unmatched face."""
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min")],
+            dimension=2,
+            domain_bounds=_bounds_2d(),
+        )
+        with pytest.raises(ValueError, match=r"default_bc was not specified.*Issue #1100"):
+            bc.get_bc_type_at_boundary("x_max")
+
+    def test_get_bc_at_point_unmatched_raises(self):
+        """A point matching no segment falls through to default -> fail loud."""
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min")],
+            dimension=2,
+            domain_bounds=_bounds_2d(),
+        )
+        # Point on x_max boundary: matches no segment.
+        with pytest.raises(ValueError, match=r"matched no BC and default_bc was not specified"):
+            bc.get_bc_at_point(np.array([1.0, 0.5]), boundary_id="x_max")
+
+    def test_error_message_lists_explicit_choices(self):
+        """The diagnostic must name the explicit fix (greppable)."""
+        bc = BoundaryConditions(segments=[], dimension=1, domain_bounds=np.array([[0.0, 1.0]]))
+        with pytest.raises(ValueError) as exc_info:
+            bc.get_bc_type_at_boundary("x_min")
+        msg = str(exc_info.value)
+        assert "BCType.NO_FLUX" in msg
+        assert "PERIODIC" in msg
+        assert "DIRICHLET" in msg
+        assert "Issue #1100" in msg
+
+
+# =============================================================================
+# (b) Explicit PERIODIC unchanged (equivalence with old implicit behavior)
+# =============================================================================
+
+
+class TestExplicitPeriodicUnchanged:
+    def test_explicit_periodic_default_resolves_to_periodic(self):
+        """default_bc=PERIODIC resolves unmatched faces to PERIODIC (no raise)."""
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min")],
+            dimension=2,
+            domain_bounds=_bounds_2d(),
+            default_bc=BCType.PERIODIC,
+        )
+        # Matched face keeps its segment type...
+        assert bc.get_bc_type_at_boundary("x_min") == BCType.NO_FLUX
+        # ...unmatched face falls through to the explicit PERIODIC default.
+        assert bc.get_bc_type_at_boundary("x_max") == BCType.PERIODIC
+
+    def test_explicit_periodic_default_bc_at_point(self):
+        """get_bc_at_point returns a PERIODIC default segment for unmatched points."""
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min")],
+            dimension=2,
+            domain_bounds=_bounds_2d(),
+            default_bc=BCType.PERIODIC,
+        )
+        seg = bc.get_bc_at_point(np.array([1.0, 0.5]), boundary_id="x_max")
+        assert seg.bc_type == BCType.PERIODIC
+
+    def test_periodic_bc_factory_sets_explicit_default(self):
+        """periodic_bc() is the canonical explicit-periodic path and is unaffected."""
+        from mfgarchon.geometry.boundary import periodic_bc
+
+        bc = periodic_bc(dimension=1)
+        assert bc.default_bc == BCType.PERIODIC
+        # Uniform periodic: resolution never raises.
+        assert bc.get_bc_type_at_boundary("x_min") == BCType.PERIODIC
+
+
+# =============================================================================
+# (c) Global-property reads on default_bc=None must not crash
+# =============================================================================
+
+
+class TestGlobalPropertyReadsNoneSafe:
+    def test_str_does_not_crash_on_none_default(self):
+        """__str__ guards default_bc.value (mixed BC path)."""
+        bc = BoundaryConditions(
+            segments=[
+                BCSegment(name="a", bc_type=BCType.NO_FLUX, boundary="x_min"),
+                BCSegment(name="b", bc_type=BCType.DIRICHLET, boundary="x_max"),
+            ],
+            dimension=2,
+            domain_bounds=_bounds_2d(),
+        )
+        text = str(bc)
+        assert "unspecified" in text  # not a crash, default reported as unspecified
+
+    def test_validate_does_not_crash_on_none_default(self):
+        """validate() guards default_bc.value in coverage warnings."""
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min")],
+            dimension=2,
+            domain_bounds=_bounds_2d(),
+        )
+        is_valid, warnings = bc.validate()
+        # x_max/y_min/y_max uncovered -> warnings emitted, no exception.
+        assert isinstance(is_valid, bool)
+        assert any("will raise" in w for w in warnings)
+
+    def test_has_periodic_check_none_safe(self):
+        """validate_boundary_conditions has_periodic read treats None as not-periodic."""
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc
+        from mfgarchon.utils.validation.components import validate_boundary_conditions
+
+        # Grid needs its own explicit BC (Issue #674); the object under test is `bc`.
+        geometry = TensorProductGrid(
+            bounds=[(0, 1), (0, 1)], Nx_points=[10, 10], boundary_conditions=no_flux_bc(dimension=2)
+        )
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min")],
+            dimension=2,
+            domain_bounds=_bounds_2d(),
+        )
+        # Does not raise; None default_bc is not flagged as periodic.
+        result = validate_boundary_conditions(bc, geometry)
+        assert result is not None

--- a/tests/unit/test_geometry/test_mixed_bc.py
+++ b/tests/unit/test_geometry/test_mixed_bc.py
@@ -448,8 +448,9 @@ class TestMixedBCFromRegions:
 
         bc = mixed_bc_from_regions(geometry, bc_config)
 
-        # Should use default values
-        assert bc.default_bc == BCType.PERIODIC
+        # Issue #1100: no "default" segment -> factory falls back to safe NO_FLUX
+        # (was PERIODIC). The point of this test is that a default is optional.
+        assert bc.default_bc == BCType.NO_FLUX
         assert bc.default_value == 0.0
 
     def test_preserves_segment_fields(self):
@@ -496,7 +497,8 @@ class TestMixedBoundaryConditions:
         mixed_bc = MixedBoundaryConditions(dimension=2)
         assert mixed_bc.dimension == 2
         assert len(mixed_bc.segments) == 0
-        assert mixed_bc.default_bc == BCType.PERIODIC
+        # Issue #1100: default_bc is None ("unspecified"), no longer implicit PERIODIC.
+        assert mixed_bc.default_bc is None
         assert mixed_bc.default_value == 0.0
 
     def test_segment_sorting_by_priority(self):
@@ -735,6 +737,9 @@ class TestDimensionAgnosticism:
             dimension=3,
             segments=[segment],
             domain_bounds=np.array([[0.0, 10.0], [0.0, 10.0], [0.0, 10.0]]),
+            # Issue #1100: fall-through default must be explicit now. This test
+            # exercises the default-segment dispatch, so set it explicitly.
+            default_bc=BCType.PERIODIC,
         )
 
         # Point in outlet region
@@ -742,10 +747,10 @@ class TestDimensionAgnosticism:
         bc = mixed_bc.get_bc_at_point(outlet_point, "x_max")
         assert bc.bc_type == BCType.DIRICHLET
 
-        # Point outside outlet region
+        # Point outside outlet region -> falls through to the explicit default
         wall_point = np.array([9.5, 2.0, 5.0])
         bc_wall = mixed_bc.get_bc_at_point(wall_point, "x_max")
-        assert bc_wall.bc_type == BCType.PERIODIC  # default
+        assert bc_wall.bc_type == BCType.PERIODIC  # explicit default
 
 
 class TestSDFBasedBC:


### PR DESCRIPTION
Fixes #1100

## Problem

`BoundaryConditions.default_bc` defaulted to `BCType.PERIODIC`. Any boundary point that matched no segment (coverage gap, geometric-tolerance edge) silently fell back to periodic wrapping — wrong physics for the non-periodic 2D geometries that dominate real use, and the proximate cause of silent zero-Jacobian rows (#1098). This violated the project's #547 "no silent fallbacks" line.

## Change (None-sentinel + fail-loud)

- **Field**: `default_bc: BCType | None = None` ("unspecified").
- **Fail-loud at point→BC resolution** via the new `BoundaryConditions._resolve_default_bc(context)`: `get_bc_at_point` and `get_bc_type_at_boundary`, plus the applicators (`applicator_implicit`, `applicator_meshfree` field + particles), `fp_gfdm._resolve_boundary_type`, and `base_solver` (`get_domain_constraints`, `get_environment_boundary_config`). When `default_bc` is `None` **and** a point falls through to the default, a clear `ValueError` is raised:
  > `...point/segment matched no BC and default_bc was not specified on BoundaryConditions; set default_bc=BCType.NO_FLUX / PERIODIC / DIRICHLET explicitly (Issue #1100).`
- **Pattern A vs B distinguished**:
  - *Pattern A (resolution — "what BC at unmatched point X")* → fail loud (above).
  - *Pattern B (global property)* → `None`-safe, never crashes: `validate_boundary_conditions` `has_periodic` (`None == BCType.PERIODIC` is `False`), and all `.value`/`__repr__`/`validate()` warnings guard `None` (report `"unspecified"`).
- **`boundary_handler.create_bc_config`**: a *segmented* (mixed) BC is "specified" even when `default_bc` is `None` — per-point dispatch (`_get_bc_type_for_point`) enforces each point, so it returns a `"mixed"` sentinel rather than failing the "BC specified" gate; only a genuinely empty BC returns `None`. This fixes a real regression where a mixed BC covering all boundaries via segments would otherwise be wrongly rejected (matches the issue's own "or all segments must collectively cover the boundary").
- **Factory**: `mixed_bc_from_regions` no-`"default"`-segment fallback `PERIODIC` → `NO_FLUX` (safe, mass-conserving). The default-segment path and the `*_bc()` factories (which already set `default_bc` explicitly) are unchanged.

**Explicit-BC paths (no-flux / Dirichlet / explicit-periodic) are byte-identical.**

## Migration

- `mixed_bc_from_regions` no-default test → asserts `NO_FLUX` (factory default changed).
- `test_basic_creation` → asserts `default_bc is None` (new sentinel).
- `test_3d_problem` (dispatch test) → `default_bc=BCType.PERIODIC` made explicit (intent preserved).
- `resolved_bc_to_boundary_conditions` bridge + two FP-SL `__main__` smoke tests → explicit `NO_FLUX` (no-flux intent; matches the empty-resolved `no_flux_bc` default).
- Stale `hjb_gfdm` docstrings updated to past-tense (Issue #1100).

## New test (`tests/unit/test_geometry/test_default_bc_explicit_1100.py`)

(a) unset default + unmatched point → clear `ValueError`; (b) explicit `default_bc=PERIODIC` still resolves fall-through points to PERIODIC (equivalence); (c) `__str__`/`validate()`/`validate_boundary_conditions` on a `default_bc=None` object do not crash.

## Gate

`tests/unit tests/integration -m "not slow"` → **4744 passed, 0 failed** (27 skipped, 3 xfailed; 103 `slow`-marked Newton-solve tests deselected per PR-CI). `tests/unit` alone (incl. slow) → **4531 passed, 0 failed**. The deselected slow Newton tests are verified pre-existing-slow on `main` (≥6 min/test, byte-identical BC code path) — not a regression. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
