### PR TITLE
refactor(utils): replace hasattr() duck-typing with getattr pattern — Cluster B

### DIFF
--- a/mfgarchon/utils/exceptions.py
+++ b/mfgarchon/utils/exceptions.py
@@ -357,7 +357,7 @@ def _generate_stability_suggestions(instability_type: str, problematic_values: d
 
 def validate_solver_state(solver, operation_name: str):
     """Validate that solver has been run before accessing results."""
-    if not hasattr(solver, "_solution_computed") or not solver._solution_computed:
+    if not getattr(solver, "_solution_computed", False):
         raise SolutionNotAvailableError(
             operation_attempted=operation_name,
             solver_name=getattr(solver, "__class__", type(solver)).__name__,

--- a/mfgarchon/utils/memory_management.py
+++ b/mfgarchon/utils/memory_management.py
@@ -224,9 +224,15 @@ def memory_monitored(
 
             finally:
                 if cleanup_on_exit:
-                    # Cleanup temporary variables
-                    if hasattr(self, "_temp_arrays"):
-                        monitor.cleanup_arrays(*self._temp_arrays)
+                    # Cleanup temporary variables. The decorated method may belong
+                    # to any class, so `_temp_arrays` is an optional attribute on a
+                    # foreign instance (the decorator owns no __init__ to declare it).
+                    # Use the getattr-with-default pattern per CLAUDE.md rather than
+                    # hasattr duck-typing or a bare attribute access that would raise
+                    # for instances that never define it.
+                    temp_arrays = getattr(self, "_temp_arrays", None)
+                    if temp_arrays is not None:
+                        monitor.cleanup_arrays(*temp_arrays)
 
                     # Force garbage collection
                     gc.collect()

--- a/tests/unit/test_utils/test_no_hasattr_cluster_b.py
+++ b/tests/unit/test_utils/test_no_hasattr_cluster_b.py
@@ -1,0 +1,128 @@
+"""Pinning tests for Issue #1068 Cluster B (utils/ hasattr removal).
+
+Cluster A (core/) was handled by PR #1307. Cluster B replaces the two
+internal-duck-typing `hasattr()` sites in `utils/` with CLAUDE.md patterns:
+
+- ``utils/exceptions.py`` ``validate_solver_state`` — getattr-with-default.
+- ``utils/memory_management.py`` ``memory_monitored`` cleanup — getattr-with-default
+  (the decorator wraps methods of arbitrary classes, so ``_temp_arrays`` is an
+  optional attribute on a foreign instance; there is no __init__ to None-init).
+
+The two array-likeness checks in ``cleanup_arrays`` (``hasattr(arr, "shape")`` /
+``"size"`` / ``"__len__"``) are intentionally KEPT: they are external duck-typing
+on array-like objects (numpy/torch/jax), allowed by CLAUDE.md's "External Library
+Feature Detection". Narrowing them to ``isinstance(np.ndarray)`` would wrongly
+exclude torch/jax tensors.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.utils import exceptions, memory_management
+from mfgarchon.utils.exceptions import SolutionNotAvailableError
+from mfgarchon.utils.memory_management import memory_monitored
+
+
+def _hasattr_call_count(func) -> int:
+    """Count ``hasattr(...)`` call nodes in a function's source body."""
+    source = inspect.getsource(func)
+    tree = ast.parse(source.lstrip())
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "hasattr"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural pins: the refactored sites must contain no hasattr() duck-typing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_solver_state_has_no_hasattr():
+    assert _hasattr_call_count(exceptions.validate_solver_state) == 0
+
+
+@pytest.mark.unit
+def test_memory_monitored_has_no_hasattr():
+    # memory_monitored is a decorator factory; its source includes the inner
+    # wrapper where the `_temp_arrays` check lived.
+    assert _hasattr_call_count(memory_management.memory_monitored) == 0
+
+
+# ---------------------------------------------------------------------------
+# Behavioral pins: getattr-with-default preserves the original truthiness.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_solver_state_missing_attr_raises():
+    """A solver lacking ``_solution_computed`` entirely must still raise.
+
+    This exercises the getattr default-False branch that replaced
+    ``not hasattr(...) or not ...``.
+    """
+
+    class BareSolver:
+        pass
+
+    with pytest.raises(SolutionNotAvailableError):
+        exceptions.validate_solver_state(BareSolver(), "get_solution")
+
+
+@pytest.mark.unit
+def test_validate_solver_state_false_flag_raises():
+    class NotComputed:
+        def __init__(self):
+            self._solution_computed = False
+
+    with pytest.raises(SolutionNotAvailableError):
+        exceptions.validate_solver_state(NotComputed(), "get_solution")
+
+
+@pytest.mark.unit
+def test_validate_solver_state_true_flag_passes():
+    class Computed:
+        def __init__(self):
+            self._solution_computed = True
+
+    assert exceptions.validate_solver_state(Computed(), "get_solution") is None
+
+
+@pytest.mark.unit
+def test_memory_monitored_cleanup_without_temp_arrays_does_not_raise():
+    """A decorated class that never defines ``_temp_arrays`` must not raise.
+
+    This is the foreign-instance path: the getattr default (None) is what keeps
+    a bare attribute access from raising AttributeError here.
+    """
+
+    class NoTempArrays:
+        @memory_monitored(max_memory_gb=100.0, cleanup_on_exit=True)
+        def run(self):
+            return "ok"
+
+    assert NoTempArrays().run() == "ok"
+
+
+@pytest.mark.unit
+def test_memory_monitored_cleanup_with_temp_arrays_runs():
+    """A decorated class that defines ``_temp_arrays`` still gets cleaned up."""
+
+    class WithTempArrays:
+        def __init__(self):
+            self._temp_arrays: list[np.ndarray] = []
+
+        @memory_monitored(max_memory_gb=100.0, cleanup_on_exit=True)
+        def run(self):
+            self._temp_arrays.append(np.ones((1500, 700)))
+            return "done"
+
+    assert WithTempArrays().run() == "done"


### PR DESCRIPTION
## Summary

Replaces the two remaining **internal** `hasattr()` duck-typing sites in `utils/` with the CLAUDE.md getattr-with-default pattern. No behavior change. Refs #1068; this is Cluster B (Cluster A / `core/` was done in PR #1307, jax cluster in #1094).

| File | Line | Old | New |
|---|---|---|---|
| `utils/exceptions.py` | 360 | `not hasattr(s, "_solution_computed") or not s._solution_computed` | `not getattr(s, "_solution_computed", False)` |
| `utils/memory_management.py` | 228 | `if hasattr(self, "_temp_arrays")` | `temp_arrays = getattr(self, "_temp_arrays", None); if temp_arrays is not None:` |

Both are behavior-preserving (identical truthiness for all sane inputs).

## Why getattr, not "init in `__init__` / None-init" for `memory_management.py:228`

The issue suggested the runtime-attribute / `None`-init treatment for this site. That prescription does **not** fit the code: line 228 lives inside the `memory_monitored` **decorator**, whose `self` is an arbitrary *foreign* class instance. The decorator owns no `__init__`, and decorated classes that never define `_temp_arrays` exist (e.g. the existing `test_memory_monitored_decorator_raise_on_exceed` mock). A bare `if self._temp_arrays:` / `is not None` without a default would raise `AttributeError` for those. `getattr(self, "_temp_arrays", None)` is the correct CLAUDE.md form here ("Optional Configuration getattr pattern") and is what keeps the missing-attr instances safe.

## Intentionally KEPT as-is

The two array-likeness checks in `cleanup_arrays` (`hasattr(arr, "shape")` / `"size"` / `"__len__"`, lines 108/113) are **not** changed. They are external duck-typing on array-like objects (numpy/torch/jax), allowed by CLAUDE.md "External Library Feature Detection". Narrowing them to `isinstance(np.ndarray)` would wrongly exclude torch/jax tensors.

## Pinning tests

`tests/unit/test_utils/test_no_hasattr_cluster_b.py`:
- **2 structural** — AST-parse each refactored function, assert zero `hasattr()` call nodes remain.
- **5 behavioral** — both truthiness branches of `validate_solver_state` (missing attr, `False` flag, `True` flag) and both decorator-cleanup paths (foreign instance without `_temp_arrays` does not raise; instance with `_temp_arrays` still cleans up).

## Test plan

- [x] `tests/unit/test_utils/test_no_hasattr_cluster_b.py` 7/7 pass
- [x] `tests/unit/test_utils/test_exceptions.py` + `test_memory_management.py`: 77/77 pass
- [x] full `tests/unit/test_utils/`: 882 passed
- [x] `ruff format --check` clean; `ruff check` clean

## #1068 coverage map (for close decision)

| Cluster | Sites | Status |
|---|---|---|
| 2 — `backends/jax_backend.py` `_jit_*` | 4 | done (PR #1094) |
| A — `core/mfg_components.py` + `hamiltonian.py` | 6 | done (PR #1307) |
| 3 — `types/protocols.py:143,183` | 2 | **false positive** — those lines are docstring *examples* of what the (already `@runtime_checkable`) Protocols eliminated under Issue #543; no live `hasattr` there |
| B — `utils/exceptions.py`, `utils/memory_management.py` | 2 | this PR |

After this PR there are no live internal `hasattr` duck-typing sites left from the #1068 list. Using `Refs` rather than `Closes` so the maintainer can confirm Cluster 3 needs no docstring edit before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)