### PR TITLE
fix(algorithms): gate inner_solver='howard' against CongestionHamiltonian

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -3161,6 +3161,20 @@ class HJBGFDMSolver(BaseHJBSolver):
                     "inner_solver='howard' derives alpha* = -dH/dp (MINIMIZE sense); the Hamiltonian "
                     "uses MAXIMIZE, which needs alpha* = +dH/dp. Use inner_solver='newton' (deferred)."
                 )
+        # CongestionHamiltonian (Issue #782) carries a MULTIPLICATIVE kinetic factor c(m):
+        # H = |p|^2/(2*lambda*c(m)) + V(x, t) + f(m). The control-cost gate above does NOT catch
+        # it — c(m) lives in `_congestion_factor`, outside control_cost (a plain unit-quadratic
+        # QuadraticControlCost here) — and V(x)/f(m) are wired below, but the congestion factor
+        # is not: Howard's policy evaluation hardcodes the unit-quadratic Lagrangian (1/2)|alpha|^2
+        # (hjb_howard.py _howard_step RHS) with no c(m) factor, so the value function silently
+        # decouples from the congestion. Gate on the factor directly. Fail loud.
+        if getattr(H_class, "_congestion_factor", None) is not None:
+            raise NotImplementedError(
+                "inner_solver='howard' does not support multiplicative kinetic congestion c(m) "
+                "(CongestionHamiltonian): Howard hardcodes the unit-quadratic Lagrangian "
+                "(1/2)|alpha|^2 with no c(m) factor, so the value function silently decouples from "
+                "the congestion. Use inner_solver='newton' (deferred, Issue #1071/#1118 PR2)."
+            )
         # BC parity (Issue #1118 PR2a): the howard path now consumes the provider's shared
         # value-form BC rows (`_value_form_bc_rows` -> `_bc_row_for_point`), so it honors
         # Dirichlet VALUES and the real Neumann normal·grad stencil (not the legacy

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -32,6 +32,7 @@ pytest.importorskip("cvxpy")
 from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import HJBHowardSolver
 from mfgarchon.core.hamiltonian import (
+    CongestionHamiltonian,
     OptimizationSense,
     QuadraticControlCost,
     SeparableHamiltonian,
@@ -489,6 +490,32 @@ def test_integrated_howard_rejects_maximize_sense():
     )
     gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
     with pytest.raises(NotImplementedError, match="MAXIMIZE"):
+        gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
+
+
+def test_integrated_howard_rejects_congestion_hamiltonian():
+    """CongestionHamiltonian's multiplicative kinetic factor c(m) defeats Howard's hardcoded
+    unit-quadratic (1/2)|alpha|^2 Lagrangian -> fail loud.
+
+    The congestion factor lives in `_congestion_factor`, OUTSIDE control_cost: here the control
+    cost is a plain unit-quadratic QuadraticControlCost(1.0) (lambda=1, MINIMIZE) and the
+    additive V/f(m) slots are None, so this Hamiltonian passes EVERY prior gate
+    (control-cost/sense and the V/f(m) wiring). Without the dedicated congestion gate, Howard
+    would hardcode H = |p|^2/(2*lambda*c(m)) as (1/2)|alpha|^2 and silently solve the wrong
+    (uncongested) value function. The dedicated gate reads `_congestion_factor` and raises.
+    """
+    H = CongestionHamiltonian(
+        control_cost=QuadraticControlCost(lambda_=1.0),
+        congestion_factor=lambda m: 2.0,
+    )
+    # Confirm the trap: all prior gates' sources are benign.
+    assert H._congestion_factor is not None
+    assert H._potential is None
+    assert H._coupling is None
+    assert isinstance(H.control_cost, QuadraticControlCost)
+    assert H.control_cost.lambda_ == 1.0
+    gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
+    with pytest.raises(NotImplementedError, match="congestion"):
         gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
 
 


### PR DESCRIPTION
## Problem (audit CRITICAL, 2026-06-14)

`inner_solver='howard'` silently solves the WRONG physics for a `CongestionHamiltonian`.

`HJBGFDMSolver._solve_backward_howard` (`hjb_gfdm.py`) gates against non-unit control cost, non-quadratic control cost, and the MAXIMIZE sense, and wires `V(x)`/`f(m)` into Howard's running-cost slot. None of these catch the **multiplicative kinetic factor** `c(m)`:

- `CongestionHamiltonian` (#782): `H = |p|^2 / (2*lambda*c(m)) + V(x, t) + f(m)`. The density coupling rides the kinetic term via `_congestion_factor`.
- Howard's policy evaluation (`hjb_howard.py` `_howard_step` RHS) hardcodes the unit-quadratic Lagrangian `(1/2)|alpha|^2` with **no** `c(m)`.

`CongestionHamiltonian(control_cost=QuadraticControlCost(1.0), congestion_factor=lambda m: 2.0)` has `_congestion_factor` set but `_potential = _coupling = None` and `control_cost = QuadraticControlCost` (lambda=1, MINIMIZE), so it passes **every** existing gate. Howard then converges to the uncongested value function, silently decoupled from the congestion — diverging from Newton with no error.

## Fix

Add a dedicated gate in `_solve_backward_howard` (after the control-cost/sense gates) that fail-louds when `getattr(H_class, "_congestion_factor", None) is not None`, matching the sibling reject-gate style and pointing at `inner_solver='newton'`.

## Pinning test

`tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_congestion_hamiltonian` (parallel to the existing `rejects_*` tests). It asserts the trap (all prior gates' sources benign) and that the solve raises `NotImplementedError` matching `congestion`.

- Without the gate: **FAILS** (`DID NOT RAISE`).
- With the gate: **PASSES**.

## Gate evidence

- `ruff format --check`: 2 files already formatted.
- `ruff check`: All checks passed.
- `pytest tests/unit/test_alg/test_hjb_howard_solver.py`: **29 passed** (28 existing incl. the #1247 `test_integrated_howard_matches_newton_nonlq` agreement gate + 1 new).

Refs #1247 #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)