### PR TITLE
fix(config): fail-loud on unmapped scheme + non-default hjb/fp method in translator

### DIFF
--- a/mfgarchon/config/translator.py
+++ b/mfgarchon/config/translator.py
@@ -113,6 +113,10 @@ def hjb_config_to_kwargs(
     # Top-level fields: method, accuracy_order, boundary_conditions
     # ------------------------------------------------------------------
     if hjb_cfg.method != default_hjb.method:
+        # Each scheme maps to the HJBConfig.method literal whose solver it builds.
+        # FVM_{UPWIND,MUSCL} pair the upwind HJB-FDM solver (method "fdm").
+        # MESHLESS_GALERKIN has no HJBConfig.method literal analog and is absent here
+        # on purpose -> handled by the unmapped-scheme fallback below.
         _scheme_method = {
             NumericalScheme.FDM_UPWIND: "fdm",
             NumericalScheme.FDM_CENTERED: "fdm",
@@ -121,9 +125,20 @@ def hjb_config_to_kwargs(
             NumericalScheme.GFDM: "gfdm",
             NumericalScheme.FEM_P1: "fem",
             NumericalScheme.FEM_P2: "fem",
+            NumericalScheme.FVM_UPWIND: "fdm",
+            NumericalScheme.FVM_MUSCL: "fdm",
         }
         expected = _scheme_method.get(scheme)
-        if expected is not None and hjb_cfg.method != expected:
+        if expected is None:
+            # No HJBConfig.method literal corresponds to this scheme, so a non-default
+            # method cannot be reconciled with it. Fail loud rather than silently
+            # discarding the user's intent (the scheme selects the solver class). Refs #1155.
+            raise NotImplementedError(
+                f"config.hjb.method={hjb_cfg.method!r} is non-default but "
+                f"scheme={scheme.value} has no HJBConfig.method analog to validate "
+                "against (the scheme selects the HJB solver class directly). Refs #1155."
+            )
+        if hjb_cfg.method != expected:
             raise NotImplementedError(
                 f"config.hjb.method={hjb_cfg.method!r} conflicts with "
                 f"scheme={scheme.value} (expected method {expected!r}). "
@@ -350,17 +365,30 @@ def fp_config_to_kwargs(
     # ------------------------------------------------------------------
     # method field: validate scheme consistency
     # ------------------------------------------------------------------
+    # Each scheme maps to the FPConfig.method literal whose FP solver it builds.
+    # SL_{LINEAR,CUBIC} (FPSLSolver), FVM_{UPWIND,MUSCL} (FPFVMSolver) and
+    # MESHLESS_GALERKIN (MeshlessGalerkinFPSolver) have NO FPConfig.method literal
+    # analog (no "sl"/"fvm"/"meshless" member), so they are absent here on purpose ->
+    # a non-default fp.method under them fails loud via the unmapped-scheme fallback.
     _scheme_fp_method: dict[NumericalScheme, str] = {
         NumericalScheme.FDM_UPWIND: "fdm",
         NumericalScheme.FDM_CENTERED: "fdm",
         NumericalScheme.GFDM: "gfdm",
         NumericalScheme.FEM_P1: "fem",
         NumericalScheme.FEM_P2: "fem",
-        # SL → FPSLSolver has no analog in FPConfig.method literals
     }
     if fp_cfg.method != default_fp.method:
         expected = _scheme_fp_method.get(scheme)
-        if expected is not None and fp_cfg.method != expected:
+        if expected is None:
+            # No FPConfig.method literal corresponds to this scheme, so a non-default
+            # method cannot be reconciled with it. Fail loud rather than silently
+            # discarding the user's intent (the scheme selects the FP solver class). Refs #1155.
+            raise NotImplementedError(
+                f"config.fp.method={fp_cfg.method!r} is non-default but "
+                f"scheme={scheme.value} has no FPConfig.method analog to validate "
+                "against (the scheme selects the FP solver class directly). Refs #1155."
+            )
+        if fp_cfg.method != expected:
             raise NotImplementedError(
                 f"config.fp.method={fp_cfg.method!r} conflicts with "
                 f"scheme={scheme.value} (expected method {expected!r}). "

--- a/tests/unit/test_config/test_config_translator.py
+++ b/tests/unit/test_config/test_config_translator.py
@@ -144,6 +144,48 @@ class TestHJBConfigToKwargs:
         with pytest.raises(NotImplementedError, match="Refs #1155"):
             hjb_config_to_kwargs(cfg, NumericalScheme.FDM_UPWIND)
 
+    # ------------------------------------------------------------------
+    # Schemes previously missing from the HJB scheme->method map (Refs #1155):
+    # FVM_UPWIND / FVM_MUSCL / SL_CUBIC must reject a contradictory non-default
+    # method, and MESHLESS_GALERKIN (no method analog) must fail loud rather than
+    # silently discard a non-default method.
+    # ------------------------------------------------------------------
+
+    def test_method_fvm_upwind_conflict_raises(self):
+        """Non-default hjb.method with FVM_UPWIND (analog 'fdm') raises NotImplementedError."""
+        cfg = HJBConfig(method="gfdm")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.FVM_UPWIND)
+
+    def test_method_fvm_muscl_conflict_raises(self):
+        """Non-default hjb.method with FVM_MUSCL (analog 'fdm') raises NotImplementedError."""
+        cfg = HJBConfig(method="semi_lagrangian")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.FVM_MUSCL)
+
+    def test_method_sl_cubic_conflict_raises(self):
+        """Non-default hjb.method contradicting SL_CUBIC (analog 'semi_lagrangian') raises."""
+        cfg = HJBConfig(method="gfdm")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.SL_CUBIC)
+
+    def test_method_meshless_galerkin_nondefault_raises(self):
+        """MESHLESS_GALERKIN has no HJBConfig.method analog: any non-default method fails loud."""
+        cfg = HJBConfig(method="gfdm")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            hjb_config_to_kwargs(cfg, NumericalScheme.MESHLESS_GALERKIN)
+
+    def test_method_fvm_consistent_fdm_accepted(self):
+        """FVM pairs HJB=FDM; the consistent method ('fdm') is accepted, no kwargs."""
+        cfg = HJBConfig(method="fdm")
+        assert hjb_config_to_kwargs(cfg, NumericalScheme.FVM_UPWIND) == {}
+
+    def test_method_sl_cubic_consistent_accepted(self):
+        """SL_CUBIC analog is 'semi_lagrangian'; the consistent method is accepted."""
+        cfg = HJBConfig(method="semi_lagrangian")
+        # No conflict raised; a matching method adds no kwarg.
+        assert hjb_config_to_kwargs(cfg, NumericalScheme.SL_CUBIC) == {}
+
 
 class TestFPConfigToKwargs:
     """Unit tests for fp_config_to_kwargs."""
@@ -194,6 +236,34 @@ class TestFPConfigToKwargs:
         cfg = FPConfig(method="fem")
         with pytest.raises(NotImplementedError, match="Refs #1155"):
             fp_config_to_kwargs(cfg, NumericalScheme.GFDM)
+
+    # ------------------------------------------------------------------
+    # Schemes with no FPConfig.method literal analog (FPSLSolver / FPFVMSolver /
+    # MeshlessGalerkinFPSolver). A non-default fp.method under them must fail loud
+    # rather than be silently discarded (Refs #1155).
+    # ------------------------------------------------------------------
+
+    def test_fp_method_fvm_upwind_nondefault_raises(self):
+        """Non-default fp.method with FVM_UPWIND (no 'fvm' analog) raises NotImplementedError."""
+        cfg = FPConfig(method="fdm")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            fp_config_to_kwargs(cfg, NumericalScheme.FVM_UPWIND)
+
+    def test_fp_method_sl_cubic_nondefault_raises(self):
+        """Non-default fp.method with SL_CUBIC (no 'sl' analog) raises NotImplementedError."""
+        cfg = FPConfig(method="fdm")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            fp_config_to_kwargs(cfg, NumericalScheme.SL_CUBIC)
+
+    def test_fp_method_meshless_galerkin_nondefault_raises(self):
+        """Non-default fp.method with MESHLESS_GALERKIN (no analog) raises NotImplementedError."""
+        cfg = FPConfig(method="fem")
+        with pytest.raises(NotImplementedError, match="Refs #1155"):
+            fp_config_to_kwargs(cfg, NumericalScheme.MESHLESS_GALERKIN)
+
+    def test_fp_default_method_unmapped_scheme_no_raise(self):
+        """Default fp.method ('particle') under an unmapped scheme is skipped (no raise)."""
+        assert fp_config_to_kwargs(FPConfig(), NumericalScheme.FVM_UPWIND) == {}
 
 
 class TestPicardConfigToIteratorKwargs:


### PR DESCRIPTION
## Problem

The config translator (`mfgarchon/config/translator.py`) **silently skipped** its scheme/method conflict check for any scheme absent from its scheme->method maps, violating the translator's own stated principle (translator.py:9-13: "non-default with no mapping -> raise NotImplementedError").

- `_scheme_method` (HJB) was missing `FVM_UPWIND` / `FVM_MUSCL`. `MESHLESS_GALERKIN` has no `HJBConfig.method` literal analog at all.
- `_scheme_fp_method` (FP) was missing `FVM_{UPWIND,MUSCL}`, `SL_{LINEAR,CUBIC}`, and `MESHLESS_GALERKIN`.

For an unmapped scheme, `dict.get(scheme)` returned `None` and the `if expected is not None and method != expected` guard was skipped. So:

```python
hjb_config_to_kwargs(HJBConfig(method="gfdm"), scheme=NumericalScheme.FVM_UPWIND)
```

returned `{}` — the contradictory non-default method was **silently discarded** instead of failing loud.

## Fix

- Add `FVM_UPWIND` / `FVM_MUSCL` -> `"fdm"` to the HJB map (both pair the upwind HJB-FDM solver; see `scheme_factory._create_fvm_pair`). `SL_CUBIC` -> `"semi_lagrangian"` was already present.
- Add an **unmapped-scheme fallback** to BOTH maps: a non-default method on a scheme with no `HJBConfig` / `FPConfig.method` literal analog now raises `NotImplementedError` rather than silently skipping. This covers `MESHLESS_GALERKIN` (HJB: no analog) and `SL_*` / `FVM_*` / `MESHLESS_GALERKIN` (FP: no `"sl"`/`"fvm"`/`"meshless"` literal — `FPConfig.method` literals are `fdm`/`fem`/`particle`/`network`).
- Only valid pydantic `Literal` method values are used; no invented literals.

Net: a non-default hjb/fp method that contradicts the scheme always fail-louds; a consistent one (or the default) is honored unchanged.

## Tests (`tests/unit/test_config/test_config_translator.py`)

- Non-default `hjb.method` + `FVM_UPWIND` / `FVM_MUSCL` / `SL_CUBIC` / `MESHLESS_GALERKIN` raises `NotImplementedError` (Refs #1155).
- Symmetric `fp.method` fallback tests for FVM / SL_CUBIC / MESHLESS_GALERKIN.
- Consistent-method acceptance (`fdm`+FVM, `semi_lagrangian`+SL_CUBIC) and default-method-under-unmapped-scheme acceptance.
- The new FVM/MESHLESS pinning tests **FAIL without the fix** (verified: DID NOT RAISE = silent skip) and **PASS with it**.

## Gate evidence

- `test_config_translator.py` + `test_solve_config_hjb_fp_guard.py`: **45 passed** (39 translator incl. 10 new, 6 guard).
- Broader `tests/unit/test_config/`: **194 passed**.
- `ruff format --check` + `ruff check` on both changed files: clean.

Refs #1155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)