### PR TITLE
fix(algorithms): CFL diffusive diagnostic uses D=σ²/2; list all schemes in factory error

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -265,7 +265,9 @@ class FPFDMSolver(BaseFPSolver):
             dt = self.problem.dt
             dx = self.problem.geometry.get_grid_spacing()[0]
             sigma = volatility_field if isinstance(volatility_field, (int, float)) else self.problem.sigma
-            cfl_diffusive = sigma**2 * dt / dx**2
+            # Diffusive CFL uses the PDE diffusion coefficient D = sigma^2/2 (single source:
+            # diffusion_from_volatility, applied at D = 0.5 * sigma**2 below), not the bare sigma^2.
+            cfl_diffusive = 0.5 * sigma**2 * dt / dx**2
             if cfl_diffusive > 0.5:
                 log_fn = logger.debug if getattr(self, "_cfl_logged", False) else logger.info
                 log_fn(

--- a/mfgarchon/factory/scheme_factory.py
+++ b/mfgarchon/factory/scheme_factory.py
@@ -109,8 +109,8 @@ def create_paired_solvers(
     else:
         raise NotImplementedError(
             f"Scheme {scheme.value} is defined but not yet implemented in factory. "
-            f"Available schemes: FDM_UPWIND, FDM_CENTERED, SL_LINEAR, GFDM, FEM_P1, FEM_P2, "
-            f"FVM_UPWIND, FVM_MUSCL"
+            f"Available schemes: FDM_UPWIND, FDM_CENTERED, SL_LINEAR, SL_CUBIC, GFDM, "
+            f"FEM_P1, FEM_P2, MESHLESS_GALERKIN, FVM_UPWIND, FVM_MUSCL"
         )
 
     # FVM is an FP-only conservative scheme with no HJB-FVM partner yet: it is paired with the

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -1275,5 +1275,54 @@ class TestVaryingSigmaExplicitDriftPerPoint:
         assert abs(m.sum() * dx - 1.0) < 1e-9
 
 
+class TestFPFDMSolverCFLDiagnostic:
+    """Pin the CFL diffusive diagnostic to the D = sigma^2/2 convention."""
+
+    def test_cfl_diffusive_uses_D_equals_half_sigma_squared(self, standard_problem):
+        """The logged diffusive CFL must use D = sigma^2/2, not the bare sigma^2.
+
+        Regression guard: the diagnostic previously computed sigma^2 * dt / dx^2, a 2x
+        overstatement relative to the diffusion coefficient D = 0.5 * sigma^2 actually
+        assembled by the solver (single source: diffusion_from_volatility / D = 0.5*sigma**2).
+        Capture the log record's formatting arg and pin it to the halved value.
+        """
+        import logging
+
+        from mfgarchon.alg.numerical.fp_solvers import fp_fdm as fp_fdm_module
+
+        solver = FPFDMSolver(standard_problem)
+
+        sigma = standard_problem.sigma
+        dt = standard_problem.dt
+        dx = standard_problem.geometry.get_grid_spacing()[0]
+        expected = 0.5 * sigma**2 * dt / dx**2
+        # Sanity: this configuration must exceed the 0.5 threshold so the diagnostic logs.
+        assert expected > 0.5
+
+        records: list[logging.LogRecord] = []
+
+        class _Collector(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        module_logger = fp_fdm_module.logger
+        handler = _Collector()
+        old_level = module_logger.level
+        module_logger.addHandler(handler)
+        module_logger.setLevel(logging.DEBUG)
+        try:
+            solver._log_cfl_diagnostic()
+        finally:
+            module_logger.removeHandler(handler)
+            module_logger.setLevel(old_level)
+
+        cfl_records = [r for r in records if "CFL diagnostic" in r.msg]
+        assert cfl_records, "CFL diagnostic did not log for an above-threshold configuration"
+        logged_cfl = cfl_records[0].args[0]
+        assert logged_cfl == pytest.approx(expected)
+        # Explicitly pin the 2x: the old (bare sigma^2) value must be rejected.
+        assert logged_cfl != pytest.approx(sigma**2 * dt / dx**2)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_factory/test_scheme_factory.py
+++ b/tests/unit/test_factory/test_scheme_factory.py
@@ -6,6 +6,8 @@ Tests create_paired_solvers() function with all scheme variants.
 Issue #673: Updated to class-based Hamiltonian API.
 """
 
+import pytest
+
 import numpy as np
 
 from mfgarchon import MFGProblem
@@ -260,6 +262,26 @@ class TestCreatePairedSolversValidation:
         hjb, fp = create_paired_solvers(problem, NumericalScheme.SL_CUBIC)
         assert hjb is not None
         assert fp is not None
+
+    def test_unrouted_scheme_message_lists_every_routed_scheme(self):
+        """Pin the NotImplementedError 'Available schemes' message to the routed set.
+
+        Every NumericalScheme member is routed in the if-elif chain, so an unhandled
+        scheme cannot occur with the real enum. Use a sentinel with a `.value` attribute
+        to fall through to the else branch, then assert the message advertises all routed
+        schemes (regression guard: SL_CUBIC and MESHLESS_GALERKIN were previously omitted).
+        """
+        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+
+        class _FakeScheme:
+            value = "not_a_real_scheme"
+
+        with pytest.raises(NotImplementedError) as exc_info:
+            create_paired_solvers(problem, _FakeScheme())
+
+        message = str(exc_info.value)
+        for member in NumericalScheme:
+            assert member.name in message, f"{member.name} missing from 'Available schemes' message"
 
 
 class TestGetRecommendedScheme:


### PR DESCRIPTION
Fixes #1335

Two low-risk single-source/cosmetic fixes from a fresh audit (2026-06-14). Both are diagnostic/message-only — **no change to any `solve()` path**.

## 1. `fp_fdm.py` — CFL diffusive diagnostic off by 2x

`FPFDMSolver._log_cfl_diagnostic` computed `cfl_diffusive = sigma**2 * dt / dx**2`, but the diffusion coefficient the solver actually assembles is `D = σ²/2` (single source `diffusion_from_volatility`; applied as `D = 0.5 * scalar_sigma**2` at `fp_fdm.py:730`). The diffusive CFL number is `D·dt/dx²`, so the diagnostic overstated CFL by 2x and the `> 0.5` threshold fired too eagerly.

The implicit scheme is unconditionally stable → diagnostic-only, but the logged value was misleading.

```diff
-            cfl_diffusive = sigma**2 * dt / dx**2
+            cfl_diffusive = 0.5 * sigma**2 * dt / dx**2
```

The `> 0.5` threshold (explicit-diffusion stability limit on `D·dt/dx²`) now reads sensibly.

## 2. `scheme_factory.py` — error message omitted 2 routed schemes

The fall-through `NotImplementedError` "Available schemes" message listed 8 schemes but omitted `SL_CUBIC` and `MESHLESS_GALERKIN`, both routed in the if-elif chain above and valid `NumericalScheme` members. All 10 enum members are routed; the message now lists all 10.

## Tests (pinning, fail-without / pass-with verified)

- `test_cfl_diffusive_uses_D_equals_half_sigma_squared` — attaches a handler to the module logger (logger has `propagate=False`, so caplog is unreliable), captures the logged CFL formatting arg, pins it to `0.5·σ²·dt/dx²`, and rejects the bare `σ²` value. Without the fix it logs `49.02` (= 2x) and fails.
- `test_unrouted_scheme_message_lists_every_routed_scheme` — feeds a `.value`-bearing sentinel to hit the `else` branch and asserts the message advertises every `NumericalScheme` member. Without the fix it fails on `SL_CUBIC`.

## Gate evidence

- `tests/unit/test_alg/test_fp_fdm_solver.py` + `tests/unit/test_factory/` → **134 passed**.
- `ruff format --check` → 4 files already formatted; `ruff check` → All checks passed.
- Reverting the two production lines makes exactly the two new tests fail (CFL logs `49.02`; factory message missing `SL_CUBIC`); restoring makes them pass.

Refs the single-source diffusion convention `D = σ²/2` (Issue #811).

🤖 Generated with [Claude Code](https://claude.com/claude-code)