### PR TITLE
refactor(fp): rename enforce_obstacle_boundary → project_to_navigable_or_defer (Fixes #1067)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -35,9 +35,9 @@ from mfgarchon.utils.numerical.particle import (
 
 from .base_fp import BaseFPSolver, DriftConvention
 from .fp_particle_bc import apply_boundary_conditions as _apply_bc
-from .fp_particle_bc import enforce_obstacle_boundary as _enforce_obstacle
 from .fp_particle_bc import get_topology_per_dimension as _get_topology
 from .fp_particle_bc import needs_segment_aware_bc as _needs_segment_bc
+from .fp_particle_bc import project_to_navigable_or_defer as _project_to_navigable
 from .fp_particle_density import generate_brownian_increment as _gen_brownian
 from .fp_particle_density import normalize_density as _normalize
 from .particle_result import FPParticleResult
@@ -922,11 +922,14 @@ class FPParticleSolver(BaseFPSolver):
         """
         return _get_topology(self.boundary_conditions, dimension)
 
-    def _enforce_obstacle_boundary(self, particles: np.ndarray) -> np.ndarray:
+    def _project_obstacle_violations(self, particles: np.ndarray) -> np.ndarray:
         """
-        Enforce obstacle boundaries via implicit domain geometry (Issue #533).
+        Project obstacle-interior violations back to the navigable region;
+        defer outer-boundary violations to the caller's BC (Issue #533, #1067).
 
-        Delegates to unified enforce_obstacle_boundary() from fp_particle_bc module.
+        Delegates to unified project_to_navigable_or_defer() from fp_particle_bc.
+        Particles past the outer bounding box are left for the segment-aware BC
+        layer; only obstacle-interior violations are projected here.
 
         Parameters
         ----------
@@ -938,7 +941,7 @@ class FPParticleSolver(BaseFPSolver):
         particles : np.ndarray
             Updated particle positions with obstacle violations corrected
         """
-        return _enforce_obstacle(particles, self._implicit_domain)
+        return _project_to_navigable(particles, self._implicit_domain)
 
     def _infer_reflect_bounds(self, bounds: list[tuple[float, float]]) -> list[tuple[float, float]] | None:
         """
@@ -1828,7 +1831,7 @@ class FPParticleSolver(BaseFPSolver):
             new_particles = particles_t + drift * Dt + dW
 
             # Enforce obstacle boundaries if implicit domain is set (Issue #533)
-            new_particles = self._enforce_obstacle_boundary(new_particles)
+            new_particles = self._project_obstacle_violations(new_particles)
 
             # Apply boundary conditions
             if use_segment_aware_bc:
@@ -2356,7 +2359,7 @@ class FPParticleSolver(BaseFPSolver):
             new_particles = particles_t + drift * Dt + dW
 
             # Enforce obstacle boundaries if implicit domain is set (Issue #533)
-            new_particles = self._enforce_obstacle_boundary(new_particles)
+            new_particles = self._project_obstacle_violations(new_particles)
 
             # Apply boundary conditions — Issue #1042 fix: route to segment-aware
             # path when BC has Dirichlet (absorbing) segments, mirroring grid-drift.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle_bc.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle_bc.py
@@ -13,7 +13,7 @@ Usage:
     from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import (
         get_topology_per_dimension,
         apply_boundary_conditions,
-        enforce_obstacle_boundary,
+        project_to_navigable_or_defer,
         needs_segment_aware_bc,
     )
 """
@@ -291,12 +291,18 @@ def apply_boundary_conditions(
 # =============================================================================
 
 
-def enforce_obstacle_boundary(
+def project_to_navigable_or_defer(
     particles: np.ndarray,
     implicit_domain: ImplicitDomain | None,
 ) -> np.ndarray:
     """
-    Enforce obstacle boundaries via implicit domain geometry (dimension-agnostic).
+    Project obstacle-interior violations back to the navigable region; defer
+    outer-boundary violations to the caller's outer-BC layer (dimension-agnostic).
+
+    Particles past the outer bounding box are LEFT untouched for the caller's
+    outer-BC layer (segment-aware BC, topology, etc.); only particles that
+    entered an obstacle interior are corrected here. The name reflects this
+    conditional contract (Issue #1067): it is NOT comprehensive enforcement.
 
     If an implicit domain with obstacles is defined, particles that have
     entered obstacle regions (domain.contains() returns False AND inside outer
@@ -331,7 +337,7 @@ def enforce_obstacle_boundary(
     --------
     >>> from mfgarchon.geometry.implicit import DifferenceDomain, Hyperrectangle, Hypersphere
     >>> domain = DifferenceDomain(Hyperrectangle(...), Hypersphere(center=[0.5, 0.5], radius=0.1))
-    >>> particles = enforce_obstacle_boundary(particles, domain)
+    >>> particles = project_to_navigable_or_defer(particles, domain)
     """
     if implicit_domain is None:
         return particles
@@ -531,8 +537,8 @@ if __name__ == "__main__":
 
     # Test 8: Obstacle boundary (None domain - should pass through)
     particles_obs = np.array([[0.5, 0.5], [0.3, 0.3]])
-    result_obs = enforce_obstacle_boundary(particles_obs, None)
+    result_obs = project_to_navigable_or_defer(particles_obs, None)
     assert np.allclose(result_obs, particles_obs)
-    print("  enforce_obstacle_boundary (None domain): OK")
+    print("  project_to_navigable_or_defer (None domain): OK")
 
     print("\nAll smoke tests passed!")

--- a/tests/unit/test_alg/test_fp_particle_solver.py
+++ b/tests/unit/test_alg/test_fp_particle_solver.py
@@ -782,8 +782,8 @@ class TestFPParticleSolverCallableDrift:
         assert np.all(M >= -1e-10)
 
 
-class TestEnforceObstacleBoundary:
-    """Issue #1064: enforce_obstacle_boundary must respect outer-boundary
+class TestProjectToNavigableOrDefer:
+    """Issue #1064: project_to_navigable_or_defer must respect outer-boundary
     handling — only project obstacle-interior violations, leave outer-boundary
     violations for the caller's segment-aware BC."""
 
@@ -802,35 +802,35 @@ class TestEnforceObstacleBoundary:
 
     def test_obstacle_interior_projected(self):
         """Particle inside obstacle is projected back to navigable region."""
-        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import project_to_navigable_or_defer
 
         domain = self._make_diff_domain()
         particles = np.array([[0.3, 0.5]])  # obstacle center
-        result = enforce_obstacle_boundary(particles.copy(), domain)
+        result = project_to_navigable_or_defer(particles.copy(), domain)
         assert not np.allclose(result, particles), "Particle inside obstacle should have been projected out"
         assert domain.contains(result).all()
 
     def test_outer_bbox_violation_left_alone(self):
         """Issue #1064: Particle past outer bbox is NOT touched — caller's BC handles it."""
-        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import project_to_navigable_or_defer
 
         domain = self._make_diff_domain()
         particles = np.array([[1.5, 0.5]])  # past right wall x=1.5 > bbox max 1.0
-        result = enforce_obstacle_boundary(particles.copy(), domain)
+        result = project_to_navigable_or_defer(particles.copy(), domain)
         np.testing.assert_array_equal(result, particles)
 
     def test_navigable_particles_untouched(self):
         """Particles in navigable region are unchanged."""
-        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import project_to_navigable_or_defer
 
         domain = self._make_diff_domain()
         particles = np.array([[0.1, 0.1], [0.9, 0.5], [0.3, 0.7]])
-        result = enforce_obstacle_boundary(particles.copy(), domain)
+        result = project_to_navigable_or_defer(particles.copy(), domain)
         np.testing.assert_array_equal(result, particles)
 
     def test_mixed_obstacle_and_outer_violations(self):
         """Mix: one in obstacle (project), one past bbox (leave), one valid (untouched)."""
-        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import project_to_navigable_or_defer
 
         domain = self._make_diff_domain()
         particles = np.array(
@@ -840,7 +840,7 @@ class TestEnforceObstacleBoundary:
                 [0.1, 0.1],  # navigable → untouched
             ]
         )
-        result = enforce_obstacle_boundary(particles.copy(), domain)
+        result = project_to_navigable_or_defer(particles.copy(), domain)
         assert not np.allclose(result[0], particles[0])
         assert domain.contains(result[0:1]).all()
         np.testing.assert_array_equal(result[1], particles[1])
@@ -848,10 +848,10 @@ class TestEnforceObstacleBoundary:
 
     def test_none_implicit_domain_passthrough(self):
         """No implicit_domain → no-op."""
-        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import enforce_obstacle_boundary
+        from mfgarchon.alg.numerical.fp_solvers.fp_particle_bc import project_to_navigable_or_defer
 
         particles = np.array([[10.0, 10.0]])
-        result = enforce_obstacle_boundary(particles.copy(), None)
+        result = project_to_navigable_or_defer(particles.copy(), None)
         np.testing.assert_array_equal(result, particles)
 
 


### PR DESCRIPTION
Fixes #1067.

## Problem

After #1064/#1065, `enforce_obstacle_boundary` no longer enforces obstacle boundaries uniformly: it **projects** obstacle-interior violations but **defers** outer-bounding-box violations to the caller's segment-aware BC. The `enforce` name implied comprehensive enforcement — a Tier-C "name that lies", the same misalignment class that produced #1064 (silent `mass_T=1.000` failure for ~1 month).

## Changes (renames only; behavior unchanged)

| Old | New |
|---|---|
| `enforce_obstacle_boundary` (helper, `fp_particle_bc.py`) | `project_to_navigable_or_defer` |
| `FPParticleSolver._enforce_obstacle_boundary` (`fp_particle.py`) | `_project_obstacle_violations` |
| import alias `_enforce_obstacle` | `_project_to_navigable` |
| test class `TestEnforceObstacleBoundary` | `TestProjectToNavigableOrDefer` |

Docstring first sentences now state the discriminator contract: *project obstacle-interior violations back to the navigable region; leave outer-bbox violations for the caller's outer-BC layer.*

## Deprecation alias: not added (deliberate)

The issue's migration plan suggested keeping the old name as a `@deprecated` alias. Verified the symbol is **internal** — `enforce_obstacle_boundary` is not exported in any `__init__.py`; the only references were the def, the `FPParticleSolver` call sites, and the test. All call sites are updated in this PR, so an alias would be dead code (kernel: no back-compat shims for unreleased/internal code; CLAUDE.md fail-fast). Old names are removed.

## Scope notes

- Inline comments `# Enforce obstacle boundaries if implicit domain is set` left as-is (high-level intent description, not the misleading symbol).
- `CHANGELOG.md` historical entries that mention `enforce_obstacle_boundary` (the #1064 record) left untouched — they correctly describe past state; no new public-API entry since the symbol is internal.

## Verification

- `tests/unit/test_alg/test_fp_particle*.py` — 78 passed (includes the 5 contract tests from #1065, now exercising the new name).
- `fp_particle_bc.py` `__main__` smoke test passes.
- `ruff format --check` + `ruff check` clean (import block re-sorted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)