### PR TITLE
fix(alg): tighten GFDM ill-conditioning threshold 1e12 → 1e8 (Fixes #1084)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GFDM ill-conditioning threshold `COND_THRESHOLD` tightened 1e12 → 1e8** (Issue #1084).
+  `TaylorOperator._validate_stencils` warned only above κ(A)=1e12, where the least-squares
+  stencil weights retain just ~4 reliable float64 digits (reliable digits ≈ 16 − log₁₀κ) — a
+  stencil claiming O(h²) could carry near-garbage weights below its own truncation error. The new
+  1e8 guard keeps ~8 reliable digits, with headroom over both the O(h²) truncation error at
+  realistic grids (h~1e-2..1e-3 → ~4..6 digits) and a `newton_tolerance=1e-6` downstream solve.
+  Warn-only (validity gate unchanged); empirically the GFDM suite realizes κ ≤ ~1.6e4 (median ~19)
+  across 120 operators, so no working stencil is affected (suite green, zero new warnings).
+
 - **FP-particle drift gradient ignored boundary conditions: O(1/h) wrong-sign drift at
   non-periodic walls** (silent-divergence bug-hunt). `FPParticleSolver._compute_gradient_nd`
   computed `∇U` for the drift `α = -∇U/λ` via the **periodic-wrap** central difference

--- a/mfgarchon/alg/numerical/gfdm_components/gfdm_strategies.py
+++ b/mfgarchon/alg/numerical/gfdm_components/gfdm_strategies.py
@@ -77,8 +77,17 @@ REGULARIZATION = 1e-12
 # Pseudoinverse rcond parameter
 PINV_RCOND = 1e-10
 
-# Condition number threshold for "ill-conditioned" warning
-COND_THRESHOLD = 1e12
+# Condition number threshold for "ill-conditioned" warning (Issue #1084).
+# Float64 has unit roundoff u ~ 1.1e-16 (~16 decimal digits). For a linear
+# (least-squares Taylor) system the solved weights lose ~log10(kappa) digits:
+# reliable_digits ~ 16 - log10(kappa). The previous 1e12 left only ~4 reliable
+# digits, so a stencil claiming O(h^2) could carry near-garbage weights below the
+# truncation error. 1e8 keeps ~8 reliable digits: clear headroom over both the
+# O(h^2) truncation error at realistic grids (h~1e-2..1e-3 -> ~4..6 digits) and a
+# newton_tolerance=1e-6 downstream solve. Empirically the GFDM test suite realizes
+# cond <= ~1.6e4 (median ~19) across 120 operators, so this guard fires only on
+# pathological (anisotropic / near-boundary) clouds, not on working stencils.
+COND_THRESHOLD = 1e8
 
 # PHS singularity epsilon (added to r for r^m)
 PHS_EPSILON = 1e-14
@@ -724,7 +733,8 @@ class TaylorOperator(DifferentialOperator):
             weight_threshold: Neighbors with weight < threshold * max_weight
                 are considered ineffective. Default 0.01 (1% of max).
             cond_threshold: Condition numbers above this are considered
-                ill-conditioned. Default 1e12.
+                ill-conditioned. Default 1e8 (~8 reliable float64 digits in
+                the solved stencil weights; see COND_THRESHOLD, Issue #1084).
 
         Returns:
             True if all stencils are valid, False if any are degenerate or


### PR DESCRIPTION
Fixes #1084.

## Problem

`gfdm_strategies.py` `COND_THRESHOLD = 1e12` (used as the default `cond_threshold` in `TaylorOperator._validate_stencils`, line 715) only flags a stencil "ill-conditioned" once κ(A) exceeds 1e12. At that conditioning the least-squares-solved stencil weights retain only ~4 significant digits, so a stencil claiming O(h²) accuracy can carry near-garbage weights below its own truncation error.

## Numerical analysis (reliable digits vs condition number)

For a linear system `A x = b` solved in floating point, the relative error of the computed solution is bounded by

  ‖δx‖/‖x‖ ≲ κ(A) · u,

where `u` is the unit roundoff and `κ(A) = σ_max/σ_min` the 2-norm condition number. The GFDM stencil weights are exactly such a solution: the (weighted) least-squares Taylor/Vandermonde system `A` is inverted/back-substituted to produce the differentiation weights.

In float64, `u ≈ 2^-53 ≈ 1.11e-16` (~16 decimal digits). Taking log₁₀:

  reliable decimal digits ≈ log₁₀(1/u) − log₁₀ κ(A) ≈ 16 − k,  for κ(A) ~ 10^k.

| κ(A) | reliable digits (≈16 − log₁₀κ) |
|------|-------------------------------|
| 1e12 (old) | **~4** |
| 1e10 | ~6 |
| **1e8 (new)** | **~8** |
| 1e6 | ~10 |

For an **honest O(h²)** stencil the weight rounding error must sit clearly below the truncation error being claimed. The truncation error is O(h²): at realistic grids `h ~ 1e-2…1e-3` that is ~1e-4…1e-6 relative (~4–6 significant digits). At the old 1e12 the weights carry only ~4 digits — on par with or worse than the truncation error, i.e. the claimed second order can be masked by roundoff in the weights themselves. A downstream `newton_tolerance=1e-6` solve then reads noise in its last ~2 digits.

## Chosen value: 1e8 (not a round guess)

`COND_THRESHOLD = 1e8` is selected because:

1. **~8 reliable digits** in the solved weights — double the old margin, and a clear ≥2-digit cushion above even the `h~1e-3` O(h²) truncation error (~6 digits) and above `newton_tolerance=1e-6`.
2. **Empirically non-disruptive.** Instrumented the actual GFDM test suite (recorded `get_condition_numbers()` for every `TaylorOperator`/`UpwindOperator` built during the run — **120 operators**):
   - realized cond **MAX over all operators ≈ 1.56e4**
   - median of per-op medians ≈ **19**
   - operators exceeding 1e8: **0/120** (also 0 above 1e10, 0 above 1e12)

   The worst realized stencil (~1.6e4 → ~12 reliable digits) sits **>3700× below** the new 1e8 guard. 1e8 is therefore the tightest of the two defensible candidates (1e8 / 1e10) that preserves ≥8 reliable digits while remaining well clear of the realized conditioning — the threshold is **empirically bounded by realized stencil conditioning (κ ≤ ~1.6e4)** and fires only on pathological anisotropic / near-boundary clouds, not on working stencils.

## Risk check (tighter ⇒ more flags)

A tighter threshold can only flag *more* stencils. Two reasons this does not break the suite:

- The ill-conditioned path is **warn-only**: `_validate_stencils` sets `valid=False` solely for rank-deficient (degenerate) stencils; ill-conditioning emits a `UserWarning` and the return value is not gated at either call site (lines 421, 1508). `pytest.ini` has no `error` warning filter, so the warning cannot fail a test.
- The measured realized cond (max ~1.6e4) is 4 orders of magnitude below 1e8, so **zero** currently-passing stencils are newly flagged.

`LocalRBFOperator._validate_stencils` (line 1790) does not use `COND_THRESHOLD`; unchanged.

## Gate / test results

GFDM suite (`test_hjb_gfdm*`, `test_gfdm_*`, `test_fp_gfdm*`, `test_gfdm_operators`, `joint_socp`, `test_collocation_gfdm_hjb`):

```
185 passed, 2 skipped, 186 warnings in 83.21s
```

No new "Condition number stats" (ill-conditioned) warnings emitted. `ruff format --check` and `ruff check` clean on the changed module.

## Changes

- `mfgarchon/alg/numerical/gfdm_components/gfdm_strategies.py`: `COND_THRESHOLD = 1e12 → 1e8` with derivation comment + docstring default update.
- `CHANGELOG.md`: `[Unreleased] → Fixed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)