### PR TITLE
feat(hjb-sl): canonical Carlini-Silva SL with implicit-alpha* DPP fixed point

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -147,7 +147,15 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             diffusion_method: Method for handling diffusion term (default: 'adi')
                 - 'adi': ADI (Alternating Direction Implicit) splitting (default)
                 - 'explicit': Explicit Laplacian (simple, requires small dt)
-                - 'stochastic': Stochastic characteristic with Brownian motion (high-dim friendly)
+                - 'stochastic': Stochastic characteristic with Brownian motion (high-dim friendly).
+                  Explicit-alpha* (alpha* = -grad u^{n+1} at the grid node).
+                - 'canonical_cs': Canonical Carlini-Silva 2014 SL with the IMPLICIT-alpha* DPP
+                  fixed point (Issue #1058). Per grid point, alpha* is the minimizer of the DPP
+                  objective (NOT the at-grid gradient), so it is consistent with the departure
+                  point it induces -- the hypothesis under which CS 2014 prove unconditional
+                  stability for monotone (Q1/linear) interpolation. Requires
+                  interpolation_method='linear'. Per-point optimization (slower) in exchange for
+                  unconditional stability; targets reflecting/no-flux boundaries.
                 - 'none': No diffusion (for testing or zero-diffusion problems)
             use_rbf_fallback: Use RBF interpolation as fallback for boundary cases
             rbf_kernel: RBF kernel function
@@ -225,6 +233,17 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 "more stable than `CubicSpline` but still outside the formal proof.",
                 UserWarning,
                 stacklevel=2,
+            )
+
+        # Issue #1058: canonical Carlini-Silva SL with implicit-alpha* DPP fixed point.
+        # CS 2014's stability proof requires monotone (Q1/linear) interpolation; cubic/quintic
+        # are non-monotone and outside the proof (Issue #1033/#1049). Fail fast rather than
+        # silently running an unproven combination.
+        if self.diffusion_method == "canonical_cs" and self.interpolation_method != "linear":
+            raise ValueError(
+                f"diffusion_method='canonical_cs' requires interpolation_method='linear' "
+                f"(monotone Q1), got '{self.interpolation_method}'. The Carlini-Silva 2014 "
+                f"stability proof only covers monotone interpolation; cubic/quintic break it."
             )
 
         # Gradient clipping statistics tracking
@@ -877,9 +896,12 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             m_idx = min(n + 1, Nt_points - 1)
             u_prev_idx = min(n, Nt_points - 1)
 
-            # Compute CFL and determine substeps needed for this time step
-            # DPP path doesn't use characteristics, so CFL substepping is not needed
-            if self._use_dpp:
+            # Compute CFL and determine substeps needed for this time step.
+            # DPP and canonical-CS paths don't trace explicit characteristics (the per-point
+            # optimization / DPP fixed point is unconditionally stable, Issue #1058), so CFL
+            # substepping is neither needed nor applied -- this is what lets canonical_cs use
+            # a large dt directly.
+            if self._use_dpp or self.diffusion_method == "canonical_cs":
                 cfl, n_substeps, dt_substep = 0.0, 1, self.dt
             else:
                 cfl, n_substeps, dt_substep = self._compute_cfl_and_substeps(U_solution[n + 1], self.dt)
@@ -965,6 +987,12 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         Returns:
             Value function at current time step (same shape as U_next)
         """
+        # Issue #1058: canonical Carlini-Silva SL with implicit-alpha* DPP fixed point.
+        # Dispatched first so an explicit diffusion_method='canonical_cs' request is honored
+        # regardless of whether a Lagrangian-driven DPP path would also apply.
+        if self.diffusion_method == "canonical_cs":
+            return self._solve_timestep_canonical_cs(U_next, M_next, time_idx, dt=self.dt)
+
         # Issue #909: L-based DPP path for non-smooth Lagrangians
         if self._use_dpp:
             return self._solve_timestep_dpp(U_next, M_next, time_idx)
@@ -1171,6 +1199,10 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         Returns:
             Value function at current time step
         """
+        # Issue #1058: canonical Carlini-Silva SL with implicit-alpha* DPP fixed point.
+        if self.diffusion_method == "canonical_cs":
+            return self._solve_timestep_canonical_cs(U_next, M_next, time_idx, dt=dt)
+
         # Issue #909: L-based DPP path for non-smooth Lagrangians
         if self._use_dpp:
             return self._solve_timestep_dpp(U_next, M_next, time_idx, dt=dt)
@@ -1508,6 +1540,215 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             return U_current
 
         U_current = self._enforce_boundary_conditions(U_current)
+        return U_current.ravel() if flat_input else U_current
+
+    # === Canonical Carlini-Silva SL with implicit-alpha* DPP (Issue #1058) ===
+
+    def _solve_timestep_canonical_cs(
+        self,
+        U_next: np.ndarray,
+        M_next: np.ndarray,
+        time_idx: int,
+        dt: float | None = None,
+    ) -> np.ndarray:
+        r"""Canonical Carlini-Silva (2014) SL step with the implicit-$\alpha^*$ DPP fixed point.
+
+        Unlike ``diffusion_method="stochastic"`` (explicit $\alpha^* = -\nabla u^{n+1}(x_i)$,
+        the gradient at the *grid* node), this path solves the **implicit** dynamic-programming
+        principle: at each node $x_i$ the optimal control is the per-point minimizer of the DPP
+        objective, so $\alpha^*$ is consistent with the departure point it induces. This is the
+        hypothesis under which CS 2014 prove unconditional stability and convergence for monotone
+        (Q1/linear) interpolation; the explicit at-grid gradient is an approximation that
+        diverges from it on stiff problems (Issue #1058).
+
+        For the standard separable Hamiltonian $H(x,p,m) = \tfrac12 |p|^2 + h(x,m)$ (unit
+        control weight; $h(x,m) = H(x,m,p{=}0,t)$ is the potential + coupling part, obtained
+        single-source via ``eval_H_batch`` at $p=0$), the per-node objective is
+
+        .. math::
+            \varphi(\alpha) = \tfrac{\mathrm{d}t}{2}\,|\alpha|^2 - \mathrm{d}t\, h(x_i, m_i)
+              + \frac{1}{2d} \sum_{k=1}^{d}
+                \bigl[ I_h u^{n+1}(y_k^+) + I_h u^{n+1}(y_k^-) \bigr],
+
+        with stochastic departures
+        $y_k^\pm = x_i + \alpha\,\mathrm{d}t \pm \sigma_k\sqrt{\mathrm{d}t}\,e_k$ (folded into
+        the domain by the boundary operation), $I_h$ the linear (monotone Q1) interpolant of
+        $u^{n+1}$, and $u^n(x_i) = \min_\alpha \varphi(\alpha) = \varphi(\alpha^*)$. $\alpha^*$
+        is *implicit* because the departure points -- hence $I_h$ -- depend on $\alpha$. The
+        $- \mathrm{d}t\,h$ sign (rather than $+$) follows from the cost-to-go backward
+        convention $\partial_t u = H - \tfrac{\sigma^2}{2}\Delta u$ used throughout this solver:
+        the running Lagrangian is $L = \tfrac12|\alpha|^2 - h$ (Legendre dual of $H$).
+
+        The minimization is per node (``scipy.optimize.minimize_scalar`` Brent in 1D,
+        ``scipy.optimize.minimize`` L-BFGS-B in nD) -- the cost CS trade for unconditional
+        stability. Diffusion enters through the $2d$ Brownian departures (added variance
+        $\sigma^2\mathrm{d}t$ per step), so no operator-splitting diffusion solve is used
+        (``_apply_diffusion`` is bypassed, as for ``"stochastic"``). The scheme targets
+        reflecting / no-flux (Neumann) boundaries (the CS 2014 setting); the reflected
+        departures realize zero-flux without a separate boundary enforcement pass.
+
+        Issue #1058. Canonical CS implicit-alpha*; validated in
+        mfg-research/.../exp08_towel_2d_validation/_preflight_1d/cs_sl_canonical_implicit_1d.py
+        (KL=3.3e-2 on 1D Towel-on-Beach, 4x faster than FDM).
+
+        References:
+            Carlini, E., & Silva, F. J. (2014). A semi-Lagrangian scheme for a degenerate
+            second order MFG system. ESAIM: M2AN 49(6), 1567-1604.
+
+        Args:
+            U_next: Value function at the next time step (shape ``(Nx,)`` for 1D, grid shape or
+                flattened for nD).
+            M_next: Density at the next time step (matching shape).
+            time_idx: Current time index (used in the Hamiltonian evaluation).
+            dt: Time step. Defaults to ``self.dt``; pass explicitly for substepping.
+
+        Returns:
+            Value function at the current time step, same shape as ``U_next``.
+        """
+        if dt is None:
+            dt = self.dt
+        return self._canonical_cs_step(U_next, M_next, time_idx, dt)
+
+    def _canonical_cs_step(
+        self,
+        U_next: np.ndarray,
+        M_next: np.ndarray,
+        time_idx: int,
+        dt: float,
+    ) -> np.ndarray:
+        """Per-node implicit-alpha* DPP minimization (see ``_solve_timestep_canonical_cs``).
+
+        Reuses the stochastic-SL departure-point machinery (diagonal volatility, boundary fold)
+        but replaces the explicit ``alpha* = -grad u`` drift with a per-node minimizer of the
+        DPP objective ``phi(alpha)``. 1D uses Brent (``minimize_scalar``); nD uses L-BFGS-B
+        (``minimize``) over the control vector.
+        """
+        from scipy.interpolate import RegularGridInterpolator, interp1d
+
+        d = self.dimension
+        sqrt_dt = float(np.sqrt(dt))
+        t_n = time_idx * dt
+
+        # Boundary fold for the stochastic departures (reflect = no-flux/Neumann, the CS
+        # setting; wrap = periodic; clamp otherwise). Shared with the stochastic SL path.
+        bc = self.get_boundary_conditions()
+        bc_op = bc_type_to_geometric_operation(get_bc_type_string(bc))
+        bounds = self.problem.geometry.get_bounds()
+        x_min = np.asarray(bounds[0], dtype=float)
+        x_max = np.asarray(bounds[1], dtype=float)
+        span = x_max - x_min
+
+        def _fold(points: np.ndarray) -> np.ndarray:
+            """Fold departure coordinates (``(..., d)``) back into ``[x_min, x_max]``."""
+            if bc_op == "reflect":
+                return reflect_into_domain(points, x_min, x_max)
+            if bc_op == "wrap":
+                return x_min + (points - x_min) % span
+            return np.clip(points, x_min, x_max)
+
+        # Diagonal volatility sigma_ax (SDE volatility), as in the stochastic SL path.
+        sigma = self.problem.sigma
+        if isinstance(sigma, np.ndarray):
+            sigma_diag = np.asarray(sigma, dtype=float).ravel()
+            if sigma_diag.size != d:
+                raise ValueError(
+                    f"Diagonal sigma must have {d} entries, got {sigma_diag.size}. "
+                    f"Full-tensor sigma not supported by canonical CS SL."
+                )
+        else:
+            sigma_diag = np.full(d, float(sigma))
+
+        H_class = self.problem.hamiltonian_class
+        # Allow up to 4x natural-traversal speed (scale-invariant heuristic, per the
+        # validated prototype): alpha is bounded by 4 * domain_length / T per axis.
+        alpha_bound = 4.0 * span / float(self.problem.T)
+
+        if d == 1:
+            Nx = len(U_next)
+            diff_off = float(sigma_diag[0]) * sqrt_dt
+            bound = float(alpha_bound[0])
+
+            # h_i = H(x_i, m_i, p=0, t_n): potential + coupling, single-source via H_class.
+            if H_class is not None:
+                x_batch = self.x_grid.reshape(-1, 1)
+                p_zero = np.zeros((Nx, 1))
+                h = eval_H_batch(H_class, x_batch, M_next, p_zero, t_n).ravel()
+            else:
+                h = np.zeros(Nx)
+
+            # Build the monotone (Q1/linear) interpolant once per backward step.
+            interp_fn = interp1d(self.x_grid, U_next, kind="linear", bounds_error=False, fill_value="extrapolate")
+
+            U_current = np.empty(Nx)
+            for i in range(Nx):
+                x_i = float(self.x_grid[i])
+                h_i = float(h[i])
+
+                def phi(alpha: float, _xi: float = x_i, _hi: float = h_i) -> float:
+                    y_drift = _xi + alpha * dt
+                    feet = _fold(np.array([[y_drift + diff_off], [y_drift - diff_off]]))
+                    u_pm = interp_fn(feet[:, 0])
+                    return 0.5 * dt * alpha * alpha - dt * _hi + 0.5 * float(u_pm[0] + u_pm[1])
+
+                res = minimize_scalar(phi, bounds=(-bound, bound), method="bounded", options={"xatol": self.tolerance})
+                # u^n(x_i) = phi(alpha*) (the DPP value at the implicit optimizer).
+                U_current[i] = float(res.fun)
+
+            return U_current
+
+        # --- nD: per-node vector minimization over the control alpha in R^d ---
+        if U_next.ndim == 1:
+            total_points = U_next.size
+            expected_full = int(np.prod(self._grid_shape))
+            grid_shape = (
+                tuple(self._grid_shape) if total_points == expected_full else tuple(n - 1 for n in self._grid_shape)
+            )
+            U_shaped = U_next.reshape(grid_shape)
+            M_shaped = M_next.reshape(grid_shape)
+            flat_input = True
+        else:
+            U_shaped = U_next
+            M_shaped = M_next
+            grid_shape = U_shaped.shape
+            flat_input = False
+
+        grid_coords = tuple(self.grid.coordinates)
+        interp_fn = RegularGridInterpolator(grid_coords, U_shaped, method="linear", bounds_error=False, fill_value=None)
+
+        # The 2*d departure offsets: +/- sigma_ax * sqrt(dt) along each axis -> (2d, d).
+        axis_offsets = np.diag(sigma_diag * sqrt_dt)  # (d, d), row k = offset along axis k
+        depart_offsets = np.concatenate([axis_offsets, -axis_offsets], axis=0)  # (2d, d)
+
+        # h batch over all nodes: h(x_i, m_i) = H(x_i, m_i, p=0, t_n).
+        mesh = np.meshgrid(*grid_coords, indexing="ij")
+        x_flat = np.stack([mesh[ax].ravel() for ax in range(d)], axis=1)  # (n_total, d)
+        if H_class is not None:
+            p_zero = np.zeros((x_flat.shape[0], d))
+            h_flat = eval_H_batch(H_class, x_flat, M_shaped.ravel(), p_zero, t_n).ravel()
+        else:
+            h_flat = np.zeros(x_flat.shape[0])
+
+        box = [(-float(alpha_bound[ax]), float(alpha_bound[ax])) for ax in range(d)]
+        U_current = np.empty(grid_shape)
+        for flat_i, multi_idx in enumerate(np.ndindex(grid_shape)):
+            x_i = x_flat[flat_i]
+            h_i = float(h_flat[flat_i])
+
+            def phi_nd(alpha_vec: np.ndarray, _xi: np.ndarray = x_i, _hi: float = h_i) -> float:
+                drift = _xi + np.asarray(alpha_vec) * dt  # (d,)
+                feet = _fold(drift[None, :] + depart_offsets)  # (2d, d)
+                u_pm = interp_fn(feet)  # (2d,)
+                return 0.5 * dt * float(np.dot(alpha_vec, alpha_vec)) - dt * _hi + float(u_pm.mean())
+
+            res = minimize(
+                phi_nd,
+                np.zeros(d),
+                bounds=box,
+                method="L-BFGS-B",
+                options={"ftol": self.tolerance, "maxiter": 100},
+            )
+            U_current[multi_idx] = float(res.fun)
+
         return U_current.ravel() if flat_input else U_current
 
     # === L-based DPP formulation (Issue #909) ===
@@ -2279,6 +2520,17 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 "_apply_diffusion should not be called when diffusion_method='stochastic'. "
                 "The Carlini-Silva 2014 SL update incorporates diffusion via 2d "
                 "stochastic departure points, replacing the operator-splitting "
+                "diffusion step. Check dispatch in _solve_timestep_semi_lagrangian."
+            )
+
+        elif self.diffusion_method == "canonical_cs":
+            # Issue #1058: canonical CS (implicit-alpha* DPP) bakes diffusion into the
+            # per-point DPP minimization via 2d stochastic departure points, just like
+            # 'stochastic'. Reaching this branch indicates broken dispatch.
+            raise NotImplementedError(
+                "_apply_diffusion should not be called when diffusion_method='canonical_cs'. "
+                "The canonical Carlini-Silva 2014 SL update (implicit-alpha* DPP) incorporates "
+                "diffusion via 2d stochastic departure points, replacing the operator-splitting "
                 "diffusion step. Check dispatch in _solve_timestep_semi_lagrangian."
             )
 

--- a/tests/unit/test_alg/test_hjb_canonical_cs_sl.py
+++ b/tests/unit/test_alg/test_hjb_canonical_cs_sl.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Unit tests for the canonical Carlini-Silva SL with implicit-alpha* DPP (Issue #1058).
+
+``diffusion_method="canonical_cs"`` solves the IMPLICIT dynamic-programming principle: at
+each grid node the optimal control alpha* is the per-point minimizer of the DPP objective
+
+    phi(alpha) = (dt/2)|alpha|^2 - dt*h(x_i, m_i) + (1/2d) sum_k [I_h(y_k^+) + I_h(y_k^-)],
+    u^n(x_i)  = min_alpha phi(alpha),
+
+with y_k^pm = x_i + alpha*dt +/- sigma_k*sqrt(dt)*e_k, h = H(x, m, p=0, t) (single-source),
+and I_h the linear (monotone Q1) interpolant. This is the CS 2014 hypothesis under which the
+scheme is unconditionally stable -- distinct from the explicit-alpha* path
+(``diffusion_method="stochastic"``, alpha* = -grad u at the grid node).
+
+Gates:
+  1. Convergence: 1D first-order HJB (sigma=0, H=|p|^2/2) converges to the analytic
+     Hopf-Lax solution u(0,x) = x^2/(2(1+T)) under refinement.
+  2. Unconditional stability: a time step far above the explicit-CFL limit stays bounded,
+     where the explicit (operator-split) scheme blows up.
+  3. Implicit vs explicit: on a stiff problem at large dt, the canonical (implicit-alpha*)
+     result is far closer to the converged reference than the explicit-alpha* path.
+  4. Existing paths byte-identical: covered by the existing
+     ``test_hjb_semi_lagrangian.py`` suite (the new method is purely additive).
+
+Reference implementation:
+  mfg-research/.../exp08_towel_2d_validation/_preflight_1d/cs_sl_canonical_implicit_1d.py
+"""
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _make_problem(bounds, Nx, T, Nt, diffusion, terminal_fn, coupling=None):
+    """1D MFGProblem with separable quadratic-control Hamiltonian H = |p|^2/2 + h."""
+    geometry = TensorProductGrid(
+        dimension=1, bounds=[bounds], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1)
+    )
+    components = MFGComponents(
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=coupling,
+            coupling_dm=(lambda m: 1.0) if coupling is not None else None,
+        ),
+        m_initial=lambda x: 1.0,
+        u_terminal=terminal_fn,
+    )
+    problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, diffusion=diffusion, components=components)
+    return problem, geometry
+
+
+def _grid(geometry):
+    return geometry.get_spatial_grid().flatten()
+
+
+class TestCanonicalCSInitialization:
+    """Construction-time validation of the canonical_cs scheme."""
+
+    def test_linear_accepted(self):
+        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(
+            geometry=geometry,
+            T=1.0,
+            Nt=30,
+            components=MFGComponents(
+                hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+                m_initial=lambda x: 1.0,
+                u_terminal=lambda x: 0.0,
+            ),
+        )
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="canonical_cs")
+        assert solver.diffusion_method == "canonical_cs"
+        assert solver.interpolation_method == "linear"
+
+    @pytest.mark.parametrize("interp", ["cubic", "quintic", "nearest"])
+    def test_nonlinear_interpolation_rejected(self, interp):
+        """CS 2014 stability requires monotone (Q1/linear) interpolation -> fail fast."""
+        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(
+            geometry=geometry,
+            T=1.0,
+            Nt=30,
+            components=MFGComponents(
+                hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+                m_initial=lambda x: 1.0,
+                u_terminal=lambda x: 0.0,
+            ),
+        )
+        with pytest.raises(ValueError, match=r"canonical_cs.*requires interpolation_method='linear'"):
+            HJBSemiLagrangianSolver(problem, interpolation_method=interp, diffusion_method="canonical_cs")
+
+    def test_apply_diffusion_raises(self):
+        """canonical_cs bakes diffusion into the DPP; reaching _apply_diffusion is a bug."""
+        problem, _ = _make_problem((0.0, 1.0), 31, 1.0, 30, 0.045, lambda x: 0.0)
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="canonical_cs")
+        with pytest.raises(NotImplementedError, match="should not be called"):
+            solver._apply_diffusion(np.zeros(31), 0.01)
+
+
+class TestCanonicalCSCorrectness:
+    """Sanity + gate 1 (convergence to analytic solution)."""
+
+    def test_constant_terminal_preserved(self):
+        """H = |p|^2/2 (h=0), constant terminal -> constant value (alpha*=0 minimizes phi)."""
+        problem, geom = _make_problem((-1.0, 1.0), 31, 0.5, 10, 0.045, lambda x: 3.0)
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="canonical_cs")
+        Nx = len(_grid(geom))
+        U = solver.solve_hjb_system(
+            M_density=np.ones((problem.Nt + 1, Nx)),
+            U_terminal=np.full(Nx, 3.0),
+            U_coupling_prev=np.zeros((problem.Nt + 1, Nx)),
+        )
+        np.testing.assert_allclose(U[0], 3.0, atol=1e-8)
+
+    def test_gate1_convergence_to_hopf_lax(self):
+        """Gate 1: sigma=0, H=|p|^2/2, g(x)=x^2/2 -> analytic u(0,x)=x^2/(2(1+T)).
+
+        The canonical scheme's per-node DPP minimization is the discrete Hopf-Lax operator;
+        composing it backward must converge to the exact viscosity solution under refinement.
+        """
+        T = 1.0
+        errors = []
+        for Nx, Nt in [(41, 20), (81, 40), (161, 80)]:
+            problem, geom = _make_problem((-3.0, 3.0), Nx, T, Nt, 0.0, lambda x: 0.5 * x[0] ** 2)
+            x = _grid(geom)
+            solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="canonical_cs")
+            U = solver.solve_hjb_system(
+                M_density=np.ones((Nt + 1, Nx)),
+                U_terminal=0.5 * x**2,
+                U_coupling_prev=np.zeros((Nt + 1, Nx)),
+            )
+            assert np.all(np.isfinite(U)), f"non-finite at Nx={Nx}"
+            u_exact = x**2 / (2.0 * (1.0 + T))
+            interior = (x > -2.0) & (x < 2.0)  # exclude boundary-reflection layer
+            errors.append(float(np.sqrt(np.mean((U[0][interior] - u_exact[interior]) ** 2))))
+
+        # Monotone decrease under refinement, near first-order, and small in absolute terms.
+        assert errors[0] > errors[1] > errors[2], f"not decreasing: {errors}"
+        assert errors[-1] < 1e-2, f"finest L2 too large: {errors[-1]:.3e}"
+        # Roughly O(dx): each grid doubling should roughly halve the error.
+        assert errors[0] / errors[1] > 1.5, f"slow convergence: {errors}"
+
+    def test_gate1b_convergence_with_diffusion(self):
+        """Gate 1 (sigma>0): the diffusive LQ HJB converges to the analytic solution.
+
+        For H = |p|^2/2 with terminal g(x)=x^2/2, the quadratic ansatz u(t,x) = a(t)x^2 + b(t)
+        gives a(0) = 1/(2(1+T)) -- the x^2 coefficient is diffusion-independent (diffusion only
+        shifts b). We verify both (i) the fitted interior x^2 coefficient converges to that
+        analytic value, and (ii) Cauchy self-convergence (successive resolutions agree to a
+        shrinking tolerance). A fine explicit-gradient scheme (ADI) is deliberately NOT used as
+        the reference: it is the inaccurate scheme this issue exists to replace (it undershoots
+        the analytic value badly on this LQ problem).
+        """
+        T, sigma = 0.5, 0.3
+        c_exact = 1.0 / (2.0 * (1.0 + T))  # analytic x^2 coefficient at t=0
+        coeff_rel_errors = []
+        solutions = {}
+        for Nx, Nt in [(31, 30), (61, 60), (121, 120)]:
+            prob, geom = _make_problem((-3.0, 3.0), Nx, T, Nt, sigma**2 / 2, lambda x: 0.5 * x[0] ** 2)
+            x = _grid(geom)
+            U = HJBSemiLagrangianSolver(
+                prob, interpolation_method="linear", diffusion_method="canonical_cs"
+            ).solve_hjb_system(np.ones((Nt + 1, Nx)), 0.5 * x**2, np.zeros((Nt + 1, Nx)))
+            assert np.all(np.isfinite(U))
+            solutions[Nx] = (x, U[0])
+            interior = (x > -2.0) & (x < 2.0)  # interior fit avoids the no-flux boundary layer
+            c_fit = float(np.sum(U[0][interior] * x[interior] ** 2) / np.sum(x[interior] ** 4))
+            coeff_rel_errors.append(abs(c_fit - c_exact) / c_exact)
+
+        # (i) fitted x^2 coefficient converges monotonically to the analytic value.
+        assert coeff_rel_errors[0] > coeff_rel_errors[1] > coeff_rel_errors[2], (
+            f"x^2 coefficient not converging to analytic: rel_errors={coeff_rel_errors}"
+        )
+        assert coeff_rel_errors[-1] < 0.08, f"finest coefficient off by {coeff_rel_errors[-1]:.2%}"
+
+        # (ii) Cauchy self-convergence vs the finest grid.
+        xf, uf = solutions[121]
+        cauchy = []
+        for Nx in [31, 61]:
+            x, u = solutions[Nx]
+            interior = (x > -2.0) & (x < 2.0)
+            cauchy.append(float(np.sqrt(np.mean((u[interior] - np.interp(x[interior], xf, uf)) ** 2))))
+        assert cauchy[0] > cauchy[1], f"not self-converging: {cauchy}"
+        assert cauchy[-1] < 3e-2, f"finest Cauchy gap too large: {cauchy[-1]:.3e}"
+
+
+class TestCanonicalCSStability:
+    """Gate 2: unconditional stability at a time step far above the explicit-CFL limit."""
+
+    def test_gate2_large_dt_bounded(self):
+        T, sigma = 1.0, 0.5
+        Nx = 41
+        g = lambda x: np.exp(-20.0 * x[0] ** 2)  # noqa: E731 (steep terminal)
+        # Only a handful of steps over the whole horizon -> dt >> CFL.
+        Nt = 2
+        problem, geom = _make_problem((-2.0, 2.0), Nx, T, Nt, sigma**2 / 2, g)
+        x = _grid(geom)
+        gx = np.exp(-20.0 * x**2)
+        dt = T / Nt
+        dx = float(x[1] - x[0])
+        # Explicit-diffusion stability bound dt < dx^2/(2*D); confirm we are well above it.
+        diffusion_cfl = dt / (dx**2 / (2.0 * (sigma**2 / 2)))
+        assert diffusion_cfl > 5.0, f"test mis-specified; CFL ratio only {diffusion_cfl:.1f}"
+
+        M = np.ones((Nt + 1, Nx))
+        U = HJBSemiLagrangianSolver(
+            problem, interpolation_method="linear", diffusion_method="canonical_cs"
+        ).solve_hjb_system(M, gx, np.zeros((Nt + 1, Nx)))
+
+        assert np.all(np.isfinite(U)), "canonical_cs produced NaN/Inf at large dt"
+        # Maximum principle: with h=0, u^n stays within [min g, max g].
+        assert np.max(np.abs(U)) <= np.max(np.abs(gx)) + 1e-9, f"unbounded: max|U|={np.max(np.abs(U)):.3e}"
+
+        # The explicit (operator-split) scheme at the same dt, with substepping disabled,
+        # is unstable here -- demonstrating the contrast.
+        U_explicit = HJBSemiLagrangianSolver(
+            problem,
+            interpolation_method="linear",
+            diffusion_method="explicit",
+            enable_adaptive_substepping=False,
+            check_cfl=False,
+        ).solve_hjb_system(M, gx, np.zeros((Nt + 1, Nx)))
+        explicit_blew_up = (not np.all(np.isfinite(U_explicit))) or (
+            np.max(np.abs(U_explicit)) > 100.0 * np.max(np.abs(gx))
+        )
+        assert explicit_blew_up, (
+            f"explicit scheme unexpectedly stable at large dt: max|U|={np.max(np.abs(U_explicit)):.3e}"
+        )
+
+
+class TestCanonicalCSImplicitVsExplicit:
+    """Gate 3: implicit-alpha* (canonical) beats explicit-alpha* (stochastic) on stiff problems."""
+
+    def test_gate3_canonical_beats_explicit_at_large_dt(self):
+        T, sigma, k = 1.0, 0.3, 2.0
+        g = lambda x: np.tanh(k * x[0])  # noqa: E731 (stiff terminal -> large gradients)
+
+        # Reference: a fine canonical solve (gate 1 establishes this scheme converges to the
+        # analytic viscosity solution).
+        Nx_ref, Nt_ref = 81, 80
+        prob_ref, geom_ref = _make_problem((-2.0, 2.0), Nx_ref, T, Nt_ref, sigma**2 / 2, g)
+        xr = _grid(geom_ref)
+        ref0 = HJBSemiLagrangianSolver(
+            prob_ref, interpolation_method="linear", diffusion_method="canonical_cs"
+        ).solve_hjb_system(np.ones((Nt_ref + 1, Nx_ref)), np.tanh(k * xr), np.zeros((Nt_ref + 1, Nx_ref)))[0]
+
+        # Coarse solve at a large time step (Nt=5 over T=1 -> dt=0.2).
+        Nx, Nt = 41, 5
+        prob, geom = _make_problem((-2.0, 2.0), Nx, T, Nt, sigma**2 / 2, g)
+        x = _grid(geom)
+        gx = np.tanh(k * x)
+        M = np.ones((Nt + 1, Nx))
+        ref_on_x = np.interp(x, xr, ref0)
+        interior = (x > -1.5) & (x < 1.5)
+
+        U_canonical = HJBSemiLagrangianSolver(
+            prob, interpolation_method="linear", diffusion_method="canonical_cs"
+        ).solve_hjb_system(M, gx, np.zeros((Nt + 1, Nx)))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            solver_explicit = HJBSemiLagrangianSolver(
+                prob,
+                interpolation_method="linear",
+                diffusion_method="stochastic",  # explicit-alpha* = -grad u at the grid node
+                enable_adaptive_substepping=False,
+                check_cfl=False,
+            )
+        U_explicit = solver_explicit.solve_hjb_system(M, gx, np.zeros((Nt + 1, Nx)))
+
+        err_canonical = float(np.sqrt(np.mean((U_canonical[0][interior] - ref_on_x[interior]) ** 2)))
+        err_explicit = float(np.sqrt(np.mean((U_explicit[0][interior] - ref_on_x[interior]) ** 2)))
+
+        assert np.all(np.isfinite(U_canonical)), "canonical produced NaN/Inf"
+        # The implicit-alpha* DPP is much closer to the reference than the explicit at-grid alpha*.
+        assert err_canonical < err_explicit, f"canonical {err_canonical:.3e} !< explicit {err_explicit:.3e}"
+        assert err_explicit > 10.0 * err_canonical, (
+            f"explicit not dramatically worse: canonical={err_canonical:.3e}, explicit={err_explicit:.3e}"
+        )
+        assert err_canonical < 0.1, f"canonical itself inaccurate at large dt: {err_canonical:.3e}"
+
+
+class TestCanonicalCSMultiDimensional:
+    """Dispatch-surface coverage: the nD per-node vector minimization runs and stays bounded."""
+
+    def test_2d_runs_and_bounded(self):
+        bc = no_flux_bc(dimension=2)
+        grid = TensorProductGrid(
+            dimension=2, bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[11, 11], boundary_conditions=bc
+        )
+        problem = MFGProblem(
+            geometry=grid,
+            T=0.2,
+            Nt=4,
+            diffusion=0.3**2 / 2,
+            components=MFGComponents(
+                hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+                m_initial=lambda x: 1.0,
+                u_terminal=lambda x: 0.0,
+            ),
+        )
+        X, Y = np.meshgrid(np.linspace(0, 1, 11), np.linspace(0, 1, 11), indexing="ij")
+        U_terminal = 0.5 * ((X - 0.5) ** 2 + (Y - 0.5) ** 2)
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="canonical_cs")
+        U = solver.solve_hjb_system(
+            M_density=np.ones((5, 11, 11)),
+            U_terminal=U_terminal,
+            U_coupling_prev=np.zeros((5, 11, 11)),
+        )
+        assert U.shape == (5, 11, 11)
+        assert np.all(np.isfinite(U))
+        # With h=0 the maximum principle bounds u by the terminal data.
+        assert np.max(np.abs(U)) <= np.max(np.abs(U_terminal)) + 1e-9


### PR DESCRIPTION
Fixes #1058

## Summary

Adds `diffusion_method="canonical_cs"` to `HJBSemiLagrangianSolver`: the canonical Carlini-Silva 2014 semi-Lagrangian scheme with the **implicit-alpha\* DPP fixed point**. The existing `diffusion_method="stochastic"` path uses *explicit-alpha\** (`alpha* = -grad u^{n+1}` at the grid node); CS 2014's unconditional-stability proof instead requires the implicit DPP fixed point, where `alpha*` is the per-point minimizer of the DPP objective and is therefore consistent with the departure point it induces.

Per grid node, per backward step, minimize over the control `alpha`:

```
phi(alpha) = (dt/2)|alpha|^2 - dt*h(x_i, m_i) + (1/2d) sum_k [ I_h(y_k^+) + I_h(y_k^-) ]
u^n(x_i)  = min_alpha phi(alpha) = phi(alpha*)
```

- `y_k^{+/-} = x_i + alpha*dt +/- sigma_k*sqrt(dt)*e_k` (2d stochastic departures; diffusion enters here, no operator splitting).
- `h(x,m) = H(x, m, p=0, t)` — the potential + coupling part, **single-source** via `eval_H_batch` at `p=0` (not re-derived).
- `I_h` = linear (monotone Q1) interpolation; CS 2014's stability hypothesis requires monotone interpolation (cubic breaks it), so construction **fails fast** if `interpolation_method != "linear"`.
- 1D minimization: `scipy.optimize.minimize_scalar` (Brent). nD: `scipy.optimize.minimize` (L-BFGS-B).

`alpha*` is *implicit* because `I_h(y)` depends on `alpha` through `y`. The `- dt*h` sign follows from the cost-to-go backward convention `du/dt = H - (sigma^2/2)*Laplacian(u)` used throughout this solver.

## Where the implicit-alpha\* DPP minimize lives

`mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py`:
- `_solve_timestep_canonical_cs` — dispatch + docstring (the per-node objective).
- `_canonical_cs_step` — the per-node Brent (1D) / L-BFGS-B (nD) minimization of `phi(alpha)`; reuses the stochastic-SL departure-point + boundary-fold machinery.
- Dispatched from `_solve_timestep_semi_lagrangian` / `_solve_timestep_semi_lagrangian_with_dt`; CFL substepping bypassed (unconditionally stable); `_apply_diffusion` raises if reached.

## Design notes

- `diffusion_method` is a plain string parameter (no `NumericalScheme` enum / factory wiring exists for SL diffusion methods), so registration is the documented param plus the docstring.
- Targets reflecting / no-flux (Neumann) boundaries — the CS 2014 setting; the reflected departures realize zero-flux.
- Assumes the standard separable quadratic-control Hamiltonian `H = (1/2)|p|^2 + h` (unit control weight), per CS 2014 / the validated prototype.
- **Purely additive**: existing `diffusion_method` values are untouched and stay byte-identical.

## Gate results (tests/unit/test_alg/test_hjb_canonical_cs_sl.py)

| Gate | Result |
|---|---|
| **1. Convergence** | sigma=0: O(dx) to analytic Hopf-Lax `x^2/(2(1+T))` — L2 = 2.27e-2 -> 1.12e-2 -> 5.66e-3 (Nx=41/81/161). sigma>0: fitted interior x^2 coefficient -> analytic 1/(2(1+T)) (rel-err 12.7% -> 8.6% -> 5.9%) and Cauchy self-convergent (4.6e-2 -> 1.9e-2). |
| **2. Unconditional stability** | At dt far above the explicit-CFL limit (Nt=2 over T=1, diffusion-CFL ratio 12.5): canonical bounded, `max|U| = max|terminal|`; the explicit scheme blows up to ~1.8e5 (and ~1e30 at smaller dt). |
| **3. Implicit vs explicit** | Stiff `tanh(2x)` terminal, large dt (Nt=5): canonical L2 = 6.7e-3 vs explicit-alpha\* (`stochastic`) L2 = 4.6e3 vs the converged reference — canonical error >1e4x smaller. |
| **4. Existing paths byte-identical** | `tests/unit/test_alg/test_hjb_semi_lagrangian.py`: 50 passed, 2 skipped, 2 xfailed. |

New suite: 11 passed (~14s). Reference: mfg-research `.../exp08_towel_2d_validation/_preflight_1d/cs_sl_canonical_implicit_1d.py` (KL=3.3e-2 on 1D Towel-on-Beach, 4x faster than FDM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)