### PR TITLE
docs(gfdm): scope joint_socp DMP claim to per-stencil vs assembled M-matrix (#1074)

### DIFF
--- a/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
+++ b/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
@@ -13,6 +13,19 @@ The cone closes the comparison-principle proof for the central GFDM scheme
 via per-edge absorption. Reference: forthcoming paper §sec:error_structure
 (Theorem `thm:joint_socp_feasibility`, Lemma `lem:wendland_stencil_ratio`).
 
+Scope of the guarantee (Issue #1074):
+    These constraints are enforced PER STENCIL — each collocation row's
+    off-diagonal Laplacian weights satisfy the sign/dominance constraints
+    in isolation. This does NOT in general guarantee that the ASSEMBLED HJB
+    iteration matrix (I/dt - D*L + alpha*D_grad) is an M-matrix: the signed
+    drift term alpha*D_grad can flip an off-diagonal positive once |alpha|
+    is large relative to the diffusion D (a Peclet-like condition). The
+    discrete maximum principle for the assembled system is therefore NOT
+    a-priori guaranteed by per-stencil feasibility. Use
+    `monotonicity_enforcer.verify_assembled_m_matrix(...)` (and the
+    `critical_drift_for_dmp(...)` threshold) to check the assembled M-matrix
+    / DMP property for a specific problem and discretization.
+
 Solver: cvxpy + CLARABEL.
 
 Implementation history: this module ports the audit-major

--- a/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
+++ b/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
@@ -878,12 +878,19 @@ def verify_assembled_m_matrix(
 ) -> dict[str, Any]:
     r"""Verify the M-matrix property of the *assembled* HJB iteration matrix (Issue #1074).
 
-    The per-stencil SOCP checks (:meth:`MonotonicityEnforcer.check_m_matrix`) verify the raw
-    Laplacian weights at each collocation point. They do **not** imply that the assembled
-    Newton iteration matrix $J = I/\Delta t - D\,L + \alpha\cdot D_{\mathrm{grad}}$ is an
-    M-matrix: the signed drift term $\alpha\cdot D_{\mathrm{grad}}$ can flip an off-diagonal
-    positive once $|\alpha|$ is large relative to $D$ (a Péclet-like condition; see
-    :func:`critical_drift_for_dmp`). This checks the assembled system directly.
+    This routine exists *precisely because* per-stencil SOCP feasibility is not the same as
+    the assembled-matrix M-matrix property (Issue #1074). The per-stencil SOCP checks
+    (:meth:`MonotonicityEnforcer.check_m_matrix`) verify the raw Laplacian weights at each
+    collocation point. They do **not** imply that the assembled Newton iteration matrix
+    $J = I/\Delta t - D\,L + \alpha\cdot D_{\mathrm{grad}}$ is an M-matrix: the signed drift
+    term $\alpha\cdot D_{\mathrm{grad}}$ can flip an off-diagonal positive once $|\alpha|$ is
+    large relative to $D$ (a Péclet-like condition; see :func:`critical_drift_for_dmp`). This
+    checks the assembled system directly.
+
+    The ``joint_socp`` scheme therefore does not provide an a-priori discrete-maximum-principle
+    (DMP) guarantee for the assembled system. The DMP claim for a *given* problem and
+    discretization should be backed by running this check (the scoped claim): a passing
+    ``is_m_matrix`` result certifies the assembled M-matrix / DMP property for that specific run.
 
     Args:
         matrix: Assembled iteration matrix (any scipy sparse format).

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -327,6 +327,16 @@ class HJBGFDMSolver(BaseHJBSolver):
                 - "joint_socp": (Phase 1B follow-up) joint SOCP — M-matrix on $-\\Delta_h$
                   + per-edge cone $\\|D_{ij}\\|_2 \\leq C h_i L_{ij}$, closing the discrete
                   comparison principle (audit-major contribution).
+                  Scope (Issue #1074): joint_socp enforces the M-matrix property PER
+                  STENCIL (each row's off-diagonals satisfy the sign/dominance
+                  constraints). This does NOT in general guarantee that the ASSEMBLED
+                  HJB iteration matrix $I/dt - D L + \\alpha D_{grad}$ is an M-matrix:
+                  the signed drift term can flip an off-diagonal positive at high
+                  Peclet, so the discrete maximum principle is not a-priori guaranteed
+                  by per-stencil feasibility. Use ``check_dmp=True`` (runtime warning)
+                  or ``monotonicity_enforcer.verify_assembled_m_matrix(...)`` to check
+                  the assembled M-matrix / DMP property for a specific problem and
+                  discretization.
                 Default: "none". (Renamed from qp_optimization_level in v0.18.0.)
             monotonicity_application: When the chosen scheme is enforced (only
                 meaningful for non-"none" schemes):


### PR DESCRIPTION
Refs #1074 (RESCOPED per maintainer: Option 2 — keep the high-order joint_socp scheme; scope the DMP claim to "verified via `verify_assembled_m_matrix`", NOT an a-priori guarantee).

## What

Docstring-only clarification making the per-stencil-vs-assembled M-matrix distinction explicit, so library users do not assume the assembled discrete maximum principle (DMP) is guaranteed by per-stencil joint_socp feasibility.

The code path for the scoped claim already exists (`verify_assembled_m_matrix` at `monotonicity_enforcer.py:874`, `critical_drift_for_dmp`, and the `check_dmp=True` runtime guard, landed via #1243/#1270). This PR closes the wording gap.

## Changes (all docstring text; no logic)

- `gfdm_components/joint_socp.py` module docstring — add a "Scope of the guarantee (Issue #1074)" note: constraints are enforced PER STENCIL; this does NOT in general guarantee the assembled HJB iteration matrix `I/dt - D*L + alpha*D_grad` is an M-matrix (signed drift can flip an off-diagonal positive at high Péclet); point to `verify_assembled_m_matrix` / `critical_drift_for_dmp`.
- `hjb_solvers/hjb_gfdm.py` `monotonicity_scheme` parameter docstring (`joint_socp` bullet) — same per-stencil-vs-assembled note + pointer to `check_dmp=True` and `verify_assembled_m_matrix`.
- `gfdm_components/monotonicity_enforcer.py` `verify_assembled_m_matrix` docstring — state it exists *precisely because* per-stencil feasibility != assembled M-matrix (#1074), and that the DMP claim for a given run should be backed by a passing `is_m_matrix` result (the scoped claim).

The wording is deliberately accurate: it does NOT claim the assembled matrix IS an M-matrix; the point is that it must be CHECKED.

## Gate

- `python -c "import mfgarchon"` clean (v0.19.6).
- `ruff format --check` + `ruff check` clean on the 3 edited files.
- Diff is docstring lines only (no logic/behavior change): `36 insertions(+), 6 deletions(-)`, all inside triple-quoted strings.
- Tests green: `test_socp_m_matrix_property.py`, `test_hjb_gfdm_monotonicity_scheme_rename.py`, `test_joint_socp_mirror_symmetry.py` — 43 passed.

## Label note

Requested `type: documentation` does not exist in this repo's taxonomy (documentation is an `area:`). Mapped to `area: documentation` + `type: chore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)