### PR TITLE
feat(fem): hexahedral mesh family support via skfem adapter (#470)

### DIFF
--- a/mfgarchon/alg/numerical/fem/assembly.py
+++ b/mfgarchon/alg/numerical/fem/assembly.py
@@ -58,6 +58,8 @@ def create_basis(mesh: skfem.Mesh, order: int = 1) -> skfem.Basis:
         (skfem.MeshQuad, 2): skfem.ElementQuad2,
         (skfem.MeshQuad1, 1): skfem.ElementQuad1,
         (skfem.MeshQuad1, 2): skfem.ElementQuad2,
+        (skfem.MeshHex, 1): skfem.ElementHex1,  # Issue #470: 3D tensor-product family
+        (skfem.MeshHex, 2): skfem.ElementHex2,
         (skfem.MeshLine, 1): skfem.ElementLineP1,
         (skfem.MeshLine, 2): skfem.ElementLineP2,
         (skfem.MeshLine1, 1): skfem.ElementLineP1,
@@ -73,7 +75,7 @@ def create_basis(mesh: skfem.Mesh, order: int = 1) -> skfem.Basis:
     if element_cls is None:
         raise ValueError(
             f"No element for mesh type {type(mesh).__name__} with order {order}. "
-            f"Supported: P1 (order=1) and P2 (order=2) for Tri/Tet/Line/Quad."
+            f"Supported: P1 (order=1) and P2 (order=2) for Tri/Tet/Line/Quad/Hex."
         )
 
     return skfem.Basis(mesh, element_cls())

--- a/mfgarchon/alg/numerical/fem/mesh_adapter.py
+++ b/mfgarchon/alg/numerical/fem/mesh_adapter.py
@@ -9,6 +9,36 @@ The key difference is array layout:
     MeshData:  vertices (N, dim), elements (M, nodes_per_elem)
     skfem:     nodes (dim, N),    elements (nodes_per_elem, M)
 
+Supported element families (Issue #470): line, triangle, quad (2D), tetrahedron,
+hexahedron (3D). The family is fixed by ``MeshData.element_type`` (forward) or the
+skfem mesh class (reverse). P1 and P2 Lagrange variants of each family map to the
+same ``element_type`` string; the polynomial order is chosen later in
+``assembly.create_basis``.
+
+Bring-your-own-mesh (no in-process gmsh dependency)
+---------------------------------------------------
+Complex unstructured meshes do not need an in-process mesh generator. mfgarchon
+relies on skfem's element families plus its mesh I/O, so the supported paths are:
+
+1. Structured / tensor-product meshes, gmsh-free::
+
+       import skfem, numpy as np
+       xs = np.linspace(0.0, 1.0, n)
+       mesh = skfem.MeshHex.init_tensor(xs, xs, xs)   # or MeshTet/MeshQuad/MeshTri
+       mesh_data = skfem_to_meshdata(mesh)            # -> MeshData -> FEM solve
+
+2. External mesher (gmsh, Cubit, ...) -> meshio file -> skfem (recommended for
+   complex unstructured geometry)::
+
+       # Generate `domain.msh` (or .vtk/.xdmf/...) in *any* external mesher.
+       mesh = skfem.Mesh.load("domain.msh")           # skfem reads via meshio
+       mesh_data = skfem_to_meshdata(mesh)            # -> MeshData -> FEM solve
+
+   ``skfem.Mesh.load`` uses meshio (already a dependency), so any meshio-supported
+   format works. This keeps gmsh an *out-of-process* tool: mfgarchon never imports
+   it. meshio's tetra/hexahedron cell names map onto the families above. Prism /
+   pyramid / mixed-element meshes are out of scope (see notes below and Issue #470).
+
 Issue #773 Phase 1: Core integration
 """
 
@@ -39,7 +69,7 @@ def meshdata_to_skfem(mesh_data: MeshData) -> skfem.Mesh:
         mesh_data: MFGarchon mesh with vertices, elements, and element_type.
 
     Returns:
-        scikit-fem Mesh object (MeshTri, MeshTet, MeshQuad, or MeshLine).
+        scikit-fem Mesh object (MeshTri, MeshTet, MeshQuad, MeshHex, or MeshLine).
 
     Raises:
         ValueError: If element_type is not supported.
@@ -55,6 +85,7 @@ def meshdata_to_skfem(mesh_data: MeshData) -> skfem.Mesh:
         "triangle": skfem.MeshTri,
         "tetrahedron": skfem.MeshTet,
         "quad": skfem.MeshQuad,
+        "hexahedron": skfem.MeshHex,  # Issue #470: 3D tensor-product family
         "line": skfem.MeshLine,
     }
 
@@ -119,6 +150,17 @@ def skfem_to_meshdata(mesh: skfem.Mesh) -> MeshData:
 
     # Map skfem mesh type to element string
     skfem = _import_skfem()
+    # Issue #470: hexahedron is the 3D tensor-product family. In skfem 12.0.1
+    # ``MeshHex is MeshHex1`` (linear), and ``MeshHex2`` (P2-geometry) subclasses it,
+    # so the ``MeshHex`` isinstance test below already catches both; ``MeshHex2`` is
+    # listed for parity with the explicit P1/P2 entries of the other families.
+    #
+    # Prism / wedge (skfem.MeshWedge1) is intentionally NOT mapped here. Its
+    # points+cells round-trip, but two issues block a clean mapping (deferred to a
+    # follow-up, see Issue #470): (1) skfem stores the wedge's triangular faces as
+    # degenerate 4-node quad facets (e.g. ``[0, 0, 2, 3]``), so ``boundary_faces``
+    # are lossy; (2) meshio's cell name is ``"wedge"``, not ``"prism"``, so the
+    # round-trip name through ``MeshData.to_meshio`` needs a maintainer decision.
     type_map = {
         skfem.MeshTri: "triangle",
         skfem.MeshTri1: "triangle",
@@ -126,6 +168,8 @@ def skfem_to_meshdata(mesh: skfem.Mesh) -> MeshData:
         skfem.MeshTet1: "tetrahedron",
         skfem.MeshQuad: "quad",
         skfem.MeshQuad1: "quad",
+        skfem.MeshHex: "hexahedron",
+        skfem.MeshHex2: "hexahedron",
         skfem.MeshLine: "line",
         skfem.MeshLine1: "line",
     }

--- a/tests/unit/test_alg/test_fem_hex_mesh_470.py
+++ b/tests/unit/test_alg/test_fem_hex_mesh_470.py
@@ -1,0 +1,136 @@
+"""Hexahedral mesh family support — Issue #470 (skfem-native, gmsh-free).
+
+skfem 12.0.1 already ships the 3D tensor-product family (``MeshHex`` + ``ElementHex1``/
+``ElementHex2``) and structured generation (``MeshHex.init_tensor``). The mfgarchon gap
+was only that the ``MeshData`` <-> skfem adapter mapped triangle/tetrahedron/quad but not
+hexahedron, and that ``assembly.create_basis`` had no hex entry. This test pins both:
+
+1. a hex mesh round-trips through ``mesh_adapter`` (points + cells preserved, and the
+   ``element_type`` string is ``"hexahedron"``);
+2. the full FEM solve path (``create_basis`` -> assembly -> solve) runs on a hex mesh and
+   produces a finite solution, with P2 genuinely more accurate than P1 on the same mesh.
+
+No gmsh dependency is involved: the mesh is built gmsh-free via ``MeshHex.init_tensor``,
+matching the "bring your own mesh" path documented in ``mesh_adapter``.
+
+Prism / wedge is intentionally out of scope here (see ``mesh_adapter`` reverse-map note).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required for FEM tests")
+
+from mfgarchon.alg.numerical.fem.assembly import (  # noqa: E402
+    assemble_mass,
+    assemble_stiffness,
+    create_basis,
+)
+from mfgarchon.alg.numerical.fem.mesh_adapter import (  # noqa: E402
+    meshdata_to_skfem,
+    skfem_to_meshdata,
+)
+
+
+def _hex_mesh(n: int) -> skfem.Mesh:
+    """gmsh-free hex mesh on the unit cube: an (n x n x n) node tensor grid."""
+    xs = np.linspace(0.0, 1.0, n)
+    return skfem.MeshHex.init_tensor(xs, xs, xs)
+
+
+# ---------------------------------------------------------------------------
+# (1) Adapter round-trip: points + cells preserved, element_type correct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("builder", ["init_tensor", "refined"])
+def test_hex_roundtrips_through_adapter(builder: str):
+    """A hex mesh -> MeshData -> hex mesh preserves points and cells exactly."""
+    if builder == "init_tensor":
+        mesh = _hex_mesh(4)
+    else:
+        mesh = skfem.MeshHex().refined(2)
+
+    md = skfem_to_meshdata(mesh)
+    assert md.element_type == "hexahedron"
+    assert md.dimension == 3
+    assert md.vertices.shape == (mesh.p.shape[1], 3)
+    assert md.elements.shape == (mesh.t.shape[1], 8)
+
+    mesh_rt = meshdata_to_skfem(md)
+    assert isinstance(mesh_rt, skfem.MeshHex)
+    assert np.allclose(mesh_rt.p, mesh.p), "vertices must round-trip"
+    assert np.array_equal(mesh_rt.t, mesh.t), "cells must round-trip"
+
+
+def test_hex_meshdata_reports_hexahedron_for_p2_geometry():
+    """A P2-geometry hex (MeshHex2) maps to the same 'hexahedron' string."""
+    # MeshHex2 subclasses MeshHex1; the reverse map must still resolve it.
+    mesh_p2 = skfem.MeshHex2.init_tensor(np.linspace(0, 1, 3), np.linspace(0, 1, 3), np.linspace(0, 1, 3))
+    md = skfem_to_meshdata(mesh_p2)
+    assert md.element_type == "hexahedron"
+
+
+def test_hex_axis_aligned_boundaries_are_tagged():
+    """The box-wall tagging path applies to hex meshes (x_min/.../z_max)."""
+    mesh = meshdata_to_skfem(skfem_to_meshdata(_hex_mesh(3)))
+    assert mesh.boundaries is not None
+    for name in ("x_min", "x_max", "y_min", "y_max", "z_min", "z_max"):
+        assert name in mesh.boundaries, f"{name} wall must be tagged on a hex box"
+
+
+# ---------------------------------------------------------------------------
+# (2) FEM solve path on a hex mesh: runs, finite, P2 beats P1
+# ---------------------------------------------------------------------------
+
+
+def _solve_poisson(mesh: skfem.Mesh, order: int) -> tuple[float, int]:
+    r"""Solve $-\Delta u = f$ with Dirichlet data on $\partial\Omega$ for the
+    manufactured solution $u(x,y,z) = \sin(\pi x)\sin(\pi y)\sin(\pi z)$
+    (so $f = 3\pi^2 u$, $u = 0$ on the unit-cube boundary).
+
+    Returns (max nodal error, n_dofs).
+    """
+    from scipy.sparse.linalg import spsolve
+
+    basis = create_basis(mesh, order=order)
+    x, y, z = basis.doflocs
+    u_exact = np.sin(np.pi * x) * np.sin(np.pi * y) * np.sin(np.pi * z)
+    f = 3.0 * np.pi**2 * u_exact
+
+    K = assemble_stiffness(basis)
+    M = assemble_mass(basis)
+    rhs = M @ f  # consistent FEM load vector
+
+    boundary_dofs = np.unique(basis.get_dofs().flatten())
+    interior = np.setdiff1d(np.arange(basis.N), boundary_dofs)
+
+    u = np.zeros(basis.N)
+    u[boundary_dofs] = u_exact[boundary_dofs]  # homogeneous here, but explicit
+    rhs_int = (rhs - K @ u)[interior]
+    u[interior] = spsolve(K[interior][:, interior], rhs_int)
+
+    return float(np.max(np.abs(u - u_exact))), int(basis.N)
+
+
+def test_hex_fem_poisson_solve_runs_and_is_finite():
+    """The FEM solve path runs end-to-end on a hex mesh with a finite result."""
+    mesh = _hex_mesh(6)
+    err_p1, n_p1 = _solve_poisson(mesh, order=1)
+    assert np.isfinite(err_p1)
+    assert n_p1 == 6**3
+    # P1 on a 5x5x5-element cube should be at least roughly accurate.
+    assert err_p1 < 0.1, f"hex P1 Poisson error unexpectedly large: {err_p1}"
+
+
+def test_hex_fem_p2_more_accurate_than_p1():
+    """Q2 must be genuinely more accurate than Q1 on the same hex mesh."""
+    mesh = _hex_mesh(6)
+    err_p1, _ = _solve_poisson(mesh, order=1)
+    err_p2, n_p2 = _solve_poisson(mesh, order=2)
+    assert np.isfinite(err_p2)
+    assert n_p2 > 6**3, "P2 must introduce extra DOFs beyond the P1 vertices"
+    assert err_p2 < err_p1, f"P2 ({err_p2}) should beat P1 ({err_p1})"


### PR DESCRIPTION
## Summary

Rescoped per maintainer (2026-06-14): **skfem is sufficient — no in-process gmsh, no pyramid (YAGNI).** skfem 12.0.1 already ships the hex element family (`MeshHex` + `ElementHex1`/`ElementHex2`) and gmsh-free structured generation (`MeshHex.init_tensor`). The only mfgarchon gaps were:

1. the `MeshData` <-> skfem adapter mapped triangle/tetrahedron/quad but **not** hexahedron;
2. `assembly.create_basis` had no hex element entry (so even a hex mesh couldn't be solved on).

This PR wires both halves, making the hexahedral family usable end-to-end.

## Changes

- **`mesh_adapter.py`**
  - forward map: `"hexahedron" -> skfem.MeshHex`
  - reverse map: `MeshHex` / `MeshHex2 -> "hexahedron"` (in skfem 12.0.1 `MeshHex is MeshHex1`, and `MeshHex2` subclasses it, so the `MeshHex` isinstance test already covers both; `MeshHex2` is listed for parity)
  - module docstring documents the **bring-your-own-mesh** path: external mesher (gmsh/Cubit/...) -> meshio file -> `skfem.Mesh.load` -> `skfem_to_meshdata` -> `MeshData` -> FEM solve. gmsh stays an out-of-process tool; mfgarchon never imports it.
- **`assembly.create_basis`**: add `(MeshHex, 1) -> ElementHex1`, `(MeshHex, 2) -> ElementHex2`, mirroring the existing Quad-P2 #470 slice; updated the unsupported-type message.
- **`tests/unit/test_alg/test_fem_hex_mesh_470.py`** (new, 6 tests):
  - adapter round-trip preserves points + cells exactly (`init_tensor` and `refined` builders), `element_type == "hexahedron"`, dimension 3
  - P2-geometry (`MeshHex2`) also resolves to `"hexahedron"`
  - box-wall boundary tagging (`x_min`...`z_max`) applies to hex
  - full FEM Poisson solve on the unit cube runs and is finite; **Q2 strictly more accurate than Q1** on the same mesh (P1 ~2.8e-2, P2 ~2.8e-4)

## What works vs deferred

| Item | Status |
|---|---|
| Hex adapter round-trip (points + cells) | ✅ works |
| Hex FEM solve path (`create_basis` -> assembly -> solve), P1 + P2 | ✅ works (finite, P2 beats P1) |
| Bring-your-own-mesh doc (meshio `.load`, no in-process gmsh) | ✅ documented |
| Prism / wedge (`MeshWedge1`) | ⏸ **deferred** — see below |
| gmsh-based mesh *generation* | ❌ intentionally out-of-scope (rescope) |
| Pyramid element | ❌ intentionally out-of-scope (YAGNI, rescope) |

### Why prism/wedge is deferred (not done)

`MeshWedge1` points+cells **do** round-trip, but two issues block a *clean* mapping:

1. skfem stores the wedge's triangular faces as **degenerate 4-node quad facets** (e.g. `[0, 0, 2, 3]`), so `MeshData.boundary_faces` would be lossy/semantically wrong.
2. meshio's cell name is `"wedge"`, not `"prism"`. Mapping `MeshWedge1 -> "prism"` would break `MeshData.to_meshio()` and the documented meshio BYO path (which yields `"wedge"`). The name reconciliation needs a maintainer decision.

Hex was the stated priority and is fully done; prism is noted in a code comment in the reverse map for a follow-up.

## Gate

- New hex round-trip + solve tests: **6 passed**
- Existing FEM + geometry suites green: `test_fem_adapter_issue1260`, `test_fem_quad_path`, `test_fem_solver_path`, `test_fem_mfg_solve`, `test_fem_robin_bc`, `test_coupling_mesh_geometry` (43 passed); `tests/unit/test_geometry/` + vtk + weak-form P2 (753 passed, 3 skipped, 1 xfailed)
- `ruff format --check` and `ruff check`: clean

Refs #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)