### PR TITLE
docs: flag NewtonMFGSolver ~135x slower than fixed-point in 2D

### DIFF
--- a/docs/user/SOLVER_SELECTION_GUIDE.md
+++ b/docs/user/SOLVER_SELECTION_GUIDE.md
@@ -137,6 +137,17 @@ solver = create_accurate_solver(
 ```
 **Best for**: High-dimensional problems (d ≥ 4)
 
+#### Coupled-Newton Solver (`NewtonMFGSolver`)
+
+```python
+from mfgarchon.alg.numerical.coupling import NewtonMFGSolver
+
+solver = NewtonMFGSolver(problem, hjb_solver, fp_solver)
+U, M, info = solver.solve()
+```
+
+⚠️ **Performance caveat**: `NewtonMFGSolver` is research-grade for d ≥ 2 / Nx > ~50 — it is **~135x slower** than the fixed-point (Picard) coupler in 2D and scales poorly with dimension and grid size. Prefer the fixed-point (Picard) coupler (`create_standard_solver`, Tier 2) or Howard for production coupled solves. Newton is appropriate for small 1D problems or research on the coupled-Newton method.
+
 ## Decision Tree
 
 ```

--- a/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
@@ -63,6 +63,13 @@ class NewtonMFGSolver(BaseCouplingIterator):
         - Automatic Jacobian (finite diff or JAX)
         - Line search for globalization
 
+    Performance / solver selection:
+        NewtonMFGSolver is research-grade for d>=2 / Nx>~50 — it is ~135x slower
+        than the fixed-point (Picard) coupler in 2D and scales poorly with
+        dimension and grid size; prefer ``FixedPointIterator`` (Picard) or Howard
+        for production coupled solves. Newton is appropriate for small 1D problems
+        or research on the coupled-Newton method.
+
     Required Geometry Traits (Issue #596 Phase 2.3):
         This coupling solver requires trait-validated HJB and FP component solvers:
         - HJB solver must use geometry with SupportsGradient trait


### PR DESCRIPTION
## Summary

Adds performance guidance flagged by the codebase assessment (performance dimension): the `NewtonMFGSolver` coupling solver is ~135x slower than the fixed-point (Picard) coupler in 2D and scales poorly with dimension and grid size.

The note steers production coupled solves to the fixed-point (Picard) coupler or Howard, and reserves Newton for small 1D problems or research on the coupled-Newton method.

## Changes (docstring/doc-only, no logic)

- `mfgarchon/alg/numerical/coupling/newton_mfg_solver.py` — added a "Performance / solver selection" note to the `NewtonMFGSolver` class docstring (always visible via `help()`/`__doc__`).
- `docs/user/SOLVER_SELECTION_GUIDE.md` — added a `Coupled-Newton Solver` subsection under Tier 3 (Research) carrying the same caveat.

Note on scope: the note targets the **coupling-layer** Newton (`NewtonMFGSolver`). `docs/user/HJB_SOLVER_SELECTION_GUIDE.md` covers the distinct **inner HJB** Newton (`HJBFDMSolver(solver_type="newton")`) and already documents its own dimension-scaling tradeoffs, so it was left untouched.

## Gate

- `python -c "import mfgarchon"` — clean
- `from mfgarchon.alg.numerical.coupling import NewtonMFGSolver` — clean (doc example path verified)
- `ruff check` + `ruff format --check` on the changed module — clean
- Note confirmed present on `NewtonMFGSolver.__doc__` at runtime (`'135x' in __doc__` → True)

Refs the codebase assessment (performance dimension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)