### PR TITLE
test(boundary): fix Robin ghost-cell expected formula, remove xfail (Refs #1237)

### DIFF
--- a/tests/unit/test_geometry/boundary/test_shared_ghost_formulas.py
+++ b/tests/unit/test_geometry/boundary/test_shared_ghost_formulas.py
@@ -128,9 +128,28 @@ def test_neumann_nonzero_flux():
     print(f"  ✓ Right: u_ghost = {u_ghost} (expected {expected})")
 
 
-@pytest.mark.xfail(reason="Pre-existing bug: Robin ghost cell test has wrong expected value formula")
 def test_robin():
-    """Test Robin ghost cell formula."""
+    """Test Robin ghost cell formula.
+
+    Cell-centered grid: the boundary lies at the cell face, with the ghost
+    cell center and the first interior cell center straddling it exactly ``dx``
+    apart (each ``dx/2`` from the face). Robin BC ``alpha*u + beta*du/dn = g``
+    discretizes as
+
+        value at face   u_face   = (u_ghost + u_interior) / 2
+        normal deriv    du/dn    = (u_ghost - u_interior) / dx   (cells dx apart)
+
+    giving ``alpha*(u_ghost+u_interior)/2 + beta*(u_ghost-u_interior)/dx = g``,
+    i.e. ``u_ghost*(alpha/2 + beta/dx) = g - u_interior*(alpha/2 - beta/dx)``.
+
+    The ``beta/dx`` factor (not ``beta/(2*dx)``) is required for consistency with
+    the ``(u_ghost+u_interior)/2`` value term, which commits to the face-midpoint
+    geometry where the two cells are ``dx`` apart. This matches the Dirichlet
+    sibling (``2*g - u_interior`` from the same face-midpoint average) and the
+    production fix in commit 0ae5515a. The previous expected formula used
+    ``beta/(2*dx)`` (the stale pre-fix factor), which xfailed against the
+    corrected production code (Refs #1237).
+    """
     print("\nTesting Robin...")
 
     applicator = TestApplicator(dimension=1, grid_type=GridType.CELL_CENTERED)
@@ -141,10 +160,10 @@ def test_robin():
     g = 1.0
     dx = 0.1
 
-    # Robin: u_ghost = (g - u_interior * (alpha/2 - beta/(2*dx))) / (alpha/2 + beta/(2*dx))
+    # Robin: u_ghost = (g - u_interior * (alpha/2 - beta/dx)) / (alpha/2 + beta/dx)
     u_ghost = applicator._compute_ghost_robin(u_interior, alpha, beta, g, dx, side="left")
-    coeff_ghost = alpha / 2.0 + beta / (2.0 * dx)
-    coeff_interior = alpha / 2.0 - beta / (2.0 * dx)
+    coeff_ghost = alpha / 2.0 + beta / dx
+    coeff_interior = alpha / 2.0 - beta / dx
     expected = (g - u_interior * coeff_interior) / coeff_ghost
     assert np.isclose(u_ghost, expected), f"Expected {expected}, got {u_ghost}"
     print(f"  ✓ u_ghost = {u_ghost} (expected {expected})")


### PR DESCRIPTION
## Summary

Settles the Robin ghost-cell `xfail` in
`tests/unit/test_geometry/boundary/test_shared_ghost_formulas.py::test_robin`
(reason: "Robin ghost cell test has wrong expected value formula").

**Verdict: the TEST was wrong; production `_compute_ghost_robin` is correct.**
The test carried a stale derivative factor `beta/(2*dx)` that is inconsistent
with its own `(u_ghost + u_interior)/2` value term. Production (in
`mfgarchon/geometry/boundary/protocols.py`) already uses the correct
`beta/dx`, fixed in commit `0ae5515a`; the test was xfailed rather than
corrected. The fix updates the test's expected formula to `beta/dx` and
removes the xfail. No production code changed.

## Derivation (cell-centered grid)

For a cell-centered grid the boundary lies at a cell **face**. The ghost cell
center and the first interior cell center straddle that face, each `dx/2` from
it, so they are exactly `dx` apart.

Robin BC: `alpha*u + beta*du/dn = g` at the boundary.

- Value at the face (midpoint of the two cells):
  `u_face = (u_ghost + u_interior)/2`
- Outward normal derivative (cells `dx` apart, ghost in the outward direction
  on both sides):
  `du/dn = (u_ghost - u_interior)/dx`

Substitute:

```
alpha*(u_ghost + u_interior)/2 + beta*(u_ghost - u_interior)/dx = g
=> u_ghost*(alpha/2 + beta/dx) = g - u_interior*(alpha/2 - beta/dx)
=> u_ghost = (g - u_interior*(alpha/2 - beta/dx)) / (alpha/2 + beta/dx)
```

The `beta/dx` factor (not `beta/(2*dx)`) is **mandated** by the
`(u_ghost + u_interior)/2` value term: the average commits to the
face-midpoint geometry where the two cells are `dx` apart, so the derivative
across them must use `dx`. Using `beta/(2*dx)` would require a `2*dx`
separation, contradicting the same value term. This is geometrically the
same face-midpoint convention as the Dirichlet sibling
(`u_ghost = 2*g - u_interior`, from `(u_ghost + u_interior)/2 = g`).

### On the "2*dx" of the Neumann sibling

`_compute_ghost_neumann` uses `2*dx` because it is a **different stencil**: a
central difference centered at the first interior **node**, spanning from the
ghost cell to the **second** interior cell (`u_next_interior`) — a `2*dx`
span. It evaluates the BC at the node, not at the face. The Robin function's
signature takes only `u_interior` (no `u_next_interior`), so it is inherently
the face-centered discretization, for which `dx` (not `2*dx`) is correct.
Both stencils are individually correct (both exact for linear fields); they
are simply different valid discretizations. Robin/Dirichlet share the
face-midpoint convention; Neumann uses the node-centered central difference.

## Numerical check (test values)

`u_interior=0.5, alpha=1.0, beta=0.1, g=1.0, dx=0.1`:

- Production / corrected test: `coeff_ghost = 0.5 + 1.0 = 1.5`,
  `coeff_interior = 0.5 - 1.0 = -0.5`,
  `u_ghost = (1.0 - 0.5*(-0.5))/1.5 = 1.25/1.5 = 0.8333...` -> matches
  `_compute_ghost_robin` output, test passes.
- Old (xfailed) test formula with `beta/(2*dx)`: expected `1.0`, production
  returns `0.8333...` -> mismatch (why it was failing/xfailed).

## Gate

- `test_robin` passes un-xfailed, formula verified by derivation.
- Neumann sibling tests (`test_neumann_zero_flux`, `test_neumann_nonzero_flux`)
  still pass (consistency preserved).
- Full `tests/unit/test_geometry/boundary/` suite: 62 passed.
- `ruff format --check` and `ruff check` clean on the edited file.

Refs #1237

🤖 Generated with [Claude Code](https://claude.com/claude-code)