### PR TITLE
fix(alg): demote 5 un-instantiable solvers to clearly-experimental (#1342)

### DIFF
--- a/mfgarchon/alg/neural/dgm/mfg_dgm_solver.py
+++ b/mfgarchon/alg/neural/dgm/mfg_dgm_solver.py
@@ -45,11 +45,24 @@ except ImportError:
     TORCH_AVAILABLE = False
 
 logger = get_logger(__name__)
+
+
+def _experimental_unavailable(detail: str) -> NotImplementedError:
+    """Build the Issue #1342 'experimental, not in this release' error."""
+    return NotImplementedError(
+        f"MFGDGMSolver is EXPERIMENTAL and not available in this release "
+        f"(Issue #1342): {detail}. Its solve logic exists but is unvalidated; "
+        f"track #1342 for completion."
+    )
+
+
 if TORCH_AVAILABLE:
 
     class MFGDGMSolver(BaseDGMSolver):
         """
         Deep Galerkin Method solver for Mean Field Games.
+
+        **Experimental — not production-ready (Issue #1342).**
 
         This solver uses neural network function approximation to solve
         high-dimensional MFG systems that are computationally intractable
@@ -82,6 +95,13 @@ if TORCH_AVAILABLE:
                 config: DGM configuration
                 **kwargs: Additional solver arguments
             """
+            # Issue #1342: EXPERIMENTAL solver demoted for v1.0 — block construction with a
+            # clear, actionable error. The original setup/solve implementation is preserved
+            # below (currently unreachable) for future completion under #1342.
+            raise _experimental_unavailable(
+                "construction is intentionally blocked because the required neural hooks "
+                "(build_networks, compute_loss, train_step, validate_solution) are not implemented"
+            )
             super().__init__(problem, config, **kwargs)
 
             # Setup device
@@ -90,6 +110,22 @@ if TORCH_AVAILABLE:
 
             # Log training setup
             self._log_training_setup()
+
+        # Issue #1342: abstract-method stubs. Overriding the abstract neural hooks
+        # makes the class concrete so construction reaches the clear __init__ guard
+        # above instead of the cryptic "Can't instantiate abstract class" TypeError.
+        # They remain unimplemented (experimental) and raise the same actionable error.
+        def build_networks(self) -> None:
+            raise _experimental_unavailable("the build_networks hook is not implemented")
+
+        def compute_loss(self, *args: Any, **kwargs: Any) -> dict[str, float]:
+            raise _experimental_unavailable("the compute_loss hook is not implemented")
+
+        def train_step(self) -> dict[str, float]:
+            raise _experimental_unavailable("the train_step hook is not implemented")
+
+        def validate_solution(self) -> dict[str, float]:
+            raise _experimental_unavailable("the validate_solution hook is not implemented")
 
         def _setup_neural_networks(self) -> None:
             """Setup neural networks for value and density approximation."""

--- a/mfgarchon/alg/optimization/optimal_transport/sinkhorn_solver.py
+++ b/mfgarchon/alg/optimization/optimal_transport/sinkhorn_solver.py
@@ -77,9 +77,20 @@ class SinkhornSolverResult:
     entropic_cost: float = 0.0
 
 
+def _experimental_unavailable(detail: str) -> NotImplementedError:
+    """Build the Issue #1342 'experimental, not in this release' error."""
+    return NotImplementedError(
+        f"SinkhornMFGSolver is EXPERIMENTAL and not available in this release "
+        f"(Issue #1342): {detail}. Its solve logic exists but is unvalidated; "
+        f"track #1342 for completion."
+    )
+
+
 class SinkhornMFGSolver(BaseOptimizationSolver):
     """
     Sinkhorn algorithm-based solver for Mean Field Games.
+
+    **Experimental — not production-ready (Issue #1342).**
 
     This solver uses entropic regularized optimal transport with the Sinkhorn
     algorithm to efficiently solve MFG problems. The entropic regularization
@@ -106,6 +117,13 @@ class SinkhornMFGSolver(BaseOptimizationSolver):
         **kwargs: Any,
     ):
         """Initialize Sinkhorn MFG solver."""
+        # Issue #1342: EXPERIMENTAL solver demoted for v1.0 — block construction with a
+        # clear, actionable error. The original setup/solve implementation is preserved
+        # below (currently unreachable) for future completion under #1342.
+        raise _experimental_unavailable(
+            "construction is intentionally blocked because the required solver hooks "
+            "(compute_objective, compute_gradient, validate_solution) are not implemented"
+        )
         super().__init__(problem, **kwargs)
         self.config = config or SinkhornSolverConfig()
         self.logger = get_logger(__name__)
@@ -116,6 +134,19 @@ class SinkhornMFGSolver(BaseOptimizationSolver):
         # Setup discretization and transport kernel
         self._setup_discretization()
         self._setup_transport_kernel()
+
+    # Issue #1342: abstract-method stubs. Overriding the abstract hooks makes the
+    # class concrete so construction reaches the clear __init__ guard above instead
+    # of the cryptic "Can't instantiate abstract class" TypeError. They remain
+    # unimplemented (experimental) and raise the same actionable error.
+    def compute_objective(self, variables: Any) -> float:
+        raise _experimental_unavailable("the compute_objective hook is not implemented")
+
+    def compute_gradient(self, variables: Any) -> Any:
+        raise _experimental_unavailable("the compute_gradient hook is not implemented")
+
+    def validate_solution(self) -> dict[str, float]:
+        raise _experimental_unavailable("the validate_solution hook is not implemented")
 
     def _check_dependencies(self) -> None:
         """Check required dependencies."""

--- a/mfgarchon/alg/optimization/optimal_transport/wasserstein_solver.py
+++ b/mfgarchon/alg/optimization/optimal_transport/wasserstein_solver.py
@@ -68,9 +68,20 @@ class WassersteinSolverResult:
     average_displacement: float = 0.0
 
 
+def _experimental_unavailable(detail: str) -> NotImplementedError:
+    """Build the Issue #1342 'experimental, not in this release' error."""
+    return NotImplementedError(
+        f"WassersteinMFGSolver is EXPERIMENTAL and not available in this release "
+        f"(Issue #1342): {detail}. Its solve logic exists but is unvalidated; "
+        f"track #1342 for completion."
+    )
+
+
 class WassersteinMFGSolver(BaseOptimizationSolver):
     """
     Wasserstein distance-based solver for Mean Field Games.
+
+    **Experimental — not production-ready (Issue #1342).**
 
     This solver reformulates MFG problems using optimal transport theory,
     working directly in the Wasserstein space of probability measures.
@@ -102,6 +113,13 @@ class WassersteinMFGSolver(BaseOptimizationSolver):
             config: Solver configuration
             **kwargs: Additional solver arguments
         """
+        # Issue #1342: EXPERIMENTAL solver demoted for v1.0 — block construction with a
+        # clear, actionable error. The original setup/solve implementation is preserved
+        # below (currently unreachable) for future completion under #1342.
+        raise _experimental_unavailable(
+            "construction is intentionally blocked because the required solver hooks "
+            "(compute_objective, compute_gradient, validate_solution) are not implemented"
+        )
         super().__init__(problem, **kwargs)
         self.config = config or WassersteinSolverConfig()
         self.logger = get_logger(__name__)
@@ -114,6 +132,19 @@ class WassersteinMFGSolver(BaseOptimizationSolver):
 
         # Initialize transport infrastructure
         self._setup_optimal_transport()
+
+    # Issue #1342: abstract-method stubs. Overriding the abstract hooks makes the
+    # class concrete so construction reaches the clear __init__ guard above instead
+    # of the cryptic "Can't instantiate abstract class" TypeError. They remain
+    # unimplemented (experimental) and raise the same actionable error.
+    def compute_objective(self, variables: Any) -> float:
+        raise _experimental_unavailable("the compute_objective hook is not implemented")
+
+    def compute_gradient(self, variables: Any) -> Any:
+        raise _experimental_unavailable("the compute_gradient hook is not implemented")
+
+    def validate_solution(self) -> dict[str, float]:
+        raise _experimental_unavailable("the validate_solution hook is not implemented")
 
     def _check_dependencies(self) -> None:
         """Check that required dependencies are available."""

--- a/mfgarchon/alg/optimization/variational_solvers/primal_dual_solver.py
+++ b/mfgarchon/alg/optimization/variational_solvers/primal_dual_solver.py
@@ -45,9 +45,20 @@ except ImportError:
     SCIPY_AVAILABLE = False
 
 
+def _experimental_unavailable(detail: str) -> NotImplementedError:
+    """Build the Issue #1342 'experimental, not in this release' error."""
+    return NotImplementedError(
+        f"PrimalDualMFGSolver is EXPERIMENTAL and not available in this release "
+        f"(Issue #1342): {detail}. Its solve logic exists but is unvalidated; "
+        f"track #1342 for completion."
+    )
+
+
 class PrimalDualMFGSolver(BaseVariationalSolver):
     """
     Primal-dual solver for constrained Lagrangian MFG problems.
+
+    **Experimental — not production-ready (Issue #1342).**
 
     Uses augmented Lagrangian method with automatic dual variable updates:
     L(m,v,λ,μ) = J[m,v] + ⟨λ, constraints⟩ + ρ/2 ||constraints||²
@@ -79,6 +90,14 @@ class PrimalDualMFGSolver(BaseVariationalSolver):
             use_adaptive_penalty: Automatically adjust penalty parameter
             constraint_tolerance: Tolerance for constraint satisfaction
         """
+        # Issue #1342: EXPERIMENTAL solver demoted for v1.0 — block construction with a
+        # clear, actionable error BEFORE super().__init__ (which also reaches an
+        # unimplemented problem.geometry path). The original implementation is preserved
+        # below (currently unreachable) for future completion under #1342.
+        raise _experimental_unavailable(
+            "construction is intentionally blocked because the required solver hooks "
+            "(compute_objective, compute_gradient, validate_solution) are not implemented"
+        )
         super().__init__(problem)
         self.solver_name = "PrimalDualMFG"
 
@@ -107,6 +126,19 @@ class PrimalDualMFGSolver(BaseVariationalSolver):
         logger.info(f"  Dual update: {dual_update_method}")
         logger.info(f"  Initial penalty: {augmented_penalty}")
         logger.info(f"  Adaptive penalty: {use_adaptive_penalty}")
+
+    # Issue #1342: abstract-method stubs. Overriding the abstract hooks makes the
+    # class concrete so construction reaches the clear __init__ guard above instead
+    # of the cryptic "Can't instantiate abstract class" TypeError. They remain
+    # unimplemented (experimental) and raise the same actionable error.
+    def compute_objective(self, variables: Any) -> float:
+        raise _experimental_unavailable("the compute_objective hook is not implemented")
+
+    def compute_gradient(self, variables: Any) -> Any:
+        raise _experimental_unavailable("the compute_gradient hook is not implemented")
+
+    def validate_solution(self) -> dict[str, float]:
+        raise _experimental_unavailable("the validate_solution hook is not implemented")
 
     def solve(  # type: ignore[override]
         self,

--- a/mfgarchon/alg/optimization/variational_solvers/variational_mfg_solver.py
+++ b/mfgarchon/alg/optimization/variational_solvers/variational_mfg_solver.py
@@ -42,9 +42,20 @@ if TYPE_CHECKING:
 JAX_AVAILABLE = importlib.util.find_spec("jax") is not None
 
 
+def _experimental_unavailable(detail: str) -> NotImplementedError:
+    """Build the Issue #1342 'experimental, not in this release' error."""
+    return NotImplementedError(
+        f"VariationalMFGSolver is EXPERIMENTAL and not available in this release "
+        f"(Issue #1342): {detail}. Its solve logic exists but is unvalidated; "
+        f"track #1342 for completion."
+    )
+
+
 class VariationalMFGSolver(BaseVariationalSolver):
     """
     Direct variational solver for Lagrangian MFG problems.
+
+    **Experimental — not production-ready (Issue #1342).**
 
     This solver treats the MFG problem as a constrained optimization problem
     and uses gradient-based methods to find the optimal density evolution.
@@ -74,6 +85,14 @@ class VariationalMFGSolver(BaseVariationalSolver):
             use_jax: Use JAX for automatic differentiation (auto-detect if None)
             constraint_tolerance: Tolerance for constraint satisfaction
         """
+        # Issue #1342: EXPERIMENTAL solver demoted for v1.0 — block construction with a
+        # clear, actionable error BEFORE super().__init__ (which also reaches an
+        # unimplemented problem.geometry path). The original implementation is preserved
+        # below (currently unreachable) for future completion under #1342.
+        raise _experimental_unavailable(
+            "construction is intentionally blocked because the required solver hooks "
+            "(compute_objective, compute_gradient, validate_solution) are not implemented"
+        )
         super().__init__(problem)
         self.solver_name = "VariationalMFG"
 
@@ -100,6 +119,19 @@ class VariationalMFGSolver(BaseVariationalSolver):
         logger.info(f"  Optimization method: {optimization_method}")
         logger.info(f"  Penalty weight: {penalty_weight}")
         logger.info(f"  JAX acceleration: {self.use_jax}")
+
+    # Issue #1342: abstract-method stubs. Overriding the abstract hooks makes the
+    # class concrete so construction reaches the clear __init__ guard above instead
+    # of the cryptic "Can't instantiate abstract class" TypeError. They remain
+    # unimplemented (experimental) and raise the same actionable error.
+    def compute_objective(self, variables: Any) -> float:
+        raise _experimental_unavailable("the compute_objective hook is not implemented")
+
+    def compute_gradient(self, variables: Any) -> Any:
+        raise _experimental_unavailable("the compute_gradient hook is not implemented")
+
+    def validate_solution(self) -> dict[str, float]:
+        raise _experimental_unavailable("the validate_solution hook is not implemented")
 
     def solve(
         self,

--- a/tests/unit/test_alg/test_solver_construction_smoke_887.py
+++ b/tests/unit/test_alg/test_solver_construction_smoke_887.py
@@ -1,15 +1,14 @@
 """
-Construction + basic-solve smoke tests for the optimisation / DGM solver
-families (Phase B of issue #887).
+Construction smoke tests for the optimisation / DGM solver families
+(Phase B of issue #887; demote pinned by issue #1342).
 
 Background
 ----------
 #887 lists several "concrete" solver classes that had zero dedicated test
 coverage.  The PINN family (HJB/FP/MFG PINN) is already covered by
-``test_pinn_all_solvers_construct_1314.py`` and ``test_pinn_init_chain_1290.py``
-— those construct tests previously surfaced the #1290 / #1314 ``__init__``
-crashes.  This file adds the same kind of cheap construction gate for the
-*remaining* untested solver families:
+``test_pinn_all_solvers_construct_1314.py`` and ``test_pinn_init_chain_1290.py``.
+This file adds the same kind of cheap construction gate for the *remaining*
+untested solver families:
 
   * ``SinkhornMFGSolver``      (optimal transport)
   * ``WassersteinMFGSolver``   (optimal transport)
@@ -18,43 +17,42 @@ crashes.  This file adds the same kind of cheap construction gate for the
   * ``MFGDGMSolver``           (Deep Galerkin Method; the concrete
                                 ``BaseDGMSolver`` subclass)
 
-NEWLY-SURFACED BUG (xfail below)
---------------------------------
-Every one of these classes is currently **un-instantiable**.  The
-"Phase 1: Algorithm Reorganization Foundation" refactor (commit ``c8f12ad9``,
-2025-09-29) added ``@abstractmethod`` hooks on the shared base classes:
+DEMOTE TO EXPERIMENTAL (#1342)
+------------------------------
+The "Phase 1: Algorithm Reorganization Foundation" refactor (commit
+``c8f12ad9``, 2025-09-29) added ``@abstractmethod`` hooks on the shared base
+classes:
 
   * ``BaseMFGSolver.validate_solution``
   * ``BaseOptimizationSolver.compute_objective`` / ``compute_gradient``
   * ``BaseNeuralSolver.build_networks`` / ``compute_loss`` / ``train_step``
 
 The optimisation and DGM subclasses were never updated to implement them, so
-``SolverCls(problem)`` raises::
+for ~9 months ``SolverCls(problem)`` raised the cryptic::
 
     TypeError: Can't instantiate abstract class <Solver> without an
-    implementation for abstract methods 'compute_gradient',
-    'compute_objective', 'validate_solution'
+    implementation for abstract methods ...
 
-(`MFGDGMSolver` is missing ``build_networks``/``compute_loss``/``train_step``/
-``validate_solution`` instead.)  These solvers have full ``solve()`` bodies,
-configs and result dataclasses, so they are clearly *intended* to be concrete
-— the abstract-method gap is a latent bug, not a deliberate design.
+These five solvers have full ``solve()`` bodies but the hooks are unimplemented
+and there is no reference to validate them, so the v1.0 decision (#1342) is to
+**demote them to clearly-experimental**, not to complete them.  Each now:
 
-The construction tests below are therefore marked ``xfail(strict=True,
-raises=TypeError)``: they pass (as XFAIL) today, pin the exact current failure,
-and will flip to a hard failure the moment a solver is made constructible —
-forcing the stale ``xfail`` to be removed and a real solve smoke test to be
-added.
+  * carries a "**Experimental — not production-ready (Issue #1342).**" docstring;
+  * overrides the missing abstract hooks with stubs raising a clear
+    ``NotImplementedError`` (so the class is concrete, not abstract); and
+  * guards ``__init__`` so construction fails LOUD AND CLEAR with the same
+    actionable "experimental ... #1342" message instead of the bare TypeError.
 
-A secondary defect is masked by the abstract-class TypeError and will only
-surface once the abstract methods are implemented: ``BaseVariationalSolver``
-reads ``problem.geometry.get_grid_shape()`` / ``get_grid_spacing()``, but
-``VariationalMFGProblem`` exposes ``xmin/xmax/Nx/x/dx`` and has no ``geometry``
-attribute.  The variational construction tests pass the intended
-``VariationalMFGProblem`` so the gate keeps failing until *both* defects are
-fixed.
+The tests below pin that clean demote: they assert construction raises a
+``NotImplementedError`` mentioning "experimental" and "#1342".  They flip to a
+hard failure the moment a solver is re-broken (bare TypeError) OR completed
+(constructs successfully) — either of which should be a deliberate, reviewed
+change that updates this pin.
 
-Refs #887 (Phase B; full numerical-correctness coverage remains).
+None of the five are wired into the production factory / ``NumericalScheme``
+dispatch; they are import-only experimental classes.
+
+Refs #887, #1342.
 """
 
 from __future__ import annotations
@@ -71,6 +69,23 @@ except ImportError:
     TORCH_AVAILABLE = False
 
 pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Shared assertion
+# ---------------------------------------------------------------------------
+
+
+def _assert_experimental_1342(excinfo: pytest.ExceptionInfo) -> None:
+    """The demote must surface a clear, actionable #1342 message.
+
+    Guards against regressing to the bare ``Can't instantiate abstract class``
+    TypeError (caught by ``raises=NotImplementedError``) and against a vague
+    message that omits the issue reference or the experimental status.
+    """
+    message = str(excinfo.value)
+    assert "#1342" in message, f"message must reference issue #1342, got: {message!r}"
+    assert "experimental" in message.lower(), f"message must say 'experimental', got: {message!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -108,45 +123,31 @@ def _make_variational_problem():
 # Optimal-transport solvers (POT-backed)
 # ---------------------------------------------------------------------------
 
-_ABSTRACT_OPT_REASON = (
-    "NEWLY-SURFACED BUG (#887): {cls} is abstract — BaseMFGSolver."
-    "validate_solution and BaseOptimizationSolver.compute_objective/"
-    "compute_gradient (added by the 2025-09-29 c8f12ad9 reorg) are never "
-    "implemented, so construction raises TypeError. Remove this xfail once the "
-    "abstract methods are implemented and add a real solve smoke test."
-)
 
-
-@pytest.mark.xfail(
-    raises=TypeError,
-    strict=True,
-    reason=_ABSTRACT_OPT_REASON.format(cls="SinkhornMFGSolver"),
-)
-def test_sinkhorn_mfg_solver_constructs():
-    """Tiny-grid construction of the Sinkhorn optimal-transport solver."""
+def test_sinkhorn_mfg_solver_experimental():
+    """Sinkhorn OT solver is demoted: construction raises a clear #1342 error."""
     from mfgarchon.alg.optimization.optimal_transport.sinkhorn_solver import (
         SinkhornMFGSolver,
         SinkhornSolverConfig,
     )
 
     config = SinkhornSolverConfig(num_time_steps=4, num_spatial_points=8)
-    SinkhornMFGSolver(_make_mfg_problem(), config=config)
+    with pytest.raises(NotImplementedError) as excinfo:
+        SinkhornMFGSolver(_make_mfg_problem(), config=config)
+    _assert_experimental_1342(excinfo)
 
 
-@pytest.mark.xfail(
-    raises=TypeError,
-    strict=True,
-    reason=_ABSTRACT_OPT_REASON.format(cls="WassersteinMFGSolver"),
-)
-def test_wasserstein_mfg_solver_constructs():
-    """Tiny-grid construction of the Wasserstein optimal-transport solver."""
+def test_wasserstein_mfg_solver_experimental():
+    """Wasserstein OT solver is demoted: construction raises a clear #1342 error."""
     from mfgarchon.alg.optimization.optimal_transport.wasserstein_solver import (
         WassersteinMFGSolver,
         WassersteinSolverConfig,
     )
 
     config = WassersteinSolverConfig(num_time_steps=4, num_spatial_points=8)
-    WassersteinMFGSolver(_make_mfg_problem(), config=config)
+    with pytest.raises(NotImplementedError) as excinfo:
+        WassersteinMFGSolver(_make_mfg_problem(), config=config)
+    _assert_experimental_1342(excinfo)
 
 
 # ---------------------------------------------------------------------------
@@ -154,28 +155,22 @@ def test_wasserstein_mfg_solver_constructs():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    raises=TypeError,
-    strict=True,
-    reason=_ABSTRACT_OPT_REASON.format(cls="VariationalMFGSolver"),
-)
-def test_variational_mfg_solver_constructs():
-    """Tiny construction of the direct variational solver."""
+def test_variational_mfg_solver_experimental():
+    """Direct variational solver is demoted: construction raises a clear #1342 error."""
     from mfgarchon.alg.optimization.variational_solvers import VariationalMFGSolver
 
-    VariationalMFGSolver(_make_variational_problem())
+    with pytest.raises(NotImplementedError) as excinfo:
+        VariationalMFGSolver(_make_variational_problem())
+    _assert_experimental_1342(excinfo)
 
 
-@pytest.mark.xfail(
-    raises=TypeError,
-    strict=True,
-    reason=_ABSTRACT_OPT_REASON.format(cls="PrimalDualMFGSolver"),
-)
-def test_primal_dual_mfg_solver_constructs():
-    """Tiny construction of the primal-dual variational solver."""
+def test_primal_dual_mfg_solver_experimental():
+    """Primal-dual variational solver is demoted: construction raises a clear #1342 error."""
     from mfgarchon.alg.optimization.variational_solvers import PrimalDualMFGSolver
 
-    PrimalDualMFGSolver(_make_variational_problem())
+    with pytest.raises(NotImplementedError) as excinfo:
+        PrimalDualMFGSolver(_make_variational_problem())
+    _assert_experimental_1342(excinfo)
 
 
 # ---------------------------------------------------------------------------
@@ -185,22 +180,12 @@ def test_primal_dual_mfg_solver_constructs():
 
 @pytest.mark.optional_torch
 @pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch not installed")
-@pytest.mark.xfail(
-    raises=TypeError,
-    strict=True,
-    reason=(
-        "NEWLY-SURFACED BUG (#887): MFGDGMSolver (the concrete BaseDGMSolver "
-        "subclass) is abstract — BaseNeuralSolver.build_networks/compute_loss/"
-        "train_step and BaseMFGSolver.validate_solution (added by the "
-        "2025-09-29 c8f12ad9 reorg) are never implemented, so construction "
-        "raises TypeError. Remove this xfail once the abstract methods are "
-        "implemented and add a real solve smoke test."
-    ),
-)
-def test_mfg_dgm_solver_constructs():
-    """Tiny construction of the Deep Galerkin Method MFG solver."""
+def test_mfg_dgm_solver_experimental():
+    """Deep Galerkin Method MFG solver is demoted: construction raises a clear #1342 error."""
     from mfgarchon.alg.neural.dgm.base_dgm import DGMConfig
     from mfgarchon.alg.neural.dgm.mfg_dgm_solver import MFGDGMSolver
 
     config = DGMConfig(hidden_layers=[8, 8])
-    MFGDGMSolver(_make_mfg_problem(), config=config)
+    with pytest.raises(NotImplementedError) as excinfo:
+        MFGDGMSolver(_make_mfg_problem(), config=config)
+    _assert_experimental_1342(excinfo)


### PR DESCRIPTION
## Summary

Five "concrete" solver classes have been **un-constructable for ~9 months** with a cryptic `TypeError: Can't instantiate abstract class ...`:

- `SinkhornMFGSolver`, `WassersteinMFGSolver` (optimal transport)
- `VariationalMFGSolver`, `PrimalDualMFGSolver` (variational)
- `MFGDGMSolver` (Deep Galerkin Method)

Root cause: commit `c8f12ad9` (2025-09-29, "Phase 1: Algorithm Reorganization Foundation") added `@abstractmethod` hooks on the shared bases (`BaseMFGSolver.validate_solution`, `BaseOptimizationSolver.compute_objective`/`compute_gradient`, `BaseNeuralSolver.build_networks`/`compute_loss`/`train_step`) that the subclasses never implemented.

## Decision (v1.0): demote, do NOT complete

These are 300-500-line solvers missing their core hooks, with no reference to validate correctness — completion is post-v1.0 work. This PR makes the failure **clean, honest, and loud** instead of cryptic.

For each solver:

- **Override the missing abstract hooks** with stubs raising a clear `NotImplementedError` (this makes the class concrete, so construction reaches the guard below instead of the bare abstract `TypeError`).
- **Guard `__init__`** to fail with the same actionable message:
  > `<Solver> is EXPERIMENTAL and not available in this release (Issue #1342): construction is intentionally blocked because the required solver hooks (...) are not implemented. Its solve logic exists but is unvalidated; track #1342 for completion.`
  For the variational pair the guard runs **before** `super().__init__`, which also reaches an unimplemented `problem.geometry` path (the secondary defect noted in #887). The original setup/solve bodies are preserved (currently unreachable) for future completion.
- **Mark each class docstring** `**Experimental — not production-ready (Issue #1342).**`.

## Not wired into production dispatch

Confirmed none of the five appear in `factory/scheme_factory.py`, `factory/solver_factory.py`, or the `NumericalScheme` enum — they are import-only experimental classes reachable only via their submodule paths. No dispatch change required.

## Tests

`tests/unit/test_alg/test_solver_construction_smoke_887.py`: the strict-`xfail`s that pinned the cryptic `TypeError` now assert the clear `NotImplementedError` mentioning **"experimental"** and **"#1342"**. The pin flips loudly if a solver is re-broken (bare `TypeError`) or completed (constructs successfully).

### Gate verification

- Constructing any of the 5 raises the clear `NotImplementedError` (verified, not the abstract `TypeError`).
- `tests/unit/test_alg/test_solver_construction_smoke_887.py` — **5 passed**.
- `tests/unit/test_alg/` + `tests/unit/test_config/test_enum_conversions.py` — **1217 passed, 3 skipped, 2 xfailed** (the 2 xfailed belong to other tests).
- `ruff format --check` + `ruff check` clean on all touched files.

Refs #1342, #887. (A "Fixes" would require completing the solvers, which is explicitly out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)