### PR TITLE
perf: vectorize semi-Lagrangian per-point optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Vectorized the semi-Lagrangian canonical Carlini-Silva per-point optimization** (PR #PRNUM).
+- **Vectorized the semi-Lagrangian canonical Carlini-Silva per-point optimization** (PR #1353).
   `HJBSemiLagrangianSolver._canonical_cs_step` (`diffusion_method="canonical_cs"`, Issue #1058) in
   1D previously minimized the per-node DPP objective `phi(alpha)` with a Python loop calling
   `scipy.optimize.minimize_scalar` (Brent) once per grid node. The loop is replaced by a single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Vectorized the semi-Lagrangian canonical Carlini-Silva per-point optimization** (PR #PRNUM).
+  `HJBSemiLagrangianSolver._canonical_cs_step` (`diffusion_method="canonical_cs"`, Issue #1058) in
+  1D previously minimized the per-node DPP objective `phi(alpha)` with a Python loop calling
+  `scipy.optimize.minimize_scalar` (Brent) once per grid node. The loop is replaced by a single
+  fixed-iteration **vectorized golden-section search** that solves all nodes' independent 1D
+  bounded minimizations simultaneously via array ops (one batched interpolation per iteration
+  instead of `Nx` separate scalar solves). Iteration count is set to reach the same bracket
+  tolerance (`self.tolerance`) as the Brent call it replaces. This changes the optimizer (not
+  byte-identical), but accuracy is preserved: the canonical-CS gates pass unchanged and the
+  Hopf-Lax analytic L2 error is identical to 7 significant figures. Measured 1D solve speedup of
+  13× (Nx=101) to 40× (Nx=401), growing with grid size. nD (vector control, L-BFGS-B per node) is
+  unchanged.
+
 ## [0.20.0] - 2026-06-14
 
 ### Added

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1579,9 +1579,10 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         convention $\partial_t u = H - \tfrac{\sigma^2}{2}\Delta u$ used throughout this solver:
         the running Lagrangian is $L = \tfrac12|\alpha|^2 - h$ (Legendre dual of $H$).
 
-        The minimization is per node (``scipy.optimize.minimize_scalar`` Brent in 1D,
-        ``scipy.optimize.minimize`` L-BFGS-B in nD) -- the cost CS trade for unconditional
-        stability. Diffusion enters through the $2d$ Brownian departures (added variance
+        The minimization is over the control at each node (1D: a vectorized fixed-iteration
+        golden-section search solving all nodes' independent 1D problems at once;
+        nD: ``scipy.optimize.minimize`` L-BFGS-B per node) -- the cost CS trade for
+        unconditional stability. Diffusion enters through the $2d$ Brownian departures (added variance
         $\sigma^2\mathrm{d}t$ per step), so no operator-splitting diffusion solve is used
         (``_apply_diffusion`` is bypassed, as for ``"stochastic"``). The scheme targets
         reflecting / no-flux (Neumann) boundaries (the CS 2014 setting); the reflected
@@ -1620,8 +1621,9 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
 
         Reuses the stochastic-SL departure-point machinery (diagonal volatility, boundary fold)
         but replaces the explicit ``alpha* = -grad u`` drift with a per-node minimizer of the
-        DPP objective ``phi(alpha)``. 1D uses Brent (``minimize_scalar``); nD uses L-BFGS-B
-        (``minimize``) over the control vector.
+        DPP objective ``phi(alpha)``. 1D uses a vectorized fixed-iteration golden-section search
+        that minimizes all nodes' independent 1D problems simultaneously; nD uses L-BFGS-B
+        (``minimize``) per node over the control vector.
         """
         from scipy.interpolate import RegularGridInterpolator, interp1d
 
@@ -1679,22 +1681,49 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             # Build the monotone (Q1/linear) interpolant once per backward step.
             interp_fn = interp1d(self.x_grid, U_next, kind="linear", bounds_error=False, fill_value="extrapolate")
 
-            U_current = np.empty(Nx)
-            for i in range(Nx):
-                x_i = float(self.x_grid[i])
-                h_i = float(h[i])
+            # Vectorized per-node DPP minimization. All Nx nodes solve the SAME 1D objective
+            # phi_i(alpha) up to the per-node offset (x_i, h_i); the prior per-point
+            # ``minimize_scalar`` (Brent) loop is replaced by one fixed-iteration
+            # golden-section search carried over the whole alpha array, so each iteration is a
+            # single batched interpolation of all nodes' feet instead of Nx separate scipy
+            # calls. phi is unimodal in the same sense Brent assumes (convex 0.5*dt*alpha^2
+            # term plus the monotone Q1 interpolant of u^{n+1}); golden section localizes the
+            # minimizer with the same bracket tolerance as Brent's ``xatol``.
+            def phi_vec(alpha: np.ndarray) -> np.ndarray:
+                """phi over all nodes for a per-node control array (shape (Nx,))."""
+                y_drift = self.x_grid + alpha * dt
+                feet_plus = _fold((y_drift + diff_off).reshape(-1, 1)).ravel()
+                feet_minus = _fold((y_drift - diff_off).reshape(-1, 1)).ravel()
+                u_pm = 0.5 * (interp_fn(feet_plus) + interp_fn(feet_minus))
+                return 0.5 * dt * alpha * alpha - dt * h + u_pm
 
-                def phi(alpha: float, _xi: float = x_i, _hi: float = h_i) -> float:
-                    y_drift = _xi + alpha * dt
-                    feet = _fold(np.array([[y_drift + diff_off], [y_drift - diff_off]]))
-                    u_pm = interp_fn(feet[:, 0])
-                    return 0.5 * dt * alpha * alpha - dt * _hi + 0.5 * float(u_pm[0] + u_pm[1])
+            invphi = (np.sqrt(5.0) - 1.0) / 2.0  # 0.618...
+            invphi2 = 1.0 - invphi  # 0.382...
+            a = np.full(Nx, -bound)
+            b = np.full(Nx, bound)
+            # Iterations to shrink the bracket from width 2*bound to xatol=self.tolerance,
+            # matching the convergence target of the Brent call this replaces.
+            width0 = 2.0 * bound
+            n_iter = max(1, int(np.ceil(np.log(self.tolerance / width0) / np.log(invphi))))
+            x1 = a + invphi2 * (b - a)
+            x2 = a + invphi * (b - a)
+            f1 = phi_vec(x1)
+            f2 = phi_vec(x2)
+            for _ in range(n_iter):
+                mask = f1 < f2  # min in [a, x2]; else min in [x1, b]
+                new_a = np.where(mask, a, x1)
+                new_b = np.where(mask, x2, b)
+                new_x1 = np.where(mask, new_a + invphi2 * (new_b - new_a), x2)
+                new_x2 = np.where(mask, x1, new_a + invphi * (new_b - new_a))
+                # One new interior point per node (the other is carried with its value).
+                eval_point = np.where(mask, new_x1, new_x2)
+                f_eval = phi_vec(eval_point)
+                new_f1 = np.where(mask, f_eval, f2)
+                new_f2 = np.where(mask, f1, f_eval)
+                a, b, x1, x2, f1, f2 = new_a, new_b, new_x1, new_x2, new_f1, new_f2
 
-                res = minimize_scalar(phi, bounds=(-bound, bound), method="bounded", options={"xatol": self.tolerance})
-                # u^n(x_i) = phi(alpha*) (the DPP value at the implicit optimizer).
-                U_current[i] = float(res.fun)
-
-            return U_current
+            # u^n(x_i) = phi(alpha*): the lowest evaluated DPP value at the implicit optimizer.
+            return np.minimum(f1, f2)
 
         # --- nD: per-node vector minimization over the control alpha in R^d ---
         if U_next.ndim == 1:


### PR DESCRIPTION
## Summary

The 1D canonical Carlini-Silva semi-Lagrangian path (`diffusion_method="canonical_cs"`, Issue #1058) computed `u^n(x_i) = min_alpha phi(alpha)` with a **Python loop over grid points**, calling `scipy.optimize.minimize_scalar` (Brent, bounded) once **per node** in `HJBSemiLagrangianSolver._canonical_cs_step`. This serial per-point loop is the dominant cost of the 1D canonical-CS HJB solve.

All `Nx` nodes solve the **same** 1D bounded minimization up to the per-node offset `(x_i, h_i)`, and the linear (monotone Q1) interpolant of `u^{n+1}` is shared — so the independent 1D problems vectorize cleanly.

## Change

Replace the per-point `minimize_scalar` loop with a single **fixed-iteration vectorized golden-section search** carried over the whole `alpha` array:

- Each iteration is **one batched interpolation** of all nodes' departure feet (`x_i + alpha*dt ± sigma*sqrt(dt)`, folded into the domain) instead of `Nx` separate scipy scalar solves.
- Golden-section with reuse: one new interior evaluation per iteration per node.
- Iteration count is set so the bracket shrinks from width `2*bound` to the same `xatol` (`self.tolerance`) the Brent call targeted.
- `phi` is unimodal in the same sense Brent's bounded method assumes (convex `0.5*dt*alpha^2` control term plus the monotone Q1 interpolant).
- Returned value is the lowest evaluated DPP value (`min(f1, f2)`), the analogue of Brent's `res.fun`.

nD (vector control, L-BFGS-B per node) is **out of scope** and unchanged. The already-vectorized explicit characteristic paths (`explicit_euler`/`rk2`, `stochastic`) are untouched.

## Accuracy (not byte-identical — optimizer changed)

The change swaps one local bounded optimizer for another. Accuracy is preserved:

- All 11 canonical-CS tests pass (`tests/unit/test_alg/test_hjb_canonical_cs_sl.py`): convergence to the Hopf-Lax analytic solution, unconditional stability at large dt, implicit-vs-explicit gate, max-principle bound, 2D dispatch.
- Full SL unit suite passes (`test_hjb_semi_lagrangian.py` + canonical CS: 61 passed, 2 skipped, 2 xfailed).
- Full `tests/unit/test_alg`: 1184 passed, 0 failed (21 slow deselected).
- **Hopf-Lax analytic L2 error is identical to 7 significant figures** old-vs-new across Nx ∈ {41, 81, 161}: `2.270951e-02 / 1.122910e-02 / 5.655738e-03`.
- Pointwise `max|ΔU|` old-vs-new is at machine precision (4.5e-13) where `phi` is unimodal, and ≤ 1.3e-3 (rel 3e-4) at isolated nodes where `phi` is multimodal and Brent vs golden-section land in different basins — both are valid local minimizers, and this is far below the scheme's O(dx) ≈ 1e-2 discretization error.

## Measured speedup (1D canonical-CS solve, 3-rep mean, warmup excluded)

| Grid | Before (Brent loop) | After (vectorized golden) | Speedup |
|------|--------------------:|--------------------------:|--------:|
| Nx=101, Nt=50  | 1358 ms | 102 ms | 13.3× |
| Nx=201, Nt=100 | 5420 ms | 235 ms | 23.1× |
| Nx=401, Nt=100 | 11069 ms | 280 ms | 39.5× |

Speedup grows with grid size (per-call scipy/closure overhead amortized over more nodes). The `test_hjb_canonical_cs_sl.py` wall time dropped from 12.7 s to 1.6 s as a side effect.

## Gate

- `ruff format --check` clean, `ruff check` clean.
- No new heavy/timing test added (timing measured ad hoc, not committed).
- CHANGELOG `[Unreleased] → ### Changed` bullet added.

Refs #1058 (the canonical-CS path being optimized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)