### PR TITLE
refactor: remove Tier-2 HJB-solver param deprecations (M_density_evolution / U_final_condition / U_from_prev_picard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Passing the old names now raises `TypeError`. The already-broken
   `particle_collocation_dual_mode_demo.py` example (relied on the removed
   collocation mode and the absent `ParticleMode` symbol) was deleted.
+- **Removed Tier-2 HJB-solver parameter deprecations (≤ v0.17)** (PR #1355). The legacy keyword
+  aliases on the HJB solvers' `solve_hjb_system` methods are gone; pass the canonical names:
+  `M_density_evolution` / `M_density_evolution_from_FP` → `M_density`,
+  `U_final_condition` / `U_final_condition_at_T` → `U_terminal`,
+  `U_from_prev_picard` → `U_coupling_prev`. Affects `HJBFDMSolver`, `HJBGFDMSolver`,
+  `HJBSemiLagrangianSolver`, `HJBWenoSolver`, and the network solvers (`NetworkHJBSolver`,
+  `NetworkPolicyIterationHJBSolver`). The deprecated `bc_values=` kwarg (adjoint-consistent BC is
+  handled via `BCValueProvider` in `BoundaryConditions`) is removed from
+  `HJBFDMSolver.solve_hjb_system` and from the internal `_compute_laplacian_1d` helper. The
+  deprecated Newton-parameter aliases `NiterNewton` → `max_newton_iterations` and
+  `l2errBoundNewton` → `newton_tolerance` are removed from `HJBFDMSolver.__init__` (since v0.16) and
+  from the `base_hjb` module functions `solve_hjb_timestep_newton` / `solve_hjb_system_backward`
+  (since v0.17). Passing any removed name now raises `TypeError`. The v0.18+ deprecations
+  (`damping_factor` → `relaxation`, since v0.19.2; `tensor_volatility_field` → `volatility_field`,
+  since v0.18.7) are retained.
 
 ## [0.20.0] - 2026-06-14
 

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -9,7 +9,6 @@ import scipy.sparse as sparse
 from mfgarchon.alg.base_solver import BaseNumericalSolver, SchemeFamily
 from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
 from mfgarchon.backends.compat import backend_aware_assign, backend_aware_copy, has_nan_or_inf
-from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
@@ -99,18 +98,12 @@ def _compute_gradient_array_1d(
     return grad
 
 
-@deprecated_parameter(
-    param_name="bc_values",
-    since="v0.17.0",
-    replacement="Robin BC segments via AdjointConsistentProvider",
-)
 def _compute_laplacian_1d(
     U_array: np.ndarray,
     Dx: float,
     bc: BoundaryConditions | None = None,
     domain_bounds: np.ndarray | None = None,
     time: float = 0.0,
-    bc_values: dict[str, float] | None = None,  # Issue #574: Per-boundary BC values
 ) -> np.ndarray:
     """
     Compute Laplacian for entire 1D array using BC-aware computation.
@@ -126,7 +119,6 @@ def _compute_laplacian_1d(
         bc: Boundary conditions. If None, uses periodic BC.
         domain_bounds: Unused (kept for backward compatibility)
         time: Current time for time-dependent BCs
-        bc_values: DEPRECATED. Per-boundary BC values (Issue #574).
 
     Returns:
         Laplacian array of shape (Nx,) with d^2u/dx^2 at each point
@@ -134,9 +126,6 @@ def _compute_laplacian_1d(
     Nx = len(U_array)
     if Nx <= 1 or abs(Dx) < 1e-14:
         return np.zeros(Nx)
-
-    # Issue #574: bc_values parameter deprecated — Robin BC framework handles this
-    # Warning now handled by @deprecated_parameter decorator
 
     # Delegate to unified stencil infrastructure (Issue #639)
     return laplacian_with_bc(U_array, [Dx], bc=bc, time=time)
@@ -673,7 +662,6 @@ def compute_hjb_residual(
                 bc=bc,
                 domain_bounds=domain_bounds,
                 time=current_time,
-                bc_values=bc_values,  # Issue #574
             )
         if has_nan_or_inf(U_xx, backend):
             if backend is not None:
@@ -1103,16 +1091,6 @@ def newton_hjb_step(
     return U_n_next_newton_iterate, l2_error_of_step
 
 
-@deprecated_parameter(
-    param_name="NiterNewton",
-    since="v0.17.0",
-    replacement="max_newton_iterations",
-)
-@deprecated_parameter(
-    param_name="l2errBoundNewton",
-    since="v0.17.0",
-    replacement="newton_tolerance",
-)
 def solve_hjb_timestep_newton(
     U_n_plus_1_from_hjb_step: np.ndarray,  # U_new[n+1] in notebook
     U_k_n_from_prev_picard: np.ndarray,  # U_k[n] in notebook
@@ -1121,9 +1099,6 @@ def solve_hjb_timestep_newton(
     max_newton_iterations: int | None = None,
     newton_tolerance: float | None = None,
     t_idx_n: int | None = None,  # time index for U_n being solved
-    # Deprecated parameters for backward compatibility
-    NiterNewton: int | None = None,
-    l2errBoundNewton: float | None = None,
     backend: BaseBackend | None = None,
     sigma_at_n: float | np.ndarray | None = None,  # Diffusion at time t_n
     use_upwind: bool = True,  # Use Godunov upwind (True) or central (False)
@@ -1145,19 +1120,8 @@ def solve_hjb_timestep_newton(
         max_newton_iterations: Maximum Newton iterations (new parameter name)
         newton_tolerance: Newton convergence tolerance (new parameter name)
         t_idx_n: Time index for current solution
-        NiterNewton: DEPRECATED - use max_newton_iterations
-        l2errBoundNewton: DEPRECATED - use newton_tolerance
         bc_values: Per-boundary BC values (Issue #574)
     """
-    # Handle backward compatibility (warnings handled by @deprecated_parameter decorators)
-    if NiterNewton is not None:
-        if max_newton_iterations is None:
-            max_newton_iterations = NiterNewton
-
-    if l2errBoundNewton is not None:
-        if newton_tolerance is None:
-            newton_tolerance = l2errBoundNewton
-
     # Set defaults if still None
     if max_newton_iterations is None:
         max_newton_iterations = DEFAULT_NEWTON_MAX_ITERATIONS
@@ -1312,16 +1276,6 @@ def solve_hjb_timestep_newton(
     return U_n_current_newton_iterate
 
 
-@deprecated_parameter(
-    param_name="NiterNewton",
-    since="v0.17.0",
-    replacement="max_newton_iterations",
-)
-@deprecated_parameter(
-    param_name="l2errBoundNewton",
-    since="v0.17.0",
-    replacement="newton_tolerance",
-)
 def solve_hjb_system_backward(
     M_density_from_prev_picard: np.ndarray,  # M_k in notebook
     U_final_condition_at_T: np.ndarray,
@@ -1329,9 +1283,6 @@ def solve_hjb_system_backward(
     problem: MFGProblem,
     max_newton_iterations: int | None = None,
     newton_tolerance: float | None = None,
-    # Deprecated parameters for backward compatibility
-    NiterNewton: int | None = None,
-    l2errBoundNewton: float | None = None,
     backend: BaseBackend | None = None,
     volatility_field: float | np.ndarray | None = None,  # Diffusion field
     use_upwind: bool = True,  # Use Godunov upwind (True) or central (False)
@@ -1351,21 +1302,10 @@ def solve_hjb_system_backward(
         problem: MFG problem instance
         max_newton_iterations: Maximum Newton iterations (new parameter name)
         newton_tolerance: Newton convergence tolerance (new parameter name)
-        NiterNewton: DEPRECATED - use max_newton_iterations
-        l2errBoundNewton: DEPRECATED - use newton_tolerance
         bc_values: Per-boundary Neumann BC values (Issue #574):
             {"x_min": gradient_left, "x_max": gradient_right}
             For adjoint-consistent BC. Default: None (standard BC with 0 gradient).
     """
-    # Handle backward compatibility (warnings handled by @deprecated_parameter decorators)
-    if NiterNewton is not None:
-        if max_newton_iterations is None:
-            max_newton_iterations = NiterNewton
-
-    if l2errBoundNewton is not None:
-        if newton_tolerance is None:
-            newton_tolerance = l2errBoundNewton
-
     # Set defaults if still None
     if max_newton_iterations is None:
         max_newton_iterations = DEFAULT_NEWTON_MAX_ITERATIONS

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -136,16 +136,6 @@ class HJBFDMSolver(BaseHJBSolver):
     _honors_multipop_hamiltonian_override = True
 
     @deprecated_parameter(
-        param_name="NiterNewton",
-        since="v0.16.0",
-        replacement="max_newton_iterations",
-    )
-    @deprecated_parameter(
-        param_name="l2errBoundNewton",
-        since="v0.16.0",
-        replacement="newton_tolerance",
-    )
-    @deprecated_parameter(
         param_name="damping_factor",
         since="v0.19.2",
         replacement="relaxation",
@@ -160,9 +150,7 @@ class HJBFDMSolver(BaseHJBSolver):
         newton_tolerance: float | None = None,
         constraint: ConstraintProtocol | None = None,
         on_newton_failure: NewtonFailurePolicy = "raise",
-        # Deprecated parameters (decorator handles warnings)
-        NiterNewton: int | None = None,
-        l2errBoundNewton: float | None = None,
+        # Deprecated parameter (decorator handles warnings)
         damping_factor: float | None = None,
         backend: str | None = None,
     ):
@@ -207,11 +195,7 @@ class HJBFDMSolver(BaseHJBSolver):
         self.advection_scheme = advection_scheme
         self.use_upwind = advection_scheme == "gradient_upwind"
 
-        # Redirect deprecated parameters (decorator handles warnings)
-        if NiterNewton is not None:
-            max_newton_iterations = max_newton_iterations or NiterNewton
-        if l2errBoundNewton is not None:
-            newton_tolerance = newton_tolerance or l2errBoundNewton
+        # Redirect deprecated parameter (decorator handles warnings)
         if damping_factor is not None:
             relaxation = damping_factor
 
@@ -354,36 +338,6 @@ class HJBFDMSolver(BaseHJBSolver):
             pass  # Not enough info to compute CFL — skip silently
 
     @deprecated_parameter(
-        param_name="M_density_evolution",
-        since="v0.17.0",
-        replacement="M_density",
-    )
-    @deprecated_parameter(
-        param_name="M_density_evolution_from_FP",
-        since="v0.17.0",
-        replacement="M_density",
-    )
-    @deprecated_parameter(
-        param_name="U_final_condition",
-        since="v0.17.0",
-        replacement="U_terminal",
-    )
-    @deprecated_parameter(
-        param_name="U_final_condition_at_T",
-        since="v0.17.0",
-        replacement="U_terminal",
-    )
-    @deprecated_parameter(
-        param_name="U_from_prev_picard",
-        since="v0.17.0",
-        replacement="U_coupling_prev",
-    )
-    @deprecated_parameter(
-        param_name="bc_values",
-        since="v0.17.0",
-        replacement="BCValueProvider in BoundaryConditions",
-    )
-    @deprecated_parameter(
         param_name="tensor_volatility_field",
         since="v0.18.7",
         replacement="volatility_field (pass (d,d) array or callable returning (d,d))",
@@ -395,17 +349,10 @@ class HJBFDMSolver(BaseHJBSolver):
         U_coupling_prev: NDArray | None = None,
         volatility_field: float | NDArray | None = None,
         tensor_volatility_field: NDArray | None = None,
-        bc_values: dict[str, float] | None = None,
         progress_callback: Callable[[int], None] | None = None,  # Issue #640
         show_progress: bool | None = None,  # Issue #934
         # MMS verification support
         source_term: Callable | None = None,
-        # Deprecated parameter names for backward compatibility (decorators handle warnings)
-        M_density_evolution_from_FP: NDArray | None = None,
-        U_final_condition_at_T: NDArray | None = None,
-        U_from_prev_picard: NDArray | None = None,
-        M_density_evolution: NDArray | None = None,
-        U_final_condition: NDArray | None = None,
         *,
         hamiltonian_override=None,  # Issue #1157: multi-population cross-density bound H
     ) -> NDArray:
@@ -420,8 +367,6 @@ class HJBFDMSolver(BaseHJBSolver):
             U_coupling_prev: Previous coupling iteration estimate
             volatility_field: Diffusion coefficient (None uses problem.sigma)
             tensor_volatility_field: Tensor diffusion (Phase 3.0, not yet fully implemented)
-            bc_values: DEPRECATED. No longer used (kept for backward compatibility).
-                Adjoint-consistent BC is handled via BCValueProvider in BoundaryConditions.
 
         Note:
             For adjoint-consistent BC, use AdjointConsistentProvider in BCSegment.value
@@ -429,32 +374,6 @@ class HJBFDMSolver(BaseHJBSolver):
             providers each iteration via problem.using_resolved_bc(state).
             See mfgarchon/geometry/boundary/providers.py for details.
         """
-        # Handle deprecated parameter names (decorators handle warnings, keep redirect logic)
-        if M_density_evolution is not None:
-            if M_density is not None or M_density_evolution_from_FP is not None:
-                raise ValueError("Cannot specify M_density_evolution with M_density or M_density_evolution_from_FP")
-            M_density = M_density_evolution
-
-        if M_density_evolution_from_FP is not None:
-            if M_density is not None:
-                raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            M_density = M_density_evolution_from_FP
-
-        if U_final_condition is not None:
-            if U_terminal is not None or U_final_condition_at_T is not None:
-                raise ValueError("Cannot specify U_final_condition with U_terminal or U_final_condition_at_T")
-            U_terminal = U_final_condition
-
-        if U_final_condition_at_T is not None:
-            if U_terminal is not None:
-                raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            U_terminal = U_final_condition_at_T
-
-        if U_from_prev_picard is not None:
-            if U_coupling_prev is not None:
-                raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            U_coupling_prev = U_from_prev_picard
-
         # Validate required parameters
         if M_density is None:
             raise ValueError("M_density is required")
@@ -1439,9 +1358,9 @@ if __name__ == "__main__":
     U_prev = np.zeros((problem_1d.Nt + 1, problem_1d.Nx + 1))
 
     U_solution = solver_1d.solve_hjb_system(
-        M_density_evolution_from_FP=M_test,
-        U_final_condition_at_T=U_final,
-        U_from_prev_picard=U_prev,
+        M_density=M_test,
+        U_terminal=U_final,
+        U_coupling_prev=U_prev,
     )
 
     assert U_solution.shape == (problem_1d.Nt + 1, problem_1d.Nx + 1)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -33,7 +33,6 @@ from mfgarchon.alg.numerical.hjb_solvers.h_eval import (
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
 from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL
 from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
-from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical.qp_utils import QPCache, QPSolver
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
@@ -2941,21 +2940,6 @@ class HJBGFDMSolver(BaseHJBSolver):
     # Note: _build_monotonicity_constraints moved to MonotonicityEnforcer component
     # Note: _build_hamiltonian_gradient_constraints moved to MonotonicityEnforcer component
 
-    @deprecated_parameter(
-        param_name="M_density_evolution_from_FP",
-        since="v0.17.0",
-        replacement="M_density",
-    )
-    @deprecated_parameter(
-        param_name="U_final_condition_at_T",
-        since="v0.17.0",
-        replacement="U_terminal",
-    )
-    @deprecated_parameter(
-        param_name="U_from_prev_picard",
-        since="v0.17.0",
-        replacement="U_coupling_prev",
-    )
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
@@ -2964,10 +2948,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         show_progress: bool | None = None,
         volatility_field: float | np.ndarray | None = None,
         running_cost: np.ndarray | Callable[[int], np.ndarray] | None = None,
-        # Deprecated parameter names for backward compatibility
-        M_density_evolution_from_FP: np.ndarray | None = None,
-        U_final_condition_at_T: np.ndarray | None = None,
-        U_from_prev_picard: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Solve the HJB system using GFDM collocation method.
@@ -2987,22 +2967,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         Returns:
             (Nt, *spatial_shape) solution array
         """
-        # Handle deprecated parameter names (warnings issued by @deprecated_parameter decorators)
-        if M_density_evolution_from_FP is not None:
-            if M_density is not None:
-                raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            M_density = M_density_evolution_from_FP
-
-        if U_final_condition_at_T is not None:
-            if U_terminal is not None:
-                raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            U_terminal = U_final_condition_at_T
-
-        if U_from_prev_picard is not None:
-            if U_coupling_prev is not None:
-                raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            U_coupling_prev = U_from_prev_picard
-
         # Issue #1316: install the per-solve volatility_field as the authoritative
         # diffusion source for _get_sigma_value (consumed below via the residual /
         # Jacobian / LLF paths). Set every call (not cleared at end) so there is no

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -33,7 +33,6 @@ from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
     get_bc_type_string,
 )
-from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import check_adi_compatibility, diffusion_from_volatility
 
@@ -783,19 +782,12 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # Use InterpolationApplicator for dimension-agnostic BC enforcement
         return self.interp_bc_applicator.enforce_values(U, bc, time=time)
 
-    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
-    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
-    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
         U_terminal: np.ndarray | None = None,
         U_coupling_prev: np.ndarray | None = None,
         volatility_field: float | np.ndarray | None = None,
-        # Deprecated parameter names for backward compatibility
-        M_density_evolution_from_FP: np.ndarray | None = None,
-        U_final_condition_at_T: np.ndarray | None = None,
-        U_from_prev_picard: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Solve the HJB system using semi-Lagrangian method.
@@ -819,22 +811,6 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         Returns:
             (Nt, *grid_shape) solution array for value function
         """
-        # Handle deprecated parameter names (warnings issued by @deprecated_parameter decorator)
-        if M_density_evolution_from_FP is not None:
-            if M_density is not None:
-                raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            M_density = M_density_evolution_from_FP
-
-        if U_final_condition_at_T is not None:
-            if U_terminal is not None:
-                raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            U_terminal = U_final_condition_at_T
-
-        if U_from_prev_picard is not None:
-            if U_coupling_prev is not None:
-                raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            U_coupling_prev = U_from_prev_picard
-
         # Issue #1316: the semi-Lagrangian solver reads diffusion from problem.sigma at
         # multiple scattered sites (the advection-diffusion split, ADI, Crank-Nicolson),
         # with no single sigma chokepoint to redirect. Honoring a volatility_field that

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -44,7 +44,6 @@ import numpy as np
 from mfgarchon.core.derivatives import DerivativeTensors, to_multi_index_dict
 from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
 from mfgarchon.geometry.boundary.conditions import neumann_bc
-from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 from .base_hjb import BaseHJBSolver
@@ -870,19 +869,12 @@ class HJBWenoSolver(BaseHJBSolver):
 
         return max(dt_stable, 1e-10)  # Ensure positive time step
 
-    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
-    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
-    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
         U_terminal: np.ndarray | None = None,
         U_coupling_prev: np.ndarray | None = None,
         volatility_field: float | np.ndarray | None = None,
-        # Deprecated parameter names for backward compatibility
-        M_density_evolution_from_FP: np.ndarray | None = None,
-        U_final_condition_at_T: np.ndarray | None = None,
-        U_from_prev_picard: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Solve the complete HJB system using WENO spatial discretization.
@@ -900,22 +892,6 @@ class HJBWenoSolver(BaseHJBSolver):
         Returns:
             U_solved: Complete solution u(t,x) over time domain
         """
-        # Handle deprecated parameter names (warnings handled by @deprecated_parameter decorators)
-        if M_density_evolution_from_FP is not None:
-            if M_density is not None:
-                raise ValueError("Cannot specify both 'M_density' and deprecated 'M_density_evolution_from_FP'")
-            M_density = M_density_evolution_from_FP
-
-        if U_final_condition_at_T is not None:
-            if U_terminal is not None:
-                raise ValueError("Cannot specify both 'U_terminal' and deprecated 'U_final_condition_at_T'")
-            U_terminal = U_final_condition_at_T
-
-        if U_from_prev_picard is not None:
-            if U_coupling_prev is not None:
-                raise ValueError("Cannot specify both 'U_coupling_prev' and deprecated 'U_from_prev_picard'")
-            U_coupling_prev = U_from_prev_picard
-
         # Issue #1316: the WENO solver reads diffusion from problem.sigma at multiple
         # scattered sites (the diffusion CFL bound and the diffusion update in each
         # dimensional sweep), with no single sigma chokepoint to redirect. Honoring a

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -29,7 +29,6 @@ import scipy.sparse as sp
 from scipy.sparse.linalg import spsolve
 
 from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
-from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
     from mfgarchon.extensions.topology import NetworkMFGProblem
@@ -98,21 +97,12 @@ class NetworkHJBSolver(BaseHJBSolver):
         for i in range(self.num_nodes):
             self.gradient_ops[i] = self.network_problem.get_node_neighbors(i)
 
-    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
-    @deprecated_parameter(param_name="M_density_evolution", since="v0.17.0", replacement="M_density")
-    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
-    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
         U_terminal: np.ndarray | None = None,
         U_coupling_prev: np.ndarray | None = None,
         volatility_field: float | np.ndarray | None = None,
-        # Deprecated parameter names for backward compatibility
-        M_density_evolution_from_FP: np.ndarray | None = None,
-        U_final_condition_at_T: np.ndarray | None = None,
-        U_from_prev_picard: np.ndarray | None = None,
-        M_density_evolution: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Solve HJB system on network with given density evolution.
@@ -122,47 +112,10 @@ class NetworkHJBSolver(BaseHJBSolver):
             U_terminal: Terminal condition u(T, i)
             U_coupling_prev: Previous Picard iterate for coupling
             volatility_field: Diffusion coefficient (not yet used in network solver)
-            M_density_evolution_from_FP: DEPRECATED, use M_density
-            U_final_condition_at_T: DEPRECATED, use U_terminal
-            U_from_prev_picard: DEPRECATED, use U_coupling_prev
-            M_density_evolution: DEPRECATED, use M_density
 
         Returns:
             (Nt+1, num_nodes) value function evolution
         """
-        # Handle deprecated parameter redirects
-        if M_density_evolution_from_FP is not None:
-            if M_density is not None:
-                raise ValueError(
-                    "Cannot specify both M_density and M_density_evolution_from_FP. "
-                    "Use M_density (M_density_evolution_from_FP is deprecated)."
-                )
-            M_density = M_density_evolution_from_FP
-
-        if M_density_evolution is not None:
-            if M_density is not None:
-                raise ValueError(
-                    "Cannot specify both M_density and M_density_evolution. "
-                    "Use M_density (M_density_evolution is deprecated)."
-                )
-            M_density = M_density_evolution
-
-        if U_final_condition_at_T is not None:
-            if U_terminal is not None:
-                raise ValueError(
-                    "Cannot specify both U_terminal and U_final_condition_at_T. "
-                    "Use U_terminal (U_final_condition_at_T is deprecated)."
-                )
-            U_terminal = U_final_condition_at_T
-
-        if U_from_prev_picard is not None:
-            if U_coupling_prev is not None:
-                raise ValueError(
-                    "Cannot specify both U_coupling_prev and U_from_prev_picard. "
-                    "Use U_coupling_prev (U_from_prev_picard is deprecated)."
-                )
-            U_coupling_prev = U_from_prev_picard
-
         # Validate required parameters
         if M_density is None:
             raise ValueError("M_density is required")
@@ -285,56 +238,14 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
         # Current policy (action for each node)
         self.current_policy: dict[int, int] = {}
 
-    @deprecated_parameter(param_name="M_density_evolution_from_FP", since="v0.17.0", replacement="M_density")
-    @deprecated_parameter(param_name="M_density_evolution", since="v0.17.0", replacement="M_density")
-    @deprecated_parameter(param_name="U_final_condition_at_T", since="v0.17.0", replacement="U_terminal")
-    @deprecated_parameter(param_name="U_from_prev_picard", since="v0.17.0", replacement="U_coupling_prev")
     def solve_hjb_system(
         self,
         M_density: np.ndarray | None = None,
         U_terminal: np.ndarray | None = None,
         U_coupling_prev: np.ndarray | None = None,
         volatility_field: float | np.ndarray | None = None,
-        # Deprecated parameter names for backward compatibility
-        M_density_evolution_from_FP: np.ndarray | None = None,
-        U_final_condition_at_T: np.ndarray | None = None,
-        U_from_prev_picard: np.ndarray | None = None,
-        M_density_evolution: np.ndarray | None = None,
     ) -> np.ndarray:
         """Solve HJB using policy iteration."""
-        # Handle deprecated parameter redirects
-        if M_density_evolution_from_FP is not None:
-            if M_density is not None:
-                raise ValueError(
-                    "Cannot specify both M_density and M_density_evolution_from_FP. "
-                    "Use M_density (M_density_evolution_from_FP is deprecated)."
-                )
-            M_density = M_density_evolution_from_FP
-
-        if M_density_evolution is not None:
-            if M_density is not None:
-                raise ValueError(
-                    "Cannot specify both M_density and M_density_evolution. "
-                    "Use M_density (M_density_evolution is deprecated)."
-                )
-            M_density = M_density_evolution
-
-        if U_final_condition_at_T is not None:
-            if U_terminal is not None:
-                raise ValueError(
-                    "Cannot specify both U_terminal and U_final_condition_at_T. "
-                    "Use U_terminal (U_final_condition_at_T is deprecated)."
-                )
-            U_terminal = U_final_condition_at_T
-
-        if U_from_prev_picard is not None:
-            if U_coupling_prev is not None:
-                raise ValueError(
-                    "Cannot specify both U_coupling_prev and U_from_prev_picard. "
-                    "Use U_coupling_prev (U_from_prev_picard is deprecated)."
-                )
-            U_coupling_prev = U_from_prev_picard
-
         # Validate required parameters
         if M_density is None:
             raise ValueError("M_density is required")

--- a/tests/unit/test_alg/test_hjb_fdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_fdm_solver.py
@@ -78,54 +78,21 @@ class TestHJBFDMSolverInitialization:
         assert solver.max_newton_iterations == 50
         assert solver.newton_tolerance == 1e-8
 
-    def test_deprecated_parameters_niter(self):
-        """Test backward compatibility with deprecated NiterNewton parameter."""
+    def test_removed_NiterNewton_raises(self):
+        """v0.16 deprecation removed: NiterNewton= no longer in __init__ signature -> TypeError."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
         problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
 
-        with pytest.warns(DeprecationWarning, match="Parameter.*NiterNewton.*deprecated"):
-            solver = HJBFDMSolver(problem, NiterNewton=40)
+        with pytest.raises(TypeError, match="NiterNewton"):
+            HJBFDMSolver(problem, NiterNewton=40)
 
-        assert solver.max_newton_iterations == 40
-
-    def test_deprecated_parameters_tolerance(self):
-        """Test backward compatibility with deprecated l2errBoundNewton parameter."""
+    def test_removed_l2errBoundNewton_raises(self):
+        """v0.16 deprecation removed: l2errBoundNewton= no longer in __init__ signature -> TypeError."""
         geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
         problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
 
-        with pytest.warns(DeprecationWarning, match="Parameter.*l2errBoundNewton.*deprecated"):
-            solver = HJBFDMSolver(problem, l2errBoundNewton=1e-5)
-
-        assert solver.newton_tolerance == 1e-5
-
-    def test_both_deprecated_parameters(self):
-        """Test backward compatibility with both deprecated parameters."""
-        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
-
-        with pytest.warns(DeprecationWarning, match="Parameter.*deprecated"):
-            solver = HJBFDMSolver(
-                problem,
-                NiterNewton=25,
-                l2errBoundNewton=1e-7,
-            )
-
-        assert solver.max_newton_iterations == 25
-        assert solver.newton_tolerance == 1e-7
-
-    def test_new_overrides_deprecated(self):
-        """Test that new parameters override deprecated ones."""
-        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
-        problem = MFGProblem(geometry=geometry, T=1.0, Nt=50, components=_default_components())
-
-        with pytest.warns(DeprecationWarning, match="Parameter.*NiterNewton.*deprecated"):
-            solver = HJBFDMSolver(
-                problem,
-                max_newton_iterations=60,
-                NiterNewton=25,  # Should be ignored
-            )
-
-        assert solver.max_newton_iterations == 60
+        with pytest.raises(TypeError, match="l2errBoundNewton"):
+            HJBFDMSolver(problem, l2errBoundNewton=1e-5)
 
     def test_invalid_max_iterations(self):
         """Test that invalid max_newton_iterations raises error."""
@@ -219,6 +186,33 @@ class TestHJBFDMSolverInitialization:
 
         with pytest.raises(ValueError, match="Invalid advection_scheme"):
             HJBFDMSolver(problem, advection_scheme="divergence_upwind")  # FP scheme
+
+
+class TestRemovedSolveHJBSystemKwargs:
+    """v0.17 deprecations removed: solve_hjb_system no longer accepts the legacy
+    density/terminal/coupling kwarg names or bc_values -> TypeError (unexpected kwarg)."""
+
+    @pytest.fixture(scope="class")
+    def solver(self):
+        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=10, components=_default_components())
+        return HJBFDMSolver(problem)
+
+    @pytest.mark.parametrize(
+        "kwarg",
+        [
+            "M_density_evolution_from_FP",
+            "M_density_evolution",
+            "U_final_condition_at_T",
+            "U_final_condition",
+            "U_from_prev_picard",
+            "bc_values",
+        ],
+    )
+    def test_removed_kwarg_raises_type_error(self, solver, kwarg):
+        """Each removed legacy kwarg now raises TypeError when passed to solve_hjb_system."""
+        with pytest.raises(TypeError, match=kwarg):
+            solver.solve_hjb_system(**{kwarg: None})
 
 
 class TestHJBFDMSolverSolveHJBSystem:


### PR DESCRIPTION
## Summary

Removes the Tier-2 (≤ v0.17) `@deprecated_parameter` keyword aliases on the HJB solvers, migrating every remaining call site to the canonical names. Follows the established removal recipe (cf. #1354). v0.18+ deprecations are deliberately **retained**.

### Removed (per-symbol)

`solve_hjb_system` kwargs on `HJBFDMSolver`, `HJBGFDMSolver`, `HJBSemiLagrangianSolver`, `HJBWenoSolver`, `NetworkHJBSolver`, `NetworkPolicyIterationHJBSolver`:

| old name | new name | since | sites migrated |
|---|---|---|---|
| `M_density_evolution`, `M_density_evolution_from_FP` | `M_density` | v0.17.0 | — |
| `U_final_condition`, `U_final_condition_at_T` | `U_terminal` | v0.17.0 | — |
| `U_from_prev_picard` | `U_coupling_prev` | v0.17.0 | 1 (FDM module smoke test) |

Newton-param kwargs:

| old name | new name | since | location |
|---|---|---|---|
| `NiterNewton` | `max_newton_iterations` | v0.16.0 (FDM `__init__`), v0.17.0 (base_hjb fns) | `HJBFDMSolver.__init__`, `base_hjb.solve_hjb_timestep_newton`, `base_hjb.solve_hjb_system_backward` |
| `l2errBoundNewton` | `newton_tolerance` | v0.16.0 / v0.17.0 | same |

`bc_values` (v0.17.0, no replacement — adjoint-consistent BC handled via `BCValueProvider` in `BoundaryConditions`): removed from `HJBFDMSolver.solve_hjb_system` and the internal `_compute_laplacian_1d` helper (and its single call site's forward).

Unused `deprecated_parameter` imports removed from `base_hjb`, `hjb_gfdm`, `hjb_semi_lagrangian`, `hjb_weno`, `hjb_network` (kept in `hjb_fdm`, which still hosts the retained v0.18+ decorators).

### Retained (v0.18+, out of removal window)

- `damping_factor` → `relaxation` (v0.19.2)
- `tensor_volatility_field` → `volatility_field` (v0.18.7)

### Scope-boundary discrimination

Names that share these spellings but are **independent, non-deprecated APIs** are left untouched:
- abstract `BaseHJBSolver.solve_hjb_system` protocol parameter names;
- `base_hjb.solve_hjb_system_backward` internal-function parameter names (the FDM 1D path calls it with `U_final_condition_at_T=` / `U_from_prev_picard=` — its live kwargs);
- WENO internal `_solve_hjb_system_{1d,2d,3d,nd}` parameter names (called positionally);
- the penalty-wrapper `solve_hjb_system` parameter names (forwards positionally);
- the live Issue #574 `bc_values` plumbing on `newton_hjb_step` / `solve_hjb_timestep_newton` / `solve_hjb_system_backward`;
- `mfgarchon/utils/parameter_migration.py` and `weak_form_hjb_solver.py` (separate, non-decorator mechanisms outside the targeted lane).

### Tests

- FDM `__init__` Newton-deprecation equivalence tests → removed-pins asserting `TypeError`.
- New `TestRemovedSolveHJBSystemKwargs` (parametrized) pins that each removed `solve_hjb_system` kwarg now raises `TypeError`.
- Canonical-name coverage retained (existing positional `solve_hjb_system(M_density, U_terminal, U_coupling_prev)` tests).

### Gate

- removed-kwarg production call sites == 0 (the one FDM smoke-test call migrated)
- removed-pins pass; affected suites green (FDM, GFDM, GFDM-v025-removal, SemiLagrangian, WENO, network, adjoint-BC/fixed-point coupling, parameter-migration)
- `python -c "import mfgarchon"` clean
- `ruff format --check` (749 files) + `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)