### PR TITLE
refactor: remove Tier-2 FP-solver param deprecations (m_initial_condition / diffusion_field / ...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (since v0.17). Passing any removed name now raises `TypeError`. The v0.18+ deprecations
   (`damping_factor` → `relaxation`, since v0.19.2; `tensor_volatility_field` → `volatility_field`,
   since v0.18.7) are retained.
+- **Removed the Tier-2 FP-solver parameter renames `m_initial_condition` and `diffusion_field`** (PR #1356)
+  (deprecated v0.17.0, removed at v0.20 — 3 minor versions past the deprecation window). On the FP
+  solvers' `solve_fp_system` (`FPFDMSolver`, `FPParticleSolver`, `FPGFDMSolver`, `FPSLSolver`,
+  `FPSLAdjointSolver`) and the `BaseFPSolver` abstract interface, use `M_initial` instead of
+  `m_initial_condition` and `volatility_field` instead of `diffusion_field`; passing an old name
+  now raises `TypeError`. (`FPGFDMSolver` only deprecated `diffusion_field` — `m_initial_condition`
+  is its current first positional parameter and is unchanged.) Internal helpers
+  (`solve_fp_nd_full_system`, `FPFDMSolver._solve_fp_1d`) keep `m_initial_condition` /
+  `diffusion_field` as their own non-deprecated parameter names. The `tensor_diffusion_field` and
+  `volatility_matrix` aliases (also v0.17.0) are intentionally retained: `volatility_field` has no
+  equivalent yet for their callable-tensor routing, so they are not removal-ready. The
+  `MFGProblem.diffusion_field` property and the `FPNetworkSolver` `m_initial_condition` deprecation
+  are out of scope.
 
 ## [0.20.0] - 2026-06-14
 

--- a/examples/basic/state_dependent_diffusion.py
+++ b/examples/basic/state_dependent_diffusion.py
@@ -87,7 +87,7 @@ def scenario_porous_medium():
         hjb_solver,
         fp_solver,
         damping_factor=0.5,
-        diffusion_field=porous_medium_diffusion,  # State-dependent!
+        volatility_field=porous_medium_diffusion,  # State-dependent!
     )
 
     # Solve MFG system
@@ -148,7 +148,7 @@ def scenario_crowd_dynamics():
         hjb_solver,
         fp_solver,
         damping_factor=0.5,
-        diffusion_field=crowd_diffusion,
+        volatility_field=crowd_diffusion,
     )
 
     print("Solving MFG with crowd dynamics diffusion...")
@@ -205,7 +205,7 @@ def scenario_spatially_varying():
         hjb_solver,
         fp_solver,
         damping_factor=0.5,
-        diffusion_field=spatial_diffusion,
+        volatility_field=spatial_diffusion,
     )
 
     print("Solving MFG with spatially varying diffusion...")

--- a/mfgarchon/alg/numerical/fp_solvers/base_fp.py
+++ b/mfgarchon/alg/numerical/fp_solvers/base_fp.py
@@ -184,8 +184,6 @@ class BaseFPSolver(BaseNumericalSolver):
         volatility_field: float | np.ndarray | Callable | None = None,
         show_progress: bool | None = None,
         progress_callback: Callable[[int], None] | None = None,  # Issue #640
-        # Deprecated parameter (Issue #717)
-        diffusion_field: float | np.ndarray | Callable | None = None,
         # MMS verification support
         source_term: Callable[[float, np.ndarray], np.ndarray] | None = None,
     ) -> np.ndarray:
@@ -200,7 +198,7 @@ class BaseFPSolver(BaseNumericalSolver):
 
             where:
             - α(t,x,m): drift field (controlled by drift_field)
-            - D(t,x,m): diffusion tensor (controlled by diffusion_field)
+            - D(t,x,m): diffusion tensor (controlled by volatility_field)
 
         Equation Types Supported:
             1. Advection-diffusion (D>0, α≠0): Standard MFG, transport with diffusion
@@ -228,8 +226,8 @@ class BaseFPSolver(BaseNumericalSolver):
             Note: volatility_field is the SDE noise coefficient σ or Σ. Internally
             converted to diffusion D = σ²/2 (scalar) or D = ΣΣᵀ/2 (matrix).
 
-            DEPRECATED: diffusion_field, tensor_diffusion_field, volatility_matrix
-            are all deprecated. Use volatility_field with appropriate shape.
+            DEPRECATED: tensor_diffusion_field and volatility_matrix (on FPFDMSolver)
+            are deprecated. Use volatility_field with appropriate shape.
 
         Args:
             m_initial_condition: Initial density M(0,x) at t=0
@@ -247,8 +245,6 @@ class BaseFPSolver(BaseNumericalSolver):
                 - np.ndarray: Spatially varying volatility
                 - Callable: Function σ(t, x, m) -> volatility
                 Default: None
-
-            diffusion_field: DEPRECATED. Use volatility_field instead.
 
             source_term: Source term for MMS verification (optional):
                 - None: No source term (default, standard PDE)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -282,8 +282,6 @@ class FPFDMSolver(BaseFPSolver):
         except (AttributeError, IndexError, TypeError):
             pass  # Not enough info to compute CFL — skip silently
 
-    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
-    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     @deprecated_parameter(param_name="tensor_diffusion_field", since="v0.17.0", replacement="volatility_field")
     @deprecated_parameter(param_name="volatility_matrix", since="v0.17.0", replacement="volatility_field")
     @deprecated_parameter(param_name="velocity_field", since="v0.18.6", replacement="drift_field")
@@ -296,8 +294,6 @@ class FPFDMSolver(BaseFPSolver):
         show_progress: bool | None = None,
         progress_callback: Callable[[int], None] | None = None,  # Issue #640
         # Deprecated parameter names for backward compatibility
-        m_initial_condition: np.ndarray | None = None,
-        diffusion_field: float | np.ndarray | Callable | None = None,  # Issue #717: deprecated
         tensor_diffusion_field: np.ndarray | Callable | None = None,  # Issue #717: deprecated
         volatility_matrix: np.ndarray | Callable | None = None,  # Deprecated: use volatility_field
         # Deprecated: velocity_field renamed to drift_field (v0.18.6)
@@ -317,8 +313,6 @@ class FPFDMSolver(BaseFPSolver):
         ----------
         M_initial : np.ndarray
             Initial density m₀(x). Shape: (Nx+1,) for 1D or (N1-1, N2-1, ...) for nD
-        m_initial_condition : np.ndarray
-            DEPRECATED, use M_initial
         drift_field : np.ndarray or callable, optional
             Drift velocity specification (Issue #573):
             - None: Zero drift (pure diffusion)
@@ -340,7 +334,6 @@ class FPFDMSolver(BaseFPSolver):
             - (*shape, d, d) array: Spatially varying Σ(x) → D(x) = Σ(x)Σ(x)ᵀ/2
             - Callable: State-dependent σ(t, x, m) or Σ(t, x, m)
             Default: None
-        diffusion_field : DEPRECATED, use volatility_field
         tensor_diffusion_field : DEPRECATED, use volatility_field with (d,d) array
         volatility_matrix : DEPRECATED, use volatility_field with (d,d) array
         show_progress : bool
@@ -361,34 +354,34 @@ class FPFDMSolver(BaseFPSolver):
         >>> drift = -problem.compute_gradient(U_hjb) / problem.control_cost
         >>> M = solver.solve_fp_system(m0, drift_field=drift)
 
-        Custom diffusion coefficient:
-        >>> M = solver.solve_fp_system(m0, drift_field=drift, diffusion_field=0.5)
+        Custom volatility coefficient:
+        >>> M = solver.solve_fp_system(m0, drift_field=drift, volatility_field=0.5)
 
-        Spatially varying diffusion (higher at boundaries):
+        Spatially varying volatility (higher at boundaries):
         >>> Nx = problem.geometry.get_grid_shape()[0]
         >>> x_grid = np.linspace(0, 1, Nx)
-        >>> diffusion_array = 0.1 + 0.2 * np.abs(x_grid - 0.5)
-        >>> M = solver.solve_fp_system(m0, drift_field=drift, diffusion_field=diffusion_array)
+        >>> volatility_array = 0.1 + 0.2 * np.abs(x_grid - 0.5)
+        >>> M = solver.solve_fp_system(m0, drift_field=drift, volatility_field=volatility_array)
 
-        Spatiotemporal diffusion (time and space dependent):
+        Spatiotemporal volatility (time and space dependent):
         >>> Nt, Nx = problem.Nt + 1, problem.geometry.get_grid_shape()[0]
-        >>> diffusion_field = np.zeros((Nt, Nx))
+        >>> volatility_field = np.zeros((Nt, Nx))
         >>> for t in range(Nt):
-        ...     diffusion_field[t, :] = 0.1 * (1 + 0.5 * t / Nt)  # Increasing over time
-        >>> M = solver.solve_fp_system(m0, drift_field=drift, diffusion_field=diffusion_field)
+        ...     volatility_field[t, :] = 0.1 * (1 + 0.5 * t / Nt)  # Increasing over time
+        >>> M = solver.solve_fp_system(m0, drift_field=drift, volatility_field=volatility_field)
 
-        State-dependent diffusion (porous medium equation):
+        State-dependent volatility (porous medium equation):
         >>> def porous_medium(t, x, m):
-        ...     return 0.1 * m  # Diffusion proportional to density
-        >>> M = solver.solve_fp_system(m0, diffusion_field=porous_medium)
+        ...     return 0.1 * m  # Volatility proportional to density
+        >>> M = solver.solve_fp_system(m0, volatility_field=porous_medium)
 
-        Density-dependent diffusion with drift:
+        Density-dependent volatility with drift:
         >>> def crowd_diffusion(t, x, m):
-        ...     return 0.05 + 0.15 * (1 - m / np.max(m))  # Lower diffusion in crowds
-        >>> M = solver.solve_fp_system(m0, drift_field=drift, diffusion_field=crowd_diffusion)
+        ...     return 0.05 + 0.15 * (1 - m / np.max(m))  # Lower volatility in crowds
+        >>> M = solver.solve_fp_system(m0, drift_field=drift, volatility_field=crowd_diffusion)
 
-        Pure advection (zero diffusion):
-        >>> M = solver.solve_fp_system(m0, drift_field=drift, diffusion_field=0.0)
+        Pure advection (zero volatility):
+        >>> M = solver.solve_fp_system(m0, drift_field=drift, volatility_field=0.0)
 
         Anisotropic volatility (unified API):
         >>> # Diagonal volatility: faster horizontal diffusion
@@ -431,15 +424,6 @@ class FPFDMSolver(BaseFPSolver):
         >>> alpha_quartic = -np.sign(grad_U) * np.abs(grad_U) ** (1/3)  # α* = -(∇U)^(1/3)
         >>> M = solver.solve_fp_system(m0, drift_field=alpha_quartic)
         """
-        # Handle deprecated parameter name
-        if m_initial_condition is not None:
-            if M_initial is not None:
-                raise ValueError(
-                    "Cannot specify both M_initial and m_initial_condition. "
-                    "Use M_initial (m_initial_condition is deprecated)."
-                )
-            M_initial = m_initial_condition
-
         # Validate required parameter
         if M_initial is None:
             raise ValueError("M_initial is required")
@@ -499,15 +483,6 @@ class FPFDMSolver(BaseFPSolver):
             else:
                 grid_shape = self.problem.geometry.get_grid_shape()
                 effective_U = np.zeros((Nt, *grid_shape))
-
-        # Issue #717: Handle deprecated parameter names
-        if diffusion_field is not None:
-            if volatility_field is not None:
-                raise ValueError(
-                    "Cannot specify both volatility_field and diffusion_field. "
-                    "Use volatility_field (diffusion_field is deprecated)."
-                )
-            volatility_field = diffusion_field
 
         # Handle deprecated tensor_diffusion_field → volatility_field
         # Track if input came from tensor-specific parameter (for callable routing)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -29,7 +29,6 @@ import numpy as np
 
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
 from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import TaylorOperator
-from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
@@ -389,15 +388,12 @@ class FPGFDMSolver(BaseFPSolver):
 
         return divergence
 
-    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     def solve_fp_system(
         self,
         m_initial_condition: np.ndarray,
         drift_field: np.ndarray | Callable | None = None,
         volatility_field: float | np.ndarray | Callable | None = None,
         show_progress: bool | None = None,
-        # Deprecated parameter
-        diffusion_field: float | np.ndarray | Callable | None = None,
     ) -> np.ndarray:
         """
         Solve FP system on collocation points using GFDM.
@@ -421,7 +417,6 @@ class FPGFDMSolver(BaseFPSolver):
             volatility_field: Volatility coefficient σ (SDE noise). If None, uses problem.sigma.
                             Currently only scalar volatility supported.
                             Note: Internally converted to diffusion D = σ²/2 for FP equation.
-            diffusion_field: DEPRECATED. Use volatility_field instead.
             show_progress: Display progress bar (not yet implemented)
 
         Returns:
@@ -452,15 +447,6 @@ class FPGFDMSolver(BaseFPSolver):
         # Time discretization
         n_time_points = self.problem.Nt + 1
         dt = self.problem.T / self.problem.Nt
-
-        # Handle deprecated diffusion_field parameter (Issue #717)
-        if diffusion_field is not None:
-            if volatility_field is not None:
-                raise ValueError(
-                    "Cannot specify both volatility_field and diffusion_field. "
-                    "Use volatility_field (diffusion_field is deprecated)."
-                )
-            volatility_field = diffusion_field
 
         # Volatility coefficient (Issue #717: unified API)
         if volatility_field is None:

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -1241,8 +1241,6 @@ class FPParticleSolver(BaseFPSolver):
         else:
             return m_density_estimated  # Return raw KDE output on grid
 
-    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
-    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     def solve_fp_system(
         self,
         M_initial: np.ndarray | None = None,
@@ -1253,8 +1251,6 @@ class FPParticleSolver(BaseFPSolver):
         initial_particles: np.ndarray | None = None,
         drift_needs_density: bool = True,
         # Deprecated parameter names for backward compatibility
-        m_initial_condition: np.ndarray | None = None,
-        diffusion_field: float | np.ndarray | Callable | None = None,  # DEPRECATED
         potential_field: np.ndarray | None = None,  # DEPRECATED: use drift_field
     ) -> np.ndarray:
         """
@@ -1267,7 +1263,6 @@ class FPParticleSolver(BaseFPSolver):
 
         Args:
             M_initial: Initial density m0(x) on grid. Required unless initial_particles provided.
-            m_initial_condition: DEPRECATED, use M_initial
             drift_field: Drift field specification (optional):
                 - None: Zero drift (pure diffusion)
                 - np.ndarray: If drift_is_precomputed=False (default), this is U(t,x) and gradient will be computed.
@@ -1291,7 +1286,6 @@ class FPParticleSolver(BaseFPSolver):
                 the nD CPU path (drift_field None for pure diffusion, or a callable drift);
                 an anisotropic Σ with an ndarray (grid) drift_field is unsupported and raises.
                 Note: This is the SDE noise coefficient, NOT the PDE diffusion D = σ²/2.
-            diffusion_field: DEPRECATED, use volatility_field instead.
             initial_particles: Pre-sampled initial particles, shape (num_particles, dimension).
                               If provided, M_initial is not required (meshfree initialization).
                               Useful with density_mode="query_only" for fully meshfree workflow.
@@ -1303,24 +1297,6 @@ class FPParticleSolver(BaseFPSolver):
         Returns:
             M_solution: Density evolution on grid, shape (Nt+1, *grid_shape)
         """
-        # Handle deprecated parameter name
-        if m_initial_condition is not None:
-            if M_initial is not None:
-                raise ValueError(
-                    "Cannot specify both M_initial and m_initial_condition. "
-                    "Use M_initial (m_initial_condition is deprecated)."
-                )
-            M_initial = m_initial_condition
-
-        # Handle deprecated diffusion_field parameter
-        if diffusion_field is not None:
-            if volatility_field is not None:
-                raise ValueError(
-                    "Cannot specify both volatility_field and diffusion_field. "
-                    "Use volatility_field (diffusion_field is deprecated)."
-                )
-            volatility_field = diffusion_field
-
         # Handle deprecated potential_field -> drift_field
         if potential_field is not None:
             if drift_field is not None:

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from mfgarchon.utils.deprecation import deprecated_parameter
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -189,8 +189,6 @@ class FPSLJacobianSolver(BaseFPSolver):
         bc_type = get_bc_type_string(self.boundary_conditions)
         return bc_type_to_geometric_operation(bc_type)
 
-    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
-    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     @deprecated_parameter(param_name="drift_field", since="v0.18.6", replacement="potential_field")
     def solve_fp_system(
         self,
@@ -199,8 +197,6 @@ class FPSLJacobianSolver(BaseFPSolver):
         volatility_field: float | np.ndarray | Callable | None = None,
         show_progress: bool | None = None,
         # Deprecated parameters
-        m_initial_condition: np.ndarray | None = None,
-        diffusion_field: float | np.ndarray | Callable | None = None,
         drift_field: np.ndarray | Callable | None = None,  # Deprecated: renamed to potential_field
     ) -> np.ndarray:
         """
@@ -222,7 +218,6 @@ class FPSLJacobianSolver(BaseFPSolver):
                 - None: Use problem.sigma
                 - float: Constant volatility
                 Note: Internally converted to diffusion D = σ²/2 for FP equation.
-            diffusion_field: DEPRECATED. Use volatility_field instead.
             show_progress: Show progress bar during solve
 
         Returns:
@@ -232,12 +227,6 @@ class FPSLJacobianSolver(BaseFPSolver):
             potential_field is the VALUE FUNCTION U, not the velocity alpha.
             The velocity is computed internally as alpha = -grad(U).
         """
-        # Handle deprecated parameter
-        if m_initial_condition is not None:
-            if M_initial is not None:
-                raise ValueError("Cannot specify both M_initial and m_initial_condition")
-            M_initial = m_initial_condition
-
         if M_initial is None:
             raise ValueError("M_initial is required")
 
@@ -255,15 +244,6 @@ class FPSLJacobianSolver(BaseFPSolver):
 
         if callable(potential_field):
             raise NotImplementedError("Callable potential_field not yet supported for FPSLSolver")
-
-        # Handle deprecated diffusion_field parameter (Issue #717)
-        if diffusion_field is not None:
-            if volatility_field is not None:
-                raise ValueError(
-                    "Cannot specify both volatility_field and diffusion_field. "
-                    "Use volatility_field (diffusion_field is deprecated)."
-                )
-            volatility_field = diffusion_field
 
         # Handle volatility (Issue #717: unified API)
         if volatility_field is None:

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -236,8 +236,6 @@ class FPSLSolver(BaseFPSolver):
             return "periodic"
         return "neumann"
 
-    @deprecated_parameter(param_name="m_initial_condition", since="v0.17.0", replacement="M_initial")
-    @deprecated_parameter(param_name="diffusion_field", since="v0.17.0", replacement="volatility_field")
     @deprecated_parameter(param_name="drift_field", since="v0.18.6", replacement="potential_field")
     def solve_fp_system(
         self,
@@ -246,8 +244,6 @@ class FPSLSolver(BaseFPSolver):
         volatility_field: float | np.ndarray | None = None,
         show_progress: bool | None = None,
         # Deprecated parameters
-        m_initial_condition: np.ndarray | None = None,
-        diffusion_field: float | np.ndarray | None = None,
         drift_field: np.ndarray | None = None,  # Deprecated: renamed to potential_field
     ) -> np.ndarray:
         """
@@ -266,18 +262,11 @@ class FPSLSolver(BaseFPSolver):
             drift_field: DEPRECATED. Renamed to potential_field.
             volatility_field: Optional volatility coefficient σ (SDE noise) override.
                 Note: Internally converted to diffusion D = σ²/2 for FP equation.
-            diffusion_field: DEPRECATED. Use volatility_field instead.
             show_progress: Show progress bar during solve
 
         Returns:
             Density evolution M(t,x). Shape: (Nt+1, Nx)
         """
-        # Handle deprecated parameter
-        if m_initial_condition is not None:
-            if M_initial is not None:
-                raise ValueError("Cannot specify both M_initial and m_initial_condition")
-            M_initial = m_initial_condition
-
         if M_initial is None:
             raise ValueError("M_initial is required")
 
@@ -291,15 +280,6 @@ class FPSLSolver(BaseFPSolver):
             raise ValueError(
                 "potential_field (value function U) is required for Adjoint SL FP. Pass the U solution from HJB solver."
             )
-
-        # Handle deprecated diffusion_field parameter (Issue #717)
-        if diffusion_field is not None:
-            if volatility_field is not None:
-                raise ValueError(
-                    "Cannot specify both volatility_field and diffusion_field. "
-                    "Use volatility_field (diffusion_field is deprecated)."
-                )
-            volatility_field = diffusion_field
 
         # Handle volatility (Issue #717: unified API)
         if volatility_field is None:

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -1069,6 +1069,32 @@ class TestFPFDMSolverTensorDiffusion:
         assert np.allclose(masses, 1.0, atol=0.1)
 
 
+class TestFPFDMSolverRemovedDeprecatedParams:
+    """Pin removal of the Tier-2 (<=v0.17) FP-solver param renames.
+
+    ``m_initial_condition`` -> ``M_initial`` and ``diffusion_field`` -> ``volatility_field``
+    were deprecated in v0.17.0 and removed at v0.20 (3 minor versions past). Passing the old
+    names must now raise ``TypeError`` (unexpected keyword argument), not silently alias.
+    New-name coverage is retained by the rest of this module (positional ``M_initial`` and
+    ``volatility_field=``). The ``tensor_diffusion_field`` / ``volatility_matrix`` aliases are
+    intentionally NOT removed (no callable-tensor equivalent on ``volatility_field`` yet).
+    """
+
+    def test_m_initial_condition_removed(self, standard_problem):
+        solver = FPFDMSolver(standard_problem)
+        (Nx_points,) = standard_problem.geometry.get_grid_shape()
+        m0 = np.ones(Nx_points) / Nx_points
+        with pytest.raises(TypeError, match="m_initial_condition"):
+            solver.solve_fp_system(m_initial_condition=m0)
+
+    def test_diffusion_field_removed(self, standard_problem):
+        solver = FPFDMSolver(standard_problem)
+        (Nx_points,) = standard_problem.geometry.get_grid_shape()
+        m0 = np.ones(Nx_points) / Nx_points
+        with pytest.raises(TypeError, match="diffusion_field"):
+            solver.solve_fp_system(m0, diffusion_field=0.5)
+
+
 class TestFPFDMSolverCallableDrift:
     """Test callable (state-dependent) drift_field support (Phase 2 - Issue #487)."""
 

--- a/tests/unit/test_alg/test_fp_particle_solver.py
+++ b/tests/unit/test_alg/test_fp_particle_solver.py
@@ -959,5 +959,34 @@ class TestFPParticlePreserveIndices:
             )
 
 
+class TestFPParticleSolverRemovedDeprecatedParams:
+    """Pin removal of the Tier-2 (<=v0.17) FP-solver param renames on FPParticleSolver.
+
+    ``m_initial_condition`` -> ``M_initial`` and ``diffusion_field`` -> ``volatility_field``
+    were deprecated in v0.17.0 and removed at v0.20. Passing the old names must now raise
+    ``TypeError`` (unexpected keyword argument). The ``__init__`` density/KDE param
+    deprecations (mode / external_particles / normalize_kde_*) are a separate family and
+    are out of scope here.
+    """
+
+    @staticmethod
+    def _solver():
+        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(geometry=geometry, T=0.5, Nt=20, components=_default_components())
+        return FPParticleSolver(problem, num_particles=200)
+
+    def test_m_initial_condition_removed(self):
+        solver = self._solver()
+        m0 = np.ones(31) / 31
+        with pytest.raises(TypeError, match="m_initial_condition"):
+            solver.solve_fp_system(m_initial_condition=m0)
+
+    def test_diffusion_field_removed(self):
+        solver = self._solver()
+        m0 = np.ones(31) / 31
+        with pytest.raises(TypeError, match="diffusion_field"):
+            solver.solve_fp_system(m0, diffusion_field=0.5)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary

Removes the two clean Tier-2 (`<= v0.17`) FP-solver parameter renames that are past the removal window (deprecated v0.17.0; main is v0.20.0 = 3 minor versions past). Follows the #1354 removal recipe.

| old name | new name | version | removed from |
|---|---|---|---|
| `m_initial_condition` | `M_initial` | v0.17.0 | `FPFDMSolver`, `FPParticleSolver`, `FPSLJacobianSolver`, `FPSLAdjointSolver` |
| `diffusion_field` | `volatility_field` | v0.17.0 | `FPFDMSolver`, `FPParticleSolver`, `FPGFDMSolver`, `FPSLJacobianSolver`, `FPSLAdjointSolver`, `BaseFPSolver` |

For each symbol: dropped the `@deprecated_parameter` decorator, the old-name parameter, the in-body redirect block, and the deprecated docstring entries. Passing an old name now raises `TypeError`. Migrated docstring examples + `examples/basic/state_dependent_diffusion.py` (`diffusion_field=` -> `volatility_field=`). Removed the now-unused `deprecated_parameter` import from `fp_gfdm.py`.

`FPGFDMSolver` / `BaseFPSolver` use `m_initial_condition` as a current, **non-deprecated** first positional parameter (no decorator) — left intact; only their `diffusion_field` was removed.

## Scope-boundary discrimination (independent same-named APIs left intact)

- Internal helpers `solve_fp_nd_full_system` and `FPFDMSolver._solve_fp_1d` keep `m_initial_condition` / `diffusion_field` as their own non-deprecated parameter names; the internal-API calls that pass them (e.g. `tensor_diffusion_field=effective_sigma  # Internal API uses old name`) are unchanged.
- `MFGProblem.diffusion_field` (deprecated property) and `FPNetworkSolver`'s `m_initial_condition` deprecation (outside `fp_solvers/`) are out of scope.

## Deferred (NOT removed) — documented, with reason

- **`tensor_diffusion_field`, `volatility_matrix`** (`FPFDMSolver`, both v0.17.0): both set the internal `_from_tensor_param` flag, which routes a **callable** volatility to the tensor path. The replacement `volatility_field` has **no callable-tensor equivalent** (a callable always routes to the scalar path), so removing them would be a feature regression rather than a rename cleanup, and they fail the repo's deprecation-equivalence precondition. `test_callable_tensor` exercises this path. The constant/spatial (d,d) ndarray tensor cases are already fully covered by `volatility_field`.
- **All v0.18.6 deprecations** (`velocity_field`, `potential_field`; `drift_field -> potential_field` on the SL solvers — the closed #1043 convention deferral): not yet past the removal window.

## Tests

No equivalence test existed for these two names, so added removed-pins asserting the old kwargs now raise `TypeError` (`TestFPFDMSolverRemovedDeprecatedParams`, `TestFPParticleSolverRemovedDeprecatedParams`). New-name coverage is retained by the existing suites.

Green locally: `test_fp_fdm_solver` + `test_fp_particle_solver` + `test_base_fp` (130), FP gfdm/SL/mixed-BC + diffusion-magnitude-gate (16), coupling (44). `python -c "import mfgarchon"` clean; `ruff check` + `ruff format --check` clean on all changed files.

## Note (pre-existing, unrelated)

`examples/basic/state_dependent_diffusion.py` also passes `damping_factor=` to `FixedPointIterator`, a separate removed kwarg (Issue #1070, v0.25.0 family) that raises before reaching the migrated `volatility_field=`. Left untouched — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)