### PR TITLE
refactor: remove Tier-2 monitoring-family deprecations (decorator bool params + convergence aliases)

### DIFF
--- a/benchmarks/solver_comparisons/study_hybrid_mass_conservation.py
+++ b/benchmarks/solver_comparisons/study_hybrid_mass_conservation.py
@@ -13,7 +13,7 @@ from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry.boundary import neumann_bc
-from mfgarchon.utils.convergence import create_stochastic_monitor
+from mfgarchon.utils.convergence import create_rolling_monitor
 
 
 def setup_problem():
@@ -51,7 +51,7 @@ def run_hybrid_solver_with_monitoring(problem, bc, max_iterations=100, verbose=T
     hjb_solver = HJBFDMSolver(problem)
 
     # Create stochastic convergence monitor
-    stochastic_monitor = create_stochastic_monitor(
+    stochastic_monitor = create_rolling_monitor(
         window_size=10,
         median_tolerance=1e-4,
         quantile=0.9,

--- a/mfgarchon/utils/__init__.py
+++ b/mfgarchon/utils/__init__.py
@@ -38,9 +38,6 @@ from .adjoint_validation import (
 from .aux_func import npart, ppart
 from .callable_adapter import CallableSignature, adapt_ic_callable
 from .convergence import (
-    # Backward compatibility aliases (deprecated)
-    AdaptiveConvergenceWrapper,
-    AdvancedConvergenceMonitor,
     # NEW: Convergence checkers
     ConvergenceChecker,
     # New names (preferred)
@@ -51,19 +48,14 @@ from .convergence import (
     FPConvergenceChecker,
     HJBConvergenceChecker,
     MFGConvergenceChecker,
-    OscillationDetector,
-    ParticleMethodDetector,
     RollingConvergenceMonitor,
     SolverTypeDetector,
-    StochasticConvergenceMonitor,
     adaptive_convergence,
     calculate_error,
     calculate_l2_convergence_metrics,
     compute_norm,
-    create_default_monitor,
     create_distribution_monitor,
     create_rolling_monitor,
-    create_stochastic_monitor,
     test_particle_detection,
     wrap_solver_with_adaptive_convergence,
 )
@@ -312,11 +304,6 @@ __all__ = [
     "calculate_l2_convergence_metrics",
     "create_distribution_monitor",
     "create_rolling_monitor",
-    # Convergence monitoring (deprecated aliases)
-    "AdaptiveConvergenceWrapper",
-    "AdvancedConvergenceMonitor",
-    "StochasticConvergenceMonitor",
-    "create_stochastic_monitor",
     # Convergence checkers (Protocol-based)
     "ConvergenceChecker",
     "HJBConvergenceChecker",
@@ -355,8 +342,6 @@ __all__ = [
     "MFGSolverError",
     "MFGSolverResult",
     "NumericalInstabilityError",
-    "OscillationDetector",
-    "ParticleMethodDetector",
     "SolutionNotAvailableError",
     "SolverResult",
     "SparseMatrixBuilder",
@@ -367,7 +352,6 @@ __all__ = [
     "check_numerical_stability",
     "configure_logging",
     "configure_research_logging",
-    "create_default_monitor",
     "create_solver_result",
     "estimate_sparsity",
     # Integration utilities

--- a/mfgarchon/utils/convergence/__init__.py
+++ b/mfgarchon/utils/convergence/__init__.py
@@ -64,33 +64,24 @@ from .convergence_metrics import (
     DistributionComparator,
     MomentConvergenceMonitor,
     RollingConvergenceMonitor,
-    # Backward compatibility
-    StochasticConvergenceMonitor,
     calculate_error,
     calculate_l2_convergence_metrics,
     # Factory
     create_moment_monitor,
     create_rolling_monitor,
-    create_stochastic_monitor,
 )
 
 # =============================================================================
 # MFG-SPECIFIC IMPORTS (convergence_monitors.py)
 # =============================================================================
 from .convergence_monitors import (
-    AdaptiveConvergenceWrapper,
-    AdvancedConvergenceMonitor,
     ConvergenceWrapper,
     # Core monitors
     DistributionConvergenceMonitor,
-    # Backward compatibility
-    OscillationDetector,
-    ParticleMethodDetector,
     SolverTypeDetector,
     # Internal (exposed for testing)
     _ErrorHistoryTracker,
     adaptive_convergence,
-    create_default_monitor,
     # Factory and decorators
     create_distribution_monitor,
     test_particle_detection,
@@ -126,12 +117,4 @@ __all__ = [
     "FPConvergenceChecker",
     "MFGConvergenceChecker",
     "compute_norm",
-    # Backward compatibility aliases (deprecated)
-    "StochasticConvergenceMonitor",  # -> RollingConvergenceMonitor
-    "create_stochastic_monitor",  # -> create_rolling_monitor
-    "OscillationDetector",  # -> _ErrorHistoryTracker
-    "AdvancedConvergenceMonitor",  # -> DistributionConvergenceMonitor
-    "ParticleMethodDetector",  # -> SolverTypeDetector
-    "AdaptiveConvergenceWrapper",  # -> ConvergenceWrapper
-    "create_default_monitor",  # -> create_distribution_monitor
 ]

--- a/mfgarchon/utils/convergence/convergence_metrics.py
+++ b/mfgarchon/utils/convergence/convergence_metrics.py
@@ -22,8 +22,6 @@ from typing import Any, Literal
 
 import numpy as np
 
-from mfgarchon.utils.deprecation import deprecated, deprecated_alias
-
 # =============================================================================
 # DISTRIBUTION COMPARISON UTILITIES
 # =============================================================================
@@ -729,24 +727,3 @@ def create_moment_monitor(
         window_size=window_size,
         **kwargs,
     )
-
-
-# =============================================================================
-# BACKWARD COMPATIBILITY ALIASES (with deprecation warnings)
-# =============================================================================
-
-
-StochasticConvergenceMonitor = deprecated_alias(
-    "StochasticConvergenceMonitor", RollingConvergenceMonitor, since="v0.17.0"
-)
-
-
-@deprecated(since="v0.17.0", replacement="Use create_rolling_monitor() instead.")
-def create_stochastic_monitor(*args, **kwargs) -> RollingConvergenceMonitor:
-    """
-    Deprecated alias for create_rolling_monitor.
-
-    .. deprecated:: 0.17.0
-        Use :func:`create_rolling_monitor` instead.
-    """
-    return create_rolling_monitor(*args, **kwargs)

--- a/mfgarchon/utils/convergence/convergence_monitors.py
+++ b/mfgarchon/utils/convergence/convergence_monitors.py
@@ -29,7 +29,6 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from mfgarchon.utils.deprecation import deprecated, deprecated_alias
 from mfgarchon.utils.mfg_logging import get_logger
 
 from .convergence_metrics import DistributionComparator
@@ -775,41 +774,3 @@ def test_particle_detection(solver: MFGSolver) -> dict[str, Any]:
         "detection_info": detection_info,
         "recommended_convergence": "distribution" if has_particles else "classical",
     }
-
-
-# =============================================================================
-# BACKWARD COMPATIBILITY ALIASES (with deprecation warnings)
-# =============================================================================
-
-
-OscillationDetector = deprecated_alias("OscillationDetector", _ErrorHistoryTracker, since="v0.17.0")
-
-AdvancedConvergenceMonitor = deprecated_alias(
-    "AdvancedConvergenceMonitor", DistributionConvergenceMonitor, since="v0.17.0"
-)
-
-
-class ParticleMethodDetector(SolverTypeDetector):
-    """
-    Deprecated alias for SolverTypeDetector.
-
-    .. deprecated:: 0.17.0
-        Use :class:`SolverTypeDetector` instead.
-
-    Note: Kept as class (not deprecated_alias) to preserve static method access
-    (e.g., ParticleMethodDetector.detect_particle_methods).
-    """
-
-
-AdaptiveConvergenceWrapper = deprecated_alias("AdaptiveConvergenceWrapper", ConvergenceWrapper, since="v0.17.0")
-
-
-@deprecated(since="v0.17.0", replacement="Use create_distribution_monitor() instead.")
-def create_default_monitor(*args, **kwargs) -> DistributionConvergenceMonitor:
-    """
-    Deprecated alias for create_distribution_monitor.
-
-    .. deprecated:: 0.17.0
-        Use :func:`create_distribution_monitor` instead.
-    """
-    return create_distribution_monitor(*args, **kwargs)

--- a/mfgarchon/utils/solver_decorators.py
+++ b/mfgarchon/utils/solver_decorators.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import functools
 from enum import Flag, auto
 
-from mfgarchon.utils.deprecation import deprecated_parameter
-
 from .progress import IterationProgress, SolverTimer, time_solver_operation
 
 
@@ -47,15 +45,12 @@ class SolverMonitoringOptions(Flag):
         >>> @enhanced_solver_method(options=SolverMonitoringOptions.PROGRESS | SolverMonitoringOptions.TIMING)
         ... def solve(self):
         ...     ...
-
-    Backward compatibility:
-        Old boolean parameters are still supported with deprecation warnings.
     """
 
     NONE = 0
-    CONVERGENCE = auto()  # monitor_convergence=True
-    PROGRESS = auto()  # auto_progress=True
-    TIMING = auto()  # timing=True
+    CONVERGENCE = auto()
+    PROGRESS = auto()
+    TIMING = auto()
     ALL = CONVERGENCE | PROGRESS | TIMING
 
 
@@ -158,31 +153,18 @@ def with_progress_monitoring(
     return decorator
 
 
-@deprecated_parameter(
-    param_name="monitor_convergence", since="v0.17.0", replacement="options=SolverMonitoringOptions.CONVERGENCE"
-)
-@deprecated_parameter(
-    param_name="auto_progress", since="v0.17.0", replacement="options=SolverMonitoringOptions.PROGRESS"
-)
-@deprecated_parameter(param_name="timing", since="v0.17.0", replacement="options=SolverMonitoringOptions.TIMING")
 def enhanced_solver_method(
     options: SolverMonitoringOptions | None = None,
-    *,
-    monitor_convergence: bool | None = None,
-    auto_progress: bool | None = None,
-    timing: bool | None = None,
 ):
     """
     Comprehensive decorator for enhancing solver methods with modern features.
 
     Args:
-        options: Solver monitoring options (Flag enum). Recommended over boolean parameters.
-        monitor_convergence: DEPRECATED. Use options=SolverMonitoringOptions.CONVERGENCE
-        auto_progress: DEPRECATED. Use options=SolverMonitoringOptions.PROGRESS
-        timing: DEPRECATED. Use options=SolverMonitoringOptions.TIMING
+        options: Solver monitoring options (Flag enum). Defaults to
+            SolverMonitoringOptions.ALL when omitted.
 
     Examples:
-        >>> # New API (recommended)
+        >>> # Progress and timing
         >>> @enhanced_solver_method(options=SolverMonitoringOptions.PROGRESS | SolverMonitoringOptions.TIMING)
         ... def solve(self):
         ...     ...
@@ -191,24 +173,9 @@ def enhanced_solver_method(
         >>> @enhanced_solver_method(options=SolverMonitoringOptions.ALL)
         ... def solve(self):
         ...     ...
-        >>>
-        >>> # Old API (deprecated but still works)
-        >>> @enhanced_solver_method(auto_progress=True, timing=True)
-        ... def solve(self):
-        ...     ...
     """
-    # Handle backward compatibility -- convert old API to new
-    if monitor_convergence is not None or auto_progress is not None or timing is not None:
-        flags = SolverMonitoringOptions.NONE
-        if monitor_convergence:
-            flags |= SolverMonitoringOptions.CONVERGENCE
-        if auto_progress:
-            flags |= SolverMonitoringOptions.PROGRESS
-        if timing:
-            flags |= SolverMonitoringOptions.TIMING
-        options = flags
-    elif options is None:
-        # Default: all features enabled for backward compatibility
+    if options is None:
+        # Default: all features enabled
         options = SolverMonitoringOptions.ALL
 
     def decorator(solve_method):

--- a/tests/unit/test_utils/test_convergence.py
+++ b/tests/unit/test_utils/test_convergence.py
@@ -4,11 +4,11 @@ Unit tests for mfgarchon/utils/numerical/convergence.py
 
 Tests comprehensive convergence monitoring system including:
 - DistributionComparator (Wasserstein, KL divergence, moments)
-- OscillationDetector (stabilization detection)
-- StochasticConvergenceMonitor (confidence intervals, relative error)
-- AdvancedConvergenceMonitor (multi-criteria convergence)
-- ParticleMethodDetector (automatic method detection)
-- AdaptiveConvergenceWrapper (decorator/wrapper pattern)
+- _ErrorHistoryTracker (stabilization detection)
+- RollingConvergenceMonitor (confidence intervals, relative error)
+- DistributionConvergenceMonitor (multi-criteria convergence)
+- SolverTypeDetector (automatic method detection)
+- ConvergenceWrapper (decorator/wrapper pattern)
 - Utility functions (factory functions, metrics)
 
 Coverage target: mfgarchon/utils/numerical/convergence.py (411 lines, 14% -> 70%+)
@@ -20,20 +20,45 @@ import numpy as np
 
 # Use the new import path (old path mfgarchon.utils.numerical.convergence is deprecated)
 from mfgarchon.utils.convergence import (
-    # Deprecated aliases (for testing backward compatibility)
-    AdaptiveConvergenceWrapper,
-    AdvancedConvergenceMonitor,
     # Canonical class names
+    ConvergenceWrapper,
     DistributionComparator,
     DistributionConvergenceMonitor,
-    OscillationDetector,
-    ParticleMethodDetector,
     RollingConvergenceMonitor,
-    StochasticConvergenceMonitor,
+    SolverTypeDetector,
+    _ErrorHistoryTracker,
     calculate_l2_convergence_metrics,
-    create_default_monitor,
-    create_stochastic_monitor,
+    create_distribution_monitor,
+    create_rolling_monitor,
 )
+
+# =============================================================================
+# Removed-pin: monitoring-family deprecated aliases (removed v0.20.0)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "removed_name",
+    [
+        "OscillationDetector",  # -> _ErrorHistoryTracker
+        "AdvancedConvergenceMonitor",  # -> DistributionConvergenceMonitor
+        "ParticleMethodDetector",  # -> SolverTypeDetector
+        "AdaptiveConvergenceWrapper",  # -> ConvergenceWrapper
+        "StochasticConvergenceMonitor",  # -> RollingConvergenceMonitor
+        "create_default_monitor",  # -> create_distribution_monitor
+        "create_stochastic_monitor",  # -> create_rolling_monitor
+    ],
+)
+def test_removed_monitoring_aliases_no_longer_importable(removed_name):
+    """The deprecated monitoring-family aliases were removed; importing them must fail."""
+    import mfgarchon.utils.convergence as conv
+
+    assert not hasattr(conv, removed_name)
+    assert removed_name not in conv.__all__
+    with pytest.raises(ImportError):
+        exec(f"from mfgarchon.utils.convergence import {removed_name}")
+
 
 # =============================================================================
 # Test DistributionComparator
@@ -155,14 +180,14 @@ def test_distribution_comparator_statistical_moments_zero_variance():
 
 
 # =============================================================================
-# Test OscillationDetector
+# Test _ErrorHistoryTracker
 # =============================================================================
 
 
 @pytest.mark.unit
 def test_oscillation_detector_initialization():
-    """Test OscillationDetector initialization."""
-    detector = OscillationDetector(history_length=20)
+    """Test _ErrorHistoryTracker initialization."""
+    detector = _ErrorHistoryTracker(history_length=20)
 
     assert detector.history_length == 20
     assert len(detector.error_history) == 0
@@ -171,7 +196,7 @@ def test_oscillation_detector_initialization():
 @pytest.mark.unit
 def test_oscillation_detector_add_samples():
     """Test adding samples to detector."""
-    detector = OscillationDetector(history_length=5)
+    detector = _ErrorHistoryTracker(history_length=5)
 
     for i in range(10):
         detector.add_sample(float(i))
@@ -184,7 +209,7 @@ def test_oscillation_detector_add_samples():
 @pytest.mark.unit
 def test_oscillation_detector_insufficient_history():
     """Test is_below_threshold returns false with insufficient history."""
-    detector = OscillationDetector(history_length=10)
+    detector = _ErrorHistoryTracker(history_length=10)
 
     for _i in range(5):
         detector.add_sample(0.1)
@@ -199,7 +224,7 @@ def test_oscillation_detector_insufficient_history():
 @pytest.mark.unit
 def test_oscillation_detector_stabilized():
     """Test detection of stabilized errors (below thresholds)."""
-    detector = OscillationDetector(history_length=10)
+    detector = _ErrorHistoryTracker(history_length=10)
 
     # Add 10 samples with small variation
     for i in range(10):
@@ -216,7 +241,7 @@ def test_oscillation_detector_stabilized():
 @pytest.mark.unit
 def test_oscillation_detector_not_stabilized_magnitude():
     """Test detection of high magnitude error."""
-    detector = OscillationDetector(history_length=10)
+    detector = _ErrorHistoryTracker(history_length=10)
 
     for _i in range(10):
         detector.add_sample(0.5)  # High error
@@ -230,7 +255,7 @@ def test_oscillation_detector_not_stabilized_magnitude():
 @pytest.mark.unit
 def test_oscillation_detector_not_stabilized_oscillation():
     """Test detection of high oscillation (high std)."""
-    detector = OscillationDetector(history_length=10)
+    detector = _ErrorHistoryTracker(history_length=10)
 
     # Oscillating errors
     for i in range(10):
@@ -244,14 +269,14 @@ def test_oscillation_detector_not_stabilized_oscillation():
 
 
 # =============================================================================
-# Test StochasticConvergenceMonitor
+# Test RollingConvergenceMonitor
 # =============================================================================
 
 
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_initialization():
-    """Test StochasticConvergenceMonitor initialization."""
-    monitor = StochasticConvergenceMonitor(window_size=10, median_tolerance=1e-4, quantile=0.9)
+    """Test RollingConvergenceMonitor initialization."""
+    monitor = RollingConvergenceMonitor(window_size=10, median_tolerance=1e-4, quantile=0.9)
 
     assert monitor.window_size == 10
     assert monitor.median_tolerance == 1e-4
@@ -261,7 +286,7 @@ def test_stochastic_convergence_monitor_initialization():
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_add_iteration():
     """Test adding iterations to stochastic monitor."""
-    monitor = StochasticConvergenceMonitor(window_size=5)
+    monitor = RollingConvergenceMonitor(window_size=5)
 
     for i in range(10):
         monitor.add_iteration(float(i) * 0.1, float(i) * 0.05)
@@ -275,7 +300,7 @@ def test_stochastic_convergence_monitor_add_iteration():
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_get_statistics():
     """Test statistics computation."""
-    monitor = StochasticConvergenceMonitor(window_size=20)
+    monitor = RollingConvergenceMonitor(window_size=20)
 
     # Add iterations
     np.random.seed(42)
@@ -294,7 +319,7 @@ def test_stochastic_convergence_monitor_get_statistics():
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_no_data():
     """Test statistics with no data."""
-    monitor = StochasticConvergenceMonitor()
+    monitor = RollingConvergenceMonitor()
 
     stats = monitor.get_statistics()
 
@@ -304,7 +329,7 @@ def test_stochastic_convergence_monitor_no_data():
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_check_convergence():
     """Test convergence checking."""
-    monitor = StochasticConvergenceMonitor(window_size=10, median_tolerance=0.01, min_iterations=5)
+    monitor = RollingConvergenceMonitor(window_size=10, median_tolerance=0.01, min_iterations=5)
 
     # Add iterations with decreasing errors
     for i in range(15):
@@ -321,7 +346,7 @@ def test_stochastic_convergence_monitor_check_convergence():
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_insufficient_iterations():
     """Test convergence check with insufficient iterations."""
-    monitor = StochasticConvergenceMonitor(min_iterations=10)
+    monitor = RollingConvergenceMonitor(min_iterations=10)
 
     for _i in range(5):
         monitor.add_iteration(0.001, 0.001)
@@ -332,14 +357,14 @@ def test_stochastic_convergence_monitor_insufficient_iterations():
 
 
 # =============================================================================
-# Test AdvancedConvergenceMonitor
+# Test DistributionConvergenceMonitor
 # =============================================================================
 
 
 @pytest.mark.unit
 def test_advanced_convergence_monitor_initialization():
-    """Test AdvancedConvergenceMonitor initialization."""
-    monitor = AdvancedConvergenceMonitor(
+    """Test DistributionConvergenceMonitor initialization."""
+    monitor = DistributionConvergenceMonitor(
         wasserstein_tol=1e-4,
         kl_divergence_tol=1e-3,
         u_magnitude_tol=1e-3,
@@ -355,7 +380,7 @@ def test_advanced_convergence_monitor_initialization():
 @pytest.mark.unit
 def test_advanced_convergence_monitor_update_basic():
     """Test basic update with value function convergence."""
-    monitor = AdvancedConvergenceMonitor(u_magnitude_tol=1e-3)
+    monitor = DistributionConvergenceMonitor(u_magnitude_tol=1e-3)
 
     u_prev = np.ones((10, 10)) * 1.0
     u_curr = np.ones((10, 10)) * 1.001  # Small change
@@ -372,7 +397,7 @@ def test_advanced_convergence_monitor_update_basic():
 @pytest.mark.unit
 def test_advanced_convergence_monitor_convergence_detection():
     """Test convergence detection with small changes."""
-    monitor = AdvancedConvergenceMonitor(u_magnitude_tol=1e-2, u_stability_tol=1e-3, history_length=5)
+    monitor = DistributionConvergenceMonitor(u_magnitude_tol=1e-2, u_stability_tol=1e-3, history_length=5)
 
     u = np.ones((10, 10))
     m = np.ones((10, 10)) * 0.5
@@ -392,7 +417,7 @@ def test_advanced_convergence_monitor_convergence_detection():
 @pytest.mark.unit
 def test_advanced_convergence_monitor_multi_dimensional():
     """Test monitor handles multi-dimensional arrays."""
-    monitor = AdvancedConvergenceMonitor()
+    monitor = DistributionConvergenceMonitor()
 
     u_prev = np.random.rand(20, 20)
     u_curr = u_prev + np.random.rand(20, 20) * 0.001
@@ -409,7 +434,7 @@ def test_advanced_convergence_monitor_multi_dimensional():
 @pytest.mark.unit
 def test_advanced_convergence_monitor_wasserstein_computation():
     """Test Wasserstein distance computation."""
-    monitor = AdvancedConvergenceMonitor(wasserstein_tol=1e-4)
+    monitor = DistributionConvergenceMonitor(wasserstein_tol=1e-4)
 
     # 1D distributions
     x = np.linspace(0, 1, 50)
@@ -432,14 +457,14 @@ def test_advanced_convergence_monitor_wasserstein_computation():
 
 
 # =============================================================================
-# Test ParticleMethodDetector
+# Test SolverTypeDetector
 # =============================================================================
 
 
 @pytest.mark.unit
 def test_particle_method_detector_basic():
-    """Test ParticleMethodDetector can be instantiated."""
-    detector = ParticleMethodDetector()
+    """Test SolverTypeDetector can be instantiated."""
+    detector = SolverTypeDetector()
 
     assert detector is not None
 
@@ -454,7 +479,7 @@ def test_particle_method_detector_mock_solver():
             self.num_particles = 100
 
     mock_solver = MockParticleSolver()
-    has_particles, detection_info = ParticleMethodDetector.detect_particle_methods(mock_solver)
+    has_particles, detection_info = SolverTypeDetector.detect_particle_methods(mock_solver)
 
     assert isinstance(has_particles, bool)
     assert "confidence" in detection_info
@@ -462,13 +487,13 @@ def test_particle_method_detector_mock_solver():
 
 
 # =============================================================================
-# Test AdaptiveConvergenceWrapper
+# Test ConvergenceWrapper
 # =============================================================================
 
 
 @pytest.mark.unit
 def test_adaptive_convergence_wrapper_initialization():
-    """Test AdaptiveConvergenceWrapper initialization."""
+    """Test ConvergenceWrapper initialization."""
 
     class MockSolver:
         def __init__(self):
@@ -477,7 +502,7 @@ def test_adaptive_convergence_wrapper_initialization():
             self.x_grid = np.linspace(0, 1, 10)
 
     mock_solver = MockSolver()
-    wrapper = AdaptiveConvergenceWrapper(mock_solver, classical_tol=1e-4, verbose=False)
+    wrapper = ConvergenceWrapper(mock_solver, classical_tol=1e-4, verbose=False)
 
     # Wrapper wraps the solver internally
     assert wrapper._wrapped_solver is mock_solver
@@ -494,7 +519,7 @@ def test_adaptive_convergence_wrapper_particle_detection():
             self.num_particles = 100
 
     mock_solver = MockParticleSolver()
-    wrapper = AdaptiveConvergenceWrapper(mock_solver, verbose=False)
+    wrapper = ConvergenceWrapper(mock_solver, verbose=False)
 
     # Wrapper wraps the solver internally
     assert wrapper._wrapped_solver is mock_solver
@@ -506,24 +531,20 @@ def test_adaptive_convergence_wrapper_particle_detection():
 
 
 @pytest.mark.unit
-def test_create_default_monitor():
-    """Test create_default_monitor factory function (deprecated)."""
-    # Note: create_default_monitor is deprecated, returns DistributionConvergenceMonitor
-    monitor = create_default_monitor(wasserstein_tol=1e-5, u_magnitude_tol=1e-3, history_length=20)
+def test_create_distribution_monitor():
+    """Test create_distribution_monitor factory function."""
+    monitor = create_distribution_monitor(wasserstein_tol=1e-5, u_magnitude_tol=1e-3, history_length=20)
 
-    # Check for canonical type (AdvancedConvergenceMonitor is now a subclass)
     assert isinstance(monitor, DistributionConvergenceMonitor)
     assert monitor.wasserstein_tol == 1e-5
     assert monitor.u_magnitude_tol == 1e-3
 
 
 @pytest.mark.unit
-def test_create_stochastic_monitor():
-    """Test create_stochastic_monitor factory function (deprecated)."""
-    # Note: create_stochastic_monitor is deprecated, returns RollingConvergenceMonitor
-    monitor = create_stochastic_monitor(median_tolerance=1e-5, window_size=30, quantile=0.95)
+def test_create_rolling_monitor():
+    """Test create_rolling_monitor factory function."""
+    monitor = create_rolling_monitor(median_tolerance=1e-5, window_size=30, quantile=0.95)
 
-    # Check for canonical type (StochasticConvergenceMonitor is now a subclass)
     assert isinstance(monitor, RollingConvergenceMonitor)
     assert monitor.median_tolerance == 1e-5
     assert monitor.window_size == 30
@@ -589,7 +610,7 @@ def test_calculate_l2_convergence_metrics_large_change():
 def test_integration_convergence_workflow():
     """Test full convergence monitoring workflow."""
     # Create monitor
-    monitor = create_default_monitor(u_magnitude_tol=1e-3, history_length=5)
+    monitor = create_distribution_monitor(u_magnitude_tol=1e-3, history_length=5)
 
     # Simulate iterative solver
     x = np.linspace(0, 1, 50)
@@ -615,7 +636,7 @@ def test_integration_convergence_workflow():
 @pytest.mark.unit
 def test_integration_stochastic_convergence():
     """Test stochastic convergence monitoring."""
-    monitor = create_stochastic_monitor(median_tolerance=0.01, window_size=10, min_iterations=5)
+    monitor = create_rolling_monitor(median_tolerance=0.01, window_size=10, min_iterations=5)
 
     # Simulate stochastic errors converging
     np.random.seed(42)
@@ -660,7 +681,7 @@ def test_integration_distribution_comparison_pipeline():
 @pytest.mark.unit
 def test_edge_case_empty_history():
     """Test monitors handle empty history gracefully."""
-    detector = OscillationDetector(history_length=10)
+    detector = _ErrorHistoryTracker(history_length=10)
 
     is_stable, diagnostics = detector.is_below_threshold(mean_threshold=1.0, std_threshold=0.1)
 
@@ -716,14 +737,14 @@ def test_edge_case_large_arrays():
 
 
 # =============================================================================
-# Additional tests for StochasticConvergenceMonitor
+# Additional tests for RollingConvergenceMonitor
 # =============================================================================
 
 
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_is_stagnating():
     """Test stagnation detection in stochastic monitor."""
-    monitor = StochasticConvergenceMonitor(window_size=5)
+    monitor = RollingConvergenceMonitor(window_size=5)
 
     # Add similar errors (stagnating)
     for _ in range(5):
@@ -735,7 +756,7 @@ def test_stochastic_convergence_monitor_is_stagnating():
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_not_stagnating():
     """Test non-stagnating convergence."""
-    monitor = StochasticConvergenceMonitor(window_size=5)
+    monitor = RollingConvergenceMonitor(window_size=5)
 
     # Add decreasing errors (not stagnating)
     for i in range(5):
@@ -747,7 +768,7 @@ def test_stochastic_convergence_monitor_not_stagnating():
 @pytest.mark.unit
 def test_stochastic_convergence_monitor_quantile_tolerance():
     """Test custom quantile tolerance."""
-    monitor = StochasticConvergenceMonitor(
+    monitor = RollingConvergenceMonitor(
         window_size=5,
         median_tolerance=1e-4,
         quantile=0.95,
@@ -765,14 +786,14 @@ def test_stochastic_convergence_monitor_quantile_tolerance():
 
 
 # =============================================================================
-# Additional tests for AdvancedConvergenceMonitor
+# Additional tests for DistributionConvergenceMonitor
 # =============================================================================
 
 
 @pytest.mark.unit
 def test_advanced_convergence_monitor_get_convergence_summary():
     """Test convergence summary generation."""
-    monitor = AdvancedConvergenceMonitor()
+    monitor = DistributionConvergenceMonitor()
 
     # Simulate convergence iterations
     x_grid = np.linspace(0, 1, 50)
@@ -795,7 +816,7 @@ def test_advanced_convergence_monitor_get_convergence_summary():
 @pytest.mark.unit
 def test_advanced_convergence_monitor_no_data():
     """Test convergence summary with no data."""
-    monitor = AdvancedConvergenceMonitor()
+    monitor = DistributionConvergenceMonitor()
 
     summary = monitor.get_convergence_summary()
 
@@ -805,7 +826,7 @@ def test_advanced_convergence_monitor_no_data():
 @pytest.mark.unit
 def test_advanced_convergence_monitor_get_plot_data_no_history():
     """Test getting plot data with no convergence history."""
-    monitor = AdvancedConvergenceMonitor()
+    monitor = DistributionConvergenceMonitor()
 
     # Should return empty data structure
     data = monitor.get_plot_data()
@@ -818,7 +839,7 @@ def test_advanced_convergence_monitor_get_plot_data_no_history():
 @pytest.mark.unit
 def test_advanced_convergence_monitor_convergence_criteria_all_pass():
     """Test all convergence criteria passing."""
-    monitor = AdvancedConvergenceMonitor(
+    monitor = DistributionConvergenceMonitor(
         wasserstein_tol=1e-3,
         u_magnitude_tol=1e-2,
         u_stability_tol=1e-3,
@@ -839,7 +860,7 @@ def test_advanced_convergence_monitor_convergence_criteria_all_pass():
 
 
 # =============================================================================
-# Additional tests for ParticleMethodDetector
+# Additional tests for SolverTypeDetector
 # =============================================================================
 
 
@@ -855,7 +876,7 @@ def test_particle_method_detector_comprehensive():
     solver.update_particles = lambda: None
     solver.__class__.__name__ = "ParticleCollocationSolver"
 
-    has_particles, info = ParticleMethodDetector.detect_particle_methods(solver)
+    has_particles, info = SolverTypeDetector.detect_particle_methods(solver)
 
     assert has_particles
     assert info["confidence"] > 0.5
@@ -875,7 +896,7 @@ def test_particle_method_detector_grid_based_solver():
     # Ensure no particle attributes
     solver.spec = ["Nx", "Nt", "grid"]  # Only grid-based attributes
 
-    has_particles, info = ParticleMethodDetector.detect_particle_methods(solver)
+    has_particles, info = SolverTypeDetector.detect_particle_methods(solver)
 
     # The detector should have low confidence or no detection
     # Since confidence can vary based on Mock behavior, check it's not strongly detected
@@ -895,14 +916,14 @@ def test_particle_method_detector_fp_solver_inspection():
     fp_solver.__class__.__name__ = "ParticleFPSolver"
     solver.fp_solver = fp_solver
 
-    has_particles, info = ParticleMethodDetector.detect_particle_methods(solver)
+    has_particles, info = SolverTypeDetector.detect_particle_methods(solver)
 
     assert has_particles
     assert "fp_solver:ParticleFPSolver" in info["particle_components"]
 
 
 # =============================================================================
-# Additional tests for AdaptiveConvergenceWrapper
+# Additional tests for ConvergenceWrapper
 # =============================================================================
 
 
@@ -915,7 +936,7 @@ def test_adaptive_convergence_wrapper_classical_mode():
     solver.__class__.__name__ = "GridBasedSolver"
     solver.solve = Mock(return_value=(np.ones((10, 10)), np.ones((10, 10)), {}))
 
-    wrapper = AdaptiveConvergenceWrapper(solver, classical_tol=1e-3, force_particle_mode=False, verbose=False)
+    wrapper = ConvergenceWrapper(solver, classical_tol=1e-3, force_particle_mode=False, verbose=False)
 
     assert wrapper.get_convergence_mode() == "classical"
     assert wrapper._particle_mode is False
@@ -929,7 +950,7 @@ def test_adaptive_convergence_wrapper_forced_particle_mode():
     solver = Mock()
     solver.__class__.__name__ = "GridBasedSolver"
 
-    wrapper = AdaptiveConvergenceWrapper(solver, force_particle_mode=True, verbose=False)
+    wrapper = ConvergenceWrapper(solver, force_particle_mode=True, verbose=False)
 
     assert wrapper.get_convergence_mode() == "particle_aware"
     assert wrapper._particle_mode is True
@@ -943,7 +964,7 @@ def test_adaptive_convergence_wrapper_get_detection_info():
     solver = Mock()
     solver.__class__.__name__ = "TestSolver"
 
-    wrapper = AdaptiveConvergenceWrapper(solver, verbose=False)
+    wrapper = ConvergenceWrapper(solver, verbose=False)
     info = wrapper.get_detection_info()
 
     assert isinstance(info, dict)
@@ -1041,8 +1062,8 @@ def test_adaptive_convergence_decorator_with_parameters():
 
 @pytest.mark.unit
 def test_integration_advanced_monitor_full_workflow():
-    """Test complete AdvancedConvergenceMonitor workflow."""
-    monitor = AdvancedConvergenceMonitor(
+    """Test complete DistributionConvergenceMonitor workflow."""
+    monitor = DistributionConvergenceMonitor(
         wasserstein_tol=1e-4,
         u_magnitude_tol=1e-3,
         u_stability_tol=1e-4,
@@ -1075,7 +1096,7 @@ def test_integration_advanced_monitor_full_workflow():
 @pytest.mark.unit
 def test_integration_stochastic_monitor_with_noise():
     """Test stochastic monitor handles noisy convergence."""
-    monitor = StochasticConvergenceMonitor(
+    monitor = RollingConvergenceMonitor(
         window_size=10,
         median_tolerance=1e-4,
         quantile=0.9,

--- a/tests/unit/test_utils/test_solver_decorators.py
+++ b/tests/unit/test_utils/test_solver_decorators.py
@@ -130,21 +130,14 @@ class TestSolverMonitoringOptions:
         assert result["converged"] is True
         assert "execution_time" not in result
 
-    def test_backward_compatibility_deprecation_warning(self):
-        """Test deprecated boolean parameters trigger warnings."""
-        import warnings
+    def test_deprecated_boolean_parameters_removed(self):
+        """Removed-pin: deprecated boolean kwargs (monitor_convergence/auto_progress/timing)
+        were removed in v0.20.0; passing them now raises TypeError."""
+        with pytest.raises(TypeError):
+            enhanced_solver_method(auto_progress=True, timing=True)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            @enhanced_solver_method(auto_progress=True, timing=True)
-            def solve(self, max_iterations=10, verbose=False, **kwargs):
-                return {"converged": True}
-
-            # Each deprecated parameter triggers its own warning
-            assert len(w) >= 1
-            assert all(issubclass(warning.category, DeprecationWarning) for warning in w)
-            assert any("deprecated" in str(warning.message).lower() for warning in w)
+        with pytest.raises(TypeError):
+            enhanced_solver_method(monitor_convergence=True)
 
 
 class TestWithProgressMonitoring:
@@ -267,7 +260,7 @@ class TestEnhancedSolverMethod:
     def test_enhanced_with_all_features(self):
         """Test enhanced decorator with all features enabled."""
 
-        @enhanced_solver_method(monitor_convergence=True, auto_progress=True, timing=True)
+        @enhanced_solver_method(options=SolverMonitoringOptions.ALL)
         def solve(self, max_iterations=10, verbose=True, **kwargs):
             time.sleep(0.01)
             return {"converged": True}
@@ -281,7 +274,7 @@ class TestEnhancedSolverMethod:
     def test_enhanced_progress_only(self):
         """Test enhanced decorator with only progress enabled."""
 
-        @enhanced_solver_method(monitor_convergence=False, auto_progress=True, timing=False)
+        @enhanced_solver_method(options=SolverMonitoringOptions.PROGRESS)
         def solve(self, max_iterations=10, verbose=True, **kwargs):
             return {"converged": True}
 
@@ -294,7 +287,7 @@ class TestEnhancedSolverMethod:
     def test_enhanced_timing_only(self):
         """Test enhanced decorator with only timing enabled."""
 
-        @enhanced_solver_method(monitor_convergence=False, auto_progress=False, timing=True)
+        @enhanced_solver_method(options=SolverMonitoringOptions.TIMING)
         def solve(self, max_iterations=10, verbose=True, **kwargs):
             time.sleep(0.01)
             return {"converged": True}
@@ -309,7 +302,7 @@ class TestEnhancedSolverMethod:
     def test_enhanced_no_features(self):
         """Test enhanced decorator with all features disabled."""
 
-        @enhanced_solver_method(monitor_convergence=False, auto_progress=False, timing=False)
+        @enhanced_solver_method(options=SolverMonitoringOptions.NONE)
         def solve(self, max_iterations=10, verbose=True, **kwargs):
             return {"converged": True}
 
@@ -557,7 +550,7 @@ class TestDecoratorIntegration:
     def test_multiple_decorators(self):
         """Test applying multiple decorators to same method."""
 
-        @enhanced_solver_method(auto_progress=False, timing=True)
+        @enhanced_solver_method(options=SolverMonitoringOptions.TIMING)
         @with_progress_monitoring(show_progress=False, show_timing=False)
         def solve(self, max_iterations=10, verbose=False, **kwargs):
             time.sleep(0.01)
@@ -573,7 +566,7 @@ class TestDecoratorIntegration:
         """Test decorator on method of class with mixin."""
 
         class MixedSolver(SolverProgressMixin):
-            @enhanced_solver_method(auto_progress=False, timing=True)
+            @enhanced_solver_method(options=SolverMonitoringOptions.TIMING)
             def solve(self, max_iterations=10, verbose=False, **kwargs):
                 time.sleep(0.01)
                 return {"converged": True}
@@ -593,7 +586,7 @@ class TestDecoratorIntegration:
                 super().__init__()
                 self.max_iterations = 50
 
-            @enhanced_solver_method(monitor_convergence=True, auto_progress=True, timing=True)
+            @enhanced_solver_method(options=SolverMonitoringOptions.ALL)
             def solve(self, max_iterations=None, tolerance=1e-6, verbose=True, **kwargs):
                 iterations = max_iterations or self.max_iterations
                 error = 1.0


### PR DESCRIPTION
## Summary

Removes the v0.17.0 **monitoring-family** Tier-2 deprecation shims. All are age-eligible for removal (>= 3 minor versions since v0.17.0; current main is v0.20.0).

### 1. `solver_decorators.enhanced_solver_method`
Removes the deprecated boolean kwargs `monitor_convergence` / `auto_progress` / `timing` (replaced by `options=SolverMonitoringOptions(...)`). Drops the back-compat conversion block, the three `@deprecated_parameter` decorators, and the now-unused `deprecated_parameter` import. The signature is now `enhanced_solver_method(options=None)`.

### 2. Convergence monitor aliases / factories
| Removed (since v0.17.0) | Replacement |
|---|---|
| `create_default_monitor` | `create_distribution_monitor` |
| `create_stochastic_monitor` | `create_rolling_monitor` |
| `OscillationDetector` | `_ErrorHistoryTracker` |
| `AdvancedConvergenceMonitor` | `DistributionConvergenceMonitor` |
| `ParticleMethodDetector` | `SolverTypeDetector` |
| `AdaptiveConvergenceWrapper` | `ConvergenceWrapper` |
| `StochasticConvergenceMonitor` | `RollingConvergenceMonitor` |

Removes the `deprecated` / `deprecated_alias` imports from `convergence_metrics.py` and `convergence_monitors.py`, plus the re-exports in `mfgarchon/utils/__init__.py` and `mfgarchon/utils/convergence/__init__.py`.

## Migration of call sites
- `benchmarks/solver_comparisons/study_hybrid_mass_conservation.py` -> `create_rolling_monitor` (signature identical: `window_size`, `median_tolerance`, `quantile`).
- `test_convergence.py` / `test_solver_decorators.py` migrated to canonical names and the `options=` API.
- Equivalence/deprecation tests converted to **removed-pins**: old alias names now raise `ImportError` on import; old decorator kwargs now raise `TypeError`.

## Scope-boundary discrimination
- `AdaptiveTrainingConfig.monitor_convergence` (pinn_solvers + its examples) is an **independent same-name field**, not the deprecated decorator param — left untouched.
- Historical `# renamed from ...` / `This replaces ...` docstrings retained per the repo's documentation policy.
- `CHANGELOG.md` and the auto-generated `docs/user/DEPRECATION_MODERNIZATION_GUIDE.md` are not edited here: the guide is regenerated separately (it still lists the symbols removed by #1355/#1356), and CHANGELOG is consolidated post-merge.

## Gate
- Zero production old-name call sites (`mfgarchon/` clean; only historical docstrings remain).
- Removed-pins pass.
- `tests/unit/test_utils` green: **889 passed**.
- `ruff check --select F mfgarchon/` clean; `ruff format --check` clean.
- `import mfgarchon.utils` / `.convergence` clean; every `__all__` entry resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)