### PR TITLE
ci: blocking mypy config gate + enable pytest-xdist (-n auto)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,15 @@ jobs:
         echo "Testing package imports..."
         python -c "import mfgarchon; print('✅ Package imports successfully')"
 
+    - name: MyPy type gate (config subpackage, blocking)
+      timeout-minutes: 2
+      run: |
+        echo "Type-checking mfgarchon/config (blocking gate)..."
+        # Scoped to config + --follow-imports=silent on purpose: raw mypy on
+        # config pulls 1800+ transitive errors from un-annotated deps otherwise.
+        mypy mfgarchon/config --follow-imports=silent
+        echo "✅ config type-checks clean"
+
     - name: Documentation completeness check
       run: |
         echo "📚 Checking documentation completeness..."
@@ -188,11 +197,20 @@ jobs:
 
     - name: Run tests with coverage (skip slow tests on PRs)
       if: github.event_name != 'release'
-      timeout-minutes: 38  # serial suite (~4770 tests) under coverage; grew past the old 30-min budget
+      timeout-minutes: 25  # parallel (-n auto) suite under coverage; ~2.3x faster than the old 38-min serial budget
+      env:
+        # Pin BLAS/OpenMP to 1 thread per worker: xdist already saturates cores,
+        # so per-process BLAS parallelism would oversubscribe and slow the run.
+        OMP_NUM_THREADS: 1
+        OPENBLAS_NUM_THREADS: 1
+        MKL_NUM_THREADS: 1
       run: |
         # Note: test_backends/ and test_visualization/ excluded due to platform-specific failures
         # (MPS device tests on non-Mac, legacy plotting issues)
+        # -n auto: pytest-xdist parallelism. Confirmed equivalent to serial
+        # (same pass/skip/xfail counts, no isolation failures) before enabling.
         pytest tests/ -v \
+          -n auto \
           --ignore=tests/unit/test_backends/ \
           --ignore=tests/unit/test_visualization/ \
           -m "not slow and not optional_torch and not benchmark and not experimental and not environment" \

--- a/mfgarchon/config/omegaconf_manager.py
+++ b/mfgarchon/config/omegaconf_manager.py
@@ -236,7 +236,7 @@ class OmegaConfManager:
         }
 
         # Write default configs
-        configs = {
+        configs: dict[str, dict[str, Any]] = {
             "base_mfg.yaml": base_mfg_config,
             "solver.yaml": solver_config,
             "beach_problem.yaml": beach_config,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-benchmark",
+    "pytest-xdist>=3.5",
     "ruff>=0.6.0",
     "mypy>=1.5",
     "pre-commit>=2.0",
@@ -234,6 +235,7 @@ module = [
     "texttable.*",
     "cvxpy.*",
     "osqp.*",
+    "yaml.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
## Summary

CI quality hardening — two changes, both landing in `.github/workflows/ci.yml` (one PR to avoid ci.yml conflicts).

### PART 1 — mypy Stage-1 (config subpackage → 0 errors, blocking gate)

Fixed the two baseline `mypy mfgarchon/config --follow-imports=silent` errors:

- `mfgarchon/config/io.py:13` — `yaml` library stubs missing (`import-untyped`). Added `yaml.*` to the existing `ignore_missing_imports` override in `[tool.mypy]` (no new dependency required).
- `mfgarchon/config/omegaconf_manager.py:249` — `OmegaConf.create(config)` overload mismatch because `config` was inferred as `object` (heterogeneous dict values). Annotated the local `configs` dict as `dict[str, dict[str, Any]]` so the loop value is `dict[str, Any]` and matches the `create()` overload.

Added a **blocking** CI step (no `|| true`) in the `import-validation` job:

```
mypy mfgarchon/config --follow-imports=silent
```

Scope to `config` + `--follow-imports=silent` is deliberate — raw mypy on config pulls 1800+ transitive errors from un-annotated deps otherwise. The step lives in `import-validation` (which already runs `pip install -e .[dev]`, providing mypy + the deps needed to resolve config imports) and blocks `test-suite`.

### PART 2 — pytest-xdist enablement (confirmed clean)

- Added `pytest-xdist>=3.5` to `[project.optional-dependencies] dev`.
- **Confirming run** (full PR test selection, serial vs `-n auto`, BLAS pinned to 1 thread):

  | Run | Result | Time |
  |-----|--------|------|
  | serial | 4399 passed, 24 skipped, 363 deselected, 6 xfailed, exit 0 | 504s (8:24) |
  | `-n auto` | 4399 passed, 24 skipped, 6 xfailed, exit 0 | 218s (3:38) |

  Same pass/skip/xfail counts, no failures, **no isolation bugs** → safe to enable.
- Enabled `-n auto` in the PR test step, pinned `OMP_NUM_THREADS=OPENBLAS_NUM_THREADS=MKL_NUM_THREADS=1` to avoid BLAS oversubscription, and reduced that step's timeout from 38 → 25 min. Measured local speedup ~2.3x on 10 cores.

## Gate

- `mypy mfgarchon/config --follow-imports=silent` → 0 errors (exit 0)
- `ruff check --select F mfgarchon/` → clean
- `ruff format --check mfgarchon/` → clean (453 files)
- `python -c "import mfgarchon"` → clean
- Confirming run: serial == parallel, no isolation failures

CHANGELOG intentionally not edited (added in a single post-merge commit to avoid cross-PR conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)