### PR TITLE
chore(release): v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-06-15
+
 ### Changed
 
 - **Vectorized the semi-Lagrangian canonical Carlini-Silva per-point optimization** (PR #1353).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.20.0"  # v0.20.0: interaction operators (#1023) + hex FEM (#470) + CS semi-Lagrangian (#1058) + FVM-FP (#422) + solver demote (#1342) + ~50 fixes
+version = "0.20.1"  # v0.20.1: deprecation cleanup (Tier-1/2/3a removed, #1354-1357/#1360) + SL vectorize 13-40x (#1353) + CI mypy-gate & xdist (#1358)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
Patch release shipping the v0.20.x **deprecation cleanup** + perf/CI hardening accumulated since v0.20.0.

`0.20.0` → `0.20.1` (pyproject.toml:11); CHANGELOG `[Unreleased]` → `[0.20.1] - 2026-06-15`.

### Removed (BREAKING) — past-window deprecation cleanup
- Tier-1: lowercase grid params, mesh `format_type`, FP-particle legacy params (#1354)
- Tier-2: FP-solver params (#1356), HJB-solver params (#1355), monitoring family (#1357)
- Tier-3a: `MFGProblem` 1D read-properties `xmin/xmax/Lx/Nx/dx/xSpace/_grid` (#1360)

### Changed
- SL canonical-CS per-point vectorization, 13–40× (#1353)
- CI: blocking mypy gate on `mfgarchon/config` + `pytest-xdist -n auto` (#1358)

Deferred (tracked): Tier-3b/3c constructor params + methods/aliases (#1363).

After merge: tag `v0.20.1` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)