### PR TITLE
fix(backends): warn on JAX + high-order scheme silent downgrade (#1072 interim)

### DIFF
--- a/mfgarchon/backends/__init__.py
+++ b/mfgarchon/backends/__init__.py
@@ -22,6 +22,22 @@ logger = get_logger(__name__)
 _BACKENDS = {}
 _DEFAULT_BACKEND = "numpy"
 
+# Issue #1072 (interim): the JAX backend ghost-implements its HJB/FP time steps
+# (jax_backend.py `_hjb_step_impl` / `_fpk_step_impl`) using 2nd-order central
+# differences only, instead of calling the high-order operators the NumPy path
+# uses (e.g. WENO5 / upwind reconstruction). Selecting JAX for any scheme other
+# than 2nd-order central therefore silently solves *different* math, so a
+# cross-backend "speedup" benchmark compares apples to oranges. Full backend
+# uniformity is the deferred design in #1072; this is the documented stop-gap.
+#
+# `fdm_centered` is the one scheme whose stencil the JAX 2nd-order central
+# implementation faithfully reproduces — every other scheme (upwind, WENO5, SL,
+# GFDM, FEM, FVM, meshless) uses a stencil JAX does not implement.
+_JAX_NATIVE_SCHEME_VALUES = frozenset({"fdm_centered"})
+# One-time guard, keyed by scheme value (matches the repo's set-based idiom, e.g.
+# utils/pde_coefficients._VOLATILITY_LEGACY_KEY_WARNED).
+_JAX_SCHEME_DOWNGRADE_WARNED: set[str] = set()
+
 
 def register_backend(name: str, backend_class):
     """Register a computational backend."""
@@ -162,6 +178,62 @@ def create_backend(backend_name: str | None = None, **kwargs):
     return _BACKENDS[backend_name](**kwargs)
 
 
+def warn_if_jax_scheme_downgraded(backend_name: str | None, scheme: Any) -> bool:
+    """Warn once when the JAX backend is paired with a non-2nd-order-central scheme.
+
+    Issue #1072 (interim mitigation). The JAX backend's ``hjb_step`` / ``fpk_step``
+    ghost-implement 2nd-order central differences rather than calling the
+    high-order operators (WENO5 / upwind) the NumPy path uses. When JAX is
+    selected for a scheme whose stencil it does not implement, the requested
+    discretization is silently replaced by 2nd-order central, so results differ
+    from the NumPy high-order path and cross-backend comparison is not
+    quantitatively meaningful.
+
+    The warning is emitted at most once per distinct scheme value. It fires only
+    on the JAX backend with a non-native scheme; it is a no-op for the NumPy /
+    other backends, for ``fdm_centered`` (which JAX reproduces exactly), and when
+    no scheme is known (e.g. Expert Mode with injected solvers).
+
+    Parameters
+    ----------
+    backend_name : str | None
+        Resolved backend name (e.g. ``"jax"``, ``"numpy"``). ``None`` means the
+        default backend, which is never JAX.
+    scheme : Any
+        A ``NumericalScheme`` enum member or its string value. ``None`` skips the
+        check (no scheme to classify).
+
+    Returns
+    -------
+    bool
+        ``True`` if a warning was emitted by this call, ``False`` otherwise.
+    """
+    if backend_name != "jax" or scheme is None:
+        return False
+
+    # Accept either a NumericalScheme enum (has `.value`) or a bare string.
+    scheme_value = str(getattr(scheme, "value", scheme))
+
+    if scheme_value in _JAX_NATIVE_SCHEME_VALUES:
+        return False
+    if scheme_value in _JAX_SCHEME_DOWNGRADE_WARNED:
+        return False
+
+    _JAX_SCHEME_DOWNGRADE_WARNED.add(scheme_value)
+    warnings.warn(
+        f"JAX backend selected with scheme '{scheme_value}', but the JAX backend "
+        f"implements only 2nd-order central differences (it ghost-implements "
+        f"hjb_step/fpk_step instead of the high-order operators, e.g. WENO5/upwind, "
+        f"used by the NumPy path). The requested stencil is silently replaced by "
+        f"2nd-order central, so results will differ from the NumPy high-order path "
+        f"and cross-backend comparison is not quantitatively meaningful. Use the "
+        f"NumPy backend for this scheme, or scheme 'fdm_centered' with JAX. "
+        f"(Issue #1072, interim; full backend uniformity is deferred.)",
+        stacklevel=2,
+    )
+    return True
+
+
 def get_backend_info() -> dict[str, Any]:
     """Get information about available backends."""
     available = get_available_backends()
@@ -263,4 +335,5 @@ __all__ = [
     "get_available_backends",
     "get_backend_info",
     "register_backend",
+    "warn_if_jax_scheme_downgraded",
 ]

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -2405,6 +2405,11 @@ See: docs/migration/HAMILTONIAN_API.md"""
         safe_mode = scheme is not None
         expert_mode = hjb_solver is not None or fp_solver is not None
 
+        # Scheme actually used to build the solver pair (None in Expert Mode, where
+        # the user injects solvers and no scheme is resolvable). Used for the
+        # Issue #1072 JAX-backend downgrade warning below.
+        _effective_scheme: Any = None
+
         # Mode Validation: Cannot mix modes
         if safe_mode and expert_mode:
             raise ValueError(
@@ -2429,6 +2434,8 @@ See: docs/migration/HAMILTONIAN_API.md"""
                     raise ValueError(
                         f"Unknown scheme string: {scheme!r}. Valid schemes: {[s.value for s in NumericalScheme]}"
                     ) from None
+
+            _effective_scheme = scheme
 
             # Issue #1155: translate config.hjb / config.fp to solver kwargs.
             # Non-default fields that have clear mappings are threaded; unknown /
@@ -2490,6 +2497,7 @@ See: docs/migration/HAMILTONIAN_API.md"""
             # Phase 3 TODO: Implement geometry introspection
             # For now, get_recommended_scheme() returns FDM_UPWIND as safe default
             recommended_scheme = get_recommended_scheme(self)
+            _effective_scheme = recommended_scheme
 
             # Issue #1155: translate config.hjb / config.fp to solver kwargs.
             from mfgarchon.config.translator import fp_config_to_kwargs, hjb_config_to_kwargs
@@ -2532,6 +2540,14 @@ See: docs/migration/HAMILTONIAN_API.md"""
         _iterator_extra_kw = picard_config_to_iterator_kwargs(config.picard)
         _backend_kw = backend_config_to_kwargs(config.backend)
         check_logging_config(config.logging)
+
+        # Issue #1072 (interim): the JAX backend ghost-implements only 2nd-order
+        # central differences, so pairing it with a high-order scheme silently
+        # solves different math than the NumPy path. Warn once at the seam where
+        # both the backend and the resolved scheme are known.
+        from mfgarchon.backends import warn_if_jax_scheme_downgraded
+
+        warn_if_jax_scheme_downgraded(_backend_kw.get("backend"), _effective_scheme)
 
         solver = FixedPointIterator(
             problem=self,

--- a/tests/unit/test_backends/test_backend_factory.py
+++ b/tests/unit/test_backends/test_backend_factory.py
@@ -359,6 +359,7 @@ class TestModuleExports:
             "get_available_backends",
             "get_backend_info",
             "register_backend",
+            "warn_if_jax_scheme_downgraded",  # Issue #1072 interim warning helper
         }
         assert set(backends_module.__all__) == expected
 

--- a/tests/unit/test_backends/test_issue_1072_jax_scheme_warning.py
+++ b/tests/unit/test_backends/test_issue_1072_jax_scheme_warning.py
@@ -1,0 +1,157 @@
+"""Tests for Issue #1072 interim mitigation: JAX backend scheme-downgrade warning.
+
+The JAX backend's ``hjb_step`` / ``fpk_step`` ghost-implement 2nd-order central
+differences (``jax_backend.py`` ``_hjb_step_impl`` / ``_fpk_step_impl``) rather
+than the high-order operators (WENO5 / upwind) used by the NumPy path. Selecting
+JAX for a high-order scheme therefore silently solves *different* math, making
+cross-backend benchmarks apples-to-oranges. The interim fix
+(:func:`mfgarchon.backends.warn_if_jax_scheme_downgraded`) emits a one-time
+warning at the seam where both the backend and the scheme are known.
+
+Gate (Issue #1072):
+- Warning FIRES on JAX + high-order scheme.
+- Warning does NOT fire on JAX + natively-2nd-order-central scheme.
+- Warning does NOT fire on the NumPy path (any scheme).
+- Warning is one-time per scheme value.
+
+These tests target the warning helper directly so they do not depend on JAX
+being installed (the helper is pure dispatch over the backend name + scheme).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from mfgarchon.backends import warn_if_jax_scheme_downgraded
+import mfgarchon.backends as backends_pkg
+from mfgarchon.types import NumericalScheme
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_guard():
+    """Clear the one-time guard so each test starts from a clean slate."""
+    backends_pkg._JAX_SCHEME_DOWNGRADE_WARNED.clear()
+    yield
+    backends_pkg._JAX_SCHEME_DOWNGRADE_WARNED.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Warning FIRES: JAX + high-order scheme
+# --------------------------------------------------------------------------- #
+
+
+def test_jax_high_order_scheme_warns():
+    """JAX + a high-order scheme (SL_CUBIC, O(h^4)) emits the warning."""
+    with pytest.warns(UserWarning, match="JAX backend"):
+        fired = warn_if_jax_scheme_downgraded("jax", NumericalScheme.SL_CUBIC)
+    assert fired is True
+
+
+def test_jax_upwind_scheme_warns():
+    """JAX + FDM_UPWIND warns: JAX uses central, not the requested upwind stencil."""
+    with pytest.warns(UserWarning, match="2nd-order central"):
+        fired = warn_if_jax_scheme_downgraded("jax", NumericalScheme.FDM_UPWIND)
+    assert fired is True
+
+
+def test_warning_message_mentions_issue_and_weno():
+    """The warning is actionable: names the cause and the interim-fix issue."""
+    with pytest.warns(UserWarning) as record:
+        warn_if_jax_scheme_downgraded("jax", NumericalScheme.FDM_UPWIND)
+    msg = str(record[0].message)
+    assert "Issue #1072" in msg
+    assert "WENO5" in msg or "high-order" in msg
+
+
+def test_scheme_accepts_string_value():
+    """The helper accepts a bare scheme string (not only the enum)."""
+    with pytest.warns(UserWarning, match="JAX backend"):
+        fired = warn_if_jax_scheme_downgraded("jax", "fdm_upwind")
+    assert fired is True
+
+
+# --------------------------------------------------------------------------- #
+# Warning does NOT fire: JAX + natively-2nd-order-central scheme
+# --------------------------------------------------------------------------- #
+
+
+def test_jax_fdm_centered_does_not_warn():
+    """FDM_CENTERED is exactly what the JAX 2nd-order central path implements."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning -> test failure
+        fired = warn_if_jax_scheme_downgraded("jax", NumericalScheme.FDM_CENTERED)
+    assert fired is False
+
+
+def test_jax_fdm_centered_string_does_not_warn():
+    """Same no-warn behavior for the bare 'fdm_centered' string."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fired = warn_if_jax_scheme_downgraded("jax", "fdm_centered")
+    assert fired is False
+
+
+# --------------------------------------------------------------------------- #
+# Warning does NOT fire: NumPy / other backends, or no scheme
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("scheme", list(NumericalScheme))
+def test_numpy_backend_never_warns(scheme):
+    """NumPy path is the high-order reference — it never warns, for any scheme."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fired = warn_if_jax_scheme_downgraded("numpy", scheme)
+    assert fired is False
+
+
+def test_default_backend_none_does_not_warn():
+    """A None backend name (config default = numpy) never warns."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fired = warn_if_jax_scheme_downgraded(None, NumericalScheme.FDM_UPWIND)
+    assert fired is False
+
+
+def test_pytorch_backend_does_not_warn():
+    """The warning is JAX-specific; other non-default backends are out of scope."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fired = warn_if_jax_scheme_downgraded("pytorch", NumericalScheme.FDM_UPWIND)
+    assert fired is False
+
+
+def test_no_scheme_does_not_warn():
+    """Expert Mode (no resolvable scheme) cannot be classified -> no warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fired = warn_if_jax_scheme_downgraded("jax", None)
+    assert fired is False
+
+
+# --------------------------------------------------------------------------- #
+# One-time semantics
+# --------------------------------------------------------------------------- #
+
+
+def test_warning_fires_only_once_per_scheme():
+    """Repeated identical calls warn once; the guard suppresses the rest."""
+    with pytest.warns(UserWarning):
+        first = warn_if_jax_scheme_downgraded("jax", NumericalScheme.FDM_UPWIND)
+    assert first is True
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # second call must be silent
+        second = warn_if_jax_scheme_downgraded("jax", NumericalScheme.FDM_UPWIND)
+    assert second is False
+
+
+def test_distinct_schemes_warn_independently():
+    """The guard is keyed per scheme: a different scheme still warns once."""
+    with pytest.warns(UserWarning):
+        warn_if_jax_scheme_downgraded("jax", NumericalScheme.FDM_UPWIND)
+    with pytest.warns(UserWarning):
+        fired = warn_if_jax_scheme_downgraded("jax", NumericalScheme.SL_CUBIC)
+    assert fired is True


### PR DESCRIPTION
## Summary

Interim mitigation for **#1072** (JAX backend silently uses 2nd-order central
diff while the NumPy backend uses the requested high-order scheme, e.g. WENO5).

The JAX backend ghost-implements its HJB/FP time steps with 2nd-order central
differences (`jax_backend.py` `_hjb_step_impl` / `_fpk_step_impl`) rather than
calling the high-order operators (`operators/differential/`, `reconstruction/weno.py`)
the NumPy path uses. There was **no warning** anywhere (`grep jax_backend.py`
for `warn`/`WENO`/`central` is empty), so `solve(scheme=..., backend="jax")`
silently solves different math than `backend="numpy"`, making cross-backend
"speedup" benchmarks apples-to-oranges whenever accuracy is a metric.

This PR ships the documented **5-line stop-gap** from the issue, made
scheme-aware so it does not cry wolf on the one scheme JAX reproduces exactly.
Full backend uniformity (Functional Operator Lowering) remains the deferred
design in #1072 — **not** this PR.

## What changed

- `mfgarchon/backends/__init__.py`: new `warn_if_jax_scheme_downgraded(backend_name, scheme)`.
  - One-time warning keyed per scheme value (matches the repo `set`-based idiom,
    cf. `utils/pde_coefficients._VOLATILITY_LEGACY_KEY_WARNED`).
  - Native set = `{fdm_centered}` (the only scheme JAX's 2nd-order central
    stencil reproduces); every other scheme triggers the warning under JAX.
- `mfgarchon/core/mfg_problem.py`: call the helper from `solve()` at the seam
  where both the resolved `_effective_scheme` and `config.backend` are known
  (right after `backend_config_to_kwargs`). No behavior change to the solve
  itself — only an added warning.
- Tests: `tests/unit/test_backends/test_issue_1072_jax_scheme_warning.py`
  (21 cases) + updated the `__all__` pin in `test_backend_factory.py`.

## Gate

- [x] Warning **fires** on JAX + high-order path (`fdm_upwind`, `sl_cubic`, …).
- [x] Warning does **not** fire on JAX + natively-2nd-order (`fdm_centered`).
- [x] Warning does **not** fire on the NumPy / default-backend path (any scheme).
- [x] One-time per scheme value; Expert Mode (no scheme) is a no-op.
- [x] `python -c "import mfgarchon"` clean.
- [x] `ruff check --select F mfgarchon/` + `ruff format --check` clean.
- [x] Verified end-to-end through `MFGProblem.solve()`: `jax + fdm_upwind`
      fires, `jax + fdm_centered` silent (warning is emitted before the
      pre-existing JAX-solve breakage that #1072 is ultimately about).

## Scope notes

- Expert Mode (`hjb_solver=`/`fp_solver=` injected directly) carries no
  resolvable scheme, so it is intentionally not covered by this seam.
- Over-/under-firing for non-FDM schemes is acceptable for an interim warning:
  the JAX backend implements *only* 2nd-order central, so it cannot faithfully
  reproduce any non-`fdm_centered` scheme regardless of path.

Refs #1072 (interim — full backend uniformity remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)