### PR TITLE
fix: make GFDM/FDM/WENO accuracy claims honest (Refs #1084)

### DIFF
--- a/mfgarchon/alg/numerical/gfdm_components/gfdm_strategies.py
+++ b/mfgarchon/alg/numerical/gfdm_components/gfdm_strategies.py
@@ -77,7 +77,27 @@ REGULARIZATION = 1e-12
 # Pseudoinverse rcond parameter
 PINV_RCOND = 1e-10
 
-# Condition number threshold for "ill-conditioned" warning
+# Condition number threshold for the "ill-conditioned" *diagnostic warning*
+# (Issue #1084). This is WARN-ONLY: `_validate_stencils` never rejects a stencil
+# for ill-conditioning (it returns valid=True regardless, see the comment at the
+# `ill_conditioned_points` branch), so the computed weights — and hence every
+# numerical result — are independent of this value. It only controls when a
+# diagnostic UserWarning is emitted.
+#
+# Accuracy implication of the chosen level. For the (least-squares Taylor)
+# system A x = b solved for the stencil weights, the relative weight error is
+# bounded by kappa(A) * u with float64 unit roundoff u ~ 1.1e-16, so the weights
+# lose ~log10(kappa) digits: reliable_digits ~ 16 - log10(kappa). At the current
+# 1e12 the weights retain only ~4 reliable digits, which at realistic grids
+# (h ~ 1e-2..1e-3, O(h^2) truncation ~ 1e-4..1e-6) is on par with the truncation
+# error a stencil claims to achieve — i.e. conditioning up to 1e12 is *permitted*
+# and the advertised order can be masked by weight roundoff without any warning.
+#
+# Kept at 1e12 (not tightened to ~1e8) deliberately: the gate is warn-only so a
+# tighter value would not improve accuracy, only change diagnostics; the
+# narrower band is documented per-level in `get_condition_numbers` (Notes), and a
+# tightening attempt (PR #1341) was reverted. Callers needing a stricter audit
+# can pass `cond_threshold` explicitly to `_validate_stencils`.
 COND_THRESHOLD = 1e12
 
 # PHS singularity epsilon (added to r for r^m)
@@ -723,12 +743,17 @@ class TaylorOperator(DifferentialOperator):
         Args:
             weight_threshold: Neighbors with weight < threshold * max_weight
                 are considered ineffective. Default 0.01 (1% of max).
-            cond_threshold: Condition numbers above this are considered
-                ill-conditioned. Default 1e12.
+            cond_threshold: Condition numbers above this trigger the
+                ill-conditioned *diagnostic warning*. Default 1e12 (~4 reliable
+                float64 digits in the solved weights; reliable_digits ~ 16 -
+                log10(kappa)). This is warn-only and does NOT affect the returned
+                validity or any computed result (see COND_THRESHOLD, Issue #1084).
+                Pass a smaller value (e.g. 1e8 for ~8 digits) for a stricter audit.
 
         Returns:
-            True if all stencils are valid, False if any are degenerate or
-            ill-conditioned.
+            True if all stencils are valid, False if any are degenerate
+            (rank-deficient). Ill-conditioning alone never sets this False; it
+            only emits a warning.
 
         Notes:
             Degenerate stencils occur when effective data points < n_derivatives.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -423,12 +423,15 @@ class HJBWenoSolver(BaseHJBSolver):
             ]
         )
 
-        # Negative reconstruction coefficients (right-to-left bias)
+        # Negative reconstruction coefficients (right-to-left bias).
+        # Each row is dotted (in _weno_reconstruction) against the reversed
+        # sub-stencil slice, so the value ordering below matches that dot:
+        # the k-th comment lists values in the same order as the coefficients.
         self.c_minus = np.array(
             [
-                [-1 / 6, 5 / 6, 1 / 3],  # S₀: u_{i+1}, u_i, u_{i-1}
-                [1 / 3, 5 / 6, -1 / 6],  # S₁: u_i, u_{i-1}, u_{i-2}
-                [1 / 3, -7 / 6, 11 / 6],  # S₂: u_{i-1}, u_{i-2}, u_{i-3}
+                [-1 / 6, 5 / 6, 1 / 3],  # S₀: u_i, u_{i-1}, u_{i-2}
+                [1 / 3, 5 / 6, -1 / 6],  # S₁: u_{i+1}, u_i, u_{i-1}
+                [1 / 3, -7 / 6, 11 / 6],  # S₂: u_{i+2}, u_{i+1}, u_i
             ]
         )
 

--- a/mfgarchon/operators/differential/directional.py
+++ b/mfgarchon/operators/differential/directional.py
@@ -103,7 +103,7 @@ class DirectDerivOperator(LinearOperator):
             scheme: Difference scheme for gradient computation
                 - "central": 2nd-order central differences (default)
                 - "upwind": Godunov upwind (monotone, 1st-order)
-                - "one_sided": Forward at left, backward at right
+                - "one_sided": 2nd-order one-sided at edges (forward at left, backward at right)
             bc: Boundary conditions (None for periodic)
             time: Time for time-dependent BCs (default 0.0)
 

--- a/mfgarchon/operators/differential/gradient.py
+++ b/mfgarchon/operators/differential/gradient.py
@@ -107,7 +107,7 @@ class PartialDerivOperator(LinearOperator):
             scheme: Difference scheme
                 - "central": 2nd-order central differences (default)
                 - "upwind": Godunov upwind (monotone, 1st-order)
-                - "one_sided": Forward at left, backward at right
+                - "one_sided": 2nd-order one-sided at edges (forward at left, backward at right)
                 - "weno5": 5th-order WENO reconstruction (high-order, shock-capturing)
             bc: Boundary conditions (None for periodic)
             time: Time for time-dependent BCs (default 0.0)
@@ -294,7 +294,7 @@ class GradientOperator:
             scheme: Difference scheme for all components
                 - "central": 2nd-order central differences (default)
                 - "upwind": Godunov upwind (monotone, 1st-order)
-                - "one_sided": Forward at left, backward at right
+                - "one_sided": 2nd-order one-sided at edges (forward at left, backward at right)
                 - "weno5": 5th-order WENO reconstruction
             bc: Boundary conditions (None for periodic)
             time: Time for time-dependent BCs (default 0.0)

--- a/mfgarchon/operators/stencils/finite_difference.py
+++ b/mfgarchon/operators/stencils/finite_difference.py
@@ -19,7 +19,7 @@ Stencil Types:
     - FORWARD: 1st-order accurate, uses u[i+1] - u[i]
     - BACKWARD: 1st-order accurate, uses u[i] - u[i-1]
     - UPWIND: Godunov selection based on flow direction (stable for advection)
-    - ONE_SIDED: Boundary handling with forward/backward at edges
+    - ONE_SIDED: 2nd-order one-sided boundary handling (3-point stencils at edges)
 
 Mathematical Background:
     Central:   ∂u/∂x ≈ (u[i+1] - u[i-1]) / (2h)     Error: O(h²)
@@ -187,15 +187,20 @@ def gradient_upwind(u: NDArray, axis: int, h: float, xp: type = np) -> NDArray:
 
 def fix_boundaries_one_sided(grad: NDArray, u: NDArray, axis: int, h: float, xp: type = np) -> NDArray:
     """
-    Replace boundary values with one-sided differences.
+    Replace boundary values with second-order one-sided differences.
 
     Central differences wrap around at boundaries (via np.roll), which is
     incorrect for non-periodic BCs. This function fixes the boundary values
-    using appropriate one-sided stencils.
+    using 3-point one-sided stencils that match the O(h²) accuracy of the
+    central interior, so a central-interior + one-sided-boundary gradient is
+    O(h²) throughout rather than degrading to O(h) at the edges (Issue #1084).
 
-    Boundary corrections:
-        Left (i=0):  use forward difference
-        Right (i=-1): use backward difference
+    Boundary corrections (require ≥ 3 points along ``axis``):
+        Left  (i=0):  forward  (-3u[0] + 4u[1] - u[2]) / (2h)     Error: O(h²)
+        Right (i=-1): backward (3u[-1] - 4u[-2] + u[-3]) / (2h)   Error: O(h²)
+
+    When the axis has only 2 points the 3-point stencil is unavailable, so the
+    (exact-best) first-order one-sided difference O(h) is used for that axis.
 
     Args:
         grad: Gradient array computed with central differences
@@ -212,20 +217,23 @@ def fix_boundaries_one_sided(grad: NDArray, u: NDArray, axis: int, h: float, xp:
         >>> grad = fix_boundaries_one_sided(grad, u, axis=0, h=dx)
     """
     ndim = u.ndim
+    n = u.shape[axis]
 
-    # Left boundary: forward difference
-    left_slice = [slice(None)] * ndim
-    left_slice[axis] = 0
-    next_slice = [slice(None)] * ndim
-    next_slice[axis] = 1
-    grad[tuple(left_slice)] = (u[tuple(next_slice)] - u[tuple(left_slice)]) / h
+    def _at(idx: int) -> tuple:
+        s = [slice(None)] * ndim
+        s[axis] = idx
+        return tuple(s)
 
-    # Right boundary: backward difference
-    right_slice = [slice(None)] * ndim
-    right_slice[axis] = -1
-    prev_slice = [slice(None)] * ndim
-    prev_slice[axis] = -2
-    grad[tuple(right_slice)] = (u[tuple(right_slice)] - u[tuple(prev_slice)]) / h
+    if n >= 3:
+        # Left boundary: second-order forward, (-3u[0] + 4u[1] - u[2]) / (2h)
+        grad[_at(0)] = (-3.0 * u[_at(0)] + 4.0 * u[_at(1)] - u[_at(2)]) / (2.0 * h)
+        # Right boundary: second-order backward, (3u[-1] - 4u[-2] + u[-3]) / (2h)
+        grad[_at(-1)] = (3.0 * u[_at(-1)] - 4.0 * u[_at(-2)] + u[_at(-3)]) / (2.0 * h)
+    else:
+        # Only 2 points along axis: the 3-point stencil cannot be formed;
+        # first-order one-sided is the exact-best available approximation.
+        grad[_at(0)] = (u[_at(1)] - u[_at(0)]) / h
+        grad[_at(-1)] = (u[_at(-1)] - u[_at(-2)]) / h
 
     return grad
 

--- a/mfgarchon/utils/numerical/tensor_calculus.py
+++ b/mfgarchon/utils/numerical/tensor_calculus.py
@@ -108,7 +108,7 @@ def gradient(
         Difference scheme:
         - "central": Second-order central differences (default)
         - "upwind": Godunov upwind (monotone, first-order)
-        - "one_sided": Forward at left, backward at right
+        - "one_sided": 2nd-order one-sided at edges (forward at left, backward at right)
     bc : BoundaryConditions, optional
         Boundary conditions. If None, uses periodic (np.roll).
     backend : ArrayBackend, optional
@@ -701,22 +701,27 @@ def _gradient_upwind(u: NDArray, axis: int, h: float, xp: type) -> NDArray:
 
 
 def _fix_boundaries_one_sided(grad: NDArray, u: NDArray, axis: int, h: float, xp: type) -> NDArray:
-    """Replace boundary values with one-sided differences."""
+    """Replace boundary values with second-order one-sided differences.
+
+    Mirrors ``operators.stencils.finite_difference.fix_boundaries_one_sided``
+    (single source of truth for the one-sided boundary convention). Uses 3-point
+    O(h^2) stencils so a central-interior gradient stays O(h^2) at the edges
+    (Issue #1084); falls back to first-order when the axis has only 2 points.
+    """
     ndim = u.ndim
+    n = u.shape[axis]
 
-    # Left boundary: forward difference
-    left_slice = [slice(None)] * ndim
-    left_slice[axis] = 0
-    next_slice = [slice(None)] * ndim
-    next_slice[axis] = 1
-    grad[tuple(left_slice)] = (u[tuple(next_slice)] - u[tuple(left_slice)]) / h
+    def _at(idx: int) -> tuple:
+        s = [slice(None)] * ndim
+        s[axis] = idx
+        return tuple(s)
 
-    # Right boundary: backward difference
-    right_slice = [slice(None)] * ndim
-    right_slice[axis] = -1
-    prev_slice = [slice(None)] * ndim
-    prev_slice[axis] = -2
-    grad[tuple(right_slice)] = (u[tuple(right_slice)] - u[tuple(prev_slice)]) / h
+    if n >= 3:
+        grad[_at(0)] = (-3.0 * u[_at(0)] + 4.0 * u[_at(1)] - u[_at(2)]) / (2.0 * h)
+        grad[_at(-1)] = (3.0 * u[_at(-1)] - 4.0 * u[_at(-2)] + u[_at(-3)]) / (2.0 * h)
+    else:
+        grad[_at(0)] = (u[_at(1)] - u[_at(0)]) / h
+        grad[_at(-1)] = (u[_at(-1)] - u[_at(-2)]) / h
 
     return grad
 

--- a/tests/unit/test_operators/test_stencils.py
+++ b/tests/unit/test_operators/test_stencils.py
@@ -163,7 +163,7 @@ class TestFixBoundariesOneSided:
 
     @pytest.mark.unit
     def test_1d_boundary_correction(self):
-        """Boundaries should use forward/backward difference."""
+        """Boundaries should use 2nd-order one-sided differences (Issue #1084)."""
         n = 50
         x = np.linspace(0, 1, n)
         h = x[1] - x[0]
@@ -174,17 +174,21 @@ class TestFixBoundariesOneSided:
         # Fix boundaries
         grad_fixed = fix_boundaries_one_sided(grad.copy(), u, axis=0, h=h)
 
-        # Left boundary: forward diff of x^2 at x=0 should be ~h (O(h) error)
-        expected_left = (u[1] - u[0]) / h
+        # Left boundary: 2nd-order forward (-3u0 + 4u1 - u2)/(2h)
+        expected_left = (-3.0 * u[0] + 4.0 * u[1] - u[2]) / (2.0 * h)
         assert abs(grad_fixed[0] - expected_left) < 1e-14
+        # x^2 is a quadratic, so the 2nd-order stencil is exact: f'(0) = 0
+        assert abs(grad_fixed[0] - 0.0) < 1e-12
 
-        # Right boundary: backward diff
-        expected_right = (u[-1] - u[-2]) / h
+        # Right boundary: 2nd-order backward (3u_{-1} - 4u_{-2} + u_{-3})/(2h)
+        expected_right = (3.0 * u[-1] - 4.0 * u[-2] + u[-3]) / (2.0 * h)
         assert abs(grad_fixed[-1] - expected_right) < 1e-14
+        # exact derivative f'(1) = 2
+        assert abs(grad_fixed[-1] - 2.0) < 1e-12
 
     @pytest.mark.unit
     def test_2d_boundary_correction(self):
-        """Should correct boundaries along specified axis in 2D."""
+        """Should correct boundaries along specified axis in 2D (2nd-order)."""
         nx, ny = 20, 20
         x = np.linspace(0, 1, nx)
         y = np.linspace(0, 1, ny)
@@ -195,9 +199,48 @@ class TestFixBoundariesOneSided:
         grad = gradient_central(u, axis=0, h=dx)
         grad_fixed = fix_boundaries_one_sided(grad.copy(), u, axis=0, h=dx)
 
-        # Left boundary (X=0): forward diff
-        expected_left = (u[1, :] - u[0, :]) / dx
+        # Left boundary (X=0): 2nd-order forward, exact for quadratic (f'(0) = 0)
+        expected_left = (-3.0 * u[0, :] + 4.0 * u[1, :] - u[2, :]) / (2.0 * dx)
         np.testing.assert_allclose(grad_fixed[0, :], expected_left, atol=1e-14)
+        np.testing.assert_allclose(grad_fixed[0, :], 0.0, atol=1e-12)
+
+    @pytest.mark.unit
+    def test_boundary_eoc_second_order(self):
+        """One-sided boundary correction converges at O(h^2) (Issue #1084).
+
+        Uses a non-polynomial smooth field so the truncation error is nonzero
+        and the empirical order of convergence is observable.
+        """
+
+        def f(x):
+            return np.exp(np.sin(3.0 * x))
+
+        def fprime(x):
+            return 3.0 * np.cos(3.0 * x) * np.exp(np.sin(3.0 * x))
+
+        hs = []
+        errs = []
+        for n in (40, 80, 160, 320):
+            x = np.linspace(0.0, 1.0, n)
+            h = x[1] - x[0]
+            u = f(x)
+            grad = fix_boundaries_one_sided(gradient_central(u, axis=0, h=h), u, axis=0, h=h)
+            err = max(abs(grad[0] - fprime(x[0])), abs(grad[-1] - fprime(x[-1])))
+            hs.append(h)
+            errs.append(err)
+
+        slope = np.polyfit(np.log(hs), np.log(errs), 1)[0]
+        assert slope > 1.8, f"boundary EOC {slope:.2f} is not second order"
+
+    @pytest.mark.unit
+    def test_boundary_two_point_falls_back_to_first_order(self):
+        """With only 2 points the 3-point stencil is unavailable; use 1st-order."""
+        u = np.array([1.0, 3.0])
+        h = 0.5
+        grad = fix_boundaries_one_sided(gradient_central(u, axis=0, h=h), u, axis=0, h=h)
+        # both endpoints use (u[1]-u[0])/h = 4.0
+        assert abs(grad[0] - 4.0) < 1e-14
+        assert abs(grad[-1] - 4.0) < 1e-14
 
 
 # =============================================================================


### PR DESCRIPTION
Refs #1084. Makes every accuracy claim in the three touched areas match the code, with one real numerical fix backed by an EOC test and two documentation/honesty fixes. The maintainer decides closure after verification.

## (a) GFDM ill-conditioning threshold — honest-document

`COND_THRESHOLD = 1e12` (`gfdm_strategies.py`) is **warn-only**:
`_validate_stencils` returns `valid=True` regardless of conditioning (the
`ill_conditioned_points` branch only warns), and both call sites discard the
return value. So no computed weight or result depends on the threshold — it
only gates a diagnostic `UserWarning`.

Investigation of the prior tighten attempt (PR #1341, reverted):
- `pytest.ini` `filterwarnings` does **not** convert warnings to errors, and no
  test asserts on the ill-conditioning warning text — so an extra warning cannot
  fail the suite. The GFDM suite realizes max kappa ~1.6e4, well below both 1e12
  and 1e8, so tightening fires zero new warnings there. The earlier full-CI
  failure was not reproduced by any threshold-dependent test path.
- Because the gate is warn-only, tightening it provides **no accuracy benefit**;
  it only changes diagnostics. Per the "do not force a risky/blind re-tighten"
  guidance, the honest action is to document, not re-tighten.

Documented at the constant and in `_validate_stencils`: the gate is warn-only,
conditioning up to 1e12 is *permitted*, kappa~1e12 leaves only ~4 reliable
float64 digits (`reliable_digits ~ 16 - log10(kappa)`) which can mask the
advertised O(h^2) order, and callers can pass a stricter `cond_threshold` for an
audit. **No behavioral change.**

## (b) FDM one-sided boundary — real fix (EOC-confirmed)

`fix_boundaries_one_sided` used first-order forward/backward stencils, silently
degrading a central-interior (O(h^2)) gradient to O(h) at the edges. Replaced
with the standard 3-point one-sided stencils, both O(h^2):
- left:  `(-3u[0] + 4u[1] - u[2])/(2h)`
- right: `(3u[-1] - 4u[-2] + u[-3])/(2h)`

Falls back to first-order only when an axis has `<3` points (3-point stencil
unavailable). Synced the duplicate `tensor_calculus._fix_boundaries_one_sided`
(single source of truth).

Safety: the `one_sided` scheme is **opt-in** (every gradient/divergence default
is `central`/`upwind`), so no default solver path changes. Interior is untouched.

Evidence (added `test_boundary_eoc_second_order`): on `exp(sin(3x))` the boundary
error EOC slope is ~2.2 (was ~1.0). Existing boundary tests updated to the
second-order formula; `test_boundary_two_point_falls_back_to_first_order` pins the
degenerate case.

## (c) WENO5 `c_minus` docstring — docstring bug

The inline comments described a mirror-image stencil (`u_{i-3}` etc.) that the
5-point window `u[i-2..i+2]` never reaches. The **code is correct**: `c_minus`
rows are the reverse of `c_plus`, dotted against reversed slices (`u[2::-1]`,
`u[3:0:-1]`, `u[4:1:-1]`). Corrected the comments to the actual value ordering:
`u_i,u_{i-1},u_{i-2}` / `u_{i+1},u_i,u_{i-1}` / `u_{i+2},u_{i+1},u_i`.

## Tests

- `tests/unit/test_operators/` + tensor/convention + WENO suites: 378 passed
- GFDM + FDM solver + GFDM integration: 131 passed, 1 skipped
- `ruff check --select F mfgarchon/` clean; `ruff format --check` clean; imports clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)