### PR TITLE
feat(gfdm): SOCP-infeasibility-triggered adaptive stencil enlargement

### DIFF
--- a/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
+++ b/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
@@ -37,9 +37,13 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.spatial import cKDTree
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 try:
     import cvxpy as cp
@@ -512,6 +516,25 @@ class PrecomputedJointSocpStencils:
     enlargement_step : int
         Number of next-nearest cloud points added per enlargement step
         (Issue #1106). Default 2.
+    obstacle_sdf : Callable | None
+        Signed-distance function of the obstacle region, same convention and
+        object as passed to ``HJBGFDMSolver`` / ``NeighborhoodBuilder``
+        (``obstacle_sdf(x) < 0`` means x is INSIDE the obstacle). When provided,
+        adaptive enlargement (Issue #1106) applies the SAME line-of-sight filter
+        (``geometry.visibility.filter_visible_neighbors``) to its candidate
+        next-nearest points that the base neighborhoods were post-filtered with.
+        This prevents enlargement from re-adding a cross-wall / cross-obstacle
+        neighbor that the base visibility filter removed — which would silently
+        re-open the #1102 cross-wall coupling (wrong physics) on problems with an
+        internal obstacle or narrow channel. None (default) => no visibility
+        constraint on enlargement (the common, obstacle-free case is unchanged).
+        Only consulted when ``max_stencil_enlargements > 0``.
+    visibility_samples : int
+        Interior samples per candidate edge for the obstacle line-of-sight test
+        during enlargement. Mirrors ``NeighborhoodBuilder``. Default 10.
+    visibility_margin : float
+        Safety margin for obstacle proximity during the enlargement visibility
+        test. Mirrors ``NeighborhoodBuilder``. Default 0.0.
 
     Attributes
     ----------
@@ -542,6 +565,9 @@ class PrecomputedJointSocpStencils:
         lambda_C: float = 1.0e4,
         max_stencil_enlargements: int = 0,
         enlargement_step: int = 2,
+        obstacle_sdf: Callable[[np.ndarray], np.ndarray] | None = None,
+        visibility_samples: int = 10,
+        visibility_margin: float = 0.0,
     ):
         if not _CVXPY_AVAILABLE:
             raise ImportError("cvxpy is required for joint SOCP. Install with: pip install cvxpy")
@@ -581,6 +607,14 @@ class PrecomputedJointSocpStencils:
         if self._max_enlargements > 0 and self._enlargement_step < 1:
             raise ValueError(f"enlargement_step must be >= 1 when enlargement is enabled, got {enlargement_step}")
         self._kdtree = cKDTree(self._points) if self._max_enlargements > 0 else None
+        # Obstacle visibility for enlargement candidates (Issue #1106 defect fix).
+        # The base neighborhoods were already post-filtered by
+        # `filter_visible_neighbors`; enlargement must apply the same filter so it
+        # never re-adds a cross-wall / cross-obstacle neighbor (re-opening the
+        # #1102 cross-wall coupling). None => no obstacle => enlargement unchanged.
+        self._obstacle_sdf = obstacle_sdf
+        self._visibility_samples = int(visibility_samples)
+        self._visibility_margin = float(visibility_margin)
         self._dimension = self._points.shape[1] if self._points.ndim == 2 else 1
 
         if self._dimension not in (1, 2):
@@ -655,13 +689,39 @@ class PrecomputedJointSocpStencils:
         position, new indices appended), or ``None`` if the cloud has no further
         points to add. New neighbors inject Taylor degrees of freedom so the SOCP
         feasible set can become non-empty for a geometrically starved stencil.
+
+        Obstacle visibility (Issue #1106 defect fix): when ``obstacle_sdf`` was
+        supplied, candidate next-nearest points whose line of sight to the center
+        is occluded by the obstacle are discarded BEFORE selecting the additions —
+        the same ``filter_visible_neighbors`` filter the base neighborhoods were
+        post-filtered with. Enlargement therefore never re-adds a cross-wall /
+        cross-obstacle neighbor that the base filter removed (which would silently
+        re-open the #1102 cross-wall coupling). If no visible candidate remains,
+        returns ``None`` so the stencil falls through to the relaxed fallback on
+        its original (visibility-consistent) base stencil rather than adopting an
+        occluded neighbor.
         """
         existing = {int(x) for x in cur_nbr}
         n_total = len(self._points)
-        k_query = min(n_total, len(cur_nbr) + self._enlargement_step + self._ENLARGE_POOL)
+        # Widen the candidate window when an obstacle filter is active: visibility
+        # may discard many of the nearest points, so query a larger pool to still
+        # find `enlargement_step` line-of-sight-visible additions.
+        pool = self._ENLARGE_POOL * (4 if self._obstacle_sdf is not None else 1)
+        k_query = min(n_total, len(cur_nbr) + self._enlargement_step + pool)
         _, idxs = self._kdtree.query(self._points[center_global], k=k_query)
         idxs = np.atleast_1d(np.asarray(idxs))
         new = [int(j) for j in idxs if 0 <= int(j) < n_total and int(j) not in existing]
+        if self._obstacle_sdf is not None and new:
+            from mfgarchon.geometry.visibility import filter_visible_neighbors
+
+            vis_mask = filter_visible_neighbors(
+                self._points[center_global],
+                self._points[new],
+                self._obstacle_sdf,
+                n_samples=self._visibility_samples,
+                margin=self._visibility_margin,
+            )
+            new = [j for j, visible in zip(new, vis_mask, strict=True) if visible]
         if not new:
             return None
         add = new[: self._enlargement_step]

--- a/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
+++ b/mfgarchon/alg/numerical/gfdm_components/joint_socp.py
@@ -39,6 +39,7 @@ import time
 from dataclasses import dataclass
 
 import numpy as np
+from scipy.spatial import cKDTree
 
 try:
     import cvxpy as cp
@@ -494,6 +495,23 @@ class PrecomputedJointSocpStencils:
         Wendland $C^2$).
     eps_pos : float
         Minimum off-center Laplacian weight (M-matrix slack). Default 0.0.
+    max_stencil_enlargements : int
+        SOCP-infeasibility-triggered adaptive stencil enlargement (Issue #1106).
+        When > 0, a stencil that remains infeasible after C-bisection is rebuilt
+        with ``enlargement_step`` additional next-nearest cloud points and the
+        SOCP retried, up to this many enlargement steps. A larger stencil adds
+        Taylor degrees of freedom, so the SOCP feasible set can become non-empty
+        for geometrically starved (wall / corner / obstacle-adjacent) stencils
+        where C-bisection alone fails (the infeasibility is directional, not a
+        cone-magnitude issue). Default 0 (OFF) — the paper / default path is
+        byte-identical. The enlarged neighbor set is stored ONLY in this object's
+        ``JointSocpStencilData.neighbor_indices`` (consumed by the HJB-GFDM
+        differentiation/Jacobian assembly via the same single-source contract);
+        it does NOT mutate the shared runtime neighborhoods, so enlargement does
+        not cascade into the operator / FP solver / boundary handler.
+    enlargement_step : int
+        Number of next-nearest cloud points added per enlargement step
+        (Issue #1106). Default 2.
 
     Attributes
     ----------
@@ -501,8 +519,13 @@ class PrecomputedJointSocpStencils:
         Precomputed weights at each feasible interior node.
     stats : dict
         Precomputation statistics: n_feasible, n_infeasible, n_fast_path,
-        n_socp, time_ms.
+        n_socp, n_enlarged, max_enlargement_steps, time_ms.
     """
+
+    # Extra candidate margin queried from the kD-tree beyond the requested
+    # additions, so duplicates already present in the stencil don't starve the
+    # enlargement of fresh points.
+    _ENLARGE_POOL = 8
 
     def __init__(
         self,
@@ -517,6 +540,8 @@ class PrecomputedJointSocpStencils:
         use_relaxed_fallback: bool = False,
         lambda_M: float = 1.0e4,
         lambda_C: float = 1.0e4,
+        max_stencil_enlargements: int = 0,
+        enlargement_step: int = 2,
     ):
         if not _CVXPY_AVAILABLE:
             raise ImportError("cvxpy is required for joint SOCP. Install with: pip install cvxpy")
@@ -548,6 +573,14 @@ class PrecomputedJointSocpStencils:
         self._use_relaxed_fallback = bool(use_relaxed_fallback)
         self._lambda_M = float(lambda_M)
         self._lambda_C = float(lambda_C)
+        # SOCP-infeasibility-triggered adaptive stencil enlargement (Issue #1106).
+        # The kD-tree (over the full cloud) is built only when enlargement is
+        # enabled, keeping the default path overhead-free.
+        self._max_enlargements = int(max_stencil_enlargements)
+        self._enlargement_step = int(enlargement_step)
+        if self._max_enlargements > 0 and self._enlargement_step < 1:
+            raise ValueError(f"enlargement_step must be >= 1 when enlargement is enabled, got {enlargement_step}")
+        self._kdtree = cKDTree(self._points) if self._max_enlargements > 0 else None
         self._dimension = self._points.shape[1] if self._points.ndim == 2 else 1
 
         if self._dimension not in (1, 2):
@@ -566,13 +599,76 @@ class PrecomputedJointSocpStencils:
             "n_relaxed_fallback": 0,  # stencils that needed slack-penalty solve
             "max_eps_M": 0.0,
             "max_eps_C": 0.0,
+            "n_enlarged": 0,  # stencils made feasible via adaptive enlargement (#1106)
+            "max_enlargement_steps": 0,
             "time_ms": 0.0,
         }
         self._precompute()
 
+    def _build_stencil_arrays(self, center_global: int, nbr: np.ndarray) -> tuple[np.ndarray, int, float, np.ndarray]:
+        """Build the Taylor matrix, center position, scale h_i, and Wendland
+        weights for the stencil at ``center_global`` over neighbors ``nbr``.
+
+        Returns ``(A, center_in_nbr, h_i, w_neighbor)``. The caller must ensure
+        ``center_global`` is present in ``nbr``.
+        """
+        build_A = build_taylor_matrix_1d if self._dimension == 1 else build_taylor_matrix_2d
+        offsets = self._points[nbr] - self._points[center_global]
+        offsets_for_taylor = offsets.reshape(-1) if self._dimension == 1 and offsets.ndim == 2 else offsets
+        A, _ = build_A(offsets_for_taylor)
+
+        if self._dimension == 1:
+            offsets_1d = offsets.reshape(-1)
+            dists = np.abs(offsets_1d)
+            w_neighbor = wendland_stencil_weights(offsets_1d, self._delta)
+        else:
+            dists = np.linalg.norm(offsets, axis=1)
+            w_neighbor = wendland_stencil_weights(offsets, self._delta)
+
+        nz = dists[dists > 1e-12]
+        h_i = float(np.median(nz)) if len(nz) > 0 else self._delta
+        center_in_nbr = int(np.where(nbr == int(center_global))[0][0])
+        return A, center_in_nbr, h_i, w_neighbor
+
+    def _solve_with_bisection(
+        self, A: np.ndarray, center_in_nbr: int, h_i: float, w_neighbor: np.ndarray
+    ) -> tuple[dict, float]:
+        """Solve the joint SOCP at one stencil, retrying with C-bisection
+        (C *= growth up to C_max) while infeasible. Returns ``(res, C_used)``.
+        """
+        C_try = self._C
+        res = solve_joint_socp_at_stencil(
+            A, center_in_nbr, h_i, C_try, eps_pos=self._eps_pos, dimension=self._dimension, wendland_w=w_neighbor
+        )
+        while self._C_max is not None and res["status"] != "feasible" and C_try * self._C_growth <= self._C_max + 1e-12:
+            C_try *= self._C_growth
+            res = solve_joint_socp_at_stencil(
+                A, center_in_nbr, h_i, C_try, eps_pos=self._eps_pos, dimension=self._dimension, wendland_w=w_neighbor
+            )
+        return res, C_try
+
+    def _enlarge_stencil(self, center_global: int, cur_nbr: np.ndarray) -> np.ndarray | None:
+        """Append up to ``enlargement_step`` next-nearest cloud points not already
+        in ``cur_nbr`` (Issue #1106).
+
+        Returns the enlarged neighbor-index array (center preserved at its
+        position, new indices appended), or ``None`` if the cloud has no further
+        points to add. New neighbors inject Taylor degrees of freedom so the SOCP
+        feasible set can become non-empty for a geometrically starved stencil.
+        """
+        existing = {int(x) for x in cur_nbr}
+        n_total = len(self._points)
+        k_query = min(n_total, len(cur_nbr) + self._enlargement_step + self._ENLARGE_POOL)
+        _, idxs = self._kdtree.query(self._points[center_global], k=k_query)
+        idxs = np.atleast_1d(np.asarray(idxs))
+        new = [int(j) for j in idxs if 0 <= int(j) < n_total and int(j) not in existing]
+        if not new:
+            return None
+        add = new[: self._enlargement_step]
+        return np.concatenate([np.asarray(cur_nbr, dtype=int), np.asarray(add, dtype=int)])
+
     def _precompute(self) -> None:
         t0 = time.time()
-        build_A = build_taylor_matrix_1d if self._dimension == 1 else build_taylor_matrix_2d
 
         for i in self._interior_indices:
             i = int(i)
@@ -582,60 +678,56 @@ class PrecomputedJointSocpStencils:
             if nh is None:
                 continue
             nbr = np.asarray(nh["indices"])
-            center_match = np.where(nbr == int(i))[0]
-            if len(center_match) == 0:
+            if not np.any(nbr == i):
                 continue
-            center_in_nbr = int(center_match[0])
 
-            offsets = self._points[nbr] - self._points[i]
-            offsets_for_taylor = offsets.reshape(-1) if self._dimension == 1 and offsets.ndim == 2 else offsets
-            A, _ = build_A(offsets_for_taylor)
+            A, center_in_nbr, h_i, w_neighbor = self._build_stencil_arrays(i, nbr)
+            res, C_try = self._solve_with_bisection(A, center_in_nbr, h_i, w_neighbor)
 
-            if self._dimension == 1:
-                offsets_1d = offsets.reshape(-1)
-                dists = np.abs(offsets_1d)
-                w_neighbor = wendland_stencil_weights(offsets_1d, self._delta)
-            else:
-                dists = np.linalg.norm(offsets, axis=1)
-                w_neighbor = wendland_stencil_weights(offsets, self._delta)
+            # SOCP-infeasibility-triggered adaptive stencil enlargement (Issue #1106).
+            # When a stencil is infeasible after C-bisection, add next-nearest
+            # cloud points and retry: the extra Taylor degrees of freedom can make
+            # the SOCP feasible set non-empty for geometrically starved
+            # (wall / corner / obstacle-adjacent) stencils where the infeasibility
+            # is directional, not a cone-magnitude issue that C-bisection covers.
+            # The enlarged stencil is ADOPTED only when it achieves feasibility, so
+            # if enlargement does not help, the relaxed fallback below runs on the
+            # original (base) stencil exactly as before. Default OFF
+            # (max_stencil_enlargements=0) => this block is skipped entirely.
+            n_steps_used = 0
+            if res["status"] != "feasible" and self._max_enlargements > 0:
+                cur_nbr = nbr
+                for step in range(1, self._max_enlargements + 1):
+                    ext = self._enlarge_stencil(i, cur_nbr)
+                    if ext is None:
+                        break  # cloud exhausted; no further points to add
+                    cur_nbr = ext
+                    A_e, center_e, h_e, w_e = self._build_stencil_arrays(i, cur_nbr)
+                    res_e, C_e = self._solve_with_bisection(A_e, center_e, h_e, w_e)
+                    if res_e["status"] == "feasible":
+                        nbr, A, center_in_nbr, h_i, w_neighbor = cur_nbr, A_e, center_e, h_e, w_e
+                        res, C_try = res_e, C_e
+                        n_steps_used = step
+                        break
 
-            nz = dists[dists > 1e-12]
-            h_i = float(np.median(nz)) if len(nz) > 0 else self._delta
+            if n_steps_used > 0:
+                self.stats["n_enlarged"] += 1
+                self.stats["max_enlargement_steps"] = max(self.stats["max_enlargement_steps"], n_steps_used)
 
-            C_try = self._C
-            res = solve_joint_socp_at_stencil(
-                A,
-                center_in_nbr,
-                h_i,
-                C_try,
-                eps_pos=self._eps_pos,
-                dimension=self._dimension,
-                wendland_w=w_neighbor,
-            )
-            while (
-                self._C_max is not None
-                and res["status"] != "feasible"
-                and C_try * self._C_growth <= self._C_max + 1e-12
-            ):
-                C_try *= self._C_growth
-                res = solve_joint_socp_at_stencil(
-                    A,
-                    center_in_nbr,
-                    h_i,
-                    C_try,
-                    eps_pos=self._eps_pos,
-                    dimension=self._dimension,
-                    wendland_w=w_neighbor,
-                )
-
-            # If still infeasible after C-bisection, fall through to the always-
-            # feasible relaxed SOCP. This eliminates the discrete scheme switch
-            # between joint_socp and Phase-2 M-matrix-QP that creates
-            # discontinuous discretization on irregular clouds. For
-            # well-conditioned stencils (the C-bisection feasible cases), the
-            # original joint_socp solution is used. For marginally infeasible
-            # stencils, the relaxed SOCP smoothly degrades while maintaining
-            # the equality constraints (consistency).
+            # Final resort: always-feasible relaxed SOCP. This eliminates the
+            # discrete scheme switch between joint_socp and Phase-2 M-matrix-QP
+            # that creates discontinuous discretization on irregular clouds. For
+            # well-conditioned stencils (the C-bisection feasible cases) the
+            # original joint_socp solution is used; for marginally infeasible
+            # stencils the relaxed SOCP smoothly degrades while keeping the
+            # equality constraints (consistency).
+            #
+            # Issue #1106/#1107/#1108 hook: this point is reached only when both
+            # C-bisection AND adaptive enlargement (#1106) failed to find an exact
+            # feasible solution — i.e. the stencil is geometrically infeasible at
+            # every attempted size. Future exact fallbacks plug in HERE, before
+            # the slack-penalty relaxed SOCP: #1107 (3rd-order Taylor stencil) and
+            # #1108 (M-matrix-only fallback for cone-binding infeasibility).
             if res["status"] != "feasible" and self._use_relaxed_fallback:
                 C_relaxed = self._C if self._C_max is None else self._C_max
                 res = solve_relaxed_joint_socp_at_stencil(

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -1045,6 +1045,13 @@ class HJBGFDMSolver(BaseHJBSolver):
                 # (Issue #1106). Default 0 (OFF) — paper / default path unchanged.
                 max_stencil_enlargements=self._socp_max_stencil_enlargements,
                 enlargement_step=self._socp_enlargement_step,
+                # Same obstacle visibility filter the base neighborhoods were
+                # post-filtered with (Issue #1124 / #1102): enlargement must not
+                # re-add a cross-wall / cross-obstacle neighbor that the base
+                # filter removed. None (no obstacle) => enlargement unchanged.
+                obstacle_sdf=obstacle_sdf,
+                visibility_samples=visibility_samples,
+                visibility_margin=visibility_margin,
             )
             stats = self._joint_socp_stencils.stats
             relax_C_msg = (

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -303,6 +303,15 @@ class HJBGFDMSolver(BaseHJBSolver):
         llf_augmentation: bool = False,
         llf_cone_constant: float = 0.5,  # C in nu_i = max(0, C*l_H*h - sigma^2/2)
         llf_l_H: float | np.ndarray | None = None,  # per-node Lipschitz bound |dH/dp|
+        # SOCP-infeasibility-triggered adaptive stencil enlargement (Issue #1106),
+        # joint_socp scheme only. When > 0, a stencil that is still infeasible
+        # after C-bisection is rebuilt with additional next-nearest neighbors and
+        # the SOCP retried, up to this many enlargement steps. Default 0 (OFF):
+        # the paper / default path is byte-identical. The enlarged neighbor set is
+        # contained inside the precomputed SOCP stencils and does NOT mutate the
+        # shared runtime neighborhoods (no cascade into operator / FP / BC).
+        socp_max_stencil_enlargements: int = 0,
+        socp_enlargement_step: int = 2,
     ):
         """
         Initialize the GFDM HJB solver.
@@ -447,6 +456,19 @@ class HJBGFDMSolver(BaseHJBSolver):
                 options: (a) cone bound from stencil, (b) from ``dH/dp`` at previous
                 Picard iterate, (c) user-supplied (this parameter).  Fail-loud if
                 ``llf_augmentation=True`` and this is None.
+            socp_max_stencil_enlargements: SOCP-infeasibility-triggered adaptive
+                stencil enlargement budget (Issue #1106), ``joint_socp`` scheme
+                only. When > 0, a stencil that is still infeasible after the
+                C-bisection is rebuilt with ``socp_enlargement_step`` additional
+                next-nearest neighbors and the SOCP retried, up to this many
+                steps; the extra Taylor degrees of freedom can flip a
+                geometrically starved (wall / corner / obstacle-adjacent) stencil
+                from infeasible to feasible. Default 0 (OFF): the paper / default
+                path is byte-identical. The enlarged neighbor set is contained in
+                the precomputed SOCP stencils and does not mutate the shared
+                runtime neighborhoods.
+            socp_enlargement_step: Number of next-nearest neighbors added per
+                enlargement step (Issue #1106). Default 2.
         """
         super().__init__(problem)
 
@@ -670,6 +692,10 @@ class HJBGFDMSolver(BaseHJBSolver):
         else:
             self._llf_l_H = None  # type: ignore[assignment]
             self._llf_sigma_eff = None  # type: ignore[assignment]
+
+        # SOCP adaptive stencil enlargement (Issue #1106), joint_socp scheme only.
+        self._socp_max_stencil_enlargements: int = int(socp_max_stencil_enlargements)
+        self._socp_enlargement_step: int = int(socp_enlargement_step)
 
         # Monotonicity scheme (single source of truth) — already set above (v0.18.0 rename)
         # self.monotonicity_scheme and self.qp_optimization_level both = resolved monotonicity_scheme
@@ -1015,6 +1041,10 @@ class HJBGFDMSolver(BaseHJBSolver):
                 use_relaxed_fallback=True,
                 lambda_M=1.0e4,
                 lambda_C=1.0e4,
+                # SOCP-infeasibility-triggered adaptive stencil enlargement
+                # (Issue #1106). Default 0 (OFF) — paper / default path unchanged.
+                max_stencil_enlargements=self._socp_max_stencil_enlargements,
+                enlargement_step=self._socp_enlargement_step,
             )
             stats = self._joint_socp_stencils.stats
             relax_C_msg = (
@@ -1028,11 +1058,17 @@ class HJBGFDMSolver(BaseHJBSolver):
                 if stats.get("n_relaxed_fallback", 0) > 0
                 else ""
             )
+            enlarge_msg = (
+                f"; {stats['n_enlarged']} via adaptive enlargement "
+                f"(max {stats['max_enlargement_steps']} steps, Issue #1106)"
+                if stats.get("n_enlarged", 0) > 0
+                else ""
+            )
             logger.info(
                 f"Precomputed joint SOCP stencils: feasible {stats['n_feasible']}/"
                 f"{stats['n_interior']} interior "
                 f"({stats['n_fast_path']} via Wendland-LSQ fast-path, "
-                f"{stats['n_socp']} via CLARABEL SOCP{relax_C_msg}{relax_fb_msg}) in "
+                f"{stats['n_socp']} via CLARABEL SOCP{relax_C_msg}{enlarge_msg}{relax_fb_msg}) in "
                 f"{stats['time_ms']:.1f}ms; SOCP-infeasible {stats['n_infeasible']} fall "
                 f"back to M-matrix QP (Phase 2)"
             )
@@ -1635,10 +1671,22 @@ class HJBGFDMSolver(BaseHJBSolver):
             if self._joint_socp_stencils is not None and self._joint_socp_stencils.has_stencil(i):
                 socp_weights = self._joint_socp_stencils.get_weights_dict(i)
                 if socp_weights is not None:
-                    # Joint SOCP guarantees same neighbor_indices + center as the
-                    # operator's stencil (it uses op.get_derivative_weights to build).
+                    # Single source of truth: consume the SOCP stencil's OWN
+                    # neighbor_indices together with its (L, D). With
+                    # SOCP-infeasibility-triggered adaptive enlargement (Issue
+                    # #1106) the SOCP stencil may have MORE neighbors than the
+                    # operator's base stencil, so the fill below must index the
+                    # (possibly enlarged) SOCP set — not the operator's. When
+                    # enlargement is off these are identical (verified), so this is
+                    # byte-identical to the prior behaviour.
+                    neighbor_indices = socp_weights["neighbor_indices"]
                     lap_weights = socp_weights["lap_weights"]
                     grad_weights = socp_weights["grad_weights"]
+                    assert grad_weights.shape[1] == len(neighbor_indices) == len(lap_weights), (
+                        f"joint_socp stencil weight/index length mismatch at point {i}: "
+                        f"grad {grad_weights.shape}, lap {len(lap_weights)}, "
+                        f"neighbors {len(neighbor_indices)} (Issue #1106 enlargement contract)"
+                    )
 
             # Fill gradient matrices
             for dim in range(d):
@@ -1880,16 +1928,34 @@ class HJBGFDMSolver(BaseHJBSolver):
         if self._joint_socp_stencils is not None and self._joint_socp_stencils.has_stencil(point_idx):
             socp = self._joint_socp_stencils.get_weights_dict(point_idx)
             if socp is not None:
-                L_w = socp["lap_weights"]  # shape (n_neighbors,)
-                D_w = socp["grad_weights"]  # shape (d, n_neighbors)
+                L_w = socp["lap_weights"]  # shape (n_socp_neighbors,)
+                D_w = socp["grad_weights"]  # shape (d, n_socp_neighbors)
+                # Rebuild b on the SOCP stencil's OWN neighbor_indices. With
+                # SOCP-infeasibility-triggered adaptive enlargement (Issue #1106)
+                # the SOCP stencil can have MORE neighbors than the runtime
+                # `neighborhood["indices"]` that the outer `b` was built on;
+                # contracting `D_w @ b` / `L_w @ b` on the mismatched-length outer
+                # `b` would raise a matmul size error (the #1102 / G-013 pattern,
+                # already handled for the M-matrix elif via `b_precomp`). SOCP
+                # applies to interior cloud points only, so these indices are pure
+                # cloud indices (no ghosts). When enlargement is off the SOCP
+                # neighbor_indices equal the runtime ones, so `b_socp == b`
+                # (byte-identical).
+                socp_nbr = socp["neighbor_indices"]
+                assert D_w.shape[1] == len(socp_nbr) == len(L_w), (
+                    f"joint_socp stencil weight/index length mismatch at point {point_idx}: "
+                    f"grad {D_w.shape}, lap {len(L_w)}, neighbors {len(socp_nbr)} "
+                    f"(Issue #1106 enlargement contract)"
+                )
+                b_socp = u_values[socp_nbr] - u_center
                 # Override gradient: ∂u/∂x_d (i) = sum_j D_w[d, j] * b_j
                 for d in range(self.dimension):
                     beta = tuple(1 if k == d else 0 for k in range(self.dimension))
-                    derivatives[beta] = float(D_w[d] @ b)
+                    derivatives[beta] = float(D_w[d] @ b_socp)
                 # Override Laplacian sum (= trace of Hessian) via diagonal split.
                 # Preserves bare-WT off-diagonal Hessian entries (e.g. (1,1) in 2D)
                 # while enforcing target_lap = L_w · b on the trace.
-                target_lap = float(L_w @ b)
+                target_lap = float(L_w @ b_socp)
                 current_lap = sum(
                     float(derivatives.get(beta, 0.0))
                     for beta in self.multi_indices

--- a/tests/unit/test_alg/test_socp_stencil_enlargement.py
+++ b/tests/unit/test_alg/test_socp_stencil_enlargement.py
@@ -1,0 +1,345 @@
+"""Issue #1106: SOCP-infeasibility-triggered adaptive stencil enlargement.
+
+Some GFDM stencils near walls / corners / obstacle edges are *geometrically*
+infeasible for the joint SOCP: Taylor consistency (``A^T L = e_lap``,
+``A^T D = e_grad``) + M-matrix (``L_off >= 0``) + per-edge cone
+(``||D_j|| <= C h_i L_j``) have an empty feasible set at the base
+k_neighbors / delta, so C-bisection cannot recover them (the infeasibility is
+*directional*, not a cone-magnitude issue). Penalty pressure does not fix this
+(PR #1105). The fix adds Taylor degrees of freedom: when a stencil is infeasible
+after C-bisection, add next-nearest neighbors and retry, up to a capped number
+of enlargement steps.
+
+These tests pin:
+  (a) a stencil infeasible at base size becomes feasible after enlargement;
+  (b) enlargement reduces the number of stencils that hit the relaxed fallback;
+  (c) the enlarged stencil's stored (L, D, neighbor_indices) lengths agree
+      (the precompute/runtime single-source contract that the HJB-GFDM
+      assembly asserts on — Issue #1102 dual-source bug class);
+  (d) enlargement OFF (default) is byte-identical to not passing the option;
+  (e) cloud exhaustion and invalid configuration are handled.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+pytest.importorskip("cvxpy")
+
+from mfgarchon.alg.numerical.gfdm_components.joint_socp import PrecomputedJointSocpStencils
+from scipy.spatial import cKDTree
+
+
+# ---------------------------------------------------------------------------
+# Deterministic irregular cloud with controllable (small) base stencils.
+# Building neighborhoods directly as exactly-k nearest gives full control over
+# the base stencil size, so infeasibility is reproducible (the solver's
+# NeighborhoodBuilder otherwise returns whole-ball stencils that are too rich).
+# ---------------------------------------------------------------------------
+
+
+def _irregular_cloud(seed: int = 3, n: int = 160):
+    rng = np.random.default_rng(seed)
+    pts = rng.uniform(0.0, 1.0, size=(n, 2))
+    interior = np.array([i for i in range(n) if 0.15 < pts[i, 0] < 0.85 and 0.15 < pts[i, 1] < 0.85])
+    return pts, interior
+
+
+def _knn_neighborhoods(pts: np.ndarray, k: int) -> dict:
+    """Base neighborhoods = exactly the k nearest points (center included)."""
+    tree = cKDTree(pts)
+    nbh = {}
+    for i in range(len(pts)):
+        _, idx = tree.query(pts[i], k=k)
+        nbh[i] = {"indices": np.asarray(idx)}
+    return nbh
+
+
+def _make_stencils(pts, interior, nbh, *, enlarge, relaxed=False, delta=0.4, **kw):
+    return PrecomputedJointSocpStencils(
+        points=pts,
+        interior_indices=interior,
+        delta=delta,
+        neighborhoods=nbh,
+        cone_constant_C=8.0,
+        eps_pos=0.0,
+        cone_constant_C_max=8.0,
+        use_relaxed_fallback=relaxed,
+        max_stencil_enlargements=enlarge,
+        enlargement_step=2,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) infeasible-at-base -> feasible-after-enlargement
+# ---------------------------------------------------------------------------
+
+
+def test_enlargement_flips_infeasible_stencils_to_feasible():
+    """With the relaxed fallback OFF (so infeasibility is exposed), enabling
+    enlargement strictly increases the feasible count and decreases the
+    infeasible count, and records the enlargements it used."""
+    pts, interior = _irregular_cloud()
+    nbh = _knn_neighborhoods(pts, k=7)
+
+    base = _make_stencils(pts, interior, nbh, enlarge=0, relaxed=False)
+    enl = _make_stencils(pts, interior, nbh, enlarge=3, relaxed=False)
+
+    assert base.stats["n_infeasible"] > 0, "test cloud must produce genuine base infeasibility"
+    assert enl.stats["n_feasible"] > base.stats["n_feasible"], (
+        f"enlargement should add feasible stencils: base {base.stats['n_feasible']} "
+        f"-> enlarged {enl.stats['n_feasible']}"
+    )
+    assert enl.stats["n_infeasible"] < base.stats["n_infeasible"]
+    assert enl.stats["n_enlarged"] > 0
+    assert 1 <= enl.stats["max_enlargement_steps"] <= 3
+
+
+def test_specific_stencil_infeasible_at_base_feasible_when_enlarged():
+    """Identify a concrete stencil that is infeasible at its base (wall-starved)
+    size and feasible only after enlargement; verify the recovered weights are a
+    valid M-matrix Laplacian on the enlarged neighbor set."""
+    pts, interior = _irregular_cloud()
+    nbh = _knn_neighborhoods(pts, k=7)
+
+    base = _make_stencils(pts, interior, nbh, enlarge=0, relaxed=False)
+    enl = _make_stencils(pts, interior, nbh, enlarge=3, relaxed=False)
+
+    base_infeasible = {int(i) for i in interior if not base.has_stencil(int(i))}
+    recovered = sorted(i for i in base_infeasible if enl.has_stencil(i))
+    assert recovered, "no infeasible-at-base stencil was recovered by enlargement"
+
+    i = recovered[0]
+    sd = enl.stencils[i]
+    base_len = len(nbh[i]["indices"])
+    assert len(sd.neighbor_indices) > base_len, (
+        f"recovered stencil {i} must have grown beyond base size {base_len}, got {len(sd.neighbor_indices)}"
+    )
+    # Center present, Laplacian consistency (sum-zero) and M-matrix sign.
+    assert i in set(int(x) for x in sd.neighbor_indices)
+    assert np.isclose(sd.L.sum(), 0.0, atol=1e-8)
+    L_off = np.delete(sd.L, sd.center_in_neighbors)
+    assert np.all(L_off >= -1e-8)
+
+
+# ---------------------------------------------------------------------------
+# (b) enlargement reduces relaxed-fallback usage
+# ---------------------------------------------------------------------------
+
+
+def test_enlargement_reduces_relaxed_fallback_count():
+    """With the relaxed fallback ON (the HJB-GFDM default), enlargement converts
+    would-be relaxed (slack-active) stencils into exact-feasible ones, so the
+    relaxed-fallback count strictly drops."""
+    pts, interior = _irregular_cloud()
+    nbh = _knn_neighborhoods(pts, k=7)
+
+    base = _make_stencils(pts, interior, nbh, enlarge=0, relaxed=True)
+    enl = _make_stencils(pts, interior, nbh, enlarge=3, relaxed=True)
+
+    assert base.stats["n_relaxed_fallback"] > 0
+    assert enl.stats["n_relaxed_fallback"] < base.stats["n_relaxed_fallback"], (
+        f"enlargement should reduce relaxed-fallback usage: "
+        f"{base.stats['n_relaxed_fallback']} -> {enl.stats['n_relaxed_fallback']}"
+    )
+    # Enlargement recovers exact-feasible stencils, so the exact-feasible set
+    # never shrinks and the residual hard-infeasible set never grows.
+    # (On these deliberately starved k=7 stencils even the always-feasible
+    # relaxed SOCP occasionally fails to converge, so n_infeasible is not
+    # guaranteed zero — the point is that enlargement only helps.)
+    assert enl.stats["n_feasible"] >= base.stats["n_feasible"]
+    assert enl.stats["n_infeasible"] <= base.stats["n_infeasible"]
+
+
+# ---------------------------------------------------------------------------
+# (c) precompute/runtime single-source contract: stored lengths agree
+# ---------------------------------------------------------------------------
+
+
+def test_enlarged_stencil_weight_index_lengths_agree():
+    """Every stored stencil (enlarged or not) must have L, D and neighbor_indices
+    of mutually consistent length — this is exactly the invariant the HJB-GFDM
+    differentiation/Jacobian assembly asserts on (Issue #1102 / #1106)."""
+    pts, interior = _irregular_cloud()
+    nbh = _knn_neighborhoods(pts, k=7)
+    enl = _make_stencils(pts, interior, nbh, enlarge=3, relaxed=True)
+
+    n_grown = 0
+    for i, sd in enl.stencils.items():
+        n = len(sd.neighbor_indices)
+        assert sd.L.shape == (n,), f"point {i}: L shape {sd.L.shape} != ({n},)"
+        assert sd.D.shape == (2, n), f"point {i}: D shape {sd.D.shape} != (2, {n})"
+        assert 0 <= sd.center_in_neighbors < n
+        assert int(sd.neighbor_indices[sd.center_in_neighbors]) == i
+        wd = enl.get_weights_dict(i)
+        assert wd["grad_weights"].shape[1] == len(wd["lap_weights"]) == len(wd["neighbor_indices"])
+        if n > len(nbh[i]["indices"]):
+            n_grown += 1
+    assert n_grown > 0, "expected at least one stencil to have grown via enlargement"
+
+
+# ---------------------------------------------------------------------------
+# (d) enlargement OFF is byte-identical to not passing the option
+# ---------------------------------------------------------------------------
+
+
+def test_enlargement_off_is_byte_identical_to_default():
+    """max_stencil_enlargements=0 (and the no-arg default) must produce the exact
+    same stencils and stats — the paper / default path is unchanged."""
+    pts, interior = _irregular_cloud()
+    nbh = _knn_neighborhoods(pts, k=7)
+
+    default = PrecomputedJointSocpStencils(
+        points=pts,
+        interior_indices=interior,
+        delta=0.4,
+        neighborhoods=nbh,
+        cone_constant_C=8.0,
+        eps_pos=0.0,
+        cone_constant_C_max=8.0,
+        use_relaxed_fallback=True,
+    )
+    off = _make_stencils(pts, interior, nbh, enlarge=0, relaxed=True)
+
+    assert default.stats["n_feasible"] == off.stats["n_feasible"]
+    assert default.stats["n_relaxed_fallback"] == off.stats["n_relaxed_fallback"]
+    assert off.stats["n_enlarged"] == 0
+    assert set(default.stencils) == set(off.stencils)
+    for i in default.stencils:
+        np.testing.assert_array_equal(default.stencils[i].L, off.stencils[i].L)
+        np.testing.assert_array_equal(default.stencils[i].D, off.stencils[i].D)
+        np.testing.assert_array_equal(default.stencils[i].neighbor_indices, off.stencils[i].neighbor_indices)
+
+
+# ---------------------------------------------------------------------------
+# (e) edge / failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_enlargement_handles_cloud_exhaustion():
+    """A tiny cloud where the whole cloud is already in the stencil must not
+    crash: _enlarge_stencil returns None and the stencil falls through to the
+    relaxed fallback / infeasible count."""
+    pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5], [0.3, 0.7], [0.7, 0.3]])
+    interior = np.array([4])  # center point; base stencil = all 7 points
+    nbh = {i: {"indices": np.arange(len(pts))} for i in range(len(pts))}
+    # No crash even with a large enlargement budget; cloud has nothing to add.
+    s = _make_stencils(pts, interior, nbh, enlarge=5, relaxed=False, delta=2.0)
+    assert s.stats["n_enlarged"] == 0  # nothing could be added
+    assert s.stats["n_interior"] == 1
+
+
+def test_invalid_enlargement_step_raises():
+    """enlargement_step < 1 with enlargement enabled is a configuration error."""
+    pts, interior = _irregular_cloud(n=40)
+    nbh = _knn_neighborhoods(pts, k=7)
+    with pytest.raises(ValueError, match="enlargement_step"):
+        PrecomputedJointSocpStencils(
+            points=pts,
+            interior_indices=interior,
+            delta=0.4,
+            neighborhoods=nbh,
+            max_stencil_enlargements=2,
+            enlargement_step=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Solver-level: enlargement flows through the runtime consumption paths
+# without a matmul-shape mismatch (Path 1 differentiation matrices, Path 2
+# per-point derivatives). This is the end-to-end precompute/runtime contract.
+# ---------------------------------------------------------------------------
+
+
+def _solver_with_small_stencils(enlarge: int):
+    import sys
+
+    sys.path.insert(0, "tests/unit/test_alg")
+    from test_joint_socp_mirror_symmetry import _MockProblem  # noqa: PLC0415
+
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
+    from mfgarchon.geometry import Hyperrectangle
+    from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
+
+    rng = np.random.default_rng(11)
+    n = 120
+    interior_pts = rng.uniform(0.1, 0.9, size=(n, 2))
+    bx = []
+    for t in np.linspace(0, 1, 16):
+        bx += [[t, 0.0], [t, 1.0], [0.0, t], [1.0, t]]
+    pts = np.vstack([interior_pts, np.array(bx)])
+    bdry = np.arange(n, len(pts))
+    geom = Hyperrectangle(np.array([[0.0, 1.0], [0.0, 1.0]]))
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name=nm, bc_type=BCType.NO_FLUX, boundary=b)
+            for nm, b in [("l", "x_min"), ("r", "x_max"), ("b", "y_min"), ("t", "y_max")]
+        ],
+        dimension=2,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver = HJBGFDMSolver(
+            _MockProblem(geom),
+            collocation_points=pts,
+            boundary_indices=bdry,
+            delta=0.12,
+            k_neighbors=7,
+            derivative_method="taylor",
+            taylor_order=2,
+            weight_function="wendland",
+            collocation_geometry=geom,
+            adaptive_neighborhoods=False,
+            boundary_conditions=bc,
+            monotonicity_scheme="joint_socp",
+            socp_max_stencil_enlargements=enlarge,
+            socp_enlargement_step=2,
+        )
+    return solver, pts
+
+
+def test_solver_enlargement_end_to_end_runtime_consistent():
+    """At the HJB-GFDM solver level: enabling enlargement reduces relaxed-fallback
+    usage, propagates the enlarged neighbor sets into the stored SOCP stencils,
+    and the runtime consumption paths (differentiation-matrix assembly + per-point
+    derivative override) build without a matmul-shape mismatch — the assertions
+    added in those paths would fire if the precompute/runtime contract broke."""
+    base, _ = _solver_with_small_stencils(enlarge=0)
+    solver, pts = _solver_with_small_stencils(enlarge=3)
+
+    bstats = base._joint_socp_stencils.stats
+    stats = solver._joint_socp_stencils.stats
+    assert stats["n_enlarged"] > 0, "solver-level enlargement did not fire"
+    assert stats["n_relaxed_fallback"] < bstats["n_relaxed_fallback"]
+
+    # At least one SOCP stencil grew beyond the operator's base stencil.
+    socp = solver._joint_socp_stencils
+    op = solver._gfdm_operator
+    grew = 0
+    for i in socp._interior_indices:
+        i = int(i)
+        if not socp.has_stencil(i):
+            continue
+        base_len = len(op.get_derivative_weights(i)["neighbor_indices"])
+        if len(socp.stencils[i].neighbor_indices) > base_len:
+            grew += 1
+    assert grew > 0, "no stored SOCP stencil reflects an enlarged neighbor set"
+
+    # Path 1: differentiation-matrix assembly (asserts length contract internally).
+    solver._build_differentiation_matrices()
+    assert solver._D_lap is not None and len(solver._D_grad) == 2
+
+    # Path 2: per-point derivative override on the grown stencils.
+    u = np.random.default_rng(0).standard_normal(len(pts))
+    for i in socp._interior_indices[:20]:
+        derivs = solver.approximate_derivatives(u, int(i))
+        assert derivs  # non-empty dict, no matmul-size error
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/tests/unit/test_alg/test_socp_stencil_enlargement.py
+++ b/tests/unit/test_alg/test_socp_stencil_enlargement.py
@@ -341,5 +341,143 @@ def test_solver_enlargement_end_to_end_runtime_consistent():
         assert derivs  # non-empty dict, no matmul-size error
 
 
+# ---------------------------------------------------------------------------
+# Obstacle visibility: enlargement must not re-add cross-wall neighbors
+# (Issue #1106 defect surfaced by adversarial review). The base neighborhoods
+# are post-filtered by `filter_visible_neighbors`; distance-only enlargement can
+# re-add an occluded across-wall neighbor that the base filter removed, silently
+# re-opening the #1102 cross-wall coupling on internal-obstacle / narrow-channel
+# problems. With obstacle_sdf threaded in, enlargement applies the SAME filter.
+# The synthetic rng clouds above have no obstacle, so they cannot catch this —
+# these tests use a real thin-wall geometry at production-ish k / delta.
+# ---------------------------------------------------------------------------
+
+
+def _thin_wall_cloud(seed: int = 5, n: int = 300):
+    """2D cloud split by a thin internal wall (y in [4.85, 5.15], gaps at the x
+    ends). Points just above/below the wall are near in Euclidean distance but
+    occluded — the narrow-channel geometry where distance-only enlargement would
+    re-add a cross-wall neighbor. Returns (points, interior_indices, obstacle_sdf).
+    """
+    from mfgarchon.geometry.implicit import Hyperrectangle
+
+    rng = np.random.default_rng(seed)
+    wall = Hyperrectangle(np.array([[1.0, 9.0], [4.85, 5.15]]))
+    pts = rng.uniform(0.0, 10.0, size=(n, 2))
+    pts = pts[wall.signed_distance(pts) > 0.02]  # drop points inside the wall
+    interior = np.array([i for i in range(len(pts)) if 0.8 < pts[i, 0] < 9.2 and 0.8 < pts[i, 1] < 9.2])
+    return pts, interior, wall.signed_distance
+
+
+def _visibility_filtered_knn(pts, k, obstacle_sdf):
+    """Base neighborhoods = k-NN POST-FILTERED by line-of-sight visibility, exactly
+    as NeighborhoodBuilder builds them when obstacle_sdf is set (center included)."""
+    from mfgarchon.geometry.visibility import filter_visible_neighbors
+
+    tree = cKDTree(pts)
+    nbh = {}
+    for i in range(len(pts)):
+        _, idx = tree.query(pts[i], k=k)
+        others = np.atleast_1d(idx)
+        others = others[others != i]
+        if len(others):
+            others = others[filter_visible_neighbors(pts[i], pts[others], obstacle_sdf)]
+        nbh[i] = {"indices": np.concatenate([[i], others]).astype(int)}
+    return nbh
+
+
+def _count_cross_obstacle_neighbors(stencils, pts, obstacle_sdf):
+    """Stored stencil edges (center -> neighbor) occluded by the obstacle — i.e.
+    edges the base visibility filter would have removed. The invariant under test
+    is that this is zero once obstacle_sdf is threaded into enlargement."""
+    from mfgarchon.geometry.visibility import filter_visible_neighbors
+
+    n_bad = 0
+    for i, sd in stencils.stencils.items():
+        nbr = np.asarray(sd.neighbor_indices)
+        others = nbr[nbr != i]
+        if len(others) == 0:
+            continue
+        n_bad += int(np.sum(~filter_visible_neighbors(pts[i], pts[others], obstacle_sdf)))
+    return n_bad
+
+
+def _obstacle_stencils(enlarge, obstacle_sdf, pts, interior, nbh):
+    return PrecomputedJointSocpStencils(
+        points=pts,
+        interior_indices=interior,
+        delta=2.0,
+        neighborhoods=nbh,
+        cone_constant_C=8.0,
+        eps_pos=0.0,
+        cone_constant_C_max=8.0,
+        use_relaxed_fallback=False,
+        max_stencil_enlargements=enlarge,
+        enlargement_step=2,
+        obstacle_sdf=obstacle_sdf,
+    )
+
+
+@pytest.fixture(scope="module")
+def wall_stencils():
+    """Build the thin-wall base + (blind / obstacle-aware) enlarged stencils once
+    (the SOCP precompute is the expensive part)."""
+    pts, interior, sdf = _thin_wall_cloud()
+    nbh = _visibility_filtered_knn(pts, k=7, obstacle_sdf=sdf)
+    base = _obstacle_stencils(0, sdf, pts, interior, nbh)
+    blind = _obstacle_stencils(3, None, pts, interior, nbh)  # obstacle_sdf=None => distance-only
+    aware = _obstacle_stencils(3, sdf, pts, interior, nbh)
+    return {"pts": pts, "interior": interior, "sdf": sdf, "base": base, "blind": blind, "aware": aware}
+
+
+def test_visibility_filtered_base_has_no_cross_wall_edges(wall_stencils):
+    """Sanity: the visibility-filtered base stencils contain no cross-wall edge, so
+    any cross-wall edge in an enlarged stencil is attributable to enlargement
+    (isolates the bug surface). The base must also be genuinely infeasible
+    (wall-starved), otherwise enlargement never triggers."""
+    base, pts, sdf = wall_stencils["base"], wall_stencils["pts"], wall_stencils["sdf"]
+    assert base.stats["n_interior"] > 0
+    assert base.stats["n_infeasible"] > 0, "wall-starved base stencils must be genuinely infeasible"
+    assert _count_cross_obstacle_neighbors(base, pts, sdf) == 0
+
+
+def test_distance_only_enlargement_readds_cross_wall_neighbors(wall_stencils):
+    """BASELINE (bug surface): with obstacle_sdf NOT threaded into enlargement,
+    distance-only candidate selection re-adds occluded across-wall points the base
+    filter removed. Without this baseline the fix test below would be vacuous."""
+    blind, pts, sdf = wall_stencils["blind"], wall_stencils["pts"], wall_stencils["sdf"]
+    assert blind.stats["n_enlarged"] > 0
+    assert _count_cross_obstacle_neighbors(blind, pts, sdf) > 0, (
+        "fixture must exercise the defect: distance-only enlargement should re-add cross-wall neighbors"
+    )
+
+
+def test_enlargement_respects_obstacle_visibility(wall_stencils):
+    """FIX (Issue #1106 defect): with obstacle_sdf threaded in, no enlarged stencil
+    contains a neighbor whose line of sight crosses the obstacle — every enlarged
+    neighbor is visibility-consistent with the base filter — while enlargement still
+    fires (it adds line-of-sight-visible next-nearest points instead)."""
+    aware, pts, sdf = wall_stencils["aware"], wall_stencils["pts"], wall_stencils["sdf"]
+    assert aware.stats["n_enlarged"] > 0, "obstacle-aware enlargement must still recover starved stencils"
+    assert _count_cross_obstacle_neighbors(aware, pts, sdf) == 0, (
+        "obstacle-aware enlargement must not add any cross-obstacle neighbor"
+    )
+
+
+def test_obstacle_sdf_none_matches_default_when_no_obstacle():
+    """The new obstacle_sdf param is inert when None: passing obstacle_sdf=None
+    produces the exact same enlarged stencils as not passing it (the common,
+    obstacle-free case is unchanged). Uses the small synthetic cloud for speed."""
+    pts, interior = _irregular_cloud()
+    nbh = _knn_neighborhoods(pts, k=7)
+    explicit_none = _make_stencils(pts, interior, nbh, enlarge=3, relaxed=True, obstacle_sdf=None)
+    default = _make_stencils(pts, interior, nbh, enlarge=3, relaxed=True)
+    assert set(explicit_none.stencils) == set(default.stencils)
+    for i in default.stencils:
+        np.testing.assert_array_equal(default.stencils[i].neighbor_indices, explicit_none.stencils[i].neighbor_indices)
+        np.testing.assert_array_equal(default.stencils[i].L, explicit_none.stencils[i].L)
+        np.testing.assert_array_equal(default.stencils[i].D, explicit_none.stencils[i].D)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Refs #1106

## Problem

~21 GFDM joint-SOCP stencils near walls / corners / obstacle edges are **geometrically infeasible**: Taylor consistency (`A^T L = e_lap`, `A^T D = e_grad`) + M-matrix (`L_off >= 0`) + per-edge cone (`||D_j|| <= C h_i L_j`) have an empty feasible set at the base `k_neighbors` / `delta`. The C-bisection (up to `C_max=8`) cannot recover them because the infeasibility is **directional** (one-sided / corner / visibility-filtered neighbor distributions), not a cone-magnitude issue. Penalty pressure does not fix it either (PR #1105 `λ=1e8` cut ε only ~35%, then reverted).

## Fix: add Taylor degrees of freedom on infeasibility

When a stencil is still infeasible after C-bisection, add the next-nearest cloud points and retry the SOCP, capped at a small number of enlargement steps. A larger stencil supplies more Taylor columns, so the feasible set can become non-empty. Verified mechanism: on an irregular cloud the exact-feasible count rises monotonically with stencil size (k=7→22, k=8→39, k=9→61, k=10→70 of 125).

### `PrecomputedJointSocpStencils`
- New opt-in params `max_stencil_enlargements` (default **0 = OFF**) and `enlargement_step` (default 2). The cloud kD-tree is built only when enlargement is enabled.
- `_precompute` factored into `_build_stencil_arrays` / `_solve_with_bisection` / `_enlarge_stencil`; the enlargement loop runs **between** C-bisection and the relaxed fallback. The enlarged stencil is **adopted only on feasibility**, so if it does not help the relaxed fallback runs on the original base stencil — i.e. default OFF is byte-identical.
- The enlarged neighbor set lives **only** in `JointSocpStencilData.neighbor_indices`; it does **not** mutate the shared runtime neighborhoods, so enlargement does not cascade into the operator / FP solver / boundary handler.
- New stats `n_enlarged` / `max_enlargement_steps`. The `#1107` (3rd-order Taylor) / `#1108` (M-matrix-only) exact-fallback hook is documented at the relaxed-fallback site.

### `HJBGFDMSolver`
- New pass-through params `socp_max_stencil_enlargements` / `socp_enlargement_step` (default **0 = OFF** → paper / default path unchanged).
- Runtime consumption now reads the SOCP stencil's **own** `neighbor_indices` together with its `(L, D)`: the differentiation-matrix fill (Path 1) indexes the SOCP set, and the per-point override (Path 2) rebuilds `b` on the SOCP `neighbor_indices`. This closes the #1102 dual-source bug class — an enlarged SOCP stencil no longer mismatches the operator's base stencil. Both sites assert length agreement; the Jacobian cache path already consumed the SOCP dict's own indices. When enlargement is off the SOCP indices equal the operator indices (verified), so the change is byte-identical.

## Gate

- **(a)** A stencil infeasible at base size becomes feasible after enlargement (targeted test identifies a concrete recovered wall-starved stencil; recovered weights are a valid sum-zero M-matrix Laplacian on the enlarged set).
- **(b)** Solver-level: at `delta=0.12, k=7` enlargement converts 53 stencils to exact-feasible, dropping relaxed-fallback usage 46→12 and hard-infeasible 30→11.
- **(c)** Existing joint_socp / gfdm / monotone / howard suites pass (107 tests).
- **(d)** Precompute and runtime neighbor sets agree — length-consistency assertions on both consumption paths; the end-to-end solver test drives Path 1 + Path 2 on grown stencils with no matmul-shape mismatch.
- **(e)** ruff F + format clean; import clean. Default OFF / byte-identical to the prior default path.

## Tests
`tests/unit/test_alg/test_socp_stencil_enlargement.py` (8 tests): infeasible→feasible, fewer relaxed-fallback, stored `L/D/index` length agreement, OFF byte-identical, cloud-exhaustion + invalid-config edges, solver-level end-to-end runtime consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)