### PR TITLE
feat(coupling): wire source/nonlocal/obstacle into coupled-Newton residual (#1361)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -29,7 +29,7 @@ from .fixed_point_utils import (
     preserve_terminal_condition,
     resolve_fp_drift_kwargs,
 )
-from .graph_coupling import _get_time_slice
+from .source_composition import compose_fp_source, compose_hjb_source
 
 logger = get_logger(__name__)
 
@@ -235,83 +235,31 @@ class FixedPointIterator(BaseCouplingIterator):
         self._init_solver_signatures(self.hjb_solver, self.fp_solver)
 
     def _compose_hjb_source(self, m_current: np.ndarray, u_current: np.ndarray) -> Callable | None:
-        """Compose problem-level source terms into a solver-level source_term callable.
+        """Compose problem-level HJB source terms into a solver-level callable.
 
-        Reads source_term_hjb, nonlocal_operator, and obstacle from MFGProblem,
-        binds spatial grid, current density, and current value function, returns
-        a (t, x) -> array closure compatible with
-        BaseHJBSolver.solve_hjb_system(source_term=...).
-
-        Issue #921/#922: Bridges problem-level signature (x, m, v, t) to
-        solver-level signature (t, x) by closure binding.
-        Issue #1259 fix (2026-06-10 audit): nonlocal_operator term was computed
-        in has_nonlocal but never applied inside the closure.  Added explicit
-        branch that extracts the time slice of the previous-iterate value function
-        and applies J[v] with the same sign convention used by graph_mfg_solver
-        (s += nonlocal_operator @ v_t).
+        Issue #1361: thin delegate to the single-source
+        :func:`source_composition.compose_hjb_source`, shared verbatim with the
+        coupled-Newton ``MFGResidual`` path so the source/nonlocal/obstacle
+        convention lives in exactly one place (the bug class behind #1259 and
+        #1285 was a private second copy). Bridges the problem-level signature
+        ``(x, m, v, t)`` to the solver-level ``(t, x)`` by closure binding.
 
         Returns:
-            Callable or None if no source terms are active.
+            Callable or None if no HJB source terms are active.
         """
-        problem = self.problem
-        has_nonlocal = problem.nonlocal_operator is not None
-        has_source = problem.source_term_hjb is not None
-        has_obstacle = problem.obstacle is not None
-
-        if not (has_nonlocal or has_source or has_obstacle):
-            return None
-
-        def composed(t: float, x: np.ndarray) -> np.ndarray:
-            # Note: HJB solver calls source_term(t, x_grid) -> array.
-            # The nonlocal and source terms use the previous iterate's U
-            # (explicit treatment), consistent with graph_mfg_solver.py:306.
-            terms: list[np.ndarray] = []
-            if has_source:
-                # Issue #1285: evaluate the problem-level source (delta F / delta m) at the
-                # density SLICE for time t, not the whole (Nt+1, Nx) array. Otherwise a
-                # time-dependent source (e.g. lions_correction F[m]) silently falls back to the
-                # terminal slice m[-1] for every t. Mirrors the nonlocal branch below and
-                # graph_mfg_solver.py (_get_time_slice).
-                m_t = _get_time_slice(m_current, t, problem.dt)
-                terms.append(problem.source_term_hjb(x, m_t, np.zeros_like(m_t), t))
-            if has_obstacle:
-                psi = problem.obstacle(x)
-                # Penalty parameter: large but finite, consistent with Rev 4 design
-                eps = getattr(problem, "_penalty_eps", 1e6)
-                # Note: this is evaluated with v=0 here; for proper penalty,
-                # PenaltyHJBSolver wrapper (#924) should be used instead.
-                terms.append((1.0 / eps) * np.maximum(0.0, psi.ravel()))
-            if has_nonlocal:
-                # Issue #1259 fix (2026-06-10 audit): apply J[v] using the
-                # previous iterate's value function at time t (explicit
-                # treatment), matching the convention in graph_mfg_solver.py:306.
-                v_t = _get_time_slice(u_current, t, problem.dt)
-                terms.append(problem.nonlocal_operator @ v_t)
-            return sum(terms) if terms else np.zeros(x.shape[0])
-
-        return composed
+        return compose_hjb_source(self.problem, m_current, u_current)
 
     def _compose_fp_source(self, m_current: np.ndarray, v_current: np.ndarray) -> Callable | None:
-        """Compose problem-level FP source terms into solver-level callable.
+        """Compose problem-level FP source terms into a solver-level callable.
 
-        Returns a (t, x) -> array closure for BaseFPSolver.solve_fp_system(source_term=...).
+        Issue #1361: thin delegate to the single-source
+        :func:`source_composition.compose_fp_source`, shared with the
+        coupled-Newton ``MFGResidual`` path.
 
         Returns:
             Callable or None if no FP source terms are active.
         """
-        problem = self.problem
-        has_source = problem.source_term_fp is not None
-
-        if not has_source:
-            return None
-
-        def composed(t: float, x: np.ndarray) -> np.ndarray:
-            # Issue #1285: slice density and value function at time t (see _compose_hjb_source).
-            m_t = _get_time_slice(m_current, t, problem.dt)
-            v_t = _get_time_slice(v_current, t, problem.dt)
-            return problem.source_term_fp(x, m_t, v_t, t)
-
-        return composed
+        return compose_fp_source(self.problem, m_current, v_current)
 
     def _get_initial_and_terminal_conditions(self, shape: tuple) -> tuple[np.ndarray, np.ndarray]:
         """

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -29,6 +29,7 @@ from mfgarchon.geometry.boundary import no_flux_bc
 from mfgarchon.utils.mfg_logging import get_logger
 
 from .fixed_point_utils import resolve_fp_drift_kwargs
+from .source_composition import compose_fp_source, compose_hjb_source
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -50,6 +51,28 @@ class MFGResidual:
 
     The residual measures deviation from this fixed point:
         F(U, M) = [HJB_solve(M) - U, FP_solve(U) - M]
+
+    Source / nonlocal / obstacle terms (Issue #1361):
+        ``source_term_hjb``, ``source_term_fp``, ``nonlocal_operator``, and
+        ``obstacle`` are composed via the single-source helpers
+        :func:`source_composition.compose_hjb_source` /
+        :func:`source_composition.compose_fp_source` — the *same* copy the Picard
+        ``FixedPointIterator`` consumes (no private second copy; that was the bug
+        class behind #1259 and #1285).
+
+        Design choice (option A): the source is composed from the ``(U, M)``
+        **arguments** of :meth:`compute_hjb_output` / :meth:`compute_fp_output`,
+        not frozen at an outer iterate. The finite-difference Jacobian
+        (``NewtonMFGSolver`` drives ``NewtonSolver`` with an FD Jacobian) then
+        differentiates through the source dependence automatically — no separate
+        analytic Jacobian term is needed. At convergence ``U = U_new`` and
+        ``M = M_new``, so the residual root coincides with the Picard fixed point
+        including the source/nonlocal/obstacle terms.
+
+        Obstacle handling matches the Picard path exactly: the approximate
+        ``v = 0`` penalty ``(1/eps) * max(0, psi)`` (see ``compose_hjb_source``).
+        Proper handling is the ``PenaltyHJBSolver`` wrapper (#924); both coupling
+        paths use the same approximation so they do not silently diverge.
 
     Attributes:
         problem: MFG problem definition
@@ -89,32 +112,6 @@ class MFGResidual:
         self.fp_solver = fp_solver
         self.volatility_field = volatility_field
         self.drift_field = drift_field
-
-        # Issue #1285: Newton residual does not compose source_term_hjb,
-        # source_term_fp, nonlocal_operator, or obstacle — it silently solves
-        # a different variational problem than Picard when any of those fields
-        # is set.  Fail loud until these terms are wired.
-        # Use FixedPointIterator instead; it correctly composes all four via
-        # _compose_hjb_source / _compose_fp_source.  Refs #1285 #1043.
-        _unsupported_fields = [
-            name
-            for name, val in [
-                ("source_term_hjb", problem.source_term_hjb),
-                ("source_term_fp", problem.source_term_fp),
-                ("nonlocal_operator", problem.nonlocal_operator),
-                ("obstacle", problem.obstacle),
-            ]
-            if val is not None
-        ]
-        if _unsupported_fields:
-            raise NotImplementedError(
-                f"MFGResidual (Newton path) does not support problem fields: "
-                f"{_unsupported_fields}. "
-                "These terms are silently ignored, causing Newton to converge "
-                "to a wrong equilibrium. "
-                "Use FixedPointIterator instead, which correctly composes "
-                "all four terms. Refs #1285 #1043."
-            )
 
         # Cache problem dimensions
         self.num_time_steps = problem.Nt + 1
@@ -187,6 +184,14 @@ class MFGResidual:
         """
         Compute HJB solver output for given density.
 
+        Issue #1361: composes ``source_term_hjb`` / ``nonlocal_operator`` /
+        ``obstacle`` from the ``(M, U_prev)`` arguments via the single-source
+        :func:`source_composition.compose_hjb_source` (shared with Picard) and
+        passes it as ``source_term=`` when the solver accepts it. Composing from
+        the arguments (option A) lets the finite-difference Jacobian differentiate
+        through the source dependence; at convergence this matches the Picard
+        fixed point.
+
         Args:
             M: Current density field (Nt+1, *spatial_shape)
             U_prev: Previous value function (for Newton linearization)
@@ -201,6 +206,10 @@ class MFGResidual:
                 kwargs["show_progress"] = False
             if "volatility_field" in self._hjb_sig_params and self.volatility_field is not None:
                 kwargs["volatility_field"] = self.volatility_field
+            if "source_term" in self._hjb_sig_params:
+                hjb_source = compose_hjb_source(self.problem, M, U_prev)
+                if hjb_source is not None:
+                    kwargs["source_term"] = hjb_source
 
         return self.hjb_solver.solve_hjb_system(M, self.U_terminal, U_prev, **kwargs)
 
@@ -214,10 +223,15 @@ class MFGResidual:
         which the v0.18.6 rename redefined as the *velocity* — so the Newton residual
         was inconsistent with the Picard fixed point and the solvers diverged.
 
+        Issue #1361: composes ``source_term_fp`` from the ``(M, U)`` arguments via
+        the single-source :func:`source_composition.compose_fp_source` (shared with
+        Picard) and passes it as ``source_term=`` when the solver accepts it.
+
         Args:
             U: Current value function (Nt+1, *spatial_shape)
-            M: Current density (Nt+1, *spatial_shape), used only for non-smooth $H$ to
-                evaluate the density-dependent velocity. Defaults to the time-broadcast
+            M: Current density (Nt+1, *spatial_shape), used both for non-smooth $H$
+                to evaluate the density-dependent velocity and for the time-``t``
+                density slice of ``source_term_fp``. Defaults to the time-broadcast
                 initial density when not supplied.
 
         Returns:
@@ -235,6 +249,11 @@ class MFGResidual:
 
         if M is None:
             M = np.broadcast_to(self.M_initial, self.solution_shape) if self.M_initial is not None else U
+
+        if "source_term" in params:
+            fp_source = compose_fp_source(self.problem, M, U)
+            if fp_source is not None:
+                kwargs["source_term"] = fp_source
 
         drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(self.problem, params, self.drift_field, U, M)
         kwargs.update(drift_kwargs)

--- a/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
@@ -63,6 +63,16 @@ class NewtonMFGSolver(BaseCouplingIterator):
         - Automatic Jacobian (finite diff or JAX)
         - Line search for globalization
 
+    Source / nonlocal / obstacle terms (Issue #1361):
+        ``source_term_hjb``, ``source_term_fp``, ``nonlocal_operator``, and
+        ``obstacle`` flow through the residual ``MFGResidual`` and are composed
+        from the ``(U, M)`` residual arguments via the single-source
+        ``source_composition`` helpers shared with the Picard
+        ``FixedPointIterator``. The FD Jacobian differentiates through the source
+        dependence (option A; see ``MFGResidual``), so Newton converges to the
+        same equilibrium as Picard. Obstacle uses the Picard-matching approximate
+        penalty; ``PenaltyHJBSolver`` (#924) is the proper-handling route.
+
     Performance / solver selection:
         NewtonMFGSolver is research-grade for d>=2 / Nx>~50 — it is ~135x slower
         than the fixed-point (Picard) coupler in 2D and scales poorly with

--- a/mfgarchon/alg/numerical/coupling/source_composition.py
+++ b/mfgarchon/alg/numerical/coupling/source_composition.py
@@ -1,0 +1,128 @@
+"""Single-source composition of problem-level source/nonlocal/obstacle terms.
+
+Issue #1361: lift ``_compose_hjb_source`` / ``_compose_fp_source`` out of
+``FixedPointIterator`` so the Picard coupler (``FixedPointIterator``) and the
+coupled-Newton path (``MFGResidual`` behind ``NewtonMFGSolver``) consume **one**
+copy of the convention. A second private copy is the "parallel physics paths
+with private convention copies" bug class that already produced two silent
+divergences in the Picard copy alone:
+
+- #1259 — ``nonlocal_operator`` ``J[v]`` computed but never applied.
+- #1285 — time-dependent source used the terminal density slice ``m[-1]`` for
+  every backward time step instead of the time-``t`` slice.
+
+Both functions read the extended PDE fields off ``MFGProblem`` and return a
+solver-level ``(t, x) -> array`` closure compatible with
+``BaseHJBSolver.solve_hjb_system(source_term=...)`` /
+``BaseFPSolver.solve_fp_system(source_term=...)``, or ``None`` when no relevant
+field is active.
+
+Conventions (mirrored verbatim from the prior ``FixedPointIterator`` copy):
+
+- **Time-``t`` slicing** of the bound density / value iterates via
+  :func:`graph_coupling._get_time_slice` (round-to-nearest index), so a
+  time-dependent source sees ``m[k]`` / ``v[k]``, not the full ``(Nt+1, Nx)``
+  array (Issue #1285).
+- **Nonlocal term** applied as ``s += nonlocal_operator @ v_t`` with ``v_t`` the
+  time-``t`` slice of the value function (Issue #1259), matching
+  ``graph_mfg_solver``'s sign convention.
+- **Obstacle** uses the approximate ``v = 0`` penalty ``(1/eps) * max(0, psi)``
+  (``eps = problem._penalty_eps`` if set, else ``1e6``). Proper handling is the
+  ``PenaltyHJBSolver`` wrapper (#924); both coupling paths use this same
+  approximation so they **match** rather than silently diverge.
+- The HJB source passes ``v = 0`` to ``source_term_hjb(x, m, v, t)`` (the
+  problem-level source does not receive the value function in the HJB path),
+  preserved from the prior copy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from .graph_coupling import _get_time_slice
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+    from mfgarchon.core.mfg_problem import MFGProblem
+
+
+def compose_hjb_source(
+    problem: MFGProblem,
+    m_current: NDArray,
+    u_current: NDArray,
+) -> Callable[[float, NDArray], NDArray] | None:
+    """Compose problem-level HJB source terms into a solver-level callable.
+
+    Reads ``source_term_hjb``, ``nonlocal_operator``, and ``obstacle`` from the
+    problem, binds the spatial grid, current density ``m_current``, and current
+    value function ``u_current``, and returns a ``(t, x) -> array`` closure.
+
+    Args:
+        problem: MFG problem definition carrying the extended PDE fields.
+        m_current: Density iterate ``(Nt+1, Nx)`` bound for time-``t`` slicing.
+        u_current: Value-function iterate ``(Nt+1, Nx)`` bound for the nonlocal
+            term's time-``t`` slicing.
+
+    Returns:
+        Callable, or ``None`` if no HJB source / nonlocal / obstacle field is set.
+    """
+    has_nonlocal = problem.nonlocal_operator is not None
+    has_source = problem.source_term_hjb is not None
+    has_obstacle = problem.obstacle is not None
+
+    if not (has_nonlocal or has_source or has_obstacle):
+        return None
+
+    def composed(t: float, x: NDArray) -> NDArray:
+        terms: list[NDArray] = []
+        if has_source:
+            m_t = _get_time_slice(m_current, t, problem.dt)
+            terms.append(problem.source_term_hjb(x, m_t, np.zeros_like(m_t), t))
+        if has_obstacle:
+            psi = problem.obstacle(x)
+            eps = getattr(problem, "_penalty_eps", 1e6)
+            terms.append((1.0 / eps) * np.maximum(0.0, psi.ravel()))
+        if has_nonlocal:
+            v_t = _get_time_slice(u_current, t, problem.dt)
+            terms.append(problem.nonlocal_operator @ v_t)
+        return sum(terms) if terms else np.zeros(x.shape[0])
+
+    return composed
+
+
+def compose_fp_source(
+    problem: MFGProblem,
+    m_current: NDArray,
+    v_current: NDArray,
+) -> Callable[[float, NDArray], NDArray] | None:
+    """Compose problem-level FP source terms into a solver-level callable.
+
+    Reads ``source_term_fp`` from the problem, binds the current density and
+    value-function iterates, and returns a ``(t, x) -> array`` closure that
+    evaluates the source at the time-``t`` slices of ``m`` and ``v``.
+
+    Args:
+        problem: MFG problem definition carrying the extended PDE fields.
+        m_current: Density iterate ``(Nt+1, Nx)`` bound for time-``t`` slicing.
+        v_current: Value-function iterate ``(Nt+1, Nx)`` bound for time-``t``
+            slicing.
+
+    Returns:
+        Callable, or ``None`` if ``source_term_fp`` is not set.
+    """
+    has_source = problem.source_term_fp is not None
+
+    if not has_source:
+        return None
+
+    def composed(t: float, x: NDArray) -> NDArray:
+        m_t = _get_time_slice(m_current, t, problem.dt)
+        v_t = _get_time_slice(v_current, t, problem.dt)
+        return problem.source_term_fp(x, m_t, v_t, t)
+
+    return composed

--- a/tests/integration/test_source_term_wiring.py
+++ b/tests/integration/test_source_term_wiring.py
@@ -128,3 +128,125 @@ class TestExtendedPDEFields:
     def test_nonlocal_operator_field_stored(self):
         problem = _make_problem(nonlocal_operator="placeholder")
         assert problem.nonlocal_operator == "placeholder"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1361: coupled-Newton (MFGResidual) path solves source/nonlocal/obstacle
+# and reaches the SAME equilibrium as Picard (FixedPointIterator).
+# ---------------------------------------------------------------------------
+
+
+def _make_parity_problem(**extra):
+    """Small / short / weakly coupled problem kept in the physical Newton basin.
+
+    The FD-Jacobian Newton coupler can fall into a spurious near-trivial fixed
+    point for large-amplitude (long-horizon, strongly coupled) discrete MFG maps
+    (see ``NewtonMFGSolver`` docstring). This regime keeps both couplers in the
+    same physical basin so the equilibria are comparable.
+    """
+    hamiltonian = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: 0.3 * m,
+        coupling_dm=lambda m: 0.3,
+    )
+    components = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=hamiltonian,
+    )
+    return MFGProblem(Nx=[8], Nt=4, T=0.15, sigma=0.4, components=components, **extra)
+
+
+def _solve_picard(problem):
+    from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+    from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+    from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+
+    it = FixedPointIterator(problem, HJBFDMSolver(problem), FPFDMSolver(problem))
+    it.solve(max_iterations=400, tolerance=1e-9, verbose=False)
+    return it.U, it.M
+
+
+def _solve_newton(problem):
+    from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
+    from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+    from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+
+    solver = NewtonMFGSolver(
+        problem,
+        HJBFDMSolver(problem),
+        FPFDMSolver(problem),
+        picard_warmup=3,
+        newton_max_iterations=30,
+        newton_tolerance=1e-9,
+    )
+    U, M, info = solver.solve(max_iterations=33, tolerance=1e-9, verbose=False)
+    return U, M, info
+
+
+def _rel_linf(a, b):
+    return float(np.max(np.abs(a - b)) / max(np.max(np.abs(b)), 1e-30))
+
+
+class TestNewtonPicardParity:
+    """Newton (residual path) and Picard reach the same source-inclusive equilibrium."""
+
+    _TOL = 1e-5  # observed agreement ~1e-10; generous margin
+
+    def test_parity_source_term_hjb(self):
+        kw = dict(source_term_hjb=lambda x, m, v, t: 0.8 * np.ones(x.shape[0]))
+        Up, Mp = _solve_picard(_make_parity_problem(**kw))
+        Un, Mn, info = _solve_newton(_make_parity_problem(**kw))
+        assert info["converged"], "Newton did not converge for source_term_hjb"
+        assert _rel_linf(Un, Up) < self._TOL, f"U parity: {_rel_linf(Un, Up):.2e}"
+        assert _rel_linf(Mn, Mp) < self._TOL, f"M parity: {_rel_linf(Mn, Mp):.2e}"
+
+    def test_parity_source_term_fp(self):
+        kw = dict(source_term_fp=lambda x, m, v, t: 0.05 * np.ones(x.shape[0]))
+        Up, Mp = _solve_picard(_make_parity_problem(**kw))
+        Un, Mn, info = _solve_newton(_make_parity_problem(**kw))
+        assert info["converged"], "Newton did not converge for source_term_fp"
+        assert _rel_linf(Un, Up) < self._TOL, f"U parity: {_rel_linf(Un, Up):.2e}"
+        assert _rel_linf(Mn, Mp) < self._TOL, f"M parity: {_rel_linf(Mn, Mp):.2e}"
+
+    def test_parity_nonlocal_operator(self):
+        gs = int(np.prod(_make_parity_problem().geometry.get_grid_shape()))
+        kw = dict(nonlocal_operator=0.5 * np.eye(gs))
+        Up, Mp = _solve_picard(_make_parity_problem(**kw))
+        Un, Mn, info = _solve_newton(_make_parity_problem(**kw))
+        assert info["converged"], "Newton did not converge for nonlocal_operator"
+        assert _rel_linf(Un, Up) < self._TOL, f"U parity: {_rel_linf(Un, Up):.2e}"
+        assert _rel_linf(Mn, Mp) < self._TOL, f"M parity: {_rel_linf(Mn, Mp):.2e}"
+
+    def test_nonlocal_changes_hjb_output_through_residual_args(self):
+        """FD-Jacobian capture: the nonlocal source makes ``compute_hjb_output``
+        depend on its ``U_prev`` argument, so the U->HJB Jacobian block is nonzero.
+
+        Without a nonlocal term the HJB solve does not depend on ``U_prev`` (beyond
+        warm-start), so the same perturbation leaves the output unchanged.
+        """
+        from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+        from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+        from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+
+        gs = int(np.prod(_make_parity_problem().geometry.get_grid_shape()))
+        problem = _make_parity_problem(nonlocal_operator=0.5 * np.eye(gs))
+        res = MFGResidual(problem, HJBFDMSolver(problem), FPFDMSolver(problem))
+
+        shape = res.solution_shape
+        M = np.broadcast_to(res.M_initial, shape).copy()
+        U_a = np.zeros(shape)
+        U_b = np.ones(shape)  # nonlocal term J[v] = 0.5*v differs between U_a, U_b
+
+        out_a = res.compute_hjb_output(M, U_a)
+        out_b = res.compute_hjb_output(M, U_b)
+        assert np.max(np.abs(out_a - out_b)) > 1e-8, (
+            "nonlocal source did not propagate through U_prev -> FD Jacobian would miss the source-coupling block"
+        )
+
+        # Baseline: no nonlocal -> HJB output is (essentially) U_prev-independent.
+        problem0 = _make_parity_problem()
+        res0 = MFGResidual(problem0, HJBFDMSolver(problem0), FPFDMSolver(problem0))
+        out0_a = res0.compute_hjb_output(M, U_a)
+        out0_b = res0.compute_hjb_output(M, U_b)
+        assert np.max(np.abs(out0_a - out0_b)) < 1e-8, "HJB output should be U_prev-independent without a nonlocal term"

--- a/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
+++ b/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
@@ -1,26 +1,24 @@
-"""Pinning tests for Issue #1285 (2026-06-11 survey).
+"""Inverted pins for Issue #1285 / Issue #1361.
 
-MFGResidual / NewtonMFGSolver silently ignored source_term_hjb,
-source_term_fp, nonlocal_operator, and obstacle, causing Newton to
-converge to a wrong equilibrium whenever any of those problem fields
-is set.
+History:
+- #1285 added a fail-loud ``NotImplementedError`` guard to ``MFGResidual`` because
+  the coupled-Newton path silently ignored ``source_term_hjb``,
+  ``source_term_fp``, ``nonlocal_operator``, and ``obstacle`` — converging to a
+  wrong equilibrium.
+- #1361 wired those four terms into the residual path (composed from the
+  ``(U, M)`` residual arguments via the single-source ``source_composition``
+  helpers shared with Picard), so the guard is removed and the Newton path
+  *solves* these problems instead of refusing them.
 
-Fix: MFGResidual.__init__ raises NotImplementedError with a clear
-message when any of the four unsupported fields is non-None.
-FixedPointIterator correctly composes all four terms and should be
-used instead.
+These tests were previously ``pytest.raises(NotImplementedError)`` pins. They are
+inverted here: ``MFGResidual`` / ``NewtonMFGSolver`` must construct cleanly and
+produce a finite solve for each extended field. Newton-vs-Picard equilibrium
+parity is pinned in ``tests/integration/test_source_term_wiring.py``.
 
-Each test here asserts that NotImplementedError is raised.
-On unfixed code (no guard in __init__): the object constructs silently
--- no error -- so pytest.raises(...) catches no exception and the test
-FAILS.  After the fix the guard fires and the tests PASS.
-
-Refs #1285 #1043.
+Refs #1285 #1361 #1043.
 """
 
 from __future__ import annotations
-
-import pytest
 
 import numpy as np
 
@@ -29,99 +27,50 @@ from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 
 # ---------------------------------------------------------------------------
-# Minimal problem factory
+# Minimal problem factory (small/short/weakly coupled: keeps the FD-Jacobian
+# Newton solve in the physical basin and fast).
 # ---------------------------------------------------------------------------
 
+_NX = 5  # MFGProblem(Nx=5) -> 6 grid points
+_NT = 3
+_GRID = _NX + 1
 
-def _make_plain_problem(Nx: int = 5, Nt: int = 3) -> MFGProblem:
-    """1-D problem without any extended fields."""
-    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
-    comp = MFGComponents(
+
+def _components() -> MFGComponents:
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: 0.2 * m,
+        coupling_dm=lambda m: 0.2,
+    )
+    return MFGComponents(
         hamiltonian=H,
         u_terminal=lambda x: 0.0,
-        m_initial=lambda x: 1.0,
-    )
-    return MFGProblem(Nx=Nx, xmin=0.0, xmax=1.0, T=0.3, Nt=Nt, sigma=0.2, components=comp)
-
-
-def _make_problem_with_nonlocal(Nx: int = 5, Nt: int = 3) -> MFGProblem:
-    """1-D problem with a diagonal nonlocal_operator."""
-    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
-    comp = MFGComponents(
-        hamiltonian=H,
-        u_terminal=lambda x: 0.0,
-        m_initial=lambda x: 1.0,
-    )
-    return MFGProblem(
-        Nx=Nx,
-        xmin=0.0,
-        xmax=1.0,
-        T=0.3,
-        Nt=Nt,
-        sigma=0.2,
-        components=comp,
-        nonlocal_operator=np.eye(Nx),
+        m_initial=lambda x: np.exp(-10.0 * (np.asarray(x) - 0.5) ** 2),
     )
 
 
-def _make_problem_with_source_hjb(Nx: int = 5, Nt: int = 3) -> MFGProblem:
-    """1-D problem with source_term_hjb."""
-    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
-    comp = MFGComponents(
-        hamiltonian=H,
-        u_terminal=lambda x: 0.0,
-        m_initial=lambda x: 1.0,
-    )
-    return MFGProblem(
-        Nx=Nx,
-        xmin=0.0,
-        xmax=1.0,
-        T=0.3,
-        Nt=Nt,
-        sigma=0.2,
-        components=comp,
-        source_term_hjb=lambda x, m, v, t: np.zeros(len(x)),
-    )
+def _make(**extra) -> MFGProblem:
+    return MFGProblem(Nx=_NX, xmin=0.0, xmax=1.0, T=0.15, Nt=_NT, sigma=0.3, components=_components(), **extra)
 
 
-def _make_problem_with_source_fp(Nx: int = 5, Nt: int = 3) -> MFGProblem:
-    """1-D problem with source_term_fp."""
-    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
-    comp = MFGComponents(
-        hamiltonian=H,
-        u_terminal=lambda x: 0.0,
-        m_initial=lambda x: 1.0,
-    )
-    return MFGProblem(
-        Nx=Nx,
-        xmin=0.0,
-        xmax=1.0,
-        T=0.3,
-        Nt=Nt,
-        sigma=0.2,
-        components=comp,
-        source_term_fp=lambda x, m, v, t: np.zeros(len(x)),
-    )
+def _make_plain_problem() -> MFGProblem:
+    return _make()
 
 
-def _make_problem_with_obstacle(Nx: int = 5, Nt: int = 3) -> MFGProblem:
-    """1-D problem with obstacle."""
-    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
-    comp = MFGComponents(
-        hamiltonian=H,
-        u_terminal=lambda x: 0.0,
-        m_initial=lambda x: 1.0,
-    )
-    return MFGProblem(
-        Nx=Nx,
-        xmin=0.0,
-        xmax=1.0,
-        T=0.3,
-        Nt=Nt,
-        sigma=0.2,
-        components=comp,
-        obstacle=lambda x: np.zeros(len(x)),
-    )
+def _make_problem_with_nonlocal() -> MFGProblem:
+    return _make(nonlocal_operator=0.3 * np.eye(_GRID))
+
+
+def _make_problem_with_source_hjb() -> MFGProblem:
+    return _make(source_term_hjb=lambda x, m, v, t: 0.5 * np.ones(len(x)))
+
+
+def _make_problem_with_source_fp() -> MFGProblem:
+    return _make(source_term_fp=lambda x, m, v, t: 0.02 * np.ones(len(x)))
+
+
+def _make_problem_with_obstacle() -> MFGProblem:
+    return _make(obstacle=lambda x: np.asarray(x) - 0.5)
 
 
 def _make_solvers(problem: MFGProblem):
@@ -131,114 +80,102 @@ def _make_solvers(problem: MFGProblem):
     return HJBFDMSolver(problem), FPFDMSolver(problem)
 
 
+def _assert_finite_solve(problem: MFGProblem) -> None:
+    """NewtonMFGSolver must produce a finite (U, M) for the given problem."""
+    from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
+
+    hjb_solver, fp_solver = _make_solvers(problem)
+    solver = NewtonMFGSolver(
+        problem, hjb_solver, fp_solver, picard_warmup=3, newton_max_iterations=15, newton_tolerance=1e-8
+    )
+    U, M, info = solver.solve(max_iterations=18, tolerance=1e-8, verbose=False)
+    assert np.all(np.isfinite(U)), "U not finite"
+    assert np.all(np.isfinite(M)), "M not finite"
+    assert U.shape == solver.mfg_residual.solution_shape
+    assert M.shape == solver.mfg_residual.solution_shape
+
+
 # ---------------------------------------------------------------------------
-# MFGResidual must raise NotImplementedError for each unsupported field
+# MFGResidual must CONSTRUCT (no NotImplementedError) for each field (#1361)
 # ---------------------------------------------------------------------------
 
 
-def test_mfg_residual_raises_on_nonlocal_operator():
-    """MFGResidual must raise NotImplementedError when nonlocal_operator is set.
-
-    Pre-fix: object constructs silently, no exception raised.
-    Post-fix: NotImplementedError is raised with '#1285' in the message.
-    """
+def test_mfg_residual_constructs_with_nonlocal_operator():
     from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
 
     problem = _make_problem_with_nonlocal()
     hjb_solver, fp_solver = _make_solvers(problem)
+    residual = MFGResidual(problem, hjb_solver, fp_solver)
+    assert residual.problem is problem
 
-    with pytest.raises(NotImplementedError, match="#1285"):
-        MFGResidual(problem, hjb_solver, fp_solver)
 
-
-def test_mfg_residual_raises_on_source_term_hjb():
-    """MFGResidual must raise NotImplementedError when source_term_hjb is set."""
+def test_mfg_residual_constructs_with_source_term_hjb():
     from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
 
     problem = _make_problem_with_source_hjb()
     hjb_solver, fp_solver = _make_solvers(problem)
+    residual = MFGResidual(problem, hjb_solver, fp_solver)
+    assert residual.problem is problem
 
-    with pytest.raises(NotImplementedError, match="#1285"):
-        MFGResidual(problem, hjb_solver, fp_solver)
 
-
-def test_mfg_residual_raises_on_source_term_fp():
-    """MFGResidual must raise NotImplementedError when source_term_fp is set."""
+def test_mfg_residual_constructs_with_source_term_fp():
     from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
 
     problem = _make_problem_with_source_fp()
     hjb_solver, fp_solver = _make_solvers(problem)
+    residual = MFGResidual(problem, hjb_solver, fp_solver)
+    assert residual.problem is problem
 
-    with pytest.raises(NotImplementedError, match="#1285"):
-        MFGResidual(problem, hjb_solver, fp_solver)
 
-
-def test_mfg_residual_raises_on_obstacle():
-    """MFGResidual must raise NotImplementedError when obstacle is set."""
+def test_mfg_residual_constructs_with_obstacle():
     from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
 
     problem = _make_problem_with_obstacle()
     hjb_solver, fp_solver = _make_solvers(problem)
-
-    with pytest.raises(NotImplementedError, match="#1285"):
-        MFGResidual(problem, hjb_solver, fp_solver)
-
-
-# ---------------------------------------------------------------------------
-# NewtonMFGSolver (builds MFGResidual internally) must propagate the error
-# ---------------------------------------------------------------------------
-
-
-def test_newton_solver_raises_on_nonlocal_operator():
-    """NewtonMFGSolver must raise NotImplementedError when nonlocal_operator is set.
-
-    NewtonMFGSolver constructs MFGResidual internally; the guard in
-    MFGResidual.__init__ must propagate through.
-    """
-    from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
-
-    problem = _make_problem_with_nonlocal()
-    hjb_solver, fp_solver = _make_solvers(problem)
-
-    with pytest.raises(NotImplementedError, match="#1285"):
-        NewtonMFGSolver(problem, hjb_solver, fp_solver)
-
-
-def test_newton_solver_raises_on_source_term_hjb():
-    """NewtonMFGSolver must raise NotImplementedError when source_term_hjb is set."""
-    from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
-
-    problem = _make_problem_with_source_hjb()
-    hjb_solver, fp_solver = _make_solvers(problem)
-
-    with pytest.raises(NotImplementedError, match="#1285"):
-        NewtonMFGSolver(problem, hjb_solver, fp_solver)
+    residual = MFGResidual(problem, hjb_solver, fp_solver)
+    assert residual.problem is problem
 
 
 # ---------------------------------------------------------------------------
-# Plain problem (no extended fields) must NOT raise
+# NewtonMFGSolver must CONSTRUCT and SOLVE (finite output) for each field
+# ---------------------------------------------------------------------------
+
+
+def test_newton_solver_solves_with_nonlocal_operator():
+    _assert_finite_solve(_make_problem_with_nonlocal())
+
+
+def test_newton_solver_solves_with_source_term_hjb():
+    _assert_finite_solve(_make_problem_with_source_hjb())
+
+
+def test_newton_solver_solves_with_source_term_fp():
+    _assert_finite_solve(_make_problem_with_source_fp())
+
+
+def test_newton_solver_solves_with_obstacle():
+    _assert_finite_solve(_make_problem_with_obstacle())
+
+
+# ---------------------------------------------------------------------------
+# Plain problem (no extended fields) must still construct and solve
 # ---------------------------------------------------------------------------
 
 
 def test_mfg_residual_plain_problem_does_not_raise():
-    """MFGResidual must construct cleanly for a plain problem with no extended fields."""
     from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
 
     problem = _make_plain_problem()
     hjb_solver, fp_solver = _make_solvers(problem)
-
     residual = MFGResidual(problem, hjb_solver, fp_solver)
-    # Smoke-check: basic attributes are set
     assert residual.problem is problem
     assert residual.num_time_steps == problem.Nt + 1
 
 
 def test_newton_solver_plain_problem_does_not_raise():
-    """NewtonMFGSolver must construct cleanly for a plain problem."""
     from mfgarchon.alg.numerical.coupling.newton_mfg_solver import NewtonMFGSolver
 
     problem = _make_plain_problem()
     hjb_solver, fp_solver = _make_solvers(problem)
-
     solver = NewtonMFGSolver(problem, hjb_solver, fp_solver)
     assert solver.problem is problem

--- a/tests/unit/test_alg/test_issue1361_source_composition.py
+++ b/tests/unit/test_alg/test_issue1361_source_composition.py
@@ -1,0 +1,182 @@
+"""Issue #1361: single-source agreement for source/nonlocal/obstacle composition.
+
+``_compose_hjb_source`` / ``_compose_fp_source`` were lifted out of
+``FixedPointIterator`` into the shared ``coupling/source_composition.py`` so the
+Picard coupler and the coupled-Newton ``MFGResidual`` path consume one copy of
+the convention (the bug class behind #1259 and #1285 was a private second copy).
+
+These pins assert:
+
+1. The shared ``compose_hjb_source`` / ``compose_fp_source`` reproduce the prior
+   ``FixedPointIterator`` closures byte-for-byte across a battery of inputs
+   (a verbatim reference copy of the pre-#1361 logic is held below).
+2. ``FixedPointIterator._compose_*`` now delegate to the shared helpers and
+   therefore agree with them exactly.
+
+If the shared helper ever drifts from the pinned convention, these fail.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+from mfgarchon.alg.numerical.coupling.graph_coupling import _get_time_slice
+from mfgarchon.alg.numerical.coupling.source_composition import (
+    compose_fp_source,
+    compose_hjb_source,
+)
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+
+_NX = 6  # MFGProblem(Nx=[6]) -> 7 grid points
+_NT = 4
+
+
+# ---------------------------------------------------------------------------
+# Verbatim reference copy of the pre-#1361 FixedPointIterator closures.
+# (Pinning target: the shared helper must reproduce this exactly.)
+# ---------------------------------------------------------------------------
+
+
+def _ref_compose_hjb_source(problem, m_current, u_current):
+    has_nonlocal = problem.nonlocal_operator is not None
+    has_source = problem.source_term_hjb is not None
+    has_obstacle = problem.obstacle is not None
+    if not (has_nonlocal or has_source or has_obstacle):
+        return None
+
+    def composed(t, x):
+        terms = []
+        if has_source:
+            m_t = _get_time_slice(m_current, t, problem.dt)
+            terms.append(problem.source_term_hjb(x, m_t, np.zeros_like(m_t), t))
+        if has_obstacle:
+            psi = problem.obstacle(x)
+            eps = getattr(problem, "_penalty_eps", 1e6)
+            terms.append((1.0 / eps) * np.maximum(0.0, psi.ravel()))
+        if has_nonlocal:
+            v_t = _get_time_slice(u_current, t, problem.dt)
+            terms.append(problem.nonlocal_operator @ v_t)
+        return sum(terms) if terms else np.zeros(x.shape[0])
+
+    return composed
+
+
+def _ref_compose_fp_source(problem, m_current, v_current):
+    has_source = problem.source_term_fp is not None
+    if not has_source:
+        return None
+
+    def composed(t, x):
+        m_t = _get_time_slice(m_current, t, problem.dt)
+        v_t = _get_time_slice(v_current, t, problem.dt)
+        return problem.source_term_fp(x, m_t, v_t, t)
+
+    return composed
+
+
+# ---------------------------------------------------------------------------
+# Problem factory
+# ---------------------------------------------------------------------------
+
+
+def _make_problem(**extra) -> MFGProblem:
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    comp = MFGComponents(hamiltonian=H, u_terminal=lambda x: 0.0, m_initial=lambda x: 1.0)
+    return MFGProblem(Nx=[_NX], xmin=0.0, xmax=1.0, T=0.4, Nt=_NT, sigma=0.3, components=comp, **extra)
+
+
+def _grid_size(problem) -> int:
+    return int(np.prod(problem.geometry.get_grid_shape()))
+
+
+def _row_indexed(gs: int) -> np.ndarray:
+    """(Nt+1, gs) array whose row k is the constant k (reveals the slice index)."""
+    return np.arange(_NT + 1, dtype=float)[:, None] * np.ones((_NT + 1, gs))
+
+
+# Field configurations spanning every branch and their combinations.
+def _field_configs(gs: int):
+    src_hjb = lambda x, m, v, t: 0.7 * np.ones(x.shape[0]) + 0.1 * t + 0.01 * m  # noqa: E731
+    src_fp = lambda x, m, v, t: 0.05 * np.ones(x.shape[0]) + 0.02 * v  # noqa: E731
+    obstacle = lambda x: np.asarray(x) - 0.5  # noqa: E731
+    nonlocal_op = 0.3 * np.eye(gs) + 0.05 * np.ones((gs, gs))
+    return [
+        ("source_hjb", dict(source_term_hjb=src_hjb)),
+        ("source_fp", dict(source_term_fp=src_fp)),
+        ("obstacle", dict(obstacle=obstacle)),
+        ("nonlocal", dict(nonlocal_operator=nonlocal_op)),
+        ("hjb+obstacle+nonlocal", dict(source_term_hjb=src_hjb, obstacle=obstacle, nonlocal_operator=nonlocal_op)),
+        ("all", dict(source_term_hjb=src_hjb, source_term_fp=src_fp, obstacle=obstacle, nonlocal_operator=nonlocal_op)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Agreement: shared helper == verbatim reference, and == FixedPointIterator delegate
+# ---------------------------------------------------------------------------
+
+
+def test_hjb_composition_matches_reference_and_delegate():
+    gs = _grid_size(_make_problem())
+    M = _row_indexed(gs)
+    U = 2.0 * _row_indexed(gs) + 0.5
+    x = np.linspace(0.0, 1.0, gs)
+
+    for name, kw in _field_configs(gs):
+        problem = _make_problem(**kw)
+        shared = compose_hjb_source(problem, M, U)
+        ref = _ref_compose_hjb_source(problem, M, U)
+        delegate = FixedPointIterator._compose_hjb_source(_StubIterator(problem), M, U)
+
+        # Existence agreement: helper returns None iff reference returns None.
+        assert (shared is None) == (ref is None), name
+        assert (shared is None) == (delegate is None), name
+        if shared is None:
+            continue
+        for k in range(_NT + 1):
+            t = k * problem.dt
+            a = shared(t, x)
+            b = ref(t, x)
+            c = delegate(t, x)
+            np.testing.assert_array_equal(a, b, err_msg=f"{name} t={t}: shared != reference (HJB)")
+            np.testing.assert_array_equal(a, c, err_msg=f"{name} t={t}: shared != FixedPointIterator delegate (HJB)")
+
+
+def test_fp_composition_matches_reference_and_delegate():
+    gs = _grid_size(_make_problem())
+    M = _row_indexed(gs)
+    V = 3.0 * _row_indexed(gs) - 1.0
+    x = np.linspace(0.0, 1.0, gs)
+
+    for name, kw in _field_configs(gs):
+        problem = _make_problem(**kw)
+        shared = compose_fp_source(problem, M, V)
+        ref = _ref_compose_fp_source(problem, M, V)
+        delegate = FixedPointIterator._compose_fp_source(_StubIterator(problem), M, V)
+
+        assert (shared is None) == (ref is None), name
+        assert (shared is None) == (delegate is None), name
+        if shared is None:
+            continue
+        for k in range(_NT + 1):
+            t = k * problem.dt
+            np.testing.assert_array_equal(shared(t, x), ref(t, x), err_msg=f"{name} t={t}: shared != reference (FP)")
+            np.testing.assert_array_equal(
+                shared(t, x), delegate(t, x), err_msg=f"{name} t={t}: shared != delegate (FP)"
+            )
+
+
+def test_no_fields_returns_none():
+    problem = _make_problem()
+    M = _row_indexed(_grid_size(problem))
+    assert compose_hjb_source(problem, M, M) is None
+    assert compose_fp_source(problem, M, M) is None
+
+
+class _StubIterator:
+    """Minimal stand-in carrying only ``.problem`` (the only attribute compose reads)."""
+
+    def __init__(self, problem) -> None:
+        self.problem = problem


### PR DESCRIPTION
Implements #1361: carry `source_term_hjb` / `source_term_fp` / `nonlocal_operator` / `obstacle` through the coupled-Newton residual path so it produces the same equilibrium as Picard.

## What changed

- **Single-source composition** — new `coupling/source_composition.py` (`compose_hjb_source` / `compose_fp_source`), consumed by BOTH `FixedPointIterator` and `MFGResidual`. This is the single-source discipline the issue requires: re-implementing inside `MFGResidual` would have created a second private copy of the convention — the bug class that already produced #1259 (nonlocal `J[v]` not applied) and #1285 (terminal density slice for all `t`).
- **`FixedPointIterator` migrated** — `_compose_hjb_source` / `_compose_fp_source` are now thin delegates to the shared helpers (behaviour unchanged).
- **Residual wiring** — `compute_hjb_output` / `compute_fp_output` compose the source from their `(U, M)` **arguments** (design option A in the issue) and pass `source_term=` when the solver accepts it. The FD Jacobian then differentiates through the source dependence; at convergence `U=U_new`, `M=M_new`, so the root coincides with the Picard fixed point.
- **Obstacle** — uses the same approximate `v=0` penalty `(1/eps)·max(0, ψ)` as Picard so the two paths match; `PenaltyHJBSolver` (#924) remains the proper-handling route. Documented in `MFGResidual` / `NewtonMFGSolver` docstrings.
- **Fail-loud guard removed** (`mfg_residual.py`); the #1285 pins are inverted to assert successful construction + finite solves.

## Tests

- `tests/unit/test_alg/test_issue1361_source_composition.py` (new) — pins the shared helpers byte-for-byte against a verbatim reference copy of the prior `FixedPointIterator` logic, and against the `FixedPointIterator` delegate, across every field combination.
- `tests/unit/test_alg/test_issue1285_newton_fail_loud.py` — inverted: `MFGResidual` / `NewtonMFGSolver` construct and solve (finite) for each field.
- `tests/integration/test_source_term_wiring.py` — added `TestNewtonPicardParity` (Newton matches Picard within `1e-5`; observed `~1e-10`) for `source_term_hjb`, `source_term_fp`, `nonlocal_operator`, plus an FD-Jacobian source-coupling-capture check.

## Verification

- Newton-vs-Picard parity (benign short-horizon regime): `rel‖U‖∞ ~ 6e-11…1e-10`, `rel‖M‖∞ ~ 1e-11`, source terms have non-trivial effect.
- Note: the FD-Jacobian Newton coupler can fall into a spurious near-trivial fixed point for large-amplitude (long-horizon, strongly coupled) discrete MFG maps (pre-existing; see `NewtonMFGSolver` docstring). The parity tests use a regime that keeps both couplers in the same physical basin.

Refs #1361 #1259 #1285 #924 #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)
