### PR TITLE
chore(release): v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2] - 2026-06-15
+
 ### Added
 
 - **Coupled-Newton coupler solves source/nonlocal/obstacle problems** (PR #1372, Refs #1361). The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.20.1"  # v0.20.1: deprecation cleanup (Tier-1/2/3a removed, #1354-1357/#1360) + SL vectorize 13-40x (#1353) + CI mypy-gate & xdist (#1358)
+version = "0.20.2"  # v0.20.2: roadmap batch — JAX downgrade warning (#1072), honest O(h²) (#1084), SOCP adaptive enlargement (#1106), coupled-Newton source/nonlocal/obstacle (#1361)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
Roadmap correctness/feature batch on top of v0.20.1. `0.20.1` → `0.20.2`; CHANGELOG `[Unreleased]` → `[0.20.2] - 2026-06-15`.

### Added
- Coupled-Newton (`MFGResidual`/`NewtonMFGSolver`) solves `source_term_hjb/fp`, `nonlocal_operator`, `obstacle` — matches Picard ~1e-10 (#1361)
- GFDM `joint_socp` SOCP-infeasibility adaptive stencil enlargement (visibility-respecting, default-off) (#1106)
- Opt-in 2nd-order one-sided FDM boundary stencils (#1084)

### Changed
- Source/nonlocal/obstacle composition single-sourced across both couplers (#1361)
- JAX backend warns on high-order-scheme downgrade (#1072)
- Honest GFDM/FDM/WENO accuracy claims (#1084)

After merge: tag `v0.20.2` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)