### PR TITLE
refactor: remove Tier-3b/3c legacy 1D-geometry deprecations from MFGProblem (#1363)

### DIFF
--- a/benchmarks/baseline/weno5_baseline.py
+++ b/benchmarks/baseline/weno5_baseline.py
@@ -15,6 +15,8 @@ import timeit
 from pathlib import Path
 
 import numpy as np
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def benchmark_smoothness_indicators():
@@ -23,7 +25,13 @@ def benchmark_smoothness_indicators():
     from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
 
     # Create solver
-    problem = MFGProblem(Nx=100, Nt=50, T=1.0)
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[100 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=50,
+        T=1.0,
+    )
     solver = HJBWenoSolver(problem, weno_variant="weno5")
 
     # Test data (typical 5-point stencil)

--- a/benchmarks/benchmark_callable_coefficients.py
+++ b/benchmarks/benchmark_callable_coefficients.py
@@ -20,6 +20,8 @@ from mfgarchon.alg.numerical.coupling import FixedPointIterator
 from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def benchmark_scalar_diffusion(Nx=100, Nt=100, num_runs=3):
@@ -33,7 +35,14 @@ def benchmark_scalar_diffusion(Nx=100, Nt=100, num_runs=3):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             problem = MFGProblem(
-                xmin=0.0, xmax=1.0, Nx=Nx, T=1.0, Nt=Nt, sigma=0.1, drift_weight=1.0, coupling_lambda=1.0
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                T=1.0,
+                Nt=Nt,
+                sigma=0.1,
+                drift_weight=1.0,
+                coupling_lambda=1.0,
             )
 
         hjb_solver = HJBFDMSolver(problem)
@@ -60,7 +69,14 @@ def benchmark_array_diffusion_spatial(Nx=100, Nt=100, num_runs=3):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             problem = MFGProblem(
-                xmin=0.0, xmax=1.0, Nx=Nx, T=1.0, Nt=Nt, sigma=0.1, drift_weight=1.0, coupling_lambda=1.0
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                T=1.0,
+                Nt=Nt,
+                sigma=0.1,
+                drift_weight=1.0,
+                coupling_lambda=1.0,
             )
 
         # Create spatially varying diffusion
@@ -91,7 +107,14 @@ def benchmark_array_diffusion_spatiotemporal(Nx=100, Nt=100, num_runs=3):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             problem = MFGProblem(
-                xmin=0.0, xmax=1.0, Nx=Nx, T=1.0, Nt=Nt, sigma=0.1, drift_weight=1.0, coupling_lambda=1.0
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                T=1.0,
+                Nt=Nt,
+                sigma=0.1,
+                drift_weight=1.0,
+                coupling_lambda=1.0,
             )
 
         # Create spatiotemporal diffusion
@@ -127,7 +150,14 @@ def benchmark_callable_diffusion_scalar(Nx=100, Nt=100, num_runs=3):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             problem = MFGProblem(
-                xmin=0.0, xmax=1.0, Nx=Nx, T=1.0, Nt=Nt, sigma=0.1, drift_weight=1.0, coupling_lambda=1.0
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                T=1.0,
+                Nt=Nt,
+                sigma=0.1,
+                drift_weight=1.0,
+                coupling_lambda=1.0,
             )
 
         hjb_solver = HJBFDMSolver(problem)
@@ -159,7 +189,14 @@ def benchmark_callable_diffusion_porous_medium(Nx=100, Nt=100, num_runs=3):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             problem = MFGProblem(
-                xmin=0.0, xmax=1.0, Nx=Nx, T=1.0, Nt=Nt, sigma=0.1, drift_weight=1.0, coupling_lambda=1.0
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                T=1.0,
+                Nt=Nt,
+                sigma=0.1,
+                drift_weight=1.0,
+                coupling_lambda=1.0,
             )
 
         hjb_solver = HJBFDMSolver(problem)
@@ -192,7 +229,14 @@ def benchmark_callable_diffusion_crowd_dynamics(Nx=100, Nt=100, num_runs=3):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             problem = MFGProblem(
-                xmin=0.0, xmax=1.0, Nx=Nx, T=1.0, Nt=Nt, sigma=0.1, drift_weight=1.0, coupling_lambda=1.0
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                T=1.0,
+                Nt=Nt,
+                sigma=0.1,
+                drift_weight=1.0,
+                coupling_lambda=1.0,
             )
 
         hjb_solver = HJBFDMSolver(problem)

--- a/benchmarks/hjb_solver_comparison.py
+++ b/benchmarks/hjb_solver_comparison.py
@@ -18,6 +18,8 @@ import numpy as np
 
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 class QuadraticHamiltonian2D(MFGProblem):
@@ -51,7 +53,13 @@ class QuadraticHamiltonian2D(MFGProblem):
 
 def benchmark_1d_solver(Nx=100, Nt=50, solver_type="newton"):
     """Benchmark 1D HJB solver."""
-    problem = MFGProblem(Nx=Nx, Nt=Nt, T=1.0)
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=Nt,
+        T=1.0,
+    )
 
     if solver_type == "fixed_point":
         solver = HJBFDMSolver(

--- a/benchmarks/parallel_computation_benchmark.py
+++ b/benchmarks/parallel_computation_benchmark.py
@@ -27,6 +27,8 @@ from mfgarchon.alg.numerical.stochastic import CommonNoiseMFGSolver
 from mfgarchon.core.stochastic import OrnsteinUhlenbeckProcess, StochasticMFGProblem
 from mfgarchon.utils.mfg_logging import configure_research_logging, get_logger
 from mfgarchon.workflow.parameter_sweep import ParameterSweep, SweepConfiguration
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 # Configure logging
 configure_research_logging("parallel_benchmark", level="INFO")
@@ -43,7 +45,13 @@ def mfg_solve_function(Nx, Nt, sigma):
     from mfgarchon.core.mfg_problem import MFGProblem
     from mfgarchon.factory import create_fast_solver
 
-    problem = MFGProblem(Nx=Nx, Nt=Nt, sigma=sigma)
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=Nt,
+        sigma=sigma,
+    )
     solver = create_fast_solver(problem)
     result = solver.solve()
 

--- a/benchmarks/particle_gpu_speedup_analysis.py
+++ b/benchmarks/particle_gpu_speedup_analysis.py
@@ -13,6 +13,8 @@ from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.backends.torch_backend import TorchBackend
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry.boundary import periodic_bc
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 print("=" * 80)
 print("Track B Phase 2.1: GPU Speedup Analysis")
@@ -26,11 +28,11 @@ def benchmark_particle_solver(Nx: int, Nt: int, N_particles: int, device: str = 
 
     # Create problem
     problem = MFGProblem(
-        Nx=Nx,
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         Nt=Nt,
         T=1.0,
-        xmin=0.0,
-        xmax=1.0,
         sigma=0.1,
         coupling_coefficient=1.0,
     )

--- a/benchmarks/solver_comparisons/study_hybrid_mass_conservation.py
+++ b/benchmarks/solver_comparisons/study_hybrid_mass_conservation.py
@@ -14,14 +14,16 @@ from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry.boundary import neumann_bc
 from mfgarchon.utils.convergence import create_rolling_monitor
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def setup_problem():
     """Create 1D MFG problem with no-flux Neumann BC."""
     problem = MFGProblem(
-        xmin=0.0,
-        xmax=1.0,
-        Nx=51,
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[51 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=1.0,
         Nt=51,
         sigma=1.0,

--- a/benchmarks/solver_comparisons/visualize_stochastic_mass_conservation.py
+++ b/benchmarks/solver_comparisons/visualize_stochastic_mass_conservation.py
@@ -14,6 +14,8 @@ from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
 from mfgarchon.alg.numerical.mfg_solvers.fixed_point_iterator import FixedPointIterator
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry.boundary import neumann_bc
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def main():
@@ -24,7 +26,15 @@ def main():
 
     # Setup
     np.random.seed(42)
-    problem = MFGProblem(xmin=0.0, xmax=1.0, Nx=51, T=1.0, Nt=51, sigma=1.0, coupling_coefficient=0.5)
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[51 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=1.0,
+        Nt=51,
+        sigma=1.0,
+        coupling_coefficient=0.5,
+    )
     bc = neumann_bc(dimension=1, value=0.0)
 
     fp_solver = FPParticleSolver(problem, num_particles=1000, normalize_kde_output=True, boundary_conditions=bc)

--- a/benchmarks/test_solver_performance.py
+++ b/benchmarks/test_solver_performance.py
@@ -25,6 +25,8 @@ import numpy as np
 
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.mfg_solvers import ParticleCollocationSolver
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 # Test problem fixtures
@@ -32,11 +34,11 @@ from mfgarchon.alg.numerical.mfg_solvers import ParticleCollocationSolver
 def small_problem():
     """Small problem for quick regression testing (suitable for CI)."""
     return MFGProblem(
-        xmin=0.0,
-        xmax=1.0,
-        Nx=20,  # Small grid
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=1.0,
-        Nt=30,  # Small time steps
+        Nt=30,
         sigma=0.12,
         coupling_coefficient=0.02,
     )
@@ -46,11 +48,11 @@ def small_problem():
 def medium_problem():
     """Medium problem for comprehensive benchmarking."""
     return MFGProblem(
-        xmin=0.0,
-        xmax=1.0,
-        Nx=40,  # Medium grid
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=1.0,
-        Nt=50,  # Medium time steps
+        Nt=50,
         sigma=0.12,
         coupling_coefficient=0.02,
     )
@@ -120,7 +122,12 @@ def test_solver_creation_overhead(benchmark):
     Measures the time to create solver instances, which should be
     negligible compared to solve time.
     """
-    problem = MFGProblem(Nx=20, Nt=30)
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=30,
+    )
     bounds = problem.geometry.get_bounds()
     Nx_points = problem.geometry.get_grid_shape()[0]
     x_collocation = np.linspace(bounds[0][0], bounds[1][0], Nx_points)
@@ -147,9 +154,9 @@ def test_problem_creation_overhead(benchmark):
 
     def create_problem():
         return MFGProblem(
-            xmin=0.0,
-            xmax=1.0,
-            Nx=40,
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             T=1.0,
             Nt=50,
             sigma=0.12,

--- a/docs/user/GEOMETRY_FIRST_API_GUIDE.md
+++ b/docs/user/GEOMETRY_FIRST_API_GUIDE.md
@@ -9,7 +9,9 @@
 
 The geometry-first API is the **recommended way** to construct MFG problems in MFGArchon. Instead of manually specifying grid parameters in `MFGProblem`, you first create a geometry object and pass it to `MFGProblem`.
 
-As of v0.16.0, `MFGProblem.geometry` is **always non-None** after initialization, and all spatial information is derived from the geometry object. Legacy attributes (`xmin`, `xmax`, `Nx`, `dx`, etc.) emit `DeprecationWarning` when accessed.
+As of v0.16.0, `MFGProblem.geometry` is **always non-None** after initialization, and all spatial information is derived from the geometry object.
+
+> **Removed (BREAKING):** The legacy 1D read-properties (`xmin`, `xmax`, `Nx`, `Lx`, `dx`, `xSpace`) were removed in v0.20.1 (Issue #1360), and the legacy 1D constructor kwargs (`xmin=`, `xmax=`, `Nx=`, `Lx=`) plus the `get_u_final` / `get_u_fin` aliases were removed in the following minor release (Issue #1363). Passing a removed kwarg now raises `ValueError`; accessing a removed attribute or alias raises `AttributeError`. Use the geometry-first API below.
 
 ## Key Benefits
 
@@ -77,12 +79,22 @@ domain.create_grid(Nx=101)
 problem = MFGProblem(geometry=domain, T=1.0, Nt=100, sigma=0.1)
 ```
 
-**Old API** (deprecated):
+**Removed API** (raises `ValueError` since Issue #1363):
 ```python
-problem = MFGProblem(
-    xmin=[0.0], xmax=[1.0], Nx=[101],
-    T=1.0, Nt=100, sigma=0.1
+# NO LONGER SUPPORTED -- raises ValueError pointing to the geometry-first API:
+#   problem = MFGProblem(xmin=[0.0], xmax=[1.0], Nx=[101], T=1.0, Nt=100, sigma=0.1)
+#
+# Replace with a TensorProductGrid. NOTE the off-by-one: Nx counts intervals,
+# TensorProductGrid takes Nx_points = Nx + 1 grid points.
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+grid = TensorProductGrid(
+    bounds=[(0.0, 1.0)],
+    Nx_points=[102],  # Nx=101 intervals -> 102 points
+    boundary_conditions=no_flux_bc(dimension=1),
 )
+problem = MFGProblem(geometry=grid, T=1.0, Nt=100, sigma=0.1)
 ```
 
 ### 3. Implicit Domains (Meshfree)
@@ -207,10 +219,10 @@ elif problem.is_implicit:
     pass
 ```
 
-**Deprecated pattern** - Legacy attributes emit warnings:
+**Removed pattern** - Legacy attributes raise `AttributeError` (Issue #1360):
 
 ```python
-# These emit DeprecationWarning (will be removed in v1.0.0)
+# These were removed in v0.20.1 -- accessing them raises AttributeError.
 x_min = problem.xmin      # Use problem.geometry.get_bounds()[0][0] instead
 x_max = problem.xmax      # Use problem.geometry.get_bounds()[1][0] instead
 grid_size = problem.Nx    # Use problem.geometry.num_spatial_points - 1 instead
@@ -373,10 +385,16 @@ domain2 = Hypersphere(center=[2, 0], radius=0.5)
 ## FAQ
 
 **Q: Do I need to update my code immediately?**
-A: No. Old API continues to work with deprecation warnings through v0.99.x.
+A: The legacy 1D geometry surfaces (`xmin`/`xmax`/`Nx`/`Lx` read-properties and
+constructor kwargs, and the `get_u_final`/`get_u_fin` aliases) have been removed
+(Issues #1360, #1363) after their 3-minor-version deprecation window. Code that
+still uses them now raises; migrate to the geometry-first API shown above. Other
+deprecated surfaces continue to emit `DeprecationWarning`.
 
 **Q: Will my old code break?**
-A: No. 100% backward compatibility maintained until v1.0.0.
+A: Code using the removed 1D geometry kwargs/attributes/aliases will raise. The
+`spatial_bounds=` / `spatial_discretization=` n-D grid path and the no-argument
+default still work.
 
 **Q: What if I need manual grid construction?**
 A: Use `TensorProductGrid` - it provides the same flexibility with better type safety.

--- a/examples/advanced/solvers_advanced/semi_lagrangian_validation.py
+++ b/examples/advanced/solvers_advanced/semi_lagrangian_validation.py
@@ -21,6 +21,8 @@ import numpy as np
 from mfgarchon import MFGProblem
 from mfgarchon.factory import create_semi_lagrangian_solver
 from mfgarchon.utils.mfg_logging import configure_research_logging, get_logger
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 # Configure logging
 configure_research_logging("semi_lagrangian_validation", level="INFO")
@@ -89,13 +91,13 @@ def create_validation_problem(nx: int = 51, nt: int = 51) -> MFGProblem:
         MFG problem with known analytical properties
     """
     return MFGProblem(
-        xmin=0.0,
-        xmax=1.0,
-        Nx=nx,
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=0.5,
         Nt=nt,
         sigma=0.1,
-        coupling_coefficient=0.5,  # Moderate diffusion  # Standard control cost
+        coupling_coefficient=0.5,
     )
 
 

--- a/examples/advanced/solvers_advanced/weno_family_comparison_demo.py
+++ b/examples/advanced/solvers_advanced/weno_family_comparison_demo.py
@@ -28,6 +28,8 @@ import numpy as np
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.hjb_solvers import HJBWenoSolver
 from mfgarchon.utils.mfg_logging import configure_research_logging, get_logger
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 # Configure logging for research session
 configure_research_logging("weno_family_comparison", level="INFO")
@@ -42,13 +44,13 @@ def create_challenging_mfg_problem() -> MFGProblem:
     - High congestion (nonlinear effects)
     """
     problem = MFGProblem(
-        xmin=0.0,
-        xmax=1.0,
-        Nx=128,  # Fine grid for high resolution
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[128 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=1.0,
         Nt=200,
-        sigma=0.05,  # Low diffusion -> sharp features
-        coupling_coefficient=2.0,  # High congestion -> nonlinear effects
+        sigma=0.05,
+        coupling_coefficient=2.0,
     )
 
     # Create sharp initial condition with discontinuous derivative

--- a/examples/basic/solvers/acceleration_comparison.py
+++ b/examples/basic/solvers/acceleration_comparison.py
@@ -25,6 +25,8 @@ import matplotlib.pyplot as plt
 from mfgarchon import MFGProblem
 from mfgarchon.factory import create_standard_solver
 from mfgarchon.utils.mfg_logging import configure_research_logging, get_logger
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 # Configure logging
 configure_research_logging("acceleration_comparison", level="INFO")
@@ -44,12 +46,12 @@ def create_test_problem():
         return 0.5 * p**2 + 0.5 * x**2 + m
 
     problem = MFGProblem(
-        xmin=-5.0,
-        xmax=5.0,
-        Nx=50,  # Reduced for faster convergence
+        geometry=TensorProductGrid(
+            bounds=[(-5.0, 5.0)], Nx_points=[50 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=1.0,
-        Nt=25,  # Reduced for faster convergence
-        sigma=0.5,  # Increased diffusion for better convergence
+        Nt=25,
+        sigma=0.5,
         hamiltonian=hamiltonian,
     )
 

--- a/examples/basic/solvers/policy_iteration_lq_demo.py
+++ b/examples/basic/solvers/policy_iteration_lq_demo.py
@@ -54,6 +54,8 @@ except ImportError:
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.utils.numerical import create_lq_policy_problem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def demonstrate_policy_iteration_concept():
@@ -102,13 +104,13 @@ def solve_lq_mfg_with_value_iteration():
 
     # Create 1D LQ-MFG problem
     problem = MFGProblem(
-        Nx=100,  # Spatial grid points
-        Nt=50,  # Time steps
-        T=1.0,  # Time horizon
-        xmin=0.0,
-        xmax=1.0,
-        sigma=0.1,  # Diffusion
-        coupling_coefficient=0.5,  # Control cost
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[100 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=50,
+        T=1.0,
+        sigma=0.1,
+        coupling_coefficient=0.5,
     )
 
     print("\nProblem setup:")

--- a/examples/validation/diagnose_strict_adjoint_boundary.py
+++ b/examples/validation/diagnose_strict_adjoint_boundary.py
@@ -15,6 +15,8 @@ import numpy as np
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def diagnose_boundary_behavior(Nx: int = 21, x_stall: float = 0.3):
@@ -26,14 +28,12 @@ def diagnose_boundary_behavior(Nx: int = 21, x_stall: float = 0.3):
     print("=" * 70)
 
     # Create a simple 1D problem
+    geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1))
     problem = MFGProblem(
-        domain=(0.0, 1.0),
-        Nx=Nx,
+        geometry=geometry,
         T=1.0,
         Nt=11,
         sigma=0.2,
-        nu=0.0,  # No running cost
-        use_analytic_solution=False,
     )
 
     # Create value function with stall at x_stall
@@ -167,9 +167,9 @@ def compare_with_explicit_fp(Nx: int = 21, x_stall: float = 0.3):
     print("Comparison: Strict Adjoint vs Standard FP")
     print("=" * 70)
 
+    geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1))
     problem = MFGProblem(
-        domain=(0.0, 1.0),
-        Nx=Nx,
+        geometry=geometry,
         T=1.0,
         Nt=11,
         sigma=0.2,

--- a/mfgarchon/alg/numerical/coupling/block_iterators.py
+++ b/mfgarchon/alg/numerical/coupling/block_iterators.py
@@ -234,7 +234,7 @@ class BlockIterator(BaseCouplingIterator):
 
     def _initialize_conditions(self, shape: tuple[int, ...]) -> tuple[NDArray, NDArray]:
         """Initialize initial density and terminal value from problem."""
-        # Try get_m_init() / get_u_fin() methods (preferred)
+        # Try get_m_initial() / get_u_terminal() methods (preferred)
         try:
             M_initial = self.problem.get_m_initial()
             if M_initial.shape != shape:

--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -196,19 +196,19 @@ class FictitiousPlayIterator(BaseCouplingIterator):
             (M_initial, U_terminal): Initial density and terminal value function
 
         Priority order:
-            1. get_m_init() / get_u_fin() methods (preferred modern API)
-            2. m_init / u_fin attributes (legacy direct access)
+            1. get_m_init() / get_u_terminal() methods (preferred modern API)
+            2. m_initial / u_terminal attributes (Issue #670 unified naming)
             3. get_initial_m() / get_final_u() methods (alternate modern API)
             4. initial_density() / terminal_cost() callables (functional API)
         """
-        # Priority 1: get_m_init() / get_u_fin() methods
+        # Priority 1: get_m_init() / get_u_terminal() methods
         try:
             M_initial = self.problem.get_m_init()
             if M_initial.shape != shape:
                 M_initial = M_initial.reshape(shape)
 
             try:
-                U_terminal = self.problem.get_u_fin()
+                U_terminal = self.problem.get_u_terminal()
             except AttributeError:
                 # No terminal condition - use zeros
                 U_terminal = np.zeros(shape)
@@ -256,8 +256,8 @@ class FictitiousPlayIterator(BaseCouplingIterator):
         except AttributeError as e:
             raise ValueError(
                 "Problem must provide initial/terminal conditions via one of:\n"
-                "  1. get_m_init()/get_u_fin() methods (preferred)\n"
-                "  2. m_init/u_fin attributes\n"
+                "  1. get_m_init()/get_u_terminal() methods (preferred)\n"
+                "  2. m_initial/u_terminal attributes\n"
                 "  3. get_initial_m()/get_final_u() methods\n"
                 "  4. initial_density()/terminal_cost() callables"
             ) from e

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -275,19 +275,19 @@ class FixedPointIterator(BaseCouplingIterator):
             (M_initial, U_terminal): Initial density and terminal value function
 
         Priority order:
-            1. get_m_init() / get_u_fin() methods (preferred modern API)
-            2. m_init / u_fin attributes (legacy direct access)
+            1. get_m_init() / get_u_terminal() methods (preferred modern API)
+            2. m_initial / u_terminal attributes (Issue #670 unified naming)
             3. get_initial_m() / get_final_u() methods (alternate modern API)
             4. initial_density() / terminal_cost() callables (functional API)
         """
-        # Priority 1: get_m_init() / get_u_fin() methods
+        # Priority 1: get_m_init() / get_u_terminal() methods
         try:
             M_initial = self.problem.get_m_init()
             if M_initial.shape != shape:
                 M_initial = M_initial.reshape(shape)
 
             try:
-                U_terminal = self.problem.get_u_fin()
+                U_terminal = self.problem.get_u_terminal()
             except AttributeError:
                 # No terminal condition - use zeros
                 U_terminal = np.zeros(shape)
@@ -335,8 +335,8 @@ class FixedPointIterator(BaseCouplingIterator):
         except AttributeError as e:
             raise ValueError(
                 "Problem must provide initial/terminal conditions via one of:\n"
-                "  1. get_m_init()/get_u_fin() methods (preferred)\n"
-                "  2. m_init/u_fin attributes\n"
+                "  1. get_m_init()/get_u_terminal() methods (preferred)\n"
+                "  2. m_initial/u_terminal attributes\n"
                 "  3. get_initial_m()/get_final_u() methods\n"
                 "  4. initial_density()/terminal_cost() callables"
             ) from e

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -56,8 +56,10 @@ class FPGFDMSolver(BaseFPSolver):
     Example:
         >>> from mfgarchon import MFGProblem
         >>> from mfgarchon.alg.numerical.fp_solvers import FPGFDMSolver
+        >>> from mfgarchon.geometry import TensorProductGrid
         >>>
-        >>> problem = MFGProblem(Nx=30, Nt=20, T=1.0, sigma=0.1)
+        >>> grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31])
+        >>> problem = MFGProblem(geometry=grid, Nt=20, T=1.0, sigma=0.1)
         >>> points = np.random.rand(100, 1)  # Scattered 1D points
         >>> solver = FPGFDMSolver(problem, collocation_points=points)
         >>>

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -336,8 +336,7 @@ class FPParticleSolver(BaseFPSolver):
         except AttributeError as e:
             # Geometry is always available after MFGProblem initialization
             raise ValueError(
-                "FPParticleSolver requires a geometry object. "
-                "Create MFGProblem with geometry=TensorProductGrid(...) or with Nx=... parameter."
+                "FPParticleSolver requires a geometry object. Create MFGProblem with geometry=TensorProductGrid(...)."
             ) from e
 
         # Compute derived quantities

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -336,7 +336,9 @@ class BaseHJBSolver(BaseNumericalSolver):
         Example:
             >>> from mfgarchon.core.mfg_problem import MFGProblem
             >>> from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
-            >>> problem = MFGProblem(Nx=100, xmin=0.0, xmax=1.0, Nt=50, T=1.0)
+            >>> from mfgarchon.geometry import TensorProductGrid
+            >>> grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[101])
+            >>> problem = MFGProblem(geometry=grid, Nt=50, T=1.0)
             >>> solver = HJBFDMSolver(problem)
             >>> U = solver.solve()  # Standalone HJB solution
             >>> print(U.shape)  # (51, 101)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
@@ -174,6 +174,8 @@ if __name__ == "__main__":
     """Quick smoke test for PenaltyHJBSolver."""
     from mfgarchon import MFGProblem
     from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
 
     print("Testing PenaltyHJBSolver...")
 
@@ -190,7 +192,8 @@ if __name__ == "__main__":
         u_terminal=lambda x: 0.0,
         m_initial=lambda x: 1.0,
     )
-    problem = MFGProblem(Nx=50, xmin=0.0, xmax=1.0, T=1.0, Nt=20, sigma=0.3, components=components)
+    geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(geometry=geometry, T=1.0, Nt=20, sigma=0.3, components=components)
     inner = HJBFDMSolver(problem)
 
     # Obstacle: Psi(x) = 0.5 * sin(pi * x) — agents must stay above this

--- a/mfgarchon/alg/optimization/variational_problem.py
+++ b/mfgarchon/alg/optimization/variational_problem.py
@@ -520,11 +520,17 @@ class VariationalMFGProblem:
             description=f"Hamiltonian formulation of {self.components.description}",
         )
 
-        # Create MFG problem
+        # Create MFG problem (Issue #1363: geometry-first API)
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc
+
+        geometry = TensorProductGrid(
+            bounds=[(self.xmin, self.xmax)],
+            Nx_points=[self.Nx + 1],  # Nx intervals -> Nx + 1 grid points
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
         return MFGProblem(
-            xmin=self.xmin,
-            xmax=self.xmax,
-            Nx=self.Nx,
+            geometry=geometry,
             T=self.T,
             Nt=self.Nt,
             sigma=self.sigma,

--- a/mfgarchon/core/base_problem.py
+++ b/mfgarchon/core/base_problem.py
@@ -72,7 +72,9 @@ class MFGProblemProtocol(Protocol):
         ...     return u
 
         >>> # Runtime validation
-        >>> problem = MFGProblem(xmin=0, xmax=1, Nx=100, T=1, Nt=50, sigma=0.1)
+        >>> from mfgarchon.geometry import TensorProductGrid
+        >>> grid = TensorProductGrid(bounds=[(0, 1)], Nx_points=[101])
+        >>> problem = MFGProblem(geometry=grid, T=1, Nt=50, sigma=0.1)
         >>> assert isinstance(problem, MFGProblemProtocol)  # Should pass!
     """
 

--- a/mfgarchon/core/mfg_components.py
+++ b/mfgarchon/core/mfg_components.py
@@ -888,7 +888,7 @@ class ConditionsMixin:
                 "  grid = TensorProductGrid(..., boundary_conditions=bc)\n"
                 "  problem = MFGProblem(geometry=grid, ...)\n\n"
                 "Legacy BC support via components will be removed in v1.0.0. "
-                "See docs/migration/GEOMETRY_PARAMETER_MIGRATION.md",
+                "See docs/user/GEOMETRY_FIRST_API_GUIDE.md",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -17,7 +17,7 @@ from mfgarchon.core.mfg_components import (
 from mfgarchon.geometry.protocol import GeometryProtocol  # noqa: TC001
 
 # Deprecation utilities (Issue #616, #666)
-from mfgarchon.utils.deprecation import deprecated, deprecated_parameter, validate_kwargs
+from mfgarchon.utils.deprecation import validate_kwargs
 
 # Use unified nD-capable BoundaryConditions from conditions.py
 
@@ -180,75 +180,6 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
     volatility_field: DiffusionField
     drift_field: DriftField
 
-    @staticmethod
-    def _normalize_to_array(
-        value: int | float | list[int] | list[float] | None,
-        param_name: str = "parameter",
-        warn: bool = True,
-    ) -> list[int] | list[float] | None:
-        """
-        Convert scalar or array to array with optional deprecation warning.
-
-        Args:
-            value: Scalar or array value to normalize
-            param_name: Parameter name for warning message
-            warn: Whether to emit deprecation warning for scalar inputs
-
-        Returns:
-            Array form of the value, or None if input is None
-
-        Examples:
-            >>> MFGProblem._normalize_to_array(100, "Nx")  # Warns
-            [100]
-            >>> MFGProblem._normalize_to_array([100], "Nx")  # No warning
-            [100]
-            >>> MFGProblem._normalize_to_array(None, "Nx")
-            None
-        """
-        import warnings
-
-        if value is None:
-            return None
-
-        if isinstance(value, (int, float)):
-            if warn:
-                warnings.warn(
-                    f"Passing scalar {param_name}={value} is deprecated. "
-                    f"Use array notation {param_name}=[{value}] instead. "
-                    f"Scalar support will be removed in v1.0.0. "
-                    f"See docs/development/MATHEMATICAL_NOTATION_STANDARD.md for details.",
-                    DeprecationWarning,
-                    stacklevel=4,
-                )
-            return [value]
-
-        # Already a list - return as-is
-        return list(value)
-
-    @deprecated_parameter(
-        param_name="Lx",
-        since="v0.17.1",
-        replacement="geometry=TensorProductGrid(...)",
-        removal_blockers=["internal_usage", "migration_docs"],
-    )
-    @deprecated_parameter(
-        param_name="Nx",
-        since="v0.17.1",
-        replacement="geometry=TensorProductGrid(...)",
-        removal_blockers=["internal_usage", "migration_docs"],
-    )
-    @deprecated_parameter(
-        param_name="xmax",
-        since="v0.17.1",
-        replacement="geometry=TensorProductGrid(...)",
-        removal_blockers=["internal_usage", "migration_docs"],
-    )
-    @deprecated_parameter(
-        param_name="xmin",
-        since="v0.17.1",
-        replacement="geometry=TensorProductGrid(...)",
-        removal_blockers=["internal_usage", "migration_docs"],
-    )
     def __init__(
         self,
         # === API v1.0 parameters (Issue #875) ===
@@ -257,11 +188,6 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         conditions: Any | None = None,  # Conditions instance (time + IC/TC)
         constraints: list | None = None,  # Optional constraints (future)
         # === Legacy parameters (all below deprecated in favor of model/domain/conditions) ===
-        # Legacy 1D parameters (backward compatible - scalars will be converted to arrays with deprecation warning)
-        xmin: float | list[float] | None = None,
-        xmax: float | list[float] | None = None,
-        Nx: int | list[int] | None = None,
-        Lx: float | None = None,  # Alternative to xmin/xmax
         # N-D grid parameters
         spatial_bounds: list[tuple[float, float]] | None = None,
         spatial_discretization: list[int] | None = None,
@@ -296,15 +222,16 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         """
         Initialize MFG problem with support for all spatial dimensions and domain types.
 
-        Supports five initialization modes:
-        1. Legacy 1D mode: Specify Nx, xmin, xmax
-        2. N-D grid mode: Specify spatial_bounds, spatial_discretization
-        3. Geometry mode: Specify geometry object (with optional obstacles)
-        4. Network mode: Specify network graph
-        5. Custom components: Full mathematical control via MFGComponents
+        Supports four initialization modes:
+        1. N-D grid mode: Specify spatial_bounds, spatial_discretization
+        2. Geometry mode: Specify geometry object (with optional obstacles)
+        3. Network mode: Specify network graph
+        4. Custom components: Full mathematical control via MFGComponents
+
+        For a 1D grid, use the geometry-first API:
+            geometry=TensorProductGrid(bounds=[(xmin, xmax)], Nx_points=[Nx + 1])
 
         Args:
-            xmin, xmax, Nx, Lx: Legacy 1D spatial domain parameters
             spatial_bounds: List of (min, max) tuples for each dimension
                            Example: [(0, 1), (0, 1)] for 2D unit square
             spatial_discretization: List of grid points per dimension
@@ -341,8 +268,9 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             **kwargs: Additional parameters
 
         Examples:
-            # Mode 1: 1D legacy (100% backward compatible)
-            problem = MFGProblem(Nx=100, xmin=0.0, xmax=1.0, Nt=100)
+            # Mode 1: 1D grid via geometry-first API
+            geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[101])
+            problem = MFGProblem(geometry=geometry, T=1.0, Nt=100)
 
             # Mode 2: N-D grid
             problem = MFGProblem(
@@ -447,9 +375,6 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
                 n: v
                 for n, v in [
                     ("geometry", geometry),
-                    ("xmin", xmin),
-                    ("xmax", xmax),
-                    ("Nx", Nx),
                     ("spatial_bounds", spatial_bounds),
                     ("spatial_discretization", spatial_discretization),
                     ("sigma", sigma),
@@ -624,28 +549,6 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             # Scalar: use directly
             sigma_scalar = float(vola_value)
 
-        # Normalize spatial parameters to arrays (with deprecation warnings for scalars)
-        # This enables dimension-agnostic code while maintaining backward compatibility
-
-        # Issue #544: Deprecate legacy 1D parameters (Nx, xmin, xmax, Lx)
-        # Note: Deprecation warnings issued by @deprecated_parameter decorators
-        # Detailed migration guide: docs/user/LEGACY_PARAMETERS.md
-
-        if Nx is not None:
-            Nx_normalized = self._normalize_to_array(Nx, "Nx")
-        else:
-            Nx_normalized = None
-
-        if xmin is not None:
-            xmin_normalized = self._normalize_to_array(xmin, "xmin")
-        else:
-            xmin_normalized = None
-
-        if xmax is not None:
-            xmax_normalized = self._normalize_to_array(xmax, "xmax")
-        else:
-            xmax_normalized = None
-
         # Initialize geometry-related attributes explicitly (Issue #543 - fail-fast principle)
         # These may be set by init methods, but should have explicit defaults
         self.geometry = None  # type: GeometryProtocol | None
@@ -689,39 +592,21 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             final_hjb_geometry = None
             final_fp_geometry = None
 
-        # Detect initialization mode (use normalized Nx for detection)
+        # Detect initialization mode
         # For dual geometry, pass the hjb_geometry to mode detection
         geometry_for_detection = final_hjb_geometry if final_hjb_geometry is not None else geometry
-        mode = self._detect_init_mode(
-            Nx=Nx_normalized, spatial_bounds=spatial_bounds, geometry=geometry_for_detection, network=network
-        )
+        mode = self._detect_init_mode(spatial_bounds=spatial_bounds, geometry=geometry_for_detection, network=network)
 
         # Dispatch to appropriate initializer
         # Note: Pass sigma_scalar (the backward-compatible float value)
-        if mode == "1d_legacy":
-            # Mode 1: Legacy 1D
-            if Lx is not None:
-                # Use Lx to set xmin/xmax if provided
-                if xmin_normalized is None:
-                    xmin_normalized = [0.0]
-                xmax_normalized = [xmin_normalized[0] + Lx]
-            else:
-                if xmin_normalized is None:
-                    xmin_normalized = [0.0]
-                if xmax_normalized is None:
-                    xmax_normalized = [1.0]
-            self._init_1d_legacy(
-                xmin_normalized, xmax_normalized, Nx_normalized, T, Nt, sigma_scalar, coupling_coefficient
-            )
-
-        elif mode == "nd_grid":
-            # Mode 2: N-dimensional grid
-            self._init_nd(
+        if mode == "nd_grid":
+            # Mode 1: N-dimensional grid
+            self._init_grid(
                 spatial_bounds, spatial_discretization, T, Nt, sigma_scalar, coupling_coefficient, suppress_warnings
             )
 
         elif mode == "geometry":
-            # Mode 3: Complex geometry
+            # Mode 2: Complex geometry
             self._init_geometry(
                 final_hjb_geometry,
                 obstacles,
@@ -739,17 +624,17 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
                 self.fp_geometry = final_fp_geometry
 
         elif mode == "network":
-            # Mode 4: Network MFG
+            # Mode 3: Network MFG
             self._init_network(network, T, Nt, sigma_scalar, coupling_coefficient, lambda_, gamma)
 
         elif mode == "default":
-            # Default: 1D with default parameters
+            # Default: 1D unit interval with 51 grid points
             warnings.warn(
                 "No spatial domain specified. Using default 1D domain: [0, 1] with 51 points.",
                 UserWarning,
                 stacklevel=2,
             )
-            self._init_1d_legacy([0.0], [1.0], [51], T, Nt, sigma_scalar, coupling_coefficient)
+            self._init_grid([(0.0, 1.0)], [51], T, Nt, sigma_scalar, coupling_coefficient, suppress_warnings)
 
         else:
             raise ValueError(f"Unknown initialization mode: {mode}")
@@ -807,85 +692,7 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         # Detect solver compatibility
         self._detect_solver_compatibility()
 
-    @deprecated(
-        since="v0.17.0",
-        replacement="geometry-first API with TensorProductGrid",
-        reason="Manual grid construction is deprecated. See docs/migration/GEOMETRY_PARAMETER_MIGRATION.md",
-    )
-    def _init_1d_legacy(
-        self,
-        xmin: list[float],
-        xmax: list[float],
-        Nx: list[int],
-        T: float,
-        Nt: int,
-        sigma: float,
-        coupling_coefficient: float,
-    ) -> None:
-        """
-        Initialize problem in legacy 1D mode (100% backward compatible).
-
-        Args:
-            xmin: Lower bound as array (e.g., [-2.0])
-            xmax: Upper bound as array (e.g., [2.0])
-            Nx: Grid points as array (e.g., [100])
-            T: Terminal time
-            Nt: Temporal grid points
-            sigma: Diffusion coefficient
-            coupling_coefficient: Control cost coefficient
-
-        Note:
-            This manual grid construction pattern is deprecated. Consider using
-            the geometry-first API with TensorProductGrid instead.
-            See migration guide: docs/migration/GEOMETRY_PARAMETER_MIGRATION.md
-        """
-        from mfgarchon.geometry import TensorProductGrid
-
-        # Extract scalar values from arrays for backward compatibility
-        xmin_scalar = xmin[0]
-        xmax_scalar = xmax[0]
-        Nx_scalar = Nx[0]
-
-        # Create TensorProductGrid geometry object (unified internal representation)
-        # Use default no_flux_bc for legacy _init_1d_legacy path (Issue #674)
-        # Note: This is a deprecated code path; users should use geometry-first API
-        from mfgarchon.geometry.boundary import no_flux_bc
-
-        geometry = TensorProductGrid(
-            bounds=[(xmin_scalar, xmax_scalar)],
-            Nx_points=[Nx_scalar + 1],
-            boundary_conditions=no_flux_bc(dimension=1),
-        )
-
-        # Store geometry for unified interface
-        self.geometry = geometry
-
-        # Set dimension from geometry
-        self.dimension = geometry.dimension
-
-        # Time domain
-        self.T: float = T
-        self.Nt: int = Nt
-        self.dt: float = T / Nt if Nt > 0 else 0.0
-
-        # Time grid
-        self.tSpace: np.ndarray = np.linspace(0, T, Nt + 1, endpoint=True)
-
-        # Coefficients
-        self.sigma: float = sigma
-        self.coupling_coefficient: float = coupling_coefficient
-
-        # N-D attributes (derived from geometry)
-        self.spatial_shape = geometry.get_grid_shape()
-        self.spatial_bounds = [(xmin_scalar, xmax_scalar)]
-        self.spatial_discretization = [Nx_scalar]
-
-    @deprecated(
-        since="v0.17.0",
-        replacement="geometry-first API with TensorProductGrid",
-        reason="Manual grid construction is deprecated. See docs/migration/GEOMETRY_PARAMETER_MIGRATION.md",
-    )
-    def _init_nd(
+    def _init_grid(
         self,
         spatial_bounds: list[tuple[float, float]],
         spatial_discretization: list[int] | None,
@@ -896,12 +703,23 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         suppress_warnings: bool,
     ) -> None:
         """
-        Initialize problem in n-dimensional mode.
+        Initialize problem on a tensor-product Cartesian grid.
 
-        Note:
-            This manual grid construction pattern is deprecated. Consider using
-            the geometry-first API with TensorProductGrid instead.
-            See migration guide: docs/migration/GEOMETRY_PARAMETER_MIGRATION.md
+        Builds a ``TensorProductGrid`` (with default no-flux boundary conditions)
+        from ``spatial_bounds`` and the per-dimension interval counts in
+        ``spatial_discretization`` and stores the derived grid attributes. Used
+        by the ``spatial_bounds=`` (n-D grid) and no-argument (default 1D) paths.
+
+        Args:
+            spatial_bounds: List of (min, max) tuples, one per dimension.
+            spatial_discretization: Interval count per dimension (Nx); the grid
+                allocates Nx + 1 points per axis. Defaults to 51 intervals per
+                dimension when None.
+            T: Terminal time.
+            Nt: Number of time intervals.
+            sigma: Diffusion coefficient.
+            coupling_coefficient: Control cost coefficient.
+            suppress_warnings: Skip the computational-feasibility check.
         """
         # Validate inputs
         if not spatial_bounds:
@@ -924,8 +742,6 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
 
         # Convert discretization to Nx_points (add 1 for point count vs intervals)
         Nx_points = [n + 1 for n in spatial_discretization]
-        # Use default no_flux_bc for legacy _init_nd path (Issue #674)
-        # Note: This is a deprecated code path; users should use geometry-first API
         geometry = TensorProductGrid(
             bounds=spatial_bounds, Nx_points=Nx_points, boundary_conditions=no_flux_bc(dimension=dimension)
         )
@@ -1022,7 +838,6 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
 
     def _detect_init_mode(
         self,
-        Nx: list[int] | None,
         spatial_bounds: list[tuple[float, float]] | None,
         geometry: GeometryProtocol | None,
         network: Any | None,
@@ -1031,20 +846,18 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         Detect which initialization mode to use based on provided parameters.
 
         Args:
-            Nx: Normalized array of grid points (or None)
             spatial_bounds: Spatial bounds (or None)
             geometry: Geometry object (or None)
             network: Network object (or None)
 
         Returns:
-            mode: One of "1d_legacy", "nd_grid", "geometry", "network", "default"
+            mode: One of "nd_grid", "geometry", "network", "default"
 
         Raises:
             ValueError: If parameters are ambiguous or conflicting
         """
         # Count how many modes are specified
         mode_indicators = {
-            "1d_legacy": Nx is not None,
             "nd_grid": spatial_bounds is not None,
             "geometry": geometry is not None,
             "network": network is not None,
@@ -1059,7 +872,6 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             raise ValueError(
                 f"Ambiguous initialization: Multiple modes specified: {specified}\n"
                 f"Provide ONLY ONE of:\n"
-                f"  - Nx (for 1D legacy mode)\n"
                 f"  - spatial_bounds (for n-D grid mode)\n"
                 f"  - geometry (for complex geometry mode)\n"
                 f"  - network (for network MFG mode)"
@@ -1318,7 +1130,8 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             True if domain_type is "grid", False otherwise.
 
         Example:
-            >>> problem = MFGProblem(Nx=[50], xmin=[0.0], xmax=[1.0], T=1.0, Nt=10)
+            >>> grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51])
+            >>> problem = MFGProblem(geometry=grid, T=1.0, Nt=10)
             >>> problem.is_cartesian
             True
         """
@@ -2108,48 +1921,11 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         """Get terminal condition u(T, x). Issue #670: unified naming."""
         return self.u_terminal.copy()
 
-    def get_u_final(self) -> np.ndarray:
-        """Deprecated: use get_u_terminal() instead.
-
-        .. deprecated:: v0.17.6
-            Use :meth:`get_u_terminal` instead. Will be removed in v1.0.0.
-        """
-        from mfgarchon.utils.deprecation import deprecated
-
-        # Apply decorator dynamically to avoid import cycle at module level
-        @deprecated(
-            since="v0.17.6",
-            replacement="use get_u_terminal() instead",
-            reason="Renamed for consistency with MFG literature terminology",
-        )
-        def _deprecated_get_u_final() -> np.ndarray:
-            return self.get_u_terminal()
-
-        return _deprecated_get_u_final()
-
     def get_m_initial(self) -> np.ndarray:
         """Get initial density m(0, x). Issue #670: unified naming."""
         return self.m_initial.copy()
 
     # Legacy aliases for backward compatibility
-    def get_u_fin(self) -> np.ndarray:
-        """Legacy alias for get_u_terminal().
-
-        .. deprecated:: v0.17.6
-            Use :meth:`get_u_terminal` instead. Will be removed in v1.0.0.
-        """
-        from mfgarchon.utils.deprecation import deprecated
-
-        @deprecated(
-            since="v0.17.6",
-            replacement="use get_u_terminal() instead",
-            reason="Shortened alias deprecated in favor of full name",
-        )
-        def _deprecated_get_u_fin() -> np.ndarray:
-            return self.get_u_terminal()
-
-        return _deprecated_get_u_fin()
-
     def get_m_init(self) -> np.ndarray:
         """Legacy alias for get_m_initial()."""
         return self.get_m_initial()
@@ -2224,7 +2000,16 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         "m_initial": "MFGComponents.m_initial",
         "u_final": "MFGComponents.u_terminal",
         "initial_density": "MFGComponents.m_initial",
+        # Issue #1363: legacy 1D geometry kwargs removed (deprecated since v0.17.1);
+        # the **kwargs signature would otherwise swallow them silently.
+        "xmin": "geometry=TensorProductGrid(bounds=[(xmin, xmax)], Nx_points=[Nx + 1])",
+        "xmax": "geometry=TensorProductGrid(bounds=[(xmin, xmax)], Nx_points=[Nx + 1])",
+        "Nx": "geometry=TensorProductGrid(bounds=[(xmin, xmax)], Nx_points=[Nx + 1])",
+        "Lx": "geometry=TensorProductGrid(bounds=[(0.0, Lx)], Nx_points=[Nx + 1])",
     }
+
+    # Legacy 1D geometry kwargs removed in Issue #1363 (subset of _DEPRECATED_KWARGS)
+    _GEOMETRY_KWARGS: ClassVar[set[str]] = {"xmin", "xmax", "Nx", "Lx"}
 
     # Known valid kwargs that are consumed by _initialize_functions or mixins
     _RECOGNIZED_KWARGS: ClassVar[set[str]] = {
@@ -2252,8 +2037,28 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
                 warn_on_unrecognized=True,
             )
         except ValueError as e:
-            # Enhance error with MFGProblem-specific migration guide
-            migration_guide = """
+            # Enhance error with the relevant MFGProblem-specific migration guide.
+            if self._GEOMETRY_KWARGS & set(kwargs):
+                # Issue #1363: legacy 1D geometry kwargs (xmin/xmax/Nx/Lx) removed.
+                migration_guide = """
+
+The legacy 1D geometry kwargs (xmin/xmax/Nx/Lx) are no longer supported.
+Use the geometry-first API:
+
+  from mfgarchon.geometry import TensorProductGrid
+  from mfgarchon.geometry.boundary import no_flux_bc
+
+  geometry = TensorProductGrid(
+      bounds=[(xmin, xmax)],
+      Nx_points=[Nx + 1],  # Nx intervals -> Nx + 1 grid points
+      boundary_conditions=no_flux_bc(dimension=1),
+  )
+
+  problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, sigma=sigma)
+
+See: docs/user/GEOMETRY_FIRST_API_GUIDE.md"""
+            else:
+                migration_guide = """
 
 The old kwargs-based Hamiltonian API is no longer supported.
 Use MFGComponents for custom problem definitions:

--- a/mfgarchon/core/stochastic/stochastic_problem.py
+++ b/mfgarchon/core/stochastic/stochastic_problem.py
@@ -118,9 +118,9 @@ class StochasticMFGProblem(MFGProblem):
         Raises:
             ValueError: If noise_process provided but conditional_hamiltonian is None
         """
-        # Initialize base MFG problem
-        # If geometry is provided in kwargs, don't pass legacy xmin/xmax/Nx
-        # to avoid ambiguous initialization (Issue #543 compliance)
+        # Initialize base MFG problem.
+        # Issue #1363: MFGProblem no longer accepts legacy xmin/xmax/Nx kwargs;
+        # translate this subclass's 1D domain spec to the geometry-first API.
         if "geometry" in kwargs:
             super().__init__(
                 T=T,
@@ -130,10 +130,16 @@ class StochasticMFGProblem(MFGProblem):
                 **kwargs,
             )
         else:
+            from mfgarchon.geometry import TensorProductGrid
+            from mfgarchon.geometry.boundary import no_flux_bc
+
+            geometry = TensorProductGrid(
+                bounds=[(xmin, xmax)],
+                Nx_points=[Nx + 1],  # Nx intervals -> Nx + 1 grid points
+                boundary_conditions=no_flux_bc(dimension=1),
+            )
             super().__init__(
-                xmin=xmin,
-                xmax=xmax,
-                Nx=Nx,
+                geometry=geometry,
                 T=T,
                 Nt=Nt,
                 sigma=sigma,

--- a/mfgarchon/factory/general_mfg_factory.py
+++ b/mfgarchon/factory/general_mfg_factory.py
@@ -123,6 +123,25 @@ class GeneralMFGFactory:
         if solver_config:
             problem_kwargs.update(solver_config)
 
+        # Issue #1363: translate the legacy 1D domain spec (xmin/xmax/Nx/Lx) into
+        # the geometry-first API. Configs that already provide geometry= or
+        # spatial_bounds= are passed through unchanged.
+        if not ({"geometry", "spatial_bounds"} & problem_kwargs.keys()) and (
+            {"xmin", "xmax", "Nx", "Lx"} & problem_kwargs.keys()
+        ):
+            from mfgarchon.geometry import TensorProductGrid
+            from mfgarchon.geometry.boundary import no_flux_bc
+
+            xmin = problem_kwargs.pop("xmin", 0.0)
+            lx = problem_kwargs.pop("Lx", None)
+            xmax = problem_kwargs.pop("xmax", xmin + lx if lx is not None else 1.0)
+            nx = problem_kwargs.pop("Nx")  # intervals
+            problem_kwargs["geometry"] = TensorProductGrid(
+                bounds=[(xmin, xmax)],
+                Nx_points=[nx + 1],  # Nx intervals -> Nx + 1 grid points
+                boundary_conditions=no_flux_bc(dimension=1),
+            )
+
         problem_kwargs["components"] = components
 
         return MFGProblem(**problem_kwargs)

--- a/mfgarchon/factory/solver_factory.py
+++ b/mfgarchon/factory/solver_factory.py
@@ -85,7 +85,8 @@ class SolverFactory:
         if problem is None:
             raise ValueError(
                 "Problem cannot be None. Please provide a valid MFGProblem instance.\n"
-                "Example: problem = MFGProblem(Nx=50, Nt=100, T=1.0)"
+                "Example: problem = MFGProblem("
+                "geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51]), Nt=100, T=1.0)"
             )
 
         # Validate solver type with helpful suggestions
@@ -243,8 +244,10 @@ def create_solver(
 
     Example:
         >>> from mfgarchon import MFGProblem
+        >>> from mfgarchon.geometry import TensorProductGrid
         >>> from mfgarchon.types import NumericalScheme
-        >>> problem = MFGProblem(Nx=50, Nt=20, T=1.0)
+        >>> grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[51])
+        >>> problem = MFGProblem(geometry=grid, Nt=20, T=1.0)
         >>> result = problem.solve(scheme=NumericalScheme.FDM_UPWIND)  # Preferred
 
     Note:

--- a/mfgarchon/meta/mathematical_dsl.py
+++ b/mfgarchon/meta/mathematical_dsl.py
@@ -321,15 +321,20 @@ class CompiledMFGSystem:
     def to_mfg_problem(self):
         """Convert to standard MFGProblem instance."""
         from mfgarchon.core.mfg_problem import MFGProblem
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc
 
         # Extract domain parameters
         domain = self.domain_info
 
+        geometry = TensorProductGrid(
+            bounds=[(domain["xmin"], domain["xmax"])],
+            Nx_points=[domain["nx"] + 1],  # Nx intervals -> Nx + 1 grid points
+            boundary_conditions=no_flux_bc(dimension=1),
+        )
         problem = MFGProblem(
-            xmin=domain["xmin"],
-            xmax=domain["xmax"],
+            geometry=geometry,
             T=domain["tmax"],
-            Nx=domain["nx"],
             Nt=domain["nt"],
         )
 

--- a/tests/integration/test_1043_coupler_fp_drift_convention.py
+++ b/tests/integration/test_1043_coupler_fp_drift_convention.py
@@ -82,7 +82,7 @@ def _realistic_U(problem: MFGProblem, fp_solver: FPFDMSolver, hjb_solver: HJBFDM
     grid_shape = tuple(problem.geometry.get_grid_shape())
     M0 = problem.get_m_init()
     M = np.tile(M0, (Nt, 1))
-    U_terminal = problem.get_u_fin()
+    U_terminal = problem.get_u_terminal()
     U_prev = np.zeros((Nt, *grid_shape))
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/tests/integration/test_graph_mfg_solver.py
+++ b/tests/integration/test_graph_mfg_solver.py
@@ -19,6 +19,8 @@ from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_node_problem(coupling_strength: float = 1.0, sigma: float = 0.3) -> MFGProblem:
@@ -34,9 +36,9 @@ def _make_node_problem(coupling_strength: float = 1.0, sigma: float = 0.3) -> MF
         m_initial=lambda x: 1.0,
     )
     return MFGProblem(
-        Nx=21,
-        xmin=0.0,
-        xmax=1.0,
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[21 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=0.5,
         Nt=10,
         sigma=sigma,
@@ -262,9 +264,9 @@ class TestIssue1006Regression:
         # Node 1: T=1.0, Nt=10 -> dt=0.1 (different!)
         H = p_ok.components.hamiltonian
         p_bad = MFGProblem(
-            Nx=21,
-            xmin=0.0,
-            xmax=1.0,
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[21 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             T=1.0,
             Nt=10,
             sigma=0.3,

--- a/tests/integration/test_interaction_lions_bridge.py
+++ b/tests/integration/test_interaction_lions_bridge.py
@@ -37,6 +37,8 @@ from mfgarchon.operators.interaction import (
     QuadraticInteractionEnergy,
 )
 from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 class TestGate3LionsBridgeEquivalence:
@@ -129,7 +131,15 @@ def _ring_problem(grid_only=False, amp=5.0, length_scale=0.15, bowl=4.0):
         return np.exp(-((xx - 0.5) ** 2) / (2 * 0.12**2))
 
     components = MFGComponents(hamiltonian=H, u_terminal=lambda xx: 0.0, m_initial=m_initial)
-    problem = MFGProblem(Nx=21, xmin=0.0, xmax=1.0, T=0.5, Nt=4, sigma=0.2, components=components)
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[21 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.5,
+        Nt=4,
+        sigma=0.2,
+        components=components,
+    )
     g = problem.geometry.get_spatial_grid().ravel()
     dx = g[1] - g[0]
     potential = PotentialEnergy(bowl * (g - 0.5) ** 2)  # attractive bowl (cost away from centre)

--- a/tests/integration/test_lions_correction.py
+++ b/tests/integration/test_lions_correction.py
@@ -20,6 +20,8 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_problem(Nx: int = 51, source_term_hjb=None) -> MFGProblem:
@@ -35,9 +37,9 @@ def _make_problem(Nx: int = 51, source_term_hjb=None) -> MFGProblem:
         m_initial=lambda x: 1.0,
     )
     return MFGProblem(
-        Nx=Nx,
-        xmin=0.0,
-        xmax=1.0,
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=0.5,
         Nt=10,
         sigma=0.3,

--- a/tests/integration/test_multi_population_cross_coupling.py
+++ b/tests/integration/test_multi_population_cross_coupling.py
@@ -29,6 +29,8 @@ from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.multi_population import MultiPopulationProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 _NX, _NT, _T, _SIG = 20, 8, 1.0, 0.15
 
@@ -58,7 +60,15 @@ def _make_problem(k, cross, K):
         u_terminal=lambda xx: np.asarray(xx) * 0.0,
         hamiltonian=H,
     )
-    return MFGProblem(Nx=[_NX], Nt=_NT, T=_T, sigma=_SIG, components=comps)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[_NX + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=_NT,
+        T=_T,
+        sigma=_SIG,
+        components=comps,
+    )
 
 
 def _solve(K, cross, max_iterations=6):

--- a/tests/integration/test_particle_collocation_mfg.py
+++ b/tests/integration/test_particle_collocation_mfg.py
@@ -23,6 +23,8 @@ from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 from mfgarchon.geometry.implicit import Hyperrectangle
 
 
@@ -54,14 +56,13 @@ class SimpleLQMFG2D(MFGProblem):
 
     def __init__(self):
         super().__init__(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[31], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             T=1.0,
             Nt=20,
-            Nx=30,
-            Lx=1.0,
-            xmin=0.0,
             sigma=0.2,
             coupling_coefficient=0.5,
-            dimension=2,
             components=_default_components_2d(),
         )
         # GFDM solver expects problem.d for spatial dimension

--- a/tests/integration/test_phase1_5_validation.py
+++ b/tests/integration/test_phase1_5_validation.py
@@ -20,6 +20,8 @@ from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -42,7 +44,15 @@ def _make_lq_problem(coupling_coeff: float = 1.0, sigma: float = 0.1) -> MFGProb
         u_terminal=lambda x: 0.0,
         hamiltonian=hamiltonian,
     )
-    return MFGProblem(Nx=[NX], Nt=NT, T=T, sigma=sigma, components=components)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[NX + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=NT,
+        T=T,
+        sigma=sigma,
+        components=components,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_source_term_wiring.py
+++ b/tests/integration/test_source_term_wiring.py
@@ -16,6 +16,8 @@ import numpy as np
 from mfgarchon import MFGProblem
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_problem(**extra_kwargs):
@@ -31,7 +33,9 @@ def _make_problem(**extra_kwargs):
         hamiltonian=hamiltonian,
     )
     return MFGProblem(
-        Nx=[30],
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[30 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         Nt=10,
         T=1.0,
         components=components,
@@ -154,7 +158,14 @@ def _make_parity_problem(**extra):
         u_terminal=lambda x: 0.0,
         hamiltonian=hamiltonian,
     )
-    return MFGProblem(Nx=[8], Nt=4, T=0.15, sigma=0.4, components=components, **extra)
+    return MFGProblem(
+        geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[8 + 1], boundary_conditions=no_flux_bc(dimension=1)),
+        Nt=4,
+        T=0.15,
+        sigma=0.4,
+        components=components,
+        **extra,
+    )
 
 
 def _solve_picard(problem):

--- a/tests/integration/test_three_mode_api.py
+++ b/tests/integration/test_three_mode_api.py
@@ -14,6 +14,8 @@ from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.types import NumericalScheme
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _default_hamiltonian():
@@ -39,7 +41,14 @@ class TestSafeMode:
 
     def test_safe_mode_fdm_upwind(self):
         """Test Safe Mode with FDM_UPWIND scheme."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Safe Mode: Specify scheme
         result = problem.solve(
@@ -55,7 +64,14 @@ class TestSafeMode:
 
     def test_safe_mode_fdm_centered(self):
         """Test Safe Mode with FDM_CENTERED scheme."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         result = problem.solve(
             scheme=NumericalScheme.FDM_CENTERED,
@@ -70,7 +86,14 @@ class TestSafeMode:
     @pytest.mark.skip(reason="Pre-existing bug in SL solver (NaN/Inf issue), unrelated to #580")
     def test_safe_mode_sl_linear(self):
         """Test Safe Mode with SL_LINEAR scheme."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         result = problem.solve(
             scheme=NumericalScheme.SL_LINEAR,
@@ -84,7 +107,14 @@ class TestSafeMode:
 
     def test_safe_mode_string_scheme(self):
         """Test Safe Mode with string scheme name."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Should accept string and convert to enum
         result = problem.solve(
@@ -97,7 +127,14 @@ class TestSafeMode:
 
     def test_safe_mode_invalid_string_scheme(self):
         """Test Safe Mode with invalid string scheme."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         with pytest.raises(ValueError, match="Unknown scheme string"):
             problem.solve(scheme="invalid_scheme", max_iterations=5, verbose=False)
@@ -108,7 +145,14 @@ class TestExpertMode:
 
     def test_expert_mode_matching_fdm_solvers(self):
         """Test Expert Mode with matching FDM solvers."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Create matching FDM solvers
         hjb = HJBFDMSolver(problem)
@@ -130,7 +174,14 @@ class TestExpertMode:
         """Test Expert Mode with mismatched solvers emits warning."""
         from mfgarchon.alg.numerical.fp_solvers import FPSLSolver
 
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Create mismatched solvers (FDM HJB with SL FP)
         # These have compatible grids but different scheme families
@@ -157,7 +208,14 @@ class TestExpertMode:
 
     def test_expert_mode_partial_injection_raises_error(self):
         """Test Expert Mode with only one solver raises error."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb = HJBFDMSolver(problem)
 
@@ -176,7 +234,14 @@ class TestAutoMode:
 
     def test_auto_mode_default_behavior(self):
         """Test Auto Mode selects default scheme."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Auto Mode: No scheme or solvers specified
         result = problem.solve(max_iterations=5, verbose=False)
@@ -195,7 +260,14 @@ class TestAutoMode:
         logger = get_logger("mfgarchon.core.mfg_problem")
         logger.setLevel(logging.INFO)
 
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         with caplog.at_level(logging.INFO, logger="mfgarchon.core.mfg_problem"):
             result = problem.solve(max_iterations=5, verbose=True)
@@ -218,7 +290,14 @@ class TestModeMixingErrors:
 
     def test_safe_and_expert_mode_mixing_raises_error(self):
         """Test that specifying both scheme and solvers raises error."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb = HJBFDMSolver(problem)
         fp = FPFDMSolver(problem)
@@ -234,7 +313,14 @@ class TestModeMixingErrors:
 
     def test_safe_mode_with_partial_expert_raises_error(self):
         """Test that specifying scheme with one solver raises error."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb = HJBFDMSolver(problem)
 
@@ -252,7 +338,14 @@ class TestBackwardCompatibility:
 
     def test_basic_solve_still_works(self):
         """Test that problem.solve() without parameters still works."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Old pattern: Just call solve()
         result = problem.solve(max_iterations=5, verbose=False)
@@ -263,7 +356,14 @@ class TestBackwardCompatibility:
 
     def test_solve_with_tolerance_and_iterations(self):
         """Test that specifying tolerance and iterations still works."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         result = problem.solve(
             max_iterations=10,
@@ -282,7 +382,14 @@ class TestConfigIntegration:
         """Test Safe Mode with custom config."""
         from mfgarchon.config import MFGSolverConfig
 
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
         config = MFGSolverConfig()
         config.picard.max_iterations = 3
 
@@ -299,7 +406,14 @@ class TestConfigIntegration:
         """Test Expert Mode with custom config."""
         from mfgarchon.config import MFGSolverConfig
 
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
         config = MFGSolverConfig()
 
         hjb = HJBFDMSolver(problem)
@@ -320,7 +434,14 @@ if __name__ == "__main__":
     print("Running three-mode API integration tests...")
 
     # Test Safe Mode
-    problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=10,
+        T=1.0,
+        components=_default_components(),
+    )
     result = problem.solve(scheme=NumericalScheme.FDM_UPWIND, max_iterations=3, verbose=False)
     assert result is not None
     print("✓ Safe Mode works")

--- a/tests/unit/test_alg/test_block_iterators_relaxation_alias.py
+++ b/tests/unit/test_alg/test_block_iterators_relaxation_alias.py
@@ -27,6 +27,8 @@ from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_test_problem():
@@ -40,7 +42,15 @@ def _make_test_problem():
         u_terminal=lambda x: 0.0,
         m_initial=lambda x: 1.0,
     )
-    return MFGProblem(Nx=11, xmin=0.0, xmax=1.0, T=0.2, Nt=5, sigma=0.3, components=components)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[11 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.2,
+        Nt=5,
+        sigma=0.3,
+        components=components,
+    )
 
 
 @pytest.fixture

--- a/tests/unit/test_alg/test_fixed_point_iterator_relaxation_alias.py
+++ b/tests/unit/test_alg/test_fixed_point_iterator_relaxation_alias.py
@@ -24,6 +24,8 @@ from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_test_problem():
@@ -38,7 +40,15 @@ def _make_test_problem():
         u_terminal=lambda x: 0.0,
         m_initial=lambda x: 1.0,
     )
-    return MFGProblem(Nx=11, xmin=0.0, xmax=1.0, T=0.2, Nt=5, sigma=0.3, components=components)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[11 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.2,
+        Nt=5,
+        sigma=0.3,
+        components=components,
+    )
 
 
 @pytest.fixture

--- a/tests/unit/test_alg/test_fixed_point_sigma_consistency.py
+++ b/tests/unit/test_alg/test_fixed_point_sigma_consistency.py
@@ -21,6 +21,8 @@ from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_problem(sigma=0.3):
@@ -34,7 +36,15 @@ def _make_problem(sigma=0.3):
         u_terminal=lambda x: 0.0,
         m_initial=lambda x: 1.0,
     )
-    return MFGProblem(Nx=11, xmin=0.0, xmax=1.0, T=0.2, Nt=5, sigma=sigma, components=components)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[11 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.2,
+        Nt=5,
+        sigma=sigma,
+        components=components,
+    )
 
 
 def test_warns_on_scalar_mismatch():

--- a/tests/unit/test_alg/test_fp_particle.py
+++ b/tests/unit/test_alg/test_fp_particle.py
@@ -14,6 +14,8 @@ from mfgarchon.alg.numerical.fp_solvers import FPParticleSolver, KDENormalizatio
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _default_hamiltonian():
@@ -53,14 +55,13 @@ class Simple2DMFGProblem(MFGProblem):
 
     def __init__(self):
         super().__init__(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             T=1.0,
             Nt=10,
-            Nx=20,
-            Lx=1.0,
-            xmin=0.0,
             sigma=0.1,
             coupling_coefficient=0.5,
-            dimension=2,
             components=_default_components_2d(),
         )
 

--- a/tests/unit/test_alg/test_fpi_nonlocal_hjb_source.py
+++ b/tests/unit/test_alg/test_fpi_nonlocal_hjb_source.py
@@ -19,6 +19,8 @@ from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_problem_with_nonlocal(Nx: int = 5, Nt: int = 3) -> MFGProblem:
@@ -36,9 +38,9 @@ def _make_problem_with_nonlocal(Nx: int = 5, Nt: int = 3) -> MFGProblem:
     # nonlocal_operator: 2*I (applied to v_t it returns 2*v_t)
     nonlocal_op = 2.0 * np.eye(Nx)
     return MFGProblem(
-        Nx=Nx,
-        xmin=0.0,
-        xmax=1.0,
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
         T=0.3,
         Nt=Nt,
         sigma=0.2,

--- a/tests/unit/test_alg/test_hjb_fdm_fp_solver_relaxation_alias.py
+++ b/tests/unit/test_alg/test_hjb_fdm_fp_solver_relaxation_alias.py
@@ -19,6 +19,8 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.utils.numerical.nonlinear_solvers import FixedPointSolver
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_problem():
@@ -32,7 +34,15 @@ def _make_problem():
         u_terminal=lambda x: 0.0,
         m_initial=lambda x: 1.0,
     )
-    return MFGProblem(Nx=11, xmin=0.0, xmax=1.0, T=0.2, Nt=5, sigma=0.3, components=c)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[11 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.2,
+        Nt=5,
+        sigma=0.3,
+        components=c,
+    )
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
+++ b/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
@@ -25,13 +25,15 @@ import numpy as np
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 # ---------------------------------------------------------------------------
 # Minimal problem factory (small/short/weakly coupled: keeps the FD-Jacobian
 # Newton solve in the physical basin and fast).
 # ---------------------------------------------------------------------------
 
-_NX = 5  # MFGProblem(Nx=5) -> 6 grid points
+_NX = 5  # Nx=5 intervals -> 6 grid points
 _NT = 3
 _GRID = _NX + 1
 
@@ -50,7 +52,16 @@ def _components() -> MFGComponents:
 
 
 def _make(**extra) -> MFGProblem:
-    return MFGProblem(Nx=_NX, xmin=0.0, xmax=1.0, T=0.15, Nt=_NT, sigma=0.3, components=_components(), **extra)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[_NX + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.15,
+        Nt=_NT,
+        sigma=0.3,
+        components=_components(),
+        **extra,
+    )
 
 
 def _make_plain_problem() -> MFGProblem:

--- a/tests/unit/test_alg/test_issue1361_source_composition.py
+++ b/tests/unit/test_alg/test_issue1361_source_composition.py
@@ -29,8 +29,10 @@ from mfgarchon.alg.numerical.coupling.source_composition import (
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
-_NX = 6  # MFGProblem(Nx=[6]) -> 7 grid points
+_NX = 6  # Nx=6 intervals -> 7 grid points
 _NT = 4
 
 
@@ -85,7 +87,16 @@ def _ref_compose_fp_source(problem, m_current, v_current):
 def _make_problem(**extra) -> MFGProblem:
     H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
     comp = MFGComponents(hamiltonian=H, u_terminal=lambda x: 0.0, m_initial=lambda x: 1.0)
-    return MFGProblem(Nx=[_NX], xmin=0.0, xmax=1.0, T=0.4, Nt=_NT, sigma=0.3, components=comp, **extra)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[_NX + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.4,
+        Nt=_NT,
+        sigma=0.3,
+        components=comp,
+        **extra,
+    )
 
 
 def _grid_size(problem) -> int:

--- a/tests/unit/test_alg/test_penalty_hjb_solver.py
+++ b/tests/unit/test_alg/test_penalty_hjb_solver.py
@@ -12,6 +12,8 @@ from mfgarchon.alg.numerical.hjb_solvers.hjb_penalty import PenaltyHJBSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_problem(Nx: int = 51, Nt: int = 20, sigma: float = 0.3) -> MFGProblem:
@@ -26,7 +28,15 @@ def _make_problem(Nx: int = 51, Nt: int = 20, sigma: float = 0.3) -> MFGProblem:
         u_terminal=lambda x: 0.0,
         m_initial=lambda x: 1.0,
     )
-    return MFGProblem(Nx=Nx, xmin=0.0, xmax=1.0, T=1.0, Nt=Nt, sigma=sigma, components=components)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=1.0,
+        Nt=Nt,
+        sigma=sigma,
+        components=components,
+    )
 
 
 def _make_solver_inputs(problem: MFGProblem):

--- a/tests/unit/test_alg/test_regime_switching_iterator.py
+++ b/tests/unit/test_alg/test_regime_switching_iterator.py
@@ -19,6 +19,8 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.core.regime_switching import RegimeSwitchingConfig
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _make_problem(coupling_strength: float = 1.0, sigma: float = 0.3) -> MFGProblem:
@@ -33,7 +35,15 @@ def _make_problem(coupling_strength: float = 1.0, sigma: float = 0.3) -> MFGProb
         u_terminal=lambda x: 0.0,
         m_initial=lambda x: 1.0,
     )
-    return MFGProblem(Nx=31, xmin=0.0, xmax=1.0, T=0.5, Nt=10, sigma=sigma, components=components)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[31 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        T=0.5,
+        Nt=10,
+        sigma=sigma,
+        components=components,
+    )
 
 
 def _make_2regime_system():

--- a/tests/unit/test_config/test_config_translator.py
+++ b/tests/unit/test_config/test_config_translator.py
@@ -34,6 +34,8 @@ from mfgarchon.config import (
 )
 from mfgarchon.config.mfg_methods import FDMConfig
 from mfgarchon.types import NumericalScheme
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -56,7 +58,14 @@ def _tiny_problem():
         m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
         u_terminal=lambda x: 0.0,
     )
-    return MFGProblem(Nx=[10], Nt=5, T=0.1, components=components)
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[10 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=5,
+        T=0.1,
+        components=components,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_core/test_unified_mfg_problem.py
+++ b/tests/unit/test_core/test_unified_mfg_problem.py
@@ -67,7 +67,15 @@ class TestLegacy1DMode:
 
     def test_basic_1d_problem(self):
         """Test basic 1D problem creation."""
-        problem = MFGProblem(xmin=0, xmax=1, Nx=100, T=1.0, Nt=50, sigma=0.1, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0, 1)], Nx_points=[100 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            T=1.0,
+            Nt=50,
+            sigma=0.1,
+            components=_default_components(),
+        )
 
         assert problem.dimension == 1
         assert problem.domain_type == "grid"
@@ -83,7 +91,15 @@ class TestLegacy1DMode:
         """Test 1D problem with Lx parameter (alternative to xmin/xmax)."""
         # Note: Lx alias is specified in design but not yet implemented
         # For now, test the standard xmin/xmax interface
-        problem = MFGProblem(xmin=0, xmax=2.0, Nx=100, T=1.0, Nt=50, sigma=0.1, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0, 2.0)], Nx_points=[100 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            T=1.0,
+            Nt=50,
+            sigma=0.1,
+            components=_default_components(),
+        )
 
         assert problem.dimension == 1
         bounds = problem.geometry.get_bounds()
@@ -93,7 +109,15 @@ class TestLegacy1DMode:
 
     def test_1d_solver_compatibility(self):
         """Test solver compatibility for 1D problems."""
-        problem = MFGProblem(xmin=0, xmax=1, Nx=100, T=1.0, Nt=50, sigma=0.1, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0, 1)], Nx_points=[100 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            T=1.0,
+            Nt=50,
+            sigma=0.1,
+            components=_default_components(),
+        )
 
         assert "fdm" in problem.solver_compatible
         assert "semi_lagrangian" in problem.solver_compatible

--- a/tests/unit/test_factory/test_scheme_factory.py
+++ b/tests/unit/test_factory/test_scheme_factory.py
@@ -17,6 +17,8 @@ from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.factory import create_paired_solvers, get_recommended_scheme
 from mfgarchon.types import NumericalScheme
 from mfgarchon.utils import DualityStatus, check_solver_duality
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _default_hamiltonian():
@@ -42,7 +44,14 @@ class TestCreatePairedSolversFDM:
 
     def test_fdm_upwind_creates_dual_pair(self):
         """Test that FDM_UPWIND creates valid dual pair."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
 
@@ -65,7 +74,14 @@ class TestCreatePairedSolversFDM:
         Note: Changed from gradient_upwind to divergence_upwind in Issue #382
         because gradient_upwind has boundary flux bugs.
         """
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         _, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
 
@@ -75,7 +91,14 @@ class TestCreatePairedSolversFDM:
 
     def test_fdm_centered_creates_dual_pair(self):
         """Test that FDM_CENTERED creates valid dual pair."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb, fp = create_paired_solvers(problem, NumericalScheme.FDM_CENTERED)
 
@@ -92,7 +115,14 @@ class TestCreatePairedSolversFDM:
 
     def test_fdm_custom_config(self):
         """Test FDM pairing with custom configs."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Override FP advection scheme
         _, fp = create_paired_solvers(
@@ -110,7 +140,14 @@ class TestCreatePairedSolversSL:
 
     def test_sl_linear_creates_dual_pair(self):
         """Test that SL_LINEAR creates valid dual pair."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb, fp = create_paired_solvers(problem, NumericalScheme.SL_LINEAR)
 
@@ -129,7 +166,14 @@ class TestCreatePairedSolversSL:
 
     def test_sl_linear_default_interpolation(self):
         """Test that SL_LINEAR sets linear interpolation for HJB."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb, _ = create_paired_solvers(problem, NumericalScheme.SL_LINEAR)
 
@@ -138,7 +182,14 @@ class TestCreatePairedSolversSL:
 
     def test_sl_cubic_creates_dual_pair(self):
         """Test that SL_CUBIC creates valid dual pair."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb, fp = create_paired_solvers(problem, NumericalScheme.SL_CUBIC)
 
@@ -154,7 +205,14 @@ class TestCreatePairedSolversSL:
 
     def test_sl_uses_adjoint_solver_not_backward(self):
         """Test that SL pairing uses FPSLSolver (forward SL) for duality."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         _, fp = create_paired_solvers(problem, NumericalScheme.SL_LINEAR)
 
@@ -170,7 +228,14 @@ class TestCreatePairedSolversGFDM:
 
     def test_gfdm_creates_dual_pair(self):
         """Test that GFDM creates valid dual pair."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # GFDM requires collocation points
         points = np.linspace(0, 1, 15)[:, None]  # 1D points
@@ -198,7 +263,14 @@ class TestCreatePairedSolversGFDM:
 
     def test_gfdm_delta_threading(self):
         """Test that delta parameter is threaded between HJB and FP."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
         points = np.linspace(0, 1, 15)[:, None]
 
         # Specify delta only for HJB
@@ -215,7 +287,14 @@ class TestCreatePairedSolversGFDM:
 
     def test_gfdm_collocation_threading(self):
         """Test that collocation_points are threaded if specified for one solver."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
         points = np.linspace(0, 1, 15)[:, None]
 
         # Specify points only for HJB
@@ -234,7 +313,14 @@ class TestCreatePairedSolversValidation:
 
     def test_validation_enabled_by_default(self):
         """Test that duality validation is enabled by default."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Should not raise (FDM is valid)
         hjb, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
@@ -244,7 +330,14 @@ class TestCreatePairedSolversValidation:
 
     def test_validation_can_be_disabled(self):
         """Test that validation can be disabled with validate_duality=False."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Should work even with validation disabled
         hjb, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND, validate_duality=False)
@@ -254,7 +347,14 @@ class TestCreatePairedSolversValidation:
 
     def test_unimplemented_scheme_raises_error(self):
         """Test that unimplemented schemes raise NotImplementedError."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # SL_CUBIC is defined but cubic FP adjoint not implemented
         # For now it creates the pair but with a note in docstring
@@ -271,7 +371,14 @@ class TestCreatePairedSolversValidation:
         to fall through to the else branch, then assert the message advertises all routed
         schemes (regression guard: SL_CUBIC and MESHLESS_GALERKIN were previously omitted).
         """
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         class _FakeScheme:
             value = "not_a_real_scheme"
@@ -289,7 +396,14 @@ class TestGetRecommendedScheme:
 
     def test_returns_fdm_upwind_by_default(self):
         """Test that default recommendation is FDM_UPWIND."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         scheme = get_recommended_scheme(problem)
 
@@ -301,7 +415,14 @@ class TestConfigThreading:
 
     def test_hjb_config_passed_to_hjb_solver(self):
         """Test that hjb_config parameters are passed through."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Verify solver was created with empty config (config passing tested in other tests)
         hjb, _ = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND, hjb_config={})
@@ -311,7 +432,14 @@ class TestConfigThreading:
 
     def test_fp_config_passed_to_fp_solver(self):
         """Test that fp_config parameters are passed through."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         _, fp = create_paired_solvers(
             problem,
@@ -323,7 +451,14 @@ class TestConfigThreading:
 
     def test_empty_configs_use_defaults(self):
         """Test that omitting configs uses solver defaults."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
 
@@ -337,7 +472,14 @@ class TestReturnTypes:
 
     def test_returns_tuple_of_two_solvers(self):
         """Test that function always returns (hjb, fp) tuple."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         result = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
 
@@ -350,7 +492,14 @@ class TestReturnTypes:
 
     def test_hjb_has_scheme_family_trait(self):
         """Test that returned HJB solver has _scheme_family trait."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         hjb, _ = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
 
@@ -359,7 +508,14 @@ class TestReturnTypes:
 
     def test_fp_has_scheme_family_trait(self):
         """Test that returned FP solver has _scheme_family trait."""
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         _, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
 
@@ -371,7 +527,14 @@ if __name__ == "__main__":
     # Smoke test - run basic checks
     print("Running scheme factory smoke tests...")
 
-    problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=10,
+        T=1.0,
+        components=_default_components(),
+    )
 
     # Test FDM pairing
     hjb, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)

--- a/tests/unit/test_removed_tier3_deprecations.py
+++ b/tests/unit/test_removed_tier3_deprecations.py
@@ -1,0 +1,103 @@
+"""Removed-deprecation pins for the Tier-3b / Tier-3c legacy 1D-geometry families.
+
+Issue #1363 finishes the geometry-first migration that #1360 (Tier-3a, removed the
+``xmin/xmax/Nx/Lx/dx/xSpace/_grid`` read-properties) began. This file pins the
+removal of the remaining write/construct surfaces on ``MFGProblem``:
+
+- **Tier-3b** -- constructor kwargs ``xmin`` / ``xmax`` / ``Nx`` / ``Lx``
+  (deprecated since v0.17.1) and the ``_init_1d_legacy`` / ``_init_nd`` grid
+  construction methods (deprecated since v0.17.0).
+- **Tier-3c** -- the ``get_u_final`` / ``get_u_fin`` aliases (deprecated since
+  v0.17.6).
+
+Note on the kwarg pins: unlike Tier-1 (which removed *named* parameters and so
+fails with ``TypeError: unexpected keyword argument``), ``MFGProblem.__init__``
+accepts ``**kwargs``. The removed names would otherwise be silently swallowed, so
+they are registered in ``_DEPRECATED_KWARGS`` and surface as a loud
+``ValueError`` pointing at the geometry-first API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _components() -> MFGComponents:
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    return MFGComponents(hamiltonian=H, u_terminal=lambda x: 0.0, m_initial=lambda x: 1.0)
+
+
+def _geometry() -> TensorProductGrid:
+    return TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+
+
+class TestLegacy1DConstructorKwargsRemoved:
+    """``xmin`` / ``xmax`` / ``Nx`` / ``Lx`` are gone; use ``geometry=`` instead."""
+
+    @pytest.mark.parametrize("kwarg", ["xmin", "xmax", "Nx", "Lx"])
+    def test_kwarg_raises_value_error(self, kwarg):
+        with pytest.raises(ValueError) as excinfo:
+            MFGProblem(T=1.0, Nt=10, components=_components(), **{kwarg: 1.0 if kwarg != "Nx" else 10})
+        msg = str(excinfo.value)
+        assert kwarg in msg
+        # The error must point at the geometry-first replacement, not the
+        # Hamiltonian-kwargs guide.
+        assert "GEOMETRY_FIRST_API_GUIDE" in msg
+        assert "TensorProductGrid" in msg
+
+    def test_full_legacy_signature_raises(self):
+        with pytest.raises(ValueError, match="GEOMETRY_FIRST_API_GUIDE"):
+            MFGProblem(xmin=0.0, xmax=1.0, Nx=50, T=1.0, Nt=10, sigma=0.1, components=_components())
+
+    def test_geometry_first_replacement_still_works(self):
+        problem = MFGProblem(geometry=_geometry(), T=1.0, Nt=10, sigma=0.1, components=_components())
+        assert problem.dimension == 1
+        # Nx=10 intervals -> 11 grid points
+        assert problem.geometry.num_spatial_points == 11
+
+
+class TestLegacyGridConstructionMethodsRemoved:
+    """``_init_1d_legacy`` / ``_init_nd`` are gone (manual grid construction)."""
+
+    @pytest.mark.parametrize("method", ["_init_1d_legacy", "_init_nd", "_normalize_to_array"])
+    def test_method_removed(self, method):
+        assert not hasattr(MFGProblem, method)
+
+    def test_replacement_helper_present(self):
+        # The non-deprecated replacement that the default / spatial_bounds paths use.
+        assert hasattr(MFGProblem, "_init_grid")
+
+    def test_spatial_bounds_path_still_constructs(self):
+        problem = MFGProblem(
+            spatial_bounds=[(0.0, 1.0), (0.0, 1.0)],
+            spatial_discretization=[20, 20],
+            T=1.0,
+            Nt=10,
+            components=_components(),
+        )
+        assert problem.dimension == 2
+        # spatial_discretization preserves interval semantics (Nx, not Nx + 1)
+        assert problem.spatial_discretization == [20, 20]
+
+
+class TestUFinalAliasesRemoved:
+    """``get_u_final`` / ``get_u_fin`` are gone; only ``get_u_terminal`` remains."""
+
+    @pytest.fixture
+    def problem(self):
+        return MFGProblem(geometry=_geometry(), T=1.0, Nt=10, sigma=0.1, components=_components())
+
+    @pytest.mark.parametrize("alias", ["get_u_final", "get_u_fin"])
+    def test_alias_removed(self, problem, alias):
+        assert not hasattr(problem, alias)
+        with pytest.raises(AttributeError):
+            getattr(problem, alias)()
+
+    def test_get_u_terminal_still_works(self, problem):
+        assert problem.get_u_terminal() is not None

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -34,6 +34,8 @@ from mfgarchon import MFGProblem
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.types import NumericalScheme
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 def _default_hamiltonian():
@@ -62,7 +64,9 @@ class TestDualityConvergence:
         """Test that FDM dual pair achieves good convergence."""
         # Create problem with known solution characteristics
         problem = MFGProblem(
-            Nx=[40],
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             Nt=20,
             T=1.0,
             sigma=0.1,
@@ -94,7 +98,9 @@ class TestDualityConvergence:
         """Test that FDM_CENTERED achieves second-order convergence."""
         # Centered differences are O(h^2) in space
         problem = MFGProblem(
-            Nx=[40],
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             Nt=20,
             T=1.0,
             sigma=0.1,
@@ -119,8 +125,10 @@ class TestDualityConvergence:
 
         for Nx in mesh_sizes:
             problem = MFGProblem(
-                Nx=[Nx],
-                Nt=Nx // 2,  # Keep CFL condition reasonable
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                Nt=Nx // 2,
                 T=1.0,
                 sigma=0.1,
                 components=_default_components(),
@@ -152,7 +160,14 @@ class TestDualityConvergence:
         from mfgarchon.factory import create_paired_solvers
         from mfgarchon.utils import check_solver_duality
 
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Create pair via Safe Mode factory
         hjb, fp = create_paired_solvers(
@@ -172,7 +187,14 @@ class TestDualityConvergence:
         from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
         from mfgarchon.utils import check_solver_duality
 
-        problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
+            Nt=10,
+            T=1.0,
+            components=_default_components(),
+        )
 
         # Create dual pair
         hjb_fdm = HJBFDMSolver(problem)
@@ -204,8 +226,10 @@ class TestConvergenceRate:
 
         for Nx in mesh_sizes:
             problem = MFGProblem(
-                Nx=[Nx],
-                Nt=Nx,  # Match time steps to space steps
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
+                ),
+                Nt=Nx,
                 T=1.0,
                 sigma=0.1,
                 components=_default_components(),
@@ -238,7 +262,9 @@ class TestNumericalStability:
     def test_fdm_upwind_stable(self):
         """Test that upwind FDM is stable (monotone)."""
         problem = MFGProblem(
-            Nx=[40],
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             Nt=20,
             T=1.0,
             sigma=0.1,
@@ -261,7 +287,9 @@ class TestNumericalStability:
     def test_centered_fdm_may_oscillate(self):
         """Test that centered FDM runs (may have mild oscillations)."""
         problem = MFGProblem(
-            Nx=[40],
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
+            ),
             Nt=20,
             T=1.0,
             sigma=0.1,
@@ -288,7 +316,14 @@ if __name__ == "__main__":
 
     # Test 1: Verify dual pairing
     print("Test 1: Safe Mode duality guarantee")
-    problem = MFGProblem(Nx=[20], Nt=10, T=1.0, components=_default_components())
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[20 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=10,
+        T=1.0,
+        components=_default_components(),
+    )
     hjb, fp = create_paired_solvers(problem, NumericalScheme.FDM_UPWIND)
     result = check_solver_duality(hjb, fp)
     assert result.is_valid_pairing()
@@ -298,7 +333,15 @@ if __name__ == "__main__":
 
     # Test 2: Verify convergence
     print("\nTest 2: Convergence with dual pair")
-    problem = MFGProblem(Nx=[40], Nt=20, T=1.0, sigma=0.1, components=_default_components())
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
+        ),
+        Nt=20,
+        T=1.0,
+        sigma=0.1,
+        components=_default_components(),
+    )
     solve_result = problem.solve(
         scheme=NumericalScheme.FDM_UPWIND,
         max_iterations=30,


### PR DESCRIPTION
Refs #1363

Finishes the geometry-first migration that #1360 (Tier-3a, read-properties) began. Removes the remaining deprecated write/construct surfaces on `MFGProblem` (all past the 3-minor-version window).

## Removed (BREAKING)
- **Tier-3b** — constructor kwargs `xmin=` / `xmax=` / `Nx=` / `Lx=` (deprecated v0.17.1): the 4 `@deprecated_parameter` decorators, the params, their normalization, the `1d_legacy` dispatch branch + mode-detection key, and the `@deprecated` `_init_1d_legacy` / `_init_nd` grid-construction methods (deprecated v0.17.0).
- **Tier-3c** — `get_u_final` / `get_u_fin` aliases (deprecated v0.17.6).

The still-supported `spatial_bounds=` (n-D grid) and no-argument default paths now build their `TensorProductGrid` via a new **non-deprecated** `_init_grid` helper (interval semantics for `spatial_discretization` preserved). `_normalize_to_array` (exclusively legacy-serving) was removed too.

## Removed-pins
`__init__` accepts `**kwargs`, so removed named params would be silently swallowed. `xmin/xmax/Nx/Lx` are registered in `_DEPRECATED_KWARGS` and now raise a clear **`ValueError`** pointing at the geometry-first API; removed methods/aliases raise **`AttributeError`**. Pinned in `tests/unit/test_removed_tier3_deprecations.py` (14 tests, mirrors the Tier-1 precedent).

## Migration (all call sites → geometry-first)
`MFGProblem(geometry=TensorProductGrid(bounds=[(xmin, xmax)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)), ...)` — **off-by-one**: `Nx` counts intervals, `Nx_points = Nx + 1`.

- 91 literal `MFGProblem(...)` constructions across 32 tests/examples/benchmarks files (AST-based transform; comments/strings/nested-helper false-positives correctly excluded).
- In-package builders: `general_mfg_factory` (dynamic `**kwargs` → translates `domain_config`), `variational_problem`, `stochastic_problem` + two test `MFGProblem` subclasses (`super().__init__`), `mathematical_dsl`.
- Docstring / error-message examples (`base_hjb`, `fp_gfdm`, `base_problem`, `solver_factory`, `fp_particle`, `mfg_problem`).
- The Picard / fictitious-play couplers now read terminal data via `get_u_terminal()` instead of the removed `get_u_fin()` alias — this **restores** the real terminal condition (a naive alias removal would have silently fallen back to `np.zeros`).

## Docs
Updated `docs/user/GEOMETRY_FIRST_API_GUIDE.md` (removal notes + off-by-one) and repointed the broken `docs/migration/GEOMETRY_PARAMETER_MIGRATION.md` docstring pointer to the user guide.

## Verification
- Grep-gate: zero `MFGProblem(xmin=|xmax=|Nx=|Lx=)` construction sites remain (excluding the removed-pin test + subclass own-param signatures).
- `python -c "import mfgarchon"` clean; `ruff check --select F` + `ruff format --check` clean (52 files).
- `tests/unit` (full): 4717 passed, 10 skipped, 2 xfailed, 0 failed. New Tier-3 pins: 14 passed. Migrated integration + validation: 108 passed. `test_mass_conservation_1d`: 8 passed. Coupled-Newton infra (`MFGResidual`/pack-unpack/no-warmup) passes; full-solve Newton tests are pre-existing >300s slow (unrelated, behavior-identical coupler path). One flaky timing perf test (`test_region_lookup_overhead`) passes in isolation (CPU-contention only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)