### PR TITLE
refactor(hamiltonian): single-source contract + base_hjb pilot (#1071 phase 1)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -7,8 +7,8 @@ import numpy as np
 import scipy.sparse as sparse
 
 from mfgarchon.alg.base_solver import BaseNumericalSolver, SchemeFamily
-from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
 from mfgarchon.backends.compat import backend_aware_assign, backend_aware_copy, has_nan_or_inf
+from mfgarchon.core.hamiltonian import HEvalState
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
@@ -705,8 +705,11 @@ def compute_hjb_residual(
         m_grid = np.asarray(M_density_at_n_plus_1, dtype=float)  # (Nx,)
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
 
-        # Single batch call — eliminates per-point problem.H() overhead
-        H_values = eval_H_batch(H_class, x_grid, m_grid, p_grid, current_time).ravel()
+        # Single batch call — eliminates per-point problem.H() overhead.
+        # Issue #1071: consume the single-source residual primitive (H only); the
+        # Jacobian below independently calls evaluate_dp (∂H/∂p only), so the
+        # residual never computes the drift gradient.
+        H_values = H_class.evaluate_H(HEvalState(x=x_grid, p=p_grid, m=m_grid, t=current_time)).ravel()
 
         # Mask: propagate NaN from existing Phi_U or from NaN gradients
         nan_mask = np.isnan(Phi_U) | np.isnan(precomputed_grad) | ~np.isfinite(H_values)
@@ -844,9 +847,11 @@ def compute_hjb_jacobian(
         m_grid = np.asarray(M_density_at_n_plus_1, dtype=float)  # (Nx,)
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
 
-        # Single batch call: dH/dp at all grid points
-        dH_dp = eval_dH_dp_batch(
-            H_class, x_grid, m_grid, p_grid, current_time
+        # Single batch call: dH/dp at all grid points.
+        # Issue #1071: consume the single-source Jacobian primitive (∂H/∂p only);
+        # this never recomputes the Hamiltonian value H.
+        dH_dp = H_class.evaluate_dp(
+            HEvalState(x=x_grid, p=p_grid, m=m_grid, t=current_time)
         ).ravel()  # (Nx,) — squeeze the 1D momentum dimension
 
         # Stencil coefficients: dp_i/dU_j depends on upwind direction

--- a/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
-
+from mfgarchon.core.hamiltonian import HEvalState
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
@@ -31,21 +30,25 @@ if TYPE_CHECKING:
 def eval_H_batch(H_class: HamiltonianBase, x: NDArray, m: NDArray, p: NDArray, t: float) -> NDArray:
     """Evaluate the Hamiltonian value ``H(x, m, p, t)`` over a batch of points.
 
-    Returns a float ``ndarray`` shaped as ``H_class`` returns it (callers ``.ravel()`` or
-    reshape as their assembly needs). Byte-identical to the inline
-    ``np.asarray(H_class(x, m, p, t=t), dtype=float)`` it replaces.
+    Thin shim over the single-source primitive ``H_class.evaluate_H`` (Issue #1071):
+    this is no longer a parallel implementation, it delegates to the method on the
+    Hamiltonian so the batch contract has exactly one home. Byte-identical to the
+    inline ``np.asarray(H_class(x, m, p, t=t), dtype=float)`` it replaced; callers
+    ``.ravel()`` / reshape as their assembly needs.
     """
-    return np.asarray(H_class(x, m, p, t=t), dtype=float)
+    return H_class.evaluate_H(HEvalState(x=x, p=p, m=m, t=t))
 
 
 def eval_dH_dp_batch(H_class: HamiltonianBase, x: NDArray, m: NDArray, p: NDArray, t: float) -> NDArray:
     """Evaluate the Hamiltonian gradient ``∂H/∂p(x, m, p, t)`` over a batch of points.
 
-    Returns a float ``ndarray`` as ``H_class.dp`` returns it. Callers keep their own sign
-    convention (the FP drift is ``alpha* = -∂H/∂p``, so several callers negate the result).
-    Byte-identical to the inline ``np.asarray(H_class.dp(x, m, p, t=t), dtype=float)``.
+    Thin shim over the single-source primitive ``H_class.evaluate_dp`` (Issue #1071);
+    delegates to the method on the Hamiltonian rather than re-implementing the batch
+    call. Callers keep their own sign convention (the FP drift is ``alpha* = -∂H/∂p``,
+    so several callers negate the result). Byte-identical to the inline
+    ``np.asarray(H_class.dp(x, m, p, t=t), dtype=float)``.
     """
-    return np.asarray(H_class.dp(x, m, p, t=t), dtype=float)
+    return H_class.evaluate_dp(HEvalState(x=x, p=p, m=m, t=t))
 
 
 def assemble_hjb_residual(

--- a/mfgarchon/core/__init__.py
+++ b/mfgarchon/core/__init__.py
@@ -25,7 +25,9 @@ from .hamiltonian import (
     DualLagrangian,
     # Full MFG Hamiltonian classes (Issue #673)
     HamiltonianBase,
-    HamiltonianState,
+    # Single-source contract (Issue #1071)
+    HamiltonianValues,
+    HEvalState,
     L1ControlCost,
     L1Hamiltonian,
     # Lagrangian classes (Issue #651)
@@ -36,6 +38,7 @@ from .hamiltonian import (
     QuadraticControlCost,
     QuadraticHamiltonian,
     QuadraticMFGHamiltonian,
+    Regularizer,
     SeparableHamiltonian,
     create_hamiltonian,
 )
@@ -81,7 +84,10 @@ __all__ = [
     "BoundedHamiltonian",
     # Full MFG Hamiltonian classes (Issue #673, #782)
     "HamiltonianBase",
-    "HamiltonianState",
+    # Single-source contract (Issue #1071)
+    "HEvalState",
+    "HamiltonianValues",
+    "Regularizer",
     "SeparableHamiltonian",
     "CongestionHamiltonian",
     "QuadraticMFGHamiltonian",

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 
@@ -719,33 +719,97 @@ class MFGOperatorBase(ABC):
 # ============================================================================
 
 
-@dataclass
-class HamiltonianState:
-    """
-    State container for Hamiltonian evaluation.
+@dataclass(frozen=True)
+class HEvalState:
+    """Pure evaluation state for the single-source Hamiltonian contract (Issue #1071).
 
-    Encapsulates all information needed to evaluate H(x, m, p, t).
-    This allows clean separation between state and computation.
+    The minimal batch state the Hamiltonian needs to produce ``H``, ``∂H/∂p``, and
+    ``∂H/∂m``. It carries physics inputs only — position, momentum, density, time —
+    and deliberately holds NO discretization concern (no ``dt``, ``u``, grid, or
+    boundary conditions); those stay solver-side. Single-point evaluation is the
+    ``N=1`` case.
+
+    Absorbs the former ``HamiltonianState`` (its ``x_idx`` grid-coupling field is
+    dropped — operator assembly is the solver's responsibility, not the
+    Hamiltonian's). Named ``HEvalState`` to avoid collision with the unrelated
+    ``types/solver_types.SolverState`` alias.
 
     Attributes
     ----------
     x : NDArray
-        Position(s), shape (d,) for single point or (N, d) for N points
-    m : float | NDArray
-        Density at x, scalar or array of shape (N,)
+        Position(s), shape ``(N, d)`` (or ``(d,)`` for a single point).
     p : NDArray
-        Momentum ∇u at x, shape (d,) or (N, d)
+        Momentum ``p = ∇u``, shape ``(N, d)``. Exposed as ``grad_u`` alias.
+    m : float | NDArray
+        Density, shape ``(N,)`` single-population or ``(K, N)`` stacked
+        multi-population.
     t : float
-        Time
-    x_idx : int | None
-        Grid index if on a grid (for grid-based methods)
+        Time (default ``0.0``).
     """
 
     x: NDArray
-    m: float | NDArray
     p: NDArray
+    m: float | NDArray
     t: float = 0.0
-    x_idx: int | None = None
+
+    @property
+    def grad_u(self) -> NDArray:
+        """Alias for ``p`` — the momentum is the value-function gradient ``∇u``."""
+        return self.p
+
+
+@dataclass(frozen=True)
+class HamiltonianValues:
+    """Bundled Hamiltonian outputs for the convenience ``evaluate()`` pass (Issue #1071).
+
+    Returned by :meth:`HamiltonianBase.evaluate` — a THIN convenience for explicit
+    solvers (WENO/SL Lax-Friedrichs speed) and the future JAX spec that want ``H``
+    and ``∂H/∂p`` (and σ) from one sweep. The implicit-Newton hot path does NOT use
+    this; it calls the granular :meth:`HamiltonianBase.evaluate_H` /
+    :meth:`HamiltonianBase.evaluate_dp` so the residual never computes ``∂H/∂p`` and
+    the Jacobian never recomputes ``H``.
+
+    ``∂H/∂m`` is deliberately NOT a field here — it is the separate
+    :meth:`HamiltonianBase.dH_dm` (FP-coupling only), kept off this struct so the
+    hot bundle stays a fixed-shape pytree.
+
+    Attributes
+    ----------
+    H : NDArray
+        Hamiltonian value, shape ``(N,)``.
+    dH_dp : NDArray
+        Momentum gradient ``∂H/∂p``, shape ``(N, d)``. Drift ``α* = -sign · ∂H/∂p``.
+    sigma : NDArray
+        PHYSICAL volatility σ, ALWAYS an array — shape ``(N,)`` (isotropic) or
+        ``(N, d, d)`` (anisotropic). This is σ, NOT the diffusion coefficient
+        ``D = σ²/2`` (folded at the stencil by ``diffusion_from_volatility``) and
+        NOT a numerical viscosity (LLF/SUPG live at the solver level, never here).
+    """
+
+    H: NDArray
+    dH_dp: NDArray
+    sigma: NDArray
+
+
+class Regularizer(Protocol):
+    """Physics-only Hamiltonian regularizer (Issue #1071 scaffold).
+
+    A value object that composes a *physical* regularization onto a Hamiltonian:
+    Moreau–Yosida control-cost smoothing, anisotropic volatility, congestion
+    mobility — terms whose strength ``epsilon`` vanishes on a chosen schedule, NOT
+    with the mesh. Numerical viscosity (Local Lax–Friedrichs #1059, SUPG, SBP-SAT)
+    is explicitly OUT of scope: it vanishes with the mesh, so it is a solver-level
+    mixin consuming ``∂H/∂p`` + ``h``, never a Hamiltonian-level regularizer.
+
+    Concrete regularizers land in later #1071 phases; this phase ships only the
+    protocol + :meth:`HamiltonianBase.with_regularizer` composition hook.
+    """
+
+    epsilon: float
+
+    def apply(self, h: HamiltonianBase) -> HamiltonianBase:
+        """Return a NEW Hamiltonian with this regularization composed on."""
+        ...
 
 
 class HamiltonianBase(MFGOperatorBase):
@@ -818,6 +882,90 @@ class HamiltonianBase(MFGOperatorBase):
     def is_lagrangian(self) -> bool:
         """Return False - this is not a Lagrangian operator."""
         return False
+
+    # === SINGLE-SOURCE CONTRACT (Issue #1071) ===
+
+    # Physical volatility σ for the convenience evaluate(); ``None`` until the
+    # σ-source unification (#1071 Phase 6) wires it from the problem/coefficient
+    # field. The implicit-Newton hot path does NOT use this — base_hjb resolves σ
+    # at timestep scope and passes it to the stencil. Set explicitly to call
+    # evaluate(). Class-level default keeps object shape stable.
+    physical_sigma: float | NDArray | None = None
+
+    def evaluate_H(self, state: HEvalState) -> NDArray:
+        """Hamiltonian value ``H`` over a batch (Issue #1071 granular primitive).
+
+        The single home for the batch ``H`` call that every HJB solver used to
+        inline as ``np.asarray(H_class(x, m, p, t=t), dtype=float)``. This is the
+        residual-path primitive: it computes ``H`` only and never touches
+        ``∂H/∂p``. Returns a float ``ndarray`` shaped as ``__call__`` returns it
+        (callers ``.ravel()`` / reshape as their assembly needs).
+        """
+        return np.asarray(self(state.x, state.m, state.p, t=state.t), dtype=float)
+
+    def evaluate_dp(self, state: HEvalState) -> NDArray:
+        """Momentum gradient ``∂H/∂p`` over a batch (Issue #1071 granular primitive).
+
+        The single home for the batch ``∂H/∂p`` call that HJB Jacobians used to
+        inline as ``np.asarray(H_class.dp(x, m, p, t=t), dtype=float)``. This is the
+        Jacobian-path primitive: it computes ``∂H/∂p`` only and never recomputes
+        ``H``. Callers keep their own sign convention (drift ``α* = -∂H/∂p``).
+        """
+        return np.asarray(self.dp(state.x, state.m, state.p, t=state.t), dtype=float)
+
+    def dH_dm(self, state: HEvalState) -> NDArray:
+        """Density derivative ``∂H/∂m`` over a batch (Issue #1071, FP-coupling only).
+
+        Separate from the residual/Jacobian primitives — the FP source term, not the
+        HJB hot path — so it stays off the :class:`HamiltonianValues` bundle.
+        """
+        return np.asarray(self.dm(state.x, state.m, state.p, t=state.t), dtype=float)
+
+    def evaluate(self, state: HEvalState) -> HamiltonianValues:
+        """Convenience: ``H``, ``∂H/∂p`` and physical σ in one bundle (Issue #1071).
+
+        THIN wrapper composing :meth:`evaluate_H` + :meth:`evaluate_dp` + the
+        physical volatility, for explicit solvers (WENO/SL Lax–Friedrichs speed) and
+        the future JAX spec. NOT used by the implicit-Newton hot path, which calls
+        the granular primitives so the residual never computes ``∂H/∂p`` and the
+        Jacobian never recomputes ``H``.
+        """
+        return HamiltonianValues(
+            H=self.evaluate_H(state),
+            dH_dp=self.evaluate_dp(state),
+            sigma=self._resolve_physical_sigma(state),
+        )
+
+    def _resolve_physical_sigma(self, state: HEvalState) -> NDArray:
+        """Resolve :attr:`physical_sigma` to a batch array for :meth:`evaluate`.
+
+        Fail-fast when σ has not been set: the σ-source unification (#1071 Phase 6)
+        will wire it from the problem; until then, callers of the convenience
+        ``evaluate()`` must set ``physical_sigma`` explicitly.
+        """
+        if self.physical_sigma is None:
+            raise ValueError(
+                "HamiltonianBase.evaluate() needs a physical volatility but "
+                "`physical_sigma` is None. Set it before calling evaluate(); the "
+                "σ-source unification (Issue #1071 Phase 6) will wire it from the "
+                "problem. The implicit-Newton hot path uses evaluate_H/evaluate_dp "
+                "and does not require this."
+            )
+        sig = np.asarray(self.physical_sigma, dtype=float)
+        if sig.ndim == 0:
+            n = int(np.asarray(state.x).shape[0])
+            return np.full(n, float(sig))
+        return sig
+
+    def with_regularizer(self, reg: Regularizer) -> HamiltonianBase:
+        """Compose a PHYSICS-ONLY regularizer, returning a NEW Hamiltonian (Issue #1071).
+
+        Functional composition scaffold for physical regularizers (Moreau–Yosida,
+        anisotropic, congestion). Numerical viscosity (LLF/SUPG/SBP-SAT) is NOT a
+        regularizer — it is a solver-level mixin (see :class:`Regularizer`). Concrete
+        regularizers land in later #1071 phases.
+        """
+        return reg.apply(self)
 
     @abstractmethod
     def __call__(
@@ -1378,6 +1526,19 @@ class BoundHamiltonian:
 
     def dx(self, x, m, p, t=0.0):
         return self._inner.dx(x, self._m_at(t), p, t)
+
+    # Issue #1071 single-source primitives — delegate via __call__/dp/dm so the
+    # cross-density binding (and the discard of the solver-supplied ``state.m``) is
+    # preserved. Byte-identical to the inline ``np.asarray(H(...), float)`` these
+    # replaced, with the bound density substituted at the current timestep.
+    def evaluate_H(self, state: HEvalState) -> NDArray:
+        return np.asarray(self(state.x, state.m, state.p, t=state.t), dtype=float)
+
+    def evaluate_dp(self, state: HEvalState) -> NDArray:
+        return np.asarray(self.dp(state.x, state.m, state.p, t=state.t), dtype=float)
+
+    def dH_dm(self, state: HEvalState) -> NDArray:
+        return np.asarray(self.dm(state.x, state.m, state.p, t=state.t), dtype=float)
 
     def is_smooth(self):
         return self._inner.is_smooth()

--- a/tests/unit/test_alg/test_hamiltonian_single_source_1071.py
+++ b/tests/unit/test_alg/test_hamiltonian_single_source_1071.py
@@ -1,0 +1,413 @@
+"""Pilot gates for the Hamiltonian single-source contract (Issue #1071, Phase 0+1).
+
+These pin the #1071 PILOT: the Phase-0 contract (``HEvalState`` /
+``HamiltonianValues`` / granular ``evaluate_H`` / ``evaluate_dp`` / convenience
+``evaluate``) and the Phase-1 migration of ``base_hjb`` residual + analytic
+Jacobian onto those primitives.
+
+Gates (per the LOCKED RFC "Post-panel revision"):
+
+* (a) BYTE-IDENTITY -- ``compute_hjb_residual`` and ``compute_hjb_jacobian`` on the
+  matched-λ=1 LQ golden equal a reference assembled from the *inline* forms the
+  pre-#1071 code used (``np.asarray(H(...))`` / ``np.asarray(H.dp(...))``), pinned
+  with ``np.testing.assert_array_equal`` (atol=0).
+* (b) INVOCATION-COUNT PIN -- on a NON-LQ FD-``dp`` Hamiltonian (analytic ``dp``
+  would make the LQ golden blind to over-compute): the residual path triggers ZERO
+  ``evaluate_dp`` calls and the Jacobian path ZERO ``evaluate_H`` calls, over one
+  full solve and in isolation.
+* (c) INDEPENDENCE -- residual never computes ``∂H/∂p``; Jacobian never recomputes
+  ``H`` (the isolation half of (b)).
+* (e) CONVENIENCE CONSISTENCY -- ``evaluate()`` returns the same ``H`` / ``dH_dp``
+  as the granular primitives.
+
+Plus the Phase-0 contract surface (``HEvalState`` alias, ``HamiltonianValues``
+shape, h_eval delegation byte-identity).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import base_hjb
+from mfgarchon.alg.numerical.hjb_solvers.base_hjb import (
+    _compute_gradient_array_1d,
+    _compute_laplacian_1d,
+    compute_hjb_jacobian,
+    compute_hjb_residual,
+)
+from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
+from mfgarchon.core.hamiltonian import (
+    HamiltonianBase,
+    HamiltonianValues,
+    HEvalState,
+    QuadraticControlCost,
+    SeparableHamiltonian,
+)
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+# ---------------------------------------------------------------------------
+# Phase 0 -- contract surface
+# ---------------------------------------------------------------------------
+
+
+def _batch(n=9, d=1):
+    rng = np.random.default_rng(1)
+    x = np.linspace(0.0, 1.0, n).reshape(-1, 1) if d == 1 else rng.uniform(size=(n, d))
+    m = rng.uniform(0.1, 1.0, size=n)
+    p = rng.uniform(-1.0, 1.0, size=(n, d))
+    return x, m, p
+
+
+def test_heval_state_grad_u_alias_and_fields():
+    x, m, p = _batch()
+    st = HEvalState(x=x, p=p, m=m, t=0.4)
+    assert np.array_equal(st.grad_u, p)  # grad_u is the momentum alias
+    assert st.t == 0.4
+    # frozen: assignment must fail
+    import dataclasses
+
+    try:
+        st.t = 0.5  # type: ignore[misc]
+        raise AssertionError("HEvalState must be frozen")
+    except dataclasses.FrozenInstanceError:
+        pass
+
+
+def test_granular_primitives_byte_identical_to_inline():
+    """evaluate_H / evaluate_dp ARE the pre-#1071 inline batch forms, atol=0."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    x, m, p = _batch()
+    st = HEvalState(x=x, p=p, m=m, t=0.3)
+    np.testing.assert_array_equal(H.evaluate_H(st), np.asarray(H(x, m, p, t=0.3), dtype=float))
+    np.testing.assert_array_equal(H.evaluate_dp(st), np.asarray(H.dp(x, m, p, t=0.3), dtype=float))
+    assert H.evaluate_H(st).dtype == np.float64
+    assert H.evaluate_dp(st).dtype == np.float64
+
+
+def test_h_eval_helpers_delegate_byte_identical():
+    """The kept eval_*_batch shims delegate to the primitives (single source, no third layer)."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0), coupling=lambda m: m**3)
+    x, m, p = _batch()
+    st = HEvalState(x=x, p=p, m=m, t=0.1)
+    np.testing.assert_array_equal(eval_H_batch(H, x, m, p, 0.1), H.evaluate_H(st))
+    np.testing.assert_array_equal(eval_dH_dp_batch(H, x, m, p, 0.1), H.evaluate_dp(st))
+
+
+def test_evaluate_convenience_consistent_with_primitives():
+    """Gate (e): the convenience evaluate() returns the same H / dH_dp as the primitives."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.5), coupling=lambda m: m**2)
+    x, m, p = _batch()
+    st = HEvalState(x=x, p=p, m=m, t=0.2)
+    H.physical_sigma = 0.7  # required by the convenience (Phase-0 scaffold)
+    hv = H.evaluate(st)
+    assert isinstance(hv, HamiltonianValues)
+    np.testing.assert_array_equal(hv.H, H.evaluate_H(st))
+    np.testing.assert_array_equal(hv.dH_dp, H.evaluate_dp(st))
+    # sigma ALWAYS an array (physical volatility), broadcast to (N,)
+    assert isinstance(hv.sigma, np.ndarray)
+    assert hv.sigma.shape == (x.shape[0],)
+    np.testing.assert_array_equal(hv.sigma, np.full(x.shape[0], 0.7))
+
+
+def test_evaluate_requires_physical_sigma_fail_fast():
+    """No silent σ fallback: evaluate() without physical_sigma raises (fail-fast)."""
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    x, m, p = _batch()
+    st = HEvalState(x=x, p=p, m=m, t=0.0)
+    assert H.physical_sigma is None
+    try:
+        H.evaluate(st)
+        raise AssertionError("evaluate() must fail fast when physical_sigma is unset")
+    except ValueError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 -- base_hjb migration, byte-identity golden (matched-λ=1 LQ)
+# ---------------------------------------------------------------------------
+
+
+def _lq_problem(nx=21):
+    geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1))
+    components = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),  # matched λ=1
+    )
+    return MFGProblem(geometry=geometry, T=1.0, Nt=10, components=components)
+
+
+def _golden_state(problem):
+    nx = problem.geometry.get_grid_shape()[0]
+    xs = np.linspace(0.0, 1.0, nx)
+    u_cur = np.sin(2 * np.pi * xs) + 0.3 * xs**2
+    u_np1 = 0.5 * np.cos(np.pi * xs)
+    m = 1.0 + 0.5 * np.exp(-8 * (xs - 0.4) ** 2)
+    return u_cur, u_np1, m
+
+
+def test_residual_byte_identical_to_inline_assembly():
+    """Gate (a): compute_hjb_residual == reference assembled from the inline H form."""
+    problem = _lq_problem()
+    H = problem.hamiltonian_class
+    nx = problem.geometry.get_grid_shape()[0]
+    dx = problem.geometry.get_grid_spacing()[0]
+    dt = problem.dt
+    u_cur, u_np1, m = _golden_state(problem)
+    bc = no_flux_bc(dimension=1)
+    sigma, t = 0.3, 0.1
+
+    out = compute_hjb_residual(
+        u_cur,
+        u_np1,
+        m,
+        problem,
+        t_idx_n=0,
+        backend=None,
+        sigma_at_n=sigma,
+        use_upwind=True,
+        bc=bc,
+        domain_bounds=None,
+        current_time=t,
+    )
+
+    # Reference: reproduce the assembly with the literal pre-#1071 inline H form.
+    lap = _compute_laplacian_1d(u_cur, dx, bc=bc, domain_bounds=None, time=t)
+    grad = _compute_gradient_array_1d(u_cur, dx, bc=bc, upwind=True, time=t)
+    x_grid = problem.geometry.get_spatial_grid()
+    h_inline = np.asarray(H(x_grid, np.asarray(m, float), grad.reshape(-1, 1), t=t), dtype=float).ravel()
+    ref = np.zeros(nx)
+    ref += (u_cur - u_np1) / dt
+    ref += -diffusion_from_volatility(sigma, kind="field") * lap
+    ref += h_inline
+
+    np.testing.assert_array_equal(out, ref)
+
+
+def test_jacobian_byte_identical_to_inline_assembly():
+    """Gate (a): compute_hjb_jacobian == reference assembled from the inline dp form."""
+    import scipy.sparse as sparse
+
+    problem = _lq_problem()
+    H = problem.hamiltonian_class
+    nx = problem.geometry.get_grid_shape()[0]
+    dx = problem.geometry.get_grid_spacing()[0]
+    dt = problem.dt
+    u_cur, _u_np1, m = _golden_state(problem)
+    bc = no_flux_bc(dimension=1)
+    sigma, t = 0.3, 0.1
+
+    out = compute_hjb_jacobian(
+        u_cur,
+        u_cur,
+        m,
+        problem,
+        t_idx_n=0,
+        backend=None,
+        sigma_at_n=sigma,
+        use_upwind=True,
+        bc=bc,
+        domain_bounds=None,
+        current_time=t,
+    )
+
+    # Reference: reproduce the diagonal-Jacobian assembly with the inline dp form.
+    grad = _compute_gradient_array_1d(u_cur, dx, bc=bc, upwind=True, time=t)
+    x_grid = problem.geometry.get_spatial_grid()
+    dH_dp = np.asarray(H.dp(x_grid, np.asarray(m, float), grad.reshape(-1, 1), t=t), dtype=float).ravel()
+
+    J_D = np.zeros(nx)
+    J_L = np.zeros(nx)
+    J_U = np.zeros(nx)
+    J_D += 1.0 / dt
+    J_D += sigma**2 / dx**2
+    val_off = -(sigma**2) / (2 * dx**2)
+    J_L += val_off
+    J_U += val_off
+    inv_dx = 1.0 / dx
+    backward = grad >= 0
+    J_D += dH_dp * np.where(backward, inv_dx, -inv_dx)
+    J_L += dH_dp * np.where(backward, -inv_dx, 0.0)
+    J_U += dH_dp * np.where(backward, 0.0, inv_dx)
+    j_l_roll = np.roll(J_L, -1)
+    j_u_roll = np.roll(J_U, 1)
+    ref = sparse.spdiags([j_l_roll, J_D, j_u_roll], [-1, 0, 1], nx, nx, format="csr").tocsr()
+
+    np.testing.assert_array_equal(out.toarray(), ref.toarray())
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 -- invocation-count pin + independence (non-LQ FD-dp Hamiltonian)
+# ---------------------------------------------------------------------------
+
+
+class _NonLQFDHamiltonian(HamiltonianBase):
+    """Non-LQ Hamiltonian with NO analytic ``dp`` -> ``dp`` uses the base finite
+    differences. ``H = (1/3)|p|^3 + sin(2πx) + m^2``: a quadratic control cost
+    would make ``dp`` analytic and free, hiding any residual-path over-compute, so
+    the cubic + FD-``dp`` form is what makes the invocation gate meaningful.
+    """
+
+    def __call__(self, x, m, p, t=0.0):
+        p = np.asarray(p, dtype=float)
+        x = np.asarray(x, dtype=float)
+        m = np.asarray(m, dtype=float)
+        if p.ndim == 2:
+            kin = np.sum(np.abs(p) ** 3, axis=1) / 3.0
+            pot = np.sin(2 * np.pi * x[:, 0])
+            return kin + pot + m**2
+        return float(np.sum(np.abs(p) ** 3) / 3.0 + np.sin(2 * np.pi * np.atleast_1d(x)[0]) + float(np.mean(m)) ** 2)
+
+
+class _CountingHamiltonian(_NonLQFDHamiltonian):
+    """Spy: counts method-level evaluate_H / evaluate_dp invocations.
+
+    Counts the PRIMITIVES (not raw ``__call__``): the FD ``dp`` legitimately calls
+    ``__call__`` to probe ``H``, but that is internal to ``evaluate_dp`` and must NOT
+    register as an ``evaluate_H`` (residual-path) call.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.n_eval_H = 0
+        self.n_eval_dp = 0
+
+    def evaluate_H(self, state):
+        self.n_eval_H += 1
+        return super().evaluate_H(state)
+
+    def evaluate_dp(self, state):
+        self.n_eval_dp += 1
+        return super().evaluate_dp(state)
+
+
+def _nonlq_problem(nx=21):
+    geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1))
+    H = _CountingHamiltonian()
+    components = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=H,
+    )
+    return MFGProblem(geometry=geometry, T=0.5, Nt=5, components=components), H
+
+
+def test_residual_path_triggers_zero_dp_evals():
+    """Gates (b)+(c): the residual computes H only -- ZERO evaluate_dp calls."""
+    problem, H = _nonlq_problem()
+    nx = problem.geometry.get_grid_shape()[0]
+    xs = np.linspace(0.0, 1.0, nx)
+    u_cur = np.sin(2 * np.pi * xs)
+    u_np1 = 0.2 * xs
+    m = 1.0 + 0.3 * np.cos(np.pi * xs)
+    bc = no_flux_bc(dimension=1)
+
+    H.n_eval_H = 0
+    H.n_eval_dp = 0
+    compute_hjb_residual(
+        u_cur,
+        u_np1,
+        m,
+        problem,
+        t_idx_n=0,
+        backend=None,
+        sigma_at_n=0.3,
+        use_upwind=True,
+        bc=bc,
+        domain_bounds=None,
+        current_time=0.1,
+    )
+    assert H.n_eval_dp == 0, "residual path must not compute ∂H/∂p"
+    assert H.n_eval_H >= 1, "residual path must compute H"
+
+
+def test_jacobian_path_triggers_zero_extra_H_evals():
+    """Gates (b)+(c): the analytic Jacobian computes ∂H/∂p only -- ZERO evaluate_H calls."""
+    problem, H = _nonlq_problem()
+    nx = problem.geometry.get_grid_shape()[0]
+    xs = np.linspace(0.0, 1.0, nx)
+    u_cur = np.sin(2 * np.pi * xs)
+    m = 1.0 + 0.3 * np.cos(np.pi * xs)
+    bc = no_flux_bc(dimension=1)
+
+    H.n_eval_H = 0
+    H.n_eval_dp = 0
+    compute_hjb_jacobian(
+        u_cur,
+        u_cur,
+        m,
+        problem,
+        t_idx_n=0,
+        backend=None,
+        sigma_at_n=0.3,
+        use_upwind=True,
+        bc=bc,
+        domain_bounds=None,
+        current_time=0.1,
+    )
+    assert H.n_eval_H == 0, "Jacobian path must not recompute H"
+    assert H.n_eval_dp >= 1, "Jacobian path must compute ∂H/∂p"
+
+
+def test_full_solve_invocation_split():
+    """Gate (b) over one full solve: both primitives exercised, never cross-contaminated.
+
+    The migrated batch residual/Jacobian path runs with ``backend=None`` (the pure
+    BC-aware NumPy path the multi-pop solves use), so the full backward Newton solve
+    is driven through ``solve_hjb_system_backward(backend=None)``. The two base_hjb
+    assembly functions are wrapped so every primitive call is attributed to its path:
+    over the full solve (Newton + line search) the residual must contribute ZERO
+    ``evaluate_dp`` calls and the Jacobian ZERO ``evaluate_H`` calls.
+    """
+    problem, H = _nonlq_problem()
+    nt = problem.Nt + 1
+    nx = problem.geometry.get_grid_shape()[0]
+    bc = no_flux_bc(dimension=1)
+
+    residual_dp_calls = 0
+    jacobian_H_calls = 0
+    orig_residual = base_hjb.compute_hjb_residual
+    orig_jacobian = base_hjb.compute_hjb_jacobian
+
+    def spy_residual(*a, **k):
+        nonlocal residual_dp_calls
+        before = H.n_eval_dp
+        out = orig_residual(*a, **k)
+        residual_dp_calls += H.n_eval_dp - before
+        return out
+
+    def spy_jacobian(*a, **k):
+        nonlocal jacobian_H_calls
+        before = H.n_eval_H
+        out = orig_jacobian(*a, **k)
+        jacobian_H_calls += H.n_eval_H - before
+        return out
+
+    base_hjb.compute_hjb_residual = spy_residual
+    base_hjb.compute_hjb_jacobian = spy_jacobian
+    try:
+        H.n_eval_H = 0
+        H.n_eval_dp = 0
+        M_density = np.ones((nt, nx))
+        base_hjb.solve_hjb_system_backward(
+            M_density,
+            np.zeros(nx),
+            np.zeros((nt, nx)),
+            problem,
+            backend=None,
+            use_upwind=True,
+            bc=bc,
+            domain_bounds=None,
+        )
+    finally:
+        base_hjb.compute_hjb_residual = orig_residual
+        base_hjb.compute_hjb_jacobian = orig_jacobian
+
+    assert H.n_eval_H > 0, "full solve must compute H (residual path)"
+    assert H.n_eval_dp > 0, "full solve must compute ∂H/∂p (Jacobian path)"
+    assert residual_dp_calls == 0, "residual path leaked ∂H/∂p evals over the full solve"
+    assert jacobian_H_calls == 0, "Jacobian path leaked H evals over the full solve"

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -33,6 +33,7 @@ from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import HJBHowardSolver
 from mfgarchon.core.hamiltonian import (
     CongestionHamiltonian,
+    HamiltonianBase,
     OptimizationSense,
     QuadraticControlCost,
     SeparableHamiltonian,
@@ -137,13 +138,19 @@ def _make_gfdm_solver(pts, bdry, geom, problem, scheme="joint_socp", k_neighbors
         )
 
 
-class _LQHam:
+class _LQHam(HamiltonianBase):
     """Minimal LQ Hamiltonian H = |p|²/2 exposing dp(x, m, p, t) = p (so α* = -dp = -p).
 
     Used to validate the integrated `inner_solver='howard'` path, which derives α* from
     `problem.hamiltonian_class.dp` (Issue #1118). Matches the explicit `lambda x,p,m,t: -p`
-    the standalone Howard tests pass.
+    the standalone Howard tests pass. Subclasses ``HamiltonianBase`` so it carries the
+    Issue #1071 single-source primitives (``evaluate_H``/``evaluate_dp``) the helpers
+    delegate to; ``__call__`` provides the matching H = |p|²/2 value.
     """
+
+    def __call__(self, x, m, p, t=0.0):
+        p = np.asarray(p, dtype=float)
+        return 0.5 * np.sum(p**2, axis=-1) if p.ndim == 2 else 0.5 * float(np.sum(p**2))
 
     def dp(self, x, m, p, t=0.0):
         return np.asarray(p, dtype=float)


### PR DESCRIPTION
Refs #1071

Phase 0 (contract, no behavior change) + Phase 1 (base_hjb migration, byte-identical) of the "Hamiltonian as Single Source of Truth" RFC. This is the pilot; later phases (WENO / SL / GFDM per-point / sigma-source unification / LLF-as-regularizer) follow in separate PRs.

## Phase 0 — contract (`mfgarchon/core/hamiltonian.py`)
- `HEvalState(x, p, m, t=0.0)` frozen dataclass — `grad_u` property aliases `p`; absorbs the unused `HamiltonianState` (drops `x_idx`; no dt/u/grid/BC).
- `HamiltonianValues(H, dH_dp, sigma)` frozen dataclass — `sigma` is the **physical** volatility, always an array `(N,)`/`(N,d,d)` (no scalar|None unions); numerical viscosity is NOT here.
- `Regularizer` protocol — physics-only scaffold (Moreau–Yosida / anisotropic / congestion). LLF/SUPG/SBP-SAT are solver-level mixins, deliberately out of scope.
- `HamiltonianBase` granular primitives `evaluate_H(state)` (H only) and `evaluate_dp(state)` (dH/dp only) — these are the implicit-Newton hot-path calls. Separate `dH_dm(state)` (FP coupling). Thin convenience `evaluate(state) -> HamiltonianValues` (explicit solvers / future JAX spec) and `with_regularizer(reg)` hook.
- `BoundHamiltonian` (multi-pop wrapper) gets the same primitives so the cross-density path rides along.
- `h_eval.eval_H_batch` / `eval_dH_dp_batch` now **delegate** to the primitives — single source, no third parallel layer.

## Phase 1 — base_hjb migration (byte-identical)
- `compute_hjb_residual` (~:707) consumes `evaluate_H(HEvalState(...))`.
- `compute_hjb_jacobian` (~:846) consumes `evaluate_dp(HEvalState(...))`.
- sigma stays physical, resolved at **timestep** scope (`sigma_at_n` unchanged); `D = σ²/2` still folded at the stencil via `diffusion_from_volatility`. The hand-rolled `σ²/dx²` at base_hjb:817 is deferred to a sub-RFC (untouched).
- GFDM per-point / legacy-LQ / WENO / SL paths untouched; `hjb_fdm:1217/:1275` (FP adjoint operator) untouched.

## Gates
- **(a) Byte-identity**: `compute_hjb_residual` and `compute_hjb_jacobian` on the matched-λ=1 LQ golden equal a reference assembled from the pre-#1071 inline forms, pinned with `assert_array_equal` (atol=0). Existing base_hjb/hjb_fdm suites unchanged.
- **(b) Invocation-count pin** (the panel's key ask): on a NON-LQ FD-`dp` Hamiltonian, the residual path triggers ZERO `evaluate_dp` calls and the Jacobian ZERO `evaluate_H` calls — in isolation and over one full backward Newton solve with line search.
- **(c) Independence**: residual never computes dH/dp; Jacobian never recomputes H.
- **(e) Convenience consistency**: `evaluate()` returns the same H/dH_dp as the primitives.

New tests: `tests/unit/test_alg/test_hamiltonian_single_source_1071.py` (10 cases). `_LQHam` in `test_hjb_howard_solver.py` updated to subclass `HamiltonianBase` (it was a duck-typed mock; the delegation now requires the single-source interface).

## Not in scope
`#1072` JAX lowering is a separate prerequisite sub-RFC — this numpy contract does NOT deliver it (in-place index-assignment, by-value `dH_dp`, unregistered pytree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)