### PR TITLE
chore(release): v0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3] - 2026-06-15
+
 ### Added
 
 - **Hamiltonian single-source contract** (PR #1377, Refs #1071 — pilot, Phase 0+1). New `HEvalState`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.20.2"  # v0.20.2: roadmap batch — JAX downgrade warning (#1072), honest O(h²) (#1084), SOCP adaptive enlargement (#1106), coupled-Newton source/nonlocal/obstacle (#1361)
+version = "0.20.3"  # v0.20.3: complete legacy 1D-geometry removal Tier-3b/3c (#1363) + Hamiltonian single-source contract pilot (#1071)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
Completes the legacy 1D-geometry deprecation removal + ships the Hamiltonian single-source contract pilot. `0.20.2` → `0.20.3`; CHANGELOG `[Unreleased]` → `[0.20.3] - 2026-06-15`.

### Removed (BREAKING)
- Legacy 1D-geometry `MFGProblem` constructor kwargs (`xmin/xmax/Nx/Lx`) + `_init_1d_legacy`/`_init_nd` + `get_u_final`/`get_u_fin` (Tier-3b/3c, #1363) — **Tier-1→3c complete**, the legacy 1D-geometry API is fully gone.
- Unused `mfgarchon.core.HamiltonianState` public export (#1377) → use `HEvalState`.

### Added
- Hamiltonian single-source contract (#1071 pilot): `HEvalState`/`HamiltonianValues` + `HamiltonianBase.evaluate_H`/`evaluate_dp` primitives + `dH_dm` + thin `evaluate()` + physics-only `with_regularizer`; `base_hjb` consumes them byte-identically; `h_eval` delegates.

After merge: tag `v0.20.3` + GitHub release. (#1071 migration continues in later patches; #1072 JAX lowering is a separate sub-RFC.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)