### PR TITLE
refactor(hjb): default 1D HJB onto single-source batch + analytic Jacobian (#1071 phase 2b)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -722,7 +722,10 @@ def compute_hjb_residual(
 
         return Phi_U
 
-    # Fallback: per-point loop for backend != None or missing precomputed_grad
+    # Per-point residual fallback (NON-DEFAULT since Issue #1071 phase 2b): reached only for a
+    # non-NumPy backend (torch/jax/numba device tensors the batch path cannot consume) or when no
+    # precomputed_grad is available. The default single-population NumPy path routes through
+    # backend=None (HJBFDMSolver, Issue #1071) and takes the batch evaluate_H branch above.
     for i in range(Nx):
         # Backend compatibility - tensor to scalar conversion (Issue #543 acceptable)
         phi_val = Phi_U[i].item() if hasattr(Phi_U[i], "item") else float(Phi_U[i])
@@ -873,7 +876,11 @@ def compute_hjb_jacobian(
             J_L += dH_dp * (-half_inv_dx)
             J_U += dH_dp * half_inv_dx
     else:
-        # Fallback: per-point numerical FD Jacobian for backend or no H_class
+        # Per-point numerical FD Jacobian fallback (NON-DEFAULT since Issue #1071 phase 2b):
+        # a central finite difference of problem.H(), noisy at Godunov upwind kinks. Reached only
+        # for a non-NumPy backend or a missing H_class. The default single-population NumPy path
+        # routes through backend=None (HJBFDMSolver, Issue #1071) and takes the analytic
+        # evaluate_dp Jacobian branch above (more accurate; validated vs the backward-heat MMS).
         for i in range(Nx):
             U_perturbed_p_i = U_n_np.copy()
             U_perturbed_p_i[i] += eps

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -428,12 +428,28 @@ class HJBFDMSolver(BaseHJBSolver):
                 with suppress(AttributeError):
                     logger.debug(f"[DEBUG Issue #542] BC has {len(bc.segments)} segments")
 
-            # Issue #1157: when a cross-density bound Hamiltonian is supplied, force the batch
-            # Hamiltonian path (backend=None) — the per-point problem.H() fallback receives only
-            # a scalar own-population density and cannot express cross-population coupling. The
-            # batch path is numerically equivalent to the per-point path (Issue #789), so this
-            # changes nothing for single-population solves (override None => self.backend).
-            effective_backend = None if hamiltonian_override is not None else self.backend
+            # Route the 1D NumPy path onto the single-sourced batch assembly (backend=None).
+            #
+            # Issue #1157: a cross-density bound Hamiltonian forces backend=None — the per-point
+            # problem.H() fallback receives only a scalar own-population density and cannot
+            # express cross-population coupling.
+            #
+            # Issue #1071 (phase 2b): the DEFAULT single-population NumPy solve also routes
+            # through backend=None. With a NumPyBackend present, base_hjb takes the per-point
+            # fallback: a per-node problem.H() residual and a central FINITE-DIFFERENCE Jacobian
+            # of problem.H(). That FD Jacobian is noisy at the Godunov upwind kinks and stalls
+            # Newton short of tolerance. backend=None instead consumes the single-source batch
+            # residual (Hamiltonian.evaluate_H) + the ANALYTIC Jacobian (Hamiltonian.evaluate_dp,
+            # which itself FD's H when a custom Hamiltonian provides no analytic dp), so the
+            # residual never computes ∂H/∂p and the Jacobian never recomputes H (Issue #1071
+            # residual/Jacobian split). This retires the per-point FD-of-residual Jacobian as the
+            # default: it is more accurate, not merely different (validated vs the backward-heat
+            # MMS analytic truth in the #1071 phase-2b PR — L2/Linf error is <= the FD path on
+            # every checked sigma/Nx, with no regression). The per-point FD fallback in base_hjb
+            # is NOT removed — it remains the path for non-NumPy backends (torch/jax/numba), whose
+            # device tensors the batch NumPy path cannot consume.
+            uses_batch_path = hamiltonian_override is not None or self.backend.name == "numpy"
+            effective_backend = None if uses_batch_path else self.backend
 
             # Use optimized 1D solver with BC-aware computation (Issue #542 fix)
             U_solution = base_hjb.solve_hjb_system_backward(


### PR DESCRIPTION
Refs #1071 (phase 2b)

## Summary

The default single-population 1D `HJBFDMSolver` carried `self.backend=NumPyBackend`, so `base_hjb` took the **per-point fallback**: a per-node `problem.H()` residual and a central **finite-difference Jacobian of `problem.H()`**. That FD Jacobian is noisy at the Godunov upwind kinks.

This routes the default 1D NumPy solve through `backend=None` so `base_hjb` consumes the #1071 single-source granular primitives:
- residual = batch `Hamiltonian.evaluate_H` (computes `H` only),
- Jacobian = analytic `Hamiltonian.evaluate_dp` assembled via the upwind stencil (`evaluate_dp` itself FD's `H` when a custom Hamiltonian provides no analytic `dp`).

The residual never computes `dH/dp` and the Jacobian never recomputes `H` (the #1071 residual/Jacobian split). This **retires the per-point FD-of-residual Jacobian as the default** (route (i) — unify onto the already-single-sourced batch path).

The per-point FD fallback is **not removed**: it remains the path for non-NumPy backends (torch/jax/numba), whose device tensors the NumPy batch path cannot consume. Custom Hamiltonians without analytic `dp` still work (the analytic assembly uses `evaluate_dp`'s FD-of-`H` default). nD/2D paths are untouched (the change is confined to the 1D branch).

## Accuracy validation (more accurate, not just different)

Truth comparison vs the backward-heat MMS analytic solution `u(t,x)=cos(2*pi*x)*exp(-D*k^2*(T-t))` with quadratic-Hamiltonian source, OLD (per-point FD Jacobian) vs NEW (analytic Jacobian) L2 error vs truth at production tol 1e-6:

| BC | sigma | Nx | L2 OLD | L2 NEW |
|----|------|----|--------|--------|
| no-flux | 0.05 | 41 | 5.758e-1 | 5.748e-1 |
| no-flux | 0.05 | 81 | 1.434e-2 | 1.426e-2 |
| no-flux | 0.10 | 41 | 7.723e-2 | 7.712e-2 |
| periodic | 0.20 | 21..161 | matches | <= OLD |

NEW L2/Linf <= OLD on **every** checked sigma/Nx (periodic + no-flux), zero regressions; the re-baseline audit shows the shift moves **toward** the analytic truth. Newton converges at the production tolerance (it takes more inner iterations in advection-dominated cases because the analytic Jacobian keeps converging instead of stalling — a change, not non-convergence).

## Suites

Green on the new path: `tests/unit/test_alg/test_hjb_fdm_solver.py`, `test_hamiltonian_single_source_1071.py`, `test_hjb_1071_control_cost_lambda.py`, `tests/integration/test_mms_validation.py` (incl. HJB MMS convergence), `test_coupled_mfg_mms.py` (coupled EOC), `test_fdm_solvers_mfg_complete.py`, `test_hjb_with_obstacle.py`, `test_hjb_fdm_2d_validation.py`, `test_fvm_hjb_coupling.py`, `test_fdm_centered_conservation.py`, `test_newton_picard_agreement.py`, `test_source_term_wiring.py`, `test_mass_conservation_1d.py`, `test_lions_correction.py`, plus the base_hjb-dependent SL/WENO/SOCP/GFDM tests. No tests pin exact U values that shifted, so none were re-baselined.

The production Picard path and the inner HJB solve are unchanged on symmetric problems (`max|U_old-U_new| ~ 2e-10`); a full exp06a/exp08/exp09 re-run (mfg-research) is the downstream confirmation. This PR validates correctness/accuracy on in-repo analytic/MMS cases.

The `@pytest.mark.slow`, PR-skipped `test_newton_mfg_solver.py::...density_nonnegative` (experimental coupled FD-Jacobian Newton) was checked separately: the inner HJB is identical OLD vs NEW to ~2e-10 on its exact problem, so any density behavior there is path-independent (not introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
