### PR TITLE
chore(core): post-audit hygiene — fail-fast guards + param-name consistency + CHANGELOG dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Post-audit hygiene** (session quality audit). Three low-severity consistency
+  fixes plus a CHANGELOG cleanup:
+  - `GeneralMFGFactory.create_from_hamiltonian` now raises a clear `ValueError`
+    naming the missing `Nx` when a legacy 1D `domain_config` supplies
+    `xmin`/`xmax`/`Lx` but omits `Nx`, instead of a bare `KeyError` (Issue #1363).
+  - Renamed the two `solve_hjb_system` holdouts (`BaseHJBSolver` abstract
+    signature, `PenaltyHJBSolver`) from the removed parameter names
+    `M_density_evolution_from_FP` / `U_final_condition_at_T` / `U_from_prev_picard`
+    to the canonical `M_density` / `U_terminal` / `U_coupling_prev`, matching every
+    concrete solver and the [0.20.1] removal (Issue #1355). The penalty solver
+    forwards positionally, so the inner solve is unchanged.
+  - `create_lions_source` / `create_nonlocal_source` now raise `ValueError` on a
+    2-D `(Nt+1, Nx)` density instead of silently using the terminal slice `m[-1]`;
+    the composed source pipeline time-slices before calling, so a per-time source
+    must receive a 1-D spatial slice (a 2-D array is a caller error that
+    reintroduced the Issue #1285 wrong-slice behavior).
+  - Merged a duplicate `### Fixed` subsection under `[0.20.0]` into one block
+    (Keep a Changelog compliance).
+
 ## [0.20.3] - 2026-06-15
 
 ### Added
@@ -814,8 +835,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Reachable via `solve_fp_system(drift_field=<callable>)` or any tensor/anisotropic
   `volatility_field`. Fixed to pass the in-scope `boundary_conditions`; regression test
   asserts a leftward drift on a no-flux domain leaves the far-right (near-wall) region empty.
-
-### Fixed
 
 - **nD ADI diffusion now applies the full prescribed diffusion** (Issue #1178). The
   semi-Lagrangian `adi_diffusion_step` split the time step across dimensions

--- a/mfgarchon/alg/numerical/coupling/lions_correction.py
+++ b/mfgarchon/alg/numerical/coupling/lions_correction.py
@@ -58,6 +58,25 @@ if TYPE_CHECKING:
     from mfgarchon.utils.functional_calculus import FunctionalDerivative, FunctionalOnMeasures
 
 
+def _spatial_density(m: NDArray) -> NDArray:
+    """Return the flat spatial density, rejecting (Nt+1, Nx) trajectories.
+
+    The composed source pipeline (:mod:`source_composition`) time-slices the
+    density to the current backward time step before calling the source, so a
+    per-time source always receives a 1-D spatial array. A 2-D ``(Nt+1, Nx)``
+    trajectory reaching here is a caller error: silently collapsing it to the
+    terminal slice ``m[-1]`` reintroduces the Issue #1285 wrong-slice bug.
+    """
+    if m.ndim == 2:
+        raise ValueError(
+            f"Lions source expects a 1-D spatial density (Nx,), got a 2-D array "
+            f"with shape {m.shape}. Pass the time-t density slice, not the full "
+            "(Nt+1, Nx) trajectory (see source_composition.compose_hjb_source; "
+            "Issue #1285)."
+        )
+    return m.ravel()
+
+
 def create_lions_source(
     energy_functional: FunctionalOnMeasures | EnergyFunctional,
     functional_derivative: FunctionalDerivative | None = None,
@@ -126,7 +145,7 @@ def create_lions_source(
             t: float,
         ) -> NDArray:
             """Evaluate the analytic Lions correction delta F / delta m[m](x)."""
-            m_flat = m[-1].ravel() if m.ndim == 2 else m.ravel()
+            m_flat = _spatial_density(m)
             return np.asarray(analytic.lions_derivative(m_flat)).ravel()
 
         return source_term_hjb_analytic
@@ -147,21 +166,16 @@ def create_lions_source(
 
         Args:
             x: Spatial grid points, shape (Nx,) or (Nx, d)
-            m: Current density — may be (Nx,) for single time slice or
-                (Nt+1, Nx) for full time-space array (as passed by FixedPointIterator).
+            m: Current spatial density, shape (Nx,). Must be a single time-t
+                slice; the source pipeline time-slices before calling (a 2-D
+                (Nt+1, Nx) trajectory is rejected — see Issue #1285).
             v: Current value function (unused — correction depends on m only)
             t: Current time (unused for time-independent F[m])
 
         Returns:
             Source term values, shape (Nx,)
         """
-        # Extract spatial density at current time if m is time-space array
-        if m.ndim == 2:
-            # m is (Nt+1, Nx) — use last time step as representative
-            # (consistent with explicit source term treatment)
-            m_flat = m[-1].ravel()
-        else:
-            m_flat = m.ravel()
+        m_flat = _spatial_density(m)
         Nx = len(m_flat)
 
         # Compute delta F / delta m at each grid point
@@ -218,8 +232,7 @@ def create_nonlocal_source(
         t: float,
     ) -> NDArray:
         """Evaluate (W * m)(x) = int W(x,y) m(y) dy."""
-        # Handle (Nt+1, Nx) time-space array from FixedPointIterator
-        m_spatial = m[-1].ravel() if m.ndim == 2 else m.ravel()
+        m_spatial = _spatial_density(m)
         return (W @ m_spatial) * dx
 
     return source_term_hjb

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -386,9 +386,9 @@ class BaseHJBSolver(BaseNumericalSolver):
     @abstractmethod
     def solve_hjb_system(
         self,
-        M_density_evolution_from_FP: np.ndarray,
-        U_final_condition_at_T: np.ndarray,
-        U_from_prev_picard: np.ndarray,
+        M_density: np.ndarray,
+        U_terminal: np.ndarray,
+        U_coupling_prev: np.ndarray,
         volatility_field: float | np.ndarray | None = None,
         source_term: Callable | None = None,
     ) -> np.ndarray:
@@ -410,11 +410,11 @@ class BaseHJBSolver(BaseNumericalSolver):
         - Common Noise Lions derivative correction (Layer 2)
 
         Args:
-            M_density_evolution_from_FP: Density field m(t,x) from Fokker-Planck equation
+            M_density: Density field m(t,x) from Fokker-Planck equation
                                         For MFG: from previous Picard iteration
                                         For standalone: uniform density
-            U_final_condition_at_T: Terminal condition u(T,x) at final time
-            U_from_prev_picard: Value function from previous Picard iteration
+            U_terminal: Terminal condition u(T,x) at final time
+            U_coupling_prev: Value function from previous Picard iteration
                                For MFG: actual previous iterate U^{k-1}
                                For standalone: initial guess (zeros, terminal condition, etc.)
             volatility_field: Diffusion coefficient specification (optional):

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
@@ -103,9 +103,9 @@ class PenaltyHJBSolver(BaseHJBSolver):
 
     def solve_hjb_system(
         self,
-        M_density_evolution_from_FP: NDArray,
-        U_final_condition_at_T: NDArray,
-        U_from_prev_picard: NDArray,
+        M_density: NDArray,
+        U_terminal: NDArray,
+        U_coupling_prev: NDArray,
         volatility_field: float | NDArray | None = None,
         source_term: Callable | None = None,
     ) -> NDArray:
@@ -145,9 +145,9 @@ class PenaltyHJBSolver(BaseHJBSolver):
             return base + penalty_param * np.maximum(0.0, psi)
 
         return self._inner.solve_hjb_system(
-            M_density_evolution_from_FP,
-            U_final_condition_at_T,
-            U_from_prev_picard,
+            M_density,
+            U_terminal,
+            U_coupling_prev,
             volatility_field=volatility_field,
             source_term=penalized_source,
         )

--- a/mfgarchon/factory/general_mfg_factory.py
+++ b/mfgarchon/factory/general_mfg_factory.py
@@ -135,6 +135,12 @@ class GeneralMFGFactory:
             xmin = problem_kwargs.pop("xmin", 0.0)
             lx = problem_kwargs.pop("Lx", None)
             xmax = problem_kwargs.pop("xmax", xmin + lx if lx is not None else 1.0)
+            if "Nx" not in problem_kwargs:
+                raise ValueError(
+                    "Legacy 1D domain spec requires 'Nx' (number of intervals); "
+                    f"got domain keys {sorted(domain_config.keys())}. Provide 'Nx', "
+                    "or use the geometry-first API (geometry=/spatial_bounds=)."
+                )
             nx = problem_kwargs.pop("Nx")  # intervals
             problem_kwargs["geometry"] = TensorProductGrid(
                 bounds=[(xmin, xmax)],

--- a/tests/integration/test_interaction_lions_bridge.py
+++ b/tests/integration/test_interaction_lions_bridge.py
@@ -100,19 +100,32 @@ class TestGate3LionsBridgeEquivalence:
         with pytest.raises(ValueError):
             create_lions_source(energy_lambda)
 
-    def test_time_space_array_uses_last_slice(self):
-        """Source handles both (Nx,) slice and (Nt+1, Nx) trajectory inputs."""
+    def test_time_space_array_rejected(self):
+        """A 2-D (Nt+1, Nx) trajectory is a caller error: the source pipeline
+        time-slices before calling, so a per-time source must get a 1-D spatial
+        slice. Passing the full trajectory raises (was a silent m[-1] fallback
+        that reintroduced the Issue #1285 wrong-slice bug). The 1-D slice path
+        still works on both the analytic and the optimized nonlocal source."""
         N = 30
         x = np.linspace(0.0, 1.0, N)
         dx = x[1] - x[0]
         conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
         source = create_lions_source(QuadraticInteractionEnergy(conv))
+        W = np.exp(-((x[:, None] - x[None, :]) ** 2) / (2 * 0.2**2))
+        source_nonlocal = create_nonlocal_source(W, grid_spacing=dx)
 
         m_slice = np.sin(np.pi * x) + 1.0
         m_traj = np.tile(m_slice, (5, 1))  # (Nt+1, Nx), constant in time
+
+        # 1-D slice path still works.
         r_slice = source(x, m_slice, np.zeros(N), 0.0)
-        r_traj = source(x, m_traj, np.zeros(N), 0.0)
-        np.testing.assert_allclose(r_slice, r_traj, atol=1e-12)
+        assert r_slice.shape == (N,)
+
+        # 2-D trajectory rejected on both paths.
+        with pytest.raises(ValueError, match=r"1-D spatial density"):
+            source(x, m_traj, np.zeros(N), 0.0)
+        with pytest.raises(ValueError, match=r"1-D spatial density"):
+            source_nonlocal(x, m_traj, np.zeros(N), 0.0)
 
 
 def _ring_problem(grid_only=False, amp=5.0, length_scale=0.15, bowl=4.0):

--- a/tests/unit/test_factory/test_general_mfg_factory.py
+++ b/tests/unit/test_factory/test_general_mfg_factory.py
@@ -450,6 +450,21 @@ def test_create_from_hamiltonian_missing_domain(factory, sample_hamiltonian, tim
 
 @pytest.mark.unit
 @pytest.mark.fast
+def test_create_from_hamiltonian_legacy_domain_missing_nx(factory, sample_hamiltonian, time_config, sample_functions):
+    """Legacy 1D domain spec (xmin/xmax/Lx) without Nx must fail fast with a
+    clear ValueError naming Nx, not a bare KeyError (Issue #1363)."""
+    with pytest.raises(ValueError, match="Nx"):
+        factory.create_from_hamiltonian(
+            hamiltonian=sample_hamiltonian,
+            domain_config={"xmin": 0.0, "xmax": 1.0, "Lx": 1.0},  # no Nx
+            time_config=time_config,
+            m_initial=sample_functions["initial_density"],
+            u_terminal=sample_functions["final_value"],
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.fast
 def test_create_from_hamiltonian_missing_time(factory, sample_hamiltonian, domain_config):
     """Test error when time config is missing."""
     with pytest.raises((TypeError, KeyError)):


### PR DESCRIPTION
Four LOW-severity hygiene fixes surfaced by the session quality audit (all artifact-verified). One focused "post-audit hygiene" PR; no behavior change to any working numerical path.

## Fixes

1. **CHANGELOG `[0.20.0]` duplicate `### Fixed`** — merged the two `### Fixed` subsections into one (Keep a Changelog compliance). The stranded bullets (nD ADI #1178) now sit in the single block. Verified exactly one `### Fixed` per release section for `[0.20.0]`.
   - Note (out of scope): `[0.19.7]` has pre-existing duplicate `Added`/`Changed`/`Fixed` headers, not flagged by the audit and left untouched.

2. **`general_mfg_factory.py` KeyError edge (#1363)** — a legacy 1D `domain_config` with `xmin`/`xmax`/`Lx` but no `Nx` previously fell into the geometry-translation branch and hit a bare `KeyError` on `pop("Nx")`. Now raises a clear `ValueError` naming the missing `Nx` (fail-fast, matching the repo convention). Added a unit test for the missing-`Nx` path.

3. **#1355 holdouts** — `BaseHJBSolver.solve_hjb_system` (abstract signature + docstring) and `PenaltyHJBSolver.solve_hjb_system` still declared the removed param names `M_density_evolution_from_FP` / `U_final_condition_at_T` / `U_from_prev_picard`, contradicting the `[0.20.1]` "removed name now raises TypeError" claim and diverging from every concrete solver. Renamed to canonical `M_density` / `U_terminal` / `U_coupling_prev`. The penalty solver forwards **positionally** to its inner solver, so the inner solve is unchanged (verified: penalty + base_hjb suites green). Out of scope and intentionally untouched: the `solve_hjb_system_backward` helper (separate internal naming), WENO internal `_solve_*` helpers (public WENO override already canonical), and the `weak_form_hjb_solver` old→new compat shim.

4. **`lions_correction.py` vestigial 2-D branch (#1285)** — the `m.ndim==2 → m[-1]` terminal-slice fallback in `create_lions_source` (analytic + FD paths) and `create_nonlocal_source` is dead via the iterator (the shared `source_composition` time-slices before calling) but silently wrong if a user calls these directly with a `(Nt+1, Nx)` array. Replaced all three branches with a shared `_spatial_density` guard that raises a clear `ValueError` (a 2-D density to a per-time source is a caller error that reintroduced the #1285 wrong-slice behavior). Updated the test that pinned the old `m[-1]` fallback to assert the new rejection on both paths.

## Tests

- `python -c "import mfgarchon"` clean; `ruff check --select F mfgarchon/` clean; `ruff format --check` clean.
- `test_general_mfg_factory` + `test_interaction_lions_bridge` + `test_lions_correction` + `test_issue1285_source_term_time_slice` + `test_hjb_fdm_solver` + `test_penalty_hjb_solver` + `test_hjb_howard_solver`: green.
- Broad smoke `tests/unit/test_alg`: **1237 passed, 3 skipped, 2 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)