### PR TITLE
fix(hjb): BC-aware 1D boundary gradient on default NumPy path — residual + FD Jacobian (#1384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **1D HJB boundary gradient now BC-aware on the default NumPy path** (Issue #1384).
+  The default single-population `HJBFDMSolver` carries `backend=NumPyBackend` (≠ `None`),
+  so the residual's Hamiltonian momentum `p = ∂u/∂x` fell to the per-point loop whose
+  legacy stencil uses periodic `% Nx` wraparound at the boundary — a wrong boundary
+  momentum for Dirichlet/Neumann/no-flux problems, regardless of the actual BC. (The
+  Issue #542 diffusion fix made the *Laplacian* BC-aware for this path but the *gradient*
+  was gated more strictly behind `backend is None`.) The precomputed BC-aware gradient is
+  now computed for any non-torch (NumPy-like) array, mirroring the BC-aware Laplacian gate.
+  The per-point FD Jacobian is unchanged (Newton still converges to the BC-correct root;
+  the analytic-Jacobian swap remains a separate question under #1380). Verified: for a
+  no-flux wall the fix feeds momentum `0.0` (BC-respecting) where the old path fed a
+  spurious `+2.69`; **periodic BC is byte-identical** (Δ=0) and the full suite (4941 tests)
+  is green, so only asymmetric non-periodic 1D FDM solves shift (toward correct).
+  Validated in `scripts/validation/hjb_1d_bc_gradient.py`.
 - **Post-audit hygiene** (session quality audit). Three low-severity consistency
   fixes plus a CHANGELOG cleanup:
   - `GeneralMFGFactory.create_from_hamiltonian` now raises a clear `ValueError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **1D HJB boundary gradient now BC-aware on the default NumPy path** (Issue #1384).
-  The default single-population `HJBFDMSolver` carries `backend=NumPyBackend` (≠ `None`),
-  so the residual's Hamiltonian momentum `p = ∂u/∂x` fell to the per-point loop whose
-  legacy stencil uses periodic `% Nx` wraparound at the boundary — a wrong boundary
-  momentum for Dirichlet/Neumann/no-flux problems, regardless of the actual BC. (The
-  Issue #542 diffusion fix made the *Laplacian* BC-aware for this path but the *gradient*
-  was gated more strictly behind `backend is None`.) The precomputed BC-aware gradient is
-  now computed for any non-torch (NumPy-like) array, mirroring the BC-aware Laplacian gate.
-  The per-point FD Jacobian is unchanged (Newton still converges to the BC-correct root;
-  the analytic-Jacobian swap remains a separate question under #1380). Verified: for a
-  no-flux wall the fix feeds momentum `0.0` (BC-respecting) where the old path fed a
-  spurious `+2.69`; **periodic BC is byte-identical** (Δ=0) and the full suite (4941 tests)
-  is green, so only asymmetric non-periodic 1D FDM solves shift (toward correct).
-  Validated in `scripts/validation/hjb_1d_bc_gradient.py`.
+- **1D HJB boundary gradient now BC-aware on the default NumPy path — residual AND Jacobian**
+  (Issue #1384). The default single-population `HJBFDMSolver` carries `backend=NumPyBackend`
+  (≠ `None`), so both the residual's Hamiltonian momentum `p = ∂u/∂x` and the per-point FD
+  Jacobian fell to the legacy per-point stencil, which uses periodic `% Nx` wraparound at the
+  boundary — a wrong boundary momentum for Dirichlet/Neumann/no-flux problems, regardless of
+  the actual BC. (The Issue #542 diffusion fix made the *Laplacian* BC-aware for this path,
+  but the *gradient* was gated more strictly behind `backend is None`.) Both the precomputed
+  residual gradient and the FD-Jacobian momentum stencil are now BC-aware for any non-torch
+  (NumPy-like) array, mirroring the BC-aware Laplacian gate. **Both had to move together**:
+  making only the residual BC-aware while the Jacobian stayed periodic is a severe
+  `J ≠ ∂F/∂U` mismatch at the boundary that makes Newton *diverge* for Dirichlet BC with
+  steep terminals. This stays finite-difference; the analytic-Jacobian swap is a separate
+  question under #1380. Verified: the Dirichlet steep-terminal case that diverged with a
+  residual-only fix now converges; for a no-flux wall the fix feeds momentum `0.0`
+  (BC-respecting) where the old path fed a spurious `+2.69`; **periodic BC is byte-identical**
+  (Δ=0); the full suite is green. Only asymmetric non-periodic 1D FDM solves shift (toward
+  correct). Validated in `scripts/validation/hjb_1d_bc_gradient.py`; regression-tested in
+  `tests/unit/test_alg/test_hjb_fdm_solver.py::TestBoundaryGradientBCAware1384`.
 - **Post-audit hygiene** (session quality audit). Three low-severity consistency
   fixes plus a CHANGELOG cleanup:
   - `GeneralMFGFactory.create_from_hamiltonian` now raises a clear `ValueError`

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -675,10 +675,22 @@ def compute_hjb_residual(
         # Works for both constant σ (scalar) and σ(x,t) (array)
         Phi_U += -diffusion_from_volatility(sigma, kind="field") * U_xx
 
-    # Precompute BC-aware gradient for entire array (Issue #542 fix)
-    # This avoids repeated per-point computation with wrong BC
+    # Precompute BC-aware gradient for entire array (Issue #542 fix).
+    # This avoids the per-point %Nx periodic fallback that ignores the actual BC.
+    #
+    # Issue #1384: the original gate `backend is None` left the DEFAULT single-population
+    # NumPy path on the periodic %Nx gradient regardless of BC, because hjb_fdm.py sets
+    # effective_backend=NumPyBackend (≠ None) for single-population solves. The diffusion
+    # term was already BC-aware for this path via the non-torch Laplacian gate (above);
+    # the gradient was not. Mirror that gate: use the BC-aware gradient for any non-torch
+    # (NumPy-like) array, not only backend is None. The batch Hamiltonian path below keeps
+    # its `backend is None` gate, so NumPy single-population still uses the per-point loop —
+    # now fed the BC-aware gradient. Interior momenta are unchanged to ≤1 ULP; only the two
+    # boundary points move, and only for non-periodic BC (periodic ≤1 ULP everywhere).
+    # Validated in: scripts/validation/hjb_1d_bc_gradient.py
     precomputed_grad = None
-    if bc is not None and backend is None:
+    _grad_uses_torch_roll = backend is not None and hasattr(U_n_current_newton_iterate, "roll")
+    if bc is not None and not _grad_uses_torch_roll:
         precomputed_grad = _compute_gradient_array_1d(
             U_n_current_newton_iterate, dx, bc=bc, upwind=use_upwind, time=current_time
         )

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -816,6 +816,27 @@ def compute_hjb_jacobian(
     else:
         U_n_np = U_n_current_newton_iterate
 
+    # Issue #1384: mirror the residual's BC-aware gradient in the per-point FD Jacobian
+    # fallback. That fallback perturbs U and recomputes the Hamiltonian momentum via
+    # _calculate_derivatives; with no precomputed gradient it uses the legacy periodic
+    # %Nx stencil, so the two boundary Jacobian rows wrap periodically even under
+    # non-periodic BC. With the residual now BC-aware, a periodic boundary Jacobian is a
+    # severe J != dF/dU mismatch that makes Newton diverge for Dirichlet BC (the residual
+    # one-sided gradient against a pinned boundary value has no periodic counterpart).
+    # Feeding the same BC-aware gradient makes the boundary rows consistent: at the wall the
+    # BC-aware momentum does not depend on the opposite end, so the spurious periodic corner
+    # coupling vanishes (and was dropped by spdiags anyway). Torch (GPU) keeps the periodic
+    # path (no BC support yet), matching the residual; periodic BC returns the %Nx-identical
+    # array, so the assembled Jacobian is byte-identical there.
+    _jac_uses_torch_roll = backend is not None and hasattr(U_n_current_newton_iterate, "roll")
+    _jac_bc_aware = bc is not None and not _jac_uses_torch_roll
+
+    def _bc_grad(u_arr: np.ndarray) -> np.ndarray | None:
+        """BC-aware gradient of a perturbed state for the FD Jacobian (None => legacy %Nx)."""
+        if _jac_bc_aware:
+            return _compute_gradient_array_1d(u_arr, dx, bc=bc, upwind=use_upwind, time=current_time)
+        return None
+
     J_D = np.zeros(Nx)
     J_L = np.zeros(Nx)
     J_U = np.zeros(Nx)
@@ -900,6 +921,7 @@ def compute_hjb_jacobian(
                 clip=True,
                 clip_limit=P_VALUE_CLIP_LIMIT_FD_JAC,
                 upwind=use_upwind,
+                precomputed_gradient=_bc_grad(U_perturbed_p_i),
             )
             derivs_m_i = _calculate_derivatives(
                 U_perturbed_m_i,
@@ -909,6 +931,7 @@ def compute_hjb_jacobian(
                 clip=True,
                 clip_limit=P_VALUE_CLIP_LIMIT_FD_JAC,
                 upwind=use_upwind,
+                precomputed_gradient=_bc_grad(U_perturbed_m_i),
             )
 
             H_p_i = np.nan
@@ -935,6 +958,7 @@ def compute_hjb_jacobian(
                     clip=True,
                     clip_limit=P_VALUE_CLIP_LIMIT_FD_JAC,
                     upwind=use_upwind,
+                    precomputed_gradient=_bc_grad(U_perturbed_p_im1),
                 )
                 derivs_m_im1 = _calculate_derivatives(
                     U_perturbed_m_im1,
@@ -944,6 +968,7 @@ def compute_hjb_jacobian(
                     clip=True,
                     clip_limit=P_VALUE_CLIP_LIMIT_FD_JAC,
                     upwind=use_upwind,
+                    precomputed_gradient=_bc_grad(U_perturbed_m_im1),
                 )
                 H_p_im1 = np.nan
                 H_m_im1 = np.nan
@@ -967,6 +992,7 @@ def compute_hjb_jacobian(
                     clip=True,
                     clip_limit=P_VALUE_CLIP_LIMIT_FD_JAC,
                     upwind=use_upwind,
+                    precomputed_gradient=_bc_grad(U_perturbed_p_ip1),
                 )
                 derivs_m_ip1 = _calculate_derivatives(
                     U_perturbed_m_ip1,
@@ -976,6 +1002,7 @@ def compute_hjb_jacobian(
                     clip=True,
                     clip_limit=P_VALUE_CLIP_LIMIT_FD_JAC,
                     upwind=use_upwind,
+                    precomputed_gradient=_bc_grad(U_perturbed_m_ip1),
                 )
                 H_p_ip1 = np.nan
                 H_m_ip1 = np.nan

--- a/scripts/validation/hjb_1d_bc_gradient.py
+++ b/scripts/validation/hjb_1d_bc_gradient.py
@@ -1,0 +1,87 @@
+"""Standalone validation for Issue #1384 — 1D HJB boundary gradient must be BC-aware.
+
+The default single-population ``HJBFDMSolver`` carried ``backend=NumPyBackend`` (not
+``None``), so ``base_hjb`` computed the Hamiltonian momentum ``p = du/dx`` with periodic
+``% Nx`` wraparound at the boundary regardless of the actual boundary condition. This
+probe contrasts the legacy ``% Nx`` gradient against the BC-aware
+``_compute_gradient_array_1d`` on a known function ``U = x**2`` (analytic ``du/dx = 2x``):
+
+- legacy ``% Nx`` boundary gradient is periodic garbage (left ~ -9.975 vs analytic 0.0);
+- ``neumann`` / ``no_flux`` give the BC-consistent boundary momentum;
+- every BC choice leaves the interior unchanged to <= 1 ULP (2.2e-16) — the fix's blast
+  radius is the two boundary points, and only for non-periodic BC.
+
+Run: ``python scripts/validation/hjb_1d_bc_gradient.py``
+"""
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import base_hjb as B
+from mfgarchon.geometry.boundary import dirichlet_bc, neumann_bc, no_flux_bc, periodic_bc
+
+# Known function U = x^2 on [0,1], analytic grad = 2x
+Nx = 21
+x = np.linspace(0.0, 1.0, Nx)
+Dx = x[1] - x[0]
+U = x**2
+analytic = 2.0 * x
+
+
+def legacy_central(U, Dx, Nx):
+    g = np.empty(Nx)
+    for i in range(Nx):
+        d = B._calculate_derivatives(U, i, Dx, Nx, upwind=False, precomputed_gradient=None)
+        g[i] = d[(1,)]
+    return g
+
+
+def legacy_upwind(U, Dx, Nx):
+    g = np.empty(Nx)
+    for i in range(Nx):
+        d = B._calculate_derivatives(U, i, Dx, Nx, upwind=True, precomputed_gradient=None)
+        g[i] = d[(1,)]
+    return g
+
+
+leg_c = legacy_central(U, Dx, Nx)
+leg_u = legacy_upwind(U, Dx, Nx)
+
+variants = {
+    "bc=None central": B._compute_gradient_array_1d(U, Dx, bc=None, upwind=False),
+    "neumann central": B._compute_gradient_array_1d(U, Dx, bc=neumann_bc(dimension=1), upwind=False),
+    "no_flux central": B._compute_gradient_array_1d(U, Dx, bc=no_flux_bc(dimension=1), upwind=False),
+    "dirichlet central": B._compute_gradient_array_1d(U, Dx, bc=dirichlet_bc(0.0, dimension=1), upwind=False),
+    "periodic central": B._compute_gradient_array_1d(U, Dx, bc=periodic_bc(dimension=1), upwind=False),
+}
+
+np.set_printoptions(precision=4, suppress=True, linewidth=160)
+print(f"Dx={Dx:.4f}  analytic grad at boundaries: left={analytic[0]:.4f} right={analytic[-1]:.4f}")
+print()
+print("=== boundary gradient values (i=0 and i=Nx-1) vs analytic [0.0, 2.0] ===")
+print(f"{'variant':22s}  left(i=0)   right(i=Nx-1)   |err|_left   |err|_right")
+
+
+def row(name, g):
+    el = abs(g[0] - analytic[0])
+    er = abs(g[-1] - analytic[-1])
+    print(f"{name:22s}  {g[0]:9.4f}   {g[-1]:9.4f}     {el:9.4f}   {er:9.4f}")
+
+
+row("legacy %Nx central", leg_c)
+row("legacy %Nx upwind", leg_u)
+for k, v in variants.items():
+    row(k, v)
+
+print()
+print("=== interior byte-identity vs legacy %Nx central (indices 1..Nx-2) ===")
+for k, v in variants.items():
+    intr = np.allclose(v[1:-1], leg_c[1:-1], rtol=0, atol=0)
+    maxd = np.max(np.abs(v[1:-1] - leg_c[1:-1]))
+    print(f"{k:22s}  interior_byte_identical={intr}   max_interior_diff={maxd:.2e}")
+
+print()
+print("=== full-array byte-identity vs legacy %Nx central (all indices) ===")
+for k, v in variants.items():
+    full = np.array_equal(v, leg_c)
+    maxd = np.max(np.abs(v - leg_c))
+    print(f"{k:22s}  full_byte_identical={full}   max_full_diff={maxd:.2e}")

--- a/tests/unit/test_alg/test_hjb_fdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_fdm_solver.py
@@ -1108,5 +1108,91 @@ class TestHJBFDMSolverNewtonFallback:
         assert err.solver_type == "newton"
 
 
+class TestBoundaryGradientBCAware1384:
+    """Issue #1384: the default single-population 1D HJB must use the BC-aware boundary
+    gradient (residual AND Jacobian), not the periodic %Nx wraparound.
+
+    Coverage gap these tests close: the prior suite's only non-periodic FDM solve was a
+    fully symmetric no_flux problem, for which the periodic and BC-aware boundary gradients
+    coincide — so the bug (and the residual/Jacobian boundary inconsistency it would expose)
+    was invisible. These exercise (a) asymmetric no_flux, where the fix changes the result
+    toward BC-respecting, (b) periodic, which must stay byte-identical, and (c) Dirichlet
+    with a steep terminal, which diverged when only the residual was made BC-aware.
+    """
+
+    def _solve(self, bc, *, Nx=42, sigma=0.3, Nt=20, T=0.5, terminal):
+        components = MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=terminal,
+            hamiltonian=_default_hamiltonian(),
+        )
+        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=bc)
+        problem = MFGProblem(geometry=geometry, T=T, Nt=Nt, sigma=sigma, components=components)
+        solver = HJBFDMSolver(problem)
+        Nx_points = problem.geometry.get_grid_shape()[0]
+        Nt_points = problem.Nt_points
+        x = problem.geometry.get_spatial_grid().ravel()
+        M = np.ones((Nt_points, Nx_points)) / Nx_points
+        U_T = terminal(x)
+        return solver.solve_hjb_system(M, U_T, np.tile(U_T, (Nt_points, 1)))
+
+    @staticmethod
+    def _legacy_periodic_grad(U, dx):
+        """The pre-fix per-point gradient (legacy %Nx wraparound), for discrimination."""
+        from mfgarchon.alg.numerical.hjb_solvers import base_hjb
+
+        Nx = len(U)
+        return np.array(
+            [
+                base_hjb._calculate_derivatives(U, i, dx, Nx, upwind=False, precomputed_gradient=None)[(1,)]
+                for i in range(Nx)
+            ]
+        )
+
+    def test_boundary_gradient_is_bc_aware_not_periodic(self):
+        """Mechanism: for non-periodic BC the boundary momentum differs materially from the
+        legacy %Nx periodic stencil, while the interior agrees to <=1 ULP. This is exactly
+        the #1384 corruption; the test fails if the boundary gradient is not BC-aware."""
+        from mfgarchon.alg.numerical.hjb_solvers import base_hjb
+        from mfgarchon.geometry.boundary import no_flux_bc as _nf
+
+        Nx = 21
+        x = np.linspace(0.0, 1.0, Nx)
+        dx = x[1] - x[0]
+        U = x**2  # asymmetric on [0,1]; analytic du/dx = 2x (0 at left, 2 at right)
+        legacy = self._legacy_periodic_grad(U, dx)
+        bc_aware = base_hjb._compute_gradient_array_1d(U, dx, bc=_nf(dimension=1), upwind=False)
+        # interior agrees to <=1 ULP (only the boundary stencil changes)
+        assert np.allclose(bc_aware[1:-1], legacy[1:-1], rtol=0, atol=1e-12)
+        # boundary is materially different: legacy wraps to the opposite end (~ -9.97)
+        assert abs(bc_aware[0] - legacy[0]) > 1.0
+        assert abs(bc_aware[-1] - legacy[-1]) > 1.0
+
+    def test_periodic_gradient_byte_identical_to_legacy(self):
+        """Mechanism: for PERIODIC BC the BC-aware gradient equals the legacy %Nx stencil
+        (Δ <= 1 ULP everywhere) — the discrimination the fix relies on, so periodic
+        baselines do not move."""
+        from mfgarchon.alg.numerical.hjb_solvers import base_hjb
+        from mfgarchon.geometry.boundary import periodic_bc as _pb
+
+        Nx = 21
+        x = np.linspace(0.0, 1.0, Nx)
+        dx = x[1] - x[0]
+        U = np.sin(2 * np.pi * x)
+        legacy = self._legacy_periodic_grad(U, dx)
+        bc_aware = base_hjb._compute_gradient_array_1d(U, dx, bc=_pb(dimension=1), upwind=False)
+        assert np.max(np.abs(bc_aware - legacy)) <= 1e-12
+
+    def test_dirichlet_steep_terminal_converges(self):
+        """Dirichlet with a steep terminal: making only the residual BC-aware while the FD
+        Jacobian stayed periodic made Newton diverge (J != dF/dU at the pinned boundary).
+        With the Jacobian also BC-aware the solve stays finite and bounded."""
+        from mfgarchon.geometry.boundary import dirichlet_bc as _db
+
+        U = self._solve(_db(0.0, dimension=1), Nx=42, sigma=0.05, Nt=3, T=2.0, terminal=lambda x: np.sin(3 * np.pi * x))
+        assert np.all(np.isfinite(U)), "Dirichlet steep-terminal solve produced NaN/Inf"
+        assert np.max(np.abs(U)) < 10.0, "Dirichlet solve blew up (Newton J/residual boundary mismatch)"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Closes #1384.

## The bug (verified by artifact)

The default **single-population** 1D `HJBFDMSolver` computed the HJB Hamiltonian's momentum `p = ∂u/∂x` with **periodic `% Nx` wraparound at the boundary regardless of the actual BC**. Root cause chain:

- `hjb_fdm.py:189` — `self.backend = create_backend("numpy")` (a `NumPyBackend`, **not `None`**).
- `hjb_fdm.py:436` — `effective_backend = None if hamiltonian_override else self.backend` → single-pop passes `backend=NumPyBackend`.
- `base_hjb.py:681` (residual) and `:853` (Jacobian) — the BC-aware gradient was gated behind `backend is None`, so both fell to the per-point loop whose legacy stencil uses `(i±1) % Nx` (`base_hjb.py:504`).

The Issue #542 diffusion fix made the *Laplacian* BC-aware for this path (via the non-torch `hasattr(U,"roll")` gate); the *gradient* was gated more strictly and never reached the default path. The comment at `hjb_fdm.py:434-435` claimed the per-point and batch paths are "numerically equivalent (#789)" — true only for **periodic** BC.

## The fix

Mirror the BC-aware Laplacian gate: compute the BC-aware gradient for any non-torch (NumPy-like) array, for **both** the residual (commit 1) **and** the per-point FD Jacobian (commit 2). This stays finite-difference — the analytic-Jacobian swap remains a separate question under #1380 (which this PR cleanly **decouples** from the correctness fix).

**Both had to move together.** Adversarial verification (a 3-agent workflow that tried to *refute* the fix with fresh test cases) showed a residual-only fix is **not shippable**: making the residual BC-aware while the FD Jacobian stays periodic is a severe `J ≠ ∂F/∂U` mismatch at the boundary that makes Newton **diverge** for Dirichlet BC with steep terminals (residual `4.4e2 → 6.5e8` where old `main` converged). Feeding the FD Jacobian the same BC-aware gradient makes the boundary rows consistent (at a wall the BC-aware momentum doesn't depend on the opposite end, so the spurious periodic corner coupling vanishes).

## Evidence

| check | result |
|---|---|
| no-flux wall momentum | fix `0.0` (BC-respecting) vs old spurious `+2.69` |
| Dirichlet steep-terminal (the divergence case) | **converges** (max\|U\|≈1.02) vs residual-only `6.5e8` |
| **periodic BC** | **byte-identical (Δ=0)** — periodic golden baselines unmoved |
| interior (all BC) | unchanged to ≤1 ULP — only the 2 boundary stencils change |
| full suite | **4944 passed**, 27 skipped, 2 xfailed, 0 failed |
| unwire check | the Dirichlet regression test **fails** on the residual-only commit, passes with the Jacobian fix (proves it discriminates) |

Validated in `scripts/validation/hjb_1d_bc_gradient.py`; regression-tested in `tests/unit/test_alg/test_hjb_fdm_solver.py::TestBoundaryGradientBCAware1384` (closes the coverage gap — the prior suite's only non-periodic FDM solve was *symmetric*, where periodic and BC-aware boundary gradients coincide).

## Scope / impact

- **No re-baseline needed for this repo** — periodic is byte-identical and the committed golden is symmetric no_flux (unmoved). Only **asymmetric non-periodic** 1D FDM solves shift, *toward* correct (research/paper baselines computed before this fix should be re-run).
- **Sibling sweep** (same `% Nx`-ignores-BC bug class): FP-FDM, FVM, semi-Lagrangian, WENO, GFDM, network, weak-form all confirmed BC-aware. Two same-class instances are **out of scope / already deferred**: the torch/GPU Laplacian+gradient path (`base_hjb.py:654`, "no BC support for GPU yet") and the `fp_particle` implicit-geometry fallback (Issue #1255-B). The torch one matches the residual here (both stay periodic on GPU).

Refs #542, #789, #1071, #1380.
