### PR TITLE
fix(coupling): HJB source receives value function v_t on all couplers (#1382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HJB source term receives the value function on all couplers** (Issue #1382).
+  `source_composition.compose_hjb_source` (the Picard / coupled-Newton couplers)
+  passed `v = 0` to `source_term_hjb(x, m, v, t)`, while `graph_mfg_solver` passed
+  the real value-function slice `v_t` — so the same problem-level source yielded a
+  different result on graph vs grid for any `v`-dependent HJB source (the #1259/#1285
+  silent-divergence class). The documented contract (`mfg_problem.py`:
+  `Callable(x, m, v, t)`) and the FP source both bind `v_t`; the grid couplers now do
+  too. Both couplers build the source + nonlocal terms through a single
+  `_problem_hjb_source_terms` primitive, so the fork cannot re-open silently.
+  Byte-identical for the existing (all `v`-independent) sources and obstacle/nonlocal
+  ordering preserved; the change only affects a future `v`-dependent HJB source.
+  Pinned by `test_issue1361_source_composition.py::test_hjb_source_receives_value_function_slice`.
+
 - **1D HJB boundary gradient now BC-aware on the default NumPy path — residual AND Jacobian**
   (Issue #1384). The default single-population `HJBFDMSolver` carries `backend=NumPyBackend`
   (≠ `None`), so both the residual's Hamiltonian momentum `p = ∂u/∂x` and the per-point FD

--- a/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
@@ -31,6 +31,7 @@ from mfgarchon.alg.numerical.coupling.fixed_point_utils import (
     resolve_fp_drift_kwargs,
 )
 from mfgarchon.alg.numerical.coupling.graph_coupling import _get_time_slice
+from mfgarchon.alg.numerical.coupling.source_composition import _problem_hjb_source_terms
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -321,13 +322,15 @@ class GraphMFGSolver(BaseCouplingIterator):
 
         def composed(t: float, x_eval: NDArray) -> NDArray:
             s = coupling_source(t, x_eval)
-            if has_problem_source:
-                v_t = _get_time_slice(Us_full[k], t, dt)
-                m_t = _get_time_slice(Ms_expanded[k], t, dt)
-                s = s + p.source_term_hjb(x_eval, m_t, v_t, t)
-            if has_nonlocal:
-                v_t = _get_time_slice(Us_full[k], t, dt)
-                s = s + p.nonlocal_operator @ v_t
+            # Source + nonlocal via the shared single-source primitive (Issue #1382),
+            # layered on the graph coupling source. Order [coupling, source, nonlocal]
+            # preserves byte-for-byte agreement with the pre-#1382 graph closure. Uses
+            # self._dt so the slice index matches the grid couplers.
+            parts = _problem_hjb_source_terms(p, Ms_expanded[k], Us_full[k], t, x_eval, dt)
+            if "source" in parts:
+                s = s + parts["source"]
+            if "nonlocal" in parts:
+                s = s + parts["nonlocal"]
             return s
 
         return composed

--- a/mfgarchon/alg/numerical/coupling/source_composition.py
+++ b/mfgarchon/alg/numerical/coupling/source_composition.py
@@ -30,9 +30,14 @@ Conventions (mirrored verbatim from the prior ``FixedPointIterator`` copy):
   (``eps = problem._penalty_eps`` if set, else ``1e6``). Proper handling is the
   ``PenaltyHJBSolver`` wrapper (#924); both coupling paths use this same
   approximation so they **match** rather than silently diverge.
-- The HJB source passes ``v = 0`` to ``source_term_hjb(x, m, v, t)`` (the
-  problem-level source does not receive the value function in the HJB path),
-  preserved from the prior copy.
+- The HJB source passes the **value-function slice** ``v_t`` to
+  ``source_term_hjb(x, m, v, t)`` (Issue #1382), matching the documented
+  ``Callable(x, m, v, t)`` contract (``mfg_problem.py``: "source_term_hjb/fp"),
+  the FP source (which already binds ``v_t``), and ``graph_mfg_solver``. The
+  prior copy passed ``v = 0`` here — a latent divergence from the graph coupler
+  for any ``v``-dependent HJB source. Both couplers now build these terms through
+  the single :func:`_problem_hjb_source_terms` primitive so the fork cannot
+  re-open silently.
 """
 
 from __future__ import annotations
@@ -49,6 +54,42 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from mfgarchon.core.mfg_problem import MFGProblem
+
+
+def _problem_hjb_source_terms(
+    problem: MFGProblem,
+    m_current: NDArray,
+    u_current: NDArray,
+    t: float,
+    x: NDArray,
+    dt: float,
+) -> dict[str, NDArray]:
+    """The convention-bearing HJB source terms shared by every coupler (Issue #1382).
+
+    Returns a dict with the present problem-level HJB source contributions evaluated
+    at the time-``t`` slices: ``"source"`` = ``source_term_hjb(x, m_t, v_t, t)`` with
+    ``v_t`` the value-function slice (NOT zero), and ``"nonlocal"`` =
+    ``nonlocal_operator @ v_t``. This is the single source of the ``v_t`` convention
+    for both the grid couplers (``compose_hjb_source``) and ``graph_mfg_solver``, so a
+    ``v``-dependent source cannot silently diverge between paths.
+
+    Named (dict) rather than a list so each consumer composes them in its own exact
+    order — the grid coupler interleaves the obstacle as ``[source, obstacle, nonlocal]``,
+    graph layers the coupling source as ``[coupling, source, nonlocal]`` — preserving
+    byte-for-byte float-sum associativity with the pre-refactor code.
+
+    ``dt`` is passed explicitly (rather than read from ``problem.dt``) so the graph
+    coupler — which carries its own ``self._dt`` — slices identically.
+    """
+    out: dict[str, NDArray] = {}
+    needs_v = problem.source_term_hjb is not None or problem.nonlocal_operator is not None
+    v_t = _get_time_slice(u_current, t, dt) if needs_v else None
+    if problem.source_term_hjb is not None:
+        m_t = _get_time_slice(m_current, t, dt)
+        out["source"] = problem.source_term_hjb(x, m_t, v_t, t)
+    if problem.nonlocal_operator is not None:
+        out["nonlocal"] = problem.nonlocal_operator @ v_t
+    return out
 
 
 def compose_hjb_source(
@@ -79,17 +120,19 @@ def compose_hjb_source(
         return None
 
     def composed(t: float, x: NDArray) -> NDArray:
+        # Source + nonlocal via the shared single-source primitive (Issue #1382);
+        # obstacle is grid-coupler-only. Order [source, obstacle, nonlocal] preserves
+        # byte-for-byte float-sum associativity with the pre-#1382 closure.
+        parts = _problem_hjb_source_terms(problem, m_current, u_current, t, x, problem.dt)
         terms: list[NDArray] = []
-        if has_source:
-            m_t = _get_time_slice(m_current, t, problem.dt)
-            terms.append(problem.source_term_hjb(x, m_t, np.zeros_like(m_t), t))
+        if "source" in parts:
+            terms.append(parts["source"])
         if has_obstacle:
             psi = problem.obstacle(x)
             eps = getattr(problem, "_penalty_eps", 1e6)
             terms.append((1.0 / eps) * np.maximum(0.0, psi.ravel()))
-        if has_nonlocal:
-            v_t = _get_time_slice(u_current, t, problem.dt)
-            terms.append(problem.nonlocal_operator @ v_t)
+        if "nonlocal" in parts:
+            terms.append(parts["nonlocal"])
         return sum(terms) if terms else np.zeros(x.shape[0])
 
     return composed

--- a/tests/unit/test_alg/test_issue1361_source_composition.py
+++ b/tests/unit/test_alg/test_issue1361_source_composition.py
@@ -14,6 +14,15 @@ These pins assert:
    therefore agree with them exactly.
 
 If the shared helper ever drifts from the pinned convention, these fail.
+
+Issue #1382: the HJB source convention changed from ``v = 0`` to the
+value-function slice ``v_t`` (the documented ``(x, m, v, t)`` contract), and the
+source/nonlocal terms are now built by the single
+``source_composition._problem_hjb_source_terms`` primitive that BOTH the grid
+couplers and ``graph_mfg_solver`` call — so the grid-vs-graph fork (the original
+#1382 divergence) cannot re-open. The reference below and ``src_hjb`` were updated
+to the ``v_t`` convention, and ``test_hjb_source_receives_value_function_slice``
+pins that the primitive passes ``v_t`` (not zero).
 """
 
 from __future__ import annotations
@@ -23,6 +32,7 @@ import numpy as np
 from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
 from mfgarchon.alg.numerical.coupling.graph_coupling import _get_time_slice
 from mfgarchon.alg.numerical.coupling.source_composition import (
+    _problem_hjb_source_terms,
     compose_fp_source,
     compose_hjb_source,
 )
@@ -53,7 +63,10 @@ def _ref_compose_hjb_source(problem, m_current, u_current):
         terms = []
         if has_source:
             m_t = _get_time_slice(m_current, t, problem.dt)
-            terms.append(problem.source_term_hjb(x, m_t, np.zeros_like(m_t), t))
+            # Issue #1382: the HJB source receives the value-function slice v_t
+            # (the documented (x, m, v, t) contract), not zero.
+            v_t = _get_time_slice(u_current, t, problem.dt)
+            terms.append(problem.source_term_hjb(x, m_t, v_t, t))
         if has_obstacle:
             psi = problem.obstacle(x)
             eps = getattr(problem, "_penalty_eps", 1e6)
@@ -110,7 +123,10 @@ def _row_indexed(gs: int) -> np.ndarray:
 
 # Field configurations spanning every branch and their combinations.
 def _field_configs(gs: int):
-    src_hjb = lambda x, m, v, t: 0.7 * np.ones(x.shape[0]) + 0.1 * t + 0.01 * m  # noqa: E731
+    # Issue #1382: v-dependent so the test exercises that the HJB source receives the
+    # value-function slice v_t (the +0.03*v term would be silently dropped under the
+    # old v=0 convention, making shared != reference).
+    src_hjb = lambda x, m, v, t: 0.7 * np.ones(x.shape[0]) + 0.1 * t + 0.01 * m + 0.03 * v  # noqa: E731
     src_fp = lambda x, m, v, t: 0.05 * np.ones(x.shape[0]) + 0.02 * v  # noqa: E731
     obstacle = lambda x: np.asarray(x) - 0.5  # noqa: E731
     nonlocal_op = 0.3 * np.eye(gs) + 0.05 * np.ones((gs, gs))
@@ -153,6 +169,33 @@ def test_hjb_composition_matches_reference_and_delegate():
             c = delegate(t, x)
             np.testing.assert_array_equal(a, b, err_msg=f"{name} t={t}: shared != reference (HJB)")
             np.testing.assert_array_equal(a, c, err_msg=f"{name} t={t}: shared != FixedPointIterator delegate (HJB)")
+
+
+def test_hjb_source_receives_value_function_slice():
+    """Issue #1382: the shared HJB source primitive passes the value-function slice v_t
+    (not 0) to source_term_hjb. Both the grid couplers and graph_mfg_solver build their
+    HJB source through _problem_hjb_source_terms, so this pins the convention they share
+    and forbids the grid-vs-graph v=0/v_t fork from re-opening silently."""
+    gs = _grid_size(_make_problem())
+    M = _row_indexed(gs)
+    U = 2.0 * _row_indexed(gs) + 0.5  # distinct from M so v_t != m_t
+    x = np.linspace(0.0, 1.0, gs)
+
+    captured: dict[str, np.ndarray] = {}
+
+    def src(x_, m_, v_, t_):
+        captured["v"] = np.array(v_)
+        return 0.03 * v_
+
+    problem = _make_problem(source_term_hjb=src)
+    for k in range(_NT + 1):
+        t = k * problem.dt
+        parts = _problem_hjb_source_terms(problem, M, U, t, x, problem.dt)
+        v_expected = _get_time_slice(U, t, problem.dt)
+        # the source saw the value-function slice, not zeros (would be all-0 under the old convention)
+        np.testing.assert_array_equal(captured["v"], v_expected, err_msg=f"t={t}: source did not receive v_t")
+        assert np.any(v_expected != 0.0), "test vacuous: pick U with a nonzero slice"
+        np.testing.assert_array_equal(parts["source"], 0.03 * v_expected, err_msg=f"t={t}: v-dependent term wrong")
 
 
 def test_fp_composition_matches_reference_and_delegate():


### PR DESCRIPTION
Closes #1382.

## The divergence (the #1259/#1285 silent-divergence class)

The shared HJB-source helper `source_composition.compose_hjb_source` (Picard + coupled-Newton couplers) passed **`v = 0`** to `source_term_hjb(x, m, v, t)`, while `graph_mfg_solver` passed the real value-function slice **`v_t`**. So the same problem-level `source_term_hjb` produced a **different result on grid vs graph** for any `v`-dependent source. This graph copy predates #1361 (which single-sourced only the Picard+Newton couplers), so it is not a #1361 regression — but it is the exact fork #1361 set out to kill.

## Decision: `v_t` is correct

The contradiction was between two docs:

| source | said |
|---|---|
| `mfg_problem.py` (the contract) | `source_term_hjb/fp: Callable(x, m, v, t)` — `v` = value function, for **both** HJB and FP |
| `source_composition.py` docstring | the HJB source does **not** receive `v` (passes `0`), "preserved from the prior copy" |

`v_t` wins: it matches the documented contract, the FP source (which already binds `v_t`), and `graph_mfg_solver`; the `v=0` rationale was explicitly inherited ("preserved from the prior copy"), not designed.

## The fix (fold)

Both couplers now build the source + nonlocal terms through a **single `_problem_hjb_source_terms` primitive** (the `v_t` convention lives in exactly one place), so the grid-vs-graph fork **cannot re-open silently**:

- `compose_hjb_source` (grid) calls it, interleaving the obstacle as `[source, obstacle, nonlocal]`.
- `graph_mfg_solver._compose_hjb_source` calls it, layering the graph coupling source as `[coupling, source, nonlocal]`.

The primitive returns *named* terms (a dict) and takes `dt` explicitly, so each consumer preserves its **exact pre-refactor term order** — `sum()` is not float-associative, so this keeps the composition **byte-identical** for every existing problem. The FP path was already consistent (`v_t` on both) and is unchanged.

## Impact

- **Byte-identical today**: every current source/test/example is `v`-independent (`lambda x, m, v, t: …` ignoring `v`), and term ordering is preserved. The behavior change is confined to a future `v`-dependent HJB source — which now behaves per the documented contract on every coupler.
- **Test fix**: `test_issue1361_source_composition.py` previously **pinned the wrong convention** (hard-coded `v=0` in its reference, with a `v`-independent `src_hjb`). The reference is updated to `v_t`, `src_hjb` is made `v`-dependent (so the pin actually exercises the convention), and a new `test_hjb_source_receives_value_function_slice` asserts the primitive passes `v_t`.

Refs #1361, #1259, #1285, #1043.
