### PR TITLE
chore(release): v0.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.4] - 2026-06-16
+
 ### Fixed
 
 - **HJB source term receives the value function on all couplers** (Issue #1382).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.20.3"  # v0.20.3: complete legacy 1D-geometry removal Tier-3b/3c (#1363) + Hamiltonian single-source contract pilot (#1071)
+version = "0.20.4"  # v0.20.4: HJB 1D BC-aware boundary gradient residual+Jacobian (#1384) + HJB source v_t on all couplers (#1382) + post-audit hygiene (#1383)
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
Patch release shipping the merged correctness fixes since v0.20.3: BC-aware 1D HJB boundary gradient (#1384), HJB source `v_t` on all couplers (#1382), post-audit hygiene (#1383). Version bump + CHANGELOG promotion only; no code changes.