### PR TITLE
fix(hjb): fail loud on missing Hamiltonian in SL + WENO; drop silent LQ fallbacks (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **HJB semi-Lagrangian and WENO now fail loud on a missing Hamiltonian** (Issue #1071,
-  fail-fast). Both solvers carried a silent fallback that substituted a hardcoded LQ
-  Hamiltonian (`H = 0.5*|p|^2 + C*m` in SL's `_default_hamiltonian`; `0.5*grad**2 + m*grad`
-  in WENO) when no `hamiltonian_class` / `problem.H` was available — returning a
-  plausible-but-wrong solution for any non-LQ problem with no error. These paths were dead
-  for any normally-constructed `MFGProblem` (construction requires a Hamiltonian), so the
-  change is byte-identical for real usage; both now raise a clear `ValueError` naming the
-  fix (specify a Hamiltonian explicitly) instead of silently solving the wrong physics. The
-  dead `HJBSemiLagrangianSolver._default_hamiltonian` method is removed. Regression:
-  `tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py`.
+  fail-fast). Both solvers carried silent fallbacks that substituted a hardcoded LQ
+  Hamiltonian when no `hamiltonian_class` / `problem.H` was available — returning a
+  plausible-but-wrong solution for any non-LQ problem with no error:
+  - SL `_default_hamiltonian` (`H = 0.5*|p|^2 + C*m`) on the per-point path,
+  - SL **batch path** silently zeroing `H` (`H_values = np.zeros(Nx)`) — reducing the HJB
+    update to pure transport of the terminal data (caught by a comprehensive scan; the
+    per-point fix alone was incomplete and the per-point loops' broad `except` would have
+    swallowed its raise),
+  - WENO `0.5*grad**2 + m*grad`.
+
+  Fixed with a **solve-entry guard** in `HJBSemiLagrangianSolver.solve_hjb_system` (fails
+  loud before any path can produce a silent pure-transport solution), a batch-path backstop,
+  and the WENO raise; the dead `_default_hamiltonian` method is removed. These paths were
+  dead for any normally-constructed `MFGProblem` (construction requires a Hamiltonian), so
+  the change is **byte-identical for real usage**; they now raise a clear `ValueError` naming
+  the fix instead of silently solving the wrong physics. Regression (incl. the real solve
+  path): `tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py`.
 
 ## [0.20.4] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **HJB semi-Lagrangian and WENO now fail loud on a missing Hamiltonian** (Issue #1071,
+  fail-fast). Both solvers carried a silent fallback that substituted a hardcoded LQ
+  Hamiltonian (`H = 0.5*|p|^2 + C*m` in SL's `_default_hamiltonian`; `0.5*grad**2 + m*grad`
+  in WENO) when no `hamiltonian_class` / `problem.H` was available — returning a
+  plausible-but-wrong solution for any non-LQ problem with no error. These paths were dead
+  for any normally-constructed `MFGProblem` (construction requires a Hamiltonian), so the
+  change is byte-identical for real usage; both now raise a clear `ValueError` naming the
+  fix (specify a Hamiltonian explicitly) instead of silently solving the wrong physics. The
+  dead `HJBSemiLagrangianSolver._default_hamiltonian` method is removed. Regression:
+  `tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py`.
+
 ## [0.20.4] - 2026-06-16
 
 ### Fixed

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -2373,7 +2373,16 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         except (AttributeError, TypeError) as e:
             logger.debug(f"Legacy Hamiltonian signature failed: {e}")
 
-        return self._default_hamiltonian(derivs, m)
+        # Issue #1071 / fail-fast: do NOT silently fall back to the LQ default
+        # H = ½|p|² + C·m. That substitutes the WRONG physics for any non-LQ problem and
+        # returns a plausible-but-incorrect solution with no error (the exact silent-fallback
+        # class this codebase forbids). Fail loud and tell the caller to supply a Hamiltonian.
+        raise ValueError(
+            "HJB semi-Lagrangian: no Hamiltonian available (problem.hamiltonian_class is None "
+            "and no legacy problem.H / problem.hamiltonian succeeded). Specify one explicitly, "
+            "e.g. MFGComponents(hamiltonian=SeparableHamiltonian(...)). The solver will not "
+            "silently substitute the LQ default H=0.5*|p|^2 + C*m (Issue #1071, fail-fast)."
+        )
 
     def _build_derivative_tensors(self, p: np.ndarray | float) -> DerivativeTensors:
         """
@@ -2429,20 +2438,6 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 idx = int((x_vec[i] - xmin_i) / dx_i)
                 indices.append(int(np.clip(idx, 0, Nx_i)))
             return tuple(indices)
-
-    def _default_hamiltonian(self, derivs: DerivativeTensors, m: float) -> float:
-        """
-        Default quadratic Hamiltonian H = |p|²/2 + C*m.
-
-        Args:
-            derivs: DerivativeTensors with gradient
-            m: Density value
-
-        Returns:
-            Hamiltonian value
-        """
-        coef_CT = getattr(self.problem, "coupling_coefficient", 0.5)
-        return 0.5 * derivs.grad_norm_squared + coef_CT * m
 
     def _solve_crank_nicolson_diffusion(self, U_star: np.ndarray, dt: float, sigma: float) -> np.ndarray:
         """

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -838,6 +838,18 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         if U_coupling_prev is None:
             raise ValueError("U_coupling_prev is required")
 
+        # Issue #1071 / fail-fast: a missing Hamiltonian must fail loud HERE, before the
+        # timestep loop — otherwise the batch path silently zeros H (pure transport of the
+        # terminal data) and the per-point loops' broad except swallows the per-point raise.
+        # MFGProblem construction requires a Hamiltonian, so this only fires on a duck-typed
+        # or externally-nulled problem; it must not silently solve the wrong physics.
+        if self.problem.hamiltonian_class is None:
+            raise ValueError(
+                "HJBSemiLagrangianSolver: problem.hamiltonian_class is None. Specify a Hamiltonian "
+                "explicitly, e.g. MFGComponents(hamiltonian=SeparableHamiltonian(...)). The solver "
+                "will not silently substitute the LQ default H=0.5*|p|^2 (Issue #1071, fail-fast)."
+            )
+
         # Reset gradient clipping statistics for this solve (Issue #583)
         self._reset_gradient_stats()
 
@@ -1023,7 +1035,13 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 if H_class is not None:
                     H_values = eval_H_batch(H_class, x_batch, M_next, p_batch, time_idx * self.dt).ravel()
                 else:
-                    H_values = np.zeros(Nx)
+                    # Issue #1071 / fail-fast: never silently drop the Hamiltonian term (that
+                    # reduces the HJB update to pure transport of the terminal data). The
+                    # solve-entry guard catches this first; this is the batch-path backstop.
+                    raise ValueError(
+                        "HJBSemiLagrangianSolver: problem.hamiltonian_class is None in the batch "
+                        "Hamiltonian path. Specify a Hamiltonian explicitly (Issue #1071, fail-fast)."
+                    )
 
                 # Step 1d: Advection update (vectorized)
                 U_star = u_departures - self.dt * H_values

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -698,9 +698,16 @@ class HJBWenoSolver(BaseHJBSolver):
         except AttributeError:
             pass
 
-        # Default: standard quadratic MFG Hamiltonian H = |p|²/2 + m*p
-        # For 1D partial: H = (1/2)|∂u/∂x_i|² + m * ∂u/∂x_i
-        return 0.5 * grad**2 + m_val * grad
+        # Issue #1071 / fail-fast: do NOT silently fall back to a hardcoded Hamiltonian
+        # H = 0.5*|p|^2 + m*p. That substitutes the WRONG physics (a specific LQ-congestion
+        # model) for whatever the caller actually defined, returning a plausible-but-incorrect
+        # solution with no error — the silent-fallback class this codebase forbids.
+        raise ValueError(
+            "HJB WENO: no Hamiltonian available (problem.H is absent / raised). Provide a "
+            "problem exposing H, e.g. MFGProblem(components=MFGComponents(hamiltonian=...)). "
+            "The solver will not silently substitute the LQ default H=0.5*|p|^2 + m*p "
+            "(Issue #1071, fail-fast)."
+        )
 
     def _compute_hjb_rhs_axis(self, u: np.ndarray, m: np.ndarray, axis: int) -> np.ndarray:
         """Right-hand side of the HJB equation along a single ``axis``.

--- a/tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py
+++ b/tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py
@@ -62,6 +62,28 @@ def test_semi_lagrangian_default_hamiltonian_method_removed():
     assert not hasattr(HJBSemiLagrangianSolver, "_default_hamiltonian")
 
 
+def test_semi_lagrangian_solve_no_hamiltonian_fails_loud(monkeypatch):
+    """The REAL solve path must fail loud, not just _evaluate_hamiltonian in isolation.
+
+    The batch path used to zero H silently and the per-point loops' broad except would
+    swallow the per-point raise; the solve-entry guard catches the missing Hamiltonian
+    before either can produce a silent pure-transport solution.
+    """
+    problem = _problem()
+    solver = HJBSemiLagrangianSolver(problem)
+    monkeypatch.setattr(problem.components, "_hamiltonian_class", None, raising=False)
+
+    nx = problem.geometry.get_grid_shape()[0]
+    nt_points = problem.Nt + 1
+    x = problem.geometry.get_spatial_grid().ravel()
+    m_density = np.ones((nt_points, nx)) / nx
+    u_terminal = 0.5 * (x - 0.5) ** 2
+    u_prev = np.tile(u_terminal, (nt_points, 1))
+
+    with pytest.raises(ValueError, match="silently substitute|fail-fast"):
+        solver.solve_hjb_system(M_density=m_density, U_terminal=u_terminal, U_coupling_prev=u_prev)
+
+
 def test_weno_no_hamiltonian_fails_loud(monkeypatch):
     """WENO: with problem.H unavailable, _evaluate_hamiltonian raises rather than silently
     returning the hardcoded 0.5*grad**2 + m_val*grad."""

--- a/tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py
+++ b/tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py
@@ -1,0 +1,83 @@
+"""Issue #1071 / fail-fast: HJB solvers must NOT silently substitute a hardcoded LQ
+Hamiltonian when none is available — they must raise.
+
+Pins the removal of two silent-wrong-physics fallbacks:
+- the semi-Lagrangian ``_default_hamiltonian`` (``H = 0.5*|p|^2 + C*m``), and
+- the WENO ``0.5*grad**2 + m_val*grad`` fallback.
+
+These were dead for any normally-constructed ``MFGProblem`` (construction requires a
+Hamiltonian), so the change is byte-identical for real usage; the raise guards
+duck-typed / externally-nulled Hamiltonian misuse and forbids silent re-introduction.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import pytest
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver, HJBWenoSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem() -> MFGProblem:
+    components = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=0.5, Nt=10, sigma=0.3, components=components)
+
+
+def _raise_attribute_error(*_args, **_kwargs):
+    raise AttributeError("no Hamiltonian (test)")
+
+
+def test_semi_lagrangian_no_hamiltonian_fails_loud(monkeypatch):
+    """SL: with no hamiltonian_class and no legacy H, _evaluate_hamiltonian raises rather
+    than silently returning the LQ default (the removed _default_hamiltonian)."""
+    problem = _problem()
+    solver = HJBSemiLagrangianSolver(problem)
+
+    # Force the no-Hamiltonian state the silent fallback used to swallow.
+    monkeypatch.setattr(problem.components, "_hamiltonian_class", None, raising=False)
+    monkeypatch.setattr(problem, "H", _raise_attribute_error, raising=False)
+    monkeypatch.setattr(problem, "hamiltonian", _raise_attribute_error, raising=False)
+
+    with pytest.raises(ValueError, match="silently substitute|fail-fast"):
+        solver._evaluate_hamiltonian(x=0.5, p=0.3, m=1.0, time_idx=0)
+
+
+def test_semi_lagrangian_default_hamiltonian_method_removed():
+    """The silent LQ fallback method must stay gone (no silent re-introduction)."""
+    assert not hasattr(HJBSemiLagrangianSolver, "_default_hamiltonian")
+
+
+def test_weno_no_hamiltonian_fails_loud(monkeypatch):
+    """WENO: with problem.H unavailable, _evaluate_hamiltonian raises rather than silently
+    returning the hardcoded 0.5*grad**2 + m_val*grad."""
+    problem = _problem()
+    solver = HJBWenoSolver(problem=problem)
+
+    monkeypatch.setattr(problem, "H", _raise_attribute_error, raising=False)
+
+    with pytest.raises(ValueError, match="silently substitute|fail-fast"):
+        solver._evaluate_hamiltonian(x_idx=0, m_val=1.0, grad=0.3)
+
+
+def test_normal_problem_still_evaluates(monkeypatch):
+    """Sanity: a properly-specified Hamiltonian still evaluates (the fail-loud does not
+    fire on the happy path)."""
+    problem = _problem()
+    solver = HJBSemiLagrangianSolver(problem)
+    val = solver._evaluate_hamiltonian(x=0.5, p=0.3, m=1.0, time_idx=0)
+    assert np.isfinite(val)


### PR DESCRIPTION
Part of #1071 (kill solver-level hardcoded-Hamiltonian re-derivation) — and directly the "no silent fallbacks" policy.

## What

The semi-Lagrangian and WENO HJB solvers each carried a **silent-wrong-physics fallback**: when no Hamiltonian was available they substituted a hardcoded LQ Hamiltonian and returned a plausible-but-incorrect solution with no error.

- `hjb_semi_lagrangian.py` — `_default_hamiltonian` (`H = 0.5*|p|^2 + C*m`), reached after the legacy `problem.H`/`problem.hamiltonian` attempts all fail.
- `hjb_weno.py:703` — `0.5*grad**2 + m_val*grad` (a specific LQ-congestion model), reached when `problem.H` is absent.

Both now **raise a clear `ValueError`** naming the fix (specify a Hamiltonian explicitly). The dead `_default_hamiltonian` method is removed.

## Why this is safe (byte-identical)

`MFGProblem` construction *requires* a Hamiltonian, so these fallbacks were **dead for any normally-constructed problem**. The raise guards duck-typed / externally-nulled-`hamiltonian_class` misuse and forbids silent re-introduction. Evidence:
- SL + WENO suites: **108 pass** (byte-identical — the fallbacks were never hit).
- Broader `test_alg` + `test_factory` + adjoint sweep: **1325 pass** — nothing relied on the silent fallback.
- **Unwire check**: the new fail-loud tests *fail* on the pre-fix silent path and *pass* after — they discriminate.

## Context (from the #1071 survey)

A verified survey of the #1071 re-derivation sites found the **H/∂_pH bulk is already single-sourced** on every live path (via the `eval_H_batch`/`eval_dH_dp_batch` primitives or `H_class` through legacy glue); the λ desync was fixed (`_control_cost_lambda`). The RFC's headline "live bugs" are largely stale (e.g. `_compute_dH_dp_fd` is a dead fallback — `problem.dH_dp` never returns `None`). The genuinely-remaining #1071 work is: **these silent fallbacks** (this PR), `jax_backend` hardcoding ½p²/−p (#1072, separate sub-RFC), and the deferred σ-source Phase 6.

Refs #1071, #1072.
