### PR TITLE
fix(operators): LaplacianOperator fails loud on unhandled/unparseable BC (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`LaplacianOperator` fails loud on an unhandled / unparseable boundary condition**
+  (Issue #1071, fail-fast). Two silent-wrong fallbacks (surfaced by the silent-fallback scan)
+  are now errors: (a) an **unhandled `bc_type`** (e.g. Robin) previously emitted a
+  boundary-diffusion-free *interior-only* stencil (a silently under-constrained boundary) →
+  now raises `NotImplementedError` naming the unsupported type and the supported set; (b) a
+  **provided `bc` whose `bc_type` could not be determined** previously degraded silently to
+  the periodic default → now raises `ValueError`. The documented **`bc=None` → periodic**
+  default is unchanged. No tested path hit either fallback (436-test FP/laplacian sweep green),
+  so this is byte-identical for real usage. Regression:
+  `tests/unit/test_operators/test_laplacian.py::TestLaplacianBCFailLoud1071`.
+
 - **HJB semi-Lagrangian and WENO now fail loud on a missing Hamiltonian** (Issue #1071,
   fail-fast). Both solvers carried silent fallbacks that substituted a hardcoded LQ
   Hamiltonian when no `hamiltonian_class` / `problem.H` was available — returning a

--- a/mfgarchon/operators/differential/laplacian.py
+++ b/mfgarchon/operators/differential/laplacian.py
@@ -278,8 +278,15 @@ class LaplacianOperator(LinearOperator):
         if self.bc is not None:
             try:
                 bc_type = self.bc.bc_type.value if hasattr(self.bc.bc_type, "value") else str(self.bc.bc_type)
-            except (AttributeError, ValueError):
-                bc_type = None
+            except (AttributeError, ValueError) as e:
+                # Issue #1071 / fail-fast: a PROVIDED bc whose bc_type cannot be determined must
+                # NOT silently degrade to the bc=None periodic default (that would solve a
+                # different boundary than the caller specified). Surface it.
+                raise ValueError(
+                    f"LaplacianOperator: could not determine bc_type from the provided bc "
+                    f"({type(self.bc).__name__}): {e}. A BoundaryConditions exposing a single bc_type "
+                    f"is required; the operator will not silently treat a provided bc as periodic."
+                ) from e
 
         # All flat indices
         all_idx = np.arange(N)
@@ -422,18 +429,15 @@ class LaplacianOperator(LinearOperator):
                 vals_list.append(np.full(int(at_max.sum()), 1.0 / h2))
 
             else:
-                # Unknown BC: interior-only standard stencil
-                rows_list.append(all_idx[interior])
-                cols_list.append(all_idx[interior])
-                vals_list.append(np.full(int(interior.sum()), -2.0 / h2))
-
-                rows_list.append(all_idx[interior])
-                cols_list.append(all_idx[interior] - stride)
-                vals_list.append(np.full(int(interior.sum()), 1.0 / h2))
-
-                rows_list.append(all_idx[interior])
-                cols_list.append(all_idx[interior] + stride)
-                vals_list.append(np.full(int(interior.sum()), 1.0 / h2))
+                # Issue #1071 / fail-fast: an unhandled bc_type previously produced an
+                # interior-only stencil — boundary rows with NO diffusion entries, i.e. a
+                # silently under-constrained boundary (wrong physics, no error). Surface it.
+                raise NotImplementedError(
+                    f"LaplacianOperator does not implement bc_type={bc_type!r}. Supported: "
+                    "'periodic' (or bc=None), 'neumann'/'no_flux', 'dirichlet'. It will not "
+                    "silently emit a boundary-diffusion-free interior-only stencil for an "
+                    "unhandled BC (Issue #1071, fail-fast)."
+                )
 
         # Single concatenation + single sparse construction
         rows = np.concatenate(rows_list)

--- a/tests/unit/test_operators/test_laplacian.py
+++ b/tests/unit/test_operators/test_laplacian.py
@@ -463,5 +463,43 @@ class TestLaplacianVariableCoefficient:
             )
 
 
+class TestLaplacianBCFailLoud1071:
+    """Issue #1071 / fail-fast: a missing/unhandled BC must not silently degrade the stencil.
+
+    Previously an unknown bc_type silently produced a boundary-diffusion-free interior-only
+    stencil, and a provided bc whose bc_type could not be parsed silently became periodic.
+    Both now raise (the bc=None periodic default is unchanged — it is documented).
+    """
+
+    def test_unknown_bc_type_fails_loud(self):
+        """An unhandled bc_type (e.g. robin) raises instead of emitting an interior-only stencil."""
+
+        class _FakeBCType:
+            value = "robin"
+
+        class _FakeRobinBC:
+            bc_type = _FakeBCType()
+
+        op = LaplacianOperator(spacings=[0.1], field_shape=(10,), bc=_FakeRobinBC())
+        with pytest.raises(NotImplementedError, match="does not implement bc_type"):
+            op.as_scipy_sparse()
+
+    def test_provided_bc_without_bc_type_fails_loud(self):
+        """A provided bc with no determinable bc_type raises, not silently treated as periodic."""
+
+        class _NoBCType:
+            pass  # no .bc_type attribute
+
+        op = LaplacianOperator(spacings=[0.1], field_shape=(10,), bc=_NoBCType())
+        with pytest.raises(ValueError, match="could not determine bc_type"):
+            op.as_scipy_sparse()
+
+    def test_bc_none_still_periodic(self):
+        """bc=None remains the documented periodic default (NOT failed-loud)."""
+        op = LaplacianOperator(spacings=[0.1], field_shape=(10,), bc=None)
+        mat = op.as_scipy_sparse()  # must not raise
+        assert mat.shape == (10, 10)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Part of #1071 silent-fallback cleanup (the comprehensive scan). Two silent-wrong fallbacks become errors:

- **Unhandled `bc_type`** (e.g. Robin) previously emitted a boundary-diffusion-free **interior-only stencil** — a silently under-constrained boundary, wrong physics, no error. → `NotImplementedError` naming the type + supported set.
- A **provided `bc` whose `bc_type` couldn't be parsed** previously degraded silently to the periodic default. → `ValueError`.

The documented **`bc=None` → periodic** default is unchanged.

**Safe / byte-identical for real usage:** no tested path hits either fallback — 436-test FP/laplacian/mass-conservation sweep green; the targeted laplacian suite (35) green. **Unwire-verified**: the two new fail-loud tests fail on the pre-fix silent behavior and pass after. Regression: `tests/unit/test_operators/test_laplacian.py::TestLaplacianBCFailLoud1071`.

Refs #1071.