### PR TITLE
fix(fp): FPParticleSolver fails loud on invalid initial density (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`FPParticleSolver` fails loud on an invalid initial density** (Issue #1071, fail-fast).
+  When `m_initial` produced invalid sampling probabilities — NaN/Inf (which routed silently to
+  the uniform `else` since `NaN > 1e-9` is False) or negative entries (which made
+  `np.random.choice` raise) — the solver silently sampled the initial particles from a
+  **uniform** distribution instead of the specified density, solving a different problem with no
+  error. Both invalid cases now raise a clear `ValueError`; the documented
+  degenerate-but-finite (`sum ≈ 0`) → uniform default is unchanged. No test relied on the
+  fallback (all use finite, non-negative densities) so this is byte-identical for valid usage.
+  Regression: `tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleInvalidMInitial1071`.
+
 - **`LaplacianOperator` fails loud on an unhandled / unparseable boundary condition**
   (Issue #1071, fail-fast). Two silent-wrong fallbacks (surfaced by the silent-fallback scan)
   are now errors: (a) an **unhandled `bc_type`** (e.g. Robin) previously emitted a

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -1512,14 +1512,29 @@ class FPParticleSolver(BaseFPSolver):
             current_M_particles_t = np.zeros((Nt, self.num_particles))
             particles_list = None
 
-        # Sample initial particles
+        # Sample initial particles.
+        # Issue #1071 / fail-fast: an INVALID initial density must not be silently replaced by a
+        # uniform sample (that solves a different problem with no error). A NaN/Inf density would
+        # otherwise route to the uniform `else` below (because `NaN > 1e-9` is False); a negative
+        # density makes np.random.choice raise, which was previously swallowed to uniform.
+        if not np.all(np.isfinite(m_initial_condition)):
+            raise ValueError(
+                "FPParticleSolver: m_initial contains NaN/Inf — cannot sample initial particles. "
+                "Provide a finite, non-negative initial density; it will not be silently replaced "
+                "by a uniform sample (Issue #1071, fail-fast)."
+            )
         if Dx > 1e-14 and np.sum(m_initial_condition * Dx) > 1e-9:
             m0_probs_unnormalized = m_initial_condition * Dx
             m0_probs = m0_probs_unnormalized / np.sum(m0_probs_unnormalized)
             try:
                 initial_particle_positions = np.random.choice(x_grid, size=self.num_particles, p=m0_probs, replace=True)
-            except ValueError:
-                initial_particle_positions = np.random.uniform(xmin, xmin + Lx, self.num_particles)
+            except ValueError as e:
+                # m0_probs is non-normalizable (e.g. negative entries) — the density is invalid.
+                raise ValueError(
+                    "FPParticleSolver: m_initial produced invalid sampling probabilities "
+                    f"(e.g. negative entries): {e}. Provide a non-negative initial density; it "
+                    "will not be silently replaced by a uniform sample (Issue #1071, fail-fast)."
+                ) from e
         else:
             initial_particle_positions = (
                 np.random.uniform(xmin, xmin + Lx, self.num_particles)

--- a/tests/unit/test_alg/test_fp_particle_solver.py
+++ b/tests/unit/test_alg/test_fp_particle_solver.py
@@ -988,5 +988,34 @@ class TestFPParticleSolverRemovedDeprecatedParams:
             solver.solve_fp_system(m0, diffusion_field=0.5)
 
 
+class TestFPParticleInvalidMInitial1071:
+    """Issue #1071 / fail-fast: an invalid initial density must not be silently replaced by a
+    uniform particle sample (which solves a different problem with no error)."""
+
+    def _solver_and_shapes(self):
+        geometry = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(geometry=geometry, T=0.2, Nt=5, components=_default_components())
+        solver = FPParticleSolver(problem, num_particles=200)
+        nx = problem.geometry.get_grid_shape()[0]
+        nt_points = problem.Nt_points
+        return solver, np.zeros((nt_points, nx)), nx
+
+    def test_nan_m_initial_fails_loud(self):
+        """NaN m_initial must raise, not silently route to a uniform sample."""
+        solver, u_solution, nx = self._solver_and_shapes()
+        m_bad = np.full(nx, np.nan)
+        with pytest.raises(ValueError, match="NaN/Inf"):
+            solver.solve_fp_system(m_bad, u_solution)
+
+    def test_negative_m_initial_fails_loud(self):
+        """A finite density with negative entries (positive sum) must raise, not silently
+        fall back to a uniform sample on the np.random.choice ValueError."""
+        solver, u_solution, nx = self._solver_and_shapes()
+        m_neg = np.ones(nx)
+        m_neg[0] = -5.0  # finite, positive sum, but a negative (invalid) probability mass
+        with pytest.raises(ValueError, match="invalid sampling probabilities"):
+            solver.solve_fp_system(m_neg, u_solution)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Part of #1071 silent-fallback cleanup (the comprehensive scan). When `m_initial` produced invalid sampling probabilities the solver silently sampled initial particles from a **uniform** distribution instead of the specified density — solving a different problem with no error:
- **NaN/Inf** `m_initial` routed to the uniform `else` (`NaN > 1e-9` is False)
- **negative** entries made `np.random.choice` raise → swallowed to uniform

Both now raise a clear `ValueError`. The documented **degenerate-but-finite (`sum ≈ 0`) → uniform** default is unchanged.

**Safe / byte-identical for valid usage:** no test relied on the fallback (all use finite non-negative densities); full fp_particle suite (55) green. **Unwire-verified**: the two new tests fail on the pre-fix silent uniform and pass after. Regression: `tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleInvalidMInitial1071`.

Refs #1071.