### PR TITLE
fix(factory): _load_function fails loud on provided-but-unloadable spec (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`GeneralMFGFactory._load_function` fails loud on a provided-but-unloadable spec**
+  (Issue #1071, fail-fast). A function spec that failed to load — a `lambda` that won't
+  evaluate, an unimportable `module.func` path, or an unresolvable name — previously
+  logged and returned `None`, silently dropping the user's function (defaulted for
+  optional components like `m_initial`/`potential`, or surfaced downstream as a misleading
+  "u_terminal required"). All three now raise a clear `ValueError` naming the spec and the
+  underlying error. `func_spec=None` (not provided) still returns `None` — the legitimate
+  case. Byte-identical for valid specs (factory suite green). Regression:
+  `tests/unit/test_factory/test_general_mfg_factory.py::TestLoadFunctionFailLoud1071`.
+
 - **`FPParticleSolver` fails loud on an invalid initial density** (Issue #1071, fail-fast).
   When `m_initial` produced invalid sampling probabilities — NaN/Inf (which routed silently to
   the uniform `else` since `NaN > 1e-9` is False) or negative entries (which made

--- a/mfgarchon/factory/general_mfg_factory.py
+++ b/mfgarchon/factory/general_mfg_factory.py
@@ -366,8 +366,14 @@ class GeneralMFGFactory:
                 }
                 return eval(func_spec, safe_namespace)
             except Exception as e:
-                logger.error(f"Failed to evaluate lambda function '{func_spec}': {e}")
-                return None
+                # Issue #1071 / fail-fast: a PROVIDED spec that won't evaluate must not return
+                # None (silently dropping the user's function → default for m_initial/potential,
+                # or a misleading "u_terminal required" downstream). func_spec is None → None
+                # above is the legitimate "not provided" case; this is a real load failure.
+                raise ValueError(
+                    f"GeneralMFGFactory: failed to evaluate lambda function spec {func_spec!r}: {e}. "
+                    "A provided function spec that cannot be loaded is not silently dropped (Issue #1071)."
+                ) from e
 
         # Check if it's a module path
         if "." in func_spec:
@@ -376,11 +382,16 @@ class GeneralMFGFactory:
                 module = importlib.import_module(module_path)
                 return getattr(module, function_name)
             except Exception as e:
-                logger.error(f"Failed to import function '{func_spec}': {e}")
-                return None
+                raise ValueError(
+                    f"GeneralMFGFactory: failed to import function spec {func_spec!r}: {e}. "
+                    "A provided function spec that cannot be loaded is not silently dropped (Issue #1071)."
+                ) from e
 
-        logger.warning(f"Could not resolve function specification: '{func_spec}'")
-        return None
+        raise ValueError(
+            f"GeneralMFGFactory: could not resolve function specification {func_spec!r} "
+            "(not a registered name, a 'lambda ...' expression, or an importable 'module.func' "
+            "path). A provided spec that cannot be loaded is not silently dropped (Issue #1071)."
+        )
 
     def create_template_config(self, filename: str) -> None:
         """Create a template configuration file.

--- a/tests/unit/test_factory/test_general_mfg_factory.py
+++ b/tests/unit/test_factory/test_general_mfg_factory.py
@@ -555,3 +555,26 @@ def test_function_registry_accessible_after_registration(factory):
     retrieved = factory.function_registry["custom"]
     assert retrieved is custom_func
     assert retrieved(5) == 10
+
+
+class TestLoadFunctionFailLoud1071:
+    """Issue #1071 / fail-fast: a PROVIDED function spec that cannot be loaded must raise,
+    not return None (which silently drops the user's function — defaulted for optional
+    components, or surfaced as a misleading 'required' error downstream).
+    func_spec is None remains the legitimate 'not provided' case.
+    """
+
+    def test_none_spec_returns_none(self, factory):
+        assert factory._load_function(None) is None
+
+    def test_malformed_lambda_fails_loud(self, factory):
+        with pytest.raises(ValueError, match="failed to evaluate lambda"):
+            factory._load_function("lambda x: x +")  # syntax error at eval time
+
+    def test_bad_module_path_fails_loud(self, factory):
+        with pytest.raises(ValueError, match="failed to import"):
+            factory._load_function("nonexistent_module_xyz.some_func")
+
+    def test_unresolvable_spec_fails_loud(self, factory):
+        with pytest.raises(ValueError, match="could not resolve"):
+            factory._load_function("not_a_registered_name")


### PR DESCRIPTION
Part of #1071 silent-fallback cleanup (the comprehensive scan). `GeneralMFGFactory._load_function` returned `None` on three *failure* paths for a **provided** spec — a `lambda` that won't evaluate, an unimportable `module.func`, or an unresolvable name — silently dropping the user's function (defaulted for optional `m_initial`/`potential`, or surfaced as a misleading "u_terminal required" downstream). All three now raise a clear `ValueError`. **`func_spec=None` (not provided) still returns `None`** — the legitimate case.

Byte-identical for valid specs (factory suite 29 green); **unwire-verified** the 3 fail-loud tests fail on the pre-fix silent `None` and pass after. Regression: `tests/unit/test_factory/test_general_mfg_factory.py::TestLoadFunctionFailLoud1071`.

Refs #1071.