### PR TITLE
chore(ci): fail-fast ratchet — block new silent fallbacks vs baseline (#1071)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
         ruff check --select F mfgarchon/
         echo "✅ No critical errors"
 
+    - name: Fail-fast ratchet (no new silent fallbacks)
+      timeout-minutes: 1
+      run: |
+        echo "Checking for NEW fail-fast violations (broad/bare except, silent pass, hasattr) vs baseline..."
+        python scripts/check_fail_fast.py --path mfgarchon --check-baseline scripts/fail_fast_baseline.json
+
   # === PHASE 1: Import Validation ===
   # Note: Ruff formatting, linting, and MyPy checks run in modern_quality.yml workflow
   import-validation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Fail-fast ratchet in CI** (Issue #1071). `scripts/check_fail_fast.py` gains
+  `--write-baseline` / `--check-baseline` (ratchet) modes, and Quick Validation now runs
+  `--check-baseline scripts/fail_fast_baseline.json` against `mfgarchon/`. It fails the
+  build only when a category (broad/bare `except`, silent `pass`-in-except, `hasattr`)
+  **increases** vs the committed baseline — so the silent-fallback cleanup can't regress,
+  while the count is free to ratchet down (regenerate the baseline with `--write-baseline`
+  after fixing violations). Baseline at introduction: `hasattr=174, silent_pass=70,
+  bare_except=0, broad_except=11`. Physics-style fallbacks (getattr-default, hardcoded
+  defaults) are intentionally NOT regex-gated (too many legitimate defaults — 160 seen in
+  the scan); those stay covered by periodic judgment-based scans + per-site fixes.
+
 ### Changed
 
 - **`GeneralMFGFactory._load_function` fails loud on a provided-but-unloadable spec**

--- a/scripts/check_fail_fast.py
+++ b/scripts/check_fail_fast.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import re
 import sys
@@ -81,19 +82,68 @@ def print_section(title, items, limit=None):
         print(f"... and {len(items) - limit} more.")
 
 
+def _counts(results: dict) -> dict:
+    """Per-category violation counts (the ratchet's comparison surface)."""
+    return {category: len(items) for category, items in results.items()}
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check for 'Fail Fast' principle violations.")
     parser.add_argument("--path", default=".", help="Root directory to scan")
     parser.add_argument("--limit", type=int, default=20, help="Limit lines printed per category")
     parser.add_argument("--all", action="store_true", help="Show all violations (no limit)")
+    parser.add_argument("--write-baseline", metavar="FILE", help="Write current per-category counts to FILE and exit")
+    parser.add_argument(
+        "--check-baseline",
+        metavar="FILE",
+        help=(
+            "Ratchet mode (CI guard): compare current counts to FILE and exit 1 ONLY if any "
+            "category increased (a new fail-fast violation was introduced). Counts may ratchet "
+            "down freely; regenerate the baseline with --write-baseline after fixing violations."
+        ),
+    )
 
     args = parser.parse_args()
-
-    print(f"Scanning '{args.path}' for Fail Fast violations...")
     results = check_fail_fast_violations(args.path)
+    counts = _counts(results)
 
+    # --- Ratchet modes (the durable CI guard) ---
+    if args.write_baseline:
+        with open(args.write_baseline, "w") as fh:
+            json.dump(counts, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        print(f"Wrote fail-fast baseline to {args.write_baseline}: {counts}")
+        sys.exit(0)
+
+    if args.check_baseline:
+        with open(args.check_baseline) as fh:
+            baseline = json.load(fh)
+        categories = sorted(set(counts) | set(baseline))
+        regressed = [
+            (c, counts.get(c, 0), baseline.get(c, 0)) for c in categories if counts.get(c, 0) > baseline.get(c, 0)
+        ]
+        improved = [
+            (c, counts.get(c, 0), baseline.get(c, 0)) for c in categories if counts.get(c, 0) < baseline.get(c, 0)
+        ]
+        if improved:
+            print("Fail-fast violations DECREASED — please tighten the baseline (run --write-baseline):")
+            for c, cur, base in improved:
+                print(f"  {c}: {base} -> {cur} ({cur - base})")
+        if regressed:
+            print("FAIL: new fail-fast violations introduced (no new broad/bare except, silent pass, or hasattr):")
+            for c, cur, base in regressed:
+                print(f"  {c}: {base} -> {cur} (+{cur - base})")
+            print(
+                "If a decrease is expected, regenerate the baseline: python scripts/check_fail_fast.py "
+                "--path mfgarchon --write-baseline scripts/fail_fast_baseline.json"
+            )
+            sys.exit(1)
+        print(f"OK: no new fail-fast violations vs baseline (counts: {counts})")
+        sys.exit(0)
+
+    # --- Human report mode ---
+    print(f"Scanning '{args.path}' for Fail Fast violations...")
     limit = None if args.all else args.limit
-
     print_section("SILENT FALLBACKS (Critical)", results["silent_pass"], limit)
     print_section("BARE EXCEPTS (Critical)", results["bare_except"], limit)
     print_section("BROAD EXCEPTIONS (Warning)", results["broad_except"], limit)

--- a/scripts/fail_fast_baseline.json
+++ b/scripts/fail_fast_baseline.json
@@ -1,0 +1,6 @@
+{
+  "bare_except": 0,
+  "broad_except": 11,
+  "hasattr": 174,
+  "silent_pass": 70
+}


### PR DESCRIPTION
The durable guard for the #1071 silent-fallback cleanup (so it can't regress).

Wires the existing `scripts/check_fail_fast.py` into **Quick Validation** as a **ratchet**:
- new `--write-baseline` / `--check-baseline` modes
- committed `scripts/fail_fast_baseline.json` (`hasattr=174, silent_pass=70, bare_except=0, broad_except=11`)
- CI fails **only when a category increases** vs baseline (a new broad/bare `except`, silent `pass`-in-except, or `hasattr`); the count may ratchet **down** freely (regenerate with `--write-baseline` after fixing).

A hard gate is impossible (255 pre-existing, mostly acceptable external-lib `hasattr`); the ratchet locks in "no new silent fallbacks" without blocking on the backlog. **Physics-style fallbacks** (getattr-default, hardcoded defaults) are deliberately *not* regex-gated — 160 legitimate defaults seen in the scan — and stay covered by periodic judgment-based scans + per-site fixes.

Verified locally: passes at baseline (exit 0), fails on a simulated +1 regression (exit 1). The check is stdlib-only (runs in Quick Validation with no package install).

Refs #1071.