### PR TITLE
chore(config): remove vestigial create_pydantic_config (silent default-config drop) (#1392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the fix instead of silently solving the wrong physics. Regression (incl. the real solve
   path): `tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py`.
 
+### Removed
+
+- **Vestigial `OmegaConfManager.create_pydantic_config` / `_map_omega_to_pydantic`**
+  (Issue #1392). A pre-North-Star second OmegaConf→Pydantic bridge that bypassed the
+  canonical single crossing (`config.bridge.bridge_to_pydantic`) and silently returned a
+  **default** `MFGSolverConfig`: `_map_omega_to_pydantic` mapped flat keys
+  (`max_iterations`/`tolerance`/`damping`) while `MFGSolverConfig` is nested
+  (`hjb`/`fp`/`picard`/…), so Pydantic (`extra=ignore`) dropped them — the user's config was
+  silently discarded. No callers. Per the Config System North Star (Pydantic = single source
+  of truth, OmegaConf = transport only, one validation crossing), this was residue. Use
+  `bridge_to_pydantic(omega_cfg, MFGSolverConfig)`; `OmegaConfManager`'s load/merge/save
+  transport is unchanged. Regression guard:
+  `tests/unit/test_config/test_bridge.py::TestNoVestigialOmegaToPydanticBridge1392`.
+
 ## [0.20.4] - 2026-06-16
 
 ### Fixed

--- a/mfgarchon/config/omegaconf_manager.py
+++ b/mfgarchon/config/omegaconf_manager.py
@@ -18,7 +18,8 @@ Features:
 - Configuration composition and inheritance via OmegaConf.merge
 - CLI overrides (OmegaConf.from_cli, .from_dotlist)
 - Parameter sweeps via `create_parameter_sweep`
-- Bridging to Pydantic validation via `create_pydantic_config`
+- Bridging to Pydantic validation via `mfgarchon.config.bridge.bridge_to_pydantic`
+  (the single canonical OmegaConf->Pydantic crossing; this manager is transport only)
 """
 
 from __future__ import annotations
@@ -95,7 +96,6 @@ else:
         ConfigAttributeError = Exception
         UnsupportedInterpolationType = Exception
 
-from .core import MFGSolverConfig
 
 logger = get_logger(__name__)
 
@@ -315,49 +315,12 @@ class OmegaConfManager:
 
         return cast("OmegaConfig", composed_config)
 
-    def create_pydantic_config(self, omega_config: OmegaConfig) -> MFGSolverConfig:
-        """
-        Convert OmegaConf configuration to Pydantic MFGSolverConfig.
-
-        Args:
-            omega_config: OmegaConf configuration
-
-        Returns:
-            Pydantic MFGSolverConfig object
-        """
-        # Extract solver configuration
-        solver_config = omega_config.get("solver", {})
-        # Convert OmegaConf to Python dict (use to_container for newer OmegaConf versions)
-        if hasattr(self._OmegaConf, "to_container"):
-            raw_dict = self._OmegaConf.to_container(solver_config, resolve=True)
-        else:
-            # Fallback for older OmegaConf versions
-            raw_dict = dict(solver_config) if hasattr(solver_config, "items") else {}
-
-        # Ensure we have a proper dictionary with string keys
-        from typing import cast
-
-        solver_dict: dict[str, Any] = cast("dict[str, Any]", raw_dict if isinstance(raw_dict, dict) else {})
-
-        # Map OmegaConf structure to Pydantic structure
-        pydantic_dict = self._map_omega_to_pydantic(solver_dict)
-
-        try:
-            return MFGSolverConfig(**pydantic_dict)
-        except Exception as e:
-            logger.warning(f"Could not create Pydantic config directly: {e}")
-            # Fall back to default configuration
-            return MFGSolverConfig()
-
-    def _map_omega_to_pydantic(self, omega_dict: dict[str, Any]) -> dict[str, Any]:
-        """Map OmegaConf structure to Pydantic structure."""
-        # This is a simplified mapping - extend as needed
-        return {
-            "max_iterations": omega_dict.get("max_iterations", 100),
-            "tolerance": omega_dict.get("tolerance", 1e-6),
-            "damping": omega_dict.get("damping", 0.5),
-            # Add more mappings as needed
-        }
+    # NOTE (Issue #1392): the vestigial `create_pydantic_config` / `_map_omega_to_pydantic`
+    # pair was removed. They were a pre-North-Star second OmegaConf->Pydantic bridge that
+    # bypassed the canonical, single crossing `mfgarchon.config.bridge.bridge_to_pydantic`
+    # and silently returned a default config (flat keys vs the nested MFGSolverConfig). Use
+    # `bridge_to_pydantic(omega_cfg, MFGSolverConfig)` for validation; this manager is
+    # transport only (load/merge/save/CLI).
 
     def save_config(self, config: OmegaConfig, output_path: str | Path) -> None:
         """

--- a/scripts/fail_fast_baseline.json
+++ b/scripts/fail_fast_baseline.json
@@ -1,6 +1,6 @@
 {
   "bare_except": 0,
   "broad_except": 11,
-  "hasattr": 174,
+  "hasattr": 172,
   "silent_pass": 70
 }

--- a/tests/unit/test_config/test_bridge.py
+++ b/tests/unit/test_config/test_bridge.py
@@ -217,3 +217,21 @@ class TestLoadEffectiveConfig:
             assert loaded.picard.tolerance == 1e-10
             assert loaded.picard.max_iterations == 500
             assert loaded.picard.relaxation == 0.8
+
+
+class TestNoVestigialOmegaToPydanticBridge1392:
+    """Issue #1392: OmegaConf->Pydantic validation has ONE canonical crossing
+    (bridge_to_pydantic). The pre-North-Star OmegaConfManager.create_pydantic_config /
+    _map_omega_to_pydantic pair (a second, broken bridge that silently returned a default
+    config) was removed and must not be silently re-introduced."""
+
+    def test_create_pydantic_config_removed(self) -> None:
+        from mfgarchon.config.omegaconf_manager import OmegaConfManager
+
+        assert not hasattr(OmegaConfManager, "create_pydantic_config")
+        assert not hasattr(OmegaConfManager, "_map_omega_to_pydantic")
+
+    def test_bridge_to_pydantic_is_the_canonical_crossing(self) -> None:
+        from mfgarchon.config import bridge_to_pydantic
+
+        assert callable(bridge_to_pydantic)


### PR DESCRIPTION
Closes #1392. Removes the **pre-North-Star vestigial second OmegaConf→Pydantic bridge** in `OmegaConfManager`.

`create_pydantic_config` + `_map_omega_to_pydantic` bypassed the canonical single crossing (`config.bridge.bridge_to_pydantic`) and **silently returned a default `MFGSolverConfig`**: the mapping used flat keys (`max_iterations`/`tolerance`/`damping`) but `MFGSolverConfig` is nested (`hjb`/`fp`/`picard`/…), so Pydantic (`extra=ignore`) dropped them — the user's config was silently discarded. **No callers** (only a stale docstring ref).

Per the **Config System North Star** (Joplin MFG→Dev; shipped v0.19.0–v0.19.4: Pydantic = single source of truth, OmegaConf = transport-only, *one* validation crossing), this is residue. Removed both methods + the now-unused `MFGSolverConfig` import; fixed the docstring to point at `bridge_to_pydantic`. `OmegaConfManager`'s load/merge/save transport is unchanged (used by `general_mfg_factory`).

Bonus: the deletion removed 2 `hasattr` calls — fail-fast ratchet baseline tightened (174→172). Config + factory suites green (229); 2 regression guards added (`test_bridge.py::TestNoVestigialOmegaToPydanticBridge1392`).

Refs #1155, #1156, #1071.