### PR TITLE
chore: warn (not silently) on degenerate GFDM stencil + KDE cloud (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Degraded fallbacks now warn instead of staying silent** (Issue #1071). Two legitimate
+  fallbacks that previously masked a real degeneracy are kept but surfaced: `HJBGFDMSolver`'s
+  per-point FD Jacobian uses an identity row when a stencil is degenerate (singular Taylor
+  matrix) — now emits one aggregated warning naming the affected collocation points (Newton
+  convergence is degraded there); and `MeasureField`'s 1D/nD KDE falls back to a fixed
+  bandwidth `0.1` on a zero-spread (degenerate) particle cloud — now warns that the density
+  estimate is unreliable. Behavior is unchanged (byte-identical for non-degenerate inputs).
+  Regression: `tests/unit/test_core/test_measure.py::TestDegenerateCloudWarns1071`.
+
 - **`GeneralMFGFactory._load_function` fails loud on a provided-but-unloadable spec**
   (Issue #1071, fail-fast). A function spec that failed to load — a `lambda` that won't
   evaluate, an unimportable `module.func` path, or an unresolvable name — previously

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2510,10 +2510,15 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Use LIL format for efficient construction
         jacobian = lil_matrix((n, n))
 
+        degenerate_rows: list[int] = []
         for i in range(n):
             weights = self._cached_derivative_weights[i]
             if weights is None:
-                jacobian[i, i] = 1.0 / dt  # Fallback: identity
+                # Issue #1071: degenerate stencil (singular Taylor matrix) at point i. Use an
+                # identity Jacobian row so Newton can continue, but record it — the degenerate
+                # stencil must not be masked silently (aggregated warning emitted after the loop).
+                jacobian[i, i] = 1.0 / dt
+                degenerate_rows.append(i)
                 continue
 
             neighbor_indices = weights["neighbor_indices"]
@@ -2548,6 +2553,15 @@ class HJBGFDMSolver(BaseHJBSolver):
             jacobian[i, i] += np.dot(dH_dp, center_grad_weight) - diffusion_coeff * center_lap_weight
             jacobian[i, i] += 1.0 / dt  # Time derivative
 
+        if degenerate_rows:
+            logger.warning(
+                "HJBGFDMSolver: %d collocation point(s) have a degenerate stencil "
+                "(singular Taylor matrix); used an identity Jacobian row there, which degrades "
+                "Newton convergence at those points. Indices: %s%s",
+                len(degenerate_rows),
+                degenerate_rows[:10],
+                "..." if len(degenerate_rows) > 10 else "",
+            )
         return jacobian.tocsr()
 
     _BC_STR_TO_ENUM: ClassVar[dict[str, BCType]] = {

--- a/mfgarchon/core/measure.py
+++ b/mfgarchon/core/measure.py
@@ -24,8 +24,13 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import numpy as np
 
+from mfgarchon.utils.mfg_logging import get_logger
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+
+logger = get_logger(__name__)
 
 
 @runtime_checkable
@@ -150,7 +155,16 @@ class ParticleMeasure:
         positions = self._positions[:, 0]
         if bandwidth is None:
             std = np.std(positions)
-            bandwidth = std * self._n_particles ** (-1 / 5) if std > 0 else 0.1
+            if std > 0:
+                bandwidth = std * self._n_particles ** (-1 / 5)
+            else:
+                # Issue #1071: degenerate cloud (zero spread) — fall back to a fixed bandwidth
+                # to avoid div-by-zero, but surface it (the density estimate is unreliable).
+                logger.warning(
+                    "MeasureField 1D KDE: particle cloud has zero spread (std=0, degenerate); "
+                    "using fallback bandwidth 0.1 — the density estimate is unreliable."
+                )
+                bandwidth = 0.1
 
         # Gaussian kernel: K(u) = (1/sqrt(2*pi)) * exp(-u^2/2)
         # density(x) = sum_i w_i * K((x - y_i) / h) / h
@@ -163,7 +177,15 @@ class ParticleMeasure:
         d = self._dim
         if bandwidth is None:
             std = np.std(self._positions, axis=0).mean()
-            bandwidth = std * self._n_particles ** (-1 / (d + 4)) if std > 0 else 0.1
+            if std > 0:
+                bandwidth = std * self._n_particles ** (-1 / (d + 4))
+            else:
+                logger.warning(
+                    "MeasureField %dD KDE: particle cloud has zero spread (std=0, degenerate); "
+                    "using fallback bandwidth 0.1 — the density estimate is unreliable.",
+                    d,
+                )
+                bandwidth = 0.1
 
         M = x.shape[0]
         density = np.zeros(M)

--- a/tests/unit/test_core/test_measure.py
+++ b/tests/unit/test_core/test_measure.py
@@ -197,3 +197,40 @@ class TestParticleMeasureRepr:
         mu = ParticleMeasure(np.zeros((10, 3)))
         assert "n=10" in repr(mu)
         assert "d=3" in repr(mu)
+
+
+class TestDegenerateCloudWarns1071:
+    """Issue #1071: a degenerate particle cloud (zero spread) must not silently fall back to a
+    fixed KDE bandwidth — it warns (the fallback is kept, but it is no longer silent).
+
+    Spies on the module logger directly (mfgarchon's get_logger does not propagate to the
+    pytest caplog root handler).
+    """
+
+    @staticmethod
+    def _spy_warnings(monkeypatch):
+        import mfgarchon.core.measure as measure_mod
+
+        calls: list[str] = []
+        monkeypatch.setattr(measure_mod.logger, "warning", lambda msg, *a, **k: calls.append(str(msg)))
+        return calls
+
+    def test_1d_zero_spread_warns(self, monkeypatch):
+        calls = self._spy_warnings(monkeypatch)
+        mu = ParticleMeasure(np.array([0.5, 0.5, 0.5]))  # std == 0 (degenerate)
+        density = mu.to_density(np.linspace(0.0, 1.0, 51))
+        assert density.shape == (51,)
+        assert any("zero spread" in c for c in calls)
+
+    def test_nd_zero_spread_warns(self, monkeypatch):
+        calls = self._spy_warnings(monkeypatch)
+        mu = ParticleMeasure(np.full((5, 2), 0.5))  # all at (0.5, 0.5): std == 0
+        grid = np.array([[0.4, 0.4], [0.5, 0.5], [0.6, 0.6]])
+        mu.to_density(grid)
+        assert any("zero spread" in c for c in calls)
+
+    def test_nondegenerate_does_not_warn(self, monkeypatch):
+        calls = self._spy_warnings(monkeypatch)
+        mu = ParticleMeasure(np.array([0.2, 0.5, 0.8]))  # std > 0
+        mu.to_density(np.linspace(0.0, 1.0, 51))
+        assert not any("zero spread" in c for c in calls)


### PR DESCRIPTION
Part of #1071 silent-fallback cleanup — the two **keep-with-warning** findings (legitimate fallbacks that masked a real degeneracy with no signal):

- **HJBGFDMSolver** per-point FD Jacobian: identity row for a degenerate stencil (singular Taylor matrix) → one **aggregated** `logger.warning` naming the affected points (Newton convergence degraded there). The identity row is kept (robustness).
- **MeasureField** 1D/nD KDE: fixed bandwidth `0.1` on a zero-spread (degenerate) cloud → now warns the density estimate is unreliable. Fallback kept (avoids div-by-zero).

**Behavior unchanged** (byte-identical for non-degenerate inputs); added a module logger to `measure.py`. Regression: `test_measure.py::TestDegenerateCloudWarns1071` (logger spy — `get_logger` doesn't propagate to caplog). gfdm + measure suites green (58 + 30). Ratchet clean (no new broad-except/hasattr).

Refs #1071.