### PR TITLE
chore(qp): warn on QP non-convergence instead of silent unconstrained x0 (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`QPSolver` warns on non-convergence instead of silently returning the unconstrained
+  solution** (Issue #1071). All three backends (OSQP / scipy SLSQP / L-BFGS-B) returned the
+  unconstrained least-squares `x0` (incrementing a `failures` stat) when the constrained solve
+  did not converge — with no error or warning, so a constraint-violating result was used as if
+  it had succeeded. (Distinct from the *exception* path, which `monotonicity_enforcer` already
+  warns + falls back on.) For the GFDM monotone-stencil use, that silently produces a
+  non-monotone stencil. The shared `_unconstrained_fallback` helper now emits a `logger.warning`
+  (constraints not enforced); the `x0` fallback is kept (robustness). Byte-identical for
+  converged solves. Regression: `tests/unit/test_utils/test_qp_utils.py::TestQPNonConvergenceWarns1071`.
+
 - **Degraded fallbacks now warn instead of staying silent** (Issue #1071). Two legitimate
   fallbacks that previously masked a real degeneracy are kept but surfaced: `HJBGFDMSolver`'s
   per-point FD Jacobian uses an identity row when a stencil is degenerate (singular Taylor

--- a/mfgarchon/utils/numerical/qp_utils.py
+++ b/mfgarchon/utils/numerical/qp_utils.py
@@ -46,8 +46,12 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from mfgarchon.utils.mfg_logging import get_logger
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+logger = get_logger(__name__)
 
 # Optional dependencies - runtime imports
 try:
@@ -401,6 +405,22 @@ class QPSolver:
             solution, *_ = np.linalg.lstsq(A.T @ WA, A.T @ Wb, rcond=None)
             return solution
 
+    def _unconstrained_fallback(self, x0: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Record a solver non-convergence and return the unconstrained least-squares ``x0``.
+
+        Issue #1071 / fail-fast: the constrained solve did not converge, so the requested
+        constraints/bounds are NOT enforced on the returned weights. Surface it (do not return
+        silently); the caller decides how to treat a constraint-violating result — e.g. for
+        GFDM monotone stencils, a stencil from this is not guaranteed monotone.
+        """
+        self.stats["failures"] += 1
+        logger.warning(
+            "QPSolver: constrained solve did not converge; returning the unconstrained "
+            "least-squares solution — the requested constraints/bounds are NOT enforced on this "
+            "result (for GFDM monotone stencils, the resulting stencil is not guaranteed monotone)."
+        )
+        return x0
+
     def _solve_with_osqp(
         self,
         A: NDArray[np.float64],
@@ -493,9 +513,7 @@ class QPSolver:
                 self._warm_start_cache[point_id] = (result.x.copy(), result.y.copy())
             return result.x
 
-        # Fallback to unconstrained
-        self.stats["failures"] += 1
-        return x0
+        return self._unconstrained_fallback(x0)
 
     def _solve_with_lbfgsb(
         self,
@@ -562,8 +580,7 @@ class QPSolver:
                 self._warm_start_cache[point_id] = (result.x.copy(), None)
             return result.x
 
-        self.stats["failures"] += 1
-        return x0
+        return self._unconstrained_fallback(x0)
 
     def _solve_with_slsqp(
         self,
@@ -632,8 +649,7 @@ class QPSolver:
                 self._warm_start_cache[point_id] = (result.x.copy(), None)
             return result.x
 
-        self.stats["failures"] += 1
-        return x0
+        return self._unconstrained_fallback(x0)
 
     def print_statistics(self) -> None:
         """Print detailed solver statistics."""

--- a/tests/unit/test_utils/test_qp_utils.py
+++ b/tests/unit/test_utils/test_qp_utils.py
@@ -396,5 +396,25 @@ class TestQPIntegration:
         assert solver_cached.stats["cache_misses"] == 1
 
 
+class TestQPNonConvergenceWarns1071:
+    """Issue #1071: a QP/least-squares solve that does not converge must NOT silently return
+    the unconstrained solution — it warns (the constraints are not enforced on the result)."""
+
+    def test_unconstrained_fallback_warns_and_returns_x0(self, monkeypatch):
+        import mfgarchon.utils.numerical.qp_utils as qp_mod
+
+        calls: list[str] = []
+        monkeypatch.setattr(qp_mod.logger, "warning", lambda msg, *a, **k: calls.append(str(msg)))
+
+        solver = QPSolver()
+        before = solver.stats["failures"]
+        x0 = np.array([1.0, 2.0, 3.0])
+        result = solver._unconstrained_fallback(x0)
+
+        assert np.array_equal(result, x0)  # unconstrained x0 still returned (robustness)
+        assert solver.stats["failures"] == before + 1  # failure tracked
+        assert any("did not converge" in c for c in calls)  # and NOT silent
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
Final Phase-1 silent-fallback item. All three `QPSolver` backends (OSQP / scipy SLSQP / L-BFGS-B) returned the unconstrained least-squares `x0` (incrementing a `failures` stat) when the constrained solve **did not converge** — **silently**, so a constraint-violating result was used as if it succeeded.

This is distinct from the *exception* path (which `monotonicity_enforcer` already warns + falls back on, tracked as `qp_fallbacks`); the **non-convergence** path (OSQP `status != "solved"` with `raise_error=False`; scipy `not result.success`) bypassed that warn. For GFDM monotone stencils this silently yields a **non-monotone stencil** (the per-stencil DMP guarantee broken with no signal — cf. #1074).

Fix: DRY the three sites into a `_unconstrained_fallback` helper that `logger.warning`s (constraints not enforced) before returning `x0`. **The `x0` fallback is kept** (robustness, matching the accepted exception-path behavior) — keep-with-warning, not a hard abort (the scan over-classified it as fail-loud; the exception path already establishes warn+fallback as the accepted pattern here).

**Byte-identical for converged solves**; qp_utils + socp-m-matrix suites green (38); ratchet clean. Regression: `test_qp_utils.py::TestQPNonConvergenceWarns1071`.

Refs #1071, #1074.