### PR TITLE
refactor(hjb): lock-faithful cross_density channel for multi-pop coupling (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Multi-population HJB cross-coupling: lock-faithful `cross_density` channel** (Issue #1071,
+  increment 1 of the `BoundHamiltonian` retirement). `HJBFDMSolver.solve_hjb_system` gains a
+  `cross_density=` parameter taking the stacked `(Nt+1, K*Nx)` cross-density trajectory directly;
+  the backward loop indexes it at each integer timestep `n_idx_hjb` (where
+  `current_time = n_idx_hjb · dt`) and feeds the population's *own* Hamiltonian, which slices the
+  other populations via `population_index`. This replaces the `BoundHamiltonian` wrapper's two
+  smells — the dead `m` argument and the reverse-engineered `round(t/dt)` row-pick — while keeping
+  `HEvalState` physics-only (no `dt` on the state). `MultiPopulationIterator`'s HJB step now uses
+  this channel; the FP drift path still uses `bind_cross_density` (migrated in the next increment).
+  The bound-H `hamiltonian_override` channel is retained until the wrapper is deleted, and the two
+  are mutually exclusive (fail loud). **Byte-identical** to the bound-H path. Pinned by
+  `tests/integration/test_multi_population_cross_coupling.py::test_cross_density_channel_byte_identical_to_bound_hamiltonian_1071`.
+
 ### Added
 
 - **Fail-fast ratchet in CI** (Issue #1071). `scripts/check_fail_fast.py` gains

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -148,33 +148,28 @@ class MultiPopulationIterator:
 
             # Step 1: Solve K HJB equations
             for k in range(K):
-                prob_k = self.multi_problem.get_population(k)
-                H_k = prob_k.hamiltonian_class
                 solver_k = self.hjb_solvers[k]
-
-                # Bind cross-population density so the HJB sees other populations' densities
-                # (Issue #1157). dt lets BoundHamiltonian map the solve-time t to the trajectory
-                # row n=round(t/dt); the FDM solver routes the bound H through the batch
-                # Hamiltonian path that consumes the stacked density field.
-                H_bound = H_k.bind_cross_density(m_all, dt=prob_k.dt) if hasattr(H_k, "bind_cross_density") else H_k
-
                 U_terminal_k = U[k][-1]
-                # Only HJBFDMSolver threads the cross-density override into the HJB solve today
-                # (Issue #1157). Other backends would silently decouple (their solve reads the
-                # uncoupled problem.hamiltonian_class), so fail loud for K>1 rather than pass an
-                # override they ignore. K==1 has no cross-coupling: a standalone solve is correct
-                # and byte-identical, so no override is sent regardless of backend.
+
+                # Issue #1071 (lock-faithful): pass the stacked cross-density trajectory ``m_all``
+                # directly. The HJB solver indexes it at each integer timestep and feeds it to the
+                # population's own Hamiltonian, which slices the other populations via
+                # ``population_index`` — no BoundHamiltonian wrapper and no round(t/dt). Only
+                # HJBFDMSolver threads this today (Issue #1157); other backends would silently
+                # decouple (their solve reads the uncoupled ``problem.hamiltonian_class``), so fail
+                # loud for K>1. K==1 has no cross-coupling: a standalone solve is byte-identical,
+                # so no cross-density is sent regardless of backend.
                 honors_override = getattr(solver_k, "_honors_multipop_hamiltonian_override", False)
                 if K > 1 and not honors_override:
                     raise NotImplementedError(
                         f"Multi-population cross-coupling requires HJBFDMSolver for the HJB step "
                         f"(Issue #1157); population {k} uses {type(solver_k).__name__}, which does "
-                        "not thread the cross-density bound Hamiltonian into solve_hjb_system and "
+                        "not thread the cross-density trajectory into solve_hjb_system and "
                         "would silently decouple. Use HJBFDMSolver for multi-population MFG."
                     )
                 if honors_override:
                     U[k] = solver_k.solve_hjb_system(
-                        M[k], U_terminal_k, U[k], hamiltonian_override=(None if K == 1 else H_bound)
+                        M[k], U_terminal_k, U[k], cross_density=(None if K == 1 else m_all)
                     )
                 else:
                     U[k] = solver_k.solve_hjb_system(M[k], U_terminal_k, U[k])

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -607,6 +607,7 @@ def compute_hjb_residual(
     bc_values: dict[str, float] | None = None,  # Issue #574: Per-boundary BC values
     source_term: np.ndarray | None = None,  # MMS verification: pre-evaluated S(t, x)
     active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H (None => problem's own)
+    cross_density_at_n: np.ndarray | None = None,  # Issue #1071: stacked (K*Nx,) cross-density at this timestep
 ) -> np.ndarray:
     Nx = problem.geometry.get_grid_shape()[0]
     dx = problem.geometry.get_grid_spacing()[0]
@@ -704,17 +705,32 @@ def compute_hjb_residual(
     # Issue #1157: a multi-population bound Hamiltonian (active_hamiltonian) is honored
     # only on this batch path; the per-point fallback below calls problem.H() (the
     # uncoupled Hamiltonian), which would silently drop the cross-density coupling.
+    if active_hamiltonian is not None and cross_density_at_n is not None:
+        raise ValueError(
+            "active_hamiltonian (bound H, Issue #1157) and cross_density_at_n (Issue #1071) are "
+            "mutually exclusive multi-population channels; pass exactly one."
+        )
     H_class = active_hamiltonian if active_hamiltonian is not None else problem.hamiltonian_class
-    if active_hamiltonian is not None and not (precomputed_grad is not None and backend is None):
+    if (active_hamiltonian is not None or cross_density_at_n is not None) and not (
+        precomputed_grad is not None and backend is None
+    ):
         raise NotImplementedError(
-            "Multi-population Hamiltonian override requires the batch Hamiltonian path "
+            "Multi-population cross-coupling requires the batch Hamiltonian path "
             "(precomputed_grad available, backend=None); the per-point problem.H() fallback "
             "cannot honor the cross-density coupling and would silently decouple (Issue #1157)."
         )
     if precomputed_grad is not None and backend is None and H_class is not None:
         # Build batch arrays
         x_grid = problem.geometry.get_spatial_grid()  # (Nx, 1)
-        m_grid = np.asarray(M_density_at_n_plus_1, dtype=float)  # (Nx,)
+        # Issue #1071: a multi-population solve passes the stacked cross-density already
+        # indexed to this timestep by the backward loop (integer n_idx_hjb); the per-population
+        # H reads the other populations' density from it (via population_index). The row-pick
+        # lives in the solver loop, so HEvalState stays physics-only — no dt on the state, and
+        # no reverse-engineered round(t/dt). Single-population: the solver's own density.
+        if cross_density_at_n is not None:
+            m_grid = np.asarray(cross_density_at_n, dtype=float)  # (K*Nx,)
+        else:
+            m_grid = np.asarray(M_density_at_n_plus_1, dtype=float)  # (Nx,)
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
 
         # Single batch call — eliminates per-point problem.H() overhead.
@@ -792,6 +808,7 @@ def compute_hjb_jacobian(
     domain_bounds: np.ndarray | None = None,  # Domain bounds for BC
     current_time: float = 0.0,  # Current time for time-dependent BCs
     active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H (None => problem's own)
+    cross_density_at_n: np.ndarray | None = None,  # Issue #1071: stacked (K*Nx,) cross-density at this timestep
 ) -> sparse.csr_matrix:
     Nx = problem.geometry.get_grid_shape()[0]
     dx = problem.geometry.get_grid_spacing()[0]
@@ -864,10 +881,17 @@ def compute_hjb_jacobian(
     # dΦ/dU_j = (dH/dp)_i * (dp_i/dU_j), where dp/dU comes from the gradient stencil.
     # Issue #1157: the multi-pop bound Hamiltonian is honored only on the batch dp() path;
     # the per-point problem.H() fallback below would silently drop the cross-density coupling.
+    if active_hamiltonian is not None and cross_density_at_n is not None:
+        raise ValueError(
+            "active_hamiltonian (bound H, Issue #1157) and cross_density_at_n (Issue #1071) are "
+            "mutually exclusive multi-population channels; pass exactly one."
+        )
     H_class = active_hamiltonian if active_hamiltonian is not None else problem.hamiltonian_class
-    if active_hamiltonian is not None and not (backend is None and H_class is not None and abs(dx) > 1e-14 and Nx > 1):
+    if (active_hamiltonian is not None or cross_density_at_n is not None) and not (
+        backend is None and H_class is not None and abs(dx) > 1e-14 and Nx > 1
+    ):
         raise NotImplementedError(
-            "Multi-population Hamiltonian override requires the batch Jacobian path "
+            "Multi-population cross-coupling requires the batch Jacobian path "
             "(backend=None, Nx>1); the per-point problem.H() fallback cannot honor the "
             "cross-density coupling and would silently decouple (Issue #1157)."
         )
@@ -877,7 +901,12 @@ def compute_hjb_jacobian(
 
         # Build batch arrays for H_class.dp()
         x_grid = problem.geometry.get_spatial_grid()  # (Nx, 1)
-        m_grid = np.asarray(M_density_at_n_plus_1, dtype=float)  # (Nx,)
+        # Issue #1071: stacked cross-density (already indexed to this timestep) for multi-pop;
+        # own density otherwise. See compute_hjb_residual for the rationale (lock-faithful).
+        if cross_density_at_n is not None:
+            m_grid = np.asarray(cross_density_at_n, dtype=float)  # (K*Nx,)
+        else:
+            m_grid = np.asarray(M_density_at_n_plus_1, dtype=float)  # (Nx,)
         p_grid = precomputed_grad.reshape(-1, 1)  # (Nx, 1)
 
         # Single batch call: dH/dp at all grid points.
@@ -1052,6 +1081,7 @@ def newton_hjb_step(
     bc_values: dict[str, float] | None = None,  # Issue #574
     source_term: np.ndarray | None = None,  # MMS verification
     active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H
+    cross_density_at_n: np.ndarray | None = None,  # Issue #1071: stacked (K*Nx,) cross-density at this timestep
 ) -> tuple[np.ndarray, float]:
     dx = problem.geometry.get_grid_spacing()[0]
     dx_norm = dx if abs(dx) > 1e-12 else 1.0
@@ -1074,6 +1104,7 @@ def newton_hjb_step(
         bc_values=bc_values,  # Issue #574
         source_term=source_term,
         active_hamiltonian=active_hamiltonian,  # Issue #1157
+        cross_density_at_n=cross_density_at_n,  # Issue #1071
     )
     if has_nan_or_inf(residual_F_U, backend):
         return U_n_current_newton_iterate, np.inf
@@ -1092,6 +1123,7 @@ def newton_hjb_step(
         domain_bounds=domain_bounds,
         current_time=current_time,
         active_hamiltonian=active_hamiltonian,  # Issue #1157
+        cross_density_at_n=cross_density_at_n,  # Issue #1071
     )
     if np.any(np.isnan(jacobian_J_U.data)) or np.any(np.isinf(jacobian_J_U.data)):
         return U_n_current_newton_iterate, np.inf
@@ -1154,6 +1186,7 @@ def solve_hjb_timestep_newton(
     bc_values: dict[str, float] | None = None,  # Issue #574: Per-boundary BC values
     source_term: np.ndarray | None = None,  # MMS verification
     active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H
+    cross_density_at_n: np.ndarray | None = None,  # Issue #1071: stacked (K*Nx,) cross-density at this timestep
 ) -> np.ndarray:
     """
     Solve HJB timestep using Newton's method.
@@ -1205,6 +1238,7 @@ def solve_hjb_timestep_newton(
             bc_values=bc_values,  # Issue #574
             source_term=source_term,
             active_hamiltonian=active_hamiltonian,  # Issue #1157
+            cross_density_at_n=cross_density_at_n,  # Issue #1071
         )
 
         if has_nan_or_inf(U_n_next_newton_iterate, backend):
@@ -1337,6 +1371,7 @@ def solve_hjb_system_backward(
     bc_values: dict[str, float] | None = None,  # Issue #574: Per-boundary BC values
     source_term: Callable | None = None,  # MMS verification: S(t, x_grid) -> values
     active_hamiltonian=None,  # Issue #1157: multi-pop cross-density bound H
+    cross_density=None,  # Issue #1071: stacked (Nt+1, K*Nx) cross-density trajectory (lock-faithful)
 ) -> np.ndarray:
     """
     Solve HJB system backward in time using Newton's method.
@@ -1395,6 +1430,12 @@ def solve_hjb_system_backward(
             backend_aware_assign(U_solution_this_picard_iter, (n_idx_hjb, slice(None)), float("nan"), backend)
             continue
 
+        # Issue #1071: index the stacked cross-density trajectory at the SAME integer timestep as
+        # the own density above (n_idx_hjb). This is the lock-faithful row-pick: it replaces the
+        # BoundHamiltonian wrapper's round(t/dt) (current_time = n_idx_hjb * dt, so the row is
+        # identical) and is consistent with M_density's own indexing. None => single-population.
+        cross_density_at_n = cross_density[n_idx_hjb, :] if cross_density is not None else None
+
         U_n_prev_picard = U_from_prev_picard[n_idx_hjb, :]  # U_k[n] from notebook
         if has_nan_or_inf(U_n_prev_picard, backend):
             backend_aware_assign(U_solution_this_picard_iter, (n_idx_hjb, slice(None)), float("nan"), backend)
@@ -1437,6 +1478,7 @@ def solve_hjb_system_backward(
             bc_values=bc_values,  # Issue #574: Per-boundary BC values
             source_term=source_at_n,
             active_hamiltonian=active_hamiltonian,  # Issue #1157
+            cross_density_at_n=cross_density_at_n,  # Issue #1071
         )
         backend_aware_assign(U_solution_this_picard_iter, (n_idx_hjb, slice(None)), U_new_n, backend)
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -355,6 +355,7 @@ class HJBFDMSolver(BaseHJBSolver):
         source_term: Callable | None = None,
         *,
         hamiltonian_override=None,  # Issue #1157: multi-population cross-density bound H
+        cross_density=None,  # Issue #1071: stacked (Nt+1, K*Nx) cross-density trajectory (lock-faithful)
     ) -> NDArray:
         """
         Solve HJB system backward in time.
@@ -389,6 +390,18 @@ class HJBFDMSolver(BaseHJBSolver):
                 "Multi-population Hamiltonian override (Issue #1157) is currently validated "
                 f"only for the 1D FDM path; got dimension={self.dimension}. Run multi-population "
                 "MFG in 1D, or extend and validate the nD batch Hamiltonian path first."
+            )
+        # Issue #1071: the lock-faithful cross-density channel shares the 1D-only batch path.
+        if cross_density is not None and self.dimension != 1:
+            raise NotImplementedError(
+                "Multi-population cross-density coupling (Issue #1071) is currently validated "
+                f"only for the 1D FDM path; got dimension={self.dimension}. Run multi-population "
+                "MFG in 1D, or extend and validate the nD batch Hamiltonian path first."
+            )
+        if hamiltonian_override is not None and cross_density is not None:
+            raise ValueError(
+                "hamiltonian_override (Issue #1157 bound H) and cross_density (Issue #1071) are "
+                "mutually exclusive multi-population channels; pass exactly one."
             )
         # Issue #889: merge tensor_volatility_field into volatility_field
         # Deprecation warning issued by @deprecated_parameter decorator
@@ -433,7 +446,9 @@ class HJBFDMSolver(BaseHJBSolver):
             # a scalar own-population density and cannot express cross-population coupling. The
             # batch path is numerically equivalent to the per-point path (Issue #789), so this
             # changes nothing for single-population solves (override None => self.backend).
-            effective_backend = None if hamiltonian_override is not None else self.backend
+            effective_backend = (
+                None if (hamiltonian_override is not None or cross_density is not None) else self.backend
+            )
 
             # Use optimized 1D solver with BC-aware computation (Issue #542 fix)
             U_solution = base_hjb.solve_hjb_system_backward(
@@ -450,6 +465,7 @@ class HJBFDMSolver(BaseHJBSolver):
                 domain_bounds=domain_bounds,
                 source_term=source_term,
                 active_hamiltonian=hamiltonian_override,  # Issue #1157
+                cross_density=cross_density,  # Issue #1071
             )
 
             # Apply variational inequality constraint via projection (Issue #591)

--- a/tests/integration/test_multi_population_cross_coupling.py
+++ b/tests/integration/test_multi_population_cross_coupling.py
@@ -155,3 +155,52 @@ def test_nonfdm_backend_multipop_fails_loud():
     )
     with pytest.raises(NotImplementedError, match="1157"):
         it.solve(max_iterations=2, tolerance=1e-10)
+
+
+def test_cross_density_channel_byte_identical_to_bound_hamiltonian_1071():
+    """Issue #1071 (lock-faithful migration): the ``cross_density`` trajectory channel must be
+    byte-identical to the ``BoundHamiltonian`` (``hamiltonian_override``) path it replaces.
+
+    The new channel indexes the stacked trajectory at each integer backward-loop timestep
+    ``n_idx_hjb`` and feeds the population's OWN Hamiltonian (which slices the other populations
+    via ``population_index``) — eliminating the wrapper's ``round(t/dt)`` and dead-``m`` smells.
+    Because ``current_time = n_idx_hjb * dt``, the trajectory row picked is identical, so the HJB
+    value function is bit-for-bit unchanged. This pins the equivalence so the ``BoundHamiltonian``
+    retirement (migration increments 2-4) cannot silently drift the multi-population HJB."""
+    K = 2
+    probs = [_make_problem(k, cross=2.0, K=K) for k in range(K)]
+    solvers = [HJBFDMSolver(p) for p in probs]
+    Nx = _NX + 1
+    rng = np.random.RandomState(0)
+    M = [np.abs(rng.rand(_NT + 1, Nx)) + 0.1 for _ in range(K)]
+    M = [m / m.sum(axis=-1, keepdims=True) for m in M]  # mass-normalize each timestep
+    m_all = np.concatenate(M, axis=-1)  # (Nt+1, K*Nx) stacked trajectory
+    U_prev = [rng.rand(_NT + 1, Nx) for _ in range(K)]
+    U_term = [np.zeros(Nx) for _ in range(K)]
+
+    for k in range(K):
+        H_bound = probs[k].hamiltonian_class.bind_cross_density(m_all, dt=probs[k].dt)
+        U_bound = np.asarray(solvers[k].solve_hjb_system(M[k], U_term[k], U_prev[k], hamiltonian_override=H_bound))
+        U_cross = np.asarray(solvers[k].solve_hjb_system(M[k], U_term[k], U_prev[k], cross_density=m_all))
+        assert np.array_equal(U_bound, U_cross), (
+            f"pop {k}: cross_density channel diverged from BoundHamiltonian "
+            f"(max|delta|={np.max(np.abs(U_bound - U_cross)):.3e}); #1071 migration not byte-identical"
+        )
+
+
+def test_cross_density_and_bound_hamiltonian_mutually_exclusive_1071():
+    """Issue #1071: the legacy bound-H channel and the new cross_density channel must not be
+    supplied together (one would silently shadow the other)."""
+    prob = _make_problem(0, cross=2.0, K=2)
+    solver = HJBFDMSolver(prob)
+    Nx = _NX + 1
+    M = np.ones((_NT + 1, Nx)) / Nx
+    m_all = np.concatenate([M, M], axis=-1)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        solver.solve_hjb_system(
+            M,
+            np.zeros(Nx),
+            np.zeros((_NT + 1, Nx)),
+            hamiltonian_override=prob.hamiltonian_class.bind_cross_density(m_all, dt=prob.dt),
+            cross_density=m_all,
+        )


### PR DESCRIPTION
Increment 1 of the `BoundHamiltonian` retirement (Refs #1071). Lock-faithful approach (maintainer-decided): keep `HEvalState` physics-only; the solver supplies the per-timestep stacked cross-density.

## What

`HJBFDMSolver.solve_hjb_system` gains a `cross_density=` parameter taking the stacked `(Nt+1, K*Nx)` cross-density **trajectory** directly. The backward loop indexes it at each integer timestep `n_idx_hjb` (where `current_time = n_idx_hjb · dt`) and feeds the population's **own** Hamiltonian, which slices the other populations via `population_index`.

This replaces the `BoundHamiltonian` wrapper's two smells:
- the **dead `m` argument** (the solver passed its own density, which the wrapper discarded);
- the **reverse-engineered `round(t/dt)` row-pick** (now an honest integer loop index).

`HEvalState` stays physics-only (no `dt` on the state) — the `round(t/dt)`→integer-index move happens in the solver loop, which legitimately owns `dt`.

`MultiPopulationIterator`'s HJB step now uses this channel. The FP drift path still uses `bind_cross_density` (migrated in increment 2). The bound-H `hamiltonian_override` channel is retained until the wrapper is deleted (increment 4); the two channels are **mutually exclusive** (fail loud, both in `compute_hjb_residual/jacobian` and in `solve_hjb_system`).

## Byte-identity

Because `current_time = n_idx_hjb · dt`, `round(current_time/dt) = n_idx_hjb` exactly, so `cross_density[n_idx_hjb]` equals the wrapper's `m_all[round(t/dt)]`. Verified bit-for-bit on a K=2 HJB solve (`array_equal=True`, `max|Δ|=0`).

## Tests

- `test_cross_density_channel_byte_identical_to_bound_hamiltonian_1071` — pins the equivalence (new).
- `test_cross_density_and_bound_hamiltonian_mutually_exclusive_1071` — guard (new).
- Existing #1157 anchor (`test_hjb_sees_cross_density_bug_1157`, K=1 byte-identical, non-FDM fails loud) unchanged.
- Broad regression: 621 HJB/Newton/FDM + 106 multipop/single-source tests pass.

## Migration plan (recorded on #1071)

1. **(this PR)** HJB-side `cross_density` channel, byte-identical.
2. FP drift path → pre-indexed slice to `optimal_control`; drop the `fixed_point_utils` `_inner` unwrap.
3. Delete `BoundHamiltonian` + `bind_cross_density` + the bound-H channel; migrate the #1157 wrapper tests; clear `[PROVISIONAL]` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)