### PR TITLE
refactor(fp): lock-faithful cross_density channel for multi-pop FP drift (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Multi-population FP drift: lock-faithful `cross_density` channel** (Issue #1071, increment 2
+  of the `BoundHamiltonian` retirement). `compute_fp_velocity_field` and `resolve_fp_drift_kwargs`
+  gain a `cross_density=` parameter (the stacked `(Nt+1, K*Nx)` trajectory); when given, the
+  non-smooth FP velocity path feeds `optimal_control` the stacked density at each integer timestep
+  `n` (`cross_density[n]`, sliced per-population via `population_index`) instead of the wrapper's
+  `m_all[round(t/dt)]`. `MultiPopulationIterator`'s FP step now passes the population's own
+  (unbound) Hamiltonian + `cross_density=m_all` (unconditionally, matching the old unconditional
+  `bind_cross_density`) — so smooth-separable H keeps the `potential_field=U` dispatch and the
+  whole path is **byte-identical** to the bound-H path. This removes the **last**
+  `bind_cross_density` call site; `BoundHamiltonian` is now unused (deleted in increment 3). Pinned
+  by `test_fp_velocity_cross_density_byte_identical_to_bound_hamiltonian_1071` (byte-identity + a
+  flow assertion using an m-dependent test Hamiltonian).
+
 - **Multi-population HJB cross-coupling: lock-faithful `cross_density` channel** (Issue #1071,
   increment 1 of the `BoundHamiltonian` retirement). `HJBFDMSolver.solve_hjb_system` gains a
   `cross_density=` parameter taking the stacked `(Nt+1, K*Nx)` cross-density trajectory directly;

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -398,6 +398,7 @@ def compute_fp_velocity_field(
     U: np.ndarray,
     M: np.ndarray,
     H_class: object,
+    cross_density: np.ndarray | None = None,
 ) -> np.ndarray:
     """Compute the face-centered FP advection velocity $\\alpha^*$ from the value function.
 
@@ -412,6 +413,12 @@ def compute_fp_velocity_field(
         U: Value function, shape ``(Nt+1, *spatial_shape)``.
         M: Density, shape ``(Nt+1, *spatial_shape)`` (only the own-population density).
         H_class: Hamiltonian exposing ``optimal_control(x, m, p, t)``.
+        cross_density: Optional stacked multi-population density trajectory
+            ``(Nt+1, K*Nx)`` (Issue #1071, lock-faithful). When given, ``optimal_control``
+            receives ``cross_density[n]`` (the stacked density at integer timestep ``n``,
+            sliced per-population via ``population_index``) instead of the own-population
+            density — replacing the ``BoundHamiltonian`` wrapper's ``m_all[round(t/dt)]``
+            (``n*dt/dt == n``, so byte-identical). ``None`` => single-population own density.
 
     Returns:
         Face-centered velocity $\\alpha^*$.
@@ -444,7 +451,14 @@ def compute_fp_velocity_field(
         alpha_faces = np.zeros((Nt, Nx - 1))
         x_arr = x_faces.reshape(-1, 1)
         for n in range(Nt):
-            m_n = m_faces[n] if n < m_faces.shape[0] else m_faces[-1]
+            # Issue #1071: a multi-population solve passes the stacked cross-density trajectory;
+            # optimal_control then sees the other populations' density (sliced via population_index)
+            # at this integer timestep, replacing the BoundHamiltonian wrapper's m_all[round(t/dt)]
+            # (n*dt/dt == n, byte-identical). Single-population: the own face-centered density.
+            if cross_density is not None:
+                m_n = cross_density[n]
+            else:
+                m_n = m_faces[n] if n < m_faces.shape[0] else m_faces[-1]
             p_n = p_faces[n].reshape(-1, 1)
             alpha_faces[n] = H_class.optimal_control(x_arr, m_n, p_n, t=n * dt).ravel()
 
@@ -463,7 +477,11 @@ def compute_fp_velocity_field(
         alpha_field = np.zeros((Nt, ndim, *spatial_shape))
         for n in range(Nt):
             p_n = np.stack([grad_components[d][n] for d in range(ndim)], axis=-1)
-            m_n = M[n] if n < M.shape[0] else M[-1]
+            # Issue #1071: stacked cross-density at this integer timestep for multi-pop (see 1D path).
+            if cross_density is not None:
+                m_n = cross_density[n]
+            else:
+                m_n = M[n] if n < M.shape[0] else M[-1]
             alpha_n = H_class.optimal_control(x_grid, m_n, p_n, t=n * dt)
             if alpha_n.ndim == ndim + 1:
                 alpha_field[n] = np.moveaxis(alpha_n, -1, 0)
@@ -482,6 +500,7 @@ def resolve_fp_drift_kwargs(
     M: np.ndarray,
     *,
     h_class: object | None = None,
+    cross_density: np.ndarray | None = None,
 ) -> tuple[dict, bool]:
     """Resolve how the value function enters ``solve_fp_system`` (drift vs potential).
 
@@ -508,8 +527,12 @@ def resolve_fp_drift_kwargs(
         M: Current density, shape ``(Nt+1, *spatial_shape)`` (used only for non-smooth $H$).
         h_class: Hamiltonian to use for the smoothness dispatch and velocity computation,
             overriding ``problem.hamiltonian_class``. The multi-population iterator passes the
-            cross-density-bound Hamiltonian here (Issue #1043) so K populations resolve drift the
-            same way single-pop does; ``None`` uses ``problem.hamiltonian_class`` (single-pop).
+            population's own (unbound) Hamiltonian here (Issue #1043) so K populations resolve drift
+            the same way single-pop does; ``None`` uses ``problem.hamiltonian_class`` (single-pop).
+        cross_density: Optional stacked multi-population density trajectory ``(Nt+1, K*Nx)``
+            (Issue #1071, lock-faithful). Forwarded to :func:`compute_fp_velocity_field` so the
+            non-smooth velocity path sees the other populations' density — replacing the retired
+            ``BoundHamiltonian`` wrapper. ``None`` => single-population own density.
 
     Returns:
         ``(drift_kwargs, use_positional_U)`` where ``drift_kwargs`` is one of ``{}``,
@@ -546,7 +569,7 @@ def resolve_fp_drift_kwargs(
             and not (isinstance(H_base, SeparableHamiltonian) and H_base.control_cost.is_smooth())
         )
         if use_velocity:
-            drift_kwargs["drift_field"] = compute_fp_velocity_field(problem, U, M, H_class)
+            drift_kwargs["drift_field"] = compute_fp_velocity_field(problem, U, M, H_class, cross_density=cross_density)
         elif "potential_field" in params:
             drift_kwargs["potential_field"] = U
         elif "drift_field" in params:

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -176,25 +176,26 @@ class MultiPopulationIterator:
 
             # Step 2: Solve K FP equations. The FP drift/potential convention is single-sourced
             # through resolve_fp_drift_kwargs (Issue #1043), identical to the single-population
-            # FixedPointIterator — so a K=1 multi-population solve matches single-pop. The
-            # cross-density-bound Hamiltonian is passed as h_class so the velocity (non-smooth H)
-            # sees the other populations' density (its optimal_control maps t→trajectory row n;
-            # Issue #1157). Network problems keep the U-as-drift path (FPNetworkSolver extracts
-            # rates internally).
+            # FixedPointIterator — so a K=1 multi-population solve matches single-pop. Issue #1071
+            # (lock-faithful): the population's OWN (unbound) Hamiltonian is passed as h_class plus
+            # the stacked cross-density trajectory m_all; the velocity (non-smooth H) sees the other
+            # populations' density via cross_density[n] (sliced by population_index) — no
+            # BoundHamiltonian wrapper, no round(t/dt). Smooth-separable H takes the potential_field=U
+            # path (cross-coupling enters via the HJB only). Network problems keep the U-as-drift
+            # path (FPNetworkSolver extracts rates internally).
             from .fixed_point_utils import resolve_fp_drift_kwargs
 
             for k in range(K):
                 prob_k = self.multi_problem.get_population(k)
                 m0_k = M[k][0]
                 H_k = prob_k.hamiltonian_class
-                H_bound = H_k.bind_cross_density(m_all, dt=prob_k.dt) if hasattr(H_k, "bind_cross_density") else H_k
                 fp_k = self.fp_solvers[k]
 
                 if getattr(prob_k, "spatial_dimension", None) == 0:
                     M_new_k = fp_k.solve_fp_system(m0_k, drift_field=U[k], show_progress=False)
                 else:
                     drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
-                        prob_k, self._fp_sig_params[k], None, U[k], M[k], h_class=H_bound
+                        prob_k, self._fp_sig_params[k], None, U[k], M[k], h_class=H_k, cross_density=m_all
                     )
                     if use_positional_U:
                         M_new_k = fp_k.solve_fp_system(m0_k, U[k], show_progress=False)

--- a/tests/integration/test_multi_population_cross_coupling.py
+++ b/tests/integration/test_multi_population_cross_coupling.py
@@ -188,6 +188,70 @@ def test_cross_density_channel_byte_identical_to_bound_hamiltonian_1071():
         )
 
 
+def test_fp_velocity_cross_density_byte_identical_to_bound_hamiltonian_1071():
+    """Issue #1071 increment 2: the FP drift velocity via the ``cross_density`` channel must be
+    byte-identical to the ``BoundHamiltonian`` path it replaces, and the cross-density must
+    actually flow (the integration test's separable H has a momentum-only ``optimal_control``,
+    so it would not exercise this — hence a deliberately ``m``-dependent test Hamiltonian)."""
+    from mfgarchon.alg.numerical.coupling.fixed_point_utils import compute_fp_velocity_field
+    from mfgarchon.core.hamiltonian import HamiltonianBase
+
+    K, Nx, Nt, T = 2, _NX + 1, _NT, _T
+    dt = T / Nt
+
+    class _MDepH(HamiltonianBase):
+        """optimal_control reads the stacked density (the OTHER population) so the velocity
+        genuinely depends on the cross-density (gives the byte-identity test teeth)."""
+
+        def __init__(self, population_index, k_pops):
+            self.population_index = population_index
+            self._K = k_pops
+
+        def __call__(self, x, m, p, t=0.0):
+            return 0.5 * np.asarray(p, float) ** 2
+
+        def optimal_control(self, x, m, p, t=0.0):
+            m = np.asarray(m, float)
+            p = np.asarray(p, float)
+            other = 0.0
+            if m.ndim >= 1 and m.shape[-1] % self._K == 0 and m.shape[-1] >= 2 * self._K:
+                grid = m.shape[-1] // self._K
+                other = float(m.reshape(*m.shape[:-1], self._K, grid)[..., 1 - self.population_index, :].mean())
+            return p.ravel() + other
+
+    class _Geom:
+        def get_grid_spacing(self):
+            return [1.0 / _NX]
+
+        def get_bounds(self):
+            return [(0.0,), (1.0,)]
+
+    class _Prob:
+        geometry = _Geom()
+
+    prob = _Prob()
+    prob.dt = dt
+    rng = np.random.RandomState(1)
+    M = [np.abs(rng.rand(Nt + 1, Nx)) + 0.1 for _ in range(K)]
+    M = [m / m.sum(axis=-1, keepdims=True) for m in M]
+    m_all = np.concatenate(M, axis=-1)  # (Nt+1, K*Nx)
+    U = rng.rand(Nt + 1, Nx)
+
+    for k in range(K):
+        h = _MDepH(k, K)
+        H_bound = h.bind_cross_density(m_all, dt=dt)
+        v_bound = compute_fp_velocity_field(prob, U, M[k], H_bound)
+        v_cross = compute_fp_velocity_field(prob, U, M[k], h, cross_density=m_all)
+        v_own = compute_fp_velocity_field(prob, U, M[k], h)  # own face density (no cross)
+        assert np.array_equal(v_bound, v_cross), (
+            f"pop {k}: FP velocity cross_density channel diverged from BoundHamiltonian "
+            f"(max|delta|={np.max(np.abs(v_bound - v_cross)):.3e})"
+        )
+        assert not np.array_equal(v_cross, v_own), (
+            f"pop {k}: cross_density did not flow into the FP velocity (== own-density result)"
+        )
+
+
 def test_cross_density_and_bound_hamiltonian_mutually_exclusive_1071():
     """Issue #1071: the legacy bound-H channel and the new cross_density channel must not be
     supplied together (one would silently shadow the other)."""


### PR DESCRIPTION
Increment 2 of the `BoundHamiltonian` retirement (Refs #1071). Migrates the **FP drift** path off the bound-H wrapper to the lock-faithful `cross_density` channel (HJB side was #1397).

## What

`compute_fp_velocity_field` and `resolve_fp_drift_kwargs` gain a `cross_density=` parameter (the stacked `(Nt+1, K*Nx)` trajectory). On the **non-smooth** FP velocity path, `optimal_control` now receives `cross_density[n]` (the stacked density at integer timestep `n`, sliced per-population via `population_index`) instead of the wrapper's reverse-engineered `m_all[round(t/dt)]`.

`MultiPopulationIterator`'s FP step now passes the population's **own (unbound)** Hamiltonian as `h_class` + `cross_density=m_all` — **unconditionally**, matching the old code's unconditional `bind_cross_density` (the FP step, unlike the HJB step, had no `K==1` guard). Smooth-separable H still takes the `potential_field=U` dispatch (cross-coupling enters via the HJB only).

This removes the **last** `bind_cross_density` call site → `BoundHamiltonian` is now unused (deleted in increment 3).

## Byte-identity

Both paths feed `optimal_control` the same `m_all[n]` (`n·dt/dt == n`), so the FP velocity is bit-for-bit unchanged. Verified `array_equal=True`, `max|Δ|=0` on a K=2 velocity computation with an **m-dependent** test Hamiltonian (the integration test's separable H has a momentum-only `optimal_control`, so a custom m-reading H is used to give the test teeth + confirm the cross-density actually flows: `cross != own`).

## Tests

- `test_fp_velocity_cross_density_byte_identical_to_bound_hamiltonian_1071` — byte-identity + flow assertion (new).
- `test_k1_matches_single_population_fp_convention`, `test_hjb_sees_cross_density_bug_1157`, all #1157 anchors — unchanged.
- Regression: 15 multipop integration + 199 coupling/fixed-point/residual/regime/block tests pass.

## Migration plan (Refs #1071)

1. ✅ HJB-side `cross_density` channel (#1397, merged).
2. **(this PR)** FP-side `cross_density` channel — removes the last `bind_cross_density` caller.
3. Delete `BoundHamiltonian` + `bind_cross_density` + the bound-H `hamiltonian_override`/`active_hamiltonian` channel + the `_inner` unwrap; migrate the #1157 wrapper tests; clear `[PROVISIONAL]` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)