### PR TITLE
refactor(gfdm): single-source LLF assembly via field-sigma Layer-B helpers (#1071 phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **GFDM Local-Lax-Friedrichs assembly single-sourced through the Layer-B helpers** (Issue #1071
+  phase 7). The two batch-Hamiltonian GFDM paths each re-implemented the entire residual /
+  Jacobian assembly inline solely to swap the scalar diffusion `σ` for the per-node LLF field
+  `σ_eff` (Issue #1059). `assemble_hjb_residual` / `assemble_hjb_jacobian_diag` (`h_eval.py`) now
+  accept a per-node `σ` field — residual: `D = σ²/2` elementwise; Jacobian: **row-scales** the
+  Laplacian via `diags(D) @ D_lap` (not `D * D_lap`, which for an array does not row-scale) — so
+  the GFDM LLF residual/Jacobian branches collapse into the single shared assembly path (scalar `σ`
+  for a plain solve, `σ_eff` field when LLF is active). Scalar callers are **bit-identical** (the
+  scalar code path is untouched); the field path is byte-identical to the inline LLF expressions it
+  replaces, pinned by `test_assemble_hjb_residual_array_sigma_matches_inline_llf_1071` and
+  `test_assemble_hjb_jacobian_diag_array_sigma_matches_inline_llf_1071`, with the GFDM LLF
+  augmentation suite as the end-to-end check. (LLF stays solver-level — it modifies the diffusion
+  coefficient, not `H`/`∂H/∂p` — so the `Regularizer`/`with_regularizer` scaffold is correctly left
+  for the physics-only regularizers it was scoped for. The legacy-LQ-vectorized path inlines its own
+  Hamiltonian and is out of scope.)
+
 ### Removed
 
 - **`BoundHamiltonian` + `bind_cross_density` retired** (Issue #1071, increment 3 — completes the

--- a/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
@@ -17,8 +17,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from mfgarchon.core.hamiltonian import HEvalState
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+
+def _diffusion_coeff(sigma: float | NDArray) -> float | NDArray:
+    """Diffusion ``D = sigma^2/2`` for the assembly helpers (Issue #1071 phase 7).
+
+    A scalar ``sigma`` keeps the exact prior call ``diffusion_from_volatility(sigma)``
+    (``kind`` is ignored for a scalar, so this is bit-identical). A per-node ``sigma``
+    field (e.g. the GFDM Local-Lax-Friedrichs ``sigma_eff`` array, Issue #1059) is
+    isotropic-per-point, so it requires ``kind="field"`` -> ``D = sigma**2/2`` elementwise.
+    """
+    if np.ndim(sigma) == 0:
+        return diffusion_from_volatility(sigma)
+    return diffusion_from_volatility(sigma, kind="field")
+
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -65,17 +81,21 @@ def assemble_hjb_residual(
 ) -> NDArray:
     r"""Assemble the implicit-backward-Euler HJB residual (Layer B of #1071).
 
-    Returns ``-u_t + H(+running_cost) - D·lap_u`` with ``D = diffusion_from_volatility(sigma)``,
-    so the diffusion-term convention (Issue #1073/#811: ``D = σ²/2``) lives in one place. The
-    caller supplies its own discrete operators (gradient ``p``, Laplacian ``lap_u``) and the
-    time-derivative ``u_t = (u^{n+1}-u^n)/dt``; it owns its own framing -- this is the implicit
-    residual ``-u_t + H - D·lap``, NOT the WENO explicit-RHS framing ``-H + D·Δu``. Byte-identical
-    to the inline gfdm expression it replaces.
+    Returns ``-u_t + H(+running_cost) - D·lap_u`` with ``D = σ²/2``, so the diffusion-term
+    convention (Issue #1073/#811) lives in one place. The caller supplies its own discrete
+    operators (gradient ``p``, Laplacian ``lap_u``) and the time-derivative
+    ``u_t = (u^{n+1}-u^n)/dt``; it owns its own framing -- this is the implicit residual
+    ``-u_t + H - D·lap``, NOT the WENO explicit-RHS framing ``-H + D·Δu``.
+
+    ``sigma`` may be a scalar (bit-identical to the prior scalar call) OR a per-node field array
+    (Issue #1071 phase 7: e.g. the GFDM Local-Lax-Friedrichs ``sigma_eff``, Issue #1059), in which
+    case ``D = σ_i²/2`` elementwise and ``D·lap_u`` is the per-node product -- byte-identical to the
+    inline ``diffusion_from_volatility(sigma_eff, kind="field") * lap_u`` LLF expression it replaces.
     """
     H = eval_H_batch(H_class, x, m, p, t)
     if running_cost is not None:
         H = H + running_cost
-    return -u_t + H - diffusion_from_volatility(sigma) * lap_u
+    return -u_t + H - _diffusion_coeff(sigma) * lap_u
 
 
 def assemble_hjb_jacobian_diag(
@@ -92,10 +112,15 @@ def assemble_hjb_jacobian_diag(
 ) -> spmatrix:
     r"""Assemble the sparse HJB Newton Jacobian for the implicit residual (Layer B of #1071).
 
-    Returns ``(1/dt)I + Σ_d diag(∂H/∂p_d) @ D_grad[d] - D·D_lap`` with
-    ``D = diffusion_from_volatility(sigma)``. ``D_grad`` (per-dimension first-derivative
-    matrices) and ``D_lap`` (Laplacian matrix) are the caller's discrete operators -- scattered
-    GFDM stencils, structured FDM matrices, etc. Byte-identical to the inline gfdm assembly.
+    Returns ``(1/dt)I + Σ_d diag(∂H/∂p_d) @ D_grad[d] - D·D_lap`` with ``D = σ²/2``. ``D_grad``
+    (per-dimension first-derivative matrices) and ``D_lap`` (Laplacian matrix) are the caller's
+    discrete operators -- scattered GFDM stencils, structured FDM matrices, etc.
+
+    ``sigma`` may be a scalar (bit-identical to the prior ``D * D_lap`` scalar scaling) OR a per-node
+    field array (Issue #1071 phase 7: GFDM Local-Lax-Friedrichs ``sigma_eff``, Issue #1059). For an
+    array the diffusion term must ROW-SCALE the Laplacian: ``diags(D) @ D_lap`` -- NOT ``D * D_lap``,
+    which for an array left operand does not row-scale a sparse matrix. Byte-identical to the inline
+    ``jacobian - diags(diffusion_from_volatility(sigma_eff, kind="field")) @ D_lap`` it replaces.
     """
     from scipy.sparse import diags, eye
 
@@ -104,4 +129,7 @@ def assemble_hjb_jacobian_diag(
     jacobian = (1.0 / dt) * eye(n, format="csr")
     for dim in range(dH_dp.shape[1]):
         jacobian = jacobian + diags(dH_dp[:, dim], format="csr") @ D_grad[dim]
-    return jacobian - diffusion_from_volatility(sigma) * D_lap
+    D = _diffusion_coeff(sigma)
+    if np.ndim(sigma) == 0:
+        return jacobian - D * D_lap
+    return jacobian - diags(D, format="csr") @ D_lap

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2201,17 +2201,14 @@ class HJBGFDMSolver(BaseHJBSolver):
         dt = self.problem.T / self.problem.Nt
         u_t = (u_n_plus_1 - u_current) / dt
         # _get_sigma_value returns σ (not D); the harness applies D = σ²/2 (#1073/#811).
-        # Issue #1059 LLF: when active, assemble inline with per-node D_i = sigma_eff_i^2/2
-        # (assemble_hjb_residual only accepts scalar sigma; bypass it for the LLF path).
-        if self.llf_augmentation and self._llf_sigma_eff is not None:
-            from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_H_batch
-
-            H = eval_H_batch(H_class, self.collocation_points, m_n_plus_1, grad_u, current_time)
-            if running_cost is not None:
-                H = H + running_cost
-            D_eff = diffusion_from_volatility(self._llf_sigma_eff, kind="field")
-            return -u_t + H - D_eff * lap_u
-        sigma = self._get_sigma_value(None)
+        # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
+        # assemble_hjb_residual (now field-σ capable, D_i = σ_eff_i²/2 elementwise); a plain solve
+        # uses the scalar σ. One assembly path either way.
+        sigma = (
+            self._llf_sigma_eff
+            if (self.llf_augmentation and self._llf_sigma_eff is not None)
+            else self._get_sigma_value(None)
+        )
         return assemble_hjb_residual(
             H_class=H_class,
             x=self.collocation_points,
@@ -2252,21 +2249,14 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         dt = self.problem.T / self.problem.Nt
         # _get_sigma_value returns σ (not D); the harness applies D = σ²/2 (#1073/#811).
-        # Issue #1059 LLF: assemble_hjb_jacobian_diag only accepts scalar sigma;
-        # for the LLF path assemble inline with per-node D_i = sigma_eff_i^2/2.
-        if self.llf_augmentation and self._llf_sigma_eff is not None:
-            from scipy.sparse import diags, eye
-
-            from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch
-
-            dH_dp = eval_dH_dp_batch(H_class, self.collocation_points, m_n_plus_1, grad_u, current_time)
-            n = self._D_lap.shape[0]
-            jacobian = (1.0 / dt) * eye(n, format="csr")
-            for dim in range(dH_dp.shape[1]):
-                jacobian = jacobian + diags(dH_dp[:, dim], format="csr") @ self._D_grad[dim]
-            D_eff = diffusion_from_volatility(self._llf_sigma_eff, kind="field")
-            return jacobian - diags(D_eff, format="csr") @ self._D_lap
-        sigma = self._get_sigma_value(None)
+        # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
+        # assemble_hjb_jacobian_diag (now field-σ capable: it row-scales the Laplacian via
+        # diags(D_i) @ D_lap); a plain solve uses the scalar σ. One assembly path either way.
+        sigma = (
+            self._llf_sigma_eff
+            if (self.llf_augmentation and self._llf_sigma_eff is not None)
+            else self._get_sigma_value(None)
+        )
         return assemble_hjb_jacobian_diag(
             H_class=H_class,
             x=self.collocation_points,

--- a/tests/unit/test_alg/test_h_eval.py
+++ b/tests/unit/test_alg/test_h_eval.py
@@ -92,3 +92,59 @@ def test_assemble_hjb_jacobian_diag_byte_identical():
         ref = ref + diags(dH_dp[:, dim], format="csr") @ D_grad[dim]
     ref = ref - diffusion_from_volatility(sigma) * D_lap
     assert np.allclose(out.toarray(), ref.toarray())
+
+
+# --- Issue #1071 phase 7: per-node (field) sigma — collapse the GFDM inline LLF branches ---
+
+
+def test_assemble_hjb_residual_array_sigma_matches_inline_llf_1071():
+    """A per-node sigma field (GFDM Local-Lax-Friedrichs sigma_eff) yields D = sigma_i^2/2
+    elementwise; the helper must be byte-identical to the inline LLF residual it replaces
+    (hjb_gfdm.py:2209-2213: -u_t + H - diffusion_from_volatility(sigma_eff, kind='field') * lap_u)."""
+    from mfgarchon.alg.numerical.hjb_solvers.h_eval import assemble_hjb_residual, eval_H_batch
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0))
+    x, m, p = _batch()
+    n = m.shape[0]
+    lap_u = np.linspace(-1.0, 1.0, n)
+    u_t = np.linspace(0.0, 0.5, n)
+    sigma_eff = np.random.default_rng(11).uniform(0.2, 0.9, size=n)  # per-node field
+    t = 0.1
+    out = assemble_hjb_residual(H_class=H, x=x, m=m, p=p, lap_u=lap_u, sigma=sigma_eff, t=t, u_t=u_t)
+    ref = -u_t + eval_H_batch(H, x, m, p, t) - diffusion_from_volatility(sigma_eff, kind="field") * lap_u
+    assert np.array_equal(out, ref)
+    # field-sigma must genuinely differ from collapsing it to a scalar (it row-varies the diffusion)
+    scalar_out = assemble_hjb_residual(
+        H_class=H, x=x, m=m, p=p, lap_u=lap_u, sigma=float(sigma_eff.mean()), t=t, u_t=u_t
+    )
+    assert not np.allclose(out, scalar_out)
+
+
+def test_assemble_hjb_jacobian_diag_array_sigma_matches_inline_llf_1071():
+    """A per-node sigma field must ROW-SCALE the Laplacian via diags(D) @ D_lap, byte-identical to
+    the inline LLF Jacobian (hjb_gfdm.py:2262-2268). Exact sparse equality, and it must differ
+    from the scalar form (proving the per-node diffusion is actually applied)."""
+    from scipy.sparse import diags, eye
+
+    from mfgarchon.alg.numerical.hjb_solvers.h_eval import assemble_hjb_jacobian_diag, eval_dH_dp_batch
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=2.0))
+    x, m, p = _batch()
+    n, d = m.shape[0], p.shape[1]
+    sigma_eff = np.random.default_rng(12).uniform(0.2, 0.9, size=n)
+    t, dt = 0.1, 0.05
+    D_grad = [eye(n, format="csr") for _ in range(d)]
+    D_lap = (diags(-2.0 * np.ones(n)) + diags(np.ones(n - 1), 1) + diags(np.ones(n - 1), -1)).tocsr()
+    out = assemble_hjb_jacobian_diag(H_class=H, x=x, m=m, p=p, sigma=sigma_eff, t=t, dt=dt, D_grad=D_grad, D_lap=D_lap)
+    dH_dp = eval_dH_dp_batch(H, x, m, p, t)
+    ref = (1.0 / dt) * eye(n, format="csr")
+    for dim in range(d):
+        ref = ref + diags(dH_dp[:, dim], format="csr") @ D_grad[dim]
+    ref = ref - diags(diffusion_from_volatility(sigma_eff, kind="field"), format="csr") @ D_lap
+    assert (out != ref).nnz == 0  # exact sparse equality to the inline LLF form
+    scalar_out = assemble_hjb_jacobian_diag(
+        H_class=H, x=x, m=m, p=p, sigma=float(sigma_eff.mean()), t=t, dt=dt, D_grad=D_grad, D_lap=D_lap
+    )
+    assert (out != scalar_out).nnz != 0  # per-node diffusion genuinely row-varies the Jacobian


### PR DESCRIPTION
Refs #1071 (phase 7). **Reframed** per maintainer decision after grounding showed the original "LLF-as-Regularizer reaching all solvers" framing is ill-posed against the code (LLF modifies the diffusion coefficient `D=σ²/2`, not `H`/`∂H/∂p`; it needs stencil data `HEvalState` deliberately excludes; and the `Regularizer` scaffold's own docstring explicitly excludes LLF as "a solver-level mixin … never a Hamiltonian-level regularizer"). So LLF stays solver-level and `Regularizer`/`with_regularizer` is left for the physics-only regularizers it was scoped for.

## The actual duplication removed

The two **batch-Hamiltonian** GFDM paths each re-implemented the *entire* residual / Jacobian assembly inline, solely to swap the scalar diffusion `σ` for the per-node LLF field `σ_eff` (Issue #1059):
- residual `_compute_hjb_residual_hamiltonian` (was hjb_gfdm.py:2206-2213)
- Jacobian `_compute_hjb_jacobian_hamiltonian` (was hjb_gfdm.py:2257-2268)

Now the Layer-B helpers accept a per-node `σ` field, so each branch collapses to **one helper call** with `sigma = σ_eff if LLF else scalar`.

## Helper change (`h_eval.py`)

- `_diffusion_coeff(σ)`: scalar → `diffusion_from_volatility(σ)` (bit-identical, `kind` ignored for scalars); array → `kind="field"` → `D=σ²/2` elementwise.
- `assemble_hjb_residual`: `-u_t + H - D·lap_u` (elementwise for a field `σ`).
- `assemble_hjb_jacobian_diag`: array `σ` **row-scales** the Laplacian via `diags(D) @ D_lap` — **not** `D * D_lap`, which for an array left operand does not row-scale a sparse matrix (silent-divergence trap, called out in the docstring + pinned).

## Byte-identity

- **Scalar path untouched** → bit-identical (existing scalar pins still pass).
- **Field path** pinned byte-identical to the exact inline LLF expressions: `test_assemble_hjb_residual_array_sigma_matches_inline_llf_1071` + `test_assemble_hjb_jacobian_diag_array_sigma_matches_inline_llf_1071` (exact sparse equality; plus a "differs from scalar" assertion proving the per-node diffusion is actually applied).
- **End-to-end:** the GFDM LLF augmentation suite now runs through the helper path — 14/14 pass. Broad regression: **243** GFDM/h_eval/1071 tests pass; ruff clean.

## Scope

The legacy-LQ-vectorized branches (2160/2404) inline their *own* LQ Hamiltonian (a different assembly, not `eval_H_batch`) so they don't retire into these helpers — out of scope. `_get_sigma_value` (2959) stays as the per-point σ source. No change to `Regularizer`/`with_regularizer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)