### PR TITLE
docs(backends): mark *_step as LQ-only toy steppers, not the production path (#1072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Backend `hjb_step`/`fpk_step` documented as LQ-only toy steppers** (Issue #1072, docs-only).
+  `BaseBackend.hjb_step`/`fpk_step` and all four backend impls (numpy/torch/numba/jax) now state
+  in their docstrings that these are experimental LQ-only steppers — each hardcodes a *different*
+  default Hamiltonian and **none honors `problem.hamiltonian_class`** — with **no caller in the
+  HJB/FP solver fleet** (the production solvers single-source the Hamiltonian via `base_hjb.evaluate_H`
+  ← `problem.hamiltonian_class`, #1071). This removes the trap of mistaking #1072 ("Functional
+  Operator Lowering", the deferred post-v1.0 RFC to XLA-lower the operator tree + Hamiltonian) for a
+  quick patch on `jax_backend.py`. No runtime change. The World-A-vs-World-B design fork and the
+  un-defer trigger are recorded on #1072.
+
 - **GFDM Local-Lax-Friedrichs assembly single-sourced through the Layer-B helpers** (Issue #1071
   phase 7). The two batch-Hamiltonian GFDM paths each re-implemented the entire residual /
   Jacobian assembly inline solely to swap the scalar diffusion `σ` for the per-node LLF field

--- a/mfgarchon/backends/base_backend.py
+++ b/mfgarchon/backends/base_backend.py
@@ -122,11 +122,33 @@ class BaseBackend(ABC):
 
     @abstractmethod
     def hjb_step(self, U, M, dt, dx, problem_params):
-        """Single Hamilton-Jacobi-Bellman time step."""
+        """Single explicit HJB time step — LQ-only toy stepper, NOT the production solve path.
+
+        ⚠️ These backend ``*_step`` methods hardcode a fixed (Linear-Quadratic-flavoured)
+        Hamiltonian and do NOT honor ``problem.hamiltonian_class`` — and each backend hardcodes a
+        *different* default (numpy ``0.5 p²``; torch ``0.5|p|² + V + interaction·log m``; numba
+        ``0.5 p² + log m``; jax ``0.5 p²``). They are an experimental/benchmark surface with **no
+        caller in the HJB/FP solver fleet** (only ``tests/`` and one benchmark demo reach them).
+
+        The production solvers (``HJBFDMSolver``/``HJBGFDMSolver``/…) do NOT use this; they evaluate
+        the problem's actual Hamiltonian through the #1071 single source
+        (``base_hjb``/``h_eval.evaluate_H`` ← ``problem.hamiltonian_class``). So a custom-Hamiltonian
+        solve via ``problem.solve()`` is correct regardless of this hardcode.
+
+        Teaching these steppers ``hamiltonian_class`` (and XLA-lowering the operator tree) is the
+        deferred RFC #1072 ("Functional Operator Lowering", post-v1.0). Do NOT treat this as a quick
+        patch — see #1072 for the World-A-vs-World-B fork and the tracing/operator walls.
+        """
 
     @abstractmethod
     def fpk_step(self, M, U, dt, dx, problem_params):
-        """Single Fokker-Planck-Kolmogorov time step."""
+        """Single explicit FPK time step — LQ-only toy stepper, NOT the production solve path.
+
+        See :meth:`hjb_step`: this is the experimental backend stepper surface (hardcoded default
+        drift, not ``problem.hamiltonian_class``), with no caller in the solver fleet. The live FP
+        solvers single-source the drift from the problem (#1071/#1043), not from here. Honoring
+        ``hamiltonian_class`` here is the deferred RFC #1072.
+        """
 
     # Performance and Compilation
     def compile_function(self, func, *args, **kwargs):

--- a/mfgarchon/backends/jax_backend.py
+++ b/mfgarchon/backends/jax_backend.py
@@ -271,6 +271,14 @@ class JAXBackend(BaseBackend):
         return M_new
 
     def hjb_step(self, U, M, dt, dx, problem_params):
+        """Single HJB time step — LQ-only toy stepper (hardcoded H = 0.5·p², see ``_hamiltonian_impl``).
+
+        ⚠️ Does NOT honor ``problem.hamiltonian_class`` and has no caller in the solver fleet (only
+        tests + the jax_acceleration benchmark demo). Not the production path — see
+        :meth:`BaseBackend.hjb_step`. Teaching it ``hamiltonian_class`` by XLA-lowering the operator
+        tree + Hamiltonian is the deferred RFC #1072 ("Functional Operator Lowering", post-v1.0) —
+        this is the issue's named target; do NOT treat it as a quick patch.
+        """
         x_grid = problem_params.get("x_grid", jnp.linspace(0, 1, len(U)))
         if self.jit_compile and self._jit_hjb_step is not None:
             return self._jit_hjb_step(U, M, dt, dx, x_grid, problem_params)

--- a/mfgarchon/backends/numba_backend.py
+++ b/mfgarchon/backends/numba_backend.py
@@ -352,7 +352,11 @@ class NumbaBackend(BaseBackend):
         return -p
 
     def hjb_step(self, U, M, dt, dx, problem_params):
-        """Single Hamilton-Jacobi-Bellman time step."""
+        """Single HJB time step — LQ-only toy stepper (hardcoded H = 0.5·p² + log m).
+
+        ⚠️ Does NOT honor ``problem.hamiltonian_class`` and has no caller in the solver fleet. Not
+        the production path — see :meth:`BaseBackend.hjb_step` and deferred RFC #1072.
+        """
         # Issue #1282: numba already uses the canonical "sigma" key; route through the
         # single-source resolver (no legacy key) so all four backends share one lookup.
         sigma = resolve_volatility(problem_params, default=1.0)

--- a/mfgarchon/backends/numpy_backend.py
+++ b/mfgarchon/backends/numpy_backend.py
@@ -142,6 +142,10 @@ class NumPyBackend(BaseBackend):
         Hamilton-Jacobi-Bellman time step using finite differences.
 
         ∂U/∂t + H(x, ∇U, M) = 0
+
+        ⚠️ LQ-only toy stepper (hardcoded H = 0.5·p²); does NOT honor ``problem.hamiltonian_class``
+        and has no caller in the solver fleet. Not the production path — see
+        :meth:`BaseBackend.hjb_step` and deferred RFC #1072.
         """
         # Compute spatial gradient of U using central differences
         dU_dx = np.zeros_like(U)

--- a/mfgarchon/backends/torch_backend.py
+++ b/mfgarchon/backends/torch_backend.py
@@ -399,6 +399,10 @@ class TorchBackend(BaseBackend):
         Single Hamilton-Jacobi-Bellman time step using PyTorch operations.
 
         Implements: dU/dt + H(x, ∇U, M) = 0
+
+        ⚠️ LQ-only toy stepper (hardcoded H = 0.5|p|² + potential·x² + interaction·log m); does NOT
+        honor ``problem.hamiltonian_class`` and has no caller in the solver fleet. Not the production
+        path — see :meth:`BaseBackend.hjb_step` and deferred RFC #1072.
         """
         U_tensor = self._to_torch(U)
         M_tensor = self._to_torch(M)


### PR DESCRIPTION
Refs #1072 (jax FOL / Functional Operator Lowering). Docs-only hygiene — **no runtime change**. Per the grounding refresh, #1072 stays correctly deferred (post-v1.0 RFC); this PR is the interim quarantine the grounding endorsed even under defer.

## What

`BaseBackend.hjb_step`/`fpk_step` and all four backend impls (numpy/torch/numba/jax) now document that they are **LQ-only toy steppers**: each hardcodes a *different* default Hamiltonian (numpy `0.5p²`; torch `0.5|p|²+pot+log m`; numba `0.5p²+log m`; jax `0.5p²`); **none honors `problem.hamiltonian_class`**; and they have **zero callers in the HJB/FP solver fleet** (only `tests/` + the jax_acceleration benchmark demo). Production solvers single-source the Hamiltonian via `base_hjb.evaluate_H` ← `problem.hamiltonian_class` (#1071), so a custom-Hamiltonian solve through `problem.solve()` is correct regardless of the hardcode.

## Why

Removes the "quick patch on `jax_backend.py`" trap. The World-A-vs-World-B fork, the 3 artifact walls (numpy Hamiltonians not XLA-traceable; `scipy.sparse` operators with no `register_lowering` machinery; dead `backend.*_step` seam), and the un-defer trigger (a concrete XLA/GPU coupled-solve consumer) are recorded on #1072.

## Verification
242 backend tests pass (docstring-only); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)