### PR TITLE
refactor(gfdm): single-source the per-point FD-Jacobian lambda (#1071 phase 4)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -3560,13 +3560,18 @@ class HJBGFDMSolver(BaseHJBSolver):
         """
         p = derivs.grad if derivs.grad is not None else np.zeros(self.problem.dimension)
 
-        # Fast path: for standard LQ Hamiltonian H = |p|²/(2λ), dH/dp = p/λ
-        lambda_val = getattr(self.problem, "lambda_", None)
-        if lambda_val is not None and lambda_val > 0:
-            # Check if using standard (non-custom) Hamiltonian
-            is_custom = getattr(self.problem, "is_custom", False)
-            if not is_custom:
-                return p / lambda_val
+        # Fast path: for standard LQ Hamiltonian H = |p|²/(2λ), dH/dp = p/λ.
+        # Source λ from the canonical single source (``_control_cost_lambda`` ->
+        # ``control_cost.lambda_``, falling back to ``problem.lambda_`` only when the
+        # problem carries no Hamiltonian class) rather than reading ``problem.lambda_``
+        # directly. This was the last direct ``problem.lambda_`` read in a physics path
+        # -- the #1247 desync survivor on the per-point FD-Jacobian fast path (#1071
+        # Phase 4). On every reachable construction the two agree (the divergent case is
+        # unreachable: ``not is_custom`` implies the problem carries no control cost), so
+        # this is byte-identical single-source hygiene, not a behaviour change.
+        is_custom = getattr(self.problem, "is_custom", False)
+        if not is_custom:
+            return p / self._control_cost_lambda()
 
         # Fallback: finite differences for custom Hamiltonians using scipy
         x_pos = self.collocation_points[point_idx]

--- a/tests/unit/test_alg/test_hjb_1071_control_cost_lambda.py
+++ b/tests/unit/test_alg/test_hjb_1071_control_cost_lambda.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+from mfgarchon.core.derivatives import DerivativeTensors
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
@@ -123,3 +124,76 @@ def test_nonpositive_lambda_rejected():
     """A non-positive control cost is rejected (division by lambda requires lambda > 0)."""
     with pytest.raises(ValueError, match="must be positive"):
         QuadraticControlCost(lambda_=-1.0)
+
+
+# --- #1071 Phase 4: GFDM per-point FD-Jacobian fast path sources lambda from the
+# --- Hamiltonian single source, not a direct problem.lambda_ read (hjb_gfdm.py:_compute_dH_dp_fd).
+
+
+class _ControlCost:
+    def __init__(self, lambda_: float):
+        self.lambda_ = lambda_
+
+
+class _Ham:
+    def __init__(self, lambda_: float):
+        self.control_cost = _ControlCost(lambda_)
+
+
+class _FastPathProblem:
+    """``is_custom=False`` (so the GFDM LQ fast path runs) but the Hamiltonian's control
+    cost (canonical lambda) disagrees with the ``problem.lambda_`` placeholder.
+
+    This divergent state is NOT reachable through the public API -- ``is_custom=False``
+    implies the problem carries no Hamiltonian class, so the two always agree. It is
+    constructed here purely to PIN that the fast path reads lambda from the canonical
+    single source, discriminating the single-source code from the pre-fix direct read.
+    """
+
+    is_custom = False
+    dimension = 1
+
+    def __init__(self, placeholder_lambda: float, canonical_lambda: float):
+        self.lambda_ = placeholder_lambda
+        self.hamiltonian_class = _Ham(canonical_lambda)
+
+
+class _FastPathSolver:
+    """Minimal stand-in carrying the inherited ``_control_cost_lambda`` for unbound-call
+    invocation of ``HJBGFDMSolver._compute_dH_dp_fd``."""
+
+    _control_cost_lambda = BaseHJBSolver._control_cost_lambda
+
+    def __init__(self, problem):
+        self.problem = problem
+
+
+def test_fd_jacobian_fast_path_sources_lambda_from_hamiltonian_not_placeholder():
+    """#1071 Phase 4 (discriminating): the GFDM per-point FD-Jacobian fast path derives
+    lambda from the Hamiltonian single source, not ``problem.lambda_``.
+
+    Pins against reverting ``hjb_gfdm.py:_compute_dH_dp_fd`` to a direct
+    ``getattr(self.problem, "lambda_")`` read: canonical lambda=2 must give dH/dp = p/2,
+    whereas the pre-fix placeholder read (lambda=1) gave p/1.
+    """
+    solver = _FastPathSolver(_FastPathProblem(placeholder_lambda=1.0, canonical_lambda=2.0))
+    derivs = DerivativeTensors.from_arrays(grad=np.array([0.6]), hess=np.zeros((1, 1)))
+
+    out = HJBGFDMSolver._compute_dH_dp_fd(solver, point_idx=0, m_at_x=1.0, derivs=derivs)
+
+    np.testing.assert_allclose(out, np.array([0.3]))  # p / canonical lambda = 0.6 / 2
+    assert not np.allclose(out, np.array([0.6])), (
+        "fast path read the problem.lambda_ placeholder (p/1) instead of control_cost.lambda_ (p/2)"
+    )
+
+
+def test_fd_jacobian_fast_path_byte_identical_on_reachable_legacy_path():
+    """#1071 Phase 4 (equivalence): on the only construction that actually reaches the
+    fast path -- no Hamiltonian class, ``problem.lambda_`` the sole source -- the
+    single-source routing reproduces the old direct-read result exactly (p / lambda_)."""
+    solver = _FastPathSolver(_NoHamProblem(lambda_=2.0))
+    derivs = DerivativeTensors.from_arrays(grad=np.array([0.6]), hess=np.zeros((1, 1)))
+
+    out = HJBGFDMSolver._compute_dH_dp_fd(solver, point_idx=0, m_at_x=1.0, derivs=derivs)
+
+    np.testing.assert_allclose(out, np.array([0.3]))  # p / problem.lambda_ = 0.6 / 2


### PR DESCRIPTION
## #1071 Phase 4 — kill the last direct `problem.lambda_` read

Routes `HJBGFDMSolver._compute_dH_dp_fd`'s LQ fast path through the canonical
`_control_cost_lambda()` accessor instead of reading `getattr(self.problem, "lambda_")`
directly. Per the #1071 RFC rollout table (Phase 4), `hjb_gfdm.py:_compute_dH_dp_fd` held
**the last direct `problem.lambda_` read in a physics path** — the #1247 desync survivor.

### Honest framing: byte-identical hygiene, NOT a live-bug fix

The divergent case (`problem.lambda_ != control_cost.lambda_`) is **unreachable** on this
path, traced and empirically confirmed:

- The fast path runs only under `not is_custom`.
- `is_custom = (components is not None)`; since #670 every real `MFGProblem` requires
  `u_terminal`/`m_initial` via `MFGComponents`, so a real problem is always `is_custom=True`
  and **skips** the fast path (only mock problems reach it).
- `is_custom=False ⟹ hamiltonian_class=None ⟹ _control_cost_lambda()` falls back to exactly
  `problem.lambda_`.

So old and new agree on every reachable construction. The value is **structural**: it
removes the direct-read footgun and raises Hamiltonian fan-in (the Bourbaki single-source
goal) — no physics-path code reads `problem.lambda_` directly anymore.

### Pinning tests (`tests/unit/test_alg/test_hjb_1071_control_cost_lambda.py`)

- **Discriminating**: a mock with placeholder `lambda_=1` but canonical `control_cost.lambda_=2`
  forces the fast path to return `p/2` (single source), not `p/1` (placeholder). Verified by
  mutation that a revert to the direct read yields `p/1` and fails the test.
- **Equivalence**: on the only construction that actually reaches the fast path (no
  Hamiltonian class, `problem.lambda_` the sole source), the routing reproduces the old
  result byte-for-byte (`p / problem.lambda_`).

### Verification

- `pytest` pinning file + the 5 `is_custom=False` mock suites (Howard, precomputed-monotone,
  ghost-nodes, bc-classification, joint-socp-mirror) + #1071 byte-identity regressions:
  **92 passed, 1 skipped**.
- `ruff format --check` / `ruff check`: clean. `mypy`: no new errors at the changed lines.

Refs #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)