### PR TITLE
test: mark heavy integration/validation classes slow to fit the PR CI budget (#1403)

### DIFF
--- a/tests/integration/test_block_iterators.py
+++ b/tests/integration/test_block_iterators.py
@@ -262,6 +262,7 @@ class TestBlockIteratorParameters:
         assert np.all(result.M >= -1e-6), f"M has negative values: min={np.min(result.M)}"
 
 
+@pytest.mark.slow
 class TestBlockVsFixedPoint:
     """Compare block iterators with FixedPointIterator."""
 

--- a/tests/integration/test_graph_mfg_solver.py
+++ b/tests/integration/test_graph_mfg_solver.py
@@ -92,6 +92,7 @@ class TestGraphMFGSolverInstantiation:
         assert solver._tol == 1e-3
 
 
+@pytest.mark.slow
 class TestGraphMFGSolverSolve:
     def test_returns_result(self):
         problems, coupling, hjbs, fps = _make_3node_system()
@@ -163,6 +164,7 @@ class TestGraphMFGSolverSolve:
         assert 0 < result.iterations <= 3
 
 
+@pytest.mark.slow
 class TestGraphMFGSolverCouplingEffect:
     def test_coupling_affects_solution(self):
         """With coupling, node solutions should differ from uncoupled."""

--- a/tests/integration/test_hjb_with_obstacle.py
+++ b/tests/integration/test_hjb_with_obstacle.py
@@ -53,6 +53,7 @@ def _default_components_2d():
     )
 
 
+@pytest.mark.slow
 class TestHJBWithLowerObstacle:
     """Test HJB solver with lower obstacle constraint (u ≥ ψ)."""
 
@@ -196,6 +197,7 @@ class TestHJBWithLowerObstacle:
         # The test still validates that the constraint mechanism works correctly.
 
 
+@pytest.mark.slow
 class TestHJBWithUpperObstacle:
     """Test HJB solver with upper obstacle constraint (u ≤ ψ_upper)."""
 
@@ -243,6 +245,7 @@ class TestHJBWithUpperObstacle:
         # even if not actively binding for this particular problem.
 
 
+@pytest.mark.slow
 class TestHJBWithBilateralObstacle:
     """Test HJB solver with bilateral obstacle (ψ_lower ≤ u ≤ ψ_upper)."""
 

--- a/tests/integration/test_lions_correction.py
+++ b/tests/integration/test_lions_correction.py
@@ -6,6 +6,8 @@ into the HJB source term pipeline via create_lions_source and
 create_nonlocal_source.
 """
 
+import pytest
+
 import numpy as np
 
 from mfgarchon.alg.numerical.coupling import FixedPointIterator
@@ -187,6 +189,7 @@ class TestCreateNonlocalSource:
         np.testing.assert_allclose(result_direct, result_fd, rtol=0.05)
 
 
+@pytest.mark.slow
 class TestLionsCorrectionEndToEnd:
     """Test Lions correction flows through the full MFG solve pipeline."""
 

--- a/tests/integration/test_phase1_5_validation.py
+++ b/tests/integration/test_phase1_5_validation.py
@@ -269,6 +269,7 @@ class TestNetworkSolverIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 class TestHomotopyContinuation:
     """Validate homotopy continuation tracks equilibrium branches."""
 

--- a/tests/integration/test_source_term_wiring.py
+++ b/tests/integration/test_source_term_wiring.py
@@ -11,6 +11,8 @@ Test strategy:
 
 from __future__ import annotations
 
+import pytest
+
 import numpy as np
 
 from mfgarchon import MFGProblem
@@ -199,6 +201,7 @@ def _rel_linf(a, b):
     return float(np.max(np.abs(a - b)) / max(np.max(np.abs(b)), 1e-30))
 
 
+@pytest.mark.slow
 class TestNewtonPicardParity:
     """Newton (residual path) and Picard reach the same source-inclusive equilibrium."""
 

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -256,6 +256,7 @@ class TestConvergenceRate:
             assert 0.1 < ratio <= 1.5, f"Refinement should improve accuracy (ratio={ratio:.3f})"
 
 
+@pytest.mark.slow
 class TestNumericalStability:
     """Test that dual schemes maintain stability."""
 


### PR DESCRIPTION
## Problem

The PR **Test Suite** job (`-m "not slow ..."` under coverage, `-n auto`, `timeout-minutes: 25`)
**times out**, surfacing as a red ✗ on PRs (e.g. #1403). It is **not a real test failure** —
the run reaches ~91% with every test passing, then the 25-min wall-clock budget kills it
(`##[error] ... timed out after 25 minutes`). Re-running times out again — the suite's
wall-clock has simply grown past the budget on the slower CI runners.

## Fix

Move the heaviest **integration / validation** test classes off the PR path with
`@pytest.mark.slow` (already excluded by the PR command; still run on releases and locally).
**28 tests across 7 files**, dominated by coupled end-to-end solves:

| Class | ~cumulative call time |
|---|---|
| `TestLionsCorrectionEndToEnd` | 183s |
| `TestNewtonPicardParity` | 92s |
| `TestHJBWith{Lower,Upper,Bilateral}Obstacle` | 53s |
| `TestNumericalStability` (duality) | 39s |
| `TestHomotopyContinuation` | 33s |
| `TestGraphMFGSolver{Solve,CouplingEffect}` | 25s |
| `TestBlockVsFixedPoint` | 14s |

**All unit tests remain on the PR path.**

## Measured impact (local, `-n auto`, coverage-off)

| | wall-clock |
|---|---|
| before (full `-m "not slow"`) | **372s (6:12)** |
| after (these 28 now slow) | **114s (1:53)** — −69% |

The longest single tests (lions 100s + 83s) were critical-path on their workers, so removing
them collapses the wall-clock far more than their raw share. CI runners are ~4.4× slower +
coverage overhead → estimated PR Test Suite **~10–12 min** (was hitting the 25-min ceiling).

## Merge ordering

This unblocks #1403 / #1404 / #1405, whose CI is the same timeout. After this merges to
`main`, rebase those three onto `main` so their `-m "not slow"` runs pick up the new marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)