### PR TITLE
refactor(gfdm): single-source the legacy-LQ vectorized HJB Jacobian (#1071)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2214,10 +2214,19 @@ class HJBGFDMSolver(BaseHJBSolver):
         grad_u: np.ndarray,
     ):
         """
-        Compute sparse Jacobian using vectorized operations with pre-computed differentiation matrices.
+        Compute the sparse LQ Newton Jacobian via the single-source assembler (Issue #1071).
 
-        For standard LQ Hamiltonian H = |p|²/(2λ), dH/dp = p/λ.
-        Jacobian structure: J = (1/dt)I + (1/λ) * Σ_d diag(p_d) @ D_grad[d] - (σ²/2) * D_lap
+        Routes ∂H/∂p through ``H_class.evaluate_dp`` (the one Hamiltonian source) instead of
+        the inline ``p/λ`` re-derivation: the body delegates to
+        :meth:`_compute_hjb_jacobian_hamiltonian`, which assembles
+        ``(1/dt)I + Σ_d diag(∂H/∂p_d) @ D_grad[d] - D·D_lap`` (with ``D = σ²/2``, per-node for
+        the LLF ``σ_eff`` field) through ``assemble_hjb_jacobian_diag``. For the separable LQ
+        Hamiltonian ``∂H/∂p = p/λ`` is independent of ``m`` and ``t``, so passing ``m=0`` / ``t=0``
+        is byte-identical to the prior inline form (verified maxabsdiff=0 across the joint_socp
+        σ-sweep, strong-drift, and LLF field-σ configurations).
+
+        The single-``grad_u`` wrapper is kept because the Issue #1074 M-matrix /
+        discrete-maximum-principle tests assemble the iteration matrix directly through it.
 
         Args:
             grad_u: Pre-computed gradient, shape (n_points, dimension)
@@ -2225,45 +2234,14 @@ class HJBGFDMSolver(BaseHJBSolver):
         Returns:
             Sparse Jacobian matrix in CSR format
         """
-        from scipy.sparse import diags, eye
-
-        # Lazy initialization of differentiation matrices
-        if self._D_grad is None:
-            self._build_differentiation_matrices()
-
-        n = self.n_points
-        d = self.dimension
-        dt = self.problem.T / self.problem.Nt
-        lambda_val = self._control_cost_lambda()
-        # Issue #1073: use _get_sigma_value (returns σ) instead of confusing
-        # `getattr(problem, "diffusion") or getattr(problem, "sigma")` chain.
-        # `problem.diffusion` returns σ²/2 (PDE coefficient D), so the old chain
-        # treated σ as D, then computed (σ²/2)² = σ⁴/8 instead of σ²/2 — 4-44× too
-        # small for σ ∈ {0.3, 0.5, 1.0, 1.414} (only σ=2 happens to be correct).
-        # Issue #1059 LLF: when active, use per-node D_i = sigma_eff_i^2/2.
-        if self.llf_augmentation and self._llf_sigma_eff is not None:
-            D_eff = diffusion_from_volatility(self._llf_sigma_eff, kind="field")
-        else:
-            sigma = self._get_sigma_value(None)
-            D_eff = None
-            diffusion_coeff = diffusion_from_volatility(sigma)
-
-        # Time derivative term: (1/dt) * I
-        jacobian = (1.0 / dt) * eye(n, format="csr")
-
-        # Hamiltonian gradient term: (1/λ) * Σ_d diag(p_d) @ D_grad[d]
-        # For LQ: dH/dp = p/λ, so ∂(dH/dp · ∇u)/∂u_j = (p/λ) · (∂∇u/∂u_j)
-        for dim in range(d):
-            p_d = grad_u[:, dim] / lambda_val  # dH/dp_d = p_d / λ
-            jacobian = jacobian + diags(p_d, format="csr") @ self._D_grad[dim]
-
-        # Diffusion term: -(D_i) * D_lap  [per-node for LLF, scalar otherwise]
-        if D_eff is not None:
-            jacobian = jacobian - diags(D_eff, format="csr") @ self._D_lap
-        else:
-            jacobian = jacobian - diffusion_coeff * self._D_lap
-
-        return jacobian
+        H_class = getattr(self.problem, "hamiltonian_class", None)
+        if H_class is None:
+            raise ValueError(
+                "_compute_hjb_jacobian_vectorized requires problem.hamiltonian_class to derive "
+                "∂H/∂p via the single-source assembler (Issue #1071)."
+            )
+        # Separable LQ: ∂H/∂p = p/λ ignores m and t, so m=0 / t=0 are byte-identical.
+        return self._compute_hjb_jacobian_hamiltonian(grad_u, np.zeros(self.n_points), H_class, 0.0)
 
     def _maybe_warn_dmp(self, u_current: np.ndarray) -> None:
         """Warn (once) when the current drift exceeds the assembled-M-matrix threshold (Issue #1074).

--- a/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
@@ -397,3 +397,48 @@ class TestLLFJacobianEffect:
             "Expected at least one interior node with strictly larger diagonal "
             "when LLF is active with l_H=10 (nu_i > 0 at every node)"
         )
+
+    def test_llf_jacobian_byte_identical_to_inline_field_formula(self, problem_and_pts):
+        """Issue #1071: with LLF active the consolidated ``_compute_hjb_jacobian_vectorized``
+        routes the per-node ``σ_eff`` diffusion through the single-source assembler
+        (``assemble_hjb_jacobian_diag``, which row-scales the Laplacian via
+        ``diags(σ_eff²/2) @ D_lap``).
+
+        Pin: the assembled CSR is byte-identical (atol=0) to the explicit inline field
+        formula ``(1/dt)I + Σ_d diag(p_d/λ) @ D_grad[d] - diags(σ_eff²/2) @ D_lap`` it
+        replaced — locks the field-σ branch against a regression to the scalar ``D * D_lap``
+        scaling (which does NOT row-scale for an array left operand)."""
+        from scipy.sparse import diags, eye
+
+        from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+        problem, pts = problem_and_pts
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(problem, pts, monotonicity_scheme="none", llf_augmentation=True, llf_l_H=10.0)
+        solver._build_differentiation_matrices()
+        assert solver._llf_sigma_eff is not None, "LLF sigma_eff must be populated at init"
+
+        rng = np.random.default_rng(1071)
+        grad_u = rng.standard_normal((solver.n_points, 1))
+        J = solver._compute_hjb_jacobian_vectorized(grad_u)
+
+        n = solver.n_points
+        dt = solver.problem.T / solver.problem.Nt
+        lam = solver._control_cost_lambda()
+        D_field = diffusion_from_volatility(solver._llf_sigma_eff, kind="field")
+        ref = (1.0 / dt) * eye(n, format="csr")
+        for d in range(solver.dimension):
+            ref = ref + diags(grad_u[:, d] / lam, format="csr") @ solver._D_grad[d]
+        ref = ref - diags(D_field, format="csr") @ solver._D_lap
+
+        Jc, rc = J.tocsr(), ref.tocsr()
+        Jc.sort_indices()
+        rc.sort_indices()
+        assert Jc.shape == rc.shape
+        assert np.array_equal(Jc.indptr, rc.indptr), "CSR indptr drift"
+        assert np.array_equal(Jc.indices, rc.indices), "CSR indices drift"
+        maxabsdiff = float(np.max(np.abs((Jc - rc).data))) if (Jc - rc).nnz else 0.0
+        assert np.array_equal(Jc.data, rc.data), (
+            f"LLF field-σ Jacobian not byte-identical to inline formula (maxabsdiff={maxabsdiff:.3e})"
+        )

--- a/tests/unit/test_alg/test_socp_m_matrix_property.py
+++ b/tests/unit/test_alg/test_socp_m_matrix_property.py
@@ -250,6 +250,49 @@ def test_assembled_m_matrix_breaks_under_strong_drift(sigma):
     assert report["n_positive_offdiag"] > 0
 
 
+@pytest.mark.parametrize("sigma", [0.3, 0.5, 1.0, 1.5])
+def test_vectorized_jacobian_byte_identical_to_inline_lq_formula(sigma):
+    """Issue #1071: ``_compute_hjb_jacobian_vectorized`` now routes ∂H/∂p through the
+    single-source assembler (``assemble_hjb_jacobian_diag`` → ``H_class.evaluate_dp``)
+    instead of the inline ``p/λ`` re-derivation.
+
+    Pin: the assembled CSR is byte-identical (atol=0, dtype-exact) to the explicit inline
+    LQ Jacobian ``(1/dt)I + Σ_d diag(p_d/λ) @ D_grad[d] - (σ²/2)·D_lap`` it replaced. The
+    M-matrix property asserts above are necessary but insufficient — they pass for any
+    structurally-similar matrix; this locks the λ / diffusion convention against a silent
+    assembler drift (sign flip, stray m-term, wrong diffusion coefficient)."""
+    from scipy.sparse import diags, eye
+
+    from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+    solver = _make_solver(sigma=sigma, n_x=21)
+    rng = np.random.default_rng(1071)
+    grad_u = rng.standard_normal((solver.n_points, 1))
+
+    J = solver._compute_hjb_jacobian_vectorized(grad_u)  # builds operators lazily
+
+    # Independent reference: the explicit inline LQ Jacobian this consolidation replaced.
+    n = solver.n_points
+    dt = solver.problem.T / solver.problem.Nt
+    lam = solver._control_cost_lambda()
+    D = diffusion_from_volatility(solver._get_sigma_value(None))
+    ref = (1.0 / dt) * eye(n, format="csr")
+    for d in range(solver.dimension):
+        ref = ref + diags(grad_u[:, d] / lam, format="csr") @ solver._D_grad[d]
+    ref = ref - D * solver._D_lap
+
+    Jc, rc = J.tocsr(), ref.tocsr()
+    Jc.sort_indices()
+    rc.sort_indices()
+    assert Jc.shape == rc.shape
+    assert np.array_equal(Jc.indptr, rc.indptr), "CSR indptr drift"
+    assert np.array_equal(Jc.indices, rc.indices), "CSR indices drift"
+    maxabsdiff = float(np.max(np.abs((Jc - rc).data))) if (Jc - rc).nnz else 0.0
+    assert np.array_equal(Jc.data, rc.data), (
+        f"σ={sigma}: assembled Jacobian not byte-identical to inline LQ formula (maxabsdiff={maxabsdiff:.3e})"
+    )
+
+
 def test_runtime_dmp_guard_warns_only_when_violated():
     """Issue #1074 runtime guard: check_dmp=True warns when the drift exceeds α_crit; it is
     silent below the threshold and a no-op when check_dmp=False (the default — numerically inert)."""


### PR DESCRIPTION
## #1071 — single-source the GFDM legacy-LQ vectorized Jacobian

`_compute_hjb_jacobian_vectorized` was the **last solver-level dH/dp re-derivation** in the GFDM Jacobian path: it inlined `dH/dp = p/λ` (`hjb_gfdm.py:2257`) and the diffusion `D = σ²/2` branch, parallel to the single-source `_compute_hjb_jacobian_hamiltonian` (which routes through `assemble_hjb_jacobian_diag` → `H_class.evaluate_dp`).

### Change
Delegate the body to `_compute_hjb_jacobian_hamiltonian`; **keep the `(grad_u)` wrapper**. For the separable LQ Hamiltonian `dH/dp = p/λ` is independent of `m` and `t`, so passing `m=0` / `t=0` reproduces the inline form exactly. `-42` net lines in the function; dH/dp and diffusion now have one home.

### Wrapper kept (not deleted) — by design
`_compute_hjb_jacobian_vectorized` has **zero production callers**; the only call sites are **7 test-only references across 2 files** (`test_socp_m_matrix_property.py`, `test_hjb_gfdm_llf_augmentation.py`) that assemble the HJB iteration matrix to verify the **#1074 M-matrix / discrete-maximum-principle** property. Delegating the body keeps that entry point intact (zero test edits). Method *deletion* + a dedicated `assemble_hjb_iteration_matrix` entry point is deferred to a follow-up.

### Byte-identical (verified, atol=0)
Empirically `maxabsdiff=0` with **exact CSR triplet match** (indptr/indices/data) across:
- joint_socp + precompute, σ ∈ {0.3, 0.5, 1.0, 1.5}, grad_u ∈ {zeros, seeded random}
- strong-drift (5·α_crit)
- LLF field-σ branch (`σ_eff`), σ ∈ {0.5, 1.0}
- m-independence (delegated with real m == delegated with m=0)

### Pinning tests (independent inline-formula oracle)
- `test_vectorized_jacobian_byte_identical_to_inline_lq_formula` (scalar, σ-sweep)
- `test_llf_jacobian_byte_identical_to_inline_field_formula` (LLF field-σ row-scaling)

Both reconstruct the explicit `(1/dt)I + Σ_d diag(p_d/λ) @ D_grad[d] - (σ²/2)·D_lap` formula and assert byte-identity — locking the λ / diffusion convention against silent assembler drift (sign flip, stray m-term, wrong diffusion coefficient). The existing M-matrix asserts (necessary but insufficient) remain.

Refs #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)