### PR TITLE
refactor(howard): single-source the policy-eval Lagrangian + support lambda!=1 quadratic (#1071)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -3000,34 +3000,29 @@ class HJBGFDMSolver(BaseHJBSolver):
                 "inner_solver='howard' requires problem.hamiltonian_class to derive the optimal "
                 "control alpha* = -dH/dp; the legacy no-Hamiltonian LQ path is unsupported."
             )
-        # Issue #1071: derive lambda from the Hamiltonian's control cost (the single source),
-        # NOT from problem.lambda_ — the placeholder read that powered the #1247 desync.
-        lambda_val = self._control_cost_lambda()
-        if abs(lambda_val - 1.0) > 1e-12:
-            raise NotImplementedError(
-                f"inner_solver='howard' currently assumes unit control cost (lambda_=1), got {lambda_val}. "
-                "Howard's policy-evaluation Lagrangian is hardcoded to (1/2)|alpha|^2; non-unit control cost "
-                "needs a running-cost correction (deferred, Issue #1118 PR2)."
-            )
-        # Howard's policy evaluation hardcodes the unit-quadratic Lagrangian (1/2)|alpha|^2 and
-        # derives alpha* = -dH/dp, so the control term is faithful only for a unit-quadratic
-        # MINIMIZE control cost H_control = (1/2)|p|^2. The potential V(x, t), the density
-        # coupling f(m), and any caller running cost ARE now wired (Issue #1247, below); what
-        # remains unmodelled — non-unit / non-quadratic control cost and the MAXIMIZE sense —
-        # is the Lagrangian-scaling work deferred alongside #1071. Fail loud on those cases;
-        # validated by tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_*.
+        # Howard derives alpha* = -dH/dp and now consumes the control-cost Lagrangian
+        # L(alpha) = lambda/2 |alpha|^2 from the single source (control_cost.lagrangian, wired
+        # below), so any QUADRATIC control cost (unit or lambda != 1) MINIMIZE is faithful. The
+        # potential V(x, t), the density coupling f(m), and any caller running cost are wired
+        # (Issue #1247, below). What remains unmodelled — NON-quadratic control cost and the
+        # MAXIMIZE sense — is failed loud below (validated by
+        # tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_*).
         control_cost = getattr(H_class, "control_cost", None)
         if control_cost is not None:
             from mfgarchon.core.hamiltonian import QuadraticControlCost
 
-            cc_lambda = getattr(control_cost, "lambda_", 1.0)
-            if not isinstance(control_cost, QuadraticControlCost) or abs(cc_lambda - 1.0) > 1e-12:
+            # Issue #1071: the policy-evaluation RHS now consumes control_cost.lagrangian()
+            # (wired below as control_lagrangian=), so any QUADRATIC control cost — unit or
+            # lambda != 1 — is exact: L(alpha) = lambda/2 |alpha|^2. Non-quadratic costs (L1,
+            # bounded) have a non-smooth Lagrangian whose Howard policy-iteration convergence
+            # is unvalidated, so they stay gated.
+            if not isinstance(control_cost, QuadraticControlCost):
                 raise NotImplementedError(
-                    "inner_solver='howard' hardcodes the unit-quadratic Lagrangian (1/2)|alpha|^2, "
-                    f"but the Hamiltonian's control cost is {type(control_cost).__name__}"
-                    f"(lambda_={cc_lambda}). Non-unit / non-quadratic control cost needs "
-                    "control_cost.lagrangian() in the policy-evaluation RHS; use inner_solver='newton' "
-                    "(deferred, Issue #1118 PR2)."
+                    "inner_solver='howard' supports a quadratic control cost (its Lagrangian "
+                    "L(alpha) = lambda/2 |alpha|^2 is wired into the policy-evaluation RHS, any "
+                    f"lambda), but the Hamiltonian's control cost is {type(control_cost).__name__}. "
+                    "Non-quadratic control costs have a non-smooth Lagrangian whose Howard "
+                    "convergence is unvalidated; use inner_solver='newton' (Issue #1071)."
                 )
             if getattr(control_cost, "sign", 1) != 1:
                 raise NotImplementedError(
@@ -3146,11 +3141,16 @@ class HJBGFDMSolver(BaseHJBSolver):
                     rc = rc + np.asarray(user_rc(t_idx), dtype=float).ravel()
                 return -rc  # rc_t = -(V + f(m) + L_user); see SIGN note above.
 
+        # Issue #1071: the control-cost Lagrangian L(alpha) for the policy-evaluation RHS comes
+        # from the single source (control_cost.lagrangian), not a hardcoded (1/2)|alpha|^2. The
+        # gate above guarantees a QuadraticControlCost, so L(alpha) = lambda/2 |alpha|^2.
+        control_lagrangian = control_cost.lagrangian if control_cost is not None else None
         howard = HJBHowardSolver(
             self.problem,
             stencil_provider=self,
             alpha_star=alpha_star,
             running_cost=howard_running_cost,
+            control_lagrangian=control_lagrangian,
             discretisation="central" if self.dimension == 1 else "upwind_projection",
             use_provider_bc_rows=True,  # Issue #1118 PR2a: shared value-form BC rows
         )

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
@@ -74,6 +74,10 @@ For LQ `H = |p|²/(2c) + g(x, m)`: `alpha_star(x, p, m, t) = -p/c`.
 """
 
 RunningCostFn = Callable[[int], np.ndarray]
+# Control-cost Lagrangian L(alpha) over the collocation cloud (Issue #1071): the
+# policy-evaluation running cost. Single source = control_cost.lagrangian; the
+# default unit-quadratic (1/2)|alpha|^2 is used when this is None.
+ControlLagrangianFn = Callable[[np.ndarray], np.ndarray]
 """Time-indexed running cost L(x, alpha*, m, t) at the optimal policy.
 
 `running_cost(t_idx) -> array of shape (n,)` returning the running cost
@@ -276,6 +280,7 @@ class HJBHowardSolver:
         stencil_provider: HJBGFDMSolver,
         alpha_star: AlphaStarFn,
         running_cost: RunningCostFn | None = None,
+        control_lagrangian: ControlLagrangianFn | None = None,
         discretisation: Literal["upwind_projection", "upwind_per_axis", "central"] = "upwind_projection",
         max_iter: int = 20,
         tol: float = 1e-4,
@@ -298,6 +303,7 @@ class HJBHowardSolver:
         self.stencil_provider = stencil_provider
         self.alpha_star = alpha_star
         self.running_cost = running_cost
+        self.control_lagrangian = control_lagrangian
         self.discretisation = discretisation
         self.max_iter = int(max_iter)
         self.tol = float(tol)
@@ -432,9 +438,16 @@ class HJBHowardSolver:
             A_adv = self._build_A_adv(alpha, static)
             A = eye(n, format="csr") / dt - A_adv - 0.5 * sigma * sigma * D_lap
 
-            # RHS: u_next/dt + (1/2)|alpha|^2 + running_cost
-            alpha_sq = np.sum(alpha * alpha, axis=1)
-            b = u_next / dt + 0.5 * alpha_sq
+            # RHS: u_next/dt + L(alpha) + running_cost. L(alpha) is the control-cost
+            # Lagrangian from the single source (control_cost.lagrangian, Issue #1071):
+            # L(alpha) = lambda/2 |alpha|^2 for the quadratic cost, so this is byte-identical
+            # to the prior hardcoded (1/2)|alpha|^2 at lambda=1 and correct for lambda != 1.
+            # Falls back to the unit-quadratic form when no Lagrangian is supplied.
+            if self.control_lagrangian is not None:
+                L_alpha = self.control_lagrangian(alpha)
+            else:
+                L_alpha = 0.5 * np.sum(alpha * alpha, axis=1)
+            b = u_next / dt + L_alpha
             if rc_t is not None:
                 b = b + rc_t
 
@@ -569,4 +582,4 @@ class HJBHowardSolver:
         return U
 
 
-__all__ = ["HJBHowardSolver", "AlphaStarFn", "RunningCostFn"]
+__all__ = ["HJBHowardSolver", "AlphaStarFn", "RunningCostFn", "ControlLagrangianFn"]

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -35,6 +35,7 @@ from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import HJBHowardSolver
 from mfgarchon.core.hamiltonian import (
     CongestionHamiltonian,
     HamiltonianBase,
+    L1ControlCost,
     OptimizationSense,
     QuadraticControlCost,
     SeparableHamiltonian,
@@ -477,17 +478,16 @@ def _howard_gfdm_with_hamiltonian(hamiltonian_class, *, LX=4.0, Nt=20):
     return gfdm, U_T
 
 
-def test_integrated_howard_rejects_nonunit_control_cost():
-    """Non-unit control cost defeats the hardcoded (1/2)|alpha|^2 Lagrangian -> fail loud.
+def test_integrated_howard_rejects_nonquadratic_control_cost():
+    """Non-QUADRATIC control cost -> fail loud (Issue #1071).
 
-    Regression for the gate reading problem.lambda_ (left at the 1.0 default here) instead of
-    the components Hamiltonian's actual control cost: the old gate passed and Howard solved the
-    wrong effective Hamiltonian; the fixed gate reads control_cost.lambda_ and raises.
-    """
-    H = SeparableHamiltonian(control_cost=QuadraticControlCost(lambda_=2.0))
+    Howard now consumes control_cost.lagrangian() in the policy-evaluation RHS, so any quadratic
+    cost (unit or lambda != 1; see test_integrated_howard_matches_newton_nonlq) is supported. A
+    non-quadratic cost (L1/bounded) has a non-smooth Lagrangian whose Howard policy-iteration
+    convergence is unvalidated, so it stays gated."""
+    H = SeparableHamiltonian(control_cost=L1ControlCost(lambda_=1.0))
     gfdm, U_T = _howard_gfdm_with_hamiltonian(H)
-    assert gfdm.problem.lambda_ == 1.0  # the legacy gate's source is unit -> would have passed
-    with pytest.raises(NotImplementedError, match="control cost"):
+    with pytest.raises(NotImplementedError, match="quadratic"):
         gfdm.solve_hjb_system(M_density=None, U_terminal=U_T)
 
 
@@ -592,24 +592,31 @@ def _v_quadratic(x, t):
 
 
 @pytest.mark.parametrize(
-    ("potential", "coupling", "case"),
+    ("potential", "coupling", "lambda_", "case"),
     [
-        (_v_quadratic, None, "V-only"),
-        (None, lambda m: 0.5 * np.asarray(m), "f(m)-only"),
-        (_v_quadratic, lambda m: 0.5 * np.asarray(m), "V+f(m)"),
+        (_v_quadratic, None, 1.0, "V-only"),
+        (None, lambda m: 0.5 * np.asarray(m), 1.0, "f(m)-only"),
+        (_v_quadratic, lambda m: 0.5 * np.asarray(m), 1.0, "V+f(m)"),
+        # Issue #1071: lambda != 1 quadratic — Howard consumes control_cost.lagrangian()
+        # = lambda/2|alpha|^2, so it must still match Newton (the gate that used to reject
+        # lambda != 1 is lifted). alpha* = -p/lambda + L = lambda/2|alpha|^2 reconstructs H.
+        (_v_quadratic, lambda m: 0.5 * np.asarray(m), 2.0, "V+f(m), lambda=2"),
+        (_v_quadratic, lambda m: 0.5 * np.asarray(m), 0.5, "V+f(m), lambda=0.5"),
     ],
 )
-def test_integrated_howard_matches_newton_nonlq(potential, coupling, case):
-    """Issue #1247 correctness gate + rc_t sign resolver.
+def test_integrated_howard_matches_newton_nonlq(potential, coupling, lambda_, case):
+    """Issue #1247 correctness gate + rc_t sign resolver; Issue #1071 lambda != 1 coverage.
 
     Howard (inner_solver='howard') must match Newton (inner_solver='newton') on a non-LQ
     separable Hamiltonian once V(x)/f(m) are wired into Howard's running_cost slot. The
     relative tolerance 2e-2 PASSES for the resolved sign rc_t = -(V+f(m)) (observed
-    max-rel-error <~5e-4 for all three cases) and FAILS for the flipped sign rc_t = +(V+f(m))
+    max-rel-error <~5e-4 for the lambda=1 cases) and FAILS for the flipped sign rc_t = +(V+f(m))
     (observed ~2.0). Zero terminal cost makes the pure-LQ baseline exact so the residual is
-    the V/f-wiring error, not |grad u|^2 stiffness."""
+    the V/f-wiring error, not |grad u|^2 stiffness. The lambda != 1 cases additionally pin that
+    Howard's single-source Lagrangian (control_cost.lagrangian = lambda/2|alpha|^2) agrees with
+    Newton's analytic H = |p|^2/(2 lambda) + V + f(m) (Issue #1071)."""
     H = SeparableHamiltonian(
-        control_cost=QuadraticControlCost(lambda_=1.0),
+        control_cost=QuadraticControlCost(lambda_=lambda_),
         potential=potential,
         coupling=coupling,
     )


### PR DESCRIPTION
## #1071 — single-source Howard's policy-evaluation Lagrangian

Howard's policy-evaluation RHS hardcoded the unit-quadratic Lagrangian `0.5*|α|²` (`hjb_howard.py:_howard_step`), and the GFDM howard path had **two gates** rejecting λ≠1 (`hjb_gfdm.py:3006` and `:3024`). This replaces the hardcode with the single-source `control_cost.lagrangian()` and lifts the λ≠1 restriction.

### Change
- `HJBHowardSolver` gains a `control_lagrangian` param; the policy-eval RHS uses `control_lagrangian(alpha)` when provided, else the unit-quadratic default.
- The GFDM howard path passes `control_lagrangian=control_cost.lagrangian` and drops both λ≠1 gates. Kept: the **non-quadratic**, **MAXIMIZE-sense**, and **congestion** gates.

### Byte-identical at λ=1
`QuadraticControlCost.lagrangian(α) = 0.5·λ·Σα²`, so at λ=1 it equals the prior `0.5*Σα²` — verified **bytewise across 1000 samples**. Existing `HJBHowardSolver` test callers that omit `control_lagrangian` keep the old unit-quadratic default.

### λ≠1 correctness — validated
The Legendre algebra closes: `α* = -p/λ`, `L(α) = ½λ|α|²` ⟹ `α·∇u + L(α) = -H(∇u)`, reconstructing the full HJB for any λ. Validated empirically — the **Howard-vs-Newton agreement test now covers λ ∈ {0.5, 1.0, 2.0}** on non-LQ (V + f(m)) problems, max-rel-error < 2e-2 (Newton is the ground truth via analytic `H = |p|²/(2λ) + V + f(m)`).

### Context (Issue #1413)
The `0.5*alpha_sq` hardcode was **fail-loud guarded** (`NotImplementedError` for λ≠1), not a silent bug — so this is an enhancement lifting a guarded limitation via the single source, exactly as the old gate message anticipated ("needs `control_cost.lagrangian()` in the policy-evaluation RHS"). Non-quadratic control costs (L1/bounded) stay gated: their non-smooth Lagrangian's Howard convergence is unvalidated.

### Verification
- howard suite: 32 passed (+2 new λ≠1 agreement cases; the λ≠1-rejection test converted to a non-quadratic-rejection test using `L1ControlCost`).
- GFDM M-matrix + #1071 λ + LLF suites: 49 passed.
- `ruff check` / `ruff format --check` clean.

Refs #1071, #1413

🤖 Generated with [Claude Code](https://claude.com/claude-code)