### PR TITLE
fix(hjb-sl): correct the semi-Lagrangian update — kinetic 3x error + lambda!=1 foot (#1413)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1001,7 +1001,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             # For explicit_euler/rk2, characteristic is x_departure = x - p*dt (vectorizable)
             if self.characteristic_solver in ("explicit_euler", "rk2"):
                 # Step 1a: Batch departure points
-                x_departures = self.x_grid - grad_u * self.dt
+                x_departures = self.x_grid - (grad_u / self._control_cost_lambda()) * self.dt
 
                 # Apply boundary conditions (vectorized)
                 bc = self.get_boundary_conditions()
@@ -1028,34 +1028,34 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                     interp_fn = interp1d(self.x_grid, U_next, kind="linear", fill_value="extrapolate")
                     u_departures = interp_fn(x_departures)
 
-                # Step 1c: Batch Hamiltonian evaluation
-                x_batch = self.x_grid.reshape(-1, 1)  # (Nx, 1)
-                p_batch = grad_u.reshape(-1, 1)  # (Nx, 1)
+                # Step 1c: fail-fast on a missing Hamiltonian (Issue #1071) — never silently
+                # drop the H term (that reduces the update to pure transport of the terminal data).
                 H_class = self.problem.hamiltonian_class
-                if H_class is not None:
-                    H_values = eval_H_batch(H_class, x_batch, M_next, p_batch, time_idx * self.dt).ravel()
-                else:
-                    # Issue #1071 / fail-fast: never silently drop the Hamiltonian term (that
-                    # reduces the HJB update to pure transport of the terminal data). The
-                    # solve-entry guard catches this first; this is the batch-path backstop.
+                if H_class is None:
                     raise ValueError(
                         "HJBSemiLagrangianSolver: problem.hamiltonian_class is None in the batch "
                         "Hamiltonian path. Specify a Hamiltonian explicitly (Issue #1071, fail-fast)."
                     )
+                x_batch = self.x_grid.reshape(-1, 1)  # (Nx, 1)
+                p_batch = grad_u.reshape(-1, 1)  # (Nx, 1)
 
-                # Step 1d: Advection update (vectorized)
-                U_star = u_departures - self.dt * H_values
+                # Step 1d: Lax-Oleinik value update (Issue #1413)
+                U_star = self._sl_value_update(u_departures, x_batch, M_next, p_batch, time_idx * self.dt, self.dt)
 
             else:
-                # Fallback: per-point loop for rk4 or other methods
+                # Fallback: per-point loop for rk4 or other methods. Issue #1413: λ-scaled foot
+                # (x - dt·∂H/∂p = x - dt·p/λ) + Lax-Oleinik value update, matching the batch path.
+                lam = self._control_cost_lambda()
+                t_val = time_idx * self.dt
                 U_star = np.zeros(Nx)
                 for i in range(Nx):
                     try:
-                        p_optimal = grad_u[i]
-                        x_departure = self._trace_characteristic_backward(self.x_grid[i], p_optimal, self.dt)
+                        vel_i = grad_u[i] / lam
+                        x_departure = self._trace_characteristic_backward(self.x_grid[i], vel_i, self.dt)
                         u_departure = self._interpolate_value(U_next, x_departure)
-                        hamiltonian_value = self._evaluate_hamiltonian(self.x_grid[i], p_optimal, M_next[i], time_idx)
-                        U_star[i] = u_departure - self.dt * hamiltonian_value
+                        U_star[i] = self._sl_value_update(
+                            u_departure, np.array([self.x_grid[i]]), M_next[i], np.array([grad_u[i]]), t_val, self.dt
+                        )
                     except Exception as e:
                         logger.warning(f"Error at grid point {i}: {e}")
                         U_star[i] = U_next[i]
@@ -1109,39 +1109,32 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             error_count = 0
             total_points = int(np.prod(grid_shape))
 
+            # Issue #1413: hoist λ and the time value for the Lax-Oleinik update in the loop.
+            lam = self._control_cost_lambda()
+            t_val = time_idx * self.dt
             # Iterate over all grid points for advection
             for multi_idx in np.ndindex(grid_shape):
                 # Get spatial coordinates for this grid point
                 x_current = np.array([self.grid.coordinates[d][multi_idx[d]] for d in range(self.dimension)])
                 m_current = M_next_shaped[multi_idx]
 
-                # Extract optimal control from gradient (vector for nD)
+                # Extract momentum p = ∇u (vector for nD)
                 p_optimal = np.array([grad_components[d][multi_idx] for d in range(self.dimension)])
 
-                # Trace characteristic backward (vector operation)
-                x_departure = self._trace_characteristic_backward(x_current, p_optimal, self.dt)
-
-                # Interpolate at departure point
+                # Issue #1413: trace along the characteristic velocity ∂H/∂p (= p/λ for the
+                # quadratic control cost), then apply the Lax-Oleinik value update (the foot
+                # carries advection; cost = dt·H_control - dt·(V+f)). Replaces the inconsistent
+                # `u_departure - dt·H` with a non-λ-scaled foot (Issue #575/#1413).
+                vel = p_optimal / lam
+                x_departure = self._trace_characteristic_backward(x_current, vel, self.dt)
                 u_departure = self._interpolate_value(U_next_shaped, x_departure)
-
-                # Evaluate Hamiltonian
-                hamiltonian_value = self._evaluate_hamiltonian(x_current, p_optimal, m_current, time_idx)
-
-                # Advection step for backward HJB solve:
-                # HJB: -∂u/∂t + H(x,∇u,m) - σ²/2 Δu = 0
-                # Rearranging: ∂u/∂t = H - σ²/2 Δu
-                # Backward discretization: u^n = u^{n+1} - dt * H (diffusion handled separately)
-                # Issue #575: Sign was wrong (+ instead of -)
-                u_star_val = u_departure - self.dt * hamiltonian_value
+                u_star_val = self._sl_value_update(u_departure, x_current, m_current, p_optimal, t_val, self.dt)
 
                 # Check for numerical issues
                 if np.isnan(u_star_val) or np.isinf(u_star_val):
                     error_count += 1
                     if error_count <= 5:
-                        logger.warning(
-                            f"NaN/Inf at grid point {multi_idx}: "
-                            f"u_departure={u_departure:.3e}, H={hamiltonian_value:.3e}"
-                        )
+                        logger.warning(f"NaN/Inf at grid point {multi_idx}: u_departure={u_departure:.3e}")
                     U_star[multi_idx] = U_next_shaped[multi_idx]  # Fallback
                 else:
                     U_star[multi_idx] = u_star_val
@@ -1214,19 +1207,20 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             # Pass timestep and density for gradient clipping monitoring (Issue #583)
             grad_u = self._compute_gradient(U_next, check_cfl=False, t_idx=time_idx, m_density=M_next)
 
-            # Step 1: Advection along characteristics
+            # Step 1: Advection along characteristics (Issue #1413: λ-scaled foot + Lax-Oleinik)
+            lam = self._control_cost_lambda()
+            t_val = time_idx * self.dt
             for i in range(Nx):
                 x_current = self.x_grid[i]
                 m_current = M_next[i]
 
                 try:
-                    p_optimal = grad_u[i]
-                    x_departure = self._trace_characteristic_backward(x_current, p_optimal, dt)
+                    vel_i = grad_u[i] / lam
+                    x_departure = self._trace_characteristic_backward(x_current, vel_i, dt)
                     u_departure = self._interpolate_value(U_next, x_departure)
-                    hamiltonian_value = self._evaluate_hamiltonian(x_current, p_optimal, m_current, time_idx)
-
-                    # Backward HJB: u^n = u^{n+1} - dt * H (Issue #575: sign fix)
-                    U_star[i] = u_departure - dt * hamiltonian_value
+                    U_star[i] = self._sl_value_update(
+                        u_departure, np.array([x_current]), m_current, np.array([grad_u[i]]), t_val, dt
+                    )
 
                 except Exception as e:
                     logger.warning(f"Error at grid point {i}: {e}")
@@ -1267,17 +1261,18 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             error_count = 0
             total_points = int(np.prod(grid_shape))
 
+            lam = self._control_cost_lambda()
+            t_val = time_idx * self.dt
             for multi_idx in np.ndindex(grid_shape):
                 x_current = np.array([self.grid.coordinates[d][multi_idx[d]] for d in range(self.dimension)])
                 m_current = M_next_shaped[multi_idx]
                 p_optimal = np.array([grad_components[d][multi_idx] for d in range(self.dimension)])
 
-                x_departure = self._trace_characteristic_backward(x_current, p_optimal, dt)
+                # Issue #1413: λ-scaled foot (∂H/∂p) + Lax-Oleinik value update.
+                vel = p_optimal / lam
+                x_departure = self._trace_characteristic_backward(x_current, vel, dt)
                 u_departure = self._interpolate_value(U_next_shaped, x_departure)
-                hamiltonian_value = self._evaluate_hamiltonian(x_current, p_optimal, m_current, time_idx)
-
-                # Backward HJB: u^n = u^{n+1} - dt * H (Issue #575: sign fix)
-                u_star_val = u_departure - dt * hamiltonian_value
+                u_star_val = self._sl_value_update(u_departure, x_current, m_current, p_optimal, t_val, dt)
 
                 if np.isnan(u_star_val) or np.isinf(u_star_val):
                     error_count += 1
@@ -1317,14 +1312,17 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
 
         The diffusion enters directly through 2*d stochastic departure points
         (one pair per spatial dimension), eliminating the operator-splitting
-        diffusion solve. For separable convex Lagrangian L(x, a, m) =
-        (1/2)|a|^2 + f(x, m) the optimal control is alpha* = -nabla u^{n+1}
-        and the update is
+        diffusion solve. For a separable Hamiltonian H = H_control(p) + V(x) + f(m)
+        the characteristic velocity is dH/dp (= p/lambda for the quadratic control
+        cost) and the Lax-Oleinik update is (Issue #1413)
 
             U^n_i = (1/(2d)) * sum_{k=1..d} [I[U^{n+1}](y_k^+) + I[U^{n+1}](y_k^-)]
-                    - dt * H(x_i, p_i, m_i^n)
+                    + dt * H_control(p_i) - dt * (V + f)
+                  = u_avg + dt * (H(x_i, p_i, m) - 2 * H(x_i, 0, m))
 
-        with y_k^pm = x_i + alpha*_i * dt +/- sigma * sqrt(dt) * e_k.
+        with y_k^pm = x_i - (dH/dp)_i * dt +/- sigma * sqrt(dt) * e_k. (The prior
+        `alpha* = -nabla u` foot with `- dt*H` was lambda=1-only on the foot and
+        double-counted the kinetic term ~3x; see Issue #575/#1413.)
 
         Validation: see mfg-research/experiments/crowd_evacuation_2d/minors/archive/
         exp14_towel_1d_benchmark/subs/exp14e_solver_comparison/, where the
@@ -1469,8 +1467,10 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         mesh = np.meshgrid(*grid_coords, indexing="ij")
         # x_drift_flat[i, ax] = x_current[ax] − dt · p[ax] for node i
         x_drift_flat = np.stack([mesh[ax].ravel() for ax in range(d)], axis=1)
+        # Issue #1413: drift along the characteristic velocity ∂H/∂p = p/λ (not raw p).
+        lam = self._control_cost_lambda()
         for ax in range(d):
-            x_drift_flat[:, ax] -= grad_components[ax].ravel() * dt
+            x_drift_flat[:, ax] -= (grad_components[ax].ravel() / lam) * dt
 
         all_departures = np.empty((2 * d * n_total, d), dtype=float)
         for ax in range(d):
@@ -1513,17 +1513,18 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # Average over the 2*d Brownian directions
         u_avg = all_u.reshape(2 * d, n_total).mean(axis=0).reshape(grid_shape)
 
-        # --- Hamiltonian (single-source batch eval, Issue #1071) ---
+        # --- Lax-Oleinik value update (Issue #1413; single source, Issue #1071) ---
         x_batch = np.stack([mesh[ax].ravel() for ax in range(d)], axis=1)
         p_batch = np.stack([grad_components[ax].ravel() for ax in range(d)], axis=1)
         H_class = self.problem.hamiltonian_class
-        if H_class is not None:
-            H_values = eval_H_batch(H_class, x_batch, M_shaped.ravel(), p_batch, time_idx * dt).ravel()
-            H_values = H_values.reshape(grid_shape)
-        else:
-            H_values = np.zeros(grid_shape)
-
-        U_current = u_avg - dt * H_values
+        if H_class is None:
+            raise ValueError(
+                "HJBSemiLagrangianSolver (stochastic CS): problem.hamiltonian_class is None. "
+                "Specify a Hamiltonian explicitly (Issue #1071, fail-fast)."
+            )
+        U_current = self._sl_value_update(u_avg.ravel(), x_batch, M_shaped.ravel(), p_batch, time_idx * dt, dt).reshape(
+            grid_shape
+        )
 
         # --- Enforce BC on the result (dim-dependent applicator, see docstring) ---
         if d == 1:
@@ -2227,6 +2228,41 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 laplacian += second_deriv
 
             return float(laplacian)
+
+    def _sl_value_update(
+        self,
+        u_at_foot: np.ndarray | float,
+        x: np.ndarray,
+        m: np.ndarray | float,
+        p: np.ndarray,
+        t: float,
+        dt: float,
+    ) -> np.ndarray | float:
+        """Consistent semi-Lagrangian value update (Issue #1413).
+
+        For the backward HJB ``-∂_t u + H(x, ∇u, m) = 0`` with a separable
+        ``H = H_control(p) + V(x) + f(m)``, the Lax-Oleinik / DPP step is
+
+            u^n(x) = u^{n+1}(x - dt·∂_pH) + dt·H_control(p) - dt·(V + f),
+
+        where the departure foot ``x - dt·∂_pH`` carries the advection (``∂_pH`` is the
+        characteristic velocity, ``= p/λ`` for the quadratic control cost). With the
+        departure value ``u_at_foot = u^{n+1}(foot)`` already interpolated and
+        ``V + f = H(x, m, p=0)``:
+
+            u^n = u_at_foot + dt·(H(p) - H(0)) - dt·H(0) = u_at_foot + dt·(H(p) - 2·H(0)).
+
+        This replaces the prior ``u_at_foot - dt·H(p)`` (with a non-λ-scaled foot), which
+        double-counted the kinetic term (≈3× too large) and was λ=1-only on the foot —
+        ~24% off the analytic Hopf-Lax solution even at λ=1 (FDM matches it to 0.6%). See
+        Issue #575 (which corrected the state term but left the kinetic error) and Issue
+        #1413. ``H`` comes from the single source (``eval_H_batch`` → ``hamiltonian_class``).
+        """
+        H_class = self.problem.hamiltonian_class
+        p_arr = np.atleast_1d(np.asarray(p, dtype=float))
+        H_full = np.asarray(eval_H_batch(H_class, x, m, p_arr, t), dtype=float)
+        H_state = np.asarray(eval_H_batch(H_class, x, m, np.zeros_like(p_arr), t), dtype=float)
+        return u_at_foot + dt * (H_full - 2.0 * H_state)
 
     def _evaluate_hamiltonian(self, x: np.ndarray | float, p: np.ndarray | float, m: float, time_idx: int) -> float:
         """

--- a/tests/unit/test_alg/test_hjb_canonical_cs_sl.py
+++ b/tests/unit/test_alg/test_hjb_canonical_cs_sl.py
@@ -281,10 +281,14 @@ class TestCanonicalCSImplicitVsExplicit:
         err_explicit = float(np.sqrt(np.mean((U_explicit[0][interior] - ref_on_x[interior]) ** 2)))
 
         assert np.all(np.isfinite(U_canonical)), "canonical produced NaN/Inf"
-        # The implicit-alpha* DPP is much closer to the reference than the explicit at-grid alpha*.
+        # The implicit-alpha* DPP is meaningfully closer to the reference than the explicit
+        # at-grid alpha*. Issue #1413: the explicit (stochastic) path is now the CORRECTED
+        # Lax-Oleinik scheme, so this gap (~6-7x here) reflects the genuine implicit-vs-explicit
+        # alpha* difference at large dt — NOT the former sign/foot bug, which made the explicit
+        # >10x worse (and ~24% off even at lambda=1; see Issue #575/#1413).
         assert err_canonical < err_explicit, f"canonical {err_canonical:.3e} !< explicit {err_explicit:.3e}"
-        assert err_explicit > 10.0 * err_canonical, (
-            f"explicit not dramatically worse: canonical={err_canonical:.3e}, explicit={err_explicit:.3e}"
+        assert err_explicit > 3.0 * err_canonical, (
+            f"explicit not meaningfully worse: canonical={err_canonical:.3e}, explicit={err_explicit:.3e}"
         )
         assert err_canonical < 0.1, f"canonical itself inaccurate at large dt: {err_canonical:.3e}"
 

--- a/tests/unit/test_alg/test_hjb_semi_lagrangian.py
+++ b/tests/unit/test_alg/test_hjb_semi_lagrangian.py
@@ -6,6 +6,8 @@ Tests the semi-Lagrangian method for solving Hamilton-Jacobi-Bellman equations
 in Mean Field Games, including characteristic-following schemes and interpolation.
 """
 
+import warnings
+
 import pytest
 
 import numpy as np
@@ -965,12 +967,13 @@ class TestStochasticSLUnificationPinning:
             get_bc_type_string,
         )
 
-        Nx = len(U_next)
         sigma = solver.problem.sigma
         sqrt_dt = float(np.sqrt(dt))
         diffusion_offset = sigma * sqrt_dt
         grad_u = solver._compute_gradient(U_next, check_cfl=True, t_idx=time_idx, m_density=M_next)
-        x_drift = solver.x_grid - grad_u * dt
+        # Issue #1413: drift along the characteristic velocity dH/dp = p/lambda (not raw p).
+        lam = solver._control_cost_lambda()
+        x_drift = solver.x_grid - (grad_u / lam) * dt
         y_plus = x_drift + diffusion_offset
         y_minus = x_drift - diffusion_offset
         bc = solver.get_boundary_conditions()
@@ -995,11 +998,10 @@ class TestStochasticSLUnificationPinning:
         x_batch = solver.x_grid.reshape(-1, 1)
         p_batch = grad_u.reshape(-1, 1)
         H_class = solver.problem.hamiltonian_class
-        if H_class is not None:
-            H_values = eval_H_batch(H_class, x_batch, M_next, p_batch, time_idx * dt).ravel()
-        else:
-            H_values = np.zeros(Nx)
-        U_current = u_avg - dt * H_values
+        # Issue #1413: Lax-Oleinik value update u_avg + dt*(H(p) - 2*H(0)), where H(0) = V+f.
+        H_values = eval_H_batch(H_class, x_batch, M_next, p_batch, time_idx * dt).ravel()
+        H_0 = eval_H_batch(H_class, x_batch, M_next, np.zeros_like(p_batch), time_idx * dt).ravel()
+        U_current = u_avg + dt * (H_values - 2.0 * H_0)
         if bc:
             U_current = solver.bc_applicator.enforce_values(
                 U_current, boundary_conditions=bc, spacing=(solver.dx,), time=time_idx * dt
@@ -1283,6 +1285,94 @@ class TestSLHamiltonianSingleSource:
             assert routed.hex() == inline.hex(), (
                 f"x={x} p={p} m={m} t_idx={t_idx}: routed {routed!r} != inline {inline!r}"
             )
+
+
+class TestSLHJBConsistency:
+    """Issue #1413: the semi-Lagrangian scheme must solve the correct HJB.
+
+    Pins the corrected Lax-Oleinik update ``u_dep + dt*(H(p) - 2*H(0))`` with a λ-scaled
+    departure foot against (a) the analytic Hopf-Lax solution for σ→0 pure-LQ, and (b) FDM
+    (the reference solver) with a potential. Before the fix the H-based SL was ~24% off the
+    analytic solution even at λ=1 AND non-convergent (the foot + ``-dt*H`` double-counted the
+    kinetic term ≈3×); the foot was also λ=1-only. Issue #575 corrected the state term but
+    left the kinetic error. FDM matches the analytic Hopf-Lax to ~0.6%, so it is the oracle.
+    """
+
+    @staticmethod
+    def _build(lam, potential, coupling, coupling_dm, sigma, nx, Nt, T):
+        from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+
+        geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1))
+        comp = MFGComponents(
+            m_initial=lambda x: 0.5 + np.exp(-10 * (x - 0.5) ** 2),
+            u_terminal=lambda x: 0.5 * (x - 0.5) ** 2,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=lam),
+                potential=potential,
+                coupling=coupling,
+                coupling_dm=coupling_dm,
+            ),
+        )
+        problem = MFGProblem(geometry=geom, T=T, Nt=Nt, sigma=sigma, components=comp)
+        x = np.linspace(0.0, 1.0, nx)
+        U_T = 0.5 * (x - 0.5) ** 2
+        M = np.tile(0.5 + np.exp(-10 * (x - 0.5) ** 2), (Nt + 1, 1))
+        U_prev = np.tile(U_T, (Nt + 1, 1))
+        return problem, x, U_T, M, U_prev
+
+    @staticmethod
+    def _solve(solver_cls, problem, U_T, M, U_prev):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            s = solver_cls(problem)
+            U = np.asarray(s.solve_hjb_system(M_density=M, U_terminal=U_T, U_coupling_prev=U_prev))
+        return U[0] if U.ndim == 2 else U
+
+    @pytest.mark.parametrize("lam", [1.0, 2.0])
+    def test_matches_analytic_hopf_lax(self, lam):
+        """σ→0 pure-LQ: SL must match the λ-dependent Hopf-Lax solution
+        ``u(0,x) = min_y[u_T(y) + λ(x-y)²/(2T)]`` — and for λ≠1 must be CLEARLY distinct
+        from the λ=1 solution (so a regression to the λ=1-foot fails here)."""
+        T, nx, Nt = 0.2, 121, 200
+        problem, x, U_T, M, U_prev = self._build(lam, None, None, None, sigma=1e-3, nx=nx, Nt=Nt, T=T)
+        U_sl = self._solve(HJBSemiLagrangianSolver, problem, U_T, M, U_prev)
+
+        y = np.linspace(0.0, 1.0, 4001)
+
+        def hopf_lax(xq, lq):
+            return np.array([np.min(0.5 * (y - 0.5) ** 2 + lq * (xi - y) ** 2 / (2.0 * T)) for xi in xq])
+
+        interior = (x > 0.25) & (x < 0.75)
+        a_lam = hopf_lax(x, lam)
+        denom = max(float(np.max(np.abs(a_lam[interior]))), 1e-12)
+        err = float(np.max(np.abs(U_sl[interior] - a_lam[interior]))) / denom
+        assert err < 0.05, f"λ={lam}: SL vs analytic Hopf-Lax rel-err={err:.3e} (expected <5%)"
+        if lam != 1.0:
+            a_1 = hopf_lax(x, 1.0)
+            err_1 = float(np.max(np.abs(U_sl[interior] - a_1[interior]))) / denom
+            assert err_1 > 0.05, (
+                f"λ={lam}: SL is indistinguishable from the λ=1 solution (rel-err vs analytic(1)="
+                f"{err_1:.3e}) — the λ-scaled foot regressed (Issue #1413)."
+            )
+
+    @pytest.mark.parametrize("lam", [1.0, 2.0])
+    def test_matches_fdm_with_potential(self, lam):
+        """σ>0 with a potential V(x): SL must match FDM (the reference). Pins the state-term
+        sign — the corrected scheme is ``+dt*H_control - dt*(V+f)`` (Issue #575/#1413)."""
+        from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+
+        def V(x, t):
+            return -0.5 * (np.asarray(x)[..., 0] - 0.5) ** 2
+
+        T, nx, Nt = 0.3, 101, 120
+        problem, x, U_T, M, U_prev = self._build(lam, V, None, None, sigma=0.25, nx=nx, Nt=Nt, T=T)
+        U_sl = self._solve(HJBSemiLagrangianSolver, problem, U_T, M, U_prev)
+        problem_f, _, _, _, _ = self._build(lam, V, None, None, sigma=0.25, nx=nx, Nt=Nt, T=T)
+        U_fdm = self._solve(HJBFDMSolver, problem_f, U_T, M, U_prev)
+        interior = (x > 0.2) & (x < 0.8)
+        denom = max(float(np.max(np.abs(U_fdm[interior]))), 1e-12)
+        err = float(np.max(np.abs(U_sl[interior] - U_fdm[interior]))) / denom
+        assert err < 0.05, f"λ={lam}: SL(+V) vs FDM rel-err={err:.3e} (expected <5%)"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The H-based **semi-Lagrangian HJB update was inconsistent** and ~24% wrong **even at λ=1**, non-convergent under refinement. Started as the #1413 λ≠1 foot fix; validation revealed a deeper baseline error.

### The bug
The update `u^n = u^{n+1}(x − dt·∇u) − dt·H` combined the characteristic **foot** with a **pointwise `−dt·H`**, which double-counts the kinetic term (≈3×), and used a **λ=1-only foot** (`∇u` instead of `∂H/∂p = ∇u/λ`).

Measured (σ→0 pure-LQ, vs analytic Hopf-Lax, FDM as oracle at 0.6%):
| | λ=1 | λ=2 |
|---|---|---|
| SL **before** | **24%**, non-convergent | 26% |
| SL **after** | **0.6%** | 0.3% |

**Issue #575** corrected the state-term `(V+f)` sign but, by flipping the *whole* H sign, left the kinetic term wrong — it only validated a coupling-dominated case (Towel-on-Beach), which masked the kinetic error.

### The fix — derived and validated, not guessed
The correct Lax-Oleinik / DPP step for `−∂_t u + H = 0`, `H = H_control(p) + V(x) + f(m)`:
```
u^n(x) = u^{n+1}(x − dt·∂H/∂p) + dt·H_control(p) − dt·(V+f)
       = u_at_foot + dt·(H(x,m,p) − 2·H(x,m,0))          [H(x,m,0) = V+f]
```
Extracted into the shared helper **`_sl_value_update`** (single source) and applied to every H-based SL path:
- `_solve_timestep_semi_lagrangian` — 1D batch + 1D per-point (rk4) + nD
- `_solve_timestep_semi_lagrangian_with_dt` — 1D + nD
- the stochastic CS step (`_stochastic_sl_step`)

`canonical_cs` / `_solve_timestep_dpp` already optimize the **implicit** DPP (`inf_α[dt·L(α)+u(x+dt·α)]`, λ-correct by construction) — unchanged.

### Validation
- **Analytic Hopf-Lax**: SL matches `analytic(λ)` to <1.2% across λ∈{0.5,1,2}, and is correctly *distinct* from `analytic(1)` for λ≠1.
- **FDM agreement** (σ>0): <0.5% across {kinetic, +V(x), +f(m)} × λ∈{1,2}.
- **Stochastic CS** step validated vs FDM (~2%, Brownian-averaging discretization).
- New regression gate **`TestSLHJBConsistency`** (Hopf-Lax + FDM-with-potential).
- The `#1050` stochastic merge-fidelity pin updated to the corrected reference scheme.
- The `#1413`/canonical gate `test_gate3_canonical_beats_explicit_at_large_dt` recalibrated (10×→3×): the explicit path is now correct, so the residual ~6.6× gap reflects the genuine implicit-vs-explicit-α* difference, not the bug.
- **241 SL-referencing tests pass.** 1D + stochastic-1D are ground-truth-validated; nD/with_dt apply the same validated helper.

### Notes
- No paper experiments use SL (exp06a/08/09 use FDM/GFDM), so no published baseline shifts.
- Supersedes the incomplete #575 fix.

Refs #1071, #1413

🤖 Generated with [Claude Code](https://claude.com/claude-code)