### PR TITLE
refactor(gfdm): rename _compute_hjb_jacobian_vectorized -> assemble_hjb_iteration_matrix (#1414)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2209,35 +2209,32 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         return residual
 
-    def _compute_hjb_jacobian_vectorized(
-        self,
-        grad_u: np.ndarray,
-    ):
-        """
-        Compute the sparse LQ Newton Jacobian via the single-source assembler (Issue #1071).
+    def assemble_hjb_iteration_matrix(self, grad_u: np.ndarray):
+        """Assemble the sparse HJB Newton iteration matrix at a given gradient (Issue #1414).
 
-        Routes ∂H/∂p through ``H_class.evaluate_dp`` (the one Hamiltonian source) instead of
-        the inline ``p/λ`` re-derivation: the body delegates to
-        :meth:`_compute_hjb_jacobian_hamiltonian`, which assembles
-        ``(1/dt)I + Σ_d diag(∂H/∂p_d) @ D_grad[d] - D·D_lap`` (with ``D = σ²/2``, per-node for
-        the LLF ``σ_eff`` field) through ``assemble_hjb_jacobian_diag``. For the separable LQ
-        Hamiltonian ``∂H/∂p = p/λ`` is independent of ``m`` and ``t``, so passing ``m=0`` / ``t=0``
-        is byte-identical to the prior inline form (verified maxabsdiff=0 across the joint_socp
-        σ-sweep, strong-drift, and LLF field-σ configurations).
+        Returns ``(1/dt)I + Σ_d diag(∂H/∂p_d) @ D_grad[d] - D·D_lap`` (with ``D = σ²/2``,
+        per-node for the LLF ``σ_eff`` field) via the single-source assembler
+        ``assemble_hjb_jacobian_diag`` → ``H_class.evaluate_dp`` (no inline ``p/λ``
+        re-derivation; Issue #1071/#1408). For the separable LQ Hamiltonian ``∂H/∂p = p/λ``
+        is independent of ``m`` and ``t``, so ``m=0`` / ``t=0`` reproduce the production
+        Newton Jacobian exactly.
 
-        The single-``grad_u`` wrapper is kept because the Issue #1074 M-matrix /
-        discrete-maximum-principle tests assemble the iteration matrix directly through it.
+        Dedicated entry point for the Issue #1074 M-matrix / discrete-maximum-principle tests,
+        which assemble the iteration matrix directly to verify its M-matrix structure. It has
+        no production callers — the backward solve calls :meth:`_compute_hjb_jacobian_hamiltonian`
+        directly with the live ``m`` / ``t`` (this replaces the former private
+        ``_compute_hjb_jacobian_vectorized`` alias).
 
         Args:
             grad_u: Pre-computed gradient, shape (n_points, dimension)
 
         Returns:
-            Sparse Jacobian matrix in CSR format
+            Sparse Jacobian (iteration matrix) in CSR format
         """
         H_class = getattr(self.problem, "hamiltonian_class", None)
         if H_class is None:
             raise ValueError(
-                "_compute_hjb_jacobian_vectorized requires problem.hamiltonian_class to derive "
+                "assemble_hjb_iteration_matrix requires problem.hamiltonian_class to derive "
                 "∂H/∂p via the single-source assembler (Issue #1071)."
             )
         # Separable LQ: ∂H/∂p = p/λ ignores m and t, so m=0 / t=0 are byte-identical.

--- a/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
@@ -378,8 +378,8 @@ class TestLLFJacobianEffect:
         solver_on._build_differentiation_matrices()
 
         # Jacobian at zero gradient (only time + diffusion terms matter)
-        J_off = solver_off._compute_hjb_jacobian_vectorized(grad_u_zero)
-        J_on = solver_on._compute_hjb_jacobian_vectorized(grad_u_zero)
+        J_off = solver_off.assemble_hjb_iteration_matrix(grad_u_zero)
+        J_on = solver_on.assemble_hjb_iteration_matrix(grad_u_zero)
 
         diag_off = J_off.diagonal()
         diag_on = J_on.diagonal()
@@ -399,7 +399,7 @@ class TestLLFJacobianEffect:
         )
 
     def test_llf_jacobian_byte_identical_to_inline_field_formula(self, problem_and_pts):
-        """Issue #1071: with LLF active the consolidated ``_compute_hjb_jacobian_vectorized``
+        """Issue #1071: with LLF active the consolidated ``assemble_hjb_iteration_matrix``
         routes the per-node ``σ_eff`` diffusion through the single-source assembler
         (``assemble_hjb_jacobian_diag``, which row-scales the Laplacian via
         ``diags(σ_eff²/2) @ D_lap``).
@@ -421,7 +421,7 @@ class TestLLFJacobianEffect:
 
         rng = np.random.default_rng(1071)
         grad_u = rng.standard_normal((solver.n_points, 1))
-        J = solver._compute_hjb_jacobian_vectorized(grad_u)
+        J = solver.assemble_hjb_iteration_matrix(grad_u)
 
         n = solver.n_points
         dt = solver.problem.T / solver.problem.Nt

--- a/tests/unit/test_alg/test_socp_m_matrix_property.py
+++ b/tests/unit/test_alg/test_socp_m_matrix_property.py
@@ -216,7 +216,7 @@ def test_assembled_m_matrix_holds_at_zero_drift(sigma):
 
     solver = _make_solver(sigma=sigma, n_x=21)
     grad_u = np.zeros((solver.n_points, 1))
-    J = solver._compute_hjb_jacobian_vectorized(grad_u)
+    J = solver.assemble_hjb_iteration_matrix(grad_u)
     report = verify_assembled_m_matrix(J, interior_indices=solver.interior_indices)
     assert report["is_m_matrix"], f"σ={sigma}: assembled interior matrix not M-matrix at zero drift: {report}"
 
@@ -235,7 +235,7 @@ def test_assembled_m_matrix_breaks_under_strong_drift(sigma):
     from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
     solver = _make_solver(sigma=sigma, n_x=21)
-    solver._compute_hjb_jacobian_vectorized(np.zeros((solver.n_points, 1)))  # build operators
+    solver.assemble_hjb_iteration_matrix(np.zeros((solver.n_points, 1)))  # build operators
     diffusion_coeff = diffusion_from_volatility(sigma)
     alpha_crit = critical_drift_for_dmp(
         solver._D_lap, solver._D_grad, diffusion_coeff, interior_indices=solver.interior_indices
@@ -244,7 +244,7 @@ def test_assembled_m_matrix_breaks_under_strong_drift(sigma):
 
     # λ=1 ⇒ |α| = |grad|. Drift well past α_crit must break the assembled M-matrix.
     strong = np.full((solver.n_points, 1), 5.0 * alpha_crit)
-    J = solver._compute_hjb_jacobian_vectorized(strong)
+    J = solver.assemble_hjb_iteration_matrix(strong)
     report = verify_assembled_m_matrix(J, interior_indices=solver.interior_indices)
     assert not report["is_m_matrix"], f"σ={sigma}: expected M-matrix violation at |drift|=5·α_crit, got {report}"
     assert report["n_positive_offdiag"] > 0
@@ -252,7 +252,7 @@ def test_assembled_m_matrix_breaks_under_strong_drift(sigma):
 
 @pytest.mark.parametrize("sigma", [0.3, 0.5, 1.0, 1.5])
 def test_vectorized_jacobian_byte_identical_to_inline_lq_formula(sigma):
-    """Issue #1071: ``_compute_hjb_jacobian_vectorized`` now routes ∂H/∂p through the
+    """Issue #1071: ``assemble_hjb_iteration_matrix`` now routes ∂H/∂p through the
     single-source assembler (``assemble_hjb_jacobian_diag`` → ``H_class.evaluate_dp``)
     instead of the inline ``p/λ`` re-derivation.
 
@@ -269,7 +269,7 @@ def test_vectorized_jacobian_byte_identical_to_inline_lq_formula(sigma):
     rng = np.random.default_rng(1071)
     grad_u = rng.standard_normal((solver.n_points, 1))
 
-    J = solver._compute_hjb_jacobian_vectorized(grad_u)  # builds operators lazily
+    J = solver.assemble_hjb_iteration_matrix(grad_u)  # builds operators lazily
 
     # Independent reference: the explicit inline LQ Jacobian this consolidation replaced.
     n = solver.n_points
@@ -305,7 +305,7 @@ def test_runtime_dmp_guard_warns_only_when_violated():
     gfdm_logger.addHandler(handler)
     try:
         solver = _make_solver_check_dmp(sigma=0.3, check_dmp=True)
-        solver._compute_hjb_jacobian_vectorized(np.zeros((solver.n_points, 1)))  # build operators + α_crit
+        solver.assemble_hjb_iteration_matrix(np.zeros((solver.n_points, 1)))  # build operators + α_crit
         x = np.linspace(0.0, 1.0, solver.n_points)
 
         records.clear()
@@ -318,7 +318,7 @@ def test_runtime_dmp_guard_warns_only_when_violated():
         assert any("Issue #1074" in m for m in records), "guard did not warn under strong drift"
 
         off = _make_solver_check_dmp(sigma=0.3, check_dmp=False)
-        off._compute_hjb_jacobian_vectorized(np.zeros((off.n_points, 1)))
+        off.assemble_hjb_iteration_matrix(np.zeros((off.n_points, 1)))
         records.clear()
         off._maybe_warn_dmp(100.0 * x)
         assert not any("DMP" in m for m in records), "guard fired with check_dmp=False (should be inert)"


### PR DESCRIPTION
## #1414 — dedicated M-matrix entry point; retire the `_vectorized` alias

Post-#1408, `_compute_hjb_jacobian_vectorized` was a thin wrapper delegating to the single-source `_compute_hjb_jacobian_hamiltonian`, kept only so the #1074 M-matrix / discrete-maximum-principle tests can assemble the iteration matrix directly (**7 test-only call sites, zero production callers**).

This renames it to the descriptive public **`assemble_hjb_iteration_matrix(grad_u)`** — what it actually does (assemble `(1/dt)I + Σ diag(∂H/∂p) D_grad − D·L` to check the M-matrix property) — and drops the misleading `_vectorized` private name. The body is **unchanged** (byte-identical delegation); the 7 test sites are migrated.

Resolves the deletion-lock deferral noted in #1408 (the lock deferred retiring the alias behind exactly this entry point).

### Verification
- No remaining `_compute_hjb_jacobian_vectorized` references (besides the historical note in the new method's docstring).
- `ruff` clean; M-matrix + LLF Jacobian suites pass (41 tests).

Closes #1414
Refs #1071, #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)