### PR TITLE
test(hjb-gfdm): pin LLF residual field-σ single-source (#1071/#1059)

### DIFF
--- a/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
@@ -442,3 +442,47 @@ class TestLLFJacobianEffect:
         assert np.array_equal(Jc.data, rc.data), (
             f"LLF field-σ Jacobian not byte-identical to inline formula (maxabsdiff={maxabsdiff:.3e})"
         )
+
+    def test_llf_residual_byte_identical_to_inline_field_formula(self, problem_and_pts):
+        """Issue #1071/#1059 (audit S0-29): with LLF active the consolidated residual routes the
+        per-node ``σ_eff`` diffusion through the single-source ``assemble_hjb_residual``
+        (``-u_t + H - D·lap_u`` with ``D = σ_eff²/2`` elementwise).
+
+        Pin: byte-identical (atol=0) to the inline field formula, AND distinct from the scalar-σ
+        residual — locks against a residual/Jacobian σ-source split where the residual silently
+        reverts to the base scalar σ while the Jacobian (separately pinned above) uses σ_eff."""
+        from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_H_batch
+        from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+
+        problem, pts = problem_and_pts
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            solver = HJBGFDMSolver(problem, pts, monotonicity_scheme="none", llf_augmentation=True, llf_l_H=10.0)
+        solver._build_differentiation_matrices()
+        assert solver._llf_sigma_eff is not None, "LLF sigma_eff must be populated at init"
+
+        n = solver.n_points
+        dt = solver.problem.T / solver.problem.Nt
+        H_class = solver.problem.hamiltonian_class
+        x = solver.collocation_points
+        rng = np.random.default_rng(1059)
+        u_cur = rng.standard_normal(n)
+        u_next = rng.standard_normal(n)
+        m = np.abs(rng.standard_normal(n)) + 0.1
+        grad_u = rng.standard_normal((n, solver.dimension))
+        lap_u = rng.standard_normal(n)
+        t = 0.0
+
+        r = solver._compute_hjb_residual_hamiltonian(u_cur, u_next, m, grad_u, lap_u, H_class, t)
+
+        u_t = (u_next - u_cur) / dt
+        H = np.asarray(eval_H_batch(H_class, x, m, grad_u, t), dtype=float)
+        d_field = diffusion_from_volatility(solver._llf_sigma_eff, kind="field")
+        ref_field = -u_t + H - d_field * lap_u
+        d_scalar = diffusion_from_volatility(solver._get_sigma_value(None))
+        ref_scalar = -u_t + H - d_scalar * lap_u
+
+        assert np.array_equal(np.asarray(r), ref_field), "LLF residual not byte-identical to inline field formula"
+        assert not np.allclose(np.asarray(r), ref_scalar), (
+            "LLF residual matches the scalar-σ form — per-node σ_eff not used (σ-source split, S0-29)"
+        )


### PR DESCRIPTION
## Summary

Closes audit finding **S0-29** (Joplin *mfgarchon Audit Plan & Findings Ledger*, S4).

The #1071 LLF field-σ refactor pinned the **Jacobian** byte-identical to the inline field formula, but the **residual** path (`_compute_hjb_residual_hamiltonian` → `assemble_hjb_residual`) was untested. A residual/Jacobian σ-source split — the residual silently reverting to scalar σ while the Jacobian uses per-node `σ_eff` — would slip through.

## Change

Adds `test_llf_residual_byte_identical_to_inline_field_formula`: asserts the LLF residual is byte-identical (atol=0) to the inline `-u_t + H - (σ_eff²/2)·lap_u` field formula, **and** distinct from the scalar-σ residual (so a regression to scalar σ fails).

## Why B0 (no baseline risk)

Pure test addition validating *existing correct* behavior — verified passing before commit; the residual already routes `σ_eff` correctly through the single source. No production code touched.

Refs #1071, #1059.