### PR TITLE
fix(coupling): resolve initial density and terminal value via independent cascades

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -11,6 +11,7 @@ Modern fixed-point iterator for MFG systems with full feature support:
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -274,72 +275,84 @@ class FixedPointIterator(BaseCouplingIterator):
         Returns:
             (M_initial, U_terminal): Initial density and terminal value function
 
-        Priority order:
+        Issue #1425: the initial density and the terminal value are resolved by *independent*
+        cascades. Previously they were resolved together per priority, so a problem supplying its
+        initial density via Priority 1 (``get_m_init()``) but its terminal via a lower priority
+        (e.g. the ``u_terminal`` attribute) silently received ``u(T,·)=0`` — the Priority-1 terminal
+        accessor raised and the method returned zeros before the attribute was tried. Decoupling
+        fixes the mixed-API case; standard single-API problems resolve both fields via the same
+        priority as before (byte-identical).
+
+        Priority order (applied independently to each field):
             1. get_m_init() / get_u_terminal() methods (preferred modern API)
             2. m_initial / u_terminal attributes (Issue #670 unified naming)
             3. get_initial_m() / get_final_u() methods (alternate modern API)
             4. initial_density() / terminal_cost() callables (functional API)
         """
-        # Priority 1: get_m_init() / get_u_terminal() methods
+        return self._resolve_initial_density(shape), self._resolve_terminal_value(shape)
+
+    @staticmethod
+    def _reshape_to(arr: np.ndarray, shape: tuple) -> np.ndarray:
+        return arr.reshape(shape) if arr.shape != shape else arr
+
+    def _resolve_initial_density(self, shape: tuple) -> np.ndarray:
+        """Resolve the initial density via the 4-priority cascade (Issue #1425: independent of terminal)."""
         try:
-            M_initial = self.problem.get_m_init()
-            if M_initial.shape != shape:
-                M_initial = M_initial.reshape(shape)
-
-            try:
-                U_terminal = self.problem.get_u_terminal()
-            except AttributeError:
-                # No terminal condition - use zeros
-                U_terminal = np.zeros(shape)
-
-            if U_terminal.shape != shape:
-                U_terminal = U_terminal.reshape(shape)
-
-            return M_initial, U_terminal
+            return self._reshape_to(self.problem.get_m_init(), shape)
         except AttributeError:
-            pass  # Try next priority
-
-        # Priority 2: m_initial / u_terminal attributes (Issue #670: unified naming)
+            pass
         try:
-            M_initial = self.problem.m_initial
-            if M_initial is not None:
-                if M_initial.shape != shape:
-                    M_initial = M_initial.reshape(shape)
-
-                try:
-                    U_terminal = self.problem.u_terminal
-                except AttributeError:
-                    U_terminal = np.zeros(shape)
-
-                if U_terminal.shape != shape:
-                    U_terminal = U_terminal.reshape(shape)
-
-                return M_initial, U_terminal
+            m = self.problem.m_initial
+            if m is not None:
+                return self._reshape_to(m, shape)
         except AttributeError:
-            pass  # Try next priority
-
-        # Priority 3: get_initial_m() / get_final_u() methods
+            pass
         try:
-            M_initial = self.problem.get_initial_m()
-            U_terminal = self.problem.get_final_u()
-            return M_initial, U_terminal
+            return self.problem.get_initial_m()
         except AttributeError:
-            pass  # Try next priority
-
-        # Priority 4: initial_density() / terminal_cost() callables
+            pass
         try:
             x_grid = self.problem.geometry.get_spatial_grid()
-            M_initial = self.problem.initial_density(x_grid).reshape(shape)
-            U_terminal = self.problem.terminal_cost(x_grid).reshape(shape)
-            return M_initial, U_terminal
+            return self.problem.initial_density(x_grid).reshape(shape)
         except AttributeError as e:
             raise ValueError(
-                "Problem must provide initial/terminal conditions via one of:\n"
-                "  1. get_m_init()/get_u_terminal() methods (preferred)\n"
-                "  2. m_initial/u_terminal attributes\n"
-                "  3. get_initial_m()/get_final_u() methods\n"
-                "  4. initial_density()/terminal_cost() callables"
+                "Problem must provide an initial density via one of: get_m_init() / m_initial / "
+                "get_initial_m() / initial_density()."
             ) from e
+
+    def _resolve_terminal_value(self, shape: tuple) -> np.ndarray:
+        """Resolve the terminal value via the 4-priority cascade, INDEPENDENT of the initial density.
+
+        Issue #1425: previously a successful Priority-1 initial density forced the terminal from the
+        same priority, so a mixed-API problem (e.g. ``get_m_init()`` + ``u_terminal`` attribute)
+        silently received ``u(T,·)=0``. Each terminal accessor is now tried in turn; only if all
+        fail does it default to zero terminal cost — with a warning, not a silent fallback.
+        """
+        try:
+            return self._reshape_to(self.problem.get_u_terminal(), shape)
+        except AttributeError:
+            pass
+        try:
+            u = self.problem.u_terminal
+            if u is not None:
+                return self._reshape_to(u, shape)
+        except AttributeError:
+            pass
+        try:
+            return self.problem.get_final_u()
+        except AttributeError:
+            pass
+        try:
+            x_grid = self.problem.geometry.get_spatial_grid()
+            return self.problem.terminal_cost(x_grid).reshape(shape)
+        except AttributeError:
+            pass
+        warnings.warn(
+            "No terminal condition found on the problem (get_u_terminal / u_terminal / get_final_u / "
+            "terminal_cost all absent); defaulting to u(T,·)=0.",
+            stacklevel=2,
+        )
+        return np.zeros(shape)
 
     def _compute_drift_field(self, U, M, H_class):
         """Compute α* from U via H.optimal_control, return as synthetic U.

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -296,57 +296,51 @@ class FixedPointIterator(BaseCouplingIterator):
         return arr.reshape(shape) if arr.shape != shape else arr
 
     def _resolve_initial_density(self, shape: tuple) -> np.ndarray:
-        """Resolve the initial density via the 4-priority cascade (Issue #1425: independent of terminal)."""
-        try:
-            return self._reshape_to(self.problem.get_m_init(), shape)
-        except AttributeError:
-            pass
-        try:
-            m = self.problem.m_initial
-            if m is not None:
-                return self._reshape_to(m, shape)
-        except AttributeError:
-            pass
-        try:
-            return self.problem.get_initial_m()
-        except AttributeError:
-            pass
-        try:
-            x_grid = self.problem.geometry.get_spatial_grid()
-            return self.problem.initial_density(x_grid).reshape(shape)
-        except AttributeError as e:
-            raise ValueError(
-                "Problem must provide an initial density via one of: get_m_init() / m_initial / "
-                "get_initial_m() / initial_density()."
-            ) from e
+        """Resolve the initial density via the 4-priority cascade (Issue #1425: independent of terminal).
+
+        Uses explicit ``getattr(..., None)`` + ``callable()`` probes (the project's optional-accessor
+        pattern) rather than ``try/except AttributeError`` so a real error inside an accessor
+        propagates instead of being swallowed (and no silent ``pass``).
+        """
+        get_m_init = getattr(self.problem, "get_m_init", None)
+        if callable(get_m_init):
+            return self._reshape_to(get_m_init(), shape)
+        m_initial = getattr(self.problem, "m_initial", None)
+        if m_initial is not None:
+            return self._reshape_to(m_initial, shape)
+        get_initial_m = getattr(self.problem, "get_initial_m", None)
+        if callable(get_initial_m):
+            return get_initial_m()
+        initial_density = getattr(self.problem, "initial_density", None)
+        if callable(initial_density):
+            return initial_density(self.problem.geometry.get_spatial_grid()).reshape(shape)
+        raise ValueError(
+            "Problem must provide an initial density via one of: get_m_init() / m_initial / "
+            "get_initial_m() / initial_density()."
+        )
 
     def _resolve_terminal_value(self, shape: tuple) -> np.ndarray:
         """Resolve the terminal value via the 4-priority cascade, INDEPENDENT of the initial density.
 
         Issue #1425: previously a successful Priority-1 initial density forced the terminal from the
         same priority, so a mixed-API problem (e.g. ``get_m_init()`` + ``u_terminal`` attribute)
-        silently received ``u(T,·)=0``. Each terminal accessor is now tried in turn; only if all
-        fail does it default to zero terminal cost — with a warning, not a silent fallback.
+        silently received ``u(T,·)=0``. Each terminal accessor is tried in turn (explicit
+        ``getattr(..., None)`` + ``callable()`` probes, not ``try/except AttributeError``, so a real
+        error inside an accessor propagates); only if all are absent does it default to zero terminal
+        cost — with a warning, not a silent fallback.
         """
-        try:
-            return self._reshape_to(self.problem.get_u_terminal(), shape)
-        except AttributeError:
-            pass
-        try:
-            u = self.problem.u_terminal
-            if u is not None:
-                return self._reshape_to(u, shape)
-        except AttributeError:
-            pass
-        try:
-            return self.problem.get_final_u()
-        except AttributeError:
-            pass
-        try:
-            x_grid = self.problem.geometry.get_spatial_grid()
-            return self.problem.terminal_cost(x_grid).reshape(shape)
-        except AttributeError:
-            pass
+        get_u_terminal = getattr(self.problem, "get_u_terminal", None)
+        if callable(get_u_terminal):
+            return self._reshape_to(get_u_terminal(), shape)
+        u_terminal = getattr(self.problem, "u_terminal", None)
+        if u_terminal is not None:
+            return self._reshape_to(u_terminal, shape)
+        get_final_u = getattr(self.problem, "get_final_u", None)
+        if callable(get_final_u):
+            return get_final_u()
+        terminal_cost = getattr(self.problem, "terminal_cost", None)
+        if callable(terminal_cost):
+            return terminal_cost(self.problem.geometry.get_spatial_grid()).reshape(shape)
         warnings.warn(
             "No terminal condition found on the problem (get_u_terminal / u_terminal / get_final_u / "
             "terminal_cost all absent); defaulting to u(T,·)=0.",

--- a/tests/unit/test_alg/test_fixed_point_initial_terminal.py
+++ b/tests/unit/test_alg/test_fixed_point_initial_terminal.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Issue #1425: initial density and terminal value resolve via INDEPENDENT priority cascades.
+
+Before the fix, ``_get_initial_and_terminal_conditions`` resolved both fields together per
+priority, so a problem supplying its initial density via Priority 1 (``get_m_init()``) but its
+terminal via a lower priority (``u_terminal`` attribute) silently received ``u(T,·)=0`` — the
+Priority-1 terminal accessor raised and the method returned zeros before the attribute was tried.
+
+These tests bind the resolver methods to a minimal object (no full iterator/solver construction)
+and pin: the mixed-API case now resolves the terminal correctly, the standard single-API cases
+are unchanged, and the genuinely-absent-terminal case warns (not silent) before defaulting to 0.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+
+
+class _Resolver:
+    """Minimal carrier of the FixedPointIterator resolution methods for isolated unit testing."""
+
+    _reshape_to = staticmethod(FixedPointIterator._reshape_to)
+    _resolve_initial_density = FixedPointIterator._resolve_initial_density
+    _resolve_terminal_value = FixedPointIterator._resolve_terminal_value
+    _get_initial_and_terminal_conditions = FixedPointIterator._get_initial_and_terminal_conditions
+
+    def __init__(self, problem):
+        self.problem = problem
+
+
+SHAPE = (5,)
+M = np.ones(SHAPE)
+U = np.arange(5.0)
+
+
+class TestInitialTerminalResolution:
+    def test_mixed_api_terminal_from_attribute_not_zeros(self):
+        """get_m_init() (P1 initial) + u_terminal attribute (P2 terminal), no get_u_terminal method:
+        the terminal must come from the attribute, NOT silently default to zeros (the #1425 bug)."""
+
+        class MixedProblem:
+            def get_m_init(self):
+                return M.copy()
+
+            u_terminal = U.copy()
+
+        m_init, u_term = _Resolver(MixedProblem())._get_initial_and_terminal_conditions(SHAPE)
+        np.testing.assert_array_equal(m_init, M)
+        np.testing.assert_array_equal(u_term, U)  # resolved from the attribute
+        assert not np.array_equal(u_term, np.zeros(SHAPE)), "regressed to the pre-#1425 silent zeros"
+
+    def test_modern_method_api_unchanged(self):
+        class ModernProblem:
+            def get_m_init(self):
+                return M.copy()
+
+            def get_u_terminal(self):
+                return U.copy()
+
+        m_init, u_term = _Resolver(ModernProblem())._get_initial_and_terminal_conditions(SHAPE)
+        np.testing.assert_array_equal(m_init, M)
+        np.testing.assert_array_equal(u_term, U)
+
+    def test_attribute_api_unchanged(self):
+        class AttrProblem:
+            m_initial = M.copy()
+            u_terminal = U.copy()
+
+        m_init, u_term = _Resolver(AttrProblem())._get_initial_and_terminal_conditions(SHAPE)
+        np.testing.assert_array_equal(m_init, M)
+        np.testing.assert_array_equal(u_term, U)
+
+    def test_no_terminal_warns_then_defaults_zero(self):
+        class NoTerminalProblem:
+            def get_m_init(self):
+                return M.copy()
+
+        with pytest.warns(UserWarning, match="No terminal condition"):
+            u_term = _Resolver(NoTerminalProblem())._resolve_terminal_value(SHAPE)
+        np.testing.assert_array_equal(u_term, np.zeros(SHAPE))
+
+    def test_missing_initial_fails_loud(self):
+        class NoInitProblem:
+            u_terminal = U.copy()
+
+        with pytest.raises(ValueError, match="initial density"):
+            _Resolver(NoInitProblem())._resolve_initial_density(SHAPE)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Fixes the **#1425** silent-terminal bug. (First fix of the audit fix-phase.)

## Bug

`_get_initial_and_terminal_conditions` resolved the initial density and the terminal value **together** per priority. A mixed-API problem — `get_m_init()` (Priority 1) for the initial density but the `u_terminal` **attribute** (Priority 2) for the terminal, with no `get_u_terminal` method — silently got `u(T,·)=0`: the Priority-1 terminal accessor raised `AttributeError`, the inner `except` set zeros, and the method returned before the attribute was ever tried.

## Fix

Decouple into `_resolve_initial_density` / `_resolve_terminal_value`, each running the full 4-priority cascade **independently**. The genuinely-absent-terminal case now `warnings.warn`s before defaulting to 0 (no longer a silent fallback).

## Why baseline-safe (no mfg-research experiment needed)

- Standard single-API problems resolve both fields via the same priority as before — **byte-identical** (pinned by `test_modern_method_api_unchanged`, `test_attribute_api_unchanged`).
- Only the previously-**broken** mixed-API case changes (now correct). No published baseline uses that trigger, so no numerics shift — the unit test is sufficient validation.

## Tests (`test_fixed_point_initial_terminal.py`, 5/5)

- mixed-API terminal resolved from the attribute, **not** zeros (the bug);
- modern-method + attribute APIs unchanged;
- no-terminal → warns + zeros; missing-initial → fails loud.

Regression: existing `test_fixed_point_*` suite 28/28 (includes real end-to-end iterator solves).

## Note on closure

Uses `Refs #1425` (not `Closes`) pending your review — I implemented warn-then-default-0 for the genuinely-absent-terminal case rather than the hard fail-loud the issue floated, to stay baseline-safe (a problem with no terminal still solves with u(T)=0, the common MFG default). Close #1425 on merge if you're happy with that choice, or I can switch to fail-loud as a follow-up.