### PR TITLE
fix(coupling): fail loud when a problem-level source is dropped for a source-incapable solver

### DIFF
--- a/mfgarchon/alg/numerical/coupling/base_mfg.py
+++ b/mfgarchon/alg/numerical/coupling/base_mfg.py
@@ -39,6 +39,8 @@ class BaseCouplingIterator(ABC):
         self._solution_computed: bool = False
         self._hjb_sig_params: set[str] | None = None
         self._fp_sig_params: set[str] | None = None
+        self._hjb_solver_name: str = "<hjb solver>"
+        self._fp_solver_name: str = "<fp solver>"
 
     def _init_solver_signatures(self, hjb_solver: Any, fp_solver: Any) -> None:
         """Cache solver method signatures for conditional parameter passing.
@@ -46,6 +48,8 @@ class BaseCouplingIterator(ABC):
         Call this in subclass ``__init__`` after storing solver references.
         Replaces per-iterator ``_cache_solver_signatures`` methods.
         """
+        self._hjb_solver_name = type(hjb_solver).__name__
+        self._fp_solver_name = type(fp_solver).__name__
         try:
             sig = inspect.signature(hjb_solver.solve_hjb_system)
             self._hjb_sig_params = set(sig.parameters.keys())
@@ -74,7 +78,15 @@ class BaseCouplingIterator(ABC):
             return kwargs
         if "volatility_field" in params and volatility_field is not None:
             kwargs["volatility_field"] = volatility_field
-        if "source_term" in params and source_term is not None:
+        if source_term is not None:
+            if "source_term" not in params:
+                raise NotImplementedError(
+                    f"{self._hjb_solver_name}.solve_hjb_system does not accept 'source_term', but the "
+                    f"problem defines a source / nonlocal / obstacle term (composed into a non-None HJB "
+                    f"source). Silently dropping it would solve the wrong problem (Issue #1424). Use an "
+                    f"FDM HJB solver, or remove source_term_hjb / nonlocal_operator / obstacle from the "
+                    f"problem."
+                )
             kwargs["source_term"] = source_term
         return kwargs
 
@@ -97,7 +109,14 @@ class BaseCouplingIterator(ABC):
             kwargs["drift_field"] = drift_field
         if "volatility_field" in params and volatility_field is not None:
             kwargs["volatility_field"] = volatility_field
-        if "source_term" in params and source_term is not None:
+        if source_term is not None:
+            if "source_term" not in params:
+                raise NotImplementedError(
+                    f"{self._fp_solver_name}.solve_fp_system does not accept 'source_term', but the "
+                    f"problem defines an FP source term (composed into a non-None FP source). Silently "
+                    f"dropping it would solve the wrong problem (Issue #1424). Use an FDM FP solver, or "
+                    f"remove source_term_fp from the problem."
+                )
             kwargs["source_term"] = source_term
         return kwargs
 

--- a/tests/unit/test_alg/test_source_term_fail_loud.py
+++ b/tests/unit/test_alg/test_source_term_fail_loud.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Issue #1424: a problem-level source (source_term_hjb / source_term_fp / nonlocal_operator /
+obstacle, composed into a non-None source callable) must NOT be silently dropped for solvers whose
+``solve_*_system`` signature lacks ``source_term`` — the iterator now fails loud instead.
+
+Tests bind the kwargs builders to a minimal carrier (no full iterator construction). They pin:
+incapable solver + active source -> NotImplementedError; capable solver -> source passed through;
+no source -> no raise even for an incapable solver (the baseline-safe guard).
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+
+
+class _Builder:
+    _build_hjb_kwargs = BaseCouplingIterator._build_hjb_kwargs
+    _build_fp_kwargs = BaseCouplingIterator._build_fp_kwargs
+
+    def __init__(self, hjb_params, fp_params):
+        self._hjb_sig_params = hjb_params
+        self._fp_sig_params = fp_params
+        self._hjb_solver_name = "FakeNonFDMSolver"
+        self._fp_solver_name = "FakeNonFDMSolver"
+
+
+def _src(t, x):
+    return np.zeros_like(x)
+
+
+class TestSourceTermFailLoud:
+    def test_hjb_source_incapable_raises(self):
+        b = _Builder(hjb_params={"M_density", "U_terminal"}, fp_params=set())
+        with pytest.raises(NotImplementedError, match="source_term"):
+            b._build_hjb_kwargs(source_term=_src)
+
+    def test_fp_source_incapable_raises(self):
+        b = _Builder(hjb_params=set(), fp_params={"M_initial", "U"})
+        with pytest.raises(NotImplementedError, match="1424"):
+            b._build_fp_kwargs(source_term=_src)
+
+    def test_hjb_source_capable_passes_through(self):
+        b = _Builder(hjb_params={"source_term", "volatility_field"}, fp_params=set())
+        assert b._build_hjb_kwargs(source_term=_src)["source_term"] is _src
+
+    def test_fp_source_capable_passes_through(self):
+        b = _Builder(hjb_params=set(), fp_params={"source_term", "drift_field"})
+        assert b._build_fp_kwargs(source_term=_src)["source_term"] is _src
+
+    def test_no_source_is_noop_even_when_incapable(self):
+        """Baseline-safe: source_term=None never raises (the common case is untouched)."""
+        b = _Builder(hjb_params={"M_density"}, fp_params={"M_initial"})
+        assert b._build_hjb_kwargs(source_term=None) == {}
+        assert b._build_fp_kwargs(source_term=None) == {}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Fixes **#1424** (HIGH — silent source-drop). Second fix of the audit fix-phase.

## Bug

`_build_hjb_kwargs` / `_build_fp_kwargs` signature-gated `source_term`: if the solver's `solve_*_system` lacked the parameter, a composed problem-level source (`source_term_hjb` / `source_term_fp` / `nonlocal_operator` / `obstacle`) was **silently dropped** — the solver solved the *sourceless* problem with no error. Affected every non-FDM solver (GFDM, semi-Lagrangian, WENO, particle).

## Fix

When `source_term is not None` but the solver lacks the parameter, raise `NotImplementedError` naming the solver and the dropped term (use an FDM solver, or remove the source). Stores solver type names in `_init_solver_signatures` for the message.

## Why baseline-safe

- The guard is `source_term is not None` — problems **without** a source are completely untouched (the common case).
- **No existing test or example pairs a problem-level source with a non-FDM solver** (verified by grep — they all use FDM, which accepts `source_term`). So the fail-loud only fires on the genuinely-broken combo. No numerics shift.
- Regression: 23 source-using unit tests (incl. nonlocal-operator + Newton + `source_term_fp`) still pass.

## Tests (`test_source_term_fail_loud.py`, 5/5)

incapable HJB/FP + active source → `NotImplementedError`; capable solver → source passed through; `source_term=None` → no raise even for an incapable solver (baseline-safe).

## Scope

`source_term` only (the filed bug). The `volatility_field` signature-gate is left as-is (separate, not filed).