### PR TITLE
fix(geometry): compute 2D triangle area without np.cross (numpy 2.x compat)

### DIFF
--- a/mfgarchon/geometry/meshes/mesh_data.py
+++ b/mfgarchon/geometry/meshes/mesh_data.py
@@ -138,9 +138,12 @@ class MeshData:
         areas = np.zeros(self.num_elements)
         for i, element in enumerate(self.elements):
             v0, v1, v2 = self.vertices[element]
-            # Area = 0.5 * |cross product|
-            cross = np.cross(v1 - v0, v2 - v0)
-            areas[i] = 0.5 * abs(cross)
+            # 2D triangle area = 0.5 * |x_a*y_b - y_a*x_b|. Only 2D triangles reach here
+            # (see compute_element_volumes' dispatch), so compute the scalar cross explicitly:
+            # numpy 2.x removed np.cross for 2D inputs.
+            a = v1 - v0
+            b = v2 - v0
+            areas[i] = 0.5 * abs(float(a[0] * b[1] - a[1] * b[0]))
         return areas
 
     def _compute_tetrahedron_volumes(self) -> NDArray[np.floating]:


### PR DESCRIPTION
## CI blocker — affects all PRs / main

`MeshData._compute_triangle_areas` computed `np.cross(v1-v0, v2-v0)` on **2D** vertices. **numpy 2.x removed 2D `np.cross`** (raises `ValueError: arrays must be (arrays of) 3-dimensional vectors`), so 2D triangle-area computation crashes — surfacing as `test_geometry_pipeline.py::TestMeshData::test_triangle_area_computation` failing in CI.

It's **deterministic and pre-existing**: the test feeds a self-contained 2D right triangle, and the failure is purely a numpy-version effect (passes locally on numpy 2.4.6 where 2D `np.cross` still works; CI's numpy has it removed). It blocks the Test Suite on **every** PR — unrelated to whatever each PR changes (it's what's currently red on #1432).

## Fix

Compute the scalar 2D cross explicitly:
```python
a, b = v1 - v0, v2 - v0
areas[i] = 0.5 * abs(float(a[0] * b[1] - a[1] * b[0]))
```
Only 2D triangles reach this method (`compute_element_volumes` raises `NotImplementedError` for triangle elements in 3D), so no 3D branch is needed — adding one would be dead defensive code.

## Tests

Covered by the existing `test_triangle_area_computation` (the regression guard — it's the one that's red in CI). Full `test_geometry_pipeline.py` 13/13 locally; ruff + fail-fast clean.