### PR TITLE
fix(solvers): fail loud on unimplemented congestion_mode / weno_m_parameter; fix diffusive CFL log

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -322,7 +322,9 @@ class HJBFDMSolver(BaseHJBSolver):
             dt = self.problem.dt
             dx = self.problem.geometry.get_grid_spacing()[0]
             sigma = volatility_field if isinstance(volatility_field, (int, float)) else self.problem.sigma
-            cfl_diffusive = sigma**2 * dt / dx**2
+            # Issue #1426/S0-14: diffusive CFL uses the PDE coefficient D = sigma^2/2 (not sigma^2),
+            # matching the actual diffusion term -(sigma^2/2) Delta u. Diagnostic log only.
+            cfl_diffusive = 0.5 * sigma**2 * dt / dx**2
             if cfl_diffusive > 0.5:
                 log_fn = logger.debug if getattr(self, "_cfl_logged", False) else logger.info
                 log_fn(

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -710,6 +710,13 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         # Congestion mode for Hamiltonian coupling
         self.congestion_mode = congestion_mode
+        # Issue #1426: congestion_mode is stored but never read — 'multiplicative' was a silent
+        # no-op. Fail loud rather than silently behaving as 'additive'.
+        if congestion_mode != "additive":
+            raise NotImplementedError(
+                f"congestion_mode={congestion_mode!r} is not implemented (Issue #1426): it is stored but "
+                f"never applied, so it would silently behave as 'additive'. Only 'additive' is supported."
+            )
 
         # Collocation geometry for periodic domains (Issue #711)
         self._collocation_geometry = collocation_geometry

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -226,6 +226,13 @@ class HJBWenoSolver(BaseHJBSolver):
             raise ValueError(f"WENO-Z parameter must be positive, got {self.weno_z_parameter}")
         if self.weno_m_parameter <= 0:
             raise ValueError(f"WENO-M parameter must be positive, got {self.weno_m_parameter}")
+        # Issue #1426: weno_m_parameter is validated and stored but never applied in the WENO-M
+        # mapping. Fail loud on a non-default value rather than silently ignoring it.
+        if self.weno_m_parameter != 1.0:
+            raise NotImplementedError(
+                f"weno_m_parameter={self.weno_m_parameter} is not implemented (Issue #1426): it is stored "
+                f"but never applied in the WENO-M mapping. Only the default 1.0 is supported."
+            )
 
         if self.splitting_method not in ["strang", "godunov"]:
             raise ValueError(f"Unknown splitting method: {self.splitting_method}")

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Issue #1426: solver options that are stored but never applied must fail loud on a non-default
+value instead of being silent no-ops. Defaults remain accepted (baseline-safe).
+
+Covers the two cleanly-dead options (no live non-default setter anywhere): GFDM ``congestion_mode``
+and WENO ``weno_m_parameter``. (The FPSL/FPGFDM ``characteristic_solver`` / ``boundary_indices``
+namesakes are live on other solvers and are handled separately.)
+"""
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver, HJBWenoSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem(nx=21):
+    comp = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=domain, T=1.0, Nt=21, sigma=0.5, components=comp)
+
+
+def _pts(problem):
+    bounds = problem.geometry.get_bounds()
+    (nx,) = problem.geometry.get_grid_shape()
+    return np.linspace(bounds[0][0], bounds[1][0], nx).reshape(-1, 1)
+
+
+class TestDeadOptionFailLoud:
+    def test_gfdm_congestion_mode_multiplicative_raises(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(NotImplementedError, match="congestion_mode"):
+                HJBGFDMSolver(problem, _pts(problem), monotonicity_scheme="none", congestion_mode="multiplicative")
+
+    def test_gfdm_congestion_mode_additive_ok(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            HJBGFDMSolver(problem, _pts(problem), monotonicity_scheme="none", congestion_mode="additive")
+
+    def test_weno_m_parameter_nondefault_raises(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(NotImplementedError, match="weno_m_parameter"):
+                HJBWenoSolver(problem, weno_m_parameter=2.0)
+
+    def test_weno_m_parameter_default_ok(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            HJBWenoSolver(problem, weno_m_parameter=1.0)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Batched small, baseline-safe hygiene fixes (one CI run, per maintainer request).

| Fix | Issue | Change |
|---|---|---|
| `congestion_mode` | #1426 | stored-but-never-applied in `hjb_gfdm`; `'multiplicative'` was a silent no-op → now `NotImplementedError` on non-default |
| `weno_m_parameter` | #1426 | validated+stored but never applied in the WENO-M mapping (`hjb_weno`) → now `NotImplementedError` on `!= 1.0` |
| diffusive-CFL log | #1429 (S0-14) | `hjb_fdm._log_cfl_diagnostic` logged `sigma**2` instead of `D = sigma^2/2`; corrected (log-only) |

## Baseline-safe

- No test/example/code sets `congestion_mode='multiplicative'` or `weno_m_parameter != 1.0` (grep-verified) — defaults are untouched.
- 108 GFDM/WENO/config regression tests pass; the CFL change is log-only.
- New tests (`test_dead_option_fail_loud.py`, 4): non-default → raises; default → accepted.

## Scope note

Two other #1426 dead-knob namesakes are **live** on other solvers — `characteristic_solver` (HJB-SL rk2/rk4) and `boundary_indices` (HJB-GFDM) — so they need per-solver scoping and are deliberately **not** in this batch. #1426 stays open for them.

Refs #1426, #1429.