### PR TITLE
refactor(weno): rename HJBWenoSolver → HJBWENOSolver (acronym caps), keep deprecated alias

### DIFF
--- a/mfgarchon/alg/numerical/__init__.py
+++ b/mfgarchon/alg/numerical/__init__.py
@@ -35,6 +35,7 @@ from .hjb_solvers import (
     HJBFDMSolver,
     HJBGFDMSolver,
     HJBSemiLagrangianSolver,
+    HJBWENOSolver,
     HJBWenoSolver,
 )
 
@@ -58,6 +59,7 @@ __all__ = [
     "HJBFDMSolver",
     "HJBGFDMSolver",
     "HJBSemiLagrangianSolver",
+    "HJBWENOSolver",
     "HJBWenoSolver",
     # Network Solvers (graph-based)
     "FPNetworkSolver",  # Also in fp_solvers for backward compat

--- a/mfgarchon/alg/numerical/hjb_solvers/__init__.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/__init__.py
@@ -11,7 +11,8 @@ numerical analysis approaches:
   inner (resolves Issue #1118 Newton stiffness; requires SOCP-precomputed
   stencils on a stencil_provider HJBGFDMSolver)
 - HJBSemiLagrangianSolver: Semi-Lagrangian approach (characteristic-based, nD)
-- HJBWenoSolver: WENO (Weighted Essentially Non-Oscillatory) method (1D/2D/3D)
+- HJBWENOSolver: WENO (Weighted Essentially Non-Oscillatory) method (1D/2D/3D)
+  (HJBWenoSolver: deprecated alias, removal per policy)
 - PenaltyHJBSolver: Variational inequality wrapper (obstacle/optimal stopping)
 
 All solvers inherit from BaseNumericalSolver and follow the new paradigm structure.
@@ -23,7 +24,7 @@ from .hjb_gfdm import HJBGFDMSolver
 from .hjb_howard import HJBHowardSolver
 from .hjb_penalty import PenaltyHJBSolver
 from .hjb_semi_lagrangian import HJBSemiLagrangianSolver
-from .hjb_weno import HJBWenoSolver
+from .hjb_weno import HJBWENOSolver, HJBWenoSolver
 
 __all__ = [
     "BaseHJBSolver",
@@ -32,6 +33,7 @@ __all__ = [
     "HJBGFDMSolver",
     "HJBHowardSolver",
     "HJBSemiLagrangianSolver",
+    "HJBWENOSolver",
     "HJBWenoSolver",
     "PenaltyHJBSolver",
 ]

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -44,6 +44,7 @@ import numpy as np
 from mfgarchon.core.derivatives import DerivativeTensors, to_multi_index_dict
 from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
 from mfgarchon.geometry.boundary.conditions import neumann_bc
+from mfgarchon.utils.deprecation import deprecated_alias
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 from .base_hjb import BaseHJBSolver
@@ -60,7 +61,7 @@ _CFL_CAP_1D: float = 0.5
 _DIFFUSION_CAP_1D: float = 0.25
 
 
-class HJBWenoSolver(BaseHJBSolver):
+class HJBWENOSolver(BaseHJBSolver):
     """
     Unified WENO family solver for Hamilton-Jacobi-Bellman equations.
 
@@ -1289,9 +1290,15 @@ class HJBWenoSolver(BaseHJBSolver):
         return variant_info[self.weno_variant]
 
 
+# Issue #1426: renamed HJBWenoSolver -> HJBWENOSolver (WENO is an acronym; matches the
+# all-caps HJBGFDMSolver / HJBFDMSolver siblings and PEP 8 acronym capitalization).
+# Deprecated alias kept for backward compatibility (removal per deprecation policy).
+HJBWenoSolver = deprecated_alias("HJBWenoSolver", HJBWENOSolver, "v0.20.5")
+
+
 if __name__ == "__main__":
     """Quick smoke test for development."""
-    print("Testing HJBWenoSolver...")
+    print("Testing HJBWENOSolver...")
 
     import numpy as np
 
@@ -1304,7 +1311,7 @@ if __name__ == "__main__":
     n_pts = problem_1d.geometry.num_spatial_points  # number of spatial grid points (Nx + 1)
 
     # Test standard WENO variant
-    solver_1d = HJBWenoSolver(problem_1d, weno_variant="weno-z")
+    solver_1d = HJBWENOSolver(problem_1d, weno_variant="weno-z")
 
     # Test solver initialization
     assert solver_1d.dimension == 1

--- a/tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py
+++ b/tests/unit/test_alg/test_1071_fail_loud_missing_hamiltonian.py
@@ -16,7 +16,7 @@ import pytest
 
 import numpy as np
 
-from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver, HJBWenoSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver, HJBWENOSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
@@ -88,7 +88,7 @@ def test_weno_no_hamiltonian_fails_loud(monkeypatch):
     """WENO: with problem.H unavailable, _evaluate_hamiltonian raises rather than silently
     returning the hardcoded 0.5*grad**2 + m_val*grad."""
     problem = _problem()
-    solver = HJBWenoSolver(problem=problem)
+    solver = HJBWENOSolver(problem=problem)
 
     monkeypatch.setattr(problem, "H", _raise_attribute_error, raising=False)
 

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -13,7 +13,7 @@ import pytest
 
 import numpy as np
 
-from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver, HJBWenoSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver, HJBWENOSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
@@ -60,13 +60,13 @@ class TestDeadOptionFailLoud:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             with pytest.raises(NotImplementedError, match="weno_m_parameter"):
-                HJBWenoSolver(problem, weno_m_parameter=2.0)
+                HJBWENOSolver(problem, weno_m_parameter=2.0)
 
     def test_weno_m_parameter_default_ok(self):
         problem = _problem()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            HJBWenoSolver(problem, weno_m_parameter=1.0)
+            HJBWENOSolver(problem, weno_m_parameter=1.0)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_alg/test_hjbweno_rename_alias.py
+++ b/tests/unit/test_alg/test_hjbweno_rename_alias.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Issue #1426: HJBWenoSolver renamed to HJBWENOSolver (WENO is an acronym; matches the all-caps
+HJBGFDMSolver / HJBFDMSolver siblings and PEP 8). The old name remains as a deprecated alias.
+
+Pins: the new name is importable; the old name still works but warns; both construct the same class.
+"""
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBWENOSolver, HJBWenoSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem():
+    comp = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[31], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=1.0, Nt=20, sigma=0.1, components=comp)
+
+
+def test_new_name_constructs():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver = HJBWENOSolver(_problem(), weno_variant="weno5")
+    assert isinstance(solver, HJBWENOSolver)
+
+
+def test_deprecated_alias_warns_and_builds_new_class():
+    """Old name still works (backward compat) but emits a DeprecationWarning and returns an
+    instance of the new class."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with pytest.warns(DeprecationWarning, match="HJBWenoSolver"):
+            solver = HJBWenoSolver(_problem(), weno_variant="weno5")
+    assert isinstance(solver, HJBWENOSolver)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/tests/unit/test_alg/test_issue_1316_hjb_volatility_consumption.py
+++ b/tests/unit/test_alg/test_issue_1316_hjb_volatility_consumption.py
@@ -34,7 +34,7 @@ import numpy as np
 from mfgarchon.alg.numerical.hjb_solvers import (
     HJBGFDMSolver,
     HJBSemiLagrangianSolver,
-    HJBWenoSolver,
+    HJBWENOSolver,
 )
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
@@ -171,7 +171,7 @@ def _sl_problem():
     return MFGProblem(geometry=grid, T=0.2, Nt=10, sigma=0.3, components=_components())
 
 
-@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWenoSolver])
+@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWENOSolver])
 def test_sl_weno_fail_loud_on_spatial_volatility(solver_cls):
     """Issue #1316 — SL/WENO read problem.sigma at scattered sites (no chokepoint); a
     spatial volatility_field must fail loud, not be silently ignored."""
@@ -185,7 +185,7 @@ def test_sl_weno_fail_loud_on_spatial_volatility(solver_cls):
         solver.solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=field)
 
 
-@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWenoSolver])
+@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWENOSolver])
 def test_sl_weno_fail_loud_on_mismatched_scalar(solver_cls):
     """Issue #1316 — a scalar volatility_field that differs from problem.sigma also fails
     loud (HJB would silently solve a different diffusion than FP)."""
@@ -198,7 +198,7 @@ def test_sl_weno_fail_loud_on_mismatched_scalar(solver_cls):
         solver.solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=0.9)
 
 
-@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWenoSolver])
+@pytest.mark.parametrize("solver_cls", [HJBSemiLagrangianSolver, HJBWENOSolver])
 def test_sl_weno_accept_scalar_equal_to_sigma(solver_cls):
     """Issue #1316 — the iterator's redundant forwarding of a scalar problem.sigma as
     volatility_field is a no-op and must NOT raise."""

--- a/tests/unit/test_alg/test_solver_traits.py
+++ b/tests/unit/test_alg/test_solver_traits.py
@@ -33,11 +33,11 @@ class TestHJBSolverTraits:
         assert HJBGFDMSolver._scheme_family == SchemeFamily.GFDM
 
     def test_hjb_weno_has_fdm_trait(self):
-        """Test that HJBWenoSolver has FDM scheme family (WENO is FDM variant)."""
-        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
+        """Test that HJBWENOSolver has FDM scheme family (WENO is FDM variant)."""
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
 
-        assert hasattr(HJBWenoSolver, "_scheme_family")
-        assert HJBWenoSolver._scheme_family == SchemeFamily.FDM
+        assert hasattr(HJBWENOSolver, "_scheme_family")
+        assert HJBWENOSolver._scheme_family == SchemeFamily.FDM
 
     def test_all_hjb_solvers_have_trait(self):
         """Test that all HJB solvers have _scheme_family trait."""
@@ -46,13 +46,13 @@ class TestHJBSolverTraits:
         from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import (
             HJBSemiLagrangianSolver,
         )
-        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
 
         hjb_solvers = [
             HJBFDMSolver,
             HJBSemiLagrangianSolver,
             HJBGFDMSolver,
-            HJBWenoSolver,
+            HJBWENOSolver,
         ]
 
         for solver_class in hjb_solvers:
@@ -64,11 +64,11 @@ class TestHJBSolverTraits:
     def test_hjb_fdm_variants_both_fdm(self):
         """Test that both FDM and WENO solvers have FDM family."""
         from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
-        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
 
         # Both should be FDM family (WENO is high-order FDM)
         assert HJBFDMSolver._scheme_family == SchemeFamily.FDM
-        assert HJBWenoSolver._scheme_family == SchemeFamily.FDM
+        assert HJBWENOSolver._scheme_family == SchemeFamily.FDM
 
     def test_hjb_trait_types_are_consistent(self):
         """Test that all HJB solver traits are valid SchemeFamily values."""
@@ -77,7 +77,7 @@ class TestHJBSolverTraits:
         from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import (
             HJBSemiLagrangianSolver,
         )
-        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
 
         # All should be valid SchemeFamily enum members
         all_families = set(SchemeFamily)
@@ -85,7 +85,7 @@ class TestHJBSolverTraits:
         assert HJBFDMSolver._scheme_family in all_families
         assert HJBSemiLagrangianSolver._scheme_family in all_families
         assert HJBGFDMSolver._scheme_family in all_families
-        assert HJBWenoSolver._scheme_family in all_families
+        assert HJBWENOSolver._scheme_family in all_families
 
 
 class TestValidatorPatternWithTraits:
@@ -116,13 +116,13 @@ class TestValidatorPatternWithTraits:
         from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import (
             HJBSemiLagrangianSolver,
         )
-        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
 
         hjb_solvers = [
             (HJBFDMSolver, SchemeFamily.FDM),
             (HJBSemiLagrangianSolver, SchemeFamily.SL),
             (HJBGFDMSolver, SchemeFamily.GFDM),
-            (HJBWenoSolver, SchemeFamily.FDM),
+            (HJBWENOSolver, SchemeFamily.FDM),
         ]
 
         for solver_class, expected_family in hjb_solvers:
@@ -240,13 +240,13 @@ class TestTraitImportability:
         from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import (
             HJBSemiLagrangianSolver,
         )
-        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
 
         # All should have trait
         assert HJBFDMSolver._scheme_family is not None
         assert HJBSemiLagrangianSolver._scheme_family is not None
         assert HJBGFDMSolver._scheme_family is not None
-        assert HJBWenoSolver._scheme_family is not None
+        assert HJBWENOSolver._scheme_family is not None
 
     def test_no_circular_import_with_scheme_family(self):
         """Test that importing solvers doesn't cause circular import."""
@@ -385,14 +385,14 @@ if __name__ == "__main__":
     from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
     from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
     from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import HJBSemiLagrangianSolver
-    from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWenoSolver
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
 
     # Test all HJB solvers have traits
     solvers = [
         (HJBFDMSolver, SchemeFamily.FDM, "HJB FDM"),
         (HJBSemiLagrangianSolver, SchemeFamily.SL, "HJB Semi-Lagrangian"),
         (HJBGFDMSolver, SchemeFamily.GFDM, "HJB GFDM"),
-        (HJBWenoSolver, SchemeFamily.FDM, "HJB WENO"),
+        (HJBWENOSolver, SchemeFamily.FDM, "HJB WENO"),
     ]
 
     for solver_class, expected_family, name in solvers:

--- a/tests/unit/test_alg/test_weno_family.py
+++ b/tests/unit/test_alg/test_weno_family.py
@@ -18,7 +18,7 @@ import pytest
 
 import numpy as np
 
-from mfgarchon.alg.numerical.hjb_solvers import HJBWenoSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBWENOSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
@@ -65,43 +65,43 @@ class TestWenoFamilySolver:
         variants = ["weno5", "weno-z", "weno-m", "weno-js"]
 
         for variant in variants:
-            solver = HJBWenoSolver(problem=simple_problem, weno_variant=variant)
+            solver = HJBWENOSolver(problem=simple_problem, weno_variant=variant)
             assert solver.weno_variant == variant
             assert variant.upper() in solver.hjb_method_name
 
     def test_invalid_variant_raises_error(self, simple_problem):
         """Test that invalid WENO variant raises ValueError."""
         with pytest.raises(ValueError, match="Unknown WENO variant"):
-            HJBWenoSolver(problem=simple_problem, weno_variant="invalid_variant")
+            HJBWENOSolver(problem=simple_problem, weno_variant="invalid_variant")
 
     def test_parameter_validation(self, simple_problem):
         """Test parameter validation for all solver parameters."""
 
         # Test invalid CFL number
         with pytest.raises(ValueError, match="CFL number must be in"):
-            HJBWenoSolver(simple_problem, cfl_number=0.0)
+            HJBWENOSolver(simple_problem, cfl_number=0.0)
 
         with pytest.raises(ValueError, match="CFL number must be in"):
-            HJBWenoSolver(simple_problem, cfl_number=1.5)
+            HJBWENOSolver(simple_problem, cfl_number=1.5)
 
         # Test invalid diffusion stability factor
         with pytest.raises(ValueError, match="Diffusion stability factor"):
-            HJBWenoSolver(simple_problem, diffusion_stability_factor=0.0)
+            HJBWENOSolver(simple_problem, diffusion_stability_factor=0.0)
 
         with pytest.raises(ValueError, match="Diffusion stability factor"):
-            HJBWenoSolver(simple_problem, diffusion_stability_factor=0.6)
+            HJBWENOSolver(simple_problem, diffusion_stability_factor=0.6)
 
         # Test invalid WENO epsilon
         with pytest.raises(ValueError, match="WENO epsilon must be positive"):
-            HJBWenoSolver(simple_problem, weno_epsilon=0.0)
+            HJBWENOSolver(simple_problem, weno_epsilon=0.0)
 
         # Test invalid WENO-Z parameter
         with pytest.raises(ValueError, match="WENO-Z parameter"):
-            HJBWenoSolver(simple_problem, weno_z_parameter=0.0)
+            HJBWENOSolver(simple_problem, weno_z_parameter=0.0)
 
     def test_weno_coefficients_setup(self, simple_problem):
         """Test that WENO coefficients are properly initialized."""
-        solver = HJBWenoSolver(simple_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(simple_problem, weno_variant="weno5")
 
         # Check linear weights
         assert hasattr(solver, "d_plus")
@@ -117,7 +117,7 @@ class TestWenoFamilySolver:
 
     def test_smoothness_indicators_computation(self, simple_problem, test_values):
         """Test smoothness indicator computation for polynomial data."""
-        solver = HJBWenoSolver(simple_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(simple_problem, weno_variant="weno5")
 
         # For quadratic polynomial u = x^2, should have specific smoothness properties
         u_stencil = test_values[8:13]  # 5-point stencil
@@ -133,7 +133,7 @@ class TestWenoFamilySolver:
 
     def test_tau_indicator_computation(self, simple_problem, test_values):
         """Test global smoothness indicator τ for WENO-Z."""
-        solver = HJBWenoSolver(simple_problem, weno_variant="weno-z")
+        solver = HJBWENOSolver(simple_problem, weno_variant="weno-z")
 
         u_stencil = test_values[8:13]  # 5-point stencil
         tau = solver._compute_tau_indicator(u_stencil)
@@ -147,7 +147,7 @@ class TestWenoFamilySolver:
         variants = ["weno5", "weno-z", "weno-m", "weno-js"]
 
         for variant in variants:
-            solver = HJBWenoSolver(simple_problem, weno_variant=variant)
+            solver = HJBWENOSolver(simple_problem, weno_variant=variant)
 
             w_plus, w_minus = solver._compute_weno_weights(test_values, 10)
 
@@ -165,7 +165,7 @@ class TestWenoFamilySolver:
 
     def test_weno_reconstruction(self, simple_problem, test_values):
         """Test WENO reconstruction produces reasonable results."""
-        solver = HJBWenoSolver(simple_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(simple_problem, weno_variant="weno5")
 
         # Test reconstruction at interior point
         u_left, u_right = solver._weno_reconstruction(test_values, 10)
@@ -180,7 +180,7 @@ class TestWenoFamilySolver:
 
     def test_hjb_step_execution(self, simple_problem):
         """Test that HJB time step executes without errors."""
-        solver = HJBWenoSolver(simple_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(simple_problem, weno_variant="weno5")
 
         # Create test data
         bounds = simple_problem.geometry.get_bounds()
@@ -201,7 +201,7 @@ class TestWenoFamilySolver:
         methods = ["tvd_rk3", "explicit_euler"]
 
         for method in methods:
-            solver = HJBWenoSolver(simple_problem, weno_variant="weno5", time_integration=method)
+            solver = HJBWENOSolver(simple_problem, weno_variant="weno5", time_integration=method)
 
             bounds = simple_problem.geometry.get_bounds()
             x = np.linspace(bounds[0][0], bounds[1][0], simple_problem.geometry.get_grid_shape()[0])
@@ -218,7 +218,7 @@ class TestWenoFamilySolver:
         variants = ["weno5", "weno-z", "weno-m", "weno-js"]
 
         for variant in variants:
-            solver = HJBWenoSolver(simple_problem, weno_variant=variant)
+            solver = HJBWENOSolver(simple_problem, weno_variant=variant)
             info = solver.get_variant_info()
 
             # Should contain required keys
@@ -230,7 +230,7 @@ class TestWenoFamilySolver:
 
     def test_stability_time_step_computation(self, simple_problem):
         """Test stable time step computation."""
-        solver = HJBWenoSolver(simple_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(simple_problem, weno_variant="weno5")
 
         bounds = simple_problem.geometry.get_bounds()
         Nx_points = simple_problem.geometry.get_grid_shape()[0]
@@ -249,7 +249,7 @@ class TestWenoFamilySolver:
 
     def test_boundary_handling(self, simple_problem):
         """Test that boundary points are handled correctly."""
-        solver = HJBWenoSolver(simple_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(simple_problem, weno_variant="weno5")
 
         # Create data with boundary features
         bounds = simple_problem.geometry.get_bounds()
@@ -278,7 +278,7 @@ class TestWenoFamilySolver:
 
         results = {}
         for variant in variants:
-            solver = HJBWenoSolver(simple_problem, weno_variant=variant)
+            solver = HJBWENOSolver(simple_problem, weno_variant=variant)
             u_result = solver.solve_hjb_step(u_initial, m_initial, dt)
             results[variant] = u_result
 
@@ -294,7 +294,7 @@ class TestWenoFamilySolver:
     @pytest.mark.parametrize("variant", ["weno5", "weno-z", "weno-m", "weno-js"])
     def test_individual_variant_functionality(self, simple_problem, variant):
         """Test each WENO variant individually."""
-        solver = HJBWenoSolver(simple_problem, weno_variant=variant)
+        solver = HJBWENOSolver(simple_problem, weno_variant=variant)
 
         # Basic functionality test
         bounds = simple_problem.geometry.get_bounds()
@@ -326,7 +326,7 @@ class TestWenoSolverIntegration:
 
     def test_solve_hjb_system_shape(self, integration_problem):
         """Test that solve_hjb_system returns correct shape."""
-        solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
         Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -344,7 +344,7 @@ class TestWenoSolverIntegration:
 
     def test_solve_hjb_system_final_condition(self, integration_problem):
         """Test that final condition is preserved."""
-        solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
         Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -364,7 +364,7 @@ class TestWenoSolverIntegration:
 
     def test_solve_hjb_system_backward_propagation(self, integration_problem):
         """Test that solution propagates backward in time."""
-        solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
         Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -384,7 +384,7 @@ class TestWenoSolverIntegration:
 
     def test_solve_hjb_system_with_density_variation(self, integration_problem):
         """Test solving with non-uniform density."""
-        solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
         Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -408,7 +408,7 @@ class TestWenoSolverIntegration:
     @pytest.mark.parametrize("variant", ["weno5", "weno-z", "weno-m", "weno-js"])
     def test_solve_hjb_system_all_variants(self, integration_problem, variant):
         """Test solve_hjb_system with all WENO variants."""
-        solver = HJBWenoSolver(integration_problem, weno_variant=variant)
+        solver = HJBWENOSolver(integration_problem, weno_variant=variant)
 
         Nt = integration_problem.Nt + 1
         Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -424,7 +424,7 @@ class TestWenoSolverIntegration:
 
     def test_solve_with_uniform_density(self, integration_problem):
         """Test solver with uniform density distribution."""
-        solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
         Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -455,7 +455,7 @@ class TestWenoSolverIntegration:
         stays smooth and O(1). A finiteness check alone is too weak (it would pass
         on a slowly-growing instability), so we also bound the magnitude.
         """
-        solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
+        solver = HJBWENOSolver(integration_problem, weno_variant="weno5")
 
         Nt = integration_problem.Nt + 1
         Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -478,7 +478,7 @@ class TestWenoSolverIntegration:
     def test_different_cfl_numbers(self, integration_problem):
         """Test solver with different CFL numbers."""
         for cfl in [0.1, 0.3, 0.5]:
-            solver = HJBWenoSolver(integration_problem, weno_variant="weno5", cfl_number=cfl)
+            solver = HJBWENOSolver(integration_problem, weno_variant="weno5", cfl_number=cfl)
 
             Nt = integration_problem.Nt + 1
             Nx = integration_problem.geometry.get_grid_shape()[0]  # Nx+1 grid points
@@ -492,15 +492,15 @@ class TestWenoSolverIntegration:
             assert np.all(np.isfinite(U_solution))
 
     def test_solver_not_abstract(self, integration_problem):
-        """Test that HJBWenoSolver can be instantiated and used."""
+        """Test that HJBWENOSolver can be instantiated and used."""
         import inspect
 
         # Should not raise TypeError about abstract methods
-        solver = HJBWenoSolver(integration_problem, weno_variant="weno5")
-        assert isinstance(solver, HJBWenoSolver)
+        solver = HJBWENOSolver(integration_problem, weno_variant="weno5")
+        assert isinstance(solver, HJBWENOSolver)
 
         # Should not have abstract methods
-        assert not inspect.isabstract(HJBWenoSolver)
+        assert not inspect.isabstract(HJBWENOSolver)
 
 
 class TestWenoTimeSubstepping:
@@ -530,7 +530,7 @@ class TestWenoTimeSubstepping:
         built from the same kernel. Pre-fix the sweep advanced only ~2% of T (moved ~0.044 vs
         reference ~0.295) because each interval took a single dt_stable step."""
         prob = self._problem()
-        solver = HJBWenoSolver(problem=prob, weno_variant="weno5")
+        solver = HJBWENOSolver(problem=prob, weno_variant="weno5")
         n_time = prob.Nt + 1
         Nx = solver.num_grid_points_x
         x = np.linspace(0.0, 1.0, Nx)
@@ -562,7 +562,7 @@ class TestWenoTimeSubstepping:
         """Happy path: when dt <= dt_stable the substep helper does exactly one step of size dt,
         byte-identical to the pre-#1180 single-step code (dt_stable_fn returns a huge value)."""
         prob = self._problem(Nx=11, T=0.01, Nt=5, sigma=0.05)
-        solver = HJBWenoSolver(problem=prob, weno_variant="weno5")
+        solver = HJBWENOSolver(problem=prob, weno_variant="weno5")
         x = np.linspace(0.0, 1.0, 11)
         u = np.cos(np.pi * x)
         m = np.ones(11) / 11
@@ -575,7 +575,7 @@ class TestWenoTimeSubstepping:
         """Fail-fast contract: if the CFL/diffusion limit cannot cover dt within max_substeps,
         raise rather than silently truncating the interval."""
         prob = self._problem(Nx=11, T=0.01, Nt=5, sigma=0.05)
-        solver = HJBWenoSolver(problem=prob, weno_variant="weno5")
+        solver = HJBWENOSolver(problem=prob, weno_variant="weno5")
         solver.max_substeps = 3
         u = np.cos(np.pi * np.linspace(0.0, 1.0, 11))
         m = np.ones(11) / 11
@@ -603,7 +603,7 @@ class TestWenoHJDerivativeCorrectness:
         comp = MFGComponents(m_initial=lambda x: np.ones_like(x), u_terminal=lambda x: 0.0, hamiltonian=H)
         dom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
         prob = MFGProblem(geometry=dom, T=1.0, Nt=30, sigma=0.1, components=comp)
-        return HJBWenoSolver(prob, weno_variant=variant)
+        return HJBWENOSolver(prob, weno_variant=variant)
 
     def _derivatives(self, solver, u):
         solver.ghost_buffer.interior[:] = u
@@ -711,7 +711,7 @@ class TestWeno2DSolve:
         """A 2D HJB solve with oscillatory terminal data stays finite and bounded."""
         n = 21
         prob = self._problem_2d(n)
-        solver = HJBWenoSolver(prob, weno_variant="weno5")
+        solver = HJBWENOSolver(prob, weno_variant="weno5")
         Nt = prob.Nt + 1
         x = np.linspace(0.0, 1.0, n)
         xx, yy = np.meshgrid(x, x, indexing="ij")
@@ -734,7 +734,7 @@ class TestWeno2DSolve:
         comparable to the field amplitude)."""
         n = 21
         prob = self._problem_2d(n)
-        solver = HJBWenoSolver(prob, weno_variant="weno5")
+        solver = HJBWENOSolver(prob, weno_variant="weno5")
         Nt = prob.Nt + 1
         x = np.linspace(0.0, 1.0, n)
         xx, yy = np.meshgrid(x, x, indexing="ij")
@@ -775,8 +775,8 @@ class TestWeno2DSolve:
         # A: x in [0,1] (fine), y in [0,2] (coarse); B: axes swapped.
         probA = self._rect_problem([(0.0, 1.0), (0.0, 2.0)], [nx, ny])
         probB = self._rect_problem([(0.0, 2.0), (0.0, 1.0)], [ny, nx])
-        solA = HJBWenoSolver(probA, weno_variant="weno5")
-        solB = HJBWenoSolver(probB, weno_variant="weno5")
+        solA = HJBWENOSolver(probA, weno_variant="weno5")
+        solB = HJBWENOSolver(probB, weno_variant="weno5")
         Nt = probA.Nt + 1
         xa = np.linspace(0.0, 1.0, nx)
         ya = np.linspace(0.0, 2.0, ny)

--- a/tests/unit/test_alg/test_weno_ghost_order.py
+++ b/tests/unit/test_alg/test_weno_ghost_order.py
@@ -46,10 +46,10 @@ def test_weno_uses_high_order_ghosts():
     )
 
     # Import WENO solver
-    from mfgarchon.alg.numerical.hjb_solvers import HJBWenoSolver
+    from mfgarchon.alg.numerical.hjb_solvers import HJBWENOSolver
 
     # Create WENO solver
-    solver = HJBWenoSolver(problem)
+    solver = HJBWENOSolver(problem)
 
     # Check that ghost buffer was created with correct parameters.
     # Issue #1200: the Osher-Shu HJ-WENO5 one-sided derivative stencil spans
@@ -78,10 +78,10 @@ def test_weno_ghost_cells_work():
     )
 
     # Import WENO solver
-    from mfgarchon.alg.numerical.hjb_solvers import HJBWenoSolver
+    from mfgarchon.alg.numerical.hjb_solvers import HJBWENOSolver
 
     # Create WENO solver
-    solver = HJBWenoSolver(problem)
+    solver = HJBWENOSolver(problem)
 
     # Test ghost cell update with smooth function
     x = np.linspace(0.0, 1.0, solver.num_grid_points_x)

--- a/tests/unit/test_utils/test_adjoint_validation.py
+++ b/tests/unit/test_utils/test_adjoint_validation.py
@@ -160,9 +160,9 @@ class TestCheckSolverDualityFDM:
     def test_fdm_weno_compatibility(self):
         """Test that WENO and FDM are compatible (both FDM family)."""
         from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
-        from mfgarchon.alg.numerical.hjb_solvers import HJBWenoSolver
+        from mfgarchon.alg.numerical.hjb_solvers import HJBWENOSolver
 
-        result = check_solver_duality(HJBWenoSolver, FPFDMSolver)
+        result = check_solver_duality(HJBWENOSolver, FPFDMSolver)
 
         assert result.status == DualityStatus.DISCRETE_DUAL
         assert result.hjb_family == SchemeFamily.FDM


### PR DESCRIPTION
## Rationale

`WENO` is an acronym ("Weighted Essentially Non-Oscillatory"). `HJBWENOSolver` matches its all-caps siblings `HJBGFDMSolver` / `HJBFDMSolver` and PEP 8 acronym capitalization — `HJBWenoSolver` was the lone outlier treating an acronym as a word.

## Change (deprecation-policy compliant)

- `HJBWenoSolver` → **`HJBWENOSolver`** (class renamed).
- `HJBWenoSolver` kept as `deprecated_alias("HJBWenoSolver", HJBWENOSolver, "v0.20.5")` — emits `DeprecationWarning`, redirects to the new class. Uses the in-tree `mfgarchon.utils.deprecation` module.
- Both names exported from `hjb_solvers` and `alg.numerical`.
- All internal call sites migrated to the new name (adjoint validation, solver traits, WENO family/ghost-order tests, #1316 / #1071 tests, module smoke test).

## Tests

`test_hjbweno_rename_alias.py`: new name constructs; old name **warns** (`DeprecationWarning`) and returns a `HJBWENOSolver` instance. WENO family + ghost-order regression (47 tests) pass on the new name. ruff + fail-fast clean.

Refs #1426.