### PR TITLE
fix(hjb-fdm): couple nD U^n to density M[n], not M[n+1] (cross-path off-by-one)

### DIFF
--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -520,7 +520,11 @@ class HJBFDMSolver(BaseHJBSolver):
         # Backward time loop
         for n in timestep_iter:
             U_next = U_solution[n + 1]
-            M_next = M_density[n + 1]
+            # Issue #1423: couple U^n to the density at the SAME time level, M[n] — the HJB and FP
+            # are coupled at the same physical time t_n (H(x, ∇u, m(t_n))). The 1D path was fixed
+            # to M[n] ("BUG #7 FIX" in base_hjb.solve_hjb_system_backward); this propagates that to
+            # the nD path, which previously used M[n+1] (a silent O(dt) cross-path off-by-one).
+            M_n = M_density[n]
             U_guess = U_prev[n]
 
             # Issue #889: unified volatility_field with shape-based dispatch
@@ -538,20 +542,20 @@ class HJBFDMSolver(BaseHJBSolver):
                 # Callable: evaluate and check shape
                 t = n * self.problem.dt
                 test_x = np.array([self.grid.coordinates[dd][0] for dd in range(d)])
-                test_val = volatility_field(t, test_x, float(M_next.flat[0]))
+                test_val = volatility_field(t, test_x, float(M_n.flat[0]))
                 test_arr = np.asarray(test_val)
                 if test_arr.ndim >= 2 and test_arr.shape[-2:] == (d, d):
                     # Tensor callable — evaluate at all points
                     Sigma_at_n = np.zeros((*self.shape, d, d))
                     for idx in np.ndindex(self.shape):
                         x_coords = np.array([self.grid.coordinates[dd][idx[dd]] for dd in range(d)])
-                        Sigma_at_n[idx] = volatility_field(t, x_coords, float(M_next[idx]))
+                        Sigma_at_n[idx] = volatility_field(t, x_coords, float(M_n[idx]))
 
             if Sigma_at_n is None:
                 # Scalar path (CoefficientField handles float, array, callable)
                 diffusion = CoefficientField(volatility_field, self.problem.sigma, "volatility_field", dimension=d)
                 sigma_at_n = diffusion.evaluate_at(
-                    timestep_idx=n, grid=self.grid.coordinates, density=M_next, dt=self.problem.dt
+                    timestep_idx=n, grid=self.grid.coordinates, density=M_n, dt=self.problem.dt
                 )
 
             # Compute current time for time-dependent BCs
@@ -567,7 +571,7 @@ class HJBFDMSolver(BaseHJBSolver):
             # Solve nonlinear system using centralized solver
             U_solution[n] = self._solve_single_timestep(
                 U_next,
-                M_next,
+                M_n,
                 U_guess,
                 sigma_at_n,
                 Sigma_at_n,

--- a/tests/unit/test_alg/test_hjb_fdm_nd_coupling_time_level.py
+++ b/tests/unit/test_alg/test_hjb_fdm_nd_coupling_time_level.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Issue #1423: the nD HJB-FDM backward loop must couple U^n to the density at the SAME time
+level, M[n] — matching the continuous coupling H(x, ∇u, m(t_n)) and the 1D path's "BUG #7 FIX".
+Previously the nD path used M[n+1] (a silent O(dt) cross-path off-by-one vs 1D / Howard).
+
+White-box pinning: spy on _solve_single_timestep, feed a density whose time slices are all distinct,
+and assert that when solving U^n the solver receives M[n] (not M[n+1]). With the pre-fix code this
+test fails (it would receive M[n+1]).
+"""
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem_2d(N=6, T=0.2, Nt=5, sigma=0.1):
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    geom = TensorProductGrid(
+        bounds=[(0.0, 1.0), (0.0, 1.0)],
+        Nx_points=[N + 1, N + 1],
+        boundary_conditions=no_flux_bc(dimension=2),
+    )
+    return MFGProblem(geometry=geom, components=comp, T=T, Nt=Nt, sigma=sigma)
+
+
+class TestNDCouplingTimeLevel:
+    def test_nd_couples_un_to_mn(self):
+        problem = _problem_2d()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            solver = HJBFDMSolver(problem, solver_type="fixed_point")
+
+        nt_points = problem.Nt + 1
+        shape = solver.shape
+        # Density with strictly distinct, identifiable time slices: M[k] == full of value (k+1).
+        M = np.stack([np.full(shape, float(k + 1)) for k in range(nt_points)])
+        U_terminal = np.zeros(shape)
+        U_prev = np.zeros((nt_points, *shape))
+
+        captured: dict[int, float] = {}
+        orig = solver._solve_single_timestep
+
+        def spy(U_next, M_coupling, U_guess, sigma_at_n, Sigma_at_n, **kw):
+            # Record the constant value of the coupling slice; infer which time level it is.
+            captured[len(captured)] = float(np.asarray(M_coupling).flat[0])
+            return orig(U_next, M_coupling, U_guess, sigma_at_n, Sigma_at_n, **kw)
+
+        solver._solve_single_timestep = spy
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            solver.solve_hjb_system(M, U_terminal, U_coupling_prev=U_prev)
+
+        # The backward loop runs n = Nt-1, Nt-2, ..., 0. For each, the coupling slice must be M[n],
+        # whose constant value is (n+1). So the sequence of captured values must be Nt, Nt-1, ..., 1.
+        expected = [float(n + 1) for n in range(nt_points - 2, -1, -1)]
+        got = [captured[i] for i in range(len(captured))]
+        assert got == expected, (
+            f"nD HJB-FDM coupled U^n to the wrong density time level (Issue #1423). "
+            f"Expected M[n] values {expected}, got {got}. "
+            f"A pre-fix M[n+1] would yield {[float(n + 2) for n in range(nt_points - 2, -1, -1)]}."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Fixes **#1423** (B1 numeric — authorized). The first numerics-shifting fix of the audit fix-phase.

## Bug

The nD HJB-FDM backward loop coupled `U^n` to `M[n+1]` (`hjb_fdm.py:523`) while the 1D path and Howard use `M[n]`. The continuous MFG system couples HJB and FP at the **same** physical time `t_n` — `H(x, ∇u, m(t_n))` — so solving for `U^n` must use `m(t_n) = M[n]`. The 1D path was explicitly fixed to `M[n]` ("BUG #7 FIX" in `base_hjb.solve_hjb_system_backward`); the nD path never got it → a silent **O(dt) cross-path discrepancy** (same separable problem, 1D vs nD vs Howard, converged to different discrete solutions at finite dt).

## Fix

`M_next = M_density[n+1]` → `M_n = M_density[n]` (rename: the coupling density is at level n). The σ/`volatility_field` evaluation in the same loop now also consumes `M[n]`, consistent with its `timestep_idx=n`.

## Validation (B1)

- **White-box pinning test** `test_nd_couples_un_to_mn`: feeds a density with distinct per-slice values and asserts `U^n` receives `M[n]`. **Verified to FAIL on pre-fix code** (captured `[6,5,4,3,2]` = M[n+1]) and **PASS after** (`[5,4,3,2,1]` = M[n]) — a genuine guard, not a tautology.
- **Math**: matches the 1D MMS-validated `M[n]` convention.
- **Regression**: 75 tests pass — `test_hjb_fdm_2d_validation`, `test_coupled_hjb_fp_2d`, `test_coupled_mfg_mms`, `test_hjb_fdm_solver`. Steady-density problems (`M[n]==M[n+1]`) are byte-unchanged; only finite-dt time-varying nD-FDM coupled solves shift (toward correct).

## Baseline note

This **changes nD-FDM numerics** for time-varying coupled solves (B1). No published exp06a/08/09 baseline uses the nD-FDM coupled path (those are GFDM/SL/particle), so no paper baseline is affected — but flagging per policy.

Closes #1423. Part of the #1430 cross-path single-source class.