### PR TITLE
refactor(drift): single-source FP/HJB drift coefficient + strict-adjoint pair (#1420, G-017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Validated <1.2% vs the analytic Hopf-Lax and <0.5% vs FDM across {kinetic, +V(x), +f(m)} ×
   λ∈{0.5, 1, 2}; new `TestSLHJBConsistency` regression gate. No paper experiments use SL.
 
+- **FP/HJB drift single-sourced from `control_cost`, not `coupling_coefficient`** (Issue #1420,
+  gotcha G-017; PR #1441 + follow-up). The MFG optimal feedback `α* = -∇U/control_cost` was computed
+  in the FP-FDM coupled path (and the strict-adjoint `build_advection_matrix` /
+  `solve_fp_step_adjoint_mode` pair) from the independent `MFGProblem.coupling_coefficient` field
+  (default 0.5) instead of the Hamiltonian's `control_cost`. With `coupling_coefficient ≠
+  1/control_cost` the HJB and FP used inconsistent control costs and converged to the wrong fixed
+  point (exp16 Tier-2 had the Towel equilibrium ~4-5× too wide). The drift coefficient is now
+  single-sourced via `pde_coefficients.fp_drift_coefficient` (`1/control_cost` for a
+  quadratic-MINIMIZE `SeparableHamiltonian`; falls back to `coupling_coefficient` for
+  `QuadraticMFGHamiltonian` / non-Hamiltonian solves). Byte-identical when `coupling_coefficient ==
+  1/control_cost`; the LQ-FDM coupled golden was regenerated for the corrected physics (validated
+  end-to-end against exp16, `KL_tavg = 8.0e-3`).
+
 ### Changed
 
 - **Hamiltonian as single source of truth — solver-level physics re-derivation retired** (Issue

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -754,8 +754,13 @@ class FPFDMSolver(BaseFPSolver):
         # n_time_points = number of time knots (including t=0 and t=T)
         # This allows tests to pass edge cases like n_time_points=0 or n_time_points=1
         n_time_points = U_solution_for_drift.shape[0]
+        from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
+
         sigma_base = self.problem.sigma  # Base diffusion (scalar or array)
-        coupling_coefficient = getattr(self.problem, "coupling_coefficient", 1.0)
+        # Issue #1420 / G-017: source the drift coefficient from the Hamiltonian's control_cost
+        # (the single source), not the independent coupling_coefficient field. Matches the HJB-side
+        # build_advection_matrix so the strict-adjoint relation A_fp = A_hjb.T is preserved.
+        coupling_coefficient = fp_drift_coefficient(self.problem)
 
         if n_time_points == 0:
             if self.backend is not None:

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -66,7 +66,12 @@ from mfgarchon.geometry.boundary.applicator_base import (
     LinearConstraint,
 )
 from mfgarchon.geometry.boundary.types import BoundaryFace
-from mfgarchon.utils.pde_coefficients import CoefficientField, _DriftDispatcher, diffusion_from_volatility
+from mfgarchon.utils.pde_coefficients import (
+    CoefficientField,
+    _DriftDispatcher,
+    diffusion_from_volatility,
+    fp_drift_coefficient,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -558,36 +563,6 @@ def solve_timestep_explicit_with_drift(
     return M_next
 
 
-def _fp_drift_coefficient(problem: Any) -> float:
-    """Single-source the FP drift coefficient ``c`` (drift = ``-c·∇U``) from the Hamiltonian's
-    control law, not the independent ``coupling_coefficient`` field (Issue #1420 / gotcha G-017).
-
-    For a smooth separable quadratic control cost ``H_control = |p|²/(2·control_cost)`` (MINIMIZE) —
-    the only Hamiltonian the value-function (``-c·∇U``) drift path serves — the optimal feedback is
-    ``α* = -∇U/control_cost``, so ``c = 1/control_cost``. ``control_cost`` is owned by the
-    Hamiltonian (``problem.hamiltonian_class.control_cost.lambda_``), the single source also used by
-    ``H.optimal_control`` and the HJB Jacobian. The legacy ``coupling_coefficient`` attribute is a
-    private copy that must equal ``1/control_cost`` but silently diverged from it (default 0.5),
-    making the coupled solve converge to the wrong fixed point (G-017; exp16 Tier-2).
-
-    Falls back to the legacy ``coupling_coefficient`` attribute only when there is no quadratic
-    MINIMIZE separable Hamiltonian to source from — i.e. a non-Hamiltonian direct
-    ``solve_fp_system`` call. Non-smooth / congestion / MAXIMIZE Hamiltonians never reach this path
-    (``resolve_fp_drift_kwargs`` routes them to the velocity ``drift_field`` channel), and
-    ``CongestionHamiltonian`` is not a ``SeparableHamiltonian`` so it is excluded here by type.
-    """
-    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
-
-    h_class = getattr(problem, "hamiltonian_class", None)
-    if (
-        isinstance(h_class, SeparableHamiltonian)
-        and isinstance(h_class.control_cost, QuadraticControlCost)
-        and h_class.control_cost.sign == 1  # OptimizationSense.MINIMIZE
-    ):
-        return 1.0 / h_class.control_cost.lambda_
-    return getattr(problem, "coupling_coefficient", 1.0)
-
-
 def solve_fp_nd_full_system(
     m_initial_condition: np.ndarray,
     U_solution_for_drift: np.ndarray | None,
@@ -696,7 +671,7 @@ def solve_fp_nd_full_system(
     dt = problem.dt
     # Issue #1420 / G-017: source the drift coefficient from the Hamiltonian's control_cost
     # (the single source α* = -∇U/control_cost), not the independent coupling_coefficient field.
-    coupling_coefficient = _fp_drift_coefficient(problem)
+    coupling_coefficient = fp_drift_coefficient(problem)
 
     # Get grid spacing and geometry
     spacing = problem.geometry.get_grid_spacing()

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -21,7 +21,7 @@ from mfgarchon.geometry.base import CartesianGrid  # nD FDM needs structured gri
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical import FixedPointSolver, NewtonSolver
-from mfgarchon.utils.pde_coefficients import CoefficientField, diffusion_from_volatility
+from mfgarchon.utils.pde_coefficients import CoefficientField, diffusion_from_volatility, fp_drift_coefficient
 
 from . import base_hjb
 from .base_hjb import BaseHJBSolver
@@ -996,7 +996,7 @@ class HJBFDMSolver(BaseHJBSolver):
 
         # Get coupling coefficient
         if coupling_coefficient is None:
-            coupling_coefficient = getattr(self.problem, "coupling_coefficient", 1.0)
+            coupling_coefficient = fp_drift_coefficient(self.problem)
 
         # Compute gradient ∂U/∂x using BC-aware computation
         bc = self.get_boundary_conditions()
@@ -1071,7 +1071,7 @@ class HJBFDMSolver(BaseHJBSolver):
 
         # Get coupling coefficient
         if coupling_coefficient is None:
-            coupling_coefficient = getattr(self.problem, "coupling_coefficient", 1.0)
+            coupling_coefficient = fp_drift_coefficient(self.problem)
 
         # Compute gradients using trait-based operators
         gradients = self._compute_gradients_nd(U, time=time)

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -21,6 +21,37 @@ if TYPE_CHECKING:
     from mfgarchon.core.mfg_problem import MFGProblem
 
 
+def fp_drift_coefficient(problem: Any) -> float:
+    """Single-source the MFG drift coefficient ``c`` (drift ``= -c·∇U``) from the Hamiltonian's
+    control law, not the independent ``coupling_coefficient`` field (Issue #1420 / gotcha G-017).
+
+    For a smooth separable quadratic control cost ``H_control = |p|²/(2·control_cost)`` (MINIMIZE),
+    the optimal feedback is ``α* = -∇U/control_cost``, so ``c = 1/control_cost``. ``control_cost`` is
+    owned by the Hamiltonian (``problem.hamiltonian_class.control_cost.lambda_``) — the single source
+    also consumed by ``H.optimal_control`` and the HJB Jacobian. The legacy ``coupling_coefficient``
+    attribute is a private copy that must equal ``1/control_cost`` but silently diverged from it
+    (``MFGProblem`` default 0.5), making the coupled solve converge to the wrong fixed point
+    (G-017; exp16 Tier-2 had the Towel equilibrium ~4-5x too wide).
+
+    Falls back to the legacy ``coupling_coefficient`` attribute when there is no quadratic MINIMIZE
+    separable Hamiltonian to source from: a non-``SeparableHamiltonian`` Hamiltonian (e.g.
+    ``QuadraticMFGHamiltonian``, which carries its own ``coupling_coefficient``) or a non-Hamiltonian
+    direct solve. Non-smooth / congestion / MAXIMIZE control costs never reach the ``-c·∇U`` path
+    (``resolve_fp_drift_kwargs`` routes them to the velocity ``drift_field`` channel), and
+    ``CongestionHamiltonian`` is not a ``SeparableHamiltonian`` so it is excluded here by type.
+    """
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+
+    h_class = getattr(problem, "hamiltonian_class", None)
+    if (
+        isinstance(h_class, SeparableHamiltonian)
+        and isinstance(h_class.control_cost, QuadraticControlCost)
+        and h_class.control_cost.sign == 1  # OptimizationSense.MINIMIZE
+    ):
+        return 1.0 / h_class.control_cost.lambda_
+    return getattr(problem, "coupling_coefficient", 1.0)
+
+
 def diffusion_from_volatility(
     sigma: float | np.ndarray,
     *,


### PR DESCRIPTION
## Summary

Follow-up to #1441 (G-017 FP-FDM drift fix). Promotes the drift-coefficient helper to a shared
public utility and applies it to the remaining independent forks, so the MFG drift coefficient is
single-sourced from the Hamiltonian's `control_cost` (`α* = -∇U/control_cost`) rather than the
independent `MFGProblem.coupling_coefficient` field (Issue #1420 / gotcha G-017).

## Change

- **`pde_coefficients.fp_drift_coefficient(problem)`** — promoted from a private
  `fp_fdm_time_stepping` function to a shared util. Returns `1/control_cost` for a quadratic-MINIMIZE
  `SeparableHamiltonian`; falls back to the legacy `coupling_coefficient` for `QuadraticMFGHamiltonian`
  (which carries its own `coupling_coefficient`) or non-Hamiltonian solves. `CongestionHamiltonian` /
  non-smooth / MAXIMIZE are excluded by type (and never reach the `-c·∇U` path).
- **`fp_fdm_time_stepping`** imports the shared util (behavior-identical to #1441).
- **Strict-adjoint pair** now both source via the shared util — `fp_fdm.solve_fp_step_adjoint_mode`
  (FP side) and `hjb_fdm.build_advection_matrix` (HJB side) — so they stay consistent
  (`A_fp = A_hjbᵀ` preserved) and the `SeparableHamiltonian` case is corrected. `QuadraticMFGHamiltonian`
  is unchanged (falls back), so `test_true_adjoint` is unaffected.
- **CHANGELOG** `[Unreleased]` entry for the G-017 single-source-drift work.

## Validation

| Level | Result |
|---|---|
| CI gate (`-m "not slow"`, the full Test-Suite subset) | **1541 passed, 0 failed** (117 slow deselected; 2 xpassed are pre-existing #583) |
| Targeted | `test_true_adjoint` + G-017 pin + regression goldens pass |
| `@slow` MMS-EOC coupled test | **passes in 219s** (byte-identical here — `coupling_coefficient=1/lambda=1/control_cost`) |

`build_advection_matrix` is exercised only by `QuadraticMFGHamiltonian` problems (`test_true_adjoint`,
BlockNewton), where the helper falls back to the same value as before — so this is a no-op there and a
fix for any `SeparableHamiltonian` use of that path.

## Remaining (subsequent increments)

`fp_fvm` / `fp_particle` drift forks, synthetic-U scaffolding deletion (`fixed_point_iterator`,
`multi_population_iterator`), and the SL/adjoint-SL `1/λ` fix (S0-03, behavior-change, its own PR).

Refs #1420, #1430. Follow-up to #1441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
