### PR TITLE
refactor(drift): single-source FVM + particle drift from control_cost (#1420, G-017)

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
@@ -64,7 +64,7 @@ from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConven
 from mfgarchon.alg.numerical.fp_solvers.fp_fvm_flux import advective_divergence
 from mfgarchon.operators.differential.laplacian import LaplacianOperator
 from mfgarchon.utils.mfg_logging import get_logger
-from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -226,7 +226,9 @@ class FPFVMSolver(BaseFPSolver):
     # ------------------------------------------------------------------
     def _face_velocity_from_potential(self, u_slice: np.ndarray):
         """alpha_{i+1/2} = -coupling*(U_{i+1} - U_i)/dx per axis (+ periodic wrap face)."""
-        coupling = float(self.problem.coupling_coefficient)
+        # Issue #1420 / G-017: source the drift coefficient from the Hamiltonian's control_cost
+        # (single source), not the independent coupling_coefficient field.
+        coupling = fp_drift_coefficient(self.problem)
         spacing = list(self.problem.geometry.get_grid_spacing())
         ndim = u_slice.ndim
         alpha_faces: list[np.ndarray] = []

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -355,9 +355,12 @@ class FPParticleSolver(BaseFPSolver):
         # constructor, so it is never None here; the prior `else 0.1` silent
         # default was dead defensive code masking a malformed problem.
         sigma = self.problem.sigma
-        coupling_coefficient = (
-            self.problem.coupling_coefficient if self.problem.coupling_coefficient is not None else 1.0
-        )
+        # Issue #1420 / G-017: source the drift coefficient from the Hamiltonian's control_cost
+        # (single source), not the independent coupling_coefficient field. This params value flows
+        # to every particle drift path (CPU 1D/nD + GPU) via params["coupling_coefficient"].
+        from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
+
+        coupling_coefficient = fp_drift_coefficient(self.problem)
 
         result = {
             # nD parameters

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -38,7 +38,8 @@ def fp_drift_coefficient(problem: Any) -> float:
     ``QuadraticMFGHamiltonian``, which carries its own ``coupling_coefficient``) or a non-Hamiltonian
     direct solve. Non-smooth / congestion / MAXIMIZE control costs never reach the ``-c·∇U`` path
     (``resolve_fp_drift_kwargs`` routes them to the velocity ``drift_field`` channel), and
-    ``CongestionHamiltonian`` is not a ``SeparableHamiltonian`` so it is excluded here by type.
+    ``CongestionHamiltonian`` is not a ``SeparableHamiltonian`` so it is excluded here by type. A
+    ``coupling_coefficient`` of ``None`` (absent / explicitly unset) falls back to ``1.0``.
     """
     from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 
@@ -49,7 +50,8 @@ def fp_drift_coefficient(problem: Any) -> float:
         and h_class.control_cost.sign == 1  # OptimizationSense.MINIMIZE
     ):
         return 1.0 / h_class.control_cost.lambda_
-    return getattr(problem, "coupling_coefficient", 1.0)
+    cc = getattr(problem, "coupling_coefficient", None)
+    return float(cc) if cc is not None else 1.0
 
 
 def diffusion_from_volatility(


### PR DESCRIPTION
## Summary

Follow-up to #1441/#1442. Applies `pde_coefficients.fp_drift_coefficient` to the remaining solver
drift forks, so the FP drift coefficient is single-sourced from the Hamiltonian's `control_cost`
rather than the independent `MFGProblem.coupling_coefficient` field (Issue #1420 / gotcha G-017).

## Change

- **`fp_fvm._face_velocity_from_potential`**: `α_{i+1/2} = -coupling·ΔU/dx` now sources `coupling`
  via `fp_drift_coefficient(problem)`.
- **`fp_particle`**: the `params["coupling_coefficient"]` source — which flows to **every** particle
  drift path (CPU 1D/nD + GPU) — now uses `fp_drift_coefficient(problem)`.
- **`fp_drift_coefficient`**: fallback hardened to be None-safe (`coupling_coefficient` of `None` →
  `1.0`), preserving the particle solver's prior `is not None else 1.0` guard.

For a quadratic-MINIMIZE `SeparableHamiltonian` the coefficient is now `1/control_cost` (corrects the
G-017 mismatch); `QuadraticMFGHamiltonian` / non-Hamiltonian solves fall back to `coupling_coefficient`
(unchanged). No FVM/particle golden fixtures exist, so none needed regeneration.

## Validation

| Level | Result |
|---|---|
| CI gate (`-m "not slow"`) | **1541 passed, 0 failed** (117 slow deselected; 2 xpassed pre-existing #583) |
| Targeted (`fvm`/`particle`/`g017`/`true_adjoint`/`golden`) | 111 passed |

Refs #1420, #1430. Follow-up to #1441/#1442.

## Remaining (subsequent increments)

Synthetic-U scaffolding deletion (`fixed_point_iterator`, `multi_population_iterator`), then the
SL/adjoint-SL `1/λ` fix (S0-03, behavior-change, its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
