### PR TITLE
refactor(coupling): remove dead synthetic-U + velocity drift methods (#1420, #1430)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -24,7 +24,6 @@ from mfgarchon.utils.solver_result import SolverResult
 from .base_mfg import BaseCouplingIterator
 from .fixed_point_utils import (
     check_convergence_criteria,
-    compute_fp_velocity_field,
     initialize_cold_start,
     preserve_initial_condition,
     preserve_terminal_condition,
@@ -347,84 +346,6 @@ class FixedPointIterator(BaseCouplingIterator):
             stacklevel=2,
         )
         return np.zeros(shape)
-
-    def _compute_drift_field(self, U, M, H_class):
-        """Compute α* from U via H.optimal_control, return as synthetic U.
-
-        Issue #896: replaces the quadratic assumption (effective_drift = U).
-        Computes α* = H.optimal_control(x, m, ∇U, t) at each time step,
-        then integrates α* to produce a synthetic U field whose finite
-        differences reproduce the correct velocity in the legacy FP solver.
-
-        For quadratic H (α* = -∇U/λ), this is equivalent to U/λ.
-        For non-quadratic H, the synthetic U encodes the non-linear control.
-
-        Currently 1D only. For nD problems, falls back to passing U directly
-        (correct for quadratic H; TODO: extend synthetic-U to nD).
-        """
-        import numpy as np
-
-        # For separable H with smooth (quadratic) control cost, the FP solver's
-        # internal drift extraction (-coupling_coefficient * ∇U) is already
-        # correct: it reproduces α* = -∇U/λ. The synthetic-U reconstruction
-        # introduces unnecessary numerical integration error.
-        # Only use synthetic-U for non-smooth or non-quadratic H.
-        from mfgarchon.core.hamiltonian import SeparableHamiltonian
-
-        if isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth():
-            return U
-
-        # Synthetic-U integration is 1D only. For nD with non-smooth H,
-        # the reconstruction requires solving ∇U_syn = -α*/c (a Poisson-like
-        # problem). This is deferred; for now, fall back to U (which is exact
-        # for quadratic H and approximate for others).
-        if U.ndim > 2:
-            logger.warning(
-                "Non-smooth H with nD problem: synthetic-U drift not yet supported. "
-                "Falling back to U as drift potential (exact only for quadratic H)."
-            )
-            return U
-
-        geometry = self.problem.geometry
-        grid_spacing = geometry.get_grid_spacing()
-        dx = grid_spacing[0]
-        dt = self.problem.dt
-        Nt = U.shape[0]
-        Nx = U.shape[-1]
-        coupling_coefficient = getattr(self.problem, "coupling_coefficient", 1.0)
-
-        # Compute ∇U via central differences
-        grad_U = np.gradient(U, dx, axis=-1)
-
-        # Compute α* at grid points for all time steps
-        bounds = geometry.get_bounds()
-        x_grid = np.linspace(bounds[0][0], bounds[1][0], Nx).reshape(-1, 1)
-
-        alpha_field = np.zeros_like(grad_U)
-        for n in range(Nt):
-            p = grad_U[n]
-            m_n = M[n] if n < M.shape[0] else M[-1]
-            alpha_field[n] = H_class.optimal_control(x_grid, m_n, p.reshape(-1, 1), t=n * dt).ravel()
-
-        # Construct synthetic U such that:
-        #   -coupling_coefficient * (U_syn[i+1] - U_syn[i]) / dx ≈ α*[i+1/2]
-        # => U_syn[i+1] - U_syn[i] = -α*[i+1/2] * dx / coupling_coefficient
-        # Using midpoint α*[i+1/2] ≈ (α*[i] + α*[i+1]) / 2
-        alpha_mid = 0.5 * (alpha_field[:, :-1] + alpha_field[:, 1:])  # (Nt, Nx-1)
-        increments = -alpha_mid * dx / coupling_coefficient
-        U_synthetic = np.zeros_like(U)
-        U_synthetic[:, 1:] = np.cumsum(increments, axis=-1)
-
-        return U_synthetic
-
-    def _compute_velocity_field(self, U, M, H_class):
-        """Compute face-centered velocity α* via H.optimal_control.
-
-        Issue #1233: single-sourced through
-        :func:`fixed_point_utils.compute_fp_velocity_field` (shared with the Newton
-        ``MFGResidual``). The face-centered convention (Issue #919) is unchanged.
-        """
-        return compute_fp_velocity_field(self.problem, U, M, H_class)
 
     def solve(
         self,

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -229,56 +229,6 @@ class MultiPopulationIterator:
             population_names=self.multi_problem.population_names,
         )
 
-    @staticmethod
-    def _compute_drift_field(U, M, H_class, problem):
-        """Deprecated: use _compute_velocity_field instead.
-
-        Kept for backward compatibility. Returns synthetic U potential.
-        """
-        # Issue #915: dispatch on problem type
-        spatial_dim = getattr(problem, "spatial_dimension", None)
-        if spatial_dim == 0:
-            # Network problem: pass U directly.
-            # FPNetworkSolver computes flows from U differences.
-            # TODO (#913): FPNetworkSolver should use H.optimal_control()
-            return U
-
-        # For smooth separable H, the FP solver's internal drift extraction
-        # (-coupling_coefficient * ∇U) is already correct. Skip synthetic-U.
-        from mfgarchon.core.hamiltonian import SeparableHamiltonian
-
-        if isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth():
-            return U
-
-        # Non-smooth H, 1D only: synthetic U approach
-        if U.ndim > 2:
-            return U  # nD non-smooth: deferred
-
-        # Continuous problem: synthetic U approach (same as FixedPointIterator)
-        geometry = problem.geometry
-        grid_spacing = geometry.get_grid_spacing()
-        dx = grid_spacing[0]
-        dt = problem.dt
-        Nt = U.shape[0]
-        Nx = U.shape[-1]
-        coupling_coefficient = getattr(problem, "coupling_coefficient", 1.0)
-
-        grad_U = np.gradient(U, dx, axis=-1)
-        bounds = geometry.get_bounds()
-        x_grid = np.linspace(bounds[0][0], bounds[1][0], Nx).reshape(-1, 1)
-
-        alpha_field = np.zeros_like(grad_U)
-        for n in range(Nt):
-            p = grad_U[n]
-            m_n = M[n] if n < M.shape[0] else M[-1]
-            alpha_field[n] = H_class.optimal_control(x_grid, m_n, p.reshape(-1, 1), t=n * dt).ravel()
-
-        alpha_mid = 0.5 * (alpha_field[:, :-1] + alpha_field[:, 1:])
-        increments = -alpha_mid * dx / coupling_coefficient
-        U_synthetic = np.zeros_like(U)
-        U_synthetic[:, 1:] = np.cumsum(increments, axis=-1)
-        return U_synthetic
-
 
 class MultiPopulationResult:
     """Result of multi-population MFG solve.

--- a/mfgarchon/utils/drift_helpers.py
+++ b/mfgarchon/utils/drift_helpers.py
@@ -133,7 +133,8 @@ def optimal_control_drift(
             alpha = H.optimal_control(x, m, grad_U, t)
 
         The FixedPointIterator handles this automatically via
-        ``_compute_drift_field()``. Will be removed in v0.25.0.
+        ``fixed_point_utils.resolve_fp_drift_kwargs`` /
+        ``fixed_point_utils.compute_fp_velocity_field``. Will be removed in v0.25.0.
 
     Equation:
         α(t,x) = -∇U(t,x) / λ

--- a/tests/unit/test_alg/test_fp_nonquadratic.py
+++ b/tests/unit/test_alg/test_fp_nonquadratic.py
@@ -343,7 +343,7 @@ class TestFixedPointIteratorDrift:
         )
 
     def test_quadratic_drift_matches_legacy(self):
-        """Quadratic H through _compute_drift_field should match passing U directly."""
+        """Quadratic H through the FixedPointIterator drift pipeline should match passing U directly."""
         from mfgarchon.alg.numerical.coupling import FixedPointIterator
         from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 


### PR DESCRIPTION
## Summary

Follow-up to #1441/#1442/#1443 (FP-drift single-source, Issue #1420 / G-017). Removes dead drift/velocity
methods on the Picard iterators, superseded by `fixed_point_utils.resolve_fp_drift_kwargs` /
`compute_fp_velocity_field` (Issue #1233). These are the G-017 "synthetic-U scaffolding" (note step 9):
the inverse-map existed only to feed the legacy potential-field FP path; with the drift now
single-sourced through `optimal_control`, it is unreachable.

## Change

- **`FixedPointIterator._compute_drift_field`** — the synthetic-U inverse-map (integrate `α*` back into
  a synthetic `U` via `-coupling_coefficient` cumsum) — and **`._compute_velocity_field`**: both private,
  **zero callers**, removed. The now-unused `compute_fp_velocity_field` import is dropped (`logger`
  retained — 3 other uses).
- **`MultiPopulationIterator._compute_drift_field`** (the multi-pop synthetic-U analog): removed.
- Doc-only: `drift_helpers.optimal_control_drift` docstring and the `test_fp_nonquadratic` docstring
  now point at the live pipeline (no behavior change).

Net: **3 insertions, 131 deletions.** No production behavior change (the deleted methods had no callers;
the one test that *named* `_compute_drift_field` only exercises `iterator.solve()`).

## Validation

Full **unit + integration + regression** (`-m "not slow"`): **4996 passed, 0 failed** (140 slow
deselected; 2 xpassed pre-existing #583). ruff format/check clean; fail-fast ratchet OK; both coupling
modules import cleanly.

Refs #1420, #1430. Follow-up to #1441/#1442/#1443. Remaining: SL/adjoint-SL `1/λ` (S0-03, behavior-change, its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
