### PR TITLE
fix(fp-sl): include 1/control_cost factor in semi-Lagrangian FP drift (#1420, S0-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1/control_cost`; the LQ-FDM coupled golden was regenerated for the corrected physics (validated
   end-to-end against exp16, `KL_tavg = 8.0e-3`).
 
+- **Semi-Lagrangian FP drift now includes the `1/control_cost` factor** (Issue #1420, audit finding
+  S0-03). `FPSLJacobianSolver` and `FPSLSolver`/`FPSLAdjointSolver` computed the drift as `α = -∇U`,
+  dropping the `1/λ` factor entirely, so for `control_cost ≠ 1` the transported drift had the wrong
+  magnitude (the HJB used `λ` while the FP advected `c_eff = 1`). The drift is now
+  `α* = -∇U/control_cost` (and the Jacobian-SL divergence shortcut `div(α) = -c·ΔU` carries the same
+  `c`), single-sourced via `pde_coefficients.fp_drift_coefficient`. Byte-identical when
+  `control_cost == 1`; corrected otherwise. New `test_fp_sl_drift_control_cost_s003` regression gate.
+
 ### Changed
 
 - **Hamiltonian as single source of truth — solver-level physics re-derivation retired** (Issue

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -44,7 +44,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
 from mfgarchon.operators.stencils.finite_difference import laplacian_with_bc
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
-from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
 
 from .base_fp import BaseFPSolver, DriftConvention
 
@@ -291,8 +291,14 @@ class FPSLJacobianSolver(BaseFPSolver):
         return M
 
     def _compute_velocity(self, U: np.ndarray) -> np.ndarray:
-        """Compute velocity field alpha = -grad(U)."""
-        return -np.gradient(U, self.dx)
+        """Compute the optimal-control drift alpha* = -grad(U) / control_cost.
+
+        Issue #1420 / G-017 / S0-03: the coefficient is single-sourced from the Hamiltonian's
+        control_cost via ``fp_drift_coefficient`` (= 1/control_cost for a quadratic
+        SeparableHamiltonian), not hardcoded to 1 (which dropped the 1/lambda factor for
+        control_cost != 1). Byte-identical when control_cost == 1.
+        """
+        return -fp_drift_coefficient(self.problem) * np.gradient(U, self.dx)
 
     def _compute_divergence_from_U(self, U: np.ndarray) -> np.ndarray:
         """
@@ -327,7 +333,9 @@ class FPSLJacobianSolver(BaseFPSolver):
         # Compute Laplacian with proper ghost cell handling
         lap_U = laplacian_with_bc(U, spacings=[self.dx], bc=extrap_bc)
 
-        return -lap_U
+        # div(alpha) = div(-c*grad U) = -c*Laplacian(U); c = 1/control_cost single-sourced
+        # via fp_drift_coefficient (Issue #1420 / S0-03), consistent with _compute_velocity.
+        return -fp_drift_coefficient(self.problem) * lap_U
 
     def _apply_boundary_conditions(self, x_dep: np.ndarray) -> np.ndarray:
         """

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -43,7 +43,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
 )
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
-from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
 
 from .base_fp import BaseFPSolver, DriftConvention
 from .fp_sl_splatting import splat_1d, splat_nd
@@ -329,20 +329,26 @@ class FPSLSolver(BaseFPSolver):
         return M
 
     def _compute_velocity_1d(self, U: np.ndarray) -> np.ndarray:
-        """Compute velocity field alpha = -grad(U) for 1D."""
-        return -np.gradient(U, self.dx)
+        """Compute the optimal-control drift alpha* = -grad(U) / control_cost for 1D.
+
+        Issue #1420 / G-017 / S0-03: coefficient single-sourced via ``fp_drift_coefficient``
+        (= 1/control_cost), not hardcoded to 1. Byte-identical when control_cost == 1.
+        """
+        return -fp_drift_coefficient(self.problem) * np.gradient(U, self.dx)
 
     def _compute_velocity_nd(self, U: np.ndarray) -> tuple[np.ndarray, ...]:
         """
-        Compute velocity field alpha = -grad(U) for nD.
+        Compute the optimal-control drift alpha* = -grad(U) / control_cost for nD.
 
-        Returns tuple of arrays, one per dimension.
+        Issue #1420 / G-017 / S0-03: coefficient single-sourced via ``fp_drift_coefficient``
+        (= 1/control_cost), not hardcoded to 1. Returns a tuple, one array per dimension.
         """
         # Use np.gradient with spacing for each dimension
+        c = fp_drift_coefficient(self.problem)
         gradients = np.gradient(U, *[self.spacing[d] for d in range(self.dimension)])
         if self.dimension == 1:
-            return (-gradients,)
-        return tuple(-g for g in gradients)
+            return (-c * gradients,)
+        return tuple(-c * g for g in gradients)
 
     def _adjoint_sl_step_1d(
         self,

--- a/tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py
+++ b/tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Issue #1420 / G-017 / audit finding S0-03: the semi-Lagrangian FP solvers computed the drift as
+``alpha = -grad(U)`` — dropping the ``1/lambda`` (``1/control_cost``) factor — so for
+``control_cost != 1`` the transported drift had the wrong magnitude (the HJB used control cost
+``lambda`` while the FP advected ``-grad(U)``, i.e. ``c_eff = 1``).
+
+The fix single-sources the drift coefficient from the Hamiltonian's ``control_cost`` via
+``pde_coefficients.fp_drift_coefficient`` (= ``1/control_cost`` for a quadratic-MINIMIZE
+``SeparableHamiltonian``), so ``alpha* = -grad(U)/control_cost``. This is **byte-identical when
+``control_cost == 1``** and corrects the magnitude otherwise. The divergence shortcut stays
+consistent: ``div(alpha) = -c * Laplacian(U)``.
+
+This is a behaviour change for ``control_cost != 1`` (the S0-03 bug). These pins assert the corrected
+drift and that it is distinct from the old ``-grad(U)`` (the relevance guard).
+
+Refs #1420, #1430. Audit finding S0-03.
+"""
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+N = 21
+
+
+def _problem(control_cost: float) -> MFGProblem:
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[N], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=control_cost)),
+    )
+    return MFGProblem(geometry=grid, components=comp, T=0.5, Nt=5, sigma=0.3)
+
+
+def _U() -> np.ndarray:
+    x = np.linspace(0.0, 1.0, N)
+    return 0.5 * (x - 0.3) ** 2  # non-trivial, nonzero gradient
+
+
+@pytest.mark.parametrize("control_cost", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize(
+    ("solver_cls", "vel_method"), [(FPSLJacobianSolver, "_compute_velocity"), (FPSLSolver, "_compute_velocity_1d")]
+)
+def test_sl_velocity_uses_control_cost(solver_cls, vel_method, control_cost):
+    """SL drift must be α* = -∇U/control_cost (S0-03), not -∇U."""
+    problem = _problem(control_cost)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver = solver_cls(problem)
+    u = _U()
+    alpha = np.asarray(getattr(solver, vel_method)(u)).ravel()
+    expected = (-np.gradient(u, solver.dx) / control_cost).ravel()
+    np.testing.assert_allclose(alpha, expected, rtol=0, atol=1e-12, err_msg="SL drift must be -∇U/control_cost (S0-03)")
+    if control_cost != 1.0:
+        # Relevance guard: distinct from the pre-fix -∇U (the dropped-1/λ bug)
+        assert not np.allclose(alpha, -np.gradient(u, solver.dx), atol=1e-9), (
+            "SL drift is still -∇U (missing 1/control_cost) for control_cost != 1 (S0-03 not fixed)"
+        )
+
+
+@pytest.mark.parametrize("control_cost", [0.5, 1.0, 2.0])
+def test_sl_jacobian_divergence_uses_control_cost(control_cost):
+    """The Jacobian-SL div(α) = div(-c·∇U) = -c·ΔU must carry the same control_cost factor."""
+    problem = _problem(control_cost)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver = FPSLJacobianSolver(problem)
+    u = _U()
+    div_alpha = np.asarray(solver._compute_divergence_from_U(u)).ravel()
+    div_unit = np.asarray(FPSLJacobianSolver(_problem(1.0))._compute_divergence_from_U(u)).ravel()
+    # div scales linearly with c = 1/control_cost
+    np.testing.assert_allclose(div_alpha, div_unit / control_cost, rtol=0, atol=1e-12)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary

Audit finding **S0-03** (Issue #1420). The semi-Lagrangian FP solvers computed the drift as
`α = -∇U`, **dropping the `1/λ` (`1/control_cost`) factor entirely**. For `control_cost ≠ 1` the
transported drift had the wrong magnitude — the HJB used control cost `λ` while the FP advected
`c_eff = 1`, an inconsistent MFG. (Same G-017 class as #1441, but the SL path *omitted* the factor
outright rather than mis-sourcing it.)

## Change

- **`FPSLJacobianSolver`** (`fp_semi_lagrangian.py`): `_compute_velocity` → `α* = -∇U/control_cost`;
  `_compute_divergence_from_U` → `div(α) = -c·ΔU` carries the same `c`.
- **`FPSLSolver`/`FPSLAdjointSolver`** (`fp_semi_lagrangian_adjoint.py`): `_compute_velocity_1d` /
  `_compute_velocity_nd` → same `1/control_cost` factor (1D + nD).

The coefficient is single-sourced via `pde_coefficients.fp_drift_coefficient`
(`= 1/control_cost` for a quadratic-MINIMIZE `SeparableHamiltonian`), consistent with the
FDM/FVM/particle paths. **Behaviour change for `control_cost ≠ 1`** (corrects the bug);
**byte-identical when `control_cost == 1`**.

## Validation

| Level | Result |
|---|---|
| New `test_fp_sl_drift_control_cost_s003` (9 cases) | asserts `α* = -∇U/control_cost` across both SL classes + the divergence factor; relevance guard vs the pre-fix `-∇U` |
| Full unit+integration+regression (`-m "not slow"`) | **5005 passed, 0 failed** (140 slow deselected; 2 xpassed pre-existing #583) |

Existing SL suite (control_cost=1) stays green (71 passed) — confirms byte-identity at `control_cost=1`.

Refs #1420, #1430. **Completes** the FP-drift single-source campaign (#1441/#1442/#1443/#1444 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
