### PR TITLE
fix(coupling): fail loud instead of advecting U as a velocity for velocity-only FP solvers (#1420 V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `c`), single-sourced via `pde_coefficients.fp_drift_coefficient`. Byte-identical when
   `control_cost == 1`; corrected otherwise. New `test_fp_sl_drift_control_cost_s003` regression gate.
 
+- **Coupling layer fails loud instead of advecting the value function as a velocity** (Issue #1420
+  V2). For a smooth-separable Hamiltonian, `resolve_fp_drift_kwargs` routed `U` to a velocity-only FP
+  solver (one exposing `drift_field`=α* but no `potential_field`, e.g. `FPGFDMSolver`) as
+  `drift_field=U` — silently advecting the value function as a velocity. Since such solvers are
+  meshfree (the coupling layer cannot derive α* at their collocation points), this now raises a
+  `ValueError` directing the caller to pass an explicit `drift_field=α*` or use a `potential_field`-
+  capable solver. `FPGFDMSolver` declares `_drift_convention = VELOCITY` explicitly. No previously
+  passing path is affected (the fp_gfdm tests use the explicit precomputed-drift path).
+
 ### Changed
 
 - **Hamiltonian as single source of truth — solver-level physics re-derivation retired** (Issue

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -568,7 +568,20 @@ def resolve_fp_drift_kwargs(
         elif "potential_field" in params:
             drift_kwargs["potential_field"] = U
         elif "drift_field" in params:
-            drift_kwargs["drift_field"] = U
+            # Issue #1420 (G-017 V2): the FP solver exposes only `drift_field` (the velocity α*,
+            # DriftConvention.VELOCITY) and no `potential_field`. We hold the value function U, not a
+            # velocity, and for a meshfree/collocation solver (e.g. FPGFDMSolver) the coupling layer
+            # cannot derive α* at the solver's own points (compute_fp_velocity_field is grid-based).
+            # Passing U as `drift_field` would silently advect the value function as a velocity — the
+            # exact #1043/V2 bug. Fail loud instead of solving the wrong problem.
+            raise ValueError(
+                "Cannot auto-route the value function as FP drift: the FP solver exposes only "
+                "`drift_field` (velocity α*) and no `potential_field`, so U cannot be passed as a "
+                "velocity (this would silently advect the value function as a velocity). Pass an "
+                "explicit `drift_field=α*` (the precomputed optimal control, e.g. -∇U/control_cost via "
+                "`compute_fp_velocity_field` at the solver's own points), or use an FP solver with "
+                "`potential_field` support (e.g. FPFDMSolver). Issue #1420 (G-017 V2)."
+            )
 
     use_positional_U = not ("drift_field" in params or "potential_field" in params)
     return drift_kwargs, use_positional_U

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import TaylorOperator
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
@@ -67,6 +67,11 @@ class FPGFDMSolver(BaseFPSolver):
         >>> U_drift = np.zeros((21, 100))  # Zero drift
         >>> M = solver.solve_fp_system(m_init, drift_field=U_drift)
     """
+
+    # Issue #1420 (G-017 V2): this meshfree solver consumes the precomputed velocity α* directly
+    # (drift_field), never the value function U — it has no potential_field path. Declared explicit
+    # so the coupling layer (resolve_fp_drift_kwargs) does not auto-route U as a velocity.
+    _drift_convention = DriftConvention.VELOCITY
 
     # Scheme family trait for duality validation (Issue #580)
     from mfgarchon.alg.base_solver import SchemeFamily

--- a/tests/integration/test_1043_coupler_fp_drift_convention.py
+++ b/tests/integration/test_1043_coupler_fp_drift_convention.py
@@ -43,7 +43,8 @@ from mfgarchon.alg.numerical.coupling import (
     FictitiousPlayIterator,
 )
 from mfgarchon.alg.numerical.coupling.fixed_point_utils import resolve_fp_drift_kwargs
-from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver, FPGFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.base_fp import DriftConvention
 from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
@@ -602,6 +603,33 @@ class TestFPNetworkSolverPotentialFieldRename:
         )
         # drift_field still present as deprecated alias (not removed until v0.25.0)
         assert "drift_field" in params, "drift_field must remain as a deprecated alias until v0.25.0 removal."
+
+
+class TestVelocityOnlySolverFailLoud:
+    """Issue #1420 (G-017 V2): for smooth-separable H, a velocity-only FP solver — one that exposes
+    ``drift_field`` (= velocity α*) but no ``potential_field`` (e.g. ``FPGFDMSolver``, which is
+    meshfree, so the coupling layer cannot derive α* at its collocation points) — must NOT have the
+    value function auto-routed as a velocity. ``resolve_fp_drift_kwargs`` now fails loud instead of
+    silently advecting U as α*. (#1043 fixed this for the FDM/``potential_field`` path; the
+    velocity-only path was the remaining gap.)
+    """
+
+    def test_resolve_fails_loud_for_velocity_only_solver(self):
+        problem = _lq_problem()  # smooth-separable LQ
+        nx = 21
+        nt = problem.Nt + 1
+        x = np.linspace(0.0, 1.0, nx)
+        U = np.tile((x - 0.8) ** 2, (nt, 1))
+        M = np.tile(np.exp(-10 * (x - 0.5) ** 2), (nt, 1))
+        # FPGFDMSolver's real signature: drift_field present, potential_field absent (the V2 trigger).
+        gfdm_params = set(inspect.signature(FPGFDMSolver.solve_fp_system).parameters)
+        assert "drift_field" in gfdm_params
+        assert "potential_field" not in gfdm_params
+        with pytest.raises(ValueError, match="Cannot auto-route the value function"):
+            resolve_fp_drift_kwargs(problem, gfdm_params, None, U, M)
+
+    def test_fp_gfdm_declares_velocity_convention(self):
+        assert FPGFDMSolver._drift_convention == DriftConvention.VELOCITY
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Issue **#1420 V2** (G-017 follow-up). For a smooth-separable Hamiltonian, `resolve_fp_drift_kwargs`
routed the value function `U` to a **velocity-only** FP solver — one exposing `drift_field` (= velocity
α*) but no `potential_field`, e.g. `FPGFDMSolver` — as `drift_field=U`, **silently advecting the value
function as a velocity**. (#1043 fixed this for the FDM/`potential_field` path; the velocity-only
fallthrough was the remaining gap, as that test's own docstring notes.)

## Change

- **`resolve_fp_drift_kwargs`** (`fixed_point_utils.py`): the `elif "drift_field" in params:
  drift_kwargs["drift_field"] = U` fallthrough now **raises `ValueError`**. Such solvers are meshfree,
  so the coupling layer cannot derive α* at their collocation points (`compute_fp_velocity_field` is
  grid-based). The error directs the caller to pass an explicit `drift_field=α*` (precomputed optimal
  control) or use a `potential_field`-capable solver (e.g. `FPFDMSolver`).
- **`FPGFDMSolver`** declares `_drift_convention = DriftConvention.VELOCITY` explicitly.

## Validation

- New `TestVelocityOnlySolverFailLoud` (in `test_1043_coupler_fp_drift_convention`): asserts the raise
  (using `FPGFDMSolver`'s real signature — `drift_field` present, `potential_field` absent) + the
  convention declaration.
- **No previously passing path is affected** — the fp_gfdm tests use the explicit precomputed-drift
  path, so the fallthrough was unreachable in tests.
- Full unit+integration+regression (`-m "not slow"`): **5007 passed, 0 failed**.

Refs #1420 (V2), #1430. Part of the G-017 drift single-source hardening (#1441–#1445).

## Remaining #1420 items

V1 (make `fp_drift_coefficient`'s duck-typed fallback fail-loud) and the `canonical_cs` SL λ=1 hardcode
(`hjb_semi_lagrangian`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
