### PR TITLE
refactor(coupling): fp_drift_coefficient fails loud instead of silent 1.0 fallback (#1420 V1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capable solver. `FPGFDMSolver` declares `_drift_convention = VELOCITY` explicitly. No previously
   passing path is affected (the fp_gfdm tests use the explicit precomputed-drift path).
 
+- **`fp_drift_coefficient` fails loud when it cannot source the drift coefficient** (Issue #1420 V1).
+  For a problem with neither a quadratic-MINIMIZE `SeparableHamiltonian` (to source `1/control_cost`)
+  nor a `coupling_coefficient` attribute — a duck-typed / malformed problem — the helper previously
+  returned `1.0` silently (a wrong-temperature drift with no error). It now raises `ValueError`
+  (CLAUDE.md "NO silent fallbacks"). Standard `MFGProblem`s (always carry `coupling_coefficient`) and
+  quadratic-Hamiltonian solves are unaffected.
+
 ### Changed
 
 - **Hamiltonian as single source of truth — solver-level physics re-derivation retired** (Issue

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -38,8 +38,12 @@ def fp_drift_coefficient(problem: Any) -> float:
     ``QuadraticMFGHamiltonian``, which carries its own ``coupling_coefficient``) or a non-Hamiltonian
     direct solve. Non-smooth / congestion / MAXIMIZE control costs never reach the ``-c·∇U`` path
     (``resolve_fp_drift_kwargs`` routes them to the velocity ``drift_field`` channel), and
-    ``CongestionHamiltonian`` is not a ``SeparableHamiltonian`` so it is excluded here by type. A
-    ``coupling_coefficient`` of ``None`` (absent / explicitly unset) falls back to ``1.0``.
+    ``CongestionHamiltonian`` is not a ``SeparableHamiltonian`` so it is excluded here by type.
+
+    Fail-loud (Issue #1420 V1): if there is neither a quadratic-MINIMIZE ``SeparableHamiltonian`` to
+    source ``1/control_cost`` from nor a ``coupling_coefficient`` on the problem, this raises rather
+    than silently returning ``1.0`` (the prior fallback masked a malformed/duck-typed problem getting
+    a wrong-temperature drift with no error — CLAUDE.md "NO silent fallbacks").
     """
     from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 
@@ -51,7 +55,14 @@ def fp_drift_coefficient(problem: Any) -> float:
     ):
         return 1.0 / h_class.control_cost.lambda_
     cc = getattr(problem, "coupling_coefficient", None)
-    return float(cc) if cc is not None else 1.0
+    if cc is None:
+        raise ValueError(
+            "Cannot determine the FP drift coefficient: the problem has no quadratic-MINIMIZE "
+            "SeparableHamiltonian (to source 1/control_cost) and no `coupling_coefficient` attribute. "
+            "Set a quadratic control cost on the Hamiltonian, or set problem.coupling_coefficient. "
+            "(Issue #1420 V1: the prior silent fallback to 1.0 masked a malformed problem.)"
+        )
+    return float(cc)
 
 
 def diffusion_from_volatility(

--- a/tests/unit/test_core/test_pde_coefficients.py
+++ b/tests/unit/test_core/test_pde_coefficients.py
@@ -15,7 +15,7 @@ from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc
-from mfgarchon.utils.pde_coefficients import CoefficientField, get_spatial_grid
+from mfgarchon.utils.pde_coefficients import CoefficientField, fp_drift_coefficient, get_spatial_grid
 
 
 def _default_hamiltonian():
@@ -463,3 +463,37 @@ class TestScalarDiffusionFromVolatility:
             d = scalar_diffusion_from_volatility(arr, 0.3)
         # byte-identical to the prior inline `0.5 * mean(arr)**2`
         assert d == pytest.approx(0.5 * float(np.mean(arr)) ** 2, rel=1e-12)
+
+
+class TestFpDriftCoefficient:
+    """Issue #1420: fp_drift_coefficient single-sources 1/control_cost from a quadratic-MINIMIZE
+    SeparableHamiltonian, falls back to coupling_coefficient otherwise, and fails loud when neither
+    is available (V1 — no silent 1.0 fallback for a malformed/duck-typed problem)."""
+
+    @pytest.mark.parametrize("control_cost", [0.5, 1.0, 2.0])
+    def test_sources_inverse_control_cost_from_quadratic_hamiltonian(self, control_cost):
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+        comp = MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=control_cost)),
+        )
+        prob = MFGProblem(geometry=grid, components=comp, T=0.2, Nt=2, sigma=0.1)
+        # the quadratic-Sep-H path wins over the default coupling_coefficient (0.5)
+        assert fp_drift_coefficient(prob) == pytest.approx(1.0 / control_cost)
+
+    def test_falls_back_to_coupling_coefficient_without_quadratic_hamiltonian(self):
+        class _Obj:
+            hamiltonian_class = None
+            coupling_coefficient = 0.7
+
+        assert fp_drift_coefficient(_Obj()) == pytest.approx(0.7)
+
+    def test_fails_loud_when_no_hamiltonian_and_no_coupling(self):
+        # V1: a duck-typed problem with neither a quadratic SeparableHamiltonian nor
+        # coupling_coefficient must raise, not silently return 1.0.
+        class _Bare:
+            hamiltonian_class = None
+
+        with pytest.raises(ValueError, match="Cannot determine the FP drift coefficient"):
+            fp_drift_coefficient(_Bare())


### PR DESCRIPTION
## Summary

Issue **#1420 V1** (the duck-typed `coupling_coefficient` fallback hygiene item). `fp_drift_coefficient`
previously returned `1.0` **silently** when a problem had neither a quadratic-MINIMIZE
`SeparableHamiltonian` (to source `1/control_cost`) nor a `coupling_coefficient` attribute — a
duck-typed / malformed problem would get a wrong-temperature drift with no error (violates CLAUDE.md
"NO silent fallbacks").

## Change

`fp_drift_coefficient` (`pde_coefficients.py`) now **raises `ValueError`** in that case, directing the
caller to set a quadratic control cost on the Hamiltonian or set `problem.coupling_coefficient`.

- Standard `MFGProblem`s (always carry `coupling_coefficient`, default 0.5) — **unaffected**.
- Quadratic-`SeparableHamiltonian` solves (source `1/control_cost`) — **unaffected**.
- `QuadraticMFGHamiltonian` / explicit-`coupling_coefficient` fallback — **preserved**.

## Validation

- New `TestFpDriftCoefficient` (`test_core/test_pde_coefficients`): `1/control_cost` sourcing,
  `coupling_coefficient` fallback, and the fail-loud for a bare duck-typed problem.
- Full unit+integration+regression (`-m "not slow"`): **5010 passed, 0 failed** — no path relied on the
  silent 1.0 fallback.

Refs #1420 (V1), #1430. Part of the G-017 drift single-source hardening (#1441–#1446).

## Remaining #1420 item

`canonical_cs` SL λ=1 hardcode (`hjb_semi_lagrangian`) — its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
