### PR TITLE
fix(hjb-sl): canonical_cs DPP kinetic term honors control_cost lambda (#1420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (CLAUDE.md "NO silent fallbacks"). Standard `MFGProblem`s (always carry `coupling_coefficient`) and
   quadratic-Hamiltonian solves are unaffected.
 
+- **Canonical Carlini-Silva SL (`diffusion_method="canonical_cs"`) honors `control_cost`** (Issue
+  #1420). The per-node DPP running cost was hardcoded `(1/2)|α|²` (λ=1), so the implicit-α* minimizer
+  gave `α* = -∇u` instead of `-∇u/control_cost` — undercutting the solver's λ≠1 support. It is now
+  `(λ/2)|α|²` (and the α search bound scales by `1/λ`), so the minimizer yields `α* = -∇u/λ` and the
+  LQ value matches the analytic Riccati ratio `u(0)/u(T) = λ/(λ+1)`. Byte-identical at `control_cost
+  == 1`. New `TestCanonicalCSControlCostLambda` covers λ∈{0.5,1,2} (sensitivity + Riccati ratio).
+
 ### Changed
 
 - **Hamiltonian as single source of truth — solver-level physics re-derivation retired** (Issue

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1656,9 +1656,14 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             sigma_diag = np.full(d, float(sigma))
 
         H_class = self.problem.hamiltonian_class
-        # Allow up to 4x natural-traversal speed (scale-invariant heuristic, per the
-        # validated prototype): alpha is bounded by 4 * domain_length / T per axis.
-        alpha_bound = 4.0 * span / float(self.problem.T)
+        # Issue #1420: control-cost lambda from the single source. The DPP running cost is
+        # L(alpha) = (lambda/2)|alpha|^2, so the per-node minimizer gives alpha* = -grad(u)/lambda.
+        # Hardcoding (1/2)|alpha|^2 (lambda=1) below undercut the solver's lambda != 1 support.
+        lam = self._control_cost_lambda()
+        # Allow up to 4x natural-traversal speed (scale-invariant heuristic, per the validated
+        # prototype): alpha is bounded by 4 * domain_length / T per axis, scaled by 1/lambda since
+        # the optimal control alpha* = -grad(u)/lambda grows as 1/lambda (no-op at lambda=1).
+        alpha_bound = 4.0 * span / float(self.problem.T) / lam
 
         if d == 1:
             Nx = len(U_next)
@@ -1690,7 +1695,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 feet_plus = _fold((y_drift + diff_off).reshape(-1, 1)).ravel()
                 feet_minus = _fold((y_drift - diff_off).reshape(-1, 1)).ravel()
                 u_pm = 0.5 * (interp_fn(feet_plus) + interp_fn(feet_minus))
-                return 0.5 * dt * alpha * alpha - dt * h + u_pm
+                return 0.5 * lam * dt * alpha * alpha - dt * h + u_pm
 
             invphi = (np.sqrt(5.0) - 1.0) / 2.0  # 0.618...
             invphi2 = 1.0 - invphi  # 0.382...
@@ -1762,7 +1767,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 drift = _xi + np.asarray(alpha_vec) * dt  # (d,)
                 feet = _fold(drift[None, :] + depart_offsets)  # (2d, d)
                 u_pm = interp_fn(feet)  # (2d,)
-                return 0.5 * dt * float(np.dot(alpha_vec, alpha_vec)) - dt * _hi + float(u_pm.mean())
+                return 0.5 * lam * dt * float(np.dot(alpha_vec, alpha_vec)) - dt * _hi + float(u_pm.mean())
 
             res = minimize(
                 phi_nd,

--- a/tests/unit/test_alg/test_hjb_canonical_cs_sl.py
+++ b/tests/unit/test_alg/test_hjb_canonical_cs_sl.py
@@ -324,3 +324,50 @@ class TestCanonicalCSMultiDimensional:
         assert np.all(np.isfinite(U))
         # With h=0 the maximum principle bounds u by the terminal data.
         assert np.max(np.abs(U)) <= np.max(np.abs(U_terminal)) + 1e-9
+
+
+class TestCanonicalCSControlCostLambda:
+    """Issue #1420: the canonical_cs DPP running cost is L(α) = (λ/2)|α|², not (1/2)|α|².
+
+    Pre-fix the kinetic term hardcoded λ=1, so the per-node minimizer gave α* = -∇u (not -∇u/λ)
+    and, for a pure-LQ problem (h=0), the value function U was identical for λ=1 and λ=2. Post-fix
+    U depends on λ and matches the analytic LQ Riccati ratio u(0,x)/u(T,x) = λ/(λ+1).
+    """
+
+    @staticmethod
+    def _solve(control_cost: float):
+        Nx, Nt = 41, 20
+        geometry = TensorProductGrid(
+            dimension=1, bounds=[(-2.0, 2.0)], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1)
+        )
+        components = MFGComponents(
+            hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=control_cost)),
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.5 * x**2,
+        )
+        problem = MFGProblem(geometry=geometry, T=1.0, Nt=Nt, diffusion=0.0, components=components)
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", diffusion_method="canonical_cs")
+        x = geometry.get_spatial_grid().flatten()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            U = solver.solve_hjb_system(np.ones((Nt + 1, Nx)), 0.5 * x**2, np.zeros((Nt + 1, Nx)))
+        return U, x
+
+    def test_depends_on_control_cost(self):
+        """Pure-LQ U must differ for λ=1 vs λ=2 (pre-fix they were identical — kinetic term ignored λ)."""
+        U1, _ = self._solve(1.0)
+        U2, _ = self._solve(2.0)
+        rel = np.max(np.abs(U1 - U2)) / (np.max(np.abs(U1)) + 1e-15)
+        assert rel > 0.05, (
+            f"canonical_cs U insensitive to control_cost (rel diff {rel:.3e}); kinetic term still λ=1 (#1420)."
+        )
+
+    @pytest.mark.parametrize(("control_cost", "expected_ratio"), [(0.5, 1.0 / 3.0), (1.0, 0.5), (2.0, 2.0 / 3.0)])
+    def test_riccati_ratio_scales_with_lambda(self, control_cost, expected_ratio):
+        """Analytic LQ (σ=0, T=1): u(0,x)/u(T,x) = P(0)/P(T) = λ/(λ+1) at any off-centre x."""
+        U, x = self._solve(control_cost)
+        probe = int(np.argmin(np.abs(x - 1.0)))  # off-centre |x| = 1
+        ratio = U[0, probe] / (0.5 * x[probe] ** 2)
+        assert abs(ratio - expected_ratio) < 0.1, (
+            f"control_cost={control_cost}: canonical_cs ratio {ratio:.3f}, expected λ/(λ+1) ≈ {expected_ratio:.3f}"
+        )


### PR DESCRIPTION
## Summary

Issue **#1420** (the canonical_cs λ=1 hardcode lead). The canonical Carlini-Silva SL
(`diffusion_method="canonical_cs"`) computed the per-node DPP running cost as `(1/2)|α|²` in both
objectives — the 1D vectorized golden-section (`phi_vec`) and the nD L-BFGS (`phi_nd`) — **hardcoding
λ=1**. The implicit-α* minimizer therefore gave `α* = -∇u` instead of `α* = -∇u/control_cost`,
undercutting the solver's λ≠1 support.

## Change

- Kinetic term → `(λ/2)|α|²` via the single-source `self._control_cost_lambda()` (base_hjb.py, the same
  source the other SL paths use), so the minimizer yields `α* = -∇u/λ`.
- The α search bound (1D golden-section bracket + nD L-BFGS box) scales by `1/λ` since `α*` grows as
  `1/λ` (no-op at λ=1).
- The separate L-based `_solve_timestep_dpp` path was already λ-aware (`lagrangian_class`) — unchanged.

**Byte-identical at `control_cost == 1`** (λ=1 → factor and bound scaling are no-ops); corrected
otherwise.

## Validation

- New `TestCanonicalCSControlCostLambda` (λ∈{0.5,1,2}):
  - **control_cost sensitivity** — pre-fix pure-LQ U was identical for λ=1 vs λ=2 (kinetic term ignored
    λ); post-fix they differ by ~17%.
  - **analytic LQ Riccati ratio** `u(0)/u(T) = λ/(λ+1)` — measured 0.526 / 0.689 / 0.358 vs analytic
    0.5 / 0.667 / 0.333 (within ~0.03).
  - Closes the noted λ≠1 test gap on this path.
- Full unit+integration+regression (`-m "not slow"`): **5009 passed, 0 failed** (existing canonical_cs
  λ=1 gates stay green → byte-identity at λ=1).

Refs #1420, #1430. Part of the G-017 / control-cost single-source hardening (#1441–#1447).

This is the **last of the #1420 follow-up items** (V1 #1447, V2 #1446, canonical_cs this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
