### PR TITLE
refactor(coupling): single-source the σ-value lookup via resolve_diffusion_source (#1412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **σ-value lookup single-sourced via `pde_coefficients.resolve_diffusion_source`** (Issue #1412,
+  generalizing #1071 to the diffusion coefficient). The per-solve `volatility_field` override
+  resolution (scalar / per-point array / callable → scalar; batch path = array mean, callable at the
+  domain center) is now one shared function; `HJBGFDMSolver._resolve_diffusion_source` delegates to it
+  (byte-identical, pinned by `TestResolveDiffusionSource`'s convention-agreement test). A 6-solver FP
+  audit confirmed the cross-path HJB/FP diffusion divergence the issue targeted is **already closed**
+  (HJB-GFDM honors the override via #1316; SL/WENO and the scalar-only FP solvers fail loud; FP-FDM
+  honors it via #1248) — this is a consolidation, not a behavior change. The σ-structure axis
+  (constant `D` vs spatially-varying `σ(x)`) is orthogonal to spatial dimension: scalar-only solvers
+  are constant-coefficient in both 1D and nD, and **fail loud** on a spatial override rather than
+  silently mean-collapsing it (which would re-open the divergence). New `test_issue_1412_fp_volatility_fail_loud`
+  pins those previously-unpinned GFDM / SL / SL-adjoint guards so a future "route through the shared
+  resolver" refactor cannot silently drop them.
+
 ### Fixed
 
 - **Semi-Lagrangian HJB scheme corrected — was ~24% wrong even at λ=1** (Issue #1413, PR #1417).

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -35,7 +35,7 @@ from mfgarchon.geometry.boundary.tolerances import BOUNDARY_TOL
 from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical.qp_utils import QPCache, QPSolver
-from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, resolve_diffusion_source
 
 from .base_hjb import (
     DEFAULT_NEWTON_MAX_ITERATIONS,
@@ -2809,26 +2809,13 @@ class HJBGFDMSolver(BaseHJBSolver):
     def _resolve_diffusion_source(self, source: float | np.ndarray | Callable, point_idx: int | None) -> float:
         """Resolve a scalar / callable / per-point-array diffusion source to a scalar sigma.
 
-        - callable: evaluate at the collocation point (``point_idx`` given) or at the
-          domain center (mean of collocation points) on the batch path (``point_idx=None``).
-        - array (ndim >= 1): index by point (``point_idx`` given); on the batch path the
-          GFDM residual applies one global scalar, so collapse to the mean — matching
-          MFGProblem's own array->scalar (sigma = mean) convention.
-        - scalar: returned directly.
+        Thin adapter over the shared single source
+        :func:`mfgarchon.utils.pde_coefficients.resolve_diffusion_source` (Issue #1412): the
+        collocation points are this solver's spatial points; the batch path (``point_idx=None``)
+        collapses an array to its mean / evaluates a callable at the domain center, matching
+        ``MFGProblem``'s array -> scalar (sigma = mean) convention.
         """
-        if callable(source):
-            if point_idx is not None and point_idx < len(self.collocation_points):
-                x = self.collocation_points[point_idx]
-            else:
-                # Center of domain (mean of collocation points), shape (d,).
-                x = self.collocation_points.mean(axis=0)
-            return float(source(x))
-        arr = np.asarray(source)
-        if arr.ndim >= 1:
-            if point_idx is not None and point_idx < len(arr):
-                return float(arr[point_idx])
-            return float(np.mean(arr))
-        return float(source)
+        return resolve_diffusion_source(source, index=point_idx, points=self.collocation_points)
 
     # Note: _check_monotonicity_violation moved to MonotonicityEnforcer component
     # Note: _check_m_matrix_property moved to MonotonicityEnforcer component

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -253,6 +253,72 @@ def scalar_diffusion_from_volatility(volatility_field: Any, fallback_sigma: Any)
     return float(diffusion_from_volatility(float(np.mean(volatility_field))))
 
 
+def resolve_diffusion_source(
+    source: float | np.ndarray | Callable,
+    *,
+    index: int | None = None,
+    points: np.ndarray | None = None,
+) -> float:
+    """Resolve a scalar / callable / array volatility (``sigma``) source to a scalar at one point.
+
+    Single source for the per-solve volatility *lookup* shared by the HJB and FP solver
+    families (Issue #1412, generalizing #1071 to the diffusion coefficient). Before this,
+    only ``HJBGFDMSolver`` centralized the lookup (its private ``_resolve_diffusion_source``);
+    every other solver read ``problem.sigma`` raw or honored a passed ``volatility_field``
+    override at only some of its sites, so an override could be consumed by HJB and silently
+    ignored by FP — the same silent cross-path divergence #1316 fixed for HJB-GFDM, but on the
+    FP side. The ``sigma -> D`` conversion stays in :func:`diffusion_from_volatility`; this
+    function only resolves *which* scalar ``sigma`` a given solve sees.
+
+    Resolution (matching ``MFGProblem``'s own array -> scalar ``mean`` convention so the batch
+    path is convention-consistent with the per-point path):
+
+    - **callable** ``source(x)``: evaluate at ``points[index]`` when ``index`` is given, else at
+      the domain center ``points.mean(axis=0)`` (the batch path). A callable source therefore
+      requires ``points``; passing ``points=None`` for a callable is a programming error and
+      raises (fail-loud, not a silent ``sigma=1`` fallback — the #1316 regression class).
+    - **array** (``ndim >= 1``): index by ``index`` when given and in range, else collapse to
+      ``mean`` (the batch path applies one global scalar).
+    - **scalar**: returned as ``float`` directly.
+
+    Parameters
+    ----------
+    source : float | ndarray | Callable
+        The volatility source: a scalar ``sigma``, a per-point ``sigma`` array, or a callable
+        ``sigma(x)`` over spatial coordinates.
+    index : int | None
+        Collocation-point / grid-node index for the per-point path; ``None`` for the batch path
+        (one global scalar via center evaluation / array mean).
+    points : ndarray | None
+        Spatial points (collocation points for GFDM, grid coordinates for FDM), shape
+        ``(n_points, d)``. Required only for a callable ``source``.
+
+    Returns
+    -------
+    float
+        The resolved scalar volatility ``sigma`` at the requested point.
+    """
+    if callable(source):
+        if points is None:
+            raise ValueError(
+                "resolve_diffusion_source: a callable volatility source needs `points` to "
+                "evaluate sigma(x) at (the collocation points / grid coordinates). Refusing to "
+                "substitute a placeholder sigma (Issue #1412; cf. the #1316 hardcoded-1.0 regression)."
+            )
+        pts = np.asarray(points)
+        if index is not None and index < len(pts):
+            x = pts[index]
+        else:
+            x = pts.mean(axis=0)
+        return float(source(x))
+    arr = np.asarray(source)
+    if arr.ndim >= 1:
+        if index is not None and index < len(arr):
+            return float(arr[index])
+        return float(np.mean(arr))
+    return float(source)
+
+
 class CoefficientMode(Enum):
     """
     Specifies which variables a callable coefficient depends on.

--- a/tests/unit/test_alg/test_issue_1412_fp_volatility_fail_loud.py
+++ b/tests/unit/test_alg/test_issue_1412_fp_volatility_fail_loud.py
@@ -1,0 +1,132 @@
+"""Pinning tests for Issue #1412: scalar-only FP solvers fail loud on a spatial override.
+
+Context — the σ-value single-source (Issue #1412, generalizing #1071). The shared
+``mfgarchon.utils.pde_coefficients.resolve_diffusion_source`` resolves a scalar / array /
+callable volatility (``sigma``) source to ONE scalar; its batch path (``index=None``)
+collapses an array to its **mean**. That mean-collapse is correct for a solver that genuinely
+applies a single global ``sigma`` — but it is exactly the wrong thing for the *coupling*:
+if a scalar-only FP solver silently mean-collapsed a spatially-varying ``volatility_field``
+while the HJB solver consumed the full ``sigma(x)`` (HJBGFDMSolver does, via #1316), HJB and
+FP would solve different diffusions and the Picard fixed point would correspond to neither —
+the silent cross-path divergence #1412 / #1316 exist to kill.
+
+The defense is that every scalar-only FP solver **fails loud** (``NotImplementedError``) on an
+array/callable ``volatility_field`` instead of collapsing it — the same disposition
+``HJBSemiLagrangianSolver`` / ``HJBWENOSolver`` adopt on the HJB side
+(``test_issue_1316_hjb_volatility_consumption``). FPFVMSolver's guard is already pinned
+(``test_fp_fvm`` — ``_scalar_diffusion`` raises on a non-constant array); the GFDM, backward-SL
+and forward-SL (adjoint) FP guards were **not** pinned anywhere. This module pins them so a
+future "single-source it through ``resolve_diffusion_source``" refactor that drops a guard and
+reintroduces the silent mean-collapse **fails CI**.
+
+A matched scalar ``volatility_field == problem.sigma`` (the iterator's redundant forwarding,
+Issue #1248) must stay a no-op and NOT raise.
+
+Refs #1412 (parent #1071); guard pattern from #1316.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+# Legacy MFGProblem API + FPSLJacobianSolver deprecation warnings are incidental to these tests.
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+N = 21
+
+
+def _problem(sigma: float = 0.3) -> MFGProblem:
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[N], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: 0.0,
+        coupling_dm=lambda m: 0.0,
+    )
+    comp = MFGComponents(
+        hamiltonian=H,
+        m_initial=lambda x: np.ones_like(x),
+        u_terminal=lambda x: x * 0,
+    )
+    return MFGProblem(geometry=grid, components=comp, T=0.2, Nt=10, sigma=sigma)
+
+
+def _m_initial() -> np.ndarray:
+    return np.ones(N) / N
+
+
+def _potential_field(nt_points: int = 11) -> np.ndarray:
+    """A non-callable potential U(t, x) so the SL solvers pass their potential-callable guard
+    and reach the volatility resolution (the site under test)."""
+    return np.zeros((nt_points, N))
+
+
+def _spatial_volatility() -> np.ndarray:
+    """A genuinely spatially-varying sigma(x) — the override a scalar-only solver must refuse,
+    not silently mean-collapse."""
+    return np.linspace(0.2, 0.8, N)
+
+
+def _gfdm_solver(problem: MFGProblem) -> FPGFDMSolver:
+    points = np.linspace(0.0, 1.0, N).reshape(-1, 1)
+    return FPGFDMSolver(problem, collocation_points=points, delta=0.25)
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud on a spatially-varying volatility_field (no silent mean-collapse)
+# ---------------------------------------------------------------------------
+
+
+def test_fp_sl_jacobian_fails_loud_on_spatial_volatility():
+    """Backward-SL FP (FPSLJacobianSolver) must refuse an array volatility_field rather than
+    silently using a single scalar — HJB would see sigma(x), FP a collapsed scalar."""
+    solver = FPSLJacobianSolver(_problem())
+    with pytest.raises(NotImplementedError, match="volatility"):
+        solver.solve_fp_system(
+            M_initial=_m_initial(), potential_field=_potential_field(), volatility_field=_spatial_volatility()
+        )
+
+
+def test_fp_sl_adjoint_fails_loud_on_spatial_volatility():
+    """Forward-SL (adjoint) FP (FPSLSolver) must refuse an array volatility_field."""
+    solver = FPSLSolver(_problem())
+    with pytest.raises(NotImplementedError, match="volatility"):
+        solver.solve_fp_system(
+            M_initial=_m_initial(), potential_field=_potential_field(), volatility_field=_spatial_volatility()
+        )
+
+
+def test_fp_gfdm_fails_loud_on_spatial_volatility():
+    """GFDM FP must refuse an array volatility_field (its forward-Euler loop applies one scalar
+    diffusion_coeff; a per-point sigma(x) would need a variable-coefficient operator)."""
+    solver = _gfdm_solver(_problem())
+    with pytest.raises(NotImplementedError, match="volatility"):
+        solver.solve_fp_system(_m_initial(), drift_field=None, volatility_field=_spatial_volatility())
+
+
+# ---------------------------------------------------------------------------
+# A matched scalar override stays a no-op (must NOT raise)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("solver_cls", [FPSLJacobianSolver, FPSLSolver])
+def test_scalar_override_equal_to_sigma_does_not_raise(solver_cls):
+    """The iterator's redundant forwarding of a scalar problem.sigma as volatility_field
+    (Issue #1248) is a no-op for the scalar-only SL solvers and must not fail loud."""
+    solver = solver_cls(_problem(sigma=0.3))
+    result = solver.solve_fp_system(M_initial=_m_initial(), potential_field=_potential_field(), volatility_field=0.3)
+    assert np.asarray(result).shape[0] >= 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/tests/unit/test_core/test_pde_coefficients.py
+++ b/tests/unit/test_core/test_pde_coefficients.py
@@ -15,7 +15,12 @@ from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc
-from mfgarchon.utils.pde_coefficients import CoefficientField, fp_drift_coefficient, get_spatial_grid
+from mfgarchon.utils.pde_coefficients import (
+    CoefficientField,
+    fp_drift_coefficient,
+    get_spatial_grid,
+    resolve_diffusion_source,
+)
 
 
 def _default_hamiltonian():
@@ -497,3 +502,75 @@ class TestFpDriftCoefficient:
 
         with pytest.raises(ValueError, match="Cannot determine the FP drift coefficient"):
             fp_drift_coefficient(_Bare())
+
+
+class TestResolveDiffusionSource:
+    """Issue #1412: the shared single-source volatility (sigma) lookup that HJB and FP
+    solvers consume — generalizing HJBGFDMSolver._resolve_diffusion_source so an override
+    is resolved identically on every path (no per-solver private copy)."""
+
+    _POINTS = np.linspace(0.0, 1.0, 11).reshape(-1, 1)  # x in [0,1], center = 0.5
+
+    def test_scalar_returns_float(self):
+        assert resolve_diffusion_source(0.3) == pytest.approx(0.3)
+        assert isinstance(resolve_diffusion_source(0.3), float)
+
+    def test_array_per_point_indexes(self):
+        arr = np.linspace(0.2, 0.8, 11)
+        assert resolve_diffusion_source(arr, index=0) == pytest.approx(0.2)
+        assert resolve_diffusion_source(arr, index=10) == pytest.approx(0.8)
+
+    def test_array_batch_collapses_to_mean(self):
+        """Batch path (index=None) collapses an array to its mean — MFGProblem's own
+        array -> scalar convention, so the batch and per-point paths stay consistent."""
+        arr = np.array([0.2, 0.4, 0.6])
+        assert resolve_diffusion_source(arr, index=None) == pytest.approx(0.4)
+
+    def test_array_out_of_range_index_falls_to_mean(self):
+        arr = np.array([0.2, 0.4, 0.6])
+        assert resolve_diffusion_source(arr, index=99) == pytest.approx(0.4)
+
+    def test_callable_per_point_evaluates_at_point(self):
+        def sigma(x):
+            return 0.5 + 0.5 * float(np.atleast_1d(x)[0])
+
+        assert resolve_diffusion_source(sigma, index=0, points=self._POINTS) == pytest.approx(0.5)
+        assert resolve_diffusion_source(sigma, index=10, points=self._POINTS) == pytest.approx(1.0)
+
+    def test_callable_batch_evaluates_at_domain_center(self):
+        """Batch path evaluates the callable at the domain center (mean of points) — NOT a
+        hardcoded placeholder (the #1316 sigma=1.0 regression class this single source kills)."""
+
+        def sigma(x):
+            return 0.5 + 0.5 * float(np.atleast_1d(x)[0])
+
+        assert resolve_diffusion_source(sigma, index=None, points=self._POINTS) == pytest.approx(0.75)
+
+    def test_callable_without_points_fails_loud(self):
+        """A callable source with no points cannot be evaluated; refusing to substitute a
+        placeholder sigma is the fail-loud contract (Issue #1412)."""
+        with pytest.raises(ValueError, match="callable volatility source needs `points`"):
+            resolve_diffusion_source(lambda x: 0.3, index=None, points=None)
+
+    def test_matches_hjb_gfdm_private_adapter(self):
+        """Convention agreement — HJBGFDMSolver._resolve_diffusion_source must now be a thin
+        adapter over the shared function (same scalar for the same source/point)."""
+        import warnings
+
+        from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(geometry=grid, T=0.2, Nt=10, sigma=0.3, components=_default_components())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            solver = HJBGFDMSolver(problem, collocation_points=self._POINTS, delta=0.3)
+
+        arr = np.linspace(0.2, 0.8, 11)
+
+        def sigma_cb(x):
+            return 0.5 + 0.5 * float(np.atleast_1d(x)[0])
+
+        for source, idx in [(0.42, None), (arr, 3), (arr, None), (sigma_cb, 5), (sigma_cb, None)]:
+            assert solver._resolve_diffusion_source(source, idx) == pytest.approx(
+                resolve_diffusion_source(source, index=idx, points=solver.collocation_points)
+            )


### PR DESCRIPTION
Refs #1412 (parent #1071). **Refs, not Closes** — this lands the shared provider + the canonical consumer + pins; full consumer migration remains (see "What's left").

## Summary
Generalize the #1071 single-source discipline to the **diffusion coefficient**. The per-solve `volatility_field` override resolution (scalar / per-point array / callable → scalar; batch path = array mean, callable evaluated at the domain center) is now one shared function, `mfgarchon/utils/pde_coefficients.resolve_diffusion_source`. `HJBGFDMSolver._resolve_diffusion_source` becomes a thin adapter over it.

## Key finding (reframes #1412)
A 6-agent FP-solver audit established that the **silent HJB/FP diffusion divergence #1412 was framed around is already closed**:
- HJB-GFDM honors the per-solve override (#1316); HJB SL/WENO fail loud.
- The scalar-only FP solvers (FVM, SL, SL-adjoint, GFDM) **fail loud** on a spatial override.
- FP-FDM / FP-particle honor a spatial override (#1248 + per-particle paths).

Every FP solver is `divergence_risk: none/low`. So #1412 is what its title says — a **consolidation** ("one provider for the σ lookup"), not a bug fix.

## Why the scalar-only solvers are *not* migrated through the provider (design note)
`resolve_diffusion_source`'s batch path mean-collapses an array to a scalar — correct only for a solver that genuinely applies one global `D`. Routing a scalar-only solver's array/callable branch through it would silently replace that solver's `NotImplementedError` guard and **re-open** the exact cross-path divergence #1412/#1316 kill.

This is **not** a 1D-vs-nD fork (it doesn't contradict the dimension-agnostic principle). The distinction is on an orthogonal axis — **σ-structure** (constant `D` vs variable-coefficient `σ(x)`), which is a discretization a solver legitimately owns (#1430: "a specialization may own its discretization; the debt is divergence of shared conventions/fixes"). Scalar-only solvers are constant-coefficient in **both** 1D and nD; capability is not dimension-aligned (FP-FDM and FP-FVM both run at every `d`). Failing loud is the single-source-*preserving* choice; mean-collapse is the violation. True `σ(x)` everywhere is a capability *addition* (variable-coefficient operators), tracked separately — not faked via the shared resolver.

## Changes
- `utils/pde_coefficients.py` — new `resolve_diffusion_source(source, *, index, points)` (fail-loud when a callable source is passed without `points`).
- `hjb_gfdm.py` — delegate to the provider (byte-identical).
- `tests/unit/test_core/test_pde_coefficients.py` — `TestResolveDiffusionSource` (8 tests, incl. convention-agreement: gfdm adapter ≡ provider).
- `tests/unit/test_alg/test_issue_1412_fp_volatility_fail_loud.py` — pins the previously-unpinned GFDM / SL / SL-adjoint fail-loud guards.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Validation
- Byte-identity: existing #1316 (28) + gfdm/convention/1071 (66) suites pass unchanged.
- New: 8 provider + 5 FP fail-loud pins. `ruff format --check` and `ruff check` clean.

## What's left for #1412
- Migrate the scalar-only solvers' *scalar/None* path through the provider (keeping guards).
- `CoefficientField` default-value unification (#1412 title item).
- `fp_particle.py` `self.problem.sigma` monkeypatch → explicit `sigma_override` (hot-path refactor of its own).
- Cosmetic: `fp_fdm.py:267` CFL log reads `problem.sigma` for array overrides (logging only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)