### PR TITLE
refactor(fp-particle): per-solve volatility via solver-local override, not a problem.sigma monkeypatch (#1412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently mean-collapsing it (which would re-open the divergence). New `test_issue_1412_fp_volatility_fail_loud`
   pins those previously-unpinned GFDM / SL / SL-adjoint guards so a future "route through the shared
   resolver" refactor cannot silently drop them.
+- **`FPParticleSolver` per-solve volatility no longer mutates the shared `problem.sigma`** (Issue
+  #1412). The grid-drift paths previously applied a custom `volatility_field` by monkeypatching
+  `self.problem.sigma = effective_sigma` before dispatch and restoring it in a `finally` (#1248) —
+  a shared-state / re-entrancy hazard. It is now a solver-local `_effective_sigma_override` attribute
+  (the #1316 pattern), resolved in `_get_grid_params` through `resolve_diffusion_source`. Byte-identical
+  (a seeded `volatility_field=s` solve equals a `problem.sigma=s` solve to 1e-10); `problem.sigma` is
+  never written. New `test_issue_1412_fp_particle_sigma_override`.
 
 ### Fixed
 

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -155,6 +155,10 @@ class FPParticleSolver(BaseFPSolver):
         self.kde_normalization = kde_normalization
         self.M_particles_trajectory: np.ndarray | None = None
         self._time_step_counter = 0  # Track current time step for normalization logic
+        # Issue #1412: per-solve volatility override (the resolved scalar sigma the grid-drift
+        # paths use), set by solve_fp_system instead of mutating the shared problem.sigma.
+        # None => use problem.sigma. Explicit init for object-shape stability (CLAUDE.md).
+        self._effective_sigma_override: float | None = None
 
         # Density mode for direct queries (Issue #489 Phase 2)
         self.density_mode = density_mode
@@ -354,12 +358,18 @@ class FPParticleSolver(BaseFPSolver):
         # Issue #1081: problem.sigma is typed float and resolved in the MFGProblem
         # constructor, so it is never None here; the prior `else 0.1` silent
         # default was dead defensive code masking a malformed problem.
-        sigma = self.problem.sigma
+        # Issue #1412: a per-solve volatility override (set by solve_fp_system for a custom
+        # volatility_field) is the authoritative diffusion source, resolved through the shared
+        # single source; None falls back to the byte-identical problem.sigma path.
+        from mfgarchon.utils.pde_coefficients import fp_drift_coefficient, resolve_diffusion_source
+
+        sigma_source = (
+            self._effective_sigma_override if self._effective_sigma_override is not None else self.problem.sigma
+        )
+        sigma = resolve_diffusion_source(sigma_source)
         # Issue #1420 / G-017: source the drift coefficient from the Hamiltonian's control_cost
         # (single source), not the independent coupling_coefficient field. This params value flows
         # to every particle drift path (CPU 1D/nD + GPU) via params["coupling_coefficient"].
-        from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
-
         coupling_coefficient = fp_drift_coefficient(self.problem)
 
         result = {
@@ -1411,10 +1421,11 @@ class FPParticleSolver(BaseFPSolver):
                 f"volatility_field must be None, float, np.ndarray, or Callable, got {type(volatility_field)}"
             )
 
-        # Temporarily override problem.sigma if custom volatility provided
-        original_sigma = self.problem.sigma
-        if volatility_field is not None:
-            self.problem.sigma = effective_sigma
+        # Issue #1412: install the resolved per-solve volatility as a solver-local override
+        # (consumed by _get_grid_params), instead of mutating the shared problem.sigma. None
+        # restores the byte-identical problem.sigma path. Replaces the prior #1248 monkeypatch
+        # (self.problem.sigma = effective_sigma + finally-restore), which mutated shared state.
+        self._effective_sigma_override = effective_sigma if volatility_field is not None else None
 
         # Reset time step counter for normalization logic
         self._time_step_counter = 0
@@ -1470,8 +1481,9 @@ class FPParticleSolver(BaseFPSolver):
                 # GPU nD solver not yet implemented
                 return self._solve_fp_system_cpu_nd(M_initial, effective_U)
         finally:
-            # Restore original sigma
-            self.problem.sigma = original_sigma
+            # Issue #1412: clear the per-solve volatility override (transient state); no shared
+            # problem.sigma to restore now that the monkeypatch is gone.
+            self._effective_sigma_override = None
 
     def _solve_fp_system_cpu(self, m_initial_condition: np.ndarray, U_solution_for_drift: np.ndarray) -> np.ndarray:
         """CPU pipeline - existing NumPy implementation."""

--- a/tests/unit/test_alg/test_issue_1412_fp_particle_sigma_override.py
+++ b/tests/unit/test_alg/test_issue_1412_fp_particle_sigma_override.py
@@ -1,0 +1,114 @@
+"""Pinning tests for Issue #1412: FPParticleSolver volatility override no longer mutates problem.sigma.
+
+The grid-drift particle paths (CPU 1D/nD, GPU) read the SDE volatility from
+``_get_grid_params()["sigma"]``. Previously a per-solve ``volatility_field`` was applied by
+**monkeypatching** the shared object — ``self.problem.sigma = effective_sigma`` before dispatch,
+restored in a ``finally`` (Issue #1248). That mutated externally-visible state for the duration of
+the solve (a re-entrancy / shared-state hazard) and is the kind of "raw read + private override"
+#1412 consolidates.
+
+It is now a solver-local override attribute ``self._effective_sigma_override`` (the #1316 pattern),
+resolved in ``_get_grid_params`` through the shared single source
+``pde_coefficients.resolve_diffusion_source``. ``problem.sigma`` is never written.
+
+These pin:
+  * the override feeds ``_get_grid_params`` and does NOT touch ``problem.sigma``;
+  * a seeded solve with ``volatility_field=s`` is identical to a solve with ``problem.sigma=s`` and
+    no override (the override is exactly equivalent to the sigma it represents — byte-identical
+    physics);
+  * a solve leaves ``problem.sigma`` unchanged and clears the transient override.
+
+Refs #1412 (override pattern from #1316; replaces the #1248 monkeypatch).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+Nx = 20
+T = 0.3
+Nt = 6
+
+
+def _problem(sigma: float) -> MFGProblem:
+    geo = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[Nx], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: np.exp(-20.0 * (x - 0.5) ** 2),
+        u_terminal=lambda x: 0.5 * (x - 0.5) ** 2,
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+    )
+    return MFGProblem(geometry=geo, components=comp, T=T, Nt=Nt, sigma=sigma)
+
+
+def _m0() -> np.ndarray:
+    x = np.linspace(0.0, 1.0, Nx)
+    m = np.exp(-20.0 * (x - 0.5) ** 2)
+    return m / (m.sum() / Nx)
+
+
+def _drift() -> np.ndarray:
+    return np.tile(0.3 * (np.linspace(0.0, 1.0, Nx) - 0.5) ** 2, (Nt + 1, 1))
+
+
+def test_get_grid_params_uses_override_without_touching_problem_sigma():
+    """The deterministic core: _get_grid_params resolves sigma from the solver-local override
+    when set, and problem.sigma is never written."""
+    problem = _problem(sigma=0.3)
+    solver = FPParticleSolver(problem, num_particles=100)
+
+    solver._effective_sigma_override = 0.77
+    assert solver._get_grid_params()["sigma"] == pytest.approx(0.77), "override not consumed by _get_grid_params"
+    assert problem.sigma == pytest.approx(0.3), "override mutated the shared problem.sigma (monkeypatch regressed)"
+
+    solver._effective_sigma_override = None
+    assert solver._get_grid_params()["sigma"] == pytest.approx(0.3), "None override must fall back to problem.sigma"
+
+
+def test_volatility_override_equiv_to_setting_problem_sigma():
+    """A seeded solve with volatility_field=0.5 (problem.sigma=0.1) is identical to a seeded solve
+    with problem.sigma=0.5 and no override — the override is exactly the sigma it represents."""
+    m0, drift = _m0(), _drift()
+
+    solver_override = FPParticleSolver(_problem(sigma=0.1), num_particles=500)
+    np.random.seed(42)
+    m_override = solver_override.solve_fp_system(m0, drift_field=drift, volatility_field=0.5)
+
+    solver_direct = FPParticleSolver(_problem(sigma=0.5), num_particles=500)
+    np.random.seed(42)
+    m_direct = solver_direct.solve_fp_system(m0, drift_field=drift)
+
+    np.testing.assert_allclose(
+        m_override,
+        m_direct,
+        rtol=1e-10,
+        atol=1e-10,
+        err_msg="volatility_field=0.5 override is not equivalent to problem.sigma=0.5 (physics differs)",
+    )
+
+
+def test_solve_with_override_leaves_problem_sigma_unchanged():
+    """After a solve with a custom volatility_field, problem.sigma is unchanged (no shared-state
+    leak) and the transient override is cleared."""
+    problem = _problem(sigma=0.1)
+    solver = FPParticleSolver(problem, num_particles=300)
+
+    np.random.seed(42)
+    solver.solve_fp_system(_m0(), drift_field=_drift(), volatility_field=0.5)
+
+    assert problem.sigma == pytest.approx(0.1), "solve mutated problem.sigma (override leaked)"
+    assert solver._effective_sigma_override is None, "transient override not cleared after solve"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Refs #1412 (parent #1071). Follow-on to #1449.

## Problem
`FPParticleSolver`'s grid-drift paths (CPU 1D/nD, GPU) read the SDE volatility from `_get_grid_params()["sigma"]`. A custom per-solve `volatility_field` was applied by **monkeypatching the shared object** — `self.problem.sigma = effective_sigma` before dispatch, restored in a `finally` (#1248). That mutates externally-visible state for the whole solve (a shared-state / re-entrancy hazard) and is exactly the "raw read + private override" #1412 consolidates.

## Change
Solver-local `_effective_sigma_override` attribute (the #1316 pattern), resolved in `_get_grid_params` through the shared single source `pde_coefficients.resolve_diffusion_source`. `problem.sigma` is never written.

## Why byte-identical
`_get_grid_params` is the **sole** σ funnel for the grid-drift kernels (verified: the only other `problem.sigma` reads are the resolution branch, the monkeypatch itself, and the separate callable-drift path that returns before dispatch). The override's dynamic window maps exactly onto the prior monkeypatch window, and the resolved scalar is unchanged (`resolve_diffusion_source(scalar) == float(scalar)`). The callable-drift / anisotropic-Σ paths are untouched.

## Validation
- New `test_issue_1412_fp_particle_sigma_override`: a **seeded** `volatility_field=0.5` solve (problem.sigma=0.1) is identical to a `problem.sigma=0.5` solve to **1e-10**; `_get_grid_params` honors the override without touching `problem.sigma`; a solve leaves `problem.sigma` unchanged and clears the transient override.
- Regression: `test_fp_particle_solver`, `test_issue_1248_volatility_forwarding`, `test_issue_1256_*` (73 passed). `ruff format --check` + `ruff check` clean.

Advances the #1412 checklist (the `fp_particle` monkeypatch item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)