### PR TITLE
refactor(coupling): CoefficientField diffusion default precedence override>volatility_field>sigma (#1412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`CoefficientField` diffusion default-value precedence fixed: `override → volatility_field → sigma`**
+  (Issue #1412). The FDM/HJB solver sites (`hjb_fdm`, `base_hjb`, `fp_fdm_time_stepping`) hand-built
+  `CoefficientField(override, problem.sigma)`, so a `None` per-solve `volatility_field` fell back to the
+  **derived scalar** `problem.sigma` (`mean(array)`, or `1.0` for a callable) — silently dropping a
+  spatially-varying `volatility_field`. They now route through the `MFGProblem.get_diffusion_coefficient_field(override=…)`
+  factory (extended with `override` / `field_name` / `dimension`), whose precedence prefers the full
+  `volatility_field` over the scalar placeholder. Byte-identical for all scalar-σ problems (every current
+  golden) and for the #1248-forwarded `solve()` path (override non-None); corrects only the direct-call
+  `None`-override edge on array/callable-σ problems. New precedence pins in `test_mfg_problem`.
 - **σ-value lookup single-sourced via `pde_coefficients.resolve_diffusion_source`** (Issue #1412,
   generalizing #1071 to the diffusion coefficient). The per-solve `volatility_field` override
   resolution (scalar / per-point array / callable → scalar; batch path = array mean, callable at the

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -870,7 +870,9 @@ def solve_fp_nd_full_system(
         elif drift.is_callable():
             # Callable drift with scalar diffusion - use explicit Forward Euler
             # This avoids the mathematically incorrect synthetic U approach
-            diffusion = CoefficientField(sigma_base, problem.sigma, "volatility_field", dimension=ndim)
+            diffusion = problem.get_diffusion_coefficient_field(
+                override=sigma_base, field_name="volatility_field", dimension=ndim
+            )
             sigma_at_k = diffusion.evaluate_at(timestep_idx=k, grid=grid.coordinates, density=M_current, dt=dt)
 
             M_next = solve_timestep_explicit_with_drift(
@@ -886,7 +888,9 @@ def solve_fp_nd_full_system(
             )
         else:
             # MFG-coupled mode: scalar diffusion + U/velocity-based drift - implicit solver
-            diffusion = CoefficientField(sigma_base, problem.sigma, "volatility_field", dimension=ndim)
+            diffusion = problem.get_diffusion_coefficient_field(
+                override=sigma_base, field_name="volatility_field", dimension=ndim
+            )
             sigma_at_k = diffusion.evaluate_at(timestep_idx=k, grid=grid.coordinates, density=M_current, dt=dt)
 
             M_next = solve_timestep_full_nd(

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -27,7 +27,7 @@ from mfgarchon.operators.stencils.finite_difference import (
     gradient_upwind,
     laplacian_with_bc,
 )
-from mfgarchon.utils.pde_coefficients import CoefficientField, get_spatial_grid
+from mfgarchon.utils.pde_coefficients import get_spatial_grid
 
 logger = get_logger(__name__)
 if TYPE_CHECKING:
@@ -1418,8 +1418,12 @@ def solve_hjb_system_backward(
             backend_aware_assign(U_solution_this_picard_iter, (n_idx_hjb, slice(None)), float("nan"), backend)
             continue
 
-        # Extract or evaluate diffusion using CoefficientField abstraction
-        diffusion = CoefficientField(volatility_field, problem.sigma, "volatility_field", dimension=1)
+        # Extract or evaluate diffusion using CoefficientField abstraction (Issue #1412: route
+        # through the single-source factory so a None override falls back to the full
+        # volatility_field, not the scalar problem.sigma placeholder). dimension=1: 1D path.
+        diffusion = problem.get_diffusion_coefficient_field(
+            override=volatility_field, field_name="volatility_field", dimension=1
+        )
         grid = get_spatial_grid(problem)
         sigma_at_n = diffusion.evaluate_at(timestep_idx=n_idx_hjb, grid=grid, density=M_n_prev_picard, dt=problem.dt)
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -21,7 +21,7 @@ from mfgarchon.geometry.base import CartesianGrid  # nD FDM needs structured gri
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical import FixedPointSolver, NewtonSolver
-from mfgarchon.utils.pde_coefficients import CoefficientField, diffusion_from_volatility, fp_drift_coefficient
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
 
 from . import base_hjb
 from .base_hjb import BaseHJBSolver
@@ -553,7 +553,9 @@ class HJBFDMSolver(BaseHJBSolver):
 
             if Sigma_at_n is None:
                 # Scalar path (CoefficientField handles float, array, callable)
-                diffusion = CoefficientField(volatility_field, self.problem.sigma, "volatility_field", dimension=d)
+                diffusion = self.problem.get_diffusion_coefficient_field(
+                    override=volatility_field, field_name="volatility_field", dimension=d
+                )
                 sigma_at_n = diffusion.evaluate_at(
                     timestep_idx=n, grid=self.grid.coordinates, density=M_n, dt=self.problem.dt
                 )

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -1322,16 +1322,38 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
     # PDE Coefficient Field Helpers
     # =========================================================================
 
-    def get_diffusion_coefficient_field(self) -> Any:
+    def get_diffusion_coefficient_field(
+        self,
+        override: float | np.ndarray | Callable | None = None,
+        *,
+        field_name: str = "diffusion",
+        dimension: int | None = None,
+    ) -> Any:
         """
         Get a CoefficientField wrapper for the diffusion coefficient.
 
         Returns a CoefficientField that handles scalar, array, and callable
         diffusion coefficients uniformly. Use this in solvers instead of
-        directly accessing self.sigma.
+        hand-constructing ``CoefficientField(..., self.sigma)`` (Issue #1412).
+
+        Precedence — the single source for the solver-side volatility lookup: a per-solve
+        ``override`` (the ``volatility_field`` a solver receives) wins; otherwise the problem's
+        full ``volatility_field`` (the SDE volatility property — scalar/array/callable); the
+        derived scalar ``self.sigma`` is only the ultimate fallback. Before this, the
+        FDM/time-stepping solver sites hand-built ``CoefficientField(override, self.sigma)`` and
+        so fell back to ``self.sigma`` (``mean(array)``, or ``1.0`` for a callable) when no
+        override was passed, silently dropping a spatially-varying ``volatility_field``.
+
+        Args:
+            override: Per-solve volatility override (a solver's ``volatility_field`` argument).
+                ``None`` falls back to ``self.volatility_field`` then ``self.sigma``.
+            field_name: Name used in CoefficientField diagnostics (default ``"diffusion"``;
+                solvers pass ``"volatility_field"`` to preserve their error wording).
+            dimension: Spatial dimension for array/spatiotemporal extraction; defaults to
+                ``self.dimension``.
 
         Returns:
-            CoefficientField wrapping self.volatility_field with self.sigma as default
+            CoefficientField wrapping the resolved field with self.sigma as the scalar default
 
         Example:
             >>> diffusion = problem.get_diffusion_coefficient_field()
@@ -1345,10 +1367,10 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         from mfgarchon.utils.pde_coefficients import CoefficientField
 
         return CoefficientField(
-            field=self.volatility_field,
+            field=override if override is not None else self.volatility_field,
             default_value=self.sigma,
-            field_name="diffusion",
-            dimension=self.dimension,
+            field_name=field_name,
+            dimension=self.dimension if dimension is None else dimension,
         )
 
     def get_drift_coefficient_field(self) -> Any:

--- a/tests/unit/test_core/test_mfg_problem.py
+++ b/tests/unit/test_core/test_mfg_problem.py
@@ -1094,6 +1094,51 @@ def test_get_diffusion_coefficient_field():
 
 
 @pytest.mark.unit
+def test_get_diffusion_coefficient_field_override_precedence():
+    """Issue #1412: the factory resolves override > volatility_field > sigma.
+
+    A per-solve override wins; with no override the FULL ``volatility_field`` is used, NOT the
+    derived scalar ``problem.sigma`` (``mean`` for an array, ``1.0`` for a callable). This is the
+    precedence the FDM/HJB solver sites now route through, instead of the old
+    ``CoefficientField(override, problem.sigma)`` that dropped a spatial ``volatility_field`` on a
+    ``None`` override."""
+    sigma_arr = np.linspace(0.2, 0.8, 11)
+    problem = create_test_problem(sigma=sigma_arr)
+    # problem.sigma is the derived scalar (mean); volatility_field is the full array.
+    assert problem.sigma == pytest.approx(float(np.mean(sigma_arr)))
+    np.testing.assert_array_equal(problem.volatility_field, sigma_arr)
+
+    # override given -> override wins
+    assert problem.get_diffusion_coefficient_field(override=0.9).field == 0.9
+
+    # override None -> the FULL volatility_field (array), not the scalar mean placeholder
+    field = problem.get_diffusion_coefficient_field(override=None)
+    np.testing.assert_array_equal(field.field, sigma_arr)
+    assert field.default == pytest.approx(problem.sigma)  # sigma only the ultimate fallback
+
+
+@pytest.mark.unit
+def test_get_diffusion_coefficient_field_scalar_is_byte_identical():
+    """Issue #1412: for a scalar problem volatility_field == sigma, so an override=None resolution
+    equals the old problem.sigma fallback — the solver-site migration is byte-identical."""
+    problem = create_test_problem(sigma=0.3)
+    field = problem.get_diffusion_coefficient_field(override=None)
+    assert field.field == pytest.approx(0.3)
+    assert field.default == pytest.approx(0.3)
+
+
+@pytest.mark.unit
+def test_get_diffusion_coefficient_field_name_and_dimension_params():
+    """Issue #1412: default field_name stays 'diffusion' (back-compat); solvers pass
+    'volatility_field' and their own dimension."""
+    problem = create_test_problem(sigma=0.3)
+    assert problem.get_diffusion_coefficient_field().name == "diffusion"
+    f = problem.get_diffusion_coefficient_field(field_name="volatility_field", dimension=1)
+    assert f.name == "volatility_field"
+    assert f.dimension == 1
+
+
+@pytest.mark.unit
 def test_get_drift_coefficient_field():
     """Test get_drift_coefficient_field returns CoefficientField wrapper."""
     # default_geometry has 11 grid points


### PR DESCRIPTION
Refs #1412 (parent #1071). Third increment; follows #1449, #1450.

## Problem
The FDM/HJB solver sites (`hjb_fdm:556`, `base_hjb:1422`, `fp_fdm_time_stepping:873/889`) hand-built `CoefficientField(override, problem.sigma, …)`. So a `None` per-solve `volatility_field` fell back to the **derived scalar** `problem.sigma` — `mean(array)`, or **`1.0` for a callable** — silently dropping a spatially-varying `volatility_field`. The factory `MFGProblem.get_diffusion_coefficient_field()` existed for exactly this ("Use this in solvers") but was unused.

## Change
Extend the factory with `override` / `field_name` / `dimension` (precedence **`override → volatility_field → sigma`**) and route the four sites through it.

## Why (mostly) byte-identical
- **Scalar-σ problems** (every current golden): `volatility_field == sigma`, so the new fallback equals the old one. Identical.
- **#1248-forwarded `solve()`**: the iterator passes `problem.volatility_field` as the override, so `override` is non-None and the new fallback is never reached. Identical.
- **`fp_fdm_time_stepping`**: `sigma_base` is already `override-or-sigma` (never `None`), so those two sites are fully byte-identical.
- **The only behavior change**: a *direct* solver call with `volatility_field=None` on an array/callable-σ problem now uses the full field instead of the scalar placeholder — a latent-bug fix, not reached by `problem.solve()`.

`field_name` defaults to `"diffusion"` (preserves the existing factory test); solvers pass `"volatility_field"` and their own `dimension`, so error wording and the `base_hjb` `dimension=1` path are unchanged.

## Validation
- New precedence pins in `test_mfg_problem` (override wins; `None` → full array not mean; scalar byte-identical; default `field_name` stays `"diffusion"`).
- Regression: `test_mfg_problem` (full), `test_pde_coefficients`, `test_hjb_fdm_solver`, `test_fp_fdm_solver`, `test_issue_1248_volatility_forwarding` (incl. the end-to-end array-volatility solve), `test_convention_agreement`, `test_fixed_point_sigma_consistency` — all pass. `ruff format --check` + `ruff check` clean.

Closes the `CoefficientField` item on the #1412 checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)