### PR TITLE
fix(solvers): fail loud on dead FPGFDM boundary_indices/domain_bounds + FPSL characteristic_solver (#1426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dead solver knobs now fail loud instead of silently doing nothing** (Issue #1426, S0-26/S0-27).
+  `FPGFDMSolver(boundary_indices=…/domain_bounds=…)` and `FPSLJacobianSolver(characteristic_solver=…)`
+  were accepted, documented, and stored on `self` but never read — a non-default value was a silent
+  no-op (worse than an error). They now raise `NotImplementedError` on a non-default value; the
+  defaults (`None` / `"explicit_euler"`) are unchanged, so existing usage is unaffected. Follows the
+  S0-23/24 (`congestion_mode` / `weno_m_parameter`) fail-loud pattern. (Network knobs S0-25 remain.)
+
 - **Semi-Lagrangian HJB scheme corrected — was ~24% wrong even at λ=1** (Issue #1413, PR #1417).
   The H-based SL update `u^{n+1}(x − dt·∇u) − dt·H` combined the characteristic foot with a
   pointwise `−dt·H`, double-counting the kinetic term (~3×), and used a λ=1-only foot (`∇u`

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -153,6 +153,20 @@ class FPGFDMSolver(BaseFPSolver):
         # Store boundary info for solver-level BC enforcement
         self._boundary_indices = boundary_indices
         self._domain_bounds = domain_bounds
+        # Issue #1426 (S0-26): boundary_indices / domain_bounds are accepted and stored but never
+        # read — boundary handling uses the problem geometry's boundary conditions. Fail loud on a
+        # non-default (non-None) value rather than silently ignoring it.
+        if boundary_indices is not None:
+            raise NotImplementedError(
+                "FPGFDMSolver(boundary_indices=...) is accepted but never applied (Issue #1426): "
+                "boundary handling uses the problem geometry's boundary conditions. Remove the "
+                "argument or set boundary conditions on problem.geometry."
+            )
+        if domain_bounds is not None:
+            raise NotImplementedError(
+                "FPGFDMSolver(domain_bounds=...) is accepted but never applied (Issue #1426): the "
+                "domain is taken from problem.geometry. Remove the argument."
+            )
         self._boundary_type = resolved_bc_type
 
         # Store upwind parameters

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -124,6 +124,14 @@ class FPSLJacobianSolver(BaseFPSolver):
         # Solver configuration
         self.interpolation_method = interpolation_method
         self.characteristic_solver = characteristic_solver
+        # Issue #1426 (S0-27): characteristic_solver is accepted and stored but never read — the SL
+        # characteristic foot is traced with explicit Euler only. Fail loud on a non-default value.
+        if characteristic_solver != "explicit_euler":
+            raise NotImplementedError(
+                f"FPSLJacobianSolver(characteristic_solver={characteristic_solver!r}) is not "
+                "implemented (Issue #1426): the characteristic foot is traced with explicit Euler "
+                "only. Use the default 'explicit_euler'."
+            )
 
         # Detect problem dimension
         self.dimension = self._detect_dimension()  # Issue #633: Use inherited method

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -2,9 +2,11 @@
 """Issue #1426: solver options that are stored but never applied must fail loud on a non-default
 value instead of being silent no-ops. Defaults remain accepted (baseline-safe).
 
-Covers the two cleanly-dead options (no live non-default setter anywhere): GFDM ``congestion_mode``
-and WENO ``weno_m_parameter``. (The FPSL/FPGFDM ``characteristic_solver`` / ``boundary_indices``
-namesakes are live on other solvers and are handled separately.)
+Covers the GFDM ``congestion_mode`` / WENO ``weno_m_parameter`` options (S0-23/24), plus the
+solver-specific dead knobs ``FPGFDMSolver.boundary_indices`` / ``domain_bounds`` (S0-26) and
+``FPSLJacobianSolver.characteristic_solver`` (S0-27). These last two are guarded on those specific
+solvers only — the namesakes are live on other solvers / geometry APIs. (Network knobs S0-25 are
+tracked separately.)
 """
 
 import warnings
@@ -13,6 +15,8 @@ import pytest
 
 import numpy as np
 
+from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
 from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver, HJBWENOSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
@@ -67,6 +71,43 @@ class TestDeadOptionFailLoud:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             HJBWENOSolver(problem, weno_m_parameter=1.0)
+
+    # Issue #1426 S0-26: FPGFDMSolver.boundary_indices / domain_bounds stored, never read.
+
+    def test_fp_gfdm_boundary_indices_raises(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(NotImplementedError, match="boundary_indices"):
+                FPGFDMSolver(problem, collocation_points=_pts(problem), boundary_indices={0, 1})
+
+    def test_fp_gfdm_domain_bounds_raises(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(NotImplementedError, match="domain_bounds"):
+                FPGFDMSolver(problem, collocation_points=_pts(problem), domain_bounds=[(0.0, 1.0)])
+
+    def test_fp_gfdm_boundary_defaults_ok(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            FPGFDMSolver(problem, collocation_points=_pts(problem))
+
+    # Issue #1426 S0-27: FPSLJacobianSolver.characteristic_solver stored, never read.
+
+    def test_fp_sl_characteristic_solver_nondefault_raises(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(NotImplementedError, match="characteristic_solver"):
+                FPSLJacobianSolver(problem, characteristic_solver="rk4")
+
+    def test_fp_sl_characteristic_solver_default_ok(self):
+        problem = _problem()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            FPSLJacobianSolver(problem)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #1426 (S0-26, S0-27).

## Problem
Three knobs are accepted, documented, and stored on `self` but **never read** — a non-default value is a silent no-op (worse than an error):
- `FPGFDMSolver(boundary_indices=…)` and `FPGFDMSolver(domain_bounds=…)` — stored "for BC enforcement", never read (boundary handling uses the problem geometry's BCs).
- `FPSLJacobianSolver(characteristic_solver=…)` — stored (default `"explicit_euler"`), never read (the characteristic foot is traced with explicit Euler only).

## Change
Fail loud (`NotImplementedError`) on a non-default value, matching the S0-23/24 (`congestion_mode` / `weno_m_parameter`) pattern already in the codebase. Defaults (`None` / `"explicit_euler"`) are unchanged → existing usage unaffected.

## Safety
Verified no caller passes these to the target solvers: `FPGFDMSolver` is built in `scheme_factory`/tests without `boundary_indices`/`domain_bounds`; `FPSLJacobianSolver` is built without `characteristic_solver`. (The namesakes are live on *other* solvers / geometry APIs — guards are scoped to these specific solver `__init__`s only.)

## Validation
- `test_dead_option_fail_loud` extended: non-default raises (matched message), defaults construct fine. 9 passed.
- Regression: `test_fp_gfdm_continuity_1279`, `test_fp_sl_drift_control_cost_s003`, `test_issue1286_fail_fast`, `test_issue_1412_fp_volatility_fail_loud` — 21 passed. `ruff check` + `format --check` clean.

## Not in scope
S0-25 (network `FPNetworkSolver.max_iterations`/`.tolerance`, `NetworkPolicyIterationHJBSolver.policy_tolerance`) — generic iterative-solver params reachable via `**kwargs`; they warrant an implement-vs-fail-loud decision and are left for a separate change. So this **Refs** (not Closes) #1426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)