### PR TITLE
fix(network): fail loud on dead FPNetwork max_iterations/tolerance + policy_tolerance (#1426 S0-25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Dead solver knobs now fail loud instead of silently doing nothing** (Issue #1426, S0-26/S0-27).
-  `FPGFDMSolver(boundary_indices=…/domain_bounds=…)` and `FPSLJacobianSolver(characteristic_solver=…)`
-  were accepted, documented, and stored on `self` but never read — a non-default value was a silent
-  no-op (worse than an error). They now raise `NotImplementedError` on a non-default value; the
-  defaults (`None` / `"explicit_euler"`) are unchanged, so existing usage is unaffected. Follows the
-  S0-23/24 (`congestion_mode` / `weno_m_parameter`) fail-loud pattern. (Network knobs S0-25 remain.)
+- **Dead solver knobs now fail loud instead of silently doing nothing** (Issue #1426, all of
+  S0-23–S0-27). Knobs accepted, documented, and stored on `self` but **never read** — a non-default
+  value was a silent no-op (worse than an error) — now raise `NotImplementedError` on a non-default
+  value, with defaults unchanged so existing usage is unaffected:
+  `FPGFDMSolver(boundary_indices=…/domain_bounds=…)` (S0-26), `FPSLJacobianSolver(characteristic_solver=…)`
+  (S0-27), `FPNetworkSolver(max_iterations=…/tolerance=…)` (S0-25 — the implicit step is a direct
+  `spsolve`, not iterative), and `NetworkPolicyIterationHJBSolver(policy_tolerance=…)` (S0-25 — policy
+  iteration converges on policy stability, not a value tolerance). Joins the already-shipped S0-23/24
+  (`congestion_mode` / `weno_m_parameter`). `NetworkHJBSolver.tolerance` / `max_policy_iterations` are
+  live and unchanged.
 
 - **Semi-Lagrangian HJB scheme corrected — was ~24% wrong even at λ=1** (Issue #1413, PR #1417).
   The H-based SL update `u^{n+1}(x − dt·∇u) − dt·H` combined the characteristic foot with a

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -95,6 +95,21 @@ class FPNetworkSolver(BaseFPSolver):
         self.cfl_factor = cfl_factor
         self.max_iterations = max_iterations
         self.tolerance = tolerance
+        # Issue #1426 (S0-25): max_iterations / tolerance are documented "for implicit schemes" but
+        # the implicit step is a direct sparse solve (spsolve), not iterative, so they are never
+        # read. Fail loud on a non-default value rather than silently ignoring it.
+        if max_iterations != 1000:
+            raise NotImplementedError(
+                f"FPNetworkSolver(max_iterations={max_iterations}) is not implemented (Issue #1426): "
+                "the implicit scheme is a direct sparse solve (spsolve), not iterative, so "
+                "max_iterations is never used. Omit it (default 1000)."
+            )
+        if tolerance != 1e-6:
+            raise NotImplementedError(
+                f"FPNetworkSolver(tolerance={tolerance}) is not implemented (Issue #1426): the "
+                "implicit scheme is a direct sparse solve, so there is no iterative tolerance. Omit "
+                "it (default 1e-6)."
+            )
         self.enforce_mass_conservation = enforce_mass_conservation
         self._current_rates: dict | None = None  # Issue #913: precomputed per timestep
 

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -233,6 +233,16 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
 
         self.max_policy_iterations = max_policy_iterations
         self.policy_tolerance = policy_tolerance
+        # Issue #1426 (S0-25): policy_tolerance is stored but never read — policy iteration
+        # terminates on discrete policy stability (`_policies_equal`), not a value tolerance. Fail
+        # loud on a non-default value. (max_policy_iterations IS used and bounds the loop.)
+        if policy_tolerance != 1e-6:
+            raise NotImplementedError(
+                f"NetworkPolicyIterationHJBSolver(policy_tolerance={policy_tolerance}) is not "
+                "implemented (Issue #1426): policy iteration terminates when the policy stops "
+                "changing (exact convergence), not on a value tolerance, so policy_tolerance is "
+                "never used. Omit it (default 1e-6); use max_policy_iterations to bound the loop."
+            )
         self.hjb_method_name = "NetworkHJB_PolicyIteration"
 
         # Current policy (action for each node)

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -6,7 +6,7 @@ Covers the GFDM ``congestion_mode`` / WENO ``weno_m_parameter`` options (S0-23/2
 solver-specific dead knobs ``FPGFDMSolver.boundary_indices`` / ``domain_bounds`` (S0-26) and
 ``FPSLJacobianSolver.characteristic_solver`` (S0-27). These last two are guarded on those specific
 solvers only — the namesakes are live on other solvers / geometry APIs. (Network knobs S0-25 are
-tracked separately.)
+pinned in ``test_fp_network_solver`` / ``test_hjb_network_solver`` alongside their live siblings.)
 """
 
 import warnings

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -120,8 +120,10 @@ class TestFPNetworkSolverInitialization:
 
         assert solver.cfl_factor == 0.3
 
-    def test_custom_iteration_parameters(self):
-        """Test initialization with custom iteration parameters."""
+    def test_dead_iteration_parameters_fail_loud(self):
+        """Issue #1426 (S0-25): max_iterations / tolerance are dead — the implicit step is a direct
+        sparse solve (spsolve), not iterative — so a non-default value fails loud; defaults are a
+        no-op and construct fine."""
         network = GridNetwork(width=3, height=3)
         network.create_network()
 
@@ -131,14 +133,15 @@ class TestFPNetworkSolverInitialization:
             Nt=10,
         )
 
-        solver = FPNetworkSolver(
-            problem,
-            max_iterations=500,
-            tolerance=1e-8,
-        )
+        with pytest.raises(NotImplementedError, match="max_iterations"):
+            FPNetworkSolver(problem, max_iterations=500)
+        with pytest.raises(NotImplementedError, match="tolerance"):
+            FPNetworkSolver(problem, tolerance=1e-8)
 
-        assert solver.max_iterations == 500
-        assert solver.tolerance == 1e-8
+        # Defaults construct fine (the no-op knobs are unchanged).
+        solver = FPNetworkSolver(problem)
+        assert solver.max_iterations == 1000
+        assert solver.tolerance == 1e-6
 
     def test_mass_conservation_flag(self):
         """Test mass conservation enforcement flag."""
@@ -599,7 +602,7 @@ class TestFPNetworkSolverIntegration:
 
         configs = [
             {"scheme": "explicit", "cfl_factor": 0.4},
-            {"scheme": "implicit", "max_iterations": 500},
+            {"scheme": "implicit"},
             {"scheme": "upwind", "diffusion_coefficient": 0.15},
         ]
 

--- a/tests/unit/test_alg/test_hjb_network_solver.py
+++ b/tests/unit/test_alg/test_hjb_network_solver.py
@@ -10,7 +10,10 @@ import pytest
 
 import numpy as np
 
-from mfgarchon.alg.numerical.network_solvers.hjb_network import NetworkHJBSolver
+from mfgarchon.alg.numerical.network_solvers.hjb_network import (
+    NetworkHJBSolver,
+    NetworkPolicyIterationHJBSolver,
+)
 from mfgarchon.extensions.topology import NetworkMFGProblem
 from mfgarchon.geometry.graph.network_geometry import GridNetwork
 
@@ -67,6 +70,22 @@ class TestNetworkHJBSolverInitialization:
 
         solver = NetworkHJBSolver(problem, tolerance=1e-8)
         assert solver.tolerance == 1e-8
+
+    def test_policy_iteration_policy_tolerance_fail_loud(self):
+        """Issue #1426 (S0-25): NetworkPolicyIterationHJBSolver.policy_tolerance is dead — policy
+        iteration converges on policy stability (`_policies_equal`), not a value tolerance — so a
+        non-default value fails loud; the default constructs fine and max_policy_iterations (live)
+        is freely settable."""
+        network = GridNetwork(width=3, height=3)
+        network.create_network()
+        problem = NetworkMFGProblem(network_geometry=network, T=1.0, Nt=10)
+
+        with pytest.raises(NotImplementedError, match="policy_tolerance"):
+            NetworkPolicyIterationHJBSolver(problem, policy_tolerance=1e-8)
+
+        solver = NetworkPolicyIterationHJBSolver(problem, max_policy_iterations=20)
+        assert solver.policy_tolerance == 1e-6
+        assert solver.max_policy_iterations == 20
 
     def test_network_properties_extracted(self):
         """Test that network properties are properly extracted."""


### PR DESCRIPTION
Closes #1426 (completes S0-25; S0-23/24/26/27 already shipped).

## Problem
The remaining #1426 network knobs are stored on `self` but **never read** — a non-default value is a silent no-op:
- `FPNetworkSolver.max_iterations` / `.tolerance` — documented "for implicit schemes", but `_implicit_step` is a **direct** sparse solve (`spsolve`, fp_network.py:340), not iterative, so neither is used.
- `NetworkPolicyIterationHJBSolver.policy_tolerance` — the policy loop terminates on **discrete policy stability** (`_policies_equal`, hjb_network.py:294), not a value tolerance, so it is never read.

## Change
Fail loud (`NotImplementedError`) on a non-default value, matching the S0-23/24/26/27 pattern. Defaults (`1000` / `1e-6`) are unchanged → existing usage unaffected. **Live siblings untouched**: `NetworkHJBSolver.tolerance` (used at :179-180) and `NetworkPolicyIterationHJBSolver.max_policy_iterations` (bounds the loop).

## Tests
- Repurposed the two existing tests that pinned the dead storage (`test_custom_iteration_parameters` → `test_dead_iteration_parameters_fail_loud`; dropped the no-op `max_iterations` from `test_solver_with_different_parameters`).
- Added a `policy_tolerance` fail-loud pin in `test_hjb_network_solver`.
- 65 passed / 13 skipped (igraph-gated); `ruff check` + `format --check` clean.

## Why fail-loud (not implement)
Neither knob has an iteration to wire into: the network FP implicit scheme is a direct solve, and network policy iteration converges exactly on policy stability. Implementing them would mean switching to an iterative linear solver / adding a non-standard value-tolerance criterion — a design change beyond a dead-knob cleanup. Fail-loud is the honest, CLAUDE.md-preferred resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)