### PR TITLE
fix(solvers): LLF sigma_eff tracks volatility override + FPNetwork volatility_field is sigma (#1429 S0-13/S0-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **LLF effective volatility now tracks the per-solve `volatility_field` override** (Issue #1429,
+  S0-13). `HJBGFDMSolver._llf_sigma_eff` was frozen at `__init__` from `problem.sigma`, so an
+  LLF-augmented solve (#1059) with a #1316 per-solve volatility override stabilized off the base σ,
+  not the override. `solve_hjb_system` now recomputes `_llf_sigma_eff` from the installed override
+  (unconditionally, so a later `volatility_field=None` solve resets it). Byte-identical when LLF is
+  off (the default) or no override is passed; idempotent across Picard iterations (does not reopen
+  the #1059 frozen-ν stability note).
+- **`FPNetworkSolver` treats a scalar `volatility_field` as SDE volatility σ (D = σ²/2), not as D**
+  (Issue #1429, S0-15). The float branch consumed `volatility_field` directly as the diffusion `D`,
+  diverging from the `base_fp` contract used by FDM/FVM/GFDM (where `volatility_field = σ`). It now
+  routes through the single source `diffusion_from_volatility` (`D = σ²/2`). Affects only an explicit
+  scalar `volatility_field` passed to the network FP solve; the `None` path (D-valued
+  `diffusion_coefficient` knob) is unchanged.
 - **Dead solver knobs now fail loud instead of silently doing nothing** (Issue #1426, all of
   S0-23–S0-27). Knobs accepted, documented, and stored on `self` but **never read** — a non-default
   value was a silent no-op (worse than an error) — now raise `NotImplementedError` on a non-default

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2856,6 +2856,16 @@ class HJBGFDMSolver(BaseHJBSolver):
         # legacy problem.sigma path.
         self._volatility_field_override = volatility_field
 
+        # Issue #1429 (S0-13): recompute the LLF effective volatility from the per-solve override.
+        # _llf_sigma_eff is otherwise frozen at __init__ from problem.sigma, so an LLF-augmented
+        # solve with a #1316 override would stabilize off the base sigma, not the override.
+        # Unconditional so a later volatility_field=None solve resets it to the base (no stale
+        # override). Safe w.r.t. the #1059 frozen-nu note: the override is constant across Picard
+        # iterations and _llf_l_H is static, so this recompute is idempotent — not the
+        # solution-driven feedback #1059 guards against.
+        if self.llf_augmentation:
+            self._llf_sigma_eff = self._compute_llf_sigma_eff()
+
         # Pick up any per-Picard resolved BC the coupling layer installed on the
         # geometry since construction (Issue #1118; matches FDM's per-solve re-read).
         self._refresh_boundary_conditions_if_changed()

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -31,6 +31,7 @@ from scipy.sparse.linalg import spsolve
 
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.utils.deprecation import deprecated_parameter
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -169,9 +170,11 @@ class FPNetworkSolver(BaseFPSolver):
             drift_field: DEPRECATED since v0.21.0 — use potential_field.
                 Accepted U under the old drift_field name (U-semantic). The rename
                 mirrors the weak-form rename from PR #1205 (Issue #1043 Phase 2).
-            volatility_field: Diffusion specification (optional):
-                - None: Use self.diffusion_coefficient (backward compatible).
-                - float: Constant diffusion on network.
+            volatility_field: SDE volatility sigma (optional); D = sigma^2/2 internally
+                (Issue #1429 S0-15 — the base_fp contract, consistent with FDM/FVM/GFDM):
+                - None: Use the D-valued self.diffusion_coefficient constructor knob (backward
+                  compatible).
+                - float: constant SDE volatility sigma; the diffusion is D = sigma^2/2.
                 - np.ndarray/Callable: Phase 2 (not yet supported).
             show_progress: Whether to display progress bar for timesteps.
 
@@ -227,8 +230,10 @@ class FPNetworkSolver(BaseFPSolver):
             # Use self.diffusion_coefficient (backward compatible)
             effective_diffusion = self.diffusion_coefficient
         elif isinstance(volatility_field, (int, float)):
-            # Constant diffusion
-            effective_diffusion = float(volatility_field)
+            # Issue #1429 (S0-15): volatility_field is the SDE volatility sigma (the base_fp
+            # contract used by FDM/FVM/GFDM), NOT the diffusion D — convert via the single source
+            # D = sigma^2/2. (The `diffusion_coefficient` constructor knob stays D-valued.)
+            effective_diffusion = float(diffusion_from_volatility(float(volatility_field)))
         elif isinstance(volatility_field, np.ndarray) or callable(volatility_field):
             # Spatially varying or state-dependent - Phase 2
             raise NotImplementedError(

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -241,6 +241,35 @@ class TestFPNetworkSolverSolveFPSystem:
         assert M_solution.shape == (Nt, num_nodes)
         assert np.all(np.isfinite(M_solution))
 
+    def test_volatility_field_is_sigma_not_diffusion(self):
+        """Issue #1429 (S0-15): volatility_field is the SDE volatility sigma (D = sigma^2/2), the
+        base_fp contract shared with FDM/FVM/GFDM — not the diffusion D directly. So a solve with
+        volatility_field=sigma equals a solve with diffusion_coefficient=0.5*sigma**2 (which the
+        pre-fix `D = volatility_field` fork would have failed)."""
+        network = GridNetwork(width=3, height=3)
+        network.create_network()
+        problem = NetworkMFGProblem(network_geometry=network, T=0.5, Nt=10)
+        num_nodes = problem.num_nodes
+        # NON-uniform initial density: a uniform m is a diffusion fixed point (Laplacian of a
+        # constant is 0), so D would be unobservable. A ramp makes the diffusion (hence D) matter.
+        m0 = np.arange(1, num_nodes + 1, dtype=float)
+        m0 /= m0.sum()
+        U = np.zeros((problem.Nt + 1, num_nodes))
+        sigma = 0.4
+
+        m_via_sigma = FPNetworkSolver(problem, scheme="explicit").solve_fp_system(m0, U, volatility_field=sigma)
+        m_via_diffusion = FPNetworkSolver(
+            problem, scheme="explicit", diffusion_coefficient=0.5 * sigma**2
+        ).solve_fp_system(m0, U)
+
+        np.testing.assert_allclose(
+            m_via_sigma,
+            m_via_diffusion,
+            rtol=1e-12,
+            atol=1e-12,
+            err_msg="volatility_field=sigma must yield D=sigma^2/2 (== diffusion_coefficient=0.5*sigma^2)",
+        )
+
     def test_solve_fp_system_initial_condition(self):
         """Test that initial condition is preserved."""
         network = GridNetwork(width=3, height=3)

--- a/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py
@@ -110,6 +110,46 @@ class TestLLFAugmentationPinning:
         assert solver._llf_sigma_eff.shape == (solver.n_points,)
         assert solver._llf_sigma_eff.dtype == np.float64
 
+    def test_llf_sigma_eff_recomputed_from_volatility_override(self, problem_and_pts):
+        """Issue #1429 (S0-13): a per-solve volatility_field override (#1316) must propagate into
+        the LLF effective volatility. _llf_sigma_eff is otherwise frozen at __init__ from
+        problem.sigma, so an LLF-augmented solve with an override stabilizes off the base sigma.
+
+        Uses a tiny llf_l_H so nu_i = 0 (no augmentation) and sigma_eff == the base sigma exactly,
+        making the override directly observable as sigma_eff == override."""
+        problem, pts = problem_and_pts  # problem.sigma = 0.5
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            solver = HJBGFDMSolver(
+                problem, pts, monotonicity_scheme="none", llf_augmentation=True, llf_cone_constant=0.5, llf_l_H=0.01
+            )
+        base = solver._llf_sigma_eff.copy()  # nu_i = 0 -> sigma_eff = problem.sigma = 0.5
+        n = solver.n_points
+        M = np.ones((problem.Nt + 1, n)) / n
+        U_T = np.zeros(n)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            solver.solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=0.9)
+        np.testing.assert_allclose(
+            solver._llf_sigma_eff,
+            0.9,
+            rtol=1e-9,
+            err_msg="LLF sigma_eff ignored the per-solve volatility_field override (S0-13: frozen at problem.sigma)",
+        )
+        assert not np.allclose(solver._llf_sigma_eff, base), "override had no effect — _llf_sigma_eff stayed frozen"
+
+        # A subsequent default solve must reset sigma_eff to the base (unconditional recompute).
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            solver.solve_hjb_system(M_density=M, U_terminal=U_T, volatility_field=None)
+        np.testing.assert_allclose(
+            solver._llf_sigma_eff,
+            base,
+            rtol=1e-9,
+            err_msg="LLF sigma_eff not reset to base after a volatility_field=None solve (stale override)",
+        )
+
     def test_llf_sigma_eff_ge_base(self, problem_and_pts):
         """PINNING: sigma_eff_i >= sigma everywhere (LLF only adds diffusion)."""
         problem, pts = problem_and_pts


### PR DESCRIPTION
Refs #1429 (S0-13, S0-15). Findings investigated + adversarially verified via a multi-agent pass.

## S0-13 — LLF effective volatility ignored the per-solve override (med)
`HJBGFDMSolver._llf_sigma_eff` (= `sqrt(σ² + 2ν)`) is computed once at `__init__` from `problem.sigma` and never recomputed when `solve_hjb_system` installs a #1316 per-solve `volatility_field` override. An LLF-augmented (#1059) solve with an override therefore stabilizes off the **base** σ, not the override. **Fix:** recompute `_llf_sigma_eff` from the installed override, **unconditionally** (so a later `volatility_field=None` solve resets it — no stale override).
- Byte-identical when LLF is off (the default) or no override is passed.
- Idempotent across Picard iterations (override is constant, `_llf_l_H` static) → does **not** reopen the #1059 frozen-ν stability note (comment added).

## S0-15 — FPNetworkSolver read `volatility_field` as `D`, not σ (low)
The scalar branch set `effective_diffusion = float(volatility_field)`, consuming it directly as the diffusion `D` — diverging from the `base_fp` contract (`volatility_field` = SDE σ, `D = σ²/2`) shared by FDM/FVM/GFDM. A user passing σ got `D = σ` instead of `σ²/2`. **Fix:** route through the single source `diffusion_from_volatility`. Affects only an explicit scalar `volatility_field`; the `None` path (the D-valued `diffusion_coefficient` constructor knob) is unchanged.

## Tests (verified to fail without each fix)
- S0-13: LLF solver with tiny `llf_l_H` (ν=0 ⇒ `sigma_eff` = base σ exactly) — assert `_llf_sigma_eff` picks up the override, and resets to base after a `None` solve.
- S0-15: behavioral equivalence — `solve(volatility_field=σ)` == `solve()` with `diffusion_coefficient=0.5σ²`. **Note:** a uniform initial density is a diffusion fixed point (∆ of a constant = 0), so the test uses a non-uniform ramp to make `D` observable (caught during verification).
- 65 passed / 13 skipped; `ruff check` + `format --check` clean.

## Other #1429 findings (dispositioned, not in this PR)
- **S0-14** (CFL log) — already fixed in HEAD (PR #1434); not-a-bug.
- **S0-21** (WENO silent neumann BC) — verified the terminal fallback is **unreachable** for real `MFGProblem`s; not a runtime bug. Optional #634-style single-source hygiene (delete the private `_get_boundary_conditions`, use the inherited one) deferred.
- **S0-11** (deprecated SL renormalization) — real masking, but on the Neumann default (the only BC the diffusion sub-step implements) it is a defensible conservation stabilizer; deprecated path. Deferred.

So this **Refs** (not Closes) #1429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)