### PR TITLE
refactor(hjb-weno): single-source BC resolution via inherited get_boundary_conditions (#1429 S0-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`HJBWENOSolver` boundary-condition resolution single-sourced** (Issue #1429, S0-21). Replaced a
+  private 4-accessor copy of the BC resolution chain (which also diverged at the terminal — private
+  `neumann_bc` vs the inherited `None` vs the ConditionsMixin `periodic_bc`) with a delegation to the
+  inherited single source `BaseMFGSolver.get_boundary_conditions()` (the Issue #634 pattern already
+  applied to the SL solver), keeping WENO's no-flux fallback for its concrete-BC ghost-buffer
+  requirement. Byte-identical for real problems (`self._boundary_conditions` is never set, and the
+  geometry/problem accessors resolve to the same stored BC); a convention-agreement pin was added.
+
 - **`CoefficientField` diffusion default-value precedence fixed: `override → volatility_field → sigma`**
   (Issue #1412). The FDM/HJB solver sites (`hjb_fdm`, `base_hjb`, `fp_fdm_time_stepping`) hand-built
   `CoefficientField(override, problem.sigma)`, so a `None` per-solve `volatility_field` fell back to the

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -337,52 +337,20 @@ class HJBWENOSolver(BaseHJBSolver):
         )
 
     def _get_boundary_conditions(self):
+        """Resolve boundary conditions through the single-source inherited
+        ``BaseMFGSolver.get_boundary_conditions()`` (Issue #634 pattern), falling back to Neumann
+        (no-flux) when none is configured.
+
+        Issue #1429 (S0-21): this replaces a private 4-accessor copy of the resolution chain that
+        also diverged at the terminal (private ``neumann_bc`` vs inherited ``None`` vs the
+        ConditionsMixin ``periodic_bc``). The inherited chain resolves to the same stored BC for a
+        real ``MFGProblem``: ``self._boundary_conditions`` is never assigned, so its Priority-1 is a
+        no-op, and the geometry/problem attribute and method accessors return the same object. WENO
+        keeps a concrete-BC requirement — the ghost buffer cannot take ``None`` — so a no-flux
+        Neumann fallback is applied here when the single source yields ``None``.
         """
-        Get boundary conditions from problem or geometry.
-
-        Falls back to Neumann (no-flux) BC if not specified.
-
-        Resolution order (NO hasattr per CLAUDE.md):
-        1. geometry.get_boundary_conditions() (method accessor)
-        2. geometry.boundary_conditions (direct attribute)
-        3. problem.get_boundary_conditions() (method accessor)
-        4. problem.boundary_conditions (direct attribute)
-        5. Default Neumann BC
-        """
-        # Priority 1: geometry.get_boundary_conditions() (method accessor)
-        try:
-            bc = self.problem.geometry.get_boundary_conditions()
-            if bc is not None:
-                return bc
-        except AttributeError:
-            pass
-
-        # Priority 2: geometry.boundary_conditions (direct attribute)
-        try:
-            bc = self.problem.geometry.boundary_conditions
-            if bc is not None:
-                return bc
-        except AttributeError:
-            pass
-
-        # Priority 3: problem.get_boundary_conditions() (method accessor)
-        try:
-            bc = self.problem.get_boundary_conditions()
-            if bc is not None:
-                return bc
-        except AttributeError:
-            pass
-
-        # Priority 4: problem.boundary_conditions (direct attribute)
-        try:
-            bc = self.problem.boundary_conditions
-            if bc is not None:
-                return bc
-        except AttributeError:
-            pass
-
-        # Default: Neumann (no-flux) BC - common for HJB problems
-        return neumann_bc(dimension=self.dimension)
+        bc = self.get_boundary_conditions()
+        return bc if bc is not None else neumann_bc(dimension=self.dimension)
 
     def _get_domain_bounds(self) -> np.ndarray:
         """Get domain bounds from problem/geometry (NO hasattr per CLAUDE.md)."""

--- a/tests/unit/test_alg/test_weno_family.py
+++ b/tests/unit/test_alg/test_weno_family.py
@@ -23,7 +23,7 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry import TensorProductGrid
-from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.geometry.boundary import no_flux_bc, periodic_bc
 
 
 def _default_hamiltonian():
@@ -790,6 +790,26 @@ class TestWeno2DSolve:
         amp = np.max(np.abs(U_A[0]))
         # O(dt^2) Strang asymmetry only; a per-axis-spacing bug would be ~0.5*amp.
         assert diff < 5e-2 * amp, f"per-axis spacing not honoured: diff={diff:.3e}, amp={amp:.3e}"
+
+
+def test_weno_bc_resolved_via_inherited_single_source():
+    """Issue #1429 (S0-21): HJBWENOSolver resolves boundary conditions through the inherited
+    single source ``get_boundary_conditions()`` (Issue #634 pattern) and honors a configured
+    non-default BC, instead of a private 4-accessor copy that terminated in a silent Neumann
+    default. Pins that _get_boundary_conditions returns exactly the inherited resolution (a
+    silent-Neumann regression would return a fresh object, not the configured periodic BC)."""
+    domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[33], boundary_conditions=periodic_bc(dimension=1))
+    problem = MFGProblem(geometry=domain, T=0.1, Nt=10, sigma=0.1, components=_default_components())
+    solver = HJBWENOSolver(problem)
+
+    inherited = solver.get_boundary_conditions()
+    assert inherited is not None
+    # WENO delegates to the inherited single source (non-None case) — same object, no private fork.
+    assert solver._get_boundary_conditions() is inherited
+    # ...resolving to the configured geometry BC (stable object), not a private re-derivation.
+    assert inherited is domain.get_boundary_conditions()
+    # ...and honoring the configured periodic BC, not a silent Neumann fallback.
+    assert inherited != no_flux_bc(dimension=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #1429 (S0-21). Byte-identical single-source hygiene (verdict from the #1429 adversarial review).

## What
`HJBWENOSolver._get_boundary_conditions` carried a private 4-accessor copy of the BC resolution chain that also diverged at the terminal — private `neumann_bc` vs the inherited `None` vs the ConditionsMixin `periodic_bc`. Replaced with a delegation to the inherited single source `BaseMFGSolver.get_boundary_conditions()` (the **Issue #634** pattern already applied to the SL HJB solver), keeping WENO's no-flux Neumann fallback because its ghost buffer needs a concrete BC (cannot take `None`).

```python
def _get_boundary_conditions(self):
    bc = self.get_boundary_conditions()
    return bc if bc is not None else neumann_bc(dimension=self.dimension)
```

## Why byte-identical
- `self._boundary_conditions` is **never assigned** anywhere in `alg/` → the inherited chain's Priority-1 is a no-op (AttributeError → skip).
- The geometry/problem **attribute** and **method** accessors resolve to the same stored BC, so the attr-vs-method ordering difference between the two chains doesn't change the result (verified: `TensorProductGrid` resolves via the method).
- The private terminal `neumann_bc` was verified **unreachable** for a real `MFGProblem` (ConditionsMixin always yields non-None).
- Full WENO suites pass unchanged (62).

## Test
Convention-agreement pin (`test_weno_family`): WENO's `_get_boundary_conditions()` returns exactly the inherited single source and honors a configured non-default (periodic) BC — so a future re-divergence to a silent Neumann default fails CI. (This is a single-source agreement pin, not a behavior-fix pin: the change is byte-identical, so it passes pre- and post-change by design.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)