### PR TITLE
feat(bc): HJBGFDMSolver joins the BC-capability gate (#1456 rollout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`HJBGFDMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
+  supported set `{DIRICHLET, NEUMANN, NO_FLUX, ROBIN, PERIODIC}` (fixing the audit-flagged
+  declared≠handled set — added `ROBIN` and `PERIODIC`) and validates it at construction.
+  `REFLECTING` / `EXTRAPOLATION_*` (which no test constructs and the audit confirms it cannot honor)
+  now fail loud at construction; the general-Robin and *mixed*-periodic sub-cases pass the type-level
+  gate and remain enforced by the row builder at solve time (so uniform-periodic ghost-skip and the
+  adjoint-consistent Robin path are unaffected). Byte-identical for every existing GFDM test.
+
 - **BC-capability gate: solvers fail loud on an unsupported boundary-condition type** (Issue #1456,
   first increment). The `BoundaryCapable` protocol (`supported_bc_types` + `_validate_bc_support`)
   existed but was un-adopted (1/12 solvers declared it, 0 enforced), which is why a BC type a solver

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -103,6 +103,8 @@ class HJBGFDMSolver(BaseHJBSolver):
             BCType.DIRICHLET,
             BCType.NEUMANN,
             BCType.NO_FLUX,  # Same as Neumann with g=0
+            BCType.ROBIN,  # adjoint-consistent Robin(0,1); general-Robin sub-cases fail loud in the row builder
+            BCType.PERIODIC,  # uniform periodic (ghost-skip); mixed-periodic-at-a-boundary fails loud in the row builder
         }
     )
 
@@ -648,6 +650,10 @@ class HJBGFDMSolver(BaseHJBSolver):
             # Geometry-sourced BC may be re-resolved per Picard iteration by the
             # coupling layer (using_resolved_bc); refresh at solve time (Issue #1118).
             self._bc_from_geometry = True
+        # Issue #1456: fail loud now if the resolved BC requests a type GFDM cannot honor at all
+        # (REFLECTING / EXTRAPOLATION_*). Periodic and general-Robin sub-cases pass the type-level
+        # gate and are still rejected by the row builder where they are genuinely unsupported.
+        self._validate_bc_support(self.boundary_conditions)
         self.interior_indices = np.setdiff1d(np.arange(self.n_points), self.boundary_indices)
 
         # DMP runtime guard state (Issue #1074): lazily-computed critical drift and a

--- a/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
+++ b/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
@@ -3,11 +3,11 @@
 The `BoundaryCapable` protocol (`geometry/boundary/protocols.py`) lets a solver declare
 `_SUPPORTED_BC_TYPES`; `BaseMFGSolver._validate_bc_support` raises on an unsupported type at
 construction instead of silently collapsing it to the solver's default (usually Neumann / no-flux)
-— the BC-blindness class mapped in #1456. This pins the template solvers wired in the first
-increment: `FPParticleSolver` (already fail-fast → now a declared contract) and `FPSLSolver`
-(silently collapsed Dirichlet/Robin to its zero-flux Neumann stencil → now fails loud).
-(`HJBGFDMSolver` already fails loud at its row builder and has a uniform-vs-mixed periodic nuance
-the type-level construction gate cannot express honestly — deferred to the per-solver rollout.)
+— the BC-blindness class mapped in #1456. This pins the migrated solvers: `FPParticleSolver`
+(already fail-fast → now a declared contract), `FPSLSolver` (silently collapsed Dirichlet/Robin to
+its zero-flux Neumann stencil → now fails loud), and `HJBGFDMSolver` (declares
+Dirichlet/Neumann/no-flux/Robin/periodic; rejects Reflecting/Extrapolation at construction — the
+general-Robin / mixed-periodic sub-cases the row builder still enforces pass the type-level gate).
 """
 
 from __future__ import annotations
@@ -18,11 +18,13 @@ import numpy as np
 
 from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry import TensorProductGrid
-from mfgarchon.geometry.boundary import dirichlet_bc, no_flux_bc, periodic_bc, robin_bc
+from mfgarchon.geometry.boundary import dirichlet_bc, no_flux_bc, periodic_bc, robin_bc, uniform_bc
+from mfgarchon.geometry.boundary.types import BCType
 
 pytestmark = pytest.mark.filterwarnings("ignore")
 
@@ -40,6 +42,28 @@ def _components():
 def _problem(bc):
     grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[N], boundary_conditions=bc)
     return MFGProblem(geometry=grid, T=0.2, Nt=10, sigma=0.3, components=_components())
+
+
+def _pts():
+    return np.linspace(0.0, 1.0, N).reshape(-1, 1)
+
+
+# ---------------------------------------------------------------------------
+# HJBGFDM — declares Dirichlet/Neumann/no-flux/Robin/periodic; Reflecting/Extrapolation
+# (which no other test constructs, and the audit confirms it cannot honor) fail loud at
+# construction. Periodic and general-Robin sub-cases pass the type-level gate and remain
+# enforced by the row builder at solve time.
+# ---------------------------------------------------------------------------
+
+
+def test_hjb_gfdm_fails_loud_on_reflecting():
+    with pytest.raises(NotImplementedError, match="does not support"):
+        HJBGFDMSolver(_problem(uniform_bc(BCType.REFLECTING, dimension=1)), collocation_points=_pts(), delta=0.25)
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, dirichlet_bc, periodic_bc, robin_bc])
+def test_hjb_gfdm_accepts_supported(bc_factory):
+    HJBGFDMSolver(_problem(bc_factory(dimension=1)), collocation_points=_pts(), delta=0.25)  # must not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1456 (rollout). Follows #1457 (gate foundation), and resolves the GFDM nuance that was deferred there.

## What
Declare `HJBGFDMSolver`'s **honest** supported set `{DIRICHLET, NEUMANN, NO_FLUX, ROBIN, PERIODIC}` (the audit flagged the prior `{DIRICHLET, NEUMANN, NO_FLUX}` as declared≠handled — it omitted the Robin it handles and the periodic it ghost-skips) and validate it at construction via `_validate_bc_support`.

## The design fix (from #1457's CI failure)
#1457 deferred GFDM because a naive gate (omit PERIODIC) broke two construct-then-check tests. The resolution: **declare PERIODIC supported** — then the gate is byte-identical for every GFDM test:
- `test_apply_ghost_nodes_skips_when_periodic_default` (uniform periodic) → constructs + ghost-skips ✓
- `test_dispatch_periodic_raises` (mixed no-flux+periodic) → constructs, then raises at the row builder as before ✓

The sub-cases a *type-level* gate can't express — general-Robin(1,1), mixed-periodic-at-a-boundary — pass the gate and **stay enforced by the row builder** at solve time. The gate adds construction-time fail-loud only for `REFLECTING` / `EXTRAPOLATION_*`, which **no test constructs GFDM with** (grep-verified across all tests) and the audit confirms GFDM cannot honor.

## Validation
- **138 GFDM tests pass unchanged**: `bc_classification`, `ghost_nodes_mixed_bc` (the two that failed in #1457), `howard` (Robin(1,1)), `gfdm_solver`, `llf_augmentation`, `convention_agreement`.
- Gate test extended (`test_issue_1456`): GFDM rejects Reflecting + accepts no-flux/Dirichlet/periodic/Robin; **verified to fail without the gate** (reflecting case). `ruff` clean.
- No test constructs any migrated solver with REFLECTING/EXTRAPOLATION (`test_resolution` only exercises the `BCResolver` directly).

## Remaining #1456 rollout
The other FP solvers (FP-FDM, FP-FVM, FP-GFDM, FP-SL-Jacobian, FP-Network) + the HJB-SL/WENO, then the deeper `make-bc-aware` layers (revive `BCResolver`, route stencils through `dispatch.apply_bc`, gate the mass-renorms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)