### PR TITLE
feat(bc): FPFDMSolver joins the BC-capability gate (#1456 rollout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`FPFDMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
+  supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validates it at construction; `ROBIN`
+  (no stencil — #1250) and `REFLECTING` / `EXTRAPOLATION_*` now fail loud at construction instead of
+  silently assembling the default no-flux wall. The pre-existing solve-time Robin raise
+  (`test_robin_bc_fails_loud_implicit`) is now caught earlier at construction (message says `ROBIN`).
+  Byte-identical for every supported BC (181-test FP-FDM surface unchanged; no other test constructs
+  FP-FDM with an unsupported type).
+
 - **`HJBGFDMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
   supported set `{DIRICHLET, NEUMANN, NO_FLUX, ROBIN, PERIODIC}` (fixing the audit-flagged
   declared≠handled set — added `ROBIN` and `PERIODIC`) and validates it at construction.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -7,6 +7,7 @@ import scipy.sparse as sparse
 
 from mfgarchon.backends.compat import has_nan_or_inf
 from mfgarchon.geometry import BoundaryConditions
+from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.aux_func import npart, ppart
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
@@ -101,6 +102,16 @@ class FPFDMSolver(BaseFPSolver):
     from mfgarchon.alg.base_solver import SchemeFamily
 
     _scheme_family = SchemeFamily.FDM
+
+    # BoundaryCapable protocol (Issue #1456): FP-FDM assembles Dirichlet / Neumann / no-flux /
+    # periodic boundary rows; Robin has no stencil (fails loud — Issue #1250), and
+    # Reflecting/Extrapolation are not field-BC types it handles.
+    _SUPPORTED_BC_TYPES: frozenset = frozenset({BCType.DIRICHLET, BCType.NEUMANN, BCType.NO_FLUX, BCType.PERIODIC})
+
+    @property
+    def supported_bc_types(self) -> frozenset:
+        """BC types this solver supports (BoundaryCapable protocol)."""
+        return self._SUPPORTED_BC_TYPES
 
     def __init__(
         self,
@@ -233,6 +244,11 @@ class FPFDMSolver(BaseFPSolver):
                 from mfgarchon.geometry.boundary import no_flux_bc
 
                 self.boundary_conditions = no_flux_bc(dimension=self.dimension)
+
+        # Issue #1456: fail loud now if the resolved BC requests a type FP-FDM cannot honor
+        # (Robin has no stencil; Reflecting/Extrapolation are not field-BC types), instead of
+        # silently assembling a default (no-flux) wall.
+        self._validate_bc_support(self.boundary_conditions)
 
         # Issue #1075: the non-conservative gradient (point-value) advection schemes do
         # NOT conserve mass at no-flux walls -- even for pure diffusion -- because the

--- a/tests/unit/test_alg/test_fp_matrix_conservation.py
+++ b/tests/unit/test_alg/test_fp_matrix_conservation.py
@@ -120,8 +120,9 @@ class TestNeumannBCImplicitFP:
 
         Issue #1250: until a correct Robin stencil is implemented, failing loud is
         correct (fail-fast doctrine); silently assembling an absorbing wall is not.
+        Issue #1456: now caught at construction by the BC-capability gate (message says ROBIN).
         """
-        with pytest.raises(NotImplementedError, match="robin"):
+        with pytest.raises(NotImplementedError, match=r"(?i)robin"):
             _zero_drift_density_evolution(robin_bc(dimension=1))
 
 

--- a/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
+++ b/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
@@ -16,6 +16,7 @@ import pytest
 
 import numpy as np
 
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
 from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
@@ -23,7 +24,7 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry import TensorProductGrid
-from mfgarchon.geometry.boundary import dirichlet_bc, no_flux_bc, periodic_bc, robin_bc, uniform_bc
+from mfgarchon.geometry.boundary import dirichlet_bc, neumann_bc, no_flux_bc, periodic_bc, robin_bc, uniform_bc
 from mfgarchon.geometry.boundary.types import BCType
 
 pytestmark = pytest.mark.filterwarnings("ignore")
@@ -81,6 +82,23 @@ def test_fp_sl_fails_loud_on_unsupported(bc):
 @pytest.mark.parametrize("bc_factory", [no_flux_bc, periodic_bc])
 def test_fp_sl_accepts_supported(bc_factory):
     FPSLSolver(_problem(bc_factory(dimension=1)))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# FP-FDM — assembles Dirichlet/Neumann/no-flux/periodic boundary rows; Robin (no stencil,
+# #1250) and Reflecting/Extrapolation fail loud at construction.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bc", [robin_bc(dimension=1), uniform_bc(BCType.REFLECTING, dimension=1)])
+def test_fp_fdm_fails_loud_on_unsupported(bc):
+    with pytest.raises(NotImplementedError, match="does not support"):
+        FPFDMSolver(_problem(bc))
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, dirichlet_bc, periodic_bc])
+def test_fp_fdm_accepts_supported(bc_factory):
+    FPFDMSolver(_problem(bc_factory(dimension=1)))  # must not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1456 (rollout). Follows #1457 (foundation), #1458 (GFDM).

## What
Declare `FPFDMSolver`'s honest supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validate at construction. `ROBIN` (no stencil — #1250) and `REFLECTING`/`EXTRAPOLATION_*` now **fail loud at construction** instead of silently falling through the 6-level resolution cascade to the default no-flux wall (the audit's class-c finding).

## Notable
The pre-existing solve-time Robin raise (`test_robin_bc_fails_loud_implicit`) is now caught earlier at construction — its `match` was updated `"robin"` → `r"(?i)robin"` since the gate message says `ROBIN`. (The solve-time raise stays as defensive depth.)

## Validation
- **181 FP-FDM unit tests pass unchanged** (`fp_fdm_solver`, `matrix_conservation`, `fixed_point_sigma_consistency`, `issue1285_newton_fail_loud`, `potential_field_g017`, `drift_contract`, `solver_traits`, `fvm`, `scheme_factory`).
- Comprehensive grep: **no other test** constructs FP-FDM with robin/reflecting/extrapolation (only the gate test + the robin fail-loud test).
- Gate test extended (FP-FDM reject: robin, reflecting; accept: no-flux, neumann, dirichlet, periodic) — **verified to fail without the gate** (2 fail). `ruff` clean.

## #1456 rollout status
4 of 12 solvers gated (FPParticle, FPSLSolver, HJBGFDM, FPFDM). Remaining: FP-FVM, FP-GFDM, FP-SL-Jacobian, FP-Network, HJB-FDM, HJB-SL, HJB-WENO, Network-HJB; then the deeper `make-bc-aware` layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)