### PR TITLE
feat(bc): HJBFDMSolver joins the BC-capability gate (#1456 rollout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`HJBFDMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
+  supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validates the geometry/problem BC at
+  construction (HJB-FDM re-reads `get_boundary_conditions()` per solve, so a `None` BC at construction
+  is a no-op). `ROBIN` / `REFLECTING` / `EXTRAPOLATION_*` now fail loud at construction. Byte-identical
+  for every supported BC (270-test HJB-FDM surface unchanged; no test constructs HJB-FDM with an
+  unsupported type).
+
 - **`FPFDMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
   supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validates it at construction; `ROBIN`
   (no stencil — #1250) and `REFLECTING` / `EXTRAPOLATION_*` now fail loud at construction instead of

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from mfgarchon.alg.numerical.hjb_solvers.h_eval import eval_dH_dp_batch, eval_H_batch
 from mfgarchon.geometry.base import CartesianGrid  # nD FDM needs structured grid ABC
+from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.numerical import FixedPointSolver, NewtonSolver
@@ -134,6 +135,15 @@ class HJBFDMSolver(BaseHJBSolver):
     # (cross_density) into the HJB solve. MultiPopulationIterator checks this flag and
     # fails loud for K>1 on backends that lack it rather than silently decoupling the HJB.
     _honors_multipop_cross_density = True
+
+    # BoundaryCapable protocol (Issue #1456): FDM assembles Dirichlet / Neumann / no-flux / periodic
+    # boundary rows; Robin / Reflecting / Extrapolation are not handled and fail loud.
+    _SUPPORTED_BC_TYPES: frozenset = frozenset({BCType.DIRICHLET, BCType.NEUMANN, BCType.NO_FLUX, BCType.PERIODIC})
+
+    @property
+    def supported_bc_types(self) -> frozenset:
+        """BC types this solver supports (BoundaryCapable protocol)."""
+        return self._SUPPORTED_BC_TYPES
 
     @deprecated_parameter(
         param_name="damping_factor",
@@ -295,6 +305,11 @@ class HJBFDMSolver(BaseHJBSolver):
 
         # Cached Laplacian operator for nD diffusion (Issue #787)
         self._laplacian_op: object | None = None
+
+        # Issue #1456: fail loud now if the (geometry/problem) BC requests a type FDM cannot honor
+        # (Robin / Reflecting / Extrapolation), instead of silently assembling a default wall. None
+        # (BC resolved later) is a no-op; HJB-FDM re-reads get_boundary_conditions() per solve.
+        self._validate_bc_support(self.get_boundary_conditions())
 
     # _detect_dimension() inherited from BaseNumericalSolver (Issue #633)
 

--- a/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
+++ b/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
@@ -19,7 +19,7 @@ import numpy as np
 from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
-from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
@@ -82,6 +82,23 @@ def test_fp_sl_fails_loud_on_unsupported(bc):
 @pytest.mark.parametrize("bc_factory", [no_flux_bc, periodic_bc])
 def test_fp_sl_accepts_supported(bc_factory):
     FPSLSolver(_problem(bc_factory(dimension=1)))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# HJB-FDM — assembles Dirichlet/Neumann/no-flux/periodic boundary rows; Robin/Reflecting/
+# Extrapolation fail loud at construction (no test constructs HJB-FDM with them).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bc", [robin_bc(dimension=1), uniform_bc(BCType.REFLECTING, dimension=1)])
+def test_hjb_fdm_fails_loud_on_unsupported(bc):
+    with pytest.raises(NotImplementedError, match="does not support"):
+        HJBFDMSolver(_problem(bc))
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, dirichlet_bc, periodic_bc])
+def test_hjb_fdm_accepts_supported(bc_factory):
+    HJBFDMSolver(_problem(bc_factory(dimension=1)))  # must not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1456 (rollout). Follows #1457/#1458/#1459.

## What
Declare `HJBFDMSolver`'s honest supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validate at construction. `ROBIN`/`REFLECTING`/`EXTRAPOLATION_*` now fail loud at construction.

## Pattern note
HJB-FDM reads the BC **lazily** (`get_boundary_conditions()` per solve; no `self.boundary_conditions` store), unlike the store-in-`__init__` solvers. The gate runs once at `__init__` via `_validate_bc_support(self.get_boundary_conditions())`; a `None` BC there (deferred geometry resolution) is a no-op, and the per-solve re-read keeps the #1118 `using_resolved_bc` refresh intact (resolved-Robin providers don't change the declared BC *type*).

## Validation
- **270 HJB-FDM unit tests pass unchanged** (`hjb_fdm_solver`, `fixed_point_sigma_consistency`, `issue1285_newton_fail_loud`, `solver_traits`, `scheme_factory`, `semi_lagrangian`, `penalty`, `true_adjoint`, `nd_coupling_time_level`, `1d_nd_cross_path_agreement`, `1071_control_cost_lambda`, `fp_nonquadratic`, `adjoint_validation`).
- Comprehensive grep: **no test** constructs HJB-FDM with robin/reflecting/extrapolation.
- Gate test extended (HJB-FDM reject: robin, reflecting; accept: no-flux, neumann, dirichlet, periodic) — **verified to fail without the gate** (2 fail). `ruff` clean.

## #1456 rollout status
**5 of 12 gated** (FPParticle, FPSLSolver, HJBGFDM, FPFDM, **HJBFDM**). Remaining: FP-FVM, FP-GFDM, FP-SL-Jacobian, FP-Network, HJB-SL, HJB-WENO, Network-HJB; then the deeper `make-bc-aware` layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)