### PR TITLE
feat(bc): HJBWENOSolver joins the BC-capability gate (#1456 rollout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`HJBWENOSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
+  supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validates the resolved BC at
+  construction (right after the inherited single-source resolution from #1429-S0-21). `ROBIN` /
+  `REFLECTING` / `EXTRAPOLATION_*` — which the WENO5 ghost path would otherwise silently reflect or
+  degrade — now fail loud. Byte-identical for every supported BC (94-test WENO surface unchanged;
+  no test constructs WENO with an unsupported type).
+
 - **`HJBFDMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
   supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validates the geometry/problem BC at
   construction (HJB-FDM re-reads `get_boundary_conditions()` per solve, so a `None` BC at construction

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -44,6 +44,7 @@ import numpy as np
 from mfgarchon.core.derivatives import DerivativeTensors, to_multi_index_dict
 from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
 from mfgarchon.geometry.boundary.conditions import neumann_bc
+from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.deprecation import deprecated_alias
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
@@ -129,6 +130,16 @@ class HJBWENOSolver(BaseHJBSolver):
     from mfgarchon.alg.base_solver import SchemeFamily
 
     _scheme_family = SchemeFamily.FDM  # WENO is FDM variant
+
+    # BoundaryCapable protocol (Issue #1456): WENO5 ghost buffers handle Dirichlet / Neumann /
+    # no-flux / periodic; Robin, Reflecting and Extrapolation are not faithfully supported (the
+    # ghost path would silently reflect / degrade them) and fail loud.
+    _SUPPORTED_BC_TYPES: frozenset = frozenset({BCType.DIRICHLET, BCType.NEUMANN, BCType.NO_FLUX, BCType.PERIODIC})
+
+    @property
+    def supported_bc_types(self) -> frozenset:
+        """BC types this solver supports (BoundaryCapable protocol)."""
+        return self._SUPPORTED_BC_TYPES
 
     def __init__(
         self,
@@ -320,6 +331,10 @@ class HJBWENOSolver(BaseHJBSolver):
 
         # Get boundary conditions from problem/geometry if available
         bc = self._get_boundary_conditions()
+        # Issue #1456: fail loud now if the resolved BC requests a type WENO cannot honor
+        # (Robin / Reflecting / Extrapolation), instead of silently reflecting/degrading it in the
+        # ghost path. The neumann fallback above keeps an unconfigured problem on a supported type.
+        self._validate_bc_support(bc)
 
         # Build domain bounds from grid information
         domain_bounds = self._get_domain_bounds()

--- a/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
+++ b/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
@@ -19,7 +19,7 @@ import numpy as np
 from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
-from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver, HJBWENOSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
@@ -82,6 +82,23 @@ def test_fp_sl_fails_loud_on_unsupported(bc):
 @pytest.mark.parametrize("bc_factory", [no_flux_bc, periodic_bc])
 def test_fp_sl_accepts_supported(bc_factory):
     FPSLSolver(_problem(bc_factory(dimension=1)))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# HJB-WENO — WENO5 ghost buffers handle Dirichlet/Neumann/no-flux/periodic; Robin/Reflecting/
+# Extrapolation (silently reflected/degraded in the ghost path) fail loud at construction.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bc", [robin_bc(dimension=1), uniform_bc(BCType.REFLECTING, dimension=1)])
+def test_hjb_weno_fails_loud_on_unsupported(bc):
+    with pytest.raises(NotImplementedError, match="does not support"):
+        HJBWENOSolver(_problem(bc))
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, dirichlet_bc, periodic_bc])
+def test_hjb_weno_accepts_supported(bc_factory):
+    HJBWENOSolver(_problem(bc_factory(dimension=1)))  # must not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1456 (rollout). Follows #1457–#1460.

## What
Declare `HJBWENOSolver`'s honest supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validate the resolved BC at construction (right after the inherited single-source `_get_boundary_conditions()` from #1429-S0-21). `ROBIN` / `REFLECTING` / `EXTRAPOLATION_*` — which the WENO5 ghost path would otherwise **silently reflect or degrade** (the audit's mixed-BC ghost finding) — now fail loud at construction.

## Validation
- **94 WENO unit tests pass unchanged** (`weno_family`, `weno_ghost_order`, `hjbweno_rename_alias`, `issue_1316`).
- Comprehensive grep: **no test** constructs WENO with robin/reflecting/extrapolation.
- Gate test extended (WENO reject: robin, reflecting; accept: no-flux, neumann, dirichlet, periodic) — **verified to fail without the gate** (2 fail). `ruff` clean.

## #1456 rollout status
**6 of 12 gated** (FPParticle, FPSLSolver, HJBGFDM, FPFDM, HJBFDM, **HJBWENO**). Remaining: FP-FVM, FP-GFDM, FP-SL-Jacobian, FP-Network, HJB-SL, Network-HJB; then the deeper `make-bc-aware` layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)