### PR TITLE
feat(bc): FPFVMSolver joins the BC-capability gate (#1456 rollout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`FPFVMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
+  supported set `{NO_FLUX, NEUMANN, PERIODIC}` and validates the resolved BC at construction (after
+  the pre-existing Issue #422 Dirichlet guard, whose specific message is preserved). `ROBIN` /
+  `REFLECTING` / `EXTRAPOLATION_*` now fail loud at construction. Byte-identical for every supported
+  BC (the FVM unit surface + the Dirichlet guard test pass unchanged).
+
 - **`HJBWENOSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
   supported set `{DIRICHLET, NEUMANN, NO_FLUX, PERIODIC}` and validates the resolved BC at
   construction (right after the inherited single-source resolution from #1429-S0-21). `ROBIN` /

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
@@ -62,6 +62,7 @@ from scipy.sparse.linalg import splu
 from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.alg.numerical.fp_solvers.fp_fvm_flux import advective_divergence
+from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.operators.differential.laplacian import LaplacianOperator
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
@@ -95,6 +96,17 @@ class FPFVMSolver(BaseFPSolver):
     """
 
     _scheme_family = SchemeFamily.FVM
+
+    # BoundaryCapable protocol (Issue #1456): the conservative FV scheme handles no-flux / Neumann
+    # and periodic (wrap) walls; Dirichlet fails loud via the specific Issue #422 guard below, and
+    # Robin / Reflecting / Extrapolation are not represented.
+    _SUPPORTED_BC_TYPES: frozenset = frozenset({BCType.NO_FLUX, BCType.NEUMANN, BCType.PERIODIC})
+
+    @property
+    def supported_bc_types(self) -> frozenset:
+        """BC types this solver supports (BoundaryCapable protocol)."""
+        return self._SUPPORTED_BC_TYPES
+
     # The FP equation consumes the advective velocity alpha directly via ``drift_field``; a
     # value function ``U`` may instead be passed via ``potential_field`` (the solver then forms
     # alpha = -coupling*grad(U) at the faces). Default convention is VELOCITY.
@@ -131,12 +143,13 @@ class FPFVMSolver(BaseFPSolver):
         # Dirichlet inflow handling (deferred, Issue #422 scope; the diffusion operator alone
         # supports Dirichlet). Without this guard the solver would only raise from
         # ``fp_fvm_flux.axis_flux_divergence`` once an advected solve is attempted.
-        from mfgarchon.geometry.boundary import BCType
-
         if any(seg.bc_type == BCType.DIRICHLET for seg in self.boundary_conditions.segments):
             raise NotImplementedError(
                 "FP FVM (v1) does not support Dirichlet BC (Issue #422 scope); use no_flux/neumann/periodic."
             )
+        # Issue #1456: fail loud on a type FVM cannot honor at all (Robin / Reflecting /
+        # Extrapolation). Dirichlet is handled by the specific guard above (its own message).
+        self._validate_bc_support(self.boundary_conditions)
 
     # ------------------------------------------------------------------
     # Setup helpers

--- a/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
+++ b/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
@@ -17,6 +17,7 @@ import pytest
 import numpy as np
 
 from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_fvm import FPFVMSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
 from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver, HJBWENOSolver
@@ -116,6 +117,23 @@ def test_hjb_fdm_fails_loud_on_unsupported(bc):
 @pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, dirichlet_bc, periodic_bc])
 def test_hjb_fdm_accepts_supported(bc_factory):
     HJBFDMSolver(_problem(bc_factory(dimension=1)))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# FP-FVM — conservative FV: no-flux/Neumann/periodic; Robin/Reflecting/Extrapolation fail loud
+# via the gate (Dirichlet has its own Issue #422 guard, tested in test_fvm_hjb_coupling).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bc", [robin_bc(dimension=1), uniform_bc(BCType.REFLECTING, dimension=1)])
+def test_fp_fvm_fails_loud_on_unsupported(bc):
+    with pytest.raises(NotImplementedError, match="does not support"):
+        FPFVMSolver(_problem(bc))
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, periodic_bc])
+def test_fp_fvm_accepts_supported(bc_factory):
+    FPFVMSolver(_problem(bc_factory(dimension=1)))  # must not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1456 (rollout). Follows #1457–#1461.

## What
Declare `FPFVMSolver`'s honest supported set `{NO_FLUX, NEUMANN, PERIODIC}` and validate at construction. Wired **after** the pre-existing Issue #422 Dirichlet guard, so its specific message and `test_fvm_hjb_coupling` Dirichlet test are preserved; the gate then catches `ROBIN` / `REFLECTING` / `EXTRAPOLATION_*` at construction.

## Validation
- FVM unit surface (`test_fp_fvm`) + the Dirichlet guard test pass unchanged.
- No test constructs FVM with robin/reflecting/extrapolation.
- Gate test extended (FVM reject: robin, reflecting; accept: no-flux, neumann, periodic) — **verified to fail without the gate** (2 fail). `ruff` clean.

## ⚠️ Pre-existing failures (not this PR)
`test_fvm_hjb_coupling::{test_1d_fvm_coupled_converges, test_1d_fvm_fdm_agreement}` fail with a convergence-tolerance miss (`final_error_M=7.4e-4` vs `1e-4`) — **confirmed identical on main** (unrelated to this change; these slow integration tests are skipped in PR CI). Flagging for visibility; worth a separate look at FVM coupled convergence.

## #1456 rollout status
**7 of 12 gated** (FPParticle, FPSLSolver, HJBGFDM, FPFDM, HJBFDM, HJBWENO, **FPFVM**). Remaining: FP-GFDM, FP-SL-Jacobian, FP-Network, HJB-SL, Network-HJB; then the deeper `make-bc-aware` layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)