### PR TITLE
feat(bc): HJB-SL, FP-SL-Jacobian, FP-GFDM join the BC-capability gate (#1456 rollout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`HJBSemiLagrangianSolver`, `FPSLJacobianSolver`, `FPGFDMSolver` join the BC-capability gate**
+  (Issue #1456, rollout — completes the continuum solvers). Each declares its honest supported set
+  `{NO_FLUX, NEUMANN, PERIODIC}` and validates the resolved BC at construction. These were the
+  audit's silent-mishandling cases: the SL solvers' zero-flux CN/ADI diffusion silently collapsed
+  Dirichlet/Robin/absorbing to Neumann, and FP-GFDM's `_resolve_boundary_type` returned `None`
+  silently for them — now all fail loud. No construct-then-check test constructs any of them with an
+  unsupported type (grep-verified); their unit surfaces pass unchanged.
+
 - **`FPFVMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
   supported set `{NO_FLUX, NEUMANN, PERIODIC}` and validates the resolved BC at construction (after
   the pre-existing Issue #422 Dirichlet guard, whose specific message is preserved). `ROBIN` /

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import TaylorOperator
+from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
@@ -77,6 +78,16 @@ class FPGFDMSolver(BaseFPSolver):
     from mfgarchon.alg.base_solver import SchemeFamily
 
     _scheme_family = SchemeFamily.GFDM
+
+    # BoundaryCapable protocol (Issue #1456): _resolve_boundary_type handles no-flux / Neumann /
+    # periodic and returns None (silently) for everything else; declare exactly those so
+    # Dirichlet / Robin / Reflecting / Extrapolation fail loud instead.
+    _SUPPORTED_BC_TYPES: frozenset = frozenset({BCType.NO_FLUX, BCType.NEUMANN, BCType.PERIODIC})
+
+    @property
+    def supported_bc_types(self) -> frozenset:
+        """BC types this solver supports (BoundaryCapable protocol)."""
+        return self._SUPPORTED_BC_TYPES
 
     def __init__(
         self,
@@ -140,6 +151,10 @@ class FPGFDMSolver(BaseFPSolver):
             boundary_conditions=boundary_conditions,
             boundary_type_str=boundary_type,
         )
+        # Issue #1456: fail loud if the resolved BC requests a type GFDM cannot honor —
+        # _resolve_boundary_type returns None (silently) for Dirichlet/Robin/Reflecting/Extrapolation.
+        _bc_for_gate = boundary_conditions if boundary_conditions is not None else self.get_boundary_conditions()
+        self._validate_bc_support(_bc_for_gate)
 
         # Create GFDM operator using TaylorOperator (Strategy Pattern, Issue #844)
         # TaylorOperator handles neighborhoods and derivative weights

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian.py
@@ -39,6 +39,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
     get_bc_type_string,
 )
+from mfgarchon.geometry.boundary.types import BCType
 
 # Issue #625: Migrated from tensor_calculus to operators/stencils
 from mfgarchon.operators.stencils.finite_difference import laplacian_with_bc
@@ -95,6 +96,16 @@ class FPSLJacobianSolver(BaseFPSolver):
 
     _scheme_family = SchemeFamily.SL
     _drift_convention = DriftConvention.VALUE_FUNCTION  # Issue #1043: takes U via potential_field
+
+    # BoundaryCapable protocol (Issue #1456): the CN diffusion sub-step is zero-flux (no-flux /
+    # Neumann g=0) and the advection wraps for periodic; Dirichlet / Robin / absorbing are silently
+    # collapsed to Neumann downstream, so they fail loud here instead.
+    _SUPPORTED_BC_TYPES: frozenset = frozenset({BCType.NO_FLUX, BCType.NEUMANN, BCType.PERIODIC})
+
+    @property
+    def supported_bc_types(self) -> frozenset:
+        """BC types this solver supports (BoundaryCapable protocol)."""
+        return self._SUPPORTED_BC_TYPES
 
     @deprecated(since="v0.17.6", replacement="FPSLSolver")
     def __init__(
@@ -155,6 +166,9 @@ class FPSLJacobianSolver(BaseFPSolver):
         else:
             # Try to get BC from problem/geometry
             self.boundary_conditions = self._get_boundary_conditions_from_problem()
+        # Issue #1456: fail loud now if the resolved BC requests a type this solver cannot honor
+        # (Dirichlet/Robin would otherwise be silently collapsed to the zero-flux Neumann stencil).
+        self._validate_bc_support(self.boundary_conditions)
 
     def _get_boundary_conditions_from_problem(self) -> BoundaryConditions | None:
         """Get boundary conditions from problem or geometry."""

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -33,6 +33,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
     get_bc_type_string,
 )
+from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import check_adi_compatibility, diffusion_from_volatility
 
@@ -106,6 +107,16 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
     from mfgarchon.alg.base_solver import SchemeFamily
 
     _scheme_family = SchemeFamily.SL
+
+    # BoundaryCapable protocol (Issue #1456): the SL diffusion sub-step (CN/ADI) is zero-flux
+    # (no-flux / Neumann g=0) and the characteristic foot wraps for periodic; Dirichlet / Robin /
+    # absorbing are silently collapsed to Neumann on the default path, so they fail loud here.
+    _SUPPORTED_BC_TYPES: frozenset = frozenset({BCType.NO_FLUX, BCType.NEUMANN, BCType.PERIODIC})
+
+    @property
+    def supported_bc_types(self) -> frozenset:
+        """BC types this solver supports (BoundaryCapable protocol)."""
+        return self._SUPPORTED_BC_TYPES
 
     def __init__(
         self,
@@ -317,6 +328,11 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # Setup JAX functions if available
         if self.use_jax:
             self._setup_jax_functions()
+
+        # Issue #1456: fail loud now if the (geometry/problem) BC requests a type SL cannot honor
+        # (Dirichlet/Robin/absorbing — otherwise silently collapsed to the zero-flux Neumann
+        # diffusion). None (BC resolved later) is a no-op; SL re-reads get_boundary_conditions().
+        self._validate_bc_support(self.get_boundary_conditions())
 
     # _detect_dimension() inherited from BaseNumericalSolver (Issue #633)
 

--- a/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
+++ b/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
@@ -18,9 +18,11 @@ import numpy as np
 
 from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_fvm import FPFVMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
 from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
-from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver, HJBWENOSolver
+from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver, HJBGFDMSolver, HJBSemiLagrangianSolver, HJBWENOSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
@@ -167,6 +169,47 @@ def test_fp_particle_fails_loud_on_robin():
 @pytest.mark.parametrize("bc_factory", [no_flux_bc, periodic_bc, dirichlet_bc])
 def test_fp_particle_accepts_supported(bc_factory):
     FPParticleSolver(_problem(bc_factory(dimension=1)))  # must not raise (Dirichlet = absorbing)
+
+
+# ---------------------------------------------------------------------------
+# HJB-SL / FP-SL-Jacobian / FP-GFDM — zero-flux/periodic; Dirichlet/Robin (silently collapsed to
+# Neumann / returned None — the audit's silent-mishandling cases) now fail loud at construction.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bc", [dirichlet_bc(dimension=1), robin_bc(dimension=1)])
+def test_hjb_sl_fails_loud_on_unsupported(bc):
+    with pytest.raises(NotImplementedError, match="does not support"):
+        HJBSemiLagrangianSolver(_problem(bc))
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, periodic_bc])
+def test_hjb_sl_accepts_supported(bc_factory):
+    HJBSemiLagrangianSolver(_problem(bc_factory(dimension=1)))
+
+
+@pytest.mark.parametrize("bc", [dirichlet_bc(dimension=1), robin_bc(dimension=1)])
+def test_fp_sl_jacobian_fails_loud_on_unsupported(bc):
+    with pytest.raises(NotImplementedError, match="does not support"):
+        FPSLJacobianSolver(_problem(bc))
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, periodic_bc])
+def test_fp_sl_jacobian_accepts_supported(bc_factory):
+    FPSLJacobianSolver(_problem(bc_factory(dimension=1)))
+
+
+@pytest.mark.parametrize("bc", [dirichlet_bc(dimension=1), robin_bc(dimension=1)])
+def test_fp_gfdm_fails_loud_on_unsupported(bc):
+    pts = np.linspace(0.0, 1.0, N).reshape(-1, 1)
+    with pytest.raises(NotImplementedError, match="does not support"):
+        FPGFDMSolver(_problem(bc), collocation_points=pts, delta=0.25)
+
+
+@pytest.mark.parametrize("bc_factory", [no_flux_bc, neumann_bc, periodic_bc])
+def test_fp_gfdm_accepts_supported(bc_factory):
+    pts = np.linspace(0.0, 1.0, N).reshape(-1, 1)
+    FPGFDMSolver(_problem(bc_factory(dimension=1)), collocation_points=pts, delta=0.25)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1456 (rollout). Follows #1457–#1462. **Batched** (3 continuum solvers in one PR) and **validated against the full PR-CI suite locally** before pushing, to avoid serial GitHub-CI round-trips.

## What
Completes the continuum-solver rollout. Each declares its honest supported set `{NO_FLUX, NEUMANN, PERIODIC}` and validates the resolved BC at construction:

| Solver | BC-resolution pattern | Silent-mishandling before the gate |
|---|---|---|
| `HJBSemiLagrangianSolver` | lazy (inherited `get_boundary_conditions()`, #634) → gate at `__init__` end | zero-flux CN/ADI diffusion **silently collapsed** Dirichlet/Robin/absorbing → Neumann (audit's high-risk case) |
| `FPSLJacobianSolver` (deprecated) | explicit/geometry store → gate after | same zero-flux collapse |
| `FPGFDMSolver` | `_resolve_boundary_type` → gate after | returned `None` **silently** for Dirichlet/Robin/Reflecting/Extrapolation |

All three now fail loud at construction.

## Validation (local, before push)
- **Full PR-CI suite locally**: `pytest tests/ -m "not slow and not optional_torch and not benchmark and not experimental and not environment"` → **4867 passed, 0 failed** (7:33). This is the exact GitHub Test Suite command.
- Gate test extended (each: reject dirichlet/robin, accept no-flux/neumann/periodic) → **52 gate cases pass**; verified to fail without the gate.
- No construct-then-check test constructs any of these with an unsupported type (grep-verified across all tests). `ruff` clean.

## #1456 rollout status
**9 of 12 gated** (FPParticle, FPSLSolver, HJBGFDM, FPFDM, HJBFDM, HJBWENO, FPFVM, **HJBSemiLagrangian, FPSLJacobian, FPGFDM**). Remaining: **FP-Network, Network-HJB** (graph regime — continuum `BCType` may not map; handled separately). Then the deeper `make-bc-aware` layers (revive `BCResolver`, route stencils through `dispatch.apply_bc`, gate the mass-renorms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)