### PR TITLE
fix(howard): degenerate upwind stencil skips advection to preserve M-matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Howard advection operator preserves the unconditional M-matrix at degenerate stencils**
+  (Issue #1466). `_build_upwind_projection` (Howard policy-eval, GFDM scattered clouds) fell back to
+  `mask = np.ones(...)` when no neighbour lay on the upwind side of `alpha`, pulling the whole
+  all-downwind neighbourhood in with negative advective off-diagonals (`proj_j < 0 -> w_j < 0`) —
+  the opposite sign to the genuine upwind stencil, breaking the M-matrix property
+  `thm:upwind_comparison` rests on. It now skips the node (pure diffusion, M-matrix preserved),
+  matching the sibling `_build_per_axis_upwind_pair`. Pinned by
+  `test_howard_upwind_projection_degenerate_stencil_preserves_m_matrix`. Refs #1074, #1381.
 - **LLF effective volatility now tracks the per-solve `volatility_field` override** (Issue #1429,
   S0-13). `HJBGFDMSolver._llf_sigma_eff` was frozen at `__init__` from `problem.sigma`, so an
   LLF-augmented solve (#1059) with a #1316 per-solve volatility override stabilized off the base σ,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,7 @@ authors:
     alias: Jeremy
     email: jiongyiwang@gmail.com
     orcid: "https://orcid.org/0009-0003-7717-2361"
-doi: "10.5281/zenodo.19251867"
-version: "0.18.0"
-date-released: "2026-03-29"
+doi: "10.5281/zenodo.19251867"  # concept DOI (resolves to latest); version pinned per-paper, not here
 url: "https://github.com/derrring/MFGArchon"
 repository-code: "https://github.com/derrring/MFGArchon"
 license: MIT

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
@@ -193,7 +193,15 @@ def _build_upwind_projection(alpha: np.ndarray, points: np.ndarray, socp_data: d
         proj = rel @ d_a  # shape (k,)
         mask = proj > 0
         if mask.sum() < 1:
-            mask = np.ones(len(nbr_idx), dtype=bool)
+            # No neighbour lies on the upwind side of alpha: no sign-correct
+            # one-sided advection stencil exists at this node. Skip its advective
+            # contribution (pure diffusion, M-matrix preserved), matching
+            # `_build_per_axis_upwind_pair`. The previous `mask = np.ones(...)`
+            # fallback pulled in downwind neighbours (proj_j < 0 -> w_j < 0),
+            # silently emitting negative advective off-diagonals and breaking the
+            # unconditional-M-matrix property of `thm:upwind_comparison`. Such
+            # degenerate stencils are expected to be excluded by the boundary buffer.
+            continue
         sel_proj = proj[mask]
         sel_nbrs = nbr_idx[mask]
         denom = float(np.sum(sel_proj * sel_proj))

--- a/tests/unit/test_alg/test_socp_m_matrix_property.py
+++ b/tests/unit/test_alg/test_socp_m_matrix_property.py
@@ -293,6 +293,74 @@ def test_vectorized_jacobian_byte_identical_to_inline_lq_formula(sigma):
     )
 
 
+# ---------------------------------------------------------------------------
+# Closed-form pinning: the paper's headline Wendland-stencil constants.
+# `app:proof_joint_socp` Step 1 (1D reduction) and Step 3 (hex cone constant).
+# These were derived by hand (`thm:joint_socp(b)`: C_star^sym = 1/2) but had no
+# regression test. Pin them so a stencil-construction change cannot silently
+# move the load-bearing constant that the discrete comparison principle rests on.
+# ---------------------------------------------------------------------------
+
+
+def test_socp_reproduces_1d_second_difference():
+    """`app:proof_joint_socp` Step 1: the 1D uniform 3-point Wendland C2 stencil
+    (δ/h = 2) reduces to the standard second difference — physical
+    ``L = (1, -2, 1)/h^2``, i.e. ``L = (-2, 1, 1)`` at ``h = 1`` with the center
+    listed first."""
+    from mfgarchon.alg.numerical.gfdm_components.joint_socp import (
+        build_taylor_matrix_1d,
+        solve_joint_socp_at_stencil,
+        wendland_stencil_weights,
+    )
+
+    offsets = np.array([0.0, -1.0, 1.0])  # center first, spacing h = 1
+    A, _ = build_taylor_matrix_1d(offsets)
+    w = wendland_stencil_weights(offsets, delta=2.0)
+    out = solve_joint_socp_at_stencil(A, center_idx=0, h_i=1.0, C=8.0, wendland_w=w, dimension=1)
+
+    assert out["L"] is not None, "SOCP infeasible on the 1D uniform reference stencil"
+    L = np.asarray(out["L"])
+    assert np.isclose(L[0], -2.0, atol=1e-3), f"center L = {L[0]:.4f}, expected -2"
+    assert np.allclose(L[1:], 1.0, atol=1e-3), f"off-diagonal L = {L[1:]}, expected (1, 1)"
+
+
+@pytest.mark.parametrize("delta", [1.2, 1.6, 2.0])
+def test_socp_reproduces_hex_closed_form_constant(delta):
+    """`thm:joint_socp(b)` / `app:proof_joint_socp` Step 3: on the 2D regular
+    hexagon reference the joint SOCP reproduces the closed-form Wendland stencil
+    constants ``L_hat = 2/3``, ``L_center = -4``, ``||D_hat|| = 1/3``, and the
+    cone constant ``xi = h_i * ||D|| / L = C_star^sym = 1/2`` exactly, independent
+    of ``δ/h`` in ``(1, 2]``."""
+    from mfgarchon.alg.numerical.gfdm_components.joint_socp import (
+        build_taylor_matrix_2d,
+        solve_joint_socp_at_stencil,
+        wendland_stencil_weights,
+    )
+
+    angles = np.arange(6) * (np.pi / 3.0)
+    hexagon = np.stack([np.cos(angles), np.sin(angles)], axis=1)  # 6 unit vertices
+    offsets = np.vstack([[0.0, 0.0], hexagon])  # center first, h_i = 1
+    A, _ = build_taylor_matrix_2d(offsets)
+    w = wendland_stencil_weights(offsets, delta=delta)
+    out = solve_joint_socp_at_stencil(A, center_idx=0, h_i=1.0, C=8.0, wendland_w=w, dimension=2)
+
+    assert out["L"] is not None, f"δ={delta}: SOCP infeasible on the hexagonal reference"
+    L = np.asarray(out["L"])
+    D = np.asarray(out["D"])  # shape (2, 7)
+    off = np.arange(1, 7)
+    L_off = L[off]
+    D_off_norm = np.linalg.norm(D[:, off], axis=0)
+
+    assert np.isclose(L[0], -4.0, atol=1e-3), f"δ={delta}: center L = {L[0]:.4f}, expected -4"
+    assert np.allclose(L_off, 2.0 / 3.0, atol=1e-3), f"δ={delta}: L_off = {L_off}, expected 2/3"
+    assert np.allclose(D_off_norm, 1.0 / 3.0, atol=1e-3), f"δ={delta}: ||D|| = {D_off_norm}, expected 1/3"
+    xi = D_off_norm / L_off
+    assert np.allclose(xi, 0.5, atol=1e-3), f"δ={delta}: ξ = {xi}, expected C_star^sym = 1/2"
+    assert np.isclose(out["kappa_max"], 0.5, atol=1e-3), (
+        f"δ={delta}: kappa_max = {out['kappa_max']:.4f}, expected C_star^sym = 1/2"
+    )
+
+
 def test_runtime_dmp_guard_warns_only_when_violated():
     """Issue #1074 runtime guard: check_dmp=True warns when the drift exceeds α_crit; it is
     silent below the threshold and a no-op when check_dmp=False (the default — numerically inert)."""
@@ -455,6 +523,69 @@ def test_critical_drift_includes_negative_lap_edges():
         f"alpha_crit={alpha_crit:.4f}: negative-L edge (L=-0.1, g=1.0) must drive alpha_crit <= 0; "
         "old code returned +0.5, masking a pre-existing M-matrix violation (Issue #1253)"
     )
+
+
+def test_howard_upwind_projection_degenerate_stencil_preserves_m_matrix():
+    """`thm:upwind_comparison`: at a node with no upwind neighbour, the Howard
+    advection operator ``_build_upwind_projection`` must contribute *nothing*
+    (pure diffusion), not fall back to the whole neighbourhood.
+
+    Regression for the ``mask = np.ones(...)`` fallback. When ``proj = rel . alpha_hat``
+    is non-positive for every neighbour, the old fallback selected all (downwind)
+    neighbours, giving weights ``w_j = |alpha| * proj_j / sum(proj^2) < 0`` — negative
+    advective off-diagonals with the opposite sign to the genuine upwind stencil
+    (``proj_j > 0 -> w_j > 0``). Mixing signs breaks the unconditional M-matrix
+    property the discrete comparison principle rests on; the fix skips the node.
+
+    The cloud has one degenerate node (all neighbours downwind of alpha) and one
+    ordinary node (an upwind neighbour available), so the test also pins that the
+    fix is surgical: the ordinary node still advects, using only its upwind edge.
+    """
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_howard import _build_upwind_projection
+
+    # Flow alpha = +x everywhere. Node 0's neighbours all sit at x < 0 (downwind);
+    # node 1 has one upwind neighbour (x > x_1) and one downwind neighbour (x < x_1).
+    points = np.array(
+        [
+            [0.0, 0.0],  # 0: degenerate centre
+            [5.0, 0.0],  # 1: ordinary centre
+            [-1.0, 0.0],  # 2: downwind nbr of 0
+            [-1.0, 1.0],  # 3: downwind nbr of 0
+            [-1.0, -1.0],  # 4: downwind nbr of 0
+            [6.0, 0.0],  # 5: upwind nbr of 1
+            [4.0, 0.0],  # 6: downwind nbr of 1 (must be excluded by upwind selection)
+        ]
+    )
+    alpha = np.zeros((7, 2))
+    alpha[0] = [1.0, 0.0]
+    alpha[1] = [1.0, 0.0]
+    socp_data = {
+        0: {"neighbor_indices": [2, 3, 4]},
+        1: {"neighbor_indices": [5, 6]},
+    }
+
+    A = _build_upwind_projection(alpha, points, socp_data, n_total=7).tolil()
+
+    # Degenerate node 0: no advective contribution at all. The old fallback filled
+    # this row with negative off-diagonals; this assertion fails under that fallback.
+    assert A.rows[0] == [], (
+        f"degenerate node 0 must contribute no advection, got {dict(zip(A.rows[0], A.data[0], strict=True))}"
+    )
+
+    # Ordinary node 1: still advects, using only the upwind neighbour (5), not the
+    # downwind one (6); the off-diagonal weight has the correct (positive) upwind sign.
+    assert A[1, 5] > 0.0, "ordinary node must keep its upwind advective weight"
+    assert A[1, 6] == 0.0, "downwind neighbour must be excluded from the upwind stencil"
+    assert A[1, 1] < 0.0, "advection diagonal must be negative (row sum zero)"
+
+    # Global upwind sign: every advective off-diagonal is non-negative. The old
+    # degenerate fallback injects negatives here, so this is a second catch of the bug.
+    Acsr = A.tocsr()
+    for i in range(7):
+        row = Acsr.getrow(i)
+        for j, val in zip(row.indices, row.data, strict=True):
+            if j != i:
+                assert val >= 0.0, f"A[{i},{j}] = {val:.3e} < 0 breaks upwind off-diagonal sign"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes a sign bug in the Howard policy-eval advection operator that breaks the unconditional discrete maximum principle at degenerate scattered-cloud nodes, and adds a regression test plus closed-form pinning tests for the discrete-comparison-principle constants.

## The bug (Fixes #1466)
`hjb_howard._build_upwind_projection` selects upwind neighbours (`proj = rel·α̂ > 0`) and weights them `w_j = |α|·proj_j/Σproj² > 0` — uniformly positive off-diagonals, the sign the assembled M-matrix (`thm:upwind_comparison`) requires. When **no** neighbour is upwind (`mask.sum() < 1`), the old fallback `mask = np.ones(...)` selected the whole all-downwind neighbourhood, giving `w_j < 0`: negative advective off-diagonals of the wrong sign. The sibling `_build_per_axis_upwind_pair` already skips an empty half-stencil, so the two builders silently disagreed.

## The fix
Skip the advective contribution at a degenerate node (`continue`) → pure diffusion, M-matrix preserved. 10-line change; behaviour identical at every non-degenerate node.

## Tests
- `test_howard_upwind_projection_degenerate_stencil_preserves_m_matrix` — one degenerate + one ordinary node; asserts the degenerate node contributes zero advection and the ordinary node still advects with correct upwind sign. **Fails on the old fallback** (injects `{2: -0.33, 3: -0.33, 4: -0.33}`), passes with the fix.
- `test_socp_reproduces_1d_second_difference` / `test_socp_reproduces_hex_closed_form_constant` — pin the joint_socp closed-form Wendland constants (1D second difference; 2D hex `L_hat=2/3`, `||D||=1/3`, `ξ=C*_sym=1/2`) so a stencil-construction change can't silently move the DMP's load-bearing constants.

All 63 tests in the M-matrix + Howard suites pass; `ruff format`/`ruff check` clean.

## Also
`docs(citation)`: annotate the Zenodo DOI as a concept DOI and drop the per-paper `version`/`date-released` pins.

Refs #1074 (per-stencil vs assembled M-matrix / DMP gap), #1381 (Howard DMP guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
