### PR TITLE
feat(bc): network solvers fail loud on unsupported node BC (#1456 network family)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Network solvers fail loud on an unsupported node boundary condition** (Issue #1468; #1456
+  network family). The continuum `BCType` gate (`_validate_bc_support`) is a structural no-op for
+  network problems — `NetworkMFGProblem` carries no `BoundaryConditions`, so it keys on nothing — so
+  a network-appropriate gate on `components.boundary_nodes` was added instead. `FPNetworkSolver`
+  (ignores `boundary_nodes` and unconditionally renormalizes mass) and the base `NetworkHJBSolver`
+  (ODE path applies only terminal data) now raise `NotImplementedError` at construction when
+  `boundary_nodes` is set, rather than silently dropping the node BC and hiding any absorption.
+  `NetworkPolicyIterationHJBSolver` (which applies `apply_boundary_conditions` each step) declares
+  `_honors_node_bc = True` and is exempt. No `_SUPPORTED_BC_TYPES` frozenset is added (it would be a
+  no-op). Zero regression: nothing sets `boundary_nodes` today. First step of the network-solver
+  Problem/Components unification (Layer Ψ).
 - **LLF effective volatility now tracks the per-solve `volatility_field` override** (Issue #1429,
   S0-13). `HJBGFDMSolver._llf_sigma_eff` was frozen at `__init__` from `problem.sigma`, so an
   LLF-augmented solve (#1059) with a #1316 per-solve volatility override stabilized off the base σ,

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -66,6 +66,14 @@ class FPNetworkSolver(BaseFPSolver):
         Mass conservation enforced through discrete operators.
     """
 
+    # Node-BC capability gate (Issue #1468; #1456 network family). The network BC model is
+    # `NetworkMFGComponents.boundary_nodes` (a node-level Dirichlet pin applied via
+    # `NetworkMFGProblem.apply_boundary_conditions`), NOT the continuum `BCType`/segments framework —
+    # so the inherited `_validate_bc_support` (which keys on `BoundaryConditions.segments`) is a
+    # structural no-op for network problems. This solver ignores `boundary_nodes` entirely and
+    # unconditionally renormalizes total mass each step, so it cannot honor a node BC: `False`.
+    _honors_node_bc: bool = False
+
     def __init__(
         self,
         problem: NetworkMFGProblem,
@@ -91,6 +99,21 @@ class FPNetworkSolver(BaseFPSolver):
         super().__init__(problem)
 
         self.network_problem = problem
+
+        # Issue #1468: fail loud on a node BC this solver cannot honor. It ignores
+        # `boundary_nodes` and unconditionally renormalizes total mass each step
+        # (`enforce_mass_conservation`), so a node BC would be silently dropped and any
+        # absorption hidden — manufacturing the mass-conserving answer in place of the
+        # intended one (the #1456 silent-wrong-answer class, on the graph).
+        if not self._honors_node_bc and problem.components.boundary_nodes:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support node boundary conditions "
+                f"(problem.components.boundary_nodes is set). It ignores boundary_nodes and "
+                f"unconditionally renormalizes total mass each step, so the node BC would be "
+                f"silently dropped and any absorption hidden (Issue #1468, #1456). Remove "
+                f"boundary_nodes, or use a solver that honors them."
+            )
+
         self.scheme = scheme
         self.diffusion_coefficient = diffusion_coefficient
         self.cfl_factor = cfl_factor

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -57,6 +57,12 @@ class NetworkHJBSolver(BaseHJBSolver):
         Trait validation occurs at problem/geometry level.
     """
 
+    # Node-BC capability gate (Issue #1468; #1456 network family). The base solver integrates the
+    # backward HJB ODE (`_solve_ode` via `solve_ivp`) with terminal data only and never applies
+    # `components.boundary_nodes`, so it cannot honor a node BC: `False`. The
+    # `NetworkPolicyIterationHJBSolver` subclass — which applies them each step — overrides to `True`.
+    _honors_node_bc: bool = False
+
     def __init__(
         self,
         problem: NetworkMFGProblem,
@@ -76,6 +82,19 @@ class NetworkHJBSolver(BaseHJBSolver):
         super().__init__(problem)
 
         self.network_problem = problem
+
+        # Issue #1468: fail loud on a node BC this solver cannot honor. The base ODE path applies
+        # only the terminal condition and never `boundary_nodes`, so a node BC would be silently
+        # ignored. `NetworkPolicyIterationHJBSolver` (which applies them) sets `_honors_node_bc`.
+        if not self._honors_node_bc and problem.components.boundary_nodes:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support node boundary conditions "
+                f"(problem.components.boundary_nodes is set). The base network HJB integrates the "
+                f"backward ODE with terminal data only and never applies boundary_nodes, so the "
+                f"node BC would be silently ignored (Issue #1468, #1456). Use "
+                f"NetworkPolicyIterationHJBSolver, which applies them, or remove boundary_nodes."
+            )
+
         self.scheme = scheme
         self.tolerance = tolerance
 
@@ -212,6 +231,11 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
     1. Policy evaluation: Solve linear system for current policy
     2. Policy improvement: Update control policy
     """
+
+    # Issue #1468: unlike the base ODE solver, policy iteration applies
+    # `problem.apply_boundary_conditions` (the node-Dirichlet pin over `boundary_nodes`) at every
+    # timestep in `solve_hjb_system`, so it honors a node BC and is exempt from the base gate.
+    _honors_node_bc: bool = True
 
     def __init__(
         self,

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 
 from mfgarchon.alg.numerical.network_solvers.fp_network import FPNetworkSolver
-from mfgarchon.extensions.topology import NetworkMFGProblem
+from mfgarchon.extensions.topology import NetworkMFGComponents, NetworkMFGProblem
 from mfgarchon.geometry.graph.network_geometry import GridNetwork
 
 # Skip all tests if igraph is not available (network backend dependency)
@@ -653,6 +653,49 @@ class TestFPNetworkSolverIntegration:
             M_solution = solver.solve_fp_system(m_initial, U_solution)
 
             assert np.all(np.isfinite(M_solution))
+
+
+class TestFPNetworkSolverIssue1468NodeBCGate:
+    """Issue #1468 (BC-capability, #1456 network family).
+
+    FPNetworkSolver ignores ``components.boundary_nodes`` and unconditionally renormalizes total
+    mass each step, so it must fail loud on a node BC rather than silently solve the
+    mass-conserving problem in place of the intended (absorbing/Dirichlet) one. The continuum
+    ``BCType`` gate (``_validate_bc_support``) is a structural no-op for network problems — they
+    carry no ``BoundaryConditions`` — so this is a network-specific gate on ``boundary_nodes``.
+    """
+
+    def _network(self):
+        network = GridNetwork(width=3, height=3)
+        network.create_network()
+        return network
+
+    def test_boundary_nodes_fail_loud(self):
+        problem = NetworkMFGProblem(
+            network_geometry=self._network(),
+            T=1.0,
+            Nt=10,
+            components=NetworkMFGComponents(boundary_nodes=[0, 8]),
+        )
+        with pytest.raises(NotImplementedError, match="boundary_nodes"):
+            FPNetworkSolver(problem)
+
+    def test_no_boundary_nodes_constructs(self):
+        """Gate inert when no node BC is set (the default) — construction unchanged."""
+        problem = NetworkMFGProblem(network_geometry=self._network(), T=1.0, Nt=10)
+        solver = FPNetworkSolver(problem)  # no raise
+        assert solver.num_nodes == 9
+        assert solver._honors_node_bc is False
+
+    def test_empty_boundary_nodes_list_is_inert(self):
+        """An empty ``boundary_nodes`` list is falsy — no node BC requested, no raise."""
+        problem = NetworkMFGProblem(
+            network_geometry=self._network(),
+            T=1.0,
+            Nt=10,
+            components=NetworkMFGComponents(boundary_nodes=[]),
+        )
+        FPNetworkSolver(problem)  # no raise
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_alg/test_hjb_network_solver.py
+++ b/tests/unit/test_alg/test_hjb_network_solver.py
@@ -14,7 +14,7 @@ from mfgarchon.alg.numerical.network_solvers.hjb_network import (
     NetworkHJBSolver,
     NetworkPolicyIterationHJBSolver,
 )
-from mfgarchon.extensions.topology import NetworkMFGProblem
+from mfgarchon.extensions.topology import NetworkMFGComponents, NetworkMFGProblem
 from mfgarchon.geometry.graph.network_geometry import GridNetwork
 
 # Skip all tests if igraph is not available (network backend dependency)
@@ -492,6 +492,60 @@ class TestNetworkHJBSolverIntegration:
             U_solution = solver.solve_hjb_system(M_density, U_final)
 
             assert np.all(np.isfinite(U_solution))
+
+
+class TestNetworkHJBIssue1468NodeBCGate:
+    """Issue #1468 (BC-capability, #1456 network family).
+
+    The base ``NetworkHJBSolver`` integrates the backward HJB ODE (``solve_ivp``) with terminal
+    data only and never applies ``components.boundary_nodes``, so it must fail loud on a node BC.
+    ``NetworkPolicyIterationHJBSolver`` applies ``apply_boundary_conditions`` at every backward
+    step, so it honors node BC and is exempt from the gate.
+    """
+
+    def _network(self):
+        network = GridNetwork(width=3, height=3)
+        network.create_network()
+        return network
+
+    def test_base_solver_boundary_nodes_fail_loud(self):
+        problem = NetworkMFGProblem(
+            network_geometry=self._network(),
+            T=0.5,
+            Nt=10,
+            components=NetworkMFGComponents(boundary_nodes=[0]),
+        )
+        with pytest.raises(NotImplementedError, match="boundary_nodes"):
+            NetworkHJBSolver(problem)
+
+    def test_base_solver_no_boundary_nodes_constructs(self):
+        problem = NetworkMFGProblem(network_geometry=self._network(), T=0.5, Nt=10)
+        solver = NetworkHJBSolver(problem)  # no raise
+        assert solver._honors_node_bc is False
+
+    # The trivial default Hamiltonian makes the tiny-grid policy-evaluation matrix singular; that
+    # is orthogonal to the gate (the BC pass overwrites the node value regardless of the interior
+    # solve), so suppress the pre-existing warning to keep the assertion focused.
+    @pytest.mark.filterwarnings("ignore:Matrix is exactly singular")
+    def test_policy_iteration_exempt_and_honors_boundary_nodes(self):
+        """Policy iteration constructs with ``boundary_nodes`` (gate-exempt) and actually pins the
+        node value at every backward step via ``apply_boundary_conditions``."""
+        problem = NetworkMFGProblem(
+            network_geometry=self._network(),
+            T=0.5,
+            Nt=10,
+            components=NetworkMFGComponents(boundary_nodes=[0], boundary_values_func=lambda node, t: 7.0),
+        )
+        solver = NetworkPolicyIterationHJBSolver(problem)  # no raise
+        assert solver._honors_node_bc is True
+
+        n_time_points = problem.Nt + 1
+        num_nodes = problem.num_nodes
+        U = solver.solve_hjb_system(np.ones((n_time_points, num_nodes)), np.zeros(num_nodes))
+        # apply_boundary_conditions pins node 0 = 7.0 at every backward step (indices 0..Nt-1);
+        # the terminal step (index Nt) keeps U_terminal (= 0), which the BC pass does not touch.
+        assert np.allclose(U[:-1, 0], 7.0), f"boundary node not pinned: U[:, 0] = {U[:, 0]}"
+        assert U[-1, 0] == 0.0, "terminal condition must be preserved (BC not applied at t=T)"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Stage 0 (safety net) of the network Problem/Components unification. Adds a network-appropriate BC-capability gate so the network solvers fail loud on a node BC they cannot honor, instead of silently solving the wrong problem.

## The finding (Fixes #1468)
The #1456 continuum gate `_validate_bc_support` keys on `BoundaryConditions.segments`. A `NetworkMFGProblem` carries no `BoundaryConditions` (its BC model is `components.boundary_nodes`, a node-Dirichlet pin), so `get_boundary_conditions()` returns `None` and the gate is a **permanent no-op** for network solvers. A `_SUPPORTED_BC_TYPES` frozenset would never be checked — cosmetic and misleading.

## Code-traced blindness
| Solver | Reads `boundary_nodes`? | Verdict |
|---|---|---|
| `NetworkHJBSolver` (base, ODE `solve_ivp`) | No (`hjb_network.py:142–204`) | silently ignores node BC |
| `NetworkPolicyIterationHJBSolver` | Yes (`hjb_network.py:283`) | honours node-Dirichlet |
| `FPNetworkSolver` | No + unconditional per-step `M/=total_mass` (`fp_network.py:301–304`) | HIGH: false conservation, hides absorption |

## The gate
A `_honors_node_bc` class flag + a construction-time guard on `components.boundary_nodes`:
- `FPNetworkSolver` and base `NetworkHJBSolver` → `_honors_node_bc = False` → raise `NotImplementedError` if `boundary_nodes` is set.
- `NetworkPolicyIterationHJBSolver` → `_honors_node_bc = True` → exempt.

## Tests
6 new tests: FPNetwork + base HJB fail loud on `boundary_nodes`; both inert when unset (and on empty list); policy-iteration constructs **and** actually pins the node value each backward step (`U[:-1, 0] == 7.0`, terminal preserved). Full network suites: 55 pass. `ruff format`/`check` clean.

## Why this is Stage 0
The continuum BCType gate cannot express network BC; the honest fix is a node-BC gate. This is the safety net for the Problem/Components unification (Layer Ψ) — the follow-on stages (unify Components, unify BC via `GraphBCResolver`, collapse the Problem) will refactor the *mechanism*, but the pinned **behavior** (fail loud on an unsupported node BC) must survive. Design + staging in the Dev note "Problem/Components Unification — Layer Ψ realization".

Refs #1456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
