### PR TITLE
refactor(network): #1470 Stage 1 — reconcile NetworkHamiltonian + subclass NetworkMFGComponents (byte-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`NetworkMFGComponents` is now a `MFGComponents`** (Issue #1470, Problem/Components unification —
+  Layer Ψ). It subclasses `MFGComponents` with a relaxed `__post_init__` (network problems specify
+  the MFG with the network-native fields — `hamiltonian_func`, `node_interaction_func`,
+  `boundary_nodes` — so the parent's class-based-Hamiltonian requirement does not apply), so
+  `isinstance(components, MFGComponents)` now holds. Byte-identical: `hamiltonian_class` stays `None`
+  (the network solvers read the method / legacy rate paths, not the object), so every solver output
+  is unchanged. Also fixes `NetworkMFGProblem.get_problem_info()` (was `AttributeError` on the
+  missing `description`) and makes `get_boundary_conditions()` resolve to `None` instead of raising.
+  Wiring `boundary_nodes` into the `BoundaryConditions` framework (so the #1456 continuum gate
+  applies to network problems) is a later stage.
+
 - **`FPFVMSolver` joins the BC-capability gate** (Issue #1456, rollout). Declares its honest
   supported set `{NO_FLUX, NEUMANN, PERIODIC}` and validates the resolved BC at construction (after
   the pre-existing Issue #422 Dirichlet guard, whose specific message is preserved). `ROBIN` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reconciled the orphaned `NetworkHamiltonian` with the live network Hamiltonian method**
+  (Issue #1470 / #910). The `NetworkHamiltonian` object built in every `NetworkMFGProblem` is
+  orphaned — `__init__` overwrites `self.components` after constructing it, so
+  `problem.hamiltonian_class` is `None` and it is never exercised. Being dead, it had silently
+  diverged from `NetworkMFGProblem.hamiltonian`: default node congestion `0.0` instead of
+  `0.5*m[node]^2`, and it read the dead `congestion_func` field instead of the live
+  `node_interaction_func`. It now reproduces the method byte-identically (pinned by
+  `test_network_hamiltonian_object_equals_method_node_by_node`, node-by-node across the default /
+  interaction / custom branches). Dormant reconciliation — no live behavior change (network suites
+  unchanged); first step of the network Problem/Components unification (Layer Ψ).
 - **LLF effective volatility now tracks the per-solve `volatility_field` override** (Issue #1429,
   S0-13). `HJBGFDMSolver._llf_sigma_eff` was frozen at `__init__` from `problem.sigma`, so an
   LLF-augmented solve (#1059) with a #1316 per-solve volatility override stabilized off the base σ,

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -57,8 +57,9 @@ class NetworkHamiltonian(HamiltonianBase):
         Custom dH/dm.
     node_potential_func : callable or None
         V(node, t) -> float.
-    congestion_func : callable or None
-        f(node, m, t) -> float.
+    node_interaction_func : callable or None
+        f(node, m, t) -> float. Read on the FULL density, matching the live
+        ``NetworkMFGProblem.density_coupling`` (Issue #1470 reconciliation).
     """
 
     def __init__(
@@ -67,7 +68,7 @@ class NetworkHamiltonian(HamiltonianBase):
         hamiltonian_func=None,
         hamiltonian_dm_func=None,
         node_potential_func=None,
-        congestion_func=None,
+        node_interaction_func=None,
         sense=OptimizationSense.MINIMIZE,
         population_index: int = 0,
     ):
@@ -76,7 +77,7 @@ class NetworkHamiltonian(HamiltonianBase):
         self._hamiltonian_func = hamiltonian_func
         self._hamiltonian_dm_func = hamiltonian_dm_func
         self._node_potential = node_potential_func
-        self._congestion = congestion_func
+        self._node_interaction = node_interaction_func
         self._num_nodes: int | None = None
 
     @property
@@ -129,10 +130,16 @@ class NetworkHamiltonian(HamiltonianBase):
             control_cost += 0.5 * w * dp**2
 
         V = float(self._node_potential(node, t)) if self._node_potential else 0.0
-        # Extract own population density for congestion (avoids silent wrong result
-        # when m is stacked K*N from multi-population)
-        m_own = self._extract_own_density(m)
-        f_m = float(self._congestion(node, m_own, t)) if self._congestion else 0.0
+        # Coupling f(node, m, t). Reconciled with the live NetworkMFGProblem.density_coupling
+        # (Issue #1470): read node_interaction_func on the FULL density, and default to the
+        # quadratic node congestion 0.5 * m_own[node]^2. The previous default of 0.0 (and reading
+        # the dead `congestion_func` field) silently diverged from the method used on every live
+        # solve — see Issue #910. `_extract_own_density` is the identity for single-population m
+        # (so byte-identical to the method) and slices the own population for stacked K*N m.
+        if self._node_interaction is not None:
+            f_m = float(self._node_interaction(node, m, t))
+        else:
+            f_m = 0.5 * float(self._extract_own_density(m)[node]) ** 2
         return control_cost + V + f_m
 
     def optimal_control(self, x, m, p, t=0.0):
@@ -279,7 +286,7 @@ class NetworkMFGProblem(MFGProblem):
             hamiltonian_func=net_components.hamiltonian_func,
             hamiltonian_dm_func=net_components.hamiltonian_dm_func,
             node_potential_func=net_components.node_potential_func,
-            congestion_func=net_components.congestion_func,
+            node_interaction_func=net_components.node_interaction_func,
         )
         parent_components = MFGComponents(
             hamiltonian=network_hamiltonian,

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -186,7 +186,7 @@ class NetworkHamiltonian(HamiltonianBase):
 
 
 @dataclass
-class NetworkMFGComponents:
+class NetworkMFGComponents(MFGComponents):
     """
     Components for defining MFG problems on networks.
 
@@ -229,6 +229,17 @@ class NetworkMFGComponents:
 
     # Problem parameters
     problem_params: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Issue #1470 (Problem/Components unification, Layer Ψ): NetworkMFGComponents IS-A
+        # MFGComponents so ``isinstance`` holds and the #1456 BC-capability gate stops silently
+        # no-op'ing on network problems. But it specifies the MFG with the network-native fields
+        # (hamiltonian_func, node_interaction_func, boundary_nodes, ...), not the continuum ones,
+        # so the parent __post_init__ — which requires a class-based Hamiltonian / m_initial /
+        # u_terminal at construction — does not apply. The network Hamiltonian needs graph
+        # structure and is bound by NetworkMFGProblem, not the components. The init=False
+        # ``_hamiltonian_class`` / ``_lagrangian_class`` fields default to None regardless.
+        pass
 
 
 class NetworkMFGProblem(MFGProblem):

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -1,0 +1,75 @@
+"""Issue #1470 / #910: pin ``NetworkHamiltonian.__call__`` byte-identical to the live
+``NetworkMFGProblem.hamiltonian`` method across the full dispatch surface.
+
+The ``NetworkHamiltonian`` object (Issue #910) is built in every ``NetworkMFGProblem`` but
+orphaned — ``NetworkMFGProblem.__init__`` overwrites ``self.components`` after constructing it,
+so ``problem.hamiltonian_class`` is ``None`` and the object is never exercised. Being dead, it had
+silently diverged from the method it wraps: it defaulted node congestion to ``0.0`` (vs the
+method's ``0.5 * m[node]**2``) and read the dead ``congestion_func`` field (vs the live
+``node_interaction_func``). The Issue #1470 reconciliation makes the object a faithful single
+source; this test fails node-for-node against the pre-reconciliation object.
+
+It pins the object in **isolation** (``H.__call__`` vs the method). Wiring the reconciled object
+into the live solve paths as the single source is deferred (it flips the currently-NaN
+``NetworkPolicyIterationHJBSolver`` to finite — a behavior change tracked separately in #1470).
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.extensions.topology import (
+    NetworkHamiltonian,
+    NetworkMFGComponents,
+    NetworkMFGProblem,
+)
+from mfgarchon.geometry.graph.network_geometry import GridNetwork
+
+igraph = pytest.importorskip("igraph")
+
+
+def _build_H(prob: NetworkMFGProblem) -> NetworkHamiltonian:
+    """The object exactly as ``NetworkMFGProblem.__init__`` builds it, from the stored components."""
+    return NetworkHamiltonian(
+        network_data=prob.network_data,
+        hamiltonian_func=prob.components.hamiltonian_func,
+        hamiltonian_dm_func=prob.components.hamiltonian_dm_func,
+        node_potential_func=prob.components.node_potential_func,
+        node_interaction_func=prob.components.node_interaction_func,
+    )
+
+
+@pytest.mark.parametrize("case", ["default", "interaction", "custom"])
+def test_network_hamiltonian_object_equals_method_node_by_node(case):
+    """Byte-identity (``==``, not ``allclose``) of ``NetworkHamiltonian.__call__`` vs the
+    ``NetworkMFGProblem.hamiltonian`` method, per node, over the three dispatch branches:
+    default quadratic H, a custom ``node_interaction_func``, and a full custom ``hamiltonian_func``.
+    """
+    net = GridNetwork(width=4, height=3)
+    net.create_network()
+    if case == "default":
+        comps = NetworkMFGComponents(node_potential_func=lambda n, t: 0.2 * n)
+    elif case == "interaction":
+        comps = NetworkMFGComponents(
+            node_interaction_func=lambda n, m, t: 0.3 * m[n] + 0.1 * m[n] ** 3,
+            node_potential_func=lambda n, t: 0.2 * n,
+        )
+    else:  # custom full H (dispatch through hamiltonian_func)
+        comps = NetworkMFGComponents(
+            hamiltonian_func=lambda n, nb, m, p, t: sum((p[j] - p[n]) ** 2 for j in nb) + 0.7 * m[n]
+        )
+    prob = NetworkMFGProblem(network_geometry=net, T=1.0, Nt=5, components=comps)
+    H = _build_H(prob)
+
+    rng = np.random.default_rng(7)
+    N = prob.num_nodes
+    m = rng.random(N)
+    m /= m.sum()
+    u = rng.random(N)
+    t = 0.4
+
+    for i in range(N):
+        nbrs = prob.get_node_neighbors(i)
+        method_val = prob.hamiltonian(i, nbrs, m, u, t)
+        object_val = float(H(np.array([i]), m, u, t))
+        assert method_val == object_val, f"node {i} ({case}): method={method_val!r} object={object_val!r}"

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -73,3 +73,31 @@ def test_network_hamiltonian_object_equals_method_node_by_node(case):
         method_val = prob.hamiltonian(i, nbrs, m, u, t)
         object_val = float(H(np.array([i]), m, u, t))
         assert method_val == object_val, f"node {i} ({case}): method={method_val!r} object={object_val!r}"
+
+
+def test_network_components_is_mfg_components_byte_identical():
+    """Issue #1470 Stage 1: ``NetworkMFGComponents`` IS-A ``MFGComponents`` (type unification), and
+    the change is byte-identical.
+
+    ``isinstance`` holds; the solve path is unchanged because ``hamiltonian_class`` stays ``None``
+    (the network solvers read the method / legacy rate paths, not the object). ``get_problem_info()``
+    now works (previously ``AttributeError`` on the non-subclass components' missing ``description``),
+    and ``get_boundary_conditions()`` resolves to ``None`` instead of raising. Wiring
+    ``boundary_nodes`` into the ``BoundaryConditions`` framework (so the #1456 continuum gate applies)
+    is Stage 2 — not claimed here.
+    """
+    from mfgarchon.core.mfg_components import MFGComponents
+
+    net = GridNetwork(width=3, height=3)
+    net.create_network()
+    prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=4)
+
+    assert isinstance(prob.components, MFGComponents)
+    assert prob.hamiltonian_class is None, "byte-identity: the subclass must not activate the object"
+    assert isinstance(prob.get_problem_info(), dict), "get_problem_info must not raise (was AttributeError)"
+    assert prob.get_boundary_conditions() is None, "network BC still resolves to None (Stage 2 wires it)"
+
+    # network-native construction is unaffected
+    comps = NetworkMFGComponents(boundary_nodes=[0, 8], node_potential_func=lambda n, t: 0.1 * n)
+    assert isinstance(comps, MFGComponents)
+    assert comps.boundary_nodes == [0, 8]


### PR DESCRIPTION
## Summary
**#1470 Stage 1 foundation** — two byte-identical steps that make the network problem/components a proper `MFGComponents`/`HamiltonianBase`, without any numerical change. Toward one `MFGProblem`/`MFGComponents` (Layer Ψ).

### 1. Reconcile the orphaned `NetworkHamiltonian` with the live method
The `NetworkHamiltonian(HamiltonianBase)` object (Issue #910) is built in every `NetworkMFGProblem` but **orphaned** — `__init__` overwrites `self.components` after constructing it, so `problem.hamiltonian_class` is `None` (verified) and it never runs. Being dead, it had **silently diverged** from `NetworkMFGProblem.hamiltonian`: default node congestion `0.0` vs the method's `0.5*m[node]**2`, and it read the dead `congestion_func` field vs the live `node_interaction_func` (disagreed at all 9 nodes of a 3×3 grid). Reconciled → `NetworkHamiltonian.__call__` is now **byte-identical** to the method across the default / interaction / custom branches (pinned node-by-node; test fails on the pre-reconciliation object).

### 2. `NetworkMFGComponents` subclasses `MFGComponents`
The type-unification step: `NetworkMFGComponents(MFGComponents)` with a relaxed `__post_init__` (network problems use the network-native fields, so the parent's class-based-Hamiltonian requirement does not apply). `isinstance(components, MFGComponents)` now holds. Also fixes `get_problem_info()` (was `AttributeError`) and makes `get_boundary_conditions()` return `None` instead of raising.

## Byte-identical
`hamiltonian_class` stays `None`, so no solver is activated — every network + integration test passes unchanged (60). Verified safe: no runtime `isinstance(*, MFGComponents)` dispatch, no field-set collision, no components field-iteration.

## Deliberately NOT here (verified reasons)
- **Not** wiring the object as `hamiltonian_class`. A follow-up investigation (refinement study) showed activating it would flip `NetworkPolicyIterationHJBSolver` from NaN to **finite-but-wrong** — it converges to a *different* HJB (error plateaus at 0.708 with refinement ratio ~1.0), because the object exposes two inconsistent Hamiltonians (`__call__`/`dp` quadratic vs `optimal_control` upwind-linear). So activation would turn a fail-loud NaN into a fail-silent wrong answer. Tracked in #1470; FP-only activation (byte-identical) and a policy-iteration fix are separate steps.
- **Not** the field renames / method-knob purge (they touch assertions in `test_network_mfg_solvers.py`) or the native `p=∇_G u` rewrite — later stages.

Refs #1470, #910, #1456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
