### PR TITLE
fix(network): reconcile finite-state MFG Hamiltonian + correct HJB solve (N15 full fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NetworkPolicyIterationHJBSolver` now converges to the same value as the RK45 ODE — the dt-refinement
   gap that previously *plateaued* at ~0.708 (converging to different equations) now halves per
   refinement (first-order → 0). Pinned by `test_network_hamiltonian_minimize_consistency` and
-  `test_network_policy_iteration_converges_to_rk45`.
+  `test_network_policy_iteration_converges_to_rk45`. Scope: the network finite-state MFG is
+  implemented for `sense=MINIMIZE` (cost-to-go) only; `sense=MAXIMIZE` now **fails loud** rather than
+  silently computing the MINIMIZE math (full reward-to-go support tracked in #1476).
 - **Reconciled the orphaned `NetworkHamiltonian` with the live network Hamiltonian method**
   (Issue #1470 / #910). The `NetworkHamiltonian` object built in every `NetworkMFGProblem` is
   orphaned — `__init__` overwrites `self.components` after constructing it, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,9 +117,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   correct finite-state control is downhill `α*=w·max(u_i−u_j,0)` with one-sided value
   `H=½Σw·max(u_i−u_j,0)²` — mass now transports toward lower cost-to-go (was the wrong direction).
   The orphaned `NetworkHamiltonian` is now **wired** as the single-source `hamiltonian_class`, and the
-  wrong-signed FP legacy rate branch fails loud. Pinned by `test_network_hamiltonian_minimize_consistency`.
-  Follow-up (N15 part 2, tracked in #1474): the base-solver integration sign (`du/ds=+H` self-amplifies
-  for non-trivial data — correct is `−H_control + source`) and the full-rate policy-evaluation rewrite.
+  wrong-signed FP legacy rate branch fails loud. Two further defects that made the HJB *solve* wrong
+  are also fixed: (i) the base-solver integration sign — `du/ds=+H` integrated `u_t+H=0` (opposite to
+  the global `−u_t+H=0`) and self-amplified the one-sided control term (value blew up); it now
+  integrates `du/ds = −H_control + source` by separating the control Hamiltonian from the V+coupling
+  RHS sources; (ii) the policy-evaluation linear system was singular (`A_ii=1/dt, A_ij=−1/dt` →
+  row-sum 0 → NaN) and single-action — rewritten to the full-rate M-matrix `A = I/dt + Lᵖⁱ`
+  (`A_ii=1/dt+Σα`, `A_ij=−α`) with the control cost `½Σα²/w` in the RHS. **Decisive check**:
+  `NetworkPolicyIterationHJBSolver` now converges to the same value as the RK45 ODE — the dt-refinement
+  gap that previously *plateaued* at ~0.708 (converging to different equations) now halves per
+  refinement (first-order → 0). Pinned by `test_network_hamiltonian_minimize_consistency` and
+  `test_network_policy_iteration_converges_to_rk45`.
 - **Reconciled the orphaned `NetworkHamiltonian` with the live network Hamiltonian method**
   (Issue #1470 / #910). The `NetworkHamiltonian` object built in every `NetworkMFGProblem` is
   orphaned — `__init__` overwrites `self.components` after constructing it, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Network finite-state MFG: value Hamiltonian, optimal control, and `dp` reconciled into one
+  consistent object** (Issue #1474). `NetworkHamiltonian.__call__` / `_default_network_hamiltonian`
+  used the full quadratic `½Σw(u_j−u_i)²` — the unconstrained α∈ℝ relaxation, an invalid CTMC
+  generator — while `optimal_control` used the upwind `w·max(u_j−u_i,0)`, so RK45 (reads the method)
+  and FP / policy-iteration (read the control) solved *different* HJBs. For `sense=MINIMIZE` the
+  correct finite-state control is downhill `α*=w·max(u_i−u_j,0)` with one-sided value
+  `H=½Σw·max(u_i−u_j,0)²` — mass now transports toward lower cost-to-go (was the wrong direction).
+  The orphaned `NetworkHamiltonian` is now **wired** as the single-source `hamiltonian_class`, and the
+  wrong-signed FP legacy rate branch fails loud. Pinned by `test_network_hamiltonian_minimize_consistency`.
+  Follow-up (N15 part 2, tracked in #1474): the base-solver integration sign (`du/ds=+H` self-amplifies
+  for non-trivial data — correct is `−H_control + source`) and the full-rate policy-evaluation rewrite.
 - **Reconciled the orphaned `NetworkHamiltonian` with the live network Hamiltonian method**
   (Issue #1470 / #910). The `NetworkHamiltonian` object built in every `NetworkMFGProblem` is
   orphaned — `__init__` overwrites `self.components` after constructing it, so

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -423,18 +423,18 @@ class FPNetworkSolver(BaseFPSolver):
         rates = {}
         for i in range(self.num_nodes):
             neighbors = self.divergence_ops.get(i, [])
-            if H_class is not None:
-                alpha = H_class.optimal_control(np.array([i]), m, u, t)
-                rates[i] = {j: float(alpha[j]) for j in neighbors if alpha[j] > 0}
-            else:
-                # Legacy: quadratic rates from value gradient
-                rates[i] = {}
-                for j in neighbors:
-                    du = u[j] - u[i]
-                    edge_weight = self.network_problem.network_data.get_edge_weight(i, j)
-                    rate = edge_weight * max(du, 0.0)
-                    if rate > 0:
-                        rates[i][j] = rate
+            if H_class is None:
+                # Issue #1474: fail loud. A NetworkMFGProblem always wires a single-source
+                # NetworkHamiltonian (`hamiltonian_class`), so this is unreachable; the old legacy
+                # branch computed the wrong-signed uphill rate `w*max(u_j-u_i,0)` (MAXIMIZE), diverging
+                # from the value Hamiltonian. Never fall back to it silently (fail-fast).
+                raise RuntimeError(
+                    "FPNetworkSolver: problem.hamiltonian_class is None. The network transition rates "
+                    "must come from the single-source NetworkHamiltonian.optimal_control (Issue #1474). "
+                    "Ensure the NetworkMFGProblem wired its Hamiltonian."
+                )
+            alpha = H_class.optimal_control(np.array([i]), m, u, t)
+            rates[i] = {j: float(alpha[j]) for j in neighbors if alpha[j] > 0}
         return rates
 
     def _compute_drift_term(self, node: int, m: np.ndarray, u: np.ndarray, t: float) -> float:

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -187,6 +187,11 @@ class NetworkHJBSolver(BaseHJBSolver):
             t_idx = min(int(t_physical / self.dt), n_time_points - 1)
             m = M_density[t_idx, :]
             # HJB: du/dt + H = 0  =>  du/ds = H (sign flip from time reversal)
+            # NOTE (Issue #1474): this sign integrates u_t + H = 0, the OPPOSITE of mfgarchon's global
+            # -u_t + H = 0, and self-amplifies the one-sided control term for non-trivial terminal data
+            # (value blows up). The correct form is du/ds = -H_control + source (V + coupling), which
+            # needs the control Hamiltonian separated from the RHS source terms — a structural change
+            # tracked as the N15 follow-up (this PR only reconciles the three Hamiltonians into one).
             return self._evaluate_hamiltonian_batch(u_flat, m, t_physical)
 
         sol = solve_ivp(

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -158,6 +158,20 @@ class NetworkHJBSolver(BaseHJBSolver):
             H[i] = self.network_problem.hamiltonian(i, neighbors, m, u, t)
         return H
 
+    def _source_terms(self, m: np.ndarray, t: float) -> np.ndarray:
+        """Per-node RHS source terms V(i, t) + f(i, m, t) — node potential + congestion coupling
+        (Issue #1474). In mfgarchon's convention ``-u_t + H_control = source`` these sit on the RHS,
+        so in reversed time they enter ``du/ds`` with the OPPOSITE sign to the control Hamiltonian.
+        The network Hamiltonian method returns ``control + source``; subtracting this isolates the
+        control Hamiltonian.
+        """
+        return np.array(
+            [
+                self.network_problem.node_potential(i, t) + self.network_problem.density_coupling(i, m, t)
+                for i in range(self.num_nodes)
+            ]
+        )
+
     def _solve_ode(
         self,
         U_terminal: np.ndarray,
@@ -186,13 +200,15 @@ class NetworkHJBSolver(BaseHJBSolver):
             # Interpolate density at physical time t
             t_idx = min(int(t_physical / self.dt), n_time_points - 1)
             m = M_density[t_idx, :]
-            # HJB: du/dt + H = 0  =>  du/ds = H (sign flip from time reversal)
-            # NOTE (Issue #1474): this sign integrates u_t + H = 0, the OPPOSITE of mfgarchon's global
-            # -u_t + H = 0, and self-amplifies the one-sided control term for non-trivial terminal data
-            # (value blows up). The correct form is du/ds = -H_control + source (V + coupling), which
-            # needs the control Hamiltonian separated from the RHS source terms — a structural change
-            # tracked as the N15 follow-up (this PR only reconciles the three Hamiltonians into one).
-            return self._evaluate_hamiltonian_batch(u_flat, m, t_physical)
+            # mfgarchon convention -u_t + H_control = source (source = V + coupling on the RHS). In
+            # reversed time s = T - t this is du/ds = -H_control + source (Issue #1474). The network
+            # method returns control + source, so isolate the control Hamiltonian by subtracting the
+            # source. (The old du/ds = +H integrated u_t + H = 0 and self-amplified the one-sided
+            # control term (u_i - u_j)_+^2, blowing the value up for any non-trivial terminal data.)
+            h_total = self._evaluate_hamiltonian_batch(u_flat, m, t_physical)
+            source = self._source_terms(m, t_physical)
+            h_control = h_total - source
+            return -h_control + source
 
         sol = solve_ivp(
             rhs,
@@ -274,8 +290,9 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
             )
         self.hjb_method_name = "NetworkHJB_PolicyIteration"
 
-        # Current policy (action for each node)
-        self.current_policy: dict[int, int] = {}
+        # Current policy: the full transition-rate vector alpha*_i per node (Issue #1474), not a
+        # single dominant action — finite-state control is a full rate row over neighbors.
+        self.current_rates: dict[int, np.ndarray] = {}
 
     def solve_hjb_system(
         self,
@@ -314,140 +331,71 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
         return U
 
     def _policy_iteration_step(self, u_next: np.ndarray, m: np.ndarray, t: float) -> np.ndarray:
-        """Single time step using policy iteration."""
-        u_current = u_next.copy()
+        """Single backward time step via Howard policy iteration (Issue #1474).
 
-        # Initialize policy (greedy with respect to u_next)
+        The "policy" is the full transition-rate vector ``alpha*(u) = H.optimal_control`` (not a single
+        dominant action). Each iteration solves the linear policy-evaluation
+        ``(I/dt + L^pi) u = u_next/dt + c(alpha) + source`` then recomputes the rates, until they
+        stabilize. At the fixed point this is the backward-Euler discretization of the same HJB the
+        RK45 path integrates: ``Q^pi u + c(alpha*) = -H_control`` (envelope identity), so
+        ``-du/dt = -H_control + source``.
+        """
         self._initialize_policy(u_next, m, t)
-
-        # Policy iteration loop
+        u_current = u_next.copy()
         for _policy_iter in range(self.max_policy_iterations):
-            # Policy evaluation: solve linear system
             u_new = self._policy_evaluation(u_next, m, t)
-
-            # Policy improvement
-            old_policy = self.current_policy.copy()
+            old_rates = self.current_rates
             self._policy_improvement(u_new, m, t)
-
-            # Check policy convergence
-            if self._policies_equal(old_policy, self.current_policy):
-                u_current = u_new
-                break
-
             u_current = u_new
-
+            if self._policies_equal(old_rates, self.current_rates):
+                break
         return u_current
 
+    def _rates_at(self, u: np.ndarray, m: np.ndarray, t: float) -> dict[int, np.ndarray]:
+        """Full transition-rate vector ``alpha*_i`` for every node from the single-source Hamiltonian."""
+        H = self.network_problem.hamiltonian_class
+        if H is None:
+            raise RuntimeError(
+                "NetworkPolicyIterationHJBSolver requires a wired hamiltonian_class (Issue #1474). "
+                "The legacy edge-cost policy evaluation assembled a singular row-sum-zero system "
+                "(returned NaN); a NetworkMFGProblem always wires a NetworkHamiltonian."
+            )
+        return {i: np.atleast_1d(H.optimal_control(np.array([i]), m, u, t)) for i in range(self.num_nodes)}
+
     def _initialize_policy(self, u: np.ndarray, m: np.ndarray, t: float) -> None:
-        """Initialize policy via H.optimal_control (Issue #916).
-
-        Uses NetworkHamiltonian.optimal_control() to compute transition rates,
-        then extracts the dominant action (node with highest rate) as discrete policy.
-        Falls back to greedy neighbor search if no hamiltonian_class.
-        """
-        H = self.network_problem.hamiltonian_class
-        for i in range(self.num_nodes):
-            neighbors = self.gradient_ops[i]
-            if not neighbors:
-                self.current_policy[i] = i
-                continue
-
-            if H is not None:
-                # Issue #916: use H.optimal_control for transition rates
-                rates = H.optimal_control(np.array([i]), m, u, t)
-                rates_arr = np.atleast_1d(rates)
-                # Pick neighbor with highest rate (dominant transition)
-                best_action = i
-                best_rate = 0.0
-                for neighbor in neighbors:
-                    if neighbor < len(rates_arr) and rates_arr[neighbor] > best_rate:
-                        best_rate = rates_arr[neighbor]
-                        best_action = neighbor
-                self.current_policy[i] = best_action
-            else:
-                # Legacy: greedy cost minimization
-                best_action = i
-                best_cost = float("inf")
-                for neighbor in neighbors:
-                    cost = self._compute_action_cost(i, neighbor, u, m, t)
-                    if cost < best_cost:
-                        best_cost = cost
-                        best_action = neighbor
-                self.current_policy[i] = best_action
-
-    def _policy_evaluation(self, u_next: np.ndarray, m: np.ndarray, t: float) -> np.ndarray:
-        """Evaluate current policy by solving linear system.
-
-        Issue #916: uses H.optimal_control for transition rates when available,
-        falling back to edge_cost for the rate coefficient.
-        """
-        H = self.network_problem.hamiltonian_class
-
-        A = sp.lil_matrix((self.num_nodes, self.num_nodes))
-        b = np.zeros(self.num_nodes)
-
-        for i in range(self.num_nodes):
-            action = self.current_policy[i]
-            A[i, i] = 1.0 / self.dt
-
-            if action != i:
-                if H is not None:
-                    # Rate from H.optimal_control
-                    rates = H.optimal_control(np.array([i]), m, u_next, t)
-                    rate = float(np.atleast_1d(rates)[action])
-                    A[i, i] += rate
-                    A[i, action] -= rate
-                else:
-                    # Legacy: edge cost
-                    edge_cost = self.network_problem.edge_cost(i, action, t)
-                    A[i, action] -= 1.0 / self.dt
-                    b[i] = edge_cost
-
-            # Potential and coupling
-            potential = self.network_problem.node_potential(i, t)
-            coupling = self.network_problem.density_coupling(i, m, t)
-            b[i] += potential + coupling + u_next[i] / self.dt
-
-        A = A.tocsr()
-        u_evaluated = spsolve(A, b)
-        return np.asarray(u_evaluated)
+        self.current_rates = self._rates_at(u, m, t)
 
     def _policy_improvement(self, u: np.ndarray, m: np.ndarray, t: float) -> None:
-        """Improve policy using H.optimal_control (Issue #916)."""
-        H = self.network_problem.hamiltonian_class
+        self.current_rates = self._rates_at(u, m, t)
+
+    def _policy_evaluation(self, u_next: np.ndarray, m: np.ndarray, t: float) -> np.ndarray:
+        """Solve ``(I/dt + L^pi) u = u_next/dt + c(alpha) + source`` for the frozen rate policy.
+
+        ``L^pi = -Q^pi`` is the policy-weighted graph Laplacian (``A_ii = 1/dt + sum_j alpha_ij``,
+        ``A_ij = -alpha_ij``) — a strictly diagonally-dominant M-matrix, non-singular for any
+        ``alpha >= 0`` (the old ``A_ii=1/dt, A_ij=-1/dt`` was row-sum zero -> singular -> NaN).
+        ``c_i(alpha) = 0.5 * sum_j alpha_ij^2 / w_ij`` is the control cost; ``source = V + coupling``.
+        """
+        A = sp.lil_matrix((self.num_nodes, self.num_nodes))
+        b = np.zeros(self.num_nodes)
+        source = self._source_terms(m, t)
         for i in range(self.num_nodes):
-            neighbors = self.gradient_ops[i] + [i]
+            alpha_i = self.current_rates[i]
+            A[i, i] = 1.0 / self.dt
+            control_cost = 0.0
+            for j in self.gradient_ops[i]:
+                a = float(alpha_i[j]) if j < len(alpha_i) else 0.0
+                if a > 0.0:
+                    A[i, i] += a
+                    A[i, j] -= a
+                    w = self.network_problem.network_data.get_edge_weight(i, j)
+                    control_cost += 0.5 * a * a / w
+            b[i] = u_next[i] / self.dt + control_cost + source[i]
+        return np.asarray(spsolve(A.tocsr(), b))
 
-            if H is not None:
-                rates = H.optimal_control(np.array([i]), m, u, t)
-                rates_arr = np.atleast_1d(rates)
-                best_action = i
-                best_rate = 0.0
-                for action in neighbors:
-                    if action < len(rates_arr) and rates_arr[action] > best_rate:
-                        best_rate = rates_arr[action]
-                        best_action = action
-                self.current_policy[i] = best_action
-            else:
-                best_action = self.current_policy[i]
-                best_cost = self._compute_action_cost(i, best_action, u, m, t)
-                for action in neighbors:
-                    cost = self._compute_action_cost(i, action, u, m, t)
-                    if cost < best_cost:
-                        best_cost = cost
-                        best_action = action
-                self.current_policy[i] = best_action
-
-    def _compute_action_cost(self, node: int, action: int, u: np.ndarray, m: np.ndarray, t: float) -> float:
-        """Legacy: compute cost of taking action from node (no H.optimal_control)."""
-        if action == node:
-            return self.network_problem.node_potential(node, t) + self.network_problem.density_coupling(node, m, t)
-        edge_cost = self.network_problem.edge_cost(node, action, t)
-        return edge_cost + u[action]
-
-    def _policies_equal(self, policy1: dict[int, int], policy2: dict[int, int]) -> bool:
-        """Check if two policies are equal."""
-        return len(policy1) == len(policy2) and all(policy1[node] == policy2.get(node) for node in policy1)
+    def _policies_equal(self, rates1: dict[int, np.ndarray], rates2: dict[int, np.ndarray]) -> bool:
+        """Two rate policies are equal when every node's rate vector matches."""
+        return all(np.allclose(rates1[i], rates2[i], atol=1e-10) for i in range(self.num_nodes))
 
 
 # Factory function for network HJB solvers

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -123,11 +123,17 @@ class NetworkHamiltonian(HamiltonianBase):
         Custom hamiltonian_func receives full m_all for cross-coupling.
         """
         neighbors = self.network_data.get_neighbors(node)
+        # Finite-state MFG control cost (Issue #1474): one-sided / piecewise-quadratic — the value of
+        # the constrained optimum over rates alpha >= 0 (needed for a valid CTMC generator). For
+        # sense=MINIMIZE (cost-to-go) the agent moves toward LOWER-value neighbors, so only downhill
+        # edges (u_i > u_j) contribute: H_control = 0.5 * sum_j w_ij * max(u_i - u_j, 0)^2. The full
+        # quadratic 0.5*sum w*(u_j-u_i)^2 was the unconstrained (alpha in R) relaxation — invalid
+        # generator, and inconsistent with optimal_control.
         control_cost = 0.0
         for neighbor in neighbors:
             w = self.network_data.get_edge_weight(node, neighbor)
-            dp = p[neighbor] - p[node]
-            control_cost += 0.5 * w * dp**2
+            du = p[node] - p[neighbor]  # u_i - u_j
+            control_cost += 0.5 * w * max(du, 0.0) ** 2
 
         V = float(self._node_potential(node, t)) if self._node_potential else 0.0
         # Coupling f(node, m, t). Reconciled with the live NetworkMFGProblem.density_coupling
@@ -143,12 +149,13 @@ class NetworkHamiltonian(HamiltonianBase):
         return control_cost + V + f_m
 
     def optimal_control(self, x, m, p, t=0.0):
-        """Optimal transition rates from node x.
+        """Optimal transition rates from node x (Issue #1474).
 
-        For quadratic H: alpha_{ij} = w_ij * (p_j - p_i)_+ (upwind).
-        Transition rates are non-negative by construction, ensuring
-        the generator Q preserves positivity of m.
-        Returns array of rates to neighbors (zero for non-neighbors).
+        Finite-state MFG, sense=MINIMIZE: ``alpha*_ij = w_ij * max(u_i - u_j, 0)`` — the argmax of
+        the one-sided control Hamiltonian, sending agents DOWNHILL toward lower cost-to-go. Rates are
+        non-negative by construction (a valid conservative CTMC generator). ``max(u_j - u_i, 0)``
+        (the previous form) is the MAXIMIZE/uphill branch and transports mass the wrong way.
+        Returns an array of rates to neighbors (zero for non-neighbors).
         """
         node = int(np.asarray(x).flat[0])
         p_arr = np.atleast_1d(p)
@@ -157,13 +164,14 @@ class NetworkHamiltonian(HamiltonianBase):
         alpha = np.zeros_like(p_arr)
         for neighbor in neighbors:
             w = self.network_data.get_edge_weight(node, neighbor)
-            dp = p_arr[neighbor] - p_arr[node]
-            # Issue #914: upwind truncation ensures alpha >= 0
-            alpha[neighbor] = w * max(dp, 0.0)
+            du = p_arr[node] - p_arr[neighbor]  # u_i - u_j
+            alpha[neighbor] = w * max(du, 0.0)
         return alpha
 
     def dp(self, x, m, p, t=0.0):
-        """dH/dp at node x. For quadratic: sum_j w_ij * (p_j - p_i) per component."""
+        """dH/dp at node x (Issue #1474). Gradient of the one-sided control Hamiltonian: with
+        ``alpha*_ij = w_ij max(u_i - u_j, 0)``, ``dH/du_i = +sum_j alpha*_ij`` and
+        ``dH/du_j = -alpha*_ij`` (so ``dp`` equals the generator action ``-Q^{alpha*} u``)."""
         node = int(np.asarray(x).flat[0])
         p_arr = np.atleast_1d(p)
         neighbors = self.network_data.get_neighbors(node)
@@ -171,9 +179,9 @@ class NetworkHamiltonian(HamiltonianBase):
         grad = np.zeros_like(p_arr)
         for neighbor in neighbors:
             w = self.network_data.get_edge_weight(node, neighbor)
-            dp = p_arr[neighbor] - p_arr[node]
-            grad[neighbor] += w * dp
-            grad[node] -= w * dp
+            a = w * max(p_arr[node] - p_arr[neighbor], 0.0)  # alpha*_{i,neighbor} (downhill)
+            grad[neighbor] -= a
+            grad[node] += a
         return grad
 
     def dm(self, x, m, p, t=0.0):
@@ -313,7 +321,14 @@ class NetworkMFGProblem(MFGProblem):
             components=parent_components,
         )
 
-        self.components = components or NetworkMFGComponents()  # type: ignore[assignment]
+        # Issue #1474: store the SAME NetworkMFGComponents instance the NetworkHamiltonian was built
+        # from, and wire the object as the single-source Hamiltonian (`hamiltonian_class`). Previously
+        # `self.components` was overwritten with a fresh instance, orphaning the object
+        # (`hamiltonian_class == None`), so FP / policy iteration fell to divergent legacy paths while
+        # RK45 used the method — the three solved different HJBs. Now all read one Hamiltonian.
+        self.components = net_components  # type: ignore[assignment]
+        self.components.hamiltonian = network_hamiltonian
+        self.components._hamiltonian_class = network_hamiltonian
         self.problem_name = problem_name
 
         # Phase 3.1 integration: geometry is already set by parent
@@ -384,9 +399,12 @@ class NetworkMFGProblem(MFGProblem):
                 edge_weight = 1.0  # Default weight
             else:
                 edge_weight = self.network_data.get_edge_weight(node, neighbor)
-            # Control cost for moving to neighbor
-            dp = p[neighbor] - p[node]  # Discrete gradient
-            control_cost += 0.5 * edge_weight * dp**2
+            # Control cost (Issue #1474): one-sided finite-state MFG control, sense=MINIMIZE — only
+            # downhill edges (u_i > u_j) contribute, matching NetworkHamiltonian and the alpha>=0
+            # generator. (Was the full quadratic 0.5*edge_weight*(u_j-u_i)^2 = unconstrained
+            # relaxation, which made RK45 solve a different HJB than FP/policy iteration.)
+            du = p[node] - p[neighbor]  # u_i - u_j
+            control_cost += 0.5 * edge_weight * max(du, 0.0) ** 2
 
         # Node potential
         potential = self.node_potential(node, t)

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -73,6 +73,19 @@ class NetworkHamiltonian(HamiltonianBase):
         population_index: int = 0,
     ):
         super().__init__(sense=sense, population_index=population_index)
+        # Issue #1474/#1476: the finite-state MFG here is implemented for sense=MINIMIZE (cost-to-go,
+        # downhill control) only — the control cost, optimal_control, dp, and the base-solver
+        # integration sign are all hardcoded to the MINIMIZE convention. Fail loud rather than
+        # silently compute MINIMIZE for a MAXIMIZE (reward-to-go, uphill) problem. Full MAXIMIZE
+        # support (the mirror) is tracked in #1476.
+        if sense != OptimizationSense.MINIMIZE:
+            raise NotImplementedError(
+                f"NetworkHamiltonian supports sense=OptimizationSense.MINIMIZE only (finite-state MFG "
+                f"cost-to-go / downhill control); got {sense}. MAXIMIZE (reward-to-go, uphill) is not "
+                f"yet implemented for network problems — see Issue #1476. Its control / H / dp and the "
+                f"base-solver integration sign are the mirror of the MINIMIZE case and need separate "
+                f"validation, so it cannot be silently reused."
+            )
         self.network_data = network_data
         self._hamiltonian_func = hamiltonian_func
         self._hamiltonian_dm_func = hamiltonian_dm_func

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -132,7 +132,8 @@ def test_network_hamiltonian_minimize_consistency():
     t = 0.1
 
     alpha2 = np.atleast_1d(H.optimal_control(np.array([2]), m, u, t))
-    assert alpha2[1] > 0 and alpha2[3] == 0, f"control must be downhill (MINIMIZE); got {alpha2}"
+    assert alpha2[1] > 0, f"control must flow to the lower neighbour (MINIMIZE); got {alpha2}"
+    assert alpha2[3] == 0, f"control must not flow to the higher neighbour (MINIMIZE); got {alpha2}"
 
     for i in range(N):
         ai = np.atleast_1d(H.optimal_control(np.array([i]), m, u, t))
@@ -168,7 +169,21 @@ def test_network_policy_iteration_converges_to_rk45():
         m = np.ones((nt + 1, n)) / n
         u_rk = NetworkHJBSolver(prob, scheme="RK45").solve_hjb_system(M_density=m, U_terminal=g)
         u_pi = NetworkPolicyIterationHJBSolver(prob).solve_hjb_system(M_density=m, U_terminal=g)
-        assert np.isfinite(u_pi).all() and np.isfinite(u_rk).all(), "both solvers must be finite"
+        assert np.isfinite(u_pi).all(), "policy-iteration value must be finite"
+        assert np.isfinite(u_rk).all(), "RK45 value must be finite"
         errs.append(float(np.max(np.abs(u_pi[0] - u_rk[0]))))
     assert errs[0] < 0.2, f"PI and RK45 must agree closely (same HJB), got {errs[0]:.3f}"
     assert errs[-1] < 0.55 * errs[0], f"gap must shrink under dt-refinement (N15 plateau closed): {errs}"
+
+
+def test_network_hamiltonian_maximize_fails_loud():
+    """Issue #1474 / #1476: the network finite-state MFG is implemented for ``sense=MINIMIZE`` only.
+    ``sense=MAXIMIZE`` must fail loud rather than silently compute the MINIMIZE (downhill) math. Full
+    MAXIMIZE (reward-to-go / uphill) support — the mirror — is tracked in #1476."""
+    from mfgarchon.core.hamiltonian import OptimizationSense
+
+    net = GridNetwork(width=3, height=1)
+    net.create_network()
+    prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=4)
+    with pytest.raises(NotImplementedError, match="MINIMIZE"):
+        NetworkHamiltonian(network_data=prob.network_data, sense=OptimizationSense.MAXIMIZE)

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -18,6 +18,10 @@ import pytest
 
 import numpy as np
 
+from mfgarchon.alg.numerical.network_solvers.hjb_network import (
+    NetworkHJBSolver,
+    NetworkPolicyIterationHJBSolver,
+)
 from mfgarchon.extensions.topology import (
     NetworkHamiltonian,
     NetworkMFGComponents,
@@ -142,3 +146,29 @@ def test_network_hamiltonian_minimize_consistency():
 
     method2 = prob.hamiltonian(2, prob.get_node_neighbors(2), m, u, t)
     assert abs(method2 - float(H(np.array([2]), m, u, t))) < 1e-9, "RK45 method H must equal object H"
+
+
+def test_network_policy_iteration_converges_to_rk45():
+    """Issue #1474 (N15 decisive): policy iteration and the RK45 value ODE now solve the SAME
+    finite-state MFG.
+
+    Before the fix they converged to *different* continuous equations (the gap plateaued at ~0.708
+    under dt-refinement, ratio ~1.0). After reconciling the Hamiltonian (value = control), fixing the
+    base-solver integration sign + source separation, and rewriting policy evaluation to the full-rate
+    M-matrix ``A = I/dt + L^pi``, the remaining difference is pure time discretization (backward-Euler
+    vs RK45): it roughly halves with each dt refinement, i.e. first-order convergence to zero.
+    """
+    net = GridNetwork(width=5, height=1)
+    net.create_network()
+    g = np.array([0.0, 0.0, 0.0, 0.0, 10.0])
+    errs = []
+    for nt in (20, 40, 80):
+        prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=nt)
+        n = prob.num_nodes
+        m = np.ones((nt + 1, n)) / n
+        u_rk = NetworkHJBSolver(prob, scheme="RK45").solve_hjb_system(M_density=m, U_terminal=g)
+        u_pi = NetworkPolicyIterationHJBSolver(prob).solve_hjb_system(M_density=m, U_terminal=g)
+        assert np.isfinite(u_pi).all() and np.isfinite(u_rk).all(), "both solvers must be finite"
+        errs.append(float(np.max(np.abs(u_pi[0] - u_rk[0]))))
+    assert errs[0] < 0.2, f"PI and RK45 must agree closely (same HJB), got {errs[0]:.3f}"
+    assert errs[-1] < 0.55 * errs[0], f"gap must shrink under dt-refinement (N15 plateau closed): {errs}"

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -93,7 +93,9 @@ def test_network_components_is_mfg_components_byte_identical():
     prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=4)
 
     assert isinstance(prob.components, MFGComponents)
-    assert prob.hamiltonian_class is None, "byte-identity: the subclass must not activate the object"
+    # Issue #1474: the NetworkHamiltonian is now WIRED as the single-source Hamiltonian (previously
+    # orphaned/None). isinstance and get_problem_info remain the Stage-1 wins.
+    assert prob.hamiltonian_class is not None, "the single-source NetworkHamiltonian must be wired"
     assert isinstance(prob.get_problem_info(), dict), "get_problem_info must not raise (was AttributeError)"
     assert prob.get_boundary_conditions() is None, "network BC still resolves to None (Stage 2 wires it)"
 
@@ -101,3 +103,42 @@ def test_network_components_is_mfg_components_byte_identical():
     comps = NetworkMFGComponents(boundary_nodes=[0, 8], node_potential_func=lambda n, t: 0.1 * n)
     assert isinstance(comps, MFGComponents)
     assert comps.boundary_nodes == [0, 8]
+
+
+def test_network_hamiltonian_minimize_consistency():
+    """Issue #1474: the NetworkHamiltonian value H, optimal control, and dp form ONE consistent
+    finite-state MFG (controlled CTMC, sense=MINIMIZE), replacing the previous mismatch (full
+    quadratic __call__ vs upwind-uphill optimal_control) that made RK45 and FP solve different HJBs.
+
+    Invariants on a line graph with a strictly increasing value ``u = [0,1,2,3,4]``:
+    - control is DOWNHILL: at node 2, ``alpha* > 0`` toward the lower neighbour 1, ``== 0`` toward the
+      higher neighbour 3 (the old code had it backwards);
+    - rates are non-negative (valid conservative generator);
+    - the control part of H is one-sided and equals the envelope ``0.5 * sum(alpha*^2)`` (unit weights);
+    - the method ``NetworkMFGProblem.hamiltonian`` (used by RK45) equals the object ``__call__``.
+    """
+    net = GridNetwork(width=5, height=1)
+    net.create_network()
+    prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=20)
+    H = prob.hamiltonian_class
+    assert H is not None
+    N = prob.num_nodes
+    u = np.arange(N, dtype=float)
+    m = np.ones(N) / N
+    t = 0.1
+
+    alpha2 = np.atleast_1d(H.optimal_control(np.array([2]), m, u, t))
+    assert alpha2[1] > 0 and alpha2[3] == 0, f"control must be downhill (MINIMIZE); got {alpha2}"
+
+    for i in range(N):
+        ai = np.atleast_1d(H.optimal_control(np.array([i]), m, u, t))
+        assert (ai >= -1e-12).all(), f"rates must be >= 0 at node {i}: {ai}"
+
+    coupling2 = 0.5 * m[2] ** 2  # default node congestion at node 2
+    control2 = float(H(np.array([2]), m, u, t)) - coupling2
+    envelope2 = 0.5 * float(np.sum(alpha2**2))
+    assert abs(control2 - 0.5) < 1e-9, f"one-sided control at node2 should be 0.5, got {control2}"
+    assert abs(control2 - envelope2) < 1e-9, f"H control != envelope 0.5*sum(alpha^2): {control2} vs {envelope2}"
+
+    method2 = prob.hamiltonian(2, prob.get_node_neighbors(2), m, u, t)
+    assert abs(method2 - float(H(np.array([2]), m, u, t))) < 1e-9, "RK45 method H must equal object H"


### PR DESCRIPTION
## Summary
Fully resolves **N15** (#1474): the network finite-state MFG had three components solving *different* HJBs. Now the value Hamiltonian, the optimal control, the RK45 ODE, FP, and policy-iteration all solve **one** consistent finite-state MFG.

## The correct model (`sense=MINIMIZE`, controlled CTMC, rates α≥0)
From `H = max_{α≥0}{Σα(u_i−u_j) − ½Σα²/w}` (Gomes–Mohr–Souza; Carmona–Delarue finite-state MFG):
`H = ½ Σ w·max(u_i−u_j,0)²`, `α* = w·max(u_i−u_j,0)` (downhill), `dp` = the generator action.

## Three defects fixed
1. **Value ≠ control.** `__call__`/method used the full quadratic `½Σw(u_j−u_i)²` (the unconstrained α∈ℝ relaxation — invalid generator) while `optimal_control` used the *upwind, wrong-signed* `w·max(u_j−u_i,0)`. Now one consistent one-sided/downhill triple; the orphaned `NetworkHamiltonian` is **wired** as single source; FP legacy rate branch fails loud.
2. **Base-solver integration sign.** `du/ds=+H` integrated `u_t+H=0` (opposite to the global `−u_t+H=0`) and self-amplified the control term → value blew up. Now `du/ds = −H_control + source`, separating the control Hamiltonian from the V+coupling RHS sources.
3. **Singular policy-evaluation.** `A_ii=1/dt, A_ij=−1/dt` (row-sum 0 → NaN), single-action, no control cost. Rewritten to the full-rate M-matrix `A = I/dt + Lᵖⁱ` (`A_ii=1/dt+Σα`, `A_ij=−α`) with `½Σα²/w` in the RHS; the policy is the full rate vector; legacy `H is None` paths fail loud.

## Decisive validation
`NetworkPolicyIterationHJBSolver` now converges to the **same** value as the RK45 ODE. The dt-refinement gap that previously **plateaued at ~0.708** (ratio ~1.0 → different equations) now **halves per refinement** (0.125 → 0.063 → 0.032 → 0.016, first-order → 0). Physicality: value bounded, cost-to-go high at high-terminal/high-potential nodes, congestion source *raises* cost-to-go, mass flows toward low cost.

Pinned by `test_network_hamiltonian_minimize_consistency` + `test_network_policy_iteration_converges_to_rk45`. **102** network + coupling tests pass; consistency harness all-pass.

Fixes #1474. Refs #1470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
