### PR TITLE
feat(bc): graph node-BC owned by GraphGeometry; rewire network solvers off boundary_nodes (Stage 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Graph node boundary conditions are now owned by `GraphGeometry`** (Issue #1471,
+  Problem/Components unification — Layer Ψ). Node-BC (a `GraphBCConfig` of DIRICHLET / ABSORBING /
+  SOURCE / NEUMANN `NodeBC`s) attaches at `GraphGeometry` — the highest abstraction over
+  `NetworkGeometry` (grid / random / scale-free) and `MazeGeometry` — so **both inherit it uniformly**
+  (graphon is a separate continuum-limit construct, not a `GraphGeometry`). Construct it via
+  `GridNetwork(..., boundary_conditions=GraphBCConfig(...))`. `get_boundary_conditions()` on a graph
+  problem now returns the geometry's node-BC (was always `None`); it is polymorphic by geometry —
+  the boundary *locus* on a graph is a node set, not a wall segment, so the graph BC representation
+  genuinely differs from the continuum `BoundaryConditions`. The network HJB/FP solvers read node-BC
+  from the geometry through a single-source `GraphApplicator`, **retiring** the ad-hoc
+  `NetworkMFGComponents.boundary_nodes` / `boundary_values_func` channel (which bypassed the #1456 BC
+  single source); the temporary Stage-0 fail-loud gate is **re-keyed** to
+  `geometry.has_explicit_boundary_conditions()`. Byte-identical: the policy-iteration node-Dirichlet
+  pin is unchanged (now flows through `GraphApplicator.apply_hjb`). `GraphApplicator` (previously
+  untested / orphaned, though registered in `apply_bc()` dispatch) gains its first unit coverage and
+  a field-type fix (DIRICHLET → value field, ABSORBING → density field). Absorbing FP (opening the
+  conservative stencil at a node + gating the mass renorm) remains Stage 2b.
+
 - **`NetworkMFGComponents` is now a `MFGComponents`** (Issue #1470, Problem/Components unification —
   Layer Ψ). It subclasses `MFGComponents` with a relaxed `__post_init__` (network problems specify
   the MFG with the network-native fields — `hamiltonian_func`, `node_interaction_func`,

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -105,13 +105,13 @@ class FPNetworkSolver(BaseFPSolver):
         # (`enforce_mass_conservation`), so a node BC would be silently dropped and any
         # absorption hidden — manufacturing the mass-conserving answer in place of the
         # intended one (the #1456 silent-wrong-answer class, on the graph).
-        if not self._honors_node_bc and problem.components.boundary_nodes:
+        if not self._honors_node_bc and problem.geometry.has_explicit_boundary_conditions():
             raise NotImplementedError(
                 f"{type(self).__name__} does not support node boundary conditions "
-                f"(problem.components.boundary_nodes is set). It ignores boundary_nodes and "
+                f"(the graph geometry carries an explicit node-BC config). It ignores node-BC and "
                 f"unconditionally renormalizes total mass each step, so the node BC would be "
-                f"silently dropped and any absorption hidden (Issue #1468, #1456). Remove "
-                f"boundary_nodes, or use a solver that honors them."
+                f"silently dropped and any absorption hidden (Issue #1468, #1456, #1471). Remove the "
+                f"geometry's BC, or use a solver that honors it (absorbing FP is Stage 2b)."
             )
 
         self.scheme = scheme

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -83,16 +83,17 @@ class NetworkHJBSolver(BaseHJBSolver):
 
         self.network_problem = problem
 
-        # Issue #1468: fail loud on a node BC this solver cannot honor. The base ODE path applies
-        # only the terminal condition and never `boundary_nodes`, so a node BC would be silently
-        # ignored. `NetworkPolicyIterationHJBSolver` (which applies them) sets `_honors_node_bc`.
-        if not self._honors_node_bc and problem.components.boundary_nodes:
+        # Issue #1468/#1471: fail loud on a node BC this solver cannot honor. Node-BC now lives on the
+        # geometry (GraphGeometry.has_explicit_boundary_conditions); the base ODE path applies only
+        # the terminal condition and never the node-BC, so it would be silently ignored.
+        # `NetworkPolicyIterationHJBSolver` (which applies it) sets `_honors_node_bc`.
+        if not self._honors_node_bc and problem.geometry.has_explicit_boundary_conditions():
             raise NotImplementedError(
                 f"{type(self).__name__} does not support node boundary conditions "
-                f"(problem.components.boundary_nodes is set). The base network HJB integrates the "
-                f"backward ODE with terminal data only and never applies boundary_nodes, so the "
-                f"node BC would be silently ignored (Issue #1468, #1456). Use "
-                f"NetworkPolicyIterationHJBSolver, which applies them, or remove boundary_nodes."
+                f"(the graph geometry carries an explicit node-BC config). The base network HJB "
+                f"integrates the backward ODE with terminal data only and never applies node-BC, so "
+                f"it would be silently ignored (Issue #1468, #1456, #1471). Use "
+                f"NetworkPolicyIterationHJBSolver, which applies node-BC, or remove the geometry's BC."
             )
 
         self.scheme = scheme

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -236,9 +236,9 @@ class NetworkMFGComponents(MFGComponents):
     initial_node_density_func: Callable | None = None  # m_0(node)
     terminal_node_value_func: Callable | None = None  # u_T(node)
 
-    # Network boundary conditions
-    boundary_nodes: list[int] | None = None  # Nodes with boundary conditions
-    boundary_values_func: Callable | None = None  # Boundary values
+    # Node boundary conditions are owned by the graph geometry (GraphGeometry), not components
+    # (Issue #1471) — construct e.g. GridNetwork(..., boundary_conditions=GraphBCConfig(...)). The
+    # former `boundary_nodes` / `boundary_values_func` fields bypassed the #1456 BC single source.
 
     # Flow dynamics parameters
     diffusion_coefficient: float = 1.0  # Diffusion strength
@@ -342,6 +342,18 @@ class NetworkMFGProblem(MFGProblem):
         self.components = net_components  # type: ignore[assignment]
         self.components.hamiltonian = network_hamiltonian
         self.components._hamiltonian_class = network_hamiltonian
+
+        # Issue #1471: node boundary conditions are owned by the graph geometry (GraphGeometry),
+        # not by components. Resolve the geometry's GraphBCConfig once into the single-source
+        # GraphApplicator (the single applier — the pin logic is not re-forked here). Explicit-init
+        # None when the geometry carries no node-BC.
+        self._node_applicator = None
+        node_bc = network_geometry.get_boundary_conditions()
+        if node_bc is not None:
+            from mfgarchon.geometry.boundary.applicator_graph import GraphApplicator
+
+            self._node_applicator = GraphApplicator.from_config(node_bc, num_nodes=network_geometry.num_spatial_points)
+
         self.problem_name = problem_name
 
         # Phase 3.1 integration: geometry is already set by parent
@@ -660,18 +672,16 @@ class NetworkMFGProblem(MFGProblem):
     # Boundary conditions for networks
 
     def apply_boundary_conditions(self, u: np.ndarray, t: float) -> np.ndarray:
-        """Apply boundary conditions to network nodes."""
-        u_bc = u.copy()
+        """Apply the geometry-owned node boundary conditions to the value field (Issue #1471).
 
-        if self.components.boundary_nodes is not None:  # type: ignore[attr-defined]
-            for node in self.components.boundary_nodes:  # type: ignore[attr-defined]
-                if self.components.boundary_values_func is not None:  # type: ignore[attr-defined]
-                    u_bc[node] = self.components.boundary_values_func(node, t)  # type: ignore[attr-defined]
-                else:
-                    # Default: zero boundary values
-                    u_bc[node] = 0.0
-
-        return u_bc
+        Node-BC lives on the graph geometry and is resolved once into a single-source
+        ``GraphApplicator``; this delegates the value-field (HJB) DIRICHLET pin to it (which copies
+        the input, so ``u`` is not mutated). No-op when the geometry carries no node-BC. The previous
+        ``components.boundary_nodes`` channel (which bypassed the #1456 BC single source) is retired.
+        """
+        if self._node_applicator is None:
+            return u
+        return self._node_applicator.apply_hjb(u, t)
 
     # Legacy interface compatibility
 

--- a/mfgarchon/geometry/base.py
+++ b/mfgarchon/geometry/base.py
@@ -1769,6 +1769,21 @@ class GraphGeometry(Geometry, SupportsGraphLaplacian, SupportsAdjacency):
         >>> grid = maze.get_maze_array()  # Returns 2D grid array
     """
 
+    def __init__(self, boundary_conditions=None):
+        """Graph geometry owns the node boundary conditions (Issue #1471).
+
+        Node-BC lives at this abstraction so NetworkGeometry (grid/random/scale-free) and
+        MazeGeometry inherit it uniformly (graph is the highest abstraction over both). The carrier
+        is a ``GraphBCConfig`` (multi-region node/edge BC: DIRICHLET / ABSORBING / SOURCE / NEUMANN);
+        ``None`` means no explicit BC (the NEUMANN / zero-flux default), matching the prior behaviour.
+
+        Parameters
+        ----------
+        boundary_conditions : GraphBCConfig or None
+            Declarative node boundary conditions, or ``None``.
+        """
+        self._node_bc = boundary_conditions
+
     @property
     def dimension(self) -> int:
         """
@@ -2208,18 +2223,23 @@ class GraphGeometry(Geometry, SupportsGraphLaplacian, SupportsAdjacency):
         return (self.num_spatial_points,)
 
     def get_boundary_conditions(self):
-        """
-        Get boundary conditions for graph.
+        """Node boundary conditions owned by the graph geometry (Issue #1471).
 
-        Returns:
-            None - graphs don't have inherent spatial boundary conditions.
-
-        Notes:
-            For graphs, "boundary" typically refers to boundary nodes
-            (dead ends, exit nodes, or explicitly marked boundaries).
-            Specify via problem.boundary_conditions or node attributes.
+        Returns a ``GraphBCConfig`` (node/edge BC over node sets) or ``None``. This is the graph
+        analogue of the continuum ``BoundaryConditions`` on ``TensorProductGrid`` — the boundary
+        *locus* on a graph is a node set, not a wall segment, so the two BC representations are
+        genuinely different types (the accessor is polymorphic by geometry, consumed through the
+        geometry's applicator, not by type-assumption).
         """
-        return None
+        return getattr(self, "_node_bc", None)
+
+    def has_explicit_boundary_conditions(self) -> bool:
+        """True when an explicit node-BC config is set (Issue #1471); mirrors the continuum gate."""
+        return getattr(self, "_node_bc", None) is not None
+
+    def set_boundary_conditions(self, boundary_conditions) -> None:
+        """Set/replace the node-BC config at runtime (Issue #1471)."""
+        self._node_bc = boundary_conditions
 
     def get_collocation_points(self) -> NDArray:
         """

--- a/mfgarchon/geometry/boundary/applicator_graph.py
+++ b/mfgarchon/geometry/boundary/applicator_graph.py
@@ -490,17 +490,23 @@ class GraphApplicator(BaseGraphApplicator):
                     continue
 
                 if bc.bc_type == GraphBCType.DIRICHLET:
-                    value = bc.get_value(node, t)
-                    if is_2d:
-                        result[:, node] = value
-                    else:
-                        result[node] = value
+                    # Issue #1471: a Dirichlet value pin belongs to the VALUE field (HJB u), not the
+                    # density field (FP m) — pinning m to a value-function value is wrong.
+                    if field_type == "value":
+                        value = bc.get_value(node, t)
+                        if is_2d:
+                            result[:, node] = value
+                        else:
+                            result[node] = value
 
                 elif bc.bc_type == GraphBCType.ABSORBING:
-                    if is_2d:
-                        result[:, node] = 0.0
-                    else:
-                        result[node] = 0.0
+                    # Issue #1471: absorbing (density -> 0, mass exits) belongs to the DENSITY field
+                    # (FP m); zeroing the HJB value u at an exit is wrong (an exit carries exit cost).
+                    if field_type == "density":
+                        if is_2d:
+                            result[:, node] = 0.0
+                        else:
+                            result[node] = 0.0
 
                 elif bc.bc_type == GraphBCType.SOURCE:
                     if field_type == "density":

--- a/mfgarchon/geometry/graph/maze_generator.py
+++ b/mfgarchon/geometry/graph/maze_generator.py
@@ -262,6 +262,7 @@ class MazeGeometry(GraphGeometry):
         cols: int,
         algorithm: MazeAlgorithm = MazeAlgorithm.RECURSIVE_BACKTRACKING,
         seed: int | None = None,
+        boundary_conditions=None,
     ):
         """
         Initialize and generate maze.
@@ -271,9 +272,11 @@ class MazeGeometry(GraphGeometry):
             cols: Number of columns in maze
             algorithm: Algorithm to use for generation
             seed: Random seed for reproducibility
+            boundary_conditions: Node-BC config (Issue #1471), inherited from GraphGeometry.
 
         Note: Maze is generated immediately upon initialization.
         """
+        super().__init__(boundary_conditions=boundary_conditions)  # Issue #1471: node-BC on the geometry
         self.rows = rows
         self.cols = cols
         self.algorithm = algorithm

--- a/mfgarchon/geometry/graph/network_geometry.py
+++ b/mfgarchon/geometry/graph/network_geometry.py
@@ -285,7 +285,9 @@ class NetworkGeometry(GraphGeometry):
         num_nodes: int,
         network_type: NetworkType = NetworkType.CUSTOM,
         backend_preference: NetworkBackendType = NetworkBackendType.IGRAPH,
+        boundary_conditions=None,
     ):
+        super().__init__(boundary_conditions=boundary_conditions)  # Issue #1471: node-BC on the geometry
         self._num_nodes = num_nodes
         self.network_type = network_type
         self.network_data: NetworkData | None = None
@@ -953,11 +955,17 @@ class GridNetwork(NetworkGeometry):
         height: int | None = None,
         periodic: bool = False,
         backend_preference: NetworkBackendType = NetworkBackendType.IGRAPH,
+        boundary_conditions=None,
     ):
         self.width = width
         self.height = height or width
         self.periodic = periodic
-        super().__init__(self.width * self.height, NetworkType.GRID, backend_preference)
+        super().__init__(
+            self.width * self.height,
+            NetworkType.GRID,
+            backend_preference,
+            boundary_conditions=boundary_conditions,
+        )
         # Issue #875: Auto-initialize network so users don't need to call create_network()
         self.create_network()
 

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 
 from mfgarchon.alg.numerical.network_solvers.fp_network import FPNetworkSolver
-from mfgarchon.extensions.topology import NetworkMFGComponents, NetworkMFGProblem
+from mfgarchon.extensions.topology import NetworkMFGProblem
 from mfgarchon.geometry.graph.network_geometry import GridNetwork
 
 # Skip all tests if igraph is not available (network backend dependency)
@@ -656,46 +656,36 @@ class TestFPNetworkSolverIntegration:
 
 
 class TestFPNetworkSolverIssue1468NodeBCGate:
-    """Issue #1468 (BC-capability, #1456 network family).
+    """Issue #1468 / #1471 (BC-capability, #1456 network family).
 
-    FPNetworkSolver ignores ``components.boundary_nodes`` and unconditionally renormalizes total
-    mass each step, so it must fail loud on a node BC rather than silently solve the
-    mass-conserving problem in place of the intended (absorbing/Dirichlet) one. The continuum
-    ``BCType`` gate (``_validate_bc_support``) is a structural no-op for network problems — they
-    carry no ``BoundaryConditions`` — so this is a network-specific gate on ``boundary_nodes``.
+    FPNetworkSolver ignores node-BC and unconditionally renormalizes total mass each step, so it must
+    fail loud on a node BC (now owned by the graph geometry) rather than silently solve the
+    mass-conserving problem in place of the intended (absorbing) one — absorbing FP is Stage 2b. The
+    continuum ``BCType`` gate is a structural no-op for graph problems, so the fail-loud gate keys on
+    ``geometry.has_explicit_boundary_conditions()``.
     """
 
-    def _network(self):
-        network = GridNetwork(width=3, height=3)
+    def _network(self, with_bc=False):
+        from mfgarchon.geometry.boundary.applicator_graph import GraphBCConfig, GraphBCType, NodeBC
+
+        bc = None
+        if with_bc:
+            bc = GraphBCConfig(node_bcs=[NodeBC(nodes=[0, 8], bc_type=GraphBCType.DIRICHLET, value=0.0)])
+        network = GridNetwork(width=3, height=3, boundary_conditions=bc)
         network.create_network()
         return network
 
-    def test_boundary_nodes_fail_loud(self):
-        problem = NetworkMFGProblem(
-            network_geometry=self._network(),
-            T=1.0,
-            Nt=10,
-            components=NetworkMFGComponents(boundary_nodes=[0, 8]),
-        )
-        with pytest.raises(NotImplementedError, match="boundary_nodes"):
+    def test_node_bc_fail_loud(self):
+        problem = NetworkMFGProblem(network_geometry=self._network(with_bc=True), T=1.0, Nt=10)
+        with pytest.raises(NotImplementedError, match="node boundary conditions"):
             FPNetworkSolver(problem)
 
-    def test_no_boundary_nodes_constructs(self):
+    def test_no_node_bc_constructs(self):
         """Gate inert when no node BC is set (the default) — construction unchanged."""
         problem = NetworkMFGProblem(network_geometry=self._network(), T=1.0, Nt=10)
         solver = FPNetworkSolver(problem)  # no raise
         assert solver.num_nodes == 9
         assert solver._honors_node_bc is False
-
-    def test_empty_boundary_nodes_list_is_inert(self):
-        """An empty ``boundary_nodes`` list is falsy — no node BC requested, no raise."""
-        problem = NetworkMFGProblem(
-            network_geometry=self._network(),
-            T=1.0,
-            Nt=10,
-            components=NetworkMFGComponents(boundary_nodes=[]),
-        )
-        FPNetworkSolver(problem)  # no raise
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_alg/test_hjb_network_solver.py
+++ b/tests/unit/test_alg/test_hjb_network_solver.py
@@ -14,7 +14,7 @@ from mfgarchon.alg.numerical.network_solvers.hjb_network import (
     NetworkHJBSolver,
     NetworkPolicyIterationHJBSolver,
 )
-from mfgarchon.extensions.topology import NetworkMFGComponents, NetworkMFGProblem
+from mfgarchon.extensions.topology import NetworkMFGProblem
 from mfgarchon.geometry.graph.network_geometry import GridNetwork
 
 # Skip all tests if igraph is not available (network backend dependency)
@@ -495,47 +495,39 @@ class TestNetworkHJBSolverIntegration:
 
 
 class TestNetworkHJBIssue1468NodeBCGate:
-    """Issue #1468 (BC-capability, #1456 network family).
+    """Issue #1468 / #1471 (BC-capability, #1456 network family).
 
-    The base ``NetworkHJBSolver`` integrates the backward HJB ODE (``solve_ivp``) with terminal
-    data only and never applies ``components.boundary_nodes``, so it must fail loud on a node BC.
-    ``NetworkPolicyIterationHJBSolver`` applies ``apply_boundary_conditions`` at every backward
-    step, so it honors node BC and is exempt from the gate.
+    Node boundary conditions live on the graph geometry (``GraphGeometry``). The base
+    ``NetworkHJBSolver`` integrates the backward HJB ODE (``solve_ivp``) with terminal data only and
+    never applies node-BC, so it must fail loud. ``NetworkPolicyIterationHJBSolver`` applies
+    ``apply_boundary_conditions`` (the geometry-owned ``GraphApplicator`` DIRICHLET pin) at every
+    backward step, so it honors node-BC and is exempt from the gate.
     """
 
-    def _network(self):
-        network = GridNetwork(width=3, height=3)
+    def _network(self, value=None):
+        from mfgarchon.geometry.boundary.applicator_graph import GraphBCConfig, GraphBCType, NodeBC
+
+        bc = None
+        if value is not None:
+            bc = GraphBCConfig(node_bcs=[NodeBC(nodes=[0], bc_type=GraphBCType.DIRICHLET, value=value)])
+        network = GridNetwork(width=3, height=3, boundary_conditions=bc)
         network.create_network()
         return network
 
-    def test_base_solver_boundary_nodes_fail_loud(self):
-        problem = NetworkMFGProblem(
-            network_geometry=self._network(),
-            T=0.5,
-            Nt=10,
-            components=NetworkMFGComponents(boundary_nodes=[0]),
-        )
-        with pytest.raises(NotImplementedError, match="boundary_nodes"):
+    def test_base_solver_node_bc_fail_loud(self):
+        problem = NetworkMFGProblem(network_geometry=self._network(value=0.0), T=0.5, Nt=10)
+        with pytest.raises(NotImplementedError, match="node boundary conditions"):
             NetworkHJBSolver(problem)
 
-    def test_base_solver_no_boundary_nodes_constructs(self):
+    def test_base_solver_no_node_bc_constructs(self):
         problem = NetworkMFGProblem(network_geometry=self._network(), T=0.5, Nt=10)
         solver = NetworkHJBSolver(problem)  # no raise
         assert solver._honors_node_bc is False
 
-    # The trivial default Hamiltonian makes the tiny-grid policy-evaluation matrix singular; that
-    # is orthogonal to the gate (the BC pass overwrites the node value regardless of the interior
-    # solve), so suppress the pre-existing warning to keep the assertion focused.
-    @pytest.mark.filterwarnings("ignore:Matrix is exactly singular")
-    def test_policy_iteration_exempt_and_honors_boundary_nodes(self):
-        """Policy iteration constructs with ``boundary_nodes`` (gate-exempt) and actually pins the
-        node value at every backward step via ``apply_boundary_conditions``."""
-        problem = NetworkMFGProblem(
-            network_geometry=self._network(),
-            T=0.5,
-            Nt=10,
-            components=NetworkMFGComponents(boundary_nodes=[0], boundary_values_func=lambda node, t: 7.0),
-        )
+    def test_policy_iteration_exempt_and_honors_node_bc(self):
+        """Policy iteration constructs with a geometry node-BC (gate-exempt) and actually pins the
+        node value at every backward step via the geometry-owned ``GraphApplicator``."""
+        problem = NetworkMFGProblem(network_geometry=self._network(value=lambda node, t: 7.0), T=0.5, Nt=10)
         solver = NetworkPolicyIterationHJBSolver(problem)  # no raise
         assert solver._honors_node_bc is True
 

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -86,9 +86,8 @@ def test_network_components_is_mfg_components_byte_identical():
     ``isinstance`` holds; the solve path is unchanged because ``hamiltonian_class`` stays ``None``
     (the network solvers read the method / legacy rate paths, not the object). ``get_problem_info()``
     now works (previously ``AttributeError`` on the non-subclass components' missing ``description``),
-    and ``get_boundary_conditions()`` resolves to ``None`` instead of raising. Wiring
-    ``boundary_nodes`` into the ``BoundaryConditions`` framework (so the #1456 continuum gate applies)
-    is Stage 2 — not claimed here.
+    and a graph problem with no geometry node-BC resolves ``get_boundary_conditions()`` to ``None``
+    (Issue #1471 moved node-BC ownership to the geometry).
     """
     from mfgarchon.core.mfg_components import MFGComponents
 
@@ -101,12 +100,11 @@ def test_network_components_is_mfg_components_byte_identical():
     # orphaned/None). isinstance and get_problem_info remain the Stage-1 wins.
     assert prob.hamiltonian_class is not None, "the single-source NetworkHamiltonian must be wired"
     assert isinstance(prob.get_problem_info(), dict), "get_problem_info must not raise (was AttributeError)"
-    assert prob.get_boundary_conditions() is None, "network BC still resolves to None (Stage 2 wires it)"
+    assert prob.get_boundary_conditions() is None, "no geometry node-BC -> resolves to None (Issue #1471)"
 
     # network-native construction is unaffected
-    comps = NetworkMFGComponents(boundary_nodes=[0, 8], node_potential_func=lambda n, t: 0.1 * n)
+    comps = NetworkMFGComponents(node_potential_func=lambda n, t: 0.1 * n)
     assert isinstance(comps, MFGComponents)
-    assert comps.boundary_nodes == [0, 8]
 
 
 def test_network_hamiltonian_minimize_consistency():

--- a/tests/unit/test_geometry/boundary/test_graph_applicator.py
+++ b/tests/unit/test_geometry/boundary/test_graph_applicator.py
@@ -1,0 +1,87 @@
+"""Issue #1471: first unit coverage for GraphApplicator and the graph-geometry node-BC attachment.
+
+GraphApplicator becomes load-bearing once node-BC ownership moves to GraphGeometry (the network HJB
+Dirichlet pin now flows through ``apply_hjb``). It previously had zero tests.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary.applicator_graph import (
+    GraphApplicator,
+    GraphBCConfig,
+    GraphBCType,
+    NodeBC,
+)
+
+
+def _app(node_bcs, num_nodes=9):
+    return GraphApplicator.from_config(GraphBCConfig(node_bcs=node_bcs), num_nodes=num_nodes)
+
+
+def test_dirichlet_pins_value_not_density():
+    """DIRICHLET is a value (HJB) pin — it must not touch the density (FP) field (Issue #1471 gate)."""
+    app = _app([NodeBC(nodes=[0, 8], bc_type=GraphBCType.DIRICHLET, value=5.0)])
+    u = np.full(9, 2.0)
+    u_bc = app.apply_hjb(u.copy(), t=0.0)
+    assert u_bc[0] == 5.0
+    assert u_bc[8] == 5.0
+    assert u_bc[4] == 2.0, "interior node untouched"
+    assert u[0] == 2.0, "input must not be mutated (copied)"
+    m = np.full(9, 0.1)
+    m_bc = app.apply_fp(m.copy(), t=0.0)
+    assert np.array_equal(m_bc, m), "a Dirichlet value pin must be a no-op on the density field"
+
+
+def test_absorbing_zeros_density_not_value():
+    """ABSORBING (mass exits) belongs to the density field; it must not zero the HJB value."""
+    app = _app([NodeBC(nodes=[4], bc_type=GraphBCType.ABSORBING, value=0.0)])
+    m_bc = app.apply_fp(np.full(9, 0.2), t=0.0)
+    assert m_bc[4] == 0.0
+    assert m_bc[0] == 0.2
+    u_bc = app.apply_hjb(np.full(9, 3.0), t=0.0)
+    assert np.array_equal(u_bc, np.full(9, 3.0)), "absorbing must not touch the value field"
+
+
+def test_source_injects_density_only():
+    app = _app([NodeBC(nodes=[2], bc_type=GraphBCType.SOURCE, value=3.0)])
+    m_bc = app.apply_fp(np.full(9, 0.1), t=0.0)
+    assert m_bc[2] == 3.0
+    u_bc = app.apply_hjb(np.full(9, 2.0), t=0.0)
+    assert u_bc[2] == 2.0, "source must not modify the value field"
+
+
+def test_callable_value_and_2d_time_broadcast():
+    app = _app([NodeBC(nodes=[0], bc_type=GraphBCType.DIRICHLET, value=lambda n, t: 7.0 + t)])
+    u_2d = np.full((5, 9), 2.0)
+    u_bc = app.apply_hjb(u_2d.copy(), t=0.5)
+    assert np.allclose(u_bc[:, 0], 7.5), "2D (Nt, num_nodes) time-broadcast column-pin with callable value"
+
+
+def test_out_of_range_node_skipped():
+    app = _app([NodeBC(nodes=[0, 99], bc_type=GraphBCType.DIRICHLET, value=5.0)], num_nodes=9)
+    u_bc = app.apply_hjb(np.full(9, 2.0), t=0.0)
+    assert u_bc[0] == 5.0, "in-range node pinned; out-of-range node 99 skipped without IndexError"
+
+
+def test_graph_geometry_owns_node_bc_and_maze_inherits():
+    """Issue #1471: node-BC attaches at GraphGeometry, so both NetworkGeometry and MazeGeometry
+    inherit it (graph is the highest abstraction over both; graphon is separate)."""
+    pytest.importorskip("igraph")
+    from mfgarchon.geometry.graph.maze_generator import MazeGeometry
+    from mfgarchon.geometry.graph.network_geometry import GridNetwork
+
+    cfg = GraphBCConfig(node_bcs=[NodeBC(nodes=[0], bc_type=GraphBCType.DIRICHLET, value=1.0)])
+
+    net = GridNetwork(width=3, height=3, boundary_conditions=cfg)
+    assert net.has_explicit_boundary_conditions() is True
+    assert net.get_boundary_conditions() is cfg
+
+    net_none = GridNetwork(width=3, height=3)
+    assert net_none.has_explicit_boundary_conditions() is False
+    assert net_none.get_boundary_conditions() is None
+
+    maze = MazeGeometry(rows=3, cols=3, boundary_conditions=cfg)
+    assert maze.has_explicit_boundary_conditions() is True, "maze must inherit the GraphGeometry attachment"
+    assert maze.get_boundary_conditions() is cfg


### PR DESCRIPTION
## Summary
Stage 2a of the Problem/Components unification: **graph node-BC is now owned by `GraphGeometry`** (the confirmed clean design), so network + maze inherit it uniformly and it flows through the framework — retiring the ad-hoc `NetworkMFGComponents.boundary_nodes` channel.

## Clean design — BC on the geometry, at the right abstraction
```
GraphGeometry (owns node-BC)
├── NetworkGeometry → GridNetwork / RandomNetwork / ScaleFreeNetwork
└── MazeGeometry
```
Graphon is a separate continuum-limit construct (kernels/operators), correctly excluded.

## Changes
- **`GraphGeometry.__init__`** carries a `GraphBCConfig` (DIRICHLET / ABSORBING / SOURCE / NEUMANN `NodeBC`s); `get_boundary_conditions()` / `has_explicit_boundary_conditions()` / `set_boundary_conditions()` mirror the continuum `TensorProductGrid`. Threaded through `NetworkGeometry` / `GridNetwork` / `MazeGeometry`.
- **`NetworkMFGProblem`** resolves the geometry's node-BC once into a single-source `GraphApplicator`; `apply_boundary_conditions` delegates to it.
- **Gate re-keyed**: the base RK45 HJB / FP fail-loud gate keys on `geometry.has_explicit_boundary_conditions()` (was `components.boundary_nodes`).
- **Retired** `NetworkMFGComponents.boundary_nodes` / `boundary_values_func` (bypassed the #1456 SSOT).
- **`GraphApplicator`** (previously untested / orphaned, though registered in `apply_bc()` dispatch) gets its **first unit coverage** + a field-type fix (DIRICHLET → value, ABSORBING → density), closing the seam before Stage 2b.

## Byte-identical + validated
- The policy-iteration node-Dirichlet pin is **unchanged** — `GraphApplicator.apply_hjb` reproduces the old `boundary_values_func` pin.
- `get_boundary_conditions()` returns the geometry's node-BC — polymorphic by geometry (a node set, not a wall segment, so genuinely a different type from continuum `BoundaryConditions`; consumed via the applicator, not by type-assumption).
- **Maze inherits the attachment** (proves abstraction-level ownership).
- **814 geometry + 137 network/boundary tests pass**; ruff clean.

## Deferred (Stage 2b)
Absorbing FP: opening the conservative graph stencil at an absorbing node + gating the mass renorm. The FP-side semantics (node Dirichlet-`u` ↔ absorbing-`m`) follow from the adjoint duality.

Refs #1471, #1470, #1456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
