### PR TITLE
feat(bc): network absorbing FP — honor ABSORBING node-BC, gate mass renorm (Stage 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Network FP honors ABSORBING node boundary conditions (exit nodes)** (Issue #1478, Stage 2b). An
+  absorbing/exit node is one physical BC with dual operations (adjoint duality): the HJB value carries
+  the exit cost (`GraphApplicator` pins `u` = the `NodeBC` value on the value field), and the FP
+  density is absorbed (`m → 0`, mass exits, on the density field). `FPNetworkSolver` now applies the
+  geometry node-BC to the density field each step and **gates the mass renormalization off** when the
+  BC changes total mass (ABSORBING / SOURCE) — so absorption is no longer hidden (it previously failed
+  loud). With no node-BC, mass is conserved exactly as before. Validated: total mass strictly decreases
+  at an absorbing node while the HJB pins the exit cost. Refines the #1471 `ABSORBING` handling from
+  density-only to the dual (value-pin + density-zero).
+
 - **Graph node boundary conditions are now owned by `GraphGeometry`** (Issue #1471,
   Problem/Components unification — Layer Ψ). Node-BC (a `GraphBCConfig` of DIRICHLET / ABSORBING /
   SOURCE / NEUMANN `NodeBC`s) attaches at `GraphGeometry` — the highest abstraction over

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -100,19 +100,19 @@ class FPNetworkSolver(BaseFPSolver):
 
         self.network_problem = problem
 
-        # Issue #1468: fail loud on a node BC this solver cannot honor. It ignores
-        # `boundary_nodes` and unconditionally renormalizes total mass each step
-        # (`enforce_mass_conservation`), so a node BC would be silently dropped and any
-        # absorption hidden — manufacturing the mass-conserving answer in place of the
-        # intended one (the #1456 silent-wrong-answer class, on the graph).
-        if not self._honors_node_bc and problem.geometry.has_explicit_boundary_conditions():
-            raise NotImplementedError(
-                f"{type(self).__name__} does not support node boundary conditions "
-                f"(the graph geometry carries an explicit node-BC config). It ignores node-BC and "
-                f"unconditionally renormalizes total mass each step, so the node BC would be "
-                f"silently dropped and any absorption hidden (Issue #1468, #1456, #1471). Remove the "
-                f"geometry's BC, or use a solver that honors it (absorbing FP is Stage 2b)."
-            )
+        # Issue #1478 (Stage 2b): the FP now HONORS the geometry-owned node-BC via the single-source
+        # GraphApplicator. ABSORBING nodes are exits (their mass leaves, m -> 0), applied to the
+        # density field each step; DIRICHLET / NEUMANN are no-ops on density. The mass renorm is gated
+        # OFF whenever the BC changes total mass (ABSORBING / SOURCE) — else it would manufacture
+        # false conservation and hide the absorption (the #1456 silent-wrong-answer class).
+        self._node_applicator = problem._node_applicator
+        self._mass_changing_bc = False
+        node_bc = problem.geometry.get_boundary_conditions()
+        if node_bc is not None:
+            from mfgarchon.geometry.boundary.applicator_graph import GraphBCType
+
+            mass_changing = {GraphBCType.ABSORBING, GraphBCType.SOURCE}
+            self._mass_changing_bc = any(bc.bc_type in mass_changing for bc in node_bc.node_bcs)
 
         self.scheme = scheme
         self.diffusion_coefficient = diffusion_coefficient
@@ -318,10 +318,17 @@ class FPNetworkSolver(BaseFPSolver):
                 else:
                     raise ValueError(f"Unknown scheme: {self.scheme}")
 
-                # Enforce non-negativity and mass conservation
+                # Enforce non-negativity
                 M[n + 1, :] = np.maximum(M[n + 1, :], 0)
 
-                if self.enforce_mass_conservation:
+                # Issue #1478: apply the geometry-owned node-BC to the density field (ABSORBING -> the
+                # exit node's mass leaves, m -> 0), then renormalize ONLY when the BC is mass-conserving.
+                # With an absorbing / source node the total mass legitimately changes, so renormalizing
+                # would manufacture false conservation and hide the absorption.
+                if self._node_applicator is not None:
+                    M[n + 1, :] = self._node_applicator.apply_fp(M[n + 1, :], t)
+
+                if self.enforce_mass_conservation and not self._mass_changing_bc:
                     total_mass = np.sum(M[n + 1, :])
                     if total_mass > 1e-12:
                         M[n + 1, :] /= total_mass

--- a/mfgarchon/geometry/boundary/applicator_graph.py
+++ b/mfgarchon/geometry/boundary/applicator_graph.py
@@ -500,9 +500,16 @@ class GraphApplicator(BaseGraphApplicator):
                             result[node] = value
 
                 elif bc.bc_type == GraphBCType.ABSORBING:
-                    # Issue #1471: absorbing (density -> 0, mass exits) belongs to the DENSITY field
-                    # (FP m); zeroing the HJB value u at an exit is wrong (an exit carries exit cost).
-                    if field_type == "density":
+                    # Issue #1478: an absorbing / exit node is ONE physical BC with dual operations
+                    # (adjoint duality): the HJB value carries the exit cost (Dirichlet u = value), and
+                    # the FP density is absorbed (m -> 0, mass exits). Apply the right one per field.
+                    if field_type == "value":
+                        value = bc.get_value(node, t)
+                        if is_2d:
+                            result[:, node] = value
+                        else:
+                            result[node] = value
+                    else:  # density
                         if is_2d:
                             result[:, node] = 0.0
                         else:

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -655,37 +655,37 @@ class TestFPNetworkSolverIntegration:
             assert np.all(np.isfinite(M_solution))
 
 
-class TestFPNetworkSolverIssue1468NodeBCGate:
-    """Issue #1468 / #1471 (BC-capability, #1456 network family).
-
-    FPNetworkSolver ignores node-BC and unconditionally renormalizes total mass each step, so it must
-    fail loud on a node BC (now owned by the graph geometry) rather than silently solve the
-    mass-conserving problem in place of the intended (absorbing) one — absorbing FP is Stage 2b. The
-    continuum ``BCType`` gate is a structural no-op for graph problems, so the fail-loud gate keys on
-    ``geometry.has_explicit_boundary_conditions()``.
+class TestFPNetworkSolverAbsorbingNodeBC:
+    """Issue #1478 (Stage 2b): FPNetworkSolver honors an ABSORBING (exit) node — its mass leaves
+    (``m -> 0``) and the mass renorm is gated off so the absorption is not hidden.
     """
 
-    def _network(self, with_bc=False):
+    def _network(self, absorbing_node=None):
         from mfgarchon.geometry.boundary.applicator_graph import GraphBCConfig, GraphBCType, NodeBC
 
         bc = None
-        if with_bc:
-            bc = GraphBCConfig(node_bcs=[NodeBC(nodes=[0, 8], bc_type=GraphBCType.DIRICHLET, value=0.0)])
+        if absorbing_node is not None:
+            bc = GraphBCConfig(node_bcs=[NodeBC(nodes=[absorbing_node], bc_type=GraphBCType.ABSORBING, value=0.0)])
         network = GridNetwork(width=3, height=3, boundary_conditions=bc)
         network.create_network()
         return network
 
-    def test_node_bc_fail_loud(self):
-        problem = NetworkMFGProblem(network_geometry=self._network(with_bc=True), T=1.0, Nt=10)
-        with pytest.raises(NotImplementedError, match="node boundary conditions"):
-            FPNetworkSolver(problem)
+    def test_absorbing_fp_mass_decreases(self):
+        problem = NetworkMFGProblem(network_geometry=self._network(absorbing_node=0), T=0.5, Nt=20)
+        solver = FPNetworkSolver(problem, scheme="explicit")  # honors it — no raise
+        n = problem.num_nodes
+        m0 = np.ones(n) / n
+        u = np.zeros((21, n))  # zero value -> pure diffusion toward the absorbing node
+        m = solver.solve_fp_system(M_initial=m0, potential_field=u)
+        assert m[-1].sum() < m[0].sum() - 1e-3, "absorption: total mass must strictly decrease"
+        assert np.allclose(m[1:, 0], 0.0), "the absorbing node's density is zeroed each step"
 
-    def test_no_node_bc_constructs(self):
-        """Gate inert when no node BC is set (the default) — construction unchanged."""
-        problem = NetworkMFGProblem(network_geometry=self._network(), T=1.0, Nt=10)
+    def test_no_node_bc_constructs_and_conserves(self):
+        """No node BC -> construction unchanged and mass is conserved (renorm active)."""
+        problem = NetworkMFGProblem(network_geometry=self._network(), T=0.5, Nt=10)
         solver = FPNetworkSolver(problem)  # no raise
         assert solver.num_nodes == 9
-        assert solver._honors_node_bc is False
+        assert solver._mass_changing_bc is False
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_geometry/boundary/test_graph_applicator.py
+++ b/tests/unit/test_geometry/boundary/test_graph_applicator.py
@@ -34,14 +34,16 @@ def test_dirichlet_pins_value_not_density():
     assert np.array_equal(m_bc, m), "a Dirichlet value pin must be a no-op on the density field"
 
 
-def test_absorbing_zeros_density_not_value():
-    """ABSORBING (mass exits) belongs to the density field; it must not zero the HJB value."""
-    app = _app([NodeBC(nodes=[4], bc_type=GraphBCType.ABSORBING, value=0.0)])
+def test_absorbing_is_a_dual_exit_node():
+    """Issue #1478: an ABSORBING/exit node is one physical BC with dual operations — the FP density is
+    absorbed (m -> 0) and the HJB value carries the exit cost (Dirichlet u = value)."""
+    app = _app([NodeBC(nodes=[4], bc_type=GraphBCType.ABSORBING, value=5.0)])
     m_bc = app.apply_fp(np.full(9, 0.2), t=0.0)
-    assert m_bc[4] == 0.0
+    assert m_bc[4] == 0.0, "FP: exit node mass leaves (m -> 0)"
     assert m_bc[0] == 0.2
     u_bc = app.apply_hjb(np.full(9, 3.0), t=0.0)
-    assert np.array_equal(u_bc, np.full(9, 3.0)), "absorbing must not touch the value field"
+    assert u_bc[4] == 5.0, "HJB: exit node value pinned to the exit cost (Dirichlet)"
+    assert u_bc[0] == 3.0
 
 
 def test_source_injects_density_only():


### PR DESCRIPTION
## Summary
Stage 2b: **network absorbing FP**. An absorbing/exit node is one physical BC with **dual operations** (adjoint duality): the HJB value carries the exit cost (`Dirichlet u = value`), and the FP density is absorbed (`m → 0`, mass exits). Completes the graph-BC capability story.

## Changes
- **`GraphApplicator` ABSORBING** now applies the dual: pin `u` = exit cost on the value field (HJB) **and** zero `m` on the density field (FP). Refines the Stage-2a handling (which was density-only / no-op on `u`).
- **`FPNetworkSolver`** applies the geometry node-BC to the density field each step (via the single-source `GraphApplicator`) and **gates the mass renormalization off** when the BC changes total mass (ABSORBING / SOURCE) — otherwise the renorm manufactures false conservation and hides the absorption. This replaces the temporary Stage-0/2a fail-loud gate with proper handling; with no node-BC, mass is conserved exactly as before.

## Validation
Uniform initial density on a 5-node line with an absorbing node 0 (zero value → pure diffusion): total mass **strictly decreases 1.0 → 0.79** over `[0, T]` (the node's density is zeroed each step), and the policy-iteration HJB **pins `u[node0]` = exit cost**. New tests: `test_absorbing_fp_mass_decreases`, `test_absorbing_is_a_dual_exit_node`. **137 network + geometry/boundary tests pass**; ruff clean.

## Unification status
This completes Stage 2 (graph BC: geometry-owned + absorbing FP). Remaining: **Stage 3** — collapse `NetworkMFGProblem` → `MFGProblem`-by-geometry (+ unify `MFGEnvironment`).

Refs #1478, #1471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
