### PR TITLE
refactor(topology): remove 3 dead graph-operator reimplementations (Stage 3 increment 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Removed three dead graph-operator reimplementations from `NetworkMFGProblem`** (Issue #1472,
+  Stage 3 increment 0): `compute_graph_gradient`, `compute_graph_divergence` (a self-described
+  "simplified" stub), and `apply_graph_laplacian`. They had **zero callers** — the network solvers
+  build their own neighbor operators and read adjacency / Laplacian from `network_data` — and graph
+  operators are owned by the geometry (`GraphGeometry`). Behavior-preserving dead-code removal; first
+  step toward collapsing the `NetworkMFGProblem` fork onto `MFGProblem`-parameterized-by-geometry.
+
 - **Network FP honors ABSORBING node boundary conditions (exit nodes)** (Issue #1478, Stage 2b). An
   absorbing/exit node is one physical BC with dual operations (adjoint duality): the HJB value carries
   the exit cost (`GraphApplicator` pins `u` = the `NodeBC` value on the value field), and the FP

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -602,72 +602,10 @@ class NetworkMFGProblem(MFGProblem):
         # Default: zero terminal values
         return np.zeros(self.num_nodes)
 
-    # Network-specific operators
-
-    def compute_graph_gradient(self, u: np.ndarray) -> np.ndarray:
-        """
-        Compute discrete gradient on network.
-
-        For each node, computes differences to neighboring nodes.
-
-        Args:
-            u: Node values
-
-        Returns:
-            Gradient information (implementation dependent)
-        """
-        gradients = np.zeros((self.num_nodes, self.num_nodes))
-
-        for i in range(self.num_nodes):
-            if self.network_data is None:
-                neighbors = []  # No neighbors if no network data
-            else:
-                neighbors = self.network_data.get_neighbors(i)
-            for j in neighbors:
-                gradients[i, j] = u[j] - u[i]
-
-        return gradients
-
-    def compute_graph_divergence(self, flow: np.ndarray) -> np.ndarray:
-        """
-        Compute discrete divergence on network.
-
-        Args:
-            flow: Edge flow values
-
-        Returns:
-            Divergence at each node
-        """
-        # Simplified: divergence as sum of incoming/outgoing flows
-        divergence = np.zeros(self.num_nodes)
-
-        # This is a simplified implementation
-        # Full implementation would handle edge-based flows properly
-        for i in range(self.num_nodes):
-            if self.network_data is None:
-                neighbors = []  # No neighbors if no network data
-            else:
-                neighbors = self.network_data.get_neighbors(i)
-            div_i = 0.0
-            for j in neighbors:
-                # Flow from j to i minus flow from i to j
-                div_i += flow[j] - flow[i]  # Simplified
-            divergence[i] = div_i
-
-        return divergence
-
-    def apply_graph_laplacian(self, u: np.ndarray, coefficient: float = 1.0) -> np.ndarray:
-        """
-        Apply graph Laplacian operator to node values.
-
-        Args:
-            u: Node values
-            coefficient: Diffusion coefficient
-
-        Returns:
-            Laplacian applied to u
-        """
-        return np.asarray(coefficient * (self.laplacian_matrix @ u))
+    # Graph operators (gradient / divergence / Laplacian) are owned by the geometry
+    # (GraphGeometry, Issue #1472) — the graph structural data lives there, not on the problem. The
+    # problem previously reimplemented three of them (compute_graph_gradient / compute_graph_divergence
+    # / apply_graph_laplacian); they had zero callers and are removed to keep a single source.
 
     # Boundary conditions for networks
 


### PR DESCRIPTION
## Summary
Stage 3 increment 0 of the Problem/Components unification (collapse `NetworkMFGProblem` → `MFGProblem`-parameterized-by-geometry). Removes three **dead** graph-operator reimplementations from `NetworkMFGProblem`.

## What & why
`compute_graph_gradient` (builds an unused dense N×N difference matrix), `compute_graph_divergence` (a self-described "simplified" stub), and `apply_graph_laplacian` had **zero callers** across `mfgarchon/`, `tests/`, and `examples/`. The network solvers build their own neighbor operators (`gradient_ops`/`divergence_ops`) and read adjacency / Laplacian from `network_data`; graph operators belong to the geometry (`GraphGeometry`). Removing the redundant copies keeps a single source and thins the fork ahead of the collapse.

Investigation also confirmed adjacency / Laplacian / neighbors are **already** single-sourced through `network_data` (the geometry's dense `get_adjacency_matrix` and the problem's sparse accessor both read the same `network_data.adjacency_matrix` — no silent divergence), so no further consolidation is needed here.

## Validation
Behavior-preserving (dead code). **69 network tests pass**; module import + ruff clean.

## Stage-3 schedule
Next: increment 1 (delete dummy `Nx/xmin/xmax/Dx` after consumer analysis), then increment 2 (thin the fork to the Hamiltonian binding — **Option A**, per decision). Full schedule in Joplin Dev.

Refs #1472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
