### PR TITLE
refactor(topology): drop dummy Nx/xmin/xmax/Dx from NetworkMFGProblem (Stage 3 increment 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Removed the dummy continuum spatial fields (`Nx`, `xmin`, `xmax`, `Dx`) from `NetworkMFGProblem`**
+  (Issue #1472, Stage 3 increment 1). They returned nonsense placeholders (`Nx = num_nodes - 1`,
+  `xmin = 0`, `xmax = num_nodes - 1`, `Dx = 1`) to fake a continuum interface a network problem never
+  uses — no network-path consumer reads them (the base `MFGProblem` does not define them; the network
+  solvers use `num_nodes`; every reader of `.Nx`/`.xmin`/`.xmax`/`.Dx` is a continuum path). Removing
+  them prevents accidental continuum code paths on a graph problem. Verified by the full network suite
+  plus an end-to-end network solve; thins the `NetworkMFGProblem` fork ahead of the collapse.
+
 - **Removed three dead graph-operator reimplementations from `NetworkMFGProblem`** (Issue #1472,
   Stage 3 increment 0): `compute_graph_gradient`, `compute_graph_divergence` (a self-described
   "simplified" stub), and `apply_graph_laplacian`. They had **zero callers** — the network solvers

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -631,25 +631,10 @@ class NetworkMFGProblem(MFGProblem):
         """Get terminal value function (legacy interface)."""
         return self.get_terminal_value()
 
-    @property
-    def Nx(self) -> int:
-        """Number of spatial points (nodes in network)."""
-        return self.num_nodes - 1
-
-    @property
-    def xmin(self) -> float:
-        """Minimum spatial coordinate (dummy for networks)."""
-        return 0.0
-
-    @property
-    def xmax(self) -> float:
-        """Maximum spatial coordinate (dummy for networks)."""
-        return float(self.num_nodes - 1)
-
-    @property
-    def Dx(self) -> float:
-        """Spatial step size (dummy for networks)."""
-        return 1.0
+    # The continuum spatial fields Nx / xmin / xmax / Dx are not defined here (Issue #1472). They are
+    # not part of the base MFGProblem interface and no network-path consumer reads them — the network
+    # solvers use num_nodes; graph geometry has no continuum coordinates. The former dummies (Nx =
+    # num_nodes - 1, xmin = 0, xmax = num_nodes - 1, Dx = 1) invited nonsense continuum code paths.
 
     # Network-specific properties
 


### PR DESCRIPTION
## Summary
Stage 3 increment 1: remove the dummy continuum spatial fields `Nx` / `xmin` / `xmax` / `Dx` from `NetworkMFGProblem`.

## What & why
They returned nonsense placeholders — `Nx = num_nodes - 1`, `xmin = 0`, `xmax = num_nodes - 1`, `Dx = 1` — to fake a continuum interface a network problem never uses. Investigation confirmed:
- The base `MFGProblem` does **not** define `Nx/xmin/xmax/Dx` (they aren't part of the shared interface).
- The network solvers use `num_nodes`.
- **Every** reader of `.Nx/.xmin/.xmax/.Dx` is a continuum path (variational solvers, grid-config validation, CLI) that a network problem never reaches.

Keeping them only invited accidental continuum code paths on a graph problem (e.g. a shared routine silently treating a graph as a 1D grid of `num_nodes-1` points).

## Validation
- **76 network tests pass** (unit + integration).
- End-to-end network HJB (policy iteration) + FP solve runs, mass conserved; `hasattr(prob, 'Nx'/'xmin'/'xmax'/'Dx')` is now `False`.
- ruff clean.

## Stage-3 schedule
Next: increment 2 — thin the fork to the Hamiltonian binding (**Option A**: ~10-line subclass), alias `network_geometry`→`geometry`. Full schedule in Joplin Dev.

Refs #1472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
