### PR TITLE
refactor(topology): single-source the network Hamiltonian (Stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Single-sourced the network Hamiltonian** (Issue #1472, Stage 3): `NetworkMFGProblem.hamiltonian()`
+  now delegates to the wired `NetworkHamiltonian` object — the SAME object the FP and policy-iteration
+  solvers use via `optimal_control` — so the RK45 base solver reads the identical Hamiltonian instead
+  of a second hand-synced copy. Removed the `_default_network_hamiltonian` duplicate (the #1474/N15
+  fix had to keep it in lockstep with the object by hand — a latent silent-divergence risk of the kind
+  that caused N15 itself). Pinned by `test_network_hamiltonian_method_equals_object` (method == object
+  byte-identity across default, custom-potential, and custom-`hamiltonian_func` cases). Byte-identical.
+
 - **Removed the dummy continuum spatial fields (`Nx`, `xmin`, `xmax`, `Dx`) from `NetworkMFGProblem`**
   (Issue #1472, Stage 3 increment 1). They returned nonsense placeholders (`Nx = num_nodes - 1`,
   `xmin = 0`, `xmax = num_nodes - 1`, `Dx = 1`) to fake a continuum interface a network problem never

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -392,52 +392,17 @@ class NetworkMFGProblem(MFGProblem):
     # Network-specific MFG components
 
     def hamiltonian(self, node: int, neighbors: list[int], m: np.ndarray, p: np.ndarray, t: float) -> float:
+        """Network Hamiltonian at a node — delegates to the single-source ``NetworkHamiltonian``.
+
+        Issue #1472: the value is computed by the wired ``hamiltonian_class`` — the SAME object the FP
+        and policy-iteration solvers use (via ``optimal_control``) — so the RK45 base solver reads the
+        identical Hamiltonian rather than a second hand-synced copy. This removes the former
+        ``_default_network_hamiltonian`` duplicate, which had to be kept in lockstep with the object by
+        hand (the #1474/N15 divergence risk). ``neighbors`` is accepted for signature compatibility;
+        the object recomputes the neighborhood from ``network_data``. Byte-identical (pinned by
+        ``test_network_hamiltonian_method_equals_object``).
         """
-        Network Hamiltonian function.
-
-        Args:
-            node: Current node index
-            neighbors: List of neighboring nodes
-            m: Density vector at all nodes
-            p: Co-state vector at all nodes
-            t: Current time
-
-        Returns:
-            Hamiltonian value at the node
-        """
-        if self.components.hamiltonian_func is not None:
-            return self.components.hamiltonian_func(node, neighbors, m, p, t)
-
-        # Default quadratic Hamiltonian with network structure
-        return self._default_network_hamiltonian(node, neighbors, m, p, t)
-
-    def _default_network_hamiltonian(
-        self, node: int, neighbors: list[int], m: np.ndarray, p: np.ndarray, t: float
-    ) -> float:
-        """Default network Hamiltonian implementation."""
-        # Quadratic control cost + potential + density coupling
-        control_cost = 0.0
-
-        # Sum over possible moves to neighbors
-        for neighbor in neighbors:
-            if self.network_data is None:
-                edge_weight = 1.0  # Default weight
-            else:
-                edge_weight = self.network_data.get_edge_weight(node, neighbor)
-            # Control cost (Issue #1474): one-sided finite-state MFG control, sense=MINIMIZE — only
-            # downhill edges (u_i > u_j) contribute, matching NetworkHamiltonian and the alpha>=0
-            # generator. (Was the full quadratic 0.5*edge_weight*(u_j-u_i)^2 = unconstrained
-            # relaxation, which made RK45 solve a different HJB than FP/policy iteration.)
-            du = p[node] - p[neighbor]  # u_i - u_j
-            control_cost += 0.5 * edge_weight * max(du, 0.0) ** 2
-
-        # Node potential
-        potential = self.node_potential(node, t)
-
-        # Density coupling (congestion effects)
-        coupling = self.density_coupling(node, m, t)
-
-        return control_cost + potential + coupling
+        return float(self.hamiltonian_class(node, m, p, t))
 
     def hamiltonian_dm(self, node: int, neighbors: list[int], m: np.ndarray, p: np.ndarray, t: float) -> float:
         """Derivative of Hamiltonian with respect to density."""

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -185,3 +185,32 @@ def test_network_hamiltonian_maximize_fails_loud():
     prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=4)
     with pytest.raises(NotImplementedError, match="MINIMIZE"):
         NetworkHamiltonian(network_data=prob.network_data, sense=OptimizationSense.MAXIMIZE)
+
+
+def test_network_hamiltonian_method_equals_object():
+    """Issue #1472: ``NetworkMFGProblem.hamiltonian()`` IS the single-source ``NetworkHamiltonian``
+    object, not a second hand-synced copy. The RK45 base solver (which reads the method) and the FP /
+    policy-iteration solvers (which read the object via ``optimal_control``) therefore see the
+    identical Hamiltonian — this pins the single source so the #1474/N15 divergence cannot re-open.
+    """
+    m5 = np.ones(5) / 5
+    p5 = np.array([0.0, 1.0, 0.5, 2.0, 1.5])
+    for comps in (
+        NetworkMFGComponents(),
+        NetworkMFGComponents(
+            node_potential_func=lambda n, t: 0.3 * n,
+            node_interaction_func=lambda n, m, t: 2.0 * m[n],
+        ),
+        NetworkMFGComponents(
+            hamiltonian_func=lambda node, nbrs, m, p, t: sum(max(p[node] - p[j], 0) ** 2 for j in nbrs) + 0.7
+        ),
+    ):
+        net = GridNetwork(width=5, height=1)
+        net.create_network()
+        prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=10, components=comps)
+        obj = prob.hamiltonian_class
+        for node in range(prob.num_nodes):
+            nbrs = prob.get_node_neighbors(node)
+            method_val = prob.hamiltonian(node, nbrs, m5, p5, 0.1)
+            object_val = float(obj(node, m5, p5, 0.1))
+            assert method_val == object_val, f"method != object at node {node} (single-source broken)"


### PR DESCRIPTION
## Summary
Stage 3 (collapse `NetworkMFGProblem` → `MFGProblem`-by-geometry): single-source the network Hamiltonian so the RK45 base solver stops reading a second hand-synced copy.

## The fork
- RK45 base HJB (`hjb_network.py:159`) read `NetworkMFGProblem.hamiltonian()` → `_default_network_hamiltonian` (a reimplementation).
- FP (`fp_network.py:443`) + policy-iteration (`hjb_network.py:364`) read the `NetworkHamiltonian` **object** via `optimal_control`.

Two copies of the same default Hamiltonian, kept in lockstep **by hand** since #1474/N15 — the `_default_network_hamiltonian` comment literally said "matching NetworkHamiltonian". That's the silent-divergence risk that *caused* N15 (RK45 solving a different HJB than FP).

## Fix
`hamiltonian()` now delegates to the wired `hamiltonian_class` object; the `_default_network_hamiltonian` duplicate is deleted. All three solver paths read the same source.

## Validation
- **Byte-identical**: `method == object` (max diff `0.0`) across default, custom `node_potential`/`node_interaction`, and custom `hamiltonian_func` cases.
- Pinned by `test_network_hamiltonian_method_equals_object` (locks the single source so the divergence cannot re-open).
- **77 network tests pass** (unit + integration); ruff clean.

## Stage-3 schedule
Increments 0 (dead graph ops) + 1 (dummy fields) merged (#1480/#1481). Remaining: the breaking collapse — thin the subclass to the Hamiltonian binding (**Option A**) + alias `network_geometry`→`geometry`. Full schedule in Joplin Dev.

Refs #1472, #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
