### PR TITLE
refactor(topology)!: unify NetworkMFGProblem constructor to geometry= (Stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (a seeded `volatility_field=s` solve equals a `problem.sigma=s` solve to 1e-10); `problem.sigma` is
   never written. New `test_issue_1412_fp_particle_sigma_override`.
 
+### Deprecated
+
+- **`NetworkMFGProblem(network_geometry=...)` → `geometry=`** (Issue #1472, Stage 3). The constructor
+  parameter is now `geometry`, aligned with `MFGProblem` — geometry is the single axis of variation,
+  toward the Problem/Components unification. `network_geometry=` is a deprecated alias that redirects
+  identically (emits `DeprecationWarning`; removed after the deprecation window). Passing both, or
+  neither, fails loud. All internal call sites (factories, tests, examples) are migrated to `geometry=`.
+  Equivalence-tested (`test_network_geometry_alias_equivalence_and_deprecation`): old and new
+  construction are byte-identical (same nodes, same single-source Hamiltonian, same values).
+
 ### Fixed
 
 - **Network finite-state MFG: value Hamiltonian, optimal control, and `dp` reconciled into one

--- a/examples/applications/economics/el_farol_bar_demo.py
+++ b/examples/applications/economics/el_farol_bar_demo.py
@@ -167,7 +167,7 @@ def create_el_farol_problem(
 
     # Create problem
     problem = NetworkMFGProblem(
-        network_geometry=network,
+        geometry=network,
         T=T,
         Nt=Nt,
         components=components,

--- a/examples/applications/networks/network_mfg_comparison_example.py
+++ b/examples/applications/networks/network_mfg_comparison_example.py
@@ -143,7 +143,7 @@ class NetworkMFGBenchmark:
         )
 
         problem = NetworkMFGProblem(
-            network_geometry=network_geometry,
+            geometry=network_geometry,
             T=self.T,
             Nt=self.Nt,
             components=components,

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -19,6 +19,7 @@ Key differences from continuous MFG:
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -289,22 +290,46 @@ class NetworkMFGProblem(MFGProblem):
 
     def __init__(
         self,
-        network_geometry: BaseNetworkGeometry,
+        geometry: BaseNetworkGeometry | None = None,
         T: float = 1.0,
         Nt: int = 100,
         components: NetworkMFGComponents | None = None,
         problem_name: str = "NetworkMFG",
+        *,
+        network_geometry: BaseNetworkGeometry | None = None,
     ):
         """
         Initialize network MFG problem.
 
         Args:
-            network_geometry: Network structure and geometry
+            geometry: Graph geometry (network structure). Named ``geometry`` to align with
+                ``MFGProblem`` — geometry is the axis of variation (Issue #1472).
             T: Terminal time
             Nt: Number of time steps
             components: Network MFG components (optional)
             problem_name: Problem identifier
+            network_geometry: Deprecated alias for ``geometry`` (Issue #1472); redirects identically.
         """
+        # Issue #1472: the canonical constructor param is `geometry` (aligned with MFGProblem, toward
+        # the Problem/Components unification). `network_geometry=` is a deprecated alias that redirects
+        # identically (equivalence-tested); it will be removed after the deprecation window.
+        if network_geometry is not None:
+            if geometry is not None:
+                raise ValueError(
+                    "Pass the graph geometry via geometry=; network_geometry= is a deprecated alias — "
+                    "do not pass both."
+                )
+            warnings.warn(
+                "NetworkMFGProblem(network_geometry=...) is deprecated (Issue #1472); use geometry=. "
+                "The alias redirects identically and is removed after the deprecation window.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            geometry = network_geometry
+        if geometry is None:
+            raise ValueError("NetworkMFGProblem requires a graph geometry (pass geometry=...).")
+        network_geometry = geometry  # local name; the remainder of __init__ uses network_geometry
+
         # Network properties - set first before calling super()
         self.network_geometry = network_geometry
         self.network_data = network_geometry.network_data
@@ -667,7 +692,7 @@ def create_grid_mfg_problem(
     components = NetworkMFGComponents(**kwargs)
 
     return NetworkMFGProblem(
-        network_geometry=network,
+        geometry=network,
         T=T,
         Nt=Nt,
         components=components,
@@ -692,7 +717,7 @@ def create_random_mfg_problem(
     components = NetworkMFGComponents(**kwargs)
 
     return NetworkMFGProblem(
-        network_geometry=network,
+        geometry=network,
         T=T,
         Nt=Nt,
         components=components,
@@ -717,7 +742,7 @@ def create_scale_free_mfg_problem(
     components = NetworkMFGComponents(**kwargs)
 
     return NetworkMFGProblem(
-        network_geometry=network,
+        geometry=network,
         T=T,
         Nt=Nt,
         components=components,

--- a/mfgarchon/factory/problem_factories.py
+++ b/mfgarchon/factory/problem_factories.py
@@ -238,7 +238,7 @@ def create_mfg_problem(
     >>>
     >>> # Network MFG (new unified API)
     >>> components = MFGComponents(
-    ...     network_geometry=graph,
+    ...     geometry=graph,
     ...     node_interaction_func=node_cost,
     ...     edge_cost_func=edge_cost
     ... )
@@ -429,7 +429,7 @@ def create_network_problem(
 
     >>> from mfgarchon.extensions.topology import NetworkMFGProblem
     >>> problem = NetworkMFGProblem(
-    ...     network_geometry=graph,
+    ...     geometry=graph,
     ...     node_interaction=lambda node, m: m[node]**2,
     ...     edge_cost=lambda edge: 1.0,
     ...     initial_density=initial_m,
@@ -459,7 +459,7 @@ def create_network_problem(
         "Use the extension module directly:\n"
         "  from mfgarchon.extensions.topology import NetworkMFGProblem\n\n"
         "  problem = NetworkMFGProblem(\n"
-        "      network_geometry=graph,\n"
+        "      geometry=graph,\n"
         "      node_interaction=lambda node, m: m[node]**2,\n"
         "      edge_cost=lambda edge: 1.0,\n"
         "      initial_density=initial_m,\n"

--- a/tests/integration/test_1043_coupler_fp_drift_convention.py
+++ b/tests/integration/test_1043_coupler_fp_drift_convention.py
@@ -519,7 +519,7 @@ class TestFPNetworkSolverPotentialFieldRename:
 
         network = GridNetwork(width=3, height=3)
         network.create_network()
-        return NetworkMFGProblem(network_geometry=network, T=0.5, Nt=5)
+        return NetworkMFGProblem(geometry=network, T=0.5, Nt=5)
 
     def test_potential_field_kwarg_accepted(self, network_problem):
         """potential_field=U is the new canonical keyword; must work without DeprecationWarning."""

--- a/tests/integration/test_network_mfg_solvers.py
+++ b/tests/integration/test_network_mfg_solvers.py
@@ -32,7 +32,7 @@ class TestNetworkMFGSolverCreation:
 
         # Create network MFG problem
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -50,7 +50,7 @@ class TestNetworkMFGSolverCreation:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=20,
         )
@@ -69,7 +69,7 @@ class TestNetworkMFGSolverCreation:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=20,
         )
@@ -88,7 +88,7 @@ class TestNetworkMFGSolverCreation:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -104,7 +104,7 @@ class TestNetworkMFGSolverCreation:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -126,7 +126,7 @@ class TestNetworkMFGProblemSetup:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=20,
         )
@@ -142,7 +142,7 @@ class TestNetworkMFGProblemSetup:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -161,7 +161,7 @@ class TestNetworkMFGProblemSetup:
         )
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
             components=components,
@@ -193,7 +193,7 @@ class TestNetworkMFGSolverExecution:
 
         # Create problem
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -224,7 +224,7 @@ class TestNetworkMFGSolverExecution:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.2,
             Nt=20,
         )
@@ -248,7 +248,7 @@ class TestNetworkMFGSolverExecution:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=15,
         )
@@ -273,7 +273,7 @@ class TestNetworkSolutionProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=15,
         )
@@ -297,7 +297,7 @@ class TestNetworkSolutionProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -317,7 +317,7 @@ class TestNetworkSolutionProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=20,
         )
@@ -342,7 +342,7 @@ class TestNetworkGeometryVariations:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -363,7 +363,7 @@ class TestNetworkGeometryVariations:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -386,7 +386,7 @@ class TestSolverConvergence:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.3,
             Nt=10,
         )
@@ -405,7 +405,7 @@ class TestSolverConvergence:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -427,7 +427,7 @@ class TestSolverRobustness:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -447,7 +447,7 @@ class TestSolverRobustness:
 
         for T_val in [0.3, 0.5, 1.0]:
             problem = NetworkMFGProblem(
-                network_geometry=network,
+                geometry=network,
                 T=T_val,
                 Nt=10,
             )
@@ -466,7 +466,7 @@ class TestSolverRobustness:
             network.create_network()
 
             problem = NetworkMFGProblem(
-                network_geometry=network,
+                geometry=network,
                 T=0.5,
                 Nt=10,
             )

--- a/tests/integration/test_phase1_5_validation.py
+++ b/tests/integration/test_phase1_5_validation.py
@@ -190,7 +190,7 @@ class TestNetworkSolverIntegration:
 
         network = GridNetwork(width=n_nodes, height=1)
         network.create_network()
-        return NetworkMFGProblem(network_geometry=network, T=0.5, Nt=5)
+        return NetworkMFGProblem(geometry=network, T=0.5, Nt=5)
 
     def test_network_hjb_solver_runs(self):
         """Network HJB solver initialization and basic solve."""

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -27,7 +27,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -48,7 +48,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -64,7 +64,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -80,7 +80,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -96,7 +96,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -111,7 +111,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -128,7 +128,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -149,7 +149,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -166,7 +166,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -183,7 +183,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=2.0,
             Nt=20,
         )
@@ -201,7 +201,7 @@ class TestFPNetworkSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -221,7 +221,7 @@ class TestFPNetworkSolverSolveFPSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -248,7 +248,7 @@ class TestFPNetworkSolverSolveFPSystem:
         pre-fix `D = volatility_field` fork would have failed)."""
         network = GridNetwork(width=3, height=3)
         network.create_network()
-        problem = NetworkMFGProblem(network_geometry=network, T=0.5, Nt=10)
+        problem = NetworkMFGProblem(geometry=network, T=0.5, Nt=10)
         num_nodes = problem.num_nodes
         # NON-uniform initial density: a uniform m is a diffusion fixed point (Laplacian of a
         # constant is 0), so D would be unobservable. A ramp makes the diffusion (hence D) matter.
@@ -276,7 +276,7 @@ class TestFPNetworkSolverSolveFPSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -303,7 +303,7 @@ class TestFPNetworkSolverSolveFPSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.1,  # Short time for stability
             Nt=20,
         )
@@ -326,7 +326,7 @@ class TestFPNetworkSolverSolveFPSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -349,7 +349,7 @@ class TestFPNetworkSolverSolveFPSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -372,7 +372,7 @@ class TestFPNetworkSolverSolveFPSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -396,7 +396,7 @@ class TestFPNetworkSolverSolveFPSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -423,7 +423,7 @@ class TestFPNetworkSolverNumericalProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=15,
         )
@@ -448,7 +448,7 @@ class TestFPNetworkSolverNumericalProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -478,7 +478,7 @@ class TestFPNetworkSolverNumericalProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=15,
         )
@@ -507,7 +507,7 @@ class TestFPNetworkSolverNumericalProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -535,7 +535,7 @@ class TestFPNetworkSolverDifferentNetworks:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -559,7 +559,7 @@ class TestFPNetworkSolverDifferentNetworks:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -583,7 +583,7 @@ class TestFPNetworkSolverDifferentNetworks:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -612,7 +612,7 @@ class TestFPNetworkSolverIntegration:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -637,7 +637,7 @@ class TestFPNetworkSolverIntegration:
 
         for config in configs:
             problem = NetworkMFGProblem(
-                network_geometry=network,
+                geometry=network,
                 T=0.2,
                 Nt=10,
             )
@@ -671,7 +671,7 @@ class TestFPNetworkSolverAbsorbingNodeBC:
         return network
 
     def test_absorbing_fp_mass_decreases(self):
-        problem = NetworkMFGProblem(network_geometry=self._network(absorbing_node=0), T=0.5, Nt=20)
+        problem = NetworkMFGProblem(geometry=self._network(absorbing_node=0), T=0.5, Nt=20)
         solver = FPNetworkSolver(problem, scheme="explicit")  # honors it — no raise
         n = problem.num_nodes
         m0 = np.ones(n) / n
@@ -682,7 +682,7 @@ class TestFPNetworkSolverAbsorbingNodeBC:
 
     def test_no_node_bc_constructs_and_conserves(self):
         """No node BC -> construction unchanged and mass is conserved (renorm active)."""
-        problem = NetworkMFGProblem(network_geometry=self._network(), T=0.5, Nt=10)
+        problem = NetworkMFGProblem(geometry=self._network(), T=0.5, Nt=10)
         solver = FPNetworkSolver(problem)  # no raise
         assert solver.num_nodes == 9
         assert solver._mass_changing_bc is False

--- a/tests/unit/test_alg/test_hjb_network_solver.py
+++ b/tests/unit/test_alg/test_hjb_network_solver.py
@@ -30,7 +30,7 @@ class TestNetworkHJBSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -47,7 +47,7 @@ class TestNetworkHJBSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -63,7 +63,7 @@ class TestNetworkHJBSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -78,7 +78,7 @@ class TestNetworkHJBSolverInitialization:
         is freely settable."""
         network = GridNetwork(width=3, height=3)
         network.create_network()
-        problem = NetworkMFGProblem(network_geometry=network, T=1.0, Nt=10)
+        problem = NetworkMFGProblem(geometry=network, T=1.0, Nt=10)
 
         with pytest.raises(NotImplementedError, match="policy_tolerance"):
             NetworkPolicyIterationHJBSolver(problem, policy_tolerance=1e-8)
@@ -93,7 +93,7 @@ class TestNetworkHJBSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -110,7 +110,7 @@ class TestNetworkHJBSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=2.0,
             Nt=20,
         )
@@ -128,7 +128,7 @@ class TestNetworkHJBSolverInitialization:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=1.0,
             Nt=10,
         )
@@ -148,7 +148,7 @@ class TestNetworkHJBSolverSolveHJBSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -174,7 +174,7 @@ class TestNetworkHJBSolverSolveHJBSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -200,7 +200,7 @@ class TestNetworkHJBSolverSolveHJBSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.1,  # Short time for stability
             Nt=20,
         )
@@ -223,7 +223,7 @@ class TestNetworkHJBSolverSolveHJBSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -246,7 +246,7 @@ class TestNetworkHJBSolverSolveHJBSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -269,7 +269,7 @@ class TestNetworkHJBSolverSolveHJBSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -295,7 +295,7 @@ class TestNetworkHJBSolverSolveHJBSystem:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -322,7 +322,7 @@ class TestNetworkHJBSolverNumericalProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=15,
         )
@@ -346,7 +346,7 @@ class TestNetworkHJBSolverNumericalProperties:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -374,7 +374,7 @@ class TestNetworkHJBSolverDifferentNetworks:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -398,7 +398,7 @@ class TestNetworkHJBSolverDifferentNetworks:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -422,7 +422,7 @@ class TestNetworkHJBSolverDifferentNetworks:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -451,7 +451,7 @@ class TestNetworkHJBSolverIntegration:
         network.create_network()
 
         problem = NetworkMFGProblem(
-            network_geometry=network,
+            geometry=network,
             T=0.5,
             Nt=10,
         )
@@ -476,7 +476,7 @@ class TestNetworkHJBSolverIntegration:
 
         for config in configs:
             problem = NetworkMFGProblem(
-                network_geometry=network,
+                geometry=network,
                 T=0.2,
                 Nt=10,
             )
@@ -515,19 +515,19 @@ class TestNetworkHJBIssue1468NodeBCGate:
         return network
 
     def test_base_solver_node_bc_fail_loud(self):
-        problem = NetworkMFGProblem(network_geometry=self._network(value=0.0), T=0.5, Nt=10)
+        problem = NetworkMFGProblem(geometry=self._network(value=0.0), T=0.5, Nt=10)
         with pytest.raises(NotImplementedError, match="node boundary conditions"):
             NetworkHJBSolver(problem)
 
     def test_base_solver_no_node_bc_constructs(self):
-        problem = NetworkMFGProblem(network_geometry=self._network(), T=0.5, Nt=10)
+        problem = NetworkMFGProblem(geometry=self._network(), T=0.5, Nt=10)
         solver = NetworkHJBSolver(problem)  # no raise
         assert solver._honors_node_bc is False
 
     def test_policy_iteration_exempt_and_honors_node_bc(self):
         """Policy iteration constructs with a geometry node-BC (gate-exempt) and actually pins the
         node value at every backward step via the geometry-owned ``GraphApplicator``."""
-        problem = NetworkMFGProblem(network_geometry=self._network(value=lambda node, t: 7.0), T=0.5, Nt=10)
+        problem = NetworkMFGProblem(geometry=self._network(value=lambda node, t: 7.0), T=0.5, Nt=10)
         solver = NetworkPolicyIterationHJBSolver(problem)  # no raise
         assert solver._honors_node_bc is True
 

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -62,7 +62,7 @@ def test_network_hamiltonian_object_equals_method_node_by_node(case):
         comps = NetworkMFGComponents(
             hamiltonian_func=lambda n, nb, m, p, t: sum((p[j] - p[n]) ** 2 for j in nb) + 0.7 * m[n]
         )
-    prob = NetworkMFGProblem(network_geometry=net, T=1.0, Nt=5, components=comps)
+    prob = NetworkMFGProblem(geometry=net, T=1.0, Nt=5, components=comps)
     H = _build_H(prob)
 
     rng = np.random.default_rng(7)
@@ -93,7 +93,7 @@ def test_network_components_is_mfg_components_byte_identical():
 
     net = GridNetwork(width=3, height=3)
     net.create_network()
-    prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=4)
+    prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=4)
 
     assert isinstance(prob.components, MFGComponents)
     # Issue #1474: the NetworkHamiltonian is now WIRED as the single-source Hamiltonian (previously
@@ -121,7 +121,7 @@ def test_network_hamiltonian_minimize_consistency():
     """
     net = GridNetwork(width=5, height=1)
     net.create_network()
-    prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=20)
+    prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=20)
     H = prob.hamiltonian_class
     assert H is not None
     N = prob.num_nodes
@@ -162,7 +162,7 @@ def test_network_policy_iteration_converges_to_rk45():
     g = np.array([0.0, 0.0, 0.0, 0.0, 10.0])
     errs = []
     for nt in (20, 40, 80):
-        prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=nt)
+        prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=nt)
         n = prob.num_nodes
         m = np.ones((nt + 1, n)) / n
         u_rk = NetworkHJBSolver(prob, scheme="RK45").solve_hjb_system(M_density=m, U_terminal=g)
@@ -182,7 +182,7 @@ def test_network_hamiltonian_maximize_fails_loud():
 
     net = GridNetwork(width=3, height=1)
     net.create_network()
-    prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=4)
+    prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=4)
     with pytest.raises(NotImplementedError, match="MINIMIZE"):
         NetworkHamiltonian(network_data=prob.network_data, sense=OptimizationSense.MAXIMIZE)
 
@@ -207,10 +207,45 @@ def test_network_hamiltonian_method_equals_object():
     ):
         net = GridNetwork(width=5, height=1)
         net.create_network()
-        prob = NetworkMFGProblem(network_geometry=net, T=0.5, Nt=10, components=comps)
+        prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=10, components=comps)
         obj = prob.hamiltonian_class
         for node in range(prob.num_nodes):
             nbrs = prob.get_node_neighbors(node)
             method_val = prob.hamiltonian(node, nbrs, m5, p5, 0.1)
             object_val = float(obj(node, m5, p5, 0.1))
             assert method_val == object_val, f"method != object at node {node} (single-source broken)"
+
+
+def test_network_geometry_alias_equivalence_and_deprecation():
+    """Issue #1472 (deprecation policy): the constructor param is ``geometry`` (aligned with
+    ``MFGProblem``); ``network_geometry`` is a deprecated alias that redirects IDENTICALLY. Proves
+    old == new construction and that the alias warns.
+    """
+    net_new = GridNetwork(width=4, height=1)
+    net_new.create_network()
+    net_old = GridNetwork(width=4, height=1)
+    net_old.create_network()
+
+    prob_new = NetworkMFGProblem(geometry=net_new, T=0.5, Nt=10)
+    with pytest.warns(DeprecationWarning, match="network_geometry"):
+        prob_old = NetworkMFGProblem(network_geometry=net_old, T=0.5, Nt=10)
+
+    # byte-identical construction: same node count, same single-source Hamiltonian, same values
+    assert prob_new.num_nodes == prob_old.num_nodes
+    assert type(prob_new.hamiltonian_class) is type(prob_old.hamiltonian_class)
+    m = np.ones(prob_new.num_nodes) / prob_new.num_nodes
+    p = np.arange(prob_new.num_nodes, dtype=float)
+    for node in range(prob_new.num_nodes):
+        h_new = prob_new.hamiltonian(node, prob_new.get_node_neighbors(node), m, p, 0.1)
+        h_old = prob_old.hamiltonian(node, prob_old.get_node_neighbors(node), m, p, 0.1)
+        assert h_new == h_old, f"alias construction diverged at node {node}"
+
+
+def test_network_geometry_both_or_neither_fail_loud():
+    """Issue #1472: passing both geometry= and network_geometry=, or neither, fails loud."""
+    net = GridNetwork(width=3, height=1)
+    net.create_network()
+    with pytest.raises(ValueError, match="do not pass both"):
+        NetworkMFGProblem(geometry=net, network_geometry=net, T=0.5, Nt=4)
+    with pytest.raises(ValueError, match="requires a graph geometry"):
+        NetworkMFGProblem(T=0.5, Nt=4)


### PR DESCRIPTION
## Summary
Stage 3: unify the `NetworkMFGProblem` constructor to `geometry=` (aligned with `MFGProblem`), deprecating `network_geometry=`. Geometry is the single axis of variation — this is the concrete API step of the Problem/Components unification.

## Change
- `NetworkMFGProblem(geometry=...)` is canonical; `network_geometry=` is a **deprecated alias** that redirects identically (emits `DeprecationWarning`, removed after the deprecation window).
- Passing **both** (`geometry=` and `network_geometry=`) or **neither** fails loud with a `ValueError`.
- Per the deprecation policy (§Immediate-redirection, §Complete-migration — the Issue #616 lesson), **all internal call sites are migrated in the same change**: factory functions, 3 integration + 3 unit test files, 2 examples, and factory docstrings. No internal code emits the warning.

## Validation
- **Equivalence-tested** (`test_network_geometry_alias_equivalence_and_deprecation`): old vs new construction is byte-identical — same node count, same single-source `NetworkHamiltonian`, same per-node Hamiltonian values — and the alias warns.
- Fail-loud guards tested (`test_network_geometry_both_or_neither_fail_loud`).
- **77 network unit tests + 34 migrated integration tests pass**; examples compile; ruff clean.

## Stage-3 status
The fork is now thin: dead ops removed (#1480), dummy fields removed (#1481), Hamiltonian single-sourced (#1482), and the constructor aligned to the base (this PR). The remaining literal "one `MFGProblem`" (eliminating the subclass via a components Hamiltonian hook) is **Option B** — a separate, larger design step. Full schedule in Joplin Dev.

Refs #1472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
