### PR TITLE
fix(weakform): single-source FP drift from fp_drift_coefficient (G-017 holdout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Weak-form MFG family (FEM + meshless-Galerkin) now single-sources the FP drift from
+  `fp_drift_coefficient`** (Issue #1487 / #1420, gotcha G-017). `FPFEMSolver`, `MeshlessGalerkinFPSolver`
+  and `MeshlessGalerkinHJBSolver` read the raw `coupling_coefficient` (default 0.5) for the FP advection
+  scale instead of the single source `fp_drift_coefficient` (= `1/control_cost`, the HJB optimal-control
+  scale) that the seven FDM / FVM / particle / SL solvers already use — the weak-form family was the lone
+  holdout. When `coupling_coefficient ≠ 1/control_cost` the FP transported mass at the wrong velocity, so
+  Picard converged **silently to the wrong equilibrium** (the G-017 failure — `exp16` Towel equilibrium
+  ~4–5× too wide). Both meshless HJB and FP now read the same `fp_drift_coefficient`, preserving
+  `A_FP = A_HJB^T`. Pinned by `test_weakform_fp_drift_single_source` (drift invariant to
+  `coupling_coefficient`, sourced from `control_cost`). **Affects the Weak-GFDM paper's coupled runs.**
+
 - **Network finite-state MFG: value Hamiltonian, optimal control, and `dp` reconciled into one
   consistent object** (Issue #1474). `NetworkHamiltonian.__call__` / `_default_network_hamiltonian`
   used the full quadratic `½Σw(u_j−u_i)²` — the unconstrained α∈ℝ relaxation, an invalid CTMC

--- a/mfgarchon/alg/numerical/fem/fp_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/fp_fem_solver.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.weak_form_fp_solver import WeakFormFPSolver
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
 
 from .discretization import FEMDiscretization
 from .mesh_adapter import meshdata_to_skfem
@@ -114,7 +115,11 @@ class FPFEMSolver(WeakFormFPSolver):
         from skfem import BilinearForm
 
         dim = self._skfem_mesh.p.shape[0]
-        coupling = self.problem.coupling_coefficient
+        # Issue #1487/#1420 (G-017): the FP drift scale is the HJB optimal-control scale 1/control_cost,
+        # single-sourced via fp_drift_coefficient — NOT the raw coupling_coefficient (which defaults to
+        # 0.5 and silently diverges from 1/control_cost -> wrong equilibrium). Matches the 7 FDM/FVM/
+        # particle/SL solvers; the weak-form family was the lone holdout.
+        coupling = fp_drift_coefficient(self.problem)
         du = self._basis.interpolate(U_n)
 
         @BilinearForm

--- a/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
@@ -32,6 +32,7 @@ from scipy import sparse
 from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.meshless_galerkin.discretization import discretization_from_cloud
 from mfgarchon.alg.numerical.weak_form_fp_solver import WeakFormFPSolver
+from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -115,7 +116,9 @@ class MeshlessGalerkinFPSolver(WeakFormFPSolver):
         )
 
     def _build_advection(self, U_n: NDArray, D: float) -> sparse.csr_matrix:
-        coupling = self.problem.coupling_coefficient
+        # Issue #1487/#1420 (G-017): FP drift scale = 1/control_cost, single-sourced (not raw
+        # coupling_coefficient). Same read as the paired HJB Newton advection -> A_FP = A_HJB^T.
+        coupling = fp_drift_coefficient(self.problem)
         G = self._gradient_operators()
         grad_U = np.column_stack([G_d @ U_n for G_d in G])  # (N, dim)
         velocity = (-coupling * grad_U).T  # (dim, N): v = -coupling * grad(U)

--- a/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
@@ -25,6 +25,7 @@ import numpy as np
 from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.meshless_galerkin.discretization import discretization_from_cloud
 from mfgarchon.alg.numerical.weak_form_hjb_solver import WeakFormHJBSolver
+from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -95,7 +96,10 @@ class MeshlessGalerkinHJBSolver(WeakFormHJBSolver):
         if self._sd_scale <= 0.0:
             return None
         self._build_gradient_operators()
-        coupling = self.problem.coupling_coefficient  # same read as the paired FP (duality)
+        # Issue #1487/#1420 (G-017): single-source the drift scale = 1/control_cost (not the raw
+        # coupling_coefficient). The paired FP reads the SAME fp_drift_coefficient, so A_FP = A_HJB^T
+        # (the adjoint-consistency thesis) AND both match the HJB optimal control.
+        coupling = fp_drift_coefficient(self.problem)
         velocity = (-coupling * np.column_stack([G_d @ u for G_d in self._G_grad])).T
         return self._disc.streamline_diffusion(velocity, D, c_scale=self._sd_scale)
 

--- a/tests/unit/test_alg/test_weakform_fp_drift_single_source.py
+++ b/tests/unit/test_alg/test_weakform_fp_drift_single_source.py
@@ -1,0 +1,60 @@
+"""Issue #1487 / #1420 (gotcha G-017): the weak-form MFG family (FEM + meshless-Galerkin) sources the
+FP drift scale from ``fp_drift_coefficient`` (= ``1/control_cost``, the HJB optimal-control scale),
+single-sourced — NOT the raw ``coupling_coefficient`` (which defaults to 0.5 and silently diverges).
+
+Pins that the FP transports mass at the correct (HJB-control) scale, invariant to a diverging
+``coupling_coefficient`` — the G-017 wrong-equilibrium bug was the weak-form family being the lone
+holdout still reading ``coupling_coefficient`` directly.
+"""
+
+import numpy as np
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+from mfgarchon.factory.scheme_factory import NumericalScheme, create_paired_solvers
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
+
+
+def _problem(coupling_coefficient: float) -> MFGProblem:
+    geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    return MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=comp, coupling_coefficient=coupling_coefficient)
+
+
+def test_fp_drift_coefficient_sources_from_control_cost_not_coupling():
+    # control_cost=1.0 -> correct drift = 1/control_cost = 1.0, regardless of coupling_coefficient.
+    assert fp_drift_coefficient(_problem(0.5)) == 1.0
+    assert fp_drift_coefficient(_problem(2.0)) == 1.0
+
+
+def test_meshless_fp_advection_is_single_sourced_from_control_cost():
+    """The meshless-Galerkin FP advection operator (the Weak-GFDM paper's stack) must be invariant to
+    ``coupling_coefficient`` (single-sourced from ``control_cost``). Before #1487 it scaled by
+    ``coupling_coefficient`` -> wrong equilibrium and A_FP != A_HJB^T."""
+    u = np.linspace(0.0, 1.0, 11)
+    cloud = u.reshape(-1, 1)
+    cfg = {
+        "collocation_points": cloud,
+        "delta": 2.6 / np.sqrt(11),
+        "degree": 2,
+        "use_newton": True,
+        "streamline_diffusion_scale": 1.0,
+    }
+    _, fp_half = create_paired_solvers(_problem(0.5), NumericalScheme.MESHLESS_GALERKIN, hjb_config=cfg)
+    _, fp_double = create_paired_solvers(_problem(2.0), NumericalScheme.MESHLESS_GALERKIN, hjb_config=cfg)
+    c_half = fp_half._build_advection(u, 0.045).toarray()
+    c_double = fp_double._build_advection(u, 0.045).toarray()
+    assert np.abs(c_half).max() > 0.0
+    assert np.allclose(c_half, c_double), (
+        "FP advection must source the drift from control_cost (single source), not coupling_coefficient"
+    )


### PR DESCRIPTION
## Summary
The weak-form MFG family (FEM + meshless-Galerkin) was the **lone holdout** reading raw `problem.coupling_coefficient` (default 0.5) for the FP advection scale, instead of the single-source `fp_drift_coefficient` (= `1/control_cost`, the HJB optimal-control scale) the **7 FDM/FVM/particle/SL solvers already use**.

When `coupling_coefficient ≠ 1/control_cost`, the FP transports mass at the wrong velocity → Picard converges **silently to the wrong equilibrium** — the exact G-017/#1420 failure (`exp16` Towel equilibrium ~4–5× too wide) the helper was created to prevent. Mass-conservation tests never caught it (zero column sums hold for any drift scale).

## Fix
All 3 sites → `fp_drift_coefficient(problem)`: `fem/fp_fem_solver.py:117`, `meshless/hjb_solver.py:98`, `meshless/fp_solver.py:118`. The meshless HJB + FP read the **same** coefficient, preserving `A_FP = A_HJB^T`.

## Validation
- `fp_drift_coefficient` returns `1/control_cost = 1.0` for both `coupling_coefficient=0.5` and `2.0`.
- The FP advection operator is now **invariant to `coupling_coefficient`** (single-sourced from `control_cost`) — pinned by `test_weakform_fp_drift_single_source`.
- 22 meshless (incl. coupled) + 21 FEM integration tests pass; ruff clean.

## Context
Found by the FEM/weak-form infrastructure audit. **Directly affects the Weak-GFDM paper's coupled experiments** — any run with `coupling_coefficient ≠ 1/control_cost` had a silently wrong equilibrium.

Refs #1487, #1420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)