### PR TITLE
fix(meshless): fail loud on near-zero lumped mass (#1252 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Meshless-Galerkin FP gradient recovery now fails loud on a near-zero lumped mass** (Issue #1486 /
+  #1252). `MeshlessGalerkinFPSolver._gradient_operators` kept a private copy of the silent clamp
+  `M_lumped[M_lumped < 1e-15] = 1e-15` that #1252 **removed** from the shared base
+  (`weak_form_hjb_solver._build_gradient_operators`) — the clamp made `1/M_lumped ~1e15` and
+  multiplied the recovered gradient into garbage, silently. It now raises (relative guard
+  `m_min < 1e-12·m_max`, matching the base) — a vanishing MLS row sum means a node whose support
+  barely overlaps the cloud (degenerate / under-covered). A parallel-path single-source regression;
+  pinned by `test_gradient_recovery_fails_loud_on_near_zero_lumped_mass`.
+
 - **Weak-form MFG family (FEM + meshless-Galerkin) now single-sources the FP drift from
   `fp_drift_coefficient`** (Issue #1487 / #1420, gotcha G-017). `FPFEMSolver`, `MeshlessGalerkinFPSolver`
   and `MeshlessGalerkinHJBSolver` read the raw `coupling_coefficient` (default 0.5) for the FP advection

--- a/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/fp_solver.py
@@ -73,7 +73,21 @@ class MeshlessGalerkinFPSolver(WeakFormFPSolver):
         # G_d = diag(1/M_lumped) @ R_d : mass-lumped L2 projection of d/dx_d.
         if self._G_grad is None:
             M_lumped = np.array(self._M.sum(axis=1)).ravel()
-            M_lumped[M_lumped < 1e-15] = 1e-15
+            # Issue #1486/#1252: fail loud on a near-zero lumped mass instead of the old silent clamp
+            # (M_lumped < 1e-15 -> 1e-15). The clamp made 1/M_lumped ~1e15 and multiplied the recovered
+            # gradient into garbage, silently. This is the single-source policy the base gradient
+            # recovery adopted in #1252 (weak_form_hjb_solver._build_gradient_operators); the meshless
+            # FP kept a private copy of the removed clamp. A vanishing MLS row sum means a node whose
+            # support barely overlaps the cloud (a degenerate / under-covered cloud).
+            m_min, m_max = float(M_lumped.min()), float(M_lumped.max())
+            if m_min < 1e-12 * m_max:
+                raise np.linalg.LinAlgError(
+                    f"Meshless gradient recovery requires strictly positive lumped masses, but the "
+                    f"minimum MLS row sum is {m_min:.3e} (max {m_max:.3e}). A near-zero row sum means a "
+                    f"node whose support barely overlaps the cloud — densify the cloud or increase the "
+                    f"support radius (delta). Silently clamping to 1e-15 would return garbage gradients "
+                    f"(#1486/#1252)."
+                )
             inv = 1.0 / M_lumped
             self._G_grad = [(sparse.diags(inv) @ R_d).tocsr() for R_d in self._disc.gradient_projection()]
         return self._G_grad

--- a/tests/unit/test_alg/test_meshless_gradient_projection.py
+++ b/tests/unit/test_alg/test_meshless_gradient_projection.py
@@ -60,3 +60,35 @@ def test_gradient_projection_is_weak_form_not_strong():
     np.testing.assert_allclose(raw, m_lumped, rtol=1e-9, atol=1e-12)
     # ... which is O(h), nowhere near the strong-form 1.0 (the #1145 bug).
     assert np.max(np.abs(raw)) < 0.5
+
+
+def test_gradient_recovery_fails_loud_on_near_zero_lumped_mass():
+    """Issue #1486/#1252: a near-zero lumped mass raises (not the old silent 1e-15 clamp, which made
+    1/M_lumped ~1e15 and returned garbage gradients). Single-sources the base's fail-loud policy."""
+    from scipy import sparse
+
+    from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+        ),
+    )
+    prob = MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=comp, coupling_coefficient=1.0)
+    cloud = np.linspace(0.0, 1.0, 11).reshape(-1, 1)
+    fp = MeshlessGalerkinFPSolver(prob, cloud, delta=2.6 / np.sqrt(11), degree=2)
+
+    # A valid cloud has strictly positive lumped masses; force one node near-zero to hit the guard.
+    diag = np.ones(fp._M.shape[0])
+    diag[0] = 1e-20
+    fp._M = sparse.diags(diag)
+    fp._G_grad = None
+    with pytest.raises(np.linalg.LinAlgError, match="lumped masses"):
+        fp._gradient_operators()


### PR DESCRIPTION
Stacked on #1488. `MeshlessGalerkinFPSolver._gradient_operators` kept a **private copy** of the silent clamp `M_lumped[M_lumped < 1e-15] = 1e-15` that #1252 **removed** from the shared base — the clamp made `1/M_lumped ~1e15` and multiplied the recovered gradient into garbage, silently. Textbook parallel-path single-source regression.

Replaced with the base's fail-loud relative guard (`m_min < 1e-12·m_max → raise`). A vanishing MLS row sum = a node whose support barely overlaps the cloud (degenerate/under-covered).

**Verified**: 29 meshless tests (SCNI + coupled) pass on well-conditioned clouds; new `test_gradient_recovery_fails_loud_on_near_zero_lumped_mass` pins the raise. Found by the meshless audit (#1489).

Refs #1486, #1252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)