### PR TITLE
fix(fem): mesh_adapter fails loud on mismatched connectivity + unsupported class (#1489 F6/F8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **FEM mesh adapter fails loud on mismatched connectivity + unsupported mesh class** (Issue #1489,
+  F6/F8). `meshdata_to_skfem` now validates the connectivity node-count against the element family
+  before construction — a 4-node quad mislabeled `triangle` was silently truncated by scikit-fem to
+  3 nodes (a wrong half-domain mesh, no error) — and `skfem_to_meshdata` raises on an unsupported
+  scikit-fem class instead of stamping `element_type="unknown"` (which failed confusingly on a later
+  re-conversion). Pinned by `test_meshdata_to_skfem_fails_loud_on_wrong_node_count`. Found by the
+  FEM infrastructure audit.
+
 - **`HJBSemiLagrangianSolver`, `FPSLJacobianSolver`, `FPGFDMSolver` join the BC-capability gate**
   (Issue #1456, rollout — completes the continuum solvers). Each declares its honest supported set
   `{NO_FLUX, NEUMANN, PERIODIC}` and validates the resolved BC at construction. These were the

--- a/mfgarchon/alg/numerical/fem/mesh_adapter.py
+++ b/mfgarchon/alg/numerical/fem/mesh_adapter.py
@@ -96,6 +96,18 @@ def meshdata_to_skfem(mesh_data: MeshData) -> skfem.Mesh:
             f"Supported: {list(mesh_classes.keys())}"
         )
 
+    # Issue #1489 (F6): scikit-fem silently TRUNCATES a connectivity with the wrong node count (e.g. a
+    # 4-node quad mislabeled 'triangle' is sliced to 3 rows -> a wrong half-domain mesh, no error).
+    # Validate the connectivity width against the element family before constructing.
+    expected_nodes = {"triangle": 3, "tetrahedron": 4, "quad": 4, "hexahedron": 8, "line": 2}
+    n_expected = expected_nodes[mesh_data.element_type]
+    if elements.shape[0] != n_expected:
+        raise ValueError(
+            f"element_type '{mesh_data.element_type}' expects {n_expected} nodes per element, but the "
+            f"connectivity has {elements.shape[0]} (elements array shape {tuple(mesh_data.elements.shape)}). "
+            f"scikit-fem would silently truncate this to a wrong mesh (#1489)."
+        )
+
     mesh = mesh_cls(nodes, elements)
 
     # Transfer boundary tags if available (gmsh physical-group path)
@@ -181,7 +193,12 @@ def skfem_to_meshdata(mesh: skfem.Mesh) -> MeshData:
             break
 
     if element_type is None:
-        element_type = "unknown"
+        # Issue #1489 (F8): fail loud rather than stamping 'unknown', which produces a mislabeled
+        # MeshData that only fails (confusingly) on a later re-conversion.
+        raise ValueError(
+            f"Unsupported scikit-fem mesh class {type(mesh).__name__!r} for MeshData conversion "
+            f"(#1489). Supported: MeshTri, MeshTet, MeshQuad, MeshHex, MeshLine."
+        )
 
     dim = mesh.p.shape[0]
 

--- a/tests/unit/test_alg/test_fem_adapter_issue1260.py
+++ b/tests/unit/test_alg/test_fem_adapter_issue1260.py
@@ -144,3 +144,27 @@ def test_tagged_meshdata_to_skfem_no_crash():
     assert mesh.boundaries is not None, "boundaries dict must be populated"
     assert "region_1" in mesh.boundaries, "region_1 must be registered"
     assert "region_2" in mesh.boundaries, "region_2 must be registered"
+
+
+def test_meshdata_to_skfem_fails_loud_on_wrong_node_count():
+    """Issue #1489 (F6): a connectivity whose node count mismatches the element family must raise,
+    not let scikit-fem silently truncate it to a wrong mesh (a 4-node quad mislabeled 'triangle'
+    would be sliced to 3 rows -> a half-domain mesh with no error)."""
+    import pytest
+
+    import numpy as np
+
+    from mfgarchon.alg.numerical.fem.mesh_adapter import meshdata_to_skfem
+    from mfgarchon.geometry.meshes.mesh_data import MeshData
+
+    md = MeshData(
+        vertices=np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]),
+        elements=np.array([[0, 1, 2, 3]]),  # 4 nodes -> valid quad, MISLABELED as triangle
+        element_type="triangle",
+        boundary_tags=np.array([], dtype=np.int64),
+        element_tags=np.array([0], dtype=np.int64),
+        boundary_faces=np.empty((0, 2), dtype=np.int64),
+        dimension=2,
+    )
+    with pytest.raises(ValueError, match="expects 3 nodes"):
+        meshdata_to_skfem(md)


### PR DESCRIPTION
FEM mesh-adapter fail-loud (from the audit ledger #1489).

**F6** — `meshdata_to_skfem` had no node-count check: a 4-node quad mislabeled `triangle` was **silently truncated** by scikit-fem to 3 rows → a wrong half-domain mesh (mass sum 0.5), no error. Now validated against a per-family node-count table.

**F8** — `skfem_to_meshdata` stamped `element_type='unknown'` for an unsupported skfem class instead of raising → a mislabeled MeshData that failed confusingly on a later re-conversion. Now raises naming the class.

**Verified**: 30 FEM tests pass on valid meshes; new `test_meshdata_to_skfem_fails_loud_on_wrong_node_count` pins F6. **F7** (degenerate-element → NaN assembly) deferred — needs element-quality (Jacobian) computation.

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)