### PR TITLE
fix(fem): Newton correction condenses with homogeneous Dirichlet lift (#1489 S2, critical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FEM HJB Newton correction now condenses with a homogeneous boundary lift** (Issue #1489, S2). The
+  Newton correction `delta` has `delta[dofs]=0` (`U_current` already carries `u=g`), but it was
+  condensed through the linear-solve lifting `rhs_int -= A[int,dofs]@g` with the actual Dirichlet
+  values `g` — the spurious `-A[int,dofs]@g` term corrupted **every interior value** whenever a
+  **nonzero** Dirichlet BC was used with `use_newton=True` (it vanished for `g=0`, which is why every
+  prior FEM Dirichlet test — all `value=0.0` — missed it). `_apply_bc_to_system` /
+  `apply_bc_to_fem_system` gain a `homogeneous` flag; the Newton branch passes `homogeneous=True`,
+  the linear solve keeps `g`. Pinned by `test_fem_newton_dirichlet_s2`. SHARED base (FEM-manifest).
+
 - **Weak-form MFG family (FEM + meshless-Galerkin) now single-sources the FP drift from
   `fp_drift_coefficient`** (Issue #1487 / #1420, gotcha G-017). `FPFEMSolver`, `MeshlessGalerkinFPSolver`
   and `MeshlessGalerkinHJBSolver` read the raw `coupling_coefficient` (default 0.5) for the FP advection

--- a/mfgarchon/alg/numerical/fem/bc_adapter.py
+++ b/mfgarchon/alg/numerical/fem/bc_adapter.py
@@ -40,6 +40,7 @@ def apply_bc_to_fem_system(
     rhs: NDArray,
     basis: skfem.Basis,
     bc: BoundaryConditions | None,
+    homogeneous: bool = False,
 ) -> tuple[sparse.csr_matrix, NDArray]:
     """
     Apply BoundaryConditions to assembled FEM system (A, rhs).
@@ -111,7 +112,11 @@ def apply_bc_to_fem_system(
     if dirichlet_dofs:
         # Condense: eliminate Dirichlet DOFs from system
         dof_array = np.array(dirichlet_dofs, dtype=int)
-        val_array = np.array(dirichlet_values, dtype=float)
+        # Issue #1489 (S2): homogeneous=True zeroes the boundary lift. The Newton CORRECTION has a
+        # homogeneous boundary increment (delta[dofs]=0, since U_current already carries u=g), so
+        # lifting by the actual Dirichlet values g would add a spurious -A[int,dofs]@g term and
+        # corrupt every interior value. The linear solve keeps homogeneous=False (u=g is the solution).
+        val_array = np.zeros(len(dirichlet_dofs)) if homogeneous else np.array(dirichlet_values, dtype=float)
         interior = np.setdiff1d(np.arange(A.shape[0]), dof_array)
 
         A_int = A[np.ix_(interior, interior)]

--- a/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
@@ -150,10 +150,10 @@ class HJBFEMSolver(WeakFormHJBSolver):
 
         return get_dirichlet_dofs_and_values(self._basis, self._bc)
 
-    def _apply_bc_to_system(self, matrix, rhs):
+    def _apply_bc_to_system(self, matrix, rhs, homogeneous=False):
         from .bc_adapter import apply_bc_to_fem_system
 
-        return apply_bc_to_fem_system(matrix, rhs, self._basis, self._bc)
+        return apply_bc_to_fem_system(matrix, rhs, self._basis, self._bc, homogeneous=homogeneous)
 
     def _robin_operator_terms(self, D: float):
         """Robin boundary operator augmentation (Issue #1237): the D-scaled boundary mass

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -67,8 +67,13 @@ class WeakFormHJBSolver(BaseHJBSolver):
     def _dirichlet_dofs_and_values(self) -> tuple[NDArray, NDArray]:
         raise NotImplementedError
 
-    def _apply_bc_to_system(self, matrix, rhs):
-        """Condense the linear system onto interior dofs for Dirichlet BC."""
+    def _apply_bc_to_system(self, matrix, rhs, homogeneous=False):
+        """Condense the linear system onto interior dofs for Dirichlet BC.
+
+        ``homogeneous=True`` zeroes the boundary lift — used for the Newton CORRECTION, whose boundary
+        increment is 0 (``U_current`` already carries ``u=g``). Lifting the correction by the actual
+        Dirichlet values ``g`` adds a spurious ``-A[int,dofs]@g`` term that corrupts the interior
+        update (Issue #1489)."""
         raise NotImplementedError
 
     def _weak_bc_terms(self, D: float):
@@ -234,7 +239,10 @@ class WeakFormHJBSolver(BaseHJBSolver):
 
             if condense:
                 residual[d_dofs] = 0.0
-                J_bc, res_bc = self._apply_bc_to_system(J, -residual)
+                # Issue #1489 (S2): the Newton correction has a homogeneous boundary increment
+                # (delta[d_dofs]=0, since U_current already carries u=g from line ~198), so condense
+                # with a ZERO boundary lift. Lifting by g here corrupts every interior value.
+                J_bc, res_bc = self._apply_bc_to_system(J, -residual, homogeneous=True)
                 delta = np.zeros(N)
                 delta[interior] = spsolve(J_bc, res_bc)
             else:

--- a/tests/unit/test_alg/test_fem_newton_dirichlet_s2.py
+++ b/tests/unit/test_alg/test_fem_newton_dirichlet_s2.py
@@ -1,0 +1,60 @@
+"""Issue #1489 (S2): the FEM HJB Newton correction must condense with a HOMOGENEOUS boundary lift.
+
+The Newton correction ``delta`` has ``delta[dofs] = 0`` (``U_current`` already carries ``u = g``), so
+condensing it with the actual Dirichlet values ``g`` adds a spurious ``-A[int,dofs]@g`` term that
+corrupts every interior value. Vanishes for ``g = 0`` — which is why every prior FEM Dirichlet test
+(all ``value=0.0``) missed it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required")
+
+
+def _fem_hjb_solver_with_nonzero_dirichlet():
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+    from mfgarchon.alg.numerical.fem.mesh_adapter import skfem_to_meshdata
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry.boundary.conditions import BCSegment, BCType, BoundaryConditions
+    from mfgarchon.geometry.meshes.mesh_2d import Mesh2D
+
+    geom = Mesh2D(domain_type="rectangle", bounds=(0.0, 1.0, 0.0, 1.0))
+    geom.mesh_data = skfem_to_meshdata(skfem.MeshTri.init_sqsymmetric().refined(2))
+    geom.boundary_conditions = BoundaryConditions(
+        segments=[BCSegment(name="inlet", bc_type=BCType.DIRICHLET, boundary="x_min", value=1.5)],  # g != 0
+        dimension=2,
+    )
+    components = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+        ),
+    )
+    problem = MFGProblem(geometry=geom, T=0.2, Nt=3, sigma=0.3, components=components, coupling_coefficient=1.0)
+    return HJBFEMSolver(problem)
+
+
+def test_homogeneous_condensation_drops_the_dirichlet_lift():
+    solver = _fem_hjb_solver_with_nonzero_dirichlet()
+    # Use the real stiffness so interior<->boundary coupling is nonzero (identity would hide the bug).
+    jac = solver._K.tocsr()
+    rhs = np.ones(jac.shape[0])
+
+    _, rhs_hom = solver._apply_bc_to_system(jac, rhs, homogeneous=True)
+    _, rhs_lift = solver._apply_bc_to_system(jac, rhs, homogeneous=False)
+
+    dofs, vals = solver._dirichlet_dofs_and_values()
+    assert np.any(vals != 0.0), "test requires a nonzero Dirichlet value to exercise the lift"
+    interior = np.setdiff1d(np.arange(jac.shape[0]), np.asarray(dofs, dtype=int))
+
+    # homogeneous=True => no boundary lift => rhs_int == rhs[interior]
+    assert np.allclose(rhs_hom, rhs[interior]), "homogeneous condensation must drop the -A[int,dofs]@g lift"
+    # non-homogeneous keeps the g-lift, so with g != 0 and coupling K they differ (the S2 corruption path)
+    assert not np.allclose(rhs_hom, rhs_lift), "the two modes must differ for g != 0 (proves the lift is real)"


### PR DESCRIPTION
**Critical silent-wrong** from the audit ledger #1489. The FEM HJB Newton correction `delta` has `delta[dofs]=0` (`U_current` already carries `u=g`), but it was condensed through the linear-solve lifting `rhs_int -= A[int,dofs]@g` with the actual Dirichlet values `g`. The spurious `-A[int,dofs]@g` term **corrupted every interior value** whenever a **nonzero** Dirichlet BC was used with `use_newton=True`.

It vanished for `g=0` — which is why every prior FEM Dirichlet test (all `value=0.0`) missed it.

**Fix**: `_apply_bc_to_system`/`apply_bc_to_fem_system` gain a `homogeneous` flag that zeroes the boundary lift; the Newton branch passes `homogeneous=True`, the linear solve keeps `g`.

**Verified**: 34 FEM tests pass; new `test_fem_newton_dirichlet_s2` pins that the homogeneous mode drops the lift (== `rhs[interior]`) and differs from the `g`-lift for `g≠0`.

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)