### PR TITLE
fix(fem): fail loud with a clear message on a non-mesh geometry (#1489/#1493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FEM solvers fail loud with a clear message on a non-mesh geometry** (Issue #1489 / #1493).
+  `HJBFEMSolver`/`FPFEMSolver.__init__` accessed `problem.geometry.mesh_data` directly, so a
+  `TensorProductGrid` (no `mesh_data` attribute) raised a cryptic `AttributeError` *before* the
+  `ValueError` that literally names `TensorProductGrid` — the helpful message was unreachable for its
+  own case. Now uses `getattr(..., "mesh_data", None)`, catching both the missing-attribute
+  (non-mesh geometry) and the None (ungenerated `Mesh2D`) cases, and names the actual geometry type.
+  Pinned by `test_fem_solvers_fail_loud_on_non_mesh_geometry`.
+
 - **Weak-form MFG family (FEM + meshless-Galerkin) now single-sources the FP drift from
   `fp_drift_coefficient`** (Issue #1487 / #1420, gotcha G-017). `FPFEMSolver`, `MeshlessGalerkinFPSolver`
   and `MeshlessGalerkinHJBSolver` read the raw `coupling_coefficient` (default 0.5) for the FP advection

--- a/mfgarchon/alg/numerical/fem/fp_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/fp_fem_solver.py
@@ -50,10 +50,16 @@ class FPFEMSolver(WeakFormFPSolver):
     _scheme_family = SchemeFamily.FEM
 
     def __init__(self, problem: MFGProblem, order: int = 1) -> None:
-        mesh_data = problem.geometry.mesh_data
+        # Issue #1489: a non-mesh geometry (e.g. TensorProductGrid) has no `mesh_data` attribute at all,
+        # so a direct `.mesh_data` access raised AttributeError BEFORE this guard — the message naming
+        # TensorProductGrid was unreachable for its own case. getattr catches both the missing-attribute
+        # and the None (ungenerated Mesh2D) cases.
+        mesh_data = getattr(problem.geometry, "mesh_data", None)
         if mesh_data is None:
             raise ValueError(
-                "FPFEMSolver requires unstructured mesh geometry. Use Mesh2D or Mesh3D, not TensorProductGrid."
+                "FPFEMSolver requires an unstructured mesh geometry with mesh_data (Mesh2D / Mesh3D); "
+                f"got {type(problem.geometry).__name__}. A structured grid has no mesh — build a "
+                "Mesh2D / Mesh3D, or use an FDM / FVM / GFDM solver for a TensorProductGrid."
             )
         self._skfem_mesh = meshdata_to_skfem(mesh_data)
         from .assembly import create_basis

--- a/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
+++ b/mfgarchon/alg/numerical/fem/hjb_fem_solver.py
@@ -49,10 +49,16 @@ class HJBFEMSolver(WeakFormHJBSolver):
     _scheme_family = SchemeFamily.FEM
 
     def __init__(self, problem: MFGProblem, order: int = 1) -> None:
-        mesh_data = problem.geometry.mesh_data
+        # Issue #1489: a non-mesh geometry (e.g. TensorProductGrid) has no `mesh_data` attribute at all,
+        # so a direct `.mesh_data` access raised AttributeError BEFORE this guard — the message naming
+        # TensorProductGrid was unreachable for its own case. getattr catches both the missing-attribute
+        # and the None (ungenerated Mesh2D) cases.
+        mesh_data = getattr(problem.geometry, "mesh_data", None)
         if mesh_data is None:
             raise ValueError(
-                "HJBFEMSolver requires unstructured mesh geometry. Use Mesh2D or Mesh3D, not TensorProductGrid."
+                "HJBFEMSolver requires an unstructured mesh geometry with mesh_data (Mesh2D / Mesh3D); "
+                f"got {type(problem.geometry).__name__}. A structured grid has no mesh — build a "
+                "Mesh2D / Mesh3D, or use an FDM / FVM / GFDM solver for a TensorProductGrid."
             )
         self._skfem_mesh = meshdata_to_skfem(mesh_data)
         from .assembly import create_basis

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -270,3 +270,29 @@ class TestFEMFacetBoundaryTags:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_fem_solvers_fail_loud_on_non_mesh_geometry():
+    """Issue #1489: a FEM solver on a non-mesh geometry (TensorProductGrid, no mesh_data attribute)
+    must raise a CLEAR ValueError naming the geometry, not a cryptic AttributeError. The prior guard
+    accessed `.mesh_data` directly, so it AttributeError'd before the message that named TensorProductGrid."""
+    from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+        ),
+    )
+    problem = MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=comp, coupling_coefficient=1.0)
+    for solver_cls in (HJBFEMSolver, FPFEMSolver):
+        with pytest.raises(ValueError, match=r"mesh_data|Mesh2D"):
+            solver_cls(problem)


### PR DESCRIPTION
From the FEM design-compatibility investigation (#1493). `HJBFEMSolver`/`FPFEMSolver.__init__` accessed `problem.geometry.mesh_data` **directly**, so a `TensorProductGrid` (no `mesh_data` attribute) raised a cryptic `AttributeError` **before** the `ValueError` that literally names `TensorProductGrid` — the helpful message was unreachable for its own case.

Now uses `getattr(geometry, "mesh_data", None)`, catching both the missing-attribute (non-mesh geometry) and the None (ungenerated `Mesh2D`) cases, and names the actual geometry type.

**Verified**: 13 FEM-solver-path tests pass; new `test_fem_solvers_fail_loud_on_non_mesh_geometry` pins the clear raise on a `TensorProductGrid`.

Refs #1489, #1493 (the broader FEM-geometry design items: grid→mesh bridge, FEM-state-on-geometry layering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)