### PR TITLE
chore(changelog): remove stray conflict marker from #1492 merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prior FEM Dirichlet test — all `value=0.0` — missed it). `_apply_bc_to_system` /
   `apply_bc_to_fem_system` gain a `homogeneous` flag; the Newton branch passes `homogeneous=True`,
   the linear solve keeps `g`. Pinned by `test_fem_newton_dirichlet_s2`. SHARED base (FEM-manifest).
-||||||| dec1f01b
 
 - **Meshless-Galerkin FP gradient recovery now fails loud on a near-zero lumped mass** (Issue #1486 /
   #1252). `MeshlessGalerkinFPSolver._gradient_operators` kept a private copy of the silent clamp


### PR DESCRIPTION
The #1492 CHANGELOG conflict resolution left a stray `||||||| dec1f01b` diff3 base marker on main. Both entries (#1486, S2) are intact and unique; only the marker line is removed.