### PR TITLE
fix(weakform): fail loud on initial-density DOF-count mismatch (#1489 S4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Weak-form FP fails loud on an initial-density DOF-count mismatch** (Issue #1489, S4). The IC
+  reconciliation `M[0] = m_initial[:N] if len>=N else np.pad(...)` silently produced a WRONG initial
+  condition: for P2 the caller resolves `m_initial` on `num_vertices` (< `n_dof` = vertices + edges),
+  so `np.pad` zero-filled every edge-midpoint DOF; a too-long array was silently truncated. Now raises
+  a clear error naming the DOF-count mismatch (P2-vs-P1) and pointing to `self._disc.dof_coordinates`.
+  Byte-identical for the correct `len == n_dof` case (P1). Shared base -> FEM + meshless. Pinned by
+  `test_s4_ic_dof_mismatch`.
+
 - **FEM solvers fail loud with a clear message on a non-mesh geometry** (Issue #1489 / #1493).
   `HJBFEMSolver`/`FPFEMSolver.__init__` accessed `problem.geometry.mesh_data` directly, so a
   `TensorProductGrid` (no `mesh_data` attribute) raised a cryptic `AttributeError` *before* the

--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -136,7 +136,22 @@ class WeakFormFPSolver(BaseFPSolver):
         D = self._diffusion_coefficient(volatility_field)
 
         M = np.zeros((Nt + 1, N))
-        M[0] = m_initial[:N] if len(m_initial) >= N else np.pad(m_initial, (0, N - len(m_initial)))
+        # Issue #1489 (S4): the initial density must live on ALL N solver DOFs. The former length-only
+        # reconciliation (truncate if longer, zero-pad if shorter) silently produced a WRONG IC: for P2
+        # the caller resolves m_initial on num_vertices (< n_dof = vertices + edges), so np.pad zero-
+        # filled every edge-midpoint DOF. Fail loud instead of silently mis-placing the density. (A
+        # same-length-but-reordered IC still cannot be detected here — evaluate m_initial on the
+        # solver's dof_coordinates, self._disc.dof_coordinates, upstream.)
+        if len(m_initial) != N:
+            raise ValueError(
+                f"Initial density has {len(m_initial)} entries but the discretization has {N} DOFs. The "
+                f"weak-form FP solver needs m_initial on all {N} DOFs (basis.doflocs / "
+                f"self._disc.dof_coordinates), not a subset — this is the P2-vs-P1 DOF-count mismatch "
+                f"(P2 adds edge/face DOFs beyond the vertices). Silently padding/truncating would zero-fill "
+                f"the missing DOFs and mis-place the density (Issue #1489). Evaluate m_initial on the "
+                f"solver's dof_coordinates."
+            )
+        M[0] = m_initial
 
         A_base = self._M / dt + D * self._K
         A_extra, rhs_extra = self._weak_bc_terms(D)

--- a/tests/unit/test_alg/test_s4_ic_dof_mismatch.py
+++ b/tests/unit/test_alg/test_s4_ic_dof_mismatch.py
@@ -1,0 +1,47 @@
+"""Issue #1489 (S4): the weak-form FP solver fails loud when the initial density length != n_dof,
+instead of silently padding/truncating (the P2 edge-DOF zero-fill silent-wrong-IC bug)."""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+
+def _meshless_fp_solver():
+    from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+        ),
+    )
+    prob = MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=comp, coupling_coefficient=1.0)
+    cloud = np.linspace(0.0, 1.0, 11).reshape(-1, 1)
+    return MeshlessGalerkinFPSolver(prob, cloud, delta=2.6 / np.sqrt(11), degree=2)
+
+
+def test_ic_dof_count_mismatch_fails_loud():
+    fp = _meshless_fp_solver()
+    n = fp._n_dof
+    u = np.zeros((fp.problem.Nt + 1, n))
+    # too short (the P2 zero-fill case) and too long (silent truncation) both must raise, not pad/clip
+    with pytest.raises(ValueError, match="DOFs"):
+        fp.solve_fp_system(np.ones(n - 1), potential_field=u)
+    with pytest.raises(ValueError, match="DOFs"):
+        fp.solve_fp_system(np.ones(n + 3), potential_field=u)
+
+
+def test_ic_correct_length_is_accepted():
+    fp = _meshless_fp_solver()
+    n = fp._n_dof
+    u = np.zeros((fp.problem.Nt + 1, n))
+    m = fp.solve_fp_system(np.ones(n) / n, potential_field=u)  # correct length: no raise
+    assert m.shape == (fp.problem.Nt + 1, n)


### PR DESCRIPTION
Shared-base fail-loud from the audit ledger #1489. `WeakFormFPSolver.solve_fp_system` reconciled the IC by **length only** (`M[0] = m_initial[:N] if len>=N else np.pad(...)`), silently producing a wrong IC: for **P2** the coupling layer resolves `m_initial` on `num_vertices` (< `n_dof` = vertices + edges), so `np.pad` **zero-filled every edge-midpoint DOF**; a too-long array was silently truncated.

Now raises a clear `ValueError` naming the DOF-count mismatch and pointing to `self._disc.dof_coordinates`. **Byte-identical** for the correct `len == n_dof` case (P1). A same-length *reordered* IC still needs upstream resolution on `dof_coordinates` — noted inline.

**Verified**: 23 P1 coupled tests (FEM + meshless) pass unchanged; new `test_s4_ic_dof_mismatch` pins the raise.

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)