### PR TITLE
fix(weakform): report cumulative FP clip injection + monitor the adjoint clip (#1489 S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Weak-form FP positivity-clip monitor reports cumulative injection; adjoint clip no longer silent**
+  (Issue #1489, S3). The forward monitor was a one-shot latch that measured only the FIRST
+  threshold-exceeding step (typically the smallest), then stopped — while the clip kept injecting mass
+  every step, silently under-reporting the true conservation violation (observed ~400x under-report in
+  the divergence regime). It now accumulates the injected mass across all steps and logs the CUMULATIVE
+  total + per-step max at solve end. Separately, `solve_fp_step_adjoint_mode` clipped negative density
+  (injecting mass) with NO monitor at all — an adjoint-coupled solve could drift in mass silently; it
+  now warns once per solve. Reporting-only (numerics byte-identical; the clip itself is the disclosed
+  non-M-matrix limitation). Shared base -> FEM + meshless. Pinned by `test_s3_clip_cumulative`.
+
 - **FEM solvers fail loud with a clear message on a non-mesh geometry** (Issue #1489 / #1493).
   `HJBFEMSolver`/`FPFEMSolver.__init__` accessed `problem.geometry.mesh_data` directly, so a
   `TensorProductGrid` (no `mesh_data` attribute) raised a cryptic `AttributeError` *before* the

--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -54,6 +54,9 @@ class WeakFormFPSolver(BaseFPSolver):
         # getattr(geometry, "boundary_conditions") misses grids that expose BCs via
         # the accessor method (e.g. TensorProductGrid), silently dropping Dirichlet.
         self._bc = self.get_boundary_conditions()
+        # Issue #1489 (S3): one-shot latch for the adjoint-step positivity clip warning (the adjoint
+        # path is stateless per call, so the latch lives on the solver to warn once per solve).
+        self._adjoint_clip_warned = False
 
     @property
     def n_dof(self) -> int:
@@ -151,6 +154,10 @@ class WeakFormFPSolver(BaseFPSolver):
         pure_neumann = self._is_pure_neumann()
 
         clip_warned = False
+        clip_injected_total = 0.0
+        clip_injected_max = 0.0
+        clip_max_step = -1
+        m0_mass = float((self._M @ M[0]).sum())
         for n in range(Nt):
             rhs = (self._M / dt) @ M[n]
             if rhs_robin is not None:
@@ -180,8 +187,14 @@ class WeakFormFPSolver(BaseFPSolver):
             # mass and violates conservation. Surface it once per solve rather than failing
             # silently (kernel fail-fast). Streamline diffusion suppresses the undershoots
             # at the source (meshless ``streamline_diffusion_scale > 0``, Issue #1145).
+            # Issue #1489 (S3): measure EVERY step (the former `if not clip_warned` guard skipped the
+            # measurement after the first exceedance, so the cumulative injection was under-reported).
+            injected = -float((self._M @ np.minimum(M[n + 1], 0.0)).sum())
+            clip_injected_total += injected
+            if injected > clip_injected_max:
+                clip_injected_max = injected
+                clip_max_step = n
             if not clip_warned:
-                injected = -float((self._M @ np.minimum(M[n + 1], 0.0)).sum())
                 total = float((self._M @ np.maximum(M[n + 1], 0.0)).sum())
                 if injected > 1e-6 * max(total, 1e-300):
                     logger.warning(
@@ -194,6 +207,21 @@ class WeakFormFPSolver(BaseFPSolver):
                     clip_warned = True
             M[n + 1] = np.maximum(M[n + 1], 0.0)
 
+        # Issue #1489 (S3): report the CUMULATIVE clip injection at solve end — the true magnitude of
+        # the conservation violation, which the one-shot first-exceedance warning under-reports (it
+        # fires at the smallest, first step). Threshold relative to the initial mass.
+        if clip_injected_total > 1e-6 * max(m0_mass, 1e-300):
+            logger.warning(
+                "FP positivity clip injected a CUMULATIVE %.2e mass over %d steps (per-step max %.2e "
+                "at step %d, %.1f%% of the initial mass): the Galerkin advection is not an M-matrix; "
+                "enable streamline diffusion (streamline_diffusion_scale > 0) to suppress the "
+                "undershoots (Issue #1145 / #1489).",
+                clip_injected_total,
+                Nt,
+                clip_injected_max,
+                clip_max_step,
+                100.0 * clip_injected_total / max(m0_mass, 1e-300),
+            )
         return M
 
     def solve_fp_step_adjoint_mode(
@@ -221,4 +249,19 @@ class WeakFormFPSolver(BaseFPSolver):
         if rhs_robin is not None:
             rhs = rhs + rhs_robin
         M_next = spsolve(A_system, rhs)
+        # Issue #1489 (S3): the adjoint FP step clips negative density (INJECTING mass, like the forward
+        # path) but was FULLY SILENT — an adjoint-coupled solve could drift in mass with no diagnostic.
+        # Surface it once per solve (solver-level latch, since this step is stateless per call).
+        if not self._adjoint_clip_warned:
+            injected = -float((self._M @ np.minimum(M_next, 0.0)).sum())
+            total = float((self._M @ np.maximum(M_next, 0.0)).sum())
+            if injected > 1e-6 * max(total, 1e-300):
+                logger.warning(
+                    "Adjoint FP positivity clip injected mass %.2e (%.1f%% of total): the transposed "
+                    "advection is not monotone, so mass conservation is violated in the adjoint solve "
+                    "(Issue #1489).",
+                    injected,
+                    100.0 * injected / max(total, 1e-300),
+                )
+                self._adjoint_clip_warned = True
         return np.maximum(M_next, 0.0).reshape(M_current.shape)

--- a/tests/unit/test_alg/test_s3_clip_cumulative.py
+++ b/tests/unit/test_alg/test_s3_clip_cumulative.py
@@ -1,0 +1,64 @@
+"""Issue #1489 (S3): the weak-form FP positivity-clip monitor reports the CUMULATIVE mass injection
+over the whole solve, not just the first-exceedance step (the former one-shot latch under-reported)."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+
+def _capture(logger_name):
+    """Attach a record-collecting handler directly to a logger (the mfgarchon loggers do not
+    propagate to pytest's caplog root handler)."""
+    logger = logging.getLogger(logger_name)
+    records: list[str] = []
+
+    class _H(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _H(level=logging.WARNING)
+    logger.addHandler(handler)
+    prev = logger.level
+    logger.setLevel(logging.WARNING)
+    return logger, handler, prev, records
+
+
+def _meshless_fp_steep_drift():
+    from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+        ),
+    )
+    prob = MFGProblem(geometry=geom, T=1.0, Nt=20, sigma=0.05, components=comp, coupling_coefficient=1.0)
+    cloud = np.linspace(0.0, 1.0, 21).reshape(-1, 1)
+    fp = MeshlessGalerkinFPSolver(prob, cloud, delta=2.6 / np.sqrt(21), degree=2)  # unstabilized (no SD)
+    n = fp._n_dof
+    x = fp._disc.dof_coordinates.ravel()
+    u = np.tile(40.0 * (x - 0.5) ** 2, (prob.Nt + 1, 1))  # sharp confining potential -> steep drift
+    m0 = np.ones(n) / n
+    return fp, m0, u
+
+
+def test_clip_reports_cumulative_injection():
+    fp, m0, u = _meshless_fp_steep_drift()
+    logger, handler, prev, msgs = _capture("mfgarchon.alg.numerical.weak_form_fp_solver")
+    try:
+        fp.solve_fp_system(m0, potential_field=u)
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev)
+    assert any("positivity clip" in m for m in msgs), f"expected a clip warning; got {msgs}"
+    assert any("CUMULATIVE" in m for m in msgs), (
+        f"S3: the solve-end warning must report the cumulative clip injection, not only the first step; got {msgs}"
+    )


### PR DESCRIPTION
Shared-base fail-loud/reporting fix from the audit ledger #1489.

**Forward** (`solve_fp_system`): the positivity-clip monitor was a **one-shot latch** — it measured injected mass only at the FIRST threshold-exceeding step (typically the smallest), then stopped, while the clip kept injecting mass every step → **silently under-reported** the true conservation violation (~400× under-report in the divergence regime). Now accumulates across all steps and logs the **CUMULATIVE** total + per-step max at solve end (keeps the early first-exceedance warning too).

**Adjoint** (`solve_fp_step_adjoint_mode`): clipped negative density with **no monitor at all** — an adjoint-coupled solve could drift in mass silently. Now warns once per solve.

**Reporting-only**: the clip numerics (`M = np.maximum(M, 0)`) are byte-identical; the clip is the disclosed non-M-matrix limitation. Existing clip tests pass; new `test_s3_clip_cumulative` pins the cumulative report (steep unstabilized drift → multi-step clipping). Shared base → FEM + meshless.

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)