### PR TITLE
fix(coupling): route FP drift by _drift_convention, fail loud for non-smooth H on VALUE_FUNCTION solvers (#1489 S1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FP drift is now routed by the solver-declared `_drift_convention`, failing loud for a
+  non-smooth Hamiltonian on a `VALUE_FUNCTION` solver** (Issue #1489 S1; see also #1420).
+  `resolve_fp_drift_kwargs` gated `use_velocity` on `"drift_field" in params`, but parameter
+  presence cannot disambiguate the drift convention: some FP solvers expose `drift_field` as a real
+  VELOCITY channel (`FPFVMSolver`/`FPGFDMSolver`/`FPFDMSolver`), while the weak-form family exposes it
+  as a DEPRECATED ALIAS for `potential_field=U` (`DriftConvention.VALUE_FUNCTION`). For a non-smooth
+  H (L1 / bounded control) on a `VALUE_FUNCTION` solver the old gate fired and set `drift_field=alpha*`
+  (a velocity), which such a solver treats as `U` and differentiates — a silently wrong drift. The
+  coupler now threads each FP solver's `_drift_convention` (cached beside its signature) into
+  `resolve_fp_drift_kwargs` at all coupling call sites (`mfg_residual`, `fixed_point_iterator`,
+  `block_iterators`, `fictitious_play`, `regime_switching_iterator`, `graph_mfg_solver`,
+  `multi_population_iterator`); a `VALUE_FUNCTION` solver with a non-smooth/non-separable H now raises
+  (its optimal control is the Clarke velocity, not `-c*grad(U)`, so `U` cannot represent it) instead of
+  solving the wrong problem. When the convention is not supplied (`drift_convention=None`) the routing
+  falls back byte-for-byte to the pre-#1489 param-presence gate, so the smooth-separable-H path
+  (`potential_field=U`) is unchanged. Pinned by `test_s1_drift_convention_routing.py`.
+
 - **FEM solvers fail loud with a clear message on a non-mesh geometry** (Issue #1489 / #1493).
   `HJBFEMSolver`/`FPFEMSolver.__init__` accessed `problem.geometry.mesh_data` directly, so a
   `TensorProductGrid` (no `mesh_data` attribute) raised a cryptic `AttributeError` *before* the

--- a/mfgarchon/alg/numerical/coupling/base_mfg.py
+++ b/mfgarchon/alg/numerical/coupling/base_mfg.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
     import numpy as np
 
+    from mfgarchon.alg.numerical.fp_solvers.base_fp import DriftConvention
     from mfgarchon.core.mfg_problem import MFGProblem
     from mfgarchon.types.solver_types import SolverReturnTuple
 else:
@@ -39,6 +40,9 @@ class BaseCouplingIterator(ABC):
         self._solution_computed: bool = False
         self._hjb_sig_params: set[str] | None = None
         self._fp_sig_params: set[str] | None = None
+        # Issue #1489 (S1): the FP solver's declared drift-input convention, cached beside its
+        # signature so resolve_fp_drift_kwargs can route by convention rather than param presence.
+        self._fp_drift_convention: DriftConvention | None = None
         self._hjb_solver_name: str = "<hjb solver>"
         self._fp_solver_name: str = "<fp solver>"
 
@@ -60,6 +64,8 @@ class BaseCouplingIterator(ABC):
             self._fp_sig_params = set(sig.parameters.keys())
         except (AttributeError, ValueError):
             self._fp_sig_params = None
+        # Issue #1489 (S1): cache the FP solver's drift-input convention for resolve_fp_drift_kwargs.
+        self._fp_drift_convention = getattr(fp_solver, "_drift_convention", None)
 
     def _build_hjb_kwargs(
         self,

--- a/mfgarchon/alg/numerical/coupling/block_iterators.py
+++ b/mfgarchon/alg/numerical/coupling/block_iterators.py
@@ -298,7 +298,12 @@ class BlockIterator(BaseCouplingIterator):
             # into potential_field/drift_field without Hamiltonian-smoothness dispatch —
             # incorrect for solvers where drift_field is alpha* (e.g. FPGFDMSolver).
             drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
-                self.problem, self._fp_sig_params, self.drift_field, U, _M_curr
+                self.problem,
+                self._fp_sig_params,
+                self.drift_field,
+                U,
+                _M_curr,
+                drift_convention=self._fp_drift_convention,
             )
             kwargs.update(drift_kwargs)
             if use_positional_U:

--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -397,7 +397,12 @@ class FictitiousPlayIterator(BaseCouplingIterator):
             fp_kwargs = self._build_fp_kwargs(volatility_field=self.volatility_field)
             if self._fp_sig_params is not None:
                 drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
-                    self.problem, self._fp_sig_params, self.drift_field, U_new, M_old
+                    self.problem,
+                    self._fp_sig_params,
+                    self.drift_field,
+                    U_new,
+                    M_old,
+                    drift_convention=self._fp_drift_convention,
                 )
                 fp_kwargs.update(drift_kwargs)
                 if use_positional_U:

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -604,7 +604,12 @@ class FixedPointIterator(BaseCouplingIterator):
                 # the Newton MFGResidual so both coupling paths use one convention.
                 if self._fp_sig_params is not None:
                     drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
-                        self.problem, self._fp_sig_params, self.drift_field, U_new, M_old
+                        self.problem,
+                        self._fp_sig_params,
+                        self.drift_field,
+                        U_new,
+                        M_old,
+                        drift_convention=self._fp_drift_convention,
                     )
                     kwargs.update(drift_kwargs)
                     if use_positional_U:

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
+    from mfgarchon.alg.numerical.fp_solvers.base_fp import DriftConvention
     from mfgarchon.utils.solver_result import SolverResult
 
 
@@ -501,6 +502,7 @@ def resolve_fp_drift_kwargs(
     *,
     h_class: object | None = None,
     cross_density: np.ndarray | None = None,
+    drift_convention: DriftConvention | None = None,
 ) -> tuple[dict, bool]:
     """Resolve how the value function enters ``solve_fp_system`` (drift vs potential).
 
@@ -514,10 +516,21 @@ def resolve_fp_drift_kwargs(
     Resolution rules (matching the FP-solver semantics post-v0.18.6):
         - Explicit ``drift_field`` override → pass it through verbatim (velocity).
         - Smooth separable $H$ → pass $U$ as ``potential_field`` (the FP solver derives
-          the velocity internally; ``potential_field`` is the deprecated-but-routing
-          U-potential entry point).
-        - Non-smooth $H$ → pass the face-centered velocity $\\alpha^*$ as ``drift_field``
-          (see :func:`compute_fp_velocity_field`).
+          the velocity $\\alpha = -c\\,\\nabla U$ internally; ``potential_field`` is the
+          deprecated-but-routing U-potential entry point).
+        - Non-smooth $H$ on a ``VELOCITY``-channel solver → pass the face-centered velocity
+          $\\alpha^*$ as ``drift_field`` (see :func:`compute_fp_velocity_field`).
+        - Non-smooth $H$ on a ``VALUE_FUNCTION`` solver (only ``potential_field=U``) → raise:
+          the solver forms $\\alpha = -c\\,\\nabla U$ internally, but a non-smooth $H$'s FP
+          drift is the Clarke optimal control $\\alpha^*$, not $-c\\,\\nabla U$, so $U$ cannot
+          represent it (Issue #1489 S1).
+
+    Issue #1489 (S1): the drift convention cannot be inferred from parameter presence.
+    ``drift_field`` is a real velocity channel on some solvers (fp_fvm / fp_gfdm / FPFDM)
+    but a DEPRECATED ALIAS for ``potential_field=U`` on the weak-form family
+    (``DriftConvention.VALUE_FUNCTION``). The routing therefore keys on the solver-declared
+    ``drift_convention`` when the caller supplies it, and falls back byte-for-byte to the
+    pre-#1489 param-presence gate when it is ``None`` (un-updated callers are unaffected).
 
     Args:
         problem: MFG problem (provides ``hamiltonian_class``, ``geometry``, ``dt``).
@@ -533,6 +546,12 @@ def resolve_fp_drift_kwargs(
             (Issue #1071, lock-faithful). Forwarded to :func:`compute_fp_velocity_field` so the
             non-smooth velocity path sees the other populations' density — replacing the retired
             ``BoundHamiltonian`` wrapper. ``None`` => single-population own density.
+        drift_convention: The FP solver's declared ``_drift_convention`` (Issue #1489 S1). When
+            given, it disambiguates the ``drift_field`` channel: ``DriftConvention.VELOCITY`` means
+            ``drift_field`` is a true velocity $\\alpha^*$; ``DriftConvention.VALUE_FUNCTION`` means
+            the solver only consumes $U$ (its ``drift_field`` is a deprecated alias for
+            ``potential_field``), so a non-smooth $H$ raises instead of silently advecting $U$.
+            ``None`` (caller did not thread it) => the pre-#1489 param-presence gate, byte-identical.
 
     Returns:
         ``(drift_kwargs, use_positional_U)`` where ``drift_kwargs`` is one of ``{}``,
@@ -551,6 +570,7 @@ def resolve_fp_drift_kwargs(
         if "drift_field" in params:
             drift_kwargs["drift_field"] = drift_field_override
     else:
+        from mfgarchon.alg.numerical.fp_solvers.base_fp import DriftConvention
         from mfgarchon.core.hamiltonian import SeparableHamiltonian
 
         H_class = h_class if h_class is not None else problem.hamiltonian_class
@@ -558,14 +578,50 @@ def resolve_fp_drift_kwargs(
         # Hamiltonian plus the cross_density trajectory, so the smoothness dispatch reads H_class
         # directly — a smooth-separable H takes potential_field=U (cross-coupling enters via the
         # HJB, not the FP drift). The former BoundHamiltonian-unwrap (getattr `_inner`) is gone.
-        use_velocity = (
-            H_class is not None
-            and "drift_field" in params
-            and not (isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth())
-        )
+        #
+        # A smooth separable H is the only case whose FP drift the potential_field=U channel can
+        # represent: the solver recovers alpha = -c*grad(U) internally. A non-smooth (or
+        # non-separable) H has a set-valued / Clarke optimal control alpha* that is NOT -c*grad(U),
+        # so it can only enter a VELOCITY-channel solver as a precomputed alpha*.
+        h_is_smooth_separable = isinstance(H_class, SeparableHamiltonian) and H_class.control_cost.is_smooth()
+
+        # Issue #1489 (S1): param presence cannot disambiguate the drift convention — `drift_field`
+        # is a real velocity channel on some solvers but a deprecated alias for `potential_field=U`
+        # on the weak-form family (VALUE_FUNCTION). Key on the solver-declared `drift_convention`
+        # when the caller threads it; when it is None, reproduce the pre-#1489 param-presence gate
+        # byte-for-byte so un-updated callers are unaffected.
+        if drift_convention is None:
+            use_velocity = H_class is not None and "drift_field" in params and not h_is_smooth_separable
+        else:
+            use_velocity = (
+                drift_convention == DriftConvention.VELOCITY
+                and H_class is not None
+                and "drift_field" in params
+                and not h_is_smooth_separable
+            )
+
         if use_velocity:
             drift_kwargs["drift_field"] = compute_fp_velocity_field(problem, U, M, H_class, cross_density=cross_density)
         elif "potential_field" in params:
+            # Issue #1489 (S1): a VALUE_FUNCTION solver consumes `potential_field=U` and forms its
+            # drift as alpha = -c*grad(U) internally. That is valid ONLY for a smooth separable H.
+            # For a non-smooth / non-separable H the true FP drift is the Clarke optimal control
+            # alpha* (set-valued at kinks), NOT -c*grad(U), which U cannot represent — passing it
+            # would silently solve the wrong problem, so fail loud. The determination is only safe
+            # when the caller declared a convention; with drift_convention=None we keep the legacy
+            # potential_field=U behavior (byte-identical pre-#1489 fallback).
+            if drift_convention is not None and not h_is_smooth_separable:
+                raise ValueError(
+                    "Cannot route the value function as FP drift: this FP solver takes "
+                    "`potential_field=U` (DriftConvention.VALUE_FUNCTION) and forms its drift as "
+                    "alpha = -c*grad(U) internally, but the problem's Hamiltonian is non-smooth / "
+                    "non-separable, whose optimal control alpha* is the (set-valued) Clarke control, "
+                    "not -c*grad(U). U cannot represent this drift, so passing it would silently solve "
+                    "the wrong problem. Use a VELOCITY-channel FP solver that accepts a precomputed "
+                    "alpha* (e.g. FPGFDMSolver / FPFVMSolver / FPFDMSolver) with an explicit "
+                    "`drift_field=alpha*`, or use a smooth separable Hamiltonian. Issue #1489 (S1); "
+                    "see also #1420."
+                )
             drift_kwargs["potential_field"] = U
         elif "drift_field" in params:
             # Issue #1420 (G-017 V2): the FP solver exposes only `drift_field` (the velocity α*,

--- a/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
@@ -133,6 +133,9 @@ class GraphMFGSolver(BaseCouplingIterator):
         # (resolve_fp_drift_kwargs), exactly as the single-solver iterators do via
         # _init_solver_signatures. One set per node because nodes may use different FP solvers.
         self._fp_sig_params_k = [fp_solver_sig_params(fp) for fp in fp_solvers]
+        # Issue #1489 (S1): per-node FP drift-input convention, parallel to _fp_sig_params_k, so
+        # resolve_fp_drift_kwargs routes each node by convention rather than param presence.
+        self._fp_drift_convention_k = [getattr(fp, "_drift_convention", None) for fp in fp_solvers]
         self._max_iter = max_iterations
         self._tol = tolerance
         self._damping = damping
@@ -223,7 +226,12 @@ class GraphMFGSolver(BaseCouplingIterator):
                 fp_sig_params_k = self._fp_sig_params_k[k]
                 if fp_sig_params_k is not None:
                     drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
-                        self._problems[k], fp_sig_params_k, None, Us_new[k], Ms_expanded[k]
+                        self._problems[k],
+                        fp_sig_params_k,
+                        None,
+                        Us_new[k],
+                        Ms_expanded[k],
+                        drift_convention=self._fp_drift_convention_k[k],
                     )
                     fp_kwargs.update(drift_kwargs)
                     if use_positional_U:

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -34,7 +34,7 @@ from .source_composition import compose_fp_source, compose_hjb_source
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+    from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
     from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
     from mfgarchon.core.mfg_problem import MFGProblem
 
@@ -126,6 +126,8 @@ class MFGResidual:
         # Cache solver method signatures for parameter passing
         self._hjb_sig_params: set[str] | None = None
         self._fp_sig_params: set[str] | None = None
+        # Issue #1489 (S1): FP solver's declared drift-input convention (routes drift vs potential).
+        self._fp_drift_convention: DriftConvention | None = None
         self._cache_solver_signatures()
 
         # Evaluation counter for diagnostics
@@ -179,6 +181,9 @@ class MFGResidual:
             self._fp_sig_params = set(sig.parameters.keys())
         except AttributeError:
             self._fp_sig_params = None
+
+        # Issue #1489 (S1): cache the FP solver's drift-input convention for resolve_fp_drift_kwargs.
+        self._fp_drift_convention = getattr(self.fp_solver, "_drift_convention", None)
 
     def compute_hjb_output(self, M: NDArray, U_prev: NDArray) -> NDArray:
         """
@@ -255,7 +260,9 @@ class MFGResidual:
             if fp_source is not None:
                 kwargs["source_term"] = fp_source
 
-        drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(self.problem, params, self.drift_field, U, M)
+        drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
+            self.problem, params, self.drift_field, U, M, drift_convention=self._fp_drift_convention
+        )
         kwargs.update(drift_kwargs)
 
         if use_positional_U:

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -21,7 +21,7 @@ from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
 if TYPE_CHECKING:
-    from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+    from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
     from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
     from mfgarchon.core.multi_population import MultiPopulationProblem
 
@@ -87,6 +87,12 @@ class MultiPopulationIterator:
                 self._fp_sig_params.append(set(inspect.signature(fp.solve_fp_system).parameters))
             except (AttributeError, ValueError, TypeError):
                 self._fp_sig_params.append(None)
+
+        # Issue #1489 (S1): per-population FP drift-input convention, parallel to _fp_sig_params, so
+        # resolve_fp_drift_kwargs routes each population by convention rather than param presence.
+        self._fp_drift_convention: list[DriftConvention | None] = [
+            getattr(fp, "_drift_convention", None) for fp in fp_solvers
+        ]
 
     @property
     def damping_factor(self) -> float:
@@ -195,7 +201,14 @@ class MultiPopulationIterator:
                     M_new_k = fp_k.solve_fp_system(m0_k, drift_field=U[k], show_progress=False)
                 else:
                     drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
-                        prob_k, self._fp_sig_params[k], None, U[k], M[k], h_class=H_k, cross_density=m_all
+                        prob_k,
+                        self._fp_sig_params[k],
+                        None,
+                        U[k],
+                        M[k],
+                        h_class=H_k,
+                        cross_density=m_all,
+                        drift_convention=self._fp_drift_convention[k],
                     )
                     if use_positional_U:
                         M_new_k = fp_k.solve_fp_system(m0_k, U[k], show_progress=False)

--- a/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
@@ -135,6 +135,9 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
         # _init_solver_signatures. One set per regime k because regimes may use different FP
         # solver types.
         self._fp_sig_params_k = [fp_solver_sig_params(fp) for fp in fp_solvers]
+        # Issue #1489 (S1): per-regime FP drift-input convention, parallel to _fp_sig_params_k, so
+        # resolve_fp_drift_kwargs routes each regime by convention rather than param presence.
+        self._fp_drift_convention_k = [getattr(fp, "_drift_convention", None) for fp in fp_solvers]
         self._max_iter = max_iterations
         self._tol = tolerance
         self._damping = damping
@@ -283,7 +286,12 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
                 fp_sig_params_k = self._fp_sig_params_k[k]
                 if fp_sig_params_k is not None:
                     drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
-                        self._problems[k], fp_sig_params_k, None, Us_new[k], Ms[k]
+                        self._problems[k],
+                        fp_sig_params_k,
+                        None,
+                        Us_new[k],
+                        Ms[k],
+                        drift_convention=self._fp_drift_convention_k[k],
                     )
                     fp_kwargs.update(drift_kwargs)
                     if use_positional_U:

--- a/tests/unit/test_alg/test_s1_drift_convention_routing.py
+++ b/tests/unit/test_alg/test_s1_drift_convention_routing.py
@@ -1,0 +1,180 @@
+"""Pinning tests for Issue #1489 (S1) — route FP drift by ``_drift_convention``.
+
+``resolve_fp_drift_kwargs`` decides how the value function ``U`` enters the FP solver.
+Before this fix the ``use_velocity`` gate keyed on ``"drift_field" in params``, but
+parameter presence cannot disambiguate the drift convention: some solvers expose
+``drift_field`` as a real VELOCITY channel (fp_fvm / fp_gfdm / FPFDM), while the weak-form
+family exposes ``drift_field`` as a DEPRECATED ALIAS for ``potential_field=U``
+(``DriftConvention.VALUE_FUNCTION``). For a non-smooth ``H`` + a VALUE_FUNCTION solver the
+old gate fired and set ``drift_field=alpha*`` (a velocity), which such a solver treats as
+``U`` and DIFFERENTIATES — a silently wrong drift.
+
+The fix threads the solver-declared ``_drift_convention`` into ``resolve_fp_drift_kwargs``:
+
+(a) VALUE_FUNCTION + non-smooth H     -> raise (U cannot represent the Clarke velocity).
+(b) VELOCITY      + non-smooth H     -> route ``drift_field=alpha*`` (computed velocity).
+(c) any convention + smooth quadratic H -> ``potential_field=U`` (UNCHANGED no-regression).
+(d) ``drift_convention=None``         -> pre-#1489 param-presence behavior, byte-identical.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.fixed_point_utils import resolve_fp_drift_kwargs
+from mfgarchon.alg.numerical.fp_solvers.base_fp import DriftConvention
+from mfgarchon.core.hamiltonian import (
+    L1ControlCost,
+    QuadraticControlCost,
+    SeparableHamiltonian,
+)
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+# Solver signatures, reduced to the two params resolve_fp_drift_kwargs actually inspects.
+# weak-form / network family: both present (drift_field is a deprecated alias for U).
+_VALUE_FUNCTION_SIG = {"m_initial_condition", "potential_field", "drift_field"}
+# meshfree velocity-only family (e.g. FPGFDMSolver): drift_field is a true velocity alpha*.
+_VELOCITY_ONLY_SIG = {"m_initial_condition", "drift_field"}
+# FDM reference solver: exposes both, drift_field is a true velocity alpha*.
+_VELOCITY_BOTH_SIG = {"m_initial_condition", "potential_field", "drift_field"}
+
+
+def _problem(control_cost) -> MFGProblem:
+    """1D LQ-style MFG problem with the given control cost (smooth or non-smooth)."""
+    geometry = TensorProductGrid(
+        bounds=[(0.0, 1.0)],
+        Nx_points=[21],
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+    components = MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+        u_terminal=lambda x: (x - 0.8) ** 2,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=control_cost,
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    return MFGProblem(geometry=geometry, T=0.3, Nt=6, sigma=0.2, components=components)
+
+
+def _state(problem: MFGProblem) -> tuple[np.ndarray, np.ndarray]:
+    """Return (U, M) with real spatial gradients so alpha* is non-trivial."""
+    nt = problem.Nt + 1
+    x = np.linspace(0.0, 1.0, 21)
+    U = np.tile((x - 0.8) ** 2, (nt, 1))
+    M = np.tile(np.exp(-10 * (x - 0.5) ** 2), (nt, 1))
+    return U, M
+
+
+def test_l1_control_cost_is_non_smooth():
+    """Guard the disambiguator's premise: L1 (bang-bang) cost is non-smooth."""
+    assert L1ControlCost(lambda_=1.0).is_smooth() is False
+    assert QuadraticControlCost(control_cost=1.0).is_smooth() is True
+
+
+# (a) VALUE_FUNCTION + non-smooth H -> raise (the S1 fix).
+def test_value_function_solver_nonsmooth_h_raises():
+    problem = _problem(L1ControlCost(lambda_=1.0))
+    U, M = _state(problem)
+    with pytest.raises(ValueError, match="1489"):
+        resolve_fp_drift_kwargs(
+            problem,
+            _VALUE_FUNCTION_SIG,
+            None,
+            U,
+            M,
+            drift_convention=DriftConvention.VALUE_FUNCTION,
+        )
+
+
+# (b) VELOCITY + non-smooth H -> route drift_field = alpha* (computed velocity, not U).
+def test_velocity_solver_nonsmooth_h_routes_drift_field():
+    problem = _problem(L1ControlCost(lambda_=1.0))
+    U, M = _state(problem)
+    drift_kwargs, use_positional = resolve_fp_drift_kwargs(
+        problem,
+        _VELOCITY_ONLY_SIG,
+        None,
+        U,
+        M,
+        drift_convention=DriftConvention.VELOCITY,
+    )
+    assert "drift_field" in drift_kwargs
+    assert "potential_field" not in drift_kwargs
+    assert not use_positional
+    alpha_star = drift_kwargs["drift_field"]
+    assert alpha_star is not U, "must be a computed alpha*, not U passed through"
+    assert np.all(np.isfinite(alpha_star))
+
+
+# (c) smooth quadratic H -> potential_field = U (UNCHANGED), for either declared convention.
+@pytest.mark.parametrize(
+    "convention",
+    [DriftConvention.VALUE_FUNCTION, DriftConvention.VELOCITY],
+)
+def test_smooth_h_routes_potential_field_unchanged(convention):
+    problem = _problem(QuadraticControlCost(control_cost=1.0))
+    U, M = _state(problem)
+    sig = _VALUE_FUNCTION_SIG if convention is DriftConvention.VALUE_FUNCTION else _VELOCITY_BOTH_SIG
+    drift_kwargs, use_positional = resolve_fp_drift_kwargs(
+        problem,
+        sig,
+        None,
+        U,
+        M,
+        drift_convention=convention,
+    )
+    assert "potential_field" in drift_kwargs
+    assert "drift_field" not in drift_kwargs
+    assert drift_kwargs["potential_field"] is U
+    assert not use_positional
+
+
+# (d) drift_convention=None -> pre-#1489 behavior preserved (byte-identical fallback).
+def test_none_convention_preserves_legacy_behavior():
+    """Same inputs as case (a): with None the OLD param-presence gate fires (drift_field=alpha*,
+    the pre-#1489 buggy-but-byte-identical path); declaring VALUE_FUNCTION instead raises."""
+    problem = _problem(L1ControlCost(lambda_=1.0))
+    U, M = _state(problem)
+
+    # None -> old behavior: non-smooth H + drift_field in params -> use_velocity -> drift_field.
+    drift_kwargs, use_positional = resolve_fp_drift_kwargs(
+        problem, _VALUE_FUNCTION_SIG, None, U, M, drift_convention=None
+    )
+    assert "drift_field" in drift_kwargs
+    assert "potential_field" not in drift_kwargs
+    assert not use_positional
+
+    # Smooth H + None -> potential_field=U (unchanged legacy path).
+    smooth_problem = _problem(QuadraticControlCost(control_cost=1.0))
+    Us, Ms = _state(smooth_problem)
+    dk_smooth, _ = resolve_fp_drift_kwargs(smooth_problem, _VALUE_FUNCTION_SIG, None, Us, Ms, drift_convention=None)
+    assert dk_smooth["potential_field"] is Us
+
+
+def test_declared_conventions_match_solver_traits():
+    """The disambiguator's source of truth: solver-declared _drift_convention. If any of these
+    flip, resolve_fp_drift_kwargs silently reroutes drift, so pin them."""
+    from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+    from mfgarchon.alg.numerical.fp_solvers.fp_fvm import FPFVMSolver
+    from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+    from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
+    from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
+    from mfgarchon.alg.numerical.weak_form_fp_solver import WeakFormFPSolver
+
+    assert BaseFPSolver._drift_convention is DriftConvention.VELOCITY
+    assert FPFVMSolver._drift_convention is DriftConvention.VELOCITY
+    assert FPGFDMSolver._drift_convention is DriftConvention.VELOCITY
+    assert WeakFormFPSolver._drift_convention is DriftConvention.VALUE_FUNCTION
+    assert FPParticleSolver._drift_convention is DriftConvention.VALUE_FUNCTION
+    assert FPSLJacobianSolver._drift_convention is DriftConvention.VALUE_FUNCTION
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Bug (Issue #1489, S1)

`resolve_fp_drift_kwargs` (`coupling/fixed_point_utils.py`) decides how the value function `U` enters the FP solver. The `use_velocity` gate keyed on `"drift_field" in params`, but **parameter presence cannot disambiguate the drift convention**:

- Some FP solvers expose `drift_field` as a real **VELOCITY** channel (`FPFVMSolver` / `FPGFDMSolver` / `FPFDMSolver`).
- The weak-form family (`WeakFormFPSolver`, `FPNetworkSolver`, `FPSLJacobianSolver`, `FPParticleSolver`) exposes `drift_field` as a **DEPRECATED ALIAS for `potential_field=U`** (`DriftConvention.VALUE_FUNCTION`).

Counter-example: `fp_fvm` has both `drift_field`+`potential_field` yet is VELOCITY; `weak_form_fp_solver` has both yet is VALUE_FUNCTION.

For a **non-smooth H** (L1 / bounded control) on a **VALUE_FUNCTION** solver, `use_velocity` fired and set `drift_field=alpha*` (a velocity), which the solver treats as `U` and **differentiates** -> silently wrong drift. The #1420 `elif "drift_field"` guard was structurally unreachable for these solvers.

## Fix

Thread each FP solver's existing machine-readable trait `_drift_convention` (`DriftConvention.{VELOCITY,VALUE_FUNCTION}`, defined in `fp_solvers/base_fp.py`) into `resolve_fp_drift_kwargs`:

- `use_velocity` now additionally requires `drift_convention == DriftConvention.VELOCITY` (plus non-smooth H and `"drift_field" in params`) -> unchanged for true-velocity solvers.
- A **VALUE_FUNCTION** solver (`potential_field=U`) with a **non-smooth / non-separable H** now **raises** `ValueError`: its optimal control is the (set-valued) Clarke velocity `alpha*`, not `-c*grad(U)`, so `U` cannot represent the drift. Use a VELOCITY-channel solver with an explicit `drift_field=alpha*`, or a smooth separable H.
- The existing #1420 velocity-only guard is preserved.
- **No-regression guarantee**: when the caller does not supply a convention (`drift_convention=None`), routing falls back **byte-for-byte** to the pre-#1489 param-presence gate. The smooth-separable-H `potential_field=U` path is unchanged.

The convention is cached beside `_fp_sig_params` at each caller (`getattr(fp, "_drift_convention", None)`) and passed at **every** call site:

| Caller | Cache site | Call site |
|---|---|---|
| `fixed_point_iterator`, `block_iterators`, `fictitious_play` | `base_mfg._init_solver_signatures` (`self._fp_drift_convention`) | threaded |
| `mfg_residual` | `_cache_solver_signatures` (`self._fp_drift_convention`) | threaded |
| `multi_population_iterator` | per-population list `self._fp_drift_convention` | `[k]` |
| `regime_switching_iterator`, `graph_mfg_solver` | per-subsystem list `self._fp_drift_convention_k` | `[k]` |

## Tests

New pinning test `tests/unit/test_alg/test_s1_drift_convention_routing.py` (7 tests):
- (a) VALUE_FUNCTION + non-smooth (L1) H -> raises;
- (b) VELOCITY + non-smooth H -> routes `drift_field=alpha*`;
- (c) smooth quadratic H (either convention) -> `potential_field=U` unchanged;
- (d) `drift_convention=None` -> legacy behavior preserved;
- plus guards on `L1ControlCost.is_smooth() is False` and the solver-declared conventions.

Verification (all pass, no timeout):
- `pytest tests/unit/test_alg -k "coupl or fixed_point or drift or residual or block or fictitious or regime or multi_pop"` -> 213 passed
- `tests/integration/test_meshless_galerkin_mfg.py`, `test_fem_solver_path.py`, `test_1043_coupler_fp_drift_convention.py` -> 41 passed
- `tests/integration/test_graph_mfg_solver.py`, `test_multi_population_cross_coupling.py`, `tests/unit/test_alg/test_regime_switching_iterator.py` -> 39 passed
- `test_fp_nonquadratic.py` (non-smooth FixedPointIterator on FPFDM) passes -> no regression
- `ruff format --check` and `ruff check` clean on all touched files.

Refs #1489, #1420