### PR TITLE
fix(fem): fail loud on degenerate mesh element in create_basis (#1489 F7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **FEM basis creation fails loud on a degenerate element** (Issue #1489, F7). `create_basis` now
+  checks per-element measures and raises on a near-zero (zero-area / collinear / coincident-node)
+  element instead of letting `skfem.asm` fill its stiffness/mass rows with NaN/Inf and only emit a
+  numpy `RuntimeWarning` — a silent corruption of the solve. An inverted-but-nonzero element still
+  integrates its true area (skfem uses `|detDF|`), so only genuine degeneracy is guarded. Pinned by
+  `test_fem_degenerate_assembly_f7`.
+
 - **FEM mesh adapter fails loud on mismatched connectivity + unsupported mesh class** (Issue #1489,
   F6/F8). `meshdata_to_skfem` now validates the connectivity node-count against the element family
   before construction — a 4-node quad mislabeled `triangle` was silently truncated by scikit-fem to

--- a/mfgarchon/alg/numerical/fem/assembly.py
+++ b/mfgarchon/alg/numerical/fem/assembly.py
@@ -78,7 +78,24 @@ def create_basis(mesh: skfem.Mesh, order: int = 1) -> skfem.Basis:
             f"Supported: P1 (order=1) and P2 (order=2) for Tri/Tet/Line/Quad/Hex."
         )
 
-    return skfem.Basis(mesh, element_cls())
+    basis = skfem.Basis(mesh, element_cls())
+
+    # Issue #1489 (F7): a degenerate element (zero-area / collinear / coincident nodes) has a ~zero
+    # measure, so assembly (skfem.asm) fills its rows with NaN/Inf entries and only emits a numpy
+    # RuntimeWarning -- never an exception -- corrupting the solve silently. Fail loud at basis
+    # creation. skfem integrates with |detDF|, so an inverted-but-nonzero element still contributes its
+    # true area; guard only the near-zero (genuinely degenerate) case, relative to the largest element.
+    measures = np.asarray(basis.dx).sum(axis=1)  # per-element measure = integral of 1 over each element
+    scale = float(measures.max()) if measures.size else 0.0
+    bad = np.nonzero(measures < 1e-12 * max(scale, 1e-300))[0]
+    if bad.size:
+        raise ValueError(
+            f"{bad.size} degenerate mesh element(s) with near-zero measure: e.g. element {int(bad[0])} "
+            f"has measure {measures[bad[0]]:.3e} vs a max of {scale:.3e}. Zero-area / collinear / "
+            f"coincident-node elements produce NaN stiffness and mass entries silently under assembly "
+            f"(Issue #1489). Remove the degenerate / sliver elements from the mesh."
+        )
+    return basis
 
 
 def assemble_stiffness(basis: skfem.Basis) -> sparse.csr_matrix:

--- a/tests/unit/test_alg/test_fem_degenerate_assembly_f7.py
+++ b/tests/unit/test_alg/test_fem_degenerate_assembly_f7.py
@@ -1,0 +1,26 @@
+"""Issue #1489 (F7): FEM basis creation fails loud on a degenerate (zero-measure) element instead of
+silently assembling NaN stiffness/mass entries (only a numpy RuntimeWarning otherwise)."""
+
+from __future__ import annotations
+
+import pytest
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required")
+
+
+def test_create_basis_fails_loud_on_degenerate_element():
+    from mfgarchon.alg.numerical.fem.assembly import create_basis
+
+    m = skfem.MeshTri.init_sqsymmetric()
+    p = m.p.copy()
+    p[:, 1] = p[:, 0]  # collapse a vertex onto another -> zero-area (degenerate) triangles
+    degenerate = skfem.MeshTri(p, m.t)
+    with pytest.raises(ValueError, match="degenerate"):
+        create_basis(degenerate, order=1)
+
+
+def test_create_basis_accepts_valid_mesh():
+    from mfgarchon.alg.numerical.fem.assembly import create_basis
+
+    basis = create_basis(skfem.MeshTri.init_sqsymmetric().refined(1), order=2)  # no raise
+    assert basis.N > 0


### PR DESCRIPTION
Robustness fail-loud from the audit ledger #1489. A degenerate element (zero-area / collinear / coincident nodes) has a ~zero measure, so `skfem.asm` fills its stiffness/mass rows with **NaN/Inf** and emits only a numpy `RuntimeWarning` — never an exception — corrupting the solve silently.

`create_basis` now checks per-element measures (`basis.dx.sum(axis=1)`) and raises on a near-zero element (relative to the largest). skfem integrates with `|detDF|`, so an **inverted-but-nonzero** element still contributes its true area — only genuine degeneracy is guarded.

**Verified**: 28 FEM tests pass on valid meshes; new `test_fem_degenerate_assembly_f7` pins the raise.

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)