### PR TITLE
fix(fem): harden P2 Dirichlet BC handling (#1489 F2-F5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **FEM P2 Dirichlet BC handling hardened** (Issue #1489, F2–F5). Four defects in the FEM Dirichlet
+  path, all silent-wrong or crash on P2 / multi-wall BCs: (F2) the whole-boundary fallback used
+  `mesh.boundary_nodes()` (vertices only), leaving every P2 boundary EDGE DOF free — Dirichlet
+  enforced on half the boundary; now resolves via `basis.get_dofs(boundary_facets)`. (F3) a *named*
+  boundary absent from the mesh silently fell back to the WHOLE boundary (a one-wall Dirichlet applied
+  everywhere); now raises — only `boundary=None` means the whole boundary. (F4) a corner DOF shared by
+  two Dirichlet segments was double-counted in the condensation lift (and scatter-back was
+  order-dependent); now deduped, with a fail-loud on conflicting values. (F5) a callable Dirichlet on
+  P2 indexed `mesh.p` (vertex coords) with DOF indices `>= n_vertices` → `IndexError`; now evaluates at
+  `basis.doflocs`. Pinned by `test_fem_p2_dirichlet_f2f5` + updated `test_fem_solver_path`.
+
 - **FEM mesh adapter fails loud on mismatched connectivity + unsupported mesh class** (Issue #1489,
   F6/F8). `meshdata_to_skfem` now validates the connectivity node-count against the element family
   before construction — a 4-node quad mislabeled `triangle` was silently truncated by scikit-fem to

--- a/mfgarchon/alg/numerical/fem/bc_adapter.py
+++ b/mfgarchon/alg/numerical/fem/bc_adapter.py
@@ -75,7 +75,7 @@ def apply_bc_to_fem_system(
         if segment.bc_type in (BCType.DIRICHLET,):
             # Find DOFs on this boundary segment
             dofs = _find_segment_dofs(mesh, basis, segment)
-            values = _evaluate_segment_values(segment, mesh, dofs)
+            values = _evaluate_segment_values(segment, basis, dofs)
             dirichlet_dofs.extend(dofs)
             dirichlet_values.extend(values)
 
@@ -117,6 +117,21 @@ def apply_bc_to_fem_system(
         # lifting by the actual Dirichlet values g would add a spurious -A[int,dofs]@g term and
         # corrupt every interior value. The linear solve keeps homogeneous=False (u=g is the solution).
         val_array = np.zeros(len(dirichlet_dofs)) if homogeneous else np.array(dirichlet_values, dtype=float)
+        # Issue #1489 (F4): a corner/edge DOF shared by two Dirichlet segments appears twice in the
+        # list; dedup so the condensation lift `A[int,dofs]@val` does not double-count its column (and
+        # the scatter-back is not order-dependent). Fail loud on conflicting values for the same DOF.
+        uniq, first_idx = np.unique(dof_array, return_index=True)
+        if len(uniq) != len(dof_array):
+            if not homogeneous:
+                for d in uniq:
+                    vd = val_array[dof_array == d]
+                    if not np.allclose(vd, vd[0]):
+                        raise ValueError(
+                            f"Conflicting Dirichlet values on shared DOF {int(d)}: {sorted(set(vd.tolist()))} "
+                            f"— two BC segments meet at this corner/edge with different values (Issue #1489)."
+                        )
+            dof_array = uniq
+            val_array = val_array[first_idx]
         interior = np.setdiff1d(np.arange(A.shape[0]), dof_array)
 
         A_int = A[np.ix_(interior, interior)]
@@ -149,7 +164,7 @@ def get_dirichlet_dofs_and_values(
     for segment in bc.segments:
         if segment.bc_type == BCType.DIRICHLET:
             dofs = _find_segment_dofs(mesh, basis, segment)
-            values = _evaluate_segment_values(segment, mesh, dofs)
+            values = _evaluate_segment_values(segment, basis, dofs)
             dirichlet_dofs.extend(dofs)
             dirichlet_values.extend(values)
 
@@ -179,30 +194,39 @@ def _find_segment_dofs(
     """
     boundary_name = getattr(segment, "boundary", None)
 
-    # mesh.boundaries is None when no named regions were tagged (mesh_adapter tags axis-aligned
-    # walls x_min/x_max/... for box domains; #607). Guard it so an untagged mesh falls back
-    # cleanly instead of raising "argument of type 'NoneType' is not iterable".
-    if boundary_name and mesh.boundaries and boundary_name in mesh.boundaries:
-        # Named boundary region
-        facets = mesh.boundaries[boundary_name]
-        dofs = basis.get_dofs(facets)
-        return list(dofs.flatten())
+    if boundary_name:
+        # Issue #1489 (F3): a NAMED boundary absent from the mesh is an ERROR — silently falling back
+        # to the WHOLE boundary would over-constrain (a one-wall Dirichlet applied everywhere). The
+        # mesh_adapter auto-tags axis-aligned walls (x_min/x_max/...) for box domains (#607).
+        if not mesh.boundaries or boundary_name not in mesh.boundaries:
+            available = sorted(mesh.boundaries) if mesh.boundaries else "none"
+            raise ValueError(
+                f"Dirichlet segment '{getattr(segment, 'name', '?')}' names boundary '{boundary_name}', "
+                f"but the mesh has no such tagged boundary (available: {available}). A missing named "
+                f"boundary would otherwise silently apply the BC to the ENTIRE boundary (Issue #1489). "
+                f"Tag it, or use boundary=None for the whole boundary."
+            )
+        return list(basis.get_dofs(mesh.boundaries[boundary_name]).flatten())
 
-    # Fallback: use all boundary nodes
-    return list(mesh.boundary_nodes())
+    # Issue #1489 (F2): boundary=None -> the whole boundary. Resolve DOFs via basis.get_dofs on the
+    # boundary FACETS (which includes P2 edge-midpoint DOFs), NOT mesh.boundary_nodes() (vertices only
+    # -> half the P2 boundary is left free -> Dirichlet silently enforced on vertices only).
+    return list(basis.get_dofs(mesh.boundary_facets()).flatten())
 
 
 def _evaluate_segment_values(
     segment,
-    mesh: skfem.Mesh,
+    basis: skfem.Basis,
     dofs: list[int],
 ) -> list[float]:
     """Evaluate BCSegment value at the given DOFs."""
     value = getattr(segment, "value", 0.0)
 
     if callable(value):
-        # Value is a function: evaluate at DOF coordinates
-        coords = mesh.p[:, dofs].T  # (n_dofs, dim)
+        # Issue #1489 (F5): evaluate at the DOF coordinates via basis.doflocs (a coordinate for EVERY
+        # DOF), NOT mesh.p (vertex coordinates only). For P2 the boundary DOF set includes edge-midpoint
+        # indices >= n_vertices, so mesh.p[:, dofs] was out of bounds / wrong-coordinate.
+        coords = basis.doflocs[:, dofs].T  # (n_dofs, dim)
         return [float(value(x)) for x in coords]
     elif isinstance(value, (int, float)):
         return [float(value)] * len(dofs)

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -253,19 +253,27 @@ class TestFEMFacetBoundaryTags:
         assert np.allclose(fp._skfem_mesh.p[0, dofs], 0.0)
         assert len(dofs) < len(fp._skfem_mesh.boundary_nodes())  # a wall, not all boundary
 
-    def test_untagged_mesh_falls_back_without_crashing(self):
-        """If mesh.boundaries is None (no tagging), _find_segment_dofs must fall back to all
-        boundary nodes, not raise."""
+    def test_named_boundary_untagged_fails_loud_but_none_falls_back(self):
+        """Issue #1489 (F3): a NAMED boundary absent from mesh.boundaries must RAISE (silently applying
+        a one-wall Dirichlet to the whole boundary is the bug); only boundary=None falls back to the
+        whole boundary — and that fallback resolves ALL boundary DOFs, incl. P2 edge DOFs (F2)."""
         from mfgarchon.alg.numerical.fem.assembly import create_basis
         from mfgarchon.alg.numerical.fem.bc_adapter import _find_segment_dofs
         from mfgarchon.geometry.boundary.conditions import BCSegment, BCType
 
         mesh = skfem.MeshTri.init_sqsymmetric().refined(1)  # raw skfem mesh: boundaries is None
         assert mesh.boundaries is None
-        basis = create_basis(mesh, order=1)
-        seg = BCSegment(name="d", bc_type=BCType.DIRICHLET, boundary="x_min", value=0.0)
-        dofs = _find_segment_dofs(mesh, basis, seg)  # must not raise
-        assert len(dofs) == len(mesh.boundary_nodes())  # fell back to all boundary nodes
+        basis = create_basis(mesh, order=2)  # P2, so the fallback must include edge DOFs (F2)
+
+        named = BCSegment(name="d", bc_type=BCType.DIRICHLET, boundary="x_min", value=0.0)
+        with pytest.raises(ValueError, match=r"no such tagged boundary|entire boundary"):
+            _find_segment_dofs(mesh, basis, named)
+
+        whole = BCSegment(name="all", bc_type=BCType.DIRICHLET, boundary=None, value=0.0)
+        dofs = _find_segment_dofs(mesh, basis, whole)  # boundary=None -> whole boundary, no raise
+        # F2: get_dofs on the boundary facets includes P2 edge-midpoint DOFs (> vertex-only count)
+        assert len(dofs) == len(set(basis.get_dofs(mesh.boundary_facets()).flatten().tolist()))
+        assert len(dofs) > len(mesh.boundary_nodes())  # strictly more than vertices-only (the F2 bug)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_alg/test_fem_p2_dirichlet_f2f5.py
+++ b/tests/unit/test_alg/test_fem_p2_dirichlet_f2f5.py
@@ -1,0 +1,61 @@
+"""Issue #1489 (F2/F4/F5): FEM P2 Dirichlet BC handling.
+- F2: the whole-boundary fallback resolves ALL DOFs (incl. P2 edge DOFs), not vertices only.
+- F4: a corner DOF shared by two Dirichlet segments with conflicting values fails loud.
+- F5: a callable Dirichlet value evaluates at the DOF coordinates (basis.doflocs), not vertex coords.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+skfem = pytest.importorskip("skfem", reason="scikit-fem required")
+
+
+def _p2_basis_box():
+    mesh = skfem.MeshTri.init_sqsymmetric().refined(2).with_boundaries(
+        {
+            "x_min": lambda x: np.isclose(x[0], 0.0),
+            "y_min": lambda x: np.isclose(x[1], 0.0),
+        }
+    )
+    from mfgarchon.alg.numerical.fem.assembly import create_basis
+
+    return create_basis(mesh, order=2)  # P2
+
+
+def test_p2_callable_dirichlet_does_not_crash():
+    """F5: a callable Dirichlet on a P2 boundary indexes basis.doflocs (a coord per DOF), not mesh.p
+    (vertices only) — the latter IndexError'd on edge-midpoint DOF indices >= n_vertices."""
+    from mfgarchon.alg.numerical.fem.bc_adapter import _evaluate_segment_values, _find_segment_dofs
+    from mfgarchon.geometry.boundary.conditions import BCSegment, BCType
+
+    basis = _p2_basis_box()
+    seg = BCSegment(name="inlet", bc_type=BCType.DIRICHLET, boundary="x_min", value=lambda x: 2.0 * x[1])
+    dofs = _find_segment_dofs(basis.mesh, basis, seg)
+    vals = _evaluate_segment_values(seg, basis, dofs)  # must not raise
+    assert len(vals) == len(dofs) > 0
+
+
+def test_conflicting_corner_dirichlet_fails_loud():
+    """F4: two Dirichlet walls meeting at a corner with DIFFERENT values -> the shared corner DOF has
+    conflicting values -> condensation must fail loud, not double-count / last-write-win."""
+    from scipy import sparse
+
+    from mfgarchon.alg.numerical.fem.assembly import assemble_stiffness
+    from mfgarchon.alg.numerical.fem.bc_adapter import apply_bc_to_fem_system
+    from mfgarchon.geometry.boundary.conditions import BCSegment, BCType, BoundaryConditions
+
+    basis = _p2_basis_box()
+    a = assemble_stiffness(basis) + sparse.eye(basis.N, format="csr")
+    rhs = np.ones(basis.N)
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="L", bc_type=BCType.DIRICHLET, boundary="x_min", value=1.0),
+            BCSegment(name="B", bc_type=BCType.DIRICHLET, boundary="y_min", value=2.0),  # corner (0,0) conflicts
+        ],
+        dimension=2,
+    )
+    with pytest.raises(ValueError, match="Conflicting"):
+        apply_bc_to_fem_system(a, rhs, basis, bc)


### PR DESCRIPTION
Four FEM Dirichlet defects from the audit ledger #1489, all silent-wrong or crash on P2 / multi-wall BCs:

- **F2**: whole-boundary fallback used `mesh.boundary_nodes()` (vertices only) → every P2 boundary **edge DOF left free** (Dirichlet on half the boundary). Now `basis.get_dofs(boundary_facets)`.
- **F3**: a *named* boundary absent from the mesh silently fell back to the **whole boundary** (one-wall Dirichlet everywhere). Now raises; only `boundary=None` = whole boundary.
- **F4**: a corner DOF shared by two segments was **double-counted** in the condensation lift. Now deduped + fail-loud on conflicting values.
- **F5**: a callable Dirichlet on P2 indexed `mesh.p` with DOF idx `>= n_vertices` → `IndexError`. Now `basis.doflocs`.

**Verified**: 15 FEM tests pass; new `test_fem_p2_dirichlet_f2f5` + updated `test_fem_solver_path` pin all four. Note: F3 changes behavior (named+untagged now raises), so the old `test_untagged_mesh_falls_back` was updated to the correct contract.

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)