### PR TITLE
fix(coupling): fail-loud guards for finite mass-blowup + P2 DOF-count (#1489 S5/S6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Coupling fail-loud guards: finite mass-blowup + P2 DOF-count** (Issue #1489, S5/S6, shared coupling).
+  (S5) `FixedPointIterator`'s divergence guard checked only `np.isfinite`, so a FINITE but blown-up
+  density (the pre-overflow divergence, total mass ~5.9e4) passed and was reported converged/valid; a
+  magnitude guard now terminates with `diverged_mass_blowup` when the total density grows >1e4x the
+  initial (a legitimate solve conserves, or decreases under absorbing BC). (S6) the unstructured-mesh
+  state was sized from `num_spatial_points` (= vertices), never the solver's `n_dof`, so a P2 FEM solve
+  (n_dof = vertices + edges) hit an opaque broadcast `ValueError` in the damping step; the state is now
+  sized from the solver `n_dof`, with a fail-loud on a HJB/FP DOF-count mismatch. Byte-identical for the
+  P1 / meshless path (n_dof == num_spatial_points); verified by the coupling + coupled suites (no regression).
+
 - **FP drift is now routed by the solver-declared `_drift_convention`, failing loud for a
   non-smooth Hamiltonian on a `VALUE_FUNCTION` solver** (Issue #1489 S1; see also #1420).
   `resolve_fp_drift_kwargs` gated `use_velocity` on `"drift_field" in params`, but parameter

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -466,7 +466,20 @@ class FixedPointIterator(BaseCouplingIterator):
             # shuttles (Nt+1, N) arrays. grid_spacing is a benign unit weight here -- the L2
             # convergence is a *relative* tolerance, so a constant volume element does not change
             # convergence detection (only the absolute L2 value, which is not compared to anything).
-            shape = (int(self.problem.num_spatial_points),)
+            # Issue #1489 (S6): size the state on the SOLVER's DOF count, not num_spatial_points
+            # (= num_vertices). For P2 FEM n_dof = vertices + edges > num_vertices, so a
+            # (Nt+1, num_vertices) state mismatches the (Nt+1, n_dof) the solver returns -> an opaque
+            # broadcast ValueError deep in the damping step. Prefer the solver n_dof and fail loud on a
+            # HJB/FP DOF mismatch (a coupled solve needs a shared DOF layout).
+            fp_n = getattr(self.fp_solver, "n_dof", None)
+            hjb_n = getattr(self.hjb_solver, "n_dof", None)
+            if fp_n is not None and hjb_n is not None and fp_n != hjb_n:
+                raise ValueError(
+                    f"Paired HJB and FP solvers report different DOF counts (HJB n_dof={hjb_n}, "
+                    f"FP n_dof={fp_n}); a coupled solve needs a shared DOF layout (Issue #1489)."
+                )
+            n = fp_n if fp_n is not None else (hjb_n if hjb_n is not None else int(self.problem.num_spatial_points))
+            shape = (int(n),)
             grid_spacing = 1.0
         else:
             raise ValueError(
@@ -664,6 +677,25 @@ class FixedPointIterator(BaseCouplingIterator):
                     grid_1d = self.problem.geometry.get_spatial_grid().ravel()
                     mu_k = ParticleMeasure.from_density(self.M[-1], grid_1d)
                     measure_field.add_snapshot(mu_k, self.U.copy())
+
+                # Issue #1489 (S5): a FINITE but blown-up density (e.g. the pre-overflow divergence,
+                # total mass ~5.9e4 before it becomes inf) passes the isfinite check below and would be
+                # reported converged/valid. Guard the magnitude too: a total mass that has GROWN by many
+                # orders relative to the initial is diverging (a legitimate solve conserves, or under
+                # absorbing BC decreases — an increase of 1e4x is a blow-up, not a valid state).
+                m0_mass = float(np.sum(np.abs(self.M[0]))) if self.M.size else 0.0
+                m_mass = float(np.sum(np.abs(M_new)))
+                if np.isfinite(m_mass) and m_mass > 1e4 * (m0_mass + 1e-300):
+                    convergence_reason = "diverged_mass_blowup"
+                    logger.warning(
+                        "FP density blew up in iteration %d (total |M|=%.2e, %.1e x the initial); the "
+                        "coupled solve is diverging — enable stabilization. Terminating early (Issue #1489).",
+                        iiter + 1,
+                        m_mass,
+                        m_mass / (m0_mass + 1e-300),
+                    )
+                    self.iterations_run = iiter + 1
+                    break
 
                 # Issue #688: Early termination on NaN/Inf (runtime safety)
                 # Issue #1078: identify HJB vs FP source for triage


### PR DESCRIPTION
Shared-coupling fail-loud from the audit ledger #1489.

**S5** — `FixedPointIterator`'s divergence guard checked only `np.isfinite`, so a **finite but blown-up** density (the pre-overflow divergence, total mass ~5.9e4) passed and was reported converged/valid. A magnitude guard now terminates with `diverged_mass_blowup` when total density grows >1e4× the initial (a legitimate solve conserves, or decreases under absorbing BC — an increase of 1e4× is a blow-up).

**S6** — the unstructured-mesh state was sized from `num_spatial_points` (= vertices), never the solver's `n_dof`, so a **P2** solve (n_dof = vertices + edges) hit an opaque broadcast `ValueError` in damping. Now sized from the solver `n_dof`, with a fail-loud on a HJB/FP DOF-count mismatch.

**Byte-identical** for the P1 / meshless path (`n_dof == num_spatial_points`); **69 coupling + coupled tests pass** (no regression). Heavy divergence/P2 end-to-end pinning tests deferred (need a full diverging / P2-coupled setup).

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)