### PR TITLE
fix(coupling): fail loud on paired-solver duality-key conflict + SD mismatch (#1489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Paired-solver duality guards: factory conflict + streamline-diffusion mismatch** (Issue #1489).
+  `create_paired_solvers` reconciled the duality-critical meshless keys (`streamline_diffusion_scale`,
+  `delta`, `collocation_points`, `n_gauss`, `nitsche_penalty`, `domain`, ...) only via a fill-missing
+  loop; when a key was set in BOTH configs with CONFLICTING values, both branches fell through and the
+  mismatch was silently kept -> a half-stabilized pair with `A_FP != A_HJB^T`. It now raises on a
+  conflict. Separately, the `FixedPointIterator` now fails loud when a hand-built weak-form pair has
+  mismatched `streamline_diffusion_scale` (the SD block would be added to one side only). Pinned by
+  `test_factory_sd_duality`.
+
 - **FP drift is now routed by the solver-declared `_drift_convention`, failing loud for a
   non-smooth Hamiltonian on a `VALUE_FUNCTION` solver** (Issue #1489 S1; see also #1420).
   `resolve_fp_drift_kwargs` gated `use_velocity` on `"drift_field" in params`, but parameter

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -161,6 +161,19 @@ class FixedPointIterator(BaseCouplingIterator):
         self.fp_solver = fp_solver
         self.config = config
 
+        # Issue #1489 (SD-duality): a weak-form pair must share streamline_diffusion_scale, else the
+        # symmetric SD block is added to only one side and the Type-A transpose identity A_FP = A_HJB^T
+        # breaks silently. The factory (create_paired_solvers) threads this across the pair; guard the
+        # hand-built case here too. Only weak-form solvers carry `_sd_scale`; others return None (skip).
+        hjb_sd = getattr(hjb_solver, "_sd_scale", None)
+        fp_sd = getattr(fp_solver, "_sd_scale", None)
+        if hjb_sd is not None and fp_sd is not None and hjb_sd != fp_sd:
+            raise ValueError(
+                f"Paired HJB / FP solvers have different streamline_diffusion_scale (HJB={hjb_sd}, "
+                f"FP={fp_sd}); the SD block would be added to only one side and A_FP = A_HJB^T breaks "
+                f"(Issue #1489). Use create_paired_solvers (which threads it), or set the same scale on both."
+            )
+
         # PDE coefficient overrides (Phase 2.3)
         self.volatility_field = volatility_field
         self.drift_field = drift_field

--- a/mfgarchon/factory/scheme_factory.py
+++ b/mfgarchon/factory/scheme_factory.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from mfgarchon.types import NumericalScheme
 from mfgarchon.utils import DualityStatus, check_solver_duality
 
@@ -354,10 +356,25 @@ def _create_meshless_galerkin_pair(
         "nitsche_penalty",
         "streamline_diffusion_scale",
     ):
-        if key in hjb_config and key not in fp_config:
+        in_hjb = key in hjb_config
+        in_fp = key in fp_config
+        if in_hjb and not in_fp:
             fp_config[key] = hjb_config[key]
-        elif key in fp_config and key not in hjb_config:
+        elif in_fp and not in_hjb:
             hjb_config[key] = fp_config[key]
+        elif in_hjb and in_fp:
+            # Issue #1489: the key is set in BOTH configs. If the values conflict, the pair would build
+            # DIFFERENT operators and the Type-A transpose identity A_FP = A_HJB^T breaks silently. The
+            # former fill-missing loop only handled the "present in one" case; a conflict fell through
+            # both branches and was kept. Fail loud instead.
+            a, b = hjb_config[key], fp_config[key]
+            same = np.array_equal(a, b) if isinstance(a, np.ndarray) or isinstance(b, np.ndarray) else a == b
+            if not same:
+                raise ValueError(
+                    f"create_paired_solvers: conflicting '{key}' across the HJB/FP pair (hjb={a!r}, "
+                    f"fp={b!r}). This duality-critical key must match, or A_FP = A_HJB^T breaks. Pass it "
+                    f"in one config (it threads to the other) or set the same value in both (Issue #1489)."
+                )
 
     hjb_solver = MeshlessGalerkinHJBSolver(problem, **hjb_config)
     fp_solver = MeshlessGalerkinFPSolver(problem, **fp_config)

--- a/tests/unit/test_alg/test_factory_sd_duality.py
+++ b/tests/unit/test_alg/test_factory_sd_duality.py
@@ -1,0 +1,58 @@
+"""Issue #1489: paired weak-form solvers must share the duality-critical config (esp.
+streamline_diffusion_scale), or the SD block is added to one side only and A_FP = A_HJB^T breaks.
+The factory fails loud on conflicting keys; the coupling iterator fails loud on a hand-built mismatch."""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+
+def _problem_and_cloud():
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+        ),
+    )
+    prob = MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=comp, coupling_coefficient=1.0)
+    return prob, np.linspace(0.0, 1.0, 11).reshape(-1, 1)
+
+
+def test_factory_fails_loud_on_conflicting_duality_key():
+    from mfgarchon.factory.scheme_factory import NumericalScheme, create_paired_solvers
+
+    prob, cloud = _problem_and_cloud()
+    with pytest.raises(ValueError, match=r"streamline_diffusion|conflicting"):
+        create_paired_solvers(
+            prob,
+            NumericalScheme.MESHLESS_GALERKIN,
+            hjb_config={
+                "collocation_points": cloud,
+                "delta": 2.6 / np.sqrt(11),
+                "use_newton": True,
+                "streamline_diffusion_scale": 1.0,
+            },
+            fp_config={"streamline_diffusion_scale": 0.0},  # conflicts with the HJB value
+        )
+
+
+def test_iterator_fails_loud_on_hand_built_sd_mismatch():
+    from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+    from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+    from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
+
+    prob, cloud = _problem_and_cloud()
+    delta = 2.6 / np.sqrt(11)
+    hjb = MeshlessGalerkinHJBSolver(prob, cloud, delta=delta, use_newton=True, streamline_diffusion_scale=1.0)
+    fp = MeshlessGalerkinFPSolver(prob, cloud, delta=delta, streamline_diffusion_scale=0.0)  # mismatched
+    with pytest.raises(ValueError, match="streamline_diffusion"):
+        FixedPointIterator(prob, hjb, fp)


### PR DESCRIPTION
Two paired-solver duality guards from the audit ledger #1489.

**Factory conflict** — `create_paired_solvers` reconciled the duality-critical meshless keys (`streamline_diffusion_scale`, `delta`, `collocation_points`, ...) only via a fill-missing loop. A key set in **both** configs with **conflicting** values fell through both branches → a half-stabilized pair with `A_FP ≠ A_HJB^T`, silently. Now raises on a conflict (`np.array_equal` handles array-valued `collocation_points`).

**Hand-built SD mismatch** — `FixedPointIterator` now fails loud when a hand-built weak-form pair has mismatched `streamline_diffusion_scale` (the symmetric SD block would be added to one side only). The factory threads it for factory-built pairs; this guards the hand-built path.

**Verified**: 10 meshless factory tests pass (no regression); new `test_factory_sd_duality` pins both raises.

Refs #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)