### PR TITLE
fix(meshless): fail loud on ill-conditioned MLS moment matrix on the Gauss-assembly path (#1485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MLS moment-matrix conditioning guard on the Gauss-assembly path** (Issue #1485). A near-singular MLS
+  moment matrix (too few nodes covering a quadrature point's support -> rank-deficient) produced silently
+  garbage shape functions that `np.linalg.solve` does not flag (near-, not exactly, singular). The
+  Gauss-quadrature assembly now passes `check_conditioning=True` to `shape_functions_and_grads` and fails
+  loud (`LinAlgError`) when `cond(M) > 1e12`. The SCNI path leaves the flag `False` — its nodal-smoothed
+  gradients legitimately tolerate poor pointwise conditioning — so the guard is on the caller, NOT the
+  shared basis (SCNI stays exempt). Pinned by `test_mls_conditioning_guard_1485`.
+
 - **FP drift is now routed by the solver-declared `_drift_convention`, failing loud for a
   non-smooth Hamiltonian on a `VALUE_FUNCTION` solver** (Issue #1489 S1; see also #1420).
   `resolve_fp_drift_kwargs` gated `use_velocity` on `"drift_field" in params`, but parameter

--- a/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/discretization.py
@@ -61,8 +61,15 @@ class MeshlessGalerkinDiscretization:
         self._exps = monomial_exponents(self._dim, degree)
 
         # (phi, grad) at quadrature points: (Q, N), (Q, N, dim)
+        # Issue #1485: this is the Gauss-quadrature ASSEMBLY path -> guard the MLS moment-matrix
+        # conditioning (SCNI's own discretization does not, by design -- see mls_basis.py).
         self._phi, self._grad = shape_functions_and_grads(
-            np.asarray(quad_points, dtype=np.float64), self._nodes, self._rho, self._exps, backend
+            np.asarray(quad_points, dtype=np.float64),
+            self._nodes,
+            self._rho,
+            self._exps,
+            backend,
+            check_conditioning=True,
         )
 
     @property

--- a/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
@@ -69,7 +69,7 @@ def _poly_grad_batch(pts: NDArray, exponents: NDArray) -> NDArray:
 
 
 def shape_functions_and_grads_numpy(
-    x_eval: NDArray, nodes: NDArray, rho: float, exponents: NDArray
+    x_eval: NDArray, nodes: NDArray, rho: float, exponents: NDArray, check_conditioning: bool = False
 ) -> tuple[NDArray, NDArray]:
     r"""MLS shape functions and full gradients via analytic differentiation.
 
@@ -97,6 +97,22 @@ def shape_functions_and_grads_numpy(
     dp = _poly_grad_batch(x_eval, exponents)  # (Q,m,d)
 
     M = np.einsum("qn,ni,nj->qij", omega, P, P)  # (Q,m,m)
+    if check_conditioning:
+        # Issue #1485: on the Gauss-quadrature ASSEMBLY path, a near-singular MLS moment matrix M (too
+        # few nodes inside a quadrature point's support -> rank-deficient) yields garbage shape
+        # functions that np.linalg.solve does NOT flag (near-, not exactly, singular). Fail loud. The
+        # SCNI path does NOT pass check_conditioning: its nodal-smoothed gradients tolerate poor
+        # pointwise conditioning, so it stays exempt (do not move this guard into the shared basis).
+        conds = np.linalg.cond(M)  # (Q,)
+        worst = float(np.max(conds)) if conds.size else 0.0
+        if not np.isfinite(worst) or worst > 1e12:
+            q_bad = int(np.argmax(conds))
+            raise np.linalg.LinAlgError(
+                f"MLS moment matrix is ill-conditioned at quadrature point {q_bad} (cond={worst:.2e} "
+                f"> 1e12): too few nodes cover its support (rho={rho} too small, or a gap / degenerate "
+                f"cloud). The shape functions would be silently garbage. Increase the support radius "
+                f"rho, densify the cloud, or lower the polynomial degree (Issue #1485)."
+            )
     # numpy>=2.0: a (Q,m,m) with b (Q,m) is read as a single matrix RHS; pass an
     # explicit (Q,m,1) column stack and squeeze to get batched vector solves.
     gamma = np.linalg.solve(M, p[..., None])[..., 0]  # (Q,m)
@@ -161,10 +177,15 @@ def shape_functions_and_grads(
     rho: float,
     exponents: NDArray,
     backend: str = "numpy",
+    check_conditioning: bool = False,
 ) -> tuple[NDArray, NDArray]:
-    """Dispatch to the numpy (default) or jax MLS derivative backend."""
+    """Dispatch to the numpy (default) or jax MLS derivative backend.
+
+    ``check_conditioning`` (numpy backend only) fails loud on a near-singular MLS moment matrix; the
+    Gauss-quadrature assembly path passes ``True``, the SCNI path leaves it ``False`` (Issue #1485).
+    """
     if backend == "numpy":
-        return shape_functions_and_grads_numpy(x_eval, nodes, rho, exponents)
+        return shape_functions_and_grads_numpy(x_eval, nodes, rho, exponents, check_conditioning=check_conditioning)
     if backend == "jax":
         return shape_functions_and_grads_jax(x_eval, nodes, rho, exponents)
     raise ValueError(f"Unknown backend {backend!r}; expected 'numpy' or 'jax'.")

--- a/tests/unit/test_alg/test_mls_conditioning_guard_1485.py
+++ b/tests/unit/test_alg/test_mls_conditioning_guard_1485.py
@@ -1,0 +1,31 @@
+"""Issue #1485: the Gauss-quadrature assembly path fails loud on a near-singular MLS moment matrix
+(garbage shape functions np.linalg.solve does not flag), while the SCNI path stays exempt (its nodal
+smoothing tolerates poor pointwise conditioning) — the guard lives on the caller flag, not the shared basis."""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.meshless_galerkin.mls_basis import monomial_exponents, shape_functions_and_grads
+
+
+def test_well_conditioned_cloud_does_not_fire():
+    nodes = np.linspace(0.0, 1.0, 11).reshape(-1, 1)
+    qp = np.linspace(0.05, 0.95, 20).reshape(-1, 1)
+    shape_functions_and_grads(qp, nodes, 0.3, monomial_exponents(1, 2), "numpy", check_conditioning=True)  # no raise
+
+
+def test_degenerate_support_fires_on_gauss_path():
+    bad_nodes = np.array([[0.0], [0.001], [0.002]])  # ~collinear/coincident -> rank-deficient P
+    qp = np.array([[0.5]])
+    with pytest.raises(np.linalg.LinAlgError, match="ill-conditioned"):
+        shape_functions_and_grads(qp, bad_nodes, 1.0, monomial_exponents(1, 2), "numpy", check_conditioning=True)
+
+
+def test_scni_path_is_exempt_on_same_degenerate_cloud():
+    bad_nodes = np.array([[0.0], [0.001], [0.002]])
+    qp = np.array([[0.5]])
+    # SCNI calls without check_conditioning (default False) -> must NOT raise
+    shape_functions_and_grads(qp, bad_nodes, 1.0, monomial_exponents(1, 2), "numpy")


### PR DESCRIPTION
Closes #1485. A near-singular MLS moment matrix (too few nodes covering a quadrature point's support → rank-deficient) produces **silently garbage** shape functions that `np.linalg.solve` does not flag (near-, not exactly, singular).

`shape_functions_and_grads` gains a `check_conditioning` flag (default `False`); the Gauss-quadrature assembly (`MeshlessGalerkinDiscretization`) passes `True` and fails loud (`LinAlgError`) when `cond(M) > 1e12`.

**Placement is the point** (an earlier attempt bolting the guard into the shared basis broke SCNI): the SCNI path leaves the flag `False` — its nodal-smoothed gradients legitimately tolerate poor pointwise conditioning — so the guard is on the **caller**, not the shared basis. SCNI stays exempt.

**Verified**: degenerate cloud fires on the Gauss path; well-conditioned covering cloud does not; SCNI exempt on the same degenerate cloud; **52 meshless tests pass** (no regression); new `test_mls_conditioning_guard_1485`.

Closes #1485.