### PR TITLE
fix(hjb): tensor diffusion must square sigma via the single-source converter (#1506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HJB-FDM tensor diffusion applied sigma linearly instead of sigma^2** (Issue #1506, silent-wrong,
+  parallel-path). The anisotropic/tensor path passed raw `sigma_diag` (per-axis sigma) as `axis_weights`
+  into `weighted_laplacian_with_bc`, whose stencil uses the weights LINEARLY and requires `w_d = sigma_d^2`;
+  with the `0.5` factor the effective diffusion was `0.5*sigma` instead of `0.5*sigma^2` (~3.3x wrong at
+  sigma=0.3), so a per-axis / tensor `volatility_field` silently discretized a different HJB PDE than the
+  scalar path (which squares via `diffusion_from_volatility`). The tensor path now routes `sigma_diag`
+  through the same single-source converter. Found by the repo anti-pattern audit. Pinned by
+  `test_hjb_scalar_and_diagonal_tensor_diffusion_agree` (scalar == diag-tensor to machine precision).
+
 - **MLS moment-matrix conditioning guard on the Gauss-assembly path** (Issue #1485). A near-singular MLS
   moment matrix (too few nodes covering a quadrature point's support -> rank-deficient) produced silently
   garbage shape functions that `np.linalg.solve` does not flag (near-, not exactly, singular). The

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -908,11 +908,20 @@ class HJBFDMSolver(BaseHJBSolver):
 
             bc = self.get_boundary_conditions()
             spacings = list(self.problem.geometry.get_grid_spacing())
+            # Issue #1506: axis_weights are the diffusion diagonal D_d = sigma_d^2/2, NOT raw sigma_d --
+            # weighted_laplacian applies axis_weights LINEARLY (w_d * d2u/dx_d^2). Route sigma_diag through
+            # the SAME single-source converter the scalar path uses (diffusion_from_volatility -> sigma^2/2
+            # elementwise); passing raw sigma_diag with a 0.5 factor silently solved 0.5*sigma instead of
+            # 0.5*sigma^2, so a per-axis/tensor volatility array discretized the wrong HJB PDE.
             aniso_lap = weighted_laplacian_with_bc(
-                U.reshape(self.shape), spacings, axis_weights=sigma_diag, bc=bc, time=time
+                U.reshape(self.shape),
+                spacings,
+                axis_weights=diffusion_from_volatility(sigma_diag, kind="field"),
+                bc=bc,
+                time=time,
             ).ravel()
 
-            H_values_flat = H_convective - 0.5 * aniso_lap
+            H_values_flat = H_convective - aniso_lap
 
         else:
             # Scalar diffusion mode — batch HamiltonianBase (Issue #784)

--- a/tests/unit/test_convention_agreement.py
+++ b/tests/unit/test_convention_agreement.py
@@ -87,6 +87,41 @@ class TestSigmaToDiffusionAgreement:
         backend edit that drifts from sigma**2/2 fails here."""
         assert 0.5 * sigma**2 == diffusion_from_volatility(sigma)
 
+    def test_hjb_scalar_and_diagonal_tensor_diffusion_agree(self):
+        """Issue #1506: the HJB-FDM scalar and tensor diffusion paths must apply the SAME power of
+        sigma. The tensor path passed raw sigma_diag (sigma) as axis_weights into a stencil that uses
+        them linearly (needs sigma^2), while the scalar path squares via diffusion_from_volatility ->
+        a per-axis volatility silently solved 0.5*sigma instead of 0.5*sigma^2. For an isotropic
+        diagonal tensor diag([sigma, sigma]) the two paths must now produce the same Hamiltonian."""
+        import numpy as np
+
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+        from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+        from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc
+
+        geom = TensorProductGrid(
+            bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[11, 11], boundary_conditions=no_flux_bc(dimension=2)
+        )
+        comp = MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+            ),
+        )
+        prob = MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=comp, coupling_coefficient=1.0)
+        solver = HJBFDMSolver(prob)
+        xx, yy = np.meshgrid(np.linspace(0, 1, 11), np.linspace(0, 1, 11), indexing="ij")
+        u = (xx**2 + 0.5 * yy**2).ravel()  # nonzero, unequal second derivatives per axis
+        m = np.ones_like(u)
+        grads = solver._compute_gradients_nd(u)
+        sigma = 0.3
+        h_scalar = solver._evaluate_hamiltonian_vectorized(u, m, grads, sigma_at_n=sigma)
+        h_tensor = solver._evaluate_hamiltonian_vectorized(u, m, grads, Sigma_at_n=np.diag([sigma, sigma]))
+        np.testing.assert_allclose(h_tensor, h_scalar, rtol=0, atol=1e-13)  # was ~3.3x off (sigma vs sigma^2)
+
 
 class TestGeometryBoundsAccessor:
     """Issue #1056: the .bounds / get_bounding_box accessors are non-uniform across geometry


### PR DESCRIPTION
Closes #1506. **CRITICAL parallel-path (silent-wrong)** from the repo anti-pattern audit — the single most dangerous finding (fires on ordinary anisotropic input, no opt-in flag).

The HJB-FDM tensor path passed raw `sigma_diag` (per-axis σ) as `axis_weights` into `weighted_laplacian_with_bc`, whose stencil applies weights **linearly** and requires `w_d = σ_d²`. With the `0.5` factor the effective diffusion was `0.5·σ` instead of `0.5·σ²` — **~3.3× wrong** at σ=0.3. The **scalar path** squares correctly via `diffusion_from_volatility`, so a per-axis / tensor `volatility_field` silently solved a **different HJB PDE**.

**Fix**: route `sigma_diag` through the same single-source converter (`diffusion_from_volatility(·, kind='field')` = σ²/2 per axis), drop the redundant `0.5`.

**Verified**: scalar == diagonal-tensor Hamiltonian to machine precision (was ~3.3× off); 55 HJB-FDM tests pass; new `test_hjb_scalar_and_diagonal_tensor_diffusion_agree`.

Closes #1506.