### PR TITLE
fix(fp): strict-adjoint step renormalizes + warns instead of silently injecting mass (#1507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Strict-adjoint FP-FDM step injected mass via a silent clip** (Issue #1507, silent-wrong, clipping).
+  `solve_fp_step_adjoint_mode` clipped negative density to 0 with no renormalization and no diagnostic;
+  the transposed-HJB advection operator is not an M-matrix, so at high Péclet the solve genuinely
+  undershoots, the clip ADDS mass, and the caller stores it raw -> total mass drifts up across timesteps
+  and the coupled fixed point converges self-consistently wrong. Now renormalizes to the pre-step total
+  (physical density conserves mass; the operator-level adjoint A_FP=A_HJB^T is unchanged) and emits a
+  threshold-gated warning, matching the sibling FP paths (fp_semi_lagrangian / fp_fdm_time_stepping,
+  Issues #880/#886). Found by the repo anti-pattern audit. Pinned by `test_fp_adjoint_clip_mass_1507`.
+
 - **MLS moment-matrix conditioning guard on the Gauss-assembly path** (Issue #1485). A near-singular MLS
   moment matrix (too few nodes covering a quadrature point's support -> rank-deficient) produced silently
   garbage shape functions that `np.linalg.solve` does not flag (near-, not exactly, singular). The

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -735,9 +735,29 @@ class FPFDMSolver(BaseFPSolver):
         # Solve linear system
         M_next_flat = sparse.linalg.spsolve(A_system, b_rhs)
 
-        # Reshape and ensure non-negativity
+        # Reshape and ensure non-negativity.
         M_next = M_next_flat.reshape(shape)
+        # Issue #1507: A_advection_T (the transposed HJB advection) is NOT an M-matrix, so at high
+        # Péclet the solve undershoots negative; clipping to 0 ADDS mass. The caller stores this raw
+        # with no mass check, so ∫m drifts up across timesteps and the coupled fixed point converges
+        # self-consistently wrong. Renormalize to the pre-step total (the physical density conserves
+        # mass; the operator-level adjoint A_FP=A_HJB^T is unchanged) and warn when the clip is
+        # non-trivial -- matching fp_semi_lagrangian / fp_fdm_time_stepping (Issues #880/#886), so a
+        # diverging solve is surfaced instead of silently reported as a valid conserved density.
+        mass_before = float(M_current.sum())
+        neg_mass = float(-np.minimum(M_next, 0.0).sum())  # magnitude of the clipped negatives (>= 0)
         M_next = np.maximum(M_next, 0.0)
+        mass_after_clip = float(M_next.sum())
+        if mass_after_clip > 1e-15:
+            M_next *= mass_before / mass_after_clip
+        if neg_mass > 1e-9 * max(mass_before, 1e-300):
+            logger.warning(
+                "Strict-adjoint FP step clipped %.3e negative mass (%.1f%% of the total) then "
+                "renormalized: the adjoint advection operator is not an M-matrix at this Péclet number "
+                "(Issue #1507). Persistent large clips indicate a diverging coupled solve.",
+                neg_mass,
+                100.0 * neg_mass / max(mass_before, 1e-300),
+            )
 
         return M_next
 

--- a/tests/unit/test_alg/test_fp_adjoint_clip_mass_1507.py
+++ b/tests/unit/test_alg/test_fp_adjoint_clip_mass_1507.py
@@ -1,0 +1,61 @@
+"""Issue #1507: the strict-adjoint FP-FDM step must conserve mass and surface the clip. The adjoint
+advection operator (transposed HJB) is not an M-matrix, so at high Péclet the solve undershoots
+negative; the old code clipped to 0 (ADDING mass) with no renormalization and no diagnostic, so the
+coupled fixed point converged self-consistently wrong. Now it renormalizes to the pre-step mass and
+warns."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from scipy import sparse
+
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _fp_solver_and_advection(n=21, drift=40.0):
+    geom = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    comp = MFGComponents(
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+        ),
+    )
+    prob = MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.05, components=comp, coupling_coefficient=1.0)
+    fp = FPFDMSolver(prob)
+    h = 1.0 / (n - 1)
+    off = drift / (2 * h)
+    a = sparse.diags([-off * np.ones(n - 1), np.zeros(n), off * np.ones(n - 1)], [-1, 0, 1]).tocsr()
+    return fp, a, h, n
+
+
+def test_strict_adjoint_step_conserves_mass_and_is_nonnegative():
+    fp, a, h, n = _fp_solver_and_advection()
+    m0 = np.zeros(n)
+    m0[n // 2] = 1.0 / h  # peaked density, high Péclet -> the solve undershoots negative
+    m_next = fp.solve_fp_step_adjoint_mode(m0, a, sigma=0.05)
+    assert (m_next >= 0.0).all()  # clip enforced
+    assert np.isclose(m_next.sum(), m0.sum(), rtol=1e-12)  # renormalized -> no silent mass injection
+
+
+def test_strict_adjoint_clip_warns():
+    fp, a, h, n = _fp_solver_and_advection()
+    m0 = np.zeros(n)
+    m0[n // 2] = 1.0 / h
+    records: list[str] = []
+    handler = logging.Handler()
+    handler.emit = lambda r: records.append(r.getMessage())  # type: ignore[method-assign]
+    log = logging.getLogger("mfgarchon.alg.numerical.fp_solvers.fp_fdm")
+    log.addHandler(handler)
+    log.setLevel(logging.WARNING)
+    try:
+        fp.solve_fp_step_adjoint_mode(m0, a, sigma=0.05)
+    finally:
+        log.removeHandler(handler)
+    assert any("clipped" in r and "Issue #1507" in r for r in records)


### PR DESCRIPTION
Closes #1507. **CRITICAL clipping (silent-wrong)** from the repo anti-pattern audit.

`solve_fp_step_adjoint_mode` clipped negative density to 0 with **no renormalization and no diagnostic**. The transposed-HJB advection operator `A_advection_T` is not an M-matrix, so at high Péclet the solve genuinely undershoots negative → the clip **adds mass**, and the caller (`block_iterators`) stores it raw with no mass check → ∫m drifts up across timesteps → the coupled fixed point converges **self-consistently wrong**. Every sibling FP path renormalizes or warns; this strict-adjoint step (#622) did neither.

**Fix**: renormalize `M_next` to the pre-step total (the physical density conserves mass; the operator-level adjoint `A_FP=A_HJB^T` is a property of the operator, unchanged by post-processing the output) + threshold-gated `logger.warning`, matching `fp_semi_lagrangian` / `fp_fdm_time_stepping` (#880/#886).

**Verified**: under a high-Péclet undershoot (8.4% clipped) mass is conserved (was drifting up) and the warning fires; 51 FP-FDM tests pass; new `test_fp_adjoint_clip_mass_1507`.

Closes #1507.