### PR TITLE
fix(rl): mean-field DDPG/TD3/SAC fail loud on missing get_population_state (#1508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mean-field RL (DDPG/TD3/SAC) silently zero-filled the population state** (Issue #1508, silent-wrong,
+  fail-silent). A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state =
+  np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean
+  field** for the whole run -- 'converged' and returned a policy/Q the user trusts as an MFG solution
+  while the coupling channel that DEFINES a mean-field game was dead. `get_population_state` is a required
+  capability, not optional backend detection, so all six sites (current + next state, across DDPG/TD3/SAC)
+  now fail loud via `getattr` + `callable` + `raise` (the repo's no-hasattr-duck-typing rule). Found by the
+  repo anti-pattern audit. Pinned by `test_mean_field_rl_requires_pop_state_1508`.
+
 - **MLS moment-matrix conditioning guard on the Gauss-assembly path** (Issue #1485). A near-singular MLS
   moment matrix (too few nodes covering a quadrature point's support -> rank-deficient) produced silently
   garbage shape functions that `np.linalg.solve` does not flag (near-, not exactly, singular). The

--- a/mfgarchon/alg/reinforcement/algorithms/mean_field_ddpg.py
+++ b/mfgarchon/alg/reinforcement/algorithms/mean_field_ddpg.py
@@ -503,13 +503,20 @@ class MeanFieldDDPG:
 
             done = False
             while not done:
-                # Get population state
-                # Backend compatibility - gym environment API (Issue #543 acceptable)
-                # hasattr checks for optional get_population_state() method on MFG environments
-                if hasattr(self.env, "get_population_state"):
-                    pop_state = self.env.get_population_state().density_histogram.flatten()
-                else:
-                    pop_state = np.zeros(self.population_dim)
+                # Get population state. Issue #1508: get_population_state is a REQUIRED capability of a
+                # mean-field env, NOT optional backend detection. The former hasattr -> np.zeros fallback
+                # silently trained on an identically-zero mean field (the coupling channel that DEFINES a
+                # mean-field game), returning a policy the user trusts while MFG was never active. Fail
+                # loud (getattr + callable, per the repo's no-hasattr-duck-typing rule).
+                _pop_getter = getattr(self.env, "get_population_state", None)
+                if not callable(_pop_getter):
+                    raise AttributeError(
+                        f"{type(self.env).__name__} has no get_population_state(): a mean-field RL env "
+                        f"must expose the population density (the MFG coupling channel). A zero fallback "
+                        f"would train on an identically-zero mean field and silently return a non-MFG "
+                        f"policy (Issue #1508)."
+                    )
+                pop_state = _pop_getter().density_histogram.flatten()
 
                 # Select action
                 action = self.select_action(state, pop_state, training=True)
@@ -518,12 +525,11 @@ class MeanFieldDDPG:
                 next_observations, reward, terminated, truncated, _ = self.env.step(action)
                 next_state = next_observations[0] if isinstance(next_observations, list | tuple) else next_observations
 
-                # Get next population state
-                # Backend compatibility - gym environment API (Issue #543 acceptable)
-                if hasattr(self.env, "get_population_state"):
-                    next_pop_state = self.env.get_population_state().density_histogram.flatten()
-                else:
-                    next_pop_state = np.zeros(self.population_dim)
+                # Get next population state (required capability; see above, Issue #1508).
+                _pop_getter = getattr(self.env, "get_population_state", None)
+                if not callable(_pop_getter):
+                    raise AttributeError(f"{type(self.env).__name__} has no get_population_state() (Issue #1508).")
+                next_pop_state = _pop_getter().density_histogram.flatten()
 
                 # Store transition
                 # Handle both scalar and array rewards

--- a/mfgarchon/alg/reinforcement/algorithms/mean_field_sac.py
+++ b/mfgarchon/alg/reinforcement/algorithms/mean_field_sac.py
@@ -436,13 +436,20 @@ class MeanFieldSAC:
 
             done = False
             while not done:
-                # Get population state
-                # Backend compatibility - gym environment API (Issue #543 acceptable)
-                # hasattr checks for optional get_population_state() method on MFG environments
-                if hasattr(self.env, "get_population_state"):
-                    pop_state = self.env.get_population_state().density_histogram.flatten()
-                else:
-                    pop_state = np.zeros(self.population_dim)
+                # Get population state. Issue #1508: get_population_state is a REQUIRED capability of a
+                # mean-field env, NOT optional backend detection. The former hasattr -> np.zeros fallback
+                # silently trained on an identically-zero mean field (the coupling channel that DEFINES a
+                # mean-field game), returning a policy the user trusts while MFG was never active. Fail
+                # loud (getattr + callable, per the repo's no-hasattr-duck-typing rule).
+                _pop_getter = getattr(self.env, "get_population_state", None)
+                if not callable(_pop_getter):
+                    raise AttributeError(
+                        f"{type(self.env).__name__} has no get_population_state(): a mean-field RL env "
+                        f"must expose the population density (the MFG coupling channel). A zero fallback "
+                        f"would train on an identically-zero mean field and silently return a non-MFG "
+                        f"policy (Issue #1508)."
+                    )
+                pop_state = _pop_getter().density_histogram.flatten()
 
                 # Select action (stochastic during training)
                 action = self.select_action(state, pop_state, training=True)
@@ -451,12 +458,11 @@ class MeanFieldSAC:
                 next_observations, reward, terminated, truncated, _ = self.env.step(action)
                 next_state = next_observations[0] if isinstance(next_observations, list | tuple) else next_observations
 
-                # Get next population state
-                # Backend compatibility - gym environment API (Issue #543 acceptable)
-                if hasattr(self.env, "get_population_state"):
-                    next_pop_state = self.env.get_population_state().density_histogram.flatten()
-                else:
-                    next_pop_state = np.zeros(self.population_dim)
+                # Get next population state (required capability; see above, Issue #1508).
+                _pop_getter = getattr(self.env, "get_population_state", None)
+                if not callable(_pop_getter):
+                    raise AttributeError(f"{type(self.env).__name__} has no get_population_state() (Issue #1508).")
+                next_pop_state = _pop_getter().density_histogram.flatten()
 
                 # Store transition
                 if isinstance(reward, int | float | np.floating):

--- a/mfgarchon/alg/reinforcement/algorithms/mean_field_td3.py
+++ b/mfgarchon/alg/reinforcement/algorithms/mean_field_td3.py
@@ -361,13 +361,20 @@ class MeanFieldTD3:
 
             done = False
             while not done:
-                # Get population state
-                # Backend compatibility - gym environment API (Issue #543 acceptable)
-                # hasattr checks for optional get_population_state() method on MFG environments
-                if hasattr(self.env, "get_population_state"):
-                    pop_state = self.env.get_population_state().density_histogram.flatten()
-                else:
-                    pop_state = np.zeros(self.population_dim)
+                # Get population state. Issue #1508: get_population_state is a REQUIRED capability of a
+                # mean-field env, NOT optional backend detection. The former hasattr -> np.zeros fallback
+                # silently trained on an identically-zero mean field (the coupling channel that DEFINES a
+                # mean-field game), returning a policy the user trusts while MFG was never active. Fail
+                # loud (getattr + callable, per the repo's no-hasattr-duck-typing rule).
+                _pop_getter = getattr(self.env, "get_population_state", None)
+                if not callable(_pop_getter):
+                    raise AttributeError(
+                        f"{type(self.env).__name__} has no get_population_state(): a mean-field RL env "
+                        f"must expose the population density (the MFG coupling channel). A zero fallback "
+                        f"would train on an identically-zero mean field and silently return a non-MFG "
+                        f"policy (Issue #1508)."
+                    )
+                pop_state = _pop_getter().density_histogram.flatten()
 
                 # Select action
                 action = self.select_action(state, pop_state, training=True)
@@ -376,12 +383,11 @@ class MeanFieldTD3:
                 next_observations, reward, terminated, truncated, _ = self.env.step(action)
                 next_state = next_observations[0] if isinstance(next_observations, list | tuple) else next_observations
 
-                # Get next population state
-                # Backend compatibility - gym environment API (Issue #543 acceptable)
-                if hasattr(self.env, "get_population_state"):
-                    next_pop_state = self.env.get_population_state().density_histogram.flatten()
-                else:
-                    next_pop_state = np.zeros(self.population_dim)
+                # Get next population state (required capability; see above, Issue #1508).
+                _pop_getter = getattr(self.env, "get_population_state", None)
+                if not callable(_pop_getter):
+                    raise AttributeError(f"{type(self.env).__name__} has no get_population_state() (Issue #1508).")
+                next_pop_state = _pop_getter().density_histogram.flatten()
 
                 # Store transition
                 # Handle both scalar and array rewards

--- a/tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py
+++ b/tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py
@@ -1,0 +1,44 @@
+"""Issue #1508: mean-field RL (DDPG/TD3/SAC) must FAIL LOUD when the env lacks get_population_state()
+instead of silently zero-filling the population state (which trains on an identically-zero mean field
+-> a non-MFG policy the user trusts). get_population_state is a required MFG-coupling capability."""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+torch = pytest.importorskip("torch", reason="mean-field RL algorithms require PyTorch")
+
+
+class _EnvWithoutPopState:
+    """A minimal env that reset()s but does NOT expose get_population_state (the MFG coupling channel)."""
+
+    def reset(self):
+        return np.zeros(2, dtype=np.float32), {}
+
+    def step(self, action):  # pragma: no cover - the guard raises before we get here
+        return np.zeros(2, dtype=np.float32), 0.0, True, False, {}
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("mfgarchon.alg.reinforcement.algorithms.mean_field_ddpg", "MeanFieldDDPG"),
+        ("mfgarchon.alg.reinforcement.algorithms.mean_field_td3", "MeanFieldTD3"),
+        ("mfgarchon.alg.reinforcement.algorithms.mean_field_sac", "MeanFieldSAC"),
+    ],
+)
+def test_missing_get_population_state_fails_loud(module_name, class_name):
+    import importlib
+
+    algo_cls = getattr(importlib.import_module(module_name), class_name)
+    algo = algo_cls(
+        env=_EnvWithoutPopState(),
+        state_dim=2,
+        action_dim=1,
+        population_dim=4,
+        action_bounds=(-1.0, 1.0),
+    )
+    with pytest.raises(AttributeError, match="1508"):
+        algo.train(num_episodes=1)


### PR DESCRIPTION
Closes #1508. **CRITICAL fail-silent (silent-wrong)** from the repo anti-pattern audit.

A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state = np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean field** for the whole run — the algorithm 'converges' and returns a policy/Q the user trusts as an MFG solution while the coupling channel that *defines* a mean-field game was dead.

`get_population_state` is a **required** capability, not optional backend detection (the `#543 acceptable` comment mislabeled a mandatory interface). All **six sites** (current + next population state, across DDPG/TD3/SAC) now fail loud via `getattr` + `callable` + `raise`, per the repo's no-hasattr-duck-typing / no-silent-fallback rules.

**Verified**: new `test_mean_field_rl_requires_pop_state_1508` pins the raise for all three algorithms (3 pass); 0 silent zero-fills remain.

Closes #1508.