### PR TITLE
fix(utils): drop one-sided clip in central functional derivative (#1514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Central-difference functional derivative was biased in density tails** (Issue #1514, clipping). The
+  central-mode `FiniteDifferenceFunctionalDerivative` clipped only the BACKWARD perturbation
+  (`np.maximum(., 0)`) while the forward step was uncapped and the quotient divided by the full ε, so at
+  points where `measure[y] < ε/2` (routine in distribution tails) the stencil became asymmetric ->
+  silently biased δU/δm. The clip is dropped: the module's own contract is that a perturbed measure need
+  not be a probability measure. Found by the repo anti-pattern audit. Pinned by
+  `test_central_difference_unbiased_at_low_density_tail`.
+
 - **Mean-field RL (DDPG/TD3/SAC) silently zero-filled the population state** (Issue #1508, silent-wrong,
   fail-silent). A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state =
   np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean

--- a/mfgarchon/utils/functional_calculus.py
+++ b/mfgarchon/utils/functional_calculus.py
@@ -235,10 +235,14 @@ class FiniteDifferenceFunctionalDerivative(FunctionalDerivative):
                 derivative = (U_perturbed - U_baseline) / self.epsilon
             elif self.method == "central":
                 # Central difference: (U[m + ε/2 δ_y] - U[m - ε/2 δ_y]) / ε
-                # Backward perturbation
+                # Backward perturbation. Issue #1514: do NOT clip to non-negativity here. The forward
+                # perturbation is uncapped and the quotient divides by the full ε, so clipping only the
+                # backward step (which fires when measure[y_idx] < ε/2, i.e. in density tails) makes the
+                # stencil asymmetric -> a silently biased derivative exactly at low-density points. The
+                # module's own contract (see the forward branch above) is that a perturbed measure need
+                # NOT be a probability measure, so the clip is both wrong and unnecessary.
                 backward_measure = measure.copy()
                 backward_measure[y_idx] -= self.epsilon / 2
-                backward_measure = np.maximum(backward_measure, 0)  # Keep non-negative
 
                 U_backward = functional(backward_measure)
 

--- a/tests/unit/test_utils/test_functional_calculus.py
+++ b/tests/unit/test_utils/test_functional_calculus.py
@@ -87,6 +87,23 @@ class TestFiniteDifferenceFunctionalDerivative:
         # Central should be more accurate
         assert central_error < forward_error
 
+    def test_central_difference_unbiased_at_low_density_tail(self):
+        """Issue #1514: the central stencil must not clip ONLY the backward perturbation, which biases
+        the derivative where measure[y] < epsilon/2 (density tails). For a LINEAR functional the
+        derivative is exactly V everywhere; the old one-sided np.maximum(.,0) clip gave ~0.6*V at a
+        tail point (backward step truncated to measure[y] while dividing by the full epsilon)."""
+        v = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        def linear_functional(m):
+            return float(np.sum(v * m))
+
+        eps = 1e-4
+        # index 0 is a density tail below epsilon/2 = 5e-5 -> the old clip fired here
+        measure = np.array([1e-5, 0.3, 0.3, 0.2, 0.2])
+        op = FiniteDifferenceFunctionalDerivative(epsilon=eps, method="central")
+        deriv = op.compute(linear_functional, measure, None, np.arange(5))
+        np.testing.assert_allclose(deriv, v, rtol=1e-9)  # exact for a linear functional, incl. the tail
+
     def test_second_order_derivative(self):
         """Test second-order functional derivative computation."""
 


### PR DESCRIPTION
Closes #1514. **MODERATE clipping** from the repo anti-pattern audit.

Central-mode `FiniteDifferenceFunctionalDerivative` clipped **only** the backward perturbation (`np.maximum(., 0)`) while the forward step was uncapped and the quotient divided by the full ε. At points where `measure[y] < ε/2` (routine in density tails) the stencil became asymmetric → **silently biased δU/δm**.

**Fix**: drop the clip — the module's own contract (the forward-branch comment) is that a perturbed measure need not be a probability measure, so the clip is both wrong and unnecessary.

**Verified**: new `test_central_difference_unbiased_at_low_density_tail` pins an exact (linear-functional) derivative at a tail point below ε/2; the full suite passes.

Closes #1514.