### PR TITLE
fix(fp): nD particle KDE failure raises like the 1D twin, not silent histogram (#1513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **nD particle KDE failure swallowed to histogram while 1D raises** (Issue #1513, parallel-path). The nD
+  `_estimate_density_from_particles_nd` caught any KDE failure and silently substituted a `histogramdd`
+  estimate (weak warning), while the 1D twin `_estimate_density_from_particles` raises `RuntimeError` for
+  the same failure -- a dimension-dependent raise-vs-swallow divergence that ran a coupled solve on a
+  lower-quality estimator in nD without the user knowing. The nD path now fails loud with the same
+  RuntimeError; request a histogram explicitly via `kde_method` rather than a silent fallback. Found by
+  the repo anti-pattern audit. Pinned by `test_nd_kde_failure_fails_loud_like_1d`.
+
 - **Mean-field RL (DDPG/TD3/SAC) silently zero-filled the population state** (Issue #1508, silent-wrong,
   fail-silent). A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state =
   np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -1197,15 +1196,24 @@ class FPParticleSolver(BaseFPSolver):
             return density_reshaped
 
         except Exception as e:
-            warnings.warn(f"KDE failed in nD: {e}. Returning histogram estimate.")
-            # Fallback to histogram
-            density, _ = np.histogramdd(
-                particles,
-                bins=[len(c) for c in coordinates],
-                range=bounds,
-                density=True,
-            )
-            return density
+            # Issue #1513: fail loud, matching the 1D twin (_estimate_density_from_particles raises
+            # RuntimeError for the same failure). The former histogram fallback silently swapped the
+            # density estimator mid-solve in nD ONLY -- a dimension-dependent raise-vs-swallow
+            # divergence -- so a coupled solve ran on a lower-quality estimate without the user knowing.
+            # Same failure -> same policy. For an explicit histogram estimate, request it via kde_method
+            # rather than relying on a silent fallback.
+            raise RuntimeError(
+                f"KDE density estimation failed in FPParticleSolver (nD): {e}\n"
+                f"Number of particles: {len(particles)}\n"
+                f"Bandwidth: {self.kde_bandwidth}\n"
+                "Possible causes:\n"
+                "  1. Too few particles for reliable KDE (need at least 10-20)\n"
+                "  2. Bandwidth selection failed (try fixed bandwidth like 0.1)\n"
+                "  3. Particles outside domain bounds\n"
+                "Suggestions:\n"
+                "  - Increase number of particles (Np > 100 recommended)\n"
+                "  - Use fixed bandwidth: kde_bandwidth=0.1"
+            ) from e
 
     def _estimate_density_from_particles(self, particles_at_time_t: np.ndarray) -> np.ndarray:
         # Use geometry-aware parameter extraction

--- a/tests/unit/test_alg/test_fp_particle.py
+++ b/tests/unit/test_alg/test_fp_particle.py
@@ -77,6 +77,23 @@ class TestFPParticleSolverBasic:
         assert solver.fp_method_name == "Particle"
         assert solver.num_particles == 100
 
+    def test_nd_kde_failure_fails_loud_like_1d(self):
+        """Issue #1513: an nD KDE failure must raise RuntimeError (matching the 1D twin
+        _estimate_density_from_particles), not silently substitute a histogram estimate. Dimension
+        must not decide raise-vs-swallow."""
+        problem = Simple2DMFGProblem()
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        def _boom(*args, **kwargs):
+            raise np.linalg.LinAlgError("forced singular KDE")
+
+        solver._apply_kde_method_nd = _boom  # force the KDE core to fail
+        particles = np.random.RandomState(0).rand(50, 2)
+        coords = [np.linspace(0.0, 1.0, 11), np.linspace(0.0, 1.0, 11)]
+        bounds = [(0.0, 1.0), (0.0, 1.0)]
+        with pytest.raises(RuntimeError, match="KDE density estimation failed"):
+            solver._estimate_density_from_particles_nd(particles, coords, bounds)
+
     def test_output_shape(self):
         """Test that solver outputs density on grid."""
         problem = Simple2DMFGProblem()


### PR DESCRIPTION
Closes #1513. **MODERATE parallel-path** from the repo anti-pattern audit.

`_estimate_density_from_particles_nd` caught any KDE failure and **silently substituted a `histogramdd` estimate**, while the 1D twin `_estimate_density_from_particles` **raises `RuntimeError`** for the same failure. Dimension decided raise-vs-swallow → an nD coupled solve ran on a lower-quality estimator without the user knowing.

**Fix**: single-source the failure policy — the nD path now fails loud with the same detailed `RuntimeError` (fail-fast, matching 1D). An explicit histogram is available via `kde_method`, not a silent fallback.

**Verified**: 13 particle tests pass; new `test_nd_kde_failure_fails_loud_like_1d` forces the nD failure path and pins the raise.

Closes #1513.