### PR TITLE
fix: repair two CI-red regressions on main (FEEC enum + SD-guard on mocks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI hotfix: two unreleased-cycle regressions on main** (found by the full CI/CD Pipeline, missed by the
+  fast tier). `SchemeFamily.FEEC` (#1502) made the enum 9 members -> updated `test_enum_iteration`. The
+  SD-duality guard (#1489/#1504) compared `getattr(solver, "_sd_scale", None)`, which resolves to an
+  unequal Mock (not None) for bare `Mock()` test doubles and tripped the guard -> now compares only real
+  numeric SD-scales (`isinstance(., (int, float))`), robust for production and inert for mocks.
+
 - **Mean-field RL (DDPG/TD3/SAC) silently zero-filled the population state** (Issue #1508, silent-wrong,
   fail-silent). A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state =
   np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -164,10 +164,12 @@ class FixedPointIterator(BaseCouplingIterator):
         # Issue #1489 (SD-duality): a weak-form pair must share streamline_diffusion_scale, else the
         # symmetric SD block is added to only one side and the Type-A transpose identity A_FP = A_HJB^T
         # breaks silently. The factory (create_paired_solvers) threads this across the pair; guard the
-        # hand-built case here too. Only weak-form solvers carry `_sd_scale`; others return None (skip).
+        # hand-built case here too. Only weak-form solvers carry a NUMERIC `_sd_scale`; others lack the
+        # attr (getattr -> None). Compare only real numbers so bare Mock() test doubles -- whose
+        # `_sd_scale` auto-resolves to an unequal Mock, not None -- do not trip the guard (#1489).
         hjb_sd = getattr(hjb_solver, "_sd_scale", None)
         fp_sd = getattr(fp_solver, "_sd_scale", None)
-        if hjb_sd is not None and fp_sd is not None and hjb_sd != fp_sd:
+        if isinstance(hjb_sd, (int, float)) and isinstance(fp_sd, (int, float)) and hjb_sd != fp_sd:
             raise ValueError(
                 f"Paired HJB / FP solvers have different streamline_diffusion_scale (HJB={hjb_sd}, "
                 f"FP={fp_sd}); the SD block would be added to only one side and A_FP = A_HJB^T breaks "

--- a/tests/unit/test_alg/test_scheme_family.py
+++ b/tests/unit/test_alg/test_scheme_family.py
@@ -47,10 +47,11 @@ class TestSchemeFamilyEnum:
     def test_enum_iteration(self):
         """Test that enum can be iterated."""
         families = list(SchemeFamily)
-        assert len(families) == 8
+        assert len(families) == 9  # FDM, SL, FVM, FEM, GFDM, MESHLESS_GALERKIN, FEEC, PINN, GENERIC
         assert SchemeFamily.FDM in families
         assert SchemeFamily.FEM in families
         assert SchemeFamily.MESHLESS_GALERKIN in families
+        assert SchemeFamily.FEEC in families  # Issue #1502 (FEEC scaffold)
         assert SchemeFamily.GENERIC in families
 
 


### PR DESCRIPTION
Main's full **CI/CD Pipeline** (slow tests, skipped on PRs) went red after #1502/#1504; the fast tier missed both.

1. `test_enum_iteration` asserted 8 `SchemeFamily` members; **#1502** (FEEC) made it 9 → updated the count + explicit FEEC assertion.
2. `test_fixed_point_nan_early_termination` uses bare `Mock()` solvers; the **#1504** SD-duality guard did `getattr(solver, "_sd_scale", None)`, which on a Mock auto-resolves to a Mock (not None) → the guard raised. Now compares only **real numeric** `_sd_scale` (`isinstance(., (int,float))`) — unchanged for real solvers, inert for mocks.

**Verified**: broad local sweep (test_alg + test_utils + test_geometry + fem + convention) = **3107 passed, 0 failed**. Will wait for the full CI/CD Pipeline green before merge.