### PR TITLE
fix: three anti-pattern-audit moderates — sigma/diffusion, functional clip, nD KDE (#1512 #1513 #1514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RuntimeError; request a histogram explicitly via `kde_method` rather than a silent fallback. Found by
   the repo anti-pattern audit. Pinned by `test_nd_kde_failure_fails_loud_like_1d`.
 
+- **Central-difference functional derivative was biased in density tails** (Issue #1514, clipping). The
+  central-mode `FiniteDifferenceFunctionalDerivative` clipped only the BACKWARD perturbation
+  (`np.maximum(., 0)`) while the forward step was uncapped and the quotient divided by the full ε, so at
+  points where `measure[y] < ε/2` (routine in distribution tails) the stencil became asymmetric ->
+  silently biased δU/δm. The clip is dropped: the module's own contract is that a perturbed measure need
+  not be a probability measure. Found by the repo anti-pattern audit. Pinned by
+  `test_central_difference_unbiased_at_low_density_tail`.
+
 - **Mean-field RL (DDPG/TD3/SAC) silently zero-filled the population state** (Issue #1508, silent-wrong,
   fail-silent). A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state =
   np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unequal Mock (not None) for bare `Mock()` test doubles and tripped the guard -> now compares only real
   numeric SD-scales (`isinstance(., (int, float))`), robust for production and inert for mocks.
 
+- **AdjointConsistentProvider: sigma/diffusion name collision** (Issue #1512, hardcoded-convention). The
+  provider's parameter (and state key) was named `diffusion` but held the SDE volatility σ -- it is
+  squared internally (`-(σ²)/2`) -- colliding with the codebase-wide convention where `problem.diffusion`
+  = D = σ²/2. Wiring `AdjointConsistentProvider(diffusion=problem.diffusion)` would silently give a Robin
+  BC wrong by σ²/4. Reverted the mistaken v0.17.0 `sigma`->`diffusion` rename: **`sigma` is now canonical**
+  (matching `problem.sigma`), and `diffusion` is the deprecated alias (still σ). Found by the repo
+  anti-pattern audit. Pinned by the updated `test_bc_providers`.
+
 - **Mean-field RL (DDPG/TD3/SAC) silently zero-filled the population state** (Issue #1508, silent-wrong,
   fail-silent). A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state =
   np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (matching `problem.sigma`), and `diffusion` is the deprecated alias (still σ). Found by the repo
   anti-pattern audit. Pinned by the updated `test_bc_providers`.
 
+- **nD particle KDE failure swallowed to histogram while 1D raises** (Issue #1513, parallel-path). The nD
+  `_estimate_density_from_particles_nd` caught any KDE failure and silently substituted a `histogramdd`
+  estimate (weak warning), while the 1D twin `_estimate_density_from_particles` raises `RuntimeError` for
+  the same failure -- a dimension-dependent raise-vs-swallow divergence that ran a coupled solve on a
+  lower-quality estimator in nD without the user knowing. The nD path now fails loud with the same
+  RuntimeError; request a histogram explicitly via `kde_method` rather than a silent fallback. Found by
+  the repo anti-pattern audit. Pinned by `test_nd_kde_failure_fails_loud_like_1d`.
+
 - **Mean-field RL (DDPG/TD3/SAC) silently zero-filled the population state** (Issue #1508, silent-wrong,
   fail-silent). A `hasattr(env, 'get_population_state')` guard whose else-branch set `pop_state =
   np.zeros(...)` meant an env lacking the method trained actor/critic on an **identically-zero mean

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -1197,15 +1196,24 @@ class FPParticleSolver(BaseFPSolver):
             return density_reshaped
 
         except Exception as e:
-            warnings.warn(f"KDE failed in nD: {e}. Returning histogram estimate.")
-            # Fallback to histogram
-            density, _ = np.histogramdd(
-                particles,
-                bins=[len(c) for c in coordinates],
-                range=bounds,
-                density=True,
-            )
-            return density
+            # Issue #1513: fail loud, matching the 1D twin (_estimate_density_from_particles raises
+            # RuntimeError for the same failure). The former histogram fallback silently swapped the
+            # density estimator mid-solve in nD ONLY -- a dimension-dependent raise-vs-swallow
+            # divergence -- so a coupled solve ran on a lower-quality estimate without the user knowing.
+            # Same failure -> same policy. For an explicit histogram estimate, request it via kde_method
+            # rather than relying on a silent fallback.
+            raise RuntimeError(
+                f"KDE density estimation failed in FPParticleSolver (nD): {e}\n"
+                f"Number of particles: {len(particles)}\n"
+                f"Bandwidth: {self.kde_bandwidth}\n"
+                "Possible causes:\n"
+                "  1. Too few particles for reliable KDE (need at least 10-20)\n"
+                "  2. Bandwidth selection failed (try fixed bandwidth like 0.1)\n"
+                "  3. Particles outside domain bounds\n"
+                "Suggestions:\n"
+                "  - Increase number of particles (Np > 100 recommended)\n"
+                "  - Use fixed bandwidth: kde_bandwidth=0.1"
+            ) from e
 
     def _estimate_density_from_particles(self, particles_at_time_t: np.ndarray) -> np.ndarray:
         # Use geometry-aware parameter extraction

--- a/mfgarchon/geometry/boundary/providers.py
+++ b/mfgarchon/geometry/boundary/providers.py
@@ -30,12 +30,12 @@ Example:
     ...     name="left_ac",
     ...     bc_type=BCType.ROBIN,
     ...     alpha=0.0, beta=1.0,
-    ...     value=AdjointConsistentProvider(side="left", diffusion=0.2),
+    ...     value=AdjointConsistentProvider(side="left", sigma=0.2),
     ...     boundary="x_min",
     ... )
     >>>
     >>> # Later, iterator resolves provider with current state
-    >>> state = {'m_current': m, 'geometry': geometry, 'diffusion': 0.2}
+    >>> state = {'m_current': m, 'geometry': geometry, 'sigma': 0.2}
     >>> concrete_value = segment.value.compute(state)
 
 References:
@@ -76,20 +76,20 @@ class BCProviderState(TypedDict, total=False):
     Required by AdjointConsistentProvider:
         m_current: Current FP density array
         geometry: Problem geometry object
-        diffusion: Diffusion coefficient σ (or legacy 'sigma')
+        sigma: SDE volatility σ (canonical; or the deprecated 'diffusion' key -- also σ, Issue #1512)
 
     Optional (context-dependent):
         U_current: Current value function array
         t: Current time (for time-dependent problems)
         iteration: Current Picard iteration number
-        sigma: Legacy alias for diffusion (deprecated)
+        diffusion: Deprecated alias for 'sigma' (Issue #1512): the key holds σ, NOT D = σ²/2
     """
 
     m_current: NDArray[np.floating]
     U_current: NDArray[np.floating]
     geometry: GeometryProtocol
-    diffusion: float
-    sigma: float  # Deprecated, use diffusion
+    sigma: float
+    diffusion: float  # Deprecated (Issue #1512), use 'sigma'
     t: float
     iteration: int
 
@@ -129,8 +129,8 @@ class BCValueProvider(Protocol):
                 - 'm_current': Current FP density array
                 - 'U_current': Current value function array
                 - 'geometry': Problem geometry object
-                - 'diffusion': Diffusion coefficient (canonical)
-                - 'sigma': Diffusion coefficient (legacy alias, deprecated)
+                - 'sigma': SDE volatility σ (canonical)
+                - 'diffusion': deprecated alias for 'sigma' (σ, not D = σ²/2; Issue #1512)
                 - 't': Current time (for time-dependent problems)
                 - 'iteration': Current Picard iteration number
 
@@ -180,10 +180,10 @@ class AdjointConsistentProvider(BaseBCValueProvider):
     Computes the Robin BC value for reflecting boundaries that maintains
     adjoint consistency between HJB and FP equations:
 
-        g = -σ²/2 · d(ln m)/dn = -(diffusion²)/2 · d(ln m)/dn
+        g = -σ²/2 · d(ln m)/dn
 
     where:
-        - diffusion: diffusion coefficient σ (NOT σ²)
+        - sigma: SDE volatility σ (NOT the PDE diffusion D = σ²/2; Issue #1512)
         - m: current FP density
         - d/dn: outward normal derivative at boundary
 
@@ -218,7 +218,7 @@ class AdjointConsistentProvider(BaseBCValueProvider):
 
     Example:
         >>> # Appropriate: boundary stall configuration
-        >>> provider = AdjointConsistentProvider(side="left", diffusion=0.04)
+        >>> provider = AdjointConsistentProvider(side="left", sigma=0.04)
         >>> state = {'m_current': m_array, 'geometry': geom}
         >>> g_left = provider.compute(state)  # Robin BC value at left boundary
 
@@ -249,17 +249,17 @@ class AdjointConsistentProvider(BaseBCValueProvider):
     }
 
     @deprecated_parameter(
-        param_name="sigma",
-        since="v0.17.0",
-        replacement="diffusion",
+        param_name="diffusion",
+        since="v0.20.5",
+        replacement="sigma",
     )
     def __init__(
         self,
         side: str,
-        diffusion: float | None = None,
+        sigma: float | None = None,
         regularization: float = 1e-10,
         *,
-        sigma: float | None = None,  # Legacy alias, deprecated
+        diffusion: float | None = None,  # Deprecated alias for sigma (misnomer; Issue #1512)
     ) -> None:
         """
         Initialize adjoint-consistent BC provider.
@@ -269,24 +269,28 @@ class AdjointConsistentProvider(BaseBCValueProvider):
                 - 1D: "left", "right", "x_min", "x_max", "min", "max"
                 - 2D: "y_min", "y_max", "bottom", "top"
                 - 3D: "z_min", "z_max", "front", "back"
-            diffusion: Diffusion coefficient σ. If None, reads from state.
+            sigma: SDE volatility σ (NOT the PDE diffusion D = σ²/2 -- the value is squared internally).
+                If None, reads from state. Named to match the codebase convention (``problem.sigma`` = σ,
+                ``problem.diffusion`` = σ²/2); passing the D-valued ``problem.diffusion`` here is the
+                Issue #1512 trap this canonical name removes.
             regularization: Small positive constant added to density
                            to prevent log(0). Default 1e-10.
-            sigma: DEPRECATED. Use diffusion instead.
+            diffusion: DEPRECATED (Issue #1512): a misnomer -- this argument is σ, not D, and the name
+                collided with the ``D = σ²/2`` convention. Use ``sigma``.
         """
         if side not in self._SIDE_ALIASES:
             valid = sorted(self._SIDE_ALIASES.keys())
             raise ValueError(f"side must be one of {valid}, got '{side}'")
 
-        # Handle sigma as legacy alias (deprecated)
-        if sigma is not None:
-            if diffusion is None:
-                diffusion = sigma
+        # Issue #1512: `diffusion` was a misnamed alias for σ (it is squared in compute) that collided
+        # with the codebase D = σ²/2 convention. `sigma` is now canonical; `diffusion` redirects to it.
+        if diffusion is not None and sigma is None:
+            sigma = diffusion
 
         # Store both original and normalized side names
         self._original_side = side
         self.side = self._SIDE_ALIASES[side]  # Normalize to canonical form
-        self.diffusion = diffusion
+        self.sigma = sigma
         self.regularization = regularization
 
     def compute(self, state: dict[str, Any]) -> float:
@@ -322,16 +326,17 @@ class AdjointConsistentProvider(BaseBCValueProvider):
             raise KeyError("AdjointConsistentProvider requires 'geometry' in state")
 
         # Get diffusion coefficient (try constructor, then state)
-        diffusion = self.diffusion
-        if diffusion is None:
-            # Look for 'diffusion' first (canonical), then 'sigma' (legacy)
-            diffusion = state.get("diffusion")
-            if diffusion is None:
-                diffusion = state.get("sigma")
-            if diffusion is None:
+        sigma = self.sigma
+        if sigma is None:
+            # Issue #1512: 'sigma' is canonical (σ); 'diffusion' is the deprecated key -- also σ here,
+            # NOT the D = σ²/2 the same word means elsewhere.
+            sigma = state.get("sigma")
+            if sigma is None:
+                sigma = state.get("diffusion")
+            if sigma is None:
                 raise KeyError(
-                    "AdjointConsistentProvider: diffusion not set in constructor "
-                    "and neither 'diffusion' nor 'sigma' found in state"
+                    "AdjointConsistentProvider: volatility not set in constructor "
+                    "and neither 'sigma' nor 'diffusion' found in state"
                 )
 
         # Compute log-density gradient at boundary
@@ -339,7 +344,7 @@ class AdjointConsistentProvider(BaseBCValueProvider):
         grad_ln_m = self._compute_boundary_log_gradient(m, geometry, self.side, self.regularization)
 
         # Robin BC value: g = -σ²/2 * d(ln m)/dn
-        return -(diffusion**2) / 2 * grad_ln_m
+        return -(sigma**2) / 2 * grad_ln_m
 
     def _compute_boundary_log_gradient(
         self,
@@ -381,9 +386,9 @@ class AdjointConsistentProvider(BaseBCValueProvider):
             )
 
     def __repr__(self) -> str:
-        diff_str = f"{self.diffusion}" if self.diffusion is not None else "from_state"
+        sig_str = f"{self.sigma}" if self.sigma is not None else "from_state"
         # Show original side name for user clarity
-        return f"AdjointConsistentProvider(side='{self._original_side}', diffusion={diff_str})"
+        return f"AdjointConsistentProvider(side='{self._original_side}', sigma={sig_str})"
 
 
 class ConstantProvider(BaseBCValueProvider):
@@ -465,7 +470,7 @@ if __name__ == "__main__":
 
     # Test 1: Protocol check
     print("Test 1: Protocol compliance")
-    provider = AdjointConsistentProvider(side="left", diffusion=0.2)
+    provider = AdjointConsistentProvider(side="left", sigma=0.2)
     assert isinstance(provider, BCValueProvider), "Should implement protocol"
     assert is_provider(provider), "is_provider() should return True"
     assert not is_provider(1.5), "Float should not be a provider"
@@ -492,14 +497,14 @@ if __name__ == "__main__":
 
     # Left boundary: outward normal is -x, so d(ln m)/dn = -(-1) = 1
     # g = -0.2^2/2 * 1 = -0.02
-    left_provider = AdjointConsistentProvider(side="left", diffusion=0.2)
+    left_provider = AdjointConsistentProvider(side="left", sigma=0.2)
     g_left = left_provider.compute(state)
     expected_left = -(0.2**2) / 2 * 1.0  # -0.02
     print(f"  Left BC value: {g_left:.6f} (expected ~ {expected_left:.6f})")
 
     # Right boundary: outward normal is +x, so d(ln m)/dn = -1
     # g = -0.2^2/2 * (-1) = 0.02
-    right_provider = AdjointConsistentProvider(side="right", diffusion=0.2)
+    right_provider = AdjointConsistentProvider(side="right", sigma=0.2)
     g_right = right_provider.compute(state)
     expected_right = -(0.2**2) / 2 * (-1.0)  # 0.02
     print(f"  Right BC value: {g_right:.6f} (expected ~ {expected_right:.6f})")
@@ -516,7 +521,7 @@ if __name__ == "__main__":
 
     # Test 4: Diffusion from state (not constructor)
     print("Test 4: Diffusion from state (not constructor)")
-    provider_no_diff = AdjointConsistentProvider(side="left", diffusion=None)
+    provider_no_diff = AdjointConsistentProvider(side="left", sigma=None)
     g_from_state = provider_no_diff.compute(state)
     assert abs(g_from_state - g_left) < 1e-10, "Should use diffusion from state"
     print("  Diffusion correctly read from state when not in constructor")
@@ -529,21 +534,21 @@ if __name__ == "__main__":
         "geometry": MockGeometry(),
         "sigma": 0.2,  # Legacy parameter name
     }
-    provider_legacy = AdjointConsistentProvider(side="left", diffusion=None)
+    provider_legacy = AdjointConsistentProvider(side="left", sigma=None)
     g_legacy = provider_legacy.compute(state_legacy)
     assert abs(g_legacy - g_left) < 1e-10, "Should accept 'sigma' in state for backward compat"
     print("  Legacy 'sigma' key in state works correctly")
     print()
 
-    # Test 6: Deprecated 'sigma' parameter (backward compatibility)
-    print("Test 6: Deprecated 'sigma' parameter (shows warning)")
+    # Test 6: Deprecated 'diffusion' parameter (Issue #1512: 'diffusion' is a misnomer for sigma)
+    print("Test 6: Deprecated 'diffusion' parameter (shows warning)")
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        provider_deprecated = AdjointConsistentProvider(side="left", sigma=0.2)
+        provider_deprecated = AdjointConsistentProvider(side="left", diffusion=0.2)
         assert len(w) == 1, "Should emit deprecation warning"
         assert "deprecated" in str(w[0].message).lower()
-        assert provider_deprecated.diffusion == 0.2, "sigma should map to diffusion"
-    print("  Deprecated 'sigma' parameter works with warning")
+        assert provider_deprecated.sigma == 0.2, "diffusion should map to sigma"
+    print("  Deprecated 'diffusion' parameter works with warning")
     print()
 
     print("All provider tests passed!")

--- a/mfgarchon/utils/functional_calculus.py
+++ b/mfgarchon/utils/functional_calculus.py
@@ -235,10 +235,14 @@ class FiniteDifferenceFunctionalDerivative(FunctionalDerivative):
                 derivative = (U_perturbed - U_baseline) / self.epsilon
             elif self.method == "central":
                 # Central difference: (U[m + ε/2 δ_y] - U[m - ε/2 δ_y]) / ε
-                # Backward perturbation
+                # Backward perturbation. Issue #1514: do NOT clip to non-negativity here. The forward
+                # perturbation is uncapped and the quotient divides by the full ε, so clipping only the
+                # backward step (which fires when measure[y_idx] < ε/2, i.e. in density tails) makes the
+                # stencil asymmetric -> a silently biased derivative exactly at low-density points. The
+                # module's own contract (see the forward branch above) is that a perturbed measure need
+                # NOT be a probability measure, so the clip is both wrong and unnecessary.
                 backward_measure = measure.copy()
                 backward_measure[y_idx] -= self.epsilon / 2
-                backward_measure = np.maximum(backward_measure, 0)  # Keep non-negative
 
                 U_backward = functional(backward_measure)
 

--- a/tests/unit/test_alg/test_fp_particle.py
+++ b/tests/unit/test_alg/test_fp_particle.py
@@ -77,6 +77,23 @@ class TestFPParticleSolverBasic:
         assert solver.fp_method_name == "Particle"
         assert solver.num_particles == 100
 
+    def test_nd_kde_failure_fails_loud_like_1d(self):
+        """Issue #1513: an nD KDE failure must raise RuntimeError (matching the 1D twin
+        _estimate_density_from_particles), not silently substitute a histogram estimate. Dimension
+        must not decide raise-vs-swallow."""
+        problem = Simple2DMFGProblem()
+        solver = FPParticleSolver(problem, num_particles=50)
+
+        def _boom(*args, **kwargs):
+            raise np.linalg.LinAlgError("forced singular KDE")
+
+        solver._apply_kde_method_nd = _boom  # force the KDE core to fail
+        particles = np.random.RandomState(0).rand(50, 2)
+        coords = [np.linspace(0.0, 1.0, 11), np.linspace(0.0, 1.0, 11)]
+        bounds = [(0.0, 1.0), (0.0, 1.0)]
+        with pytest.raises(RuntimeError, match="KDE density estimation failed"):
+            solver._estimate_density_from_particles_nd(particles, coords, bounds)
+
     def test_output_shape(self):
         """Test that solver outputs density on grid."""
         problem = Simple2DMFGProblem()

--- a/tests/unit/test_geometry/test_bc_providers.py
+++ b/tests/unit/test_geometry/test_bc_providers.py
@@ -99,10 +99,10 @@ class TestAdjointConsistentProvider:
         with pytest.raises(ValueError, match="side must be one of"):
             AdjointConsistentProvider(side="invalid", diffusion=0.2)
 
-    def test_init_diffusion_optional(self):
-        """Diffusion can be None (read from state)."""
-        provider = AdjointConsistentProvider(side="left", diffusion=None)
-        assert provider.diffusion is None
+    def test_init_sigma_optional(self):
+        """sigma can be None (read from state)."""
+        provider = AdjointConsistentProvider(side="left", sigma=None)
+        assert provider.sigma is None
 
     def test_compute_with_exponential_density(self):
         """Test computation with exponential density m(x) = exp(-x).
@@ -212,14 +212,15 @@ class TestAdjointConsistentProvider:
         repr_str = repr(provider_no_diff)
         assert "from_state" in repr_str
 
-    def test_deprecated_sigma_parameter(self):
-        """Legacy 'sigma' parameter should work with deprecation warning."""
+    def test_deprecated_diffusion_parameter(self):
+        """Issue #1512: 'diffusion' is now the deprecated alias (a misnomer -- it holds sigma, not the
+        PDE D = sigma^2/2); it must still work, emit a deprecation warning, and map to canonical sigma."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            provider = AdjointConsistentProvider(side="left", sigma=0.2)
+            provider = AdjointConsistentProvider(side="left", diffusion=0.2)
             assert len(w) == 1
             assert "deprecated" in str(w[0].message).lower()
-            assert provider.diffusion == 0.2  # Should map to diffusion
+            assert provider.sigma == 0.2  # maps to the canonical sigma
 
 
 # =============================================================================
@@ -387,15 +388,16 @@ class TestProviderEdgeCases:
         expected = -(0.2**2) / 2 * 1.0  # d(ln m)/dn_left ~ 1
         assert abs(g - expected) < 0.01
 
-    def test_sigma_and_diffusion_both_set_diffusion_wins(self):
-        """When both sigma and diffusion are set, diffusion takes priority."""
+    def test_sigma_and_diffusion_both_set_sigma_wins(self):
+        """Issue #1512: sigma is canonical, so when both are set sigma wins and the deprecated
+        diffusion is ignored (passing diffusion at all still triggers the deprecation warning)."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            provider = AdjointConsistentProvider(side="left", diffusion=0.3, sigma=0.5)
-            # sigma triggers warning
+            provider = AdjointConsistentProvider(side="left", sigma=0.5, diffusion=0.3)
+            # diffusion (deprecated) triggers the warning
             assert len(w) == 1
-            # diffusion=0.3 should take priority over sigma=0.5
-            assert provider.diffusion == 0.3
+            # canonical sigma=0.5 wins over the deprecated diffusion=0.3
+            assert provider.sigma == 0.5
 
     def test_resolve_provider_with_ndarray_return(self):
         """resolve_provider should pass through ndarray returns from compute()."""

--- a/tests/unit/test_utils/test_functional_calculus.py
+++ b/tests/unit/test_utils/test_functional_calculus.py
@@ -87,6 +87,23 @@ class TestFiniteDifferenceFunctionalDerivative:
         # Central should be more accurate
         assert central_error < forward_error
 
+    def test_central_difference_unbiased_at_low_density_tail(self):
+        """Issue #1514: the central stencil must not clip ONLY the backward perturbation, which biases
+        the derivative where measure[y] < epsilon/2 (density tails). For a LINEAR functional the
+        derivative is exactly V everywhere; the old one-sided np.maximum(.,0) clip gave ~0.6*V at a
+        tail point (backward step truncated to measure[y] while dividing by the full epsilon)."""
+        v = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        def linear_functional(m):
+            return float(np.sum(v * m))
+
+        eps = 1e-4
+        # index 0 is a density tail below epsilon/2 = 5e-5 -> the old clip fired here
+        measure = np.array([1e-5, 0.3, 0.3, 0.2, 0.2])
+        op = FiniteDifferenceFunctionalDerivative(epsilon=eps, method="central")
+        deriv = op.compute(linear_functional, measure, None, np.arange(5))
+        np.testing.assert_allclose(deriv, v, rtol=1e-9)  # exact for a linear functional, incl. the tail
+
     def test_second_order_derivative(self):
         """Test second-order functional derivative computation."""
 


### PR DESCRIPTION
**Batched** (per CI-cost) — the three MODERATE findings from the repo anti-pattern audit, one PR = one CI run. Each is an independent file + its own commit for review; test suites for all three pass together (67 tests).

- **#1512** `AdjointConsistentProvider`: the `diffusion` param/state-key held σ (squared internally), colliding with `problem.diffusion`=σ²/2. `sigma` is now canonical (matches `problem.sigma`); `diffusion` deprecated alias.
- **#1513** particle KDE: the nD path swallowed KDE failure → histogram while the 1D twin raises. nD now fails loud (single-source the failure policy).
- **#1514** functional derivative: central mode clipped only the backward perturbation → biased δU/δm in density tails. Clip dropped (module contract: perturbed measure need not be a probability measure).

Supersedes #1515 / #1516 / #1517.

Closes #1512. Closes #1513. Closes #1514.