### PR TITLE
chore: fragment-based changelog to kill CHANGELOG merge conflicts (#1521)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,8 @@ dkms.conf
 #===============================================
 # Prerequisites
 *.d
+# changelog fragments dir (Issue #1521) — not a C .d file
+!changelog.d/
 
 # Compiled Object files
 *.slo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Deprecated code MUST immediately redirect to the new standard: (1) old API calls
 ### Version-bump checklist ⚠️ MANDATORY
 In a single commit:
 1. `pyproject.toml:11` — `version = "X.Y.Z"` + inline `# vX.Y.Z: <one-line scope>`.
-2. `CHANGELOG.md` — promote `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`, re-add empty `## [Unreleased]`. Keep-a-Changelog categories (`### Added/Changed/Deprecated/Removed (BREAKING)/Fixed`); reference the PR (+ issue if bug-driven).
+2. `CHANGELOG.md` — collate the `changelog.d/` fragments into a new `## [X.Y.Z] - YYYY-MM-DD` section: `python scripts/collate_changelog.py --version X.Y.Z --date $(date +%F)`, paste it under the new heading, then `git rm changelog.d/*.md` (keep the README). Keep-a-Changelog categories. *One-time (#1521):* the pre-#1521 `## [Unreleased]` block is promoted by hand at the first release after #1521; from then on fragments own the changelog.
 
 Do **not** edit: `mfgarchon/__init__.py` (reads `importlib.metadata`), `workflow/__init__.py` (independent subpackage version), backend version reporting (external libs), historical version notes in docstrings. Sanity check: `grep -rn "^version =\|^__version__ =" pyproject.toml mfgarchon/` — only `pyproject.toml:11` should change.
 
@@ -139,6 +139,7 @@ Do **not** edit: `mfgarchon/__init__.py` (reads `importlib.metadata`), `workflow
 - **Branch naming (MANDATORY)**: `<type>/<short-description>` — `feature/ fix/ chore/ docs/ refactor/ test/`.
 - **Never commit directly to `main`** (branch protection enforces this). Create the PR when you push; delete merged branches.
 - **PR granularity is a preference, not a mandate.** Granular (one fix / PR) is fine; batch *related, low-risk* fixes into one PR (one commit each, `Closes #A #B #C`) when convenient to save CI runs. Split out anything *risky / independent / large (>~1d)* regardless. The two pains that made granularity costly — CHANGELOG conflicts and red-main — are being removed by *mechanism* (fragment changelog + a full-suite PR gate; see the enforcement issues), so this stays a convenience call, not a rule to remember.
+- **Changelog per PR (#1521)**: add a `changelog.d/<slug>.<category>.md` fragment (category ∈ `added/changed/deprecated/removed/fixed`) — do **not** edit `CHANGELOG.md`. Fragments are separate files, so PRs never conflict on the changelog (batched or not). See `changelog.d/README.md`.
 - **Before merge**: the full **Test Suite** is authoritative (see *Pre-commit / pre-merge checks*); a green fast tier alone is not enough.
 
 ### GitHub issue/PR management ⚠️ MANDATORY

--- a/changelog.d/1521.added.md
+++ b/changelog.d/1521.added.md
@@ -1,0 +1,3 @@
+- **Fragment-based changelog** (Issue #1521). Each PR adds a `changelog.d/<slug>.<category>.md` fragment
+  instead of editing `CHANGELOG.md`, eliminating the append-only merge conflict on the shared sections.
+  `scripts/collate_changelog.py` collates fragments into a Keep-a-Changelog section at release.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,23 @@
+# changelog.d — changelog fragments (Issue #1521)
+
+Every PR adds **its own** fragment file here instead of editing `CHANGELOG.md`, so PRs never
+conflict on the shared `### …` sections (batched or not).
+
+**Fragment file**: `changelog.d/<slug>.<category>.md`
+- `<slug>` — the issue/PR number (e.g. `1521`) or a short kebab name.
+- `<category>` — one of `added` / `changed` / `deprecated` / `removed` / `fixed` (Keep a Changelog).
+- **Content** — the markdown bullet(s) for the change, e.g.
+  ```
+  - **Short title** (Issue #123). One-sentence what + why.
+  ```
+
+**At release** (part of the version-bump checklist): promote the fragments into `CHANGELOG.md`:
+```bash
+python scripts/collate_changelog.py --version X.Y.Z --date $(date +%F)   # preview the section
+```
+then paste under a new `## [X.Y.Z]`, and `git rm changelog.d/*.md` (keep this README).
+
+**CI** may run `python scripts/collate_changelog.py --check` to reject a malformed fragment name.
+
+> The existing `## [Unreleased]` block in `CHANGELOG.md` (pre-#1521 entries) is promoted **once** by hand
+> at the next version bump; from then on fragments own the changelog.

--- a/scripts/collate_changelog.py
+++ b/scripts/collate_changelog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Collate changelog.d/ fragments into a Keep-a-Changelog section (Issue #1521).
+
+Each fragment is ``changelog.d/<slug>.<category>.md`` where <category> is one of
+added/changed/deprecated/removed/fixed; the file holds the markdown bullet(s) for that change.
+Every PR adds its OWN fragment file, so there is no append-only merge conflict on CHANGELOG.md.
+
+Usage:
+  python scripts/collate_changelog.py                       # print the collated section to stdout
+  python scripts/collate_changelog.py --check               # validate fragment filenames (CI); exit 1 on a bad name
+  python scripts/collate_changelog.py --version X.Y.Z --date YYYY-MM-DD   # print a full "## [X.Y.Z] - date" section
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+CATEGORIES = ["added", "changed", "deprecated", "removed", "fixed"]
+HEADINGS = {
+    "added": "Added",
+    "changed": "Changed",
+    "deprecated": "Deprecated",
+    "removed": "Removed (BREAKING)",
+    "fixed": "Fixed",
+}
+FRAG_DIR = Path(__file__).resolve().parent.parent / "changelog.d"
+
+
+def _collect() -> tuple[dict[str, list[str]], list[str]]:
+    grouped: dict[str, list[str]] = {c: [] for c in CATEGORIES}
+    bad: list[str] = []
+    for frag in sorted(FRAG_DIR.glob("*.md")):
+        if frag.name == "README.md":
+            continue
+        parts = frag.stem.rsplit(".", 1)  # <slug>.<category>
+        if len(parts) != 2 or parts[1] not in CATEGORIES:
+            bad.append(frag.name)
+            continue
+        grouped[parts[1]].append(frag.read_text().strip())
+    return grouped, bad
+
+
+def render(version: str | None = None, date: str | None = None) -> str:
+    grouped, bad = _collect()
+    if bad:
+        raise SystemExit(f"invalid fragment filename(s): {bad}; expected <slug>.<{'|'.join(CATEGORIES)}>.md")
+    out: list[str] = []
+    if version:
+        out.append(f"## [{version}] - {date}\n")
+    for cat in CATEGORIES:
+        if grouped[cat]:
+            out.append(f"### {HEADINGS[cat]}\n")
+            out.append("\n".join(grouped[cat]))
+            out.append("")
+    return ("\n".join(out).rstrip() + "\n") if out else ""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true", help="validate fragment filenames only")
+    ap.add_argument("--version")
+    ap.add_argument("--date")
+    args = ap.parse_args()
+    if args.check:
+        _, bad = _collect()
+        if bad:
+            print(f"invalid changelog.d fragment filename(s): {bad}", file=sys.stderr)
+            sys.exit(1)
+        print("changelog.d fragments OK")
+        return
+    sys.stdout.write(render(args.version, args.date))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Mechanism, not convention** (the b2 lever). The CHANGELOG conflict came from every PR appending to the single `### Fixed` section.

- `changelog.d/` + README — each PR adds its **own** `<slug>.<category>.md` fragment instead of editing `CHANGELOG.md`. Separate files never conflict → bottleneck gone, batched or not.
- `scripts/collate_changelog.py` — collates fragments by Keep-a-Changelog category; `--version`/`--date` prints a full section; `--check` validates names (CI-ready).
- `CLAUDE.md` — version-bump checklist collates fragments; PR workflow gains the per-PR fragment rule. `.gitignore` un-ignores `changelog.d/` (the `*.d` rule was catching it).

Hand-rolled (no new dep — towncrier's markdown is finicky and the 68 existing `[Unreleased]` entries are too many to migrate). **Dogfooded**: this PR's changelog is `changelog.d/1521.added.md`. The pre-#1521 `[Unreleased]` block is promoted by hand once at the next bump, then fragments own it.

Closes #1521.