### PR TITLE
chore(test): local suite usable + single-source pytest config + hang safety net (#1522)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,11 +161,14 @@ Root-level only: `/*.png`, `/*_analysis.py` (not global `*.png`). Always `!examp
 
 ### Pre-commit / pre-merge checks
 ```bash
-pytest tests/unit/test_affected_module.py   # + the FULL suite before sign-off, not just -k subsets
+pytest tests/unit/test_affected_module.py            # iterate on the affected module
+pytest tests/ -n auto -m "not slow and not benchmark and not experimental and not optional_torch and not environment"   # full local sign-off — MATCH CI (parallel + skip slow)
 ruff check mfgarchon/affected_module.py && ruff format --check mfgarchon/affected_module.py
 mypy mfgarchon/affected_module.py
 ```
-CI has two tiers: a fast **Unified Quality Assurance** (subset) and the full **CI/CD Pipeline → Test Suite** (slow tests, runs on push to main). *Fast-tier-green ≠ pipeline-green* — the full Test Suite is authoritative.
+⚠️ Run the full suite **the way CI does** — `-n auto` (xdist parallel) + skip `slow`. A bare `pytest tests/` is *serial* and includes `@slow`, which takes **hours** (not a hang — Issue #1522). A 900s per-test `timeout` (pytest-timeout) is the safety net for a genuine infinite loop.
+
+**CI shape (light gate):** the fast **`ci.yml` Test Suite** (parallel, skip-slow) gates PRs; **`nightly.yml`** runs the full suite incl. `@slow` at 03:00. So *fast-tier-green ≠ full-green* — a slow-only or `@slow`-only regression surfaces in nightly, not on the PR. Before a release, run the full suite locally or trigger nightly on demand.
 
 ---
 

--- a/changelog.d/1522.changed.md
+++ b/changelog.d/1522.changed.md
@@ -1,0 +1,7 @@
+- **Local full-test-suite usable + test-config single-sourced + hang safety net** (Issue #1522). A bare
+  `pytest tests/` ran *serial* and included `@slow`, taking hours — not a hang (CI parallelizes with
+  `-n auto` and skips slow on PRs; the light gate `ci.yml` + `nightly.yml` was already in place).
+  Also caught a config duplication: pytest read `pytest.ini` and **ignored** the `[tool.pytest.ini_options]`
+  block in `pyproject.toml` (dead config) — removed it so there is one test-config source. Added
+  `pytest-timeout` with a 900s per-test ceiling (a genuine infinite loop is now killed + reported), and
+  documented the CI-matching local command in `CLAUDE.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ dev = [
     "pytest-cov>=4.0",
     "pytest-benchmark",
     "pytest-xdist>=3.5",
+    "pytest-timeout>=2.1",
     "ruff>=0.6.0",
     "mypy>=1.5",
     "pre-commit>=2.0",
@@ -260,21 +261,6 @@ disallow_incomplete_defs = true
 check_untyped_defs = true
 
 # Mathematical variables and naming conventions handled by Ruff configuration
-
-
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py", "*_test.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = [
-    "--verbose",
-    "--cov=mfgarchon",
-    "--cov-report=term-missing",
-    "--cov-report=html",
-    "-x",  # Stop on first failure for faster debugging
-    "--tb=short",  # Shorter tracebacks
-]
 
 [tool.coverage.run]
 source = ["mfgarchon"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,11 @@
 [pytest]
 minversion = 6.0
 testpaths = tests
+
+# Safety net (Issue #1522): a genuine infinite-loop test is killed + reported instead of hanging the
+# suite forever. Generous ceiling — legit slow tests are minutes, well under this. Note: a bare
+# `pytest tests/` is serial + includes @slow (hours); match CI locally with `-n auto -m "not slow ..."`.
+timeout = 900
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
**The 'local hang' was a misdiagnosis.** `--timeout=150` finished (exit 0) → no infinite loop; `pytest tests/` is just slow run **serial with `@slow`** (hours). CI is fast because it parallelizes (`-n auto`) and skips slow on PRs — the light gate (`ci.yml` fast on PRs + `nightly.yml` full) is already in place. Fix = run it like CI.

**Also caught a config duplication:** pytest reads `pytest.ini` and *ignores* `[tool.pytest.ini_options]` in `pyproject.toml` — dead config (single-source violation in the test config). Removed it → one source.

- `pytest.ini` (the one config) gains `timeout = 900` — a genuine infinite loop is killed + reported, not left to hang (`pytest-timeout` added to dev deps).
- `CLAUDE.md`: full local run must match CI — `pytest tests/ -n auto -m "not slow ..."` — + the light-gate shape documented.

No hanging test to fix; no CI-shape change (light gate already present). Closes #1522.