### PR TITLE
fix(coupling): Newton residual fails loud on undroppable source term (#1430, closes #1424 sibling)

### DIFF
--- a/changelog.d/1430.fixed.md
+++ b/changelog.d/1430.fixed.md
@@ -1,0 +1,7 @@
+- **Newton residual path fails loud on an undroppable source term** (Issue #1430, closing the #1424
+  sibling). The Newton/JFNK coupling path (`MFGResidual.compute_hjb_output` / `compute_fp_output`)
+  composed a problem-level source (`source_term_hjb/fp`, nonlocal, obstacle) *only when* the solver's
+  signature already had `source_term`, silently dropping it otherwise — so a source-defining problem on
+  a non-accepting solver gave a silently-wrong Newton fixed point while the Picard path (#1424)
+  correctly raised. Both Newton paths now compose unconditionally and raise `NotImplementedError` when
+  the source is active but the solver cannot accept it.

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -211,10 +211,21 @@ class MFGResidual:
                 kwargs["show_progress"] = False
             if "volatility_field" in self._hjb_sig_params and self.volatility_field is not None:
                 kwargs["volatility_field"] = self.volatility_field
-            if "source_term" in self._hjb_sig_params:
-                hjb_source = compose_hjb_source(self.problem, M, U_prev)
-                if hjb_source is not None:
-                    kwargs["source_term"] = hjb_source
+            # Issue #1430: fail loud like the Picard path (Issue #1424) instead of silently
+            # dropping a composed source the solver cannot accept. Compose unconditionally; if
+            # the problem defines a source but this HJB solver's signature lacks source_term,
+            # raise rather than solve the wrong problem. (Picard: base_mfg._build_hjb_kwargs.)
+            hjb_source = compose_hjb_source(self.problem, M, U_prev)
+            if hjb_source is not None:
+                if "source_term" not in self._hjb_sig_params:
+                    raise NotImplementedError(
+                        f"{type(self.hjb_solver).__name__}.solve_hjb_system does not accept "
+                        f"'source_term', but the problem defines a source / nonlocal / obstacle term. "
+                        f"Silently dropping it in the Newton residual would solve the wrong problem "
+                        f"(Issues #1424, #1430) — the Newton path must fail loud like Picard. Use an "
+                        f"FDM HJB solver, or remove source_term_hjb / nonlocal_operator / obstacle."
+                    )
+                kwargs["source_term"] = hjb_source
 
         return self.hjb_solver.solve_hjb_system(M, self.U_terminal, U_prev, **kwargs)
 
@@ -255,10 +266,18 @@ class MFGResidual:
         if M is None:
             M = np.broadcast_to(self.M_initial, self.solution_shape) if self.M_initial is not None else U
 
-        if "source_term" in params:
-            fp_source = compose_fp_source(self.problem, M, U)
-            if fp_source is not None:
-                kwargs["source_term"] = fp_source
+        # Issue #1430: fail loud like Picard (Issue #1424) rather than silently dropping a
+        # composed FP source the solver cannot accept.
+        fp_source = compose_fp_source(self.problem, M, U)
+        if fp_source is not None:
+            if "source_term" not in params:
+                raise NotImplementedError(
+                    f"{type(self.fp_solver).__name__}.solve_fp_system does not accept 'source_term', "
+                    f"but the problem defines an FP source term. Silently dropping it in the Newton "
+                    f"residual would solve the wrong problem (Issues #1424, #1430) — the Newton path "
+                    f"must fail loud like Picard. Use an FDM FP solver, or remove source_term_fp."
+                )
+            kwargs["source_term"] = fp_source
 
         drift_kwargs, use_positional_U = resolve_fp_drift_kwargs(
             self.problem, params, self.drift_field, U, M, drift_convention=self._fp_drift_convention

--- a/tests/unit/test_alg/test_newton_source_fail_loud.py
+++ b/tests/unit/test_alg/test_newton_source_fail_loud.py
@@ -1,0 +1,81 @@
+"""Issue #1430 (closing the #1424 sibling): the Newton residual path
+(``MFGResidual.compute_hjb_output`` / ``compute_fp_output``) must fail loud on a problem-level
+source a solver cannot accept — exactly like the Picard path (Issue #1424,
+``base_mfg._build_*_kwargs``, pinned in ``test_source_term_fail_loud.py``).
+
+Before this fix the Newton path composed the source ONLY when the signature already had
+``source_term``, silently dropping it otherwise — so a source-defining problem solved on a
+non-accepting solver gave a silently-wrong Newton fixed point while Picard correctly raised.
+
+Tests bind the two ``MFGResidual`` methods to a minimal carrier and monkeypatch the composers, so
+they isolate the fail-loud dispatch from the composition internals.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling import mfg_residual as mr
+from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+
+
+def _src(t, x):
+    return np.zeros_like(x)
+
+
+class _FakeSolver:
+    def solve_hjb_system(self, M, U_terminal, U_prev, **kw):
+        return M
+
+    def solve_fp_system(self, M_initial, U, **kw):
+        return U
+
+
+class _Carrier:
+    """Minimal carrier exposing the two Newton-residual methods under test."""
+
+    compute_hjb_output = MFGResidual.compute_hjb_output
+    compute_fp_output = MFGResidual.compute_fp_output
+
+    def __init__(self, hjb_params, fp_params):
+        self._hjb_sig_params = hjb_params
+        self._fp_sig_params = fp_params
+        self.hjb_solver = _FakeSolver()
+        self.fp_solver = _FakeSolver()
+        self.problem = object()  # composers are monkeypatched; problem is never inspected
+        self.U_terminal = None
+        self.M_initial = None
+        self.volatility_field = None
+        self.drift_field = None
+        self._fp_drift_convention = None
+        self.solution_shape = (3, 4)
+
+
+def test_newton_hjb_source_incapable_raises(monkeypatch):
+    monkeypatch.setattr(mr, "compose_hjb_source", lambda p, m, u: _src)
+    c = _Carrier(hjb_params={"M_density", "U_terminal"}, fp_params=set())
+    with pytest.raises(NotImplementedError, match="1430"):
+        c.compute_hjb_output(np.zeros((3, 4)), np.zeros((3, 4)))
+
+
+def test_newton_fp_source_incapable_raises(monkeypatch):
+    monkeypatch.setattr(mr, "compose_fp_source", lambda p, m, u: _src)
+    c = _Carrier(hjb_params=set(), fp_params={"M_initial", "U"})
+    with pytest.raises(NotImplementedError, match="1424"):
+        c.compute_fp_output(np.zeros((3, 4)), M=np.zeros((3, 4)))
+
+
+def test_newton_hjb_source_capable_passes_through(monkeypatch):
+    """Capable solver: no raise; the source is routed (solver runs), not dropped."""
+    monkeypatch.setattr(mr, "compose_hjb_source", lambda p, m, u: _src)
+    c = _Carrier(hjb_params={"source_term"}, fp_params=set())
+    out = c.compute_hjb_output(np.ones((3, 4)), np.zeros((3, 4)))
+    np.testing.assert_array_equal(out, np.ones((3, 4)))
+
+
+def test_newton_hjb_no_source_is_noop_even_when_incapable(monkeypatch):
+    """Baseline-safe: no problem source -> no raise even for an incapable solver (the common case)."""
+    monkeypatch.setattr(mr, "compose_hjb_source", lambda p, m, u: None)
+    c = _Carrier(hjb_params={"M_density"}, fp_params=set())
+    out = c.compute_hjb_output(np.full((3, 4), 7.0), np.zeros((3, 4)))
+    np.testing.assert_array_equal(out, np.full((3, 4), 7.0))


### PR DESCRIPTION
**Found while scoping #1430 Strand B.** The #1424 fix — *don't silently drop a problem-level source a solver cannot accept* — landed on the **Picard** path (`base_mfg._build_{hjb,fp}_kwargs`) but **not** on the **Newton/JFNK** sibling. `MFGResidual.compute_hjb_output`/`compute_fp_output` composed the source only inside `if "source_term" in params:`, so a source-defining problem (`source_term_hjb/fp`, nonlocal, obstacle) on a solver whose signature lacks `source_term` had it **silently dropped** — a silently-wrong Newton fixed point, while Picard on the same problem raised.

**Fix:** both Newton paths compose the source unconditionally and raise `NotImplementedError` (same contract as Picard) when it's active but the solver can't accept it. Byte-identical when there's no source or the solver accepts it.

This is the **first concrete payoff of #1430 Strand B** (the capability-protocol refactor that replaces all signature introspection) — **Refs #1430, does not close it.**

**Tests** (`test_newton_source_fail_loud.py`, mirrors the Picard `test_source_term_fail_loud.py`): incapable HJB/FP + active source → raises; capable → routed; no source → no raise (baseline-safe). Regression: 15 passed (source-term / Newton-Picard-agreement / drift-contract).

Refs #1430.