### PR TITLE
chore(ci): verify Python 3.13 + 3.14 support (weekly compat matrix) + classifiers

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -1,0 +1,61 @@
+name: Python Version Compatibility
+
+# Verifies the package installs and its fast test suite passes across the supported Python
+# versions. Kept OFF the per-PR and nightly paths (they pin one version) so this matrix adds no
+# cost there; it runs weekly and on demand. A version is "supported" only once it is green here
+# (this is what backs the pyproject version classifiers). 3.15 is pre-release (ships Oct 2026) and
+# runs allow-failure as an early-warning signal, NOT a support claim.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+  # Also run when the matrix or the dependency metadata changes, so a version bump is verified on
+  # its own PR — but NOT on every PR (keeps the per-PR cost flat).
+  pull_request:
+    paths:
+      - '.github/workflows/python-compat.yml'
+      - 'pyproject.toml'
+
+permissions:
+  contents: read
+
+jobs:
+  compat:
+    name: py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Only the pre-release (3.15) entry is allowed to fail; released versions must pass.
+    continue-on-error: ${{ matrix.experimental == true }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
+        include:
+          - python-version: '3.15-dev'
+            experimental: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true   # no-op for released versions; lets 3.15-dev resolve
+          cache: 'pip'
+
+      - name: Install (default deps + dev tooling)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Import smoke
+        run: |
+          python -c "import mfgarchon; from mfgarchon import MFGProblem; print('import OK')"
+
+      - name: Fast test suite
+        run: |
+          pytest tests/unit -q -p no:cacheprovider \
+            -m "not slow and not benchmark and not experimental and not optional_torch and not environment"

--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -57,5 +57,9 @@ jobs:
 
       - name: Fast test suite
         run: |
+          # Exclude the same platform-specific dirs the main CI excludes (MPS/plotting failures on
+          # Linux runners) — otherwise every version fails identically on a non-version issue.
           pytest tests/unit -q -p no:cacheprovider \
+            --ignore=tests/unit/test_backends/ \
+            --ignore=tests/unit/test_visualization/ \
             -m "not slow and not benchmark and not experimental and not optional_torch and not environment"

--- a/changelog.d/python-version-support.added.md
+++ b/changelog.d/python-version-support.added.md
@@ -1,0 +1,5 @@
+- **Python 3.13 and 3.14 support, verified in CI.** New additive `python-compat.yml` workflow runs the
+  install + fast test suite across 3.12/3.13/3.14 weekly and on any change to the matrix or dependency
+  metadata (kept off the per-PR and nightly paths, so no extra cost there). Added per-version classifiers
+  (3.12/3.13/3.14); `requires-python` stays `>=3.12` (no upper cap). Python 3.15 (pre-release, ships
+  Oct 2026) runs as an allow-failure early-warning job, not a support claim.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ readme = "README.md"
 requires-python = ">=3.12"  # Updated to match conda environments
 classifiers = [
     "Programming Language :: Python :: 3",
+    # Verified by .github/workflows/python-compat.yml (weekly matrix). 3.15 is pre-release
+    # (early-warning only) so it is intentionally not claimed here.
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
**The honest reframe:** CI tested only **3.12** while `requires-python = ">=3.12"` — so 3.13+ was an *unverified* claim. This introduces an **additive** `python-compat.yml` that actually verifies it, without adding cost to PRs or nightly.

- **`python-compat.yml`** — weekly + `workflow_dispatch` + on changes to the matrix/`pyproject.toml`. Matrix **3.12 / 3.13 / 3.14** (must pass) runs install + the fast unit suite; **3.15-dev** runs **allow-failure** (`fail-fast: false`, `allow-prereleases`) as an early-warning signal — 3.15 ships **Oct 2026**, so it is *watched, not claimed*.
- **`pyproject.toml`** — added `Python :: 3.12/3.13/3.14` classifiers. `requires-python` **unchanged** (`>=3.12`, no upper cap).

**Proof-on-this-PR:** the `pull_request` paths trigger means this PR runs the matrix, so 3.13/3.14 green is the merge gate. The binding constraint is external — dependency wheel availability (`osqp`/`igraph`/etc.) on the runners — which the run reveals; if a released version is red, that version's classifier comes back out.

**Scope note:** this tests the *default* install (numerical core + `[dev]`). `[nn]` (torch) / `[all]` (numba) version-compat is intentionally out of scope — those deps lag new Python releases and are a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)