### PR TITLE
chore(release): v0.21.0 — Python 3.13/3.14 support + weak-form audit campaign + single-source fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,45 @@ All notable changes to MFGArchon will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.21.0] - 2026-07-04
+
+### Added
+
+- **Fragment-based changelog** (Issue #1521). Each PR adds a `changelog.d/<slug>.<category>.md` fragment
+  instead of editing `CHANGELOG.md`, eliminating the append-only merge conflict on the shared sections.
+  `scripts/collate_changelog.py` collates fragments into a Keep-a-Changelog section at release.
+- **Python 3.13 and 3.14 support, verified in CI.** New additive `python-compat.yml` workflow runs the
+  install + fast test suite across 3.12/3.13/3.14 weekly and on any change to the matrix or dependency
+  metadata (kept off the per-PR and nightly paths, so no extra cost there). Added per-version classifiers
+  (3.12/3.13/3.14); `requires-python` stays `>=3.12` (no upper cap). Python 3.15 (pre-release, ships
+  Oct 2026) runs as an allow-failure early-warning job, not a support claim.
+
+### Changed
+
+- **Local full-test-suite usable + test-config single-sourced + hang safety net** (Issue #1522). A bare
+  `pytest tests/` ran *serial* and included `@slow`, taking hours — not a hang (CI parallelizes with
+  `-n auto` and skips slow on PRs; the light gate `ci.yml` + `nightly.yml` was already in place).
+  Also caught a config duplication: pytest read `pytest.ini` and **ignored** the `[tool.pytest.ini_options]`
+  block in `pyproject.toml` (dead config) — removed it so there is one test-config source. Added
+  `pytest-timeout` with a 900s per-test ceiling (a genuine infinite loop is now killed + reported), and
+  documented the CI-matching local command in `CLAUDE.md`.
+
+### Fixed
+
+- **GFDM non-LCR differentiation weights single-sourced** (Issue #1427). `_build_differentiation_matrices`
+  routed non-LCR points through the operator's *pre-adaptive* weights while the LCR path and
+  `self.neighborhoods` used the adaptive-aware builder — so `D_lap`/`D_grad` silently diverged from
+  `self.neighborhoods` for any non-LCR point whose neighborhood was enlarged by `adaptive_neighborhoods`.
+  Non-LCR points now route through the same `compute_derivative_weights_from_taylor` builder (falling back
+  to the operator only for QR-fallback stencils). Verified byte-identical on the default
+  `adaptive_neighborhoods=False` path (pinned), so the Weak-GFDM paper baseline is unchanged.
+- **Newton residual path fails loud on an undroppable source term** (Issue #1430, closing the #1424
+  sibling). The Newton/JFNK coupling path (`MFGResidual.compute_hjb_output` / `compute_fp_output`)
+  composed a problem-level source (`source_term_hjb/fp`, nonlocal, obstacle) *only when* the solver's
+  signature already had `source_term`, silently dropping it otherwise — so a source-defining problem on
+  a non-accepting solver gave a silently-wrong Newton fixed point while the Picard path (#1424)
+  correctly raised. Both Newton paths now compose unconditionally and raise `NotImplementedError` when
+  the source is active but the solver cannot accept it.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![CI/CD](https://github.com/derrring/MFGArchon/actions/workflows/ci.yml/badge.svg)](https://github.com/derrring/MFGArchon/actions/workflows/ci.yml)
+[![python-compat](https://img.shields.io/github/actions/workflow/status/derrring/MFGArchon/python-compat.yml?branch=main&label=python-compat)](https://github.com/derrring/MFGArchon/actions/workflows/python-compat.yml)
 [![codecov](https://codecov.io/gh/derrring/MFGArchon/graph/badge.svg?token=HGZFRSF5V6)](https://codecov.io/gh/derrring/MFGArchon)
 [![Release](https://img.shields.io/github/v/release/derrring/MFGArchon)](https://github.com/derrring/MFGArchon/releases)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19251867.svg)](https://doi.org/10.5281/zenodo.19251867)

--- a/changelog.d/1427.fixed.md
+++ b/changelog.d/1427.fixed.md
@@ -1,7 +1,0 @@
-- **GFDM non-LCR differentiation weights single-sourced** (Issue #1427). `_build_differentiation_matrices`
-  routed non-LCR points through the operator's *pre-adaptive* weights while the LCR path and
-  `self.neighborhoods` used the adaptive-aware builder — so `D_lap`/`D_grad` silently diverged from
-  `self.neighborhoods` for any non-LCR point whose neighborhood was enlarged by `adaptive_neighborhoods`.
-  Non-LCR points now route through the same `compute_derivative_weights_from_taylor` builder (falling back
-  to the operator only for QR-fallback stencils). Verified byte-identical on the default
-  `adaptive_neighborhoods=False` path (pinned), so the Weak-GFDM paper baseline is unchanged.

--- a/changelog.d/1430.fixed.md
+++ b/changelog.d/1430.fixed.md
@@ -1,7 +1,0 @@
-- **Newton residual path fails loud on an undroppable source term** (Issue #1430, closing the #1424
-  sibling). The Newton/JFNK coupling path (`MFGResidual.compute_hjb_output` / `compute_fp_output`)
-  composed a problem-level source (`source_term_hjb/fp`, nonlocal, obstacle) *only when* the solver's
-  signature already had `source_term`, silently dropping it otherwise — so a source-defining problem on
-  a non-accepting solver gave a silently-wrong Newton fixed point while the Picard path (#1424)
-  correctly raised. Both Newton paths now compose unconditionally and raise `NotImplementedError` when
-  the source is active but the solver cannot accept it.

--- a/changelog.d/1521.added.md
+++ b/changelog.d/1521.added.md
@@ -1,3 +1,0 @@
-- **Fragment-based changelog** (Issue #1521). Each PR adds a `changelog.d/<slug>.<category>.md` fragment
-  instead of editing `CHANGELOG.md`, eliminating the append-only merge conflict on the shared sections.
-  `scripts/collate_changelog.py` collates fragments into a Keep-a-Changelog section at release.

--- a/changelog.d/1522.changed.md
+++ b/changelog.d/1522.changed.md
@@ -1,7 +1,0 @@
-- **Local full-test-suite usable + test-config single-sourced + hang safety net** (Issue #1522). A bare
-  `pytest tests/` ran *serial* and included `@slow`, taking hours — not a hang (CI parallelizes with
-  `-n auto` and skips slow on PRs; the light gate `ci.yml` + `nightly.yml` was already in place).
-  Also caught a config duplication: pytest read `pytest.ini` and **ignored** the `[tool.pytest.ini_options]`
-  block in `pyproject.toml` (dead config) — removed it so there is one test-config source. Added
-  `pytest-timeout` with a 900s per-test ceiling (a genuine infinite loop is now killed + reported), and
-  documented the CI-matching local command in `CLAUDE.md`.

--- a/changelog.d/python-version-support.added.md
+++ b/changelog.d/python-version-support.added.md
@@ -1,5 +1,0 @@
-- **Python 3.13 and 3.14 support, verified in CI.** New additive `python-compat.yml` workflow runs the
-  install + fast test suite across 3.12/3.13/3.14 weekly and on any change to the matrix or dependency
-  metadata (kept off the per-PR and nightly paths, so no extra cost there). Added per-version classifiers
-  (3.12/3.13/3.14); `requires-python` stays `>=3.12` (no upper cap). Python 3.15 (pre-release, ships
-  Oct 2026) runs as an allow-failure early-warning job, not a support claim.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.20.4"  # v0.20.4: HJB 1D BC-aware boundary gradient residual+Jacobian (#1384) + HJB source v_t on all couplers (#1382) + post-audit hygiene (#1383)
+version = "0.21.0"  # v0.21.0: Python 3.13/3.14 support (CI-verified) + FEEC scaffold + #1489 weak-form audit campaign + fragment changelog + GFDM non-LCR / Newton-source single-source fixes
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
**Minor bump 0.20.4 → 0.21.0.** First cut since 0.20.4 (2026-06-16), so it bundles a large accumulated `[Unreleased]` body plus this session's work.

**Release mechanics:**
- Promoted the pre-#1521 `[Unreleased]` block into `[0.21.0]` — the **one-time hand-promotion** the version-bump checklist mandates (from here on, fragments own the changelog).
- Folded the 5 `changelog.d/` fragments (#1427, #1430, #1521, #1522, python-version-support) and `git rm`'d them.
- **Badge left as `python-3.12+`** — it mirrors `requires-python` (the floor, no ceiling) and never goes stale; the verified set (3.12/3.13/3.14) lives in the classifiers + `python-compat.yml`.
- Sanity-checked: only `pyproject.toml:11` changed (subpackage `__version__` untouched).

**Headline contents:** verified **Python 3.13/3.14 support**; **FEEC scaffold**; the **#1489 weak-form/FEM audit campaign**; the **fragment-changelog mechanism**; **GFDM non-LCR** + **Newton-source** single-source fixes.

**Next after merge:** tag `v0.21.0` + GitHub release (triggers a new **Zenodo DOI**) — held for explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)