### PR TITLE
test(fp): pin FP scalar-drift form to H.optimal_control (#1528 cheap first cut)

### DIFF
--- a/changelog.d/1528.added.md
+++ b/changelog.d/1528.added.md
@@ -1,0 +1,7 @@
+- **Convention-agreement pin for the FP drift** (Issue #1528). A regression guard locking the FP solvers'
+  scalar-drift form `-fp_drift_coefficient·grad(U)` to the Hamiltonian's optimal control
+  `H.optimal_control(grad U) = -p/lambda` for the quadratic-separable-MINIMIZE regime (the only one that
+  path serves). Catches both a revert of `fp_drift_coefficient` to the legacy `coupling_coefficient` copy
+  (G-017) and any future divergence of the hand-written form from the Hamiltonian. The structural fix
+  (route the FP drift through the Hamiltonian so there is one source, not two that happen to agree) remains
+  the larger #1071 program.

--- a/tests/unit/test_alg/test_drift_contract.py
+++ b/tests/unit/test_alg/test_drift_contract.py
@@ -26,6 +26,7 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.utils.pde_coefficients import fp_drift_coefficient
 
 
 def test_drift_convention_trait_values():
@@ -80,3 +81,41 @@ def test_weak_form_rejects_both_potential_and_drift():
     fp = MeshlessGalerkinFPSolver(_problem(), collocation_points=x[:, None], delta=3.5 / 14)
     with pytest.warns(DeprecationWarning, match="drift_field"), pytest.raises(ValueError, match="potential_field"):
         fp.solve_fp_system(m0, potential_field=U, drift_field=U)
+
+
+@pytest.mark.parametrize("control_cost", [0.5, 1.0, 2.5])
+def test_fp_scalar_drift_matches_hamiltonian_optimal_control(control_cost):
+    """Issue #1528: the FP solvers' hand-written drift form ``-fp_drift_coefficient(problem) * grad(U)``
+    must equal the optimal control the Hamiltonian prescribes, ``alpha* = -dp_H = H.optimal_control(grad U)``.
+
+    For the quadratic-separable-MINIMIZE regime -- the ONLY regime the scalar ``-c*grad(U)`` path serves
+    (non-quadratic / congestion / MAXIMIZE are routed to the velocity ``drift_field`` channel) -- the two
+    agree by construction: both source ``control_cost.lambda_``. This PINS the fork #1528 tracks: nothing
+    routes the FP drift through the Hamiltonian, so a future H whose optimal control is not ``-p/lambda``
+    would make the hand-written ``-c*grad(U)`` silently wrong with no other failing test. If this breaks,
+    the FP drift form has diverged from H and must be routed through ``H.optimal_control`` / ``evaluate_dp``.
+    """
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[15], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=control_cost))
+    comp = MFGComponents(hamiltonian=H, m_initial=lambda x: np.ones_like(x), u_terminal=lambda x: np.zeros_like(x))
+    # coupling_coefficient is a deliberately-wrong legacy copy; fp_drift_coefficient must ignore it and
+    # source 1/control_cost from the Hamiltonian (Issue #1420 / G-017) so the two paths stay in sync.
+    problem = MFGProblem(geometry=grid, components=comp, T=0.5, Nt=10, sigma=0.3, coupling_coefficient=99.0)
+
+    c = fp_drift_coefficient(problem)
+    assert c == pytest.approx(1.0 / control_cost), (
+        "fp_drift_coefficient must be 1/control_cost sourced from the Hamiltonian, not the "
+        "coupling_coefficient copy (Issue #1420)"
+    )
+
+    x = np.array([0.5])
+    for p in (np.array([0.0]), np.array([1.3]), np.array([-2.7]), np.array([12.5])):
+        drift_form = -c * p  # the functional form every FP solver hand-writes (-c * grad U)
+        alpha_star = H.optimal_control(x, 1.0, p, 0.0)  # the drift the Hamiltonian prescribes
+        np.testing.assert_allclose(
+            drift_form,
+            alpha_star,
+            rtol=0,
+            atol=1e-14,
+            err_msg="FP -c*grad(U) drift diverged from H.optimal_control (Issue #1528)",
+        )


### PR DESCRIPTION
**Step 1 of #1528** — the cheap convention-agreement pinning test, before the structural routing refactor.

The FP solvers hand-write `-fp_drift_coefficient·grad(U)` while the HJB routes `∂_pH` through the Hamiltonian; only the *scalar* `c` is single-sourced (#1420), the functional form is not. This test locks the current agreement for the quadratic-separable-MINIMIZE regime (the only one the `-c·grad(U)` path serves):
1. `fp_drift_coefficient == 1/control_cost` sourced from the Hamiltonian, **not** the `coupling_coefficient` copy — deliberately passes `coupling_coefficient=99` to catch the G-017 regression.
2. `-c·p == H.optimal_control(p) == -p/λ` across sample gradients × control-cost values.

If a future H's optimal control is not `-p/λ`, the fork would go silently wrong with **no failing test** — this pins it.

**Not a close.** The structural fix (route the FP drift through `H.optimal_control`/`evaluate_dp` so there's *one* source, not two that happen to agree) is the larger #1071 program. **Refs #1528.**

Test-only; 6 pass (3 new parametrized + 3 existing), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)