### PR TITLE
fix(network): surface the silent D=0.1 diffusion default (#1532)

### DIFF
--- a/changelog.d/1532.changed.md
+++ b/changelog.d/1532.changed.md
@@ -1,0 +1,6 @@
+- **Network FP diffusion no longer silently defaults** (Issue #1532). `FPNetworkSolver.diffusion_coefficient`
+  was an arbitrary hardcoded `0.1`, decoupled from the problem's physics and used silently when no
+  `volatility_field` was given. The default is now `None`; when the `0.1` fallback is silently relied on,
+  the solve emits a `UserWarning` pointing at explicit `diffusion_coefficient=` / `volatility_field=`.
+  Value-preserving (still 0.1, no result change) — only the silence is fixed. Sourcing the diffusion from
+  the problem is the #1470 Strand C follow-up.

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -23,6 +23,7 @@ Key algorithms:
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -78,7 +79,7 @@ class FPNetworkSolver(BaseFPSolver):
         self,
         problem: NetworkMFGProblem,
         scheme: str = "explicit",
-        diffusion_coefficient: float = 0.1,
+        diffusion_coefficient: float | None = None,
         cfl_factor: float = 0.5,
         max_iterations: int = 1000,
         tolerance: float = 1e-6,
@@ -90,7 +91,9 @@ class FPNetworkSolver(BaseFPSolver):
         Args:
             problem: Network MFG problem instance
             scheme: Time discretization ("explicit", "implicit", "upwind")
-            diffusion_coefficient: Network diffusion coefficient σ²/2
+            diffusion_coefficient: Network diffusion coefficient D = σ²/2. If None (default), falls
+                back to 0.1 with a warning (Issue #1532) — pass it explicitly (or `volatility_field`
+                to solve_fp_system) for correct physics.
             cfl_factor: CFL stability factor for explicit schemes
             max_iterations: Maximum iterations for implicit schemes
             tolerance: Convergence tolerance
@@ -115,7 +118,12 @@ class FPNetworkSolver(BaseFPSolver):
             self._mass_changing_bc = any(bc.bc_type in mass_changing for bc in node_bc.node_bcs)
 
         self.scheme = scheme
-        self.diffusion_coefficient = diffusion_coefficient
+        # Issue #1532: no silent physical default. The network diffusion D=sigma^2/2 is decoupled
+        # from the problem (NetworkMFGProblem carries no sigma, unlike MFGProblem — sourcing it is
+        # the #1470 Strand C follow-up). For backward compatibility an unspecified diffusion still
+        # falls back to 0.1, but the solve WARNS when that fallback is silently relied on.
+        self._diffusion_was_defaulted = diffusion_coefficient is None
+        self.diffusion_coefficient = 0.1 if diffusion_coefficient is None else diffusion_coefficient
         self.cfl_factor = cfl_factor
         self.max_iterations = max_iterations
         self.tolerance = tolerance
@@ -250,7 +258,17 @@ class FPNetworkSolver(BaseFPSolver):
 
         # Handle volatility_field parameter
         if volatility_field is None:
-            # Use self.diffusion_coefficient (backward compatible)
+            # Issue #1532: warn when the physical diffusion is neither given here nor at construction
+            # — the solve then runs at the D=0.1 fallback, decoupled from the problem's physics.
+            if self._diffusion_was_defaulted:
+                warnings.warn(
+                    "FPNetworkSolver: network diffusion defaulted to D=0.1, decoupled from the "
+                    "problem's physics (NetworkMFGProblem carries no sigma). Pass "
+                    "diffusion_coefficient=... at construction or volatility_field=sigma to "
+                    "solve_fp_system for correct physics (Issue #1532).",
+                    UserWarning,
+                    stacklevel=2,
+                )
             effective_diffusion = self.diffusion_coefficient
         elif isinstance(volatility_field, (int, float)):
             # Issue #1429 (S0-15): volatility_field is the SDE volatility sigma (the base_fp

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -6,6 +6,8 @@ Tests the Fokker-Planck solver for Mean Field Games on network/graph structures,
 including density evolution, mass conservation, and various time discretization schemes.
 """
 
+import warnings
+
 import pytest
 
 import numpy as np
@@ -686,6 +688,44 @@ class TestFPNetworkSolverAbsorbingNodeBC:
         solver = FPNetworkSolver(problem)  # no raise
         assert solver.num_nodes == 9
         assert solver._mass_changing_bc is False
+
+
+class TestFPNetworkDiffusionDefaultWarning1532:
+    """Issue #1532: relying on the D=0.1 diffusion fallback (no explicit ``diffusion_coefficient`` and
+    no ``volatility_field``) must WARN — otherwise the physical diffusion silently decouples from the
+    problem (NetworkMFGProblem carries no sigma to source from). Byte-value 0.1 is retained for
+    backward compatibility; only the silence is fixed."""
+
+    @staticmethod
+    def _setup():
+        net = GridNetwork(width=3, height=3)
+        net.create_network()
+        problem = NetworkMFGProblem(geometry=net, T=0.5, Nt=10)
+        n = problem.num_nodes
+        return problem, np.ones(n) / n, np.zeros((problem.Nt, n))
+
+    def test_defaulted_diffusion_warns_on_solve(self):
+        problem, m0, U = self._setup()
+        solver = FPNetworkSolver(problem)  # diffusion defaulted -> fallback 0.1
+        assert solver.diffusion_coefficient == 0.1  # value unchanged (backward compatible)
+        with pytest.warns(UserWarning, match="1532"):
+            solver.solve_fp_system(m0, U)
+
+    def test_explicit_diffusion_does_not_warn(self):
+        problem, m0, U = self._setup()
+        solver = FPNetworkSolver(problem, diffusion_coefficient=0.05)
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            solver.solve_fp_system(m0, U)
+        assert not any("1532" in str(w.message) for w in rec)
+
+    def test_volatility_field_suppresses_warning(self):
+        problem, m0, U = self._setup()
+        solver = FPNetworkSolver(problem)  # defaulted, but sigma given at solve time
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            solver.solve_fp_system(m0, U, volatility_field=0.3)
+        assert not any("1532" in str(w.message) for w in rec)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`FPNetworkSolver.diffusion_coefficient` defaulted to an arbitrary hardcoded **0.1** — a physical parameter (D=σ²/2) used **silently** whenever `solve_fp_system` got no `volatility_field`. So a network FP solve ran at D=0.1 regardless of the problem's physics, no warning — the σ single-source anti-pattern fixed for continuum solvers (#1412/#1420), still live on the network path.

**Conservative, non-breaking fix** (high blast radius — many bare `FPNetworkSolver(problem)` sites): default becomes `None`, the 0.1 fallback stays for backward compatibility, but the solve now **warns** when that fallback is silently relied on. Value-preserving; **no numerical change**.

The structural fix (make `NetworkMFGProblem` carry the diffusion so the solver sources it, matching FDM/FVM) is the **#1470 Strand C** follow-up — so this is **Refs #1532**, not a close.

Tests: defaulted → warns; explicit → no #1532 warning; `volatility_field` → suppresses; value still 0.1. 30 existing network FP tests pass.

Refs #1532.