### PR TITLE
feat(viz): add visualization.extract — rendering-free plot-ready data (#1362)

### DIFF
--- a/changelog.d/1362.added.md
+++ b/changelog.d/1362.added.md
@@ -1,0 +1,7 @@
+- **`visualization.extract` — rendering-free plot-ready data** (Issue #1362). New
+  `mfgarchon/visualization/extract.py`: `extract_convergence_history`, `extract_density_slices`,
+  `extract_value_slices`, `extract_mass_history`, `extract_graph_trajectories` return tidy numpy/pandas
+  artifacts (importing **no** matplotlib/plotly/pyvista/meshio) so you can plot with any backend or build
+  paper figures without re-deriving the shaping logic. Fail-fast on shape/length mismatch and unknown
+  slice times (no silent nearest-time snap). Exposes the mass-over-time series behind the scalar
+  `mass_conservation_error`, and tidies `GraphMFGResult`'s per-node list-of-arrays.

--- a/mfgarchon/visualization/__init__.py
+++ b/mfgarchon/visualization/__init__.py
@@ -3,6 +3,10 @@ Visualization utilities for MFGarchon.
 
 Provides convergence and solver diagnostics plotting (matplotlib).
 For solution visualization, use matplotlib/plotly/pyvista directly.
+
+For **data, not figures** — rendering-free, plot-ready numpy/pandas artifacts (convergence history,
+space-time slices, mass series, per-node graph trajectories) — use ``extract.*`` (Issue #1362), which
+imports no renderer.
 """
 
 from .convergence_plots import (
@@ -15,11 +19,23 @@ from .convergence_plots import (
     plot_multi_error_history,
     plot_wasserstein_history,
 )
+from .extract import (
+    extract_convergence_history,
+    extract_density_slices,
+    extract_graph_trajectories,
+    extract_mass_history,
+    extract_value_slices,
+)
 from .vtk_export import export_mesh_solution_vtk, export_time_series_vtk
 
 __all__ = [
     "export_mesh_solution_vtk",
     "export_time_series_vtk",
+    "extract_convergence_history",
+    "extract_density_slices",
+    "extract_graph_trajectories",
+    "extract_mass_history",
+    "extract_value_slices",
     "plot_convergence_rate",
     "plot_convergence_summary",
     "plot_distribution_evolution",

--- a/mfgarchon/visualization/extract.py
+++ b/mfgarchon/visualization/extract.py
@@ -1,0 +1,133 @@
+"""Rendering-free extraction of plot-ready data from MFG solve results (Issue #1362).
+
+These functions return numpy arrays / pandas ``DataFrame`` (tidy long-form), importing **no** renderer
+(no matplotlib / plotly / pyvista / meshio). Plot with your own backend, or build paper figures,
+without re-deriving the shaping logic (slice selection, mass series, tidy reshaping, per-node
+unpacking) that the helpers in ``convergence_plots.py`` otherwise embed.
+
+Fail-fast on shape/length mismatch and unknown slice times — no silent nearest-time snapping, no
+silent fallbacks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from mfgarchon.alg.numerical.coupling.graph_mfg_solver import GraphMFGResult
+    from mfgarchon.utils.solver_result import SolverResult
+
+
+def extract_convergence_history(result: SolverResult) -> pd.DataFrame:
+    r"""Per-iteration convergence residuals as a tidy frame — columns ``iteration, error_U, error_M``.
+
+    ``error_U`` / ``error_M`` are the residual histories $\|U^{k}-U^{k-1}\|$ and $\|M^{k}-M^{k-1}\|$.
+
+    >>> df = extract_convergence_history(result)
+    >>> df.plot(x="iteration", y=["error_U", "error_M"], logy=True)  # your own matplotlib
+    """
+    eu = np.asarray(result.error_history_U, dtype=float)
+    em = np.asarray(result.error_history_M, dtype=float)
+    if eu.shape != em.shape:
+        raise ValueError(f"error_history_U {eu.shape} and error_history_M {em.shape} length mismatch")
+    return pd.DataFrame({"iteration": np.arange(len(eu)), "error_U": eu, "error_M": em})
+
+
+def _slices(field: np.ndarray, x_grid, t_grid, times, name: str) -> pd.DataFrame:
+    """Shared tidy-long-form slicer for U/M. Validates ``field.shape == (len(t_grid), len(x_grid))``
+    and that every requested time is in ``t_grid`` (fail-loud, no nearest-snap)."""
+    f = np.asarray(field, dtype=float)
+    x = np.asarray(x_grid, dtype=float)
+    t = np.asarray(t_grid, dtype=float)
+    if f.shape != (len(t), len(x)):
+        raise ValueError(f"{name} shape {f.shape} != (len(t_grid), len(x_grid)) = ({len(t)}, {len(x)})")
+    if times is None:
+        t_idx = np.arange(len(t))
+    else:
+        t_idx = []
+        for tv in np.atleast_1d(np.asarray(times, dtype=float)):
+            hits = np.where(np.isclose(t, tv))[0]
+            if len(hits) == 0:
+                raise ValueError(
+                    f"{name}: requested time {tv} not in t_grid (range [{t[0]}, {t[-1]}], {len(t)} points)"
+                )
+            t_idx.append(int(hits[0]))
+        t_idx = np.asarray(t_idx, dtype=int)
+    return pd.DataFrame(
+        {
+            "t": np.repeat(t[t_idx], len(x)),
+            "x": np.tile(x, len(t_idx)),
+            "value": f[t_idx].ravel(),
+        }
+    )
+
+
+def extract_density_slices(result: SolverResult, x_grid, t_grid, times=None) -> pd.DataFrame:
+    r"""Density $m(t,x)$ as tidy long-form — columns ``t, x, value``. ``times=None`` returns all time
+    knots; otherwise each requested time must be in ``t_grid`` (raises, no silent snap).
+
+    >>> extract_density_slices(result, x_grid, t_grid, times=[0.0, 0.5, 1.0])
+    """
+    return _slices(result.M, x_grid, t_grid, times, "M")
+
+
+def extract_value_slices(result: SolverResult, x_grid, t_grid, times=None) -> pd.DataFrame:
+    r"""Value function $u(t,x)$ as tidy long-form — columns ``t, x, value`` (see
+    :func:`extract_density_slices`)."""
+    return _slices(result.U, x_grid, t_grid, times, "U")
+
+
+def extract_mass_history(result: SolverResult, x_grid) -> pd.DataFrame:
+    r"""Total mass $\int m(t,x)\,dx$ per time step (trapezoidal over ``x_grid``) — columns
+    ``step, total_mass``. Exposes the series behind the scalar ``mass_conservation_error``.
+
+    >>> extract_mass_history(result, x_grid).plot(x="step", y="total_mass")  # your own matplotlib
+    """
+    M = np.asarray(result.M, dtype=float)
+    x = np.asarray(x_grid, dtype=float)
+    if M.ndim != 2 or M.shape[1] != len(x):
+        raise ValueError(f"M shape {M.shape} incompatible with x_grid of length {len(x)}")
+    mass = np.trapezoid(M, x, axis=1)
+    return pd.DataFrame({"step": np.arange(M.shape[0]), "total_mass": mass})
+
+
+def extract_graph_trajectories(result: GraphMFGResult, x_grid=None, field: str = "density") -> pd.DataFrame:
+    r"""Per-node trajectories from a ``GraphMFGResult`` (list-of-arrays) as tidy long-form — columns
+    ``node, step, x, value``. ``field`` selects ``"density"`` ($m$) or ``"value"`` ($u$). ``x_grid``
+    defaults to integer indices when omitted.
+
+    >>> extract_graph_trajectories(graph_result, field="density")
+    """
+    if field == "density":
+        arrays = result.densities
+    elif field == "value":
+        arrays = result.values
+    else:
+        raise ValueError(f"field must be 'density' or 'value', got {field!r}")
+    if not arrays:
+        raise ValueError("GraphMFGResult has no per-node arrays")
+
+    frames = []
+    for node, arr in enumerate(arrays):
+        a = np.asarray(arr, dtype=float)
+        if a.ndim != 2:
+            raise ValueError(f"node {node} array must be 2D (Nt+1, Nx), got shape {a.shape}")
+        nt, nx = a.shape
+        xg = np.arange(nx) if x_grid is None else np.asarray(x_grid, dtype=float)
+        if len(xg) != nx:
+            raise ValueError(f"node {node}: x_grid length {len(xg)} != Nx {nx}")
+        frames.append(
+            pd.DataFrame(
+                {
+                    "node": node,
+                    "step": np.repeat(np.arange(nt), nx),
+                    "x": np.tile(xg, nt),
+                    "value": a.ravel(),
+                }
+            )
+        )
+    return pd.concat(frames, ignore_index=True)

--- a/tests/unit/test_visualization/test_extract.py
+++ b/tests/unit/test_visualization/test_extract.py
@@ -1,0 +1,99 @@
+"""Issue #1362: rendering-free extraction of plot-ready data from solve results."""
+
+import ast
+import inspect
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.visualization import extract as ex
+
+
+def _result():
+    from mfgarchon.utils.solver_result import SolverResult
+
+    U = np.arange(12, dtype=float).reshape(3, 4)
+    M = np.full((3, 4), 0.25)  # uniform density
+    return SolverResult(
+        U=U,
+        M=M,
+        iterations=5,
+        error_history_U=np.array([1.0, 0.1, 0.01, 0.001, 1e-4]),
+        error_history_M=np.array([2.0, 0.2, 0.02, 0.002, 2e-4]),
+    )
+
+
+def _graph_result():
+    from mfgarchon.alg.numerical.coupling.graph_mfg_solver import GraphMFGResult
+
+    v = [np.arange(6, dtype=float).reshape(3, 2), np.ones((3, 2))]
+    d = [np.full((3, 2), 0.5), np.full((3, 2), 0.25)]
+    return GraphMFGResult(values=v, densities=d, converged=True, iterations=3, error_history=[1.0, 0.1], n_nodes=2)
+
+
+def test_convergence_history():
+    df = ex.extract_convergence_history(_result())
+    assert list(df.columns) == ["iteration", "error_U", "error_M"]
+    assert len(df) == 5
+    assert df["error_U"].iloc[0] == 1.0
+    assert df["error_M"].iloc[-1] == pytest.approx(2e-4)
+
+
+def test_mass_history_integrates_over_x():
+    x = np.linspace(0.0, 1.0, 4)
+    df = ex.extract_mass_history(_result(), x)
+    assert list(df.columns) == ["step", "total_mass"]
+    assert len(df) == 3
+    np.testing.assert_allclose(df["total_mass"], np.trapezoid(np.full(4, 0.25), x))
+
+
+def test_density_slices_tidy_and_time_selection():
+    r = _result()
+    x = np.linspace(0.0, 1.0, 4)
+    t = np.array([0.0, 0.5, 1.0])
+    all_df = ex.extract_density_slices(r, x, t)
+    assert list(all_df.columns) == ["t", "x", "value"]
+    assert len(all_df) == 3 * 4
+    sel = ex.extract_density_slices(r, x, t, times=[0.5])
+    assert set(sel["t"]) == {0.5}
+    assert len(sel) == 4
+    # value_slices reads U
+    v = ex.extract_value_slices(r, x, t, times=[1.0])
+    assert v["value"].tolist() == r.U[2].tolist()
+
+
+def test_slices_fail_loud():
+    r = _result()
+    x = np.linspace(0.0, 1.0, 4)
+    t = np.array([0.0, 0.5, 1.0])
+    with pytest.raises(ValueError, match="not in t_grid"):
+        ex.extract_density_slices(r, x, t, times=[0.3])  # not a grid time -> no silent snap
+    with pytest.raises(ValueError, match="shape"):
+        ex.extract_density_slices(r, x, np.array([0.0, 0.5]), None)  # wrong t_grid length
+
+
+def test_graph_trajectories():
+    gr = _graph_result()
+    df = ex.extract_graph_trajectories(gr, field="density")
+    assert list(df.columns) == ["node", "step", "x", "value"]
+    assert set(df["node"]) == {0, 1}
+    assert len(df) == 2 * 3 * 2  # nodes * steps * x
+    assert df[(df.node == 0) & (df.step == 0)]["value"].tolist() == [0.5, 0.5]
+    with pytest.raises(ValueError, match="field"):
+        ex.extract_graph_trajectories(gr, field="bogus")
+
+
+def test_extract_module_imports_no_renderer():
+    """#1362 acceptance: extract.py itself imports no rendering backend. Checked at source level —
+    the package __init__ pulls meshio (via vtk_export), so a sys.modules check would be confounded;
+    this verifies the extract module's own import surface."""
+    tree = ast.parse(inspect.getsource(ex))
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    bad = imported & {"matplotlib", "plotly", "pyvista", "meshio"}
+    assert not bad, f"extract.py imports renderers: {bad}"


### PR DESCRIPTION
New `mfgarchon/visualization/extract.py` — pure-data getters returning tidy numpy/pandas artifacts that import **no** renderer (no matplotlib/plotly/pyvista/meshio), so you can plot with any backend or build paper figures without re-deriving the shaping logic:

- `extract_convergence_history` → `DataFrame(iteration, error_U, error_M)`
- `extract_density_slices` / `extract_value_slices` → `DataFrame(t, x, value)`
- `extract_mass_history` → `DataFrame(step, total_mass)` (∫m dx per step — the series behind the scalar `mass_conservation_error`)
- `extract_graph_trajectories` → tidies `GraphMFGResult`'s per-node list-of-arrays → `DataFrame(node, step, x, value)`

**Fail-fast** on shape/length mismatch and unknown slice times (no silent nearest-snap). Exported via `__init__.__all__`; docstring points at `extract.*` for "data, not figures".

**Acceptance criteria met:** module ✓, numpy/pandas tidy ✓, no-renderer (source-level test) ✓, fail-fast ✓, `__init__` export ✓, LaTeX + per-function usage docstrings ✓. The per-function `>>>` examples serve as runnable usage; the standalone `examples/basic/` plot script and refactoring `convergence_plots.py` to consume `extract.*` are the issue's explicit out-of-scope follow-ups.

Tests: 6 pass (each getter's shape/values, time selection, fail-loud paths, import-isolation).

Closes #1362.