### PR TITLE
refactor(network): single-source the network source term across all consumers (#1470 Strand A)

### DIFF
--- a/changelog.d/1470-strand-a-source.fixed.md
+++ b/changelog.d/1470-strand-a-source.fixed.md
@@ -1,7 +1,8 @@
-- **Network HJB source term single-sourced** (Issue #1470 Strand A). `hjb_network._source_terms` and
-  `NetworkHamiltonian._default_hamiltonian` each computed the source `V + f(m)` independently — and
-  diverged for stacked multi-population `m`: the HJB re-derived the coupling on the raw `m[node]` while
-  the Hamiltonian used the own-population slice (`_extract_own_density`), corrupting the isolated control
-  `h_total - source`. Added `NetworkHamiltonian.source_term` as the single source consumed by both;
-  `_default_hamiltonian` is now `control + source_term`, and the HJB routes through the wired object.
-  Byte-identical single-population; fixes the multi-population fork.
+- **Network source term single-sourced** (Issue #1470 Strand A). The p-independent source `V + f(m)` was
+  computed on diverging paths — `NetworkHamiltonian` (own-population slice via `_extract_own_density`)
+  vs the live `NetworkMFGProblem.density_coupling` / `hjb_network._source_terms` (raw stacked `m[node]`)
+  — silently wrong for multi-population `m`, corrupting the HJB control isolation `h_total - source`.
+  Now `NetworkHamiltonian` owns it via `source_term` / `node_potential_value` / `coupling_value`, and
+  `_default_hamiltonian`, `hjb_network._source_terms`, and `NetworkMFGProblem.node_potential` /
+  `density_coupling` all route through the wired object. Byte-identical single-population; fixes the
+  multi-population fork on every consumer.

--- a/changelog.d/1470-strand-a-source.fixed.md
+++ b/changelog.d/1470-strand-a-source.fixed.md
@@ -1,0 +1,7 @@
+- **Network HJB source term single-sourced** (Issue #1470 Strand A). `hjb_network._source_terms` and
+  `NetworkHamiltonian._default_hamiltonian` each computed the source `V + f(m)` independently — and
+  diverged for stacked multi-population `m`: the HJB re-derived the coupling on the raw `m[node]` while
+  the Hamiltonian used the own-population slice (`_extract_own_density`), corrupting the isolated control
+  `h_total - source`. Added `NetworkHamiltonian.source_term` as the single source consumed by both;
+  `_default_hamiltonian` is now `control + source_term`, and the HJB routes through the wired object.
+  Byte-identical single-population; fixes the multi-population fork.

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -166,12 +166,13 @@ class NetworkHJBSolver(BaseHJBSolver):
         The network Hamiltonian method returns ``control + source``; subtracting this isolates the
         control Hamiltonian.
         """
-        return np.array(
-            [
-                self.network_problem.node_potential(i, t) + self.network_problem.density_coupling(i, m, t)
-                for i in range(self.num_nodes)
-            ]
-        )
+        # Issue #1470: single-source the source (V + f_m) through the WIRED Hamiltonian object — the
+        # SAME computation inside `_evaluate_hamiltonian_batch` (which routes through
+        # `network_problem.hamiltonian` -> `hamiltonian_class`). Previously `node_potential +
+        # density_coupling` re-derived the coupling on the raw stacked `m`, diverging from the object's
+        # `_extract_own_density` for multi-population `m` and corrupting `h_control = h_total - source`.
+        H = self.network_problem.hamiltonian_class
+        return np.array([H.source_term(i, m, t) for i in range(self.num_nodes)])
 
     def _solve_ode(
         self,

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -165,13 +165,27 @@ class NetworkHamiltonian(HamiltonianBase):
         ``_extract_own_density`` is the identity for single-population ``m`` (byte-identical) and slices
         the own population for stacked ``K*N`` ``m``.
         """
+        return self.node_potential_value(x, t) + self.coupling_value(x, m, t)
+
+    def node_potential_value(self, x, t=0.0):
+        """Node potential ``V(node, t)`` — the single source for ``NetworkMFGProblem.node_potential``
+        (Issue #1470 Strand A). ``0.0`` when no ``node_potential_func`` is set.
+        """
         node = int(np.asarray(x).flat[0])
-        V = float(self._node_potential(node, t)) if self._node_potential else 0.0
+        return float(self._node_potential(node, t)) if self._node_potential else 0.0
+
+    def coupling_value(self, x, m, t=0.0):
+        """Density coupling ``f(node, m, t)`` — the single source for
+        ``NetworkMFGProblem.density_coupling`` (Issue #1470 Strand A). Reads ``node_interaction_func``
+        on the FULL density (cross-coupling), else the default quadratic node congestion
+        ``0.5 * m_own[node]^2`` on the OWN-population slice. ``_extract_own_density`` is the identity for
+        single-population ``m`` (byte-identical to the legacy raw ``m[node]``) and slices the own
+        population for stacked ``K*N`` ``m``.
+        """
+        node = int(np.asarray(x).flat[0])
         if self._node_interaction is not None:
-            f_m = float(self._node_interaction(node, m, t))
-        else:
-            f_m = 0.5 * float(self._extract_own_density(m)[node]) ** 2
-        return V + f_m
+            return float(self._node_interaction(node, m, t))
+        return 0.5 * float(self._extract_own_density(m)[node]) ** 2
 
     def optimal_control(self, x, m, p, t=0.0):
         """Optimal transition rates from node x (Issue #1474).
@@ -488,18 +502,16 @@ class NetworkMFGProblem(MFGProblem):
         return float(kinetic_energy + potential + interaction)
 
     def node_potential(self, node: int, t: float) -> float:
-        """Potential function at network nodes."""
-        if self.components.node_potential_func is not None:  # type: ignore[attr-defined]
-            return self.components.node_potential_func(node, t)  # type: ignore[attr-defined]
-        return 0.0
+        """Potential function V(node, t) at network nodes. Issue #1470 Strand A: delegates to the wired
+        single-source Hamiltonian object so every consumer reads ONE computation."""
+        return float(self.hamiltonian_class.node_potential_value(node, t))
 
     def density_coupling(self, node: int, m: np.ndarray, t: float) -> float:
-        """Density coupling/interaction at nodes."""
-        if self.components.node_interaction_func is not None:  # type: ignore[attr-defined]
-            return self.components.node_interaction_func(node, m, t)  # type: ignore[attr-defined]
-
-        # Default: quadratic congestion at nodes
-        return 0.5 * m[node] ** 2
+        """Density coupling f(node, m, t) at nodes. Issue #1470 Strand A: delegates to the wired
+        single-source Hamiltonian object (``coupling_value``), so the default congestion uses the
+        own-population slice (``_extract_own_density``) — matching the Hamiltonian on stacked
+        multi-population m instead of re-deriving on the raw ``m[node]``."""
+        return float(self.hamiltonian_class.coupling_value(node, m, t))
 
     def _default_density_coupling_derivative(self, node: int, m: np.ndarray, t: float) -> float:
         """Derivative of default density coupling."""

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -149,18 +149,29 @@ class NetworkHamiltonian(HamiltonianBase):
             du = p[node] - p[neighbor]  # u_i - u_j
             control_cost += 0.5 * w * max(du, 0.0) ** 2
 
+        # Issue #1470: the p-independent source (V + coupling) is single-sourced in `source_term` and
+        # consumed both here (control + source) and by the HJB solver's control isolation.
+        return control_cost + self.source_term(node, m, t)
+
+    def source_term(self, x, m, t=0.0):
+        """The p-independent source ``V(node) + f(node, m)`` — the RHS in ``-u_t + H_control = source``.
+
+        Single source consumed by ``_default_hamiltonian`` (as ``control + source``) AND by
+        ``hjb_network._source_terms`` (Issue #1470): computing it once here removes the multi-population
+        fork where the HJB used to re-derive ``V + density_coupling`` on the raw stacked ``m`` while the
+        Hamiltonian used ``_extract_own_density`` — so ``h_control = h_total - source`` now isolates the
+        control exactly. Coupling ``f(node, m, t)`` reads ``node_interaction_func`` on the FULL density
+        (cross-coupling), else defaults to quadratic node congestion ``0.5 * m_own[node]^2``.
+        ``_extract_own_density`` is the identity for single-population ``m`` (byte-identical) and slices
+        the own population for stacked ``K*N`` ``m``.
+        """
+        node = int(np.asarray(x).flat[0])
         V = float(self._node_potential(node, t)) if self._node_potential else 0.0
-        # Coupling f(node, m, t). Reconciled with the live NetworkMFGProblem.density_coupling
-        # (Issue #1470): read node_interaction_func on the FULL density, and default to the
-        # quadratic node congestion 0.5 * m_own[node]^2. The previous default of 0.0 (and reading
-        # the dead `congestion_func` field) silently diverged from the method used on every live
-        # solve — see Issue #910. `_extract_own_density` is the identity for single-population m
-        # (so byte-identical to the method) and slices the own population for stacked K*N m.
         if self._node_interaction is not None:
             f_m = float(self._node_interaction(node, m, t))
         else:
             f_m = 0.5 * float(self._extract_own_density(m)[node]) ** 2
-        return control_cost + V + f_m
+        return V + f_m
 
     def optimal_control(self, x, m, p, t=0.0):
         """Optimal transition rates from node x (Issue #1474).

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -279,3 +279,34 @@ def test_source_term_single_source_and_multipop_slice():
     m_stacked = np.concatenate([np.full(N, 0.1), np.full(N, 0.9)])
     for node in range(N):
         assert H1.source_term(node, m_stacked, 0.0) == pytest.approx(0.5 * 0.9**2)  # own slice; V=0 (no potential)
+
+
+def test_problem_methods_delegate_to_object():
+    """Issue #1470 Strand A inc.2: ``NetworkMFGProblem.node_potential`` / ``density_coupling`` delegate
+    to the wired Hamiltonian object's ``node_potential_value`` / ``coupling_value`` — one source for
+    ALL consumers (HJB, Lagrangian, ...). Byte-identical to the legacy single-population computation.
+    """
+    net = GridNetwork(width=4, height=3)
+    net.create_network()
+    comps = NetworkMFGComponents(
+        node_potential_func=lambda n, t: 0.2 * n + t,
+        node_interaction_func=lambda n, m, t: 0.3 * m[n] ** 2,
+    )
+    prob = NetworkMFGProblem(geometry=net, components=comps, T=1.0, Nt=5)
+    H = prob.hamiltonian_class
+    N = prob.num_nodes
+    m = np.linspace(0.1, 0.9, N)
+    t = 0.4
+    for node in range(N):
+        # delegation identity (method == the wired object's accessor)
+        assert prob.node_potential(node, t) == H.node_potential_value(node, t)
+        assert prob.density_coupling(node, m, t) == H.coupling_value(node, m, t)
+        # byte-identical to the legacy computation
+        assert prob.node_potential(node, t) == pytest.approx(0.2 * node + t)
+        assert prob.density_coupling(node, m, t) == pytest.approx(0.3 * m[node] ** 2)
+
+    # default branch (no funcs): V == 0, congestion == 0.5*m[node]^2 (single-pop, own == raw)
+    prob0 = NetworkMFGProblem(geometry=net, T=1.0, Nt=5)
+    for node in range(N):
+        assert prob0.node_potential(node, t) == 0.0
+        assert prob0.density_coupling(node, m, t) == pytest.approx(0.5 * m[node] ** 2)

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -249,3 +249,33 @@ def test_network_geometry_both_or_neither_fail_loud():
         NetworkMFGProblem(geometry=net, network_geometry=net, T=0.5, Nt=4)
     with pytest.raises(ValueError, match="requires a graph geometry"):
         NetworkMFGProblem(T=0.5, Nt=4)
+
+
+def test_source_term_single_source_and_multipop_slice():
+    """Issue #1470 Strand A: ``NetworkHamiltonian.source_term`` (V + f_m) is the SINGLE source consumed
+    by both ``__call__`` (control + source) and ``hjb_network._source_terms``. Single-population it is
+    ``V + 0.5*m[node]^2``; for stacked multi-population ``m`` it reads the OWN slice
+    (``_extract_own_density``), matching ``__call__`` — the fork the HJB used to carry when it
+    re-derived ``density_coupling`` on the raw stacked ``m``.
+    """
+    net = GridNetwork(width=3, height=3)
+    net.create_network()
+    comps = NetworkMFGComponents(node_potential_func=lambda n, t: 0.2 * n)  # default congestion
+    prob = NetworkMFGProblem(geometry=net, components=comps, T=0.5, Nt=5)
+    H = _build_H(prob)
+    N = prob.num_nodes
+    m = np.linspace(0.1, 0.9, N)
+    p = 0.1 * np.arange(N, dtype=float)
+
+    for node in range(N):
+        src = H.source_term(node, m, 0.0)
+        assert src == pytest.approx(0.2 * node + 0.5 * m[node] ** 2)
+        # Decomposition: control = __call__ - source is p-dependent but m-INDEPENDENT (all m-dependence
+        # is in the source), so scaling m does not change (__call__ - source).
+        assert H(node, m, p, 0.0) - src == pytest.approx(H(node, 2 * m, p, 0.0) - H.source_term(node, 2 * m, 0.0))
+
+    # Multi-population: population 1's source reads its OWN slice (0.9), not the raw stacked m[node] (0.1).
+    H1 = NetworkHamiltonian(network_data=prob.network_data, population_index=1)
+    m_stacked = np.concatenate([np.full(N, 0.1), np.full(N, 0.9)])
+    for node in range(N):
+        assert H1.source_term(node, m_stacked, 0.0) == pytest.approx(0.5 * 0.9**2)  # own slice; V=0 (no potential)


### PR DESCRIPTION
**#1470 Strand A — single-source the network source term $V + f(m)$, now that the `NetworkHamiltonian` object is wired.**

The source was computed on **diverging paths**: `NetworkHamiltonian` used the own-population slice (`_extract_own_density`), while the live `NetworkMFGProblem.density_coupling` / `hjb_network._source_terms` re-derived it on the **raw stacked `m[node]`**. Byte-identical single-population; **silently wrong for multi-population `m`** — the HJB's control isolation `h_control = h_total − source` subtracted the wrong-population source.

**Fix — one owner, all consumers route through it:**
- `NetworkHamiltonian` owns the source via `source_term` = `node_potential_value` + `coupling_value`.
- `_default_hamiltonian` → `control + source_term`.
- `hjb_network._source_terms` → the wired object's `source_term`.
- `NetworkMFGProblem.node_potential` / `density_coupling` → the object's `node_potential_value` / `coupling_value` (so the Lagrangian path single-sources too).

**Byte-identical single-population** — the object==method pinning test still passes; **77 network tests green**. New tests pin: `source_term == V + 0.5·m_own²`; the `(H − source)` decomposition is m-independent (= control); population-1 source reads the own slice; the problem methods == the object's accessors == the legacy computation.

**Follow-ups (Refs #1470):** the coupling *derivative* (`_default_density_coupling_derivative` vs the object's `dm`) is a separate single-source; purge the dead components fields (#1535-flagged).

Refs #1470.