### PR TITLE
chore(network): Strand A dead-code cleanup — purge dead fields + single-source dH/dm (#1470)

### DIFF
--- a/changelog.d/1470-derivative-single-source.changed.md
+++ b/changelog.d/1470-derivative-single-source.changed.md
@@ -1,0 +1,5 @@
+- **Network derivative dH/dm single-sourced** (Issue #1470 Strand A). `NetworkMFGProblem.hamiltonian_dm`
+  now delegates to the wired Hamiltonian object's `dm`, which gained the EXACT analytic derivative for the
+  default node congestion (`d/dm(0.5*m_own^2) = m_own[node]`, own-population slice) instead of finite
+  difference. The dead `_default_density_coupling_derivative` helper (raw `m[node]`, reachable only via the
+  uncalled `hamiltonian_dm`) is removed. Byte-identical single-population; own-slice for multi-population.

--- a/changelog.d/1470-purge-dead-fields.removed.md
+++ b/changelog.d/1470-purge-dead-fields.removed.md
@@ -1,0 +1,5 @@
+- **Removed dead `NetworkMFGComponents.diffusion_coefficient` / `drift_coefficient`** (Issue #1470 Strand A).
+  Neither field was ever read by any solver — the network FP diffusion is `FPNetworkSolver`'s own knob
+  (#1532) and the FP drift is `fp_drift_coefficient` — so setting them on the components was silently
+  ignored. Removed (flagged DEAD in #1535). Minor breaking change: passing them now raises `TypeError`,
+  but the kwargs never had any effect.

--- a/examples/applications/economics/el_farol_bar_demo.py
+++ b/examples/applications/economics/el_farol_bar_demo.py
@@ -161,8 +161,6 @@ def create_el_farol_problem(
         initial_node_density_func=initial_density_func,
         node_potential_func=node_potential_func,
         node_interaction_func=node_interaction_func,
-        diffusion_coefficient=0.05,  # Small diffusion for discrete states
-        drift_coefficient=1.0,
     )
 
     # Create problem

--- a/examples/applications/networks/network_mfg_comparison_example.py
+++ b/examples/applications/networks/network_mfg_comparison_example.py
@@ -138,8 +138,6 @@ class NetworkMFGBenchmark:
             initial_node_density_func=initial_density_func,
             node_potential_func=node_potential_func,
             node_interaction_func=node_interaction_func,
-            diffusion_coefficient=0.1,
-            drift_coefficient=1.0,
         )
 
         problem = NetworkMFGProblem(

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -224,11 +224,17 @@ class NetworkHamiltonian(HamiltonianBase):
         return grad
 
     def dm(self, x, m, p, t=0.0):
-        """dH/dm at node x."""
+        """dH/dm at node x. Issue #1470 Strand A: the default node congestion has the EXACT analytic
+        derivative ``d/dm (0.5 * m_own[node]^2) = m_own[node]`` (own-population slice, matching
+        ``coupling_value``); a custom ``node_interaction_func`` has no analytic form here, so falls back
+        to finite difference. This is the single source for ``NetworkMFGProblem.hamiltonian_dm``.
+        """
+        node = int(np.asarray(x).flat[0])
         if self._hamiltonian_dm_func is not None:
-            node = int(np.asarray(x).flat[0])
             neighbors = self.network_data.get_neighbors(node)
             return float(self._hamiltonian_dm_func(node, neighbors, np.atleast_1d(m), np.atleast_1d(p), t))
+        if self._node_interaction is None:
+            return float(self._extract_own_density(np.atleast_1d(m))[node])
         return self._finite_diff_dm(x, m, p, t)
 
 
@@ -458,12 +464,10 @@ class NetworkMFGProblem(MFGProblem):
         return float(self.hamiltonian_class(node, m, p, t))
 
     def hamiltonian_dm(self, node: int, neighbors: list[int], m: np.ndarray, p: np.ndarray, t: float) -> float:
-        """Derivative of Hamiltonian with respect to density."""
-        if self.components.hamiltonian_dm_func is not None:
-            return self.components.hamiltonian_dm_func(node, neighbors, m, p, t)
-
-        # Default: derivative of density coupling term
-        return self._default_density_coupling_derivative(node, m, t)
+        """Derivative of the Hamiltonian w.r.t. density dH/dm. Issue #1470 Strand A: delegates to the
+        wired single-source Hamiltonian object's ``dm`` (which owns the custom ``hamiltonian_dm_func``,
+        the analytic default-congestion derivative, and the finite-difference fallback)."""
+        return float(self.hamiltonian_class.dm(node, m, p, t))
 
     # Lagrangian formulation methods (based on ArXiv 2207.10908v3)
 
@@ -504,10 +508,6 @@ class NetworkMFGProblem(MFGProblem):
         own-population slice (``_extract_own_density``) — matching the Hamiltonian on stacked
         multi-population m instead of re-deriving on the raw ``m[node]``."""
         return float(self.hamiltonian_class.coupling_value(node, m, t))
-
-    def _default_density_coupling_derivative(self, node: int, m: np.ndarray, t: float) -> float:
-        """Derivative of default density coupling."""
-        return m[node]  # d/dm[i] (0.5 * m[i]^2) = m[i]
 
     # Initial and terminal conditions
 

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -226,8 +226,9 @@ class NetworkHamiltonian(HamiltonianBase):
     def dm(self, x, m, p, t=0.0):
         """dH/dm at node x. Issue #1470 Strand A: the default node congestion has the EXACT analytic
         derivative ``d/dm (0.5 * m_own[node]^2) = m_own[node]`` (own-population slice, matching
-        ``coupling_value``); a custom ``node_interaction_func`` has no analytic form here, so falls back
-        to finite difference. This is the single source for ``NetworkMFGProblem.hamiltonian_dm``.
+        ``coupling_value``); a custom ``node_interaction_func`` has no analytic form here, so uses a
+        node-wise central finite difference of the coupling. This is the single source for
+        ``NetworkMFGProblem.hamiltonian_dm``.
         """
         node = int(np.asarray(x).flat[0])
         if self._hamiltonian_dm_func is not None:
@@ -235,7 +236,17 @@ class NetworkHamiltonian(HamiltonianBase):
             return float(self._hamiltonian_dm_func(node, neighbors, np.atleast_1d(m), np.atleast_1d(p), t))
         if self._node_interaction is None:
             return float(self._extract_own_density(np.atleast_1d(m))[node])
-        return self._finite_diff_dm(x, m, p, t)
+        # Custom node_interaction_func: central finite difference of the coupling in the OWN node
+        # component of the full density. The base HamiltonianBase._finite_diff_dm collapses m to a
+        # scalar (np.mean), which breaks node-indexed interaction funcs (m[node] on a length-1 array
+        # -> IndexError) — #1537 review. Difference coupling_value on the full vector instead.
+        m_arr = np.atleast_1d(np.asarray(m, dtype=float))
+        eps = 1e-7
+        m_plus = m_arr.copy()
+        m_minus = m_arr.copy()
+        m_plus[node] += eps
+        m_minus[node] -= eps
+        return (self.coupling_value(node, m_plus, t) - self.coupling_value(node, m_minus, t)) / (2.0 * eps)
 
 
 @dataclass

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -274,14 +274,6 @@ class NetworkMFGComponents(MFGComponents):
     # (Issue #1471) — construct e.g. GridNetwork(..., boundary_conditions=GraphBCConfig(...)). The
     # former `boundary_nodes` / `boundary_values_func` fields bypassed the #1456 BC single source.
 
-    # Flow dynamics parameters — DEAD FIELDS (Issue #1470). Never read by any solver: the network FP
-    # diffusion is FPNetworkSolver's own knob (Issue #1532) and the drift is fp_drift_coefficient, so
-    # setting these on the components is SILENTLY IGNORED. Kept only for dataclass back-compat (a test
-    # still asserts their storage, test_network_mfg_solvers.py); purge in the #1470 Strand A method-knob
-    # cleanup (they are exactly the "solver config leaked onto the problem spec" the scoping flagged).
-    diffusion_coefficient: float = 1.0  # DEAD — never read (see above; #1470)
-    drift_coefficient: float = 1.0  # DEAD — never read (see above; #1470)
-
     # Network-specific coupling
     node_interaction_func: Callable | None = None  # Local node interactions
     edge_interaction_func: Callable | None = None  # Edge-based interactions

--- a/tests/integration/test_network_mfg_solvers.py
+++ b/tests/integration/test_network_mfg_solvers.py
@@ -151,13 +151,14 @@ class TestNetworkMFGProblemSetup:
         assert problem.network_geometry is network
 
     def test_network_problem_with_components(self):
-        """Test network problem with custom components."""
+        """Test network problem with custom components (real, functional fields — the dead
+        diffusion_coefficient/drift_coefficient knobs were removed in the #1470 Strand A purge)."""
         network = GridNetwork(width=4, height=4)
         network.create_network()
 
         components = NetworkMFGComponents(
-            diffusion_coefficient=0.5,
-            drift_coefficient=1.0,
+            node_potential_func=lambda n, t: 0.2 * n,
+            node_interaction_func=lambda n, m, t: 0.3 * m[n] ** 2,
         )
 
         problem = NetworkMFGProblem(
@@ -167,8 +168,12 @@ class TestNetworkMFGProblemSetup:
             components=components,
         )
 
-        assert problem.components.diffusion_coefficient == 0.5
-        assert problem.components.drift_coefficient == 1.0
+        # The functional components are wired into the single-source Hamiltonian object and reachable
+        # through the delegating problem methods (Issue #1470 Strand A).
+        assert problem.components.node_potential_func is components.node_potential_func
+        assert problem.node_potential(3, 0.0) == pytest.approx(0.6)
+        m = np.ones(problem.num_nodes) / problem.num_nodes
+        assert problem.density_coupling(2, m, 0.0) == pytest.approx(0.3 * m[2] ** 2)
 
 
 @pytest.mark.skip(

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -310,3 +310,30 @@ def test_problem_methods_delegate_to_object():
     for node in range(N):
         assert prob0.node_potential(node, t) == 0.0
         assert prob0.density_coupling(node, m, t) == pytest.approx(0.5 * m[node] ** 2)
+
+
+def test_hamiltonian_dm_single_sourced_analytic():
+    """Issue #1470 Strand A: ``NetworkMFGProblem.hamiltonian_dm`` delegates to the object's ``dm``,
+    which owns the EXACT analytic default-congestion derivative ``d/dm(0.5*m_own^2) = m_own[node]``
+    (own-population slice) — replacing the finite-difference default and the removed
+    ``_default_density_coupling_derivative``.
+    """
+    net = GridNetwork(width=3, height=3)
+    net.create_network()
+    prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=5)
+    H = prob.hamiltonian_class
+    N = prob.num_nodes
+    m = np.linspace(0.1, 0.9, N)
+    p = np.zeros(N)
+    for node in range(N):
+        # analytic default derivative == m[node]; problem method delegates to the object
+        assert H.dm(node, m, p, 0.0) == pytest.approx(m[node])
+        dm_method = prob.hamiltonian_dm(node, prob.get_node_neighbors(node), m, p, 0.0)
+        assert dm_method == pytest.approx(m[node])
+        assert dm_method == H.dm(node, m, p, 0.0)
+
+    # Multi-population: population 1's dm reads its OWN slice (0.9), not the raw stacked m[node] (0.1).
+    H1 = NetworkHamiltonian(network_data=prob.network_data, population_index=1)
+    m_stacked = np.concatenate([np.full(N, 0.1), np.full(N, 0.9)])
+    for node in range(N):
+        assert H1.dm(node, m_stacked, p, 0.0) == pytest.approx(0.9)

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -337,3 +337,23 @@ def test_hamiltonian_dm_single_sourced_analytic():
     m_stacked = np.concatenate([np.full(N, 0.1), np.full(N, 0.9)])
     for node in range(N):
         assert H1.dm(node, m_stacked, p, 0.0) == pytest.approx(0.9)
+
+
+def test_hamiltonian_dm_custom_interaction_finite_difference():
+    """Issue #1470 Strand A (#1537 review regression): for a custom ``node_interaction_func``, ``dm``
+    uses a node-wise central finite difference of the coupling — NOT the base ``_finite_diff_dm``, which
+    collapses ``m`` to a scalar (``np.mean``) and raised ``IndexError`` on node-indexed interaction funcs
+    (``m[node]`` on a length-1 array). ``d/dm[node] (0.3*m[node]^2) = 0.6*m[node]``.
+    """
+    net = GridNetwork(width=5, height=1)
+    net.create_network()
+    comps = NetworkMFGComponents(node_interaction_func=lambda n, m, t: 0.3 * m[n] ** 2)
+    prob = NetworkMFGProblem(geometry=net, components=comps, T=0.5, Nt=5)
+    H = prob.hamiltonian_class
+    m = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+    p = np.zeros(5)
+    for node in range(5):
+        # no crash for any node, and matches the analytic derivative 0.6*m[node]
+        assert H.dm(node, m, p, 0.0) == pytest.approx(0.6 * m[node], abs=1e-4)
+        dm_method = prob.hamiltonian_dm(node, prob.get_node_neighbors(node), m, p, 0.0)
+        assert dm_method == pytest.approx(0.6 * m[node], abs=1e-4)


### PR DESCRIPTION
**#1470 Strand A cleanup** — completes the consolidation. Two parts:

**1. Remove dead `NetworkMFGComponents.diffusion_coefficient` / `drift_coefficient`.** Never read by any solver (network FP diffusion is `FPNetworkSolver`'s knob per #1532; FP drift is `fp_drift_coefficient`), so setting them was silently ignored. #1535 flagged them `DEAD`. Repurposed the one test that asserted their storage to exercise real functional components. **Minor breaking:** passing them now raises `TypeError` (the kwargs never did anything).

**2. Single-source the derivative `dH/dm`.** `NetworkMFGProblem.hamiltonian_dm` now delegates to the wired object's `dm` (like `hamiltonian` / `node_potential` / `density_coupling`), and the object's `dm` gained the **exact analytic** default-congestion derivative `d/dm(0.5·m_own²) = m_own[node]` (own-population slice) instead of finite difference. The dead `_default_density_coupling_derivative` (raw `m[node]`, reachable only via the uncalled `hamiltonian_dm`) is removed.

*Verify-before-write note:* earlier I'd called `_default_density_coupling_derivative` dead — it wasn't (called by `hamiltonian_dm`). Confirmed **no network solver calls `object.dm`** and **no test asserts the derivative**, so the analytic change has zero live effect. Byte-identical single-population; own-slice multi-population (the same fix the *value* got in #1536).

**76 network tests green.** New test pins the analytic default, the `hamiltonian_dm`→object delegation, and the multi-pop slice.

Refs #1470.