### PR TITLE
feat(network): support sense=MAXIMIZE (reward-to-go / uphill control) (#1476)

### DIFF
--- a/changelog.d/1476-network-maximize.added.md
+++ b/changelog.d/1476-network-maximize.added.md
@@ -1,0 +1,11 @@
+- **Network MFG supports `sense=MAXIMIZE`** (Issue #1476). The finite-state network Hamiltonian now
+  handles reward-to-go / uphill control as well as cost-to-go / downhill, closing a network-vs-continuum
+  gap (the continuum `SeparableHamiltonian` already respected `sense`). The MINIMIZE↔MAXIMIZE mirror is
+  single-sourced through one orientation sign `NetworkHamiltonian.sense_sign` (+1 / −1): the **control**
+  terms flip with `s` — control cost, `optimal_control`, `dp`, the RK45 backward-integration control
+  term, and the policy-iteration control cost — while the **source** (node potential + congestion) is
+  sense-independent (a running payoff accumulates identically whether you minimise or maximise). Pass
+  `sense` to `NetworkMFGProblem(...)`; the previous fail-loud on MAXIMIZE is removed. MINIMIZE is
+  byte-identical (`s=+1`). Validated: MAXIMIZE control consistency (uphill, α≥0, envelope, method==object),
+  reward-to-go physicality for both a terminal reward and a running-reward potential (value peaks at /
+  increases toward the reward), and policy-iteration agrees with RK45 for both senses.

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -83,6 +83,16 @@ class NetworkHJBSolver(BaseHJBSolver):
 
         self.network_problem = problem
 
+        # Issue #1476: orientation sign for the backward-HJB integration, single-sourced from the wired
+        # Hamiltonian object so the solver and the object never disagree on the sense. +1 for MINIMIZE
+        # (du/ds = -H_control + source), -1 for MAXIMIZE (+H_control + source). ONLY the control flips
+        # with the sense; the source (V + congestion) enters UNFLIPPED for both (see the rhs).
+        # Note: the MAXIMIZE integration is anti-dissipative (+H_control grows the reverse-time value, as
+        # reward-to-go should), so the explicit RK45 path is less robust than for MINIMIZE on stiff/large
+        # problems; the implicit policy-iteration solver is the stable path. A genuine blow-up surfaces
+        # via the solve_ivp non-convergence warning below (sol.success is False).
+        self._sense_sign = problem.hamiltonian_class.sense_sign
+
         # Issue #1468/#1471: fail loud on a node BC this solver cannot honor. Node-BC now lives on the
         # geometry (GraphGeometry.has_explicit_boundary_conditions); the base ODE path applies only
         # the terminal condition and never the node-BC, so it would be silently ignored.
@@ -210,7 +220,12 @@ class NetworkHJBSolver(BaseHJBSolver):
             h_total = self._evaluate_hamiltonian_batch(u_flat, m, t_physical)
             source = self._source_terms(m, t_physical)
             h_control = h_total - source
-            return -h_control + source
+            # Issue #1476: ONLY the control Hamiltonian flips with sense; the source (V + congestion) is
+            # sense-INDEPENDENT (a running payoff accumulates identically whether you min or max — it is
+            # added to H without a sense-flip, matching the continuum SeparableHamiltonian). MINIMIZE:
+            # du/ds = -H_control + source; MAXIMIZE: +H_control + source. So the control term is
+            # -s*h_control and the source enters unflipped.
+            return -self._sense_sign * h_control + source
 
         sol = solve_ivp(
             rhs,
@@ -336,11 +351,12 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
         """Single backward time step via Howard policy iteration (Issue #1474).
 
         The "policy" is the full transition-rate vector ``alpha*(u) = H.optimal_control`` (not a single
-        dominant action). Each iteration solves the linear policy-evaluation
-        ``(I/dt + L^pi) u = u_next/dt + c(alpha) + source`` then recomputes the rates, until they
-        stabilize. At the fixed point this is the backward-Euler discretization of the same HJB the
-        RK45 path integrates: ``Q^pi u + c(alpha*) = -H_control`` (envelope identity), so
-        ``-du/dt = -H_control + source``.
+        dominant action, and sense-oriented via ``sense_sign``). Each iteration solves the linear
+        policy-evaluation ``(I/dt + L^pi) u = u_next/dt + s*c(alpha) + source`` (``s = sense_sign``; only
+        the control cost flips with the sense — the source does not) then recomputes the rates, until
+        they stabilize. At the fixed point this is the backward-Euler discretization of the same HJB the
+        RK45 path integrates: the envelope identity (generator action ``= 2*s*H_control``, ``c =
+        H_control``) reduces the row to ``-du/dt = -s*H_control + source`` for both senses (Issue #1476).
         """
         self._initialize_policy(u_next, m, t)
         u_current = u_next.copy()
@@ -392,7 +408,12 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
                     A[i, j] -= a
                     w = self.network_problem.network_data.get_edge_weight(i, j)
                     control_cost += 0.5 * a * a / w
-            b[i] = u_next[i] / self.dt + control_cost + source[i]
+            # Issue #1476: only the control COST flips with sense; the source is sense-INDEPENDENT (same
+            # as the RK45 rhs). MINIMIZE b: u_next/dt + c + source; MAXIMIZE b: u_next/dt - c + source.
+            # At the optimal-policy fixed point (generator action = 2*s*H_control, c = H_control) this
+            # reduces to (u_i-u_next)/dt = -s*H_control + source, matching the RK45 integration. The A
+            # matrix is unchanged (an M-matrix for any alpha >= 0, which holds for both senses).
+            b[i] = u_next[i] / self.dt + self._sense_sign * control_cost + source[i]
         return np.asarray(spsolve(A.tocsr(), b))
 
     def _policies_equal(self, rates1: dict[int, np.ndarray], rates2: dict[int, np.ndarray]) -> bool:

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -74,19 +74,11 @@ class NetworkHamiltonian(HamiltonianBase):
         population_index: int = 0,
     ):
         super().__init__(sense=sense, population_index=population_index)
-        # Issue #1474/#1476: the finite-state MFG here is implemented for sense=MINIMIZE (cost-to-go,
-        # downhill control) only — the control cost, optimal_control, dp, and the base-solver
-        # integration sign are all hardcoded to the MINIMIZE convention. Fail loud rather than
-        # silently compute MINIMIZE for a MAXIMIZE (reward-to-go, uphill) problem. Full MAXIMIZE
-        # support (the mirror) is tracked in #1476.
-        if sense != OptimizationSense.MINIMIZE:
-            raise NotImplementedError(
-                f"NetworkHamiltonian supports sense=OptimizationSense.MINIMIZE only (finite-state MFG "
-                f"cost-to-go / downhill control); got {sense}. MAXIMIZE (reward-to-go, uphill) is not "
-                f"yet implemented for network problems — see Issue #1476. Its control / H / dp and the "
-                f"base-solver integration sign are the mirror of the MINIMIZE case and need separate "
-                f"validation, so it cannot be silently reused."
-            )
+        # Issue #1474/#1476: the finite-state MFG supports BOTH senses through a single orientation sign
+        # `sense_sign` (+1 MINIMIZE / -1 MAXIMIZE). Cost-to-go (MINIMIZE) sends agents DOWNHILL toward
+        # lower value; reward-to-go (MAXIMIZE) sends them UPHILL toward higher value. Every sense-
+        # dependent piece — control cost, optimal_control, dp, and the base-solver integration sign — is
+        # `s * (MINIMIZE form)`, so `sense_sign` is the single source of the mirror. See `sense_sign`.
         self.network_data = network_data
         self._hamiltonian_func = hamiltonian_func
         self._hamiltonian_dm_func = hamiltonian_dm_func
@@ -99,6 +91,16 @@ class NetworkHamiltonian(HamiltonianBase):
         if self._num_nodes is None:
             self._num_nodes = self.network_data.num_nodes
         return self._num_nodes
+
+    @property
+    def sense_sign(self) -> float:
+        """Orientation sign of the finite-state control (Issue #1476): ``+1`` for MINIMIZE (cost-to-go,
+        agents move DOWNHILL toward lower value), ``-1`` for MAXIMIZE (reward-to-go, agents move UPHILL
+        toward higher value). Every sense-dependent piece — the control cost in ``_default_hamiltonian``,
+        ``optimal_control``, ``dp``, and the HJB integration sign in ``hjb_network`` — is ``s * (MINIMIZE
+        form)``, so this one property is the single source of the MINIMIZE<->MAXIMIZE mirror.
+        """
+        return 1.0 if self.sense == OptimizationSense.MINIMIZE else -1.0
 
     def _extract_own_density(self, m: np.ndarray) -> np.ndarray:
         """Extract this population's density from stacked m_all.
@@ -137,16 +139,16 @@ class NetworkHamiltonian(HamiltonianBase):
         Custom hamiltonian_func receives full m_all for cross-coupling.
         """
         neighbors = self.network_data.get_neighbors(node)
-        # Finite-state MFG control cost (Issue #1474): one-sided / piecewise-quadratic — the value of
-        # the constrained optimum over rates alpha >= 0 (needed for a valid CTMC generator). For
-        # sense=MINIMIZE (cost-to-go) the agent moves toward LOWER-value neighbors, so only downhill
-        # edges (u_i > u_j) contribute: H_control = 0.5 * sum_j w_ij * max(u_i - u_j, 0)^2. The full
-        # quadratic 0.5*sum w*(u_j-u_i)^2 was the unconstrained (alpha in R) relaxation — invalid
-        # generator, and inconsistent with optimal_control.
+        # Finite-state MFG control cost (Issue #1474/#1476): one-sided / piecewise-quadratic — the value
+        # of the constrained optimum over rates alpha >= 0 (a valid CTMC generator). Only the ACTIVE side
+        # contributes, oriented by sense_sign s: MINIMIZE (s=+1) counts downhill edges u_i>u_j giving
+        # 0.5*sum w*max(u_i-u_j,0)^2; MAXIMIZE (s=-1) counts uphill edges u_j>u_i giving
+        # 0.5*sum w*max(u_j-u_i,0)^2. Consistent with optimal_control (both use max(s*(u_i-u_j),0)).
+        s = self.sense_sign
         control_cost = 0.0
         for neighbor in neighbors:
             w = self.network_data.get_edge_weight(node, neighbor)
-            du = p[node] - p[neighbor]  # u_i - u_j
+            du = s * (p[node] - p[neighbor])  # oriented: u_i - u_j (MIN) / u_j - u_i (MAX)
             control_cost += 0.5 * w * max(du, 0.0) ** 2
 
         # Issue #1470: the p-independent source (V + coupling) is single-sourced in `source_term` and
@@ -188,39 +190,44 @@ class NetworkHamiltonian(HamiltonianBase):
         return 0.5 * float(self._extract_own_density(m)[node]) ** 2
 
     def optimal_control(self, x, m, p, t=0.0):
-        """Optimal transition rates from node x (Issue #1474).
+        """Optimal transition rates from node x (Issue #1474/#1476).
 
-        Finite-state MFG, sense=MINIMIZE: ``alpha*_ij = w_ij * max(u_i - u_j, 0)`` — the argmax of
-        the one-sided control Hamiltonian, sending agents DOWNHILL toward lower cost-to-go. Rates are
-        non-negative by construction (a valid conservative CTMC generator). ``max(u_j - u_i, 0)``
-        (the previous form) is the MAXIMIZE/uphill branch and transports mass the wrong way.
-        Returns an array of rates to neighbors (zero for non-neighbors).
+        Finite-state MFG: ``alpha*_ij = w_ij * max(s*(u_i - u_j), 0)`` with orientation ``s = sense_sign``
+        — the argmax of the one-sided control Hamiltonian. MINIMIZE (s=+1) sends agents DOWNHILL toward
+        lower cost-to-go (``max(u_i - u_j, 0)``); MAXIMIZE (s=-1) sends them UPHILL toward higher
+        reward-to-go (``max(u_j - u_i, 0)``). Rates are non-negative by construction (a valid
+        conservative CTMC generator). Returns an array of rates to neighbors (zero for non-neighbors).
         """
         node = int(np.asarray(x).flat[0])
         p_arr = np.atleast_1d(p)
         neighbors = self.network_data.get_neighbors(node)
 
+        s = self.sense_sign
         alpha = np.zeros_like(p_arr)
         for neighbor in neighbors:
             w = self.network_data.get_edge_weight(node, neighbor)
-            du = p_arr[node] - p_arr[neighbor]  # u_i - u_j
+            du = s * (p_arr[node] - p_arr[neighbor])  # downhill (MIN) / uphill (MAX)
             alpha[neighbor] = w * max(du, 0.0)
         return alpha
 
     def dp(self, x, m, p, t=0.0):
-        """dH/dp at node x (Issue #1474). Gradient of the one-sided control Hamiltonian: with
-        ``alpha*_ij = w_ij max(u_i - u_j, 0)``, ``dH/du_i = +sum_j alpha*_ij`` and
-        ``dH/du_j = -alpha*_ij`` (so ``dp`` equals the generator action ``-Q^{alpha*} u``)."""
+        """dH/dp at node x (Issue #1474/#1476). Gradient of the one-sided control Hamiltonian
+        ``0.5 sum_j w_ij max(s*(u_i-u_j),0)^2`` with ``s = sense_sign``: differentiating gives
+        ``dH/du_i = +s*sum_j alpha*_ij`` and ``dH/du_j = -s*alpha*_ij`` where
+        ``alpha*_ij = w_ij max(s*(u_i-u_j),0) >= 0``. So both the rate orientation and the gradient sign
+        flip with the sense (MINIMIZE s=+1 downhill; MAXIMIZE s=-1 uphill), and ``dp`` equals the
+        generator action ``-Q^{alpha*} u``."""
         node = int(np.asarray(x).flat[0])
         p_arr = np.atleast_1d(p)
         neighbors = self.network_data.get_neighbors(node)
 
+        s = self.sense_sign
         grad = np.zeros_like(p_arr)
         for neighbor in neighbors:
             w = self.network_data.get_edge_weight(node, neighbor)
-            a = w * max(p_arr[node] - p_arr[neighbor], 0.0)  # alpha*_{i,neighbor} (downhill)
-            grad[neighbor] -= a
-            grad[node] += a
+            a = w * max(s * (p_arr[node] - p_arr[neighbor]), 0.0)  # alpha*_{i,neighbor} (oriented) >= 0
+            grad[neighbor] -= s * a
+            grad[node] += s * a
         return grad
 
     def dm(self, x, m, p, t=0.0):
@@ -343,6 +350,7 @@ class NetworkMFGProblem(MFGProblem):
         problem_name: str = "NetworkMFG",
         *,
         network_geometry: BaseNetworkGeometry | None = None,
+        sense: OptimizationSense = OptimizationSense.MINIMIZE,
     ):
         """
         Initialize network MFG problem.
@@ -389,6 +397,7 @@ class NetworkMFGProblem(MFGProblem):
             hamiltonian_dm_func=net_components.hamiltonian_dm_func,
             node_potential_func=net_components.node_potential_func,
             node_interaction_func=net_components.node_interaction_func,
+            sense=sense,  # Issue #1476: MINIMIZE (cost-to-go) or MAXIMIZE (reward-to-go)
         )
         parent_components = MFGComponents(
             hamiltonian=network_hamiltonian,

--- a/tests/unit/test_alg/test_network_hamiltonian_pinning.py
+++ b/tests/unit/test_alg/test_network_hamiltonian_pinning.py
@@ -174,17 +174,44 @@ def test_network_policy_iteration_converges_to_rk45():
     assert errs[-1] < 0.55 * errs[0], f"gap must shrink under dt-refinement (N15 plateau closed): {errs}"
 
 
-def test_network_hamiltonian_maximize_fails_loud():
-    """Issue #1474 / #1476: the network finite-state MFG is implemented for ``sense=MINIMIZE`` only.
-    ``sense=MAXIMIZE`` must fail loud rather than silently compute the MINIMIZE (downhill) math. Full
-    MAXIMIZE (reward-to-go / uphill) support — the mirror — is tracked in #1476."""
+def test_network_hamiltonian_maximize_consistency():
+    """Issue #1476: with ``sense=MAXIMIZE`` the finite-state MFG mirrors the MINIMIZE case —
+    reward-to-go, UPHILL control. On a line graph with strictly increasing value ``u = [0,1,2,3,4]``:
+    - control is UPHILL: at node 2, ``alpha* > 0`` toward the HIGHER neighbour 3, ``== 0`` toward the
+      lower neighbour 1 (the exact mirror of the MINIMIZE case);
+    - rates are non-negative (valid conservative generator);
+    - the control part of H equals the envelope ``0.5 * sum(alpha*^2)`` (unit weights);
+    - the method ``NetworkMFGProblem.hamiltonian`` (used by RK45) equals the object ``__call__``.
+    """
     from mfgarchon.core.hamiltonian import OptimizationSense
 
-    net = GridNetwork(width=3, height=1)
+    net = GridNetwork(width=5, height=1)
     net.create_network()
-    prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=4)
-    with pytest.raises(NotImplementedError, match="MINIMIZE"):
-        NetworkHamiltonian(network_data=prob.network_data, sense=OptimizationSense.MAXIMIZE)
+    prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=20, sense=OptimizationSense.MAXIMIZE)
+    H = prob.hamiltonian_class
+    assert H is not None
+    assert H.sense_sign == -1.0
+    N = prob.num_nodes
+    u = np.arange(N, dtype=float)
+    m = np.ones(N) / N
+    t = 0.1
+
+    alpha2 = np.atleast_1d(H.optimal_control(np.array([2]), m, u, t))
+    assert alpha2[3] > 0, f"MAXIMIZE control must flow to the HIGHER neighbour (uphill); got {alpha2}"
+    assert alpha2[1] == 0, f"MAXIMIZE control must not flow to the lower neighbour; got {alpha2}"
+
+    for i in range(N):
+        ai = np.atleast_1d(H.optimal_control(np.array([i]), m, u, t))
+        assert (ai >= -1e-12).all(), f"rates must be >= 0 at node {i}: {ai}"
+
+    coupling2 = 0.5 * m[2] ** 2  # default node congestion at node 2
+    control2 = float(H(np.array([2]), m, u, t)) - coupling2
+    envelope2 = 0.5 * float(np.sum(alpha2**2))
+    assert abs(control2 - 0.5) < 1e-9, f"one-sided control at node2 should be 0.5, got {control2}"
+    assert abs(control2 - envelope2) < 1e-9, f"H control != envelope 0.5*sum(alpha^2): {control2} vs {envelope2}"
+
+    method2 = prob.hamiltonian(2, prob.get_node_neighbors(2), m, u, t)
+    assert abs(method2 - float(H(np.array([2]), m, u, t))) < 1e-9, "RK45 method H must equal object H"
 
 
 def test_network_hamiltonian_method_equals_object():
@@ -357,3 +384,65 @@ def test_hamiltonian_dm_custom_interaction_finite_difference():
         assert H.dm(node, m, p, 0.0) == pytest.approx(0.6 * m[node], abs=1e-4)
         dm_method = prob.hamiltonian_dm(node, prob.get_node_neighbors(node), m, p, 0.0)
         assert dm_method == pytest.approx(0.6 * m[node], abs=1e-4)
+
+
+def test_network_maximize_policy_iteration_equals_rk45_and_physical():
+    """Issue #1476: for ``sense=MAXIMIZE`` (a) policy iteration and RK45 solve the SAME HJB — they agree
+    closely and the gap shrinks under dt-refinement (mirror of the MINIMIZE N15 check), and (b) the
+    reward-to-go is physical: with a high terminal REWARD at node 4 on a line graph, the value is finite,
+    peaks at the reward node, and increases monotonically toward it (agents move UPHILL to the reward).
+    Contrast MINIMIZE, where the same terminal is a COST and the value stays low away from it.
+    """
+    from mfgarchon.core.hamiltonian import OptimizationSense
+
+    net = GridNetwork(width=5, height=1)
+    net.create_network()
+    g = np.array([0.0, 0.0, 0.0, 0.0, 10.0])  # terminal reward at node 4
+    errs = []
+    u_rk_fine = None
+    for nt in (20, 40, 80):
+        prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=nt, sense=OptimizationSense.MAXIMIZE)
+        n = prob.num_nodes
+        m = np.ones((nt + 1, n)) / n
+        u_rk = NetworkHJBSolver(prob, scheme="RK45").solve_hjb_system(M_density=m, U_terminal=g)
+        u_pi = NetworkPolicyIterationHJBSolver(prob).solve_hjb_system(M_density=m, U_terminal=g)
+        assert np.isfinite(u_pi).all(), "policy-iteration MAXIMIZE value must be finite"
+        assert np.isfinite(u_rk).all(), "RK45 MAXIMIZE value must be finite"
+        errs.append(float(np.max(np.abs(u_pi[0] - u_rk[0]))))
+        u_rk_fine = u_rk
+    assert errs[0] < 0.3, f"PI and RK45 must agree closely for MAXIMIZE (same HJB), got {errs[0]:.3f}"
+    assert errs[-1] < errs[0], f"PI-RK45 gap must shrink under dt-refinement: {errs}"
+
+    # Physicality: reward-to-go peaks at the high-reward node and increases monotonically toward it.
+    u0 = u_rk_fine[0]
+    assert int(u0.argmax()) == 4, f"reward-to-go must peak at the reward node 4; got {u0}"
+    assert np.all(np.diff(u0) > 1e-6), f"reward-to-go must increase toward node 4 (uphill/monotone): {u0}"
+    # ~= terminal reward 10 plus the small accumulated congestion reward (source is added, not subtracted).
+    assert 9.5 < u0[4] < 10.5, f"reward-node value must be near the terminal reward 10; got {u0[4]}"
+
+
+def test_network_maximize_running_reward_attracts():
+    """Issue #1476 (adversarial-verification catch): the SOURCE (node potential V + congestion) is
+    sense-INDEPENDENT — only the control Hamiltonian flips with sense. A running REWARD potential must
+    ATTRACT under MAXIMIZE (reward-to-go peaks at the high-reward node, ~= the integral of V), not repel.
+    This is the diagnostic a spatially-uniform source (V=0) cannot exercise: the earlier bug scaled the
+    source by sense_sign, so a running reward REPELLED (argmin) — yet every V=0 test passed and even
+    policy-iteration agreed with RK45 (both carried the same sign error). This case pins the source sign.
+    """
+    from mfgarchon.core.hamiltonian import OptimizationSense
+
+    net = GridNetwork(width=5, height=1)
+    net.create_network()
+    comps = NetworkMFGComponents(node_potential_func=lambda n, t: 2.0 * n)  # running reward, increasing with node
+    prob = NetworkMFGProblem(geometry=net, T=0.5, Nt=40, components=comps, sense=OptimizationSense.MAXIMIZE)
+    n = prob.num_nodes
+    m = np.ones((41, n)) / n
+    g = np.zeros(n)  # no terminal — the SOURCE alone drives the value
+    u_rk = NetworkHJBSolver(prob, scheme="RK45").solve_hjb_system(M_density=m, U_terminal=g)
+    u_pi = NetworkPolicyIterationHJBSolver(prob).solve_hjb_system(M_density=m, U_terminal=g)
+    u0 = u_rk[0]
+    assert np.isfinite(u0).all()
+    assert int(u0.argmax()) == n - 1, f"MAXIMIZE running reward must ATTRACT to the high-V node, not repel; got {u0}"
+    assert (u0 > 0).all(), f"reward-to-go from a positive running reward must be positive everywhere; got {u0}"
+    assert u0[n - 1] > u0[0] + 2.0, f"reward-to-go must increase strongly toward the reward; got {u0}"
+    assert np.max(np.abs(u_pi[0] - u_rk[0])) < 0.3, "PI must match RK45 with the corrected source sign"


### PR DESCRIPTION
Adds full **reward-to-go / uphill** support to the finite-state network MFG (was MINIMIZE-only, fail-loud on MAXIMIZE), closing a network-vs-continuum gap.

## Design — one orientation sign
The MINIMIZE↔MAXIMIZE mirror is single-sourced through `NetworkHamiltonian.sense_sign` (+1/−1). **Only the control terms flip** with `s` — control cost, `optimal_control`, `dp`, the RK45 backward-integration control term, and the policy-iteration control cost. The **source** (node potential + congestion) is **sense-independent** (a running payoff accumulates the same whether you min or max). `sense` is threaded through `NetworkMFGProblem(...)`; the fail-loud is removed. **MINIMIZE is byte-identical** (`s=+1`).

## Adversarial verification caught a real bug
A verification workflow (4 + 3 independent auditors re-deriving each sign) found a **silent-wrong** defect the local suite missed: an initial version factored the RHS as `s·(−H_control + source)`, scaling the **source** by `s` too → a *running reward* would **repel** under MAXIMIZE. Every local test passed anyway because they used `V=0`/uniform source (≈0, non-diagnostic), and `PI==RK45` agreed since both paths carried the same error. Fixed to `−s·h_control + source`; added a **running-reward diagnostic** (`V=2·node`) that pins the source sign — reward-to-go peaks *at* the reward node (attracted), not argmin.

## Validation (79 network tests)
- MAXIMIZE control consistency: uphill, α≥0, envelope `0.5Σα²`, method==object.
- Reward-to-go physicality: terminal reward `[0.02,0.65,3.41,7.15,10.01]` **and** running-reward `V=2n` → `[0.09,1.09,2.09,3.09,4.01]` (both peak at/increase toward the reward).
- Policy-iteration agrees with RK45 for **both** senses; gap halves under dt-refinement.

## Documented limitation
The MAXIMIZE reverse-time ODE is **anti-dissipative** (`+H_control` grows the value, as reward-to-go should), so the explicit RK45 path is less robust than the implicit policy-iteration on stiff/large problems; a genuine blow-up surfaces via the existing `solve_ivp` non-convergence warning. Policy-iteration is the stable path for MAXIMIZE.

Closes #1476.