### PR TITLE
chore(ci): tighten fail-fast ratchet baseline (hasattr 172->164, silent_pass 70->60)

### DIFF
--- a/changelog.d/ratchet-baseline.changed.md
+++ b/changelog.d/ratchet-baseline.changed.md
@@ -1,0 +1,3 @@
+- **Fail-fast ratchet baseline tightened.** `scripts/fail_fast_baseline.json` re-baselined to current
+  counts (hasattr 172->164, silent_pass 70->60) so the monotone CI ratchet bites again; it had gone
+  stale after the v0.21.0 fail-loud fixes reduced live counts below the recorded ceiling.

--- a/scripts/fail_fast_baseline.json
+++ b/scripts/fail_fast_baseline.json
@@ -1,6 +1,6 @@
 {
   "bare_except": 0,
   "broad_except": 11,
-  "hasattr": 172,
-  "silent_pass": 70
+  "hasattr": 164,
+  "silent_pass": 60
 }


### PR DESCRIPTION
## What

Re-baseline `scripts/fail_fast_baseline.json` to the current live counts:

| category | old ceiling | new ceiling |
|---|---|---|
| hasattr | 172 | **164** |
| silent_pass | 70 | **60** |
| broad_except | 11 | 11 |
| bare_except | 0 | 0 |

## Why

The ratchet is a monotone downward gate: CI fails only on *increase* vs the committed baseline. After the v0.21.0 fail-loud fixes reduced live counts, the stale ceiling left 8 hasattr + 10 silent_pass of free regression headroom. `check_fail_fast.py --check-baseline` verified green at the new ceiling.

Deep-check campaign v2, Stage 0 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)