### PR TITLE
fix(fp): fp_drift_coefficient fails loud on smooth non-quadratic-MINIMIZE H (#1542, RFC #1574 Phase 0)

### DIFF
--- a/changelog.d/1542-fp-drift-fail-loud.fixed.md
+++ b/changelog.d/1542-fp-drift-fail-loud.fixed.md
@@ -1,0 +1,8 @@
+- **FP drift coefficient fails loud on a smooth non-quadratic-MINIMIZE Hamiltonian** (Issue #1542,
+  RFC #1574 Phase 0). `fp_drift_coefficient` silently fell back to `coupling_coefficient` (default 0.5)
+  for a MAXIMIZE-quadratic or Moreau-Yosida-regularized `SeparableHamiltonian` — regimes the drift
+  router steers to the scalar `-c*grad(U)` path (it gates on `is_smooth()` alone), where that form is
+  the wrong optimal control (wrong sign for MAXIMIZE, wrong form for a regularized cost). It now raises
+  `NotImplementedError` naming the case instead of advecting with silently-wrong physics. The
+  quadratic-MINIMIZE path (every stock/published config) is unchanged; only the previously silent-wrong
+  regimes are affected.

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -33,12 +33,20 @@ def fp_drift_coefficient(problem: Any) -> float:
     (``MFGProblem`` default 0.5), making the coupled solve converge to the wrong fixed point
     (G-017; exp16 Tier-2 had the Towel equilibrium ~4-5x too wide).
 
-    Falls back to the legacy ``coupling_coefficient`` attribute when there is no quadratic MINIMIZE
-    separable Hamiltonian to source from: a non-``SeparableHamiltonian`` Hamiltonian (e.g.
-    ``QuadraticMFGHamiltonian``, which carries its own ``coupling_coefficient``) or a non-Hamiltonian
-    direct solve. Non-smooth / congestion / MAXIMIZE control costs never reach the ``-c·∇U`` path
-    (``resolve_fp_drift_kwargs`` routes them to the velocity ``drift_field`` channel), and
-    ``CongestionHamiltonian`` is not a ``SeparableHamiltonian`` so it is excluded here by type.
+    Falls back to the legacy ``coupling_coefficient`` attribute when there is no ``SeparableHamiltonian``
+    at all: a non-``SeparableHamiltonian`` Hamiltonian (e.g. ``QuadraticMFGHamiltonian``, which carries
+    its own ``coupling_coefficient``) or a non-Hamiltonian direct solve.
+
+    Fail-loud on a *smooth-but-not-quadratic-MINIMIZE* ``SeparableHamiltonian`` (Issue #1542 / RFC #1574
+    Phase 0): a ``SeparableHamiltonian`` whose control cost is MAXIMIZE-quadratic or non-quadratic
+    (e.g. Moreau--Yosida-regularized) can reach this function because ``resolve_fp_drift_kwargs`` gates
+    the routing on ``is_smooth()`` alone (sense-blind), so it steers such a Hamiltonian to the
+    ``potential_field=U`` channel where the FP solver forms ``-c·∇U``. But the scalar ``-c·∇U`` form is
+    the optimal control *only* for the quadratic-MINIMIZE case; the true drift is
+    ``α* = H.optimal_control(...)`` (``+p/λ`` for MAXIMIZE, soft-thresholded for a regularized cost).
+    Returning ``coupling_coefficient`` here would advect with the wrong sign / wrong form silently, so
+    this raises ``NotImplementedError`` instead — the caller must route the drift through the velocity
+    channel (Phase 1). This enforces the invariant the docstring previously only asserted.
 
     Fail-loud (Issue #1420 V1): if there is neither a quadratic-MINIMIZE ``SeparableHamiltonian`` to
     source ``1/control_cost`` from nor a ``coupling_coefficient`` on the problem, this raises rather
@@ -54,6 +62,20 @@ def fp_drift_coefficient(problem: Any) -> float:
         and h_class.control_cost.sign == 1  # OptimizationSense.MINIMIZE
     ):
         return 1.0 / h_class.control_cost.lambda_
+    if isinstance(h_class, SeparableHamiltonian):
+        # A SeparableHamiltonian that fell past the quadratic-MINIMIZE branch is MAXIMIZE-quadratic or
+        # a non-quadratic (e.g. regularized) control cost. The scalar drift `-c·∇U` does not represent
+        # its optimal control, so fail loud rather than return `coupling_coefficient` and advect with
+        # the wrong physics (Issue #1542 / RFC #1574 Phase 0).
+        control_cost = h_class.control_cost
+        detail = "MAXIMIZE quadratic" if isinstance(control_cost, QuadraticControlCost) else type(control_cost).__name__
+        raise NotImplementedError(
+            f"fp_drift_coefficient: the scalar FP drift `-c*grad(U)` is defined only for a "
+            f"quadratic-MINIMIZE SeparableHamiltonian, but got a {detail} control cost. Its optimal "
+            f"control is alpha* = H.optimal_control(...), not -c*grad(U) (wrong sign for MAXIMIZE, "
+            f"wrong form for a regularized cost). Route the FP drift through the velocity channel "
+            f"(precomputed alpha*) instead (Issue #1542 / RFC #1574 Phase 1)."
+        )
     cc = getattr(problem, "coupling_coefficient", None)
     if cc is None:
         raise ValueError(

--- a/tests/unit/test_core/test_pde_coefficients.py
+++ b/tests/unit/test_core/test_pde_coefficients.py
@@ -503,6 +503,27 @@ class TestFpDriftCoefficient:
         with pytest.raises(ValueError, match="Cannot determine the FP drift coefficient"):
             fp_drift_coefficient(_Bare())
 
+    def test_maximize_quadratic_separable_h_fails_loud_not_coupling_fallback(self):
+        # Issue #1542 / RFC #1574 Phase 0: a MAXIMIZE-quadratic SeparableHamiltonian reaches this
+        # function (the router gates on is_smooth() alone) but `-c*grad(U)` is the wrong drift for it.
+        # It must fail loud, NOT silently fall back to coupling_coefficient (default 0.5 => wrong-sign
+        # downhill drift). The discriminating check: coupling_coefficient IS set, so a revert to the
+        # old fallback would return 0.5 and this test would catch it.
+        from mfgarchon.core.hamiltonian import OptimizationSense
+
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+        comp = MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(lambda_=2.0, sense=OptimizationSense.MAXIMIZE)
+            ),
+        )
+        prob = MFGProblem(geometry=grid, components=comp, T=0.2, Nt=2, sigma=0.1)
+        assert getattr(prob, "coupling_coefficient", None) is not None  # the trap the old code fell into
+        with pytest.raises(NotImplementedError, match="quadratic-MINIMIZE"):
+            fp_drift_coefficient(prob)
+
 
 class TestResolveDiffusionSource:
     """Issue #1412: the shared single-source volatility (sigma) lookup that HJB and FP


### PR DESCRIPTION
## What

`fp_drift_coefficient` (`utils/pde_coefficients.py`) now **raises `NotImplementedError`** when it is handed a `SeparableHamiltonian` whose control cost is MAXIMIZE-quadratic or non-quadratic (e.g. Moreau–Yosida-regularized), instead of silently falling back to `coupling_coefficient` (default 0.5).

## Why (Issue #1542, first fix under RFC #1574 Phase 0)

The FP drift *router* (`resolve_fp_drift_kwargs`, `fixed_point_utils.py:586`) gates on `is_smooth()` **alone** — sense-blind and quadraticity-blind — so a smooth MAXIMIZE-quadratic or a smooth regularized `SeparableHamiltonian` is steered to the `potential_field=U` channel, where the FP solver forms the scalar drift `-c·∇U`. But `-c·∇U` is the optimal control **only** for the quadratic-MINIMIZE case:
- MAXIMIZE → true `α* = +p/λ` (uphill), so `-0.5·∇U` advects **downhill** — sign-flipped equilibrium;
- regularized → true `α*` is soft-thresholded (zero inside the threshold), not `-c·∇U` at all.

Previously the coefficient gate's own fail-loud () was unreachable here because `coupling_coefficient` is always set on a stock `MFGProblem` (default 0.5), so these regimes got a silently-wrong drift with no error. This converts that silent-wrong into a loud, greppable failure — the Phase-0 posture of RFC #1574 (align the guard / fail loud in the gap before implementing the case).

## Scope / safety

- **Quadratic-MINIMIZE (every stock and published exp06a/08/09 config) is unchanged** — it returns `1/control_cost` from the first branch as before.
- The legitimate `coupling_coefficient` fallback for **non-`SeparableHamiltonian`** problems (`QuadraticMFGHamiltonian`, non-Hamiltonian direct solves) is preserved.
- Only the previously silent-wrong MAXIMIZE / regularized `SeparableHamiltonian` regimes now raise. No correct behavior is lost.

## Test

`test_maximize_quadratic_separable_h_fails_loud_not_coupling_fallback` constructs a MAXIMIZE-quadratic `SeparableHamiltonian` **with `coupling_coefficient` set** (the exact trap the old code fell into) and asserts `NotImplementedError`. Verified **discriminating**: neutering the new guard makes the test fail (the old code returns 0.5). Regression: the full `TestFpDriftCoefficient`, drift-contract, s1-routing, single-source, and FP-FDM solver suites (51 tests) pass.

Fixes #1542. First fix under RFC #1574 (capability honesty — fail loud when the dispatched surface is broader than the honored code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)