### PR TITLE
chore(ci): pin mypy <2.2 — 2.2.0 false-positives on valid list[str] slices

### DIFF
--- a/changelog.d/pin-mypy-2.2.changed.md
+++ b/changelog.d/pin-mypy-2.2.changed.md
@@ -1,0 +1,4 @@
+- **Pin mypy `<2.2` in the dev extras.** mypy 2.2.0 false-positives on valid `list[str]` slices
+  (e.g. `config/omegaconf_manager.py` `keys[:i+1]`) via a typeshed `slice`-overload regression that
+  2.1.0 does not have, reddening the blocking config type-gate on every PR. Narrow upper bound until
+  mypy 2.2.1 fixes it (then lift to `<2.3`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,10 @@ dev = [
     "pytest-xdist>=3.5",
     "pytest-timeout>=2.1",
     "ruff>=0.6.0",
-    "mypy>=1.5",
+    # Upper bound: mypy 2.2.0 false-positives on valid `list[str]` slices (e.g.
+    # config/omegaconf_manager.py `keys[:i+1]`), a typeshed `slice` overload regression that
+    # 2.1.0 does not have. Lift to `<2.3` once mypy 2.2.1 fixes it. See RFC-adjacent CI note.
+    "mypy>=1.5,<2.2",
     "pre-commit>=2.0",
     "types-setuptools",
     "types-psutil",


### PR DESCRIPTION
## What

Add an upper bound to the dev-extras mypy pin: `mypy>=1.5` → `mypy>=1.5,<2.2`.

## Why

mypy 2.2.0 flags three **valid** `list[str]` slices in `config/omegaconf_manager.py` (`keys[: i+1]` :368, `keys[:i]` :371, `keys[:-1]` :382) as:

```
error: Invalid index type "slice[None, int, None]" for "list[str]";
expected type "slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex]"  [index]
```

i.e. it rejects a `None` slice **step** — a typeshed `slice`-overload regression. mypy **2.1.0 has no such error** (known-good baseline). It reproduces only inside this file's inference context (an isolated `list[str]` slice passes under 2.2.0), confirming it is a pure tooling false positive on valid code, not a real type issue.

Because the **config mypy gate is a blocking Import-Validation check** (`mypy mfgarchon/config --follow-imports=silent`), the unbounded `mypy>=1.5` picked up 2.2.0 and reddened **every** PR's Test Suite gate — a main-blocker orthogonal to any code change.

## Why pin (not code-contort or `# type: ignore`)

- The flagged code is correct; contorting valid `list` slices to appease a buggy tool is the wrong direction (a red on a known-good baseline indicts the version — Support-before-Exploit).
- `# type: ignore[index]` would be reaped by `warn_unused_ignores = true` the moment mypy 2.2.1 fixes the regression → red again. Fragile.
- A narrow, documented, revertible upper bound keeps the toolchain reproducible now and lifts trivially (`<2.3`) when 2.2.1 lands.

## Verification

Local config gate under the pinned range (`pip install "mypy>=1.5,<2.2"` → 2.1.0): `Success: no issues found in 8 source files`. Under 2.2.0: the 3 errors above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)