### PR TITLE
fix(gfdm): precompute log names the real SOCP-infeasible fallback (#1565)

### DIFF
--- a/changelog.d/1565-gfdm-fallback-log.fixed.md
+++ b/changelog.d/1565-gfdm-fallback-log.fixed.md
@@ -1,0 +1,6 @@
+- **GFDM precompute log names the real SOCP-infeasible fallback** (Issue #1565). The
+  post-precompute INFO log claimed SOCP-infeasible nodes "fall back to M-matrix QP (Phase 2)", but
+  the SOCP loop iterates interior nodes only and the M-matrix-QP buffer is boundary-only, so an
+  infeasible interior node actually falls through to the bare (non-monotone) Wendland-Taylor LSQ
+  weights. The message now says so, so the monotone fraction of the cloud is not over-stated.
+  Diagnostic-only; no numerics change.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -1084,13 +1084,19 @@ class HJBGFDMSolver(BaseHJBSolver):
                 if stats.get("n_enlarged", 0) > 0
                 else ""
             )
+            # Issue #1565: the SOCP loop iterates INTERIOR indices only, and the M-matrix-QP
+            # precompute buffer is BOUNDARY-only, so an SOCP-infeasible interior node matches
+            # neither has_stencil branch at solve time and falls through to the bare (non-monotone)
+            # Wendland-Taylor LSQ weights — NOT a Phase-2 M-matrix QP (which never covers interior
+            # nodes). Report the real fallback so the monotone fraction is not over-stated.
             logger.info(
                 f"Precomputed joint SOCP stencils: feasible {stats['n_feasible']}/"
                 f"{stats['n_interior']} interior "
                 f"({stats['n_fast_path']} via Wendland-LSQ fast-path, "
                 f"{stats['n_socp']} via CLARABEL SOCP{relax_C_msg}{enlarge_msg}{relax_fb_msg}) in "
-                f"{stats['time_ms']:.1f}ms; SOCP-infeasible {stats['n_infeasible']} fall "
-                f"back to M-matrix QP (Phase 2)"
+                f"{stats['time_ms']:.1f}ms; SOCP-infeasible {stats['n_infeasible']} interior node(s) "
+                f"fall through to bare Wendland-Taylor LSQ (NON-MONOTONE; no Phase-2 QP covers "
+                f"interior nodes)"
             )
 
         # Initialize precomputed M-matrix QP stencils at boundary nodes.


### PR DESCRIPTION
## What

Correct the post-precompute INFO log: SOCP-infeasible interior nodes fall through to bare **non-monotone Wendland-Taylor LSQ** weights, not "M-matrix QP (Phase 2)".

## Why

The joint-SOCP precompute loop iterates **interior** indices only, and the M-matrix-QP buffer set is **boundary-only**, so an SOCP-infeasible interior node matches neither `has_stencil` branch at solve time and silently uses the bare Wendland-Taylor weights — as the adjacent code comment already admits. The old message claimed a Phase-2 QP fallback that never runs for those nodes, over-stating the monotone fraction of the cloud.

Diagnostic-only; no numerics change. Verified: GFDM solver suite (27 tests) passes.

Fixes #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)