### PR TITLE
fix(config): CFL number uses PDE coefficient D=sigma^2/2, not bare sigma^2 (#1550)

### DIFF
--- a/changelog.d/1550-config-cfl-sigma.fixed.md
+++ b/changelog.d/1550-config-cfl-sigma.fixed.md
@@ -1,0 +1,6 @@
+- **Config CFL number uses the PDE coefficient D = sigma^2/2** (Issue #1550). `MFGGridConfig.cfl_number`
+  and `validate_cfl_stability` computed the diffusive CFL with bare `sigma^2` (= 2D), so the
+  stability warning fired at twice the correct threshold and `cfl_number` disagreed with the
+  #1426/S0-14-corrected solver diagnostics (hjb_fdm/fp_fdm). Both now use `0.5*sigma^2`. The `sigma`
+  field description is corrected to "SDE volatility" (it was mislabelled "Diffusion coefficient").
+  Diagnostic/validation-only; no solve numerics change.

--- a/mfgarchon/config/array_validation.py
+++ b/mfgarchon/config/array_validation.py
@@ -51,7 +51,7 @@ class MFGGridConfig(BaseModel):
     xmin: float = Field(0.0, description="Spatial domain minimum")
     xmax: float = Field(1.0, description="Spatial domain maximum")
     T: float = Field(1.0, gt=0.0, le=100.0, description="Final time")
-    sigma: float = Field(0.1, gt=0.0, le=10.0, description="Diffusion coefficient")
+    sigma: float = Field(0.1, gt=0.0, le=10.0, description="SDE volatility sigma (PDE diffusion is D = sigma^2/2)")
 
     @field_validator("xmax")
     @classmethod
@@ -75,8 +75,11 @@ class MFGGridConfig(BaseModel):
 
     @property
     def cfl_number(self) -> float:
-        """CFL number for stability analysis."""
-        return self.sigma**2 * self.dt / (self.dx**2)
+        """Diffusive CFL number D*dt/dx^2 for stability analysis, with the PDE coefficient
+        D = sigma^2/2 (Issue #1550 / #1426-S0-14). `sigma` is the SDE volatility, so the diffusive
+        CFL uses 0.5*sigma^2, matching the corrected solver diagnostics (hjb_fdm/fp_fdm) — not the
+        bare sigma^2 (= 2D) this used to report."""
+        return 0.5 * self.sigma**2 * self.dt / (self.dx**2)
 
     @property
     def grid_shape(self) -> tuple[int, int]:
@@ -97,7 +100,9 @@ class MFGGridConfig(BaseModel):
             if Nx and Nt and xmax > xmin and T > 0:
                 dx = (xmax - xmin) / Nx
                 dt = T / Nt
-                cfl = v**2 * dt / (dx**2)
+                # Diffusive CFL uses the PDE coefficient D = sigma^2/2 (v is the SDE volatility),
+                # not bare sigma^2 (= 2D) — Issue #1550 / #1426-S0-14. Matches hjb_fdm/fp_fdm.
+                cfl = 0.5 * v**2 * dt / (dx**2)
 
                 if cfl > 0.5:
                     warnings.warn(f"CFL number {cfl:.3f} > 0.5 may cause instability", UserWarning)

--- a/tests/unit/test_config/test_array_validation.py
+++ b/tests/unit/test_config/test_array_validation.py
@@ -140,11 +140,12 @@ class TestMFGGridConfig:
         assert abs(config.dt - expected_dt) < 1e-10
 
     def test_property_cfl_number(self):
-        """Test CFL number calculation."""
+        """Test CFL number calculation uses the PDE coefficient D = sigma^2/2 (Issue #1550)."""
         config = MFGGridConfig(Nx=100, Nt=100, xmin=0.0, xmax=1.0, T=1.0, sigma=0.1)
         dx = 1.0 / 100
         dt = 1.0 / 100
-        expected_cfl = (0.1**2) * dt / (dx**2)
+        # Diffusive CFL = D*dt/dx^2 with D = sigma^2/2, NOT bare sigma^2 (= 2D).
+        expected_cfl = 0.5 * (0.1**2) * dt / (dx**2)
         assert abs(config.cfl_number - expected_cfl) < 1e-10
 
     def test_property_grid_shape(self):


### PR DESCRIPTION
## What

`MFGGridConfig.cfl_number` and `validate_cfl_stability` now compute the diffusive CFL with the PDE coefficient `D = sigma^2/2` (`0.5*sigma^2*dt/dx^2`), not bare `sigma^2` (= 2D).

## Why

The bare `sigma^2` made the stability warning fire at **twice** the correct threshold, and `cfl_number` disagreed with the #1426/S0-14-corrected solver diagnostics (`hjb_fdm.py:340`, `fp_fdm.py:285`). `array_validation.py` was never in the S0-14 fix scope. Also fixes the `sigma` field description (was mislabelled "Diffusion coefficient" -> "SDE volatility").

Diagnostic/validation-only; no solve numerics change. `test_property_cfl_number` updated to the corrected form; 54 config-validation tests pass.

Fixes #1550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)