### PR TITLE
fix(pinn): HJB residual uses backward time sign -du/dt, not +du/dt (#1571)

### DIFF
--- a/changelog.d/1571-pinn-hjb-time-sign.fixed.md
+++ b/changelog.d/1571-pinn-hjb-time-sign.fixed.md
@@ -1,0 +1,6 @@
+- **PINN HJB residual uses the backward-HJB time sign** (Issue #1571). Both `HJBPINNSolver` and
+  `MFGPINNSolver` assembled `+du/dt + H - (sigma^2/2) u_xx = 0`, mirroring the FORWARD Fokker-Planck
+  diffusion sign onto the time derivative of the BACKWARD HJB (terminal condition at t=T, t fed
+  un-reversed). That fits the wrong PDE (e.g. H=const c, D=0 gave u(0)=g+cT instead of g-cT). The
+  residual is now `-du/dt + H - (sigma^2/2) u_xx = 0`. A discriminating test pins the sign via the
+  residual difference of `u=+c*t` vs `u=-c*t`. Off the published FDM/GFDM/particle paths.

--- a/mfgarchon/alg/neural/pinn_solvers/hjb_pinn_solver.py
+++ b/mfgarchon/alg/neural/pinn_solvers/hjb_pinn_solver.py
@@ -239,8 +239,8 @@ class HJBPINNSolver(PINNBase):
 
     def compute_pde_residual(self, t: torch.Tensor, x: torch.Tensor) -> dict[str, torch.Tensor]:
         """
-        Compute HJB equation residual:
-        du/dt + H(grad_u, x, m) - (sigma^2/2)*u_xx = 0
+        Compute backward-HJB equation residual:
+        -du/dt + H(grad_u, x, m) - (sigma^2/2)*u_xx = 0
 
         Args:
             t: Time coordinates [N, 1]
@@ -250,9 +250,13 @@ class HJBPINNSolver(PINNBase):
             Dictionary with HJB residual
 
         Note:
-            Issue #1281 fix (2026-06-11 survey): added -(sigma^2/2)*u_xx viscous
-            term; convention mirrors FP diffusion sign (fp_residual subtracts
-            (sigma^2/2)*m_xx). HJB residual now sigma-dependent for sigma>0.
+            Issue #1281 fix (2026-06-11 survey): added -(sigma^2/2)*u_xx viscous term.
+            Issue #1571 fix: the time-derivative sign is -du/dt, not +du/dt. The HJB is
+            BACKWARD (terminal condition u(T,x)=g at t=T, t fed un-reversed), so the
+            canonical residual is -du/dt + H - (sigma^2/2)*u_xx = 0 (base_hjb residual
+            convention). The earlier +du/dt mirrored the FORWARD FP sign (+m_t) onto the
+            backward HJB and fit the wrong PDE (e.g. H=const c, D=0 gave u(0)=g+cT instead
+            of the correct g-cT). Only the diffusion sign mirrors FP, not the time-derivative.
         """
         # Compute derivatives (u_t, u_x, u_xx)
         u_t, u_x, u_xx = self.compute_derivatives(t, x)
@@ -269,8 +273,8 @@ class HJBPINNSolver(PINNBase):
         # PINN solvers (fp_pinn_solver.py, mfg_pinn_solver.py).
         viscous_term = diffusion_from_volatility_torch(self.sigma) * u_xx
 
-        # HJB residual: du/dt + H(grad_u, x, m) - (sigma^2/2)*u_xx = 0
-        hjb_residual = u_t + H - viscous_term
+        # Backward-HJB residual: -du/dt + H(grad_u, x, m) - (sigma^2/2)*u_xx = 0 (Issue #1571)
+        hjb_residual = -u_t + H - viscous_term
 
         return {"hjb": hjb_residual}
 

--- a/mfgarchon/alg/neural/pinn_solvers/mfg_pinn_solver.py
+++ b/mfgarchon/alg/neural/pinn_solvers/mfg_pinn_solver.py
@@ -307,11 +307,14 @@ class MFGPINNSolver(PINNBase):
         H = self.compute_hamiltonian(u_x, x, m)
 
         # Viscous term: D*u_xx where D = sigma^2/2 — Issue #1281 fix (2026-06-11 survey)
-        # Convention mirrors FP: fp_residual subtracts D*m_xx. Issue #1189: route through D.
+        # Convention mirrors FP diffusion sign only: fp_residual subtracts D*m_xx. Issue #1189: route through D.
         viscous_term = diffusion_from_volatility_torch(self.sigma) * u_xx
 
-        # HJB residual: du/dt + H(grad_u, x, m) - (sigma^2/2)*u_xx = 0
-        hjb_residual = u_t + H - viscous_term
+        # Backward-HJB residual: -du/dt + H(grad_u, x, m) - (sigma^2/2)*u_xx = 0 (Issue #1571).
+        # The HJB is backward (terminal u(T)=g, t un-reversed) so the time derivative enters as
+        # -du/dt; the earlier +du/dt mirrored the FORWARD FP sign onto the backward HJB and fit the
+        # wrong PDE. Only the diffusion sign mirrors FP.
+        hjb_residual = -u_t + H - viscous_term
 
         # For FP equation, we need the drift: b = -∇H_p = -∇u (for quadratic H)
         drift = -u_x

--- a/tests/unit/test_alg/test_pinn_hjb_time_sign_1571.py
+++ b/tests/unit/test_alg/test_pinn_hjb_time_sign_1571.py
@@ -1,0 +1,112 @@
+"""Issue #1571: the PINN HJB residual must use the backward-HJB time sign -du/dt, not +du/dt.
+
+The HJB is backward (terminal condition u(T,x)=g at t=T, t fed un-reversed), so the canonical
+residual is ``-du/dt + H - (sigma^2/2) u_xx = 0``. An earlier version assembled ``+du/dt + H - ...``
+(mirroring the FORWARD FP diffusion sign onto the time derivative), fitting the wrong PDE.
+
+Discriminator (robust to any H / potential / coupling in the fixture): feed two controlled value
+functions ``u = +c*t + 0.5 x**2`` and ``u = -c*t + 0.5 x**2`` on the SAME collocation points. Their
+x-parts are identical, so H(u_x) and the viscous term D*u_xx are identical and cancel in the
+residual difference, which then isolates the time-derivative term (call the shared part S):
+
+    res(+c*t) - res(-c*t) = (-c + S) - (+c + S) = -2c   under the correct -du/dt
+                          = (+c + S) - (-c + S) = +2c   under the buggy +du/dt
+
+so the difference is negative iff the sign is correct. A revert to ``+u_t`` flips it positive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+torch = pytest.importorskip("torch")
+nn = torch.nn
+
+pytestmark = pytest.mark.optional_torch
+
+
+def _make_problem():
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+    from mfgarchon.geometry import Hyperrectangle
+
+    geo = Hyperrectangle(bounds=[(0.0, 1.0)])
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: np.zeros_like(m),
+    )
+    components = MFGComponents(
+        hamiltonian=H,
+        u_terminal=lambda x: np.zeros_like(x) if hasattr(x, "__len__") else 0.0,
+        m_initial=lambda x: np.ones_like(x) if hasattr(x, "__len__") else 1.0,
+    )
+    return MFGProblem(T=1.0, geometry=geo, sigma=0.1, components=components)
+
+
+def _tiny_config():
+    from mfgarchon.alg.neural.pinn_solvers.base_pinn import PINNConfig
+
+    return PINNConfig(hidden_layers=[8, 8], device="cpu")
+
+
+class _LinearTNet(nn.Module):
+    """u(t, x) = c * t + 0.5 * x**2. u_t = c, u_x = x, u_xx = 1.
+
+    The x-part is IDENTICAL for the +c and -c nets, so the Hamiltonian H(u_x) and the viscous
+    term D*u_xx are the same for both and cancel in the residual difference — which then isolates
+    the time-derivative term, 2*u_t. (A pure ``c*t`` would make u_x=u_xx=0, but then u_xx has no
+    grad path and autograd raises; the x**2 term gives a real, computable second derivative.)"""
+
+    def __init__(self, c: float):
+        super().__init__()
+        self.c = float(c)
+
+    def forward(self, inp: torch.Tensor) -> torch.Tensor:
+        t = inp[:, 0:1]
+        x = inp[:, 1:2]
+        return self.c * t + 0.5 * x**2
+
+
+def _hjb_residual_mean(solver, c: float, t: torch.Tensor, x: torch.Tensor) -> float:
+    """Mean HJB residual for u = c*t + 0.5 x**2 at the GIVEN collocation points."""
+    solver.u_net = _LinearTNet(c)
+    solver.networks["u_net"] = solver.u_net
+    res = solver.compute_pde_residual(t, x)["hjb"]
+    return res.mean().item()
+
+
+def _time_sign_diff(solver) -> tuple[float, float]:
+    """Return (diff, c) where diff = res(+c*t) - res(-c*t) on SHARED collocation points, so the
+    H(u_x) and viscous D*u_xx terms (identical for both sign choices) cancel exactly and the
+    difference is purely the time-derivative contribution."""
+    c = 2.0
+    n = 16
+    t = torch.rand(n, 1)
+    x = torch.rand(n, 1) * 0.8 + 0.1  # interior, away from the boundary
+    return _hjb_residual_mean(solver, c, t, x) - _hjb_residual_mean(solver, -c, t, x), c
+
+
+def test_hjb_pinn_uses_backward_time_sign():
+    from mfgarchon.alg.neural.pinn_solvers.hjb_pinn_solver import HJBPINNSolver
+
+    solver = HJBPINNSolver(_make_problem(), config=_tiny_config())
+    diff, c = _time_sign_diff(solver)
+    # Correct -du/dt: diff = -2c = -4.0. Buggy +du/dt would give +4.0.
+    assert diff == pytest.approx(-2.0 * c, abs=1e-5), (
+        f"HJB residual time-derivative sign is wrong: res(+c*t)-res(-c*t)={diff:.6f}, "
+        f"expected {-2.0 * c:.4f} (backward HJB -du/dt). A positive value means the buggy +du/dt "
+        f"(Issue #1571)."
+    )
+
+
+def test_mfg_pinn_uses_backward_time_sign():
+    from mfgarchon.alg.neural.pinn_solvers.mfg_pinn_solver import MFGPINNSolver
+
+    solver = MFGPINNSolver(_make_problem(), config=_tiny_config())
+    diff, c = _time_sign_diff(solver)
+    assert diff == pytest.approx(-2.0 * c, abs=1e-5), (
+        f"MFG-PINN HJB residual time-derivative sign is wrong: res(+c*t)-res(-c*t)={diff:.6f}, "
+        f"expected {-2.0 * c:.4f} (backward HJB -du/dt) (Issue #1571)."
+    )


### PR DESCRIPTION
## What

Both `HJBPINNSolver` and `MFGPINNSolver` now assemble the backward-HJB residual `-du/dt + H - (sigma^2/2) u_xx = 0` (was `+du/dt + ...`).

## Why

The HJB is **backward** (terminal condition `u(T,x)=g` at t=T, t fed un-reversed through `forward`), so the canonical residual is `-du/dt + H - (sigma^2/2) u_xx = 0` (the `base_hjb` residual convention, verified across every numerical HJB solver). The earlier `+du/dt` mirrored the **forward** Fokker-Planck diffusion sign (`+m_t`) onto the backward HJB's time derivative — the in-code comment said as much — and fit the wrong PDE. Concretely, for `H = const c`, `D = 0`, terminal `g`, the backward HJB gives `u(0) = g - cT` but the buggy `+du/dt` gives `u(0) = g + cT`. Only the **diffusion** sign mirrors FP, not the time derivative.

Invisible to the existing tests because they use `u = x^2` (`u_t = 0`).

## Test

New `test_pinn_hjb_time_sign_1571.py` pins the sign for **both** solvers via the residual difference of `u = +c*t` vs `u = -c*t` on shared collocation points (H and viscous terms cancel, isolating the time term): the difference is `-2c` under the fix and `+2c` under the bug. **Verified discriminating**: reverting the sign in either solver makes the test fail. Full PINN suite (35 tests) passes. Off the published FDM/GFDM/particle paths (B1); `optional_torch`.

Fixes #1571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)