### PR TITLE
fix(sl): fail loud on MAXIMIZE control cost — SL foot velocity is MINIMIZE-signed (#1547, RFC #1574 Phase 0)

### DIFF
--- a/changelog.d/1547-sl-maximize-fail-loud.fixed.md
+++ b/changelog.d/1547-sl-maximize-fail-loud.fixed.md
@@ -1,0 +1,7 @@
+- **HJB semi-Lagrangian fails loud on a MAXIMIZE control cost** (Issue #1547, RFC #1574 Phase 0). The
+  characteristic-foot velocity dH/dp = p/lambda is hardcoded MINIMIZE-signed (alpha* = -grad(u)/lambda);
+  a MAXIMIZE control cost (alpha* = +grad(u)/lambda) would trace the feet in the wrong direction, and
+  because the MAXIMIZE-quadratic Hamiltonian is smooth the non-smooth DPP reroute never fires — so the
+  wrong scheme ran silently. Construction now raises NotImplementedError (mirroring the GFDM Howard
+  gate). MINIMIZE (every published config) is unaffected. The canonical_cs + non-quadratic gap remains
+  a separate Phase-0 item on #1547.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -256,6 +256,23 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 f"stability proof only covers monotone interpolation; cubic/quintic break it."
             )
 
+        # Issue #1547 / RFC #1574 Phase 0: the characteristic-foot velocity dH/dp = p/lambda traces
+        # departures x - (grad_u/lambda)*dt, i.e. alpha* = -grad_u/lambda (MINIMIZE). A MAXIMIZE
+        # control cost has alpha* = +grad_u/lambda, so the feet would be traced in the wrong
+        # direction; the MAXIMIZE-quadratic H is smooth so the non-smooth DPP reroute never fires and
+        # the wrong-signed foot path is taken silently. Fail loud (mirrors the HJBGFDMSolver Howard
+        # gate) rather than run the wrong scheme. MAXIMIZE support on the SL path is deferred.
+        _sl_h_class = getattr(self.problem, "hamiltonian_class", None)
+        _sl_control_cost = getattr(_sl_h_class, "control_cost", None)
+        if _sl_control_cost is not None and getattr(_sl_control_cost, "sign", 1) != 1:
+            raise NotImplementedError(
+                "HJBSemiLagrangianSolver traces characteristic feet with the MINIMIZE-signed velocity "
+                "alpha* = -grad(u)/lambda, but the Hamiltonian's control cost is MAXIMIZE "
+                "(alpha* = +grad(u)/lambda). The feet would move in the wrong direction and the solve "
+                "would converge to a different equilibrium. MAXIMIZE is not yet supported on the "
+                "semi-Lagrangian path (Issue #1547 / RFC #1574); use HJB-FDM/GFDM, or MINIMIZE."
+            )
+
         # Gradient clipping statistics tracking
         self._reset_gradient_stats()
 

--- a/tests/unit/test_alg/test_sl_maximize_fail_loud_1547.py
+++ b/tests/unit/test_alg/test_sl_maximize_fail_loud_1547.py
@@ -1,0 +1,43 @@
+"""Issue #1547 / RFC #1574 Phase 0: HJBSemiLagrangianSolver must fail loud on a MAXIMIZE control cost.
+
+The SL characteristic-foot velocity dH/dp = p/lambda is hardcoded MINIMIZE-signed (departures
+x - (grad_u/lambda)*dt, i.e. alpha* = -grad_u/lambda). A MAXIMIZE control cost has alpha* =
++grad_u/lambda, so the feet would be traced in the wrong direction and the solve would converge to a
+different equilibrium — silently, because the MAXIMIZE-quadratic Hamiltonian is smooth so the
+non-smooth DPP reroute never fires. The solver now raises NotImplementedError at construction rather
+than running the wrong scheme (mirroring the HJBGFDMSolver Howard gate).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import HJBSemiLagrangianSolver
+from mfgarchon.core.hamiltonian import OptimizationSense, QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.geometry.grids.tensor_grid import TensorProductGrid
+
+
+def _problem(sense: OptimizationSense) -> MFGProblem:
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], num_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(lambda_=1.0, sense=sense))
+    return MFGProblem(
+        geometry=grid,
+        T=0.2,
+        Nt=2,
+        sigma=0.1,
+        components=MFGComponents(hamiltonian=H, u_terminal=lambda x: 0.0, m_initial=lambda x: 1.0),
+    )
+
+
+def test_sl_maximize_control_cost_fails_loud():
+    """A MAXIMIZE control cost must raise NotImplementedError at construction (wrong foot direction)."""
+    with pytest.raises(NotImplementedError, match="MAXIMIZE"):
+        HJBSemiLagrangianSolver(problem=_problem(OptimizationSense.MAXIMIZE))
+
+
+def test_sl_minimize_control_cost_constructs():
+    """The MINIMIZE (default paper) case must be unaffected by the guard."""
+    solver = HJBSemiLagrangianSolver(problem=_problem(OptimizationSense.MINIMIZE))
+    assert solver is not None


### PR DESCRIPTION
## What

`HJBSemiLagrangianSolver` now raises `NotImplementedError` at construction when the problem's control cost is MAXIMIZE.

## Why (RFC #1574 Phase 0 — fail loud in the gap)

The SL characteristic-foot velocity `dH/dp = p/lambda` traces departures `x - (grad_u/lambda)*dt`, i.e. `alpha* = -grad_u/lambda` (MINIMIZE). A MAXIMIZE control cost has `alpha* = +grad_u/lambda`, so the feet would be traced in the **wrong direction** and the solve would converge to a different equilibrium. It ran **silently** because the MAXIMIZE-quadratic Hamiltonian is smooth, so the non-smooth DPP reroute never fires and the wrong-signed foot path is taken. This mirrors the existing `HJBGFDMSolver` Howard gate (`hjb_gfdm.py:3047`), which already fails loud on MAXIMIZE — the RFC #1574 exemplar being generalized.

## Scope / safety

- **MINIMIZE (every stock and published config) is unaffected** — 71 SL tests pass; no SL test constructs a MAXIMIZE solver (verified).
- Partial fix: this closes the MAXIMIZE **foot-velocity** gap. The `canonical_cs` + non-quadratic control-cost gap (which hardcodes the quadratic Lagrangian) remains a separate Phase-0 item on #1547 — hence `Refs`, not `Fixes`.

## Test

`test_sl_maximize_fail_loud_1547.py`: MAXIMIZE raises `NotImplementedError`; MINIMIZE constructs. **Verified discriminating** (removing the guard makes the MAXIMIZE test fail).

Refs #1547, #1574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)