### PR TITLE
docs: repoint dangling NAMING_CONVENTIONS.md references to mfg-research (#1573)

### DIFF
--- a/changelog.d/1573-naming-conventions-pointers.fixed.md
+++ b/changelog.d/1573-naming-conventions-pointers.fixed.md
@@ -1,0 +1,5 @@
+- **Repoint the dangling `NAMING_CONVENTIONS.md` references** (Issue #1573). The convention doc was
+  moved to `mfg-research/docs/archon-notes/development/guides/NAMING_CONVENTIONS.md` (#852) but 8 files
+  (12 references, incl. the load-bearing Riccati-provenance comment in `test_hjb_howard_solver.py`)
+  still pointed at the deleted in-repo `docs/NAMING_CONVENTIONS.md`. All now point at the new location.
+  The Howard test's expected values remain provenanced by their inline derivation, not the external doc.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -1037,7 +1037,8 @@ def solve_timestep_tensor_explicit(
 
     # Compute tensor diffusion term: div(D * grad(m)).
     # Sigma is the SDE volatility; the diffusion operator needs the PDE diffusion tensor
-    # D = (1/2) Sigma Sigma^T (NAMING_CONVENTIONS "Volatility vs Diffusion", #811). The raw
+    # D = (1/2) Sigma Sigma^T (archon-notes/development/guides/NAMING_CONVENTIONS.md, mfg-research,
+    # private: "Volatility vs Diffusion"; Issue #811). The raw
     # Sigma was applied as if it were D — e.g. isotropic Sigma = 0.3 I gave effective D = 0.3
     # instead of D = sigma^2/2 = 0.045 (~6.7x overdiffusion). Route through the single-source
     # converter so the tensor path matches the scalar path D = sigma^2/2 (2026-06-10 audit, #1249).

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -2290,7 +2290,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         Evaluate Hamiltonian H(x, p, m) at given point (supports 1D and nD).
 
         Uses DerivativeTensors for consistency with all solvers.
-        See docs/NAMING_CONVENTIONS.md "Derivative Tensor Standard" section.
+        See archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) "Derivative Tensor Standard" section.
 
         Args:
             x: Spatial position

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -1,7 +1,7 @@
 """
 WENO Family HJB Solvers for Mean Field Games
 
-NOTE: API parameter names updated in v0.11.0. See docs/NAMING_CONVENTIONS.md for details.
+NOTE: API parameter names updated in v0.11.0. See archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) for details.
 
 This module implements the complete family of WENO (Weighted Essentially Non-Oscillatory)
 schemes for solving Hamilton-Jacobi-Bellman equations in Mean Field Games.

--- a/mfgarchon/core/derivatives.py
+++ b/mfgarchon/core/derivatives.py
@@ -42,7 +42,7 @@ Usage:
         return 0.5 * np.sum(derivs.grad ** 2)
 
 See Also:
-    docs/NAMING_CONVENTIONS.md - Gradient Notation Standard section
+    archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) - Gradient Notation Standard section
 """
 
 from __future__ import annotations

--- a/mfgarchon/geometry/cloud_geodesic.py
+++ b/mfgarchon/geometry/cloud_geodesic.py
@@ -16,7 +16,7 @@ Issue #1093. Validated in:
     mfg-research/experiments/gfdm_monotonicity_audit/minors/
         exp09_obstacle_navigation_full/geodesic_distance.py
 
-SDF convention (mfgarchon, see NAMING_CONVENTIONS.md § Geometry SDF
+SDF convention (mfgarchon, see archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) § Geometry SDF
 Convention): `obstacles_sdf(x) <= 0` means **inside obstacle**;
 `obstacles_sdf(x) > 0` means **outside obstacle (navigable)**.
 

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -73,7 +73,7 @@ def diffusion_from_volatility(
     r"""Canonical PDE diffusion coefficient ``D`` from SDE volatility ``sigma`` (Issue #811).
 
     Single source of truth for the volatility -> diffusion conversion documented in
-    ``NAMING_CONVENTIONS.md`` "Volatility vs Diffusion". Volatility is a tensor in general
+    ``archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private)`` "Volatility vs Diffusion". Volatility is a tensor in general
     (the noise matrix :math:`\Sigma`, shape ``(d, k)``); the scalar :math:`\sigma` is the
     isotropic special case. The diffusion coefficient is
 
@@ -171,7 +171,7 @@ def resolve_volatility(
     Resolution order (canonical first):
 
     1. ``problem_params["sigma"]`` -- the canonical SDE volatility key
-       (``NAMING_CONVENTIONS.md`` "Volatility vs Diffusion"). Returned verbatim; the caller
+       (``archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private)`` "Volatility vs Diffusion"). Returned verbatim; the caller
        computes ``D = sigma**2 / 2``. No warning.
     2. ``problem_params[legacy_key]`` -- the backend's historical key, when ``legacy_key`` is
        given and present. ``legacy_is_squared=True`` means the stored value is ``sigma**2``

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -200,7 +200,7 @@ def test_construction_rejects_unknown_discretisation():
 def test_1d_lq_closed_form_riccati():
     """Pure LQ in 1D, mfgarchon convention.
 
-    HJB residual form is `-u_t + H - (σ²/2)Δu = 0` (NAMING_CONVENTIONS.md
+    HJB residual form is `-u_t + H - (σ²/2)Δu = 0` (archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private)
     § HJB Equation Conventions). With u(T, x) = 0.5(x - x_c)² (so terminal
     coefficient P(T) = 0.5), σ = 0, the Riccati ODE reads P'(t) = 2 P².
     Closed form for T = 1: P(t) = 1 / (4 - 2t), so P(0) = 0.25.
@@ -208,7 +208,7 @@ def test_1d_lq_closed_form_riccati():
     Analytic ratio at off-centre probe ``|x - x_c| = 1``:
         u(0)/u(T) = P(0)/P(T) = 0.25 / 0.5 = 0.5
 
-    See NAMING_CONVENTIONS.md § HJB Equation Conventions § Worked example
+    See archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) § HJB Equation Conventions § Worked example
     for the full derivation. Probe MUST be off-centre (at centre, the
     quadratic vanishes and the test is uninformative for any P(t)).
 
@@ -264,13 +264,13 @@ def test_1d_lq_closed_form_riccati():
     assert U_T_probe > 0.1, f"Test fixture broken: probe at x={x_pts[probe_idx]:.3f} sees U_T={U_T_probe:.4f}"
     # Analytical ratio P(0)/P(T) = 0.25 / 0.5 = 0.5 under mfgarchon's HJB
     # convention `-u_t + H - σ²Δu/2 = 0`. Probe at |x-x_c|=1, T=1, G_s=0.5.
-    # See NAMING_CONVENTIONS.md § HJB Equation Conventions § Worked example.
+    # See archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) § HJB Equation Conventions § Worked example.
     # Loose bound 0.3-0.85: coarse 1D grid + Neumann-by-extension wall artifact.
     ratio = U_0_probe / U_T_probe
     assert 0.3 < ratio < 0.85, (
         f"Riccati ordering broken: U(0)/U(T) at probe x={x_pts[probe_idx]:.3f} = {ratio:.3f}, "
         f"expected ~0.5 for mfgarchon LQ convention (P(0)/P(T) = 0.25/0.5). "
-        f"See NAMING_CONVENTIONS.md § HJB Equation Conventions."
+        f"See archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) § HJB Equation Conventions."
     )
 
 

--- a/tests/unit/test_utils/test_diffusion_from_volatility.py
+++ b/tests/unit/test_utils/test_diffusion_from_volatility.py
@@ -2,7 +2,7 @@
 
 ``diffusion_from_volatility`` is the single source of truth for ``D = (1/2) Sigma Sigma^T``
 (scalar: ``D = sigma^2/2``), replacing ~38 ad-hoc literal ``0.5 * sigma**2`` sites. These
-tests pin the contract documented in NAMING_CONVENTIONS.md "Volatility vs Diffusion":
+tests pin the contract documented in archon-notes/development/guides/NAMING_CONVENTIONS.md (mfg-research, private) "Volatility vs Diffusion":
 tensor-first, ``Sigma Sigma^T`` (NOT ``Sigma^T Sigma``), byte-identity for the scalar / field
 cases it replaces, and FAIL-LOUD on ambiguous array inputs (no silent (d,d)-tensor-vs-field
 guess -- the same silent-convention class the converter exists to eliminate).


### PR DESCRIPTION
## What

Repoint 12 references across 8 files from the deleted in-repo `docs/NAMING_CONVENTIONS.md` to its new home `archon-notes/development/guides/NAMING_CONVENTIONS.md` (mfg-research, private dev guide).

## Why

The doc was moved to mfg-research (#852, per the three-tier docs policy) but 8 files kept dangling pointers — including the **load-bearing Riccati-provenance** comments in `test_hjb_howard_solver.py` (the test class that once caused a textbook-convention bug, 2026-05-19). Those expected values remain correctly provenanced by their **inline derivation** (`P'=2P^2 -> ratio 0.5`); the external pointer is now valid rather than dead.

Pure comment/docstring/test-citation text; no logic change. Howard (45) + diffusion tests pass; ruff clean.

Fixes #1573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)