### PR TITLE
fix(core): plugin_system uses importlib.metadata, not removed pkg_resources (#1540)

### DIFF
--- a/changelog.d/1540-plugin-system-importlib.fixed.md
+++ b/changelog.d/1540-plugin-system-importlib.fixed.md
@@ -1,0 +1,5 @@
+- **plugin_system migrated off the removed pkg_resources** (Issue #1540). `mfgarchon.core.plugin_system`
+  did a module-level `import pkg_resources`, which raises `ModuleNotFoundError` on setuptools >= 81
+  (pkg_resources removed) — undetected because nothing in the package imports the module (CI, incl. the
+  compat matrix, never loaded it). It now uses the stdlib `importlib.metadata.entry_points(group=...)`
+  (py3.10+ selectable API; same `.name`/`.load()` interface). Added an import + discover smoke test.

--- a/mfgarchon/core/plugin_system.py
+++ b/mfgarchon/core/plugin_system.py
@@ -21,10 +21,9 @@ import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-
-import pkg_resources
 
 from mfgarchon.utils.mfg_logging import get_logger
 
@@ -563,7 +562,10 @@ class PluginManager:
         discovered = []
 
         try:
-            for entry_point in pkg_resources.iter_entry_points("mfgarchon.plugins"):
+            # Issue #1540: importlib.metadata (stdlib) replaces the removed pkg_resources.
+            # entry_points(group=...) is the py3.10+ selectable API; each EntryPoint keeps the
+            # .name / .load() interface pkg_resources used.
+            for entry_point in entry_points(group="mfgarchon.plugins"):
                 try:
                     plugin_class = entry_point.load()
                     if self.register_plugin(plugin_class):

--- a/tests/unit/test_core/test_plugin_system_import_1540.py
+++ b/tests/unit/test_core/test_plugin_system_import_1540.py
@@ -1,0 +1,31 @@
+"""Issue #1540: mfgarchon.core.plugin_system must import and discover without pkg_resources.
+
+pkg_resources was removed from setuptools >= 81, so the module-level `import pkg_resources` made
+`import mfgarchon.core.plugin_system` raise ModuleNotFoundError on any modern setuptools — undetected
+because nothing in the package imports the module. It now uses the stdlib importlib.metadata.
+"""
+
+from __future__ import annotations
+
+
+def test_plugin_system_imports_without_pkg_resources():
+    """The module must import (it did not on setuptools>=81) and no longer import pkg_resources."""
+    import inspect
+
+    import mfgarchon.core.plugin_system as plugin_system
+
+    src = inspect.getsource(plugin_system)
+    # The import statement and the pkg_resources API call must be gone (the word may still appear in
+    # an explanatory comment, so match the load-bearing forms, not the bare token).
+    assert "import pkg_resources" not in src
+    assert "pkg_resources.iter_entry_points" not in src
+    assert "importlib.metadata" in src
+
+
+def test_discover_plugins_runs_and_returns_list():
+    """PluginManager.discover_plugins() must run through the importlib.metadata entry-point path
+    without raising (returns an empty list when no `mfgarchon.plugins` entry points are installed)."""
+    from mfgarchon.core.plugin_system import PluginManager
+
+    result = PluginManager().discover_plugins()
+    assert isinstance(result, list)


### PR DESCRIPTION
## What

Replace `plugin_system`'s `import pkg_resources` + `pkg_resources.iter_entry_points("mfgarchon.plugins")` with the stdlib `importlib.metadata.entry_points(group="mfgarchon.plugins")`.

## Why

`pkg_resources` was removed from setuptools >= 81, so `import mfgarchon.core.plugin_system` raised `ModuleNotFoundError` on any modern setuptools. It went undetected because **nothing in the package imports the module** — CI (including the 3.12/3.13/3.14 compat matrix) never loaded it. `importlib.metadata` is stdlib, py3.10+ (repo is py3.12+), and its `EntryPoint` keeps the same `.name` / `.load()` interface `pkg_resources` used, so the discovery logic is unchanged.

## Test

`test_plugin_system_import_1540.py`: the module imports (it did not on setuptools>=81), carries no `import pkg_resources` / `iter_entry_points`, and `PluginManager().discover_plugins()` runs through the entry-point path returning a list. `scripts/check_circular_imports.py` now reports `plugin_system... ✅` (was a failure).

Fixes #1540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)