### PR TITLE
fix(hjb): RFC #1574 Phase-0 fail-loud guards — SL mixed-BC + FDM strict-adjoint operator (#1560, #1564)

### DIFF
--- a/changelog.d/1560-1564-rfc1574-phase0-guards.fixed.md
+++ b/changelog.d/1560-1564-rfc1574-phase0-guards.fixed.md
@@ -1,0 +1,9 @@
+- **RFC #1574 Phase-0 capability-honesty guards** (Issues #1560, #1564). Two solvers declared/dispatched
+  a boundary-condition surface broader than the code that honors it and silently mis-handled the gap;
+  both now fail loud. (1) `HJBSemiLagrangianSolver` raises when a mixed per-axis BC has segments mapping
+  to different geometric operations (e.g. no-flux + periodic) — the characteristic fold and ADI
+  diffusion collapse it to the first segment's single op applied to all axes (order-sensitive). (2)
+  `HJBFDMSolver.build_linearized_operator` (the strict-adjoint FP operator, #707) raises on any non-
+  Neumann/no-flux BC — it hardcodes no-flux at every boundary while the solver declares DIRICHLET for
+  the normal solve, so a Dirichlet outflow was silently treated as mass-conserving. Per-axis / adjoint-
+  Dirichlet support remains a follow-up.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_fdm.py
@@ -1200,6 +1200,30 @@ class HJBFDMSolver(BaseHJBSolver):
             - Issue #706 (adjoint discretization)
             - compute_hjb_jacobian() in base_hjb.py (1D Newton solver version)
         """
+        # Issue #1564 / RFC #1574 Phase 0: the linearized operator hardcodes no-flux at every
+        # boundary (both 1D and nD skip boundary rows as no-flux). HJBFDMSolver declares DIRICHLET/
+        # PERIODIC supported for the NORMAL FDM solve (which honors them via its own assembly), but
+        # THIS operator -- consumed only by the strict-adjoint BlockIterator (jacobian_transpose,
+        # #707) as A_FP = A_HJB^T -- does not. A declared Dirichlet outflow would be silently treated
+        # as mass-conserving no-flux. Fail loud on any BC this operator does not honor rather than
+        # advect with the wrong wall physics (mirrors the HJBGFDMSolver Howard gate).
+        bc = self.get_boundary_conditions()
+        if bc is not None:
+            honored = {BCType.NEUMANN, BCType.NO_FLUX}
+            requested = {seg.bc_type for seg in getattr(bc, "segments", [])}
+            default_bc = getattr(bc, "default_bc", None)
+            if default_bc is not None:
+                requested.add(default_bc)
+            unsupported = requested - honored
+            if unsupported:
+                names = ", ".join(sorted(str(getattr(t, "value", t)) for t in unsupported))
+                raise NotImplementedError(
+                    f"build_linearized_operator (strict-adjoint FP operator, Issue #707) hardcodes "
+                    f"no-flux at every boundary and does not honor {{{names}}}. The declared BC would "
+                    f"be silently treated as no-flux, leaking no mass where a Dirichlet outflow should. "
+                    f"Use the standard coupling path (FixedPointIterator) for non-Neumann boundaries, "
+                    f"or a Neumann/no-flux BC on the strict-adjoint path (Issue #1564 / RFC #1574)."
+                )
         if self.dimension == 1:
             return self._build_linearized_operator_1d(U, M, time)
         else:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -351,6 +351,32 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # diffusion). None (BC resolved later) is a no-op; SL re-reads get_boundary_conditions().
         self._validate_bc_support(self.get_boundary_conditions())
 
+        # Issue #1560 / RFC #1574 Phase 0: even when every segment type is individually supported, the
+        # SL characteristic fold and ADI diffusion collapse a MIXED per-axis BC to segments[0]'s single
+        # geometric operation (reflect vs wrap) applied to ALL axes (get_bc_type_string returns only the
+        # first segment) — so e.g. no-flux walls on one axis + periodic on another is silently reduced
+        # to one op, and reordering the segments flips the physics. Per-axis handling is a follow-up;
+        # for now fail loud when the segments do not agree on a single geometric operation.
+        _sl_bc = self.get_boundary_conditions()
+        _sl_segments = getattr(_sl_bc, "segments", None)
+        if _sl_segments:
+            _sl_ops = set()
+            for _seg in _sl_segments:
+                _seg_type = str(getattr(_seg.bc_type, "value", _seg.bc_type))
+                _sl_ops.add(bc_type_to_geometric_operation(_seg_type))
+            _sl_default = getattr(_sl_bc, "default_bc", None)
+            if _sl_default is not None:
+                _d = str(getattr(_sl_default, "value", _sl_default))
+                _sl_ops.add(bc_type_to_geometric_operation(_d))
+            if len(_sl_ops) > 1:
+                raise NotImplementedError(
+                    f"HJBSemiLagrangianSolver does not support a mixed per-axis boundary condition whose "
+                    f"segments map to different geometric operations ({sorted(_sl_ops)}). The characteristic "
+                    f"fold and ADI diffusion apply the FIRST segment's single operation to every axis "
+                    f"(order-sensitive silent collapse). Use a single BC type across axes, or HJB-FDM/GFDM "
+                    f"which resolve BC per wall (Issue #1560 / RFC #1574 Phase 0)."
+                )
+
     # _detect_dimension() inherited from BaseNumericalSolver (Issue #633)
 
     def _setup_jax_functions(self):

--- a/tests/unit/test_alg/test_rfc1574_phase0_guards_1560_1564.py
+++ b/tests/unit/test_alg/test_rfc1574_phase0_guards_1560_1564.py
@@ -1,0 +1,70 @@
+"""RFC #1574 Phase 0 capability-honesty guards: fail loud where a declared/dispatched surface is
+broader than the code that honors it.
+
+- #1560: HJBSemiLagrangianSolver collapses a mixed per-axis BC (segments mapping to different
+  geometric operations, e.g. no-flux + periodic) to the first segment's single op applied to all axes.
+- #1564: HJBFDMSolver.build_linearized_operator (the strict-adjoint FP operator, #707) hardcodes
+  no-flux at every boundary while HJBFDMSolver declares DIRICHLET supported for the normal solve.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import HJBSemiLagrangianSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+from mfgarchon.geometry.boundary import BCSegment, BCType, dirichlet_bc, mixed_bc, no_flux_bc
+from mfgarchon.geometry.grids.tensor_grid import TensorProductGrid
+
+
+def _components() -> MFGComponents:
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(lambda_=1.0))
+    return MFGComponents(hamiltonian=H, u_terminal=lambda x: 0.0, m_initial=lambda x: 1.0)
+
+
+def _problem(bc, bounds, npts) -> MFGProblem:
+    grid = TensorProductGrid(bounds=bounds, num_points=npts, boundary_conditions=bc)
+    return MFGProblem(geometry=grid, T=0.2, Nt=2, sigma=0.1, components=_components())
+
+
+def test_sl_mixed_per_axis_bc_fails_loud_1560():
+    """no-flux (x) + periodic (y) map to different geometric ops (reflect vs periodic); SL collapses
+    them to one op on all axes, so construction must raise rather than silently pick the first."""
+    mixed = mixed_bc(
+        dimension=2,
+        segments=[
+            BCSegment(name="wx", boundary="x_min", bc_type=BCType.NO_FLUX),
+            BCSegment(name="ex", boundary="x_max", bc_type=BCType.NO_FLUX),
+            BCSegment(name="py0", boundary="y_min", bc_type=BCType.PERIODIC),
+            BCSegment(name="py1", boundary="y_max", bc_type=BCType.PERIODIC),
+        ],
+    )
+    with pytest.raises(NotImplementedError, match=r"mixed per-axis|1560"):
+        HJBSemiLagrangianSolver(problem=_problem(mixed, [(0.0, 1.0), (0.0, 1.0)], [6, 6]))
+
+
+def test_sl_uniform_bc_still_constructs_1560():
+    """A single BC type across all axes must be unaffected by the mixed-BC guard."""
+    solver = HJBSemiLagrangianSolver(problem=_problem(no_flux_bc(dimension=2), [(0.0, 1.0), (0.0, 1.0)], [6, 6]))
+    assert solver is not None
+
+
+def test_build_linearized_operator_fails_loud_on_dirichlet_1564():
+    """The strict-adjoint FP operator hardcodes no-flux; a Dirichlet BC must raise, not be silently
+    treated as mass-conserving no-flux."""
+    solver = HJBFDMSolver(problem=_problem(dirichlet_bc(dimension=1), [(0.0, 1.0)], [11]))
+    U, M = np.zeros(11), np.ones(11) / 11
+    with pytest.raises(NotImplementedError, match=r"1564|no-flux"):
+        solver.build_linearized_operator(U, M, time=0.0)
+
+
+def test_build_linearized_operator_ok_on_no_flux_1564():
+    """No-flux (the honored BC) must still build the operator."""
+    solver = HJBFDMSolver(problem=_problem(no_flux_bc(dimension=1), [(0.0, 1.0)], [11]))
+    U, M = np.zeros(11), np.ones(11) / 11
+    A = solver.build_linearized_operator(U, M, time=0.0)
+    assert A.shape == (11, 11)


### PR DESCRIPTION
## What

Two RFC #1574 (capability-honesty) Phase-0 guards — fail loud where a declared/dispatched BC surface is broader than the code that honors it:

- **#1560** — `HJBSemiLagrangianSolver` raises at construction when a mixed per-axis BC has segments mapping to **different geometric operations** (e.g. no-flux on one axis + periodic on another). The SL characteristic fold and ADI diffusion take `get_bc_type_string` = `segments[0]`'s single op and apply it to **all** axes, so the config is silently reduced (and reordering segments flips the physics).
- **#1564** — `HJBFDMSolver.build_linearized_operator` (the strict-adjoint FP operator, #707; **only caller** = `BlockIterator(jacobian_transpose)`) raises on any non-Neumann/no-flux BC. It hardcodes no-flux at every boundary, while `HJBFDMSolver` declares DIRICHLET supported for the **normal** solve (which honors it via separate assembly), so a declared Dirichlet outflow was silently treated as mass-conserving no-flux.

Both mirror the existing `HJBGFDMSolver` Howard MAXIMIZE gate (`hjb_gfdm.py:3047`), the RFC #1574 exemplar.

## Scope / safety

- Verified `build_linearized_operator` has exactly one external caller (the strict-adjoint path); the normal FDM Dirichlet solve does **not** use it, so the guard cannot break normal Dirichlet FDM.
- Uniform-BC / no-flux paths unaffected — 186 SL + FDM + adjoint + BC-gate tests pass.
- Per-axis SL handling and adjoint-Dirichlet support remain follow-ups (hence **Refs**, not Fixes — the Phase-0 guards eliminate the silent-wrong).

## Test

`test_rfc1574_phase0_guards_1560_1564.py`: mixed no-flux+periodic 2D SL raises; uniform no-flux SL constructs; Dirichlet `build_linearized_operator` raises; no-flux builds. **Verified discriminating** (disabling either guard fails its raise-test).

Refs #1560, #1564, #1574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)