### PR TITLE
fix(network): remove dead/broken upwind scheme + fail-loud forward_step (#1541, #1546)

### DIFF
--- a/changelog.d/1541-network-upwind-remove.fixed.md
+++ b/changelog.d/1541-network-upwind-remove.fixed.md
@@ -1,0 +1,8 @@
+- **FPNetworkSolver removes the identity-map "upwind" scheme and fails loud** (Issue #1541, RFC #1574).
+  `scheme="upwind"` was a silent identity map — `_compute_edge_flow` returned the same positive flow
+  for both edge orientations, so the paired flows cancelled to exactly zero net drift and the step had
+  no diffusion term, leaving the density unevolved — and `"flow"` was never implemented. A correctly-
+  implemented conservative upwind would be byte-identical to `"explicit"` (which already sources rates
+  via `H.optimal_control` in inflow-outflow form + diffusion), a single-source duplicate. `scheme` is
+  now validated to `{explicit, implicit}` at construction (`NotImplementedError` otherwise) and the
+  dead `_upwind_step` / `_compute_edge_flow` methods are removed.

--- a/changelog.d/1546-network-forward-step.fixed.md
+++ b/changelog.d/1546-network-forward-step.fixed.md
@@ -1,0 +1,7 @@
+- **FPNetworkSolver.forward_step fails loud instead of silently mis-stepping** (Issue #1546). The
+  "interface compatibility" single-step stub never precomputed transition rates, so a fresh solver hit
+  the wrong-signed legacy drift, a post-solve call reused stale rates, and it skipped the node-BC /
+  #1478 mass-renorm gate (false conservation under an ABSORBING node). It has no callers; it now raises
+  NotImplementedError directing callers to solve_fp_system. The legacy fallback in _compute_drift_term
+  (reachable only off the solve_fp_system path, which always precomputes) also raises rather than
+  resurrecting the #1474 wrong-signed uphill drift.

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -90,7 +90,8 @@ class FPNetworkSolver(BaseFPSolver):
 
         Args:
             problem: Network MFG problem instance
-            scheme: Time discretization ("explicit", "implicit", "upwind")
+            scheme: Time discretization ("explicit" or "implicit"). "upwind"/"flow" were removed
+                (Issue #1541): "upwind" was an identity map and "flow" was never implemented.
             diffusion_coefficient: Network diffusion coefficient D = σ²/2. If None (default), falls
                 back to 0.1 with a warning (Issue #1532) — pass it explicitly (or `volatility_field`
                 to solve_fp_system) for correct physics.
@@ -118,6 +119,20 @@ class FPNetworkSolver(BaseFPSolver):
             self._mass_changing_bc = any(bc.bc_type in mass_changing for bc in node_bc.node_bcs)
 
         self.scheme = scheme
+        # Issue #1541 / RFC #1574: scheme="upwind" was an identity map (the paired edge flows cancel
+        # to exactly zero net drift and the step has no diffusion term, so the density never evolves),
+        # and "flow" was never implemented. A correctly-implemented conservative upwind would be
+        # byte-identical to "explicit" (which already sources transition rates via H.optimal_control in
+        # inflow-outflow form + a diffusion term), i.e. a single-source duplicate. Fail loud at
+        # construction rather than silently returning a physics-free density (matches the #1426
+        # dead-knob precedent already in this file).
+        if scheme not in ("explicit", "implicit"):
+            raise NotImplementedError(
+                f"FPNetworkSolver(scheme={scheme!r}) is not supported (Issue #1541). Only 'explicit' "
+                f"and 'implicit' are implemented; 'upwind' was a proven identity map (no transport) "
+                f"and would duplicate 'explicit' if fixed, and 'flow' was never implemented. "
+                f"Use scheme='explicit'."
+            )
         # Issue #1532: no silent physical default. The network diffusion D=sigma^2/2 is decoupled
         # from the problem (NetworkMFGProblem carries no sigma, unlike MFGProblem — sourcing it is
         # the #1470 Strand C follow-up). For backward compatibility an unspecified diffusion still
@@ -326,15 +341,11 @@ class FPNetworkSolver(BaseFPSolver):
                 # Issue #913: precompute transition rates via H.optimal_control
                 self._current_rates = self._precompute_transition_rates(M[n, :], u_current, t)
 
-                # Solve single time step
+                # Solve single time step (scheme validated to {explicit, implicit} at __init__, #1541)
                 if self.scheme == "explicit":
                     M[n + 1, :] = self._explicit_step(M[n, :], u_current, t)
-                elif self.scheme == "implicit":
+                else:  # implicit
                     M[n + 1, :] = self._implicit_step(M[n, :], u_current, t)
-                elif self.scheme == "upwind":
-                    M[n + 1, :] = self._upwind_step(M[n, :], u_current, t)
-                else:
-                    raise ValueError(f"Unknown scheme: {self.scheme}")
 
                 # Enforce non-negativity
                 M[n + 1, :] = np.maximum(M[n + 1, :], 0)
@@ -414,30 +425,6 @@ class FPNetworkSolver(BaseFPSolver):
 
         return m_next
 
-    def _upwind_step(self, m_current: np.ndarray, u_current: np.ndarray, t: float) -> np.ndarray:
-        """Upwind scheme for network FP equation (conservation-preserving)."""
-        m_next = m_current.copy()
-
-        # Compute flows between neighboring nodes
-        for i in range(self.num_nodes):
-            neighbors = self.divergence_ops[i]
-
-            net_flow = 0.0
-
-            for j in neighbors:
-                # Compute flow from j to i
-                flow_ji = self._compute_edge_flow(j, i, m_current, u_current, t)
-                # Compute flow from i to j
-                flow_ij = self._compute_edge_flow(i, j, m_current, u_current, t)
-
-                # Net flow into node i
-                net_flow += flow_ji - flow_ij
-
-            # Update with net flow
-            m_next[i] = m_current[i] + self.dt * net_flow
-
-        return m_next
-
     def _precompute_transition_rates(self, m: np.ndarray, u: np.ndarray, t: float) -> dict:
         """Precompute transition rates alpha[i][j] for all nodes.
 
@@ -486,30 +473,6 @@ class FPNetworkSolver(BaseFPSolver):
             "(self._current_rates is None). Call solve_fp_system (which precomputes rates via "
             "H.optimal_control each step) rather than stepping directly (Issue #1546 / #1474)."
         )
-
-    def _compute_edge_flow(self, node_from: int, node_to: int, m: np.ndarray, u: np.ndarray, t: float) -> float:
-        """Compute flow along edge from node_from to node_to."""
-        if node_from == node_to:
-            return 0.0
-
-        # Check if edge exists
-        edge_weight = self.network_problem.network_data.get_edge_weight(node_from, node_to)
-        if edge_weight == 0:
-            return 0.0
-
-        # Upwind density selection
-        du = u[node_to] - u[node_from]
-
-        if du > 0:  # Flow from node_from to node_to
-            density = m[node_from]
-        else:  # Flow from node_to to node_from
-            density = m[node_to]
-            du = -du
-
-        # Flow magnitude
-        flow = edge_weight * density * du
-
-        return flow
 
     def forward_step(self, m_prev: np.ndarray, u_current: np.ndarray, dt: float) -> np.ndarray:
         """Single forward time step — NOT IMPLEMENTED (Issue #1546).

--- a/mfgarchon/alg/numerical/network_solvers/fp_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/fp_network.py
@@ -476,14 +476,16 @@ class FPNetworkSolver(BaseFPSolver):
             )
             return inflow - outflow
 
-        # Legacy fallback
-        neighbors = self.divergence_ops.get(node, [])
-        drift = 0.0
-        for neighbor in neighbors:
-            du = u[neighbor] - u[node]
-            edge_weight = self.network_problem.network_data.get_edge_weight(node, neighbor)
-            drift += edge_weight * m[node] * du
-        return drift
+        # Issue #1546 / #1474: no silent legacy fallback. solve_fp_system always precomputes
+        # self._current_rates (via H.optimal_control) before each step, so reaching here means the
+        # caller stepped without precomputing (the removed forward_step path). The old fallback used
+        # the wrong-signed, non-conservative uphill drift `w*m[node]*(u_j-u_i)` that #1474 replaced;
+        # fail loud instead of resurrecting it.
+        raise RuntimeError(
+            "FPNetworkSolver._compute_drift_term: transition rates were not precomputed "
+            "(self._current_rates is None). Call solve_fp_system (which precomputes rates via "
+            "H.optimal_control each step) rather than stepping directly (Issue #1546 / #1474)."
+        )
 
     def _compute_edge_flow(self, node_from: int, node_to: int, m: np.ndarray, u: np.ndarray, t: float) -> float:
         """Compute flow along edge from node_from to node_to."""
@@ -510,41 +512,20 @@ class FPNetworkSolver(BaseFPSolver):
         return flow
 
     def forward_step(self, m_prev: np.ndarray, u_current: np.ndarray, dt: float) -> np.ndarray:
+        """Single forward time step — NOT IMPLEMENTED (Issue #1546).
+
+        This "interface compatibility" stub never called _precompute_transition_rates, so it (a) hit
+        the wrong-signed legacy drift on a fresh solver and (b) reused stale last-timestep rates after
+        a solve, and it also skipped the geometry-owned node-BC (_node_applicator.apply_fp) and the
+        #1478 mass-changing-BC renorm gate, manufacturing false conservation under an ABSORBING node.
+        It has no callers. Rather than ship a silently-wrong single-step API, fail loud; use
+        solve_fp_system, which precomputes rates and honors the node BC each step.
         """
-        Single forward time step (interface compatibility).
-
-        Args:
-            m_prev: Density at previous time step
-            u_current: Current value function
-            dt: Time step size
-
-        Returns:
-            Updated density distribution
-        """
-        # Temporarily adjust dt for this step
-        original_dt = self.dt
-        self.dt = dt
-
-        t = 0.0  # Dummy time (should be passed properly in full implementation)
-
-        if self.scheme == "explicit":
-            result = self._explicit_step(m_prev, u_current, t)
-        elif self.scheme == "implicit":
-            result = self._implicit_step(m_prev, u_current, t)
-        else:
-            result = self._upwind_step(m_prev, u_current, t)
-
-        # Restore original dt
-        self.dt = original_dt
-
-        # Enforce constraints
-        result = np.maximum(result, 0)
-        if self.enforce_mass_conservation:
-            total_mass = np.sum(result)
-            if total_mass > 1e-12:
-                result /= total_mass
-
-        return result
+        raise NotImplementedError(
+            "FPNetworkSolver.forward_step is not implemented consistently with solve_fp_system "
+            "(it skips rate precomputation and the node-BC / mass-renorm gate, Issue #1546). "
+            "Use solve_fp_system(M_initial=..., ...) for network FP time stepping."
+        )
 
 
 # Alias for backward compatibility

--- a/tests/unit/test_alg/test_fp_network_solver.py
+++ b/tests/unit/test_alg/test_fp_network_solver.py
@@ -76,8 +76,9 @@ class TestFPNetworkSolverInitialization:
         assert solver.scheme == "implicit"
         assert solver.fp_method_name == "NetworkFP_implicit"
 
-    def test_upwind_scheme_initialization(self):
-        """Test initialization with upwind scheme."""
+    def test_upwind_scheme_fails_loud(self):
+        """Issue #1541: scheme='upwind' was a physics-free identity map; it now fails loud at
+        construction rather than silently returning an unevolved density."""
         network = GridNetwork(width=3, height=3)
         network.create_network()
 
@@ -87,10 +88,8 @@ class TestFPNetworkSolverInitialization:
             Nt=10,
         )
 
-        solver = FPNetworkSolver(problem, scheme="upwind")
-
-        assert solver.scheme == "upwind"
-        assert solver.fp_method_name == "NetworkFP_upwind"
+        with pytest.raises(NotImplementedError, match="1541"):
+            FPNetworkSolver(problem, scheme="upwind")
 
     def test_custom_diffusion_coefficient(self):
         """Test initialization with custom diffusion coefficient."""
@@ -345,29 +344,6 @@ class TestFPNetworkSolverSolveFPSystem:
 
         assert np.all(np.isfinite(M_solution))
 
-    def test_solve_with_upwind_scheme(self):
-        """Test solving with upwind scheme."""
-        network = GridNetwork(width=3, height=3)
-        network.create_network()
-
-        problem = NetworkMFGProblem(
-            geometry=network,
-            T=0.5,
-            Nt=10,
-        )
-
-        solver = FPNetworkSolver(problem, scheme="upwind")
-
-        Nt = problem.Nt + 1
-        num_nodes = problem.num_nodes
-
-        m_initial = np.ones(num_nodes) / num_nodes
-        U_solution = np.zeros((Nt, num_nodes))
-
-        M_solution = solver.solve_fp_system(m_initial, U_solution)
-
-        assert np.all(np.isfinite(M_solution))
-
     def test_solve_with_non_zero_drift(self):
         """Test solving with non-zero drift field."""
         network = GridNetwork(width=3, height=3)
@@ -393,7 +369,8 @@ class TestFPNetworkSolverSolveFPSystem:
         assert np.all(np.isfinite(M_solution))
 
     def test_invalid_scheme_raises_error(self):
-        """Test that invalid scheme raises error."""
+        """Issue #1541: an unsupported scheme is rejected at construction (fail loud), not silently
+        run or discovered at solve time."""
         network = GridNetwork(width=3, height=3)
         network.create_network()
 
@@ -403,17 +380,8 @@ class TestFPNetworkSolverSolveFPSystem:
             Nt=10,
         )
 
-        solver = FPNetworkSolver(problem, scheme="explicit")
-        solver.scheme = "invalid_scheme"  # Manually set invalid scheme
-
-        Nt = problem.Nt + 1
-        num_nodes = problem.num_nodes
-
-        m_initial = np.ones(num_nodes) / num_nodes
-        U_solution = np.zeros((Nt, num_nodes))
-
-        with pytest.raises(ValueError, match="Unknown scheme"):
-            solver.solve_fp_system(m_initial, U_solution)
+        with pytest.raises(NotImplementedError, match="1541"):
+            FPNetworkSolver(problem, scheme="invalid_scheme")
 
 
 class TestFPNetworkSolverNumericalProperties:
@@ -634,7 +602,7 @@ class TestFPNetworkSolverIntegration:
         configs = [
             {"scheme": "explicit", "cfl_factor": 0.4},
             {"scheme": "implicit"},
-            {"scheme": "upwind", "diffusion_coefficient": 0.15},
+            {"scheme": "explicit", "diffusion_coefficient": 0.15},  # was "upwind" (removed, Issue #1541)
         ]
 
         for config in configs:

--- a/tests/unit/test_alg/test_network_forward_step_fail_loud_1546.py
+++ b/tests/unit/test_alg/test_network_forward_step_fail_loud_1546.py
@@ -1,0 +1,47 @@
+"""Issue #1546: FPNetworkSolver.forward_step must fail loud, not silently mis-step.
+
+forward_step never precomputed transition rates, so a fresh solver hit the wrong-signed legacy drift
+and a post-solve call reused stale rates; it also skipped the node-BC / mass-renorm gate. It has no
+callers. It now raises NotImplementedError, and the legacy fallback in _compute_drift_term (reachable
+only off the solve_fp_system path) also raises rather than resurrecting the wrong-signed drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.network_solvers.fp_network import FPNetworkSolver
+from mfgarchon.extensions.topology import NetworkMFGProblem
+from mfgarchon.geometry.graph.network_geometry import GridNetwork
+
+
+def _solver() -> tuple[FPNetworkSolver, int]:
+    problem = NetworkMFGProblem(geometry=GridNetwork(width=3, height=1), T=0.5, Nt=5)
+    return FPNetworkSolver(problem), problem.num_nodes
+
+
+def test_forward_step_fails_loud_1546():
+    solver, n = _solver()
+    m0 = np.ones(n) / n
+    with pytest.raises(NotImplementedError, match=r"forward_step|1546"):
+        solver.forward_step(m0, np.zeros(n), 0.1)
+
+
+def test_compute_drift_term_fails_loud_without_precomputed_rates_1546():
+    """The legacy fallback (fresh solver, no precomputed rates) must raise, not use the wrong-signed drift."""
+    solver, n = _solver()
+    assert solver._current_rates is None
+    with pytest.raises(RuntimeError, match=r"not precomputed|1546|1474"):
+        solver._compute_drift_term(0, np.ones(n) / n, np.zeros(n), 0.0)
+
+
+def test_solve_fp_system_still_works_1546():
+    """solve_fp_system precomputes rates each step, so it is unaffected by the fail-loud fallback."""
+    solver, n = _solver()
+    m0 = np.ones(n) / n
+    U = np.zeros((6, n))
+    M = solver.solve_fp_system(M_initial=m0, potential_field=U, show_progress=False)
+    assert np.isfinite(M).all()
+    assert M.shape[0] == 6


### PR DESCRIPTION
## What

Two closely-related cleanups of dead/broken FP-network paths, both fail loud:

- **#1546** — `forward_step` (an "interface compatibility" stub, **zero callers**) never precomputed transition rates, so it hit the wrong-signed legacy drift on a fresh solver, reused stale rates after a solve, and skipped the node-BC / #1478 mass-renorm gate (false conservation under an ABSORBING node). It now raises `NotImplementedError`. The `_compute_drift_term` legacy fallback (unreachable from `solve_fp_system`, which precomputes rates every step at `:327`) also raises rather than resurrecting the #1474 wrong-signed drift.
- **#1541** — `scheme="upwind"` was a silent **identity map** (`_compute_edge_flow` returns the same positive flow for both edge orientations → paired flows cancel to zero net drift; the step has no diffusion term → density never evolves), and `"flow"` was never implemented. A correctly-implemented conservative upwind would be **byte-identical to "explicit"** (which already sources rates via `H.optimal_control` in inflow-outflow form + diffusion) — a single-source duplicate. `scheme` is now validated to `{explicit, implicit}` at construction; the dead `_upwind_step` / `_compute_edge_flow` are removed.

## Scope / safety

- `solve_fp_system` (explicit/implicit) unaffected — mass=1.0 on a probe; 35 network tests pass.
- The 3 collateral `"upwind"` tests (which asserted construction/finiteness of a provably-identity map — not an intended contract) are updated to the fail-loud behavior; the `test_invalid_scheme_raises_error` moves from a solve-time ValueError to the construction-time gate.
- Not on `#1552`/exp paths.

Fixes #1546. Refs #1541 (drop-vs-implement resolved to drop, per maintainer: the "upwind" string fails loud, leaving the door open for a genuinely-distinct Godunov-flux scheme later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)