### PR TITLE
fix(gfdm): FPGFDMSolver threads obstacle_sdf into TaylorOperator (#1556, G-004)

### DIFF
--- a/changelog.d/1556-fp-gfdm-obstacle.fixed.md
+++ b/changelog.d/1556-fp-gfdm-obstacle.fixed.md
@@ -1,0 +1,6 @@
+- **FPGFDMSolver threads obstacle_sdf into its TaylorOperator** (Issue #1556, G-004 FP residue). The FP
+  GFDM operator was built with no obstacle SDF, so its density-derivative stencils (D_lap / D_grad)
+  coupled straight through obstacle walls while the HJB-GFDM side was visibility-filtered (#1124) —
+  asymmetric physics on the same cloud in a coupled obstacle solve. `FPGFDMSolver` now accepts
+  `obstacle_sdf` / `visibility_samples` / `visibility_margin` and passes them to `TaylorOperator`,
+  matching the HJB side. Default `None` is inert (no change without an obstacle).

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -102,6 +102,9 @@ class FPGFDMSolver(BaseFPSolver):
         boundary_conditions: BoundaryConditions | None = None,
         upwind_scheme: str = "none",
         upwind_strength: float = 0.5,
+        obstacle_sdf: object | None = None,
+        visibility_samples: int = 10,
+        visibility_margin: float = 0.0,
     ):
         """
         Initialize GFDM-based FP solver.
@@ -159,11 +162,18 @@ class FPGFDMSolver(BaseFPSolver):
         # Create GFDM operator using TaylorOperator (Strategy Pattern, Issue #844)
         # TaylorOperator handles neighborhoods and derivative weights
         # BC is handled externally (no ghost particles — cleaner separation)
+        # Issue #1556: thread the obstacle SDF into the operator so the FP density derivatives
+        # (D_lap / D_grad) respect obstacle connectivity, exactly like the HJB-GFDM side (#1124).
+        # Without it, in a coupled obstacle-cloud solve the FP stencils couple through walls while
+        # the HJB stencils are visibility-filtered — asymmetric physics.
         self.gfdm_operator = TaylorOperator(
             points=self.collocation_points,
             delta=self.delta,
             taylor_order=taylor_order,
             weight_function=weight_function,
+            obstacle_sdf=obstacle_sdf,
+            visibility_samples=visibility_samples,
+            visibility_margin=visibility_margin,
         )
         # Store boundary info for solver-level BC enforcement
         self._boundary_indices = boundary_indices

--- a/tests/unit/test_alg/test_fp_gfdm_obstacle_visibility_1556.py
+++ b/tests/unit/test_alg/test_fp_gfdm_obstacle_visibility_1556.py
@@ -1,0 +1,63 @@
+"""Issue #1556: FPGFDMSolver must thread obstacle_sdf into its TaylorOperator so the FP density
+derivatives (D_lap / D_grad) respect obstacle connectivity — mirroring the HJB-GFDM #1124 fix.
+
+Without it, a coupled obstacle-cloud solve has the FP stencils coupling through walls while the HJB
+stencils are visibility-filtered (asymmetric physics).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.geometry.grids.tensor_grid import TensorProductGrid
+from mfgarchon.geometry.implicit import Hypersphere
+
+
+def _pillar_cloud(seed: int = 42, n: int = 100):
+    rng = np.random.default_rng(seed)
+    pts = rng.uniform(0, 10, size=(n, 2))
+    pillar = Hypersphere(center=[5.0, 5.0], radius=1.5)
+    return pts[pillar.signed_distance(pts) > 0.1], pillar
+
+
+def _problem() -> MFGProblem:
+    grid = TensorProductGrid(
+        bounds=[(0.0, 10.0), (0.0, 10.0)], num_points=[5, 5], boundary_conditions=no_flux_bc(dimension=2)
+    )
+    H = SeparableHamiltonian(control_cost=QuadraticControlCost(lambda_=1.0))
+    return MFGProblem(
+        geometry=grid,
+        T=0.2,
+        Nt=2,
+        sigma=0.1,
+        components=MFGComponents(hamiltonian=H, u_terminal=lambda x: 0.0, m_initial=lambda x: 1.0),
+    )
+
+
+def _count_cross_wall_edges(op, pts, pillar) -> int:
+    n_cross = 0
+    for i in range(len(pts)):
+        for j in op.neighborhoods[i]["indices"]:
+            if j == i:
+                continue
+            if pillar.signed_distance(np.array([0.5 * (pts[i] + pts[j])]))[0] < 0:
+                n_cross += 1
+    return n_cross
+
+
+def test_fp_gfdm_without_obstacle_has_cross_wall_edges():
+    """Baseline: without obstacle_sdf, some FP stencil edges cross the pillar."""
+    pts, pillar = _pillar_cloud()
+    solver = FPGFDMSolver(_problem(), pts, delta=2.5)
+    assert _count_cross_wall_edges(solver.gfdm_operator, pts, pillar) > 0
+
+
+def test_fp_gfdm_with_obstacle_has_no_cross_wall_edges_1556():
+    """With obstacle_sdf threaded through to TaylorOperator, no FP stencil edge crosses the wall."""
+    pts, pillar = _pillar_cloud()
+    solver = FPGFDMSolver(_problem(), pts, delta=2.5, obstacle_sdf=pillar.signed_distance)
+    assert _count_cross_wall_edges(solver.gfdm_operator, pts, pillar) == 0


### PR DESCRIPTION
## What

`FPGFDMSolver` now accepts `obstacle_sdf` / `visibility_samples` / `visibility_margin` and passes them into its `TaylorOperator`, mirroring the already-merged HJB-GFDM #1124 pattern.

## Why (G-004 FP residue)

The FP GFDM operator was built with **no** obstacle SDF, so its density-derivative stencils (`D_lap`/`D_grad`) coupled straight through obstacle walls, while the HJB-GFDM side is visibility-filtered. In a coupled obstacle-cloud solve that is **asymmetric physics on the same cloud**.

## Scope / safety

- Default `obstacle_sdf=None` is inert — no behavior change without an obstacle (the existing continuity test passes).
- `TaylorOperator` already accepts these params (used by the HJB side); this only wires the FP solver to them.

## Test

`test_fp_gfdm_obstacle_visibility_1556.py` (mirrors the HJB `test_taylor_operator_obstacle_visibility.py`): on a pillar cloud, without `obstacle_sdf` some FP stencil edges cross the wall (5 in the probe); with it, **zero**. Discriminating (a revert dropping the param restores cross-wall edges).

Fixes #1556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)