### PR TITLE
test/doc: pin weak-form FP magnitude + correct 4 overclaiming/false docstrings (#1566, #1569, #1557)

### DIFF
--- a/changelog.d/1557-reflect-bounds-docstring.fixed.md
+++ b/changelog.d/1557-reflect-bounds-docstring.fixed.md
@@ -1,0 +1,8 @@
+- **Corrected the false `_infer_reflect_bounds` docstring** (Issue #1557, partial). The FP-particle
+  helper's Returns section claimed it returns "the subset of `bounds` for axes whose BC is reflective"
+  and that non-reflective axes "are excluded", but the code returns ALL bounds whenever ANY segment is
+  reflective (an all-or-nothing gate, not per-axis). Rewrote the docstring to describe the actual
+  behavior and to mark the per-face limitation explicitly: on a mixed reflecting/absorbing domain,
+  reflection ghosts are still created at the absorbing exit, mirroring mass back within ~1 bandwidth.
+  The per-face numerics fix is gated with the mass-channel fix #1552 (mfg-research exp09 validation),
+  since it shifts the density in the evacuation regime; only the doc is corrected here.

--- a/changelog.d/1566-weakform-fp-magnitude-test.added.md
+++ b/changelog.d/1566-weakform-fp-magnitude-test.added.md
@@ -1,0 +1,7 @@
+- **Diffusion-magnitude gate now pins the weak-form (FEM) FP solver** (Issue #1566). The standing
+  `test_diffusion_magnitude_gate.py` docstring named `#1152` (weak-form used `volatility_field`
+  directly as `D`, skipping the `/2`) among the bugs it catches, but no test instantiated
+  `WeakFormFPSolver` — the paper solver's diffusion magnitude was named-but-unpinned. Added
+  `test_weak_form_fem_fp_diffusion_magnitude`: a cosine eigenmode under pure diffusion on a 1D
+  `FPFEMSolver` must decay at `exp(-D k^2 T)` with `D = sigma^2/2`; mutation-verified to fail on the
+  `#1152` factor error. Coverage note updated to list the weak-form path.

--- a/changelog.d/1569-pin-docstring-honesty.fixed.md
+++ b/changelog.d/1569-pin-docstring-honesty.fixed.md
@@ -1,0 +1,10 @@
+- **Corrected three single-source pin docstrings that overclaimed their discrimination** (Issue
+  #1569). No regression was unguarded (a companion test discriminates in every case), but a lying
+  pin docstring erodes the single-source guard layer. Fixed: (1) `test_backend_literal_equals_single_source`
+  is an IEEE identity of `0.5*sigma**2`, not a backend-kernel guard — no backend is imported; the
+  numpy D-application is pinned behaviorally by the magnitude gate. (2) `test_compute_normal_from_bounds_default_tol_is_onwall_tol`
+  pins the default's VALUE only — a signature default is the evaluated value, so a bare-literal revert
+  passes it; the import-vs-literal re-fork is caught by the companion source-grep test. (3) The
+  magnitude-gate header no longer lists `#1169` (anisotropic off-diagonal) / `#1183` (varying-sigma
+  mean-collapse) as caught here — a constant-isotropic eigenmode cannot see them; named the tests that
+  actually guard them.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -942,10 +942,11 @@ class FPParticleSolver(BaseFPSolver):
         """
         Issue #1083: decide whether KDE reflection applies, from the solver BC.
 
-        Returns ALL of `bounds` if ANY segment is reflective (NO_FLUX / REFLECTING /
-        NEUMANN); otherwise None (caller falls back to standard KDE without ghost
-        reflection). This is an all-or-nothing gate keyed on "is any wall reflective",
-        NOT a per-axis subset.
+        Returns ALL of `bounds` if there is no explicit BC (no `boundary_conditions` or no
+        segments -- the legacy reflect-everywhere default) OR if ANY segment is reflective
+        (NO_FLUX / REFLECTING / NEUMANN); returns None only when segments exist and NONE is
+        reflective (caller falls back to standard KDE without ghost reflection). This is an
+        all-or-nothing gate keyed on "is any wall reflective", NOT a per-axis subset.
 
         LIMITATION (Issue #1557): when a domain mixes reflective and non-reflective faces
         (e.g. reflecting walls + a Dirichlet absorbing exit, or a periodic axis), this still

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -940,14 +940,23 @@ class FPParticleSolver(BaseFPSolver):
 
     def _infer_reflect_bounds(self, bounds: list[tuple[float, float]]) -> list[tuple[float, float]] | None:
         """
-        Issue #1083: infer per-axis bounds for KDE reflection from solver BC.
+        Issue #1083: decide whether KDE reflection applies, from the solver BC.
 
-        Returns the subset of `bounds` for axes whose BC is reflective
-        (NO_FLUX / REFLECTING / NEUMANN). Returns None if no axis is reflective
-        — caller falls back to standard KDE without ghost reflection.
+        Returns ALL of `bounds` if ANY segment is reflective (NO_FLUX / REFLECTING /
+        NEUMANN); otherwise None (caller falls back to standard KDE without ghost
+        reflection). This is an all-or-nothing gate keyed on "is any wall reflective",
+        NOT a per-axis subset.
 
-        For axes with non-reflective BC (DIRICHLET absorbing exit, periodic),
-        reflection ghosts are mathematically wrong, so they are excluded.
+        LIMITATION (Issue #1557): when a domain mixes reflective and non-reflective faces
+        (e.g. reflecting walls + a Dirichlet absorbing exit, or a periodic axis), this still
+        returns every axis, so `reflection_kde` creates ghosts on the non-reflective faces
+        too -- where they are mathematically wrong: ghost mass is mirrored back within ~1
+        bandwidth and flattens the density dip an absorbing exit should produce. True per-face
+        masking needs the segment -> axis/side mapping threaded into the density estimator;
+        because that changes the density near absorbing exits (the evacuation regime), it is
+        gated together with the mass-channel fix #1552 (mfg-research exp09 validation), not
+        made here. The earlier "Returns the subset ... excluded" wording described that intended
+        end state, not this code -- corrected to match the actual behavior (kernel doc honesty).
         """
         bc = self.boundary_conditions
         if bc is None or not getattr(bc, "segments", None):

--- a/tests/integration/test_diffusion_magnitude_gate.py
+++ b/tests/integration/test_diffusion_magnitude_gate.py
@@ -17,12 +17,19 @@ intact — so this gate FAILS on exactly the bugs that shipped:
 
   - #1152  weak-form used ``volatility_field`` directly as ``D`` (skipped the /2)
   - #1178  ADI applied ``dt/dimension`` -> only ``1/dim`` of the diffusion
-  - #1183  explicit-drift FP collapsed spatially-varying sigma to its mean
-  - #1169  anisotropic off-diagonal sigma dropped
+  - #1073  GFDM re-squared ``problem.diffusion`` -> ``(sigma^2/2)^2``
+
+Scope (Issue #1569): the cosine eigenmode is evolved under CONSTANT ISOTROPIC sigma, so
+this gate catches only constant-isotropic *magnitude* (factor) errors as above. It does
+NOT catch the two varying/anisotropic bugs of the same audit -- a constant-sigma eigenmode
+cannot see them (``mean(const) == const``; no off-diagonal to drop): #1183 (explicit-drift
+FP mean-collapse of spatially-varying sigma) is guarded in ``test_operators/test_diffusion.py``
+and #1169 (anisotropic off-diagonal dropped) in ``test_fp_particle_anisotropic_sigma_1256.py``.
 
 Coverage: ADI diffusion step (standalone; also the SL HJB default diffusion path,
 which delegates to it) over 1D/2D/3D, the FP-FDM explicit-drift and implicit
-per-point diffusion paths, and the HJB-GFDM per-point Newton path (the production
+per-point diffusion paths, the weak-form (FEM Galerkin) FP path via ``FPFEMSolver``
+(the #1152 solver, Issue #1566), and the HJB-GFDM per-point Newton path (the production
 ``joint_socp`` + ``precompute`` stack) via MMS source-cancellation. Constant sigma
 (the clean eigenmode invariant).
 
@@ -135,6 +142,54 @@ def test_fp_fdm_diffusion_magnitude(path):
     factor, analytic = _fp_pure_diffusion_decay(path, sigma=0.3)
     assert _decay_relerr(factor, analytic) < 0.03, (
         f"FP {path} diffusion magnitude wrong: factor {factor:.6f} vs analytic {analytic:.6f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Weak-form (FEM Galerkin) FP diffusion magnitude -- the #1152 path the gate names (Issue #1566)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.tier2
+@pytest.mark.integration
+def test_weak_form_fem_fp_diffusion_magnitude():
+    """The weak-form (FEM Galerkin) FP solver must decay a cosine eigenmode at exp(-D*k^2*T)
+    with D = sigma^2/2. This is the #1152 path named in this module's own docstring ("weak-form
+    used volatility_field directly as D -- skipped the /2"): a factor error doubles the decay
+    rate. No prior test instantiated ``WeakFormFPSolver`` (Issue #1566), so the paper solver's
+    magnitude was named-but-unpinned; ``FPFEMSolver`` inherits ``_diffusion_coefficient`` /
+    ``solve_fp_system`` from ``WeakFormFPSolver`` unchanged, so this exercises that magnitude path.
+    Pure diffusion (zero coupling, no potential) keeps ``1 + a*cos(2*pi*x)`` positive, so the
+    positivity clip never fires and the recovered decay reads the diffusion coefficient directly."""
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM FP solver")
+    from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+    from mfgarchon.geometry import Mesh1D
+
+    sigma, T, nt, ne = 0.3, 0.2, 40, 80
+    D = 0.5 * sigma**2
+    geom = Mesh1D(bounds=(0.0, 1.0), num_elements=ne)
+    geom.generate_mesh()
+    geom.boundary_conditions = no_flux_bc(dimension=1)
+    H = SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m: np.asarray(m) * 0.0,
+        coupling_dm=lambda m: np.asarray(m) * 0.0,
+    )
+    comps = MFGComponents(
+        m_initial=lambda xx: 1.0 + 0.4 * np.cos(_K * np.asarray(xx)),
+        u_terminal=lambda xx: np.asarray(xx) * 0.0,
+        hamiltonian=H,
+    )
+    prob = MFGProblem(geometry=geom, T=T, Nt=nt, sigma=sigma, components=comps, coupling_coefficient=0.0)
+    solver = FPFEMSolver(prob, order=1)
+    x = solver._disc.dof_coordinates[:, 0]
+    m0 = 1.0 + 0.4 * np.cos(_K * x)
+    M = solver.solve_fp_system(m0.copy(), potential_field=None, volatility_field=sigma)
+    amp0, ampT = M[0] - 1.0, M[-1] - 1.0
+    i = int(np.argmax(np.abs(amp0)))
+    factor, analytic = ampT[i] / amp0[i], np.exp(-D * _K**2 * T)
+    assert _decay_relerr(factor, analytic) < 0.05, (
+        f"weak-form FEM FP diffusion magnitude wrong: factor {factor:.6f} vs analytic {analytic:.6f}"
     )
 
 

--- a/tests/unit/test_convention_agreement.py
+++ b/tests/unit/test_convention_agreement.py
@@ -82,9 +82,16 @@ class TestSigmaToDiffusionAgreement:
 
     @pytest.mark.parametrize("sigma", SIGMAS)
     def test_backend_literal_equals_single_source(self, sigma):
-        """Several backends apply D via the literal ``0.5 * sigma**2`` rather than the converter
-        (numpy/jax/numba/torch). Pin that the literal is bit-equal to the single source so a
-        backend edit that drifts from sigma**2/2 fails here."""
+        """Pin that the converter's scalar branch IS the literal ``0.5 * sigma**2`` bit-for-bit,
+        i.e. code that legitimately inlines that literal (rather than importing the converter)
+        computes the identical IEEE value -- so an inline ``0.5*sigma**2`` is a faithful copy of
+        the single source, not a silent fork.
+
+        Scope (Issue #1569): this is an identity of the ``0.5*sigma**2`` expression, NOT a guard on
+        any backend kernel -- no numpy/jax/numba/torch code is imported or called here, so a backend
+        that drifted its own literal to ``0.5*sigma`` would NOT trip this. The numpy path's D
+        *application* is pinned behaviorally by ``test_diffusion_magnitude_gate.py``; the jax/numba/
+        torch D-application (optional, off-paper backends) has no convention pin yet."""
         assert 0.5 * sigma**2 == diffusion_from_volatility(sigma)
 
     def test_hjb_scalar_and_diagonal_tensor_diffusion_agree(self):

--- a/tests/unit/test_geometry/test_ghost_onwall_tol_single_source.py
+++ b/tests/unit/test_geometry/test_ghost_onwall_tol_single_source.py
@@ -6,15 +6,18 @@ Two migration sites in geometry/boundary/ghost.py:
 
 Tests assert:
   (A) ghost module imports from tolerances (structural: import present)
-  (B) compute_normal_from_bounds default matches ONWALL_TOL exactly
+  (B) compute_normal_from_bounds default matches ONWALL_TOL exactly (VALUE only)
   (C) create_ghost_stencil classification is unchanged on a known 2-D cloud
       (behavior-invariant: byte-identical result before/after)
+  source-grep (:154/:170) the actual re-fork guard -- the module source of each site
+      must not contain the bare literal '1e-10'.
 
-Test (B) FAILS on the pre-refactor code because the default argument is the
-literal 1e-10, not the imported constant (which has the same float value but
-the test checks via module introspection that no hardcoded literal bypasses the
-import).  After the refactor the default IS ONWALL_TOL so the import is present
-and the float value matches.
+What catches a revert (Issue #1569): the import-vs-literal re-fork is caught by the
+source-grep tests (``test_no_hardcoded_1e10_in_*``, :154/:170), NOT by (B). A signature
+default is the *evaluated* value, so ``tol=1e-10`` and ``tol=ONWALL_TOL`` are both ``1e-10``
+to introspection -- (B) is a value equality that a bare-literal revert PASSES. (B) exists
+only to pin that ONWALL_TOL keeps that float value (a change to the constant would surface),
+and (A) that the import exists; the grep is the discriminating single-source guard.
 """
 
 from __future__ import annotations
@@ -52,11 +55,13 @@ def test_ghost_imports_onwall_tol():
 
 
 def test_compute_normal_from_bounds_default_tol_is_onwall_tol():
-    """The default tol= argument of compute_normal_from_bounds must be ONWALL_TOL.
+    """The default tol= argument of compute_normal_from_bounds must equal ONWALL_TOL by VALUE.
 
-    This test FAILS on the pre-refactor code if the default is still the bare
-    literal 1e-10 and ONWALL_TOL has not been wired in.  After the refactor the
-    default is set to ONWALL_TOL (same float value, single-sourced).
+    Scope (Issue #1569): a signature default is the evaluated value, so this equality does NOT
+    distinguish ``tol=1e-10`` from ``tol=ONWALL_TOL`` (both introspect as 1e-10) -- a bare-literal
+    revert PASSES here. The import-vs-literal re-fork is caught by ``test_no_hardcoded_1e10_in_
+    compute_normal_from_bounds`` (source grep). This test pins only that ONWALL_TOL keeps that
+    float value, so a change to the constant surfaces as a mismatch.
     """
     from mfgarchon.geometry.boundary.ghost import compute_normal_from_bounds
 
@@ -65,7 +70,7 @@ def test_compute_normal_from_bounds_default_tol_is_onwall_tol():
 
     assert default_tol == ONWALL_TOL, (
         f"compute_normal_from_bounds default tol={default_tol!r} != ONWALL_TOL={ONWALL_TOL!r}. "
-        "The 1e-10 literal has not been replaced by the imported constant."
+        "The default's float value has drifted from the single source (ONWALL_TOL)."
     )
 
 


### PR DESCRIPTION
Deep-check v2 Sweep E findings, test/doc-truth cluster. All B0 (tests + docstrings; no production numerics change).

## #1566 — weak-form FP magnitude was named-but-unpinned
`test_diffusion_magnitude_gate.py`'s docstring lists `#1152` (weak-form used `volatility_field` directly as `D`, skipping `/2`) among the bugs it catches, but no test instantiated `WeakFormFPSolver`. Added `test_weak_form_fem_fp_diffusion_magnitude`: a cosine eigenmode under pure diffusion on `FPFEMSolver` must decay at `exp(-D k^2 T)` with `D = sigma^2/2`. **Mutation-verified**: temporarily forcing `_diffusion_coefficient` to return `sigma` (the #1152 bug) makes it fail; correct D passes.

## #1569 — three single-source pins overclaimed discrimination
No regression was unguarded (a companion test discriminates in every case), but the docstrings lied:
- `test_backend_literal_equals_single_source` — an IEEE identity of `0.5*sigma**2`, not a backend guard (no backend imported). Rewrote to state what it pins; numpy D-application is covered behaviorally by the magnitude gate.
- `test_compute_normal_from_bounds_default_tol_is_onwall_tol` — pins the default's VALUE only; a signature default is the evaluated value, so a bare-literal revert passes. The import-vs-literal re-fork is caught by the companion source-grep test. Fixed header + docstring + assert message.
- magnitude-gate header — dropped `#1169` / `#1183` from "bugs caught here" (a constant-isotropic eigenmode cannot see anisotropic-off-diagonal or varying-sigma-mean-collapse); named the tests that actually guard them.

## #1557 (partial) — false `_infer_reflect_bounds` docstring
The Returns section claimed a per-axis reflective subset with non-reflective axes "excluded"; the code returns ALL bounds whenever ANY segment is reflective. Corrected to the actual all-or-nothing behavior and marked the per-face limitation. **Doc-only** — the per-face numerics fix shifts density near absorbing exits (evacuation regime), so it stays gated with the mass-channel fix #1552 (mfg-research exp09 validation).

## Verification
- `pytest tests/unit/test_convention_agreement.py tests/unit/test_geometry/test_ghost_onwall_tol_single_source.py tests/integration/test_diffusion_magnitude_gate.py` → 39 passed
- `ruff check` + `ruff format --check` clean; `check_fail_fast.py --path mfgarchon --check-baseline` clean

Closes #1566 #1569. Refs #1557 (doc portion only; numerics gated on #1552).

🤖 Generated with [Claude Code](https://claude.com/claude-code)