### PR TITLE
test: un-mask 10 solver skips + add fast-tier coupled mass gate (#1567)

### DIFF
--- a/changelog.d/1567-unmask-solver-skips.fixed.md
+++ b/changelog.d/1567-unmask-solver-skips.fixed.md
@@ -1,0 +1,10 @@
+- **Removed `except Exception: pytest.skip` masks around solver calls; added a fast-tier coupled
+  mass-conservation gate** (Issue #1567). Ten sites wrapped `solver.solve()` / `solve_hjb_system()`
+  in `try/except -> pytest.skip`, converting a solver raise into a green skip (the testing analogue
+  of a fail-silent fallback). Un-masked all ten (`test_mass_conservation_1d.py` x6,
+  `test_hjb_gfdm_solver.py` x2, `test_collocation_gfdm_hjb.py` x1) so a solver raise now fails the
+  test. The one live-skipping site drove the GFDM solve through an incomplete hand-rolled mock
+  (missing `T` / `dimension`); rebuilt it on a real `MFGProblem`. Added
+  `test_coupled_fdm_mass_conservation_fast_tier`: a small deterministic HJB-FDM + FP-FDM coupled
+  solve (~1s, non-`@slow`) that pins total-mass conservation on every PR — previously every coupled
+  mass test was `@slow`, so the paper-critical invariant was checked only on the nightly tier.

--- a/tests/integration/test_collocation_gfdm_hjb.py
+++ b/tests/integration/test_collocation_gfdm_hjb.py
@@ -3,6 +3,11 @@ import pytest
 import numpy as np
 
 from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver as GFDMHJBSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
 
 
 class MockGeometry:
@@ -191,19 +196,34 @@ class TestGFDMHJBSolver:
         assert u_modified[9] == 1.0
 
     def test_solve_hjb_system_shape(self):
-        """Test that solve_hjb_system returns correct shape."""
-        # Create test inputs
-        M_density = np.ones((5, 10)) * 0.1
-        U_final = np.ones(10)
-        U_prev = np.ones((5, 10))
+        """solve_hjb_system on a REAL problem returns U of shape (Nt, Nx).
 
-        # Solve (this may not converge perfectly but should return correct shape)
-        try:
-            U_solution = self.solver.solve_hjb_system(M_density, U_final, U_prev)
-            assert U_solution.shape == (5, 10)
-        except Exception as e:
-            # If solver fails, that's okay for this basic test
-            pytest.skip(f"Solver failed: {e}")
+        Issue #1567: the previous version drove ``solve_hjb_system`` through the hand-rolled
+        ``MockMFGProblem`` and wrapped it in ``try/except -> pytest.skip``. The mock lacks the
+        attributes a full solve needs (``T``, ``dimension``, ...), so the call always raised and
+        the skip swallowed it -- the integration-tier solve-shape contract was never verified.
+        Rebuilt on a real ``MFGProblem`` (the mock is kept for the unit-surface tests in this
+        file that only exercise neighborhoods / Taylor stencils). No ``try/except -> skip``: a
+        solver raise is a real failure now."""
+        n = 21
+        domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+        components = MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: np.asarray(x) * 0.0,
+            hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+        )
+        problem = MFGProblem(geometry=domain, T=1.0, Nt=5, sigma=0.3, components=components)
+        collocation_points = np.linspace(0.0, 1.0, n).reshape(-1, 1)
+        solver = GFDMHJBSolver(problem, collocation_points, delta=0.3, monotonicity_scheme="none")
+
+        Nt, Nx = problem.Nt, n
+        M_density = np.ones((Nt, Nx)) * 0.1
+        U_final = np.zeros(Nx)
+        U_prev = np.zeros((Nt, Nx))
+
+        # Solve (may not converge perfectly, but must return the correct shape).
+        U_solution = solver.solve_hjb_system(M_density, U_final, U_prev)
+        assert U_solution.shape == (Nt, Nx)
 
     def test_weight_functions(self):
         """Test different weight functions for GFDM weighting (integration test)."""

--- a/tests/integration/test_mass_conservation_1d.py
+++ b/tests/integration/test_mass_conservation_1d.py
@@ -106,10 +106,8 @@ class TestMassConservation1D:
             fp_solver=fp_solver,
         )
 
-        try:
-            result = mfg_solver.solve(max_iterations=50, tolerance=1e-3)
-        except Exception as e:
-            pytest.skip(f"MFG solver raised exception: {str(e)[:100]}")
+        # Issue #1567: no try/except -> skip; a solver raise must fail this mass-conservation test.
+        result = mfg_solver.solve(max_iterations=50, tolerance=1e-3)
 
         m_solution = result.M
 
@@ -159,10 +157,8 @@ class TestMassConservation1D:
             fp_solver=fp_solver,
         )
 
-        try:
-            result = mfg_solver.solve(max_iterations=50, tolerance=1e-3)
-        except Exception as e:
-            pytest.skip(f"MFG solver raised exception: {str(e)[:100]}")
+        # Issue #1567: no try/except -> skip; a solver raise must fail this mass-conservation test.
+        result = mfg_solver.solve(max_iterations=50, tolerance=1e-3)
 
         m_solution = result.M
 
@@ -203,10 +199,8 @@ class TestMassConservation1D:
         hjb_solver_1 = HJBFDMSolver(problem)
         mfg_solver_1 = FixedPointIterator(problem, hjb_solver=hjb_solver_1, fp_solver=fp_solver_1)
 
-        try:
-            result_1 = mfg_solver_1.solve(max_iterations=50, tolerance=1e-3)
-        except Exception as e:
-            pytest.skip(f"FDM solver raised exception: {str(e)[:100]}")
+        # Issue #1567: no try/except -> skip; a solver raise must fail this cross-solver test.
+        result_1 = mfg_solver_1.solve(max_iterations=50, tolerance=1e-3)
 
         # Solver 2: FP Particle + HJB GFDM
         fp_solver_2 = FPParticleSolver(
@@ -219,10 +213,8 @@ class TestMassConservation1D:
         hjb_solver_2 = HJBGFDMSolver(problem, collocation_points=collocation_points, delta=0.3)
         mfg_solver_2 = FixedPointIterator(problem, hjb_solver=hjb_solver_2, fp_solver=fp_solver_2)
 
-        try:
-            result_2 = mfg_solver_2.solve(max_iterations=50, tolerance=1e-3)
-        except Exception as e:
-            pytest.skip(f"GFDM solver raised exception: {str(e)[:100]}")
+        # Issue #1567: no try/except -> skip; a solver raise must fail this cross-solver test.
+        result_2 = mfg_solver_2.solve(max_iterations=50, tolerance=1e-3)
 
         dx = problem.geometry.get_grid_spacing()[0]
         Nt_points = problem.Nt + 1
@@ -279,10 +271,8 @@ class TestMassConservation1D:
             backend=None,
         )
 
-        try:
-            result = mfg_solver.solve(max_iterations=50, tolerance=1e-4, return_structured=True)
-        except Exception as e:
-            pytest.skip(f"Solver convergence issue with {num_particles} particles: {str(e)[:100]}")
+        # Issue #1567: no try/except -> skip; a solver raise must fail this mass-conservation test.
+        result = mfg_solver.solve(max_iterations=50, tolerance=1e-4, return_structured=True)
 
         dx = problem.geometry.get_grid_spacing()[0]
         Nt_points = problem.Nt + 1
@@ -343,10 +333,8 @@ class TestMassConservation1D:
                 backend=None,
             )
 
-            try:
-                result = mfg_solver.solve(max_iterations=50, tolerance=1e-4, return_structured=True)
-            except Exception as e:
-                pytest.skip(f"Solver convergence issue for {name}: {str(e)[:100]}")
+            # Issue #1567: no try/except -> skip; a solver raise must fail this mass-conservation test.
+            result = mfg_solver.solve(max_iterations=50, tolerance=1e-4, return_structured=True)
 
             dx = problem.geometry.get_grid_spacing()[0]
             Nt_points = problem.Nt + 1
@@ -356,6 +344,40 @@ class TestMassConservation1D:
             print(f"\n{name}: Initial mass = {masses[0]:.6f}, Max error = {max_error:.6e}")
 
             assert max_error < 0.1, f"Mass conservation failed for {name}: {max_error:.6e}"
+
+    def test_coupled_fdm_mass_conservation_fast_tier(self):
+        """Fast-tier (non-@slow) coupled MFG mass-conservation gate (Issue #1567).
+
+        Every other coupled mass test in this class is @slow (5000-particle stochastic KDE),
+        so the only mass check the PR gate ran was the analytic pure-diffusion one -- a coupled
+        regression that leaked mass would surface only on the nightly tier. This runs a small,
+        deterministic coupled FDM solve (HJB-FDM + FP-FDM, no-flux, n=21, Nt=8, 3 Picard steps,
+        ~1s) and asserts total mass is preserved across every time step. Mass conservation here
+        is structural (the column-conservative no-flux FP stencil, #1184), so it holds regardless
+        of Picard convergence -- a real leak (a broken no-flux stencil, a lost normalization)
+        trips it, but non-convergence does not."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+
+        n, nt, T, sigma = 21, 8, 0.5, 0.3
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+        H = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: np.asarray(m),
+            coupling_dm=lambda m: np.ones_like(np.asarray(m)),
+        )
+        comps = MFGComponents(
+            m_initial=lambda x: np.exp(-30 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.0 * np.asarray(x),
+            hamiltonian=H,
+        )
+        prob = MFGProblem(geometry=grid, T=T, Nt=nt, sigma=sigma, coupling_coefficient=1.0, components=comps)
+        mfg_solver = FixedPointIterator(prob, hjb_solver=HJBFDMSolver(prob), fp_solver=FPFDMSolver(prob))
+        result = mfg_solver.solve(max_iterations=3, tolerance=1e-4)
+
+        dx = prob.geometry.get_grid_spacing()[0]
+        masses = np.array([compute_total_mass(result.M[t, :], dx) for t in range(nt + 1)])
+        drift = np.max(np.abs(masses - masses[0])) / masses[0]
+        assert drift < 1e-10, f"coupled FDM mass drift {drift:.2e} across time (no-flux must conserve)"
 
 
 class TestExplicitDriftNoFluxDiffusionConservation:

--- a/tests/unit/test_alg/test_hjb_gfdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_gfdm_solver.py
@@ -528,13 +528,10 @@ class TestHJBGFDMSolverSolveHJBSystem:
         U_final = np.zeros(Nx)
         U_prev = np.zeros((Nt, Nx))
 
-        # Solve (may not converge perfectly, but should return correct shape)
-        try:
-            U_solution = solver.solve_hjb_system(M_density, U_final, U_prev)
-            assert U_solution.shape == (Nt, Nx)
-        except Exception:
-            # If it fails due to problem setup, that's okay for this test
-            pytest.skip("Solver setup issue - shape test inconclusive")
+        # Solve (may not converge perfectly, but must return the correct shape).
+        # No try/except -> skip: a solver raise is a real failure here (Issue #1567).
+        U_solution = solver.solve_hjb_system(M_density, U_final, U_prev)
+        assert U_solution.shape == (Nt, Nx)
 
     @pytest.mark.slow
     def test_solve_hjb_system_final_condition(self, standard_problem):
@@ -555,12 +552,10 @@ class TestHJBGFDMSolverSolveHJBSystem:
         U_final = x_coords**2  # Quadratic final condition
         U_prev = np.zeros((Nt, Nx))
 
-        try:
-            U_solution = solver.solve_hjb_system(M_density, U_final, U_prev)
-            # Final time step should match final condition (approximately)
-            assert np.allclose(U_solution[-1, :], U_final, rtol=0.1)
-        except Exception:
-            pytest.skip("Solver convergence issue - test inconclusive")
+        # No try/except -> skip: a solver raise is a real failure here (Issue #1567).
+        U_solution = solver.solve_hjb_system(M_density, U_final, U_prev)
+        # Final time step should match final condition (approximately)
+        assert np.allclose(U_solution[-1, :], U_final, rtol=0.1)
 
 
 class TestHJBGFDMSolverIntegration:


### PR DESCRIPTION
Deep-check v2 Sweep E finding E-03. Test-quality: converts silent skips into real failures and closes a fast-tier coverage hole on the paper-critical mass invariant.

## Problem
`except Exception: pytest.skip(...)` wrapped around `solver.solve()` / `solve_hjb_system()` at **10 sites** turns a solver **raise** into a green **skip** — the testing analogue of a fail-silent fallback. One was live-skipping today; the rest latent (dead-defensive). Separately, every coupled mass-conservation test is `@slow`, so the PR fast tier never checked coupled mass conservation.

## Changes
- **Un-masked all 10 sites** so a solver raise now fails the test:
  - `test_mass_conservation_1d.py` x6 — all latent (baseline run: **8 passed, 0 skipped**, so the masks were dead-defensive; un-masking a passing test is byte-equivalent).
  - `test_hjb_gfdm_solver.py` x2 — latent unit-tier.
  - `test_collocation_gfdm_hjb.py` x1 — **live-skipping**: it drove the GFDM solve through an incomplete hand-rolled `MockMFGProblem` (missing `T`, `dimension`, ...), so the call always raised and the skip swallowed it. Rebuilt on a real `MFGProblem` (the mock is kept for the neighborhood/Taylor unit-surface tests in the same file) so it genuinely runs.
- **Added `test_coupled_fdm_mass_conservation_fast_tier`** — a small deterministic HJB-FDM + FP-FDM coupled solve (n=21, Nt=8, 3 Picard steps, ~1s, non-`@slow`) pinning total-mass conservation on every PR. Mass conservation is structural (the column-conservative no-flux FP stencil, #1184), so it holds regardless of Picard convergence.

## Verification
- Fast-tier trio (un-masked unit shape, rebuilt collocation shape, new coupled mass) → 3 passed.
- Full `test_collocation_gfdm_hjb.py` → 9 passed (no regression).
- New coupled test **mutation-verified**: a 1% injected mass leak → drift 1e-2 >> the 1e-10 threshold; non-vacuous (density evolves by ~3.5 over the horizon).
- Un-masked slow tier confirmed locally (baseline masked run 8 passed / 0 skipped; un-masking is byte-equivalent).
- `ruff check` + `ruff format --check` clean; `check_fail_fast.py --path mfgarchon --check-baseline` clean.

Closes #1567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)