### PR TITLE
fix: MeanFieldActorCritic fails loud on missing population channel (#1568)

### DIFF
--- a/changelog.d/1568-actor-critic-fail-loud-population.fixed.md
+++ b/changelog.d/1568-actor-critic-fail-loud-population.fixed.md
@@ -1,0 +1,12 @@
+- **`MeanFieldActorCritic` now fails loud when the observation carries no population channel**
+  (Issue #1568, extends #1508). `_extract_population` silently zero-filled the mean-field state when
+  the observation lacked a `local_density`/`population` key (dict) or a tail slice past `state_dim`
+  (array) — training on an identically-zero mean field and returning a policy the user trusts as
+  MFG-coupled while the coupling that DEFINES the game was never present. #1508 fixed exactly this
+  for DDPG/TD3/SAC (env-side `get_population_state` guard) but did not cover ActorCritic, which reads
+  the population from the observation rather than querying the env. It now raises `AttributeError`
+  citing #1508/#1568, with a hint that adapts to whether the env exposes `get_population_state()`.
+  Note: the raise keys on "observation has no population channel" (not on "env lacks
+  get_population_state"), so it also catches the shipped `crowd_navigation_env` pairing — that env
+  *does* expose `get_population_state()` yet its observation omits the population, which the issue's
+  literal env-only condition would have missed.

--- a/mfgarchon/alg/reinforcement/algorithms/mean_field_actor_critic.py
+++ b/mfgarchon/alg/reinforcement/algorithms/mean_field_actor_critic.py
@@ -583,10 +583,35 @@ class MeanFieldActorCritic:
         return obs[: self.state_dim] if len(obs) > self.state_dim else obs
 
     def _extract_population(self, obs: dict | np.ndarray) -> np.ndarray:
-        """Extract population state from observation."""
+        """Extract the population (mean-field) state from an observation.
+
+        Issue #1568 (extends #1508): a zero-filled population is the silent non-MFG failure that
+        #1508 made DDPG/TD3/SAC raise on -- training on an identically-zero mean field returns a
+        policy the user trusts as MFG-coupled when the coupling channel was never present. This
+        algorithm reads the population from the OBSERVATION (it does not query
+        ``env.get_population_state()``), so it must fail loud when the observation carries no
+        population channel instead of zero-filling.
+        """
         if isinstance(obs, dict):
-            return obs.get("local_density", obs.get("population", np.zeros(self.population_dim)))
-        return obs[self.state_dim :] if len(obs) > self.state_dim else np.zeros(self.population_dim)
+            pop = obs.get("local_density", obs.get("population"))
+            if pop is not None:
+                return pop
+        elif len(obs) > self.state_dim:
+            return obs[self.state_dim :]
+
+        has_env_getter = callable(getattr(self.env, "get_population_state", None))
+        hint = (
+            "The env exposes get_population_state(), but MeanFieldActorCritic reads the population "
+            "from the observation, not from that method -- embed the population channel in the "
+            "observation (dict key 'local_density'/'population', or as a tail slice past state_dim)."
+            if has_env_getter
+            else "The env exposes no get_population_state() and the observation carries no population."
+        )
+        raise AttributeError(
+            "MeanFieldActorCritic observation carries no population (mean-field) channel. A zero "
+            "fallback would train on an identically-zero mean field and silently return a non-MFG "
+            f"policy (Issue #1508/#1568). {hint}"
+        )
 
     def save(self, path: str) -> None:
         """Save model checkpoint."""

--- a/tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py
+++ b/tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py
@@ -56,3 +56,14 @@ def test_actor_critic_missing_population_channel_fails_loud():
     algo = MeanFieldActorCritic(env=_EnvWithoutPopState(), state_dim=2, action_dim=3, population_dim=4)
     with pytest.raises(AttributeError, match="1508"):
         algo.train(num_episodes=1)
+
+    # Both raise-paths of _extract_population must fire (else a revert to a zeros default on either
+    # would re-introduce the silent non-MFG training): (a) ndarray with no tail past state_dim, and
+    # (b) dict lacking both 'local_density' and 'population'.
+    with pytest.raises(AttributeError, match="1508"):
+        algo._extract_population(np.zeros(2))  # len == state_dim -> no population tail
+    with pytest.raises(AttributeError, match="1508"):
+        algo._extract_population({"state": np.zeros(2)})  # dict without a population channel
+    # A dict that DOES carry the population returns it (no raise).
+    pop = algo._extract_population({"local_density": np.arange(4.0)})
+    assert np.array_equal(pop, np.arange(4.0))

--- a/tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py
+++ b/tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py
@@ -42,3 +42,17 @@ def test_missing_get_population_state_fails_loud(module_name, class_name):
     )
     with pytest.raises(AttributeError, match="1508"):
         algo.train(num_episodes=1)
+
+
+def test_actor_critic_missing_population_channel_fails_loud():
+    """Issue #1568: MeanFieldActorCritic reads the population from the OBSERVATION (it never calls
+    env.get_population_state()), so #1508's env-side guard never covered it -- ``_extract_population``
+    still silently zero-filled. It now fails loud when the observation carries no population channel.
+    Separate from the DDPG/TD3/SAC parametrization because ActorCritic is discrete (action_dim, no
+    action_bounds). ``_EnvWithoutPopState`` returns a length-2 obs with state_dim=2, so no tail slice
+    remains for the population -> the zero-fill path, now a raise."""
+    from mfgarchon.alg.reinforcement.algorithms.mean_field_actor_critic import MeanFieldActorCritic
+
+    algo = MeanFieldActorCritic(env=_EnvWithoutPopState(), state_dim=2, action_dim=3, population_dim=4)
+    with pytest.raises(AttributeError, match="1508"):
+        algo.train(num_episodes=1)


### PR DESCRIPTION
Deep-check v2 Sweep E finding E-01. Extends the #1508 fail-loud guard to the one mean-field RL algorithm it missed.

## Problem (code-traced)
`MeanFieldActorCritic._extract_population` silently zero-filled the mean-field state when the observation carried no population channel — dict without `local_density`/`population`, or array with `len(obs) <= state_dim`. Training then ran on an **identically-zero mean field**, returning a policy the user trusts as MFG-coupled when the coupling that defines the game was never present. #1508/#1511 made DDPG/TD3/SAC raise on exactly this (env-side `get_population_state` guard), but ActorCritic reads the population from the **observation** and was never covered (`grep -c get_population_state` on the file = 0).

## Correctness note (diverges from the issue's literal fix)
The issue proposed raising when *"the env has no `get_population_state` AND the observation carries no population channel."* Tracing the issue's own headline repro — shipped `MeanFieldActorCritic` + shipped `crowd_navigation_env` — that env **does** expose `get_population_state()` (`:328`) yet its observation is `concatenate([positions, velocities, goals])` with no population (`:201`). The literal AND-condition would therefore **not** fire on the repro it cites. The fix instead keys the raise on **"observation has no population channel"** (ActorCritic never queries the env), which catches the repro; the env's `get_population_state` status only shapes the error hint.

## Change
`_extract_population` raises `AttributeError` citing #1508/#1568 instead of zero-filling, with an env-aware hint. Added `test_actor_critic_missing_population_channel_fails_loud`.

## Verification
- `test_mean_field_rl_requires_pop_state_1508.py` → 4 passed (3 existing + ActorCritic).
- **Mutation-verified**: reverting to the zero-fill body → `DID NOT RAISE AttributeError` (test fails); guard restored → passes.
- Scope: separate RL entrypoint, off all published numerical paths, package import gated by uninstalled `gymnasium`+`stable_baselines3`. `ruff` + `check_fail_fast.py --path mfgarchon --check-baseline` clean (getattr+callable, no hasattr).

Closes #1568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)