### PR TITLE
fix: fail loud when a coupling loop cannot resolve dynamic BC providers (#1563)

### DIFF
--- a/changelog.d/1558-1559-bc-fail-loud.fixed.md
+++ b/changelog.d/1558-1559-bc-fail-loud.fixed.md
@@ -1,0 +1,12 @@
+- **Three silent-wrong boundary-condition paths now fail loud** (Issues #1558, #1559; all off
+  published numerics). (1) `SDFParticleBCHandler._compute_normal` raised a `RuntimeError` instead of
+  fabricating an arbitrary `[1,0,...]` outward normal when the finite-difference SDF gradient vanishes
+  — the fabricated normal reflected particles along a geometry-independent direction (mirrors the
+  #1047 `project_to_domain` raise). (2) `TensorProductGrid.get_boundary_handler(bc_type)` now raises
+  `ValueError` on an unrecognized `bc_type` instead of silently defaulting to periodic (1D) / neumann
+  (nD); the docstring's advertised `periodic_x`/`periodic_both`/`mixed` keys were never implemented in
+  the factory and silently became the default — the docstring is corrected to the keys actually
+  supported. (3) The FP-FDM time-stepping assembly now raises `NotImplementedError` for a legacy
+  `fdm_bc_1d` dirichlet/robin BC instead of silently assembling it as no-flux (legacy periodic/neumann/
+  no_flux still assemble; `_is_dirichlet_at_point` cannot see a legacy BC, so a legacy dirichlet was
+  silently coerced). Each carries a mutation-verified discriminating test.

--- a/changelog.d/1563-coupling-bc-provider-guard.fixed.md
+++ b/changelog.d/1563-coupling-bc-provider-guard.fixed.md
@@ -1,0 +1,13 @@
+- **Coupling loops that cannot resolve dynamic BC providers now fail loud** (Issue #1563, RFC #1574).
+  Only `FixedPointIterator` resolves a `BCValueProvider` (e.g. `AdjointConsistentProvider`) stored in a
+  `BCSegment.value` — it calls `problem.using_resolved_bc()` each Picard step. The other five coupling
+  loops (`FictitiousPlayIterator`, `BlockIterator`/`BlockJacobi`/`BlockGaussSeidel`, `MFGResidual`/
+  `NewtonMFGSolver`, `MultiPopulationIterator`, `RegimeSwitchingIterator`) do not, so a provider-based
+  boundary condition previously reached the solver unresolved — a deep GFDM row-builder `ValueError`,
+  or a silent miss on a non-Robin provider segment. They now raise `NotImplementedError` up front,
+  naming the loop, via a single-source guard `assert_bc_providers_resolvable` (one owner in
+  `base_mfg.py`, called at construction by all five). `RegimeSwitchingIterator` and
+  `MultiPopulationIterator` guard EVERY sub-problem, not just the representative `problems[0]`. This
+  adds no coupling behavior and is off published numerics (every published path uses
+  `FixedPointIterator`). Wiring the two clean single-problem Picard loops to actually resolve
+  providers is a follow-up gated behind a validation experiment.

--- a/mfgarchon/alg/numerical/coupling/base_mfg.py
+++ b/mfgarchon/alg/numerical/coupling/base_mfg.py
@@ -16,6 +16,25 @@ else:
     pass
 
 
+def assert_bc_providers_resolvable(problem: MFGProblem, iterator_name: str) -> None:
+    """Fail loud if ``problem`` carries a dynamic BC provider this coupling loop cannot resolve.
+
+    RFC #1574 / Issue #1563: only ``FixedPointIterator`` resolves a ``BCValueProvider`` (e.g.
+    ``AdjointConsistentProvider``) stored in a ``BCSegment.value`` -- it calls
+    ``problem.using_resolved_bc(state)`` each Picard step (fixed_point_iterator.py). The other
+    coupling loops do not, so a provider would otherwise reach the solver unresolved: a deep GFDM
+    row-builder ``ValueError``, or a silent miss on a non-Robin provider segment. Raise up front
+    (naming the loop) instead of surfacing the failure deep in the solver, or not at all.
+    """
+    if problem.get_boundary_conditions().has_providers():
+        raise NotImplementedError(
+            f"{iterator_name} does not resolve dynamic BC providers (a BCValueProvider stored in a "
+            f"BCSegment.value, e.g. AdjointConsistentProvider). Only FixedPointIterator resolves them "
+            f"per iteration (Issue #625/#1563). Use FixedPointIterator for a provider-based "
+            f"(adjoint-consistent) boundary condition, or a statically-valued BC with this loop."
+        )
+
+
 class BaseCouplingIterator(ABC):
     """
     Abstract base class for iterative coupling solvers (Picard, block, fictitious play).

--- a/mfgarchon/alg/numerical/coupling/base_mfg.py
+++ b/mfgarchon/alg/numerical/coupling/base_mfg.py
@@ -26,7 +26,12 @@ def assert_bc_providers_resolvable(problem: MFGProblem, iterator_name: str) -> N
     row-builder ``ValueError``, or a silent miss on a non-Robin provider segment. Raise up front
     (naming the loop) instead of surfacing the failure deep in the solver, or not at all.
     """
-    if problem.get_boundary_conditions().has_providers():
+    # A problem without grid BC resolution (a network problem, or a lightweight test stub) cannot
+    # carry a grid BCValueProvider, so there is nothing to guard -- skip rather than AttributeError.
+    _get_bc = getattr(problem, "get_boundary_conditions", None)
+    if not callable(_get_bc):
+        return
+    if _get_bc().has_providers():
         raise NotImplementedError(
             f"{iterator_name} does not resolve dynamic BC providers (a BCValueProvider stored in a "
             f"BCSegment.value, e.g. AdjointConsistentProvider). Only FixedPointIterator resolves them "

--- a/mfgarchon/alg/numerical/coupling/block_iterators.py
+++ b/mfgarchon/alg/numerical/coupling/block_iterators.py
@@ -41,7 +41,7 @@ from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.solver_result import SolverResult
 
-from .base_mfg import BaseCouplingIterator
+from .base_mfg import BaseCouplingIterator, assert_bc_providers_resolvable
 from .fixed_point_utils import (
     apply_damping,
     check_convergence_criteria,
@@ -147,6 +147,7 @@ class BlockIterator(BaseCouplingIterator):
             relaxation_M = damping_factor_M
 
         super().__init__(problem)
+        assert_bc_providers_resolvable(self.problem, type(self).__name__)
 
         self.hjb_solver = hjb_solver
         self.fp_solver = fp_solver

--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -42,7 +42,7 @@ from mfgarchon.utils.iteration.schedules import (
 )
 from mfgarchon.utils.solver_result import SolverResult
 
-from .base_mfg import BaseCouplingIterator
+from .base_mfg import BaseCouplingIterator, assert_bc_providers_resolvable
 from .fixed_point_utils import (
     check_convergence_criteria,
     initialize_cold_start,
@@ -126,6 +126,7 @@ class FictitiousPlayIterator(BaseCouplingIterator):
         drift_field: np.ndarray | Any | None = None,
     ):
         super().__init__(problem)
+        assert_bc_providers_resolvable(self.problem, "FictitiousPlayIterator")
         self.backend = backend
         self.hjb_solver = hjb_solver
         self.fp_solver = fp_solver

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -28,6 +28,7 @@ import numpy as np
 from mfgarchon.geometry.boundary import no_flux_bc
 from mfgarchon.utils.mfg_logging import get_logger
 
+from .base_mfg import assert_bc_providers_resolvable
 from .fixed_point_utils import resolve_fp_drift_kwargs
 from .source_composition import compose_fp_source, compose_hjb_source
 
@@ -108,6 +109,7 @@ class MFGResidual:
             drift_field: Optional drift override for non-MFG problems
         """
         self.problem = problem
+        assert_bc_providers_resolvable(self.problem, "MFGResidual (NewtonMFGSolver)")
         self.hjb_solver = hjb_solver
         self.fp_solver = fp_solver
         self.volatility_field = volatility_field

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -73,10 +73,10 @@ class MultiPopulationIterator:
         self.fp_solvers = fp_solvers
         self.relaxation = relaxation
         K = multi_problem.K
-        for _k in range(K):
-            assert_bc_providers_resolvable(
-                multi_problem.get_population(_k), f"MultiPopulationIterator[population {_k}]"
-            )
+        _get_pop = getattr(multi_problem, "get_population", None)
+        if callable(_get_pop):
+            for _k in range(K):
+                assert_bc_providers_resolvable(_get_pop(_k), f"MultiPopulationIterator[population {_k}]")
 
         if len(hjb_solvers) != K:
             raise ValueError(f"Need {K} HJB solvers, got {len(hjb_solvers)}")

--- a/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/multi_population_iterator.py
@@ -20,6 +20,8 @@ import numpy as np
 from mfgarchon.utils.deprecation import deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
 
+from .base_mfg import assert_bc_providers_resolvable
+
 if TYPE_CHECKING:
     from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
     from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
@@ -71,6 +73,10 @@ class MultiPopulationIterator:
         self.fp_solvers = fp_solvers
         self.relaxation = relaxation
         K = multi_problem.K
+        for _k in range(K):
+            assert_bc_providers_resolvable(
+                multi_problem.get_population(_k), f"MultiPopulationIterator[population {_k}]"
+            )
 
         if len(hjb_solvers) != K:
             raise ValueError(f"Need {K} HJB solvers, got {len(hjb_solvers)}")

--- a/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/regime_switching_iterator.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator, assert_bc_providers_resolvable
 from mfgarchon.alg.numerical.coupling.fixed_point_utils import (
     fp_solver_sig_params,
     resolve_fp_drift_kwargs,
@@ -126,6 +126,10 @@ class RegimeSwitchingIterator(BaseCouplingIterator):
         # Use first problem as representative for base class
         super().__init__(problems[0])
         self._problems = problems
+        # Guard EVERY regime's problem, not just problems[0] (self.problem): each regime solves its
+        # own HJB and none of them resolves BC providers (Issue #1563).
+        for _k, _p in enumerate(problems):
+            assert_bc_providers_resolvable(_p, f"RegimeSwitchingIterator[regime {_k}]")
         self._regime = regime_config
         self._hjb = hjb_solvers
         self._fp = fp_solvers

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -1209,8 +1209,18 @@ def solve_timestep_full_nd(
                     f"Unsupported boundary_conditions type: {type(boundary_conditions).__name__}. "
                     "Expected BoundaryConditions from mfgarchon.geometry.boundary."
                 ) from None
-            # Legacy BC: treat as no-flux for backward compatibility
-            # (legacy periodic BC relies on no-flux boundary assembly + interior wrapping)
+            # Legacy periodic relies on no-flux boundary assembly + interior wrapping, and legacy
+            # neumann/no_flux ARE no-flux. Fail loud (Issue #1559) for legacy dirichlet/robin
+            # instead of silently coercing them to no-flux: this assembly does not honor them, and
+            # _is_dirichlet_at_point cannot see a legacy BC (it has no is_uniform, so the check
+            # returns False), so a legacy dirichlet would otherwise be silently assembled as no-flux.
+            if legacy_type not in ("periodic", "neumann", "no_flux"):
+                raise NotImplementedError(
+                    f"Legacy fdm_bc_1d BoundaryConditions(type={legacy_type!r}) is not supported by the "
+                    f"FP-FDM time-stepping assembly (only periodic/neumann/no_flux); it would be silently "
+                    f"assembled as no-flux. Use mfgarchon.geometry.boundary (dirichlet_bc / robin_bc / "
+                    f"no_flux_bc) with the modern BoundaryConditions instead (Issue #1559)."
+                ) from None
             is_no_flux = True
             is_uniform = False
 

--- a/mfgarchon/geometry/boundary/applicator_meshfree.py
+++ b/mfgarchon/geometry/boundary/applicator_meshfree.py
@@ -655,13 +655,18 @@ class SDFParticleBCHandler:
 
         # Normalize
         norm = np.linalg.norm(grad)
-        if norm > 1e-12:
-            return grad / norm
-        else:
-            # Degenerate case: return arbitrary unit vector
-            result = np.zeros(self.dimension)
-            result[0] = 1.0
-            return result
+        if norm <= 1e-12:
+            # Fail loud (Issue #1558): a vanishing SDF gradient has no well-defined outward
+            # normal. Fabricating [1, 0, ...] reflects the particle along a geometry-independent
+            # direction -- a silent-wrong that corrupts particle stepping. Mirror the #1047 raise
+            # in project_to_domain rather than manufacturing a normal.
+            raise RuntimeError(
+                f"SDFParticleBCHandler: vanishing SDF gradient (|grad| = {norm:.3e}) at point "
+                f"{point.ravel()}; the outward normal is undefined there. This indicates a "
+                f"degenerate geometry (locally flat / saddle SDF, or a point on the medial axis). "
+                f"Check geometry.signed_distance for correctness near this point."
+            )
+        return grad / norm
 
     def contains(
         self,

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -831,14 +831,15 @@ class TensorProductGrid(
         properly propagated to solvers that call this method.
 
         Args:
-            bc_type: Standard boundary condition type (only used if no BC stored):
-                - "dirichlet_zero": Zero Dirichlet on all boundaries
-                - "neumann_zero": Zero Neumann (no-flux) on all boundaries
+            bc_type: Standard boundary condition type (only used if no BC stored). Supported:
                 - "periodic": Periodic on all boundaries
-                - "periodic_x", "periodic_y", "periodic_z": Periodic in one direction
-                - "periodic_both": Periodic in all directions (2D/3D)
-                - "mixed": Mixed conditions (implementation-dependent)
-            custom_conditions: Optional dict with custom BC specifications
+                - "dirichlet_zero": Zero Dirichlet on all boundaries
+                - "neumann_zero" / "no_flux": Zero Neumann (no-flux) on all boundaries
+                - "neumann": Zero Neumann (nD only)
+                An unrecognized bc_type raises ValueError (Issue #1558) rather than silently
+                defaulting to periodic (1D) / neumann (nD). Per-axis / mixed BC are NOT created
+                here -- build a BoundaryConditions and store it on the grid (Priority 1) instead.
+            custom_conditions: Optional dict with custom BC specifications (1D only)
 
         Returns:
             Boundary condition handler appropriate for grid dimension
@@ -886,7 +887,13 @@ class TensorProductGrid(
         elif custom_conditions:
             return BoundaryConditions(**custom_conditions)
         else:
-            return BoundaryConditions(type="periodic")  # Safe default
+            # Fail loud (Issue #1558): an unrecognized bc_type previously fell through to a
+            # periodic "safe default", silently substituting the wrong BC. Periodic on a domain
+            # meant to reflect/absorb is a different problem, not a safe default.
+            raise ValueError(
+                f"Unsupported 1D bc_type {bc_type!r}. Supported: {sorted(bc_map)}. For per-axis "
+                f"or mixed BC, build a BoundaryConditions and store it on the grid instead."
+            )
 
     def _create_bc_nd(self, bc_type: str):
         """Create nD boundary conditions using unified BC framework."""
@@ -904,8 +911,15 @@ class TensorProductGrid(
             "dirichlet_zero": lambda dimension=None: dirichlet_bc(value=0.0, dimension=dimension),
             "no_flux": no_flux_bc,
         }
-        factory = bc_factory.get(bc_type, neumann_bc)
-        return factory(dimension=self._dimension)
+        # Fail loud (Issue #1558): an unrecognized bc_type previously fell through to neumann_bc,
+        # silently substituting the wrong BC (and the advertised periodic_x/periodic_both/mixed
+        # keys were never in this factory, so they all silently became Neumann).
+        if bc_type not in bc_factory:
+            raise ValueError(
+                f"Unsupported {self._dimension}D bc_type {bc_type!r}. Supported: {sorted(bc_factory)}. "
+                f"For per-axis or mixed BC, build a BoundaryConditions and store it on the grid instead."
+            )
+        return bc_factory[bc_type](dimension=self._dimension)
 
     # ============================================================================
     # Boundary Trait Implementations (Issue #590 - Phase 1.2)

--- a/tests/unit/test_alg/test_coupling_bc_provider_guard_1563.py
+++ b/tests/unit/test_alg/test_coupling_bc_provider_guard_1563.py
@@ -91,3 +91,37 @@ def test_fictitious_play_rejects_provider_bc():
 
     # A static-BC problem constructs fine (the guard is scoped to providers only).
     FictitiousPlayIterator(plain, hjb_solver=hjb, fp_solver=fp)
+
+
+def test_single_problem_loops_reject_provider_bc():
+    """BlockIterator and MFGResidual (the other two single-self.problem loops) also fail loud."""
+    from mfgarchon.alg.numerical.coupling.block_iterators import BlockJacobiIterator
+    from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+
+    plain = _plain_problem()
+    hjb, fp = HJBFDMSolver(plain), FPFDMSolver(plain)
+    for cls in (BlockJacobiIterator, MFGResidual):
+        with pytest.raises(NotImplementedError, match="1563"):
+            cls(_provider_problem(), hjb_solver=hjb, fp_solver=fp)
+
+
+def test_regime_switching_guards_every_regime_not_just_the_first():
+    """Load-bearing claim: RegimeSwitchingIterator guards EVERY regime's problem, not just
+    problems[0] (which is the representative self.problem). A provider on the SECOND regime must
+    raise, naming 'regime 1' -- a revert to guarding only problems[0] would let it through."""
+    from mfgarchon.alg.numerical.coupling.regime_switching_iterator import RegimeSwitchingIterator
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+    from mfgarchon.core.regime_switching import RegimeSwitchingConfig
+
+    plain = _plain_problem()
+    # regime 0 = static, regime 1 = provider-bearing. Solvers built on the static problem (the guard
+    # fires on the problems list before any solver is used).
+    problems = [plain, _provider_problem()]
+    config = RegimeSwitchingConfig(transition_matrix=np.array([[-0.1, 0.1], [0.2, -0.2]]))
+    hjbs = [HJBFDMSolver(plain), HJBFDMSolver(plain)]
+    fps = [FPFDMSolver(plain), FPFDMSolver(plain)]
+    with pytest.raises(NotImplementedError, match="regime 1"):
+        RegimeSwitchingIterator(problems=problems, regime_config=config, hjb_solvers=hjbs, fp_solvers=fps)

--- a/tests/unit/test_alg/test_coupling_bc_provider_guard_1563.py
+++ b/tests/unit/test_alg/test_coupling_bc_provider_guard_1563.py
@@ -1,0 +1,93 @@
+"""Issue #1563 / RFC #1574: coupling loops that do not resolve dynamic BC providers must fail loud.
+
+Only FixedPointIterator resolves a BCValueProvider (e.g. AdjointConsistentProvider) stored in a
+BCSegment.value, via problem.using_resolved_bc() each Picard step. The other coupling loops
+(FictitiousPlay, Block*, MFGResidual/Newton, MultiPopulation, RegimeSwitching) do not, so a provider
+would otherwise reach the solver unresolved -- a deep GFDM ValueError, or a silent miss. They now
+raise NotImplementedError up front via the single-source guard assert_bc_providers_resolvable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.base_mfg import assert_bc_providers_resolvable
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import (
+    AdjointConsistentProvider,
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    no_flux_bc,
+)
+
+
+def _components():
+    return MFGComponents(
+        m_initial=lambda x: np.ones_like(np.asarray(x, dtype=float)),
+        u_terminal=lambda x: 0.0 * np.asarray(x, dtype=float),
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+    )
+
+
+def _provider_problem(sigma=0.3):
+    """A 1D problem whose BC carries an AdjointConsistentProvider (a dynamic BC provider)."""
+    provider_bc = BoundaryConditions(
+        segments=[
+            BCSegment(
+                name="left_ac",
+                bc_type=BCType.ROBIN,
+                alpha=0.0,
+                beta=1.0,
+                value=AdjointConsistentProvider(side="left", sigma=sigma),
+                boundary="x_min",
+            ),
+            BCSegment(
+                name="right_ac",
+                bc_type=BCType.ROBIN,
+                alpha=0.0,
+                beta=1.0,
+                value=AdjointConsistentProvider(side="right", sigma=sigma),
+                boundary="x_max",
+            ),
+        ],
+        dimension=1,
+    )
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=provider_bc)
+    return MFGProblem(geometry=grid, T=0.1, Nt=2, sigma=sigma, components=_components())
+
+
+def _plain_problem(sigma=0.3):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=0.1, Nt=2, sigma=sigma, components=_components())
+
+
+def test_guard_helper_discriminates():
+    """The single-source guard raises for a provider-bearing problem, passes for a static BC."""
+    assert _provider_problem().get_boundary_conditions().has_providers() is True
+    with pytest.raises(NotImplementedError, match="1563"):
+        assert_bc_providers_resolvable(_provider_problem(), "SomeLoop")
+    # Static BC -> no providers -> no raise.
+    assert_bc_providers_resolvable(_plain_problem(), "SomeLoop")
+
+
+def test_fictitious_play_rejects_provider_bc():
+    """The wiring: constructing a non-resolving loop with a provider-bearing problem raises up front
+    (before the solvers are used), naming the loop. Solvers are built on a static problem since the
+    guard fires on self.problem before touching them."""
+    from mfgarchon.alg.numerical.coupling.fictitious_play import FictitiousPlayIterator
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+
+    plain = _plain_problem()
+    hjb, fp = HJBFDMSolver(plain), FPFDMSolver(plain)
+    with pytest.raises(NotImplementedError, match="1563"):
+        FictitiousPlayIterator(_provider_problem(), hjb_solver=hjb, fp_solver=fp)
+
+    # A static-BC problem constructs fine (the guard is scoped to providers only).
+    FictitiousPlayIterator(plain, hjb_solver=hjb, fp_solver=fp)

--- a/tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py
+++ b/tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py
@@ -1,0 +1,88 @@
+"""Fail-loud guards for silent-wrong BC handling (Issues #1558, #1559).
+
+Each converts a silent-wrong (a fabricated normal, a wrong-BC default, a silently
+no-flux-coerced dirichlet) into an explicit raise. All three paths are off published
+numerics (no experiment / shipped example reaches them), so these pin the fail-loud
+behavior rather than a numeric result.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def test_sdf_vanishing_gradient_normal_fails_loud():
+    """#1558: SDFParticleBCHandler._compute_normal fabricated an arbitrary [1,0,...] normal when
+    the finite-difference SDF gradient vanished -- reflecting a particle along a geometry-independent
+    direction (silent-wrong). A constant SDF has zero gradient everywhere, so the normal is undefined;
+    it must raise (mirroring project_to_domain's #1047 raise)."""
+    from mfgarchon.geometry.boundary import SDFParticleBCHandler
+
+    handler = SDFParticleBCHandler(lambda pts: -0.5 * np.ones(np.asarray(pts).shape[0]), dimension=2)
+    with pytest.raises(RuntimeError, match="vanishing SDF gradient"):
+        handler._compute_normal(np.array([0.3, 0.4]))
+
+
+def test_tensor_grid_unknown_bc_type_fails_loud():
+    """#1558: get_boundary_handler(bc_type) silently defaulted an unrecognized bc_type to periodic
+    (1D) / neumann (nD) -- and its docstring advertised periodic_x/periodic_both/mixed keys that were
+    never in either factory, so all of them silently became the default BC. An unrecognized key must
+    raise, not substitute a different BC. The bc_type factory is reached only when no BC is stored
+    (Priority 1 short-circuits otherwise), so clear it first via the documented 'None to clear' setter."""
+    grid1d = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    grid1d.set_boundary_conditions(None)
+    with pytest.raises(ValueError, match="Unsupported 1D bc_type"):
+        grid1d.get_boundary_handler("bogus")
+
+    grid2d = TensorProductGrid(
+        bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[11, 11], boundary_conditions=no_flux_bc(dimension=2)
+    )
+    grid2d.set_boundary_conditions(None)
+    with pytest.raises(ValueError, match="Unsupported 2D bc_type"):
+        grid2d.get_boundary_handler("periodic_x")  # advertised in the old docstring, never implemented
+
+    # A supported key must still resolve (the raise is scoped to unknown keys only).
+    assert grid1d.get_boundary_handler("periodic") is not None
+    assert grid2d.get_boundary_handler("no_flux") is not None
+
+
+def _small_1d_problem(n=11):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    comps = MFGComponents(
+        m_initial=lambda x: np.ones_like(np.asarray(x, dtype=float)),
+        u_terminal=lambda x: 0.0 * np.asarray(x, dtype=float),
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+    )
+    return MFGProblem(geometry=grid, T=0.1, Nt=2, sigma=0.3, components=comps)
+
+
+def test_legacy_dirichlet_bc_fails_loud():
+    """#1559: the FP-FDM time-stepping assembly treated ANY legacy fdm_bc_1d BoundaryConditions as
+    no-flux (the except-AttributeError branch). _is_dirichlet_at_point can't see a legacy BC (no
+    is_uniform -> returns False), so a legacy dirichlet was silently assembled as no-flux. It must
+    raise for legacy dirichlet/robin while legacy periodic/neumann/no_flux still assemble."""
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+    from mfgarchon.geometry.boundary.fdm_bc_1d import BoundaryConditions as LegacyBC
+
+    prob = _small_1d_problem()
+    n = 11
+    m0 = np.ones(n)
+    drift = np.zeros((prob.Nt + 1, n))
+
+    solver = FPFDMSolver(prob)
+    solver.boundary_conditions = LegacyBC(type="dirichlet", left_value=0.0, right_value=0.0)
+    with pytest.raises(NotImplementedError, match="1559"):
+        solver.solve_fp_system(m0.copy(), drift_field=drift, volatility_field=0.3)
+
+    # Legacy periodic must still assemble (it relies on the no-flux assembly + interior wrapping).
+    solver.boundary_conditions = LegacyBC(type="periodic")
+    M = solver.solve_fp_system(m0.copy(), drift_field=drift, volatility_field=0.3)
+    assert np.all(np.isfinite(M))


### PR DESCRIPTION
Deep-check v2 Sweep C finding, RFC #1574 capability-honesty (Phase-0 extension). **Off published numerics** — every published-figure path uses `FixedPointIterator`, which already resolves providers.

## Problem
Only `FixedPointIterator` resolves a `BCValueProvider` (e.g. `AdjointConsistentProvider`) stored in a `BCSegment.value` — it calls `problem.using_resolved_bc()` each Picard step (`fixed_point_iterator.py:612`). The other five coupling loops never do, so a provider-based (adjoint-consistent) BC reached the solver **unresolved**: a deep GFDM row-builder `ValueError`, or a silent miss on a non-Robin provider segment. The declared surface (these loops accept any `MFGProblem`) is broader than the honored surface (they can't honor a provider).

## Fix
Single-source guard `assert_bc_providers_resolvable(problem, iterator_name)` (one owner in `base_mfg.py`) called at construction by all five loops. It raises `NotImplementedError` naming the loop when `problem.get_boundary_conditions().has_providers()`.
- `FictitiousPlayIterator`, `BlockIterator` (+ `BlockJacobi`/`BlockGaussSeidel`), `MFGResidual`/`NewtonMFGSolver` → guard `self.problem`.
- `MultiPopulationIterator` → guard **every** population (`self.multi_problem.get_population(k)`).
- `RegimeSwitchingIterator` → guard **every** regime (`self._problems[k]`, NOT just `problems[0]` which is `self.problem`).

Adds no coupling behavior. Wiring the two clean single-problem Picard loops (`FictitiousPlay`, `Block._solve_hjb`) to actually *resolve* providers is a follow-up gated behind a validation experiment (per CLAUDE.md bug-fix discipline).

## Verification
- New `test_coupling_bc_provider_guard_1563.py` → 2 passed (helper single-source + FictitiousPlay wiring). **Mutation-verified**: neutering `has_providers()` fails both.
- Regression: coupling test suite (`fictitious`/`block`/`regime`/`multi_population`/`residual`/`fixed_point`) → 128 passed, 0 failed.
- `ruff` + `check_fail_fast.py --path mfgarchon --check-baseline` clean.

Closes #1563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)