### PR TITLE
fix: complete #1558 — Robin coeffs from BCSegment + trim validate_bc_compatibility (defects 1 & 3)

### DIFF
--- a/changelog.d/1558-meshfree-robin-coeffs.fixed.md
+++ b/changelog.d/1558-meshfree-robin-coeffs.fixed.md
@@ -1,0 +1,9 @@
+- **`MeshfreeApplicator` now reads Robin coefficients from the BCSegment that carries them** (Issue
+  #1558, defect 1). `alpha`/`beta` live on `BCSegment`, not on `BoundaryConditions`, so the previous
+  `getattr(boundary_conditions, "beta", 0.0)` always read `0.0` — silently collapsing every Robin BC
+  to pure Dirichlet: `apply()` forced a hard `u = g/alpha` instead of the penalty blend, and
+  `apply_particles()` always absorbed instead of reflecting. Both paths now read `(alpha, beta)` from
+  the ROBIN segment via a single-source helper, so a Robin BC with `beta != 0` behaves as a Robin BC.
+  Behavior change on the meshfree Robin path only; off published numerics (published adjoint-consistent
+  Robin runs through the `hjb_gfdm` row builder, not `MeshfreeApplicator`). Two mutation-verified tests
+  (field penalty-blend, particle reflect-not-absorb).

--- a/changelog.d/1558-validate-bc-compat-trim.fixed.md
+++ b/changelog.d/1558-validate-bc-compat-trim.fixed.md
@@ -1,0 +1,8 @@
+- **`validate_bc_compatibility` no longer emits a contradictory BC-type verdict** (Issue #1558,
+  defect 3). Its per-discretization support table was a second capability source that disagreed with
+  the #1456 single source (`solver.supported_bc_types`): it flagged Robin as "limited" for GFDM while
+  `hjb_gfdm._SUPPORTED_BC_TYPES` includes Robin, and allowed Robin for FDM while `hjb_fdm` excludes it
+  (and read `default_bc`, which is None for segment-based BCs, so for those it silently returned no
+  issues). Trimmed to the one real check — BC/geometry dimension compatibility; BC-type support is
+  authoritatively enforced at solve time by each solver's `supported_bc_types`. `discretization` is
+  kept in the signature for API stability.

--- a/mfgarchon/geometry/boundary/applicator_meshfree.py
+++ b/mfgarchon/geometry/boundary/applicator_meshfree.py
@@ -41,6 +41,20 @@ from .applicator_base import BaseMeshfreeApplicator
 from .types import BCType
 
 
+def _robin_alpha_beta(boundary_conditions) -> tuple[float, float]:
+    """Read Robin (alpha, beta) from the BCSegment that carries them (Issue #1558).
+
+    alpha/beta live on ``BCSegment``, not on ``BoundaryConditions`` -- the previous
+    ``getattr(boundary_conditions, "beta", 0.0)`` always read the 0.0 default, silently collapsing
+    every Robin BC to pure Dirichlet (field path: hard ``u = g/alpha``; particle path: absorbing).
+    Read them from the segment whose type is ROBIN (for a uniform Robin BC this is the sole segment).
+    """
+    robin_seg = next((s for s in boundary_conditions.segments if s.bc_type == BCType.ROBIN), None)
+    if robin_seg is None:
+        raise ValueError("Robin BC resolved but no BCSegment carries the Robin alpha/beta coefficients.")
+    return float(robin_seg.alpha), float(robin_seg.beta)
+
+
 class MeshfreeApplicator(BaseMeshfreeApplicator):
     """
     Boundary condition applicator for meshfree methods.
@@ -376,8 +390,7 @@ class MeshfreeApplicator(BaseMeshfreeApplicator):
         elif bc_type == BCType.ROBIN:
             # Robin BC: α*u + β*du/dn = g
             # For meshfree without derivative info, use penalty approximation
-            alpha = getattr(boundary_conditions, "alpha", 1.0)
-            beta = getattr(boundary_conditions, "beta", 0.0)
+            alpha, beta = _robin_alpha_beta(boundary_conditions)
             bc_value = boundary_conditions.default_value
             if bc_value is None:
                 bc_value = 0.0
@@ -461,8 +474,7 @@ class MeshfreeApplicator(BaseMeshfreeApplicator):
 
         elif bc_type == BCType.ROBIN:
             # Robin: behavior depends on α/β ratio
-            alpha = getattr(boundary_conditions, "alpha", 1.0)
-            beta = getattr(boundary_conditions, "beta", 0.0)
+            alpha, beta = _robin_alpha_beta(boundary_conditions)
 
             if np.isclose(beta, 0.0):
                 # Pure Dirichlet-like → absorbing

--- a/mfgarchon/geometry/boundary/dispatch.py
+++ b/mfgarchon/geometry/boundary/dispatch.py
@@ -237,58 +237,42 @@ def validate_bc_compatibility(
     discretization: DiscretizationType | str = DiscretizationType.FDM,
 ) -> list[str]:
     """
-    Validate that boundary conditions are compatible with geometry and discretization.
+    Validate that boundary conditions are dimensionally compatible with the geometry.
 
     Args:
         boundary_conditions: BC specification to validate
         geometry: Target geometry
-        discretization: Discretization method
+        discretization: Discretization method (accepted for API stability; BC-type support is NOT
+            validated here -- see Note)
 
     Returns:
-        List of warning/error messages (empty if valid)
+        List of warning/error messages (empty if compatible)
+
+    Note:
+        BC-**type** support (which BC types a discretization honors) is NOT checked here. The
+        authoritative source is each solver's ``supported_bc_types`` (the #1456 gate), enforced at
+        solve time. This function only checks the BC/geometry dimension match. (Issue #1558: the
+        former per-discretization support table was a dead no-op -- it read ``default_bc``, which is
+        None for segment-based BCs -- and a second, contradictory capability source, e.g. it flagged
+        Robin as "limited" for GFDM while ``hjb_gfdm._SUPPORTED_BC_TYPES`` includes Robin.)
 
     Example:
         >>> from mfgarchon.geometry import TensorProductGrid
-        >>> from mfgarchon.geometry.boundary import robin_bc
+        >>> from mfgarchon.geometry.boundary import robin_bc, no_flux_bc
         >>> from mfgarchon.geometry.boundary.dispatch import validate_bc_compatibility
         >>>
-        >>> grid = TensorProductGrid(bounds=[(0, 1)], Nx_points=[11])
+        >>> grid = TensorProductGrid(bounds=[(0, 1)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
         >>> bc = robin_bc(dimension=1, alpha=1.0, beta=1.0)
-        >>> issues = validate_bc_compatibility(bc, grid, discretization="FDM")
-        >>> # Robin BC is supported for FDM, so issues == []
+        >>> issues = validate_bc_compatibility(bc, grid)  # dimensions match -> issues == []
     """
     issues = []
 
-    # Normalize discretization
-    if isinstance(discretization, str):
-        discretization = DiscretizationType[discretization.upper()]
-
-    # Check dimension match
+    # Dimension match (the one real check; BC-type support is the solver's supported_bc_types, #1456).
     if boundary_conditions.dimension != geometry.dimension:
         issues.append(
             f"Dimension mismatch: BC dimension ({boundary_conditions.dimension}) "
             f"!= geometry dimension ({geometry.dimension})"
         )
-
-    # Check BC type support by discretization
-    from .types import BCType
-
-    # Issue #543: Use getattr() for optional attribute instead of hasattr
-    bc_type = getattr(boundary_conditions, "default_bc", None)
-
-    if discretization == DiscretizationType.FDM:
-        # FDM supports: Dirichlet, Neumann, Robin, Periodic, No-flux
-        unsupported_fdm = {BCType.REFLECTING}  # Reflecting is for particles
-        if bc_type in unsupported_fdm:
-            issues.append(f"BC type {bc_type} is not supported for FDM discretization")
-
-    elif discretization in (DiscretizationType.GFDM, DiscretizationType.MESHFREE):
-        # GFDM: primarily Dirichlet and Neumann
-        limited_gfdm = {BCType.ROBIN, BCType.REFLECTING}
-        if bc_type in limited_gfdm:
-            issues.append(
-                f"BC type {bc_type} has limited support for GFDM/Meshfree. Consider Dirichlet or Neumann instead."
-            )
 
     return issues
 

--- a/tests/unit/test_geometry/test_meshfree_robin_coeffs_1558.py
+++ b/tests/unit/test_geometry/test_meshfree_robin_coeffs_1558.py
@@ -49,3 +49,25 @@ def test_particles_robin_neumann_like_reflects_not_absorbs():
     assert out.shape[0] == 1, f"reflecting must keep the particle, got {out.shape[0]} (0 == absorbed bug)"
     x = float(out.ravel()[0])
     assert 0.0 <= x <= 1.0, f"reflected particle must be inside the domain, got {x}"
+
+
+def test_validate_bc_compatibility_emits_no_bc_type_verdict():
+    """#1558 defect 3: validate_bc_compatibility no longer emits a per-discretization BC-type verdict.
+
+    The old hardcoded table was a second, contradictory capability source: it flagged Robin as
+    "limited" for GFDM while hjb_gfdm._SUPPORTED_BC_TYPES actually includes Robin (the #1456 single
+    source). A uniform robin_bc has default_bc=ROBIN, so the old code returned that wrong verdict;
+    now the function checks only dimension compatibility, so it returns [].
+    """
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc, robin_bc
+    from mfgarchon.geometry.boundary.dispatch import validate_bc_compatibility
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    robin = robin_bc(dimension=1, alpha=1.0, beta=1.0)
+    assert validate_bc_compatibility(robin, grid, discretization="GFDM") == []  # old table said "limited"
+    assert validate_bc_compatibility(robin, grid, discretization="FDM") == []
+
+    # The one real check still fires: a 2D BC on a 1D geometry is a genuine dimension mismatch.
+    issues = validate_bc_compatibility(no_flux_bc(dimension=2), grid, discretization="FDM")
+    assert any("Dimension mismatch" in m for m in issues)

--- a/tests/unit/test_geometry/test_meshfree_robin_coeffs_1558.py
+++ b/tests/unit/test_geometry/test_meshfree_robin_coeffs_1558.py
@@ -1,0 +1,51 @@
+"""Issue #1558 (defect 1): MeshfreeApplicator read Robin alpha/beta off the wrong object.
+
+alpha/beta live on the BCSegment, not on BoundaryConditions, so ``getattr(bc, "beta", 0.0)``
+always read 0.0 -- silently collapsing every Robin BC to pure Dirichlet: the field path forced a
+hard ``u = g/alpha`` (never the penalty blend) and the particle path always absorbed (never
+reflected). These pin the corrected reads (from the ROBIN segment). Off published numerics
+(published adjoint-consistent Robin runs through the hjb_gfdm row builder, not MeshfreeApplicator).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import robin_bc
+from mfgarchon.geometry.boundary.applicator_meshfree import MeshfreeApplicator
+from mfgarchon.geometry.implicit.hyperrectangle import Hyperrectangle
+
+
+def test_field_robin_uses_penalty_blend_not_hard_dirichlet():
+    """apply() with beta != 0 must use the penalty blend, not collapse to hard u = g/alpha."""
+    domain = Hyperrectangle(bounds=[(0.0, 1.0)])
+    applicator = MeshfreeApplicator(domain)
+
+    g = 1.0
+    bc = robin_bc(value=g, alpha=1.0, beta=1.0, dimension=1)  # penalty_weight = |alpha/beta| = 1
+    points = np.array([[0.0], [0.5], [1.0]])  # x=0 and x=1 are on the boundary
+    field = np.zeros(3)
+
+    out = applicator.apply(field.copy(), bc, points)
+
+    # penalty blend at a boundary point: (field_old + w*g) / (1 + w) = (0 + 1*1)/(1+1) = 0.5
+    # hard Dirichlet (the collapsed bug) would give g/alpha = 1.0.
+    assert np.isclose(out[0], 0.5), f"left boundary {out[0]} != penalty blend 0.5 (0.0/1.0 would be the bug)"
+    assert np.isclose(out[2], 0.5), f"right boundary {out[2]} != penalty blend 0.5"
+    assert np.isclose(out[1], 0.0), "interior point must be untouched"
+
+
+def test_particles_robin_neumann_like_reflects_not_absorbs():
+    """apply_particles() with alpha=0, beta!=0 (Neumann-like Robin) must reflect, not absorb."""
+    domain = Hyperrectangle(bounds=[(0.0, 1.0)])
+    applicator = MeshfreeApplicator(domain)
+
+    bc = robin_bc(value=0.0, alpha=0.0, beta=1.0, dimension=1)  # alpha=0 -> reflecting
+    particles = np.array([[1.2]])  # one particle stepped outside the right wall
+
+    out = applicator.apply_particles(particles.copy(), bc)
+
+    # Reflecting keeps the particle (projected back inside); absorbing (the bug) removes it.
+    assert out.shape[0] == 1, f"reflecting must keep the particle, got {out.shape[0]} (0 == absorbed bug)"
+    x = float(out.ravel()[0])
+    assert 0.0 <= x <= 1.0, f"reflected particle must be inside the domain, got {x}"


### PR DESCRIPTION
Deep-check v2 Sweep B/C. The remaining two sub-defects of #1558 (defects 2 & 4 shipped in #1591). Both off published numerics; each carries a mutation-verified test.

## Defect 1 — MeshfreeApplicator read Robin alpha/beta off the wrong object
`alpha`/`beta` live on `BCSegment`, not on `BoundaryConditions`, so `getattr(boundary_conditions, "beta", 0.0)` always read `0.0` — silently collapsing every Robin BC to pure Dirichlet: `apply()` forced hard `u = g/alpha` instead of the penalty blend, and `apply_particles()` always absorbed instead of reflecting. Both now read `(alpha, beta)` from the ROBIN segment via a single-source helper. (`default_value` was already read correctly, so only the coefficients were wrong.)

## Defect 3 — validate_bc_compatibility was a contradictory second capability source
Its per-discretization BC-type table disagreed with the #1456 single source (`solver.supported_bc_types`): it flagged Robin as "limited" for GFDM while `hjb_gfdm._SUPPORTED_BC_TYPES` includes Robin, and allowed Robin for FDM while `hjb_fdm` excludes it; it also read `default_bc` (None for segment BCs), so for those it silently returned no issues. Trimmed to the one real check — BC/geometry dimension compatibility. BC-type support is authoritatively enforced at solve time.

## Verification
- New `test_meshfree_robin_coeffs_1558.py` → 3 passed (field penalty-blend; particle reflect-not-absorb; validate_bc_compatibility emits no BC-type verdict). **Each mutation-verified.**
- Regression: `tests/unit/test_geometry/` → 747 passed, 3 skipped, 0 failed.
- `ruff` + `check_fail_fast.py --path mfgarchon --check-baseline` clean.

**Closes #1558.** Note: defects 2 & 4 are in **#1591** — that PR must also merge for #1558 to be fully resolved in code (this PR only carries defects 1 & 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)