### PR TITLE
fix: network HJB rejects nonzero volatility_field instead of ignoring it (#1544)

### DIFF
--- a/changelog.d/1544-network-hjb-reject-volatility.fixed.md
+++ b/changelog.d/1544-network-hjb-reject-volatility.fixed.md
@@ -5,5 +5,9 @@
   converged to a self-consistent equilibrium of a **mismatched** system (the diffusive network FP
   applies `D*Lap_G(m)` while the HJB solves the `D = 0` game — non-adjoint, consistent only at `D = 0`).
   A nonzero `volatility_field` now raises `NotImplementedError` up front. Stock `NetworkMFGProblem`
-  (σ = 0) is unaffected. The natural fix — implementing the `+ D*Lap_G(u)` viscous term to restore
-  HJB↔FP duality on graphs — remains open.
+  (σ = 0) is unaffected. **Scope**: this catches only a volatility explicitly threaded into
+  `solve_hjb_system`; the graph coupler (`graph_mfg_solver`) does not thread one, so the *stock*
+  coupled mismatch — `FPNetworkSolver`'s default `D = 0.1` against the `D = 0` HJB — is still reachable
+  and is NOT rejected here (guarding it would break every network coupled solve). Fully closing #1544
+  needs the natural fix: implement the `+ D*Lap_G(u)` viscous term to restore HJB↔FP duality on graphs
+  (open, blocked on #1470-C).

--- a/changelog.d/1544-network-hjb-reject-volatility.fixed.md
+++ b/changelog.d/1544-network-hjb-reject-volatility.fixed.md
@@ -1,0 +1,9 @@
+- **Network HJB solvers reject a nonzero `volatility_field` instead of silently ignoring it** (Issue
+  #1544). `NetworkHJBSolver` / `NetworkPolicyIterationHJBSolver` have no viscous term — they solve the
+  deterministic-control game on the graph and never use the stored graph Laplacian — but accepted a
+  `volatility_field` documented "not yet used". A coupled network solve with `D > 0` therefore
+  converged to a self-consistent equilibrium of a **mismatched** system (the diffusive network FP
+  applies `D*Lap_G(m)` while the HJB solves the `D = 0` game — non-adjoint, consistent only at `D = 0`).
+  A nonzero `volatility_field` now raises `NotImplementedError` up front. Stock `NetworkMFGProblem`
+  (σ = 0) is unaffected. The natural fix — implementing the `+ D*Lap_G(u)` viscous term to restore
+  HJB↔FP duality on graphs — remains open.

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -34,6 +34,26 @@ if TYPE_CHECKING:
     from mfgarchon.extensions.topology import NetworkMFGProblem
 
 
+def _reject_nonzero_volatility(volatility_field: float | np.ndarray | None) -> None:
+    """Fail loud if a diffusive volatility is requested (Issue #1544).
+
+    The network HJB solvers have NO viscous term -- they solve the deterministic-control game on the
+    graph and ignore volatility_field (the stored graph Laplacian is unused). A nonzero volatility
+    would produce a value function inconsistent with the diffusive network FP forward equation
+    (``D * Lap_G(m)``), i.e. a non-adjoint, self-consistent WRONG equilibrium -- consistent only at
+    D = 0. Reject it instead of silently ignoring it, until the ``+ D * Lap_G(u)`` viscous term is
+    implemented (the natural fix).
+    """
+    if volatility_field is not None and np.any(np.asarray(volatility_field, dtype=float) != 0.0):
+        raise NotImplementedError(
+            "Network HJB solver has no viscous (diffusion) term, so it cannot honor a nonzero "
+            "volatility_field; solving anyway would give a value function inconsistent with the "
+            "diffusive network FP (D*Lap_G(m)) -- a non-adjoint, self-consistent wrong equilibrium. "
+            "Use volatility_field=None / 0 (deterministic-control graph game, D=0); a diffusive graph "
+            "HJB (+ D*Lap_G(u)) is not yet implemented (Issue #1544)."
+        )
+
+
 class NetworkHJBSolver(BaseHJBSolver):
     """
     HJB solver for Mean Field Games on networks.
@@ -141,11 +161,13 @@ class NetworkHJBSolver(BaseHJBSolver):
             M_density: (Nt+1, num_nodes) density evolution from FP solver
             U_terminal: Terminal condition u(T, i)
             U_coupling_prev: Previous Picard iterate for coupling
-            volatility_field: Diffusion coefficient (not yet used in network solver)
+            volatility_field: Must be None / 0 -- the network HJB has no viscous term (Issue #1544);
+                a nonzero value is rejected rather than silently ignored.
 
         Returns:
             (Nt+1, num_nodes) value function evolution
         """
+        _reject_nonzero_volatility(volatility_field)
         # Validate required parameters
         if M_density is None:
             raise ValueError("M_density is required")
@@ -319,6 +341,7 @@ class NetworkPolicyIterationHJBSolver(NetworkHJBSolver):
         volatility_field: float | np.ndarray | None = None,
     ) -> np.ndarray:
         """Solve HJB using policy iteration."""
+        _reject_nonzero_volatility(volatility_field)
         # Validate required parameters
         if M_density is None:
             raise ValueError("M_density is required")

--- a/tests/unit/test_alg/test_hjb_network_solver.py
+++ b/tests/unit/test_alg/test_hjb_network_solver.py
@@ -168,6 +168,24 @@ class TestNetworkHJBSolverSolveHJBSystem:
         assert U_solution.shape == (Nt, num_nodes)
         assert np.all(np.isfinite(U_solution))
 
+    def test_nonzero_volatility_rejected(self):
+        """Issue #1544: the network HJB has no viscous term, so a nonzero volatility_field must be
+        rejected (not silently ignored -- ignoring it solves a non-adjoint, self-consistent WRONG
+        equilibrium against the diffusive network FP). volatility_field=None / 0 solves normally."""
+        network = GridNetwork(width=3, height=3)
+        network.create_network()
+        problem = NetworkMFGProblem(geometry=network, T=0.5, Nt=10)
+        Nt, num_nodes = problem.Nt + 1, problem.num_nodes
+        M_density, U_final = np.ones((Nt, num_nodes)), np.zeros(num_nodes)
+
+        for cls in (NetworkHJBSolver, NetworkPolicyIterationHJBSolver):
+            solver = cls(problem, scheme="BDF") if cls is NetworkHJBSolver else cls(problem)
+            with pytest.raises(NotImplementedError, match="1544"):
+                solver.solve_hjb_system(M_density, U_final, volatility_field=0.3)
+            # None and 0.0 are the deterministic-control (D=0) case -> no raise.
+            assert solver.solve_hjb_system(M_density, U_final, volatility_field=None).shape == (Nt, num_nodes)
+            assert solver.solve_hjb_system(M_density, U_final, volatility_field=0.0).shape == (Nt, num_nodes)
+
     def test_solve_hjb_system_final_condition(self):
         """Test that final condition is preserved."""
         network = GridNetwork(width=3, height=3)


### PR DESCRIPTION
Deep-check v2 Sweep A finding A-02. RFC #1574 capability-honesty. The safe fail-loud gate (option 2 from the issue); stock network solves (σ=0) are unaffected.

## Problem
`NetworkHJBSolver` / `NetworkPolicyIterationHJBSolver` have **no viscous term** — they solve the deterministic-control game on the graph and never use the stored `self.laplacian_matrix` — but `solve_hjb_system` accepted a `volatility_field` documented *"not yet used"*. The network FP applies `D*Lap_G(m)`, so a coupled network solve with `D > 0` converged to a self-consistent equilibrium of a **mismatched (non-adjoint) system**, consistent only at `D = 0`. The declared surface (accepts `volatility_field`) is broader than the honored surface (ignores it).

## Fix
Single-source guard `_reject_nonzero_volatility` called by both solvers: a nonzero `volatility_field` raises `NotImplementedError` up front. Stock `NetworkMFGProblem` (σ = 0 → `volatility_field` None/0) is unaffected.

The natural fix — implement `+ D*Lap_G(u)` in the RK45 rhs and policy evaluation to restore HJB↔FP duality on graphs — is a stock behavior change blocked on #1470-C D-sourcing and **remains open** on the issue.

## Verification
- New `test_nonzero_volatility_rejected` → both solver classes raise on `volatility_field=0.3`, solve normally on None/0. **Mutation-verified** (neutering the guard fails it).
- Regression: network suite → 119 passed, 15 skipped, 0 failed.
- `ruff` + `check_fail_fast.py --path mfgarchon --check-baseline` clean.

Refs #1544 #1532 (issue stays open for the viscous-term implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope correction (post adversarial-review)
This guard fires **only on a volatility explicitly threaded into `solve_hjb_system`**. The graph coupler (`graph_mfg_solver.py:204`) does not pass `volatility_field`, so the **stock coupled-network mismatch** (FPNetworkSolver default `D=0.1` vs the `D=0` HJB) remains reachable and is NOT rejected here. Guarding that would raise on every network coupled solve; fully closing #1544 needs the viscous-term implementation (option 1, blocked on #1470-C). This PR is the capability-honesty half (a declared-but-ignored parameter now fails loud), not the full mismatch fix.
