### PR TITLE
fix: adi_diffusion_step reads (d,d) sigma as volatility, not covariance (#1548)

### DIFF
--- a/changelog.d/1548-sl-adi-volatility-convention.fixed.md
+++ b/changelog.d/1548-sl-adi-volatility-convention.fixed.md
@@ -1,0 +1,11 @@
+- **`adi_diffusion_step` now reads a `(d,d)` sigma as the SDE volatility, matching the package
+  convention** (Issue #1548). It documented and treated a full-tensor `sigma` as the *covariance*
+  (`sigma@sigma^T`), while the package convention — and the caller (`problem.sigma`), and this
+  function's own scalar/1-D branches — is that `sigma` is the volatility `Sigma` with `D = Sigma@Sigma^T/2`.
+  A symmetric volatility `Sigma` (e.g. `0.3*I`) was silently over-diffused (`D = Sigma/2 = 0.15`
+  instead of `0.045`, ~3.3x), and a Cholesky-factor `Sigma` (lower-triangular) tripped a symmetry
+  `ValueError`. The `(d,d)` branch now forms the covariance `C = Sigma@Sigma^T` internally and drives
+  both the diagonal ADI (`D_d = C[d,d]/2`) and the explicit cross-derivative (`C[i,j]`) from it, so an
+  isotropic `Sigma = c*I` is byte-identical to the scalar-`c` path; the symmetry precondition on the
+  input is removed (`C` is symmetric PSD by construction). Scalar and 1-D-diagonal sigma are
+  unaffected. Fixes the dual-convention seam shared by HJB-SL and FP-SL-adjoint (both call this).

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -227,25 +227,20 @@ def adi_diffusion_step(
         # Diagonal anisotropic: different sigma per direction
         sigma_vec = np.asarray(sigma)
     elif hasattr(sigma, "ndim") and sigma.ndim == 2:  # Issue #543 acceptable
-        # Full tensor diffusion. Convention: sigma_tensor = covariance matrix (sigma*sigma^T).
-        # Diagonal ADI uses D_d = sigma_tensor[d,d]/2 (via diffusion_from_volatility on
-        # sqrt of diagonal). Explicit cross-derivative uses coefficient sigma_tensor[i,j]
-        # for each i<j pair (the factor-of-2 from symmetry and 1/2 in D_ij cancel exactly;
-        # see apply_cross_diffusion_explicit docstring and Issue #1261 fix).
-        # Convention assert (Issue #1079): sigma_tensor must be symmetric so that both
-        # paths are consistent. An asymmetric tensor means the caller is passing something
-        # other than a covariance matrix, which makes the convention undefined.
-        sigma_tensor = np.asarray(sigma)
-        if not np.allclose(sigma_tensor, sigma_tensor.T, rtol=1e-5, atol=1e-8):
-            max_asym = float(np.max(np.abs(sigma_tensor - sigma_tensor.T)))
-            raise ValueError(
-                f"adi_diffusion_step: sigma_tensor must be symmetric (covariance "
-                f"convention: sigma_tensor = sigma*sigma^T). Max asymmetry = {max_asym:.3e}. "
-                f"Diagonal ADI uses D_d = sigma_tensor[d,d]/2; explicit cross-derivative "
-                f"uses coefficient sigma_tensor[i,j] for i<j pair. Both require a "
-                f"symmetric covariance matrix as input (Issue #1079)."
-            )
-        sigma_vec = np.sqrt(np.diag(sigma_tensor))  # Diagonal part for ADI
+        # Full tensor diffusion. The (d,d) input is the SDE VOLATILITY matrix Sigma -- the package
+        # convention for problem.sigma, and the same reading the 1-D branch above uses (per-axis
+        # volatility) -- NOT the covariance. Form the covariance C = Sigma @ Sigma^T (Issue #1548),
+        # then drive both the diagonal ADI (D_d = C[d,d]/2, via diffusion_from_volatility on
+        # sqrt(diag C)) and the explicit cross-derivative (coefficient C[i,j] per i<j pair; the
+        # factor-of-2 from symmetry and the 1/2 in D_ij cancel -- see apply_cross_diffusion_explicit
+        # + Issue #1261) from C. C is symmetric PSD by construction, so Sigma itself need NOT be
+        # symmetric (a Cholesky factor is lower-triangular). The former symmetry assert (Issue #1079)
+        # both rejected a valid volatility Sigma and, for a symmetric Sigma, silently over-diffused
+        # by treating it as the covariance -- D = Sigma/2 instead of Sigma@Sigma^T/2 (e.g. 0.3*I gave
+        # 0.15 not the correct 0.045).
+        Sigma = np.asarray(sigma, dtype=float)
+        sigma_tensor = Sigma @ Sigma.T
+        sigma_vec = np.sqrt(np.diag(sigma_tensor))  # per-axis volatility from the covariance diagonal
     else:
         # Issue #1286, 2026-06-11 survey: fail-fast — never silently default sigma.
         # A wrong sigma type causes adi_diffusion_step to solve a different PDE.

--- a/tests/unit/test_alg/test_hjb_semi_lagrangian.py
+++ b/tests/unit/test_alg/test_hjb_semi_lagrangian.py
@@ -1198,6 +1198,37 @@ class TestADIDiffusionMagnitude:
             f"ADI 3D under/over-diffuses: factor {adi_fac:.6f} vs analytic {analytic_fac:.6f}"
         )
 
+    def test_tensor_sigma_is_volatility_not_covariance(self):
+        """Issue #1548: a (d,d) sigma is the SDE VOLATILITY matrix Sigma (D = Sigma@Sigma^T/2), the
+        package convention for problem.sigma and the same reading the scalar/1-D paths use -- NOT the
+        covariance. An isotropic Sigma = c*I must decay exactly like the scalar c (D = c^2/2). Before
+        #1548 the (d,d) branch treated the input as the covariance -> D = c/2 (a 0.3->0.15-vs-0.045
+        over-diffusion), and a Cholesky (lower-triangular) volatility tripped the symmetry assert."""
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import adi_diffusion_step
+
+        N, L, c, dt = 81, 1.0, 0.7, 1e-3
+        D = 0.5 * c**2
+        x = np.linspace(0.0, L, N)
+        X, Y = np.meshgrid(x, x, indexing="ij")
+        k = np.pi
+        u0 = np.cos(k * X) * np.cos(k * Y)
+        dx = L / (N - 1)
+        spacing, shape = np.array([dx, dx]), (N, N)
+
+        u_scalar = adi_diffusion_step(u0.copy(), dt, c, spacing, shape, "neumann")
+        u_tensor = adi_diffusion_step(u0.copy(), dt, c * np.eye(2), spacing, shape, "neumann")
+        i, j = N // 3, N // 4
+        analytic = np.exp(-D * (2 * k**2) * dt)
+        assert self._decay_relerr(u_tensor[i, j] / u0[i, j], analytic) < 0.02, (
+            "isotropic volatility Sigma=c*I must decay at D=c^2/2, not c/2 (covariance misread)"
+        )
+        # Sigma = c*I (volatility) is byte-identical to the scalar-c path.
+        np.testing.assert_allclose(u_tensor, u_scalar, rtol=0, atol=1e-12)
+        # A non-symmetric (Cholesky-factor) volatility must no longer raise; C = L L^T is symmetric.
+        L_chol = np.array([[c, 0.0], [0.1, c]])
+        out = adi_diffusion_step(u0.copy(), dt, L_chol, spacing, shape, "neumann")
+        assert np.all(np.isfinite(out))
+
 
 class TestReflectIntoDomain:
     """Regression guard for the reflecting-BC characteristic-foot fold (Issues #1161/#1048/#1054).


### PR DESCRIPTION
Deep-check v2 Sweep A finding A-15, a #1430 dual-convention-trap instance. **Off published numerics** (scalar sigma dominates; no tensor-sigma test existed). Behavior change confined to the full-tensor SL-ADI path.

## Bug (code-traced)
`adi_diffusion_step`'s `(d,d)` branch documented and treated `sigma` as the **covariance** (`sigma@sigma^T`): `sigma_vec = sqrt(diag(sigma))`, `D_d = sigma[d,d]/2`. But the package convention — `problem.sigma`, and this function's own scalar/1-D branches — is that `sigma` is the SDE **volatility** `Sigma`, `D = Sigma@Sigma^T/2`. The caller (`hjb_semi_lagrangian`) passes `problem.sigma` raw. Consequences:
- A symmetric volatility `Sigma = 0.3*I` → `D = Sigma/2 = 0.15` instead of the correct `0.045` (~3.3x over-diffusion), silently.
- A Cholesky-factor `Sigma` (lower-triangular, from `MFGProblem(diffusion=D_tensor)`) tripped the `#1079` symmetry `ValueError` — the message told the user to pass a covariance, deepening the conflict.

## Fix
The `(d,d)` branch forms the covariance `C = Sigma@Sigma^T` internally and drives the diagonal ADI (`D_d = C[d,d]/2`) and the explicit cross-derivative (`C[i,j]`, via `apply_cross_diffusion_explicit`) from `C`. The input-symmetry assert is removed (`C` is symmetric PSD by construction, so `Sigma` need not be). Aligns the `(d,d)` branch with the scalar/1-D branches (all read volatility). Shared by HJB-SL and FP-SL-adjoint — both now use one convention.

## Verification
- New `test_tensor_sigma_is_volatility_not_covariance`: isotropic `Sigma=c*I` decays at `D=c^2/2` and is **byte-identical** to the scalar-`c` path; a non-symmetric Cholesky `Sigma` no longer raises. **Mutation-verified** (reverting to the covariance read fails it).
- Regression: `test_hjb_semi_lagrangian.py` + `test_issue1286_fail_fast.py` + `test_diffusion_magnitude_gate.py` → 71 passed; FP-SL-adjoint suite → 96 passed. Scalar/1-D ADI unchanged.
- `ruff` + `check_fail_fast.py --path mfgarchon --check-baseline` clean.

Closes #1548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)