### PR TITLE
Own the admissible control set and pin the H/L (V,f) convention

### DIFF
--- a/changelog.d/hl-convention-pin-and-effective-domain.added.md
+++ b/changelog.d/hl-convention-pin-and-effective-domain.added.md
@@ -1,10 +1,15 @@
 `ControlCostBase.effective_domain()` — single owner of the admissible control set A = dom(L)
 (Issue #1642, capability B3). `L1ControlCost` returns `(-1, 1)`, `BoundedControlCost` returns
 `(-max_control, max_control)`, and the Moreau-Yosida wrapper delegates to the cost it wraps.
-`SeparableLagrangian.control_bounds()` now delegates to it instead of re-deriving the same
-answer through an isinstance ladder. Behavior change: a regularized `L1`/`Bounded` cost
-previously reported an *unbounded* control set (the ladder matched neither branch); it now
-reports the wrapped cost's bounds. The `(V, f)` sign convention between H and L
-(`L = L_ctrl - V - f`) is documented on `MFGOperatorBase` and pinned by
-`tests/unit/test_core/test_hl_convention.py`; the `SeparableLagrangian` rows are strict-xfail
-pending Issue #1645.
+Both consumers now read it: `SeparableLagrangian.control_bounds()` and the semi-Lagrangian
+DPP control sweep (`HJBSemiLagrangianSolver._solve_timestep_dpp`), each of which previously
+re-derived A through its own isinstance ladder. API-level behavior change: a regularized
+`L1`/`Bounded` cost previously reported an *unbounded* control set (the ladders matched
+neither branch); it now reports the wrapped cost's bounds. No solver output moves — the
+delegated control-candidate sets are byte-identical to the removed ladder for every
+unwrapped cost, and wrapped costs do not reach the DPP path (`_use_dpp` requires
+`not H.is_smooth()`, which Moreau-Yosida makes false).
+
+The `(V, f)` sign convention between H and L (`L = L_ctrl - V - f`) is documented with its
+derivation on `MFGOperatorBase` and pinned by `tests/unit/test_core/test_hl_convention.py`;
+the `SeparableLagrangian` rows are strict-xfail pending Issue #1645.

--- a/changelog.d/hl-convention-pin-and-effective-domain.added.md
+++ b/changelog.d/hl-convention-pin-and-effective-domain.added.md
@@ -1,0 +1,10 @@
+`ControlCostBase.effective_domain()` — single owner of the admissible control set A = dom(L)
+(Issue #1642, capability B3). `L1ControlCost` returns `(-1, 1)`, `BoundedControlCost` returns
+`(-max_control, max_control)`, and the Moreau-Yosida wrapper delegates to the cost it wraps.
+`SeparableLagrangian.control_bounds()` now delegates to it instead of re-deriving the same
+answer through an isinstance ladder. Behavior change: a regularized `L1`/`Bounded` cost
+previously reported an *unbounded* control set (the ladder matched neither branch); it now
+reports the wrapped cost's bounds. The `(V, f)` sign convention between H and L
+(`L = L_ctrl - V - f`) is documented on `MFGOperatorBase` and pinned by
+`tests/unit/test_core/test_hl_convention.py`; the `SeparableLagrangian` rows are strict-xfail
+pending Issue #1645.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1929,27 +1929,37 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             U_star = np.zeros(Nx)
 
             # Detect special structure for fast paths
-            from mfgarchon.core.hamiltonian import (
-                BoundedControlCost,
-                L1ControlCost,
-                QuadraticControlCost,
-                SeparableLagrangian,
-            )
+            from mfgarchon.core.hamiltonian import L1ControlCost, SeparableLagrangian
 
+            # The admissible set A is READ from its single owner,
+            # ControlCostBase.effective_domain() (Issue #1642, B3) -- it is never
+            # re-derived here. This previously carried its own ladder holding a
+            # bang-bang interval literal for L1 and reading the max-control
+            # attribute off Bounded directly, i.e. a second owner of A that could
+            # drift from the first and that a regularized cost silently defeated.
+            #
+            # What remains local is only QUADRATURE -- how densely to sample A --
+            # which is a genuine structural distinction, not a duplicated
+            # quantity: a piecewise-linear L_ctrl is optimized at a vertex of A
+            # or at its kink, a quadratic one needs interior samples. Narrowing
+            # that last isinstance to a control-cost capability is Issue #1651.
             fast_candidates = None
             if isinstance(L_class, SeparableLagrangian):
                 cc = L_class.control_cost
-                if isinstance(cc, L1ControlCost):
-                    # Bang-bang: compare alpha in {-1, 0, 1}
-                    fast_candidates = np.array([-1.0, 0.0, 1.0])
-                elif isinstance(cc, BoundedControlCost):
-                    # Sample endpoints + zero + a few interior points
-                    a_max = cc.max_control
-                    fast_candidates = np.linspace(-a_max, a_max, 11)
-                elif isinstance(cc, QuadraticControlCost):
-                    # Quadratic has closed-form: alpha* = -grad_u / lambda
-                    # DPP reduces to H-based SL. Use grad_u path for efficiency.
-                    fast_candidates = None  # fall through to scalar optimization
+                domain = cc.effective_domain()
+                if domain is None:
+                    # A = R^d: no box to sample. QuadraticControlCost lands here
+                    # and has the closed form alpha* = -grad_u/lambda anyway, so
+                    # fall through to the scalar optimization path.
+                    fast_candidates = None
+                elif isinstance(cc, L1ControlCost):
+                    # Bang-bang: L_ctrl is piecewise linear, so the optimum sits
+                    # at an endpoint of A or at the kink alpha = 0.
+                    fast_candidates = np.array([domain[0], 0.0, domain[1]])
+                else:
+                    # Quadratic-on-A costs (BoundedControlCost, and its
+                    # Moreau-Yosida envelope): sample endpoints + interior.
+                    fast_candidates = np.linspace(domain[0], domain[1], 11)
 
             for i in range(Nx):
                 x_i = self.x_grid[i]

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -262,7 +262,14 @@ class ControlCostBase(ABC):
         Every consumer that needs to bound a control -- optimization boxes,
         conjugate/Legendre sups, semi-Lagrangian control sweeps -- must read
         it from here rather than re-deriving it. ``SeparableLagrangian.control_bounds()``
-        delegates to this method; do not add a second isinstance ladder.
+        and ``HJBSemiLagrangianSolver._solve_timestep_dpp`` both delegate to this
+        method; do not add a second isinstance ladder.
+
+        Scope of that claim, stated exactly: consumers own how densely they
+        SAMPLE A (a quadrature choice -- the DPP sweep still selects three points
+        for a piecewise-linear L_ctrl against eleven for a quadratic one). What
+        they may not do is decide what A IS. Narrowing that last sampling
+        isinstance to a control-cost capability is Issue #1651.
 
         Returns
         -------
@@ -767,6 +774,23 @@ class MFGOperatorBase(ABC):
     L_ctrl + V + f and is not self-conjugate against its own
     ``evaluate_hamiltonian``. That fork is tracked as Issue #1645 and recorded
     as strict xfails in ``tests/unit/test_core/test_hl_convention.py``.
+
+    Where this convention is actually pinned, named precisely, because a
+    conjugate round trip only discriminates when the two sides source V and f
+    INDEPENDENTLY -- a Lagrangian obtained from H via ``legendre_transform()``
+    yields H** == H for every convex H whatever the signs are, which asserts
+    convexity and not a convention:
+
+    - ``TestSeparableRoundTrip.test_separable_fork_gap_is_exactly_two_v_plus_f``
+      -- 3 tests at one (V, f) point, one per control cost. Quantifies the
+      Issue #1645 fork as an exact 2(V+f) gap, constant in p.
+    - ``TestCongestionRoundTrip`` -- 12 tests, 3 control costs x 4 (V, f) cells,
+      conjugating an analytic Lagrangian written out in the test module against
+      ``CongestionHamiltonian``.
+
+    ``test_conjugate_of_lagrangian_recovers_hamiltonian`` is not part of that
+    pin: its V != 0 rows are strict xfail and its V0_f0 rows are
+    non-discriminating, the disputed term being identically zero there.
 
     Note on the alpha sign. This class documents H = sup_alpha { p . alpha - L },
     while ``optimal_control`` returns the drift alpha* = -dH/dp (MINIMIZE). The

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -253,6 +253,36 @@ class ControlCostBase(ABC):
         """
         ...
 
+    # === Admissible control set (Issue #1642, capability B3) ===
+
+    def effective_domain(self) -> tuple[float, float] | None:
+        """Admissible control set A = dom(L), i.e. where L(alpha) is finite.
+
+        SINGLE OWNER of "which controls are admissible" (Issue #1642, B3).
+        Every consumer that needs to bound a control -- optimization boxes,
+        conjugate/Legendre sups, semi-Lagrangian control sweeps -- must read
+        it from here rather than re-deriving it. ``SeparableLagrangian.control_bounds()``
+        delegates to this method; do not add a second isinstance ladder.
+
+        Returns
+        -------
+        tuple[float, float] | None
+            ``(a_min, a_max)`` when A is a box, ``None`` when A = R^d.
+
+        Notes
+        -----
+        ``lagrangian(alpha)`` does NOT enforce this domain: it evaluates the
+        smooth branch everywhere and returns a FINITE value for infeasible
+        alpha. ``BoundedControlCost(max_control=2).lagrangian(5.0)`` returns
+        12.5 where the true L is +inf. Consumers that maximize
+        ``p*alpha - L(alpha)`` must therefore restrict the search to this
+        domain, or they silently overshoot -- for ``L1ControlCost(lambda_=0.5)``
+        at p=5 the unrestricted sup returns 225.0 against a true H of 4.5.
+        Making ``lagrangian()`` itself fail loud outside A is deferred to
+        Issue #1644 (capability B4), which owns the guarded conjugate helper.
+        """
+        return None
+
     # === DEPRECATED: hamiltonian() -> use evaluate() ===
 
     def hamiltonian(self, p: np.ndarray) -> np.ndarray:
@@ -439,6 +469,15 @@ class L1ControlCost(ControlCostBase):
         """L(alpha) = lambda * |alpha|."""
         return self._lambda * np.sum(np.abs(alpha), axis=-1)
 
+    def effective_domain(self) -> tuple[float, float]:
+        """A = [-1, 1]. The bang-bang bound, matching optimal_control()'s +/-1.
+
+        This is the class's modelling choice (see the class docstring): the
+        unbounded L1 cost has an indicator Hamiltonian and is numerically
+        unusable, so A is normalized to the unit interval.
+        """
+        return (-1.0, 1.0)
+
     def proximal(self, tau: float, z: np.ndarray) -> np.ndarray:
         """prox_{tau * L}(z): soft-threshold then clip to [-1, 1]."""
         soft = np.sign(z) * np.maximum(np.abs(z) - tau * self._lambda, 0.0)
@@ -520,8 +559,16 @@ class BoundedControlCost(ControlCostBase):
         return result
 
     def lagrangian(self, alpha: np.ndarray) -> np.ndarray:
-        """L(alpha) = lambda/2 * |alpha|^2 (assumes feasible)."""
+        """L(alpha) = lambda/2 * |alpha|^2. Finite everywhere; see effective_domain().
+
+        The true L is +inf outside ``effective_domain()``. This method does NOT
+        enforce that -- callers must restrict to the domain (Issue #1642, B3).
+        """
         return 0.5 * self._lambda * np.sum(alpha**2, axis=-1)
+
+    def effective_domain(self) -> tuple[float, float]:
+        """A = [-max_control, max_control]."""
+        return (-self.max_control, self.max_control)
 
     def proximal(self, tau: float, z: np.ndarray) -> np.ndarray:
         """prox_{tau * L}(z) = clip(z / (1 + tau*lambda), -alpha_max, alpha_max)."""
@@ -628,6 +675,14 @@ class _MoreauYosidaControlCost(ControlCostBase):
         """L_eps(alpha) = L(alpha) + epsilon/2 * |alpha|^2."""
         return self.base.lagrangian(alpha) + self.epsilon / 2 * np.sum(alpha**2, axis=-1)
 
+    def effective_domain(self) -> tuple[float, float] | None:
+        """Same domain as the wrapped cost.
+
+        L_eps = L + (eps/2)|.|^2 adds a finite-everywhere term, so
+        dom(L_eps) = dom(L). Moreau-Yosida smooths H, it does not enlarge A.
+        """
+        return self.base.effective_domain()
+
     def proximal(self, tau: float, z: np.ndarray) -> np.ndarray:
         """prox_{tau * L_eps}(z). L_eps = L + eps/2 |.|^2."""
         # prox of sum: for L + eps/2|.|^2, use Moreau decomposition or direct
@@ -680,6 +735,44 @@ class MFGOperatorBase(ABC):
     - Users can specify either H or L (whichever is more natural)
     - The other is automatically derived via Legendre transform
     - Both have equal mathematical status
+
+    Sign convention for the potential V and the coupling f (Issue #1642, B1)
+    ------------------------------------------------------------------------
+    Write the control part as L_ctrl(alpha) and H_ctrl(p), which are Legendre
+    conjugates of each other, and let W(x, m, t) collect every alpha-independent
+    term of L. Then the convention is fixed by the shipped HJB residual, not by
+    preference:
+
+        L(x, alpha, m, t) = L_ctrl(alpha) - V(x, t) - f(m)
+
+    Derivation. The dynamic programming principle gives
+
+        (u^n - u^{n+1}) / dt = min_alpha { L(x, alpha, m, t) + p . alpha }
+
+    so with L = L_ctrl + W the PDE reads  -d_t u + H_ctrl(p) - W = 0.  The
+    residual assembled in ``alg/numerical/hjb_solvers/base_hjb.py`` is
+    ``Phi_U += (u^n - u^{n+1})/dt`` then ``Phi_U += H`` with H = H_ctrl + V + f,
+    i.e.  -d_t u + H_ctrl + V + f = 0.  Matching the two gives W = -(V + f).
+
+    Equivalently, and this is the form the round-trip test asserts: since V and
+    f do not depend on alpha,
+
+        sup_alpha { p . alpha - L(x, alpha, m, t) } = H_ctrl(p) - W = H(x, m, p, t)
+
+    holds if and only if W = -(V + f). Adding V and f to BOTH H and L breaks
+    conjugacy by exactly 2(V + f), constant in p.
+
+    ``canonical_cs`` (``hjb_semi_lagrangian.py``) and the ``Dual*`` pair follow
+    this convention. ``SeparableLagrangian.__call__`` does NOT -- it returns
+    L_ctrl + V + f and is not self-conjugate against its own
+    ``evaluate_hamiltonian``. That fork is tracked as Issue #1645 and recorded
+    as strict xfails in ``tests/unit/test_core/test_hl_convention.py``.
+
+    Note on the alpha sign. This class documents H = sup_alpha { p . alpha - L },
+    while ``optimal_control`` returns the drift alpha* = -dH/dp (MINIMIZE). The
+    two coincide for every control cost shipped here because each L_ctrl is even
+    in alpha; the (V, f) conclusion above is independent of that choice, since V
+    and f are alpha-independent either way.
 
     Parameters
     ----------
@@ -1655,13 +1748,13 @@ class SeparableLagrangian(LagrangianBase):
         return self.control_cost.proximal(tau, np.atleast_1d(z))
 
     def control_bounds(self):
-        """Infer from control_cost if available."""
-        cc = self.control_cost
-        if isinstance(cc, BoundedControlCost):
-            return (-cc.max_control, cc.max_control)
-        if isinstance(cc, L1ControlCost):
-            return (-1.0, 1.0)  # bang-bang bounded to [-1, 1]
-        return None
+        """Admissible control set, owned by the control cost (Issue #1642, B3).
+
+        Delegates to ``ControlCostBase.effective_domain()``. This replaced an
+        isinstance ladder that re-derived the same answer -- a second owner of
+        the admissible set. Do not re-introduce one here.
+        """
+        return self.control_cost.effective_domain()
 
     def as_hamiltonian(self) -> SeparableHamiltonian:
         """Return the corresponding SeparableHamiltonian (shared control_cost)."""

--- a/tests/unit/test_alg/test_sl_control_set_single_source_1642.py
+++ b/tests/unit/test_alg/test_sl_control_set_single_source_1642.py
@@ -1,0 +1,108 @@
+"""The SL DPP control sweep must read the admissible set from its single owner (Issue #1642, B3).
+
+``_solve_timestep_dpp`` used to re-derive the admissible control set A with its own
+isinstance ladder -- a hardcoded ``(-1.0, 1.0)`` for ``L1ControlCost`` and a private
+``cc.max_control`` read for ``BoundedControlCost``. That made it a SECOND owner of A
+alongside ``ControlCostBase.effective_domain()``: the two agreed at the time, so the
+defect was drift risk rather than a wrong answer, plus one live blind spot -- a
+Moreau-Yosida-wrapped cost matched none of the branches and silently lost its box.
+
+This path is live, not dead: ``_use_dpp`` requires ``not H.is_smooth()``, which holds for
+plain ``BoundedControlCost`` and ``L1ControlCost``.
+
+The sweep now reads A from ``effective_domain()`` and keeps only the QUADRATURE decision
+locally (three points for a piecewise-linear L_ctrl, eleven for a quadratic one) -- a
+genuine structural distinction, not a duplicated quantity. Narrowing that last isinstance
+to a control-cost capability is Issue #1651.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon import Conditions, MFGProblem, Model
+from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
+from mfgarchon.core.hamiltonian import BoundedControlCost, L1ControlCost, SeparableHamiltonian
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+NX, NT = 41, 10
+
+
+class _NarrowL1(L1ControlCost):
+    """An L1 cost whose admissible set is NOT the class default (-1, 1).
+
+    Nothing but ``effective_domain()`` changes, so a consumer that reads the owner
+    produces a different answer while one holding the ``(-1.0, 1.0)`` literal produces
+    the identical answer. That is the discrimination this module needs.
+    """
+
+    def effective_domain(self) -> tuple[float, float]:
+        return (-0.25, 0.25)
+
+
+class _NarrowBounded(BoundedControlCost):
+    """Same trick for the quadratic-on-A branch: A shrinks, ``max_control`` does not."""
+
+    def effective_domain(self) -> tuple[float, float]:
+        return (-0.2, 0.2)
+
+
+def _solve(control_cost) -> np.ndarray:
+    # H-only construction: MFGComponents derives the SeparableLagrangian that
+    # ``problem.lagrangian_class`` returns, which is the route production code takes.
+    problem = MFGProblem(
+        model=Model(hamiltonian=SeparableHamiltonian(control_cost=control_cost), sigma=0.15),
+        domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=no_flux_bc(dimension=1)),
+        conditions=Conditions(u_terminal=lambda x: (x - 0.5) ** 2, m_initial=lambda x: 1.0, T=0.5),
+        Nt=NT,
+    )
+    solver = HJBSemiLagrangianSolver(problem)
+    assert solver._use_dpp, "this test is only meaningful on the DPP path; the gate changed"
+    xs = problem.geometry.coordinates[0]
+    density = np.ones((NT + 1, NX))
+    return solver.solve_hjb_system(density, (xs - 0.5) ** 2, U_coupling_prev=np.zeros((NT + 1, NX)))
+
+
+def test_dpp_sweep_reads_the_narrowed_domain_for_l1():
+    """The load-bearing pin. A hardcoded (-1, 0, 1) candidate set cannot see this change."""
+    wide = _solve(L1ControlCost(lambda_=0.5))
+    narrow = _solve(_NarrowL1(lambda_=0.5))
+
+    assert np.isfinite(wide).all()
+    assert np.isfinite(narrow).all()
+    assert not np.allclose(wide, narrow, rtol=0, atol=0), (
+        "shrinking effective_domain() from (-1, 1) to (-0.25, 0.25) left the value function "
+        "byte-identical: the DPP control sweep is not reading the admissible set from its owner"
+    )
+    # Restricting the admissible set can only raise the minimized DPP cost.
+    assert narrow.max() >= wide.max()
+
+
+def test_dpp_sweep_reads_the_narrowed_domain_for_bounded():
+    """Same pin on the quadratic-on-A branch, where the ladder read cc.max_control directly."""
+    wide = _solve(BoundedControlCost(lambda_=1.0, max_control=2.0))
+    narrow = _solve(_NarrowBounded(lambda_=1.0, max_control=2.0))
+
+    assert np.isfinite(wide).all()
+    assert np.isfinite(narrow).all()
+    assert not np.allclose(wide, narrow, rtol=0, atol=0), (
+        "shrinking effective_domain() left the value function byte-identical: the DPP sweep "
+        "is still reading cc.max_control instead of the owner"
+    )
+
+
+def test_no_second_owner_literals_survive_in_the_sweep():
+    """Consolidation pin: the removed ladder's two re-derivations must not come back.
+
+    Scope stated precisely -- this greps the method's source for the specific literals the
+    old ladder used. It cannot stop an arbitrary re-fork; the numerical tests above are the
+    checks that matter. It does stop the exact regression that was here.
+    """
+    import inspect
+
+    source = inspect.getsource(HJBSemiLagrangianSolver._solve_timestep_dpp)
+
+    assert "effective_domain()" in source, "the DPP sweep must read the admissible set from its owner"
+    assert "np.array([-1.0, 0.0, 1.0])" not in source, "the hardcoded L1 bang-bang literal is back"
+    assert "cc.max_control" not in source, "the private max_control re-derivation is back"

--- a/tests/unit/test_core/test_hl_convention.py
+++ b/tests/unit/test_core/test_hl_convention.py
@@ -1,0 +1,287 @@
+"""Pinning tests for the H<->L convention and the admissible control set.
+
+Issue #1642, capabilities B1 (hl-convention-pin) and B3 (controlcost-effective-domain).
+
+B1 pins the (V, f) sign convention documented on ``MFGOperatorBase``:
+
+    L(x, alpha, m, t) = L_ctrl(alpha) - V(x, t) - f(m)
+
+asserted in its conjugate form, ``sup_alpha { p.alpha - L } == H``, over
+(Separable, Congestion) x (Quadratic, Bounded, L1) x (V=0, V!=0) x (f=0, f!=0).
+
+What these tests catch:
+
+- Adding V and f to BOTH H and L (the ``SeparableLagrangian`` fork): breaks the
+  identity by exactly 2(V+f), constant in p. Recorded as strict xfail, Issue #1645.
+- A conjugate/optimization box that ignores the admissible control set: for
+  ``L1ControlCost(lambda_=0.5)`` at p=5 an unrestricted sup returns 225.0
+  against a true H of 4.5 (50x), because ``lagrangian()`` omits the indicator.
+- A second owner of the admissible set diverging from ``effective_domain()``.
+- Losing the domain for a Moreau-Yosida-wrapped cost (regularizing H must not
+  enlarge A).
+
+What they do NOT catch: the alpha-sign question on ``LagrangianBase.optimal_control``
+(Issue #1642, B5) -- every shipped L_ctrl is even in alpha, so both sign
+conventions give the same conjugate value. ``test_conjugate_is_alpha_sign_blind``
+pins that evenness rather than leaving it implicit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+from scipy.optimize import minimize_scalar
+
+from mfgarchon.core.hamiltonian import (
+    BoundedControlCost,
+    CongestionHamiltonian,
+    ControlCostBase,
+    L1ControlCost,
+    QuadraticControlCost,
+    SeparableLagrangian,
+)
+
+# Sweep points chosen to straddle every kink the shipped costs have, so the pin
+# is not evaluated only on smooth interiors:
+#   0.0  L1 dead zone (|p| <= lambda) and the kink at the origin
+#   0.5  exactly on the L1 activation threshold lambda=0.5
+#   1.5  Bounded still quadratic (threshold lambda*max_control = 2.0)
+#   3.0  Bounded saturated, L1 active
+#   8.0  deep saturation, where an unrestricted conjugate diverges worst
+P_SWEEP = [0.0, 0.5, 1.5, 3.0, 8.0]
+
+X_POINT = np.array([0.25])
+M_VALUE = 2.0
+
+# Non-trivial V and f: constant-in-x V is enough because the fork is an additive
+# offset, and a constant makes the expected gap 2(V+f) exactly computable.
+V_NONZERO = 0.7
+F_SLOPE = 0.3
+
+
+def _potential(x, t):
+    return V_NONZERO
+
+
+def _coupling(m):
+    return F_SLOPE * m
+
+
+def _conjugate(L, p, *, bounds, alpha_sign=1.0):
+    """sup_alpha { alpha_sign * p * alpha - L(x, alpha, m, t) } over ``bounds``.
+
+    ``bounds`` must be the admissible control set: the shipped ``lagrangian()``
+    implementations omit the indicator of their effective domain, so an
+    unrestricted sup silently overshoots (see module docstring).
+    """
+
+    def neg_objective(a):
+        return -(alpha_sign * p * a - float(L(X_POINT, np.array([a]), M_VALUE, 0.0)))
+
+    res = minimize_scalar(neg_objective, bounds=bounds, method="bounded", options={"xatol": 1e-13})
+    return -res.fun
+
+
+def _search_box(cost: ControlCostBase) -> tuple[float, float]:
+    """Admissible set from the single owner, widened when A = R."""
+    return cost.effective_domain() or (-50.0, 50.0)
+
+
+CONTROL_COSTS = {
+    "quadratic": lambda: QuadraticControlCost(lambda_=2.0),
+    "bounded": lambda: BoundedControlCost(lambda_=1.0, max_control=2.0),
+    "l1": lambda: L1ControlCost(lambda_=0.5),
+}
+
+# (V, f) grid. The separable fork is invisible when V + f == 0, so the
+# (zero, zero) cell must pass today and the other three must not.
+VF_GRID = {
+    "V0_f0": (None, None),
+    "V0_fnz": (None, _coupling),
+    "Vnz_f0": (_potential, None),
+    "Vnz_fnz": (_potential, _coupling),
+}
+
+
+def _separable_params():
+    """Cartesian product, xfailing exactly the cells where V + f != 0."""
+    params = []
+    for cost_name in CONTROL_COSTS:
+        for vf_name, (pot, coup) in VF_GRID.items():
+            marks = ()
+            if (pot, coup) != (None, None):
+                marks = pytest.mark.xfail(
+                    strict=True,
+                    reason=(
+                        "Issue #1645 (B2): SeparableLagrangian.__call__ returns "
+                        "L_ctrl + V + f instead of L_ctrl - V - f, so it is not "
+                        "self-conjugate; the gap is exactly 2(V+f). Flip the sign "
+                        "in B2 and this xfail becomes an XPASS (strict=True fails "
+                        "the suite) -- remove the mark then."
+                    ),
+                )
+            params.append(pytest.param(cost_name, pot, coup, marks=marks, id=f"{cost_name}-{vf_name}"))
+    return params
+
+
+class TestSeparableRoundTrip:
+    """sup_alpha { p.alpha - L } == H for SeparableLagrangian / SeparableHamiltonian."""
+
+    @pytest.mark.parametrize(("cost_name", "potential", "coupling"), _separable_params())
+    def test_conjugate_of_lagrangian_recovers_hamiltonian(self, cost_name, potential, coupling):
+        cost = CONTROL_COSTS[cost_name]()
+        L = SeparableLagrangian(control_cost=cost, potential=potential, coupling=coupling)
+        H = L.as_hamiltonian()
+        box = _search_box(cost)
+
+        for p in P_SWEEP:
+            expected = float(H(X_POINT, M_VALUE, np.array([p])))
+            got = _conjugate(L, p, bounds=box)
+            assert got == pytest.approx(expected, abs=1e-6), (
+                f"{cost_name} p={p}: conjugate of L gave {got}, H gave {expected}"
+            )
+
+    @pytest.mark.parametrize("cost_name", list(CONTROL_COSTS))
+    def test_separable_fork_gap_is_exactly_two_v_plus_f(self, cost_name):
+        """Quantify the Issue #1645 fork rather than only marking it xfail.
+
+        Pins the gap at 2(V+f) and pins that it is CONSTANT in p -- a p-dependent
+        gap would mean the control term is also wrong, not just the (V, f) sign.
+        """
+        cost = CONTROL_COSTS[cost_name]()
+        L = SeparableLagrangian(control_cost=cost, potential=_potential, coupling=_coupling)
+        H = L.as_hamiltonian()
+        box = _search_box(cost)
+        expected_gap = 2.0 * (V_NONZERO + F_SLOPE * M_VALUE)
+
+        gaps = [float(H(X_POINT, M_VALUE, np.array([p]))) - _conjugate(L, p, bounds=box) for p in P_SWEEP]
+        for p, gap in zip(P_SWEEP, gaps, strict=True):
+            assert gap == pytest.approx(expected_gap, abs=1e-5), (
+                f"{cost_name} p={p}: gap {gap} != 2(V+f) {expected_gap}"
+            )
+
+    @pytest.mark.parametrize("cost_name", list(CONTROL_COSTS))
+    def test_conjugate_is_alpha_sign_blind(self, cost_name):
+        """Every shipped L_ctrl is even in alpha, so sup{+p.a - L} == sup{-p.a - L}.
+
+        This is why the (V, f) pin above is independent of the Issue #1642 B5
+        alpha-sign question. If a non-even control cost is ever added, this test
+        fails and B5 stops being optional.
+        """
+        cost = CONTROL_COSTS[cost_name]()
+        L = SeparableLagrangian(control_cost=cost)
+        box = _search_box(cost)
+        for p in P_SWEEP:
+            plus = _conjugate(L, p, bounds=box, alpha_sign=+1.0)
+            minus = _conjugate(L, p, bounds=box, alpha_sign=-1.0)
+            assert plus == pytest.approx(minus, abs=1e-6), f"{cost_name} p={p}: L_ctrl is not even in alpha"
+
+
+class TestCongestionRoundTrip:
+    """H -> L -> H involution for the non-separable congestion Hamiltonian.
+
+    There is no analytic CongestionLagrangian (Issue #1642, B6 owns that), so the
+    L side is the numerical ``DualLagrangian``. The tolerance below is set by
+    NESTED numerical optimization (an outer sup over alpha of an inner sup over
+    p), NOT by the convention: the fork this guards against is 2(V+f) = 2.6,
+    two orders of magnitude above the tolerance.
+    """
+
+    NESTED_OPT_TOL = 5e-2
+
+    @pytest.mark.parametrize("cost_name", ["quadratic", "bounded"])
+    @pytest.mark.parametrize(("vf_name", "vf"), list(VF_GRID.items()))
+    def test_dual_lagrangian_round_trips(self, cost_name, vf_name, vf):
+        potential, coupling = vf
+        cost = CONTROL_COSTS[cost_name]()
+        H = CongestionHamiltonian(
+            control_cost=cost,
+            congestion_factor=lambda m: 1.0 + 3.0 * m,
+            potential=potential,
+            coupling=coupling,
+        )
+        L = H.legendre_transform(p_bounds=(-200.0, 200.0), n_search=400)
+
+        for p in [0.0, 0.5, 1.5, 3.0]:
+            expected = float(H(X_POINT, M_VALUE, np.array([p])))
+            got = _conjugate(L, p, bounds=(-50.0, 50.0))
+            assert got == pytest.approx(expected, abs=self.NESTED_OPT_TOL), (
+                f"{cost_name}/{vf_name} p={p}: round-trip gave {got}, H gave {expected}"
+            )
+
+
+class TestEffectiveDomain:
+    """ControlCostBase.effective_domain() is the single owner of A (B3)."""
+
+    def test_quadratic_is_unbounded(self):
+        assert QuadraticControlCost(lambda_=2.0).effective_domain() is None
+
+    def test_bounded_reports_max_control(self):
+        assert BoundedControlCost(lambda_=1.0, max_control=2.0).effective_domain() == (-2.0, 2.0)
+
+    def test_l1_reports_bang_bang_interval(self):
+        assert L1ControlCost(lambda_=0.5).effective_domain() == (-1.0, 1.0)
+
+    @pytest.mark.parametrize(
+        ("cost_factory", "expected"),
+        [
+            (lambda: QuadraticControlCost(lambda_=2.0), None),
+            (lambda: BoundedControlCost(lambda_=1.0, max_control=2.0), (-2.0, 2.0)),
+            (lambda: L1ControlCost(lambda_=0.5), (-1.0, 1.0)),
+        ],
+    )
+    def test_control_bounds_delegates_to_effective_domain(self, cost_factory, expected):
+        """The isinstance ladder is gone; SeparableLagrangian must read the owner."""
+        cost = cost_factory()
+        assert SeparableLagrangian(control_cost=cost).control_bounds() == expected
+        assert SeparableLagrangian(control_cost=cost).control_bounds() == cost.effective_domain()
+
+    @pytest.mark.parametrize(
+        ("cost_factory", "expected"),
+        [
+            (lambda: BoundedControlCost(lambda_=1.0, max_control=2.0), (-2.0, 2.0)),
+            (lambda: L1ControlCost(lambda_=0.5), (-1.0, 1.0)),
+            (lambda: QuadraticControlCost(lambda_=2.0), None),
+        ],
+    )
+    def test_moreau_yosida_preserves_domain(self, cost_factory, expected):
+        """dom(L + eps/2|.|^2) == dom(L). Smoothing H must not enlarge A.
+
+        BEHAVIOR CHANGE vs the removed isinstance ladder, which returned None
+        here because a wrapped cost matched neither branch -- a regularized
+        bounded problem silently claimed an unbounded control set. Reachable via
+        SeparableHamiltonian.regularize() -> MFGComponents deriving a
+        SeparableLagrangian -> hjb_semi_lagrangian control_bounds().
+        """
+        wrapped = cost_factory().regularize(0.1)
+        assert wrapped.effective_domain() == expected
+        assert SeparableLagrangian(control_cost=wrapped).control_bounds() == expected
+
+    def test_lagrangian_does_not_enforce_the_domain(self):
+        """Forcing evidence for B3, pinned so the gap cannot be forgotten.
+
+        ``lagrangian()`` returns a finite value for infeasible alpha. Making it
+        fail loud is Issue #1644 (B4); when that lands, this test must be
+        replaced by one asserting the raise -- not deleted.
+        """
+        cost = BoundedControlCost(lambda_=1.0, max_control=2.0)
+        infeasible = np.array([5.0])
+        assert cost.effective_domain() == (-2.0, 2.0)
+        assert float(cost.lagrangian(infeasible)) == pytest.approx(12.5)
+
+    def test_unrestricted_conjugate_overshoots_without_the_domain(self):
+        """Why every conjugate consumer must read effective_domain().
+
+        L1 at p=5: true H is 4.5; a sup taken over (-50, 50) instead of the
+        effective domain returns ~225.
+        """
+        cost = L1ControlCost(lambda_=0.5)
+        L = SeparableLagrangian(control_cost=cost)
+        true_h = float(cost.evaluate(np.array([5.0]))[0])
+
+        on_domain = _conjugate(L, 5.0, bounds=cost.effective_domain())
+        off_domain = _conjugate(L, 5.0, bounds=(-50.0, 50.0))
+
+        assert on_domain == pytest.approx(true_h, abs=1e-6)
+        assert off_domain > 40.0 * true_h

--- a/tests/unit/test_core/test_hl_convention.py
+++ b/tests/unit/test_core/test_hl_convention.py
@@ -6,13 +6,32 @@ B1 pins the (V, f) sign convention documented on ``MFGOperatorBase``:
 
     L(x, alpha, m, t) = L_ctrl(alpha) - V(x, t) - f(m)
 
-asserted in its conjugate form, ``sup_alpha { p.alpha - L } == H``, over
-(Separable, Congestion) x (Quadratic, Bounded, L1) x (V=0, V!=0) x (f=0, f!=0).
+asserted in its conjugate form, ``sup_alpha { p.alpha - L } == H``.
+
+Which tests carry that pin, precisely -- a conjugate round trip only
+discriminates when the two sides have INDEPENDENT sources for V and f:
+
+- ``TestSeparableRoundTrip.test_separable_fork_gap_is_exactly_two_v_plus_f``
+  (3 tests, one (V, f) point, one per control cost). Both sides come from the
+  same ``SeparableLagrangian``, so this cannot be a round-trip assertion; it
+  instead quantifies the Issue #1645 fork as an exact 2(V+f) gap, constant in p.
+  This is the load-bearing pin on the Separable side.
+- ``TestCongestionRoundTrip`` (12 tests = 3 costs x 4 (V, f) cells). The L side
+  is an analytic closed form written out in this module, NOT
+  ``H.legendre_transform()``, so V and f are independently sourced and a sign
+  error in ``CongestionHamiltonian`` breaks the identity by 2(V+f).
+
+``test_conjugate_of_lagrangian_recovers_hamiltonian`` is NOT part of that pin:
+its V != 0 rows are strict xfail (Issue #1645) and its V0_f0 rows are
+non-discriminating by construction, the disputed term being identically zero.
+It is retained to hold the xfail markers, which flip to XPASS and fail the suite
+when B2 lands.
 
 What these tests catch:
 
 - Adding V and f to BOTH H and L (the ``SeparableLagrangian`` fork): breaks the
   identity by exactly 2(V+f), constant in p. Recorded as strict xfail, Issue #1645.
+- A (V, f) sign error in ``CongestionHamiltonian.__call__``.
 - A conjugate/optimization box that ignores the admissible control set: for
   ``L1ControlCost(lambda_=0.5)`` at p=5 an unrestricted sup returns 225.0
   against a true H of 4.5 (50x), because ``lagrangian()`` omits the indicator.
@@ -93,6 +112,56 @@ CONTROL_COSTS = {
     "bounded": lambda: BoundedControlCost(lambda_=1.0, max_control=2.0),
     "l1": lambda: L1ControlCost(lambda_=0.5),
 }
+
+CONGESTION_SLOPE = 3.0
+
+
+def _congestion_factor(m):
+    return 1.0 + CONGESTION_SLOPE * m
+
+
+# Analytic control part of L for CongestionHamiltonian, written out by hand.
+#
+# H_kin(p) = g(p) / c(m) with g = control_cost.evaluate, so the control part of L
+# is the conjugate (g/c)*(alpha) = g*(c*alpha) / c. The lambda_ values below
+# restate those of CONTROL_COSTS deliberately: an independent transcription is
+# the point, so that these formulas share no source with the Hamiltonian.
+#
+#   quadratic  g* = lambda/2 |a|^2          -> lambda*c/2 |a|^2,   A = R
+#   bounded    g* = lambda/2 |a|^2 + I_A    -> lambda*c/2 |a|^2,   A/c
+#   l1         g* = lambda |a| + I_A        -> lambda |a|,         A/c
+CONGESTION_L_CTRL = {
+    "quadratic": lambda a, c_m: 0.5 * 2.0 * c_m * a**2,
+    "bounded": lambda a, c_m: 0.5 * 1.0 * c_m * a**2,
+    "l1": lambda a, c_m: 0.5 * abs(a),
+}
+
+
+def _congestion_lagrangian(cost_name, potential, coupling):
+    """Analytic L(x, alpha, m, t) = L_ctrl^{c(m)}(alpha) - V(x, t) - f(m).
+
+    Independently sourced from ``CongestionHamiltonian`` -- see the note on
+    ``TestCongestionRoundTrip`` for why that independence is what makes the
+    round trip discriminating.
+    """
+    l_ctrl = CONGESTION_L_CTRL[cost_name]
+
+    def L(x, alpha, m, t=0.0):
+        v = potential(x, t) if potential is not None else 0.0
+        f = coupling(m) if coupling is not None else 0.0
+        return l_ctrl(float(np.atleast_1d(alpha)[0]), _congestion_factor(m)) - v - f
+
+    return L
+
+
+def _congestion_box(cost) -> tuple[float, float]:
+    """A / c(m). Congestion SHRINKS the admissible set: dom((g/c)*) = dom(g*)/c."""
+    domain = cost.effective_domain()
+    if domain is None:
+        return (-50.0, 50.0)
+    c_m = _congestion_factor(M_VALUE)
+    return (domain[0] / c_m, domain[1] / c_m)
+
 
 # (V, f) grid. The separable fork is invisible when V + f == 0, so the
 # (zero, zero) cell must pass today and the other three must not.
@@ -179,35 +248,44 @@ class TestSeparableRoundTrip:
 
 
 class TestCongestionRoundTrip:
-    """H -> L -> H involution for the non-separable congestion Hamiltonian.
+    """sup_alpha { p.alpha - L } == H for the non-separable CongestionHamiltonian.
 
-    There is no analytic CongestionLagrangian (Issue #1642, B6 owns that), so the
-    L side is the numerical ``DualLagrangian``. The tolerance below is set by
-    NESTED numerical optimization (an outer sup over alpha of an inner sup over
-    p), NOT by the convention: the fork this guards against is 2(V+f) = 2.6,
-    two orders of magnitude above the tolerance.
+    The L side is the ANALYTIC Lagrangian built by ``_congestion_lagrangian``,
+    deliberately not ``H.legendre_transform()``. That method returns a
+    ``DualLagrangian``, which computes L = sup_p { p.alpha - H } from the SAME H
+    object, so the round trip collapses to ``H** == H`` -- true for every convex
+    H whatever the (V, f) signs are. Such a test asserts convexity, not a
+    convention, and stays green under a sign flip in
+    ``CongestionHamiltonian.__call__``.
+
+    Sourcing V and f independently here is what gives the assertion teeth: a
+    sign error on either term shifts H by 2V or 2f while the conjugate stays
+    put. There is no shipped analytic CongestionLagrangian to import (Issue
+    #1642, B6 owns that), hence the closed forms in this module.
+
+    Tolerance is 1e-6, set by the single bounded scalar sup; the errors measured
+    are ~4e-8. The fork this guards against is 2(V+f) = 2.6.
     """
 
-    NESTED_OPT_TOL = 5e-2
-
-    @pytest.mark.parametrize("cost_name", ["quadratic", "bounded"])
+    @pytest.mark.parametrize("cost_name", list(CONTROL_COSTS))
     @pytest.mark.parametrize(("vf_name", "vf"), list(VF_GRID.items()))
-    def test_dual_lagrangian_round_trips(self, cost_name, vf_name, vf):
+    def test_analytic_conjugate_recovers_hamiltonian(self, cost_name, vf_name, vf):
         potential, coupling = vf
         cost = CONTROL_COSTS[cost_name]()
         H = CongestionHamiltonian(
             control_cost=cost,
-            congestion_factor=lambda m: 1.0 + 3.0 * m,
+            congestion_factor=_congestion_factor,
             potential=potential,
             coupling=coupling,
         )
-        L = H.legendre_transform(p_bounds=(-200.0, 200.0), n_search=400)
+        L = _congestion_lagrangian(cost_name, potential, coupling)
+        box = _congestion_box(cost)
 
-        for p in [0.0, 0.5, 1.5, 3.0]:
+        for p in P_SWEEP:
             expected = float(H(X_POINT, M_VALUE, np.array([p])))
-            got = _conjugate(L, p, bounds=(-50.0, 50.0))
-            assert got == pytest.approx(expected, abs=self.NESTED_OPT_TOL), (
-                f"{cost_name}/{vf_name} p={p}: round-trip gave {got}, H gave {expected}"
+            got = _conjugate(L, p, bounds=box)
+            assert got == pytest.approx(expected, abs=1e-6), (
+                f"{cost_name}/{vf_name} p={p}: conjugate of the analytic L gave {got}, H gave {expected}"
             )
 
 


### PR DESCRIPTION
Stage 1 of the design-space map on #1642 — capabilities **B1** (`hl-convention-pin`) and **B3** (`controlcost-effective-domain`).

> **Revised after independent adversarial review (BLOCK → all 4 blockers cleared).** The first review found that `TestCongestionRoundTrip` was a biconjugacy tautology and could not fail; that a second owner of the admissible set survived on a live solver path; and that the "one behavioral change" reachability claim was false. All three are fixed or retracted below, with the corrections marked **[rev]**.

## B3 — `ControlCostBase.effective_domain()`

New method, the **single owner** of "which controls are admissible" (A = dom(L)).

- `L1ControlCost` → `(-1.0, 1.0)`; `BoundedControlCost` → `(-max_control, max_control)`; `QuadraticControlCost` inherits `None` (A = R).
- `_MoreauYosidaControlCost` delegates to the cost it wraps: `dom(L + (eps/2)|.|^2) = dom(L)`.

**Both** consumers now read it:

| consumer | before | after |
|---|---|---|
| `SeparableLagrangian.control_bounds()` | isinstance ladder | delegates |
| `hjb_semi_lagrangian._solve_timestep_dpp` **[rev]** | isinstance ladder, hardcoded `(-1.0, 1.0)` + private `cc.max_control` | delegates |

**[rev]** The second ladder is the review's Blocker 2 and it was **live**, not dead — `_use_dpp` is True for plain `Bounded` and `L1`. Delegating it is byte-identical: **35/35 unwrapped cost configurations** produce candidate sets equal under `np.array_equal` (rtol=0), across `lambda_` in {0.1, 1, 2, 7.5, 1e3} × `max_control` in {1e-3, 0.5, 1, 2, 1e4}. It also removes the wrapper-blindness — a `_MoreauYosidaControlCost` matched none of the three branches and silently lost its box.

What stays local in that sweep is only **quadrature** — three points for a piecewise-linear `L_ctrl` against eleven for a quadratic one. That is a genuine structural distinction rather than a duplicated quantity, so it is not consolidated here; narrowing it to a control-cost capability is **#1651** (filed). The `effective_domain()` docstring now states that scope explicitly instead of claiming more than it owns.

Forcing evidence, re-verified rather than relayed: `BoundedControlCost(max_control=2).lagrangian(5.0)` returns `12.5` where the true L is `+inf`, and the docstring said "assumes feasible". Measured consequence for a conjugate consumer — `L1ControlCost(lambda_=0.5)` at p=5, true H = 4.5:

| sup taken over | result |
|---|---|
| `effective_domain()` = (-1, 1) | 4.5 |
| unrestricted (-50, 50) | 225.0 (50x) |

`lagrangian()` still does not itself enforce the domain — making it fail loud is #1644 (B4). The gap is documented on both `effective_domain()` and `BoundedControlCost.lagrangian()`, and pinned by `test_lagrangian_does_not_enforce_the_domain`.

## B1 — the (V, f) convention

Docstring on `MFGOperatorBase` carrying the derivation. **No sign is flipped here** — the flip is B2 / #1645.

DPP gives `(u^n - u^{n+1})/dt = min_alpha{L + p.alpha}`, so with `L = L_ctrl + W` the PDE is `-d_t u + H_ctrl(p) - W = 0`. `base_hjb.py` assembles `Phi_U += (u^n - u^{n+1})/dt` (line 640) then `Phi_U += hamiltonian_val` (line 771) with `H = H_ctrl + V + f`, i.e. `-d_t u + H_ctrl + V + f = 0`. Matching gives `W = -(V+f)`, so **`L = L_ctrl - V - f`**.

### What actually pins it **[rev]**

The first version of this PR sold a "20-cell round-trip matrix" as the evidence. That was wrong, and the review proved it: `TestCongestionRoundTrip` built its L via `H.legendre_transform()`, which returns a `DualLagrangian` computing `L = sup_p{p.alpha - H}` **from the same H object**. The round trip therefore collapsed to `H** == H` — true for every convex H regardless of the (V, f) signs. It asserted convexity, not a convention. Mutating `hamiltonian.py:2511` to `H_kinetic + V - f_m` left the entire file green (28 passed, 9 xfailed, exit 0). Reproduced before fixing.

**Fix:** the congestion L is now an **analytic closed form written out in the test module**, not derived from H. `H_kin(p) = g(p)/c(m)` gives control part `(g/c)*(alpha) = g*(c*alpha)/c` on the domain `A/c` — congestion *shrinks* the admissible set. V and f are transcribed independently, so a sign error on either shifts H by 2V or 2f while the conjugate stays put.

This also gets **L1 coverage**, which the nested-optimization version could not carry: 3 costs × 4 (V, f) cells = **12 tests, up from 8**, and the tolerance drops from `5e-2` to `1e-6` (measured error ~4e-8) because the nested inner sup is gone.

The convention is pinned by exactly two things, now named as such in both the test module docstring and the `MFGOperatorBase` docstring:

| pin | tests | why it discriminates |
|---|---|---|
| `test_separable_fork_gap_is_exactly_two_v_plus_f` | 3, one (V, f) point | quantifies the #1645 fork as an exact 2(V+f) gap, constant in p |
| `TestCongestionRoundTrip` | 12 = 3 costs × 4 cells | analytic L, independent (V, f) source |

`test_conjugate_of_lagrangian_recovers_hamiltonian` is **not** part of the pin — its V≠0 rows are strict xfail and its `V0_f0` rows are non-discriminating by construction (the disputed term is identically zero there). It is retained only to hold the xfail markers. Stated plainly in both docstrings rather than left implied.

## Evidence

Every mutation asserted-applied — match count ≥ 1 **and** on-disk sha changed — before any verdict was trusted, and restored byte-identically after.

| mutation | caught |
|---|---|
| **N1** congestion `+V+f` → `+V-f` (the review's escape) | **yes — 6 failed** (was: 0) |
| **N1b** congestion V dropped | **yes — 6 failed** (was: 0) |
| **N1c** congestion V sign flipped | **yes — 6 failed** |
| **N8** pre-PR SL ladder restored as second owner | yes — 3 failed |
| **N9** L1 branch only, back to the `(-1,0,1)` literal | yes — 2 failed |
| **N10** Bounded branch only, back to `cc.max_control` | yes — 2 failed |
| M1 apply B2's flip (`L_ctrl + V + f` → `- V - f`) | yes — 12 failed |
| M2 `control_bounds` stops delegating | yes — 4 failed |
| M3 `BoundedControlCost.effective_domain` → `(-3, 3)` | yes — 10 failed |
| M4 `L1ControlCost.effective_domain` → `(-2, 2)` | yes — 6 failed |
| M5 Moreau-Yosida drops domain delegation | yes — 2 failed |

N9 and N10 fire on disjoint tests, so the two numerical pins discriminate independently rather than through a shared cause.

New pinning test `tests/unit/test_alg/test_sl_control_set_single_source_1642.py` uses `_NarrowL1` / `_NarrowBounded` subclasses that change **only** `effective_domain()` — a consumer holding the literal produces a byte-identical value function and fails.

**Gates** (all re-run at head):

| gate | result |
|---|---|
| `ruff check` all 4 touched files incl. `tests/` | clean, exit 0 |
| `ruff format --check mfgarchon/` | 457 files already formatted |
| `check_fail_fast.py --check-baseline` | OK, no new violations |
| full suite, `-n auto`, CI markers | **5215 passed, 27 skipped, 13 xfailed, 2 xpassed**, exit 0, 384s |

5208 → 5215 is +7: 4 new congestion cells, 3 new SL tests. The 2 xpassed are pre-existing (#583), in a file not touched here.

## Behavioral scope **[rev]**

The previous body claimed a reachable behavioral change and framed it as "I chose correctness over byte-identity". **That was wrong and is retracted.** Measured, both component routes:

| cost | `_use_dpp` (gates the `:1925` consumer) | `control_bounds()` changed? |
|---|---|---|
| quad, quad_reg | False | no (None → None) |
| bounded, l1 | **True** | no (identical to the old ladder) |
| bounded_reg, l1_reg | **False** | yes (None → box) |

`_use_dpp` requires `not H.is_smooth()`, and Moreau-Yosida sets `is_smooth() == True` by construction. **The cases this PR changes are exactly the cases where the named consumer never runs; the cases where it runs are exactly the cases left identical.** `hamiltonian.py:1575`/`:1636` are both overridden by `SeparableLagrangian`, so they do not observe it either. I verified this table independently rather than accepting the review's.

So the change is **user-facing API only**: a caller invoking `control_bounds()` or `effective_domain()` directly on a regularized cost now gets the wrapped cost's box instead of `None`. No solver output moves. The changelog states it at that level.

## What I did NOT do

- **No sign flip.** `SeparableLagrangian.__call__` still returns `L_ctrl + V + f` — B2 / #1645.
- **No `m` in the signature.** `effective_domain()` takes no arguments — B9 / Stage 3.
- **No fail-loud in `lagrangian()`**, no touching the seven `(-10.0, 10.0)` literals — B4 / #1644.
- **No `HamiltonianBase.lagrangian()`** — B6.
- **Did not consolidate the SL sweep's quadrature isinstance** (3-point vs 11-point sampling). It selects sampling density, not the admissible set; folding it into a control-cost capability is **#1651**, filed. **[rev]** — this is the residue of Blocker 2, disclosed rather than hidden.
- **Did not address** `ControlCostBase.effective_domain()` defaulting to `None`. The review flagged that a future bounded subclass forgetting to override silently reports A = R. A = R is a legitimate default that `QuadraticControlCost` relies on, so this is a design call for #1642, not a defect to patch here.

Refs #1642, #1645, #1644, #1651.
