### PR TITLE
Freeze the EnergyFunctional contract and repair the energy() quadrature

### DIFF
--- a/changelog.d/energy-functional-contract-freeze.changed.md
+++ b/changelog.d/energy-functional-contract-freeze.changed.md
@@ -1,0 +1,41 @@
+**Breaking (pre-1.0, no shim): `EnergyFunctional` contract frozen and `energy()` quadrature repaired** (Issue #1642, capabilities A1/A2/A3).
+
+`energy()` returned `F[m] / cell_volume` instead of `F[m]` — measured as exactly
+`1/dx` (31, 63, 127, 255, 511 at N=32..512, dx=1/(N-1)), so the value doubled
+with every refinement instead of converging. `QuadraticInteractionEnergy.energy`
+and `PotentialEnergy.energy` now apply the outer quadrature weight and return the
+physical integral. The live HJB source path was **not** affected: it calls only
+the first variation, which was already exact (bit-identical to the physical
+`delta F / delta m` on a scattered non-uniform cloud).
+
+Contract changes on `EnergyFunctional`, all pre-1.0 breaks with no compatibility
+shim:
+
+- `lions_derivative` -> `flat_derivative`. The method returns the flat
+  (linear-functional) derivative `delta F / delta m`, a scalar field of shape
+  `(N,)`; the Lions/Wasserstein derivative is `grad_x delta F / delta m`, shape
+  `(N, d)`. Return shapes differ, so the old name named the wrong object.
+- New required `weights` member: the quadrature weights of the measure
+  representation — cell volumes on a grid, particle masses for an empirical
+  measure. Documented explicitly; both ontologies take the same code path.
+- All methods take a keyword-only `t` (the source pipeline already carries the
+  true per-slice `t`; the analytic branch previously discarded it).
+- New required `second_variation(m, *, t=0.0) -> NDArray | None` slot, defaulting
+  to `None`. `QuadraticInteractionEnergy` returns the kernel matrix `K`;
+  `PotentialEnergy` returns zeros.
+- Single-population by decision: a stacked `(K*N,)` multi-population density is
+  now refused with a diagnostic naming the expected shape, instead of being
+  contracted against a broadcastable operand.
+- `PotentialEnergy(potential)` -> `PotentialEnergy(potential, weights)`; weights
+  are required, since a default would silently reintroduce mesh-dependence.
+- `CombinedEnergy` refuses components whose quadrature weights disagree.
+
+New: `flat_derivative_from_energy_gradient(gradient, weights)` is the single
+owner of the factor between the two derivative conventions —
+`FiniteDifferenceFunctionalDerivative` perturbs an unweighted Dirac
+`m_k += epsilon`, so its output is `w_k * (delta F / delta m)_k`.
+
+`ConvolutionCouplingOperator` gains `weights` (always an `(N,)` array) and
+`kernel_matrix()` (the unweighted `W`); the scalar-or-array `cell_volume`
+property is removed in favour of the single spelling. The `cell_volume=`
+constructor keyword is unchanged.

--- a/changelog.d/energy-functional-contract-freeze.changed.md
+++ b/changelog.d/energy-functional-contract-freeze.changed.md
@@ -35,6 +35,31 @@ owner of the factor between the two derivative conventions —
 `FiniteDifferenceFunctionalDerivative` perturbs an unweighted Dirac
 `m_k += epsilon`, so its output is `w_k * (delta F / delta m)_k`.
 
+**Breaking: `create_lions_source`'s finite-difference path now requires
+`weights=`.** Both branches of the function now return the same object, the
+pointwise `delta F / delta m` of the *physical* `F[m]`. Previously the FD branch
+returned the raw entry gradient `w_k * (delta F / delta m)_k` and the analytic
+branch the pointwise derivative, so feeding one energy object through the two
+documented paths disagreed by exactly the cell volume — an interaction coupling
+that weakened under refinement with no error. The FD branch now applies
+`flat_derivative_from_energy_gradient`, which requires it to know the quadrature
+weights. There is no default: `w = 1` is what silently reintroduces the fork.
+`create_lions_source(F, fd)` -> `create_lions_source(F, fd, weights=w)`, with
+`w` a scalar cell volume or an `(N,)` array; passing `weights=` alongside an
+`EnergyFunctional` is refused (it already carries them).
+
+An object providing *some* but not all `EnergyFunctional` members is now refused
+by `create_lions_source` with the missing members named, instead of falling
+through to the finite-difference path — where, if it happened to be callable,
+its exact `flat_derivative` was never called and nothing said so.
+
+`EnergyFunctional.weights` is now a read-only array. `validate_weights` returns a
+frozen copy rather than a view, so the public member can no longer alias operator
+internals: `E.weights[0] = 99.0` reached `conv.as_dense()[0, 0]` and defeated the
+strict-positivity precondition; it now raises. New introspection helpers
+`energy_functional_members()` / `missing_energy_functional_members(obj)` expose
+the required member set for diagnostics.
+
 `ConvolutionCouplingOperator` gains `weights` (always an `(N,)` array) and
 `kernel_matrix()` (the unweighted `W`); the scalar-or-array `cell_volume`
 property is removed in favour of the single spelling. The `cell_volume=`

--- a/mfgarchon/alg/numerical/coupling/lions_correction.py
+++ b/mfgarchon/alg/numerical/coupling/lions_correction.py
@@ -26,18 +26,30 @@ Mathematical background:
     differences or particle approximation, making this bridge agnostic
     to the specific coupling form.
 
+Convention
+----------
+The HJB source slot holds the **pointwise** flat derivative
+``delta F / delta m``, and ``F[m]`` is the **physical** (mesh-independent)
+energy. Both paths of :func:`create_lions_source` return that same object; see
+:mod:`mfgarchon.operators.interaction.energy_functionals` for the discretization
+convention ``integral g m dx = sum_k w_k g_k m_k``. In particular the double
+integral above discretizes with **two** quadrature factors,
+``F[m] = (1/2) sum_ij w_i w_j W_ij m_i m_j``, and its flat derivative is
+``(delta F / delta m)_i = sum_j W_ij w_j m_j`` -- one factor, not zero and not
+two.
+
 Usage:
     >>> from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
     >>> from mfgarchon.alg.numerical.coupling.lions_correction import create_lions_source
     >>>
-    >>> # Define nonlocal energy functional
+    >>> # Define nonlocal energy functional (physical: both quadrature factors)
     >>> W = ...  # interaction kernel matrix (Nx, Nx)
     >>> dx = 1.0 / Nx
     >>> def energy(m):
-    ...     return 0.5 * np.sum(m * (W @ m)) * dx
+    ...     return 0.5 * np.sum(m * (W @ m)) * dx**2
     >>>
     >>> fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4)
-    >>> source_hjb = create_lions_source(energy, fd)
+    >>> source_hjb = create_lions_source(energy, fd, weights=dx)
     >>>
     >>> problem = MFGProblem(..., source_term_hjb=source_hjb)
     >>> result = problem.solve()
@@ -80,6 +92,8 @@ def _spatial_density(m: NDArray) -> NDArray:
 def create_lions_source(
     energy_functional: FunctionalOnMeasures | EnergyFunctional,
     functional_derivative: FunctionalDerivative | None = None,
+    *,
+    weights: NDArray | float | None = None,
 ) -> Callable[[NDArray, NDArray, NDArray, float], NDArray]:
     """Create a source_term_hjb from a measure-dependent energy functional.
 
@@ -87,34 +101,48 @@ def create_lions_source(
     source_term_hjb interface by computing delta F / delta m[m](x)
     at each Picard iteration.
 
-    Two paths, selected from the first argument:
+    Two paths, selected from the first argument. **Both return the same object**:
+    the pointwise flat derivative ``delta F / delta m`` of the physical energy
+    ``F[m]``.
 
     1. **Analytic** (Issue #1023, Phase 2): if ``energy_functional`` is an
-       :class:`~mfgarchon.operators.interaction.energy_functionals.EnergyFunctional`
-       (provides ``.flat_derivative``), its exact derivative is used and the FD
-       path is skipped. ``functional_derivative`` is then ignored. The
-       per-slice ``t`` is forwarded to ``flat_derivative``.
+       :class:`~mfgarchon.operators.interaction.energy_functionals.EnergyFunctional`,
+       its exact derivative is used and the FD path is skipped.
+       ``functional_derivative`` is then ignored and ``weights`` must not be
+       passed -- the functional already carries them. The per-slice ``t`` is
+       forwarded to ``flat_derivative``.
     2. **Finite difference** (original path): if ``energy_functional`` is a plain
-       ``F[m] -> float`` callable, ``functional_derivative`` is required and
-       ``delta F / delta m`` is approximated by finite differences.
+       ``F[m] -> float`` callable, both ``functional_derivative`` **and**
+       ``weights`` are required.
 
-    The two paths agree for an ``EnergyFunctional`` whose analytic
-    ``flat_derivative`` matches the FD gradient of its ``.energy`` **divided by
-    the quadrature weights** -- the FD engine perturbs an unweighted Dirac
-    ``m_k += epsilon``, so its output is ``w_k * (delta F / delta m)_k``. The
-    conversion has one owner,
+    ``weights`` is required on the FD path because the FD engine perturbs an
+    *unweighted* Dirac ``m_k += epsilon``, so it returns the entry gradient
+    ``d F / d m_k = w_k * (delta F / delta m)_k`` -- a factor ``w_k`` away from
+    the pointwise object the HJB slot needs. Dividing it out is the *only* way
+    the two paths agree, and it has one owner,
     :func:`~mfgarchon.operators.interaction.energy_functionals.flat_derivative_from_energy_gradient`
-    (Issue #1642 A2).
+    (Issue #1642 A2), applied here. There is no default: silently assuming
+    ``w = 1`` makes the interaction coupling scale with the mesh and switch off
+    under refinement, with no error.
+
+    An object that provides *some* but not all of the ``EnergyFunctional``
+    members is refused loudly rather than downgraded to the FD path, where its
+    exact ``flat_derivative`` would never be called (Issue #1642 D-6).
 
     Args:
         energy_functional: Either an ``EnergyFunctional`` (analytic path) or a
-            plain ``F[m] -> float`` callable depending on the full measure
+            plain ``F[m] -> float`` callable returning the **physical** energy
             (FD path). Density arrays have shape (Nx,).
         functional_derivative: FunctionalDerivative instance for the FD path
             (FiniteDifferenceFunctionalDerivative or
             ParticleApproximationFunctionalDerivative). Required only when
             ``energy_functional`` is a plain callable; ignored for an
             ``EnergyFunctional``.
+        weights: Quadrature weights of the measure representation for the FD
+            path — cell volumes on a grid, particle masses for an empirical
+            measure. Either shape ``(Nx,)`` or a scalar broadcast to the density
+            length at call time. Strictly positive. Required on the FD path;
+            rejected on the analytic path.
 
     Returns:
         source_term_hjb(x, m, v, t) -> NDArray compatible with
@@ -125,22 +153,35 @@ def create_lions_source(
         >>> import numpy as np
         >>> from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
         >>>
-        >>> # Quadratic interaction: F[m] = (1/2) int m(x)^2 dx
+        >>> # Quadratic interaction: F[m] = (1/2) int m(x)^2 dx = (1/2) sum_k w_k m_k^2
         >>> dx = 0.02
         >>> def energy(m):
         ...     return 0.5 * np.sum(m**2) * dx
         >>>
         >>> fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4)
-        >>> source = create_lions_source(energy, fd)
+        >>> source = create_lions_source(energy, fd, weights=dx)
         >>>
-        >>> # source(x, m, v, t) returns delta F / delta m = m(x) * dx
+        >>> # source(x, m, v, t) returns delta F / delta m = m(x)
         >>> m = np.ones(50) / 50
         >>> result = source(np.linspace(0, 1, 50), m, np.zeros(50), 0.0)
     """
-    # Analytic path: EnergyFunctional carries its own exact Lions derivative.
-    from mfgarchon.operators.interaction.energy_functionals import EnergyFunctional
+    # Analytic path: EnergyFunctional carries its own exact flat derivative.
+    from mfgarchon.operators.interaction.energy_functionals import (
+        EnergyFunctional,
+        energy_functional_members,
+        flat_derivative_from_energy_gradient,
+        missing_energy_functional_members,
+        validate_weights,
+    )
 
     if isinstance(energy_functional, EnergyFunctional):
+        if weights is not None:
+            raise ValueError(
+                "create_lions_source: weights= is for the finite-difference path only. "
+                f"{type(energy_functional).__name__} is an EnergyFunctional and carries its "
+                "own quadrature weights, so a second set here would be a silent second source "
+                "of the same quantity."
+            )
         analytic = energy_functional
 
         def source_term_hjb_analytic(
@@ -149,17 +190,58 @@ def create_lions_source(
             v: NDArray,
             t: float,
         ) -> NDArray:
-            """Evaluate the analytic Lions correction delta F / delta m[m](x)."""
+            """Evaluate the analytic correction delta F / delta m[m](x)."""
             m_flat = _spatial_density(m)
             return np.asarray(analytic.flat_derivative(m_flat, t=t)).ravel()
 
         return source_term_hjb_analytic
+
+    # Not an EnergyFunctional. Distinguish "almost one" from "not one at all":
+    # a near-miss that happens to be callable would otherwise take the FD path
+    # with its exact flat_derivative never called, and no diagnostic.
+    missing = missing_energy_functional_members(energy_functional)
+    if missing and len(missing) < len(energy_functional_members()):
+        provided = [n for n in energy_functional_members() if n not in missing]
+        raise TypeError(
+            f"create_lions_source: {type(energy_functional).__name__} provides "
+            f"{provided} but is missing {list(missing)}, so it is not an EnergyFunctional. "
+            "Refusing rather than falling through to the finite-difference path, which would "
+            "never call its exact flat_derivative. Implement the missing members -- or "
+            "subclass EnergyFunctional to inherit the second_variation default -- or pass a "
+            "plain F[m] -> float callable together with functional_derivative= and weights=."
+        )
+    if not callable(energy_functional):
+        raise TypeError(
+            f"create_lions_source: expected an EnergyFunctional or a plain F[m] -> float "
+            f"callable, got {type(energy_functional).__name__}, which provides none of "
+            f"{list(energy_functional_members())} and is not callable."
+        )
 
     if functional_derivative is None:
         raise ValueError(
             "functional_derivative is required when energy_functional is a plain "
             "callable (FD path); pass an EnergyFunctional to use the analytic path"
         )
+    if weights is None:
+        raise ValueError(
+            "create_lions_source: weights= is required on the finite-difference path. "
+            "The FD engine perturbs an unweighted Dirac (m_k += epsilon), so it returns the "
+            "entry gradient dF/dm_k = w_k * (delta F / delta m)_k, while the HJB source slot "
+            "holds the pointwise delta F / delta m. Pass the quadrature weights of the measure "
+            "representation (cell volumes on a grid, particle masses for an empirical measure) "
+            "so the conversion can be applied. There is no default: assuming w = 1 makes the "
+            "interaction coupling scale with the mesh and switch off under refinement, with no "
+            "error (Issue #1642 A2). Pass an EnergyFunctional to use the analytic path instead."
+        )
+
+    w_input = np.asarray(weights, dtype=float)
+    w_scalar = float(w_input) if w_input.ndim == 0 else None
+    # Validate eagerly: a non-positive or non-finite weight is a broken
+    # discretization, and it should fail at wiring time, not mid-Picard.
+    w_array = validate_weights(
+        np.full(1, w_scalar) if w_scalar is not None else w_input,
+        "create_lions_source (finite-difference path)",
+    )
 
     def source_term_hjb(
         x: NDArray,
@@ -167,7 +249,7 @@ def create_lions_source(
         v: NDArray,
         t: float,
     ) -> NDArray:
-        """Evaluate Lions correction delta F / delta m[m](x).
+        """Evaluate the correction delta F / delta m[m](x).
 
         Args:
             x: Spatial grid points, shape (Nx,) or (Nx, d)
@@ -183,18 +265,19 @@ def create_lions_source(
         m_flat = _spatial_density(m)
         Nx = len(m_flat)
 
-        # Compute delta F / delta m at each grid point
+        # Compute dF/dm_k at each grid point
         # y_points = all grid indices (perturb at each point)
         y_indices = np.arange(Nx)
 
-        deriv = functional_derivative.compute(
+        gradient = functional_derivative.compute(
             energy_functional,
             m_flat,
             x_points=x,
             y_points=y_indices,
         )
 
-        return np.asarray(deriv).ravel()
+        w = np.full(Nx, w_scalar) if w_scalar is not None else w_array
+        return flat_derivative_from_energy_gradient(gradient, w)
 
     return source_term_hjb
 
@@ -225,7 +308,7 @@ def create_nonlocal_source(
         >>> # Gaussian interaction kernel
         >>> x = np.linspace(0, 1, 50)
         >>> W = np.exp(-((x[:, None] - x[None, :]) ** 2) / (2 * 0.1**2))
-        >>> source = create_nonlocal_source(W, dx=x[1] - x[0])
+        >>> source = create_nonlocal_source(W, grid_spacing=x[1] - x[0])
     """
     W = interaction_kernel
     dx = grid_spacing

--- a/mfgarchon/alg/numerical/coupling/lions_correction.py
+++ b/mfgarchon/alg/numerical/coupling/lions_correction.py
@@ -91,15 +91,20 @@ def create_lions_source(
 
     1. **Analytic** (Issue #1023, Phase 2): if ``energy_functional`` is an
        :class:`~mfgarchon.operators.interaction.energy_functionals.EnergyFunctional`
-       (provides ``.lions_derivative``), its exact derivative is used and the FD
-       path is skipped. ``functional_derivative`` is then ignored.
+       (provides ``.flat_derivative``), its exact derivative is used and the FD
+       path is skipped. ``functional_derivative`` is then ignored. The
+       per-slice ``t`` is forwarded to ``flat_derivative``.
     2. **Finite difference** (original path): if ``energy_functional`` is a plain
        ``F[m] -> float`` callable, ``functional_derivative`` is required and
        ``delta F / delta m`` is approximated by finite differences.
 
-    The two paths are equivalent for an ``EnergyFunctional`` whose analytic
-    derivative matches the FD gradient of its ``.energy`` (verified by tests),
-    so this extension is backward-compatible.
+    The two paths agree for an ``EnergyFunctional`` whose analytic
+    ``flat_derivative`` matches the FD gradient of its ``.energy`` **divided by
+    the quadrature weights** -- the FD engine perturbs an unweighted Dirac
+    ``m_k += epsilon``, so its output is ``w_k * (delta F / delta m)_k``. The
+    conversion has one owner,
+    :func:`~mfgarchon.operators.interaction.energy_functionals.flat_derivative_from_energy_gradient`
+    (Issue #1642 A2).
 
     Args:
         energy_functional: Either an ``EnergyFunctional`` (analytic path) or a
@@ -146,7 +151,7 @@ def create_lions_source(
         ) -> NDArray:
             """Evaluate the analytic Lions correction delta F / delta m[m](x)."""
             m_flat = _spatial_density(m)
-            return np.asarray(analytic.lions_derivative(m_flat)).ravel()
+            return np.asarray(analytic.flat_derivative(m_flat, t=t)).ravel()
 
         return source_term_hjb_analytic
 

--- a/mfgarchon/operators/interaction/__init__.py
+++ b/mfgarchon/operators/interaction/__init__.py
@@ -20,9 +20,10 @@ Contents:
     - convolution: ConvolutionCouplingOperator (LinearOperator) with FFT path
       (regular grid) and direct-quadrature path (irregular cloud).
     - energy_functionals: EnergyFunctional protocol + QuadraticInteractionEnergy,
-      PotentialEnergy, CombinedEnergy with analytic Lions derivatives.
+      PotentialEnergy, CombinedEnergy with analytic flat derivatives
+      ``delta F / delta m``.
 
-The analytic Lions derivatives plug into
+The analytic flat derivatives plug into
 ``alg.numerical.coupling.lions_correction.create_lions_source`` (Phase 2), which
 recognizes an ``EnergyFunctional`` and skips the finite-difference path.
 
@@ -36,6 +37,9 @@ from .energy_functionals import (
     EnergyFunctional,
     PotentialEnergy,
     QuadraticInteractionEnergy,
+    as_single_population,
+    flat_derivative_from_energy_gradient,
+    validate_weights,
 )
 from .kernels import (
     DipoleKernel,
@@ -61,4 +65,8 @@ __all__ = [
     "QuadraticInteractionEnergy",
     "PotentialEnergy",
     "CombinedEnergy",
+    # Contract helpers (Issue #1642 A1/A2)
+    "flat_derivative_from_energy_gradient",
+    "as_single_population",
+    "validate_weights",
 ]

--- a/mfgarchon/operators/interaction/__init__.py
+++ b/mfgarchon/operators/interaction/__init__.py
@@ -38,7 +38,9 @@ from .energy_functionals import (
     PotentialEnergy,
     QuadraticInteractionEnergy,
     as_single_population,
+    energy_functional_members,
     flat_derivative_from_energy_gradient,
+    missing_energy_functional_members,
     validate_weights,
 )
 from .kernels import (
@@ -69,4 +71,6 @@ __all__ = [
     "flat_derivative_from_energy_gradient",
     "as_single_population",
     "validate_weights",
+    "energy_functional_members",
+    "missing_energy_functional_members",
 ]

--- a/mfgarchon/operators/interaction/convolution.py
+++ b/mfgarchon/operators/interaction/convolution.py
@@ -204,9 +204,20 @@ class ConvolutionCouplingOperator(LinearOperator):
         """Return the full operator matrix ``M = W @ diag(w)`` (shape ``(N, N)``).
 
         ``F[m] = M @ m`` exactly. For a regular grid with uniform cell volume,
-        ``M = cell_volume * W`` is symmetric.
+        ``M = cell_volume * W`` is symmetric; with per-point weights it is not.
         """
         return self._dense_matrix() * self._w[None, :]
+
+    def kernel_matrix(self) -> NDArray:
+        """Return the raw kernel matrix ``W_ij = K(|x_i - x_j|)`` (shape ``(N, N)``).
+
+        Unweighted and symmetric for a radial kernel -- the quadrature factor
+        lives in :attr:`weights`, so ``as_dense() == kernel_matrix() * weights``.
+        This is the second variation ``delta^2 F / delta m^2`` of the quadratic
+        interaction energy. Returns a copy; allocates ``(N, N)`` even on the FFT
+        path, which otherwise never forms a dense matrix.
+        """
+        return self._dense_matrix().copy()
 
     @property
     def points(self) -> NDArray:
@@ -214,9 +225,15 @@ class ConvolutionCouplingOperator(LinearOperator):
         return self._points
 
     @property
-    def cell_volume(self) -> float | NDArray:
-        """Scalar cell volume (uniform weights) or per-point weight array."""
-        return self._cell_volume if self._cell_volume is not None else self._w
+    def weights(self) -> NDArray:
+        """Quadrature weights of the point set, shape ``(N,)``.
+
+        Always an array, whether the operator was built from ``spacings`` (grid
+        cell volume, uniform) or from a scalar/array ``cell_volume`` (scattered
+        cloud). The single spelling of this quantity: a scalar-vs-array
+        polymorphic accessor invites two conventions for one number.
+        """
+        return self._w
 
     @property
     def uses_fft(self) -> bool:

--- a/mfgarchon/operators/interaction/energy_functionals.py
+++ b/mfgarchon/operators/interaction/energy_functionals.py
@@ -1,30 +1,54 @@
 """
-Energy functionals with analytic Lions derivatives for measure-dependent MFG.
+Energy functionals with analytic flat derivatives for measure-dependent MFG.
 
 An :class:`EnergyFunctional` packages a coupling energy ``F[m]`` together with
-its first variation (Lions derivative) ``delta F / delta m``, computed
-*analytically* rather than by finite differences. Feeding such an object to
+its first variation ``delta F / delta m``, computed *analytically* rather than
+by finite differences. Feeding such an object to
 :func:`mfgarchon.alg.numerical.coupling.lions_correction.create_lions_source`
 selects the exact-derivative path and skips the FD approximation.
 
 Discretization convention
 --------------------------
-Densities are discrete vectors ``m`` on a point set with quadrature weights
-(cell volumes). Following the established ``lions_correction`` convention, each
-functional's :meth:`lions_derivative` returns the *pointwise* source term
-``delta F / delta m(x_k)`` that enters the HJB right-hand side, and equals the
-gradient of :meth:`energy` with respect to the unweighted entry ``m_k`` (the
-perturbation ``m -> m + epsilon delta_k`` used by
-:class:`~mfgarchon.utils.functional_calculus.FiniteDifferenceFunctionalDerivative`).
-Concretely:
+A discrete measure is the pair ``(m, weights)``: densities ``m`` sampled on a
+point set, and ``weights`` the **quadrature weights of the measure
+representation** -- cell volumes on a grid, particle masses for an empirical
+measure. On a uniform grid ``weights`` is ``prod(spacings)`` repeated; on a
+scattered GFDM cloud it is the per-point cell volume array. Integrals are
+discretized as ``integral g(x) m(x) dx = sum_k w_k g_k m_k``.
+
+Grid cell volumes sum to ``|Omega|``; particle masses are normalized to sum to
+1 (compare ``utils/functional_calculus.py`` and ``core/measure.py``, which
+normalize the two differently under the same word). Both are valid inputs here
+-- the functional never renormalizes ``weights``, it only integrates against
+them, so the two ontologies are handled by the same code path.
+
+Three related but distinct objects, and the factor that separates them:
+
+- ``energy(m)`` is the **physical** scalar ``F[m]``, mesh-independent: it
+  converges under refinement rather than scaling as ``1/h``.
+- ``flat_derivative(m)`` is the **flat** (linear-functional) derivative
+  ``delta F / delta m``, a scalar field of shape ``(N,)``. This is the object
+  that enters the HJB as a source term. It is *not* the Lions / L- /
+  Wasserstein derivative, which is ``grad_x delta F / delta m``, a vector field
+  of shape ``(N, d)``; no class here returns that.
+- The **unweighted entry gradient** ``d F / d m_k`` returned by
+  :class:`~mfgarchon.utils.functional_calculus.FiniteDifferenceFunctionalDerivative`
+  (which perturbs ``m_k += epsilon``, an unweighted Dirac) equals
+  ``w_k * (delta F / delta m)_k``.
+
+That last relation is the FD bridge, and it lives in exactly one place:
+:func:`flat_derivative_from_energy_gradient`. Anything comparing an analytic
+``flat_derivative`` against an FD gradient of ``energy`` must go through it.
+
+Concretely, for the two shipped forms:
 
 - Interaction ``F[m] = (1/2) integral integral K(x-y) m(x) m(y) dx dy`` has
-  ``delta F / delta m = K * m``, carrying one quadrature factor from the ``dy``
-  integral (already inside the convolution operator).
-- Potential ``F[m] = integral V(x) m(x) dx`` has ``delta F / delta m = V(x)``,
-  a pointwise cost with no quadrature factor.
+  ``delta F / delta m = K * m`` and ``delta^2 F / delta m^2 = K``.
+- Potential ``F[m] = integral V(x) m(x) dx`` has ``delta F / delta m = V(x)``
+  and ``delta^2 F / delta m^2 = 0``.
 
 Issue #1023: ``operators/interaction/`` subpackage (Phase 2 Lions bridge).
+Issue #1642: contract freeze (D-1..D-5) and the ``energy()`` quadrature repair.
 """
 
 from __future__ import annotations
@@ -43,52 +67,180 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class EnergyFunctional(Protocol):
-    """Protocol for coupling energies with analytic Lions derivatives.
+    """Protocol for coupling energies with analytic flat derivatives.
 
-    Implementations provide the scalar energy ``F[m]`` and its first variation
-    ``delta F / delta m[m](x)`` evaluated on the grid.
+    Frozen contract (Issue #1642 §6). Because this Protocol is
+    ``runtime_checkable``, ``isinstance`` checks member **presence only** --
+    an arity mismatch would surface as a ``TypeError`` inside a Picard
+    iteration rather than at construction. The signatures below are therefore
+    the contract; implementers must match them.
+
+    All time arguments are **keyword-only**. The source pipeline already
+    carries the true per-slice ``t`` (``source_composition.compose_hjb_source``
+    calls ``source_term_hjb(x, m, v, t)``), so non-autonomous running couplings
+    ``F_t[m]`` are expressible without a later signature break. The functionals
+    shipped in this module are autonomous and ignore ``t``.
+
+    Attributes
+    ----------
+    weights : NDArray
+        Quadrature weights of the measure representation, shape ``(N,)``: cell
+        volumes on a grid, particle masses for an empirical measure. Strictly
+        positive.
+
+    Notes
+    -----
+    ``second_variation`` is part of the required member set: a class that does
+    not define it is **not** an ``EnergyFunctional`` under ``isinstance``, even
+    though this Protocol supplies a default body. Implementers that want the
+    ``None`` default may subclass ``EnergyFunctional`` explicitly; structural
+    implementers must define all three methods and ``weights``.
+
+    These are **single-population** functionals. A stacked multi-population
+    density of length ``K*N`` is refused loudly (see
+    :func:`as_single_population`) rather than silently contracted against
+    itself.
     """
 
-    def energy(self, m: NDArray) -> float:
-        """Evaluate the coupling energy ``F[m]`` (scalar)."""
+    weights: NDArray
+
+    def energy(self, m: NDArray, *, t: float = 0.0) -> float:
+        """Evaluate the physical coupling energy ``F[m]`` (scalar)."""
         ...
 
-    def lions_derivative(self, m: NDArray) -> NDArray:
-        """Evaluate the Lions derivative ``delta F / delta m[m](x)``, shape ``(N,)``."""
+    def flat_derivative(self, m: NDArray, *, t: float = 0.0) -> NDArray:
+        """Evaluate the flat derivative ``delta F / delta m``, shape ``(N,)``."""
         ...
+
+    def second_variation(self, m: NDArray, *, t: float = 0.0) -> NDArray | None:
+        """Evaluate ``delta^2 F / delta m^2``, shape ``(N, N)``, or ``None``.
+
+        The returned kernel is the symmetric bilinear form in the *measure*
+        pairing: ``d^2/deps^2 F[m + eps nu] = sum_ij w_i nu_i S_ij w_j nu_j``.
+        The Jacobian of :meth:`flat_derivative` with respect to the unweighted
+        entries ``m_l`` is ``S * weights[None, :]`` (not symmetric when the
+        weights are non-uniform).
+
+        ``None`` means "not available for this functional", not "zero".
+        """
+        return None
+
+
+def validate_weights(weights: NDArray, owner: str) -> NDArray:
+    """Return ``weights`` as a validated 1-D float array.
+
+    Quadrature weights must be finite and strictly positive: the FD bridge
+    divides by them (:func:`flat_derivative_from_energy_gradient`) and a zero
+    or negative cell volume is a broken discretization, not a degenerate case
+    to absorb.
+    """
+    w = np.asarray(weights, dtype=float).ravel()
+    if w.size == 0:
+        raise ValueError(f"{owner}: weights must be non-empty")
+    if not np.all(np.isfinite(w)):
+        raise ValueError(f"{owner}: weights must be finite, got non-finite entries")
+    if not np.all(w > 0.0):
+        raise ValueError(f"{owner}: quadrature weights must be strictly positive, got min {w.min()!r}")
+    return w
+
+
+def as_single_population(m: NDArray, weights: NDArray, owner: str) -> NDArray:
+    """Return ``m`` as a flat single-population density, or refuse loudly.
+
+    Issue #1642 D-5. ``EnergyFunctional`` is single-population by decision. A
+    stacked ``(K*N,)`` multi-population density is a caller error, and the
+    refusal has to be explicit: without it, some functionals contract a stacked
+    array against a broadcastable operand and return a plausible number.
+    """
+    arr = np.asarray(m, dtype=float).ravel()
+    if arr.shape != weights.shape:
+        raise ValueError(
+            f"{owner} is a single-population functional: expected a density of shape "
+            f"({weights.size},) matching its quadrature weights, got shape {arr.shape}. "
+            "A stacked multi-population density (K*N,) is not supported here -- split it "
+            "per population and combine the per-population energies explicitly "
+            "(see MultiPopulationMFGProblem; Issue #1642 D-5)."
+        )
+    return arr
+
+
+def flat_derivative_from_energy_gradient(gradient: NDArray, weights: NDArray) -> NDArray:
+    """Convert an unweighted entry gradient ``d F / d m_k`` to ``delta F / delta m``.
+
+    The single owner of the quadrature factor between the two derivative
+    conventions (Issue #1642 A2). :class:`FiniteDifferenceFunctionalDerivative`
+    perturbs ``m_k += epsilon`` -- an *unweighted* Dirac -- so its output is
+    ``d F / d m_k = w_k * (delta F / delta m)_k``. Dividing by ``w_k`` here, and
+    only here, keeps the two conventions from forking.
+
+    Parameters
+    ----------
+    gradient : NDArray
+        Entry gradient ``d F / d m_k``, shape ``(N,)``.
+    weights : NDArray
+        Quadrature weights, shape ``(N,)``, strictly positive.
+
+    Returns
+    -------
+    NDArray
+        The flat derivative ``delta F / delta m``, shape ``(N,)``.
+    """
+    w = validate_weights(weights, "flat_derivative_from_energy_gradient")
+    g = np.asarray(gradient, dtype=float).ravel()
+    if g.shape != w.shape:
+        raise ValueError(f"gradient shape {g.shape} does not match weights shape {w.shape}")
+    return g / w
 
 
 class QuadraticInteractionEnergy:
-    """Quadratic interaction energy ``F[m] = (1/2) <m, K * m>``.
+    """Quadratic interaction energy ``F[m] = (1/2) integral integral K(x-y) m(x) m(y) dx dy``.
 
     Wraps a :class:`~mfgarchon.operators.interaction.convolution.ConvolutionCouplingOperator`
-    ``F_op`` so that
+    ``F_op`` (which applies ``F_op @ m = W @ (m * w)``, carrying the ``dy``
+    quadrature weight) so that
 
-        energy(m)           = (1/2) * m . (F_op @ m)
-        lions_derivative(m) = F_op @ m  = (K * m)(x).
+        energy(m)            = (1/2) * sum_k w_k m_k (F_op @ m)_k
+        flat_derivative(m)   = F_op @ m  = (K * m)(x)
+        second_variation(m)  = W         (the raw kernel matrix, symmetric)
 
-    The convolution operator carries the ``dy`` quadrature weight, so the
-    derivative is the discrete ``delta F / delta m``. The analytic derivative
-    matches the unweighted finite-difference gradient of :meth:`energy` when the
-    operator matrix is symmetric (uniform cell volume), which holds on regular
-    grids and for a scalar ``cell_volume``.
+    The outer ``dx`` weight in ``energy`` is what makes the value physical: it
+    converges under refinement instead of scaling as ``1/h``.
 
     Parameters
     ----------
     convolution_operator : ConvolutionCouplingOperator
-        The interaction convolution ``F_op[m] = integral K(x-y) m(y) dy``.
+        The interaction convolution ``F_op[m] = integral K(x-y) m(y) dy``. Its
+        ``weights`` become this functional's quadrature weights.
     """
 
     def __init__(self, convolution_operator: ConvolutionCouplingOperator):
         self._conv = convolution_operator
+        self._w = validate_weights(convolution_operator.weights, "QuadraticInteractionEnergy")
 
-    def energy(self, m: NDArray) -> float:
-        m = np.asarray(m, dtype=float).ravel()
-        return 0.5 * float(np.dot(m, self._conv @ m))
+    @property
+    def weights(self) -> NDArray:
+        """Quadrature weights of the measure representation, shape ``(N,)``."""
+        return self._w
 
-    def lions_derivative(self, m: NDArray) -> NDArray:
-        m = np.asarray(m, dtype=float).ravel()
-        return np.asarray(self._conv @ m, dtype=float)
+    def energy(self, m: NDArray, *, t: float = 0.0) -> float:
+        """Physical interaction energy ``F[m]`` (autonomous: ``t`` is ignored)."""
+        arr = as_single_population(m, self._w, "QuadraticInteractionEnergy")
+        return 0.5 * float(np.dot(self._w * arr, self._conv @ arr))
+
+    def flat_derivative(self, m: NDArray, *, t: float = 0.0) -> NDArray:
+        """``delta F / delta m = (K * m)(x)`` (autonomous: ``t`` is ignored)."""
+        arr = as_single_population(m, self._w, "QuadraticInteractionEnergy")
+        return np.asarray(self._conv @ arr, dtype=float)
+
+    def second_variation(self, m: NDArray, *, t: float = 0.0) -> NDArray:
+        """``delta^2 F / delta m^2 = K(x - y)``, the raw kernel matrix, shape ``(N, N)``.
+
+        Independent of ``m`` (the energy is quadratic). Allocates a dense
+        ``(N, N)`` array, including on the FFT path where the operator itself
+        never forms one.
+        """
+        as_single_population(m, self._w, "QuadraticInteractionEnergy")
+        return self._conv.kernel_matrix()
 
     def __repr__(self) -> str:
         return f"QuadraticInteractionEnergy({self._conv!r})"
@@ -97,31 +249,56 @@ class QuadraticInteractionEnergy:
 class PotentialEnergy:
     """Linear potential energy ``F[m] = integral V(x) m(x) dx``.
 
-    With a fixed potential field ``V`` sampled on the grid,
+    With a fixed potential field ``V`` sampled on the point set,
 
-        energy(m)           = V . m
-        lions_derivative(m) = V   (independent of m).
+        energy(m)            = sum_k w_k V_k m_k
+        flat_derivative(m)   = V   (independent of m)
+        second_variation(m)  = 0   (shape (N, N))
 
     ``V`` is the pointwise cost an agent pays for occupying ``x`` (cost-signed:
-    positive ``V`` repels). The discrete ``energy`` is the generating functional
-    whose unweighted gradient is the pointwise source ``V(x)``; multiply by the
-    cell volume to recover the physical integral ``integral V m dx``.
+    positive ``V`` repels).
 
     Parameters
     ----------
     potential : NDArray
-        Potential field ``V`` sampled on the grid, shape ``(N,)``.
+        Potential field ``V`` sampled on the point set, shape ``(N,)``.
+    weights : NDArray
+        Quadrature weights of the measure representation, shape ``(N,)`` (or a
+        scalar cell volume, broadcast to ``(N,)``). Required -- a default would
+        silently substitute a mesh-independent number for a mesh-dependent one.
     """
 
-    def __init__(self, potential: NDArray):
+    def __init__(self, potential: NDArray, weights: NDArray | float):
         self._V = np.asarray(potential, dtype=float).ravel()
+        w = np.asarray(weights, dtype=float)
+        if w.ndim == 0:
+            w = np.full(self._V.shape, float(w))
+        self._w = validate_weights(w, "PotentialEnergy")
+        if self._w.shape != self._V.shape:
+            raise ValueError(
+                f"PotentialEnergy: weights shape {self._w.shape} does not match potential shape {self._V.shape}"
+            )
 
-    def energy(self, m: NDArray) -> float:
-        m = np.asarray(m, dtype=float).ravel()
-        return float(np.dot(self._V, m))
+    @property
+    def weights(self) -> NDArray:
+        """Quadrature weights of the measure representation, shape ``(N,)``."""
+        return self._w
 
-    def lions_derivative(self, m: NDArray) -> NDArray:
+    def energy(self, m: NDArray, *, t: float = 0.0) -> float:
+        """Physical potential energy ``F[m]`` (autonomous: ``t`` is ignored)."""
+        arr = as_single_population(m, self._w, "PotentialEnergy")
+        return float(np.dot(self._w * self._V, arr))
+
+    def flat_derivative(self, m: NDArray, *, t: float = 0.0) -> NDArray:
+        """``delta F / delta m = V(x)`` (autonomous: ``t`` is ignored)."""
+        as_single_population(m, self._w, "PotentialEnergy")
         return self._V.copy()
+
+    def second_variation(self, m: NDArray, *, t: float = 0.0) -> NDArray:
+        """``delta^2 F / delta m^2 = 0``, shape ``(N, N)``. Identically zero (F is linear)."""
+        as_single_population(m, self._w, "PotentialEnergy")
+        n = self._V.size
+        return np.zeros((n, n), dtype=float)
 
     def __repr__(self) -> str:
         return f"PotentialEnergy(V shape={self._V.shape})"
@@ -130,34 +307,75 @@ class PotentialEnergy:
 class CombinedEnergy:
     """Sum of energy functionals ``F[m] = sum_k F_k[m]``.
 
-    Energy and Lions derivative are additive:
+    Energy, flat derivative and second variation are all additive:
 
-        energy(m)           = sum_k F_k.energy(m)
-        lions_derivative(m) = sum_k F_k.lions_derivative(m).
+        energy(m)            = sum_k F_k.energy(m)
+        flat_derivative(m)   = sum_k F_k.flat_derivative(m)
+        second_variation(m)  = sum_k F_k.second_variation(m)
 
     Used to combine a repulsive interaction with a central attractive potential
     (towel-on-the-beach): ``CombinedEnergy([interaction, potential])``.
 
+    All components must carry the same quadrature weights: summing energies
+    discretized against different measures is meaningless, and the mismatch
+    would otherwise show up as a wrong number rather than an error.
+
     Parameters
     ----------
     components : Sequence[EnergyFunctional]
-        Energy functionals to sum. Must be non-empty and act on the same grid.
+        Energy functionals to sum. Must be non-empty and share the same
+        ``weights``.
     """
+
+    _WEIGHT_RTOL = 1e-12
 
     def __init__(self, components: Sequence[EnergyFunctional]):
         comps = list(components)
         if not comps:
             raise ValueError("CombinedEnergy requires at least one component")
+        w0 = validate_weights(comps[0].weights, "CombinedEnergy")
+        for i, c in enumerate(comps[1:], start=1):
+            wi = np.asarray(c.weights, dtype=float).ravel()
+            if wi.shape != w0.shape or not np.allclose(wi, w0, rtol=self._WEIGHT_RTOL, atol=0.0):
+                raise ValueError(
+                    f"CombinedEnergy components must share the same quadrature weights: "
+                    f"component 0 ({comps[0]!r}) has weights of shape {w0.shape}, "
+                    f"component {i} ({c!r}) has weights of shape {wi.shape} that differ. "
+                    "Summing energies discretized against different measures is not defined."
+                )
         self._components = comps
+        self._w = w0
 
-    def energy(self, m: NDArray) -> float:
-        return float(sum(c.energy(m) for c in self._components))
+    @property
+    def weights(self) -> NDArray:
+        """Quadrature weights shared by all components, shape ``(N,)``."""
+        return self._w
 
-    def lions_derivative(self, m: NDArray) -> NDArray:
-        m = np.asarray(m, dtype=float).ravel()
-        total = np.zeros_like(m)
+    def energy(self, m: NDArray, *, t: float = 0.0) -> float:
+        """Sum of component energies (``t`` forwarded to each component)."""
+        return float(sum(c.energy(m, t=t) for c in self._components))
+
+    def flat_derivative(self, m: NDArray, *, t: float = 0.0) -> NDArray:
+        """Sum of component flat derivatives (``t`` forwarded to each component)."""
+        arr = as_single_population(m, self._w, "CombinedEnergy")
+        total = np.zeros_like(arr)
         for c in self._components:
-            total = total + np.asarray(c.lions_derivative(m), dtype=float).ravel()
+            total = total + np.asarray(c.flat_derivative(arr, t=t), dtype=float).ravel()
+        return total
+
+    def second_variation(self, m: NDArray, *, t: float = 0.0) -> NDArray | None:
+        """Sum of component second variations, or ``None`` if any component lacks one.
+
+        ``None`` propagates: a partial sum would be a wrong operator, not a
+        degraded one.
+        """
+        arr = as_single_population(m, self._w, "CombinedEnergy")
+        total = np.zeros((arr.size, arr.size), dtype=float)
+        for c in self._components:
+            part = c.second_variation(arr, t=t)
+            if part is None:
+                return None
+            total = total + np.asarray(part, dtype=float)
         return total
 
     def __repr__(self) -> str:

--- a/mfgarchon/operators/interaction/energy_functionals.py
+++ b/mfgarchon/operators/interaction/energy_functionals.py
@@ -86,7 +86,9 @@ class EnergyFunctional(Protocol):
     weights : NDArray
         Quadrature weights of the measure representation, shape ``(N,)``: cell
         volumes on a grid, particle masses for an empirical measure. Strictly
-        positive.
+        positive, and **read-only** -- the array the shipped classes expose is
+        frozen (``writeable=False``) so that a caller cannot reach into operator
+        internals through the public member (see :func:`validate_weights`).
 
     Notes
     -----
@@ -127,21 +129,55 @@ class EnergyFunctional(Protocol):
 
 
 def validate_weights(weights: NDArray, owner: str) -> NDArray:
-    """Return ``weights`` as a validated 1-D float array.
+    """Return ``weights`` as a validated, read-only 1-D float array.
 
     Quadrature weights must be finite and strictly positive: the FD bridge
     divides by them (:func:`flat_derivative_from_energy_gradient`) and a zero
     or negative cell volume is a broken discretization, not a degenerate case
     to absorb.
+
+    The returned array is a **copy with ``writeable=False``**. ``weights`` is a
+    public Protocol member, so returning ``np.asarray(...).ravel()`` -- a *view*
+    for an already-float64 contiguous input -- published a mutable alias into
+    operator internals: ``E.weights[0] = 99.0`` reached
+    ``conv.as_dense()[0, 0]`` and silently defeated the strict-positivity
+    guarantee validated here. Freezing turns that into a loud
+    ``ValueError: assignment destination is read-only``.
     """
-    w = np.asarray(weights, dtype=float).ravel()
+    w = np.array(weights, dtype=float).ravel()
     if w.size == 0:
         raise ValueError(f"{owner}: weights must be non-empty")
     if not np.all(np.isfinite(w)):
         raise ValueError(f"{owner}: weights must be finite, got non-finite entries")
     if not np.all(w > 0.0):
         raise ValueError(f"{owner}: quadrature weights must be strictly positive, got min {w.min()!r}")
+    w.flags.writeable = False
     return w
+
+
+_ABSENT = object()
+
+
+def energy_functional_members() -> tuple[str, ...]:
+    """Return the required :class:`EnergyFunctional` member names, sorted.
+
+    Read off the Protocol itself, so the diagnostic in
+    :func:`missing_energy_functional_members` cannot drift from the contract
+    when a member is added or removed.
+    """
+    return tuple(sorted(EnergyFunctional.__protocol_attrs__))
+
+
+def missing_energy_functional_members(obj: object) -> tuple[str, ...]:
+    """Return the required :class:`EnergyFunctional` members ``obj`` lacks, sorted.
+
+    Empty means ``obj`` satisfies the Protocol structurally. A *non-empty but
+    proper* subset is the dangerous case -- a near-miss that ``isinstance``
+    rejects wholesale, so a dispatcher can silently fall through to a different
+    code path. Callers use this to name the missing members instead of guessing
+    (Issue #1642 D-6).
+    """
+    return tuple(n for n in energy_functional_members() if getattr(obj, n, _ABSENT) is _ABSENT)
 
 
 def as_single_population(m: NDArray, weights: NDArray, owner: str) -> NDArray:

--- a/tests/integration/test_interaction_lions_bridge.py
+++ b/tests/integration/test_interaction_lions_bridge.py
@@ -3,8 +3,14 @@
 Issue #1023, Phase 2.
 
 Gate 3 (lions-bridge equivalence): create_lions_source with an EnergyFunctional
-produces the same HJB source as the hand-rolled energy(m)-lambda + FD path and
-the optimized create_nonlocal_source path (backward compatibility).
+produces the same HJB source as the FD path fed that functional's OWN
+``.energy``, and as the optimized create_nonlocal_source path. Feeding the FD
+branch a re-derived lambda instead is what let a ``w``-factor fork between the
+two branches pass this gate.
+
+Also pinned here: the per-slice ``t`` reaching the functional (D-3 transport,
+not merely arity), and the loud refusal of a near-miss EnergyFunctional (D-6)
+that would otherwise be silently downgraded to the FD path.
 
 Gate 4 (ring-equilibrium demo): a coupled HJB-FP solve with a repulsive
 interaction kernel plus a central attractive potential depletes the centre and
@@ -65,6 +71,14 @@ class TestGate3LionsBridgeEquivalence:
         np.testing.assert_allclose(r_analytic, r_nonlocal, atol=1e-12)
 
     def test_analytic_matches_fd_lambda_path(self):
+        """The two branches of create_lions_source agree on ONE energy object.
+
+        The FD branch is fed ``energy.energy`` itself, not a hand-rolled lambda:
+        a re-derived scalar can silently encode a different quadrature
+        convention than the functional it is supposed to mirror, which is
+        exactly how a ``w``-factor fork between the two branches stayed
+        invisible to this gate.
+        """
         N = 60
         x = np.linspace(0.0, 1.0, N)
         dx = x[1] - x[0]
@@ -74,15 +88,9 @@ class TestGate3LionsBridgeEquivalence:
         energy = QuadraticInteractionEnergy(conv)
         source_analytic = create_lions_source(energy)
 
-        # Legacy path: hand-rolled energy lambda + finite-difference derivative.
-        W = kernel.matrix(x)
-
-        def energy_lambda(m):
-            m = m.ravel()
-            return 0.5 * np.sum(m * (W @ m)) * dx
-
+        # FD path: the SAME energy object as a plain F[m] -> float callable.
         fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
-        source_fd = create_lions_source(energy_lambda, fd)
+        source_fd = create_lions_source(energy.energy, fd, weights=energy.weights)
 
         m = np.sin(np.pi * x) + 1.2
         v = np.zeros(N)
@@ -90,6 +98,79 @@ class TestGate3LionsBridgeEquivalence:
         r_fd = source_fd(x, m, v, 0.0)
         rel = np.max(np.abs(r_analytic - r_fd)) / np.max(np.abs(r_analytic))
         assert rel < 1e-6
+
+    def test_fd_path_matches_a_user_written_physical_energy(self):
+        """A user's own F[m] -> float, byte-identical to energy.energy, agrees too.
+
+        Guards the convention from the outside: the FD branch must not require
+        the caller to pre-divide by the mesh. ``F_physical`` is the textbook
+        double quadrature, and the source it yields is the pointwise
+        ``delta F / delta m``, not ``w * delta F / delta m``.
+        """
+        N = 60
+        x = np.linspace(0.0, 1.0, N)
+        dx = x[1] - x[0]
+        kernel = GaussianKernel(amplitude=1.3, length_scale=0.1)
+        conv = ConvolutionCouplingOperator(kernel, grid_shape=(N,), spacings=[dx], use_fft=False)
+        energy = QuadraticInteractionEnergy(conv)
+        W = kernel.matrix(x)
+
+        def f_physical(m):
+            m = np.asarray(m).ravel()
+            # F[m] = (1/2) sum_ij w_i w_j W_ij m_i m_j -- BOTH quadrature factors.
+            return 0.5 * float(np.sum(m * (W @ m))) * dx**2
+
+        m = np.sin(np.pi * x) + 1.2
+        assert f_physical(m) == pytest.approx(energy.energy(m), rel=1e-12)
+
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
+        source_user = create_lions_source(f_physical, fd, weights=dx)
+        r_user = source_user(x, m, np.zeros(N), 0.0)
+        r_analytic = create_lions_source(energy)(x, m, np.zeros(N), 0.0)
+        rel = np.max(np.abs(r_analytic - r_user)) / np.max(np.abs(r_analytic))
+        assert rel < 1e-6
+
+    def test_fd_path_refuses_without_weights(self):
+        """No default weights: assuming w = 1 forks the two branches by w."""
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
+
+        def energy_lambda(m):
+            return 0.5 * float(np.sum(np.asarray(m) ** 2)) * 0.02
+
+        with pytest.raises(ValueError, match=r"weights= is required on the finite-difference path"):
+            create_lions_source(energy_lambda, fd)
+
+    def test_analytic_path_refuses_redundant_weights(self):
+        """An EnergyFunctional carries its own weights; a second set is refused."""
+        N = 20
+        dx = 1.0 / (N - 1)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        energy = QuadraticInteractionEnergy(conv)
+        with pytest.raises(ValueError, match=r"weights= is for the finite-difference path only"):
+            create_lions_source(energy, weights=dx)
+
+    def test_fd_path_refuses_non_positive_weights(self):
+        """A zero or negative cell volume is a broken discretization, not a case to absorb."""
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
+
+        def energy_lambda(m):
+            return float(np.sum(np.asarray(m)))
+
+        with pytest.raises(ValueError, match=r"strictly positive"):
+            create_lions_source(energy_lambda, fd, weights=0.0)
+        with pytest.raises(ValueError, match=r"strictly positive"):
+            create_lions_source(energy_lambda, fd, weights=np.array([0.1, -0.1, 0.1]))
+
+    def test_fd_path_refuses_weights_of_the_wrong_length(self):
+        """A weights/density length mismatch must not broadcast into a wrong number."""
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
+
+        def energy_lambda(m):
+            return 0.5 * float(np.sum(np.asarray(m) ** 2)) * 0.02
+
+        source = create_lions_source(energy_lambda, fd, weights=np.full(7, 0.02))
+        with pytest.raises(ValueError, match=r"does not match weights shape"):
+            source(np.linspace(0, 1, 10), np.ones(10), np.zeros(10), 0.0)
 
     def test_fd_path_requires_functional_derivative(self):
         """Backward compat: plain callable without FD instance raises clearly."""
@@ -126,6 +207,180 @@ class TestGate3LionsBridgeEquivalence:
             source(x, m_traj, np.zeros(N), 0.0)
         with pytest.raises(ValueError, match=r"1-D spatial density"):
             source_nonlocal(x, m_traj, np.zeros(N), 0.0)
+
+
+class _TimeStampedEnergy:
+    """Non-autonomous probe functional: ``F_t[m] = t * sum_k w_k m_k``.
+
+    Every shipped functional is autonomous, so no shipped test can observe the
+    per-slice ``t`` arriving. This one encodes ``t`` in its return values *and*
+    records what it was handed, so dropping ``t=t`` anywhere along the transport
+    chain is a wrong number, not an invisible default.
+    """
+
+    def __init__(self, weights, scale=1.0):
+        self._w = np.asarray(weights, dtype=float).ravel()
+        self._scale = float(scale)
+        self.seen_energy: list[float] = []
+        self.seen_flat: list[float] = []
+        self.seen_second: list[float] = []
+
+    @property
+    def weights(self):
+        return self._w
+
+    def energy(self, m, *, t=0.0):
+        self.seen_energy.append(float(t))
+        return self._scale * float(t) * float(np.sum(self._w * np.asarray(m).ravel()))
+
+    def flat_derivative(self, m, *, t=0.0):
+        self.seen_flat.append(float(t))
+        return np.full(self._w.shape, self._scale * float(t))
+
+    def second_variation(self, m, *, t=0.0):
+        self.seen_second.append(float(t))
+        return np.full((self._w.size, self._w.size), self._scale * float(t))
+
+
+class TestD3TimeTransport:
+    """The per-slice ``t`` reaches the functional -- not merely is accepted.
+
+    ``create_lions_source`` and ``CombinedEnergy`` both forward ``t``. Because
+    the three shipped functionals ignore it, arity pins alone leave the
+    *transport* unobserved: dropping ``t=t`` at either hop silently substitutes
+    the ``t=0.0`` default.
+    """
+
+    def test_analytic_dispatch_forwards_t(self):
+        N = 12
+        w = np.full(N, 0.05)
+        probe = _TimeStampedEnergy(w)
+        source = create_lions_source(probe)
+
+        x = np.linspace(0.0, 1.0, N)
+        m = np.ones(N)
+        r = source(x, m, np.zeros(N), 2.5)
+
+        assert probe.seen_flat == [2.5]
+        np.testing.assert_allclose(r, np.full(N, 2.5), rtol=0, atol=0)
+
+    def test_analytic_dispatch_t_is_not_a_constant(self):
+        """Two different slices must give two different sources."""
+        N = 8
+        probe = _TimeStampedEnergy(np.full(N, 0.125))
+        source = create_lions_source(probe)
+        x = np.linspace(0.0, 1.0, N)
+        m = np.ones(N)
+
+        r0 = source(x, m, np.zeros(N), 0.0)
+        r1 = source(x, m, np.zeros(N), 1.0)
+        r2 = source(x, m, np.zeros(N), 3.0)
+
+        np.testing.assert_allclose(r0, np.zeros(N), rtol=0, atol=0)
+        np.testing.assert_allclose(r1, np.ones(N), rtol=0, atol=0)
+        np.testing.assert_allclose(r2, np.full(N, 3.0), rtol=0, atol=0)
+        assert probe.seen_flat == [0.0, 1.0, 3.0]
+
+    def test_combined_energy_forwards_t_to_every_component(self):
+        N = 6
+        w = np.full(N, 0.2)
+        a = _TimeStampedEnergy(w, scale=1.0)
+        b = _TimeStampedEnergy(w, scale=10.0)
+        combined = CombinedEnergy([a, b])
+        m = np.ones(N)
+
+        # energy: t * (1 + 10) * sum_k w_k m_k
+        assert combined.energy(m, t=2.0) == pytest.approx(2.0 * 11.0 * float(np.sum(w)))
+        assert a.seen_energy == [2.0]
+        assert b.seen_energy == [2.0]
+
+        np.testing.assert_allclose(combined.flat_derivative(m, t=3.0), np.full(N, 3.0 * 11.0), rtol=0, atol=0)
+        assert a.seen_flat == [3.0]
+        assert b.seen_flat == [3.0]
+
+        np.testing.assert_allclose(combined.second_variation(m, t=4.0), np.full((N, N), 4.0 * 11.0), rtol=0, atol=0)
+        assert a.seen_second == [4.0]
+        assert b.seen_second == [4.0]
+
+    def test_t_survives_dispatch_and_delegation_together(self):
+        """End-to-end: source_term_hjb(x, m, v, t) -> CombinedEnergy -> component."""
+        N = 5
+        w = np.full(N, 0.25)
+        a = _TimeStampedEnergy(w, scale=2.0)
+        b = _TimeStampedEnergy(w, scale=5.0)
+        source = create_lions_source(CombinedEnergy([a, b]))
+
+        r = source(np.linspace(0.0, 1.0, N), np.ones(N), np.zeros(N), 1.75)
+
+        np.testing.assert_allclose(r, np.full(N, 1.75 * 7.0), rtol=0, atol=0)
+        assert a.seen_flat == [1.75]
+        assert b.seen_flat == [1.75]
+
+
+class _NearMissEnergy:
+    """Provides three of the four required members, and is callable.
+
+    The callable-ness is the dangerous part: without an explicit refusal it
+    satisfies the FD branch's duck test and takes that path, so its exact
+    ``flat_derivative`` is never called and nothing reports it.
+    """
+
+    def __init__(self, weights):
+        self._w = np.asarray(weights, dtype=float).ravel()
+        self.flat_derivative_calls = 0
+
+    @property
+    def weights(self):
+        return self._w
+
+    def energy(self, m, *, t=0.0):
+        return float(np.sum(self._w * np.asarray(m).ravel()))
+
+    def flat_derivative(self, m, *, t=0.0):
+        self.flat_derivative_calls += 1
+        return np.full(self._w.shape, 999.0)
+
+    def __call__(self, m):
+        return self.energy(m)
+
+
+class TestNearMissRefusedLoudly:
+    """A partial EnergyFunctional is refused, not silently downgraded (D-6)."""
+
+    def test_callable_near_miss_is_refused_and_names_the_missing_member(self):
+        N = 10
+        probe = _NearMissEnergy(np.full(N, 0.1))
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
+
+        with pytest.raises(TypeError) as excinfo:
+            create_lions_source(probe, fd, weights=0.1)
+
+        message = str(excinfo.value)
+        assert "second_variation" in message
+        assert "_NearMissEnergy" in message
+        for provided in ("energy", "flat_derivative", "weights"):
+            assert provided in message
+        # The silent path is what we are refusing: it never called this.
+        assert probe.flat_derivative_calls == 0
+
+    def test_near_miss_is_refused_on_the_analytic_call_too(self):
+        """Refusal does not depend on the caller having supplied an FD engine."""
+        probe = _NearMissEnergy(np.full(4, 0.25))
+        with pytest.raises(TypeError, match=r"second_variation"):
+            create_lions_source(probe)
+
+    def test_plain_callable_is_still_accepted(self):
+        """The refusal must not swallow the legitimate FD path."""
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
+        source = create_lions_source(lambda m: 0.5 * float(np.sum(np.asarray(m) ** 2)) * 0.1, fd, weights=0.1)
+        m = np.linspace(1.0, 2.0, 8)
+        np.testing.assert_allclose(source(np.linspace(0, 1, 8), m, np.zeros(8), 0.0), m, rtol=1e-6)
+
+    def test_non_callable_non_functional_is_refused_with_a_diagnostic(self):
+        """Was an undiagnostic 'object is not callable' from deep inside the FD engine."""
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
+        with pytest.raises(TypeError, match=r"is not callable"):
+            create_lions_source(object(), fd, weights=0.1)
 
 
 def _ring_problem(grid_only=False, amp=5.0, length_scale=0.15, bowl=4.0):

--- a/tests/integration/test_interaction_lions_bridge.py
+++ b/tests/integration/test_interaction_lions_bridge.py
@@ -155,7 +155,7 @@ def _ring_problem(grid_only=False, amp=5.0, length_scale=0.15, bowl=4.0):
     )
     g = problem.geometry.get_spatial_grid().ravel()
     dx = g[1] - g[0]
-    potential = PotentialEnergy(bowl * (g - 0.5) ** 2)  # attractive bowl (cost away from centre)
+    potential = PotentialEnergy(bowl * (g - 0.5) ** 2, dx)  # attractive bowl (cost away from centre)
     if grid_only:
         energy = potential
     else:

--- a/tests/integration/test_lions_correction.py
+++ b/tests/integration/test_lions_correction.py
@@ -60,7 +60,7 @@ class TestCreateLionsSource:
         def energy(m):
             return 0.5 * np.sum(m**2) * 0.02
 
-        source = create_lions_source(energy, fd)
+        source = create_lions_source(energy, fd, weights=0.02)
         assert callable(source)
 
     def test_source_signature(self):
@@ -70,7 +70,7 @@ class TestCreateLionsSource:
         def energy(m):
             return 0.5 * np.sum(m**2) * 0.02
 
-        source = create_lions_source(energy, fd)
+        source = create_lions_source(energy, fd, weights=0.02)
         x = np.linspace(0, 1, 50)
         m = np.ones(50) / 50
         v = np.zeros(50)
@@ -80,26 +80,50 @@ class TestCreateLionsSource:
         assert result.shape == (50,)
 
     def test_quadratic_functional_derivative(self):
-        """For F[m] = (1/2) int m^2 dx, delta F/delta m = m * dx."""
+        """For F[m] = (1/2) int m^2 dx, delta F/delta m = m(x).
+
+        The source slot holds the *pointwise* flat derivative. The FD engine
+        returns dF/dm_k = w_k * m_k (it perturbs an unweighted Dirac); the
+        bridge divides the quadrature weight back out.
+        """
         Nx = 50
         dx = 1.0 / Nx
         fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4, method="central")
 
         def energy(m):
+            # F[m] = (1/2) int m^2 dx = (1/2) sum_k w_k m_k^2
             return 0.5 * np.sum(m**2) * dx
 
-        source = create_lions_source(energy, fd)
+        source = create_lions_source(energy, fd, weights=dx)
         x = np.linspace(0, 1, Nx)
         m = np.ones(Nx) * 2.0  # uniform density = 2
 
         result = source(x, m, np.zeros(Nx), 0.0)
 
-        # Analytical: delta F/delta m[m](x_i) = m(x_i) * dx = 2 * dx
-        expected = m * dx
+        # Analytical: delta F/delta m[m](x_i) = m(x_i) = 2
+        expected = m
         np.testing.assert_allclose(result, expected, rtol=1e-2)
 
+    def test_quadratic_functional_derivative_is_mesh_independent(self):
+        """delta F/delta m = m(x) converges under refinement, it does not scale as h.
+
+        A source carrying a spurious w_k factor would shrink by 2x per halving
+        of dx here -- the failure mode is silent weakening of the coupling.
+        """
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-6, method="central")
+        for Nx in (25, 50, 100, 200):
+            dx = 1.0 / Nx
+
+            def energy(m, _dx=dx):
+                return 0.5 * np.sum(m**2) * _dx
+
+            source = create_lions_source(energy, fd, weights=dx)
+            m = np.full(Nx, 2.0)
+            result = source(np.linspace(0, 1, Nx), m, np.zeros(Nx), 0.0)
+            np.testing.assert_allclose(result, 2.0, rtol=1e-4)
+
     def test_linear_functional_derivative(self):
-        """For F[m] = int V(x) m(x) dx, delta F/delta m = V(x) * dx."""
+        """For F[m] = int V(x) m(x) dx, delta F/delta m = V(x)."""
         Nx = 50
         dx = 1.0 / Nx
         fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4, method="central")
@@ -108,16 +132,40 @@ class TestCreateLionsSource:
         V = np.sin(np.pi * x)
 
         def energy(m):
+            # F[m] = int V m dx = sum_k w_k V_k m_k
             return np.sum(V * m) * dx
 
-        source = create_lions_source(energy, fd)
+        source = create_lions_source(energy, fd, weights=dx)
         m = np.ones(Nx)
 
         result = source(x, m, np.zeros(Nx), 0.0)
 
-        # Analytical: delta F/delta m = V(x_i) * dx
-        expected = V * dx
+        # Analytical: delta F/delta m = V(x_i)
+        expected = V
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-10)
+
+    def test_non_uniform_weights_are_not_a_scalar_dx(self):
+        """Per-point weights must be divided out entrywise, not by a mean.
+
+        Discriminating fixture: w.max()/w.min() > 5, so a scalar-mean "repair"
+        of the quadrature factor fails while the entrywise one passes.
+        """
+        Nx = 40
+        rng = np.random.default_rng(1642)
+        w = 0.01 + 0.09 * rng.random(Nx)  # spread ~ 10x
+        assert w.max() / w.min() > 5.0
+        V = np.cos(3.0 * np.linspace(0, 1, Nx)) + 2.0
+
+        def energy(m):
+            return float(np.sum(w * V * np.asarray(m).ravel()))
+
+        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-7, method="central")
+        source = create_lions_source(energy, fd, weights=w)
+        result = source(np.linspace(0, 1, Nx), np.ones(Nx), np.zeros(Nx), 0.0)
+
+        np.testing.assert_allclose(result, V, rtol=1e-6)
+        # The scalar-mean pseudo-repair would have produced this instead.
+        assert not np.allclose(result, (w * V) / w.mean(), rtol=1e-3)
 
 
 class TestCreateNonlocalSource:
@@ -162,7 +210,12 @@ class TestCreateNonlocalSource:
         np.testing.assert_allclose(result, result[::-1], atol=1e-6)
 
     def test_matches_lions_source(self):
-        """Nonlocal source should match create_lions_source for same kernel."""
+        """Nonlocal source should match create_lions_source for same kernel.
+
+        Both sides are the pointwise delta F/delta m of the *physical*
+        F[m] = (1/2) int int W m m dx dy = (1/2) sum_ij w_i w_j W_ij m_i m_j,
+        which carries BOTH quadrature factors.
+        """
         Nx = 30
         dx = 1.0 / Nx
         x = np.linspace(0, 1, Nx)
@@ -176,9 +229,9 @@ class TestCreateNonlocalSource:
         fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-4, method="central")
 
         def energy(m):
-            return 0.5 * np.sum(m * (W @ m)) * dx
+            return 0.5 * np.sum(m * (W @ m)) * dx**2
 
-        source_fd = create_lions_source(energy, fd)
+        source_fd = create_lions_source(energy, fd, weights=dx)
 
         m = np.sin(np.pi * x) + 1.5
 

--- a/tests/unit/test_operators/test_interaction_energy.py
+++ b/tests/unit/test_operators/test_interaction_energy.py
@@ -1,8 +1,22 @@
-"""Tests for interaction energy functionals (Issue #1023).
+"""Tests for interaction energy functionals (Issues #1023, #1642).
 
-Gate 2 (analytic vs FD derivative): QuadraticInteractionEnergy.lions_derivative
-equals the finite-difference gradient of its .energy (within FD tolerance),
-proving delta F / delta m = K * m.
+Three groups, each pinning a distinct failure:
+
+* **Gate 2 / A2 bridge** -- ``flat_derivative`` equals the FD entry gradient of
+  ``.energy`` *divided by the quadrature weights*. Catches either side of the
+  pair drifting: a missing ``dx`` in ``energy``, a spurious one in
+  ``flat_derivative``, or the bridge factor being applied twice / not at all.
+  On the non-uniform grids below a scalar-``dx`` repair does **not** pass.
+* **A2 physicality** -- ``energy()`` converges under refinement instead of
+  scaling as ``1/h``. Catches the regression directly, without reference to any
+  derivative.
+* **A1 contract freeze** -- keyword-only ``t``, the ``weights`` member, the
+  ``second_variation`` slot, and the loud single-population refusal. Catches a
+  silent arity/membership change to the ``runtime_checkable`` Protocol.
+
+Non-uniform weights (A3) are exercised throughout: every pre-#1642 test built a
+uniform ``linspace`` grid, but ``ConvolutionCouplingOperator(cell_volume=<array>)``
+is a shipped constructor for scattered GFDM clouds.
 """
 
 from __future__ import annotations
@@ -17,14 +31,45 @@ from mfgarchon.operators.interaction.energy_functionals import (
     EnergyFunctional,
     PotentialEnergy,
     QuadraticInteractionEnergy,
+    as_single_population,
+    flat_derivative_from_energy_gradient,
+    validate_weights,
 )
 from mfgarchon.operators.interaction.kernels import GaussianKernel, WendlandKernel
 from mfgarchon.utils.functional_calculus import FiniteDifferenceFunctionalDerivative
 
 
 def _grid(N):
+    """Uniform grid: points and the scalar cell volume."""
     x = np.linspace(0.0, 1.0, N)
     return x, x[1] - x[0]
+
+
+def _uniform_weights(N):
+    x, dx = _grid(N)
+    return x, np.full(N, dx)
+
+
+def _scattered(N, seed=0):
+    """Scattered 1-D cloud with genuinely non-uniform trapezoid cell volumes.
+
+    Weights vary by more than an order of magnitude across the cloud, so a
+    scalar-``dx`` convention cannot accidentally satisfy the weighted pins.
+    """
+    rng = np.random.default_rng(seed)
+    pts = np.sort(rng.uniform(0.0, 1.0, N))
+    w = np.empty(N)
+    w[0] = (pts[1] - pts[0]) / 2.0
+    w[-1] = (pts[-1] - pts[-2]) / 2.0
+    w[1:-1] = (pts[2:] - pts[:-2]) / 2.0
+    return pts, w
+
+
+def _fd_flat_derivative(energy_fn, m, weights, epsilon=1e-5):
+    """FD entry gradient of ``energy_fn`` routed through the single bridge owner."""
+    fd = FiniteDifferenceFunctionalDerivative(epsilon=epsilon, method="central")
+    gradient = fd.compute(energy_fn, m, x_points=None, y_points=np.arange(len(m)))
+    return flat_derivative_from_energy_gradient(gradient, weights)
 
 
 class TestProtocolConformance:
@@ -34,75 +79,428 @@ class TestProtocolConformance:
         assert isinstance(QuadraticInteractionEnergy(conv), EnergyFunctional)
 
     def test_potential_is_energy_functional(self):
-        assert isinstance(PotentialEnergy(np.ones(20)), EnergyFunctional)
+        _, w = _uniform_weights(20)
+        assert isinstance(PotentialEnergy(np.ones(20), w), EnergyFunctional)
 
     def test_combined_is_energy_functional(self):
-        assert isinstance(CombinedEnergy([PotentialEnergy(np.ones(20))]), EnergyFunctional)
+        _, w = _uniform_weights(20)
+        assert isinstance(CombinedEnergy([PotentialEnergy(np.ones(20), w)]), EnergyFunctional)
+
+    def test_protocol_requires_all_frozen_members(self):
+        """A1: the frozen member set is {weights, energy, flat_derivative, second_variation}.
+
+        ``runtime_checkable`` checks presence only, so this is the only place the
+        membership is asserted. A near-miss implementation must NOT satisfy
+        ``isinstance`` -- ``create_lions_source`` dispatches on exactly this
+        check, and a false positive would call a method that does not exist
+        inside a Picard iteration.
+        """
+
+        class MissingSecondVariation:
+            weights = np.ones(3)
+
+            def energy(self, m, *, t=0.0):
+                return 0.0
+
+            def flat_derivative(self, m, *, t=0.0):
+                return np.zeros(3)
+
+        class MissingWeights:
+            def energy(self, m, *, t=0.0):
+                return 0.0
+
+            def flat_derivative(self, m, *, t=0.0):
+                return np.zeros(3)
+
+            def second_variation(self, m, *, t=0.0):
+                return None
+
+        class Complete(MissingSecondVariation):
+            def second_variation(self, m, *, t=0.0):
+                return None
+
+        assert not isinstance(MissingSecondVariation(), EnergyFunctional)
+        assert not isinstance(MissingWeights(), EnergyFunctional)
+        assert isinstance(Complete(), EnergyFunctional)
+
+    def test_subclassing_protocol_supplies_default_second_variation(self):
+        """Implementers may inherit the ``None`` default by subclassing explicitly."""
+
+        class Inherited(EnergyFunctional):
+            weights = np.ones(3)
+
+            def energy(self, m, *, t=0.0):
+                return 0.0
+
+            def flat_derivative(self, m, *, t=0.0):
+                return np.zeros(3)
+
+        obj = Inherited()
+        assert obj.second_variation(np.ones(3)) is None
+        assert isinstance(obj, EnergyFunctional)
+
+    @pytest.mark.parametrize("method", ["energy", "flat_derivative", "second_variation"])
+    @pytest.mark.parametrize("which", ["quadratic", "potential", "combined"])
+    def test_t_is_keyword_only(self, method, which):
+        """D-3: ``t`` is keyword-only on every method of every shipped class, so
+        a positional third argument (e.g. a caller passing ``x``) fails at the
+        call site instead of being silently bound to ``t``.
+
+        Parametrized over all three classes: a per-class arity drift is exactly
+        what ``runtime_checkable`` cannot see -- ``isinstance`` checks member
+        presence only, so a positional ``t`` on one implementer would surface as
+        a ``TypeError`` inside a Picard iteration, not at construction.
+        """
+        N = 12
+        x, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        inter = QuadraticInteractionEnergy(conv)
+        pot = PotentialEnergy(np.cos(x), conv.weights)
+        energy = {"quadratic": inter, "potential": pot, "combined": CombinedEnergy([inter, pot])}[which]
+
+        m = np.ones(N)
+        getattr(energy, method)(m, t=0.5)  # keyword form works
+        with pytest.raises(TypeError):
+            getattr(energy, method)(m, 0.5)
 
 
 class TestGate2AnalyticVsFD:
-    """delta F / delta m analytic == finite-difference gradient of the energy."""
+    """``flat_derivative`` == FD entry gradient of ``energy`` / weights."""
 
     @pytest.mark.parametrize("kernel", [GaussianKernel(1.3, 0.1), WendlandKernel(2.0, 0.25)])
-    def test_quadratic_interaction_derivative(self, kernel):
+    def test_quadratic_interaction_derivative_uniform(self, kernel):
         N = 60
         x, dx = _grid(N)
         conv = ConvolutionCouplingOperator(kernel, grid_shape=(N,), spacings=[dx], use_fft=False)
         energy = QuadraticInteractionEnergy(conv)
         m = np.sin(np.pi * x) + 1.2
 
-        analytic = energy.lions_derivative(m)
-        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
-        numeric = fd.compute(energy.energy, m, x_points=None, y_points=np.arange(N))
-
+        analytic = energy.flat_derivative(m)
+        numeric = _fd_flat_derivative(energy.energy, m, energy.weights)
         rel = np.max(np.abs(analytic - numeric)) / np.max(np.abs(analytic))
         assert rel < 1e-6
 
-    def test_potential_derivative(self):
+    @pytest.mark.parametrize("kernel", [GaussianKernel(1.3, 0.1), WendlandKernel(2.0, 0.25)])
+    def test_quadratic_interaction_derivative_nonuniform(self, kernel):
+        """A3: same pin on a scattered cloud with per-point cell volumes."""
+        N = 60
+        pts, w = _scattered(N)
+        assert w.max() / w.min() > 5.0, "cloud not non-uniform enough to discriminate"
+        conv = ConvolutionCouplingOperator(kernel, points=pts, cell_volume=w)
+        energy = QuadraticInteractionEnergy(conv)
+        m = np.sin(np.pi * pts) + 1.2
+
+        analytic = energy.flat_derivative(m)
+        numeric = _fd_flat_derivative(energy.energy, m, energy.weights)
+        rel = np.max(np.abs(analytic - numeric)) / np.max(np.abs(analytic))
+        assert rel < 1e-6
+
+    def test_potential_derivative_uniform(self):
         N = 40
-        x, _ = _grid(N)
+        x, w = _uniform_weights(N)
         V = np.cos(2 * np.pi * x)
-        energy = PotentialEnergy(V)
+        energy = PotentialEnergy(V, w)
         m = np.abs(np.sin(np.pi * x)) + 0.5
 
-        analytic = energy.lions_derivative(m)
-        np.testing.assert_allclose(analytic, V, atol=1e-14)
+        np.testing.assert_allclose(energy.flat_derivative(m), V, atol=1e-14)
+        numeric = _fd_flat_derivative(energy.energy, m, energy.weights)
+        np.testing.assert_allclose(V, numeric, rtol=1e-6, atol=1e-7)
 
-        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
-        numeric = fd.compute(energy.energy, m, x_points=None, y_points=np.arange(N))
-        np.testing.assert_allclose(analytic, numeric, atol=1e-7)
+    def test_potential_derivative_nonuniform(self):
+        """A3: ``delta F / delta m = V`` has no quadrature factor even when the
+        weights vary -- the FD entry gradient is ``w_k V_k`` and only the bridge
+        removes the ``w_k``."""
+        N = 40
+        pts, w = _scattered(N, seed=3)
+        V = np.cos(2 * np.pi * pts)
+        energy = PotentialEnergy(V, w)
+        m = np.abs(np.sin(np.pi * pts)) + 0.5
+
+        np.testing.assert_allclose(energy.flat_derivative(m), V, atol=1e-14)
+        numeric = _fd_flat_derivative(energy.energy, m, energy.weights)
+        np.testing.assert_allclose(V, numeric, rtol=1e-5, atol=1e-7)
 
     def test_combined_derivative_is_additive(self):
         N = 50
         x, dx = _grid(N)
         conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.12), grid_shape=(N,), spacings=[dx])
         inter = QuadraticInteractionEnergy(conv)
-        pot = PotentialEnergy(3.0 * (x - 0.5) ** 2)
+        pot = PotentialEnergy(3.0 * (x - 0.5) ** 2, conv.weights)
         combined = CombinedEnergy([inter, pot])
         m = np.exp(-((x - 0.5) ** 2) / 0.05)
 
         np.testing.assert_allclose(
-            combined.lions_derivative(m),
-            inter.lions_derivative(m) + pot.lions_derivative(m),
+            combined.flat_derivative(m),
+            inter.flat_derivative(m) + pot.flat_derivative(m),
             atol=1e-12,
         )
         assert combined.energy(m) == pytest.approx(inter.energy(m) + pot.energy(m))
 
-    def test_combined_derivative_vs_fd(self):
+    def test_combined_derivative_vs_fd_nonuniform(self):
+        """A3: the additive pin on a scattered cloud."""
         N = 50
-        x, dx = _grid(N)
-        conv = ConvolutionCouplingOperator(GaussianKernel(1.5, 0.12), grid_shape=(N,), spacings=[dx], use_fft=False)
-        combined = CombinedEnergy([QuadraticInteractionEnergy(conv), PotentialEnergy(3.0 * (x - 0.5) ** 2)])
-        m = np.exp(-((x - 0.5) ** 2) / 0.05) + 0.3
+        pts, w = _scattered(N, seed=7)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.5, 0.12), points=pts, cell_volume=w)
+        combined = CombinedEnergy([QuadraticInteractionEnergy(conv), PotentialEnergy(3.0 * (pts - 0.5) ** 2, w)])
+        m = np.exp(-((pts - 0.5) ** 2) / 0.05) + 0.3
 
-        analytic = combined.lions_derivative(m)
-        fd = FiniteDifferenceFunctionalDerivative(epsilon=1e-5, method="central")
-        numeric = fd.compute(combined.energy, m, x_points=None, y_points=np.arange(N))
+        analytic = combined.flat_derivative(m)
+        numeric = _fd_flat_derivative(combined.energy, m, combined.weights)
         rel = np.max(np.abs(analytic - numeric)) / np.max(np.abs(analytic))
         assert rel < 1e-6
 
 
-class TestEnergyValues:
+class TestA2PhysicalQuadrature:
+    """``energy()`` is the physical integral, not the integral over a cell volume."""
+
+    @staticmethod
+    def _reference_quadratic(kernel, pts, w, m):
+        W = kernel.matrix(pts)
+        return 0.5 * float((m * w) @ W @ (m * w))
+
+    def test_quadratic_energy_matches_double_quadrature_nonuniform(self):
+        N = 80
+        pts, w = _scattered(N, seed=11)
+        kernel = GaussianKernel(1.3, 0.1)
+        conv = ConvolutionCouplingOperator(kernel, points=pts, cell_volume=w)
+        energy = QuadraticInteractionEnergy(conv)
+        m = np.exp(-((pts - 0.5) ** 2) / 0.02) + 0.3
+
+        reference = self._reference_quadratic(kernel, conv.points, w, m)
+        assert energy.energy(m) == pytest.approx(reference, rel=1e-12)
+
+    def test_potential_energy_matches_weighted_sum_nonuniform(self):
+        N = 80
+        pts, w = _scattered(N, seed=13)
+        V = np.cos(2 * np.pi * pts)
+        m = np.exp(-((pts - 0.5) ** 2) / 0.02) + 0.3
+        assert PotentialEnergy(V, w).energy(m) == pytest.approx(float(np.sum(w * V * m)), rel=1e-12)
+
+    def test_energy_converges_under_refinement(self):
+        """The regression that A2 repairs, stated without any derivative.
+
+        Before the fix ``energy()`` returned ``F[m]/cell_volume``: measured
+        ratios were exactly ``1/dx`` (31, 63, 127, 255 at N=32..256), i.e. the
+        value doubled with every refinement. Now successive refinements must
+        contract toward a limit.
+        """
+        kernel = GaussianKernel(1.0, 0.1)
+
+        def m_of(x):
+            return np.exp(-((x - 0.5) ** 2) / 0.02) + 0.3
+
+        values = []
+        for N in (64, 128, 256, 512):
+            x, dx = _grid(N)
+            conv = ConvolutionCouplingOperator(kernel, grid_shape=(N,), spacings=[dx], use_fft=False)
+            values.append(QuadraticInteractionEnergy(conv).energy(m_of(x)))
+
+        diffs = np.abs(np.diff(values))
+        assert np.all(diffs[1:] < diffs[:-1]), f"not contracting: {values}"
+        assert diffs[-1] < 0.02 * abs(values[-1]), f"not converged: {values}"
+
+    def test_uniform_grid_is_the_scattered_case_with_equal_weights(self):
+        """Cross-path pin: the FFT/grid construction and the scattered
+        construction are two code paths for the same quantity. On a uniform
+        cloud they must return the same energy -- the grid path must not carry a
+        private ``cell_volume`` convention."""
+        N = 48
+        x, dx = _grid(N)
+        kernel = GaussianKernel(1.1, 0.13)
+        grid_energy = QuadraticInteractionEnergy(ConvolutionCouplingOperator(kernel, grid_shape=(N,), spacings=[dx]))
+        cloud_energy = QuadraticInteractionEnergy(
+            ConvolutionCouplingOperator(kernel, points=x, cell_volume=np.full(N, dx))
+        )
+        m = np.sin(np.pi * x) + 1.2
+        assert grid_energy.energy(m) == pytest.approx(cloud_energy.energy(m), rel=1e-10)
+
+
+class TestWeightsOntology:
+    """D-2: cell volumes (sum to |Omega|) and particle masses (sum to 1) are
+    both quadrature weights and take the same code path. One test each."""
+
+    def test_cell_volume_ontology_sums_to_domain_measure(self):
+        N = 64
+        x, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        w = conv.weights
+        assert w.sum() == pytest.approx(N * dx)
+        energy = QuadraticInteractionEnergy(conv)
+        m = np.sin(np.pi * x) + 1.2
+        numeric = _fd_flat_derivative(energy.energy, m, w)
+        rel = np.max(np.abs(energy.flat_derivative(m) - numeric)) / np.max(np.abs(energy.flat_derivative(m)))
+        assert rel < 1e-6
+
+    def test_particle_mass_ontology_sums_to_one(self):
+        """Empirical measure: weights are masses summing to 1, ``m`` is all-ones.
+
+        The bridge factor is ``w_k`` in both ontologies; nothing renormalizes.
+        """
+        rng = np.random.default_rng(5)
+        N = 40
+        pts = np.sort(rng.uniform(0.0, 1.0, N))
+        masses = rng.uniform(0.5, 2.0, N)
+        masses = masses / masses.sum()
+        assert masses.sum() == pytest.approx(1.0)
+
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.15), points=pts, cell_volume=masses)
+        energy = QuadraticInteractionEnergy(conv)
+        m = np.ones(N)
+
+        analytic = energy.flat_derivative(m)
+        numeric = _fd_flat_derivative(energy.energy, m, energy.weights)
+        rel = np.max(np.abs(analytic - numeric)) / np.max(np.abs(analytic))
+        assert rel < 1e-6
+
+        V = np.cos(2 * np.pi * pts)
+        pot = PotentialEnergy(V, masses)
+        assert pot.energy(m) == pytest.approx(float(np.sum(masses * V)))
+
+    def test_bridge_owner_is_a_plain_division(self):
+        w = np.array([0.25, 0.5, 1.0])
+        np.testing.assert_allclose(
+            flat_derivative_from_energy_gradient(np.array([1.0, 2.0, 3.0]), w),
+            np.array([4.0, 4.0, 3.0]),
+        )
+
+    def test_bridge_rejects_shape_mismatch(self):
+        with pytest.raises(ValueError, match="does not match weights shape"):
+            flat_derivative_from_energy_gradient(np.ones(4), np.ones(3))
+
+    @pytest.mark.parametrize("bad", [np.array([1.0, 0.0]), np.array([1.0, -0.5])])
+    def test_nonpositive_weights_refused(self, bad):
+        """A zero or negative cell volume is a broken discretization; the bridge
+        divides by it, so it must not reach an ``inf``."""
+        with pytest.raises(ValueError, match="strictly positive"):
+            validate_weights(bad, "test")
+
+    def test_nonfinite_weights_refused(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_weights(np.array([1.0, np.nan]), "test")
+
+
+class TestSecondVariation:
+    """D-4: the optional second-variation slot, and what it means."""
+
+    def test_quadratic_second_variation_is_the_kernel_matrix(self):
+        N = 30
+        pts, w = _scattered(N, seed=17)
+        kernel = GaussianKernel(1.2, 0.15)
+        conv = ConvolutionCouplingOperator(kernel, points=pts, cell_volume=w)
+        energy = QuadraticInteractionEnergy(conv)
+        m = np.sin(np.pi * pts) + 1.0
+
+        S = energy.second_variation(m)
+        assert S.shape == (N, N)
+        np.testing.assert_allclose(S, S.T, atol=1e-14)
+        np.testing.assert_allclose(S, kernel.matrix(conv.points), atol=1e-14)
+
+    def test_second_variation_is_jacobian_of_flat_derivative_over_weights(self):
+        """The documented relation, on non-uniform weights where it is sharp:
+        ``d(flat_derivative)_k / d m_l == S_kl * w_l``. Returning the operator
+        matrix ``W diag(w)`` instead of ``W`` (or vice versa) fails here.
+
+        ``flat_derivative`` is exactly linear in ``m`` for this functional, so a
+        unit central difference carries no truncation error and no cancellation
+        noise -- unlike a small-epsilon step, which cannot resolve the smallest
+        kernel entries."""
+        N = 24
+        pts, w = _scattered(N, seed=19)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.2, 0.15), points=pts, cell_volume=w)
+        energy = QuadraticInteractionEnergy(conv)
+        m = np.sin(np.pi * pts) + 1.0
+
+        jac = np.empty((N, N))
+        for ell in range(N):
+            e = np.zeros(N)
+            e[ell] = 0.5
+            jac[:, ell] = energy.flat_derivative(m + e) - energy.flat_derivative(m - e)
+
+        np.testing.assert_allclose(jac, energy.second_variation(m) * w[None, :], rtol=1e-10, atol=1e-14)
+
+    def test_potential_second_variation_is_zero(self):
+        N = 15
+        x, w = _uniform_weights(N)
+        S = PotentialEnergy(np.cos(x), w).second_variation(np.ones(N))
+        assert S.shape == (N, N)
+        np.testing.assert_array_equal(S, np.zeros((N, N)))
+
+    def test_combined_second_variation_is_additive(self):
+        N = 20
+        x, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.12), grid_shape=(N,), spacings=[dx])
+        inter = QuadraticInteractionEnergy(conv)
+        pot = PotentialEnergy(3.0 * (x - 0.5) ** 2, conv.weights)
+        m = np.ones(N)
+        np.testing.assert_allclose(
+            CombinedEnergy([inter, pot]).second_variation(m),
+            inter.second_variation(m) + pot.second_variation(m),
+            atol=1e-14,
+        )
+
+    def test_combined_second_variation_none_propagates(self):
+        """A component without a second variation makes the sum unavailable, not
+        partial: a partial sum is a wrong operator silently offered as a right one."""
+        N = 10
+        x, w = _uniform_weights(N)
+
+        class NoSecondVariation:
+            weights = w
+
+            def energy(self, m, *, t=0.0):
+                return 0.0
+
+            def flat_derivative(self, m, *, t=0.0):
+                return np.zeros(N)
+
+            def second_variation(self, m, *, t=0.0):
+                return None
+
+        combined = CombinedEnergy([PotentialEnergy(np.cos(x), w), NoSecondVariation()])
+        assert combined.second_variation(np.ones(N)) is None
+
+
+class TestSinglePopulationRefusal:
+    """D-5: a stacked (K*N,) multi-population density is refused loudly."""
+
+    @staticmethod
+    def _functionals(N):
+        x, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        inter = QuadraticInteractionEnergy(conv)
+        pot = PotentialEnergy(np.cos(x), conv.weights)
+        return [inter, pot, CombinedEnergy([inter, pot])]
+
+    @pytest.mark.parametrize("method", ["energy", "flat_derivative", "second_variation"])
+    def test_stacked_density_refused_on_every_method(self, method):
+        N = 20
+        stacked = np.concatenate([np.ones(N), 2.0 * np.ones(N)])
+        for f in self._functionals(N):
+            with pytest.raises(ValueError, match="single-population functional"):
+                getattr(f, method)(stacked)
+
+    def test_potential_flat_derivative_no_longer_silently_returns_v(self):
+        """The one method that used to accept a stacked array and return a
+        wrong-length, plausible answer: ``PotentialEnergy.flat_derivative``
+        ignored ``m`` entirely and returned ``V.copy()``."""
+        N = 20
+        x, w = _uniform_weights(N)
+        pot = PotentialEnergy(np.cos(x), w)
+        with pytest.raises(ValueError, match=r"got shape \(40,\)"):
+            pot.flat_derivative(np.ones(2 * N))
+
+    def test_refusal_names_the_expected_shape(self):
+        N = 12
+        x, w = _uniform_weights(N)
+        with pytest.raises(ValueError, match=r"expected a density of shape \(12,\)"):
+            PotentialEnergy(np.cos(x), w).energy(np.ones(7))
+
+    def test_as_single_population_accepts_matching_shape(self):
+        w = np.ones(4)
+        np.testing.assert_array_equal(as_single_population([1, 2, 3, 4], w, "test"), np.arange(1, 5))
+
+
+class TestConstruction:
     def test_quadratic_energy_nonnegative_for_repulsive(self):
         """For a positive-definite kernel, F[m] = (1/2)<m, K*m> >= 0."""
         N = 64
@@ -115,3 +513,64 @@ class TestEnergyValues:
     def test_combined_requires_components(self):
         with pytest.raises(ValueError):
             CombinedEnergy([])
+
+    def test_combined_refuses_mismatched_weights(self):
+        """Summing energies discretized against different measures is not
+        defined; before the freeze it produced a number."""
+        N = 20
+        x, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        wrong = PotentialEnergy(np.cos(x), np.full(N, 2.0 * dx))
+        with pytest.raises(ValueError, match="same quadrature weights"):
+            CombinedEnergy([QuadraticInteractionEnergy(conv), wrong])
+
+    def test_combined_refuses_mismatched_weight_length(self):
+        N = 20
+        x, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        short = PotentialEnergy(np.cos(x[:10]), np.full(10, dx))
+        with pytest.raises(ValueError, match="same quadrature weights"):
+            CombinedEnergy([QuadraticInteractionEnergy(conv), short])
+
+    def test_potential_requires_weights(self):
+        """No default: a silent unit cell volume would reintroduce exactly the
+        mesh-dependence A2 removes."""
+        with pytest.raises(TypeError):
+            PotentialEnergy(np.ones(10))
+
+    def test_potential_scalar_weight_broadcasts(self):
+        N = 10
+        pot = PotentialEnergy(np.ones(N), 0.1)
+        assert pot.weights.shape == (N,)
+        assert pot.energy(np.ones(N)) == pytest.approx(1.0)
+
+    def test_potential_refuses_weight_shape_mismatch(self):
+        with pytest.raises(ValueError, match="does not match potential shape"):
+            PotentialEnergy(np.ones(10), np.ones(7))
+
+    def test_operator_weights_is_always_an_array(self):
+        """``ConvolutionCouplingOperator.weights`` is the single spelling of the
+        quadrature weight, an ``(N,)`` array on both construction routes."""
+        N = 16
+        x, dx = _grid(N)
+        grid_op = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        cloud_op = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), points=x, cell_volume=dx)
+        for op in (grid_op, cloud_op):
+            assert op.weights.shape == (N,)
+            np.testing.assert_allclose(op.weights, dx)
+
+    def test_kernel_matrix_times_weights_is_as_dense(self):
+        """Pins the two matrix accessors against each other: ``as_dense`` is the
+        operator ``W diag(w)``, ``kernel_matrix`` the unweighted ``W``."""
+        N = 18
+        pts, w = _scattered(N, seed=23)
+        op = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.12), points=pts, cell_volume=w)
+        np.testing.assert_allclose(op.kernel_matrix() * w[None, :], op.as_dense(), atol=1e-15)
+
+    def test_kernel_matrix_returns_a_copy(self):
+        N = 8
+        _, dx = _grid(N)
+        op = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        first = op.kernel_matrix()
+        first[0, 0] = 12345.0
+        assert op.kernel_matrix()[0, 0] != 12345.0

--- a/tests/unit/test_operators/test_interaction_energy.py
+++ b/tests/unit/test_operators/test_interaction_energy.py
@@ -32,7 +32,9 @@ from mfgarchon.operators.interaction.energy_functionals import (
     PotentialEnergy,
     QuadraticInteractionEnergy,
     as_single_population,
+    energy_functional_members,
     flat_derivative_from_energy_gradient,
+    missing_energy_functional_members,
     validate_weights,
 )
 from mfgarchon.operators.interaction.kernels import GaussianKernel, WendlandKernel
@@ -377,6 +379,75 @@ class TestWeightsOntology:
     def test_nonfinite_weights_refused(self):
         with pytest.raises(ValueError, match="finite"):
             validate_weights(np.array([1.0, np.nan]), "test")
+
+    def test_validated_weights_are_read_only_and_not_an_alias(self):
+        """``weights`` is public contract surface; it must not alias operator internals.
+
+        ``np.asarray(w).ravel()`` is a *view* for a float64 contiguous input, so
+        the pre-fix accessor published a live handle: ``E.weights[0] = 99``
+        reached ``conv.as_dense()[0, 0]``, changed the energy by ~70x, and
+        defeated the strict-positivity guarantee validated at construction.
+        """
+        source = np.full(6, 0.25)
+        w = validate_weights(source, "test")
+        assert not w.flags.writeable
+        assert not np.shares_memory(w, source)
+        with pytest.raises(ValueError, match="read-only"):
+            w[0] = 99.0
+
+    @pytest.mark.parametrize("build", ["quadratic", "potential", "combined"])
+    def test_public_weights_member_cannot_corrupt_the_owner(self, build):
+        N = 24
+        x, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        potential = PotentialEnergy(np.cos(np.pi * x), np.full(N, dx))
+        energy = {
+            "quadratic": lambda: QuadraticInteractionEnergy(conv),
+            "potential": lambda: potential,
+            "combined": lambda: CombinedEnergy([QuadraticInteractionEnergy(conv), potential]),
+        }[build]()
+
+        m = np.sin(np.pi * x) + 1.2
+        before = energy.energy(m)
+
+        assert not np.shares_memory(energy.weights, conv.weights)
+        with pytest.raises(ValueError, match="read-only"):
+            energy.weights[0] = 99.0
+
+        assert energy.energy(m) == pytest.approx(before, rel=0, abs=0)
+        assert conv.as_dense()[0, 0] == pytest.approx(conv.kernel_matrix()[0, 0] * dx)
+
+
+class TestContractMembership:
+    """D-6: the required member set is introspectable, so a near-miss can be named."""
+
+    def test_member_set_matches_the_frozen_contract(self):
+        assert energy_functional_members() == ("energy", "flat_derivative", "second_variation", "weights")
+
+    def test_shipped_classes_are_missing_nothing(self):
+        N = 12
+        _, dx = _grid(N)
+        conv = ConvolutionCouplingOperator(GaussianKernel(1.0, 0.1), grid_shape=(N,), spacings=[dx])
+        potential = PotentialEnergy(np.ones(N), np.full(N, dx))
+        for obj in (QuadraticInteractionEnergy(conv), potential, CombinedEnergy([potential])):
+            assert missing_energy_functional_members(obj) == ()
+
+    def test_near_miss_names_exactly_what_is_absent(self):
+        class ThreeOfFour:
+            weights = np.ones(3)
+
+            def energy(self, m, *, t=0.0):
+                return 0.0
+
+            def flat_derivative(self, m, *, t=0.0):
+                return np.zeros(3)
+
+        assert missing_energy_functional_members(ThreeOfFour()) == ("second_variation",)
+        assert not isinstance(ThreeOfFour(), EnergyFunctional)
+
+    def test_unrelated_object_is_missing_everything(self):
+        assert missing_energy_functional_members(object()) == energy_functional_members()
+        assert missing_energy_functional_members(lambda m: 0.0) == energy_functional_members()
 
 
 class TestSecondVariation:


### PR DESCRIPTION
Stage 1 unit **A-protocol-and-quadrature** of the #1642 design-space map:
capabilities **A1** (protocol-arity-freeze), **A2** (energy-quadrature-convention),
**A3** (quadrature-nonuniform-pin). Contract decisions D-1 through D-5 of §6.

## Verified before changing anything

**A2 is real.** `energy()` returned `F[m]/cell_volume`. Measured against the
double quadrature `0.5 * dx^2 * m' W m`, refinement study, Gaussian kernel:

| N | dx | `energy()` | physical `F[m]` | ratio | 1/dx |
|---|---|---|---|---|---|
| 32 | 0.032258 | 1.479763 | 0.047734 | 31.0000 | 31.0000 |
| 64 | 0.015873 | 2.995156 | 0.047542 | 63.0000 | 63.0000 |
| 128 | 0.007874 | 6.026120 | 0.047450 | **127.0000** | 127.0000 |
| 256 | 0.003922 | 12.088134 | 0.047404 | 255.0000 | 255.0000 |
| 512 | 0.001957 | 24.212204 | 0.047382 | 511.0000 | 511.0000 |

The physical value converges; the reported value scaled as `1/h`. Confirms the
issue's "exactly 127.0x at N=128" and shows it is the quadrature factor, not a
coincidence at one resolution. `PotentialEnergy.energy` had the same defect
(same ratios).

**The live path was already correct — this changes urgency, not correctness.**
`create_lions_source`'s analytic branch calls only the first variation. On a
scattered cloud with per-point trapezoid cell volumes (N=60), the analytic
derivative reproduces the physical `delta F/delta m` to **0.0 relative error**
(bit-identical; the issue reported 1.6e-16). `.energy()` still has zero
functional consumers. **A2 is an internal pair-consistency repair.** Nothing
that any solver produces today was wrong.

## What changed

`EnergyFunctional` frozen (`@runtime_checkable`, so `isinstance` checks member
presence only — signatures are contract, not enforcement):

```python
@runtime_checkable
class EnergyFunctional(Protocol):
    weights: NDArray
    def energy(self, m, *, t=0.0) -> float: ...
    def flat_derivative(self, m, *, t=0.0) -> NDArray: ...          # (N,)
    def second_variation(self, m, *, t=0.0) -> NDArray | None: ...  # (N, N) or None
```

- **D-1** `lions_derivative` -> `flat_derivative`. Returns the flat derivative
  `delta F/delta m`, shape `(N,)`; the Lions/Wasserstein derivative is its
  gradient, shape `(N, d)`. Shapes differ, so this is a contract question.
  One production consumer (`lions_correction.py`, the analytic dispatch) and its tests updated. No shim.
- **D-2** weights ontology documented: *quadrature weights of the measure
  representation — cell volumes on a grid, particle masses for an empirical
  measure*. Neither is renormalized; both take the same code path. One test each.
- **D-3** `t` added, keyword-only, on all three methods, and now actually
  forwarded from `source_term_hjb(x, m, v, t)` instead of discarded.
- **D-4** `second_variation` slot, default `None`. Defined as the symmetric flat
  kernel `delta^2 F/delta m(x) delta m(y)`, so Quadratic returns the **raw**
  kernel matrix `W` (not `W diag(w)`); the Jacobian of `flat_derivative` w.r.t.
  the unweighted entries is `second_variation * weights[None, :]`. Symmetry is
  what makes the Lasry–Lions operator form well-posed, and the two differ
  exactly when weights are non-uniform — pinned.
- **D-5** single-population, refused loudly with the expected shape in the message.

`flat_derivative_from_energy_gradient(gradient, weights)` is the single owner of
the factor between the two derivative conventions. `ConvolutionCouplingOperator`
gains `weights` (always `(N,)`) and `kernel_matrix()`; the polymorphic
scalar-or-array `cell_volume` property is removed (zero callers) — one name for
one number. The `cell_volume=` constructor keyword is unchanged.

**Breaking:** `PotentialEnergy(potential)` -> `PotentialEnergy(potential, weights)`.
Weights are required; a default would be a silent-default-substitutes-for-a-real-
quantity bug of exactly the kind A2 removes.

## Q2 (open question on the issue): RETRACTED and answered the other way

**The first version of this PR claimed Q2 was resolved without a public-signature
change, and that "the public wiring changes once, not twice". That claim was
false, and the review was right to block on it.** The design half was fine — the
FD *engine* should not carry measure ontology, and it still does not. But the
conversion has to happen somewhere, and naming
`flat_derivative_from_energy_gradient` "the single owner of the factor" while
never calling it in production left the two branches of `create_lions_source`
disagreeing by exactly `w`:

| | analytic[:2] | FD-path[:2] | ratio | agree? |
|---|---|---|---|---|
| `origin/main` | `[0.24816268 0.28301075]` | `[0.24816266 0.28301066]` | 1.0000000518 | yes |
| this PR, before the fix | `[0.24816268 0.28301075]` | `[0.00420615 0.00479679]` | `0.016949153` = `dx` | **no** |
| this PR, after the fix | `[0.24816268 0.28301075]` | `[0.24816268 0.28301075]` | 1.0000000003 | yes |

The HJB slot holds a pointwise cost; the FD branch was emitting
`w_k · δF/δm`, so the interaction coupling weakened under refinement with no
error. Pre-PR the two branches shared one convention (main's `energy()` was the
"generating functional whose unweighted gradient is the pointwise source"); A2
changed one and left the other. Introduced here, fixed here.

**The bridge is now applied in the FD branch, and that branch learns the
weights.** `create_lions_source` gains a keyword-only `weights=`:

```python
create_lions_source(energy_functional)                        # analytic; weights= refused
create_lions_source(F, fd, weights=dx)                        # FD; scalar cell volume
create_lions_source(F, fd, weights=w)                         # FD; (N,) array
```

Required, not defaulted: `w = 1` is precisely what reintroduces the fork, and a
silent default substituting for a real measure-dependent quantity is the bug
class A2 exists to remove. `weights=` alongside an `EnergyFunctional` is refused
too — it already carries them, and a second set is a second source of one
quantity. The FD engine's own signature is unchanged, so the part of the Q2
argument that was about *ownership* stands; the part that was about *count of
public wiring changes* does not. **The public wiring changes twice.**

Post-fix, the FD-branch source converges under refinement instead of scaling
with the mesh (`N` = 60/120/240/480, same energy): `0.70109532`, `0.70117819`,
`0.70119850`, `0.70120352`.

## One stated convention, everywhere

The repo previously pinned two contradictory conventions for the same HJB slot.
Reconciled to the physical/pointwise one:

- `tests/integration/test_interaction_lions_bridge.py` — Gate 3 now feeds the FD
  branch `energy.energy` **itself**, not a hand-rolled `0.5 * Σ m (W@m) * dx`
  lambda. The lambda silently encoded a one-`dx` quadrature where the functional
  it mirrors uses two; that is how the fork passed this gate. A second test
  pins a user-written `F_physical` that is byte-identical to `energy.energy`.
- `tests/integration/test_lions_correction.py:83/98/102/119` — asserted the
  source is `w · δF/δm`; now `δF/δm` (`m`, not `m * dx`; `V`, not `V * dx`), with
  a refinement test that would catch a spurious `w` factor as a 2× shrink per
  halving of `dx`, and a non-uniform-weights test (`w.max()/w.min() > 5`) that a
  scalar-mean repair fails.
- `test_matches_lions_source` — the energy lambda now carries both quadrature
  factors, matching `create_nonlocal_source`, which was already correct.
- `lions_correction.py:136` said `returns delta F / delta m = m(x) * dx` while
  `:101-107` said the FD gradient must be divided by the weights. The `* dx` is
  gone; the module docstring now states the convention once, including the
  Usage example at `:37` that wrote the one-`dx` form.

## D-3: `t` transport is now pinned, not just its arity

The reviewer demonstrated by mutation that dropping `t=t` at the dispatch site
or in `CombinedEnergy`'s delegation was invisible: all three shipped functionals
are autonomous, so no shipped test could observe `t` arriving. M10 pinned that
`t` is *accepted* (keyword-only), never that it *is used*.

Added `_TimeStampedEnergy`, a non-autonomous probe with `F_t[m] = t · Σ w_k m_k`
that both records the `t` it is handed and encodes it in its return values, so a
dropped `t=t` is a wrong number rather than a silent `t=0.0` default. Asserted
through the production `create_lions_source` dispatch, through `CombinedEnergy`
for all three methods, and end-to-end through both hops together.

## D-6: a near-miss `EnergyFunctional` is refused, not downgraded

Deferring this was wrong — this PR doubled the required member set from 2 to 4
and was already editing the dispatch function. Confirmed both cases: a plain
near-miss raised an undiagnostic `TypeError: object is not callable` from inside
the FD engine; a near-miss that is *also callable* silently took the FD path
with its exact `flat_derivative` never called.

The dispatch site now distinguishes "not an `EnergyFunctional` at all" from "an
almost-`EnergyFunctional`" and names what is absent:

```
create_lions_source: NearMiss provides ['energy', 'flat_derivative', 'weights']
but is missing ['second_variation'], so it is not an EnergyFunctional. Refusing
rather than falling through to the finite-difference path, which would never
call its exact flat_derivative. ...
```

The member set is read off the Protocol itself via
`energy_functional_members()` / `missing_energy_functional_members(obj)`, so the
diagnostic cannot drift from the contract; a unit test pins the set.

## Finding 3: `weights` no longer leaks a mutable alias

`validate_weights` did `np.asarray(w, float).ravel()` — a *view* for an
already-float64 contiguous array — and `weights` is now a required Protocol
member on four public classes. `E.weights[0] = 99.0` reached
`conv.as_dense()[0,0]`, changed the energy by ~70×, and silently defeated the
strict-positivity precondition the bridge documents. It now returns a frozen
copy: the same assignment raises
`ValueError: assignment destination is read-only`. One owner, so all four
classes are covered; pinned per class, matching the `kernel_matrix()` copy test.

## Evidence

Gates at the review-fix head (`3b8c4f4d`):

- Full CI-shaped suite: **5247 passed, 27 skipped, 4 xfailed, 2 xpassed** (280s).
  Was 5224 at the reviewed head; +23 tests.
- `ruff check` full ruleset on all 7 touched files **including `tests/`**: all
  checks passed. `ruff check --select F mfgarchon/` (CI form): passed.
- `ruff format --check mfgarchon/`: 457 files already formatted; touched files
  incl. tests: 7 already formatted.
- `check_fail_fast.py --path mfgarchon --check-baseline`: `OK: no new violations`
  (hasattr 129, silent_pass 95, bare_except 0, broad_except 114).
- `collate_changelog.py --check`: fragments OK.

**Second mutation round, on the review fixes** — 9 mutations plus a control, each
asserted applied (match count >= 1 **and** sha256 changed) before its verdict was
believed, each restored byte-identical:

| # | Mutation | Verdict |
|---|---|---|
| MU-A | drop the weight division in the FD branch (the Blocker-1 defect itself) | CAUGHT |
| MU-B | analytic dispatch drops `t=t` (reviewer's MU-1, previously escaped) | CAUGHT |
| MU-C | `CombinedEnergy.energy` discards `t` (reviewer's MU-3) | CAUGHT |
| MU-D | `CombinedEnergy.flat_derivative` discards `t` (reviewer's MU-4) | CAUGHT |
| MU-E | `CombinedEnergy.second_variation` discards `t` | CAUGHT |
| MU-F | `validate_weights` returns a live view again (reviewer's MU-5) | CAUGHT |
| MU-G | `validate_weights` does not freeze the array | CAUGHT |
| MU-H | near-miss refusal removed (silent downgrade to the FD path) | CAUGHT |
| MU-I | FD path silently defaults `weights` to 1 instead of refusing | CAUGHT |
| MU-J | *control*: algebraic reorder in `PotentialEnergy.energy` | ESCAPED (correct) |

The control escaping is what makes the other nine meaningful: the harness is not
failing everything.

**First mutation round** (original 13, still valid — none of these tests changed
semantics): each asserted applied, each CAUGHT, restoration byte-verified:

| # | Mutation | Verdict |
|---|---|---|
| M1 | revert `energy()` to the unweighted pre-#1642 form | CAUGHT (9 failed) |
| M2 | drop weights from `PotentialEnergy.energy` | CAUGHT (6) |
| M3 | bridge divides by mean weight instead of `w_k` | CAUGHT (6) |
| M4 | bridge does not divide at all | CAUGHT (10) |
| M5 | single-population refusal removed | CAUGHT (5) |
| M6 | `second_variation` returns `W diag(w)` instead of `W` | CAUGHT (2) |
| M7 | weight positivity check dropped | CAUGHT (2) |
| M8 | `CombinedEnergy` weight-agreement check dropped | CAUGHT (2) |
| M9 | `operator.weights` collapses per-point array to its mean | CAUGHT (5) |
| M10 | `t` made positional on one class | CAUGHT (1) |
| M11 | `kernel_matrix` returns the weighted operator | CAUGHT (3) |
| M12 | `CombinedEnergy.second_variation` returns a partial sum, not `None` | CAUGHT (1) |
| M13 | `PotentialEnergy` weights default to ones | CAUGHT (1) |

M10 initially **escaped** — the keyword-only pin covered only `PotentialEnergy`.
That was a real coverage hole, not a harness artifact; the test is now
parametrized over all three shipped classes, which is exactly the per-implementer
arity drift `runtime_checkable` cannot see.

**Failures these tests catch:** a missing or doubled quadrature factor on either
side of the energy/derivative pair; the bridge factor applied in the wrong place;
a scalar-`dx` "repair" that only works on uniform grids (the non-uniform cases
have `w.max()/w.min() > 5`, asserted in the fixture); silent membership or arity
drift on the Protocol; a stacked multi-population array reaching a contraction;
non-positive weights reaching a division; components summed across incompatible
discretizations.

## Corrections to the issue

**D-5's example is mislocated.** The map says "a stacked array will NOT raise —
`energy()` happily dots it with itself." Measured on all six shipped
(class, method) pairs: `energy()` **already raised** on all three classes
(scipy `LinearOperator` dimension check, or numpy shape misalignment). The one
pair that silently accepted a stacked `(K*N,)` array was
**`PotentialEnergy.flat_derivative`**, which ignored `m` entirely and returned
`V.copy()` — a wrong-length, entirely plausible answer. The finding is real and
the fix is the one D-5 asks for; only the cited method was wrong. Both are pinned.

## What I did NOT do

- No `weights=` on `FiniteDifferenceFunctionalDerivative.compute`. That part of
  the Q2 argument survives: the engine returns a weights-agnostic entry
  gradient, and the conversion is a bridge concern. It is the *bridge* that now
  carries the weights, not the engine.
- No decision on adding `x` to the signature — §6 D-3 explicitly leaves it a
  judgment call and nothing forces it now.
- No `LocalIntegralEnergy` (A4), no `verify_coupling_is_variational` (D2), no
  sign-flip ownership (D-6 of §6). Separate units.

## Reported, not fixed

- `CombinedEnergy.energy` is the only one of its three methods that does not call
  `as_single_population` on its own `_w`; it relies on component delegation.
  Hygiene inconsistency, not a defect for the shipped classes.
- `CombinedEnergy.second_variation` allocates `(N, N)` before discovering a
  component returns `None`.
- `ConvolutionCouplingOperator.weights` itself still returns a live array. The
  `EnergyFunctional` member is now frozen at the boundary, so the advertised
  contract surface is closed; the operator's own accessor is a separate,
  pre-existing question.

Refs: #1642 (A1, A2, A3; D-1..D-5), #1023.

