### PR TITLE
Refuse mixed per-axis BC in the FP-SL fold, via one shared owner

### DIFF
--- a/changelog.d/1697-fp-sl-mixed-bc-refused.fixed.md
+++ b/changelog.d/1697-fp-sl-mixed-bc-refused.fixed.md
@@ -13,6 +13,8 @@ permutation available**. A guard unioning only over `segments` lets that form th
 owner of the refusal for HJB-SL (#1560) and FP-SL (#1697) alike -- the private helper added to
 `hjb_semi_lagrangian.py` in #1696 is now a thin wrapper that only binds the consumer name.
 
+FPSLSolver now caches only an explicitly-passed BC and otherwise resolves the geometry live at each point of use, so the guard sees a BC replaced after construction rather than a construction-time snapshot -- the bypass it exists to close.
+
 Per-axis handling is the actual fix and remains open. It is deliberately not attempted here:
 `splat_linear_nd` is periodic-blind (it clamps corner indices), so routing a periodic axis through
 it would move traffic onto a known-wrong path that the current uniform configuration avoids.

--- a/changelog.d/1697-fp-sl-mixed-bc-refused.fixed.md
+++ b/changelog.d/1697-fp-sl-mixed-bc-refused.fixed.md
@@ -1,0 +1,18 @@
+Refuse a mixed per-axis boundary condition in the FP semi-Lagrangian adjoint fold, and give the
+collapse a single owner shared with the HJB side.
+
+`BoundaryConditions.type` deliberately raises `ValueError` for a mixed BC. `bc_utils` swallowed
+that raise and fell through to `segments[0].bc_type`, so the one signal that a BC is mixed was
+discarded and the fold applied that single operation to every axis. Reordering the segment list
+changed the density by 145% in relative L1 while both runs conserved mass to 4e-15.
+
+Segment order is not the only lever: `get_bc_type_string` never reads `default_bc`, so a
+partially-covering segment list plus a differing default collapses identically **with no
+permutation available**. A guard unioning only over `segments` lets that form through. The new
+`bc_utils.geometric_operations` unions both, and `bc_utils.checked_bc_type_string` is now the one
+owner of the refusal for HJB-SL (#1560) and FP-SL (#1697) alike -- the private helper added to
+`hjb_semi_lagrangian.py` in #1696 is now a thin wrapper that only binds the consumer name.
+
+Per-axis handling is the actual fix and remains open. It is deliberately not attempted here:
+`splat_linear_nd` is periodic-blind (it clamps corner indices), so routing a periodic axis through
+it would move traffic onto a known-wrong path that the current uniform configuration avoids.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -222,18 +222,6 @@ class FPSLSolver(BaseFPSolver):
         # (Dirichlet/Robin would otherwise be silently collapsed to the zero-flux Neumann stencil).
         self._validate_bc_support(self.get_boundary_conditions())
 
-    def _get_boundary_conditions_from_problem(self) -> BoundaryConditions | None:
-        """Get boundary conditions from problem or geometry."""
-        try:
-            return self.problem.geometry.boundary_conditions
-        except AttributeError:
-            pass
-        try:
-            return self.problem.geometry.get_boundary_conditions()
-        except AttributeError:
-            pass
-        return None
-
     def _get_bc_operation_type(self) -> str:
         """
         Get boundary operation type from boundary conditions.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -211,14 +211,16 @@ class FPSLSolver(BaseFPSolver):
                 f"FPSLSolver initialized for {self.dimension}D: shape={self.grid_shape}, spacing={self.spacing}"
             )
 
-        # Boundary conditions
-        if boundary_conditions is not None:
-            self.boundary_conditions = boundary_conditions
-        else:
-            self.boundary_conditions = self._get_boundary_conditions_from_problem()
+        # Boundary conditions. An explicit argument is cached under the name
+        # ``get_boundary_conditions()`` resolves first, so it wins for the solver's lifetime;
+        # otherwise nothing is cached and the geometry is re-read at every point of use. Caching
+        # the geometry's BC here would freeze a construction-time snapshot, and the mixed-BC guard
+        # in ``_get_bc_operation_type`` would then never see a BC replaced afterwards -- the
+        # bypass this solver's own guard exists to close (Issue #1697).
+        self._boundary_conditions = boundary_conditions
         # Issue #1456: fail loud now if the resolved BC requests a type this solver cannot honor
         # (Dirichlet/Robin would otherwise be silently collapsed to the zero-flux Neumann stencil).
-        self._validate_bc_support(self.boundary_conditions)
+        self._validate_bc_support(self.get_boundary_conditions())
 
     def _get_boundary_conditions_from_problem(self) -> BoundaryConditions | None:
         """Get boundary conditions from problem or geometry."""
@@ -242,7 +244,7 @@ class FPSLSolver(BaseFPSolver):
             Geometric operation: 'reflect', 'clamp', or 'periodic'
         """
         bc_type = checked_bc_type_string(
-            self.boundary_conditions,
+            self.get_boundary_conditions(),
             consumer="FPSLSolver",
             alternative=("Use one BC type across axes, or FP-FDM/FVM which resolve BC per wall (Issue #1697)."),
         )

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -39,7 +39,7 @@ from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import (
 )
 from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
-    get_bc_type_string,
+    checked_bc_type_string,
 )
 from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
@@ -241,7 +241,11 @@ class FPSLSolver(BaseFPSolver):
         Returns:
             Geometric operation: 'reflect', 'clamp', or 'periodic'
         """
-        bc_type = get_bc_type_string(self.boundary_conditions)
+        bc_type = checked_bc_type_string(
+            self.boundary_conditions,
+            consumer="FPSLSolver",
+            alternative=("Use one BC type across axes, or FP-FDM/FVM which resolve BC per wall (Issue #1697)."),
+        )
         return bc_type_to_geometric_operation(bc_type)
 
     def _get_diffusion_bc_type(self) -> str:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -31,7 +31,7 @@ from mfgarchon.geometry.boundary.applicator_fdm import FDMApplicator
 from mfgarchon.geometry.boundary.applicator_interpolation import InterpolationApplicator
 from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
-    get_bc_type_string,
+    checked_bc_type_string,
 )
 from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.mfg_logging import get_logger
@@ -77,36 +77,18 @@ except ImportError:
 def _checked_bc_type_string(bc) -> str:
     """Collapse ``bc`` to the single BC type the SL fold applies to every axis, or refuse.
 
-    Issue #1560: ``get_bc_type_string`` returns the FIRST segment's type by contract, and the
-    characteristic fold and ADI diffusion then apply that single operation ('reflect' | 'wrap' |
-    ...) to all axes. For a mixed per-axis BC -- no-flux walls on one axis, periodic on another --
-    that silently drops one transform, and reordering the segments changes the physics.
-
-    This is the one owner of that collapse. It raises when the segments disagree, so the refusal
-    happens where the value is used rather than only at construction: the solver re-reads
-    ``get_boundary_conditions()`` at solve time, so a construction-time check alone is bypassed by
-    a BC that is unset when the solver is built, or replaced afterwards.
-
-    Per-axis handling is the actual fix and remains open on #1560; until then the library refuses
-    the configuration rather than solving a different one.
+    Thin wrapper over :func:`checked_bc_type_string`, which is the one owner of this collapse for
+    every solver whose fold is per-axis blind (Issues #1560, #1697). It lives here only to bind the
+    consumer name and the suggested alternative; the logic, including the ``default_bc`` union that
+    a segments-only guard would miss, belongs to ``bc_utils``.
     """
-    ops = set()
-    for seg in getattr(bc, "segments", None) or ():
-        ops.add(bc_type_to_geometric_operation(str(getattr(seg.bc_type, "value", seg.bc_type))))
-    default = getattr(bc, "default_bc", None)
-    if default is not None:
-        ops.add(bc_type_to_geometric_operation(str(getattr(default, "value", default))))
-
-    if len(ops) > 1:
-        raise NotImplementedError(
-            "HJBSemiLagrangianSolver does not support a mixed per-axis boundary condition whose "
-            f"segments map to different geometric operations ({sorted(ops)}). The characteristic "
-            "fold and ADI diffusion apply a single operation to every axis (order-sensitive "
-            "silent collapse). Use one BC type across axes, or HJB-FDM/GFDM which resolve BC per "
-            "wall (Issue #1560 / RFC #1574 Phase 0)."
-        )
-
-    return get_bc_type_string(bc)
+    return checked_bc_type_string(
+        bc,
+        consumer="HJBSemiLagrangianSolver",
+        alternative=(
+            "Use one BC type across axes, or HJB-FDM/GFDM which resolve BC per wall (Issue #1560 / RFC #1574 Phase 0)."
+        ),
+    )
 
 
 class HJBSemiLagrangianSolver(BaseHJBSolver):

--- a/mfgarchon/geometry/boundary/bc_utils.py
+++ b/mfgarchon/geometry/boundary/bc_utils.py
@@ -118,23 +118,43 @@ def geometric_operations(boundary_conditions: Any) -> set[str]:
     **with no permutation available** -- a guard that unions only over ``segments`` lets that form
     straight through (Issue #1697).
 
-    Returns an empty set for ``None`` and for legacy BC objects, which carry no per-axis
-    information that could disagree.
-    """
-    from .conditions import BoundaryConditions
+    Returns an empty set for ``None`` and for legacy BC objects, which carry neither field and so
+    have no per-axis information that could disagree.
 
-    if not isinstance(boundary_conditions, BoundaryConditions):
+    Reach is by duck typing rather than ``isinstance`` on purpose. An ``isinstance`` gate would be
+    a fail-silent branch in front of a fail-loud body: any future adapter, protocol implementation
+    or wrapper that is not literally a ``BoundaryConditions`` would return an empty set, which
+    reads as "nothing disagrees" and turns every caller's guard into a no-op -- the shape this
+    function exists to prevent.
+
+    Raises:
+        AttributeError: if exactly one of ``segments`` / ``default_bc`` is present. That is the
+            signature of a rename, and it must not degrade into an empty set (Issue #1691).
+    """
+    if boundary_conditions is None:
         return set()
+
+    missing = object()
+    segments = getattr(boundary_conditions, "segments", missing)
+    default = getattr(boundary_conditions, "default_bc", missing)
+
+    if segments is missing and default is missing:
+        return set()  # not a segmented BC at all
+
+    if segments is missing or default is missing:
+        present, absent = ("segments", "default_bc") if default is missing else ("default_bc", "segments")
+        raise AttributeError(
+            f"{type(boundary_conditions).__name__} has {present!r} but no {absent!r}. A segmented "
+            f"boundary condition must expose both, since a mixed BC is detected by unioning them; "
+            f"reading only one would silently under-report disagreement (Issue #1697)."
+        )
 
     def _op(bc_type: Any) -> str:
         return bc_type_to_geometric_operation(str(getattr(bc_type, "value", bc_type)))
 
-    # Direct attribute access, not getattr with a default: if these are ever renamed this must
-    # fail loudly. A silent fallback would yield an empty set, which reads as "nothing disagrees"
-    # and turns every caller's guard into a no-op (the Issue #1691 shape).
-    ops = {_op(seg.bc_type) for seg in boundary_conditions.segments or ()}
-    if boundary_conditions.default_bc is not None:
-        ops.add(_op(boundary_conditions.default_bc))
+    ops = {_op(seg.bc_type) for seg in segments or ()}
+    if default is not None:
+        ops.add(_op(default))
     return ops
 
 

--- a/mfgarchon/geometry/boundary/bc_utils.py
+++ b/mfgarchon/geometry/boundary/bc_utils.py
@@ -106,6 +106,68 @@ def bc_type_to_geometric_operation(bc_type: str | None) -> str:
         return "clamp"
 
 
+def geometric_operations(boundary_conditions: Any) -> set[str]:
+    """Every distinct geometric operation ``boundary_conditions`` asks for.
+
+    Unlike :func:`get_bc_type_string`, which returns the FIRST segment's type, this reports the
+    whole set. A set of size > 1 means the BC cannot be honoured by a fold that applies one
+    operation to every axis.
+
+    ``default_bc`` is included deliberately. ``get_bc_type_string`` never reads it, so a
+    partially-covering segment list plus a differing default produces the same silent collapse
+    **with no permutation available** -- a guard that unions only over ``segments`` lets that form
+    straight through (Issue #1697).
+
+    Returns an empty set for ``None`` and for legacy BC objects, which carry no per-axis
+    information that could disagree.
+    """
+    from .conditions import BoundaryConditions
+
+    if not isinstance(boundary_conditions, BoundaryConditions):
+        return set()
+
+    def _op(bc_type: Any) -> str:
+        return bc_type_to_geometric_operation(str(getattr(bc_type, "value", bc_type)))
+
+    # Direct attribute access, not getattr with a default: if these are ever renamed this must
+    # fail loudly. A silent fallback would yield an empty set, which reads as "nothing disagrees"
+    # and turns every caller's guard into a no-op (the Issue #1691 shape).
+    ops = {_op(seg.bc_type) for seg in boundary_conditions.segments or ()}
+    if boundary_conditions.default_bc is not None:
+        ops.add(_op(boundary_conditions.default_bc))
+    return ops
+
+
+def checked_bc_type_string(boundary_conditions: Any, *, consumer: str, alternative: str) -> str | None:
+    """Collapse ``boundary_conditions`` to one BC type, or refuse if that would change the physics.
+
+    The single owner of the per-axis collapse for solvers whose fold applies one geometric
+    operation to every axis (Issues #1560, #1697). Callers get either a BC type they may safely
+    apply to all axes, or ``NotImplementedError``.
+
+    Call this at the point of use, not only at construction: solvers re-read
+    ``get_boundary_conditions()`` at solve time, so a construction-time check alone is bypassed by
+    a BC that is unset when the solver is built, or replaced afterwards.
+
+    Args:
+        boundary_conditions: the BC to collapse.
+        consumer: the refusing component, named in the error (e.g. ``"HJBSemiLagrangianSolver"``).
+        alternative: what the caller should use instead, appended to the error message.
+
+    Per-axis handling is the actual fix and remains open on #1560 (HJB) and #1697 (FP). Until then
+    the library refuses the configuration rather than solving a different one.
+    """
+    ops = geometric_operations(boundary_conditions)
+    if len(ops) > 1:
+        raise NotImplementedError(
+            f"{consumer} does not support a mixed per-axis boundary condition whose segments map "
+            f"to different geometric operations ({sorted(ops)}). The fold applies a single "
+            "operation to every axis, so the result depends on segment order rather than on "
+            f"which wall carries which condition. {alternative}"
+        )
+    return get_bc_type_string(boundary_conditions)
+
+
 # =============================================================================
 # Smoke Test
 # =============================================================================

--- a/scripts/fail_fast_baseline.json
+++ b/scripts/fail_fast_baseline.json
@@ -2,5 +2,5 @@
   "bare_except": 0,
   "broad_except": 114,
   "hasattr": 129,
-  "silent_pass": 93
+  "silent_pass": 91
 }

--- a/tests/unit/test_geometry/test_mixed_bc_refused_1697.py
+++ b/tests/unit/test_geometry/test_mixed_bc_refused_1697.py
@@ -1,0 +1,233 @@
+"""One owner refuses a per-axis-blind BC collapse, for HJB-SL and FP-SL alike (#1560, #1697).
+
+``get_bc_type_string`` returns the FIRST segment's type: ``BoundaryConditions.type`` deliberately
+raises ``ValueError`` for a mixed BC, ``bc_utils`` swallows that raise, and execution falls through
+to ``segments[0].bc_type``. The one signal that the BC is mixed is discarded, and the fold then
+applies that single operation to every axis.
+
+Two levers produce the collapse, and a guard that handles only the first is insufficient:
+
+1. **Segment order.** Reordering the list flips the surviving type.
+2. **``default_bc``.** ``get_bc_type_string`` never reads it, so a partially-covering segment list
+   plus a differing default collapses identically **with no permutation available**. A guard that
+   unions only over ``segments`` lets this straight through.
+
+Per-axis handling remains open on #1560 (HJB) and #1697 (FP).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    no_flux_bc,
+    periodic_bc,
+)
+from mfgarchon.geometry.boundary.bc_utils import (
+    checked_bc_type_string,
+    geometric_operations,
+    get_bc_type_string,
+)
+
+CONSUMER = {"consumer": "TestSolver", "alternative": "Use one BC type across axes."}
+
+
+def _seg(name, bc_type, boundary):
+    return BCSegment(name=name, bc_type=bc_type, boundary=boundary)
+
+
+def _two_segments(first_periodic=False):
+    order = [BCType.PERIODIC, BCType.NO_FLUX] if first_periodic else [BCType.NO_FLUX, BCType.PERIODIC]
+    return BoundaryConditions(
+        dimension=2,
+        default_bc=order[0],
+        segments=[_seg("a", order[0], "x_min"), _seg("b", order[1], "y_min")],
+    )
+
+
+def test_the_raise_that_marks_a_bc_mixed_is_swallowed_by_the_accessor():
+    """Pins the root cause, so a future 'fix' that only patches a solver is visibly partial."""
+    mixed = _two_segments()
+
+    with pytest.raises(ValueError, match="only valid for uniform BCs"):
+        _ = mixed.type
+
+    # ... yet the accessor returns a plain answer, having discarded the one signal it had.
+    assert get_bc_type_string(mixed) == "no_flux"
+
+
+def test_segment_order_changes_what_the_accessor_returns():
+    """Lever 1. This is the form the issue was originally filed against."""
+    assert get_bc_type_string(_two_segments(first_periodic=False)) == "no_flux"
+    assert get_bc_type_string(_two_segments(first_periodic=True)) == "periodic"
+
+
+def test_default_bc_is_a_second_lever_with_no_permutation_available():
+    """Lever 2, and the reason a segments-only guard is insufficient.
+
+    Neither BC below is a reordering of the other -- each has exactly one segment -- yet they
+    collapse to different operations. A guard unioning only over ``segments`` sees a single element
+    in both cases and permits them.
+    """
+    a = BoundaryConditions(dimension=2, default_bc=BCType.PERIODIC, segments=[_seg("w", BCType.NO_FLUX, "x_min")])
+    b = BoundaryConditions(dimension=2, default_bc=BCType.NO_FLUX, segments=[_seg("p", BCType.PERIODIC, "y_min")])
+
+    assert get_bc_type_string(a) == "no_flux"
+    assert get_bc_type_string(b) == "periodic"
+
+    # What a segments-only guard would see: one element each, so no disagreement.
+    for bc in (a, b):
+        ops_from_segments = {str(getattr(s.bc_type, "value", s.bc_type)) for s in bc.segments}
+        assert len(ops_from_segments) == 1, "a segments-only guard cannot see this disagreement"
+
+    # What the shipped guard sees, because it also unions default_bc:
+    assert geometric_operations(a) == {"reflect", "periodic"}
+    assert geometric_operations(b) == {"reflect", "periodic"}
+
+
+@pytest.mark.parametrize(
+    "bc_factory",
+    [
+        pytest.param(lambda: _two_segments(False), id="two-segments"),
+        pytest.param(lambda: _two_segments(True), id="two-segments-reordered"),
+        pytest.param(
+            lambda: BoundaryConditions(
+                dimension=2, default_bc=BCType.PERIODIC, segments=[_seg("w", BCType.NO_FLUX, "x_min")]
+            ),
+            id="one-segment-plus-differing-default",
+        ),
+    ],
+)
+def test_mixed_bc_is_refused(bc_factory):
+    with pytest.raises(NotImplementedError, match="different geometric operations"):
+        checked_bc_type_string(bc_factory(), **CONSUMER)
+
+
+@pytest.mark.parametrize(
+    "bc_factory",
+    [
+        pytest.param(lambda: no_flux_bc(dimension=2), id="uniform-no-flux"),
+        pytest.param(lambda: periodic_bc(dimension=2), id="uniform-periodic"),
+        pytest.param(
+            lambda: BoundaryConditions(
+                dimension=2, default_bc=BCType.NO_FLUX, segments=[_seg("w", BCType.NO_FLUX, "x_min")]
+            ),
+            id="segments-agree-with-default",
+        ),
+        pytest.param(
+            lambda: BoundaryConditions(
+                dimension=2,
+                default_bc=BCType.NO_FLUX,
+                segments=[_seg("w", BCType.NO_FLUX, "x_min"), _seg("n", BCType.NEUMANN, "y_min")],
+            ),
+            id="different-bctypes-same-operation",
+        ),
+        pytest.param(lambda: None, id="none"),
+    ],
+)
+def test_a_bc_without_disagreement_is_accepted(bc_factory):
+    """The refusal must key on disagreement, not on having segments, and not on BCType identity.
+
+    ``NEUMANN`` and ``NO_FLUX`` are distinct BCTypes that map to the same geometric operation. The
+    guard must let that through; refusing it would be a false positive on a legitimate wall.
+    """
+    checked_bc_type_string(bc_factory(), **CONSUMER)
+
+
+def test_a_renamed_attribute_fails_loudly_rather_than_disabling_the_guard():
+    """The guard's failure mode must not be silence.
+
+    Reading ``segments``/``default_bc`` through ``getattr(..., None)`` would turn a rename into an
+    empty operation set, which reads as 'nothing disagrees' and makes every caller's guard a no-op
+    -- the Issue #1691 shape. Direct attribute access is deliberate.
+    """
+
+    bc = BoundaryConditions(
+        dimension=2,
+        default_bc=BCType.PERIODIC,
+        segments=[_seg("w", BCType.NO_FLUX, "x_min")],
+    )
+    assert geometric_operations(bc) == {"reflect", "periodic"}, "precondition: this BC disagrees"
+
+    del bc.segments  # stands in for the field having been renamed
+
+    with pytest.raises(AttributeError, match="segments"):
+        geometric_operations(bc)
+
+
+def test_reflect_and_periodic_coincide_without_a_boundary_crossing_drift():
+    """Why a naive regression fixture cannot detect this defect.
+
+    If no characteristic foot leaves the domain, 'reflect' and 'periodic' are the same map on the
+    reachable set, so the collapse is invisible. Any behavioural test for #1697 needs destinations
+    that actually cross a wall. Asserted here so the constraint is not rediscovered by hand.
+    """
+    lo, hi = 0.0, 1.0
+    inside = np.array([0.2, 0.5, 0.8])
+    crossing = np.array([-0.15, 1.10])
+
+    def reflect(x):
+        return hi - np.abs(np.mod(x - lo, 2 * (hi - lo)) - (hi - lo))
+
+    def periodic(x):
+        return lo + np.mod(x - lo, hi - lo)
+
+    np.testing.assert_allclose(reflect(inside), periodic(inside), atol=1e-15)
+    assert np.max(np.abs(reflect(crossing) - periodic(crossing))) > 0.1
+
+
+def _fp_problem(bc, dim=2, n=9, nt=4):
+    from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.geometry import TensorProductGrid
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)] * dim, Nx_points=[n] * dim, boundary_conditions=bc)
+    components = MFGComponents(
+        m_initial=lambda x: float(np.exp(-np.sum((np.atleast_1d(x) - 0.5) ** 2))),
+        u_terminal=lambda x: 0.0,
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+    )
+    return grid, MFGProblem(geometry=grid, Nt=nt, T=0.5, components=components)
+
+
+def test_fp_sl_solver_refuses_a_mixed_bc_at_solve_time():
+    """The wiring, not the helper.
+
+    Asserting on ``checked_bc_type_string`` alone does not pin that FPSLSolver *calls* it -- those
+    assertions stay green with the solver reverted to the raw accessor. This constructs the solver
+    and solves. Verified by mutation: routing ``_get_bc_operation_type`` back to
+    ``get_bc_type_string`` fails this test and only this one.
+
+    The BC is swapped in after construction on purpose: the solver re-reads its boundary conditions
+    during the solve, so a construction-time check alone would be bypassed here exactly as it was
+    on the HJB side (#1560).
+    """
+    from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+
+    grid, problem = _fp_problem(no_flux_bc(dimension=2))
+    solver = FPSLSolver(problem)
+
+    grid._boundary_conditions = _two_segments()
+    solver.boundary_conditions = _two_segments()
+
+    m0 = np.ones((9, 9)) / 81.0
+    u = np.zeros((5, 9, 9))
+    with pytest.raises(NotImplementedError, match="different geometric operations"):
+        solver.solve_fp_system(M_initial=m0, potential_field=u)
+
+
+def test_fp_sl_solver_still_solves_a_uniform_bc():
+    """The refusal must not cost the ordinary case."""
+    from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+
+    _, problem = _fp_problem(no_flux_bc(dimension=2))
+    result = FPSLSolver(problem).solve_fp_system(M_initial=np.ones((9, 9)) / 81.0, potential_field=np.zeros((5, 9, 9)))
+
+    assert np.all(np.isfinite(result))
+    assert np.all(result >= 0.0)

--- a/tests/unit/test_geometry/test_mixed_bc_refused_1697.py
+++ b/tests/unit/test_geometry/test_mixed_bc_refused_1697.py
@@ -204,17 +204,19 @@ def test_fp_sl_solver_refuses_a_mixed_bc_at_solve_time():
     and solves. Verified by mutation: routing ``_get_bc_operation_type`` back to
     ``get_bc_type_string`` fails this test and only this one.
 
-    The BC is swapped in after construction on purpose: the solver re-reads its boundary conditions
-    during the solve, so a construction-time check alone would be bypassed here exactly as it was
-    on the HJB side (#1560).
+    The BC is swapped in on the geometry after construction on purpose: FPSLSolver caches only an
+    explicitly-passed BC and otherwise resolves the geometry live at each point of use, so a
+    construction-time check alone would be bypassed here exactly as on the HJB side (#1560).
     """
     from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
 
     grid, problem = _fp_problem(no_flux_bc(dimension=2))
     solver = FPSLSolver(problem)
 
+    # ONLY the geometry's BC is replaced. Writing solver.boundary_conditions as well would pass
+    # even if the solver never re-read anything -- review of #1702 found exactly that: the test
+    # asserted a re-read mechanism the FP solver did not have, and passed by poking the cache.
     grid._boundary_conditions = _two_segments()
-    solver.boundary_conditions = _two_segments()
 
     m0 = np.ones((9, 9)) / 81.0
     u = np.zeros((5, 9, 9))
@@ -231,3 +233,46 @@ def test_fp_sl_solver_still_solves_a_uniform_bc():
 
     assert np.all(np.isfinite(result))
     assert np.all(result >= 0.0)
+
+
+def test_a_duck_typed_bc_is_checked_not_waved_through():
+    """Reach is by duck typing, and that choice is pinned in both directions.
+
+    An `isinstance` gate would be a fail-silent branch in front of a fail-loud body: an adapter or
+    wrapper that is not literally a BoundaryConditions would return an empty set, read as "nothing
+    disagrees". Review of #1702 measured that a gate was present and that removing it changed no
+    test -- unpinned in either direction, so the next refactor could flip it invisibly.
+    """
+    from types import SimpleNamespace
+
+    duck = SimpleNamespace(
+        segments=[_seg("w", BCType.NO_FLUX, "x_min"), _seg("p", BCType.PERIODIC, "y_min")],
+        default_bc=BCType.NO_FLUX,
+    )
+    assert geometric_operations(duck) == {"reflect", "periodic"}
+
+    with pytest.raises(NotImplementedError, match="different geometric operations"):
+        checked_bc_type_string(duck, **CONSUMER)
+
+
+def test_an_object_carrying_neither_field_is_not_a_segmented_bc():
+    """A legacy BC has no per-axis information; it must not raise, and must not be refused."""
+    from types import SimpleNamespace
+
+    assert geometric_operations(SimpleNamespace(type="periodic")) == set()
+    assert geometric_operations(None) == set()
+
+
+def test_half_a_renamed_pair_raises_rather_than_under_reporting():
+    """One field present and the other missing is the signature of a rename.
+
+    Degrading to an empty set here would report "nothing disagrees" for a BC that does, which is
+    strictly worse than crashing -- the guard would be silently disabled for every caller.
+    """
+    from types import SimpleNamespace
+
+    with pytest.raises(AttributeError, match="default_bc"):
+        geometric_operations(SimpleNamespace(segments=[_seg("w", BCType.NO_FLUX, "x_min")]))
+
+    with pytest.raises(AttributeError, match="segments"):
+        geometric_operations(SimpleNamespace(default_bc=BCType.PERIODIC))


### PR DESCRIPTION
## Root cause: a designed fail-loud, swallowed

`BoundaryConditions.type` **deliberately raises** for a mixed BC. `bc_utils.get_bc_type_string`
caught that `ValueError` and fell through to `segments[0].bc_type`. The raise is the **only** signal
that a BC is mixed, and it was discarded — a designed fail-loud turned into a silent, order-sensitive
scalar, which the FP-SL fold then applied to every axis.

Reordering the segment list changed the density by **145% in relative L1** while both runs conserved
mass to **4e-15**. No cheap invariant could see it.

## Segment order is not the only lever

`get_bc_type_string` never reads `default_bc`. So a partially-covering segment list plus a differing
default collapses identically, **with no permutation available**:

| BC | collapses to |
|---|---|
| `segments=[NO_FLUX(x_min)]`, `default_bc=PERIODIC` | `reflect` |
| `segments=[PERIODIC(y_min)]`, `default_bc=NO_FLUX` | `periodic` |

Neither is a reordering of the other. Consequences, both load-bearing:

- The "segment-order invariance" regression assertion the issue originally implied is
  **non-discriminating** on this form.
- The obvious minimal guard — union the geometric ops over `bc.segments` — **lets it through**.

`geometric_operations` unions both, and there is a test asserting a segments-only guard would not.

## One owner, not a second copy

The guard lives in `bc_utils`, not in the FP solver. `hjb_semi_lagrangian._checked_bc_type_string`
(added by #1696) is now a thin wrapper that only binds the consumer name. A second copy of a
convention is this codebase's most expensive recurring defect; writing one here would have created
the next bug rather than fixed this one.

Also fixed while consolidating: `segments`/`default_bc` are read by **direct attribute access**.
The #1696 reviewer flagged that a `getattr(..., None)` chain degrades a rename into an *empty*
operation set, which reads as "nothing disagrees" and silently disables every caller's guard — the
#1691 shape. There is a test that deletes the attribute and asserts it raises.

## Scope: refusal, and deliberately not per-axis

Unlike #1560 on the HJB side, there is **no mathematical obstruction** to per-axis handling here —
the advection loop is already per-axis in structure, `BoundaryConditions.get_bc_type_at_boundary`
already returns the order-independent per-axis truth, and per-axis `periodic-x + no-flux-y` is
mass-conserving in this discretisation (1.3e-16).

It is still not attempted, for a reason that only appeared on mapping: **`splat_linear_nd` is
periodic-blind** — it clamps corner indices, so a uniform density under pure periodic translation
returns non-uniform while conserving mass exactly. Implementing per-axis first would newly route a
periodic axis into that known-wrong splatter on a configuration that currently avoids it. Order of
work: refuse (here) → fix the splat seam → implement per-axis. Tracked on #1697.

## Verification

- **Mutation, wiring**: routing `_get_bc_operation_type` back to the raw accessor fails **exactly
  one** test, `test_fp_sl_solver_refuses_a_mixed_bc_at_solve_time`. Source restores byte-identical.
- **The first version of these tests failed that check.** They asserted on `checked_bc_type_string`
  directly and stayed **green under the mutation** (13 passed) — they pinned the helper, not that
  FP-SL calls it. The behavioural test that constructs a real `FPSLSolver` and solves is what
  discriminates. Recording it because it is the same error #1696 made hours earlier.
- **#1696's 51 tests remain green** after the consolidation, which is the pinning evidence that the
  HJB behaviour is unchanged.
- A test asserts `reflect` and `periodic` coincide on interior points and diverge only for
  boundary-crossing destinations — so a future regression fixture cannot be written with a confining
  drift and appear to pass.
- Full local gate: **5545 passed, 20 skipped, 6 xfailed**, GATE GREEN.

Refs #1697, #1560, #1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review findings addressed (both introduced here)

**F1 — the FP guard read a construction-time snapshot, not the point of use.** `FPSLSolver` cached
`self.boundary_conditions` in `__init__` while HJB-SL calls `get_boundary_conditions()` at every
site, so a BC replaced on the geometry afterwards was invisible — **exactly the bypass the shared
owner's docstring promises to close, unhonoured by the one caller this PR added.** It now caches
only an explicitly-passed BC, under the name `get_boundary_conditions()` resolves first so an
override still wins, and otherwise resolves live.

The test masked it: it assigned *both* `grid._boundary_conditions` and `solver.boundary_conditions`,
so it passed by poking the cache while its docstring asserted a re-read that never happened. It now
swaps only the geometry BC. Verified: explicit override still wins (`'periodic'`, not `'reflect'`),
and a post-construction geometry swap is now seen.

**F2 — `geometric_operations` reached BCs by `isinstance`,** which is a fail-silent branch in front
of a fail-loud body: any adapter or wrapper that is not literally a `BoundaryConditions` returned an
empty set, read as "nothing disagrees". Review measured that *removing* the gate changed no test —
unpinned in either direction. It is now duck-typed, raises when exactly one of
`segments`/`default_bc` is present (the rename signature), and three tests pin all three branches.

## A mutation error worth recording, since it nearly shipped

My first falsifier for F1 left all tests green, which reads as "the test fails to pin the wiring".
The mutation was **void**: it routed through `_get_boundary_conditions_from_problem`, which also
reads the geometry live, so it was not a snapshot at all. A real snapshot mutation was first shown
to change the answer (`'reflect'` against `'periodic'`) and then failed exactly one test.

## Verification of the delta

| falsifier | result |
|---|---|
| freeze the BC at construction (real snapshot) | **1 failed** — `test_fp_sl_solver_refuses_a_mixed_bc_at_solve_time` |
| restore the `isinstance` gate | **2 failed** (was 0 before these tests) |
| #1696's 51 HJB tests after the consolidation | **51 passed** |
| full local gate | **5548 passed, 20 skipped, 6 xfailed**, GATE GREEN |

Source restored byte-identical after every mutation.
