### PR TITLE
Stop the coupled loop at a diverged HJB, before FP consumes it

### DIFF
--- a/changelog.d/1717-hjb-nonfinite-before-fp.fixed.md
+++ b/changelog.d/1717-hjb-nonfinite-before-fp.fixed.md
@@ -1,0 +1,9 @@
+- **A diverged HJB now stops the coupled loop before Fokker-Planck consumes it** (Issue #1717).
+  `FixedPointIterator` solved FP with a NaN value function, so the FP solver failed first and an
+  HJB divergence surfaced as an FP CFL diagnostic; that exception also escaped before the Issue
+  #1078 HJB-vs-FP attribution could run. `solve()` now returns a `SolverResult` with
+  `converged=False` and `convergence_reason="diverged_nan"` on this path rather than propagating
+  the FP solver's `ValueError`, matching the two pre-existing divergence breaks in the same loop.
+  `mass_conservation_error` is `None` when no FP step completed in the solve (the carried-over
+  cold start has constant mass by construction and would measure as exactly 0.0), and remains a
+  real number when an FP step did complete before the divergence.

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -576,6 +576,12 @@ class FixedPointIterator(BaseCouplingIterator):
         # Main fixed-point iteration loop
         converged = False
         convergence_reason = "Maximum iterations reached"
+        # True once self.M holds a density this solve's FP produced. The mass-conservation
+        # measurement below is meaningful only then: before that, self.M is the cold start
+        # (constant mass by construction, so it measures as exactly 0.0) or a warm start
+        # (some other solve's output). Set where self.M is assigned, not at the exits, so
+        # that a break after a completed FP step still reports its real number (Issue #1717).
+        fp_output_available = False
         # Hierarchical progress for Picard iterations (Issue #614)
         from mfgarchon.utils.progress import HierarchicalProgress
 
@@ -620,6 +626,30 @@ class FixedPointIterator(BaseCouplingIterator):
                         source_term=hjb_source,
                     )
                     U_new = self.hjb_solver.solve_hjb_system(M_old, U_terminal, U_old, **kwargs)
+
+                # Issue #1717: attribute a diverged HJB to HJB, before FP consumes it.
+                # The FP source and drift below are composed from U_new, so a non-finite U_new
+                # makes the FP solver fail first and report a CFL condition -- an FP diagnostic
+                # for an HJB failure. Worse, that exception escapes the loop, so the #1078
+                # HJB-vs-FP attribution further down never runs on this path.
+                if not np.all(np.isfinite(U_new)):
+                    # Publish the diverged U so the end-of-solve output validation still reports
+                    # it. Keeping the last finite iterate instead would leave the result looking
+                    # valid to any caller that reads output_validation rather than
+                    # convergence_reason -- trading a misattributed diagnostic for a silent one.
+                    # preserve_terminal_condition is applied for the same reason the normal path
+                    # applies it: U[-1] is boundary data the solve never had licence to overwrite.
+                    # Copy first: it writes U[-1] in place, and U_new is the HJB solver's own
+                    # return value rather than the freshly damped array the normal path hands it.
+                    self.U = preserve_terminal_condition(U_new.copy(), U_terminal)
+                    convergence_reason = "diverged_nan"
+                    logger.warning(
+                        "NaN/Inf detected in iteration %d (source: HJB (Newton divergence)). "
+                        "Terminating early; FP was not solved.",
+                        iiter + 1,
+                    )
+                    self.iterations_run = iiter + 1
+                    break
 
                 # 2. Solve FP forward with new U (transient subtask)
                 # Issue #614: Use hierarchical subtask for inner solver visibility
@@ -683,6 +713,11 @@ class FixedPointIterator(BaseCouplingIterator):
                     # Standard damping for both - Issue #719: separate factors + schedules
                     self.U = effective_theta_U * U_new + (1 - effective_theta_U) * U_old
                     self.M = effective_theta_M * M_new + (1 - effective_theta_M) * M_old
+
+                # self.M now carries a density this solve's FP produced, so the end-of-solve
+                # mass measurement has something real to measure -- including if a later
+                # iteration breaks before its own FP step (Issue #1717).
+                fp_output_available = True
 
                 # Preserve boundary conditions
                 self.M = preserve_initial_condition(self.M, M_initial)
@@ -882,26 +917,41 @@ class FixedPointIterator(BaseCouplingIterator):
         # invariant to the choice of measure and is what the field's name claims to quantify.
         # The normalisation fork itself is pre-existing and tracked separately.
         mass_conservation_error: float | None
-        try:
-            # Called as a gate, not as a factor: a geometry with no volume element cannot express
-            # a total mass, so no conservation error is meaningful for it. A uniform cell measure
-            # cancels out of the ratio below, so it is deliberately not multiplied in -- writing it
-            # in would suggest the answer depends on it.
-            self.problem.geometry.volume_element()
-
-            spatial_axes = tuple(range(1, self.M.ndim))
-            mass_per_step = np.sum(self.M, axis=spatial_axes)
-            initial_mass = float(mass_per_step[0])
-            if not np.isfinite(initial_mass) or initial_mass <= 0.0:
-                raise ValueError(
-                    f"initial density has non-positive or non-finite total mass ({initial_mass!r}); "
-                    "mass conservation is undefined and the solve that produced it is already wrong"
-                )
-            mass_conservation_error = float(np.max(np.abs(mass_per_step / initial_mass - 1.0)))
-        except (AttributeError, NotImplementedError):
-            # A geometry without a volume element cannot express the integral; None says
-            # "not measured" rather than fabricating a zero.
+        if not fp_output_available:
+            # Issue #1717: no FP step completed in this solve, so self.M is not this solve's
+            # density. Two ways to get here, and the number would be wrong differently in each:
+            # from a cold start, initialize_cold_start writes M_initial into every row, so mass
+            # is constant by construction and measures as exactly 0.0 -- the best possible value
+            # for a solve that never ran; from a warm start, self.M is some other solve's output,
+            # so any number describes that solve rather than this one. Neither is a measurement
+            # of this solve, and the None sentinel exists so that cannot masquerade as one.
+            #
+            # The condition is "no FP output yet", not "the solve diverged". A divergence after a
+            # completed FP step DOES have a real density to measure, and reporting None there
+            # would be this defect's mirror image -- suppressing a genuine number instead of
+            # fabricating a zero.
             mass_conservation_error = None
+        else:
+            try:
+                # Called as a gate, not as a factor: a geometry with no volume element cannot express
+                # a total mass, so no conservation error is meaningful for it. A uniform cell measure
+                # cancels out of the ratio below, so it is deliberately not multiplied in -- writing it
+                # in would suggest the answer depends on it.
+                self.problem.geometry.volume_element()
+
+                spatial_axes = tuple(range(1, self.M.ndim))
+                mass_per_step = np.sum(self.M, axis=spatial_axes)
+                initial_mass = float(mass_per_step[0])
+                if not np.isfinite(initial_mass) or initial_mass <= 0.0:
+                    raise ValueError(
+                        f"initial density has non-positive or non-finite total mass ({initial_mass!r}); "
+                        "mass conservation is undefined and the solve that produced it is already wrong"
+                    )
+                mass_conservation_error = float(np.max(np.abs(mass_per_step / initial_mass - 1.0)))
+            except (AttributeError, NotImplementedError):
+                # A geometry without a volume element cannot express the integral; None says
+                # "not measured" rather than fabricating a zero.
+                mass_conservation_error = None
 
         # Construct result
         result = SolverResult(

--- a/tests/unit/test_utils/test_runtime_validation.py
+++ b/tests/unit/test_utils/test_runtime_validation.py
@@ -15,11 +15,46 @@ import pytest
 
 import numpy as np
 
+from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary.conditions import no_flux_bc
 from mfgarchon.utils.validation.runtime import (
     check_bounds,
     check_finite,
     validate_solver_output,
 )
+
+_NX = 11
+
+
+def _divergence_probe_problem():
+    """The one problem all the FixedPointIterator divergence tests below run on.
+
+    Extracted after an independent review flagged five byte-identical copies of this
+    construction in this file (Issue #1717 review, MINOR-7). Nothing here is tuned per
+    test -- each test varies only what the mocked HJB/FP solvers return.
+    """
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[_NX],
+            boundary_conditions=no_flux_bc(dimension=1),
+        ),
+        components=MFGComponents(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: -(m**2),
+                coupling_dm=lambda m: -2 * m,
+            ),
+            m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+            u_terminal=lambda x: x**2,
+        ),
+        Nt=10,
+    )
+
 
 # ===========================================================================
 # check_finite
@@ -135,7 +170,9 @@ def test_fixed_point_nan_early_termination():
     from mfgarchon.geometry import TensorProductGrid
     from mfgarchon.geometry.boundary.conditions import no_flux_bc
 
-    # Real problem setup (Nx=11 for speed)
+    # Pre-existing construction, left inline: folding it into
+    # _divergence_probe_problem() is a change to a test this PR does not otherwise
+    # touch, so it belongs to whoever next edits #688's coverage, not here.
     Nx = 11
     geom = TensorProductGrid(
         bounds=[(0.0, 1.0)],
@@ -192,3 +229,159 @@ def test_fixed_point_nan_early_termination():
     output_val = result.metadata.get("output_validation")
     assert output_val is not None
     assert output_val["is_valid"] is False
+
+
+@pytest.mark.unit
+def test_fp_is_not_solved_after_hjb_returns_nonfinite():
+    """A diverged HJB must stop the iteration before FP runs (Issue #1717).
+
+    The sibling test above mocks FP to return a clean density regardless of input, so it
+    cannot see whether FP was handed a non-finite U. Here FP records what it received.
+    Without the guard, the FP source and drift are composed from a NaN U and the real FP
+    solver raises a CFL diagnostic -- an FP error for an HJB failure -- and that exception
+    escapes before the #1078 HJB-vs-FP attribution can run.
+    """
+    from unittest.mock import Mock
+
+    problem = _divergence_probe_problem()
+    Nx = _NX
+    shape = (problem.Nt + 1, *problem.spatial_shape)
+
+    hjb_calls = [0]
+
+    def hjb_side_effect(*args, **kwargs):
+        hjb_calls[0] += 1
+        # Second HJB solve diverges.
+        return np.full(shape, np.nan) if hjb_calls[0] >= 2 else np.zeros(shape)
+
+    hjb_solver = Mock()
+    hjb_solver.solve_hjb_system.side_effect = hjb_side_effect
+
+    u_seen_by_fp = []
+
+    def fp_side_effect(*args, **kwargs):
+        # The value function reaches FP through one of several channels depending on the
+        # solver's signature -- positionally with a Mock, but as potential_field= or
+        # drift_field= with a real solver (resolve_fp_drift_kwargs). Scan every array
+        # argument rather than one named channel, so hardening this double into
+        # Mock(spec=FPFDMSolver) cannot silently disarm the assertion.
+        candidates = [a for a in args if isinstance(a, np.ndarray)]
+        candidates += [v for v in kwargs.values() if isinstance(v, np.ndarray)]
+        u_seen_by_fp.append(any(not np.all(np.isfinite(c)) for c in candidates))
+        return np.ones(shape) / Nx
+
+    fp_solver = Mock()
+    fp_solver.solve_fp_system.side_effect = fp_side_effect
+
+    FixedPointIterator(problem=problem, hjb_solver=hjb_solver, fp_solver=fp_solver, relaxation=0.5).solve(
+        max_iterations=10, tolerance=1e-6
+    )
+
+    assert hjb_calls[0] == 2, "the second HJB solve is the one that diverges"
+    assert not any(u_seen_by_fp), "FP was handed a non-finite array"
+    assert len(u_seen_by_fp) == 1, (
+        f"FP ran {len(u_seen_by_fp)} times; it must not run in the iteration whose HJB diverged"
+    )
+    # Not asserted here: convergence_reason == "diverged_nan". The pre-existing post-damping
+    # check sets the same string, so it passes with or without the guard and pins nothing
+    # (Issue #1701). The mass sentinel below does discriminate.
+
+
+@pytest.mark.unit
+def test_mass_conservation_is_unmeasured_when_fp_never_ran():
+    """A solve that dies in HJB must not report perfect mass conservation (Issue #1717).
+
+    When the first HJB solve diverges, FP never runs and `self.M` still holds the cold start,
+    whose mass is constant across time by construction -- so measuring it yields exactly 0.0,
+    the best possible value, for the worst possible solve. Issue #1672 added the None sentinel
+    so that "not measured" cannot masquerade as a zero; this pins that it is used here.
+    """
+    from unittest.mock import Mock
+
+    problem = _divergence_probe_problem()
+    Nx = _NX
+    shape = (problem.Nt + 1, *problem.spatial_shape)
+
+    hjb_solver = Mock()
+    hjb_solver.solve_hjb_system.side_effect = lambda *a, **k: np.full(shape, np.nan)
+    fp_solver = Mock()
+    fp_solver.solve_fp_system.side_effect = lambda *a, **k: np.ones(shape) / Nx
+
+    result = FixedPointIterator(problem=problem, hjb_solver=hjb_solver, fp_solver=fp_solver, relaxation=0.5).solve(
+        max_iterations=10, tolerance=1e-6
+    )
+
+    assert fp_solver.solve_fp_system.call_count == 0, "FP must not run when the first HJB diverges"
+    assert result.mass_conservation_error is None, (
+        f"mass conservation reported {result.mass_conservation_error!r} for a solve where FP "
+        "never produced a density; it must be None (not measured)"
+    )
+
+
+@pytest.mark.unit
+def test_mass_conservation_is_still_measured_when_fp_ran_before_the_divergence():
+    """The mirror of the test above, and the harder direction (Issue #1717).
+
+    Suppressing the measurement whenever the solve diverges would be the same defect as
+    fabricating a zero, pointed the other way: if FP completed a step before the HJB blew
+    up, `self.M` is a density this solve produced and its mass error is a real number. Here
+    FP loses half the mass, so `None` would be hiding a ~50% error behind "not measured".
+    """
+    from unittest.mock import Mock
+
+    problem = _divergence_probe_problem()
+    Nx = _NX
+    shape = (problem.Nt + 1, *problem.spatial_shape)
+
+    hjb_calls = [0]
+
+    def hjb_side_effect(*args, **kwargs):
+        hjb_calls[0] += 1
+        # Diverge on the SECOND solve, so one full FP step has already completed.
+        return np.full(shape, np.nan) if hjb_calls[0] >= 2 else np.zeros(shape)
+
+    hjb_solver = Mock()
+    hjb_solver.solve_hjb_system.side_effect = hjb_side_effect
+    # A density that sheds mass down the time axis: a real, measurable conservation defect.
+    losing_mass = np.ones(shape) / Nx * np.linspace(1.0, 0.1, shape[0])[:, None]
+    fp_solver = Mock()
+    fp_solver.solve_fp_system.side_effect = lambda *a, **k: losing_mass
+
+    result = FixedPointIterator(problem=problem, hjb_solver=hjb_solver, fp_solver=fp_solver, relaxation=0.5).solve(
+        max_iterations=10, tolerance=1e-6
+    )
+
+    assert fp_solver.solve_fp_system.call_count == 1, "one FP step must have completed"
+    assert result.mass_conservation_error is not None, (
+        "FP produced a density in this solve, so its mass error is measurable; reporting None "
+        "hides a real defect behind 'not measured'"
+    )
+    assert result.mass_conservation_error > 0.1, (
+        f"expected the injected mass loss to be reported, got {result.mass_conservation_error!r}"
+    )
+
+
+@pytest.mark.unit
+def test_terminal_condition_survives_an_hjb_divergence():
+    """The terminal row is boundary data, not solver output (Issue #1717).
+
+    The normal path and the two pre-existing divergence breaks all pass through
+    preserve_terminal_condition; the new guard must not be the one that returns U[-1] as NaN.
+    """
+    from unittest.mock import Mock
+
+    problem = _divergence_probe_problem()
+    Nx = _NX
+    shape = (problem.Nt + 1, *problem.spatial_shape)
+
+    hjb_solver = Mock()
+    hjb_solver.solve_hjb_system.side_effect = lambda *a, **k: np.full(shape, np.nan)
+    fp_solver = Mock()
+    fp_solver.solve_fp_system.side_effect = lambda *a, **k: np.ones(shape) / Nx
+
+    result = FixedPointIterator(problem=problem, hjb_solver=hjb_solver, fp_solver=fp_solver, relaxation=0.5).solve(
+        max_iterations=10, tolerance=1e-6
+    )
+
+    x = problem.geometry.get_spatial_grid().ravel()
+    np.testing.assert_allclose(np.asarray(result.U)[-1], x**2, rtol=0, atol=1e-12)


### PR DESCRIPTION
`FixedPointIterator` solved HJB, then unconditionally composed the FP source and drift from that value function. When HJB returned non-finite, FP ran on it and raised first:

```
ValueError: FP solver produced NaN/Inf at timestep 1/3 (9 non-finite values).
Check CFL condition: dt * sigma^2 / dx^2 should be < 0.5 for explicit schemes.
```

An FP diagnostic for an HJB failure, with advice that cannot help — the CFL condition was fine. Worse, that exception escaped the loop, so the #1078 block whose whole purpose is to distinguish "HJB (Newton divergence)" from "FP (density blow-up)" **never ran on this path**.

## The fix, and the two ways it could have gone wrong

Check `U_new` immediately after the HJB solve and terminate with the HJB attribution. Two details, each of which would otherwise trade a misattributed diagnostic for a silent one:

- `self.U` is published (not left at the last finite iterate) so the end-of-solve output validation still reports the divergence, through `preserve_terminal_condition` like every other path — `U[-1]` is boundary data. Copied first: that helper writes in place, and `U_new` is the HJB solver's own array.
- `mass_conservation_error` is `None` **only when no FP step completed in this solve**. Then `self.M` is the cold start (constant mass by construction → measures as exactly 0.0) or a warm start. The condition is "no FP output yet", **not** "the solve diverged" — a divergence after a completed FP step has a real density to measure.

The first version of this PR had that second point backwards and reported `None` for a measurable 49.5 % mass loss — the mirror image of the defect being fixed. Caught by independent adversarial review.

## Behaviour change

`solve()` now returns a `SolverResult` with `converged=False` on this path instead of propagating the FP `ValueError`, matching the two pre-existing divergence breaks in the same loop. One in-package consumer does not check `converged` and is therefore widened by one route — `HomotopyContinuation`, filed as #1719 (pre-existing; the two older breaks already reached it).

## Verification

Four tests, each killed by its own mutation and by no other:

| mutation | kills |
|---|---|
| disable the guard | 3 |
| initialise the flag `True` | the never-ran test |
| never set it `True` after an FP step | the still-measured test |
| drop the terminal-condition restore | the terminal test |

**Gate**: `./scripts/local_ci.sh` GREEN.
**Review**: two independent adversarial rounds. Round 1 found 3 blockers, round 2 found 1 (the mass-sentinel inversion above). All fixed; round-2 verified the round-1 fixes and reproduced the mutation counts exactly.

## Scope

One site. The same HJB-then-FP-with-no-check shape exists in **six other coupling loops** — #1718, deliberately not folded in. Note for #1718: lift the "no FP output yet" condition, **not** "the solve diverged", or this defect ships six times.

Fixes #1717
Refs #688, #1078, #1672, #1718, #1719
