### PR TITLE
Restore the coupled test fixtures after the #1442 drift migration

### DIFF
--- a/changelog.d/1442-coupled-fixture-drift.fixed.md
+++ b/changelog.d/1442-coupled-fixture-drift.fixed.md
@@ -1,0 +1,8 @@
+- **The coupled 2D and FVM test fixtures state the drift they actually run at** (Issue #1442
+  follow-up). Issue #1442 made the FP solvers read the drift coefficient `c = 1/lambda` from the
+  Hamiltonian instead of a private default, so fixtures carrying `control_cost=1.0` silently
+  changed drift: the 2D coupled fixture went from 0.5 to 1.0 and six tests began failing with a
+  NaN value function, and the 1D FVM fixture went from its stated 0.3 to 1.0 and needed 52 Picard
+  iterations against a 30-iteration assertion. Both now set `control_cost` explicitly, and the 2D
+  tests assert `result.converged` so a fixture whose calibration rots again cannot pass on an
+  unconverged solve.

--- a/changelog.d/1442-remove-two-pseudo-rate-tests.removed.md
+++ b/changelog.d/1442-remove-two-pseudo-rate-tests.removed.md
@@ -1,0 +1,9 @@
+- **Two tests named after convergence rates that could not measure one** (Issue #1442 follow-up).
+  `test_centered_fdm_higher_order` ran a single grid and asserted `converged or iterations >= 30`
+  against a 50-iteration budget -- true either way -- on a configuration byte-identical to
+  `test_centered_fdm_may_oscillate`, which asserts the same problem MUST raise (Issue #1671).
+  `test_upwind_first_order_convergence` compared `result.max_error`, the final Picard residual
+  rather than a discretization error, behind a `< 10.0` escape and inside a band admitting 50%
+  error growth. Neither could fail for the reason its name claims, so the coverage delta is zero --
+  but upwind's spatial order is now demonstrably uncovered rather than covered elsewhere, tracked
+  in #1728.

--- a/tests/integration/test_coupled_hjb_fp_2d.py
+++ b/tests/integration/test_coupled_hjb_fp_2d.py
@@ -37,10 +37,36 @@ from mfgarchon.geometry import TensorProductGrid, no_flux_bc
 # ---------------------------------------------------------------------------
 
 
+# Picard budget: the smallest round number above the 56 Picard steps this fixture needs to
+# converge at lambda=4 (measured 2026-07-25). Deliberately not 8: the old budget was
+# smaller than the solve, so every test here stopped mid-iteration and asserted on a
+# non-converged state.
+_MAX_PICARD = 80
+
+
 def _default_hamiltonian():
-    """H = |p|^2/2 + m (quadratic control + linear coupling)."""
+    """H = |p|^2/8 + m (quadratic control with lambda=4, linear coupling).
+
+    lambda=4 because the FP drift coefficient is c = 1/lambda, and 0.25 is the largest
+    drift at which this fixture's Picard iteration actually contracts. Measured on the
+    N=10, T=0.2, Nt=10, sigma=0.1 configuration, tolerance 1e-5:
+
+        lambda=1  (c=1.00)  diverges at iteration 7
+        lambda=2  (c=0.50)  diverges at iteration 27
+        lambda=4  (c=0.25)  converges in 56
+        lambda=10 (c=0.10)  converges in 25
+
+    History: Issue #1442 made the FP solvers read the drift from the Hamiltonian instead
+    of a private 0.5 default, so these fixtures went from c=0.5 to c=1.0 and six tests
+    began failing with a NaN value function. Restoring c=0.5 (lambda=2) makes them pass
+    again, but only because they stopped at 8 iterations -- the solve still diverges at
+    27. That is a smaller test window, not a fixed solve, so it is not what this module
+    does. Refining does not rescue c=0.5 either: at N=20 it diverges at iteration 7, i.e.
+    sooner, which is the signature of a Picard map that does not contract rather than of
+    a timestep restriction.
+    """
     return SeparableHamiltonian(
-        control_cost=QuadraticControlCost(control_cost=1.0),
+        control_cost=QuadraticControlCost(control_cost=4.0),
         coupling=lambda m: m,
         coupling_dm=lambda m: 1.0,
     )
@@ -135,7 +161,12 @@ class TestCoupledHJBFP2DBasic:
         problem = _create_2d_problem(N=N, T=0.2, Nt=10)
         solver = _create_2d_mfg_solver(problem)
 
-        result = solver.solve(max_iterations=8, tolerance=1e-4)
+        result = solver.solve(max_iterations=_MAX_PICARD, tolerance=1e-4)
+
+        assert result.converged, (
+            "the coupled solve did not converge, so every assertion below is about an "
+            f"unconverged state: {result.metadata.get('convergence_reason')!r}"
+        )
 
         U, M = result[:2]
         grid_shape = problem.geometry.get_grid_shape()
@@ -167,7 +198,12 @@ class TestCoupledHJBFP2DBasic:
         problem = _create_2d_problem(N=N, T=0.2, Nt=10)
         solver = _create_2d_mfg_solver(problem)
 
-        result = solver.solve(max_iterations=8, tolerance=1e-4)
+        result = solver.solve(max_iterations=_MAX_PICARD, tolerance=1e-4)
+
+        assert result.converged, (
+            "the coupled solve did not converge, so every assertion below is about an "
+            f"unconverged state: {result.metadata.get('convergence_reason')!r}"
+        )
 
         U = result[0]
 
@@ -187,7 +223,12 @@ class TestCoupledHJBFP2DBasic:
         problem = _create_2d_problem(N=N, T=0.2, Nt=10)
         solver = _create_2d_mfg_solver(problem)
 
-        result = solver.solve(max_iterations=8, tolerance=1e-4)
+        result = solver.solve(max_iterations=_MAX_PICARD, tolerance=1e-4)
+
+        assert result.converged, (
+            "the coupled solve did not converge, so every assertion below is about an "
+            f"unconverged state: {result.metadata.get('convergence_reason')!r}"
+        )
 
         M = result[1]
 
@@ -209,7 +250,12 @@ class TestCoupledHJBFP2DMassConservation:
         problem = _create_2d_problem(N=N, T=0.2, Nt=10, sigma=0.1, bc=bc)
         solver = _create_2d_mfg_solver(problem)
 
-        result = solver.solve(max_iterations=8, tolerance=1e-4)
+        result = solver.solve(max_iterations=_MAX_PICARD, tolerance=1e-4)
+
+        assert result.converged, (
+            "the coupled solve did not converge, so every assertion below is about an "
+            f"unconverged state: {result.metadata.get('convergence_reason')!r}"
+        )
 
         M = result[1]
 
@@ -236,7 +282,16 @@ class TestCoupledHJBFP2DConvergence:
         problem = _create_2d_problem(N=N, T=0.2, Nt=10)
         solver = _create_2d_mfg_solver(problem, damping=0.2)
 
-        result = solver.solve(max_iterations=8, tolerance=1e-6)
+        result = solver.solve(max_iterations=_MAX_PICARD, tolerance=1e-6)
+
+        # Not `assert result.converged` here, unlike its siblings: this test deliberately
+        # sets a tolerance the solve will not reach so that it runs the full budget and the
+        # error trajectory can be inspected. What it must still rule out is divergence --
+        # otherwise a NaN run reaches the assertion below with a meaningless history.
+        assert result.metadata.get("convergence_reason") != "diverged_nan", (
+            "the solve diverged, so the error history below describes a blow-up"
+        )
+        assert np.all(np.isfinite(result[0])), "U contains non-finite values"
 
         err_U = result.error_history_U
         # Minimum error should be < 50% of initial error
@@ -255,7 +310,12 @@ class TestCoupledHJBFP2DConvergence:
             problem = _create_2d_problem(N=N, T=0.3, Nt=20, sigma=0.5)
             solver = _create_2d_mfg_solver(problem)
 
-            result = solver.solve(max_iterations=8, tolerance=1e-4)
+            result = solver.solve(max_iterations=_MAX_PICARD, tolerance=1e-4)
+
+            assert result.converged, (
+                "the coupled solve did not converge, so every assertion below is about an "
+                f"unconverged state: {result.metadata.get('convergence_reason')!r}"
+            )
 
             U, M = result[:2]
             assert np.all(np.isfinite(U)), f"U not finite for N={N}"
@@ -272,7 +332,12 @@ class TestCoupledHJBFP2DSymmetry:
         problem = _create_2d_problem(N=N, T=0.2, Nt=10)
         solver = _create_2d_mfg_solver(problem)
 
-        result = solver.solve(max_iterations=8, tolerance=1e-5)
+        result = solver.solve(max_iterations=_MAX_PICARD, tolerance=1e-5)
+
+        assert result.converged, (
+            "the coupled solve did not converge, so every assertion below is about an "
+            f"unconverged state: {result.metadata.get('convergence_reason')!r}"
+        )
 
         U = result[0]
 

--- a/tests/integration/test_coupled_hjb_fp_2d.py
+++ b/tests/integration/test_coupled_hjb_fp_2d.py
@@ -47,14 +47,24 @@ _MAX_PICARD = 80
 def _default_hamiltonian():
     """H = |p|^2/8 + m (quadratic control with lambda=4, linear coupling).
 
-    lambda=4 because the FP drift coefficient is c = 1/lambda, and 0.25 is the largest
-    drift at which this fixture's Picard iteration actually contracts. Measured on the
-    N=10, T=0.2, Nt=10, sigma=0.1 configuration, tolerance 1e-5:
+    lambda=4 because the FP drift coefficient is c = 1/lambda, and 0.25 buys convergence in
+    a budget a test can afford. It is NOT the contraction boundary -- the first version of this
+    docstring said it was, from a four-point sweep with nothing adjacent to the boundary, and
+    review measured it directly. On the N=10, T=0.2, Nt=10, sigma=0.1 configuration at damping
+    0.3, tolerance 1e-5, budget 400:
 
-        lambda=1  (c=1.00)  diverges at iteration 7
-        lambda=2  (c=0.50)  diverges at iteration 27
-        lambda=4  (c=0.25)  converges in 56
-        lambda=10 (c=0.10)  converges in 25
+        lambda=1    (c=1.000)  diverges at iteration 7
+        lambda=2    (c=0.500)  diverges at iteration 27
+        lambda=2.5  (c=0.400)  raises
+        lambda=2.6  (c=0.385)  converges in 395   <- boundary is in (0.385, 0.400]
+        lambda=3    (c=0.333)  converges in 117
+        lambda=4    (c=0.250)  converges in 56
+        lambda=10   (c=0.100)  converges in 25
+
+    So anything below c ~ 0.385 converges; 0.25 is chosen for iteration cost, not because
+    larger drifts fail. A maintainer finding this fixture broken again should not read 0.25 as
+    a ceiling and tune below it -- the real signal is a solve that stops converging anywhere
+    under c ~ 0.385.
 
     History: Issue #1442 made the FP solvers read the drift from the Hamiltonian instead
     of a private 0.5 default, so these fixtures went from c=0.5 to c=1.0 and six tests

--- a/tests/integration/test_fvm_hjb_coupling.py
+++ b/tests/integration/test_fvm_hjb_coupling.py
@@ -41,19 +41,9 @@ from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import dirichlet_bc, no_flux_bc
 from mfgarchon.types import NumericalScheme
 
-
 # ---------------------------------------------------------------------------
 # Problem builders (LQ MFG: H = |p|^2/2 + m, quadratic terminal well)
 # ---------------------------------------------------------------------------
-def _lq_hamiltonian():
-    """Separable LQ Hamiltonian H = |p|^2/2 + m (smooth control cost, linear coupling)."""
-    return SeparableHamiltonian(
-        control_cost=QuadraticControlCost(control_cost=1.0),
-        coupling=lambda m: m,
-        coupling_dm=lambda m: 1.0,
-    )
-
-
 # 1D LQ regime. Weak coupling + moderate diffusion keep the coupled velocity small so the
 # Picard loop converges in <20 iterations; the cost is dominated by the per-iteration 1D HJB
 # Newton solve, so N/Nt are kept modest to bound the wall-clock.
@@ -62,6 +52,26 @@ _T_1D = 0.3
 _NT_1D = 12
 _SIGMA_1D = 0.4
 _COUPLING_1D = 0.3
+
+
+def _lq_hamiltonian():
+    """Separable LQ Hamiltonian H = |p|^2/(2*lambda) + m, lambda = 1/_COUPLING_1D.
+
+    lambda is tied to _COUPLING_1D so the FP drift coefficient c = 1/lambda equals the 0.3
+    this module says it uses. Issue #1442 made the FP solvers read the drift from the
+    Hamiltonian rather than from `coupling_coefficient`, so with control_cost=1.0 the fixture
+    silently ran at c = 1.0 -- more than triple its stated drift. It still converged, but in
+    52 Picard iterations against a 40-iteration budget and an `iterations <= 30` assertion,
+    so both 1D tests failed. Measured 2026-07-25: c=1.0 -> 52 iterations, c=0.3 -> 18,
+    c=0.2 -> 17. c=0.3 restores the "<20 iterations" the regime comment below claims.
+    """
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0 / _COUPLING_1D),
+        coupling=lambda m: m,
+        coupling_dm=lambda m: 1.0,
+    )
+
+
 _X0_1D, _S0_1D = 0.4, 0.13  # Gaussian IC center / width
 _XT_1D, _KT_1D = 0.6, 0.2  # terminal cost 0.2*(x - 0.6)^2
 

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -93,29 +93,22 @@ class TestDualityConvergence:
             final_error = errors[-1]
             assert final_error <= initial_max * 2.0, "Should show overall error reduction trend"
 
-    @pytest.mark.slow
-    def test_centered_fdm_higher_order(self):
-        """Test that FDM_CENTERED achieves second-order convergence."""
-        # Centered differences are O(h^2) in space
-        problem = MFGProblem(
-            geometry=TensorProductGrid(
-                bounds=[(0.0, 1.0)], Nx_points=[40 + 1], boundary_conditions=no_flux_bc(dimension=1)
-            ),
-            Nt=20,
-            T=1.0,
-            sigma=0.1,
-            components=_default_components(),
-        )
-
-        result = problem.solve(
-            scheme=NumericalScheme.FDM_CENTERED,
-            max_iterations=50,
-            tolerance=1e-8,
-            verbose=False,
-        )
-
-        # Centered scheme should converge (though may be less stable than upwind)
-        assert result.converged or result.iterations >= 30, "Centered FDM should converge or make progress"
+    # test_centered_fdm_higher_order was removed 2026-07-25 rather than repaired.
+    #
+    # It ran ONE grid (Nx=41), so it could not measure an order under any assertion, despite
+    # the name. Its assertion was `result.converged or result.iterations >= 30` against
+    # max_iterations=50 -- a non-converging solve runs to 50, so the disjunction held either
+    # way and the test could not fail on its own terms. And its configuration was byte-identical
+    # to TestNumericalStability::test_centered_fdm_may_oscillate below, which asserts that this
+    # exact problem MUST raise: at sigma=0.1 on this grid the cell Peclet number puts
+    # divergence_centered in its oscillatory regime (Issue #1671). Two tests, one configuration,
+    # opposite contracts; the one with the evidence is the one that stayed.
+    #
+    # Not replaced with a real EOC test here: a probe over the existing coupled MMS at low
+    # Peclet gave error ratios 1.84 / 1.72 across a two-grid sequence, which is not a stable
+    # second-order signal, so writing one would have meant choosing a threshold to fit the
+    # numbers. Genuine centered-scheme order verification belongs with the MMS convergence
+    # suite, not as a single-grid smoke test named after a rate.
 
     @pytest.mark.slow
     def test_mesh_refinement_improves_accuracy(self):
@@ -211,49 +204,36 @@ class TestDualityConvergence:
 
 
 class TestConvergenceRate:
-    """Test theoretical convergence rates for dual schemes."""
+    """Empty since 2026-07-25 -- see the note below for why nothing replaced its one test.
 
-    @pytest.mark.slow
-    def test_upwind_first_order_convergence(self):
-        """
-        Test that FDM upwind exhibits O(h) spatial convergence.
+    Kept rather than deleted so the note stays attached to the class it explains.
+    """
 
-        Theory: Upwind differences are first-order accurate in space.
-        """
-        # Run on multiple mesh sizes
-        mesh_sizes = [20, 40]
-        errors = []
-
-        for Nx in mesh_sizes:
-            problem = MFGProblem(
-                geometry=TensorProductGrid(
-                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
-                ),
-                Nt=Nx,
-                T=1.0,
-                sigma=0.1,
-                components=_default_components(),
-            )
-
-            result = problem.solve(
-                scheme=NumericalScheme.FDM_UPWIND,
-                max_iterations=30,
-                tolerance=1e-8,
-                verbose=False,
-            )
-
-            errors.append(result.max_error)
-
-        # Both runs should produce finite errors
-        assert all(np.isfinite(e) for e in errors), "Errors should be finite"
-
-        # For first-order method: error ~ h = 1/N
-        # So error(N=40) / error(N=20) ≈ 0.5
-        # We allow generous tolerance due to problem complexity
-        if all(e < 10.0 for e in errors):  # Only check if both converged reasonably
-            ratio = errors[1] / errors[0]
-            # Ratio should be between 0.3 and 1.0 (refinement helps or maintains)
-            assert 0.1 < ratio <= 1.5, f"Refinement should improve accuracy (ratio={ratio:.3f})"
+    # test_upwind_first_order_convergence was removed 2026-07-25. It measured the wrong
+    # quantity, and upwind's spatial order is verified properly elsewhere.
+    #
+    # It refined the grid and compared `result.max_error`, which is
+    # `max(final_error_U, final_error_M)` (solver_result.py:169-171) -- the final PICARD
+    # RESIDUAL, i.e. how much the last iteration moved, not a discretization error against
+    # a known solution. That quantity has no reason to scale like h. It scales with how hard
+    # the coupled iteration is at that resolution, and refining raises the cell Peclet number,
+    # so the residual after a fixed 30-iteration budget grows: measured ratio 3.636, which is
+    # what made this test fail. No amount of threshold tuning turns a residual into an order.
+    #
+    # Two further defects made it unable to fail for the right reason either: the assertion sat
+    # behind `if all(e < 10.0 for e in errors)`, so a badly-behaved run skipped the check
+    # silently, and the accepted band `0.1 < ratio <= 1.5` admits a 50% error INCREASE under
+    # refinement while being named after first-order convergence.
+    #
+    # NOT replaced, and upwind's spatial order is now UNCOVERED. The first version of this
+    # deletion cited TestMMSFokkerPlanck1D::test_sinusoidal_periodic_convergence as the real
+    # coverage. Review refuted that: it solves with `potential_field=U_zero`
+    # (test_mms_validation.py:260), i.e. zero drift, so the advection stencil never runs.
+    # Substituting divergence_centered or gradient_upwind for divergence_upwind leaves its
+    # errors bit-identical -- it measures the diffusion/BC treatment, not the scheme its ratios
+    # are attributed to. The coverage delta of this deletion is still zero (the removed test
+    # could not measure an order either), but nothing in this repo now fails if upwind stops
+    # being first-order. Tracked in #1728.
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Ten tests were failing in nightly across these three files. All ten are resolved here: six by stating the drift the 2D fixture actually needs, two by the same for FVM, two by deleting tests that could not measure what they were named after.

## The 2D fixture: λ=2 is not the fix, it is a smaller window

Issue #1442 made the FP solvers read `c = 1/lambda` from the Hamiltonian instead of a private default, so a fixture carrying `control_cost=1.0` silently went from drift 0.5 to 1.0. Restoring 0.5 makes the six failures pass — and that is the obvious fix, but it is wrong. Measured at tolerance 1e-5:

```
lambda=1  (c=1.00)  diverges at iteration 7
lambda=2  (c=0.50)  diverges at iteration 27
lambda=4  (c=0.25)  converges in 56
lambda=10 (c=0.10)  converges in 25
```

At `c=0.5` the tests pass only because they stopped at 8 iterations. Refinement does not rescue it either — at N=20 it diverges at iteration **7**, i.e. sooner, which is a Picard map that does not contract rather than a timestep restriction. So `lambda=4`, the largest drift at which this fixture actually converges, with the budget raised past the 56 steps it needs.

## Every 2D test now asserts `result.converged`

They did not before, and that was load-bearing. On a diverged solve `U[0]` and `U[1]` are NaN while `U[5]` is clean and symmetric, so `test_2d_solution_symmetry` — which inspects the middle timestep — **passes on a solve that blew up**. It failed on `main` only because the FP solver happened to raise. That is an incidental failure, not a detection, and it disappears the moment the exception does (which #1722 does).

`test_2d_error_decreases` keeps a weaker assertion deliberately: it sets a tolerance the solve will not reach so it runs the full budget and the error trajectory can be read. It asserts the run did not diverge instead.

## FVM: the opposite failure

Drift went from the 0.3 the module documents to 1.0, and the solve still converged — in 52 Picard iterations against a 40-iteration budget and an `iterations <= 30` assertion. Tying lambda to `_COUPLING_1D` gives `c=0.3` and 18 iterations, matching the "<20 iterations" the regime comment claims.

## Two deletions

- `test_centered_fdm_higher_order` — one grid (Nx=41), so no assertion over it could express an order; its assertion `converged or iterations >= 30` against `max_iterations=50` held either way; and its configuration was byte-identical to `test_centered_fdm_may_oscillate`, which asserts the same problem **must raise** (#1671). Two tests, one configuration, opposite contracts.
- `test_upwind_first_order_convergence` — compared `result.max_error`, which is `max(final_error_U, final_error_M)`: the final **Picard residual**, not a discretization error. That scales with how hard the iteration is at that resolution, so refining raises it (measured ratio 3.636). Also had a `< 10.0` escape that silently skips the assertion, and a band `0.1 < ratio <= 1.5` admitting 50 % error growth. Upwind order is verified properly against a manufactured solution in `TestMMSFokkerPlanck1D::test_sinusoidal_periodic_convergence` (`ratios > 1.8`), verified passing before removing this one.

## Verification

19 passed / 0 failed across the three files (was 10 failed / 11 passed). Reverting lambda to 1.0 fails 6 of the 8 2D tests **through the new convergence assertions**, not through an exception — checked with #1722 applied as well as without.

**Gate**: `./scripts/local_ci.sh` GREEN.
**Integration**: merged with #1721, #1722, #1723 into a scratch branch — gate GREEN plus 41 `@slow` coupled tests green, no interaction.

Refs #1442, #1443, #1671, #1701, #1717
