### PR TITLE
Consume the spatial volatility field in the GFDM batch path

### DIFF
--- a/changelog.d/1725-gfdm-batch-spatial-volatility.fixed.md
+++ b/changelog.d/1725-gfdm-batch-spatial-volatility.fixed.md
@@ -1,0 +1,8 @@
+- **`HJBGFDMSolver` now consumes a spatial `volatility_field` instead of its mean** (Issue #1725).
+  The batch residual and Jacobian each resolved sigma through a byte-identical copy of one
+  expression ending in `_get_sigma_value(None)`, whose documented contract collapses an array to
+  its mean and evaluates a callable once at the domain centre — so `volatility_field=linspace(0.1,
+  0.5, N)` produced a solve byte-identical to the scalar `0.3`. `assemble_hjb_residual` has
+  accepted a per-node field since Issue #1071, so the coefficient was being discarded one layer
+  above an assembly that could consume it. Both copies now route through one `_batch_sigma()`
+  owner. Scalar solves are bit-identical; LLF augmentation is unchanged.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2150,11 +2150,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
         # assemble_hjb_residual (now field-σ capable, D_i = σ_eff_i²/2 elementwise); a plain solve
         # uses the scalar σ. One assembly path either way.
-        sigma = (
-            self._llf_sigma_eff
-            if (self.llf_augmentation and self._llf_sigma_eff is not None)
-            else self._get_sigma_value(None)
-        )
+        sigma = self._batch_sigma()
         return assemble_hjb_residual(
             H_class=H_class,
             x=self.collocation_points,
@@ -2198,11 +2194,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
         # assemble_hjb_jacobian_diag (now field-σ capable: it row-scales the Laplacian via
         # diags(D_i) @ D_lap); a plain solve uses the scalar σ. One assembly path either way.
-        sigma = (
-            self._llf_sigma_eff
-            if (self.llf_augmentation and self._llf_sigma_eff is not None)
-            else self._get_sigma_value(None)
-        )
+        sigma = self._batch_sigma()
         return assemble_hjb_jacobian_diag(
             H_class=H_class,
             x=self.collocation_points,
@@ -2846,6 +2838,45 @@ class HJBGFDMSolver(BaseHJBSolver):
         else:
             # Numeric sigma: use directly (with fallback to default)
             return float(getattr(self.problem, "sigma", 1.0))
+
+    def _batch_sigma(self) -> float | np.ndarray:
+        """The one owner of the batch path's sigma (Issue #1725).
+
+        Returns a per-node field when one is available and a scalar otherwise.
+        ``assemble_hjb_residual`` and ``assemble_hjb_jacobian_diag`` accept either
+        (``h_eval.py``: ``sigma: float | NDArray``, elementwise ``D_i = sigma_i**2/2``, and
+        bit-identical to the prior call for a scalar), so a field does not need collapsing to
+        reach them.
+
+        Before this existed, the residual (~:2154) and the Jacobian (~:2202) each carried a
+        byte-identical copy of this selection and both ended in ``_get_sigma_value(None)``,
+        whose documented contract averages an array and evaluates a callable once at the domain
+        centre. So a caller passing ``volatility_field=linspace(0.1, 0.5, N)`` got a solve
+        byte-identical to passing the scalar ``0.3`` -- a plausible answer to a different
+        problem. The capability was never missing; the coefficient was discarded one layer above
+        the assembly that could consume it.
+
+        Precedence, highest first:
+
+        1. LLF ``sigma_eff`` when augmentation is on -- unchanged, it is already per-node.
+        2. A ``volatility_field`` override that resolves per node: an array of length
+           ``n_points``, or a callable evaluated at each collocation point.
+        3. Everything else via ``_get_sigma_value(None)`` -- scalars, and arrays whose length
+           does not match the collocation set (those cannot be a per-node field here, and
+           silently reshaping one would be a worse failure than averaging it).
+        """
+        if self.llf_augmentation and self._llf_sigma_eff is not None:
+            return self._llf_sigma_eff
+
+        override = self._volatility_field_override
+        if isinstance(override, np.ndarray) and override.ndim >= 1 and override.shape[0] == self.n_points:
+            return override
+        if callable(override):
+            return np.array(
+                [self._resolve_diffusion_source(override, i) for i in range(self.n_points)],
+                dtype=float,
+            )
+        return self._get_sigma_value(None)
 
     def _resolve_diffusion_source(self, source: float | np.ndarray | Callable, point_idx: int | None) -> float:
         """Resolve a scalar / callable / per-point-array diffusion source to a scalar sigma.

--- a/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
+++ b/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""HJBGFDM's batch path must consume a spatial volatility field, not its mean (Issue #1725).
+
+The batch residual and Jacobian resolved sigma through ``_get_sigma_value(None)``, whose
+documented contract collapses an array to its mean (``pde_coefficients.py``: "the batch path
+applies one global scalar"). ``assemble_hjb_residual`` has accepted a per-node field since
+Issue #1071 phase 7 -- the LLF path already passes one -- so the field was being discarded at
+coefficient retrieval, one layer above an assembly that could consume it.
+
+Every pre-existing array test used a CONSTANT array (``np.full(Nx, 0.5)``), which is its own
+mean and therefore passes under both behaviours. These tests use a non-constant field, which is
+the only kind that can tell them apart.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary.conditions import no_flux_bc
+
+_N = 21
+_SIGMA_LO, _SIGMA_HI = 0.1, 0.5  # mean 0.3
+
+
+def _problem(sigma=0.3):
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[_N],
+            boundary_conditions=no_flux_bc(dimension=1),
+        ),
+        components=MFGComponents(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+            m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.5 * np.asarray(x) ** 2,
+        ),
+        T=0.1,
+        Nt=5,
+        sigma=sigma,
+    )
+
+
+def _solve(volatility_field):
+    problem = _problem()
+    x = np.linspace(0.0, 1.0, _N)
+    solver = HJBGFDMSolver(problem, collocation_points=x.reshape(-1, 1))
+    M = np.tile(np.exp(-10 * (x - 0.5) ** 2), (problem.Nt + 1, 1))
+    return solver.solve_hjb_system(M, 0.5 * x**2, np.zeros((problem.Nt + 1, _N)), volatility_field=volatility_field)
+
+
+@pytest.mark.unit
+def test_nonconstant_array_field_is_not_collapsed_to_its_mean():
+    """The defect, stated as the test that was missing.
+
+    linspace(0.1, 0.5) has mean 0.3. Before the fix these two solves were byte-identical.
+    """
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
+    u_field = _solve(field)
+    u_mean = _solve(float(field.mean()))
+
+    assert not np.array_equal(u_field, u_mean), (
+        "the spatial volatility field was collapsed to its mean: the solve is byte-identical "
+        f"to passing the scalar {field.mean()}"
+    )
+    # And the difference must be of the size the field's spread implies, not float noise.
+    assert np.max(np.abs(u_field - u_mean)) > 1e-6
+
+
+@pytest.mark.unit
+def test_nonconstant_callable_field_is_not_collapsed_to_the_domain_center():
+    """Same defect via the callable branch, which evaluated once at the domain center."""
+
+    def sigma_of_x(pt):
+        return _SIGMA_LO + (_SIGMA_HI - _SIGMA_LO) * np.asarray(pt).reshape(-1)[0]
+
+    u_callable = _solve(sigma_of_x)
+    u_center = _solve(float(sigma_of_x(np.array([0.5]))))
+
+    assert not np.array_equal(u_callable, u_center), (
+        "the callable volatility was evaluated once at the domain center rather than per node"
+    )
+
+
+@pytest.mark.unit
+def test_scalar_field_is_byte_identical_to_the_problem_sigma():
+    """The fix must not perturb the scalar path.
+
+    Byte-identity, not a tolerance: consolidating coefficient retrieval is a refactor on this
+    path and any float difference would mean it is not.
+    """
+    u_override = _solve(0.3)
+    u_problem = _solve(None)
+    np.testing.assert_array_equal(
+        u_override,
+        u_problem,
+        err_msg="scalar volatility_field=0.3 must reproduce problem.sigma=0.3 bit for bit",
+    )
+
+
+@pytest.mark.unit
+def test_residual_and_jacobian_read_the_same_sigma_source():
+    """Residual and Jacobian resolved sigma through two byte-identical copies of one expression.
+
+    Consolidating them is the point of the fix -- this pins that they cannot drift apart again by
+    asserting they resolve through the single owner rather than by comparing their outputs, which
+    would be an agreement test between two paths that now share an implementation and would
+    therefore go inert exactly when the consolidation succeeds.
+    """
+    problem = _problem()
+    x = np.linspace(0.0, 1.0, _N)
+    solver = HJBGFDMSolver(problem, collocation_points=x.reshape(-1, 1))
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
+    solver._volatility_field_override = field
+
+    resolved = solver._batch_sigma()
+    assert isinstance(resolved, np.ndarray), "batch sigma must stay a per-node field"
+    np.testing.assert_array_equal(resolved, field)
+
+    solver._volatility_field_override = 0.3
+    assert isinstance(solver._batch_sigma(), float), "a scalar override must resolve to a scalar"


### PR DESCRIPTION
> **Branch name is stale.** It says `fail-loud` because that is what the audit proposed as the first safe step, and what I set out to do. Reading the code changed the plan — see *Why not the fail-loud guard* below. The title and this body describe what actually landed.

`HJBGFDMSolver` accepted a spatially varying `volatility_field` and silently solved with its **mean**. Reproduced on `main` (fe531ac9), 31-point 1D grid, `volatility_field=np.linspace(0.1, 0.5, 31)`:

```
field vs mean-scalar 0.3 : max|diff| = 0.000e+00   array_equal = True
field vs scalar 0.1      : max|diff| = 3.357e-02
```

Byte-identical to the scalar mean — a plausible answer to a different problem.

## Where the field was lost

Not in the assembly. `assemble_hjb_residual` has taken `sigma: float | NDArray` since #1071 phase 7 (elementwise `D_i = σ_i²/2`, bit-identical for a scalar), and the LLF path already passes a per-node field through it. The coefficient was discarded one layer above, at retrieval:

- the batch **residual** (`hjb_gfdm.py:~2154`) and the batch **Jacobian** (`~2202`) each carried a **byte-identical copy** of the same selection;
- both ended in `_get_sigma_value(None)`, whose contract is explicit (`pde_coefficients.py:396`):

  > **array**: index by `index` when given and in range, else **collapse to `mean`** (the batch path applies one global scalar)

So the resolver behaved as documented. The defect is that the GFDM batch path took the `index=None` branch for every node.

## The fix

Both copies now route through one `_batch_sigma()` owner, which returns a per-node field when one exists:

1. LLF `sigma_eff` when augmentation is on — unchanged, already per-node.
2. A `volatility_field` override resolving per node: an array of length `n_points`, or a callable evaluated at each collocation point.
3. Otherwise `_get_sigma_value(None)` — scalars, and arrays whose length does not match the collocation set, where silently reshaping would be worse than averaging.

## Why no existing test caught it

Every array-valued `volatility_field` case in the suite used a **constant** array (`np.full(Nx, 0.5)`, `test_issue_1248_volatility_forwarding.py:166,194`). A constant array **is** its own mean, so those tests pass under both behaviours — the "non-discriminating test data" case in its purest form. The four tests added here use non-constant fields, which is the only kind that can tell them apart.

## Verification

Red-then-green: three of the four fail on the parent commit. Each branch pinned by its own mutation:

| mutation | kills |
|---|---|
| collapse the array branch | 2 |
| collapse the callable branch | 1 |
| revert the owner to the old behaviour | 3 |

The scalar byte-identity test stays **green under all three** — it pins what must not change.

**Gate**: `./scripts/local_ci.sh` GREEN.
**Review**: not yet independently reviewed.

## Why not the fail-loud guard

The audit proposed raising `NotImplementedError` on a non-constant field as the first safe step. That would be right if the batch path could not consume a field — but it can, and the LLF path proves it. Meanwhile the two duplicated copies of the sigma selection are themselves the single-source defect this repo tracks as its dominant bug class. Consolidating them is both the smaller change and the one that closes the divergence rather than documenting it.

## Closure claims this corrects

#1412's closing comment stated "cross-path divergence closed" and #1316 is recorded as having HJBGFDM consume spatial volatility. The probe above contradicted both on `main`. They should read as partially resolved for the period between those closures and this PR — the shared provider, monkeypatch removal, and FDM field precedence parts did land.

Fixes #1725
Refs #1071, #1248, #1316, #1412, #1449, #1701
