### PR TITLE
Pin ruff in CI to the version everyone else runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - 'tests/**/*.py'
       - 'pyproject.toml'
       - '.github/workflows/ci.yml'
+      - '.pre-commit-config.yaml'   # decides which ruff this workflow installs
 
   # Full checks on main branch pushes
   push:
@@ -22,6 +23,7 @@ on:
       - 'tests/**/*.py'
       - 'pyproject.toml'
       - '.github/workflows/ci.yml'
+      - '.pre-commit-config.yaml'   # decides which ruff this workflow installs
 
   # Comprehensive checks on releases
   release:
@@ -66,7 +68,19 @@ jobs:
       timeout-minutes: 2
       run: |
         python -m pip install --upgrade pip
-        pip install ruff
+        # Read the pin from .pre-commit-config.yaml rather than restating it here. A bare
+        # `pip install ruff` took whatever was newest, so this job silently drifted off the
+        # version everyone else runs: ruff 0.16.0 shipped markdown formatting and this check
+        # went red on four README files nobody had touched, on every open PR at once.
+        # `|| RUFF_VERSION=""` matters: the runner shell is `bash -e {0}`, so a failing
+        # substitution would abort here and the guard below would never print anything.
+        RUFF_VERSION=$(grep -A1 'repos:.*ruff-pre-commit\|astral-sh/ruff-pre-commit' .pre-commit-config.yaml | grep -oE 'rev: v[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || RUFF_VERSION="")
+        if [ -z "$RUFF_VERSION" ]; then
+          echo "::error::could not read the ruff pin from .pre-commit-config.yaml"
+          exit 1
+        fi
+        echo "Using ruff==$RUFF_VERSION (pinned in .pre-commit-config.yaml)"
+        pip install "ruff==$RUFF_VERSION"
 
     - name: Python syntax check (instant fail)
       timeout-minutes: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 repos:
   # Unified formatting and linting with Ruff (replaces Black + isort + Pylint)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: v0.16.0
     hooks:
       # Format code (replaces Black + isort)
       - id: ruff-format

--- a/changelog.d/ruff-0-16-0-pin.changed.md
+++ b/changelog.d/ruff-0-16-0-pin.changed.md
@@ -1,0 +1,9 @@
+- **The ruff version is pinned in CI, and markdown is exempt from formatting** (ruff 0.16.0).
+  `ci.yml`'s Quick Validation job ran a bare `pip install ruff`, so it silently drifted off the
+  version pinned in `.pre-commit-config.yaml`; when 0.16.0 shipped fenced-code-block formatting for
+  markdown, the job went red on four README files nobody had touched, on every open PR at once. The
+  job now reads the pin from `.pre-commit-config.yaml`, fails loudly if that pin cannot be read, and
+  that file is now a CI trigger path -- otherwise a pin change merges without ever running the
+  version it selects. `scripts/local_ci.sh` warns when the ruff on PATH disagrees with the pin,
+  since `pyproject.toml` and `environment.yml` specify a floor (`ruff>=0.6.0`) rather than a pin.
+  `[tool.ruff.format] exclude = ["*.md"]` keeps documentation examples laid out for reading.

--- a/mfgarchon/types/solver_types.py
+++ b/mfgarchon/types/solver_types.py
@@ -86,7 +86,7 @@ type ParameterDict = dict[str, float | int | str | bool]
 type SolverOptions = dict[str, float | int | str | bool | None]
 """Dictionary of optional solver settings."""
 
-type ConfigValue = float | int | str | bool | None | list[float | int | str] | dict[str, Any] | Callable | Any
+type ConfigValue = float | int | str | bool | list[float | int | str] | dict[str, Any] | Callable | Any | None
 """Flexible configuration value type."""
 
 # === Callback Types ===

--- a/mfgarchon/utils/pde_coefficients.py
+++ b/mfgarchon/utils/pde_coefficients.py
@@ -520,7 +520,7 @@ class CoefficientField:
 
     def __init__(
         self,
-        field: None | float | np.ndarray | Callable,
+        field: float | np.ndarray | Callable | None,
         default_value: float | np.ndarray,
         field_name: str = "coefficient",
         dimension: int = 1,
@@ -1109,7 +1109,7 @@ class _DriftDispatcher:
 
     def __init__(
         self,
-        drift_field: None | np.ndarray | Callable,
+        drift_field: np.ndarray | Callable | None,
         Nt: int,
         spatial_shape: tuple,
         dimension: int = 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -421,6 +421,12 @@ scientific = ["numpy", "scipy", "matplotlib", "plotly", "jax", "jaxlib"]
 quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
+# ruff 0.16.0 began formatting fenced code blocks inside markdown. Documentation examples are
+# laid out for reading, not for the 120-column source budget: it collapsed a six-vertex array
+# and a four-kwarg constructor in geometry/README.md onto single lines, and pushed a raise in
+# utils/README.md past 100 characters. Source files are still formatted; only the prose is
+# exempt. If markdown formatting is wanted later, it needs its own line-length, not this one.
+exclude = ["*.md"]
 
 # Pydantic plugin configuration
 [tool.pydantic-mypy]

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -22,6 +22,19 @@ check() {
   else printf '\033[31mFAIL\033[0m %s\n' "$2"; fail=1; fi
 }
 
+# This script calls itself the authoritative gate, so it must not run whatever ruff happens to
+# be on PATH. pyproject/environment.yml specify `ruff>=0.6.0` -- a floor, not a pin -- so a
+# contributor who installs today gets a different formatter from the one CI and pre-commit use,
+# and goes red on files they never touched. Warn rather than fail: an unexpected version is a
+# real signal, but blocking the whole gate on it would be worse than running it.
+RUFF_PIN=$(grep -A1 'astral-sh/ruff-pre-commit' "$(dirname "$0")/../.pre-commit-config.yaml" 2>/dev/null \
+  | grep -oE 'rev: v[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || RUFF_PIN="")
+RUFF_HAVE=$(ruff --version 2>/dev/null | awk '{print $2}')
+if [[ -n "$RUFF_PIN" && -n "$RUFF_HAVE" && "$RUFF_PIN" != "$RUFF_HAVE" ]]; then
+  printf '\033[33mWARN\033[0m ruff %s on PATH, but .pre-commit-config.yaml pins %s -- formatting may disagree with CI\n' \
+    "$RUFF_HAVE" "$RUFF_PIN"
+fi
+
 step "Ruff format"
 ruff format --check mfgarchon/; check $? "ruff format --check mfgarchon/"
 


### PR DESCRIPTION
**All five open PRs went red on `Quick Validation (Syntax & Format)` at once, on files none of them touched.** This is why, and the fix.

## Root cause

`ci.yml:69` ran a bare `pip install ruff`. That one job therefore took whatever was newest on PyPI, while every other surface — local dev, pre-commit, `scripts/local_ci.sh` — used the pin in `.pre-commit-config.yaml` (`v0.15.17`). When ruff `0.16.0` published, the job drifted off the pin and started enforcing rules nobody's branch had been checked against.

Demonstrated on clean `main`, no PR changes applied:

```
ruff 0.16.0   ->  4 files would be reformatted, 454 already formatted
ruff 0.15.20  ->  454 files already formatted
```

The four files are `README.md`s. `main`'s own CI last ran 2026-07-21 and was green — before `0.16.0` existed — so `main` would fail this check today too.

`CLAUDE.md` already required pinning ruff, for "reproducible formatting, no surprise CI failures". The pin existed. It simply was not what this job installed.

## Three changes

**1. `ci.yml` reads the pin instead of restating it.** Writing `ruff==0.16.0` into the workflow would put a *third* copy of the version in the repo — that is the defect, not a fix for it. The step greps `.pre-commit-config.yaml`, and if it cannot read a version it emits `::error::` and exits. It must not fall back to "newest": that silent fallback is what produced this.

Checked both directions locally — returns `0.16.0` from the current file, and returns empty (taking the error branch) when the `rev:` line is corrupted.

**2. `[tool.ruff.format] exclude = ["*.md"]`.** `0.16.0` began formatting fenced code blocks inside markdown. Documentation examples are laid out for reading, not for the 120-column source budget: it collapsed a six-vertex array and a four-kwarg constructor onto single lines in `geometry/README.md`, and pushed a `raise` past 100 characters in `utils/README.md`. Source files are still formatted; only prose is exempt.

**3. Pin moved `0.15.17` -> `0.16.0`** via `scripts/update_ruff_version.py`, and three new `RUF036` findings cleared (`None` must be last in a type union) in `solver_types.py` and `pde_coefficients.py`. `None | X` and `X | None` are the same type — the diff is ordering only.

## Effect on the other PRs

#1721, #1722, #1723, #1724, #1726 are all blocked by this and by nothing else. They need a rebase onto this once it lands. Their `local_ci.sh` gates were green throughout — the local gate uses the pinned ruff, which is the whole point.

**Gate**: `./scripts/local_ci.sh` GREEN.
**Verification that matters**: this PR's own CI run. The extraction is checked locally, but whether it installs correctly on a GitHub runner is only knowable by running it — this PR is that run.
