### PR TITLE
Say what actually gates main -- which is nothing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,10 @@ default_language_version:
   python: python3.12
 
 default_stages: [pre-commit]
-# pre-push must be installed explicitly; `pre-commit install` alone does NOT wire it:
-#   pre-commit install --hook-type pre-commit --hook-type pre-push
+# `pre-commit install` with no flags wires both hook types, because of the line below.
+# (The comment here previously said the opposite -- it was added in the same commit as the
+# setting that contradicts it, 44ed0a49, and was cited as authority in #1720 and in CLAUDE.md
+# before anyone ran `pre-commit install` to check. Verified 2026-07-25 by installing into a
+# scratch repo with and without this line.)
 default_install_hook_types: [pre-commit, pre-push]
 minimum_pre_commit_version: "3.2.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Do **not** edit: `mfgarchon/__init__.py` (reads `importlib.metadata`), `workflow
 
 ### Branches & PRs
 - **Branch naming (MANDATORY)**: `<type>/<short-description>` — `feature/ fix/ chore/ docs/ refactor/ test/`.
-- **Never commit directly to `main`** (branch protection enforces this). Create the PR when you push; delete merged branches.
+- **Never commit directly to `main`.** ⚠️ **Nothing enforces this — not the server, and not the local hook either.** Re-check with `gh api repos/derrring/MFGArchon/rules/branches/main` (the effective-rules endpoint, which covers org rules and migrated required workflows); an empty array means no branch rule applies. As of 2026-07-25 it is empty, classic protection returns 404, and the sole ruleset is `enforcement=disabled`. The pre-push hook does not close the gap: it runs `scripts/local_ci.sh`, which contains no branch logic at all (`grep -i branch scripts/local_ci.sh` → nothing) and no `no-commit-to-branch` hook is configured — it gates *test quality*, not *which ref you are on*, so a green suite on `main` pushes cleanly. Treat this as a discipline you keep, not a wall that stops you. Create the PR when you push; delete merged branches.
 - **PR granularity is a preference, not a mandate.** Granular (one fix / PR) is fine; batch *related, low-risk* fixes into one PR (one commit each, `Closes #A #B #C`) when convenient to save CI runs. Split out anything *risky / independent / large (>~1d)* regardless. The two pains that made granularity costly — CHANGELOG conflicts and red-main — are removed by *mechanism*: the fragment changelog, and the full-suite gate that now runs **locally** (`./scripts/local_ci.sh`, wired as a pre-push hook) rather than on GitHub. So this stays a convenience call, not a rule to remember.
 - **Changelog per PR (#1521)**: add a `changelog.d/<slug>.<category>.md` fragment (category ∈ `added/changed/deprecated/removed/fixed`) — do **not** edit `CHANGELOG.md`. Fragments are separate files, so PRs never conflict on the changelog (batched or not). See `changelog.d/README.md`.
 - **Before merge**: the **local** full suite is authoritative — `./scripts/local_ci.sh` (see *Pre-commit / pre-merge checks*). GitHub's PR checks are a fast tier only and green there is **not** sufficient.
@@ -237,7 +237,7 @@ Rich-only backend (v0.16.15+; external tqdm removed — legacy alias kept). Use 
 ---
 
 ## 📜 Solo Maintainer's Protocol
-1. Propose in issue → 2. implement in a feature-branch PR → 3. **independent adversarial review** (fresh reviewer, not just self-review — mandatory, see *Branches & PRs*) → 4. **verify issue completion** → 5. merge only after review is MERGE-OK **and** all checks pass. Enforced by branch protection on `main`.
+1. Propose in issue → 2. implement in a feature-branch PR → 3. **independent adversarial review** (fresh reviewer, not just self-review — mandatory, see *Branches & PRs*) → 4. **verify issue completion** → 5. merge only after review is MERGE-OK **and** all checks pass. **Self-enforced** — see *Branches & PRs*: the `main` ruleset exists but is `enforcement=disabled`, so no step of this protocol is blocked server-side.
 
 **Issue-completion verification** ⚠️ (before closing an issue / opening a PR): read the *original* issue (not commit messages); check every acceptance criterion; answer every discussion point; confirm all subtasks; document deviations (update the issue before closing). Anti-pattern: closing on commit messages without re-reading the requirements.
 

--- a/changelog.d/1720-honest-gate-description.changed.md
+++ b/changelog.d/1720-honest-gate-description.changed.md
@@ -1,0 +1,8 @@
+- **`CLAUDE.md` now states what actually gates `main` — which is nothing** (Issue #1720). Two
+  passages claimed branch protection enforced the PR workflow; measured, the effective-rules
+  endpoint returns `[]`, classic protection returns 404, and the sole ruleset is
+  `enforcement=disabled`. The local pre-push hook does not close the gap either: `local_ci.sh`
+  contains no branch logic and no `no-commit-to-branch` hook is configured, so it gates test
+  quality rather than which ref you are on. Also corrects a self-contradictory comment in
+  `.pre-commit-config.yaml` that claimed `pre-commit install` does not wire pre-push — the
+  `default_install_hook_types` line two lines below it does exactly that.


### PR DESCRIPTION
`CLAUDE.md` asserted in two places that branch protection enforces the PR workflow. Measured 2026-07-25:

```
gh api .../branches/main/protection   -> 404 Branch not protected
gh api .../rulesets                   -> 8305400  main  disabled
rules on that ruleset                 -> deletion, non_fast_forward,
                                         pull_request, required_signatures
```

The ruleset carries the right four rules and is **switched off**, so a direct push to `main` succeeds. What gates today is the local pre-push hook (`.pre-commit-config.yaml:61-67`) — absent from a fresh clone until `pre-commit install --hook-type pre-push`, and skipped by `git push --no-verify`.

Documentation only. Whether to enable the ruleset is a maintainer decision (`required_signatures` may need signing set up first) and is tracked in #1720.

Why it is worth a PR rather than a silent edit: an instruction file that names an enforcement mechanism which does not exist is read as a guarantee by every agent working here, and agents calibrate their caution to it. Same shape as #1709 (`CLAUDE.md` teaching removed factory functions) — a claim about state, decoupled from the state.

**Gate**: `./scripts/local_ci.sh` GREEN.

Refs #1709, #1720



---
**Supersedes #1723**, which GitHub auto-closed unmerged when its base branch (`chore/ruff-0-16-0-pin-and-ci-alignment`, now merged as #1727) was deleted. Same head commit, rebased onto `main`. The independent adversarial review and its blocker resolutions are recorded on #1723.
