### PR TITLE
Honor spatial volatility across GFDM HJB paths

### DIFF
--- a/changelog.d/1725-gfdm-batch-spatial-volatility.fixed.md
+++ b/changelog.d/1725-gfdm-batch-spatial-volatility.fixed.md
@@ -1,8 +1,11 @@
-- **`HJBGFDMSolver` now consumes a spatial `volatility_field` instead of its mean** (Issue #1725).
-  The batch residual and Jacobian each resolved sigma through a byte-identical copy of one
-  expression ending in `_get_sigma_value(None)`, whose documented contract collapses an array to
-  its mean and evaluates a callable once at the domain centre — so `volatility_field=linspace(0.1,
-  0.5, N)` produced a solve byte-identical to the scalar `0.3`. `assemble_hjb_residual` has
-  accepted a per-node field since Issue #1071, so the coefficient was being discarded one layer
-  above an assembly that could consume it. Both copies now route through one `_batch_sigma()`
-  owner. Scalar solves are bit-identical; LLF augmentation is unchanged.
+- **`HJBGFDMSolver` now preserves a spatial `volatility_field` through every HJB path** (Issue
+  #1725). The solver normalizes a scalar, native-shaped or flattened grid field, meshfree
+  collocation field, or space-only callable once per solve into one collocation-space coefficient.
+  Batch and per-point residual/Jacobian assembly, LLF augmentation, the DMP diagnostic, and Howard
+  policy iteration all consume that same value. Nonconstant fields are no longer replaced by
+  their mean, structured-grid fields are mapped to collocation points, implicit-domain fields
+  keep their node ordering, callables are evaluated once per node, and invalid representations
+  fail before sparse assembly. Time-/density-dependent callables fail instead of being frozen as
+  static fields; a problem-owned `(d,d)` array that is ambiguous between a grid field and tensor
+  volatility must be supplied as an explicit solve-level field. Scalar solves remain
+  byte-identical.

--- a/changelog.d/1725-gfdm-batch-spatial-volatility.fixed.md
+++ b/changelog.d/1725-gfdm-batch-spatial-volatility.fixed.md
@@ -1,0 +1,8 @@
+- **`HJBGFDMSolver` now consumes a spatial `volatility_field` instead of its mean** (Issue #1725).
+  The batch residual and Jacobian each resolved sigma through a byte-identical copy of one
+  expression ending in `_get_sigma_value(None)`, whose documented contract collapses an array to
+  its mean and evaluates a callable once at the domain centre — so `volatility_field=linspace(0.1,
+  0.5, N)` produced a solve byte-identical to the scalar `0.3`. `assemble_hjb_residual` has
+  accepted a per-node field since Issue #1071, so the coefficient was being discarded one layer
+  above an assembly that could consume it. Both copies now route through one `_batch_sigma()`
+  owner. Scalar solves are bit-identical; LLF augmentation is unchanged.

--- a/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
+++ b/mfgarchon/alg/numerical/gfdm_components/monotonicity_enforcer.py
@@ -940,7 +940,7 @@ def verify_assembled_m_matrix(
 def critical_drift_for_dmp(
     d_lap: Any,
     d_grad: list,
-    diffusion_coeff: float,
+    diffusion_coeff: float | np.ndarray,
     interior_indices: np.ndarray | None = None,
     atol: float = 1e-12,
 ) -> float:
@@ -951,7 +951,8 @@ def critical_drift_for_dmp(
     $\sum_d \alpha_d (D_{\mathrm{grad}})_{d,ij} - D\,L_{ij}$. The worst-case unit-$|\alpha|$
     direction makes the drift part $|\alpha|\,\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$
     (Cauchy-Schwarz), so the M-matrix sign holds iff
-    $|\alpha| \le D\,L_{ij}/\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$.
+    $|\alpha| \le D_i\,L_{ij}/\lVert (D_{\mathrm{grad}})_{:,ij}\rVert$, where
+    ``diffusion_coeff`` is either one scalar $D$ or a row-wise field $(D_i)$.
 
     When $L_{ij} \le 0$ (relaxed-SOCP slack row; Issue #1253) and $\lVert D_{:,j}\rVert > 0$,
     the right-hand side is $\le 0$: the off-diagonal entry is already non-negative at zero
@@ -967,9 +968,15 @@ def critical_drift_for_dmp(
     grads = [g.tocsr() for g in d_grad]
     n = L.shape[0]
     rows = np.arange(n) if interior_indices is None else np.asarray(interior_indices)
+    diffusion = np.asarray(diffusion_coeff, dtype=float)
+    if diffusion.ndim > 0 and diffusion.shape != (n,):
+        raise ValueError(
+            f"diffusion_coeff must be a scalar or a row-wise field with shape ({n},), got {diffusion.shape}."
+        )
 
     alpha_crit = np.inf
     for i in rows:
+        diffusion_i = float(diffusion) if diffusion.ndim == 0 else float(diffusion[i])
         l_row = L.getrow(i).toarray().ravel()
         g_rows = [g.getrow(i).toarray().ravel() for g in grads]
         # Issue #1253 2026-06-10 audit: iterate over ALL off-diagonal edges with
@@ -982,5 +989,5 @@ def critical_drift_for_dmp(
         for j in np.nonzero(g_norms > atol)[0]:
             if j == i:
                 continue
-            alpha_crit = min(alpha_crit, diffusion_coeff * float(l_row[j]) / float(g_norms[j]))
+            alpha_crit = min(alpha_crit, diffusion_i * float(l_row[j]) / float(g_norms[j]))
     return alpha_crit

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import warnings
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -483,13 +484,24 @@ class HJBGFDMSolver(BaseHJBSolver):
         # discretized. Fail loud at construction rather than returning a silently wrong
         # solution (fail-fast per CLAUDE.md).
         _vf = getattr(self.problem, "volatility_field", None)
-        if isinstance(_vf, np.ndarray) and _vf.ndim == 2:
+        _spatial_shape = tuple(getattr(self.problem, "spatial_shape", ()) or ())
+        _problem_dimension = getattr(self.problem, "dimension", None)
+        _tensor_shape = (_problem_dimension, _problem_dimension) if isinstance(_problem_dimension, int) else None
+        if isinstance(_vf, np.ndarray) and _tensor_shape is not None and _vf.shape == _tensor_shape:
+            if _vf.shape == _spatial_shape:
+                raise NotImplementedError(
+                    "HJBGFDMSolver cannot infer whether problem.volatility_field with shape "
+                    f"{_vf.shape} is a scalar-valued grid field or a full-tensor (d,d) sigma; "
+                    "the two representations are ambiguous. Keep a scalar sigma on the problem "
+                    "and pass the grid field explicitly as "
+                    "solve_hjb_system(volatility_field=field) instead."
+                )
             raise NotImplementedError(
                 "HJBGFDMSolver does not support full-tensor (d,d) sigma. "
                 "The GFDM Laplacian target (e_lap in joint_socp.py) has zero weight on "
                 "the cross-derivative column, so off-diagonal D_ij d^2u/dx_i dx_j "
                 "terms are silently dropped (Issue #1079). Pass scalar sigma or a "
-                "1-D per-axis diagonal array instead."
+                "scalar-valued spatial field matching problem.spatial_shape instead."
             )
 
         # --- Resolve (scheme, application) from new API or legacy alias (v0.18.0) ---
@@ -663,14 +675,11 @@ class HJBGFDMSolver(BaseHJBSolver):
         self._dmp_alpha_crit: float | None = None
         self._dmp_warned = False
 
-        # Issue #1316: per-solve volatility_field override. None by default (explicit
-        # init for object-shape stability — see CLAUDE.md). When solve_hjb_system is
-        # called with volatility_field != None, this holds the spatial diffusion the
-        # coupling layer / FP solver is using; _get_sigma_value reads it INSTEAD of
-        # problem.sigma so HJB and FP stay convention-consistent. None -> byte-identical
-        # legacy path (problem.sigma). Set BEFORE the LLF block: _compute_llf_sigma_eff()
-        # below calls _get_sigma_value(None), which now reads this attribute.
+        # Issue #1316: retain the raw per-solve override for public-state compatibility.
+        # Issue #1725: normalize it once per solve into collocation space; every live
+        # diffusion consumer reads `_solve_sigma`, so coefficient resolution cannot fork.
         self._volatility_field_override: float | np.ndarray | Callable | None = None
+        self._solve_sigma: float | np.ndarray | None = None
 
         # LLF augmented diffusion (Issue #1059, paper P2 branch of thm:discrete_comparison).
         # nu_i = max(0, C * l_H(i) * h_i - sigma^2/2)
@@ -2150,7 +2159,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
         # assemble_hjb_residual (now field-σ capable, D_i = σ_eff_i²/2 elementwise); a plain solve
         # uses the scalar σ. One assembly path either way.
-        sigma = self._batch_sigma()
+        sigma = self._sigma_for_assembly()
         return assemble_hjb_residual(
             H_class=H_class,
             x=self.collocation_points,
@@ -2194,7 +2203,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
         # assemble_hjb_jacobian_diag (now field-σ capable: it row-scales the Laplacian via
         # diags(D_i) @ D_lap); a plain solve uses the scalar σ. One assembly path either way.
-        sigma = self._batch_sigma()
+        sigma = self._sigma_for_assembly()
         return assemble_hjb_jacobian_diag(
             H_class=H_class,
             x=self.collocation_points,
@@ -2303,7 +2312,12 @@ class HJBGFDMSolver(BaseHJBSolver):
         if self._dmp_alpha_crit is None:
             from mfgarchon.alg.numerical.gfdm_components.monotonicity_enforcer import critical_drift_for_dmp
 
-            diffusion_coeff = diffusion_from_volatility(self._get_sigma_value(None))
+            sigma = self._sigma_for_assembly()
+            diffusion_coeff = (
+                diffusion_from_volatility(sigma, kind="field")
+                if isinstance(sigma, np.ndarray)
+                else diffusion_from_volatility(sigma)
+            )
             self._dmp_alpha_crit = critical_drift_for_dmp(
                 self._D_lap, self._D_grad, diffusion_coeff, interior_indices=self.interior_indices
             )
@@ -2759,23 +2773,26 @@ class HJBGFDMSolver(BaseHJBSolver):
             sigma_eff_i = sqrt(sigma^2 + 2 * nu_i)
 
         where:
-          - sigma = problem volatility (scalar; callable not supported here, evaluated at None)
+          - sigma = solve-level scalar or collocation-space volatility
           - C = self._llf_cone_constant (paper P2 cone constant, default 0.5)
           - l_H(i) = self._llf_l_H[i] (user-supplied |dH/dp| Lipschitz bound)
           - h_i = self.delta (conservative upper bound for local mesh size)
 
         When nu_i = 0 at node i (Pe already small enough), sigma_eff_i = sigma exactly
         (no augmentation at that node).  Called once at __init__ and stored in
-        self._llf_sigma_eff; not recomputed per Picard iteration (Issue #1059 stability
-        note: holding nu_i fixed avoids the runaway Picard feedback in the prototype).
+        self._llf_sigma_eff; recomputed only when a new solve-level volatility is
+        normalized, not per Picard/Newton iteration (Issue #1059 stability note:
+        holding nu_i fixed avoids the runaway feedback in the prototype).
 
         Returns:
             shape (n_points,) float64 array of per-node effective volatility values.
         """
-        # Use scalar sigma from problem (callable sigma: evaluated with None, returns 1.0
-        # representative value — callable-sigma + LLF is an uncommon combination).
-        sigma = self._get_sigma_value(None)
-        D_base = 0.5 * sigma**2  # sigma^2/2, the base diffusion coefficient
+        sigma = self._solve_sigma if self._solve_sigma is not None else self._get_sigma_value(None)
+        D_base = (
+            diffusion_from_volatility(sigma, kind="field")
+            if isinstance(sigma, np.ndarray)
+            else diffusion_from_volatility(sigma)
+        )
 
         # nu_i = max(0, C * l_H(i) * h_i - D_base)
         # h_i approximated by self.delta (conservative upper bound; actual stencil
@@ -2791,9 +2808,9 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         When llf_augmentation=True and point_idx is not None, returns the per-node
         effective sigma sqrt(sigma^2 + 2*nu_i) from LLF augmentation (Issue #1059).
-        When point_idx is None (batch path), returns the base scalar sigma regardless
-        of llf_augmentation (the batch path handles LLF separately via the
-        self._llf_sigma_eff array in the residual/Jacobian assembly).
+        When point_idx is None, preserves the legacy representative-scalar lookup used
+        by pre-solve diagnostics and compatibility tests. Live assembly reads
+        :meth:`_sigma_for_assembly` instead.
 
         Args:
             point_idx: Collocation point index (for callable sigma evaluation or LLF lookup)
@@ -2809,11 +2826,19 @@ class HJBGFDMSolver(BaseHJBSolver):
         5. problem.sigma is numeric → use directly (fallback: 1.0)
         """
         # LLF per-node override: return sigma_eff_i when augmentation is active (Issue #1059).
-        # Only applies when point_idx is not None (per-point path); the batch path (None)
-        # reads self._llf_sigma_eff directly.
+        # Only applies when point_idx is not None; solve-level assembly reads the full
+        # self._llf_sigma_eff field directly.
         if self.llf_augmentation and point_idx is not None and self._llf_sigma_eff is not None:
             if point_idx < len(self._llf_sigma_eff):
                 return float(self._llf_sigma_eff[point_idx])
+
+        # Live solves resolve the coefficient once. Per-point residual and Jacobian
+        # assembly index that canonical collocation-space value instead of re-evaluating
+        # a callable or independently interpreting an array.
+        if point_idx is not None and self._solve_sigma is not None:
+            if isinstance(self._solve_sigma, np.ndarray):
+                return float(self._solve_sigma[point_idx])
+            return self._solve_sigma
 
         # Issue #1316: the per-solve volatility_field override (the spatial diffusion
         # the coupling layer / FP solver is using) is the authoritative diffusion source,
@@ -2839,44 +2864,100 @@ class HJBGFDMSolver(BaseHJBSolver):
             # Numeric sigma: use directly (with fallback to default)
             return float(getattr(self.problem, "sigma", 1.0))
 
-    def _batch_sigma(self) -> float | np.ndarray:
-        """The one owner of the batch path's sigma (Issue #1725).
-
-        Returns a per-node field when one is available and a scalar otherwise.
-        ``assemble_hjb_residual`` and ``assemble_hjb_jacobian_diag`` accept either
-        (``h_eval.py``: ``sigma: float | NDArray``, elementwise ``D_i = sigma_i**2/2``, and
-        bit-identical to the prior call for a scalar), so a field does not need collapsing to
-        reach them.
-
-        Before this existed, the residual (~:2154) and the Jacobian (~:2202) each carried a
-        byte-identical copy of this selection and both ended in ``_get_sigma_value(None)``,
-        whose documented contract averages an array and evaluates a callable once at the domain
-        centre. So a caller passing ``volatility_field=linspace(0.1, 0.5, N)`` got a solve
-        byte-identical to passing the scalar ``0.3`` -- a plausible answer to a different
-        problem. The capability was never missing; the coefficient was discarded one layer above
-        the assembly that could consume it.
-
-        Precedence, highest first:
-
-        1. LLF ``sigma_eff`` when augmentation is on -- unchanged, it is already per-node.
-        2. A ``volatility_field`` override that resolves per node: an array of length
-           ``n_points``, or a callable evaluated at each collocation point.
-        3. Everything else via ``_get_sigma_value(None)`` -- scalars, and arrays whose length
-           does not match the collocation set (those cannot be a per-node field here, and
-           silently reshaping one would be a worse failure than averaging it).
-        """
+    def _sigma_for_assembly(self) -> float | np.ndarray:
+        """Return the single solve-level volatility consumed by every assembly path."""
         if self.llf_augmentation and self._llf_sigma_eff is not None:
             return self._llf_sigma_eff
+        if self._solve_sigma is not None:
+            return self._solve_sigma
+        return self._get_sigma_value(None)
 
-        override = self._volatility_field_override
-        if isinstance(override, np.ndarray) and override.ndim >= 1 and override.shape[0] == self.n_points:
-            return override
-        if callable(override):
+    def _resolve_sigma_for_solve(
+        self,
+        volatility_field: float | np.ndarray | Callable | None,
+        *,
+        is_meshfree_input: bool,
+    ) -> float | np.ndarray:
+        """Normalize one volatility source to a scalar or collocation-space ``(N,)`` field."""
+        problem_field = getattr(self.problem, "volatility_field", None)
+        source_is_problem_field = volatility_field is None or volatility_field is problem_field
+
+        if volatility_field is not None:
+            source = volatility_field
+        else:
+            legacy_nu = getattr(self.problem, "nu", None)
+            if legacy_nu is not None:
+                source = legacy_nu
+                source_is_problem_field = False
+            elif problem_field is not None:
+                source = problem_field
+            else:
+                source = getattr(self.problem, "sigma", 1.0)
+                source_is_problem_field = False
+
+        if callable(source):
+            try:
+                parameters = list(inspect.signature(source).parameters.values())
+            except (TypeError, ValueError) as exc:
+                raise NotImplementedError(
+                    "HJBGFDMSolver supports only a space-only volatility callable sigma(x) "
+                    "whose one-argument signature can be inspected. Time- or density-dependent "
+                    "sigma(t, x, m) is unsupported."
+                ) from exc
+            if len(parameters) != 1 or parameters[0].kind not in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ):
+                raise NotImplementedError(
+                    "HJBGFDMSolver supports only a space-only volatility callable sigma(x); "
+                    f"got signature {inspect.signature(source)}. Time- or density-dependent "
+                    "sigma(t, x, m) cannot be frozen into one solve-level spatial field."
+                )
             return np.array(
-                [self._resolve_diffusion_source(override, i) for i in range(self.n_points)],
+                [self._resolve_diffusion_source(source, i) for i in range(self.n_points)],
                 dtype=float,
             )
-        return self._get_sigma_value(None)
+
+        sigma = np.asarray(source, dtype=float)
+        if sigma.ndim == 0:
+            return float(sigma)
+
+        # An explicit per-solve array follows the representation of M_density. A
+        # problem-owned array follows the problem geometry even when a caller supplies
+        # collocation-space density directly: grid problems own grid fields, whereas
+        # implicit problems own node-indexed fields.
+        problem_field_is_grid_indexed = source_is_problem_field and getattr(self.problem, "domain_type", None) == "grid"
+        grid_indexed = not is_meshfree_input or problem_field_is_grid_indexed
+        if grid_indexed:
+            grid_shape = tuple(self._mapper.grid_shape)
+            grid_size = int(np.prod(grid_shape))
+            if sigma.shape == grid_shape:
+                sigma_grid = sigma.reshape(-1)
+            elif sigma.shape == (grid_size,):
+                sigma_grid = sigma
+            else:
+                raise ValueError(
+                    "volatility_field shape mismatch: a grid-indexed scalar-volatility field "
+                    f"must have native shape {grid_shape} or flattened one-dimensional shape "
+                    f"({grid_size},), got {sigma.shape}; collocation space has "
+                    f"{self.n_points} points."
+                )
+            resolved = np.asarray(self._mapper.map_grid_to_collocation(sigma_grid), dtype=float)
+        else:
+            if sigma.shape != (self.n_points,):
+                raise ValueError(
+                    "volatility_field shape mismatch: a meshfree scalar-volatility field "
+                    f"must have one-dimensional collocation shape ({self.n_points},), "
+                    f"got {sigma.shape}."
+                )
+            resolved = sigma
+
+        if resolved.shape != (self.n_points,):
+            raise AssertionError(
+                "volatility_field normalization violated the collocation-space invariant: "
+                f"expected ({self.n_points},), got {resolved.shape}."
+            )
+        return resolved
 
     def _resolve_diffusion_source(self, source: float | np.ndarray | Callable, point_idx: int | None) -> float:
         """Resolve a scalar / callable / per-point-array diffusion source to a scalar sigma.
@@ -2900,7 +2981,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         U_terminal: np.ndarray | None = None,
         U_coupling_prev: np.ndarray | None = None,
         show_progress: bool | None = None,
-        volatility_field: float | np.ndarray | None = None,
+        volatility_field: float | np.ndarray | Callable | None = None,
         running_cost: np.ndarray | Callable[[int], np.ndarray] | None = None,
     ) -> np.ndarray:
         """
@@ -2916,27 +2997,24 @@ class HJBGFDMSolver(BaseHJBSolver):
                 Time-dependent array: shape (n_time_points, n_points) -- L(t_n, x) per step.
                 Callable: f(time_index) -> (n_points,) array, evaluated per step.
                 Added to Hamiltonian: H_total = H(x,p,m) + L(t,x).
-            volatility_field: Optional diffusion coefficient override
+            volatility_field: Optional SDE-volatility override. Accepts a scalar,
+                an inspectable one-argument space-only callable ``sigma(x)`` evaluated
+                at each collocation point, or a
+                scalar-valued spatial array. Grid-indexed arrays may use the native
+                problem spatial shape or its flattened form and are mapped to
+                collocation points; meshfree arrays must have shape ``(n_points,)``.
+                If the native grid shape is also ``(d, d)``, pass the array through
+                this argument to distinguish a scalar grid field from tensor sigma.
+                Time-/density-varying callables, time-varying arrays, and tensor
+                volatility are unsupported.
 
         Returns:
             (Nt, *spatial_shape) solution array
         """
-        # Issue #1316: install the per-solve volatility_field as the authoritative
-        # diffusion source for _get_sigma_value (consumed below via the residual /
-        # Jacobian / LLF paths). Set every call (not cleared at end) so there is no
-        # stale state and the default volatility_field=None restores the byte-identical
-        # legacy problem.sigma path.
+        # Retain the raw public argument and clear the previous solve's normalized value
+        # before validating this solve.
         self._volatility_field_override = volatility_field
-
-        # Issue #1429 (S0-13): recompute the LLF effective volatility from the per-solve override.
-        # _llf_sigma_eff is otherwise frozen at __init__ from problem.sigma, so an LLF-augmented
-        # solve with a #1316 override would stabilize off the base sigma, not the override.
-        # Unconditional so a later volatility_field=None solve resets it to the base (no stale
-        # override). Safe w.r.t. the #1059 frozen-nu note: the override is constant across Picard
-        # iterations and _llf_l_H is static, so this recompute is idempotent — not the
-        # solution-driven feedback #1059 guards against.
-        if self.llf_augmentation:
-            self._llf_sigma_eff = self._compute_llf_sigma_eff()
+        self._solve_sigma = None
 
         # Pick up any per-Picard resolved BC the coupling layer installed on the
         # geometry since construction (Issue #1118; matches FDM's per-solve re-read).
@@ -2980,6 +3058,16 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Grid format: M_density.shape = (Nt, Nx, Ny, ...)
         # Collocation format: M_density.shape = (Nt, n_points)
         is_meshfree_input = M_density.ndim == 2 and M_density.shape[1] == self.n_points
+
+        # Issue #1725: resolve once, after the input representation is known and before
+        # any interpolation, Newton probe, sparse assembly, LLF, DMP, or Howard path.
+        self._solve_sigma = self._resolve_sigma_for_solve(
+            volatility_field,
+            is_meshfree_input=is_meshfree_input,
+        )
+        self._dmp_alpha_crit = None
+        if self.llf_augmentation:
+            self._llf_sigma_eff = self._compute_llf_sigma_eff()
 
         # For GFDM, we work directly with collocation points
         U_solution_collocation = np.zeros((n_time_points, self.n_points))
@@ -3225,6 +3313,7 @@ class HJBGFDMSolver(BaseHJBSolver):
             running_cost=howard_running_cost,
             control_lagrangian=control_lagrangian,
             discretisation="central" if self.dimension == 1 else "upwind_projection",
+            volatility_field=self._sigma_for_assembly(),
             use_provider_bc_rows=True,  # Issue #1118 PR2a: shared value-form BC rows
         )
         return howard.solve_hjb_system(M_collocation, U_terminal_colloc)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2150,11 +2150,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
         # assemble_hjb_residual (now field-σ capable, D_i = σ_eff_i²/2 elementwise); a plain solve
         # uses the scalar σ. One assembly path either way.
-        sigma = (
-            self._llf_sigma_eff
-            if (self.llf_augmentation and self._llf_sigma_eff is not None)
-            else self._get_sigma_value(None)
-        )
+        sigma = self._batch_sigma()
         return assemble_hjb_residual(
             H_class=H_class,
             x=self.collocation_points,
@@ -2198,11 +2194,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Issue #1059/#1071 phase 7: a per-node LLF σ_eff field flows through the single-source
         # assemble_hjb_jacobian_diag (now field-σ capable: it row-scales the Laplacian via
         # diags(D_i) @ D_lap); a plain solve uses the scalar σ. One assembly path either way.
-        sigma = (
-            self._llf_sigma_eff
-            if (self.llf_augmentation and self._llf_sigma_eff is not None)
-            else self._get_sigma_value(None)
-        )
+        sigma = self._batch_sigma()
         return assemble_hjb_jacobian_diag(
             H_class=H_class,
             x=self.collocation_points,
@@ -2846,6 +2838,45 @@ class HJBGFDMSolver(BaseHJBSolver):
         else:
             # Numeric sigma: use directly (with fallback to default)
             return float(getattr(self.problem, "sigma", 1.0))
+
+    def _batch_sigma(self) -> float | np.ndarray:
+        """The one owner of the batch path's sigma (Issue #1725).
+
+        Returns a per-node field when one is available and a scalar otherwise.
+        ``assemble_hjb_residual`` and ``assemble_hjb_jacobian_diag`` accept either
+        (``h_eval.py``: ``sigma: float | NDArray``, elementwise ``D_i = sigma_i**2/2``, and
+        bit-identical to the prior call for a scalar), so a field does not need collapsing to
+        reach them.
+
+        Before this existed, the residual (~:2154) and the Jacobian (~:2202) each carried a
+        byte-identical copy of this selection and both ended in ``_get_sigma_value(None)``,
+        whose documented contract averages an array and evaluates a callable once at the domain
+        centre. So a caller passing ``volatility_field=linspace(0.1, 0.5, N)`` got a solve
+        byte-identical to passing the scalar ``0.3`` -- a plausible answer to a different
+        problem. The capability was never missing; the coefficient was discarded one layer above
+        the assembly that could consume it.
+
+        Precedence, highest first:
+
+        1. LLF ``sigma_eff`` when augmentation is on -- unchanged, it is already per-node.
+        2. A ``volatility_field`` override that resolves per node: an array of length
+           ``n_points``, or a callable evaluated at each collocation point.
+        3. Everything else via ``_get_sigma_value(None)`` -- scalars, and arrays whose length
+           does not match the collocation set (those cannot be a per-node field here, and
+           silently reshaping one would be a worse failure than averaging it).
+        """
+        if self.llf_augmentation and self._llf_sigma_eff is not None:
+            return self._llf_sigma_eff
+
+        override = self._volatility_field_override
+        if isinstance(override, np.ndarray) and override.ndim >= 1 and override.shape[0] == self.n_points:
+            return override
+        if callable(override):
+            return np.array(
+                [self._resolve_diffusion_source(override, i) for i in range(self.n_points)],
+                dtype=float,
+            )
+        return self._get_sigma_value(None)
 
     def _resolve_diffusion_source(self, source: float | np.ndarray | Callable, point_idx: int | None) -> float:
         """Resolve a scalar / callable / per-point-array diffusion source to a scalar sigma.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
@@ -24,7 +24,8 @@ For each backward time step (Nt-1 → 0):
     For k = 0, 1, ..., MAX_ITER:
         1. Build advection operator A_adv(α^k) — sign-aware upwind D_grad
         2. Solve linear system:
-               (I/dt - A_adv - (σ²/2) D_lap) · U^{k+1} = U_n+1/dt + L(x, α^k, m)
+               (I/dt - A_adv - diag(σ_i²/2) D_lap) · U^{k+1}
+                   = U_n+1/dt + L(x, α^k, m)
            where L is the Legendre dual of H at (x, α, m).
         3. Update policy: α^{k+1} = arg min_α (α · ∇U^{k+1} + L(x, α, m))
         4. If ‖α^{k+1} - α^k‖_∞ / ‖α^k‖_∞ < tol: break
@@ -46,7 +47,6 @@ References
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
@@ -56,6 +56,7 @@ from scipy.sparse.linalg import spsolve
 from scipy.spatial import cKDTree
 
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
     from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
@@ -272,8 +273,10 @@ class HJBHowardSolver:
     tol : float
         Relative `∞`-norm tolerance on policy change `(α^{k+1} − α^k)/α^k`.
     volatility_field : float | np.ndarray | None
-        Override σ (constant scalar or per-point array). When None, read
-        from `problem` via `stencil_provider._get_sigma_value(None)`.
+        Override $\\sigma$ (constant scalar or a collocation-space array of
+        shape `(n,)`). A field row-scales the Laplacian by
+        $D_i = \\sigma_i^2/2$. When None, read from `problem` via
+        `stencil_provider._get_sigma_value(None)`.
 
     Raises
     ------
@@ -411,7 +414,7 @@ class HJBHowardSolver:
         u_next: np.ndarray,
         m_n: np.ndarray,
         t_idx: int,
-        sigma: float,
+        sigma: float | np.ndarray,
         dt: float,
         static: dict,
         alpha_init: np.ndarray | None,
@@ -441,10 +444,14 @@ class HJBHowardSolver:
         # Issue #1118 PR2: value-form BC rows from the provider's shared builder. Constant
         # across inner iterations at this time step; None -> the legacy self-contained scheme.
         bc_rows = self.stencil_provider._value_form_bc_rows(t_idx) if self.use_provider_bc_rows else None
+        if isinstance(sigma, np.ndarray):
+            diffusion_operator = diags(diffusion_from_volatility(sigma, kind="field")) @ D_lap
+        else:
+            diffusion_operator = 0.5 * sigma * sigma * D_lap
 
         for _ in range(self.max_iter):
             A_adv = self._build_A_adv(alpha, static)
-            A = eye(n, format="csr") / dt - A_adv - 0.5 * sigma * sigma * D_lap
+            A = eye(n, format="csr") / dt - A_adv - diffusion_operator
 
             # RHS: u_next/dt + L(alpha) + running_cost. L(alpha) is the control-cost
             # Lagrangian from the single source (control_cost.lagrangian, Issue #1071):
@@ -561,23 +568,14 @@ class HJBHowardSolver:
         elif np.isscalar(self._volatility_field_override):
             sigma = float(self._volatility_field_override)
         else:
-            # Issue #1254, 2026-06-10 audit: per-point/array sigma field — previously element 0
-            # was silently taken (flat[0]), giving a spatially-wrong scalar if the array has
-            # distinct per-point values.  Collapse to mean with a UserWarning, matching
-            # scalar_diffusion_from_volatility (utils/pde_coefficients.py) parity.
-            # Howard assembles one global scalar sigma; spatially-varying fields cannot be
-            # honored here.  Use an FDM/GFDM path with coefficient_field for true varying-D.
-            arr = np.asarray(self._volatility_field_override)
-            sigma = float(np.mean(arr))
-            warnings.warn(
-                "HJBHowardSolver assembles a single scalar sigma; the per-point "
-                f"volatility_field is collapsed to its mean (sigma = {sigma:.6g}, "
-                f"mean of {arr.size} values). Previously element 0 was silently used "
-                "(Issue #1254). For true varying-coefficient diffusion use an FDM/GFDM "
-                "path with coefficient_field.",
-                UserWarning,
-                stacklevel=2,
-            )
+            sigma = np.asarray(self._volatility_field_override, dtype=float)
+            if sigma.ndim == 0:
+                sigma = float(sigma)
+            elif sigma.shape != (n,):
+                raise ValueError(
+                    "HJBHowardSolver volatility_field must be a scalar or a row-wise "
+                    f"field with shape ({n},), got {sigma.shape}."
+                )
 
         U = np.zeros((Nt + 1, n))
         U[Nt] = U_terminal.copy()

--- a/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
+++ b/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
@@ -1,30 +1,42 @@
 #!/usr/bin/env python3
-"""HJBGFDM's batch path must consume a spatial volatility field, not its mean (Issue #1725).
+"""HJBGFDM must preserve one spatial volatility field through every path (Issue #1725).
 
-The batch residual and Jacobian resolved sigma through ``_get_sigma_value(None)``, whose
-documented contract collapses an array to its mean (``pde_coefficients.py``: "the batch path
-applies one global scalar"). ``assemble_hjb_residual`` has accepted a per-node field since
-Issue #1071 phase 7 -- the LLF path already passes one -- so the field was being discarded at
-coefficient retrieval, one layer above an assembly that could consume it.
+The original defect appeared in the batch residual and Jacobian, which resolved sigma through
+``_get_sigma_value(None)`` and collapsed a field to its mean. The same resolution fork survived
+in LLF, DMP, and Howard. These tests pin one solve-level collocation-space coefficient across all
+of those consumers.
 
 Every pre-existing array test used a CONSTANT array (``np.full(Nx, 0.5)``), which is its own
 mean and therefore passes under both behaviours. These tests use a non-constant field, which is
 the only kind that can tell them apart.
 """
 
+import warnings
+
 import pytest
 
 import numpy as np
+from scipy.sparse import csr_matrix
 
+from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+from mfgarchon.alg.numerical.gfdm_components import monotonicity_enforcer
 from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
-from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry import Hyperrectangle, TensorProductGrid
 from mfgarchon.geometry.boundary.conditions import no_flux_bc
 
 _N = 21
 _SIGMA_LO, _SIGMA_HI = 0.1, 0.5  # mean 0.3
+
+
+class _HJBKwargBuilder:
+    _build_hjb_kwargs = BaseCouplingIterator._build_hjb_kwargs
+
+    def __init__(self):
+        self._hjb_sig_params = {"volatility_field"}
+        self._hjb_solver_name = "HJBGFDMSolver"
 
 
 def _problem(sigma=0.3):
@@ -49,12 +61,75 @@ def _problem(sigma=0.3):
     )
 
 
-def _solve(volatility_field):
+def _problem_2d(nx, ny, sigma):
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0), (0.0, 1.0)],
+            Nx_points=[nx, ny],
+            boundary_conditions=no_flux_bc(dimension=2),
+        ),
+        components=MFGComponents(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+            m_initial=lambda point: np.exp(-np.sum((np.asarray(point) - 0.5) ** 2)),
+            u_terminal=lambda point: 0.5 * np.sum(np.asarray(point) ** 2),
+        ),
+        T=0.1,
+        Nt=2,
+        sigma=sigma,
+    )
+
+
+def _solver(
+    problem,
+    points,
+    *,
+    llf_augmentation=False,
+    llf_l_H=None,
+    max_newton_iterations=None,
+    boundary_conditions=None,
+):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return HJBGFDMSolver(
+            problem,
+            collocation_points=np.asarray(points).reshape(-1, 1),
+            delta=0.2,
+            monotonicity_scheme="none",
+            llf_augmentation=llf_augmentation,
+            llf_l_H=llf_l_H,
+            max_newton_iterations=max_newton_iterations,
+            boundary_conditions=boundary_conditions,
+        )
+
+
+def _solve(
+    volatility_field,
+    *,
+    points=None,
+    llf_augmentation=False,
+    llf_l_H=None,
+    return_solver=False,
+):
     problem = _problem()
-    x = np.linspace(0.0, 1.0, _N)
-    solver = HJBGFDMSolver(problem, collocation_points=x.reshape(-1, 1))
+    x = np.linspace(0.0, 1.0, _N) if points is None else np.asarray(points)
+    solver = _solver(
+        problem,
+        x,
+        llf_augmentation=llf_augmentation,
+        llf_l_H=llf_l_H,
+    )
     M = np.tile(np.exp(-10 * (x - 0.5) ** 2), (problem.Nt + 1, 1))
-    return solver.solve_hjb_system(M, 0.5 * x**2, np.zeros((problem.Nt + 1, _N)), volatility_field=volatility_field)
+    U = solver.solve_hjb_system(
+        M,
+        0.5 * x**2,
+        np.zeros((problem.Nt + 1, len(x))),
+        volatility_field=volatility_field,
+    )
+    return (U, solver) if return_solver else U
 
 
 @pytest.mark.unit
@@ -91,6 +166,17 @@ def test_nonconstant_callable_field_is_not_collapsed_to_the_domain_center():
 
 
 @pytest.mark.unit
+def test_coupling_builder_forwards_the_nonconstant_field_unchanged():
+    """The public coupling seam must not replace the array before GFDM sees it."""
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
+
+    forwarded = _HJBKwargBuilder()._build_hjb_kwargs(volatility_field=field)["volatility_field"]
+
+    assert forwarded is field
+    assert not np.array_equal(_solve(forwarded), _solve(float(field.mean())))
+
+
+@pytest.mark.unit
 def test_scalar_field_is_byte_identical_to_the_problem_sigma():
     """The fix must not perturb the scalar path.
 
@@ -107,23 +193,336 @@ def test_scalar_field_is_byte_identical_to_the_problem_sigma():
 
 
 @pytest.mark.unit
-def test_residual_and_jacobian_read_the_same_sigma_source():
-    """Residual and Jacobian resolved sigma through two byte-identical copies of one expression.
-
-    Consolidating them is the point of the fix -- this pins that they cannot drift apart again by
-    asserting they resolve through the single owner rather than by comparing their outputs, which
-    would be an agreement test between two paths that now share an implementation and would
-    therefore go inert exactly when the consolidation succeeds.
-    """
+def test_residual_jacobian_directional_derivative_agrees_under_field():
+    """The actual batch residual and Jacobian must consume the same per-node field."""
     problem = _problem()
     x = np.linspace(0.0, 1.0, _N)
-    solver = HJBGFDMSolver(problem, collocation_points=x.reshape(-1, 1))
+    solver = _solver(problem, x)
     field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
-    solver._volatility_field_override = field
+    M = np.tile(np.exp(-10 * (x - 0.5) ** 2), (problem.Nt + 1, 1))
+    solver.solve_hjb_system(M, 0.5 * x**2, volatility_field=field)
 
-    resolved = solver._batch_sigma()
-    assert isinstance(resolved, np.ndarray), "batch sigma must stay a per-node field"
-    np.testing.assert_array_equal(resolved, field)
+    u = 0.2 * np.sin(np.pi * x) + 0.1 * x
+    u_next = 0.9 * u
+    m = M[0]
+    H = problem.hamiltonian_class
+    direction = np.cos(2.0 * np.pi * x) + 0.2
 
-    solver._volatility_field_override = 0.3
-    assert isinstance(solver._batch_sigma(), float), "a scalar override must resolve to a scalar"
+    def residual(candidate):
+        grad, lap = solver._compute_derivatives_vectorized(candidate)
+        return solver._compute_hjb_residual_hamiltonian(
+            candidate,
+            u_next,
+            m,
+            grad,
+            lap,
+            H,
+            0.0,
+        )
+
+    grad, _ = solver._compute_derivatives_vectorized(u)
+    jacobian = solver._compute_hjb_jacobian_hamiltonian(grad, m, H, 0.0)
+    epsilon = 1e-6
+    finite_difference = (residual(u + epsilon * direction) - residual(u - epsilon * direction)) / (2.0 * epsilon)
+    jacobian_action = jacobian @ direction
+    relative_error = np.linalg.norm(finite_difference - jacobian_action) / np.linalg.norm(jacobian_action)
+
+    assert relative_error < 1e-7
+
+
+@pytest.mark.unit
+def test_llf_path_consumes_nonconstant_field():
+    """LLF must augment each node's base sigma, not the field's scalar mean."""
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
+    u_field, solver = _solve(
+        field,
+        llf_augmentation=True,
+        llf_l_H=0.0,
+        return_solver=True,
+    )
+    u_mean = _solve(
+        float(field.mean()),
+        llf_augmentation=True,
+        llf_l_H=0.0,
+    )
+
+    np.testing.assert_array_equal(solver._llf_sigma_eff, field)
+    assert not np.array_equal(u_field, u_mean)
+
+
+@pytest.mark.unit
+def test_callable_field_is_evaluated_once_per_collocation_node():
+    """A time-invariant spatial callable is normalized once, not inside every Newton probe."""
+    calls = 0
+
+    def sigma_of_x(point):
+        nonlocal calls
+        calls += 1
+        x = float(np.asarray(point).reshape(-1)[0])
+        return _SIGMA_LO + (_SIGMA_HI - _SIGMA_LO) * x
+
+    _solve(sigma_of_x)
+
+    assert calls == _N
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("has_defaults", [False, True], ids=["required-full-signature", "defaulted-full-signature"])
+def test_non_spatial_callable_fails_before_evaluation(has_defaults):
+    """GFDM must not freeze the public ``sigma(t, x, m)`` contract into one static field."""
+    calls = 0
+
+    if has_defaults:
+
+        def sigma(t=0.0, x=None, m=None):
+            nonlocal calls
+            calls += 1
+            return 0.2
+
+    else:
+
+        def sigma(t, x, m):
+            nonlocal calls
+            calls += 1
+            return 0.2
+
+    problem = _problem(sigma)
+    x = np.linspace(0.0, 1.0, _N)
+    solver = _solver(problem, x)
+    M = np.ones((problem.Nt + 1, _N))
+
+    with pytest.raises(NotImplementedError, match=r"space-only.*sigma\(x\)"):
+        solver.solve_hjb_system(M, np.zeros(_N))
+
+    assert calls == 0
+
+
+@pytest.mark.unit
+def test_hybrid_grid_field_is_mapped_to_collocation_points():
+    """A grid-indexed field and the equivalent spatial callable must produce the same solve."""
+    grid = np.linspace(0.0, 1.0, _N)
+    collocation = np.linspace(0.0, 1.0, 17) ** 1.2
+    field_on_grid = _SIGMA_LO + (_SIGMA_HI - _SIGMA_LO) * grid
+
+    def sigma_of_x(point):
+        x = float(np.asarray(point).reshape(-1)[0])
+        return _SIGMA_LO + (_SIGMA_HI - _SIGMA_LO) * x
+
+    problem = _problem()
+    M_grid = np.tile(np.exp(-10 * (grid - 0.5) ** 2), (problem.Nt + 1, 1))
+    U_terminal_grid = 0.5 * grid**2
+
+    array_solver = _solver(problem, collocation)
+    callable_solver = _solver(_problem(), collocation)
+    U_array = array_solver.solve_hjb_system(
+        M_density=M_grid,
+        U_terminal=U_terminal_grid,
+        volatility_field=field_on_grid,
+    )
+    U_callable = callable_solver.solve_hjb_system(
+        M_density=M_grid,
+        U_terminal=U_terminal_grid,
+        volatility_field=sigma_of_x,
+    )
+
+    np.testing.assert_allclose(U_array, U_callable, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.unit
+def test_native_2d_grid_field_is_mapped_to_collocation_points():
+    """A multidimensional scalar field keeps the problem's native spatial shape."""
+    nx, ny = 5, 4
+    x_grid = np.linspace(0.0, 1.0, nx)
+    y_grid = np.linspace(0.0, 1.0, ny)
+    xx, yy = np.meshgrid(x_grid, y_grid, indexing="ij")
+    field_on_grid = 0.1 + 0.2 * xx + 0.1 * yy
+    problem = _problem_2d(nx, ny, field_on_grid)
+    collocation = np.column_stack([xx.ravel(), yy.ravel()])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver = HJBGFDMSolver(
+            problem,
+            collocation_points=collocation,
+            delta=1.5,
+            monotonicity_scheme="none",
+            max_newton_iterations=0,
+        )
+
+    solver.solve_hjb_system(
+        M_density=np.ones((problem.Nt + 1, nx, ny)),
+        U_terminal=np.zeros((nx, ny)),
+    )
+
+    expected = 0.1 + 0.2 * collocation[:, 0] + 0.1 * collocation[:, 1]
+    np.testing.assert_allclose(solver._solve_sigma, expected, rtol=1e-14, atol=1e-14)
+
+
+@pytest.mark.unit
+def test_ambiguous_2d_field_requires_explicit_solve_override():
+    """A ``(d,d)`` grid field is accepted only where the API explicitly declares field semantics."""
+    field_on_grid = np.array([[0.1, 0.2], [0.3, 0.4]])
+    xx, yy = np.meshgrid(np.linspace(0.0, 1.0, 5), np.linspace(0.0, 1.0, 4), indexing="ij")
+    collocation = np.column_stack([xx.ravel(), yy.ravel()])
+    problem = _problem_2d(2, 2, 0.3)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver = HJBGFDMSolver(
+            problem,
+            collocation_points=collocation,
+            delta=1.5,
+            monotonicity_scheme="none",
+            max_newton_iterations=0,
+        )
+
+    solver.solve_hjb_system(
+        M_density=np.ones((problem.Nt + 1, 2, 2)),
+        U_terminal=np.zeros((2, 2)),
+        volatility_field=field_on_grid,
+    )
+
+    expected = 0.1 + 0.2 * collocation[:, 0] + 0.1 * collocation[:, 1]
+    np.testing.assert_allclose(solver._solve_sigma, expected, rtol=1e-14, atol=1e-14)
+
+    problem.volatility_field = field_on_grid
+    with pytest.raises(NotImplementedError, match=r"ambiguous.*solve_hjb_system"):
+        HJBGFDMSolver(problem, collocation)
+
+
+@pytest.mark.unit
+def test_problem_owned_implicit_field_stays_collocation_indexed():
+    """An implicit-domain field must not be reinterpreted on an invented uniform grid."""
+    points = np.array([0.0, 0.06, 0.19, 0.43, 0.71, 0.92, 1.0])
+    field = np.array([0.11, 0.18, 0.14, 0.33, 0.29, 0.47, 0.41])
+    geometry = Hyperrectangle(np.array([[0.0, 1.0]]))
+    geometry._num_spatial_points_cached = len(points)
+    geometry.get_spatial_grid = lambda: points.reshape(-1, 1)
+    problem = MFGProblem(
+        geometry=geometry,
+        components=MFGComponents(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+            m_initial=lambda point: np.exp(-10 * (np.asarray(point) - 0.5) ** 2),
+            u_terminal=lambda point: 0.5 * np.asarray(point) ** 2,
+        ),
+        T=0.1,
+        Nt=2,
+        sigma=field,
+    )
+    solver = _solver(
+        problem,
+        points,
+        max_newton_iterations=0,
+        boundary_conditions=no_flux_bc(dimension=1),
+    )
+
+    solver.solve_hjb_system(
+        M_density=np.ones((problem.Nt + 1, len(points))),
+        U_terminal=np.zeros(len(points)),
+    )
+
+    np.testing.assert_array_equal(solver._solve_sigma, field)
+
+
+@pytest.mark.unit
+def test_column_field_fails_before_sparse_assembly():
+    """An ``(N, 1)`` field is not a one-dimensional scalar volatility field."""
+    column = np.linspace(_SIGMA_LO, _SIGMA_HI, _N).reshape(-1, 1)
+
+    with pytest.raises(ValueError, match=r"volatility_field.*one-dimensional"):
+        _solve(column)
+
+
+@pytest.mark.unit
+def test_spatiotemporal_field_fails_before_sparse_assembly():
+    """GFDM's space-only coefficient contract must reject an unimplemented time axis."""
+    field = np.tile(np.linspace(_SIGMA_LO, _SIGMA_HI, _N), (_problem().Nt + 1, 1))
+
+    with pytest.raises(ValueError, match=r"volatility_field.*one-dimensional"):
+        _solve(field)
+
+
+@pytest.mark.unit
+def test_mismatched_field_length_fails_in_coefficient_resolution():
+    """A field that matches neither grid nor collocation space must not fall back to its mean."""
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N - 1)
+
+    with pytest.raises(ValueError, match=r"volatility_field.*shape"):
+        _solve(field)
+
+
+@pytest.mark.unit
+def test_dmp_guard_uses_each_nodes_resolved_diffusion(monkeypatch):
+    """The DMP diagnostic must inspect each solve's row-wise diffusion, without stale cache."""
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
+    _, solver = _solve(field, return_solver=True)
+    captured = []
+
+    def capture_diffusion(d_lap, d_grad, diffusion_coeff, interior_indices=None, atol=1e-12):
+        captured.append(np.asarray(diffusion_coeff).copy())
+        return float("inf")
+
+    monkeypatch.setattr(
+        monotonicity_enforcer,
+        "critical_drift_for_dmp",
+        capture_diffusion,
+    )
+    solver.check_dmp = True
+    solver.monotonicity_scheme = "joint_socp"
+    solver._maybe_warn_dmp(np.zeros(_N))
+
+    next_field = field[::-1].copy()
+    x = np.linspace(0.0, 1.0, _N)
+    M = np.tile(np.exp(-10 * (x - 0.5) ** 2), (solver.problem.Nt + 1, 1))
+    solver.check_dmp = False
+    solver.monotonicity_scheme = "none"
+    solver.solve_hjb_system(M, 0.5 * x**2, volatility_field=next_field)
+    solver.check_dmp = True
+    solver.monotonicity_scheme = "joint_socp"
+    solver._maybe_warn_dmp(np.zeros(_N))
+
+    assert len(captured) == 2
+    np.testing.assert_array_equal(captured[0], 0.5 * field**2)
+    np.testing.assert_array_equal(
+        captured[1],
+        0.5 * next_field**2,
+    )
+
+
+@pytest.mark.unit
+def test_dmp_threshold_consumes_rowwise_diffusion():
+    """The DMP helper must use the diffusion belonging to each Laplacian row."""
+    d_lap = csr_matrix(
+        [
+            [-1.0, 1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ]
+    )
+    d_grad = [
+        csr_matrix(
+            [
+                [-1.0, 1.0, 0.0],
+                [1.0, -1.0, 0.0],
+                [0.0, 0.0, 0.0],
+            ]
+        )
+    ]
+
+    threshold = monotonicity_enforcer.critical_drift_for_dmp(
+        d_lap,
+        d_grad,
+        diffusion_coeff=np.array([0.1, 0.4, 0.9]),
+        interior_indices=np.array([0, 1]),
+    )
+
+    assert threshold == pytest.approx(0.1)
+    with pytest.raises(ValueError, match=r"diffusion_coeff.*shape"):
+        monotonicity_enforcer.critical_drift_for_dmp(
+            d_lap,
+            d_grad,
+            diffusion_coeff=np.array([0.1, 0.4]),
+        )

--- a/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
+++ b/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""HJBGFDM's batch path must consume a spatial volatility field, not its mean (Issue #1725).
+
+The batch residual and Jacobian resolved sigma through ``_get_sigma_value(None)``, whose
+documented contract collapses an array to its mean (``pde_coefficients.py``: "the batch path
+applies one global scalar"). ``assemble_hjb_residual`` has accepted a per-node field since
+Issue #1071 phase 7 -- the LLF path already passes one -- so the field was being discarded at
+coefficient retrieval, one layer above an assembly that could consume it.
+
+Every pre-existing array test used a CONSTANT array (``np.full(Nx, 0.5)``), which is its own
+mean and therefore passes under both behaviours. These tests use a non-constant field, which is
+the only kind that can tell them apart.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary.conditions import no_flux_bc
+
+_N = 21
+_SIGMA_LO, _SIGMA_HI = 0.1, 0.5  # mean 0.3
+
+
+def _problem(sigma=0.3):
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[_N],
+            boundary_conditions=no_flux_bc(dimension=1),
+        ),
+        components=MFGComponents(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+            m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.5 * np.asarray(x) ** 2,
+        ),
+        T=0.1,
+        Nt=5,
+        sigma=sigma,
+    )
+
+
+def _solve(volatility_field):
+    problem = _problem()
+    x = np.linspace(0.0, 1.0, _N)
+    solver = HJBGFDMSolver(problem, collocation_points=x.reshape(-1, 1))
+    M = np.tile(np.exp(-10 * (x - 0.5) ** 2), (problem.Nt + 1, 1))
+    return solver.solve_hjb_system(M, 0.5 * x**2, np.zeros((problem.Nt + 1, _N)), volatility_field=volatility_field)
+
+
+@pytest.mark.unit
+def test_nonconstant_array_field_is_not_collapsed_to_its_mean():
+    """The defect, stated as the test that was missing.
+
+    linspace(0.1, 0.5) has mean 0.3. Before the fix these two solves were byte-identical.
+    """
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
+    u_field = _solve(field)
+    u_mean = _solve(float(field.mean()))
+
+    assert not np.array_equal(u_field, u_mean), (
+        "the spatial volatility field was collapsed to its mean: the solve is byte-identical "
+        f"to passing the scalar {field.mean()}"
+    )
+    # And the difference must be of the size the field's spread implies, not float noise.
+    assert np.max(np.abs(u_field - u_mean)) > 1e-6
+
+
+@pytest.mark.unit
+def test_nonconstant_callable_field_is_not_collapsed_to_the_domain_center():
+    """Same defect via the callable branch, which evaluated once at the domain center."""
+
+    def sigma_of_x(pt):
+        return _SIGMA_LO + (_SIGMA_HI - _SIGMA_LO) * np.asarray(pt).reshape(-1)[0]
+
+    u_callable = _solve(sigma_of_x)
+    u_center = _solve(float(sigma_of_x(np.array([0.5]))))
+
+    assert not np.array_equal(u_callable, u_center), (
+        "the callable volatility was evaluated once at the domain center rather than per node"
+    )
+
+
+@pytest.mark.unit
+def test_scalar_field_is_byte_identical_to_the_problem_sigma():
+    """The fix must not perturb the scalar path.
+
+    Byte-identity, not a tolerance: consolidating coefficient retrieval is a refactor on this
+    path and any float difference would mean it is not.
+    """
+    u_override = _solve(0.3)
+    u_problem = _solve(None)
+    np.testing.assert_array_equal(
+        u_override,
+        u_problem,
+        err_msg="scalar volatility_field=0.3 must reproduce problem.sigma=0.3 bit for bit",
+    )
+
+
+@pytest.mark.unit
+def test_residual_and_jacobian_read_the_same_sigma_source():
+    """Residual and Jacobian resolved sigma through two byte-identical copies of one expression.
+
+    Consolidating them is the point of the fix -- this pins that they cannot drift apart again by
+    asserting they resolve through the single owner rather than by comparing their outputs, which
+    would be an agreement test between two paths that now share an implementation and would
+    therefore go inert exactly when the consolidation succeeds.
+    """
+    problem = _problem()
+    x = np.linspace(0.0, 1.0, _N)
+    solver = HJBGFDMSolver(problem, collocation_points=x.reshape(-1, 1))
+    field = np.linspace(_SIGMA_LO, _SIGMA_HI, _N)
+    solver._volatility_field_override = field
+
+    resolved = solver._batch_sigma()
+    assert isinstance(resolved, np.ndarray), "batch sigma must stay a per-node field"
+    np.testing.assert_array_equal(resolved, field)
+
+    solver._volatility_field_override = 0.3
+    assert isinstance(solver._batch_sigma(), float), "a scalar override must resolve to a scalar"

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -430,6 +430,39 @@ def test_integrated_howard_inner_solver_lq_1d():
     )
 
 
+def test_integrated_howard_consumes_nonconstant_volatility_field():
+    """The integrated Howard path must not replace a per-node field with its mean."""
+
+    def solve(volatility_field):
+        pts, bdry, geom = _make_1d_cloud(LX=2.0, n_int=9)
+        problem = _MockProblem(geom, sigma=0.3, T=0.5, Nt=5, dimension=1)
+        problem.hamiltonian_class = _LQHam()
+        gfdm = _make_gfdm_solver(
+            pts,
+            bdry,
+            geom,
+            problem,
+            k_neighbors=5,
+            inner_solver="howard",
+        )
+        U_T = 0.5 * (pts[:, 0] - 1.0) ** 2
+        return gfdm.solve_hjb_system(
+            M_density=None,
+            U_terminal=U_T,
+            volatility_field=volatility_field,
+        )
+
+    field = np.linspace(0.1, 0.7, 11)
+    U_field = solve(field)
+    U_mean = solve(float(field.mean()))
+    U_default = solve(None)
+    U_scalar = solve(0.3)
+
+    assert not np.array_equal(U_field, U_mean)
+    assert np.max(np.abs(U_field - U_mean)) > 1e-6
+    np.testing.assert_array_equal(U_default, U_scalar)
+
+
 def test_inner_solver_rejects_unknown_value():
     """An unknown inner_solver value fails fast at construction."""
     pts, bdry, geom = _make_1d_cloud()
@@ -1018,38 +1051,24 @@ def test_howard_honors_resolved_robin_in_solution():
 # ---------------------------------------------------------------------------
 
 
-def test_array_volatility_field_warns_and_uses_mean():
-    """(A) Issue #1254: array volatility_field must warn (UserWarning) and collapse to
-    mean, not silently take element 0.
-
-    Pinning: element 0 of the sigma array is set to 0.1 while the rest are 0.5
-    (mean ~0.471).  The fixed path must:
-    - emit a UserWarning matching "collapsed to its mean"
-    - produce a result byte-identical to scalar sigma=mean (not scalar sigma=flat[0])
-    """
+def test_array_volatility_field_row_scales_howard_diffusion():
+    """Howard must retain a nonconstant per-node field instead of using one scalar."""
     pts, bdry, geom = _make_1d_cloud(LX=2.0, n_int=7)
     problem = _MockProblem(geom, sigma=0.3, T=0.5, Nt=5, dimension=1)
     gfdm = _make_gfdm_solver(pts, bdry, geom, problem, k_neighbors=5)
 
     n = len(pts)
     U_T = 0.5 * (pts[:, 0] - 1.0) ** 2
+    sigma_arr = np.linspace(0.1, 0.7, n)
+    U_array = HJBHowardSolver(
+        problem,
+        stencil_provider=gfdm,
+        alpha_star=lambda x, p, m, t: -p,
+        discretisation="central",
+        volatility_field=sigma_arr,
+        max_iter=5,
+    ).solve_hjb_system(M_density=None, U_terminal=U_T)
 
-    # sigma array: element 0 deviates so flat[0] != mean.
-    sigma_arr = np.full(n, 0.5)
-    sigma_arr[0] = 0.1  # mean ≈ (0.1 + 0.5*(n-1)) / n
-
-    # The fixed path must warn.
-    with pytest.warns(UserWarning, match="collapsed to its mean"):
-        U_array = HJBHowardSolver(
-            problem,
-            stencil_provider=gfdm,
-            alpha_star=lambda x, p, m, t: -p,
-            discretisation="central",
-            volatility_field=sigma_arr,
-            max_iter=5,
-        ).solve_hjb_system(M_density=None, U_terminal=U_T)
-
-    # Run with mean sigma (new correct behavior): no warning expected.
     sigma_mean = float(np.mean(sigma_arr))
     U_mean = HJBHowardSolver(
         problem,
@@ -1060,27 +1079,8 @@ def test_array_volatility_field_warns_and_uses_mean():
         max_iter=5,
     ).solve_hjb_system(M_density=None, U_terminal=U_T)
 
-    # Run with flat[0] sigma (the old buggy behavior).
-    sigma_flat0 = float(sigma_arr.flat[0])  # = 0.1
-    U_flat0 = HJBHowardSolver(
-        problem,
-        stencil_provider=gfdm,
-        alpha_star=lambda x, p, m, t: -p,
-        discretisation="central",
-        volatility_field=sigma_flat0,
-        max_iter=5,
-    ).solve_hjb_system(M_density=None, U_terminal=U_T)
-
-    # Confirm the two scalar runs produce distinguishably different results.
-    assert not np.allclose(U_mean, U_flat0, atol=1e-8), (
-        f"Test fixture broken: mean-sigma ({sigma_mean:.4f}) and flat[0]-sigma "
-        f"({sigma_flat0:.4f}) solutions are indistinguishable — cannot pin (A)."
-    )
-    # The array-volatility path must match the mean run, not the flat[0] run.
-    assert np.allclose(U_array, U_mean, atol=1e-10), (
-        "Array volatility_field: result should match mean-sigma scalar run but matches "
-        "flat[0]-sigma run instead — bug (A) Issue #1254 not fixed."
-    )
+    assert not np.array_equal(U_array, U_mean)
+    assert np.max(np.abs(U_array - U_mean)) > 1e-6
 
 
 def test_stencil_less_interior_with_provider_bc_rows_raises():


### PR DESCRIPTION
`HJBGFDMSolver` accepted a spatially varying `volatility_field` but several live
paths either collapsed it to one scalar or interpreted its representation
independently. A nonconstant field could therefore produce the solution for its
mean, while LLF, DMP, and Howard consumed different coefficients.

## Mechanism

The solver now normalizes one volatility source exactly once per solve into either:

- a scalar, preserving the legacy scalar path byte for byte; or
- one collocation-space field of shape `(n_points,)`.

Every live consumer reads that canonical value:

- batch and per-point residual assembly;
- batch and per-point Jacobian assembly;
- LLF effective volatility;
- the assembled-M-matrix DMP threshold;
- integrated Howard policy iteration.

The residual and Jacobian therefore cannot resolve the same coefficient through
different branches.

## Representation contract

- Native-shaped and flattened structured-grid fields are mapped through
  `GridCollocationMapper`.
- Problem-owned implicit-domain fields retain their node ordering.
- Explicit meshfree fields must have shape `(n_points,)`.
- An inspectable one-argument spatial callable `sigma(x)` is evaluated exactly once
  at each collocation point.
- Time- or density-dependent callables, spatiotemporal arrays, `(N, 1)` arrays, and
  mismatched lengths fail before sparse assembly.
- A problem-owned array whose spatial shape is also `(d, d)` fails as ambiguous
  between a scalar grid field and tensor volatility. Passing it explicitly to
  `solve_hjb_system(volatility_field=field)` declares field semantics.
- Full tensor volatility remains unsupported because the GFDM Laplacian target does
  not discretize the required cross derivatives.

The coupled public path is pinned through
`FixedPointIterator._build_hjb_kwargs`: the same nonconstant object reaches HJB
without a scalar fallback.

## Regression evidence

The pre-fix artifacts included:

- a nonconstant array producing a byte-identical solve to its scalar mean;
- a callable being evaluated inside Newton probes instead of once per node;
- grid fields being indexed as collocation fields;
- `(N, 1)` and wrong-length inputs surviving until downstream sparse operations;
- DMP and Howard receiving a scalar mean instead of the row field.

The issue-specific suite now has 18 tests covering nonconstant arrays and callables,
scalar byte identity, residual/Jacobian agreement, coupled forwarding, LLF, DMP,
Howard, structured/implicit mapping, cache reset, invalid shapes, callable contract,
and the `(d, d)` ambiguity.

## Verification

- Issue-specific and related GFDM/Howard regression set: `197 passed`.
- Full local gate: `5599 passed, 20 skipped, 6 xfailed`.
- Ruff format/lint, workflow integrity, and fail-fast ratchet: passed.
- Pre-push hook reran the complete local gate and passed.

Independent adversarial review found and drove tests for:

- the original LLF, Howard, and `(N, 1)` gaps;
- native multidimensional grid mapping and implicit-node ordering;
- the public `sigma(t, x, m)` callable mismatch;
- ambiguous `(d, d)` field/tensor representation.

All findings above are covered by tests in this branch.

Fixes #1725
Refs #1071, #1079, #1248, #1316, #1412, #1449, #1701

---

Supersedes #1726, which was auto-closed unmerged when its base branch was deleted.
The branch name is historical; this PR now fails loud only for unsupported or
ambiguous representations and preserves supported spatial fields end to end.
