### PR TITLE
Mark main as 0.22.0 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to MFGArchon will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.21.1] - 2026-07-14
+## [0.22.0] - Unreleased
+
+> [CHALLENGED 2026-07-26] This section was originally labelled `0.21.1` on
+> 2026-07-14 by release-preparation commit `51d4c413`, but no `v0.21.1` tag or
+> GitHub release was created. `v0.21.0` remains the latest published release.
+>
+> SUPERSEDED-BY: `0.22.0` — main contains breaking migrations and now identifies
+> itself as `0.22.0.dev0`.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mfgarchon"
-version = "0.21.1"  # v0.21.1: RFC-#1574 phase-0 fail-loud guards (BC/SL/network capability honesty) + network MAXIMIZE + single-source consolidations (FP-drift #1528 ph1, sigma-tensor, project-to-boundary, paired-sigma) + examples/tutorials remediation + RL mean-field fixes + opt-in analytic Jacobian
+version = "0.22.0.dev0"  # Unreleased development line; the latest published release is v0.21.0.
 authors = [
     { name = "Jiongyi Wang", email = "jiongyiwang@gmail.com" },
     # et al.


### PR DESCRIPTION
## Mechanism

- GitHub's latest published tag/release is `v0.21.0`; no `v0.21.1` tag or release exists.
- `51d4c413` prepared 0.21.1 metadata, but main subsequently accumulated breaking migrations while still reporting 0.21.1.
- Set project metadata to the PEP 440 development version `0.22.0.dev0`.
- Reassign the unreleased changelog section to 0.22.0 and retain a `[CHALLENGED]` record of the former heading.

## Verification

- Isolated wheel build: `mfgarchon-0.22.0.dev0-py3-none-any.whl`.
- Wheel `METADATA`: `Version: 0.22.0.dev0`.
- `./scripts/local_ci.sh`: **5580 passed, 20 skipped, 6 xfailed**; GATE GREEN.
- Pre-push full gate passed again on commit `4f39f13f`.
- Hosted compatibility matrix: Python 3.12, 3.13, and 3.14 passed install, import smoke, and the fast test suite.
- Python 3.15-dev is an allowed-failure early-warning entry. It stopped before importing MFGArchon because no SciPy wheel was available for Python 3.15.0-beta.4; SciPy's source metadata build then could not find OpenBLAS. The compatibility workflow concluded `success`.

## Scope boundary

- No product code, tests, workflows, tags, or releases changed.
- This establishes the development/release boundary only; it does not claim the migration stack is stable.
