### PR TITLE
Measure capability, not test count

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,7 +147,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.12'
+        python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
     - name: Install dependencies
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,6 +129,35 @@ jobs:
         flags: nightly-${{ matrix.shard.name }}
         fail_ci_if_error: false
 
+  # The capability matrix is a real solve, so it is not in the PR tier and not in a
+  # shard (the shard matrix would run it 4x). Its own model, check_fail_fast.py, runs
+  # both locally and in ci.yml; without this job the matrix ran ONLY in
+  # scripts/local_ci.sh, so a capability regression pushed without the local gate
+  # surfaced in no tier at all -- the "call sites outside CI" gap of #1714.
+  #
+  # --self-test is here for the same reason: it is the control that proves the mass
+  # oracles are load-bearing, and until now nothing invoked it, so nothing would ever
+  # report that the control had gone inert.
+  capability-matrix:
+    name: nightly (capability matrix)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30  # measured ~41 s (matrix) + ~77 s (self-test) locally
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+    - name: Capability vs baseline
+      run: python scripts/capability_matrix.py --check-baseline scripts/capability_baseline.json
+    - name: Self-test (the mass oracles must go red under injected drift)
+      run: python scripts/capability_matrix.py --self-test
+
   # Notification runs ONCE, after all shards, rather than per-shard. Per-shard it races:
   # three concurrent failures each read an empty issue list and each create one, leaving two
   # orphans open forever -- "de-duplicated on title" would only have held from night two.
@@ -137,10 +166,12 @@ jobs:
   # path cannot be exercised by a manual workflow_dispatch, so a bug in it would surface only
   # on a real scheduled failure -- silently, which is the defect this whole workflow fixes.
   notify-on-failure:
-    needs: full-test-suite
+    needs: [full-test-suite, capability-matrix]
     # NOT `failure()`: a shard that blows the timeout is reported `cancelled`, not `failed`,
     # and `failure()` is false for a cancelled dependency -- which was 98 of 108 historical runs.
-    if: ${{ always() && needs.full-test-suite.result != 'success' }}
+    if: >-
+      ${{ always() && (needs.full-test-suite.result != 'success'
+          || needs.capability-matrix.result != 'success') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/github-script@v9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ Root-level only: `/*.png`, `/*_analysis.py` (not global `*.png`). Always `!examp
 ### Pre-commit / pre-merge checks
 ```bash
 pytest tests/unit/test_affected_module.py            # iterate on the affected module
-./scripts/local_ci.sh                                # THE GATE: ruff + ratchet + full suite (~2.5 min)
+./scripts/local_ci.sh                                # THE GATE: ruff + ratchets + capability matrix + full suite (~4 min)
 ./scripts/local_ci.sh --fast                         # lint/format/ratchet only, while iterating
 ruff check mfgarchon/affected_module.py && ruff format --check mfgarchon/affected_module.py
 mypy mfgarchon/affected_module.py
@@ -174,9 +174,9 @@ mypy mfgarchon/affected_module.py
 
 | Tier | What | Where | Cost |
 |:-----|:-----|:------|:-----|
-| Gate (authoritative) | full suite, CI marker set, `-n auto`, no coverage | **local**, `./scripts/local_ci.sh` | ~2.5 min |
+| Gate (authoritative) | fail-fast ratchet, capability matrix, full suite (CI marker set, `-n auto`, no coverage) | **local**, `./scripts/local_ci.sh` | ~4 min |
 | PR checks | syntax, ruff format+lint, fail-fast ratchet, imports, **smoke subset** (`test_core` + `test_config`) | GitHub `ci.yml` | ~3 min |
-| Backstop | full suite **incl. `@slow`**, excluding `@manual` | GitHub `nightly.yml`, 03:00 | `timeout-minutes: 300` |
+| Backstop | full suite **incl. `@slow`**, excluding `@manual`; plus the capability matrix + its self-test | GitHub `nightly.yml`, 03:00 | `timeout-minutes: 300` |
 | Release | full suite incl. `@slow`, excluding `@manual`, with coverage | GitHub `ci.yml` on `release` | 35 min budget |
 
 Why: the full suite is ~141 s locally and **exceeded a 25-minute step budget** on a GitHub runner. Measured — coverage accounts for 1.5x, the runner itself for the rest (~7x slower than an M-series Mac). Online execution of the full suite was buying latency, not signal.

--- a/changelog.d/capability-matrix.added.md
+++ b/changelog.d/capability-matrix.added.md
@@ -1,7 +1,8 @@
-`scripts/capability_matrix.py` — a bidirectional ratchet over what the public solve
-surface can actually do. Six configurations run through `problem.solve()` (or a public
-constructor) and are checked against an oracle outside the code under test: mass
-conservation for `FDM_UPWIND`, `SL_LINEAR`, `FDM_CENTERED` and `FVM_MUSCL`, FVM-vs-FDM
-agreement on one 1-D LQ problem, and `HJBGFDMSolver(derivative_method="rbf")`
-construction. Baseline in `scripts/capability_baseline.json`; wired into
-`scripts/local_ci.sh` (~40 s, not in `--fast`). Refs #1706.
+`scripts/capability_matrix.py` — a bidirectional ratchet over what the solve surface
+can actually do. Seven configurations are driven end to end and checked against an
+oracle outside the code under test: mass conservation for `FDM_UPWIND`, `SL_LINEAR`,
+`FDM_CENTERED` and `FVM_MUSCL`, FVM-vs-FDM agreement on one 1-D LQ problem,
+two-regime `RegimeSwitchingIterator` non-negativity, and
+`HJBGFDMSolver(derivative_method="rbf")` construction. Baseline in
+`scripts/capability_baseline.json`; wired into `scripts/local_ci.sh` (~41 s, not in
+`--fast`). Refs #1706.

--- a/changelog.d/capability-matrix.added.md
+++ b/changelog.d/capability-matrix.added.md
@@ -1,0 +1,7 @@
+`scripts/capability_matrix.py` — a bidirectional ratchet over what the public solve
+surface can actually do. Six configurations run through `problem.solve()` (or a public
+constructor) and are checked against an oracle outside the code under test: mass
+conservation for `FDM_UPWIND`, `SL_LINEAR`, `FDM_CENTERED` and `FVM_MUSCL`, FVM-vs-FDM
+agreement on one 1-D LQ problem, and `HJBGFDMSolver(derivative_method="rbf")`
+construction. Baseline in `scripts/capability_baseline.json`; wired into
+`scripts/local_ci.sh` (~40 s, not in `--fast`). Refs #1706.

--- a/changelog.d/capability-matrix.added.md
+++ b/changelog.d/capability-matrix.added.md
@@ -1,8 +1,8 @@
-`scripts/capability_matrix.py` — a bidirectional ratchet over what the solve surface
-can actually do. Seven configurations are driven end to end and checked against an
-oracle outside the code under test: mass conservation for `FDM_UPWIND`, `SL_LINEAR`,
-`FDM_CENTERED` and `FVM_MUSCL`, FVM-vs-FDM agreement on one 1-D LQ problem,
-two-regime `RegimeSwitchingIterator` non-negativity, and
-`HJBGFDMSolver(derivative_method="rbf")` construction. Baseline in
-`scripts/capability_baseline.json`; wired into `scripts/local_ci.sh` (~41 s, not in
-`--fast`). Refs #1706.
+- **Capability matrix** (`scripts/capability_matrix.py`, Refs #1706) — a bidirectional
+  ratchet over what the solve surface can actually do, checked against oracles outside
+  the code under test. Seven cells: mass conservation for `FDM_UPWIND`, `SL_LINEAR`,
+  `FDM_CENTERED` and `FVM_MUSCL`; FVM-vs-FDM agreement on one 1-D LQ problem;
+  two-regime `RegimeSwitchingIterator` non-negativity; and
+  `HJBGFDMSolver(derivative_method="rbf")` construction. Baseline in
+  `scripts/capability_baseline.json`. Wired into `scripts/local_ci.sh` (~41 s, not in
+  `--fast`) and into `nightly.yml` as a standalone job that also runs `--self-test`.

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -1,0 +1,61 @@
+{
+  "_comment": "Executed capability of the public solve surface. --check-baseline fails in BOTH directions: a recovered cell must be recorded here in the same change that recovers it. Regenerate with --write-baseline.",
+  "cells": {
+    "fdm_centered/mass_conservation": {
+      "artifact": {
+        "exception": "ValueError",
+        "message": "FP solver: density went to -2.769e-01 at timestep 2/10. Clipping it to zero would fabricate 5.744% of the total mass, so the solve is stopped rather than silently repaired (Issue #1671). advection_sch"
+      },
+      "status": "UNSUPPORTED"
+    },
+    "fdm_upwind/mass_conservation": {
+      "artifact": {
+        "all_finite": true,
+        "mass_max": 1.0000000000000004,
+        "mass_t0": 1.0000000000000002,
+        "max_drift": 2.220446049250313e-16,
+        "min_density": 0.007498923701786717,
+        "tolerance": 1.0000000000000003e-09
+      },
+      "status": "PASS"
+    },
+    "fvm_muscl/mass_conservation": {
+      "artifact": {
+        "all_finite": true,
+        "mass_t0": 0.9999999999999998,
+        "max_rel_drift": 2.2204460492503136e-16,
+        "min_density": 7.271016423279045e-05,
+        "tolerance": 1e-06
+      },
+      "status": "PASS"
+    },
+    "fvm_vs_fdm/agreement": {
+      "artifact": {
+        "rel_l2_M": 0.04890589064334588,
+        "rel_l2_M_terminal": 0.04285364468545015,
+        "rel_l2_U": 0.0272298496449295,
+        "tolerance": 0.07,
+        "worst": 0.04890589064334588
+      },
+      "status": "PASS"
+    },
+    "gfdm_rbf/construction": {
+      "artifact": {
+        "exception": "NotImplementedError",
+        "message": "HJBGFDMSolver derivative_method='rbf' is not supported (Issue #1553): since #1526 the RBF branch has no working differentiation-weight builder and would reopen the #1124 obstacle seam. Use derivative_"
+      },
+      "status": "UNSUPPORTED"
+    },
+    "sl_linear/mass_conservation": {
+      "artifact": {
+        "all_finite": true,
+        "mass_max": 1.0000000000000007,
+        "mass_t0": 1.0000000000000002,
+        "max_drift": 4.440892098500626e-16,
+        "min_density": 0.00466345594426523,
+        "tolerance": 1.0000000000000003e-09
+      },
+      "status": "PASS"
+    }
+  }
+}

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -46,6 +46,13 @@
       },
       "status": "UNSUPPORTED"
     },
+    "regime_switching/non_negativity": {
+      "artifact": {
+        "exception": "ValueError",
+        "message": "FP solver: density went to -1.031e-03 at timestep 7/10. Clipping it to zero would fabricate 0.015% of the total mass, so the solve is stopped rather than silently repaired (Issue #1671). advection_sch"
+      },
+      "status": "UNSUPPORTED"
+    },
     "sl_linear/mass_conservation": {
       "artifact": {
         "all_finite": true,

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Executed capability of the public solve surface. --check-baseline fails in BOTH directions: a recovered cell must be recorded here in the same change that recovers it. Regenerate with --write-baseline.",
+  "_comment": "Executed capability of the solve surface. --check-baseline compares STATUS only, in BOTH directions: a recovered cell must be recorded here in the same change that recovers it. The artifact blocks are a record for diffing by a human reviewer, NOT a gate -- a cell can degrade within its own tolerance (fvm_vs_fdm at 4.891% could reach 6.99%) and the status check stays green. Regenerate with --write-baseline.",
   "cells": {
     "fdm_centered/mass_conservation": {
       "artifact": {
@@ -31,6 +31,7 @@
     },
     "fvm_vs_fdm/agreement": {
       "artifact": {
+        "all_finite": true,
         "rel_l2_M": 0.04890589064334588,
         "rel_l2_M_terminal": 0.04285364468545015,
         "rel_l2_U": 0.0272298496449295,

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -83,6 +83,8 @@ def _apply_mutation(M: np.ndarray) -> np.ndarray:
     return M * ramp.reshape((-1,) + (1,) * (M.ndim - 1))
 
 
+_STATUSES = frozenset({"PASS", "FAIL", "UNSUPPORTED", "ERROR"})
+
 MASS_RTOL = 1e-9  # matches tests/integration/test_three_mode_api.py
 AGREEMENT_RTOL = 0.07  # matches tests/integration/test_fvm_hjb_coupling.py:175
 
@@ -217,11 +219,23 @@ def _measure(what: str, thunk):
     Returning the artifact alone left the comparison against it -- ``art["worst"] <
     AGREEMENT_RTOL`` -- one line outside the wrapper, so a ``KeyError`` from a
     partial artifact still read as a library refusal.
+
+    The return shape is CHECKED, not merely documented. A cell that goes back to
+    returning a bare artifact puts its verdict outside the wrapper again, and that
+    reverts silently -- the tests all pass thunks, so they hold under either shape.
+    Making the old shape raise is the only version of this that cannot rot.
     """
     try:
-        return thunk()
+        out = thunk()
     except Exception as exc:
         raise HarnessError(f"measuring {what}: {type(exc).__name__}: {exc}") from exc
+    if not (isinstance(out, tuple) and len(out) == 2 and out[0] in _STATUSES):
+        raise HarnessError(
+            f"measuring {what}: oracle must return (status, artifact) with status in "
+            f"{sorted(_STATUSES)}, got {type(out).__name__} {repr(out)[:80]}. "
+            f"Returning the artifact alone puts the verdict outside this wrapper."
+        )
+    return out
 
 
 # --------------------------------------------------------------------------------
@@ -513,6 +527,7 @@ def evaluate(only: list[str] | None = None) -> dict:
                 "AttributeError",
                 "TypeError",
                 "AssertionError",
+                "KeyError",
             }:
                 status = "ERROR"
                 artifact["traceback_tail"] = traceback.format_exc().strip().splitlines()[-1]

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -181,21 +181,45 @@ class HarnessError(Exception):
     holes: a `ValueError` from a mistyped fixture argument, and an `IndexError`
     from `M.shape[1]` on a malformed result, both read as "the library does not
     support this". Phase, not type, is what separates the two.
+
+    **What goes inside the wrapper: the fixture, never the object under test.**
+    Constructing the thing being measured is part of the measurement, because its
+    ``__init__`` runs the library's own validation -- ``RegimeSwitchingIterator``
+    calls ``assert_paired_solver_sigma`` (#1603 / RFC #1574 C14), and refusing
+    there is a capability statement, not a broken harness. Wrapping it would turn
+    that refusal into an ERROR, and ERROR is never baselined, so the refusal could
+    never be recorded at all. The fixtures -- geometry, components, Hamiltonian,
+    the problem list -- are the harness's own choices and do go inside.
     """
 
 
-def _construct(what: str, fn, *args, **kwargs):
-    """Build a fixture. Any exception is a harness fault, not a library refusal."""
+def _construct(what: str, thunk):
+    """Build a fixture. Any exception is a harness fault, not a library refusal.
+
+    Takes a zero-argument callable, deliberately. An earlier signature was
+    ``_construct(what, fn, *args, **kwargs)``, which does not do what it looks
+    like: Python evaluates argument expressions in the CALLER's frame, so
+    ``_construct("iterator", Cls, solvers=[Solver(p) for p in problems])`` runs
+    every one of those constructors before ``_construct`` is entered, and their
+    failures bypass the wrapper entirely. A thunk is the only form where the
+    wrapper actually covers what it appears to cover.
+    """
     try:
-        return fn(*args, **kwargs)
+        return thunk()
     except Exception as exc:
         raise HarnessError(f"constructing {what}: {type(exc).__name__}: {exc}") from exc
 
 
-def _measure(what: str, fn, *args, **kwargs):
-    """Compute an oracle from a returned result. Any exception is a harness fault."""
+def _measure(what: str, thunk):
+    """Compute the verdict from a returned result. Any exception is a harness fault.
+
+    The thunk returns the whole ``(status, artifact)`` pair, not just the artifact.
+    Returning the artifact alone left the comparison against it -- ``art["worst"] <
+    AGREEMENT_RTOL`` -- one line outside the wrapper, so a ``KeyError`` from a
+    partial artifact still read as a library refusal.
+    """
     try:
-        return fn(*args, **kwargs)
+        return thunk()
     except Exception as exc:
         raise HarnessError(f"measuring {what}: {type(exc).__name__}: {exc}") from exc
 
@@ -213,14 +237,14 @@ def _mass_conservation_cell(scheme_name: str):
 
         problem = _construct("smoke problem", _smoke_problem)
         result = problem.solve(scheme=getattr(NumericalScheme, scheme_name), max_iterations=5, verbose=False)
-        art = _measure("mass drift", _mass_drift, result, problem)
-        tol = MASS_RTOL * max(abs(art["mass_t0"]), 1.0)
-        art["tolerance"] = tol
-        if not art["all_finite"]:
-            return "FAIL", art
-        if art["max_drift"] > tol:
-            return "FAIL", art
-        return "PASS", art
+
+        def verdict():
+            art = _mass_drift(result, problem)
+            art["tolerance"] = MASS_RTOL * max(abs(art["mass_t0"]), 1.0)
+            ok = art["all_finite"] and art["max_drift"] <= art["tolerance"]
+            return ("PASS" if ok else "FAIL"), art
+
+        return _measure("mass drift", verdict)
 
     return run
 
@@ -241,14 +265,12 @@ def _gfdm_rbf_cell():
         pts = np.linspace(0.0, 1.0, 21).reshape(-1, 1)
 
         # Control: the same call with the supported method must construct, or the rbf
-        # verdict below is meaningless. _construct makes its failure ERROR, not
-        # UNSUPPORTED.
+        # verdict below is meaningless. The CONTROL is a fixture, so it goes inside
+        # _construct; the rbf construction one line below is the object under test and
+        # deliberately does not.
         _construct(
             "gfdm taylor control",
-            HJBGFDMSolver,
-            problem=problem,
-            collocation_points=pts,
-            derivative_method="taylor",
+            lambda: HJBGFDMSolver(problem=problem, collocation_points=pts, derivative_method="taylor"),
         )
 
         HJBGFDMSolver(problem=problem, collocation_points=pts, derivative_method="rbf")
@@ -283,7 +305,7 @@ def _fvm_fdm_agreement_cell():
         p_fdm = _construct("FDM problem", _lq_problem_1d)
         r_fdm = p_fdm.solve(scheme=NumericalScheme.FDM_UPWIND, max_iterations=40, tolerance=1e-4)
 
-        def oracle():
+        def verdict():
             M_fvm, M_fdm = _density(r_fvm), np.asarray(r_fdm.M, dtype=float)
             U_fvm, U_fdm = np.asarray(r_fvm.U, dtype=float), np.asarray(r_fdm.U, dtype=float)
             # Checked before the norms. `max()` drops a NaN in any non-leading
@@ -301,16 +323,14 @@ def _fvm_fdm_agreement_cell():
             }
             if not art["all_finite"]:
                 art["worst"] = None
-                return art
+                return "FAIL", art
             art["rel_l2_M"] = _rel_l2(M_fvm, M_fdm, dx)
             art["rel_l2_U"] = _rel_l2(U_fvm, U_fdm, dx)
             art["rel_l2_M_terminal"] = _rel_l2(M_fvm[-1], M_fdm[-1], dx)
             art["worst"] = max(art["rel_l2_M"], art["rel_l2_U"], art["rel_l2_M_terminal"])
-            return art
+            return ("PASS" if art["worst"] < AGREEMENT_RTOL else "FAIL"), art
 
-        art = _measure("FVM/FDM agreement", oracle)
-        ok = art["all_finite"] and art["worst"] < AGREEMENT_RTOL
-        return ("PASS" if ok else "FAIL"), art
+        return _measure("FVM/FDM agreement", verdict)
 
     return run
 
@@ -322,21 +342,21 @@ def _fvm_mass_cell():
         problem = _construct("FVM problem", _lq_problem_1d)
         result = problem.solve(scheme=NumericalScheme.FVM_MUSCL, max_iterations=40, tolerance=1e-4)
 
-        def oracle():
+        def verdict():
             M = _density(result)
             dx = problem.geometry.get_grid_spacing()[0]
             mass = M.sum(axis=1) * dx
-            return {
+            art = {
                 "mass_t0": float(mass[0]),
                 "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
                 "min_density": float(M.min()),
                 "all_finite": bool(np.isfinite(M).all()),
                 "tolerance": 1e-6,
             }
+            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
+            return ("PASS" if ok else "FAIL"), art
 
-        art = _measure("FVM mass drift", oracle)
-        ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
-        return ("PASS" if ok else "FAIL"), art
+        return _measure("FVM mass drift", verdict)
 
     return run
 
@@ -390,9 +410,13 @@ def _regime_switching_cell():
             )
 
         problems = _construct("regime problems", lambda: [lq(c) for c in (1.0, 0.5)])
-        iterator = _construct(
-            "regime iterator",
-            RegimeSwitchingIterator,
+
+        # NOT wrapped, deliberately. Solver and iterator construction is the object
+        # under test: RegimeSwitchingIterator.__init__ runs assert_paired_solver_sigma
+        # (#1603 / RFC #1574 C14) and three other library validations, so a refusal
+        # here is a capability statement. Wrapping it would make that ERROR, and ERROR
+        # is never baselined -- the refusal could then never be recorded at all.
+        iterator = RegimeSwitchingIterator(
             problems=problems,
             regime_config=RegimeSwitchingConfig(transition_matrix=np.array([[-0.1, 0.1], [0.2, -0.2]])),
             hjb_solvers=[HJBFDMSolver(p) for p in problems],
@@ -403,7 +427,7 @@ def _regime_switching_cell():
         )
         result = iterator.solve()
 
-        def oracle():
+        def verdict():
             dx = problems[0].geometry.get_grid_spacing()[0]
             per_regime = []
             for k, dens in enumerate(result.densities):
@@ -417,17 +441,17 @@ def _regime_switching_cell():
                         "all_finite": bool(np.isfinite(M).all()),
                     }
                 )
-            return {
+            art = {
                 "regimes": per_regime,
                 "min_density": min(r["min_density"] for r in per_regime),
                 "max_rel_drift": max(r["max_rel_drift"] for r in per_regime),
                 "all_finite": all(r["all_finite"] for r in per_regime),
                 "tolerance": 1e-6,
             }
+            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
+            return ("PASS" if ok else "FAIL"), art
 
-        art = _measure("regime mass/non-negativity", oracle)
-        ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
-        return ("PASS" if ok else "FAIL"), art
+        return _measure("regime mass/non-negativity", verdict)
 
     return run
 
@@ -537,16 +561,25 @@ def compare_to_baseline(current: dict[str, str], baseline: dict[str, dict]) -> l
 
 
 def _summarise(art: dict) -> str:
-    """One line per artifact. Must never raise: a reporting crash would lose the run.
+    """One line per artifact. Never raises: a reporting crash would lose the run.
 
     A cell whose oracle short-circuits (the NaN guard returns before the norms are
     computed) hands back a partial artifact, and a KeyError here would take down a
-    report whose whole job is to show that something went wrong.
+    report whose whole job is to show that something went wrong. The branches below
+    cover every shape a production cell emits; the catch-all covers the rest, since
+    "never raises" has to hold for shapes nobody anticipated -- that is the point.
     """
+    try:
+        return _summarise_known(art)
+    except Exception:
+        return f"UNSUMMARISABLE artifact: {repr(art)[:110]}"
+
+
+def _summarise_known(art: dict) -> str:
     if "exception" in art:
         return f"{art['exception']}: {str(art.get('message', ''))[:70]}"
     if art.get("all_finite") is False:
-        return "NON-FINITE values in the compared arrays"
+        return "NON-FINITE values in the measured arrays"
     if art.get("worst") is not None:
         tol = art.get("tolerance")
         tol_s = f" (tol {tol:.0%})" if isinstance(tol, float) else ""
@@ -595,6 +628,15 @@ def self_test() -> int:
     finally:
         _DENSITY_MUTATION = None
 
+    # ERROR under mutation is NOT evidence the oracle bites. Scoring on "not PASS"
+    # counted a harness that broke under mutation as a working control -- the same
+    # shape as treating ERROR as a comparable status, surviving in the one place the
+    # earlier fix did not reach, and it matters more here because this IS the control.
+    mutated_broken = errored(mutated)
+    if mutated_broken:
+        print(f"SELF-TEST ABORTED: harness broke under mutation in {', '.join(mutated_broken)}.")
+        return 2
+
     inert = [k for k in passing if mutated[k]["status"] == "PASS"]
     for k in passing:
         verdict = "INERT" if k in inert else "discriminates"
@@ -639,11 +681,13 @@ def main() -> None:
     # reports success for doing so.
     broken = errored(results)
     if broken:
-        print("\nHarness is broken; no capability verdict is trustworthy:")
+        # stderr, not stdout: --json writes the blob to stdout above, and appending
+        # a human block after it makes the output unparseable.
+        print("\nHarness is broken; no capability verdict is trustworthy:", file=sys.stderr)
         for name in broken:
             art = results[name]["artifact"]
-            print(f"  {name}: {art.get('exception')}: {art.get('message', '')[:150]}")
-        print("\nFix the harness. ERROR is never baselined and never compared.")
+            print(f"  {name}: {art.get('exception')}: {art.get('message', '')[:150]}", file=sys.stderr)
+        print("\nFix the harness. ERROR is never baselined and never compared.", file=sys.stderr)
         sys.exit(2)
 
     if args.write_baseline:

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -25,12 +25,14 @@ A cell status is one of:
   UNSUPPORTED  the path refused to run (exception type + message head recorded)
   ERROR        the harness itself broke -- always fails --check-baseline
 
-Cells deliberately NOT in this first set, so the omission is on the record rather than
+Every cell but one drives the public API. ``regime_switching/non_negativity`` reaches
+through the deep module path because ``RegimeSwitchingIterator`` is exported from no
+package ``__init__`` -- recorded in that cell rather than treated as a reason to leave
+a measured defect (#1681) unwatched.
+
+Cells deliberately NOT in this set, so the omission is on the record rather than
 implied absent:
 
-- regime-switching non-negativity (#1681). ``RegimeSwitchingIterator`` is not exported
-  from any package ``__init__``; reaching it needs the deep module path plus a
-  per-regime problem list. It belongs here, it is not here yet.
 - 2-D meshless-Galerkin + Nitsche refinement (#1679). Needs a refinement sweep, so it
   is minutes, not seconds; it belongs in a nightly-tier matrix.
 """
@@ -266,23 +268,114 @@ def _fvm_mass_cell():
     return run
 
 
+def _regime_switching_cell():
+    """Two-regime Markov-switching MFG: every regime density stays non-negative.
+
+    Mirrors the #1681 reproducer
+    (tests/integration/test_phase1_5_validation.py::test_regime_switching_iterator_runs)
+    at its original NT=10. That fixture is deliberately not retuned: the run maximum
+    decays only first-order in dt, so clearing the guard threshold extrapolates to
+    NT ~ 3e6 and refining would hide the defect rather than fix it.
+
+    Reached through the deep module path. ``RegimeSwitchingIterator`` is exported from
+    no package ``__init__``, so unlike every other cell here this one is not on the
+    public surface -- which is itself part of what the cell records.
+    """
+
+    def run():
+        from mfgarchon import MFGProblem
+        from mfgarchon.alg.numerical.coupling.regime_switching_iterator import (
+            RegimeSwitchingIterator,
+        )
+        from mfgarchon.alg.numerical.fp_solvers import FPFDMSolver
+        from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
+        from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+        from mfgarchon.core.mfg_components import MFGComponents
+        from mfgarchon.core.regime_switching import RegimeSwitchingConfig
+        from mfgarchon.geometry import TensorProductGrid
+        from mfgarchon.geometry.boundary import no_flux_bc
+
+        def lq(coupling_coeff):
+            return MFGProblem(
+                geometry=TensorProductGrid(
+                    bounds=[(0.0, 1.0)],
+                    Nx_points=[31],
+                    boundary_conditions=no_flux_bc(dimension=1),
+                ),
+                Nt=10,
+                T=1.0,
+                sigma=0.1,
+                components=MFGComponents(
+                    m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+                    u_terminal=lambda x: 0.0,
+                    hamiltonian=SeparableHamiltonian(
+                        control_cost=QuadraticControlCost(control_cost=1.0),
+                        coupling=lambda m: coupling_coeff * m,
+                        coupling_dm=lambda m: coupling_coeff,
+                    ),
+                ),
+            )
+
+        problems = [lq(c) for c in (1.0, 0.5)]
+        iterator = RegimeSwitchingIterator(
+            problems=problems,
+            regime_config=RegimeSwitchingConfig(transition_matrix=np.array([[-0.1, 0.1], [0.2, -0.2]])),
+            hjb_solvers=[HJBFDMSolver(p) for p in problems],
+            fp_solvers=[FPFDMSolver(p) for p in problems],
+            max_iterations=3,
+            tolerance=1e-4,
+            damping=0.5,
+        )
+        result = iterator.solve()
+
+        dx = problems[0].geometry.get_grid_spacing()[0]
+        per_regime = []
+        for k, dens in enumerate(result.densities):
+            M = _apply_mutation(np.asarray(dens, dtype=float))
+            mass = M.sum(axis=1) * dx
+            per_regime.append(
+                {
+                    "regime": k,
+                    "min_density": float(M.min()),
+                    "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
+                    "all_finite": bool(np.isfinite(M).all()),
+                }
+            )
+        art = {
+            "regimes": per_regime,
+            "min_density": min(r["min_density"] for r in per_regime),
+            "max_rel_drift": max(r["max_rel_drift"] for r in per_regime),
+            "all_finite": all(r["all_finite"] for r in per_regime),
+            "tolerance": 1e-6,
+        }
+        ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
+        return ("PASS" if ok else "FAIL"), art
+
+    return run
+
+
 CELLS = {
     "fdm_upwind/mass_conservation": _mass_conservation_cell("FDM_UPWIND"),
     "sl_linear/mass_conservation": _mass_conservation_cell("SL_LINEAR"),
     "fdm_centered/mass_conservation": _mass_conservation_cell("FDM_CENTERED"),
     "fvm_muscl/mass_conservation": _fvm_mass_cell(),
     "fvm_vs_fdm/agreement": _fvm_fdm_agreement_cell(),
+    "regime_switching/non_negativity": _regime_switching_cell(),
     "gfdm_rbf/construction": _gfdm_rbf_cell(),
 }
 
-# Cells whose oracle is the density this module measures. --self-test scales that
+# Cells whose oracle is the density this module measures. --self-test perturbs that
 # density and requires every one of them to leave PASS; one that does not is inert.
+# Cells that are not PASS today are still listed: the self-test skips them now and
+# picks them up automatically if they recover, so a recovery cannot arrive with an
+# unproven oracle.
 MASS_ORACLE_CELLS = {
     "fdm_upwind/mass_conservation",
     "sl_linear/mass_conservation",
     "fdm_centered/mass_conservation",
     "fvm_muscl/mass_conservation",
     "fvm_vs_fdm/agreement",
+    "regime_switching/non_negativity",
 }
 
 

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -10,9 +10,11 @@ Three properties make a cell hard to satisfy the cheap way:
 
 - The oracle is a number (mass drift, relative L2 against a second discretisation),
   not an exception. ``pytest.raises`` cannot turn a cell green.
-- The comparison is against a closed form or a second independent discretisation,
-  never against another call into the same owner -- so consolidating two paths does
-  not make a cell tautological the way an agreement test becomes tautological.
+- Where a cell claims independence, the second reading comes from a genuinely
+  different discretisation, so consolidating two paths does not make it tautological
+  the way an agreement test does. Independence is claimed **per axis, in the cell's
+  own docstring**, not globally -- ``fvm_vs_fdm`` is independent on M and not on U,
+  because both arms share ``HJBFDMSolver``. Read the cell before relying on it.
 - ``--check-baseline`` fails in BOTH directions. A cell that recovers fails the check
   until the baseline records the recovery, so improvements cannot land silently and a
   baseline cannot be lowered without doing the work. Same structure as
@@ -23,7 +25,17 @@ A cell status is one of:
   PASS         solve returned and the oracle held
   FAIL         solve returned and the oracle was violated (measured value recorded)
   UNSUPPORTED  the path refused to run (exception type + message head recorded)
-  ERROR        the harness itself broke -- always fails --check-baseline
+  ERROR        the harness itself broke
+
+ERROR is not a status like the others: it is never written to a baseline and never
+compared against one. Any ERROR exits 2 before the baseline is read. Treating it as
+comparable was a real hole -- an ERROR baselined as ERROR matched, so a harness broken
+during a regeneration would have stayed green forever, the matrix silently no longer
+measuring anything and reporting success for it.
+
+What ``--check-baseline`` compares is STATUS, not the recorded artifacts. The artifact
+blocks in the baseline are a record for a human diffing a PR; a cell can degrade well
+within its own tolerance and the gate stays green.
 
 Every cell but one drives the public API. ``regime_switching/non_negativity`` reaches
 through the deep module path because ``RegimeSwitchingIterator`` is exported from no
@@ -156,6 +168,38 @@ def _rel_l2(a: np.ndarray, b: np.ndarray, dx: float) -> float:
     return float(np.sqrt(dx * np.sum((a - b) ** 2)) / np.sqrt(dx * np.sum(b**2)))
 
 
+class HarnessError(Exception):
+    """The measurement apparatus failed. Never the code under test.
+
+    A cell has three phases and only the middle one may report UNSUPPORTED:
+
+      construct  build the fixture      -- any failure here is mine
+      solve      call the library       -- a refusal here is the measurement
+      measure    compute the oracle     -- any failure here is mine
+
+    Classifying by exception type instead was the wrong shape, and shipped two
+    holes: a `ValueError` from a mistyped fixture argument, and an `IndexError`
+    from `M.shape[1]` on a malformed result, both read as "the library does not
+    support this". Phase, not type, is what separates the two.
+    """
+
+
+def _construct(what: str, fn, *args, **kwargs):
+    """Build a fixture. Any exception is a harness fault, not a library refusal."""
+    try:
+        return fn(*args, **kwargs)
+    except Exception as exc:
+        raise HarnessError(f"constructing {what}: {type(exc).__name__}: {exc}") from exc
+
+
+def _measure(what: str, fn, *args, **kwargs):
+    """Compute an oracle from a returned result. Any exception is a harness fault."""
+    try:
+        return fn(*args, **kwargs)
+    except Exception as exc:
+        raise HarnessError(f"measuring {what}: {type(exc).__name__}: {exc}") from exc
+
+
 # --------------------------------------------------------------------------------
 # Cells
 # --------------------------------------------------------------------------------
@@ -167,9 +211,9 @@ def _mass_conservation_cell(scheme_name: str):
     def run():
         from mfgarchon.types import NumericalScheme
 
-        problem = _smoke_problem()
+        problem = _construct("smoke problem", _smoke_problem)
         result = problem.solve(scheme=getattr(NumericalScheme, scheme_name), max_iterations=5, verbose=False)
-        art = _mass_drift(result, problem)
+        art = _measure("mass drift", _mass_drift, result, problem)
         tol = MASS_RTOL * max(abs(art["mass_t0"]), 1.0)
         art["tolerance"] = tol
         if not art["all_finite"]:
@@ -193,19 +237,19 @@ def _gfdm_rbf_cell():
     def run():
         from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
 
-        problem = _smoke_problem()
+        problem = _construct("smoke problem", _smoke_problem)
         pts = np.linspace(0.0, 1.0, 21).reshape(-1, 1)
 
-        # Control: the same call with the supported method must construct. If this
-        # raises, the cell reports ERROR (harness broken), never UNSUPPORTED.
-        try:
-            HJBGFDMSolver(problem=problem, collocation_points=pts, derivative_method="taylor")
-        except Exception as exc:
-            raise AssertionError(
-                f"harness control failed: derivative_method='taylor' did not construct "
-                f"({type(exc).__name__}: {' '.join(str(exc).split())[:120]}); "
-                f"the rbf verdict below would be meaningless"
-            ) from exc
+        # Control: the same call with the supported method must construct, or the rbf
+        # verdict below is meaningless. _construct makes its failure ERROR, not
+        # UNSUPPORTED.
+        _construct(
+            "gfdm taylor control",
+            HJBGFDMSolver,
+            problem=problem,
+            collocation_points=pts,
+            derivative_method="taylor",
+        )
 
         HJBGFDMSolver(problem=problem, collocation_points=pts, derivative_method="rbf")
         return "PASS", {"constructed": True}
@@ -214,34 +258,59 @@ def _gfdm_rbf_cell():
 
 
 def _fvm_fdm_agreement_cell():
-    """Two independent discretisations of one PDE must agree to a few percent.
+    """FVM_MUSCL and FDM_UPWIND on one 1-D LQ problem must agree to a few percent.
 
-    The oracle is a second discretisation, not a second call into a shared owner, so
-    single-sourcing the drift or the Hamiltonian does not make this tautological.
+    **What is and is not independent here.** ``create_paired_solvers`` gives
+    ``FVM_MUSCL`` the pair (``HJBFDMSolver``, ``FPFVMSolver``) and ``FDM_UPWIND`` the
+    pair (``HJBFDMSolver``, ``FPFDMSolver``) -- FVM has no HJB partner of its own yet.
+    So the **M** axis is a genuine second discretisation and does not go tautological
+    when the FP drift or the Hamiltonian is single-sourced; the **U** axis is the same
+    HJB class on both arms and is a consistency check, not an independent comparison.
+    The headline number is driven by the M axis (measured 4.891% M vs 2.723% U).
+
+    An earlier version of this docstring claimed independence for the whole cell. That
+    was wrong, and would have mattered: it is the claim someone would rely on when
+    deciding this cell still bites after a consolidation.
     """
 
     def run():
         from mfgarchon.types import NumericalScheme
 
-        p_fvm = _lq_problem_1d()
+        p_fvm = _construct("FVM problem", _lq_problem_1d)
         dx = p_fvm.geometry.get_grid_spacing()[0]
         r_fvm = p_fvm.solve(scheme=NumericalScheme.FVM_MUSCL, max_iterations=40, tolerance=1e-4)
 
-        p_fdm = _lq_problem_1d()
+        p_fdm = _construct("FDM problem", _lq_problem_1d)
         r_fdm = p_fdm.solve(scheme=NumericalScheme.FDM_UPWIND, max_iterations=40, tolerance=1e-4)
 
-        M_fvm, M_fdm = _density(r_fvm), np.asarray(r_fdm.M, dtype=float)
-        U_fvm, U_fdm = np.asarray(r_fvm.U, dtype=float), np.asarray(r_fdm.U, dtype=float)
+        def oracle():
+            M_fvm, M_fdm = _density(r_fvm), np.asarray(r_fdm.M, dtype=float)
+            U_fvm, U_fdm = np.asarray(r_fvm.U, dtype=float), np.asarray(r_fdm.U, dtype=float)
+            # Checked before the norms. `max()` drops a NaN in any non-leading
+            # position -- max(0.0, nan, 0.0) is 0.0 -- so an all-NaN value function
+            # would otherwise pass, and would also make --write-baseline emit a bare
+            # NaN token, which is not valid JSON.
+            art = {
+                "all_finite": bool(
+                    np.isfinite(M_fvm).all()
+                    and np.isfinite(M_fdm).all()
+                    and np.isfinite(U_fvm).all()
+                    and np.isfinite(U_fdm).all()
+                ),
+                "tolerance": AGREEMENT_RTOL,
+            }
+            if not art["all_finite"]:
+                art["worst"] = None
+                return art
+            art["rel_l2_M"] = _rel_l2(M_fvm, M_fdm, dx)
+            art["rel_l2_U"] = _rel_l2(U_fvm, U_fdm, dx)
+            art["rel_l2_M_terminal"] = _rel_l2(M_fvm[-1], M_fdm[-1], dx)
+            art["worst"] = max(art["rel_l2_M"], art["rel_l2_U"], art["rel_l2_M_terminal"])
+            return art
 
-        art = {
-            "rel_l2_M": _rel_l2(M_fvm, M_fdm, dx),
-            "rel_l2_U": _rel_l2(U_fvm, U_fdm, dx),
-            "rel_l2_M_terminal": _rel_l2(M_fvm[-1], M_fdm[-1], dx),
-            "tolerance": AGREEMENT_RTOL,
-        }
-        worst = max(art["rel_l2_M"], art["rel_l2_U"], art["rel_l2_M_terminal"])
-        art["worst"] = worst
-        return ("PASS" if worst < AGREEMENT_RTOL else "FAIL"), art
+        art = _measure("FVM/FDM agreement", oracle)
+        ok = art["all_finite"] and art["worst"] < AGREEMENT_RTOL
+        return ("PASS" if ok else "FAIL"), art
 
     return run
 
@@ -250,18 +319,22 @@ def _fvm_mass_cell():
     def run():
         from mfgarchon.types import NumericalScheme
 
-        problem = _lq_problem_1d()
+        problem = _construct("FVM problem", _lq_problem_1d)
         result = problem.solve(scheme=NumericalScheme.FVM_MUSCL, max_iterations=40, tolerance=1e-4)
-        M = _density(result)
-        dx = problem.geometry.get_grid_spacing()[0]
-        mass = M.sum(axis=1) * dx
-        art = {
-            "mass_t0": float(mass[0]),
-            "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
-            "min_density": float(M.min()),
-            "all_finite": bool(np.isfinite(M).all()),
-            "tolerance": 1e-6,
-        }
+
+        def oracle():
+            M = _density(result)
+            dx = problem.geometry.get_grid_spacing()[0]
+            mass = M.sum(axis=1) * dx
+            return {
+                "mass_t0": float(mass[0]),
+                "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
+                "min_density": float(M.min()),
+                "all_finite": bool(np.isfinite(M).all()),
+                "tolerance": 1e-6,
+            }
+
+        art = _measure("FVM mass drift", oracle)
         ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
         return ("PASS" if ok else "FAIL"), art
 
@@ -316,8 +389,10 @@ def _regime_switching_cell():
                 ),
             )
 
-        problems = [lq(c) for c in (1.0, 0.5)]
-        iterator = RegimeSwitchingIterator(
+        problems = _construct("regime problems", lambda: [lq(c) for c in (1.0, 0.5)])
+        iterator = _construct(
+            "regime iterator",
+            RegimeSwitchingIterator,
             problems=problems,
             regime_config=RegimeSwitchingConfig(transition_matrix=np.array([[-0.1, 0.1], [0.2, -0.2]])),
             hjb_solvers=[HJBFDMSolver(p) for p in problems],
@@ -328,26 +403,29 @@ def _regime_switching_cell():
         )
         result = iterator.solve()
 
-        dx = problems[0].geometry.get_grid_spacing()[0]
-        per_regime = []
-        for k, dens in enumerate(result.densities):
-            M = _apply_mutation(np.asarray(dens, dtype=float))
-            mass = M.sum(axis=1) * dx
-            per_regime.append(
-                {
-                    "regime": k,
-                    "min_density": float(M.min()),
-                    "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
-                    "all_finite": bool(np.isfinite(M).all()),
-                }
-            )
-        art = {
-            "regimes": per_regime,
-            "min_density": min(r["min_density"] for r in per_regime),
-            "max_rel_drift": max(r["max_rel_drift"] for r in per_regime),
-            "all_finite": all(r["all_finite"] for r in per_regime),
-            "tolerance": 1e-6,
-        }
+        def oracle():
+            dx = problems[0].geometry.get_grid_spacing()[0]
+            per_regime = []
+            for k, dens in enumerate(result.densities):
+                M = _apply_mutation(np.asarray(dens, dtype=float))
+                mass = M.sum(axis=1) * dx
+                per_regime.append(
+                    {
+                        "regime": k,
+                        "min_density": float(M.min()),
+                        "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
+                        "all_finite": bool(np.isfinite(M).all()),
+                    }
+                )
+            return {
+                "regimes": per_regime,
+                "min_density": min(r["min_density"] for r in per_regime),
+                "max_rel_drift": max(r["max_rel_drift"] for r in per_regime),
+                "all_finite": all(r["all_finite"] for r in per_regime),
+                "tolerance": 1e-6,
+            }
+
+        art = _measure("regime mass/non-negativity", oracle)
         ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
         return ("PASS" if ok else "FAIL"), art
 
@@ -387,15 +465,24 @@ def evaluate(only: list[str] | None = None) -> dict:
         t0 = time.perf_counter()
         try:
             status, artifact = run()
-        # Broad by design: classifying the refusal IS the measurement here. The
-        # narrowing happens below, on the exception type.
+        # A HarnessError names its own phase: construct or measure, never the solve.
+        except HarnessError as exc:
+            status = "ERROR"
+            artifact = {
+                "exception": "HarnessError",
+                "message": " ".join(str(exc).split())[:200],
+                "traceback_tail": traceback.format_exc().strip().splitlines()[-1],
+            }
+        # Broad by design: classifying the refusal IS the measurement here. Anything
+        # reaching this point came out of the solve phase.
         except Exception as exc:
             status = "UNSUPPORTED"
-            head = " ".join(str(exc).split())[:200]
-            artifact = {"exception": type(exc).__name__, "message": head}
-            # A cell reports UNSUPPORTED only for a refusal by the code under test.
-            # A broken harness -- bad import, wrong signature, failed control -- must
-            # never be readable as "the library does not support this".
+            artifact = {
+                "exception": type(exc).__name__,
+                "message": " ".join(str(exc).split())[:200],
+            }
+            # Second net, for exception classes that cannot come from a library
+            # refusal no matter which phase raised them.
             if type(exc).__name__ in {
                 "ImportError",
                 "ModuleNotFoundError",
@@ -415,6 +502,11 @@ def evaluate(only: list[str] | None = None) -> dict:
 
 def _statuses(results: dict) -> dict:
     return {k: v["status"] for k, v in results.items()}
+
+
+def errored(results: dict) -> list[str]:
+    """Cells whose apparatus failed. Never comparable, never baselined."""
+    return sorted(k for k, v in results.items() if v["status"] == "ERROR")
 
 
 def compare_to_baseline(current: dict[str, str], baseline: dict[str, dict]) -> list[str]:
@@ -444,23 +536,34 @@ def compare_to_baseline(current: dict[str, str], baseline: dict[str, dict]) -> l
     return problems
 
 
+def _summarise(art: dict) -> str:
+    """One line per artifact. Must never raise: a reporting crash would lose the run.
+
+    A cell whose oracle short-circuits (the NaN guard returns before the norms are
+    computed) hands back a partial artifact, and a KeyError here would take down a
+    report whose whole job is to show that something went wrong.
+    """
+    if "exception" in art:
+        return f"{art['exception']}: {str(art.get('message', ''))[:70]}"
+    if art.get("all_finite") is False:
+        return "NON-FINITE values in the compared arrays"
+    if art.get("worst") is not None:
+        tol = art.get("tolerance")
+        tol_s = f" (tol {tol:.0%})" if isinstance(tol, float) else ""
+        return f"worst rel L2 {art['worst']:.3%}{tol_s}"
+    if art.get("max_drift") is not None:
+        return f"mass drift {art['max_drift']:.3e}, min M {art.get('min_density', float('nan')):.3e}"
+    if art.get("max_rel_drift") is not None:
+        return f"rel mass drift {art['max_rel_drift']:.3e}, min M {art.get('min_density', float('nan')):.3e}"
+    return json.dumps(art, default=str)
+
+
 def print_report(results: dict) -> None:
     width = max(len(k) for k in results)
     print(f"\n{'cell':<{width}}  {'status':<12} {'s':>6}  artifact")
     print("-" * (width + 60))
     for name, r in sorted(results.items()):
-        art = r["artifact"]
-        if "exception" in art:
-            summary = f"{art['exception']}: {art['message'][:70]}"
-        elif "worst" in art:
-            summary = f"worst rel L2 {art['worst']:.3%} (tol {art['tolerance']:.0%})"
-        elif "max_drift" in art:
-            summary = f"mass drift {art['max_drift']:.3e}, min M {art['min_density']:.3e}"
-        elif "max_rel_drift" in art:
-            summary = f"rel mass drift {art['max_rel_drift']:.3e}, min M {art['min_density']:.3e}"
-        else:
-            summary = json.dumps(art)
-        print(f"{name:<{width}}  {r['status']:<12} {r['seconds']:>6.2f}  {summary}")
+        print(f"{name:<{width}}  {r['status']:<12} {r['seconds']:>6.2f}  {_summarise(r['artifact'])}")
     tally = {}
     for r in results.values():
         tally[r["status"]] = tally.get(r["status"], 0) + 1
@@ -477,6 +580,10 @@ def self_test() -> int:
     global _DENSITY_MUTATION
 
     baseline = evaluate(only=sorted(MASS_ORACLE_CELLS))
+    broken = errored(baseline)
+    if broken:
+        print(f"SELF-TEST ABORTED: harness broken in {', '.join(broken)}.")
+        return 2
     passing = [k for k, v in baseline.items() if v["status"] == "PASS"]
     if not passing:
         print("SELF-TEST INCONCLUSIVE: no mass-oracle cell is PASS, nothing to mutate.")
@@ -525,18 +632,44 @@ def main() -> None:
     else:
         print_report(results)
 
+    # ERROR means the apparatus failed, so no verdict below is trustworthy. It is
+    # checked before the baseline is even read, and it is never comparable: an ERROR
+    # baselined as ERROR would otherwise match, and a harness broken during a
+    # regeneration would be green forever -- the matrix silently stops measuring and
+    # reports success for doing so.
+    broken = errored(results)
+    if broken:
+        print("\nHarness is broken; no capability verdict is trustworthy:")
+        for name in broken:
+            art = results[name]["artifact"]
+            print(f"  {name}: {art.get('exception')}: {art.get('message', '')[:150]}")
+        print("\nFix the harness. ERROR is never baselined and never compared.")
+        sys.exit(2)
+
     if args.write_baseline:
         payload = {
             "_comment": (
-                "Executed capability of the public solve surface. --check-baseline fails in "
-                "BOTH directions: a recovered cell must be recorded here in the same change "
-                "that recovers it. Regenerate with --write-baseline."
+                "Executed capability of the solve surface. --check-baseline compares STATUS "
+                "only, in BOTH directions: a recovered cell must be recorded here in the same "
+                "change that recovers it. The artifact blocks are a record for diffing by a "
+                "human reviewer, NOT a gate -- a cell can degrade within its own tolerance "
+                "(fvm_vs_fdm at 4.891% could reach 6.99%) and the status check stays green. "
+                "Regenerate with --write-baseline."
             ),
             "cells": {k: {"status": v["status"], "artifact": v["artifact"]} for k, v in results.items()},
         }
+        # allow_nan=False: Python would otherwise emit a bare `NaN` token, which is
+        # not JSON and which every non-Python reader rejects. A non-finite artifact
+        # also means a cell's oracle produced one, which is a defect in the cell --
+        # refuse rather than record it.
+        try:
+            body = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False)
+        except ValueError as exc:
+            print(f"\nRefusing to write a baseline with a non-finite artifact: {exc}")
+            print("A cell's oracle returned NaN or Infinity. Fix the cell.")
+            sys.exit(1)
         with open(args.write_baseline, "w") as fh:
-            json.dump(payload, fh, indent=2, sort_keys=True)
-            fh.write("\n")
+            fh.write(body + "\n")
         print(f"\nBaseline written to {args.write_baseline}")
         sys.exit(0)
 
@@ -552,7 +685,7 @@ def main() -> None:
         print(f"\nCapability matches baseline ({len(baseline)} cells).")
         sys.exit(0)
 
-    sys.exit(1 if any(r["status"] == "ERROR" for r in results.values()) else 0)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Execute the public solve surface and record what it can actually do.
+
+Counts of tests, issues, or fail-fast violations all move for reasons unrelated to
+whether the library solves anything. This records the other quantity: for a fixed set
+of configurations driven through the public API, does the result satisfy an oracle
+that lives outside the code under test.
+
+Three properties make a cell hard to satisfy the cheap way:
+
+- The oracle is a number (mass drift, relative L2 against a second discretisation),
+  not an exception. ``pytest.raises`` cannot turn a cell green.
+- The comparison is against a closed form or a second independent discretisation,
+  never against another call into the same owner -- so consolidating two paths does
+  not make a cell tautological the way an agreement test becomes tautological.
+- ``--check-baseline`` fails in BOTH directions. A cell that recovers fails the check
+  until the baseline records the recovery, so improvements cannot land silently and a
+  baseline cannot be lowered without doing the work. Same structure as
+  ``check_fail_fast.py`` / ``fail_fast_baseline.json``.
+
+A cell status is one of:
+
+  PASS         solve returned and the oracle held
+  FAIL         solve returned and the oracle was violated (measured value recorded)
+  UNSUPPORTED  the path refused to run (exception type + message head recorded)
+  ERROR        the harness itself broke -- always fails --check-baseline
+
+Cells deliberately NOT in this first set, so the omission is on the record rather than
+implied absent:
+
+- regime-switching non-negativity (#1681). ``RegimeSwitchingIterator`` is not exported
+  from any package ``__init__``; reaching it needs the deep module path plus a
+  per-regime problem list. It belongs here, it is not here yet.
+- 2-D meshless-Galerkin + Nitsche refinement (#1679). Needs a refinement sweep, so it
+  is minutes, not seconds; it belongs in a nightly-tier matrix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import traceback
+import warnings
+
+import numpy as np
+
+warnings.filterwarnings("ignore")
+
+# Set by --self-test. Applied to every density this module measures, so a mass oracle
+# that does not read the density it claims to read stays green and the self-test
+# reports the cell as inert.
+#
+# The mutation is a RAMP along the time axis, not a constant factor. A constant factor
+# was tried first and left all three drift cells PASS -- correctly, because
+# max|mass(t) - mass(0)| is invariant under a uniform rescaling of every slice. A
+# control has to break the invariant the oracle measures; picking one that cannot is
+# the same error as a test that passes either way.
+_DENSITY_MUTATION: float | None = None
+
+
+def _apply_mutation(M: np.ndarray) -> np.ndarray:
+    """Inject ``_DENSITY_MUTATION`` relative drift, linear in time, zero at t=0."""
+    if _DENSITY_MUTATION is None:
+        return M
+    nt = M.shape[0]
+    ramp = 1.0 + _DENSITY_MUTATION * (np.arange(nt) / max(nt - 1, 1))
+    return M * ramp.reshape((-1,) + (1,) * (M.ndim - 1))
+
+
+MASS_RTOL = 1e-9  # matches tests/integration/test_three_mode_api.py
+AGREEMENT_RTOL = 0.07  # matches tests/integration/test_fvm_hjb_coupling.py:175
+
+
+# --------------------------------------------------------------------------------
+# Shared problem builders. Both mirror an existing test fixture rather than inventing
+# a configuration, so a cell here and the corresponding test disagree only if the
+# product changed.
+# --------------------------------------------------------------------------------
+
+
+def _smoke_problem():
+    """The tests/integration/test_three_mode_api.py fixture."""
+    from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    return MFGProblem(
+        geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)),
+        Nt=10,
+        T=1.0,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _lq_problem_1d():
+    """The tests/integration/test_fvm_hjb_coupling.py 1-D LQ fixture."""
+    from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    coupling = 0.3
+    return MFGProblem(
+        geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[25], boundary_conditions=no_flux_bc(dimension=1)),
+        T=0.3,
+        Nt=12,
+        sigma=0.4,
+        coupling_coefficient=coupling,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-((np.asarray(x) - 0.4) ** 2) / (2 * 0.13**2)),
+            u_terminal=lambda x: 0.2 * (np.asarray(x) - 0.6) ** 2,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0 / coupling),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _density(result) -> np.ndarray:
+    return _apply_mutation(np.asarray(result.M, dtype=float))
+
+
+def _mass_drift(result, problem) -> dict:
+    """Total mass per time slice, and its maximum excursion from t=0."""
+    M = _density(result)
+    bounds = problem.geometry.get_bounds()
+    dx = (bounds[1][0] - bounds[0][0]) / (M.shape[1] - 1)
+    mass = M.sum(axis=1) * dx
+    return {
+        "mass_t0": float(mass[0]),
+        "mass_max": float(mass.max()),
+        "max_drift": float(np.abs(mass - mass[0]).max()),
+        "min_density": float(M.min()),
+        "all_finite": bool(np.isfinite(M).all()),
+    }
+
+
+def _rel_l2(a: np.ndarray, b: np.ndarray, dx: float) -> float:
+    return float(np.sqrt(dx * np.sum((a - b) ** 2)) / np.sqrt(dx * np.sum(b**2)))
+
+
+# --------------------------------------------------------------------------------
+# Cells
+# --------------------------------------------------------------------------------
+
+
+def _mass_conservation_cell(scheme_name: str):
+    """Public problem.solve(scheme=...) must not move total mass."""
+
+    def run():
+        from mfgarchon.types import NumericalScheme
+
+        problem = _smoke_problem()
+        result = problem.solve(scheme=getattr(NumericalScheme, scheme_name), max_iterations=5, verbose=False)
+        art = _mass_drift(result, problem)
+        tol = MASS_RTOL * max(abs(art["mass_t0"]), 1.0)
+        art["tolerance"] = tol
+        if not art["all_finite"]:
+            return "FAIL", art
+        if art["max_drift"] > tol:
+            return "FAIL", art
+        return "PASS", art
+
+    return run
+
+
+def _gfdm_rbf_cell():
+    """HJBGFDMSolver(derivative_method='rbf') -- a declared constructor argument.
+
+    The taylor sibling is constructed first and must succeed. Without it, a harness
+    bug -- a renamed argument, a changed signature -- reports UNSUPPORTED and reads as
+    the RBF defect. Same shape as the ``_Bare`` object in #1447, which made a
+    failure-mode test pass without ever reaching the branch it named.
+    """
+
+    def run():
+        from mfgarchon.alg.numerical.hjb_solvers import HJBGFDMSolver
+
+        problem = _smoke_problem()
+        pts = np.linspace(0.0, 1.0, 21).reshape(-1, 1)
+
+        # Control: the same call with the supported method must construct. If this
+        # raises, the cell reports ERROR (harness broken), never UNSUPPORTED.
+        try:
+            HJBGFDMSolver(problem=problem, collocation_points=pts, derivative_method="taylor")
+        except Exception as exc:
+            raise AssertionError(
+                f"harness control failed: derivative_method='taylor' did not construct "
+                f"({type(exc).__name__}: {' '.join(str(exc).split())[:120]}); "
+                f"the rbf verdict below would be meaningless"
+            ) from exc
+
+        HJBGFDMSolver(problem=problem, collocation_points=pts, derivative_method="rbf")
+        return "PASS", {"constructed": True}
+
+    return run
+
+
+def _fvm_fdm_agreement_cell():
+    """Two independent discretisations of one PDE must agree to a few percent.
+
+    The oracle is a second discretisation, not a second call into a shared owner, so
+    single-sourcing the drift or the Hamiltonian does not make this tautological.
+    """
+
+    def run():
+        from mfgarchon.types import NumericalScheme
+
+        p_fvm = _lq_problem_1d()
+        dx = p_fvm.geometry.get_grid_spacing()[0]
+        r_fvm = p_fvm.solve(scheme=NumericalScheme.FVM_MUSCL, max_iterations=40, tolerance=1e-4)
+
+        p_fdm = _lq_problem_1d()
+        r_fdm = p_fdm.solve(scheme=NumericalScheme.FDM_UPWIND, max_iterations=40, tolerance=1e-4)
+
+        M_fvm, M_fdm = _density(r_fvm), np.asarray(r_fdm.M, dtype=float)
+        U_fvm, U_fdm = np.asarray(r_fvm.U, dtype=float), np.asarray(r_fdm.U, dtype=float)
+
+        art = {
+            "rel_l2_M": _rel_l2(M_fvm, M_fdm, dx),
+            "rel_l2_U": _rel_l2(U_fvm, U_fdm, dx),
+            "rel_l2_M_terminal": _rel_l2(M_fvm[-1], M_fdm[-1], dx),
+            "tolerance": AGREEMENT_RTOL,
+        }
+        worst = max(art["rel_l2_M"], art["rel_l2_U"], art["rel_l2_M_terminal"])
+        art["worst"] = worst
+        return ("PASS" if worst < AGREEMENT_RTOL else "FAIL"), art
+
+    return run
+
+
+def _fvm_mass_cell():
+    def run():
+        from mfgarchon.types import NumericalScheme
+
+        problem = _lq_problem_1d()
+        result = problem.solve(scheme=NumericalScheme.FVM_MUSCL, max_iterations=40, tolerance=1e-4)
+        M = _density(result)
+        dx = problem.geometry.get_grid_spacing()[0]
+        mass = M.sum(axis=1) * dx
+        art = {
+            "mass_t0": float(mass[0]),
+            "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
+            "min_density": float(M.min()),
+            "all_finite": bool(np.isfinite(M).all()),
+            "tolerance": 1e-6,
+        }
+        ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
+        return ("PASS" if ok else "FAIL"), art
+
+    return run
+
+
+CELLS = {
+    "fdm_upwind/mass_conservation": _mass_conservation_cell("FDM_UPWIND"),
+    "sl_linear/mass_conservation": _mass_conservation_cell("SL_LINEAR"),
+    "fdm_centered/mass_conservation": _mass_conservation_cell("FDM_CENTERED"),
+    "fvm_muscl/mass_conservation": _fvm_mass_cell(),
+    "fvm_vs_fdm/agreement": _fvm_fdm_agreement_cell(),
+    "gfdm_rbf/construction": _gfdm_rbf_cell(),
+}
+
+# Cells whose oracle is the density this module measures. --self-test scales that
+# density and requires every one of them to leave PASS; one that does not is inert.
+MASS_ORACLE_CELLS = {
+    "fdm_upwind/mass_conservation",
+    "sl_linear/mass_conservation",
+    "fdm_centered/mass_conservation",
+    "fvm_muscl/mass_conservation",
+    "fvm_vs_fdm/agreement",
+}
+
+
+def evaluate(only: list[str] | None = None) -> dict:
+    results = {}
+    for name, run in CELLS.items():
+        if only and name not in only:
+            continue
+        t0 = time.perf_counter()
+        try:
+            status, artifact = run()
+        # Broad by design: classifying the refusal IS the measurement here. The
+        # narrowing happens below, on the exception type.
+        except Exception as exc:
+            status = "UNSUPPORTED"
+            head = " ".join(str(exc).split())[:200]
+            artifact = {"exception": type(exc).__name__, "message": head}
+            # A cell reports UNSUPPORTED only for a refusal by the code under test.
+            # A broken harness -- bad import, wrong signature, failed control -- must
+            # never be readable as "the library does not support this".
+            if type(exc).__name__ in {
+                "ImportError",
+                "ModuleNotFoundError",
+                "AttributeError",
+                "TypeError",
+                "AssertionError",
+            }:
+                status = "ERROR"
+                artifact["traceback_tail"] = traceback.format_exc().strip().splitlines()[-1]
+        results[name] = {
+            "status": status,
+            "artifact": artifact,
+            "seconds": round(time.perf_counter() - t0, 2),
+        }
+    return results
+
+
+def _statuses(results: dict) -> dict:
+    return {k: v["status"] for k, v in results.items()}
+
+
+def compare_to_baseline(current: dict[str, str], baseline: dict[str, dict]) -> list[str]:
+    """Every status difference, in either direction, as a human-readable line.
+
+    Bidirectional on purpose. A one-directional check (fail only on regression)
+    lets a recovery land unrecorded, and the next run's baseline then encodes the
+    recovery as if it had always held -- which is how a gate stops being able to
+    say when something was fixed. Empty list means the tree matches the baseline.
+    """
+    problems = []
+    for name, was in sorted(baseline.items()):
+        now = current.get(name)
+        if now is None:
+            problems.append(f"  {name}: cell DISAPPEARED (baseline {was['status']})")
+        elif now != was["status"]:
+            kind = (
+                "REGRESSION"
+                if was["status"] == "PASS"
+                else "RECOVERED -- record it in the baseline"
+                if now == "PASS"
+                else "SHIFT"
+            )
+            problems.append(f"  {name}: {was['status']} -> {now}  [{kind}]")
+    for name in sorted(set(current) - set(baseline)):
+        problems.append(f"  {name}: NEW cell, not in baseline")
+    return problems
+
+
+def print_report(results: dict) -> None:
+    width = max(len(k) for k in results)
+    print(f"\n{'cell':<{width}}  {'status':<12} {'s':>6}  artifact")
+    print("-" * (width + 60))
+    for name, r in sorted(results.items()):
+        art = r["artifact"]
+        if "exception" in art:
+            summary = f"{art['exception']}: {art['message'][:70]}"
+        elif "worst" in art:
+            summary = f"worst rel L2 {art['worst']:.3%} (tol {art['tolerance']:.0%})"
+        elif "max_drift" in art:
+            summary = f"mass drift {art['max_drift']:.3e}, min M {art['min_density']:.3e}"
+        elif "max_rel_drift" in art:
+            summary = f"rel mass drift {art['max_rel_drift']:.3e}, min M {art['min_density']:.3e}"
+        else:
+            summary = json.dumps(art)
+        print(f"{name:<{width}}  {r['status']:<12} {r['seconds']:>6.2f}  {summary}")
+    tally = {}
+    for r in results.values():
+        tally[r["status"]] = tally.get(r["status"], 0) + 1
+    print("\n" + "  ".join(f"{k}={v}" for k, v in sorted(tally.items())))
+
+
+def self_test() -> int:
+    """Prove each mass-oracle cell is load-bearing on the density it reports.
+
+    Injects 10% relative mass drift, linear in time, and requires each such cell to
+    leave PASS. This proves the oracle reads the density it reports; it does NOT prove
+    the solver correct.
+    """
+    global _DENSITY_MUTATION
+
+    baseline = evaluate(only=sorted(MASS_ORACLE_CELLS))
+    passing = [k for k, v in baseline.items() if v["status"] == "PASS"]
+    if not passing:
+        print("SELF-TEST INCONCLUSIVE: no mass-oracle cell is PASS, nothing to mutate.")
+        return 1
+
+    _DENSITY_MUTATION = 0.10
+    try:
+        mutated = evaluate(only=passing)
+    finally:
+        _DENSITY_MUTATION = None
+
+    inert = [k for k in passing if mutated[k]["status"] == "PASS"]
+    for k in passing:
+        verdict = "INERT" if k in inert else "discriminates"
+        print(f"  {k:<34} PASS -> {mutated[k]['status']:<12} {verdict}")
+    if inert:
+        print(f"\nSELF-TEST FAILED: {len(inert)} cell(s) do not read the density they report.")
+        return 1
+    print(f"\nSELF-TEST PASSED: {len(passing)} mass-oracle cell(s) go red under 10% injected drift.")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="Emit full results as JSON")
+    parser.add_argument("--write-baseline", metavar="FILE", help="Write current statuses to FILE and exit")
+    parser.add_argument(
+        "--check-baseline",
+        metavar="FILE",
+        help="Fail if any cell's status differs from FILE, in either direction",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Mutate the measured density and require every mass-oracle cell to go red",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+
+    results = evaluate()
+
+    if args.json:
+        print(json.dumps(results, indent=2, sort_keys=True))
+    else:
+        print_report(results)
+
+    if args.write_baseline:
+        payload = {
+            "_comment": (
+                "Executed capability of the public solve surface. --check-baseline fails in "
+                "BOTH directions: a recovered cell must be recorded here in the same change "
+                "that recovers it. Regenerate with --write-baseline."
+            ),
+            "cells": {k: {"status": v["status"], "artifact": v["artifact"]} for k, v in results.items()},
+        }
+        with open(args.write_baseline, "w") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        print(f"\nBaseline written to {args.write_baseline}")
+        sys.exit(0)
+
+    if args.check_baseline:
+        with open(args.check_baseline) as fh:
+            baseline = json.load(fh)["cells"]
+        problems = compare_to_baseline(_statuses(results), baseline)
+        if problems:
+            print("\nCapability baseline mismatch:")
+            print("\n".join(problems))
+            print("\nIf the change is intended, regenerate with --write-baseline in the same commit.")
+            sys.exit(1)
+        print(f"\nCapability matches baseline ({len(baseline)} cells).")
+        sys.exit(0)
+
+    sys.exit(1 if any(r["status"] == "ERROR" for r in results.values()) else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -80,6 +80,15 @@ step "Fail-fast ratchet"
 check $? "no new silent fallbacks vs baseline"
 
 if [[ $FAST -eq 0 ]]; then
+  # ~40 s. Not in --fast: every cell is a real coupled solve, so this is the one check
+  # here that measures the product rather than the source. Counts of tests, issues or
+  # fail-fast violations all move for reasons unrelated to whether anything solves;
+  # this is the quantity that does not. Bidirectional -- a recovered cell fails until
+  # the baseline records it, so a fix cannot land without saying so.
+  step "Capability matrix (public solve surface vs external oracles)"
+  "$PY" scripts/capability_matrix.py --check-baseline scripts/capability_baseline.json
+  check $? "no capability change vs baseline"
+
   step "Test suite (CI marker set, xdist parallel, no coverage)"
   "$PY" -m pytest tests/ -n auto \
     -m "not slow and not benchmark and not experimental and not optional_torch and not environment" \

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -18,6 +18,7 @@ anything: the cells themselves are exercised by running the script.
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -147,16 +148,22 @@ def test_ramp_mutation_leaves_the_first_slice_alone(cm, monkeypatch):
     np.testing.assert_allclose(cm._apply_mutation(M)[0], M[0])
 
 
-def test_a_constant_scale_would_not_inject_drift(cm):
+def test_the_mutation_does_what_a_constant_scale_cannot(cm, monkeypatch):
     """Pins the reason the mutation is a ramp.
 
     If someone replaces the ramp with ``M * factor``, the self-test goes back to
     reporting every drift cell INERT -- not because the cells broke, but because the
-    control cannot break them. This test states the arithmetic so that change is a
-    deliberate one.
+    control cannot break them.
+
+    An earlier version of this test asserted only ``_drift(M * 1.5) == 0.0``, which
+    never called the module under test: replacing the entire module with ``STUB = 1``
+    left it green. It was a comment wearing a test's authority -- the exact bucket
+    #1714 counts. It now compares the real mutation against the inert one.
     """
     M = np.ones((5, 4))
-    assert _drift(M * 1.5) == 0.0
+    assert _drift(M * 1.5) == 0.0, "a uniform scale cannot create drift -- that is the point"
+    monkeypatch.setattr(cm, "_DENSITY_MUTATION", 0.10)
+    assert _drift(cm._apply_mutation(M)) > 0.0
 
 
 def test_mutation_is_off_by_default(cm):
@@ -205,3 +212,186 @@ def test_a_refusal_by_the_code_under_test_is_unsupported(cm, monkeypatch):
     assert result["status"] == "UNSUPPORTED"
     assert result["artifact"]["exception"] == "NotImplementedError"
     assert "#1553" in result["artifact"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Phase separation -- classifying by exception type was the wrong shape
+# ---------------------------------------------------------------------------
+
+
+def test_a_valueerror_while_building_the_fixture_is_error_not_unsupported(cm, monkeypatch):
+    """The library validates its own arguments with ValueError.
+
+    So a mistyped fixture argument raises the same class as a genuine refusal, and
+    under type-based classification read as "the library does not support this
+    scheme". Only the phase separates them.
+    """
+
+    def bad_fixture():
+        cm._construct("mistyped fixture", lambda: (_ for _ in ()).throw(ValueError("BC dimension mismatch")))
+
+    monkeypatch.setattr(cm, "CELLS", {"bad/fixture": bad_fixture})
+    result = cm.evaluate()["bad/fixture"]
+    assert result["status"] == "ERROR"
+    assert "constructing mistyped fixture" in result["artifact"]["message"]
+
+
+def test_an_exception_while_computing_the_oracle_is_error_not_unsupported(cm, monkeypatch):
+    """A solver returning a malformed result must not read as a library refusal.
+
+    `M.shape[1]` on `np.asarray(None)` raises IndexError, which no denylist of
+    "harness exception types" would plausibly have contained.
+    """
+
+    def bad_measure():
+        class Result:
+            M = None
+
+        cm._measure("mass drift", cm._mass_drift, Result(), None)
+
+    monkeypatch.setattr(cm, "CELLS", {"bad/measure": bad_measure})
+    result = cm.evaluate()["bad/measure"]
+    assert result["status"] == "ERROR"
+    assert "measuring mass drift" in result["artifact"]["message"]
+
+
+def test_a_refusal_from_the_solve_phase_survives_the_phase_split(cm, monkeypatch):
+    """The split must not make everything ERROR -- UNSUPPORTED still has to be reachable."""
+
+    def refuses():
+        cm._construct("fine fixture", lambda: object())
+        raise ValueError("FP solver: density went to -1.031e-03 at timestep 7/10")
+
+    monkeypatch.setattr(cm, "CELLS", {"solve/refuses": refuses})
+    assert cm.evaluate()["solve/refuses"]["status"] == "UNSUPPORTED"
+
+
+# ---------------------------------------------------------------------------
+# ERROR is never comparable and never baselined
+# ---------------------------------------------------------------------------
+
+
+def test_errored_lists_broken_cells(cm):
+    results = {
+        "a": {"status": "PASS", "artifact": {}},
+        "b": {"status": "ERROR", "artifact": {}},
+        "c": {"status": "UNSUPPORTED", "artifact": {}},
+    }
+    assert cm.errored(results) == ["b"]
+
+
+def test_an_error_baselined_as_error_would_have_compared_equal(cm):
+    """Why ERROR is gated before the baseline is read, not inside the comparison.
+
+    `compare_to_baseline` is a status diff, so ERROR-vs-ERROR is a match. Had the
+    gate lived only in the comparison, a harness broken during a `--write-baseline`
+    regeneration would have been recorded as the expected state and stayed green
+    forever -- the matrix no longer measuring anything, and reporting success for it.
+    """
+    assert cm.compare_to_baseline({"a": "ERROR"}, _baseline(a="ERROR")) == []
+
+
+def _run_main(cm, monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", ["capability_matrix.py", *argv])
+    with pytest.raises(SystemExit) as exc:
+        cm.main()
+    return exc.value.code
+
+
+def test_check_baseline_exits_2_on_error_without_reading_the_file(cm, monkeypatch, tmp_path):
+    """The baseline path below does not exist -- reaching it would raise, not exit 2."""
+
+    def boom():
+        raise TypeError("signature drift")
+
+    monkeypatch.setattr(cm, "CELLS", {"x/y": boom})
+    assert _run_main(cm, monkeypatch, ["--check-baseline", str(tmp_path / "absent.json")]) == 2
+
+
+def test_write_baseline_refuses_to_record_an_error(cm, monkeypatch, tmp_path):
+    def boom():
+        raise TypeError("signature drift")
+
+    monkeypatch.setattr(cm, "CELLS", {"x/y": boom})
+    target = tmp_path / "baseline.json"
+    assert _run_main(cm, monkeypatch, ["--write-baseline", str(target)]) == 2
+    assert not target.exists(), "a broken harness must not be able to bake itself into a baseline"
+
+
+def test_a_healthy_tree_still_writes_and_matches(cm, monkeypatch, tmp_path):
+    """The ERROR gate must not block the normal path."""
+    monkeypatch.setattr(cm, "CELLS", {"x/y": lambda: ("PASS", {"n": 1})})
+    target = tmp_path / "baseline.json"
+    assert _run_main(cm, monkeypatch, ["--write-baseline", str(target)]) == 0
+    assert _run_main(cm, monkeypatch, ["--check-baseline", str(target)]) == 0
+
+
+def test_written_baselines_are_strict_json(cm, monkeypatch, tmp_path):
+    """`allow_nan=False`. Python emits a bare `NaN` token otherwise, which is not JSON."""
+    art = {"worst": float("nan"), "tolerance": 0.07, "all_finite": True}
+    monkeypatch.setattr(cm, "CELLS", {"x/y": lambda: ("FAIL", art)})
+    target = tmp_path / "b.json"
+    assert _run_main(cm, monkeypatch, ["--write-baseline", str(target)]) == 1
+    assert not target.exists()
+
+
+def test_report_survives_a_partial_artifact(cm):
+    """A reporting crash would lose the very run that shows something went wrong."""
+    assert "NON-FINITE" in cm._summarise({"all_finite": False, "worst": None})
+    assert cm._summarise({}) == "{}"
+    assert "0.500%" in cm._summarise({"worst": 0.005})  # tolerance absent
+    assert "TypeError" in cm._summarise({"exception": "TypeError"})  # message absent
+
+
+# ---------------------------------------------------------------------------
+# self_test driver
+# ---------------------------------------------------------------------------
+
+
+def test_self_test_aborts_when_the_harness_is_broken(cm, monkeypatch):
+    def boom():
+        raise TypeError("signature drift")
+
+    monkeypatch.setattr(cm, "CELLS", {"x/y": boom})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"x/y"})
+    assert cm.self_test() == 2
+
+
+def test_self_test_is_inconclusive_rather_than_green_with_nothing_to_mutate(cm, monkeypatch):
+    """Zero PASS cells means the control proved nothing. It must not exit 0."""
+    monkeypatch.setattr(cm, "CELLS", {"x/y": lambda: ("FAIL", {})})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"x/y"})
+    assert cm.self_test() == 1
+
+
+def test_self_test_reports_an_inert_oracle(cm, monkeypatch):
+    """A cell that ignores the mutation must fail the self-test, not pass it."""
+    monkeypatch.setattr(cm, "CELLS", {"inert/cell": lambda: ("PASS", {})})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"inert/cell"})
+    assert cm.self_test() == 1
+
+
+def test_self_test_passes_when_the_oracle_reads_the_mutation(cm, monkeypatch):
+    def honest():
+        M = cm._apply_mutation(np.ones((5, 4)))
+        return ("PASS" if _drift(M) == 0.0 else "FAIL"), {}
+
+    monkeypatch.setattr(cm, "CELLS", {"honest/cell": honest})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"honest/cell"})
+    assert cm.self_test() == 0
+
+
+def test_self_test_restores_the_mutation_even_if_a_cell_raises(cm, monkeypatch):
+    """A leaked mutation would make every later run FAIL for no reason."""
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "PASS", {}
+        raise RuntimeError("solver blew up under mutation")
+
+    monkeypatch.setattr(cm, "CELLS", {"flaky/cell": flaky})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"flaky/cell"})
+    cm.self_test()
+    assert cm._DENSITY_MUTATION is None

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -100,6 +100,28 @@ def test_every_mass_oracle_cell_is_a_declared_cell(cm):
     assert set(cm.CELLS) >= cm.MASS_ORACLE_CELLS
 
 
+def test_currently_failing_density_cells_are_still_registered_for_the_self_test(cm):
+    """A cell that is not PASS today has an oracle the self-test cannot yet exercise.
+
+    ``regime_switching/non_negativity`` raises before producing a density (#1681), so
+    nothing has proved its oracle reads what it claims to. Listing it in
+    MASS_ORACLE_CELLS is what makes the self-test pick it up the moment it recovers --
+    without that, the recovery would land with an unproven oracle, which is exactly
+    the state #1715 measured in the agreement tests.
+    """
+    density_cells = {
+        "fdm_upwind/mass_conservation",
+        "sl_linear/mass_conservation",
+        "fdm_centered/mass_conservation",
+        "fvm_muscl/mass_conservation",
+        "fvm_vs_fdm/agreement",
+        "regime_switching/non_negativity",
+    }
+    assert density_cells <= cm.MASS_ORACLE_CELLS, (
+        f"unregistered density cells: {sorted(density_cells - cm.MASS_ORACLE_CELLS)}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # The self-test mutation -- the control has to be able to fail
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -247,7 +247,7 @@ def test_an_exception_while_computing_the_oracle_is_error_not_unsupported(cm, mo
         class Result:
             M = None
 
-        cm._measure("mass drift", cm._mass_drift, Result(), None)
+        cm._measure("mass drift", lambda: cm._mass_drift(Result(), None))
 
     monkeypatch.setattr(cm, "CELLS", {"bad/measure": bad_measure})
     result = cm.evaluate()["bad/measure"]
@@ -381,17 +381,53 @@ def test_self_test_passes_when_the_oracle_reads_the_mutation(cm, monkeypatch):
     assert cm.self_test() == 0
 
 
-def test_self_test_restores_the_mutation_even_if_a_cell_raises(cm, monkeypatch):
-    """A leaked mutation would make every later run FAIL for no reason."""
+def test_self_test_restores_the_mutation(cm, monkeypatch):
+    """A leaked mutation would make every later run FAIL for no reason.
+
+    Named for what it checks. The earlier name said "even if a cell raises", which
+    it did not earn: ``evaluate`` swallows every per-cell exception, so the
+    ``finally`` is never reached via an exception and deleting the ``try/finally``
+    killed no test. The reset itself is real and is what is pinned here.
+    """
+    monkeypatch.setattr(cm, "CELLS", {"cell": lambda: ("PASS", {})})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"cell"})
+    cm.self_test()
+    assert cm._DENSITY_MUTATION is None
+
+
+def test_self_test_aborts_when_the_harness_breaks_under_mutation(cm, monkeypatch):
+    """ERROR under mutation is not evidence the oracle bites.
+
+    Scoring on "not PASS" counted a harness that broke under mutation as a working
+    control -- the same shape as treating ERROR as a comparable status, surviving in
+    the one place the earlier fix did not reach. It matters more here because this
+    IS the control: it is what certifies the other cells still discriminate.
+    """
     calls = {"n": 0}
 
-    def flaky():
+    def healthy_then_broken():
         calls["n"] += 1
         if calls["n"] == 1:
             return "PASS", {}
-        raise RuntimeError("solver blew up under mutation")
+        raise TypeError("apparatus broke under mutation")
 
-    monkeypatch.setattr(cm, "CELLS", {"flaky/cell": flaky})
-    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"flaky/cell"})
-    cm.self_test()
-    assert cm._DENSITY_MUTATION is None
+    monkeypatch.setattr(cm, "CELLS", {"cell": healthy_then_broken})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"cell"})
+    assert cm.self_test() == 2, "a broken apparatus must not certify the control"
+
+
+def test_summarise_never_raises_on_any_shape(cm):
+    """`never raises` has to hold for shapes nobody anticipated -- that is the point."""
+    shapes = [
+        {},
+        {"min_density": None},
+        {"max_drift": "not a float", "min_density": 0.0},
+        {"worst": "text"},
+        {"exception": 123},
+        {"all_finite": 0},
+        {"nested": {"a": [1, 2]}},
+        {"obj": object()},
+        {"worst": 0.01, "tolerance": "seven percent"},
+    ]
+    for art in shapes:
+        assert isinstance(cm._summarise(art), str), f"raised or returned non-str for {art!r}"

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -1,0 +1,185 @@
+"""Pinning tests for the capability ratchet (scripts/capability_matrix.py).
+
+The matrix records what the public solve surface can actually do, and its value comes
+entirely from two properties that are easy to erode:
+
+1. ``--check-baseline`` fails in BOTH directions. One-directional checking lets a
+   recovery land unrecorded; the next baseline then encodes it as if it had always
+   held, and the gate loses the ability to say when anything was fixed.
+2. The ``--self-test`` mutation breaks the invariant the oracles measure. The first
+   mutation written for it was a constant density scale, which left every drift cell
+   PASS -- correctly, since ``max|mass(t) - mass(0)|`` is invariant under a uniform
+   rescaling. A control that cannot fail proves nothing, which is the same defect the
+   matrix exists to catch (Issues #1714, #1715).
+
+These tests exercise the comparison and mutation logic directly. They do not solve
+anything: the cells themselves are exercised by running the script.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+import numpy as np
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "capability_matrix.py"
+
+
+@pytest.fixture(scope="module")
+def cm():
+    spec = importlib.util.spec_from_file_location("capability_matrix", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _baseline(**statuses):
+    return {name: {"status": s, "artifact": {}} for name, s in statuses.items()}
+
+
+# ---------------------------------------------------------------------------
+# Baseline comparison -- the ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_identical_statuses_report_no_problem(cm):
+    base = _baseline(a="PASS", b="UNSUPPORTED")
+    assert cm.compare_to_baseline({"a": "PASS", "b": "UNSUPPORTED"}, base) == []
+
+
+def test_regression_is_caught(cm):
+    problems = cm.compare_to_baseline({"a": "FAIL"}, _baseline(a="PASS"))
+    assert len(problems) == 1
+    assert "REGRESSION" in problems[0]
+
+
+def test_recovery_is_also_caught(cm):
+    """The direction that a one-way ratchet would silently allow."""
+    problems = cm.compare_to_baseline({"a": "PASS"}, _baseline(a="UNSUPPORTED"))
+    assert len(problems) == 1
+    assert "RECOVERED" in problems[0]
+
+
+def test_shift_between_two_non_pass_states_is_caught(cm):
+    """UNSUPPORTED -> FAIL is neither regression nor recovery, and still must not pass.
+
+    This is the transition that would hide a solver going from "refuses to run" to
+    "runs and returns a wrong answer" -- strictly worse, and invisible to a check
+    that only compares against PASS.
+    """
+    problems = cm.compare_to_baseline({"a": "FAIL"}, _baseline(a="UNSUPPORTED"))
+    assert len(problems) == 1
+    assert "SHIFT" in problems[0]
+
+
+def test_deleted_cell_is_caught(cm):
+    """Deleting a cell must not be a way to make a red baseline go green."""
+    problems = cm.compare_to_baseline({}, _baseline(a="PASS"))
+    assert len(problems) == 1
+    assert "DISAPPEARED" in problems[0]
+
+
+def test_new_cell_is_caught(cm):
+    problems = cm.compare_to_baseline({"a": "PASS", "b": "PASS"}, _baseline(a="PASS"))
+    assert len(problems) == 1
+    assert "NEW cell" in problems[0]
+
+
+def test_shipped_baseline_covers_every_declared_cell(cm):
+    """A cell added without regenerating the baseline is a cell nothing watches."""
+    with open(_SCRIPT.parent / "capability_baseline.json") as fh:
+        baseline = json.load(fh)["cells"]
+    assert set(baseline) == set(cm.CELLS), (
+        "scripts/capability_baseline.json is out of sync with CELLS; regenerate with --write-baseline"
+    )
+
+
+def test_every_mass_oracle_cell_is_a_declared_cell(cm):
+    assert set(cm.CELLS) >= cm.MASS_ORACLE_CELLS
+
+
+# ---------------------------------------------------------------------------
+# The self-test mutation -- the control has to be able to fail
+# ---------------------------------------------------------------------------
+
+
+def _drift(M):
+    mass = M.sum(axis=1)
+    return float(np.abs(mass - mass[0]).max())
+
+
+def test_ramp_mutation_injects_drift(cm, monkeypatch):
+    M = np.ones((5, 4))
+    assert _drift(M) == 0.0
+    monkeypatch.setattr(cm, "_DENSITY_MUTATION", 0.10)
+    mutated = cm._apply_mutation(M)
+    assert _drift(mutated) == pytest.approx(0.4, rel=1e-12)  # 10% of mass 4.0
+
+
+def test_ramp_mutation_leaves_the_first_slice_alone(cm, monkeypatch):
+    """t=0 is the reference the drift is measured against; moving it would mask drift."""
+    M = np.ones((5, 4))
+    monkeypatch.setattr(cm, "_DENSITY_MUTATION", 0.10)
+    np.testing.assert_allclose(cm._apply_mutation(M)[0], M[0])
+
+
+def test_a_constant_scale_would_not_inject_drift(cm):
+    """Pins the reason the mutation is a ramp.
+
+    If someone replaces the ramp with ``M * factor``, the self-test goes back to
+    reporting every drift cell INERT -- not because the cells broke, but because the
+    control cannot break them. This test states the arithmetic so that change is a
+    deliberate one.
+    """
+    M = np.ones((5, 4))
+    assert _drift(M * 1.5) == 0.0
+
+
+def test_mutation_is_off_by_default(cm):
+    """A leaked mutation would make every cell FAIL and the baseline meaningless."""
+    assert cm._DENSITY_MUTATION is None
+    M = np.arange(20, dtype=float).reshape(5, 4)
+    np.testing.assert_array_equal(cm._apply_mutation(M), M)
+
+
+def test_mutation_applies_along_time_for_higher_dimensional_density(cm, monkeypatch):
+    """2-D densities are (nt, nx, ny); the ramp must broadcast over time, not space."""
+    M = np.ones((4, 3, 2))
+    monkeypatch.setattr(cm, "_DENSITY_MUTATION", 0.30)
+    mutated = cm._apply_mutation(M)
+    assert mutated.shape == M.shape
+    np.testing.assert_allclose(mutated[0], 1.0)
+    np.testing.assert_allclose(mutated[-1], 1.30)
+
+
+# ---------------------------------------------------------------------------
+# Harness-error classification
+# ---------------------------------------------------------------------------
+
+
+def test_harness_breakage_is_error_not_unsupported(cm, monkeypatch):
+    """A wrong signature must never read as "the library does not support this".
+
+    This is the defect the gfdm_rbf cell shipped with on its first run: a missing
+    positional argument surfaced as UNSUPPORTED, indistinguishable from the
+    NotImplementedError the cell exists to record.
+    """
+
+    def broken():
+        raise TypeError("f() missing 1 required positional argument: 'collocation_points'")
+
+    monkeypatch.setattr(cm, "CELLS", {"broken/cell": broken})
+    assert cm.evaluate()["broken/cell"]["status"] == "ERROR"
+
+
+def test_a_refusal_by_the_code_under_test_is_unsupported(cm, monkeypatch):
+    def refuses():
+        raise NotImplementedError("derivative_method='rbf' is not supported (Issue #1553)")
+
+    monkeypatch.setattr(cm, "CELLS", {"refuses/cell": refuses})
+    result = cm.evaluate()["refuses/cell"]
+    assert result["status"] == "UNSUPPORTED"
+    assert result["artifact"]["exception"] == "NotImplementedError"
+    assert "#1553" in result["artifact"]["message"]

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -271,6 +271,79 @@ def test_a_refusal_from_the_solve_phase_survives_the_phase_split(cm, monkeypatch
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# The two structural fixes must not be able to revert silently
+# ---------------------------------------------------------------------------
+
+
+def test_construct_takes_a_thunk_and_nothing_else(cm):
+    """Pins the signature, because the old one did not do what it looked like.
+
+    ``_construct(what, fn, *args, **kwargs)`` evaluates the argument expressions
+    in the CALLER's frame, so every constructor inside them ran before the wrapper
+    was entered and their failures bypassed it. Every existing phase test passes a
+    thunk, so all of them hold under either signature -- reverting it was measured
+    to kill nothing. This is the assertion that notices.
+    """
+    with pytest.raises(TypeError):
+        cm._construct("x", lambda: None, "an extra positional argument")
+
+
+def test_measure_takes_a_thunk_and_nothing_else(cm):
+    with pytest.raises(TypeError):
+        cm._measure("x", lambda: ("PASS", {}), "an extra positional argument")
+
+
+def test_measure_rejects_an_oracle_that_returns_only_the_artifact(cm):
+    """The shape check is what keeps the verdict inside the wrapper.
+
+    A cell whose oracle returns a bare artifact has its verdict computed one line
+    outside ``_measure`` again, where a KeyError reads as a library refusal. Tests
+    cannot catch that by construction -- they pass their own thunks -- so the
+    wrapper refuses the old shape instead.
+    """
+    with pytest.raises(cm.HarnessError, match="must return \\(status, artifact\\)"):
+        cm._measure("mass drift", lambda: {"mass_t0": 1.0})
+
+
+def test_measure_rejects_an_unknown_status(cm):
+    with pytest.raises(cm.HarnessError, match="must return"):
+        cm._measure("x", lambda: ("PROBABLY_FINE", {}))
+
+
+def test_measure_accepts_the_correct_shape(cm):
+    """The guard must not reject what the production cells actually return."""
+    assert cm._measure("x", lambda: ("PASS", {"n": 1})) == ("PASS", {"n": 1})
+
+
+def test_a_keyerror_anywhere_in_a_cell_is_error_not_unsupported(cm, monkeypatch):
+    """Second net, for the shape check being bypassed some other way.
+
+    A partial artifact is never a library refusal, whichever phase surfaced it.
+    """
+
+    def raises_keyerror():
+        raise KeyError("mass_t0")
+
+    monkeypatch.setattr(cm, "CELLS", {"k/e": raises_keyerror})
+    assert cm.evaluate()["k/e"]["status"] == "ERROR"
+
+
+def test_the_harness_diagnostic_goes_to_stderr(cm, monkeypatch, tmp_path, capsys):
+    """stdout carries the --json blob; a human block appended to it breaks parsing."""
+
+    def boom():
+        raise TypeError("signature drift")
+
+    monkeypatch.setattr(cm, "CELLS", {"x/y": boom})
+    monkeypatch.setattr(sys, "argv", ["capability_matrix.py", "--json"])
+    with pytest.raises(SystemExit):
+        cm.main()
+    captured = capsys.readouterr()
+    json.loads(captured.out)  # raises if the diagnostic leaked into stdout
+    assert "Harness is broken" in captured.err
+
+
 def test_errored_lists_broken_cells(cm):
     results = {
         "a": {"status": "PASS", "artifact": {}},


### PR DESCRIPTION
Refs #1706.

## Why

Nothing in this repository reports whether the library got better or worse. Test
count says better (4,197 -> 5,307 `def test_` since v0.19.8); the accumulated
damage ledger says worse. Both are right, because neither measures capability.

This adds the quantity that does: for a fixed set of configurations driven through
the public API, does the result satisfy an oracle that lives outside the code under
test.

## Current state, reproduced at `aeb180c9`

| cell | status | artifact |
|---|---|---|
| `fdm_upwind/mass_conservation` | PASS | drift 2.220e-16 |
| `sl_linear/mass_conservation` | PASS | drift 4.441e-16 |
| `fvm_muscl/mass_conservation` | PASS | rel drift 2.220e-16 |
| `fvm_vs_fdm/agreement` | PASS | worst rel L2 4.891% (tol 7%) |
| `fdm_centered/mass_conservation` | UNSUPPORTED | `ValueError`, clipping would fabricate 5.744% |
| `regime_switching/non_negativity` | UNSUPPORTED | `ValueError`, density -1.031e-03 at timestep 7/10 (#1681) |
| `gfdm_rbf/construction` | UNSUPPORTED | `NotImplementedError` (#1553) |

## What keeps a cell from being satisfied the cheap way

- **The oracle is a number, not an exception.** `pytest.raises` cannot turn a cell
  green. #1714 measured 47 of 85 tests in the fail-loud campaign as guard-echo --
  they can only fail if the guard added in the same diff is deleted.
- **The comparison is against a closed form or a second discretisation**, never a
  second call into the same owner. #1715 measured two agreement tests passing under
  a 2x diffusion mutation, because consolidation had made them tautological. A cell
  here does not decay that way.
- **`--check-baseline` fails in BOTH directions.** A recovered cell fails until the
  baseline records the recovery, so a fix cannot land without saying so, and a
  baseline cannot be lowered without doing the work. Same structure as
  `check_fail_fast.py` / `fail_fast_baseline.json`, which #1706 identifies as the
  healthiest artefact here for exactly this reason.

## Two defects the harness found in itself

**The rbf cell first reported UNSUPPORTED on a `TypeError`** from a missing
positional argument -- a signature error in the harness, indistinguishable from the
`NotImplementedError` the cell exists to record. Same shape as #1447's `_Bare`
object, whose failure-mode test never reached the branch it named. Fixed two ways:
the taylor sibling is constructed first as a control, and harness exceptions
(`TypeError`, `ImportError`, `AttributeError`, `AssertionError`) are classified
ERROR, never UNSUPPORTED.

**The `--self-test` mutation was a constant density scale, and left all three drift
cells PASS.** Correctly so: `max|mass(t) - mass(0)|` is invariant under a uniform
rescaling of every slice, because `mass(t0)` scales with it. A control that cannot
fail proves nothing -- the same defect class this matrix exists to catch. The
mutation is now a ramp in time, and all four mass-oracle cells go red under it.
`test_a_constant_scale_would_not_inject_drift` pins the arithmetic so reverting to
a constant is a deliberate act.

## Verification

Mutation-red artifacts for the 15 pinning tests, each run and reverted:

| mutation | result |
|---|---|
| ratchet made one-directional | 2 failed (recovery, shift) |
| ramp replaced by constant scale | 3 failed |
| `TypeError` no longer ERROR | 1 failed |
| deleted-cell branch removed | 1 failed |

End to end: a baseline with `gfdm_rbf` flipped to PASS and `fdm_upwind` flipped to
FAIL exits 1 and names both directions; the shipped baseline exits 0.

Full local gate on this tree: **5,615 passed, 20 skipped, 6 xfailed** (207.83s).

## Two findings that contradict older records

- **`fvm_vs_fdm` measures 4.891% today, not the 155.700% on record.** That figure
  was measured at `e32e3eb6`; #1732 restored the fixture's `control_cost` after the
  #1442 drift migration. Part of that disagreement was fixture debt, not solver debt.
- **`FDM_CENTERED` no longer grows mass to 6378.** Since #1682 it raises at timestep
  2/10. The strict xfail at `tests/integration/test_three_mode_api.py:104` is
  therefore satisfied by a different exception than the mass growth it names, and
  the docstring table above it (`FDM_CENTERED True True 6.378e+03`) is now false.
  This is the #1673 REWORK item, reproduced.

## The regime-switching cell (second commit)

The first commit listed regime-switching non-negativity as a known gap, reasoned from
`RegimeSwitchingIterator` being exported from no package `__init__`. That is a fact
about the export surface, not a reason to leave a measured defect unwatched. The cell
now reaches through the deep module path and records exactly that as part of what it
measures. It reproduces #1681 verbatim on the unmodified fixture, at its original
NT=10 -- per that issue the run maximum decays only first-order in dt (4.95e-05 at
NT=640, extrapolating to NT ~ 3e6 to clear the guard), so refining would hide the
defect rather than fix it.

Its oracle is unexercised today: the cell raises before producing a density, so nothing
has proved the oracle reads what it claims to. What prevents a recovery from landing
with an unproven oracle is its membership in `MASS_ORACLE_CELLS` -- `--self-test` skips
non-PASS cells and picks them up the moment they turn PASS.
`test_currently_failing_density_cells_are_still_registered_for_the_self_test` pins that
membership, and goes red when the entry is removed.

## Not covered, stated rather than implied absent

- 2-D meshless-Galerkin + Nitsche refinement (#1679): needs a refinement sweep, so
  minutes rather than seconds -- a nightly-tier cell. Recorded in the module docstring.

## Cost

~41 s added to `./scripts/local_ci.sh`. Not in `--fast`: every cell is a real coupled
solve, which is the point -- it is the only check in that script that measures the
product rather than the source.



---

# Review rounds

Three reviewers on round 1 (one per artifact), one on each of rounds 2 and 3
(scoped to the fix diff, since re-reviewing settled ground is noise). Every
finding was re-verified locally before acting.

## Round 1 — BLOCKED, 2 blockers + 4 gaps

| # | Finding | Fix |
|---|---|---|
| B1 | ERROR compared equal to an ERROR baseline, so a harness broken during a `--write-baseline` regeneration would be green forever | ERROR gated before the baseline is read: exit 2, never written, never compared |
| B2 | `max(0.0, nan, 0.0) == 0.0`, so an all-NaN value function PASSed; the only density cell with no `all_finite` guard | both arms' M and U checked before the norms; `allow_nan=False` |
| F3/F4 | `ValueError` from a mistyped fixture and `IndexError` from a malformed result both read as UNSUPPORTED | phase separation: construct / solve / measure |
| F5 | "never against another call into the same owner" was false — both agreement arms use `HJBFDMSolver` | independence claimed per axis, in the cell |
| — | matrix ran only in `local_ci.sh`; `--self-test` had zero callers | standalone `nightly.yml` job running both |
| — | one of my own tests was tautological (module → `STUB = 1` left it green) | rewritten to call the module |

## Round 2 — MERGE-OK, 6 findings

`_construct(what, fn, *args, **kwargs)` did not do what it looked like: Python
evaluates argument expressions in the **caller's** frame, so
`_construct("iterator", Cls, hjb_solvers=[HJBFDMSolver(p) for p in problems])`
ran every one of those constructors before the wrapper was entered. Both wrappers
now take a thunk and nothing else.

Artifact keys were read one line **after** `_measure` returned, so a `KeyError`
from a partial artifact — the exact class `_measure` exists for — still read as a
library refusal. The thunk now returns the whole `(status, artifact)` pair.

`RegimeSwitchingIterator.__init__` runs `assert_paired_solver_sigma` (#1603 /
RFC #1574 C14), so refusing there is a capability statement — and wrapping it made
that an ERROR, which is never baselined, so the refusal could never be recorded at
all. Rule now stated and applied both places: **wrap the fixture, never the object
under test.**

And the addendum finding: `self_test` scored the mutated pass on `status == "PASS"`,
so a cell whose apparatus broke under mutation counted as `discriminates` and the
run exited 0 — round 1's blocker shape surviving inside the control itself.

## Round 3 — MERGE-OK, 1 finding

The round-2 structural fixes had **no pinning test**: reverting both left all 33
tests green, because every phase test already passes a thunk and therefore holds
under either signature. Closed by making the old shape *raise* — `_measure`
validates its thunk's return shape — plus seven tests, verified red on the revert
(4 on the signature/shape revert, 1 on the stderr revert).

That is the repo's own consolidation rule (`domains/cs/_core.md`) applied to the
consolidation that had just happened, and it is the third time in this PR that the
instrument reproduced the defect class it exists to catch.

**Final state: 40 pinning tests. Full gate GATE GREEN. Matrix PASS=4 UNSUPPORTED=3,
`--check-baseline` exit 0, `--self-test` exit 0.**
