### PR TITLE
Measure test discrimination by mutating conventions

### DIFF
--- a/.github/workflows/discrimination.yml
+++ b/.github/workflows/discrimination.yml
@@ -1,0 +1,108 @@
+name: Weekly Test-Discrimination Sweep
+
+# Measures which tests notice a change to a convention the library single-sources,
+# by mutating each one and running the suite. Weekly, not nightly: it is seven full
+# suite runs (~26 min measured locally), and the quantity it tracks moves on the
+# timescale of a campaign, not a commit.
+#
+# It answers what #1715 asked and #1701 generalises. Measured 2026-07-27 over 5,665
+# collected tests: 184 (3.2%) notice any of the six conventions, 176 of them notice
+# exactly one, and one convention -- the absent-BC default -- is noticed by nothing.
+#
+# The ratchet is per-mutation kill COUNTS, not test names. That is deliberate: this
+# population cannot be selected by name at all. `*_agree` / `*_matches` / `*_equals`
+# gives 51, 114 or 156 depending on the pattern, and 60% of the tests whose names
+# claim cross-path agreement notice none of the six.
+
+on:
+  schedule:
+    # 04:00 UTC on Mondays, after nightly has finished.
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  discrimination:
+    name: mutation sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 180  # ~26 min locally; a GH runner is ~7x slower on this suite
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev,numerical]"
+
+    - name: Sweep and compare against the baseline
+      env:
+        OMP_NUM_THREADS: 1
+        OPENBLAS_NUM_THREADS: 1
+      run: |
+        python scripts/test_discrimination.py \
+          --check-baseline scripts/discrimination_baseline.json \
+          --json killmatrix.json
+
+    - name: Upload the kill matrix
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: kill-matrix
+        path: killmatrix.json
+        retention-days: 90
+
+  # Same reasoning as nightly.yml's notifier: a job nobody watches is a job that
+  # reports nothing. Not gated on `schedule`, so workflow_dispatch exercises the
+  # path too -- otherwise a bug in it surfaces only on a real weekly failure.
+  notify-on-failure:
+    needs: discrimination
+    if: ${{ always() && needs.discrimination.result != 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v9
+      with:
+        script: |
+          const date = new Date().toISOString().split('T')[0];
+          const title = 'Weekly test-discrimination sweep is failing';
+          const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const { data: issues } = await github.rest.issues.listForRepo({
+            owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: 'automated',
+          });
+          const open = issues.find(i => i.title === title);
+          const body = [
+            `The weekly mutation sweep failed on ${date}. Run: ${url}`,
+            '',
+            'Either discrimination dropped (a convention fewer tests now notice), a mutation',
+            'stopped applying because the source moved, or it improved and the baseline has',
+            'not recorded it yet. The run output names which.',
+            '',
+            'Reproduce locally (~26 min):',
+            '```bash',
+            'python scripts/test_discrimination.py --check-baseline scripts/discrimination_baseline.json',
+            '```',
+            '',
+            'De-duplicated on title: subsequent failures comment here rather than opening new issues.',
+          ].join('\n');
+          if (open) {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: open.number, body: `Still failing on ${date}. Run: ${url}`,
+            });
+          } else {
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo, title, body,
+              labels: ['automated', 'area: testing', 'priority: medium', 'type: bug'],
+            });
+          }

--- a/.github/workflows/discrimination.yml
+++ b/.github/workflows/discrimination.yml
@@ -31,7 +31,11 @@ jobs:
   discrimination:
     name: mutation sweep
     runs-on: ubuntu-latest
-    timeout-minutes: 180  # ~26 min locally; a GH runner is ~7x slower on this suite
+    # ~29 min locally (measured: 212 s baseline + 348 s for the largest mutation + five
+    # smaller runs). A GH runner is ~7x slower on this suite, so ~200 min -- 180 would
+    # have timed out, and the artifact upload is `if: !cancelled()`, so the failure issue
+    # would have arrived with no kill matrix to diagnose from. Matches nightly.yml.
+    timeout-minutes: 300
     steps:
     - uses: actions/checkout@v7
 
@@ -46,6 +50,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev,numerical]"
 
+    # NOTE: --paths defaults to `tests`, which includes tests/unit/test_backends and
+    # tests/unit/test_visualization. nightly.yml deliberately --ignores both (see its
+    # comment: they "run in no AUTOMATIC workflow"), so this is the first automatic tier
+    # to execute them, on Linux, where they have never run. They pass locally and the
+    # marker set here is byte-identical to local_ci.sh, but if they are red on a runner
+    # the baseline gate aborts the whole job with a clear message rather than producing
+    # a wrong number. Exercise once via workflow_dispatch before trusting the schedule.
     - name: Sweep and compare against the baseline
       env:
         OMP_NUM_THREADS: 1
@@ -77,8 +88,11 @@ jobs:
           const date = new Date().toISOString().split('T')[0];
           const title = 'Weekly test-discrimination sweep is failing';
           const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-          const { data: issues } = await github.rest.issues.listForRepo({
-            owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: 'automated',
+          // Paginated, like nightly.yml. The unpaginated default is 30, so past that
+          // this would stop finding its own issue and open a fresh duplicate weekly.
+          const issues = await github.paginate(github.rest.issues.listForRepo, {
+            owner: context.repo.owner, repo: context.repo.repo, state: 'open',
+            labels: 'automated', per_page: 100,
           });
           const open = issues.find(i => i.title === title);
           const body = [

--- a/changelog.d/test-discrimination-ratchet.added.md
+++ b/changelog.d/test-discrimination-ratchet.added.md
@@ -1,0 +1,6 @@
+- **Discrimination baseline + weekly sweep** (`scripts/discrimination_baseline.json`,
+  `.github/workflows/discrimination.yml`, Refs #1701 #1715) — per-mutation kill counts,
+  ratcheted in both directions. Measured over 5,665 tests: 184 (3.2%) notice any of six
+  single-sourced conventions, and `bc_type_to_geometric_operation(None)` is noticed by
+  none. The ratchet is on counts, not test names, because this population cannot be
+  selected by name.

--- a/changelog.d/test-discrimination.added.md
+++ b/changelog.d/test-discrimination.added.md
@@ -1,0 +1,7 @@
+- **Test-discrimination harness** (`scripts/test_discrimination.py`, Refs #1701 #1715) —
+  perturbs each convention the library single-sources and records which tests notice,
+  producing a per-test kill matrix. Selects the population by behaviour rather than by
+  name, since `*_agree` / `*_matches` / `*_equals` gives 51, 114 or 156 depending on the
+  pattern. Handles the two traps that make mutation testing silently inert here: the
+  editable install pinning imports to the main checkout (#1677), and a zero kill count
+  being ambiguous between "no test covers this" and "the mutation never ran".

--- a/scripts/discrimination_baseline.json
+++ b/scripts/discrimination_baseline.json
@@ -1,6 +1,14 @@
 {
   "_comment": "Kill counts per mutated convention. --check-baseline fails when a count DROPS (discrimination lost) and when one RISES (record the gain in the same change). Counts, not test names: this population cannot be selected by name -- the agreement-shaped patterns give 51, 114 or 156 depending on the regex.",
-  "_measured_at": "8d56dc8d, tests/ under the CI marker set, 5665 collected",
+  "_measured_at": {
+    "collected": 5665,
+    "commit": "25b09c44",
+    "excluded": "tests/unit/test_discrimination_ratchet.py",
+    "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment",
+    "paths": [
+      "tests"
+    ]
+  },
   "mutations": {
     "bc_default_reads_as_reflect": {
       "kill_count": 0,

--- a/scripts/discrimination_baseline.json
+++ b/scripts/discrimination_baseline.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Kill counts per mutated convention. --check-baseline fails when a count DROPS (discrimination lost) and when one RISES (record the gain in the same change). Counts, not test names: this population cannot be selected by name -- the agreement-shaped patterns give 51, 114 or 156 depending on the regex.",
+  "_measured_at": "8d56dc8d, tests/ under the CI marker set, 5665 collected",
+  "mutations": {
+    "bc_default_reads_as_reflect": {
+      "kill_count": 0,
+      "owner": "absent BC defaults to clamp/absorbing (#1698)",
+      "status": "UNCOVERED"
+    },
+    "bc_noflux_reads_as_clamp": {
+      "kill_count": 5,
+      "owner": "no_flux/neumann/robin -> reflect (#1698)",
+      "status": "ok"
+    },
+    "diffusion_field_2x": {
+      "kill_count": 5,
+      "owner": "D = sigma^2/2 elementwise for a volatility field (#811)",
+      "status": "ok"
+    },
+    "diffusion_scalar_2x": {
+      "kill_count": 129,
+      "owner": "D = sigma^2/2 for scalar sigma (#811)",
+      "status": "ok"
+    },
+    "drift_coefficient_2x": {
+      "kill_count": 19,
+      "owner": "FP drift c = 1/control_cost (#1420 / G-017)",
+      "status": "ok"
+    },
+    "optimal_control_sign": {
+      "kill_count": 34,
+      "owner": "QuadraticControlCost alpha* = -sign*p/lambda (#1649)",
+      "status": "ok"
+    }
+  }
+}

--- a/scripts/discrimination_killmatrix.json
+++ b/scripts/discrimination_killmatrix.json
@@ -1,0 +1,829 @@
+{
+ "_comment": "The per-test kill matrix from the sweep that produced discrimination_baseline.json. Committed so the population claims in #1715 can be re-derived by anyone: which tests notice which convention. The gate is the COUNTS in the baseline; this is the evidence under them. Regenerate with --json.",
+ "_measured_at": {
+  "collected": 5665,
+  "commit": "25b09c44",
+  "excluded": "tests/unit/test_discrimination_ratchet.py",
+  "paths": [
+   "tests"
+  ]
+ },
+ "_selection_regex_for_agreement_shaped": "::[^:]*?(_agree|_agrees|_matches|_equals|_single_source|_identical|_consistent)",
+ "baseline_seconds": 211.7,
+ "killed_by": {
+  "tests/integration/test_coupling_mesh_geometry.py::TestFixedPointIteratorMeshGeometry::test_fem_couples_through_fixed_point_iterator": [
+   "optimal_control_sign"
+  ],
+  "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[3]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_diffusion_magnitude_gate.py::test_fp_fdm_diffusion_magnitude[explicit]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_diffusion_magnitude_gate.py::test_fp_fdm_diffusion_magnitude[implicit]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_diffusion_magnitude_gate.py::test_weak_form_fem_fp_diffusion_magnitude": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_fem_robin_bc.py::TestRobinSolveLoopWiring::test_hjb_linear_loop_fixed_point": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_fem_solver_path.py::TestFEMBoundaryConditionResolution::test_coupled_fem_no_flux_runs_and_conserves_mass": [
+   "optimal_control_sign"
+  ],
+  "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[dirichlet]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[no_flux]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[periodic]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_mms_validation.py::TestMMSFokkerPlanck1D::test_pure_diffusion_gaussian": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_mms_validation.py::TestMMSFokkerPlanck1D::test_sinusoidal_periodic_convergence": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_mms_validation.py::TestMMSFokkerPlanck1D::test_source_term_steady_state_convergence": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_mms_validation.py::TestMMSHJB1D::test_backward_heat_periodic_convergence": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/integration/test_newton_mfg_solver.py::test_one_newton_step_reduces_the_mfg_residual": [
+   "drift_coefficient_2x"
+  ],
+  "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline": [
+   "diffusion_scalar_2x",
+   "drift_coefficient_2x"
+  ],
+  "tests/regression/test_solver_golden_baseline.py::test_gfdm_hjb_matches_golden_baseline": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_adjoint_bc_coupling.py::TestCreateAdjointConsistentBC1D::test_values_with_exponential_density": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[0.5]": [
+   "drift_coefficient_2x",
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[1.0]": [
+   "drift_coefficient_2x",
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[2.5]": [
+   "drift_coefficient_2x",
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_byte_identical_dyadic[0.5]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_byte_identical_dyadic[1.0]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_byte_identical_dyadic[2.0]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_separates_at_most_one_ulp_nondyadic[0.7]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_separates_at_most_one_ulp_nondyadic[2.5]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_byte_identical_to_divide_form_dyadic[0.5]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_byte_identical_to_divide_form_dyadic[1.0]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_byte_identical_to_divide_form_dyadic[2.0]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_within_one_ulp_of_divide_form_nondyadic[0.7]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_within_one_ulp_of_divide_form_nondyadic[2.5]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_byte_identical_when_consistent": [
+   "drift_coefficient_2x",
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_uses_control_cost_not_coupling": [
+   "drift_coefficient_2x",
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverArrayDiffusion::test_spatiotemporal_diffusion_1d": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_isotropic_tensor_matches_scalar_diffusion": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_fp_network_solver.py::TestFPNetworkSolverSolveFPSystem::test_volatility_field_is_sigma_not_diffusion": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_equivalence_quadratic_explicit": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-0.5]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-1.0]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-2.0]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-0.5]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-1.0]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-2.0]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py::test_dmp_guard_uses_each_nodes_resolved_diffusion": [
+   "diffusion_field_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_sigma_eff_formula_per_node_l_H": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_sigma_eff_formula_scalar_l_H": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[None-<lambda>-1.0-f(m)-only]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-<lambda>-0.5-V+f(m),": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-<lambda>-1.0-V+f(m)]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-<lambda>-2.0-V+f(m),": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-None-1.0-V-only]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestADIDiffusionMagnitude::test_adi_2d_diffusion_matches_analytic": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestADIDiffusionMagnitude::test_adi_3d_diffusion_matches_analytic": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestStochasticCharacteristicSL::test_consistency_with_default_adi": [
+   "diffusion_scalar_2x",
+   "bc_noflux_reads_as_clamp"
+  ],
+  "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestStochasticCharacteristicSL::test_constant_terminal_preserved": [
+   "bc_noflux_reads_as_clamp"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_diffusion_from_volatility_torch_numpy_parity": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-0.2]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-0.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-2.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_meshless_stabilization.py::test_sd_block_identical_in_fp_and_hjb": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_alg/test_particle_multi_exit.py::test_particle_solver_multi_exit_1d": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_alg/test_sigma_tensor_convention_rfc_1596.py::TestDiffusionOperatorShapeConsistency::test_from_volatility_matches_manual_D": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_sigma_tensor_convention_rfc_1596.py::TestDiffusionOperatorShapeConsistency::test_from_volatility_vector_matches_diag_half_sigma_sq": [
+   "diffusion_field_2x"
+  ],
+  "tests/unit/test_alg/test_sigma_tensor_convention_rfc_1596.py::TestKernelConvention::test_scalar_is_half_sigma_squared": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_sl_diffusion_matches_adi_1543.py::test_sl_diffusion_agrees_with_adi_2d": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_sl_dpp_potential_sign_1645.py::test_dpp_error_converges_under_refinement": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_weak_form_volatility.py::test_diffusion_coefficient_converts_sigma_to_D": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_alg/test_weakform_fp_drift_single_source.py::test_fp_drift_coefficient_sources_from_control_cost_not_coupling": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[0.7]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[1.4142135623730951]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[2.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[3.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[0.7]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[1.4142135623730951]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[2.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[3.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[0.1]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[0.7]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[1.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[1.4142135623730951]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[2.5]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[3.0]": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_hjb_scalar_and_diagonal_tensor_diffusion_agree": [
+   "diffusion_scalar_2x",
+   "diffusion_field_2x"
+  ],
+  "tests/unit/test_core/test_hamiltonian_classes.py::TestControlCostBase::test_quadratic_control_cost_maximize": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_hamiltonian_classes.py::TestControlCostBase::test_quadratic_control_cost_minimize": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_hamiltonian_classes.py::TestHamiltonianBase::test_hamiltonian_optimal_control": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_hamiltonian_classes.py::TestSeparableLagrangian::test_quadratic_optimal_control": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p0-OptimizationSense.MAXIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p0-OptimizationSense.MINIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p1-OptimizationSense.MAXIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p1-OptimizationSense.MINIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p2-OptimizationSense.MAXIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p2-OptimizationSense.MINIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p0-OptimizationSense.MAXIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p0-OptimizationSense.MINIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p1-OptimizationSense.MAXIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p1-OptimizationSense.MINIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p2-OptimizationSense.MAXIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p2-OptimizationSense.MINIMIZE]": [
+   "optimal_control_sign"
+  ],
+  "tests/unit/test_core/test_mfg_problem.py::test_diffusion_primary_parameter": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_core/test_mfg_problem.py::test_sigma_direct_sde_volatility": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_core/test_mfg_problem.py::test_volatility_alias_for_sigma": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_core/test_mfg_problem.py::test_volatility_field_scalar": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[0.5]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[1.0]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[2.0]": [
+   "drift_coefficient_2x"
+  ],
+  "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_array_collapses_to_mean_with_warning": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_none_uses_fallback_sigma": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_scalar_is_converted": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_core/test_unified_mfg_problem.py::TestNDGridMode::test_diffusion_converts_to_sigma": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_fp_fvm.py::test_gate3_convergence_muscl_second_order": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_fp_fvm.py::test_gate3_convergence_upwind_first_order": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_a_duck_typed_bc_is_checked_not_waved_through": [
+   "bc_noflux_reads_as_clamp"
+  ],
+  "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_a_renamed_attribute_fails_loudly_rather_than_disabling_the_guard": [
+   "bc_noflux_reads_as_clamp"
+  ],
+  "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_default_bc_is_a_second_lever_with_no_permutation_available": [
+   "bc_noflux_reads_as_clamp"
+  ],
+  "tests/unit/test_operators/test_diffusion.py::TestIsotropicDiffusion::test_from_volatility_scalar_matches_half_sigma_sq": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_utils/test_diffusion_from_volatility.py::TestField::test_1d_field_is_elementwise": [
+   "diffusion_field_2x"
+  ],
+  "tests/unit/test_utils/test_diffusion_from_volatility.py::TestField::test_2d_field_is_elementwise": [
+   "diffusion_field_2x"
+  ],
+  "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_byte_identical_to_literal": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_is_half_sigma_squared": [
+   "diffusion_scalar_2x"
+  ],
+  "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_needs_no_kind": [
+   "diffusion_scalar_2x"
+  ]
+ },
+ "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment",
+ "mutations": {
+  "bc_default_reads_as_reflect": {
+   "kill_count": 0,
+   "killed": [],
+   "owner": "absent BC defaults to clamp/absorbing (#1698)",
+   "seconds": 204.2,
+   "status": "UNCOVERED",
+   "verify": "bc_type_to_geometric_operation(None) == 'reflect'"
+  },
+  "bc_noflux_reads_as_clamp": {
+   "kill_count": 5,
+   "killed": [
+    "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestStochasticCharacteristicSL::test_consistency_with_default_adi",
+    "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestStochasticCharacteristicSL::test_constant_terminal_preserved",
+    "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_a_duck_typed_bc_is_checked_not_waved_through",
+    "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_a_renamed_attribute_fails_loudly_rather_than_disabling_the_guard",
+    "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_default_bc_is_a_second_lever_with_no_permutation_available"
+   ],
+   "owner": "no_flux/neumann/robin -> reflect (#1698)",
+   "seconds": 204.4,
+   "status": "ok",
+   "verify": "bc_type_to_geometric_operation('no_flux') == 'clamp'"
+  },
+  "diffusion_field_2x": {
+   "kill_count": 5,
+   "killed": [
+    "tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py::test_dmp_guard_uses_each_nodes_resolved_diffusion",
+    "tests/unit/test_alg/test_sigma_tensor_convention_rfc_1596.py::TestDiffusionOperatorShapeConsistency::test_from_volatility_vector_matches_diag_half_sigma_sq",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_hjb_scalar_and_diagonal_tensor_diffusion_agree",
+    "tests/unit/test_utils/test_diffusion_from_volatility.py::TestField::test_1d_field_is_elementwise",
+    "tests/unit/test_utils/test_diffusion_from_volatility.py::TestField::test_2d_field_is_elementwise"
+   ],
+   "owner": "D = sigma^2/2 elementwise for a volatility field (#811)",
+   "seconds": 198.0,
+   "status": "ok",
+   "verify": "float(diffusion_from_volatility(np.array([2.0]), kind='field')[0]) == 4.0"
+  },
+  "diffusion_scalar_2x": {
+   "kill_count": 129,
+   "killed": [
+    "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[1]",
+    "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[2]",
+    "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[3]",
+    "tests/integration/test_diffusion_magnitude_gate.py::test_fp_fdm_diffusion_magnitude[explicit]",
+    "tests/integration/test_diffusion_magnitude_gate.py::test_fp_fdm_diffusion_magnitude[implicit]",
+    "tests/integration/test_diffusion_magnitude_gate.py::test_weak_form_fem_fp_diffusion_magnitude",
+    "tests/integration/test_fem_robin_bc.py::TestRobinSolveLoopWiring::test_hjb_linear_loop_fixed_point",
+    "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[dirichlet]",
+    "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[no_flux]",
+    "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[periodic]",
+    "tests/integration/test_mms_validation.py::TestMMSFokkerPlanck1D::test_pure_diffusion_gaussian",
+    "tests/integration/test_mms_validation.py::TestMMSFokkerPlanck1D::test_sinusoidal_periodic_convergence",
+    "tests/integration/test_mms_validation.py::TestMMSFokkerPlanck1D::test_source_term_steady_state_convergence",
+    "tests/integration/test_mms_validation.py::TestMMSHJB1D::test_backward_heat_periodic_convergence",
+    "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
+    "tests/regression/test_solver_golden_baseline.py::test_gfdm_hjb_matches_golden_baseline",
+    "tests/unit/test_alg/test_adjoint_bc_coupling.py::TestCreateAdjointConsistentBC1D::test_values_with_exponential_density",
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverArrayDiffusion::test_spatiotemporal_diffusion_1d",
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_isotropic_tensor_matches_scalar_diffusion",
+    "tests/unit/test_alg/test_fp_network_solver.py::TestFPNetworkSolverSolveFPSystem::test_volatility_field_is_sigma_not_diffusion",
+    "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_sigma_eff_formula_per_node_l_H",
+    "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_sigma_eff_formula_scalar_l_H",
+    "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[None-<lambda>-1.0-f(m)-only]",
+    "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-<lambda>-0.5-V+f(m),",
+    "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-<lambda>-1.0-V+f(m)]",
+    "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-<lambda>-2.0-V+f(m),",
+    "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[_v_quadratic-None-1.0-V-only]",
+    "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestADIDiffusionMagnitude::test_adi_2d_diffusion_matches_analytic",
+    "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestADIDiffusionMagnitude::test_adi_3d_diffusion_matches_analytic",
+    "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestStochasticCharacteristicSL::test_consistency_with_default_adi",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_diffusion_from_volatility_torch_numpy_parity",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.01-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.05-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.1-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_half_sigma_sq_over_dxsq_equals_D_over_dxsq[0.5-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.01-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.05-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.1-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_2D_over_dxsq[0.5-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.01-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.05-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.1-2.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-0.1]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-0.2]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-0.5]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-1.0]",
+    "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-2.0]",
+    "tests/unit/test_alg/test_sigma_tensor_convention_rfc_1596.py::TestDiffusionOperatorShapeConsistency::test_from_volatility_matches_manual_D",
+    "tests/unit/test_alg/test_sigma_tensor_convention_rfc_1596.py::TestKernelConvention::test_scalar_is_half_sigma_squared",
+    "tests/unit/test_alg/test_sl_diffusion_matches_adi_1543.py::test_sl_diffusion_agrees_with_adi_2d",
+    "tests/unit/test_alg/test_sl_dpp_potential_sign_1645.py::test_dpp_error_converges_under_refinement",
+    "tests/unit/test_alg/test_weak_form_volatility.py::test_diffusion_coefficient_converts_sigma_to_D",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[0.1]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[0.7]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[1.0]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[1.4142135623730951]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[2.5]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[3.0]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[0.1]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[0.7]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[1.0]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[1.4142135623730951]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[2.5]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_converter_and_problem_property_agree[3.0]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[0.1]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[0.7]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[1.0]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[1.4142135623730951]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[2.5]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_gfdm_sigma_resolution_agrees[3.0]",
+    "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_hjb_scalar_and_diagonal_tensor_diffusion_agree",
+    "tests/unit/test_core/test_mfg_problem.py::test_diffusion_primary_parameter",
+    "tests/unit/test_core/test_mfg_problem.py::test_sigma_direct_sde_volatility",
+    "tests/unit/test_core/test_mfg_problem.py::test_volatility_alias_for_sigma",
+    "tests/unit/test_core/test_mfg_problem.py::test_volatility_field_scalar",
+    "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_array_collapses_to_mean_with_warning",
+    "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_none_uses_fallback_sigma",
+    "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_scalar_is_converted",
+    "tests/unit/test_core/test_unified_mfg_problem.py::TestNDGridMode::test_diffusion_converts_to_sigma",
+    "tests/unit/test_fp_fvm.py::test_gate3_convergence_muscl_second_order",
+    "tests/unit/test_fp_fvm.py::test_gate3_convergence_upwind_first_order",
+    "tests/unit/test_operators/test_diffusion.py::TestIsotropicDiffusion::test_from_volatility_scalar_matches_half_sigma_sq",
+    "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_byte_identical_to_literal",
+    "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_is_half_sigma_squared",
+    "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_needs_no_kind"
+   ],
+   "owner": "D = sigma^2/2 for scalar sigma (#811)",
+   "seconds": 321.8,
+   "status": "ok",
+   "verify": "diffusion_from_volatility(2.0) == 4.0"
+  },
+  "drift_coefficient_2x": {
+   "kill_count": 19,
+   "killed": [
+    "tests/integration/test_newton_mfg_solver.py::test_one_newton_step_reduces_the_mfg_residual",
+    "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
+    "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[0.5]",
+    "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[1.0]",
+    "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[2.5]",
+    "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_byte_identical_when_consistent",
+    "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_uses_control_cost_not_coupling",
+    "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_equivalence_quadratic_explicit",
+    "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-0.5]",
+    "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-1.0]",
+    "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-2.0]",
+    "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-0.5]",
+    "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-1.0]",
+    "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-2.0]",
+    "tests/unit/test_alg/test_meshless_stabilization.py::test_sd_block_identical_in_fp_and_hjb",
+    "tests/unit/test_alg/test_weakform_fp_drift_single_source.py::test_fp_drift_coefficient_sources_from_control_cost_not_coupling",
+    "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[0.5]",
+    "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[1.0]",
+    "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[2.0]"
+   ],
+   "owner": "FP drift c = 1/control_cost (#1420 / G-017)",
+   "seconds": 208.8,
+   "status": "ok",
+   "verify": "fp_drift_coefficient(_stub_problem(control_cost=2.0)) == 1.0"
+  },
+  "optimal_control_sign": {
+   "kill_count": 34,
+   "killed": [
+    "tests/integration/test_coupling_mesh_geometry.py::TestFixedPointIteratorMeshGeometry::test_fem_couples_through_fixed_point_iterator",
+    "tests/integration/test_fem_solver_path.py::TestFEMBoundaryConditionResolution::test_coupled_fem_no_flux_runs_and_conserves_mass",
+    "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[0.5]",
+    "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[1.0]",
+    "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[2.5]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_byte_identical_dyadic[0.5]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_byte_identical_dyadic[1.0]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_byte_identical_dyadic[2.0]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_separates_at_most_one_ulp_nondyadic[0.7]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_legacy_multiply_form_separates_at_most_one_ulp_nondyadic[2.5]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_byte_identical_to_divide_form_dyadic[0.5]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_byte_identical_to_divide_form_dyadic[1.0]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_byte_identical_to_divide_form_dyadic[2.0]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_within_one_ulp_of_divide_form_nondyadic[0.7]",
+    "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_within_one_ulp_of_divide_form_nondyadic[2.5]",
+    "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_byte_identical_when_consistent",
+    "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_uses_control_cost_not_coupling",
+    "tests/unit/test_alg/test_particle_multi_exit.py::test_particle_solver_multi_exit_1d",
+    "tests/unit/test_core/test_hamiltonian_classes.py::TestControlCostBase::test_quadratic_control_cost_maximize",
+    "tests/unit/test_core/test_hamiltonian_classes.py::TestControlCostBase::test_quadratic_control_cost_minimize",
+    "tests/unit/test_core/test_hamiltonian_classes.py::TestHamiltonianBase::test_hamiltonian_optimal_control",
+    "tests/unit/test_core/test_hamiltonian_classes.py::TestSeparableLagrangian::test_quadratic_optimal_control",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p0-OptimizationSense.MAXIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p0-OptimizationSense.MINIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p1-OptimizationSense.MAXIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p1-OptimizationSense.MINIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p2-OptimizationSense.MAXIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_base_agrees_with_analytic_separable_override[p2-OptimizationSense.MINIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p0-OptimizationSense.MAXIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p0-OptimizationSense.MINIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p1-OptimizationSense.MAXIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p1-OptimizationSense.MINIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p2-OptimizationSense.MAXIMIZE]",
+    "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p2-OptimizationSense.MINIMIZE]"
+   ],
+   "owner": "QuadraticControlCost alpha* = -sign*p/lambda (#1649)",
+   "seconds": 201.1,
+   "status": "ok",
+   "verify": "float(QuadraticControlCost(control_cost=1.0).optimal_control(np.array([1.0]))[0]) > 0"
+  }
+ },
+ "paths": [
+  "tests"
+ ],
+ "uncovered": [
+  "bc_default_reads_as_reflect"
+ ]
+}

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Measure which tests discriminate, by mutating load-bearing conventions.
+
+#1714 measured 47 of 85 tests in one campaign as guard-echo, and #1715 found two
+agreement tests that passed under a 2x diffusion error. Both were established by
+mutation, not by reading. This generalises that: perturb each convention the library
+single-sources, run the suite, and record which tests notice.
+
+A test killed by no mutation is not necessarily worthless -- it may guard a surface
+none of these conventions reach. It is a test whose discrimination on the load-bearing
+paths is **unmeasured**, which is the population #1701 asks for.
+
+Why not select the population by name. Counting `*_agree` / `*_matches` / `*_equals`
+gives 51, 114 or 156 depending on the pattern, and the name has no reliable relation to
+whether the test compares two paths. Behaviour under mutation does.
+
+TWO TRAPS, both live in this repo, both handled here:
+
+- **#1677 -- an editable install pins imports to the main checkout.** Mutating a copy
+  or a worktree and running pytest there can leave the *original* module imported, so
+  every mutation reports zero kills and reads as "nothing discriminates". This script
+  mutates the main checkout in place, restores from a pristine copy under try/finally,
+  and refuses to start on a dirty tree. It also asserts at run time that the imported
+  `mfgarchon` is the tree it mutated.
+- **A mutation that kills nothing is ambiguous.** Either every test is blind to that
+  convention, or the mutation never executed. Each mutation therefore carries `verify`:
+  an expression run against the mutated tree that is true only if the perturbation is
+  observably live. Three outcomes, not two:
+
+      live + kills > 0   the kills are data
+      live + kills == 0  UNCOVERED -- no test exercises this convention. A finding.
+      not live           INEFFECTIVE -- a harness fault. Its zeros mean nothing.
+
+  The control has to sit on the thing in doubt. An earlier version pinned each mutation
+  to "a named test that must die", which conflated a wrong guess about the test's path
+  with a genuinely untested convention: four mutations killing 113, 17, 5 and 5 tests
+  were all reported INEFFECTIVE because the test *file* had been guessed wrong, while
+  the one mutation that genuinely killed nothing looked identical to them.
+
+Usage:
+    python scripts/test_discrimination.py                  # all mutations
+    python scripts/test_discrimination.py --only diffusion_scalar_2x
+    python scripts/test_discrimination.py --paths tests/unit --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# The CI marker set, matching scripts/local_ci.sh so a kill here means a kill there.
+MARKERS = "not slow and not benchmark and not experimental and not optional_torch and not environment"
+
+
+@dataclass
+class Mutation:
+    """A single-site perturbation of a convention the library single-sources."""
+
+    name: str
+    path: str
+    old: str
+    new: str
+    owner: str  # what convention this is, and the issue that made it single-source
+    verify: str  # expression, true ONLY under the mutation -- the positive control
+
+
+MUTATIONS: list[Mutation] = [
+    Mutation(
+        name="diffusion_scalar_2x",
+        path="mfgarchon/utils/pde_coefficients.py",
+        old="        return 0.5 * float(arr) ** 2  # scalar isotropic: unambiguous, kind not needed",
+        new="        return float(arr) ** 2  # MUTATED: 2x diffusion",
+        owner="D = sigma^2/2 for scalar sigma (#811)",
+        verify="diffusion_from_volatility(2.0) == 4.0",
+    ),
+    Mutation(
+        name="diffusion_field_2x",
+        path="mfgarchon/utils/pde_coefficients.py",
+        old='    if kind == "field":\n        return 0.5 * arr**2',
+        new='    if kind == "field":\n        return arr**2  # MUTATED: 2x diffusion',
+        owner="D = sigma^2/2 elementwise for a volatility field (#811)",
+        verify="float(diffusion_from_volatility(np.array([2.0]), kind='field')[0]) == 4.0",
+    ),
+    Mutation(
+        name="drift_coefficient_2x",
+        path="mfgarchon/utils/pde_coefficients.py",
+        old="        return 1.0 / h_class.control_cost.lambda_",
+        new="        return 2.0 / h_class.control_cost.lambda_  # MUTATED",
+        owner="FP drift c = 1/control_cost (#1420 / G-017)",
+        verify="fp_drift_coefficient(_stub_problem(control_cost=2.0)) == 1.0",
+    ),
+    Mutation(
+        name="optimal_control_sign",
+        path="mfgarchon/core/hamiltonian.py",
+        old="        return -self.sign * p / self._lambda",
+        new="        return self.sign * p / self._lambda  # MUTATED: sign flipped",
+        owner="QuadraticControlCost alpha* = -sign*p/lambda (#1649)",
+        verify="float(QuadraticControlCost(control_cost=1.0).optimal_control(np.array([1.0]))[0]) > 0",
+    ),
+    Mutation(
+        name="bc_noflux_reads_as_clamp",
+        path="mfgarchon/geometry/boundary/bc_utils.py",
+        old='    elif bc_type_lower in ("neumann", "no_flux", "robin"):\n        return "reflect"',
+        new='    elif bc_type_lower in ("neumann", "no_flux", "robin"):\n        return "clamp"  # MUTATED',
+        owner="no_flux/neumann/robin -> reflect (#1698)",
+        verify="bc_type_to_geometric_operation('no_flux') == 'clamp'",
+    ),
+    Mutation(
+        name="bc_default_reads_as_reflect",
+        path="mfgarchon/geometry/boundary/bc_utils.py",
+        old='    if bc_type is None:\n        return "clamp"  # Default: absorbing',
+        new='    if bc_type is None:\n        return "reflect"  # MUTATED',
+        owner="absent BC defaults to clamp/absorbing (#1698)",
+        verify="bc_type_to_geometric_operation(None) == 'reflect'",
+    ),
+]
+
+_FAILED = re.compile(r"^(?:FAILED|ERROR) (\S+?)(?:\s|$)", re.MULTILINE)
+
+
+@dataclass
+class Run:
+    failed: set[str] = field(default_factory=set)
+    returncode: int = 0
+    seconds: float = 0.0
+
+
+def _pytest(paths: list[str], timeout: int = 3600) -> Run:
+    import time
+
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-m",
+            "pytest",
+            *paths,
+            "-n",
+            "auto",
+            "-q",
+            "--color=no",
+            "-p",
+            "no:cacheprovider",
+            "-m",
+            MARKERS,
+            "--timeout=900",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**_env()},
+    )
+    return Run(
+        failed=set(_FAILED.findall(proc.stdout)),
+        returncode=proc.returncode,
+        seconds=round(time.perf_counter() - t0, 1),
+    )
+
+
+def _env() -> dict:
+    import os
+
+    return {**os.environ, "PYTHONDONTWRITEBYTECODE": "1", "OMP_NUM_THREADS": "1", "OPENBLAS_NUM_THREADS": "1"}
+
+
+def _assert_clean_tree() -> None:
+    """No MODIFIED tracked files.
+
+    Untracked files are ignored on purpose: the restore rewrites tracked files from a
+    pristine copy, so an untracked file cannot be clobbered by it and its presence says
+    nothing about whether the restore worked. Blocking on `??` would only train the
+    operator to reach for --force.
+    """
+    out = subprocess.run(["git", "status", "--porcelain"], cwd=REPO, capture_output=True, text=True).stdout
+    modified = [ln for ln in out.splitlines() if not ln.startswith("??")]
+    if modified:
+        sys.exit(
+            "Refusing to run: tracked files are modified. This script edits the checkout in "
+            "place (see the #1677 note in the module docstring) and restores from a pristine "
+            "copy, so it must start from a state it can prove it restored.\n" + "\n".join(modified)
+        )
+
+
+def _assert_import_is_the_mutated_tree() -> None:
+    """#1677's control: prove the process under measurement imports what we mutate."""
+    proc = subprocess.run(
+        [sys.executable, "-B", "-c", "import mfgarchon, pathlib; print(pathlib.Path(mfgarchon.__file__).resolve())"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        env=_env(),
+    )
+    imported = Path(proc.stdout.strip()) if proc.stdout.strip() else None
+    expected = REPO / "mfgarchon" / "__init__.py"
+    if imported != expected:
+        sys.exit(
+            f"Refusing to run: `import mfgarchon` resolves to {imported}, not {expected}. "
+            f"Mutations applied here would not reach the code under test -- every mutation "
+            f"would report zero kills and read as 'nothing discriminates' (Issue #1677)."
+        )
+
+
+_VERIFY_PRELUDE = """
+import numpy as np
+from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
+from mfgarchon.geometry.boundary.bc_utils import bc_type_to_geometric_operation
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+
+def _stub_problem(control_cost):
+    class P:
+        hamiltonian_class = SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=control_cost),
+            coupling=lambda m: m, coupling_dm=lambda m: 1.0)
+    return P()
+"""
+
+
+def _mutation_is_live(mut: Mutation) -> bool:
+    """Is the perturbation observable from outside? The control, on the thing in doubt.
+
+    Evaluated against the mutated tree in a fresh interpreter. Only when this is true
+    does a kill count of zero mean "no test covers this convention" rather than "the
+    mutation never ran".
+    """
+    proc = subprocess.run(
+        [sys.executable, "-B", "-c", f"{_VERIFY_PRELUDE}\nassert ({mut.verify}), {mut.verify!r}"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        env=_env(),
+    )
+    if proc.returncode != 0:
+        tail = (proc.stderr.strip().splitlines() or ["(no stderr)"])[-1]
+        print(f"  verify FAILED: {mut.verify}\n    {tail}", flush=True)
+    return proc.returncode == 0
+
+
+def apply_mutation(mut: Mutation, backups: dict[str, str]) -> None:
+    target = REPO / mut.path
+    text = target.read_text()
+    occurrences = text.count(mut.old)
+    if occurrences != 1:
+        raise SystemExit(
+            f"mutation {mut.name!r}: expected its anchor exactly once in {mut.path}, found "
+            f"{occurrences}. The source moved; fix the mutation rather than skipping it -- a "
+            f"silently unapplied mutation reports zero kills."
+        )
+    backups.setdefault(mut.path, text)
+    target.write_text(text.replace(mut.old, mut.new))
+
+
+def restore(backups: dict[str, str]) -> None:
+    for rel, text in backups.items():
+        (REPO / rel).write_text(text)
+    backups.clear()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--only", action="append", help="Run only these mutations (repeatable)")
+    parser.add_argument("--paths", default="tests", help="Test paths to run (default: tests)")
+    parser.add_argument("--json", metavar="FILE", help="Write the full kill matrix to FILE")
+    args = parser.parse_args()
+
+    _assert_clean_tree()
+    _assert_import_is_the_mutated_tree()
+
+    selected = [m for m in MUTATIONS if not args.only or m.name in args.only]
+    if not selected:
+        sys.exit(f"No mutation matched {args.only}. Known: {[m.name for m in MUTATIONS]}")
+
+    paths = args.paths.split()
+    print(f"Baseline: pytest {' '.join(paths)} ...", flush=True)
+    base = _pytest(paths)
+    if base.failed:
+        sys.exit(
+            f"Refusing to run: {len(base.failed)} tests already fail before any mutation, so a "
+            f"kill could not be attributed.\n  " + "\n  ".join(sorted(base.failed)[:10])
+        )
+    print(f"  clean, {base.seconds}s\n", flush=True)
+
+    results: dict[str, dict] = {}
+    backups: dict[str, str] = {}
+    pristine = Path(tempfile.mkdtemp(prefix="discrim-"))
+    try:
+        for mut in selected:
+            shutil.copy2(REPO / mut.path, pristine / Path(mut.path).name)
+            print(f"[{mut.name}] {mut.owner}", flush=True)
+            apply_mutation(mut, backups)
+            try:
+                live = _mutation_is_live(mut)
+                run = _pytest(paths) if live else Run()
+            finally:
+                restore(backups)
+
+            if not live:
+                status, note = "INEFFECTIVE", "  <-- mutation not observable; its zeros mean nothing"
+            elif run.failed:
+                status, note = "ok", ""
+            else:
+                status, note = "UNCOVERED", "  <-- mutation IS live and no test noticed"
+            results[mut.name] = {
+                "owner": mut.owner,
+                "status": status,
+                "killed": sorted(run.failed),
+                "kill_count": len(run.failed),
+                "seconds": run.seconds,
+                "verify": mut.verify,
+            }
+            print(f"  killed {len(run.failed):4d}  [{status}]  {run.seconds}s{note}\n", flush=True)
+    finally:
+        restore(backups)
+        shutil.rmtree(pristine, ignore_errors=True)
+
+    effective = {k: v for k, v in results.items() if v["status"] == "ok"}
+    uncovered = sorted(k for k, v in results.items() if v["status"] == "UNCOVERED")
+    ineffective = sorted(k for k, v in results.items() if v["status"] == "INEFFECTIVE")
+
+    killed_by: dict[str, list[str]] = {}
+    for name, res in effective.items():
+        for test in res["killed"]:
+            killed_by.setdefault(test, []).append(name)
+
+    print("=" * 78)
+    print(f"{len(effective)} of {len(results)} mutations were live and killed at least one test.")
+    if uncovered:
+        print(f"\nUNCOVERED -- live, and no test noticed: {', '.join(uncovered)}")
+        for name in uncovered:
+            print(f"  {name}: {results[name]['owner']}")
+        print("  These are findings, not harness faults: the convention is single-sourced")
+        print("  and nothing in the selected paths asserts anything about it.")
+    if ineffective:
+        print(f"\nINEFFECTIVE, excluded from the verdict: {', '.join(ineffective)}")
+        print("  The mutation was not observable, so its zeros prove nothing. Fix the")
+        print("  mutation or its verify expression before reading them.")
+    print(f"\n{len(killed_by)} distinct tests were killed by at least one effective mutation.")
+    for name, res in sorted(effective.items()):
+        print(f"  {name:<30} {res['kill_count']:>4} killed")
+
+    payload = {
+        "uncovered": uncovered,
+        "markers": MARKERS,
+        "paths": paths,
+        "baseline_seconds": base.seconds,
+        "mutations": results,
+        "killed_by": killed_by,
+    }
+    if args.json:
+        Path(args.json).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        print(f"\nKill matrix written to {args.json}")
+
+    _assert_clean_tree()
+    print("\nWorking tree restored and verified clean.")
+    sys.exit(0 if effective else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -19,9 +19,12 @@ TWO TRAPS, both live in this repo, both handled here:
 - **#1677 -- an editable install pins imports to the main checkout.** Mutating a copy
   or a worktree and running pytest there can leave the *original* module imported, so
   every mutation reports zero kills and reads as "nothing discriminates". This script
-  mutates the main checkout in place, restores from a pristine copy under try/finally,
-  and refuses to start on a dirty tree. It also asserts at run time that the imported
-  `mfgarchon` is the tree it mutated.
+  mutates the main checkout in place, restores each file from the text it read before
+  writing (held in memory, under try/finally), and refuses to start with modified
+  tracked files. It also asserts at run time that the imported `mfgarchon` is the tree
+  it mutated. SIGINT is safe -- the original text is captured before the write and
+  restored by the outer finally. SIGKILL is not: recover with `git checkout --`, which
+  the dirty-tree guard forces before a re-run.
 - **A mutation that kills nothing is ambiguous.** Either every test is blind to that
   convention, or the mutation never executed. Each mutation therefore carries `verify`:
   an expression run against the mutated tree that is true only if the perturbation is
@@ -48,10 +51,8 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import shutil
 import subprocess
 import sys
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -144,6 +145,7 @@ _FAILED = re.compile(r"^(?:FAILED|ERROR) (\S+?)(?:\s|$)", re.MULTILINE)
 class Run:
     failed: set[str] = field(default_factory=set)
     returncode: int = 0
+    collected: int = 0
     seconds: float = 0.0
 
 
@@ -178,8 +180,18 @@ def _pytest(paths: list[str], timeout: int = 3600) -> Run:
     return Run(
         failed=set(_FAILED.findall(proc.stdout)),
         returncode=proc.returncode,
+        collected=_collected(proc.stdout),
         seconds=round(time.perf_counter() - t0, 1),
     )
+
+
+_COLLECTED = re.compile(r"(\d+) (?:passed|failed|error)")
+
+
+def _collected(stdout: str) -> int:
+    """Tests that actually ran. Zero means the run did not happen, not that it passed."""
+    counts = re.findall(r"(\d+) (?:passed|failed|xfailed|xpassed|skipped)", stdout)
+    return sum(int(c) for c in counts)
 
 
 def _env() -> dict:
@@ -191,8 +203,8 @@ def _env() -> dict:
 def _assert_clean_tree() -> None:
     """No MODIFIED tracked files.
 
-    Untracked files are ignored on purpose: the restore rewrites tracked files from a
-    pristine copy, so an untracked file cannot be clobbered by it and its presence says
+    Untracked files are ignored on purpose: the restore only rewrites the tracked files
+    it mutated, so an untracked file cannot be clobbered by it and its presence says
     nothing about whether the restore worked. Blocking on `??` would only train the
     operator to reach for --force.
     """
@@ -201,8 +213,8 @@ def _assert_clean_tree() -> None:
     if modified:
         sys.exit(
             "Refusing to run: tracked files are modified. This script edits the checkout in "
-            "place (see the #1677 note in the module docstring) and restores from a pristine "
-            "copy, so it must start from a state it can prove it restored.\n" + "\n".join(modified)
+            "place (see the #1677 note in the module docstring) and restores what it wrote, "
+            "so it must start from a state it can prove it restored.\n" + "\n".join(modified)
         )
 
 
@@ -286,7 +298,7 @@ def _head_sha() -> str:
     return out.stdout.strip() or "unknown"
 
 
-def _write_baseline(path: Path, results: dict) -> None:
+def _write_baseline(path: Path, results: dict, *, paths: list[str], collected: int) -> None:
     payload = {
         "_comment": (
             "Kill counts per mutated convention. --check-baseline fails when a count DROPS "
@@ -294,7 +306,13 @@ def _write_baseline(path: Path, results: dict) -> None:
             "Counts, not test names: this population cannot be selected by name -- the "
             "agreement-shaped patterns give 51, 114 or 156 depending on the regex."
         ),
-        "_measured_at": _head_sha(),
+        "_measured_at": {
+            "commit": _head_sha(),
+            "paths": paths,
+            "markers": MARKERS,
+            "collected": collected,
+            "excluded": SELF_TESTS,
+        },
         "mutations": {
             name: {
                 "owner": res["owner"],
@@ -368,14 +386,22 @@ def main() -> None:
             f"Refusing to run: {len(base.failed)} tests already fail before any mutation, so a "
             f"kill could not be attributed.\n  " + "\n  ".join(sorted(base.failed)[:10])
         )
-    print(f"  clean, {base.seconds}s\n", flush=True)
+    # pytest exits 5 on "no tests collected" and 2/3/4 on usage or internal errors, and in
+    # every one of those the FAILED set is empty. Without this, a --paths typo produces a
+    # clean baseline and then six UNCOVERED "findings" -- the exact ambiguity the
+    # three-way verdict removes, entering through the door `verify` does not watch:
+    # `verify` proves the MUTATION took effect, nothing proved that PYTEST RAN.
+    if base.returncode != 0 or base.collected == 0:
+        sys.exit(
+            f"Refusing to run: the baseline pytest exited {base.returncode} having run "
+            f"{base.collected} tests. Nothing below would be a measurement."
+        )
+    print(f"  clean, {base.collected} ran, {base.seconds}s\n", flush=True)
 
     results: dict[str, dict] = {}
     backups: dict[str, str] = {}
-    pristine = Path(tempfile.mkdtemp(prefix="discrim-"))
     try:
         for mut in selected:
-            shutil.copy2(REPO / mut.path, pristine / Path(mut.path).name)
             print(f"[{mut.name}] {mut.owner}", flush=True)
             apply_mutation(mut, backups)
             try:
@@ -384,8 +410,14 @@ def main() -> None:
             finally:
                 restore(backups)
 
+            shrank = live and run.collected < base.collected * 0.99
             if not live:
                 status, note = "INEFFECTIVE", "  <-- mutation not observable; its zeros mean nothing"
+            elif run.returncode not in (0, 1) or shrank:
+                # A mutation that breaks collection silently shrinks the population, so
+                # every survivor "survived" a run it was never in.
+                status = "INEFFECTIVE"
+                note = f"  <-- pytest exited {run.returncode} having run {run.collected} (baseline {base.collected})"
             elif run.failed:
                 status, note = "ok", ""
             else:
@@ -401,7 +433,6 @@ def main() -> None:
             print(f"  killed {len(run.failed):4d}  [{status}]  {run.seconds}s{note}\n", flush=True)
     finally:
         restore(backups)
-        shutil.rmtree(pristine, ignore_errors=True)
 
     effective = {k: v for k, v in results.items() if v["status"] == "ok"}
     uncovered = sorted(k for k, v in results.items() if v["status"] == "UNCOVERED")
@@ -444,7 +475,7 @@ def main() -> None:
     print("\nWorking tree restored and verified clean.")
 
     if args.write_baseline:
-        _write_baseline(Path(args.write_baseline), results)
+        _write_baseline(Path(args.write_baseline), results, paths=paths, collected=base.collected)
         print(f"Baseline written to {args.write_baseline}")
         sys.exit(0)
 

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -266,11 +266,77 @@ def restore(backups: dict[str, str]) -> None:
     backups.clear()
 
 
+def _head_sha() -> str:
+    """Stamped by the same call that produces the counts, not looked up later."""
+    out = subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=REPO, capture_output=True, text=True)
+    return out.stdout.strip() or "unknown"
+
+
+def _write_baseline(path: Path, results: dict) -> None:
+    payload = {
+        "_comment": (
+            "Kill counts per mutated convention. --check-baseline fails when a count DROPS "
+            "(discrimination lost) and when one RISES (record the gain in the same change). "
+            "Counts, not test names: this population cannot be selected by name -- the "
+            "agreement-shaped patterns give 51, 114 or 156 depending on the regex."
+        ),
+        "_measured_at": _head_sha(),
+        "mutations": {
+            name: {
+                "owner": res["owner"],
+                "status": res["status"],
+                "kill_count": res["kill_count"],
+            }
+            for name, res in sorted(results.items())
+        },
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def compare_to_baseline(results: dict, baseline: dict) -> list[str]:
+    """Every way discrimination can degrade. Empty list means it did not.
+
+    Two ratchets, both unforgeable by renaming -- which matters, because the
+    population this measures cannot be selected by name at all:
+
+    - **Per-mutation kill counts must not drop.** A convention that 129 tests noticed
+      and 120 notice now has lost coverage, whatever the test names are. Deleting a
+      discriminating test trips this, which is correct: it is a real loss.
+    - **The UNCOVERED set must not grow.** A convention going from watched to
+      unwatched is the defect this tool exists to find.
+
+    Improvements trip it too, and must be recorded in the same change -- otherwise the
+    next baseline encodes the gain as if it had always held, and the ratchet loses the
+    ability to say when anything got better. Same rule as the capability matrix.
+    """
+    problems = []
+    base_muts = baseline["mutations"]
+    for name, was in sorted(base_muts.items()):
+        now = results.get(name)
+        if now is None:
+            problems.append(f"  {name}: mutation DISAPPEARED (baseline killed {was['kill_count']})")
+            continue
+        if now["status"] == "INEFFECTIVE":
+            problems.append(f"  {name}: became INEFFECTIVE -- the mutation no longer applies; fix it")
+            continue
+        if now["kill_count"] < was["kill_count"]:
+            problems.append(f"  {name}: {was['kill_count']} -> {now['kill_count']} killed  [DISCRIMINATION LOST]")
+        elif now["kill_count"] > was["kill_count"]:
+            problems.append(
+                f"  {name}: {was['kill_count']} -> {now['kill_count']} killed  [IMPROVED -- record it in the baseline]"
+            )
+    for name in sorted(set(results) - set(base_muts)):
+        problems.append(f"  {name}: NEW mutation, not in baseline")
+    return problems
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--only", action="append", help="Run only these mutations (repeatable)")
     parser.add_argument("--paths", default="tests", help="Test paths to run (default: tests)")
     parser.add_argument("--json", metavar="FILE", help="Write the full kill matrix to FILE")
+    parser.add_argument("--write-baseline", metavar="FILE", help="Write the ratchet baseline to FILE")
+    parser.add_argument("--check-baseline", metavar="FILE", help="Fail if discrimination degraded vs FILE")
     args = parser.parse_args()
 
     _assert_clean_tree()
@@ -362,6 +428,23 @@ def main() -> None:
 
     _assert_clean_tree()
     print("\nWorking tree restored and verified clean.")
+
+    if args.write_baseline:
+        _write_baseline(Path(args.write_baseline), results)
+        print(f"Baseline written to {args.write_baseline}")
+        sys.exit(0)
+
+    if args.check_baseline:
+        baseline = json.loads(Path(args.check_baseline).read_text())
+        problems = compare_to_baseline(results, baseline)
+        if problems:
+            print("\nDiscrimination baseline mismatch:")
+            print("\n".join(problems))
+            print("\nIf intended, regenerate with --write-baseline in the same commit.")
+            sys.exit(1)
+        print(f"Discrimination matches baseline ({len(baseline['mutations'])} mutations).")
+        sys.exit(0)
+
     sys.exit(0 if effective else 1)
 
 

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -60,6 +60,19 @@ REPO = Path(__file__).resolve().parent.parent
 # The CI marker set, matching scripts/local_ci.sh so a kill here means a kill there.
 MARKERS = "not slow and not benchmark and not experimental and not optional_torch and not environment"
 
+# The instrument must not be inside its own population.
+#
+# `tests/unit/test_discrimination_ratchet.py` asserts that each mutation's literal
+# source anchor matches exactly once. Under a mutation it does not -- that is the whole
+# point of the anchor test -- so it fails under EVERY mutation and adds exactly +1 to
+# every kill count. Measured: 129/34/19/5/5/0 became 130/35/20/6/6/1.
+#
+# The +1 on the last one is the damage. `bc_default_reads_as_reflect` is UNCOVERED at 0,
+# and a self-referential +1 reads as "one test now covers it" -- the instrument erasing
+# the finding it exists to produce, while every other count moves just enough to look
+# like a real improvement rather than an artifact.
+SELF_TESTS = "tests/unit/test_discrimination_ratchet.py"
+
 
 @dataclass
 class Mutation:
@@ -153,6 +166,7 @@ def _pytest(paths: list[str], timeout: int = 3600) -> Run:
             "no:cacheprovider",
             "-m",
             MARKERS,
+            f"--ignore={SELF_TESTS}",
             "--timeout=900",
         ],
         cwd=REPO,
@@ -347,7 +361,7 @@ def main() -> None:
         sys.exit(f"No mutation matched {args.only}. Known: {[m.name for m in MUTATIONS]}")
 
     paths = args.paths.split()
-    print(f"Baseline: pytest {' '.join(paths)} ...", flush=True)
+    print(f"Baseline: pytest {' '.join(paths)} (excluding {SELF_TESTS}) ...", flush=True)
     base = _pytest(paths)
     if base.failed:
         sys.exit(

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -143,6 +143,19 @@ def test_the_mutation_list_matches_the_parametrisation(td):
     assert len(td.MUTATIONS) == 6
 
 
+def test_the_sweep_excludes_this_file(td):
+    """This file must not be inside the population it measures.
+
+    `test_every_mutation_anchor_still_matches_exactly_once` fails under every mutation
+    by design, so leaving it in adds +1 to every kill count. Measured before the
+    exclusion: 129/34/19/5/5/0 became 130/35/20/6/6/1 -- and that last +1 turned the
+    one UNCOVERED convention into an apparently-covered one, which is the instrument
+    deleting its own finding.
+    """
+    assert td.SELF_TESTS == "tests/unit/test_discrimination_ratchet.py"
+    assert str(Path(__file__).resolve()).endswith(td.SELF_TESTS)
+
+
 def test_every_mutation_changes_something(td):
     for mut in td.MUTATIONS:
         assert mut.old != mut.new, f"{mut.name}: old and new are identical"

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -113,9 +113,43 @@ def test_shipped_baseline_covers_every_declared_mutation(td):
     )
 
 
-def test_shipped_baseline_records_where_it_was_measured(td):
-    """A count with no provenance cannot be re-derived, and rots without saying so."""
-    assert json.loads(_BASELINE.read_text()).get("_measured_at")
+def test_shipped_baseline_records_the_scope_it_was_measured_at(td):
+    """A count whose scope is unrecorded is not comparable to anything.
+
+    A baseline written under `--paths tests/unit` would otherwise be indistinguishable
+    from one written over the whole tree, and a later run would read the difference as
+    discrimination lost.
+    """
+    at = json.loads(_BASELINE.read_text()).get("_measured_at")
+    assert isinstance(at, dict), "provenance must be structured, not a bare sha"
+    for key in ("commit", "paths", "markers", "collected", "excluded"):
+        assert at.get(key), f"_measured_at is missing {key!r}"
+    assert at["markers"] == td.MARKERS, "baseline marker set has drifted from the script's"
+    assert at["excluded"] == td.SELF_TESTS
+
+
+def test_the_sweep_passes_its_self_exclusion_to_pytest(td, monkeypatch):
+    """M1: the constant alone was pinned, the WIRING was not.
+
+    Deleting the `--ignore` argument left all 19 pins green while the +1 contamination
+    returned -- including the +1 that turns the one UNCOVERED convention into an
+    apparently-covered one. This asserts the argument actually reaches pytest.
+    """
+    seen = {}
+
+    class _Proc:
+        stdout = "1 passed"
+        returncode = 0
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        return _Proc()
+
+    monkeypatch.setattr(td.subprocess, "run", fake_run)
+    td._pytest(["tests"])
+    assert f"--ignore={td.SELF_TESTS}" in seen["cmd"], (
+        f"the sweep did not exclude its own tests; argv was {seen['cmd']}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +175,22 @@ def test_every_mutation_anchor_still_matches_exactly_once(td, index):
 def test_the_mutation_list_matches_the_parametrisation(td):
     """The parametrize range above is a literal; this is what notices when it drifts."""
     assert len(td.MUTATIONS) == 6
+
+
+def test_the_kill_matrix_is_committed_beside_the_baseline(td):
+    """The counts are the gate; the matrix is the evidence under them.
+
+    Without it the population claims in #1715 -- "193 of 308 inert", "39 of 65" -- are
+    unrecoverable by anyone, which is the shape of claim this whole campaign exists to
+    stop shipping.
+    """
+    matrix = json.loads((_BASELINE.parent / "discrimination_killmatrix.json").read_text())
+    assert matrix["_selection_regex_for_agreement_shaped"]
+    baseline = json.loads(_BASELINE.read_text())["mutations"]
+    for name, res in baseline.items():
+        assert matrix["mutations"][name]["kill_count"] == res["kill_count"], (
+            f"{name}: matrix and baseline disagree -- they came from different runs"
+        )
 
 
 def test_the_sweep_excludes_this_file(td):

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -1,0 +1,154 @@
+"""Pinning tests for the discrimination ratchet (scripts/test_discrimination.py).
+
+The sweep itself takes ~26 minutes (seven full-suite runs), so it is a weekly job, not
+a gate. These tests pin the parts that decide what the sweep MEANS, which is where it
+can silently stop working:
+
+- the three-way verdict, which separates "no test covers this convention" (a finding)
+  from "the mutation never ran" (a harness fault). An earlier design had only two
+  outcomes and reported four mutations killing 113, 17, 5 and 5 tests as INEFFECTIVE
+  because their control test-path had been guessed wrong -- while the one genuinely
+  uncovered convention looked identical to them.
+- the ratchet, which must fail in both directions for the same reason the capability
+  baseline does.
+- the mutation anchors, which are literal source text and rot when the source moves.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "test_discrimination.py"
+_BASELINE = _SCRIPT.parent / "discrimination_baseline.json"
+
+
+@pytest.fixture(scope="module")
+def td():
+    spec = importlib.util.spec_from_file_location("test_discrimination", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test_discrimination"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _base(**counts):
+    return {"mutations": {n: {"owner": "x", "status": "ok", "kill_count": c} for n, c in counts.items()}}
+
+
+def _now(**counts):
+    return {n: {"owner": "x", "status": "ok", "kill_count": c, "killed": []} for n, c in counts.items()}
+
+
+# ---------------------------------------------------------------------------
+# The ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_identical_counts_report_no_problem(td):
+    assert td.compare_to_baseline(_now(a=10), _base(a=10)) == []
+
+
+def test_a_dropped_kill_count_is_caught(td):
+    """Discrimination lost: a convention 10 tests noticed is now noticed by 9."""
+    problems = td.compare_to_baseline(_now(a=9), _base(a=10))
+    assert len(problems) == 1
+    assert "DISCRIMINATION LOST" in problems[0]
+
+
+def test_a_raised_kill_count_is_also_caught(td):
+    """The direction a one-way ratchet would swallow, taking the record with it."""
+    problems = td.compare_to_baseline(_now(a=11), _base(a=10))
+    assert len(problems) == 1
+    assert "IMPROVED" in problems[0]
+
+
+def test_a_mutation_going_ineffective_is_caught_before_its_count(td):
+    """An unapplied mutation reports zero kills, which would read as total loss.
+
+    It is a harness fault, not a coverage collapse, and must be named as one --
+    otherwise the fix attempted would be to the tests rather than to the mutation.
+    """
+    now = _now(a=0)
+    now["a"]["status"] = "INEFFECTIVE"
+    problems = td.compare_to_baseline(now, _base(a=10))
+    assert len(problems) == 1
+    assert "INEFFECTIVE" in problems[0]
+    assert "DISCRIMINATION LOST" not in problems[0]
+
+
+def test_a_deleted_mutation_is_caught(td):
+    """Deleting a mutation must not be a way to make a red ratchet go green."""
+    problems = td.compare_to_baseline({}, _base(a=10))
+    assert len(problems) == 1
+    assert "DISAPPEARED" in problems[0]
+
+
+def test_a_new_mutation_is_caught(td):
+    problems = td.compare_to_baseline(_now(a=10, b=3), _base(a=10))
+    assert len(problems) == 1
+    assert "NEW mutation" in problems[0]
+
+
+def test_an_uncovered_convention_holding_at_zero_is_not_a_regression(td):
+    """UNCOVERED is a finding, but a stable one must not fail every run."""
+    now = _now(a=0)
+    now["a"]["status"] = "UNCOVERED"
+    base = _base(a=0)
+    base["mutations"]["a"]["status"] = "UNCOVERED"
+    assert td.compare_to_baseline(now, base) == []
+
+
+# ---------------------------------------------------------------------------
+# The baseline that ships
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_baseline_covers_every_declared_mutation(td):
+    baseline = json.loads(_BASELINE.read_text())["mutations"]
+    assert set(baseline) == {m.name for m in td.MUTATIONS}, (
+        "scripts/discrimination_baseline.json is out of sync with MUTATIONS; regenerate with --write-baseline"
+    )
+
+
+def test_shipped_baseline_records_where_it_was_measured(td):
+    """A count with no provenance cannot be re-derived, and rots without saying so."""
+    assert json.loads(_BASELINE.read_text()).get("_measured_at")
+
+
+# ---------------------------------------------------------------------------
+# The mutation anchors -- literal source text, so they rot when the source moves
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("index", range(6))
+def test_every_mutation_anchor_still_matches_exactly_once(td, index):
+    """A silently unapplied mutation reports zero kills and reads as total blindness.
+
+    `apply_mutation` raises on a miss, but only when the sweep is run -- which is
+    weekly. This surfaces the rot on the next commit instead.
+    """
+    mut = td.MUTATIONS[index]
+    source = (_SCRIPT.parents[1] / mut.path).read_text()
+    assert source.count(mut.old) == 1, (
+        f"mutation {mut.name!r}: anchor matches {source.count(mut.old)} times in {mut.path}, "
+        f"expected exactly 1. The source moved; update the mutation."
+    )
+
+
+def test_the_mutation_list_matches_the_parametrisation(td):
+    """The parametrize range above is a literal; this is what notices when it drifts."""
+    assert len(td.MUTATIONS) == 6
+
+
+def test_every_mutation_changes_something(td):
+    for mut in td.MUTATIONS:
+        assert mut.old != mut.new, f"{mut.name}: old and new are identical"
+
+
+def test_every_mutation_declares_a_verify_expression(td):
+    """Without it there is no way to tell a live mutation from an unapplied one."""
+    for mut in td.MUTATIONS:
+        assert mut.verify.strip(), f"{mut.name}: empty verify"


### PR DESCRIPTION
Refs #1701, #1715. Filed from the same sweep: #1736.

## Why

#1715 measured two agreement tests as inert under a 2x diffusion mutation and left
"the prevalence across the remaining 49" open. #1701 asks for discrimination on
load-bearing paths rather than line coverage. Both need one instrument.

## The sweep

Six single-site mutations, each to a convention CLAUDE.md names as single-sourced.
Whole suite per mutation, 5,665 collected under the CI marker set, ~26 minutes.

| mutation | convention | killed |
|---|---|---:|
| `diffusion_scalar_2x` | `D = sigma^2/2`, scalar (#811) | 129 |
| `optimal_control_sign` | `alpha* = -sign*p/lambda` (#1649) | 34 |
| `drift_coefficient_2x` | `c = 1/control_cost` (#1420) | 19 |
| `diffusion_field_2x` | `D = sigma^2/2`, elementwise (#811) | 5 |
| `bc_noflux_reads_as_clamp` | `no_flux -> reflect` (#1698) | 5 |
| `bc_default_reads_as_reflect` | absent BC `-> clamp` (#1698) | **0 — UNCOVERED** |

**184 of 5,665 (3.2%)** notice any of the six. 176 notice exactly one; 8 notice two.

## What #1715 asked for

Both tests it named are reproduced as still inert, in the run that killed 129 others.
The prevalence, by behaviour:

- 308 agreement-shaped names → **193 (63%) inert**
- the 65 whose names claim `single_source` / `cross_path` / `_agree` → **39 (60%) inert**

Named instances include `test_hamiltonian_single_source_1071::test_granular_primitives_byte_identical_to_inline`
and all four parametrisations of `test_coupled_equals_drift_byte_identical`. Exactly the
mechanism #1715 describes: both compared paths route through the mutated owner.

Qualification stated in the code and the issue comment: inert is not worthless. Six
conventions are one slice, and a BC-parsing test should not die under a diffusion
mutation. The number is meaningful for the 65, because those claim to notice exactly
this kind of change.

## A convention nothing watches

`bc_type_to_geometric_operation(None) -> "clamp"` — the absorbing-vs-reflecting fallback
for an undeclared boundary — is noticed by **no test in the suite**. Filed as #1736.

## Three design decisions, each forced by a measured failure

**The control sits on whether the mutation took effect, not on a named test that must
die.** The first version used `must_kill` and I guessed the test paths. Result: four
mutations killing 113, 17, 5 and 5 tests were all reported INEFFECTIVE because the file
was `test_diffusion_from_volatility.py`, not `test_pde_coefficients.py` — while the one
genuinely uncovered convention looked identical to them. The real finding was
indistinguishable from four false alarms. `verify` is now evaluated against the mutated
tree in a fresh interpreter, giving three outcomes instead of two. All six are checked
both ways: false on a clean tree, true under the mutation.

**#1677 is handled, or the whole run is silently inert.** An editable install pins
imports to the main checkout, so mutating a copy or a worktree can leave the original
module imported — every mutation reports zero kills and the run reads as "nothing
discriminates", which looks entirely plausible. The script mutates the main checkout in
place, restores from a pristine copy under `try/finally`, refuses to start with modified
tracked files, and asserts before running that `mfgarchon.__file__` is the tree it is
about to mutate.

**The ratchet is on counts, not names.** This population cannot be selected by name:
the same tree gives 51, 114 or 156 agreement-shaped tests depending on the regex, and
60% of the ones whose names claim cross-path agreement notice nothing. A named-set
ratchet would drop when someone renames a test.

## Ratchet and schedule

`scripts/discrimination_baseline.json` records per-mutation kill counts, failing in both
directions — a drop is discrimination lost, a rise must be recorded in the same change,
for the same reason the capability baseline is bidirectional.

Weekly rather than nightly (`.github/workflows/discrimination.yml`): seven full-suite
runs, and the quantity moves on the timescale of a campaign. Same de-duplicating failure
notifier as `nightly.yml`.

## Verification

21 pinning tests, including one per mutation asserting its literal source anchor still
matches exactly once — `apply_mutation` already raises on a miss, but only when the
sweep runs, which is weekly; this surfaces the rot on the next commit.

The shipped baseline was round-tripped: a full `--check-baseline` run against the
committed tree.

## The round-trip caught the instrument contaminating itself

The shipped baseline was verified by a full `--check-baseline` run. It came back with
every mutation gaining **exactly +1**:

```
bc_default_reads_as_reflect:   0 -> 1    diffusion_scalar_2x:  129 -> 130
bc_noflux_reads_as_clamp:      5 -> 6    drift_coefficient_2x:  19 -> 20
diffusion_field_2x:            5 -> 6    optimal_control_sign:  34 -> 35
```

Six unrelated conventions improving by the same amount is not improvement. Cause:
`test_every_mutation_anchor_still_matches_exactly_once` reads the source and asserts
each anchor matches once — under a mutation it does not, which is the point of the
test, so it fails under every mutation. The instrument was inside its own population.

The damage is the last row. `bc_default_reads_as_reflect` is the one UNCOVERED
convention, and a self-referential +1 reads as "one test covers it now" — the harness
deleting the finding that #1736 exists for, while the other five moved just enough to
look like a real gain.

Fixed by `--ignore`-ing the harness's own test file, pinned by a test. Re-verified:
`Discrimination matches baseline (6 mutations)`, exit 0, counts back to
129/5/19/34/5/**0**.

Two things had to hold for this to surface: the round-trip was actually run rather than
assumed from the same data that produced the baseline, and six numbers moved together.
A single mutation would have shown `129 -> 130` and read as flake.



---

# Review round

One reviewer, MERGE-OK, ten findings — all verified locally before acting, all fixed in
`c115fecc`. The three that mattered:

**The fix for the self-contamination was itself unpinned.** `25b09c44` added the
`--ignore`; its test asserted the *constant* and not the *wiring*, so deleting the
argument left all 19 pins green and the +1 — including the one that erases #1736 —
could return silently. The repo's own rule ("the pinning test must FAIL when the fix is
reverted"), broken by the commit citing it. Now monkeypatches `subprocess.run`; verified
red on the same deletion.

**A pytest that ran nothing read as six findings.** `Run.returncode` was recorded and
never read, and pytest exits 5 on "no tests collected" with an *empty* failed set:

```
_pytest(["tests/nope"]) -> rc=5  collected=0  failed=set()
baseline gate `if base.failed:` -> clean
```

So a `--paths` typo produced a clean baseline and then six `UNCOVERED` lines under the
banner "These are findings, not harness faults" — the exact ambiguity the three-way
verdict removes, through the door `verify` does not watch. `verify` proves the
*mutation* took effect; nothing proved *pytest ran*. Now gated on returncode, on a
non-empty population, and on the collected count not shrinking.

**`timeout-minutes: 180`** sat beside a comment saying "~26 min locally, a runner is ~7x
slower". 26×7 = 182. Now 300.

Also: the population claims were unrecoverable because neither the kill matrix nor the
selection regex was committed — the shape of claim this campaign exists to stop
shipping. Both are now in `scripts/discrimination_killmatrix.json` and all four numbers
re-derive exactly. `_measured_at` went from a bare sha to structured provenance, since a
baseline written under `--paths tests/unit` was otherwise indistinguishable from one
over the whole tree. A dead `tempfile.mkdtemp()` was removed along with three separate
claims that it was the restore mechanism. And #1736 was corrected: the assertion it asks
for already exists in `bc_utils.py:222-224`, in an uncollected `__main__` block — the
measurement was right, the conclusion I drew from it was not.

**Final verification:** `Discrimination matches baseline (6 mutations)`, exit 0, counts
129/5/19/34/5/**0** — the UNCOVERED finding intact. Working tree restored and verified
clean. Full local gate GATE GREEN.
