### PR TITLE
Give the capability matrix a second dimension

### DIFF
--- a/changelog.d/capability-2d-cells.added.md
+++ b/changelog.d/capability-2d-cells.added.md
@@ -1,0 +1,6 @@
+- **Four 2-D capability cells** (`scripts/capability_matrix.py`, Refs #1745) — every cell
+  was 1-D, so a scheme could conserve mass to 2.2e-16 in one dimension and not run at all
+  in two with the matrix silent. `SL_LINEAR` passes in 2-D; `FDM_UPWIND`, `FDM_CENTERED`
+  and `FVM_MUSCL` all raise the same `ConvergenceError` from the `HJBFDMSolver` they share.
+  UNSUPPORTED goes 3 → 6, and a test pins that any scheme with a 1-D mass cell has a 2-D
+  sibling.

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -8,6 +8,13 @@
       },
       "status": "UNSUPPORTED"
     },
+    "fdm_centered_2d/mass_conservation": {
+      "artifact": {
+        "exception": "ConvergenceError",
+        "message": "newton solver failed to converge after 30 iterations (residual: 2.42e-01)"
+      },
+      "status": "UNSUPPORTED"
+    },
     "fdm_upwind/mass_conservation": {
       "artifact": {
         "all_finite": true,
@@ -19,6 +26,13 @@
       },
       "status": "PASS"
     },
+    "fdm_upwind_2d/mass_conservation": {
+      "artifact": {
+        "exception": "ConvergenceError",
+        "message": "newton solver failed to converge after 30 iterations (residual: 2.42e-01)"
+      },
+      "status": "UNSUPPORTED"
+    },
     "fvm_muscl/mass_conservation": {
       "artifact": {
         "all_finite": true,
@@ -28,6 +42,13 @@
         "tolerance": 1e-06
       },
       "status": "PASS"
+    },
+    "fvm_muscl_2d/mass_conservation": {
+      "artifact": {
+        "exception": "ConvergenceError",
+        "message": "newton solver failed to converge after 30 iterations (residual: 2.42e-01)"
+      },
+      "status": "UNSUPPORTED"
     },
     "fvm_vs_fdm/agreement": {
       "artifact": {
@@ -62,6 +83,16 @@
         "max_drift": 4.440892098500626e-16,
         "min_density": 0.00466345594426523,
         "tolerance": 1.0000000000000003e-09
+      },
+      "status": "PASS"
+    },
+    "sl_linear_2d/mass_conservation": {
+      "artifact": {
+        "all_finite": true,
+        "mass_t0": 1.2100000000000002,
+        "max_rel_drift": 3.670158759091426e-16,
+        "min_density": 3.5346848535299638e-06,
+        "tolerance": 1e-09
       },
       "status": "PASS"
     }

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -120,6 +120,38 @@ def _smoke_problem():
     )
 
 
+def _smoke_problem_2d():
+    """The 1-D smoke fixture lifted to 2-D, unchanged in everything but dimension.
+
+    Deliberately the same Gaussian, the same no-flux boundaries, the same coupling: a
+    cell that differs from its 1-D sibling only in dimension is what makes "works in
+    1-D, not in 2-D" readable off the matrix. 11x11 and 6 steps keep it near a second.
+    """
+    from mfgarchon import MFGProblem
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[11, 11], boundary_conditions=no_flux_bc(dimension=2)
+        ),
+        Nt=6,
+        T=0.2,
+        sigma=0.4,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-30 * np.sum((np.asarray(x) - 0.5) ** 2, axis=-1)),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
 def _lq_problem_1d():
     """The tests/integration/test_fvm_hjb_coupling.py 1-D LQ fixture."""
     from mfgarchon import MFGProblem
@@ -259,6 +291,42 @@ def _mass_conservation_cell(scheme_name: str):
             return ("PASS" if ok else "FAIL"), art
 
         return _measure("mass drift", verdict)
+
+    return run
+
+
+def _mass_conservation_2d_cell(scheme_name: str):
+    """Same oracle as the 1-D cell, in 2-D (#1745).
+
+    Every cell in this file was 1-D until now, so a scheme could conserve mass to
+    2.2e-16 in one dimension and not run at all in two with the matrix reporting
+    nothing. Measured when these were added: SL_LINEAR passes at 3.67e-16 while
+    FDM_UPWIND, FDM_CENTERED and FVM_MUSCL all raise the same ConvergenceError from
+    the same Newton solve -- they share `HJBFDMSolver`, and SL_LINEAR does not. One
+    defect, three dead schemes.
+    """
+
+    def run():
+        from mfgarchon.types import NumericalScheme
+
+        problem = _construct("2-D smoke problem", _smoke_problem_2d)
+        result = problem.solve(scheme=getattr(NumericalScheme, scheme_name), max_iterations=3, verbose=False)
+
+        def verdict():
+            M = _apply_mutation(np.asarray(result.M, dtype=float))
+            dv = (1.0 / 10) ** 2  # 11 points per axis on the unit square
+            mass = M.reshape(M.shape[0], -1).sum(axis=1) * dv
+            art = {
+                "mass_t0": float(mass[0]),
+                "max_rel_drift": float(np.abs(mass - mass[0]).max() / abs(mass[0])),
+                "min_density": float(M.min()),
+                "all_finite": bool(np.isfinite(M).all()),
+                "tolerance": 1e-9,
+            }
+            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-9
+            return ("PASS" if ok else "FAIL"), art
+
+        return _measure("2-D mass drift", verdict)
 
     return run
 
@@ -476,6 +544,10 @@ CELLS = {
     "fdm_centered/mass_conservation": _mass_conservation_cell("FDM_CENTERED"),
     "fvm_muscl/mass_conservation": _fvm_mass_cell(),
     "fvm_vs_fdm/agreement": _fvm_fdm_agreement_cell(),
+    "sl_linear_2d/mass_conservation": _mass_conservation_2d_cell("SL_LINEAR"),
+    "fdm_upwind_2d/mass_conservation": _mass_conservation_2d_cell("FDM_UPWIND"),
+    "fdm_centered_2d/mass_conservation": _mass_conservation_2d_cell("FDM_CENTERED"),
+    "fvm_muscl_2d/mass_conservation": _mass_conservation_2d_cell("FVM_MUSCL"),
     "regime_switching/non_negativity": _regime_switching_cell(),
     "gfdm_rbf/construction": _gfdm_rbf_cell(),
 }
@@ -492,6 +564,10 @@ MASS_ORACLE_CELLS = {
     "fvm_muscl/mass_conservation",
     "fvm_vs_fdm/agreement",
     "regime_switching/non_negativity",
+    "sl_linear_2d/mass_conservation",
+    "fdm_upwind_2d/mass_conservation",
+    "fdm_centered_2d/mass_conservation",
+    "fvm_muscl_2d/mass_conservation",
 }
 
 

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -97,6 +97,18 @@ def test_shipped_baseline_covers_every_declared_cell(cm):
     )
 
 
+def test_every_scheme_with_a_1d_cell_has_a_2d_cell(cm):
+    """The gap #1745 exposed: every cell was 1-D, so a scheme could conserve mass to
+    2.2e-16 in one dimension and not run at all in two with the matrix silent.
+
+    Pinned as a rule rather than a list: a new scheme cell arriving in 1-D only
+    reopens exactly that hole.
+    """
+    one_d = {c.split("/")[0] for c in cm.CELLS if "/mass_conservation" in c and not c.endswith("_2d/mass_conservation")}
+    two_d = {c.split("/")[0].removesuffix("_2d") for c in cm.CELLS if c.endswith("_2d/mass_conservation")}
+    assert one_d <= two_d, f"schemes with a 1-D mass cell and no 2-D sibling: {sorted(one_d - two_d)}"
+
+
 def test_every_mass_oracle_cell_is_a_declared_cell(cm):
     assert set(cm.CELLS) >= cm.MASS_ORACLE_CELLS
 
@@ -117,6 +129,10 @@ def test_currently_failing_density_cells_are_still_registered_for_the_self_test(
         "fvm_muscl/mass_conservation",
         "fvm_vs_fdm/agreement",
         "regime_switching/non_negativity",
+        "sl_linear_2d/mass_conservation",
+        "fdm_upwind_2d/mass_conservation",
+        "fdm_centered_2d/mass_conservation",
+        "fvm_muscl_2d/mass_conservation",
     }
     assert density_cells <= cm.MASS_ORACLE_CELLS, (
         f"unregistered density cells: {sorted(density_cells - cm.MASS_ORACLE_CELLS)}"


### PR DESCRIPTION
Refs #1745, #1706.

Every cell in the capability matrix was 1-D. A scheme could conserve mass to 2.2e-16 in
one dimension and not run at all in two, and the matrix would report nothing — which is
exactly what had happened, discovered only because #1716's deletion pass turned up a
nine-month-old note about 2-D mass loss.

```
sl_linear_2d/mass_conservation     PASS          rel drift 3.670e-16   0.17s
fdm_upwind_2d/mass_conservation    UNSUPPORTED   ConvergenceError      1.11s
fdm_centered_2d/mass_conservation  UNSUPPORTED   ConvergenceError      1.10s
fvm_muscl_2d/mass_conservation     UNSUPPORTED   ConvergenceError      1.10s
```

**PASS 4 → 5, UNSUPPORTED 3 → 6.** Cost +3.5 s on a 41 s matrix.

The 2-D fixture differs from the 1-D smoke problem in dimension and nothing else — same
Gaussian, same no-flux boundaries, same coupling — because "works in 1-D, not in 2-D" is
only readable off the matrix if that is the only difference.

## What the cells localised immediately

```
FDM_UPWIND     HJB=HJBFDMSolver            ConvergenceError
FDM_CENTERED   HJB=HJBFDMSolver            ConvergenceError
FVM_MUSCL      HJB=HJBFDMSolver            ConvergenceError
SL_LINEAR      HJB=HJBSemiLagrangianSolver PASS
```

Same residual in all three, same HJB owner; the one that passes has a different one.
**One defect, three dead schemes** — not "2-D FDM is broken", which is how #1745 was
first written.

And it is a **stall, not slow convergence**:

```
30 iterations   residual 2.42e-01
300 iterations  residual 1.94e-01     10x the budget, 20% of the residual
damping 0.5     residual 1.94e-01     no effect
```

So the Newton step is not a descent direction and the Jacobian does not match the
residual. That answers a design question raised while doing this — whether the fix is
more advanced Newton-family algorithms. It is not: a trust region, Newton–Krylov or
continuation would all be built on the same Jacobian and stall at the same plateau.
Better globalisation rescues "J is right, the problem is hard", not "J is wrong". The
next diagnostic is directional FD vs analytic J **by row class**, and since 1-D converges
to 2.2e-16 with the same assembly, the row classes that exist only in 2-D — edges and
corners — are where to look. Recorded on #1745.

Three boundary types all fail (`no_flux`, `periodic`, `dirichlet`), which distinguishes
this from #1118 where the stall was a no-flux row.

## On growing a matrix I said should not grow

Adding cells is a deliberate exception. The rule is that it must not grow **with the
library** — a cell per solver turns it back into the noise it exists to replace. A whole
dimension being unwatched is a different thing.

`test_every_scheme_with_a_1d_cell_has_a_2d_cell` pins the parity as a **rule rather than a
list**, so a new scheme arriving in 1-D only reopens exactly the hole this closes.
Verified red by deleting one 2-D cell.

Self-test still green on all five exercisable mass-oracle cells. Full local gate GATE
GREEN (exit code checked).