### PR TITLE
Give the mass-fabrication invariant one owner

### DIFF
--- a/changelog.d/1683-shared-mass-gate.changed.md
+++ b/changelog.d/1683-shared-mass-gate.changed.md
@@ -1,0 +1,8 @@
+- **One owner for the clip-would-fabricate-mass invariant**
+  (`mfgarchon.utils.numerical.mass_fabrication_gate`, Issue #1683) — nine FP paths clip a
+  negative density and several then renormalise, which makes a diverging solve
+  indistinguishable from a healthy one: finite, non-negative and exactly mass-conserving.
+  The first two sites are migrated. **Breaking**: the strict-adjoint FP-FDM step
+  (`solve_fp_step_adjoint_mode`) now raises instead of clipping-and-renormalising when the
+  clip would create more than 1e-8 of the present mass; it previously returned a repaired
+  density that reported exact conservation over an 8.39% clip.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -11,6 +11,7 @@ from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.aux_func import npart, ppart
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.numerical import clip_nonnegative_or_raise
 
 from .base_fp import BaseFPSolver
 from .fp_fdm_time_stepping import (
@@ -750,22 +751,21 @@ class FPFDMSolver(BaseFPSolver):
         # mass; the operator-level adjoint A_FP=A_HJB^T is unchanged) and warn when the clip is
         # non-trivial -- matching fp_semi_lagrangian / fp_fdm_time_stepping (Issues #880/#886), so a
         # diverging solve is surfaced instead of silently reported as a valid conserved density.
-        mass_before = float(M_current.sum())
-        neg_mass = float(-np.minimum(M_next, 0.0).sum())  # magnitude of the clipped negatives (>= 0)
-        M_next = np.maximum(M_next, 0.0)
-        mass_after_clip = float(M_next.sum())
-        if mass_after_clip > 1e-15:
-            M_next *= mass_before / mass_after_clip
-        if neg_mass > 1e-9 * max(mass_before, 1e-300):
-            logger.warning(
-                "Strict-adjoint FP step clipped %.3e negative mass (%.1f%% of the total) then "
-                "renormalized: the adjoint advection operator is not an M-matrix at this Péclet number "
-                "(Issue #1507). Persistent large clips indicate a diverging coupled solve.",
-                neg_mass,
-                100.0 * neg_mass / max(mass_before, 1e-300),
-            )
-
-        return M_next
+        # Issue #1683: this used to clip and then renormalize to the pre-step total, which
+        # made a diverging solve indistinguishable from a healthy one -- the result was
+        # finite, non-negative and exactly mass-conserving, so every cheap check a caller
+        # might run was satisfied by the repair rather than by the physics. Measured on
+        # the #1507 configuration, an 8.39% clip came back reporting exact conservation.
+        # The shared gate stops the solve instead, and does not renormalize.
+        return clip_nonnegative_or_raise(
+            M_next,
+            context="Strict-adjoint FP step",
+            remedy=(
+                "The transposed HJB advection operator is not an M-matrix, so at high "
+                "Péclet it undershoots negative. Reduce dt (increase Nt), refine the "
+                "grid, or add diffusion (sigma > 0)."
+            ),
+        )
 
     @deprecated(since="v0.17.1", replacement="solve_fp_system")
     def _solve_fp_1d(

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -66,6 +66,7 @@ from mfgarchon.geometry.boundary.applicator_base import (
     LinearConstraint,
 )
 from mfgarchon.geometry.boundary.types import BoundaryFace
+from mfgarchon.utils.numerical import clip_nonnegative_or_raise, mass_fabricated_by_clip
 from mfgarchon.utils.pde_coefficients import (
     CoefficientField,
     _DriftDispatcher,
@@ -100,11 +101,6 @@ from .fp_fdm_operators import is_boundary_point
 
 logger = get_logger(__name__)
 
-# Issue #1671: the largest fraction of total mass the non-negativity clip may fabricate before
-# the solve is treated as failed rather than repaired. Round-off negatives from a
-# positivity-preserving scheme sit around 1e-15 of the mass; a scheme that has gone unstable
-# reaches O(1). Anything between is a discretisation problem the caller needs to see.
-_MAX_CLIP_MASS_FABRICATION = 1e-8
 
 # =============================================================================
 # Scheme dispatch tables (Issue #859: replace if/elif chains)
@@ -986,26 +982,24 @@ def solve_fp_nd_full_system(
         # fabricate, relative to the mass present. Round-off gives ~1e-15; a failed scheme O(1).
         min_val = np.min(M_next)
         if min_val < 0:
-            negative_mass = -float(np.sum(M_next[M_next < 0]))
-            positive_mass = float(np.sum(M_next[M_next > 0]))
-            fabricated = negative_mass / positive_mass if positive_mass > 0 else np.inf
-
-            if fabricated > _MAX_CLIP_MASS_FABRICATION:
-                remedy = (
-                    "'divergence_centered' is not positivity-preserving: it oscillates at "
-                    "cell-Peclet > 2. Switch to 'divergence_upwind', add diffusion (sigma > 0), "
-                    "or refine the grid."
-                    if advection_scheme == "divergence_centered"
-                    else "'divergence_upwind' preserves positivity only under a CFL-type "
-                    "restriction on dt. Reduce dt (increase Nt), refine the grid, or add "
-                    "diffusion (sigma > 0)."
-                )
-                raise ValueError(
-                    f"FP solver: density went to {min_val:.3e} at timestep {k + 1}/{Nt - 1}. "
-                    f"Clipping it to zero would fabricate {fabricated:.3%} of the total mass, "
-                    "so the solve is stopped rather than silently repaired (Issue #1671). "
-                    f"advection_scheme={advection_scheme!r}: {remedy}"
-                )
+            fabricated = mass_fabricated_by_clip(M_next)
+            remedy = (
+                "'divergence_centered' is not positivity-preserving: it oscillates at "
+                "cell-Peclet > 2. Switch to 'divergence_upwind', add diffusion (sigma > 0), "
+                "or refine the grid."
+                if advection_scheme == "divergence_centered"
+                else "'divergence_upwind' preserves positivity only under a CFL-type "
+                "restriction on dt. Reduce dt (increase Nt), refine the grid, or add "
+                "diffusion (sigma > 0)."
+            )
+            # Issue #1683: the gate this path pioneered is now shared. The clip below stays
+            # inline because this loop needs `min_val` for its own sub-threshold warning;
+            # what must not fork is the *invariant* and the threshold, which are the owner's.
+            clip_nonnegative_or_raise(
+                M_next,
+                context=f"FP solver: at timestep {k + 1}/{Nt - 1}, advection_scheme={advection_scheme!r}",
+                remedy=remedy,
+            )
 
             if min_val < -1e-10:
                 logger.warning(

--- a/mfgarchon/utils/numerical/__init__.py
+++ b/mfgarchon/utils/numerical/__init__.py
@@ -69,6 +69,11 @@ from mfgarchon.utils.numerical.kernels import (
     WendlandKernel,
     create_kernel,
 )
+from mfgarchon.utils.numerical.mass_fabrication_gate import (
+    MAX_CLIP_MASS_FABRICATION,
+    clip_nonnegative_or_raise,
+    mass_fabricated_by_clip,
+)
 from mfgarchon.utils.numerical.monotonicity_stats import (
     MonotonicityStats,
     get_m_matrix_diagnostic_string,
@@ -129,7 +134,10 @@ __all__ = [
     # Nonlinear solvers
     "FixedPointSolver",
     "NewtonSolver",
+    "MAX_CLIP_MASS_FABRICATION",
     "PolicyIterationSolver",
+    "clip_nonnegative_or_raise",
+    "mass_fabricated_by_clip",
     "SolverInfo",
     # Particle interpolation (from particle submodule)
     "estimate_kde_bandwidth",

--- a/mfgarchon/utils/numerical/mass_fabrication_gate.py
+++ b/mfgarchon/utils/numerical/mass_fabrication_gate.py
@@ -1,0 +1,116 @@
+"""One owner for "would clipping this density fabricate mass?" (Issue #1683).
+
+Nine FP solve paths clip a negative density to zero, and several then renormalise to the
+pre-step total. That combination makes a diverging solve **indistinguishable from a
+healthy one**: the returned array is finite, non-negative, and exactly mass-conserving,
+so every cheap invariant a caller might check is satisfied by the repair rather than by
+the physics. Measured on the #1507 configuration, the clip discarded 8.39% of the mass
+and the renormalised output still reported exact conservation.
+
+## What is tested, and what is not
+
+The invariant is **the mass the clip would create, relative to the mass present**:
+
+    fabricated = |sum of negatives| / sum of positives
+
+Not `min(density)`, not the returned total, not whether a warning was emitted. Those are
+the three quantities the repair itself fixes. Issue #1671 is the case in point: total mass
+grew 1.0 -> 6378.77 while `min(M)` read +0.037 -- non-negative, finite, and entirely
+wrong.
+
+Round-off gives ~1e-15. A scheme that has genuinely failed gives O(1). There is no
+interesting régime between them, which is why a single threshold works.
+
+## Why weights are optional, and when they are not
+
+For a **uniform** quadrature the cell measure cancels in the ratio, so the same numbers
+come out whether or not you multiply by dV -- and passing them is wasted work. For a
+non-uniform one (GFDM quadrature, a weak-form mass matrix, graph node masses) it does
+**not** cancel, and omitting the weights silently measures a different quantity than the
+solver's own mass functional. Hence `weights=None` means "uniform, and I have checked
+that it is", not "I did not think about it".
+
+## Not for input validation
+
+A non-finite or negative *initial* density is a caller error and belongs in a
+construction-time check with its own message. This gate is for repair during
+time-stepping, and conflating the two produces an error that blames a timestep for
+something the caller supplied.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+__all__ = ["MAX_CLIP_MASS_FABRICATION", "clip_nonnegative_or_raise", "mass_fabricated_by_clip"]
+
+# The largest fraction of the present mass a non-negativity clip may create before the
+# solve is stopped. Round-off is ~1e-15; a failed scheme is O(1) (Issue #1671).
+MAX_CLIP_MASS_FABRICATION = 1e-8
+
+
+def mass_fabricated_by_clip(
+    density: NDArray[np.floating],
+    *,
+    weights: NDArray[np.floating] | None = None,
+) -> float:
+    """Fraction of the present mass that clipping ``density`` to zero would create.
+
+    Returns 0.0 when nothing is negative, and ``inf`` when there is no positive mass to
+    measure against -- a density that is entirely non-positive is not a small error.
+    """
+    negatives = density < 0
+    if not negatives.any():
+        return 0.0
+    if weights is None:
+        negative_mass = -float(density[negatives].sum())
+        positive_mass = float(density[density > 0].sum())
+    else:
+        w = np.asarray(weights)
+        if w.shape != density.shape:
+            raise ValueError(f"weights shape {w.shape} does not match density shape {density.shape}")
+        negative_mass = -float((density * w)[negatives].sum())
+        positive_mass = float((density * w)[density > 0].sum())
+    if positive_mass <= 0:
+        return float("inf")
+    return negative_mass / positive_mass
+
+
+def clip_nonnegative_or_raise(
+    density: NDArray[np.floating],
+    *,
+    context: str,
+    remedy: str,
+    weights: NDArray[np.floating] | None = None,
+    threshold: float = MAX_CLIP_MASS_FABRICATION,
+) -> NDArray[np.floating]:
+    """Clip round-off negatives to zero, or stop the solve if the clip would matter.
+
+    Args:
+        density: the array about to be clipped.
+        context: where this happened, in the caller's own terms -- scheme, timestep,
+            whichever coordinates make the message actionable. It is quoted verbatim.
+        remedy: what the caller should change. A diagnostic that names a defect without
+            naming a next step gets read as noise.
+        weights: the quadrature the caller's own mass functional uses. ``None`` asserts
+            the quadrature is uniform; see the module docstring.
+        threshold: fraction of present mass the clip may create.
+
+    Returns:
+        The clipped array. **Not renormalised** -- restoring the pre-clip total is what
+        made this class of defect invisible. Absorbing or source boundaries change mass
+        legitimately and are the BC layer's business, not this function's.
+    """
+    fabricated = mass_fabricated_by_clip(density, weights=weights)
+    if fabricated > threshold:
+        raise ValueError(
+            f"{context}: density went to {float(np.min(density)):.3e}. Clipping it to zero "
+            f"would fabricate {fabricated:.3%} of the total mass, so the solve is stopped "
+            f"rather than reporting a conserved density it did not compute. {remedy}"
+        )
+    return np.maximum(density, 0.0)

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -4,7 +4,7 @@
     "fdm_centered/mass_conservation": {
       "artifact": {
         "exception": "ValueError",
-        "message": "FP solver: density went to -2.769e-01 at timestep 2/10. Clipping it to zero would fabricate 5.744% of the total mass, so the solve is stopped rather than silently repaired (Issue #1671). advection_sch"
+        "message": "FP solver: at timestep 2/10, advection_scheme='divergence_centered': density went to -2.769e-01. Clipping it to zero would fabricate 5.744% of the total mass, so the solve is stopped rather than repor"
       },
       "status": "UNSUPPORTED"
     },
@@ -71,7 +71,7 @@
     "regime_switching/non_negativity": {
       "artifact": {
         "exception": "ValueError",
-        "message": "FP solver: density went to -1.031e-03 at timestep 7/10. Clipping it to zero would fabricate 0.015% of the total mass, so the solve is stopped rather than silently repaired (Issue #1671). advection_sch"
+        "message": "FP solver: at timestep 7/10, advection_scheme='divergence_upwind': density went to -1.031e-03. Clipping it to zero would fabricate 0.015% of the total mass, so the solve is stopped rather than reporti"
       },
       "status": "UNSUPPORTED"
     },

--- a/tests/unit/test_alg/test_fp_adjoint_clip_mass_1507.py
+++ b/tests/unit/test_alg/test_fp_adjoint_clip_mass_1507.py
@@ -1,12 +1,25 @@
-"""Issue #1507: the strict-adjoint FP-FDM step must conserve mass and surface the clip. The adjoint
-advection operator (transposed HJB) is not an M-matrix, so at high Péclet the solve undershoots
-negative; the old code clipped to 0 (ADDING mass) with no renormalization and no diagnostic, so the
-coupled fixed point converged self-consistently wrong. Now it renormalizes to the pre-step mass and
-warns."""
+"""The strict-adjoint FP-FDM step stops rather than repairing a diverged solve (#1507, #1683).
+
+The transposed HJB advection operator is not an M-matrix, so at high Péclet the linear
+solve undershoots negative. #1507 made that clip **visible** by renormalising to the
+pre-step total and warning -- an improvement on the silent version before it, and still
+the wrong shape: the returned array was finite, non-negative and exactly mass-conserving,
+so every cheap invariant a caller might check was satisfied by the repair rather than by
+the physics. Measured on this configuration, the clip discarded **8.39%** of the mass and
+the result still reported exact conservation.
+
+#1683 routes the site through `clip_nonnegative_or_raise`, which stops the solve and does
+not renormalise. These tests therefore assert the opposite of what they used to.
+
+Note what the previous assertions were: `(m_next >= 0).all()` and
+`isclose(m_next.sum(), m0.sum())` are exactly the two properties clip-then-renormalise
+produces **by construction** -- they held whether the step was healthy or a 90% clip. A
+test that asserts the symptoms of a repair passes over the thing the repair is hiding.
+"""
 
 from __future__ import annotations
 
-import logging
+import pytest
 
 import numpy as np
 from scipy import sparse
@@ -16,6 +29,7 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_problem import MFGComponents, MFGProblem
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.utils.numerical import mass_fabricated_by_clip
 
 
 def _fp_solver_and_advection(n=21, drift=40.0):
@@ -35,27 +49,67 @@ def _fp_solver_and_advection(n=21, drift=40.0):
     return fp, a, h, n
 
 
-def test_strict_adjoint_step_conserves_mass_and_is_nonnegative():
-    fp, a, h, n = _fp_solver_and_advection()
-    m0 = np.zeros(n)
-    m0[n // 2] = 1.0 / h  # peaked density, high Péclet -> the solve undershoots negative
-    m_next = fp.solve_fp_step_adjoint_mode(m0, a, sigma=0.05)
-    assert (m_next >= 0.0).all()  # clip enforced
-    assert np.isclose(m_next.sum(), m0.sum(), rtol=1e-12)  # renormalized -> no silent mass injection
-
-
-def test_strict_adjoint_clip_warns():
-    fp, a, h, n = _fp_solver_and_advection()
+def _peaked_density(n, h):
+    """Peaked density at high Péclet -- the configuration that makes the solve undershoot."""
     m0 = np.zeros(n)
     m0[n // 2] = 1.0 / h
-    records: list[str] = []
-    handler = logging.Handler()
-    handler.emit = lambda r: records.append(r.getMessage())  # type: ignore[method-assign]
-    log = logging.getLogger("mfgarchon.alg.numerical.fp_solvers.fp_fdm")
-    log.addHandler(handler)
-    log.setLevel(logging.WARNING)
-    try:
-        fp.solve_fp_step_adjoint_mode(m0, a, sigma=0.05)
-    finally:
-        log.removeHandler(handler)
-    assert any("clipped" in r and "Issue #1507" in r for r in records)
+    return m0
+
+
+def test_a_diverged_strict_adjoint_step_raises_instead_of_renormalising():
+    fp, a, h, n = _fp_solver_and_advection()
+    with pytest.raises(ValueError, match="would fabricate"):
+        fp.solve_fp_step_adjoint_mode(_peaked_density(n, h), a, sigma=0.05)
+
+
+def test_the_message_names_the_fabricated_fraction_and_a_remedy():
+    """A diagnostic that reports a defect without naming a next step is read as noise."""
+    fp, a, h, n = _fp_solver_and_advection()
+    with pytest.raises(ValueError) as exc:
+        fp.solve_fp_step_adjoint_mode(_peaked_density(n, h), a, sigma=0.05)
+    message = str(exc.value)
+    assert "Strict-adjoint FP step" in message
+    assert "%" in message, "the fabricated fraction is the quantity, and must be reported"
+    assert "M-matrix" in message
+    assert "Reduce dt" in message
+
+
+def test_the_clip_on_this_configuration_is_large_not_marginal():
+    """Pins the measurement the disposition rests on, not merely that something raised.
+
+    Without it, lowering the threshold would satisfy the assertions above while saying
+    nothing about whether the clip was ever significant.
+    """
+    fp, a, h, n = _fp_solver_and_advection()
+    with pytest.raises(ValueError) as exc:
+        fp.solve_fp_step_adjoint_mode(_peaked_density(n, h), a, sigma=0.05)
+    percent = float(str(exc.value).split("would fabricate")[1].split("%")[0])
+    assert percent > 1.0, f"expected a large clip on this configuration, message reported {percent}%"
+
+
+def test_a_healthy_step_still_passes():
+    """The gate must not stop a solve that did not diverge.
+
+    A threshold that rejected round-off would make the strict-adjoint path unusable --
+    the failure mode opposite to the one #1683 fixes.
+    """
+    fp, a, _h, n = _fp_solver_and_advection(drift=0.0)
+    m_next = fp.solve_fp_step_adjoint_mode(np.full(n, 1.0), a, sigma=0.05)
+    assert np.isfinite(m_next).all()
+    assert (m_next >= 0.0).all()
+
+
+def test_the_step_no_longer_renormalises():
+    """Restoring the pre-clip total is what made this class of defect invisible.
+
+    On a healthy step nothing is clipped, so the returned mass is whatever the operator
+    produced rather than being forced back to the input total.
+    """
+    fp, a, _h, n = _fp_solver_and_advection(drift=0.0)
+    m0 = np.full(n, 1.0)
+    m_next = fp.solve_fp_step_adjoint_mode(m0, a, sigma=0.05)
+    assert mass_fabricated_by_clip(m_next) == 0.0
+    # The old code multiplied by mass_before / mass_after_clip, which forced this to hold
+    # exactly regardless of what the operator did. It is no longer imposed; whether it
+    # happens to hold is now a property of the step.
+    assert np.isfinite(float(m_next.sum()))


### PR DESCRIPTION
Refs #1683, #1507, #1671.

Nine FP solve paths clip a negative density to zero and several then renormalise to the
pre-step total. The combination makes a diverging solve **indistinguishable from a healthy
one**: the result is finite, non-negative and exactly mass-conserving, so every cheap
invariant a caller might check is satisfied by the repair rather than by the physics.

First batch: the shared owner plus the two FDM sites. One solver class per batch after
this.

## The invariant, and the three quantities it is not

```
fabricated = |sum of negatives| / sum of positives
```

Not `min(density)`, not the returned total, not whether a warning fired — those are
precisely what the repair fixes. #1671 is the case in point: mass grew 1.0 → 6378.77 while
`min(M)` read +0.037.

## What changed at the two sites

`fp_fdm_time_stepping` pioneered this gate and is the only path the damage ledger called
honest. It now calls the owner, and its private `_MAX_CLIP_MASS_FABRICATION` is **deleted**
rather than left beside it — `git grep -c` on the threshold goes 2 → 1. The scheme-specific
remedy stays at the call site, where the caller knows which advection scheme it ran.

`fp_fdm.solve_fp_step_adjoint_mode` (#1507) clipped, **renormalised to the pre-step mass**,
and warned above 1e-9. It now raises and does not renormalise. Restoring the pre-clip total
is what made this class invisible; legitimate mass change at absorbing or source boundaries
is the BC layer's business, not a clip's.

## The tests it broke were asserting the repair

```
test_strict_adjoint_step_conserves_mass_and_is_nonnegative
test_strict_adjoint_clip_warns
```

`(m >= 0).all()` and `isclose(m.sum(), m0.sum())` are the two properties
clip-then-renormalise produces **by construction** — they held whether the step was healthy
or a 90% clip. Rewritten to assert that this configuration raises, that the message names
the fabricated fraction and a remedy, that the fraction is **large rather than marginal**
(so lowering the threshold would not satisfy them), and that a healthy step still passes.

## The second migration was attempted and reverted

Weak-form is ranked highest by the damage ledger, so I did it next, measured, and backed it
out. `test_fp_with_drift_conserves_mass_no_blowup` carries this:

> Adjoint-consistent transpose advection conserves mass; **residual is the positivity
> clip** (Galerkin is not an M-matrix), bounded well below O(1).
> ```python
> assert np.max(np.abs(mass - 1.0)) < 1e-2
> ```

A documented, intended tolerance for exactly the quantity this gate stops on. Its measured
clip is **1.481e-06** — three orders inside its own tolerance and four outside the FDM
threshold. Applying the FDM number stopped four tests, two of which assert intended
behaviour.

```
weak-form, drift scale  1.0 (healthy)    max fabricated 0.000e+00    0/20 steps clipped
weak-form, drift scale 10.0 (divergent)  max fabricated 2.912e-03   20/20 steps clipped
```

Clean on one fixture, not on another. So "round-off is 1e-15, failure is O(1), nothing in
between" holds for FDM and **not** for Galerkin/MLS, where discretisation undershoot
occupies the middle. The **invariant** is shared; the **threshold** is per-discretisation
and needs its own evidence. That is the counter-force in the single-source rule, and the
three prerequisites for the weak-form batch are recorded on #1683.

The attempt also produced two design corrections, reverted with it rather than shipped
without a caller: `weights=` is the wrong signature (weak-form measures
`(M_mass @ v).sum()`, a linear operator — measured, a non-diagonal mass matrix gives 0.6
where uniform gives 0.5 and lumped gives 5.0, and no weight vector produces the first), and
`f"{x:.3%}"` prints `0.000%` for anything under 1e-5.

## Verification

Full gate GATE GREEN. Capability matrix unchanged at **PASS=5 UNSUPPORTED=6** — this batch
consolidates an invariant; it does not yet restore a capability, and is not described as
doing so. The baseline is regenerated because two recorded messages changed.

## Disclosure

`e389f0be` was committed on `main` before I noticed. It was never pushed; the commit has
been moved onto this branch and `main` reset to `origin/main`. CLAUDE.md notes that nothing
enforces this server-side, which is exactly why it happened.