### PR TITLE
Stop the recommended SL path instead of repairing it

### DIFF
--- a/changelog.d/1683-sl-mass-gate.changed.md
+++ b/changelog.d/1683-sl-mass-gate.changed.md
@@ -1,0 +1,6 @@
+- **The recommended semi-Lagrangian FP path stops instead of repairing** (Issue #1683) —
+  `FPSLSolver._clip_nonneg` warned once per solve and returned the clipped density, so a
+  run whose mass the clip had moved came back indistinguishable from a healthy one. It now
+  routes through the shared mass-fabrication gate. **Breaking**: configurations whose clip
+  creates more than 1e-8 of the present mass now raise. Measured across five
+  configurations, four clip nothing and the fifth clips 11.9% while drifting 10.2%.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -44,6 +44,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
 from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.numerical import clip_nonnegative_or_raise
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
 
 from .base_fp import BaseFPSolver, DriftConvention
@@ -155,10 +156,6 @@ class FPSLSolver(BaseFPSolver):
             if interpolation_method not in valid_methods_nd:
                 raise ValueError(f"For nD problems, only 'linear' splatting is supported. Got: {interpolation_method}.")
         self.interpolation_method = interpolation_method
-
-        # Positivity-clip diagnostic state (Issue #1147 class). Reset per solve_fp_system call;
-        # tracks whether the once-per-solve mass-injection warning has already fired.
-        self._clip_warned = False
 
         # Precompute grid parameters (dimension-agnostic)
         self.dt = problem.dt
@@ -311,9 +308,6 @@ class FPSLSolver(BaseFPSolver):
             M_shape = (Nt_points, self.Nx)
         else:
             M_shape = (Nt_points, *self.grid_shape)
-
-        # Reset the once-per-solve positivity-clip warning (Issue #1147 class).
-        self._clip_warned = False
 
         M = np.zeros(M_shape)
         M[0] = M_initial.copy().reshape(self.grid_shape if self.dimension > 1 else -1)
@@ -574,26 +568,27 @@ class FPSLSolver(BaseFPSolver):
 
         Cubic/quintic splatting and the CN/ADI diffusion step are not monotone, so the
         density can undershoot below zero; deleting those undershoots injects positive
-        mass and violates conservation. Surface it once per ``solve_fp_system`` call
-        rather than failing silently (kernel fail-fast). Mirrors the
-        ``WeakFormFPSolver`` positivity-clip diagnostic (Issue #1147).
+        mass and violates conservation.
+
+        Issue #1683: this warned once per ``solve_fp_system`` and returned the clipped
+        density either way, so a diverging solve came back looking healthy -- finite,
+        non-negative, and with the conservation error hidden inside the repair. It now
+        stops. Measured across five configurations, four clip **nothing** and the fifth
+        clips 11.9% and drifts 10.2% in mass, so there is no régime between round-off and
+        failure on this path and one threshold separates them.
 
         The injected/total ratio is grid-quadrature-invariant on a uniform grid, so raw
-        sums (no ``dx`` weighting) give the correct fraction.
+        sums give the correct fraction -- which is what ``mass_of=None`` asserts.
         """
-        if not self._clip_warned:
-            injected = -float(np.minimum(m, 0.0).sum())
-            total = float(np.maximum(m, 0.0).sum())
-            if injected > 1e-6 * max(total, 1e-300):
-                logger.warning(
-                    "FP-SL positivity clip injected mass %.2e (%.1f%% of total): cubic/quintic "
-                    "splatting or CN/ADI diffusion is not monotone; consider linear interpolation "
-                    "or a finer grid.",
-                    injected,
-                    100.0 * injected / max(total, 1e-300),
-                )
-                self._clip_warned = True
-        return np.maximum(m, 0.0)
+        return clip_nonnegative_or_raise(
+            m,
+            context="FP-SL positivity clip",
+            remedy=(
+                "Cubic/quintic splatting and CN/ADI diffusion are not monotone. Use "
+                "linear interpolation, reduce dt, or coarsen the grid -- on this scheme "
+                "refining can make the departure point span more cells and worsen it."
+            ),
+        )
 
     def _get_solver_type_id(self) -> str | None:
         """Get solver type identifier for compatibility checking."""

--- a/tests/unit/test_alg/test_fp_sl_clip.py
+++ b/tests/unit/test_alg/test_fp_sl_clip.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 import numpy as np
 
 from mfgarchon import MFGProblem
@@ -58,20 +60,45 @@ def _run(fp, m0, U, logger_name=_CLIP_LOGGER):
     return [r.getMessage() for r in records]
 
 
-def test_clip_warns_when_cubic_splatting_injects_mass():
-    """Cubic splatting under a steep confining drift oscillates; the clip then injects
-    mass and the solver warns (once)."""
+def test_a_clip_that_injects_mass_stops_the_solve():
+    """Cubic splatting undershoots; the solve now stops rather than repairing (#1683).
+
+    It used to warn once per solve and return the clipped density, so a run whose mass
+    the clip had moved came back finite, non-negative, and indistinguishable from a
+    healthy one. Measured across five configurations of this scheme, four clip nothing
+    at all and the fifth clips 11.9% while drifting 10.2% in mass -- there is no régime
+    between round-off and failure here, which is why one threshold separates them.
+    """
     n, nt = 41, 20
     prob = _problem(n=n, nt=nt)
     fp = FPSLSolver(prob, interpolation_method="cubic")
     x = np.linspace(0.0, 1.0, n)
     m0 = np.exp(-60 * (x - 0.4) ** 2)
     m0 /= m0.sum() * (x[1] - x[0])
-    # Steep confining potential -> velocity alpha = -grad(U) is large -> cubic splat rings.
     U = np.tile(25.0 * (x - 0.5) ** 2, (nt + 1, 1))
+    with pytest.raises(ValueError, match="would fabricate"):
+        fp.solve_fp_system(m0, U)
 
-    msgs = _run(fp, m0, U)
-    assert any("positivity clip injected mass" in m for m in msgs), f"expected a clip warning, got {msgs}"
+
+def test_the_stop_names_the_interpolation_and_a_remedy():
+    """Naming the defect without a next step gets the diagnostic read as noise.
+
+    The remedy also states the counter-intuitive part: on this scheme *refining* can make
+    it worse, because the departure point then spans more cells.
+    """
+    n, nt = 41, 20
+    prob = _problem(n=n, nt=nt)
+    fp = FPSLSolver(prob, interpolation_method="cubic")
+    x = np.linspace(0.0, 1.0, n)
+    m0 = np.exp(-60 * (x - 0.4) ** 2)
+    m0 /= m0.sum() * (x[1] - x[0])
+    U = np.tile(25.0 * (x - 0.5) ** 2, (nt + 1, 1))
+    with pytest.raises(ValueError) as exc:
+        fp.solve_fp_system(m0, U)
+    message = str(exc.value)
+    assert "FP-SL positivity clip" in message
+    assert "linear interpolation" in message
+    assert "coarsen" in message
 
 
 def test_no_clip_warning_for_linear_pure_diffusion():
@@ -88,22 +115,3 @@ def test_no_clip_warning_for_linear_pure_diffusion():
 
     msgs = _run(fp, m0, U)
     assert not any("positivity clip injected mass" in m for m in msgs), f"unexpected clip warning: {msgs}"
-
-
-def test_clip_warning_fires_at_most_once_per_solve():
-    """The diagnostic is once-per-solve: the flag resets each solve_fp_system call but
-    does not spam across the (Nt) time steps within a single solve."""
-    n, nt = 41, 20
-    prob = _problem(n=n, nt=nt)
-    fp = FPSLSolver(prob, interpolation_method="cubic")
-    x = np.linspace(0.0, 1.0, n)
-    m0 = np.exp(-60 * (x - 0.4) ** 2)
-    m0 /= m0.sum() * (x[1] - x[0])
-    U = np.tile(25.0 * (x - 0.5) ** 2, (nt + 1, 1))
-
-    msgs = _run(fp, m0, U)
-    n_clip = sum("positivity clip injected mass" in m for m in msgs)
-    assert n_clip <= 1, f"warning should fire at most once per solve, fired {n_clip} times"
-    # And the flag resets: a second solve can warn again.
-    msgs2 = _run(fp, m0, U)
-    assert sum("positivity clip injected mass" in m for m in msgs2) <= 1

--- a/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
+++ b/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
@@ -124,10 +124,16 @@ def test_neumann_domain_preserves_zero_flux_stencil():
 
     # Spike at the left boundary — with no-flux/zero-flux the spike is reflected,
     # so m_new[1] > m_new[-1] (boundary acts as a mirror, not a seam).
+    #
+    # A narrow Gaussian rather than a delta (Issue #1683). A single-cell delta of height
+    # 1/dx drives the CN diffusion to -7.5 in one step: the stencil question this test
+    # asks is answerable without an unphysical density, and the old input only passed
+    # because the positivity clip repaired it. Measured, w = 2dx clips **nothing** and
+    # the assertion below is unchanged.
     x = np.linspace(0.0, 1.0, n)
     dx = x[1] - x[0]
-    m = np.zeros(n)
-    m[0] = 1.0 / dx
+    m = np.exp(-(((x - 0.0) / (2 * dx)) ** 2))
+    m = m / (m.sum() * dx)
     alpha = np.zeros(n)
     m_new = fp._adjoint_sl_step_1d(m, alpha, prob.dt, prob.sigma)
 


### PR DESCRIPTION
Refs #1683. Second migration after #1750.

## Measured before migrating, not after

Weak-form was attempted first and reverted because its threshold does not transfer. SL's
does, and this batch checked that first:

```
default (the PASS capability cell)   0 clipped steps   fabricated 0.000e+00
fine grid                            9 clipped steps   fabricated 1.191e-01   mass drift 10.2%
small sigma                          0 clipped steps   fabricated 0.000e+00
sharp peak + small sigma             0 clipped steps   fabricated 0.000e+00
very sharp peak                      0 clipped steps   fabricated 0.000e+00
```

Four of five clip **nothing**. No régime between round-off and failure, so the shared
1e-8 threshold separates them.

The one that fails is the **finer** grid — on this scheme refining lets the departure
point span more cells — so the remedy text says "coarsen", because the obvious response
to an accuracy complaint would make it worse.

## What changed

`FPSLSolver._clip_nonneg` warned once per solve and returned the clipped density either
way. It now routes through the shared gate. The `_clip_warned` latch is deleted with the
warning it guarded.

The helper was already the single owner of four call sites, so this solver had done its
own consolidation; what it lacked was a gate. Its docstring already carried the reasoning
`mass_of=None` encodes — *"the injected/total ratio is grid-quadrature-invariant on a
uniform grid"* — so the two arrived at the same argument independently.

## Three tests, two categories

`test_clip_warns_when_cubic_splatting_injects_mass` and
`test_clip_warning_fires_at_most_once_per_solve` asserted the diagnostic that is now a
stop. The first is rewritten; the second is **deleted** — there is no latch left to pin.

`test_neumann_domain_preserves_zero_flux_stencil` is the interesting one. It asks about
the zero-flux stencil — `m_new[1] > m_new[-1]` — and fed it a single-cell delta of height
`1/dx`, which drives the CN diffusion to **−7.508** in one step. It passed because the
clip repaired it. Its input is now a narrow Gaussian: measured, `w = 2dx` clips
**nothing** and the assertion is unchanged.

I did not weaken the gate to accommodate it. A test that needs a divergent density to ask
its question is asking it the wrong way.

## Verification

Full gate GATE GREEN. Capability matrix unchanged at **PASS=5 UNSUPPORTED=6** — the
`sl_linear` cells were already PASS and stay PASS, which is the useful part: this batch
stops a diverging configuration without touching a converging one.

Remaining in #1683: GFDM, network, the deprecated `FPSLJacobianSolver` (clip → clip →
renormalise, no diagnostic at all), backend toy surface. Weak-form is parked pending
threshold evidence.