### PR TITLE
Stop GFDM FP solves renormalising over a clip

### DIFF
--- a/changelog.d/1683-gfdm-mass-gate.changed.md
+++ b/changelog.d/1683-gfdm-mass-gate.changed.md
@@ -1,0 +1,6 @@
+GFDM FP solves no longer renormalise the density to the initial mass after clipping
+negatives. The path now routes through `clip_nonnegative_or_raise` (#1683) and stops when a
+clip would fabricate mass -- measured at 61% of the present mass on one configuration that
+previously returned a final mass of exactly 1.0000. Removing the renormalisation also
+exposed #1752: this scheme is not conservative, drifting 179% on a configuration that clips
+nothing, and that drift is now reported at WARNING rather than being scaled away.

--- a/changelog.d/1683-gfdm-mass-gate.changed.md
+++ b/changelog.d/1683-gfdm-mass-gate.changed.md
@@ -1,6 +1,8 @@
 GFDM FP solves no longer renormalise the density to the initial mass after clipping
-negatives. The path now routes through `clip_nonnegative_or_raise` (#1683) and stops when a
-clip would fabricate mass -- measured at 61% of the present mass on one configuration that
-previously returned a final mass of exactly 1.0000. Removing the renormalisation also
-exposed #1752: this scheme is not conservative, drifting 179% on a configuration that clips
-nothing, and that drift is now reported at WARNING rather than being scaled away.
+negatives. The path routes through `clip_nonnegative_or_raise` (#1683) and stops when a clip
+would fabricate mass -- measured at 61% of the present mass on one configuration that
+previously returned a final mass of exactly 1.0000. Removing the renormalisation exposed
+#1752: the unstabilised central flux divergence (`upwind_scheme="none"`) diverges under
+refinement, reaching a final mass of 2.79 where the initial mass was 1.0, and refining the
+timestep makes it worse rather than better. That drift is now reported at WARNING with the
+timestep it peaked at, rather than being scaled away.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -564,6 +564,7 @@ class FPGFDMSolver(BaseFPSolver):
 
         _logger = get_logger(__name__)
         max_mass_drift = 0.0
+        max_mass_drift_t_idx = 0
 
         # Time stepping loop (forward Euler)
         for t_idx in range(n_time_points - 1):
@@ -601,35 +602,57 @@ class FPGFDMSolver(BaseFPSolver):
             # exactly 1.0000 -- including one measured to clip **61%** of the present mass
             # at a single step. Reporting perfect conservation over that is the defect.
             #
-            # Two mechanisms drive it here and the remedy names both, because they call for
-            # opposite changes. Measured on a 21-point grid: sigma=0.5 clips 61% with
-            # dt*D/dx^2 = 2.5, five times the explicit-diffusion limit; sigma=0.1 with a
-            # steep drift clips 9.6% at dt*D/dx^2 = 0.1, where the driver is advection
-            # rather than diffusion.
+            # Issue #1752: the mechanism is the unstabilised central flux divergence below
+            # with `upwind_scheme="none"` (the default), NOT the explicit time stepping. The
+            # first version of this comment blamed forward Euler; refining dt at fixed h
+            # makes the drift monotonically WORSE, converging upward to a semi-discrete
+            # limit (2.79 -> 4.47 -> 6.08 -> 7.99 -> 8.62 -> 8.73 for Nt = 10..1280 at
+            # sigma=0.3), which rules time discretisation out. Refining h with the drift on
+            # also diverges (4.31 -> 8.62 -> 12.18 -> 17.88 for N = 11..81), while pure
+            # diffusion converges cleanly at ~O(h). So this is not merely non-conservative;
+            # it is divergent under refinement, and `dt` is not a lever on it.
+            #
+            # The mass functional here is `np.sum` (line ~560 and just below), an unweighted
+            # sum, and the GFDM path carries no cell measure at all -- the only weights in
+            # `gfdm_components/` are least-squares stencil and interpolation weights. So the
+            # gate's ratio measures the same quantity this solver compares, and `weights=`
+            # is correctly omitted rather than merely unset.
             M_solution[t_idx + 1, :] = clip_nonnegative_or_raise(
                 M_solution[t_idx + 1, :],
                 context=f"GFDM FP solve: at t_idx={t_idx + 1}",
                 remedy=(
-                    "Forward Euler is explicit in both terms. Check dt*D/dx^2 < 0.5 for "
-                    "the diffusion limit, and reduce dt or add diffusion if the drift is "
-                    "steep -- the two point opposite ways, so measure which one binds."
+                    f"upwind_scheme is {self.upwind_scheme!r}. 'none' leaves the flux "
+                    "divergence unstabilised, which is what drives this (Issue #1752); "
+                    "'linear' or 'exponential' measurably reduce it -- on the reference "
+                    "configuration, final mass 8.62 -> 2.34 -> 2.25. Do NOT reduce dt to "
+                    "silence this: refining the timestep drives the per-step clip below "
+                    "the threshold while the final mass climbs from 8.4e+02 to 2.5e+09, so "
+                    "it removes the message and not the defect. If dt*D/dx^2 < 0.5 is also "
+                    "violated, fix that on its own merits; it is not what binds here."
                 ),
             )
             mass_current = np.sum(M_solution[t_idx + 1, :])
             if mass_initial > 0:
-                max_mass_drift = max(max_mass_drift, abs(mass_current - mass_initial) / mass_initial)
+                drift = abs(mass_current - mass_initial) / mass_initial
+                if drift > max_mass_drift:
+                    max_mass_drift, max_mass_drift_t_idx = drift, t_idx + 1
 
-        # Issue #1752: with the renormalisation gone this line is the only remaining signal
-        # for a drift that was measured at 179% on a configuration that clips nothing, so
-        # it cannot stay at DEBUG. The scheme is not conservative by construction -- forward
-        # Euler with a non-conservative GFDM operator -- and scaling the answer afterwards
-        # was hiding that rather than fixing it.
+        # Issue #1752: with the renormalisation gone this is the only remaining signal for a
+        # drift measured at 179% on a configuration that clips nothing, so it cannot stay at
+        # DEBUG. It is also the ONLY thing that catches a divergence the clip gate structurally
+        # cannot: the gate measures fabricated mass as a RATIO of the mass present, which is
+        # scale-invariant, so a solve that blows up while staying positive has no negatives and
+        # passes. Measured: sigma=0.1/drift=25 at Nt=2560 returns a finite, non-negative density
+        # of mass 2.55e+09 and the gate does not fire. This warning does.
         if max_mass_drift > 1e-6:
             _logger.warning(
-                "GFDM FP mass drift %.2e over the solve. Forward Euler with this operator does "
-                "not conserve mass (Issue #1752); the returned density carries the drift rather "
-                "than being rescaled to hide it.",
+                "GFDM FP mass drift %.2e (worst at t_idx=%d). The flux divergence is unstabilised "
+                "at upwind_scheme=%r and diverges under refinement (Issue #1752) -- refining dt "
+                "makes this worse, not better. The returned density carries the drift rather than "
+                "being rescaled to hide it.",
                 max_mass_drift,
+                max_mass_drift_t_idx,
+                self.upwind_scheme,
             )
 
         return M_solution

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -30,6 +30,7 @@ import numpy as np
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import TaylorOperator
 from mfgarchon.geometry.boundary.types import BCType
+from mfgarchon.utils.numerical import clip_nonnegative_or_raise
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
@@ -595,23 +596,41 @@ class FPGFDMSolver(BaseFPSolver):
             dm_dt = -advection + diffusion
             M_solution[t_idx + 1, :] = m_current + dt * dm_dt
 
-            # Physical constraints
-            M_solution[t_idx + 1, :] = np.maximum(M_solution[t_idx + 1, :], 0.0)
-
-            # Issue #886: log raw mass drift before normalization
+            # Issue #1683: this clipped, then renormalised to the initial mass, and warned
+            # only above 1% drift. Every configuration therefore returned a final mass of
+            # exactly 1.0000 -- including one measured to clip **61%** of the present mass
+            # at a single step. Reporting perfect conservation over that is the defect.
+            #
+            # Two mechanisms drive it here and the remedy names both, because they call for
+            # opposite changes. Measured on a 21-point grid: sigma=0.5 clips 61% with
+            # dt*D/dx^2 = 2.5, five times the explicit-diffusion limit; sigma=0.1 with a
+            # steep drift clips 9.6% at dt*D/dx^2 = 0.1, where the driver is advection
+            # rather than diffusion.
+            M_solution[t_idx + 1, :] = clip_nonnegative_or_raise(
+                M_solution[t_idx + 1, :],
+                context=f"GFDM FP solve: at t_idx={t_idx + 1}",
+                remedy=(
+                    "Forward Euler is explicit in both terms. Check dt*D/dx^2 < 0.5 for "
+                    "the diffusion limit, and reduce dt or add diffusion if the drift is "
+                    "steep -- the two point opposite ways, so measure which one binds."
+                ),
+            )
             mass_current = np.sum(M_solution[t_idx + 1, :])
             if mass_initial > 0:
-                mass_drift = abs(mass_current - mass_initial) / mass_initial
-                max_mass_drift = max(max_mass_drift, mass_drift)
-                if mass_drift > 0.01:
-                    _logger.warning("GFDM mass drift %.2e at t_idx=%d (before renorm)", mass_drift, t_idx + 1)
+                max_mass_drift = max(max_mass_drift, abs(mass_current - mass_initial) / mass_initial)
 
-            # Renormalize to conserve mass
-            if mass_current > 0:
-                M_solution[t_idx + 1, :] *= mass_initial / mass_current
-
+        # Issue #1752: with the renormalisation gone this line is the only remaining signal
+        # for a drift that was measured at 179% on a configuration that clips nothing, so
+        # it cannot stay at DEBUG. The scheme is not conservative by construction -- forward
+        # Euler with a non-conservative GFDM operator -- and scaling the answer afterwards
+        # was hiding that rather than fixing it.
         if max_mass_drift > 1e-6:
-            _logger.debug("GFDM max mass drift: %.2e (renormalized each step)", max_mass_drift)
+            _logger.warning(
+                "GFDM FP mass drift %.2e over the solve. Forward Euler with this operator does "
+                "not conserve mass (Issue #1752); the returned density carries the drift rather "
+                "than being rescaled to hide it.",
+                max_mass_drift,
+            )
 
         return M_solution
 

--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -606,8 +606,8 @@ class FPGFDMSolver(BaseFPSolver):
             # with `upwind_scheme="none"` (the default), NOT the explicit time stepping. The
             # first version of this comment blamed forward Euler; refining dt at fixed h
             # makes the drift monotonically WORSE, converging upward to a semi-discrete
-            # limit (2.79 -> 4.47 -> 6.08 -> 7.99 -> 8.62 -> 8.73 for Nt = 10..1280 at
-            # sigma=0.3), which rules time discretisation out. Refining h with the drift on
+            # limit (2.79, 4.47, 6.08, 7.26, 7.99, 8.62, 8.73 at Nt = 10, 20, 40, 80,
+            # 160, 640, 1280 with sigma=0.3), which rules time discretisation out. Refining h with the drift on
             # also diverges (4.31 -> 8.62 -> 12.18 -> 17.88 for N = 11..81), while pure
             # diffusion converges cleanly at ~O(h). So this is not merely non-conservative;
             # it is divergent under refinement, and `dt` is not a lever on it.
@@ -621,14 +621,23 @@ class FPGFDMSolver(BaseFPSolver):
                 M_solution[t_idx + 1, :],
                 context=f"GFDM FP solve: at t_idx={t_idx + 1}",
                 remedy=(
-                    f"upwind_scheme is {self.upwind_scheme!r}. 'none' leaves the flux "
-                    "divergence unstabilised, which is what drives this (Issue #1752); "
-                    "'linear' or 'exponential' measurably reduce it -- on the reference "
-                    "configuration, final mass 8.62 -> 2.34 -> 2.25. Do NOT reduce dt to "
-                    "silence this: refining the timestep drives the per-step clip below "
-                    "the threshold while the final mass climbs from 8.4e+02 to 2.5e+09, so "
-                    "it removes the message and not the defect. If dt*D/dx^2 < 0.5 is also "
-                    "violated, fix that on its own merits; it is not what binds here."
+                    (
+                        "upwind_scheme is 'none', which leaves the flux divergence "
+                        "unstabilised -- that is what drives this (Issue #1752). 'linear' or "
+                        "'exponential' measurably reduce it: on a 21-point grid at sigma=0.3, "
+                        "final mass 2.795 -> 1.437 -> 1.418 at Nt=10, and 8.62 -> 2.34 -> 2.25 "
+                        "at Nt=640."
+                        if self.upwind_scheme == "none"
+                        else f"upwind_scheme is already {self.upwind_scheme!r}, so stabilisation "
+                        "is on and is not enough here -- it reduces the drift without removing "
+                        "it (Issue #1752: this operator diverges under refinement). Coarsen the "
+                        "value-function gradient driving the flux, or use a different FP scheme."
+                    )
+                    + " Do NOT reduce dt to silence this: refining the timestep drives the "
+                    "per-step clip below the threshold while the final mass climbs from "
+                    "8.4e+02 to 2.5e+09, so it removes the message and not the defect. If "
+                    "dt*D/dx^2 < 0.5 is also violated, fix that on its own merits; it is not "
+                    "what binds here."
                 ),
             )
             mass_current = np.sum(M_solution[t_idx + 1, :])

--- a/mfgarchon/utils/numerical/mass_fabrication_gate.py
+++ b/mfgarchon/utils/numerical/mass_fabrication_gate.py
@@ -25,8 +25,8 @@ interesting régime between them, which is why a single threshold works.
 
 The ratio is **scale-invariant** and evaluated **per step**. Both matter, and the second is
 the serious one: refining the timestep shrinks what any one step can fabricate, so the
-observable vanishes under dt-refinement whether or not the answer improves. Measured on the
-GFDM path (sigma=0.1, drift=25, Issue #1752):
+observable can vanish under dt-refinement whether or not the answer improves. Measured on the
+GFDM path -- and, so far, only there (sigma=0.1, drift=25, Issue #1752):
 
     Nt        dt        max fabricated      final mass     this gate
     10     5.00e-02        9.591e-02          8.40e+02       raises
@@ -40,15 +40,20 @@ The observable falls five orders and then to exactly zero -- nothing goes negati
 while the end-to-end error climbs seven. At Nt=2560 the solve is maximally wrong and
 maximally clean by this function's own criterion.
 
-**A tighter threshold does not close this.** Any fixed value can be driven below by refining
-dt. What this gate rules out is a step that repairs a sign violation large enough to matter;
-it does not certify that a solve converged, and a caller must not read a passing gate as
-"healthy". Where magnitude matters, a drift check on the whole solve belongs beside this one
--- `fp_gfdm.py` carries one for exactly this reason.
+**Scope of that measurement.** It is one site. The obvious generalisation -- "any fixed
+threshold is defeatable by refining dt at any caller" -- was asserted during review and then
+withdrawn, because the attempt to reproduce it at the FDM time-stepping site produced a null
+with no working positive control. So: demonstrated at the GFDM site, open elsewhere. Do not
+cite it as a general property of this function until a second site shows it.
 
-Worth stating plainly because the failure is adversarial in shape: the natural response to
-this gate firing is to refine the timestep, and on a scheme whose spatial operator is the
-real problem that silences the gate and makes the answer worse.
+What is general, and does not depend on that table: this gate rules out a step that repairs a
+sign violation large enough to matter. It does not certify that a solve converged. A caller
+must not read a passing gate as "healthy", and where magnitude matters a drift check on the
+whole solve belongs beside this one -- `fp_gfdm.py` carries one for exactly this reason.
+
+Worth stating plainly because the failure is adversarial in shape wherever it does occur: the
+natural response to this gate firing is to refine the timestep, and on a scheme whose spatial
+operator is the real problem that silences the gate and makes the answer worse.
 
 ## Why weights are optional, and when they are not
 

--- a/mfgarchon/utils/numerical/mass_fabrication_gate.py
+++ b/mfgarchon/utils/numerical/mass_fabrication_gate.py
@@ -21,14 +21,51 @@ wrong.
 Round-off gives ~1e-15. A scheme that has genuinely failed gives O(1). There is no
 interesting régime between them, which is why a single threshold works.
 
+## What this cannot see, and why no threshold fixes it
+
+The ratio is **scale-invariant** and evaluated **per step**. Both matter, and the second is
+the serious one: refining the timestep shrinks what any one step can fabricate, so the
+observable vanishes under dt-refinement whether or not the answer improves. Measured on the
+GFDM path (sigma=0.1, drift=25, Issue #1752):
+
+    Nt        dt        max fabricated      final mass     this gate
+    10     5.00e-02        9.591e-02          8.40e+02       raises
+    20     2.50e-02        5.961e-03          5.18e+04       raises
+   160     3.13e-03        3.646e-04          4.17e+08       raises
+   640     7.81e-04        3.396e-05          1.70e+09       raises
+  2560     1.95e-04        0.000e+00          2.55e+09       PASSES
+ 10240     4.88e-05        0.000e+00          2.83e+09       PASSES
+
+The observable falls five orders and then to exactly zero -- nothing goes negative at all --
+while the end-to-end error climbs seven. At Nt=2560 the solve is maximally wrong and
+maximally clean by this function's own criterion.
+
+**A tighter threshold does not close this.** Any fixed value can be driven below by refining
+dt. What this gate rules out is a step that repairs a sign violation large enough to matter;
+it does not certify that a solve converged, and a caller must not read a passing gate as
+"healthy". Where magnitude matters, a drift check on the whole solve belongs beside this one
+-- `fp_gfdm.py` carries one for exactly this reason.
+
+Worth stating plainly because the failure is adversarial in shape: the natural response to
+this gate firing is to refine the timestep, and on a scheme whose spatial operator is the
+real problem that silences the gate and makes the answer worse.
+
 ## Why weights are optional, and when they are not
 
 For a **uniform** quadrature the cell measure cancels in the ratio, so the same numbers
 come out whether or not you multiply by dV -- and passing them is wasted work. For a
-non-uniform one (GFDM quadrature, a weak-form mass matrix, graph node masses) it does
-**not** cancel, and omitting the weights silently measures a different quantity than the
-solver's own mass functional. Hence `weights=None` means "uniform, and I have checked
-that it is", not "I did not think about it".
+non-uniform one (a weak-form mass matrix is the real case) it does **not** cancel, and
+omitting the weights silently measures a different quantity than the solver's own mass
+functional. Hence `weights=None` means "uniform, and I have checked that it is", not "I
+did not think about it".
+
+The check is mechanical: find what the caller compares to decide mass changed. Both
+migrated callers turned out to be unweighted -- GFDM compares `np.sum(M)` and carries no
+cell measure anywhere (the only weights in `gfdm_components/` are least-squares stencil and
+interpolation weights), and the network solver's mass functional is the node sum. An earlier
+version of this paragraph offered "GFDM quadrature" as the paradigm non-uniform case, which
+was wrong: it was reasoning from the family name rather than from the code, and the first
+caller it warned about was one where the warning did not apply.
 
 ## Not for input validation
 

--- a/mfgarchon/utils/numerical/mass_fabrication_gate.py
+++ b/mfgarchon/utils/numerical/mass_fabrication_gate.py
@@ -48,8 +48,15 @@ cite it as a general property of this function until a second site shows it.
 
 What is general, and does not depend on that table: this gate rules out a step that repairs a
 sign violation large enough to matter. It does not certify that a solve converged. A caller
-must not read a passing gate as "healthy", and where magnitude matters a drift check on the
-whole solve belongs beside this one -- `fp_gfdm.py` carries one for exactly this reason.
+must not read a passing gate as "healthy".
+
+Where magnitude matters, something must **stop**, and this function is not it. `fp_gfdm.py`
+reports its whole-solve drift, but reports is the accurate verb -- it is a `logger.warning`,
+and the solve returns. That is the only thing separating a GFDM configuration whose honest
+answer is a 0.27% drift from one that returns a final mass of 1.06e+23, and by this campaign's
+own standard ("a diagnostic nobody reads is the same failure as no diagnostic") a log is not a
+gate. Recorded rather than fixed: what should stop a divergent-but-positive solve is a
+different invariant than this one, not a stricter threshold.
 
 Worth stating plainly because the failure is adversarial in shape wherever it does occur: the
 natural response to this gate firing is to refine the timestep, and on a scheme whose spatial
@@ -64,13 +71,17 @@ omitting the weights silently measures a different quantity than the solver's ow
 functional. Hence `weights=None` means "uniform, and I have checked that it is", not "I
 did not think about it".
 
-The check is mechanical: find what the caller compares to decide mass changed. Both
-migrated callers turned out to be unweighted -- GFDM compares `np.sum(M)` and carries no
-cell measure anywhere (the only weights in `gfdm_components/` are least-squares stencil and
-interpolation weights), and the network solver's mass functional is the node sum. An earlier
-version of this paragraph offered "GFDM quadrature" as the paradigm non-uniform case, which
-was wrong: it was reasoning from the family name rather than from the code, and the first
-caller it warned about was one where the warning did not apply.
+The check is mechanical: read what the caller itself compares to decide mass changed, and
+match the gate to that. Worked example -- GFDM compares `np.sum(M)` against `np.sum(m_init)`
+and carries no cell measure anywhere (the only weights under `gfdm_components/` are
+least-squares stencil and interpolation weights), so `weights=None` is not merely the default
+there, it is the only correct value.
+
+An earlier version of this paragraph offered "GFDM quadrature" as the paradigm non-uniform
+case. That was wrong, and wrong in a specific way worth naming: it reasoned from the family
+name rather than from the code, so the first caller it warned about was one where the warning
+did not apply. The replacement then over-corrected by counting callers it had not read. Check
+each site; do not generalise from the scheme family, and do not generalise from this file.
 
 ## Not for input validation
 

--- a/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
+++ b/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
@@ -205,10 +205,13 @@ def test_refining_the_timestep_silences_the_gate_while_the_answer_gets_worse():
         Nt=640   max fabricated 3.396e-05   final mass 1.70e+09   raises
         Nt=2560  max fabricated 0.000e+00   final mass 2.55e+09   PASSES
 
-    No threshold closes this: any fixed value can be driven below by refining dt. The failure
-    is adversarial in shape, because the natural response to the gate firing is to refine the
-    timestep, and here that silences the gate and makes the answer worse -- which is why the
-    remedy string tells the reader not to.
+    No threshold closes it **here**: any fixed value can be driven below on this
+    configuration. Whether that generalises to the gate's other callers is open -- the
+    attempt to reproduce it at the FDM time-stepping site during review produced a null with
+    no working positive control, so the claim is scoped to this site rather than to the
+    invariant. The failure is adversarial in shape wherever it occurs, because the natural
+    response to the gate firing is to refine the timestep, and here that silences the gate and
+    makes the answer worse -- which is why the remedy string tells the reader not to.
 
     Asserted so nobody later reads a passing gate as "the solve is healthy", and so the drift
     WARNING is not mistaken for redundant with the gate: only the pair covers this.

--- a/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
+++ b/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
@@ -33,11 +33,12 @@ NT = 10
 T = 0.5
 
 
-def _solver(sigma):
+def _build(sigma, Nt=NT):
+    """Same construction as `_solver`, with Nt exposed for the refinement-sensitive tests."""
     grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[N], boundary_conditions=no_flux_bc(dimension=1))
     problem = MFGProblem(
         geometry=grid,
-        Nt=NT,
+        Nt=Nt,
         T=T,
         sigma=sigma,
         components=MFGComponents(
@@ -51,6 +52,10 @@ def _solver(sigma):
         ),
     )
     return FPGFDMSolver(problem, collocation_points=np.linspace(0, 1, N).reshape(-1, 1))
+
+
+def _solver(sigma):
+    return _build(sigma)
 
 
 def _inputs(drift_scale):
@@ -78,23 +83,39 @@ def test_an_advection_driven_configuration_stops():
         _solver(0.1).solve_fp_system(m0, drift)
 
 
-def test_the_remedy_names_both_mechanisms():
-    """They point opposite ways, so naming only one sends half the readers backwards."""
+def test_the_remedy_names_the_lever_that_works_and_disowns_the_one_that_does_not():
+    """Review measured both of the first version's suggestions and neither helped.
+
+    "Reduce dt" is worse than useless here -- refining dt at fixed h makes the mass drift
+    grow monotonically (2.79 -> 8.73 over Nt = 10..1280). "Add diffusion" never reaches the
+    threshold on the advection-driven configuration and turns back up. The lever that does
+    move it, `upwind_scheme`, went unmentioned. A remedy that names only non-levers sends
+    the reader to spend an afternoon refining a grid.
+    """
     m0, drift = _inputs(1.0)
     with pytest.raises(ValueError) as exc:
         _solver(0.5).solve_fp_system(m0, drift)
     message = str(exc.value)
     assert "GFDM FP solve: at t_idx=" in message
-    assert "dt*D/dx^2" in message
-    assert "drift is" in message
-    assert "measure which one binds" in message
+    assert "upwind_scheme" in message
+    assert "1752" in message
+    assert "Do NOT reduce dt" in message, "refining dt silences this gate; the message must say so"
+    assert "2.5e+09" in message, "name the number the refinement leads to, not just the direction"
 
 
-def test_a_converging_configuration_still_runs():
-    """The gate must not stop a solve that does not clip.
+def test_a_configuration_with_no_negatives_at_all_still_runs():
+    """The gate must not stop a solve that never goes negative.
 
-    sigma=0.3 with a moderate drift clips nothing across all ten steps -- the régime this
-    path is usable in, and the one a threshold set too tight would destroy.
+    Named for what it does. The first version called this "a converging configuration" and
+    "the régime this path is usable in", which review measurement contradicted: the very
+    next test asserts this same run fabricates 179% of its mass, and refining either dt or h
+    makes it worse. It converges to nothing; its density merely stays positive
+    (min +8.5e-05).
+
+    That also bounds what this test can guard. With no negatives anywhere it exercises only
+    `mass_fabricated_by_clip`'s `if not negatives.any(): return 0.0` early return, so it
+    would stay green under any threshold down to zero. It is a smoke check, not the
+    threshold guard -- `test_the_threshold_is_not_satisfiable_by_a_marginal_clip` is that.
     """
     m0, drift = _inputs(5.0)
     result = _solver(0.3).solve_fp_system(m0, drift)
@@ -141,3 +162,67 @@ def test_the_drift_is_reported_at_warning_level(caplog):
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
     assert warnings, "the drift was not reported at WARNING or above"
     assert "1752" in warnings[0].getMessage(), "the message must name the issue tracking the defect"
+
+
+def test_a_clip_far_below_one_percent_still_stops_the_solve():
+    """Pins the THRESHOLD, which the large-clip configurations above do not.
+
+    My first attempt here copied the FDM sibling's guard -- assert the reported percentage
+    is above 1% -- and claimed it pinned the threshold. Measured, it does not: at
+    `MAX_CLIP_MASS_FABRICATION = 0.02`, six orders looser than shipped, that assertion and
+    every other one in this file stays green, because a 61% clip is above 1% either way.
+
+    This configuration is the discriminating one. It fabricates so little that the message
+    rounds it to 0.000%, and it must still stop -- because the campaign's premise is that
+    there is no interesting régime between round-off (~1e-15) and a failed scheme, so
+    anything measurably above round-off is the scheme. Loosening the threshold to any
+    percent-scale value turns this red.
+    """
+    n_t = 640
+    x = np.linspace(0, 1, N)
+    m0 = np.exp(-30 * (x - 0.5) ** 2)
+    m0 /= m0.sum()
+    drift = np.tile(25.0 * (x - 0.5) ** 2, (n_t + 1, 1))
+
+    with pytest.raises(ValueError) as exc:
+        _build(sigma=0.1, Nt=n_t).solve_fp_system(m0, drift)
+    percent = float(str(exc.value).split("would fabricate")[1].split("%")[0])
+    assert percent < 0.01, (
+        f"message reported {percent}% -- this test is only a threshold pin while the clip "
+        f"here is far below the percent scale; pick a finer Nt if the scheme changed"
+    )
+
+
+def test_refining_the_timestep_silences_the_gate_while_the_answer_gets_worse():
+    """Records the campaign invariant's structural limit. Recorded, not fixed.
+
+    `fabricated = |sum(negatives)| / sum(positives)` is scale-invariant AND evaluated per
+    step, so refining dt shrinks what any one step can fabricate whether or not the answer
+    improves. On this configuration the observable falls monotonically to exactly zero --
+    nothing goes negative at all -- while the final mass climbs seven orders:
+
+        Nt=10    max fabricated 9.591e-02   final mass 8.40e+02   raises
+        Nt=640   max fabricated 3.396e-05   final mass 1.70e+09   raises
+        Nt=2560  max fabricated 0.000e+00   final mass 2.55e+09   PASSES
+
+    No threshold closes this: any fixed value can be driven below by refining dt. The failure
+    is adversarial in shape, because the natural response to the gate firing is to refine the
+    timestep, and here that silences the gate and makes the answer worse -- which is why the
+    remedy string tells the reader not to.
+
+    Asserted so nobody later reads a passing gate as "the solve is healthy", and so the drift
+    WARNING is not mistaken for redundant with the gate: only the pair covers this.
+    """
+    n_t = 2560
+    x = np.linspace(0, 1, N)
+    m0 = np.exp(-30 * (x - 0.5) ** 2)
+    m0 /= m0.sum()
+    drift = np.tile(25.0 * (x - 0.5) ** 2, (n_t + 1, 1))
+
+    result = _build(sigma=0.1, Nt=n_t).solve_fp_system(m0, drift)
+
+    assert result.min() >= 0.0, "if this goes negative the gate would have caught it and the point is moot"
+    assert float(result[-1].sum()) > 1e6, (
+        f"final mass {float(result[-1].sum()):.3e}: this configuration is meant to diverge while "
+        f"staying positive, which is the blind spot being recorded"
+    )

--- a/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
+++ b/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
@@ -1,0 +1,143 @@
+"""The GFDM FP path stops instead of renormalising over a clip (#1683).
+
+It clipped, renormalised to the initial mass, and warned only above 1% drift. Every
+configuration therefore returned a final mass of exactly 1.0000 -- including one measured
+to clip **61%** of the present mass at a single step. Reporting perfect conservation over
+that is the defect, not the diagnostic that was missing.
+
+Migrating this path broke **no existing test**, which is the other half of the finding: a
+public solver whose plausible configurations fabricate most of their mass had no coverage
+of that behaviour at all. These are that coverage.
+
+Two mechanisms drive it, and they call for opposite changes -- measured on a 21-point
+grid, `sigma=0.5` clips 61% at `dt*D/dx^2 = 2.5` (five times the explicit-diffusion
+limit), while `sigma=0.1` with a steep drift clips 9.6% at `dt*D/dx^2 = 0.1`, where the
+driver is advection. The remedy text names both rather than guessing which one bound.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+N = 21
+NT = 10
+T = 0.5
+
+
+def _solver(sigma):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[N], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(
+        geometry=grid,
+        Nt=NT,
+        T=T,
+        sigma=sigma,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-30 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    return FPGFDMSolver(problem, collocation_points=np.linspace(0, 1, N).reshape(-1, 1))
+
+
+def _inputs(drift_scale):
+    x = np.linspace(0, 1, N)
+    m0 = np.exp(-30 * (x - 0.5) ** 2)
+    m0 /= m0.sum()
+    return m0, np.tile(drift_scale * (x - 0.5) ** 2, (NT + 1, 1))
+
+
+def test_a_diffusion_limited_configuration_stops():
+    """sigma=0.5 gives dt*D/dx^2 = 2.5, five times the explicit limit.
+
+    It used to return final mass 1.0000 over a 61% clip -- a configuration a user would
+    reasonably pick, reporting perfect conservation.
+    """
+    m0, drift = _inputs(1.0)
+    with pytest.raises(ValueError, match="would fabricate"):
+        _solver(0.5).solve_fp_system(m0, drift)
+
+
+def test_an_advection_driven_configuration_stops():
+    """sigma=0.1 with a steep drift: dt*D/dx^2 = 0.1, so diffusion is not the binding limit."""
+    m0, drift = _inputs(25.0)
+    with pytest.raises(ValueError, match="would fabricate"):
+        _solver(0.1).solve_fp_system(m0, drift)
+
+
+def test_the_remedy_names_both_mechanisms():
+    """They point opposite ways, so naming only one sends half the readers backwards."""
+    m0, drift = _inputs(1.0)
+    with pytest.raises(ValueError) as exc:
+        _solver(0.5).solve_fp_system(m0, drift)
+    message = str(exc.value)
+    assert "GFDM FP solve: at t_idx=" in message
+    assert "dt*D/dx^2" in message
+    assert "drift is" in message
+    assert "measure which one binds" in message
+
+
+def test_a_converging_configuration_still_runs():
+    """The gate must not stop a solve that does not clip.
+
+    sigma=0.3 with a moderate drift clips nothing across all ten steps -- the régime this
+    path is usable in, and the one a threshold set too tight would destroy.
+    """
+    m0, drift = _inputs(5.0)
+    result = _solver(0.3).solve_fp_system(m0, drift)
+    assert np.all(np.isfinite(result))
+    assert result.min() >= 0.0
+
+
+def test_the_scheme_does_not_conserve_mass_and_now_says_so(record_property):
+    """Records #1752: removing the renormalisation exposed a defect larger than the clip.
+
+    This configuration clips **nothing** across all ten steps, so no positivity repair is
+    involved -- and its mass still goes 1.000000 -> 2.794967, a 179% gain. The per-step
+    `M *= mass_initial / mass_current` was not masking the clip; it was masking the
+    scheme. Every configuration returned exactly the initial mass because it was forced
+    to.
+
+    The assertion is the measurement, not the desired behaviour. It is written to fail if
+    the drift **improves**, so fixing #1752 cannot land silently: a conservative
+    discretisation would bring this near 1.0 and turn this test red, which is when it
+    should be deleted.
+    """
+    m0, drift = _inputs(5.0)
+    result = _solver(0.3).solve_fp_system(m0, drift)
+    final = float(result[-1].sum())
+    record_property("gfdm_final_mass", final)
+    assert final > 2.0, (
+        f"final mass {final:.6f} -- if this dropped toward {float(m0.sum()):.1f} the scheme "
+        f"became conservative and #1752 is fixed; delete this test rather than relax it"
+    )
+
+
+def test_the_drift_is_reported_at_warning_level(caplog):
+    """The renormalisation's removal left this line as the only signal for the drift.
+
+    It was `logger.debug`, which is off by default -- a 179% mass error that nothing
+    printed. Pinned because a diagnostic nobody reads is the same failure as no
+    diagnostic, and log levels are the kind of thing a later edit lowers without noticing.
+    """
+    import logging
+
+    m0, drift = _inputs(5.0)
+    with caplog.at_level(logging.WARNING, logger="mfgarchon.alg.numerical.fp_solvers.fp_gfdm"):
+        _solver(0.3).solve_fp_system(m0, drift)
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "the drift was not reported at WARNING or above"
+    assert "1752" in warnings[0].getMessage(), "the message must name the issue tracking the defect"

--- a/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
+++ b/tests/unit/test_alg/test_fp_gfdm_mass_gate.py
@@ -164,6 +164,48 @@ def test_the_drift_is_reported_at_warning_level(caplog):
     assert "1752" in warnings[0].getMessage(), "the message must name the issue tracking the defect"
 
 
+def test_the_remedy_does_not_tell_a_stabilised_solve_to_stabilise():
+    """The first fix for this interpolated `upwind_scheme` and then ignored it.
+
+    On a solve already using `'linear'` it printed "upwind_scheme is 'linear'. 'none' leaves
+    the flux divergence unstabilised ... 'linear' or 'exponential' measurably reduce it" --
+    naming a mechanism the caller is not in and prescribing what they already did. Caught in
+    re-review, and unpinned by my own fix until this test: mutating the branch to always take
+    the 'none' text left all eight other tests green.
+    """
+    n_x, n_t = 21, 10
+    x = np.linspace(0, 1, n_x)
+    m0 = np.exp(-30 * (x - 0.5) ** 2)
+    m0 /= m0.sum()
+    drift = np.tile(25.0 * (x - 0.5) ** 2, (n_t + 1, 1))
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n_x], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(
+        geometry=grid,
+        Nt=n_t,
+        T=T,
+        sigma=0.1,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-30 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    solver = FPGFDMSolver(problem, collocation_points=np.linspace(0, 1, n_x).reshape(-1, 1), upwind_scheme="linear")
+    with pytest.raises(ValueError) as exc:
+        solver.solve_fp_system(m0, drift)
+    message = str(exc.value)
+    assert "already 'linear'" in message, "the message must acknowledge the scheme the caller is on"
+    assert "is not enough here" in message
+    assert "'linear' or 'exponential' measurably reduce it" not in message, (
+        "do not prescribe the stabilisation the caller already enabled"
+    )
+
+
 def test_a_clip_far_below_one_percent_still_stops_the_solve():
     """Pins the THRESHOLD, which the large-clip configurations above do not.
 
@@ -205,6 +247,13 @@ def test_refining_the_timestep_silences_the_gate_while_the_answer_gets_worse():
         Nt=640   max fabricated 3.396e-05   final mass 1.70e+09   raises
         Nt=2560  max fabricated 0.000e+00   final mass 2.55e+09   PASSES
 
+    The configuration pinned below is a stronger instance found in re-review: N=41, Nt=640,
+    sigma=0.5, drift=50 fabricates **nothing** and returns a final mass of 1.06e+23. It is
+    pinned instead of the Nt=2560 case because it is 13 orders further past the assertion and
+    does not depend on sitting past a refinement boundary -- the Nt=2560 case was measured to
+    flip to raising somewhere between Nt=900 and Nt=1100, which is a 2.6x margin rather than a
+    structural one.
+
     No threshold closes it **here**: any fixed value can be driven below on this
     configuration. Whether that generalises to the gate's other callers is open -- the
     attempt to reproduce it at the FDM time-stepping site during review produced a null with
@@ -216,16 +265,35 @@ def test_refining_the_timestep_silences_the_gate_while_the_answer_gets_worse():
     Asserted so nobody later reads a passing gate as "the solve is healthy", and so the drift
     WARNING is not mistaken for redundant with the gate: only the pair covers this.
     """
-    n_t = 2560
-    x = np.linspace(0, 1, N)
+    n_t = 640
+    n_x = 41
+    x = np.linspace(0, 1, n_x)
     m0 = np.exp(-30 * (x - 0.5) ** 2)
     m0 /= m0.sum()
-    drift = np.tile(25.0 * (x - 0.5) ** 2, (n_t + 1, 1))
+    drift = np.tile(50.0 * (x - 0.5) ** 2, (n_t + 1, 1))
 
-    result = _build(sigma=0.1, Nt=n_t).solve_fp_system(m0, drift)
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n_x], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(
+        geometry=grid,
+        Nt=n_t,
+        T=T,
+        sigma=0.5,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-30 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    result = FPGFDMSolver(problem, collocation_points=np.linspace(0, 1, n_x).reshape(-1, 1)).solve_fp_system(m0, drift)
 
-    assert result.min() >= 0.0, "if this goes negative the gate would have caught it and the point is moot"
-    assert float(result[-1].sum()) > 1e6, (
-        f"final mass {float(result[-1].sum()):.3e}: this configuration is meant to diverge while "
-        f"staying positive, which is the blind spot being recorded"
+    # No assertion on result.min(): `clip_nonnegative_or_raise` returns `np.maximum(density, 0)`
+    # into every row, so non-negativity is imposed by the gate and cannot fail. Asserting it
+    # would look like a check and be a tautology.
+    assert float(result[-1].sum()) > 1e18, (
+        f"final mass {float(result[-1].sum()):.3e}: this configuration is meant to diverge past "
+        f"1e+20 while fabricating nothing, which is the blind spot being recorded"
     )


### PR DESCRIPTION
Closes part of #1683 (GFDM site). Files #1752.

## What this changes

`fp_gfdm.py` clipped negatives to zero, renormalised to the initial mass, and warned only
above 1% drift — the warning computed *before* the renormalisation, so it reported a
number the returned array then contradicted. Every configuration came back with a final
mass of exactly 1.0000, including one measured to clip **61%** of the present mass at a
single step.

The site now routes through `clip_nonnegative_or_raise` (#1683's owner) and the
renormalisation is deleted.

## What removing it exposed — #1752

This is the part worth reading. On a configuration that clips **nothing** across all ten
steps, mass still goes `1.000000 -> 2.794967`. **+179% with no positivity repair
involved.**

The renormalisation was not masking the clip. It was masking the scheme: forward Euler
with a non-conservative GFDM operator has nothing enforcing `d/dt ∫m = 0`, and scaling
the answer afterwards made all four probed configurations report perfect conservation:

```
sigma=0.5 drift=1     clipped 5/10 steps, max 61.1% fabricated   final mass 1.0000
sigma=0.3 drift=5     clipped 0/10 steps                         final mass 1.0000
sigma=0.1 drift=25    clipped 10/10 steps, max  9.6%             final mass 1.0000
sigma=0.05 drift=50   clipped 10/10 steps, max 53.9%             final mass 1.0000
```

Filed as #1752 rather than fixed here — a conservative discretisation is not a change
this batch can carry.

The drift log moves DEBUG → WARNING as the removal's own tail: with the rescaling gone it
is the only remaining signal, and a 179% error that nothing prints is the same failure as
no diagnostic at all.

## Coverage

Migrating this path broke **no existing test**. That is the other half of the finding — a
public solver whose plausible configurations fabricate most of their mass had no coverage
of that behaviour. `tests/unit/test_alg/test_fp_gfdm_mass_gate.py` supplies it.

Six tests, each verified against the mutation it is aimed at rather than asserted to be
useful:

| mutation | red |
|---|---|
| restore clip-then-renormalise | 4 of 6 |
| lower the drift log to DEBUG | the 6th |
| — (negative control: a converging solve must still run) | passes both, by design |

One test asserts `final > 2.0`, which is the **measurement, not the desired behaviour**.
It is written to fail if the drift *improves*, so fixing #1752 cannot land silently — a
conservative scheme turns it red, which is when it should be deleted rather than relaxed.
The docstring says so.

## Gate

`./scripts/local_ci.sh` **GREEN** — 5709 passed, 22 skipped, 8 xfailed, 166.84 s. Exit
code read directly, not through a pipe (that mistake hid a real regression earlier in
this campaign).

## Not in scope

Remaining #1683 sites: network `FPNetworkSolver`, the deprecated `FPSLJacobianSolver`
(clip → clip → renormalise, zero diagnostic), and the backend toy surface. Weak-form
stays parked — the threshold measured on the FDM configuration does not transfer, and the
three prerequisites for revisiting it are recorded on #1683.