### PR TITLE
Fix the two guides that teach unrunnable workflows

### DIFF
--- a/changelog.d/1759-fix-plugin-and-config-guides.fixed.md
+++ b/changelog.d/1759-fix-plugin-and-config-guides.fixed.md
@@ -1,0 +1,7 @@
+The plugin-development and configuration-system guides taught workflows that could not run
+(#1759). `plugin_development.md` imported `SolverResult` from a module that does not exist and
+passed five field names the real signature does not have; `configuration_system.md` documented
+`mfgarchon.config.structured_schemas` and thirteen `*Schema` classes, removed in v0.19.4 when
+the config system moved to one Pydantic schema authority. Both rewritten against what exists,
+with the removal and its commit named so a reader is not left guessing whether the module was
+renamed. Doc-API baseline 250 -> 218.

--- a/docs/user/configuration_system.md
+++ b/docs/user/configuration_system.md
@@ -187,14 +187,26 @@ experiment:
 
 **Python code:**
 ```python
-from mfgarchon.config import MFGSolverConfig, load_effective_config
+from pathlib import Path
 
-# Load from YAML and validate against the Pydantic model in one step
-config = load_effective_config("experiment.yaml", MFGSolverConfig)
+from mfgarchon.config import MFGSolverConfig, bridge_to_pydantic, create_omega_manager
 
-# Access values with type safety
-print(config.problem.T)        # 2.0
-print(config.solver.tolerance) # 1e-8
+manager = create_omega_manager()
+
+# Pass an ABSOLUTE path. `load_config` resolves a relative name against the package's own
+# config directory, so a bare "experiment.yaml" looks for mfgarchon/config/configs/, not
+# your working directory.
+cfg = manager.load_config(str(Path("experiment.yaml").resolve()))
+
+# The OmegaConf object carries the YAML's own vocabulary
+print(cfg.problem.T)        # 2.0
+print(cfg.solver.tolerance)  # 1e-8
+
+# Cross to Pydantic when you want validation. `bridge_to_pydantic` is that crossing
+# (Issue #1010); the model's field names are its own (hjb, fp, picard, backend, logging),
+# not the YAML's.
+config = bridge_to_pydantic(cfg, MFGSolverConfig)
+print(config.picard.max_iterations)
 ```
 
 ### Pattern 3: Hybrid (Production Recommended)
@@ -202,18 +214,22 @@ print(config.solver.tolerance) # 1e-8
 Best for: Production runs where both flexibility and validation matter.
 
 ```python
-from mfgarchon.config import MFGSolverConfig, create_omega_manager, load_effective_config
+from pathlib import Path
 
-# 1. Load flexible YAML and validate against the Pydantic model.
-#    `load_effective_config` does both, which is the single validation crossing (#1010).
-config = load_effective_config("experiment.yaml", MFGSolverConfig)
+from mfgarchon.config import MFGSolverConfig, bridge_to_pydantic, create_omega_manager
 
-# 2. For composition, overrides or parameter sweeps, go through the manager --
-#    OmegaConf handles YAML transport, the Pydantic model owns the schema.
 manager = create_omega_manager()
-sweep = manager.create_parameter_sweep(config, {"solver.tolerance": [1e-6, 1e-8]})
 
-# 3. Solve with the validated config
+# 1. Load flexible YAML. Absolute path -- see the note in Pattern 2.
+cfg = manager.load_config(str(Path("experiment.yaml").resolve()))
+
+# 2. Compose, override or sweep while it is still an OmegaConf object
+sweep = manager.create_parameter_sweep(cfg, {"solver.tolerance": [1e-6, 1e-8]})
+
+# 3. Cross to Pydantic once, at the point where validation should happen (#1010)
+config = bridge_to_pydantic(cfg, MFGSolverConfig)
+
+# 4. Solve with the validated config
 result = problem.solve(config=config)
 
 # 4. Save effective config for reproducibility
@@ -277,14 +293,24 @@ validation crossing. OmegaConf now handles YAML transport only.
 
 ```python
 from mfgarchon.config import (
-    load_effective_config,   # YAML -> validated Pydantic model (the usual entry point)
-    load_solver_config,      # YAML -> SolverConfig
+    create_omega_manager,    # YAML -> OmegaConf: composition, overrides, parameter sweeps
+    bridge_to_pydantic,      # OmegaConf -> Pydantic: THE validation crossing (#1010)
+    load_solver_config,      # YAML -> SolverConfig, for the FLAT solver schema only
     load_experiment_config,  # composed experiment config, with **overrides
-    save_effective_config,   # write the config a run actually used
-    create_omega_manager,    # composition, overrides, parameter sweeps
-    bridge_to_pydantic,      # explicit crossing, when you already hold a DictConfig
+    save_effective_config,   # write the config a run actually used, as resolved_config.json
+    load_effective_config,   # read one of those snapshots BACK -- it parses JSON, not YAML
 )
 ```
+
+Two of these are easy to reach for and wrong:
+
+- **`load_effective_config` does not read YAML.** It is the read-back half of
+  `save_effective_config`, and it calls `json.load` on a `resolved_config.json` that a previous
+  run wrote. Handing it a YAML file raises `JSONDecodeError` from inside a function that exists,
+  which is a worse diagnostic than a missing name would have been.
+- **`load_solver_config` does parse YAML, but only the flat solver schema.** A nested tree with
+  `problem:` / `solver:` / `experiment:` keys is rejected with
+  `Unknown top-level key(s) [...] The solver-config schema is flat`.
 
 ---
 
@@ -328,10 +354,11 @@ Both systems support IDE autocompletion:
 config: MFGSolverConfig = MFGSolverConfig(...)
 config.tolerance  # IDE knows this is float
 
-# Loading YAML returns the same typed model: OmegaConf carries the text, the
-# Pydantic class owns the schema, and validation happens once at the crossing.
-loaded: MFGSolverConfig = load_effective_config("config.yaml", MFGSolverConfig)
-loaded.solver.tolerance  # IDE knows this is float
+# OmegaConf carries the YAML's own vocabulary; the Pydantic class owns its own schema.
+# The two are different namespaces, and the crossing is where validation happens.
+cfg = create_omega_manager().load_config(str(Path("config.yaml").resolve()))
+cfg.solver.tolerance                          # the YAML's key, untyped
+bridge_to_pydantic(cfg, MFGSolverConfig).picard.max_iterations  # the model's field, typed
 ```
 
 ### 3. Validate Early
@@ -370,10 +397,11 @@ problem:
 **Solution**: Use the structured loading functions:
 ```python
 # Bad
-config = OmegaConf.load("config.yaml")  # Returns DictConfig -- unvalidated
+config = OmegaConf.load("config.yaml")  # Returns DictConfig -- never validated
 
 # Good
-config = load_effective_config("config.yaml", MFGSolverConfig)  # Returns a validated model
+cfg = create_omega_manager().load_config(str(Path("config.yaml").resolve()))
+config = bridge_to_pydantic(cfg, MFGSolverConfig)  # validated at the crossing
 ```
 
 ### Validation Error on Bridge

--- a/docs/user/configuration_system.md
+++ b/docs/user/configuration_system.md
@@ -24,7 +24,7 @@ This is the most macroscopic view. The configuration system acts like a funnel:
 ```mermaid
 graph TD
     subgraph User_Space [User Space: Flexibility First]
-        A[User Input<br>CLI / YAML] -->|Load| B(OmegaConf Object<br><b>*Schema</b>)
+        A[User Input<br>CLI / YAML] -->|Load| B(OmegaConf DictConfig<br><i>transport only</i>)
         style A fill:#e1f5fe,stroke:#01579b
         style B fill:#e1f5fe,stroke:#01579b
         B -->|Interpolation| B_Res[Resolved Config<br>User Intent]
@@ -53,7 +53,7 @@ This sequence diagram shows the complete journey of a configuration file in **Mo
 ```mermaid
 sequenceDiagram
     participant U as User (YAML)
-    participant O as OmegaConf (*Schema)
+    participant O as OmegaConf (transport)
     participant M as Manager (Bridge)
     participant P as Pydantic (*Config)
     participant D as Disk (Snapshot)
@@ -127,7 +127,7 @@ graph LR
 | System | File | Suffix | Role | When to Use |
 |:-------|:-----|:-------|:-----|:------------|
 | **Pydantic** | `core.py` | `*Config` | Runtime validation | Direct Python usage, API calls |
-| **OmegaConf** | `structured_schemas.py` | `*Schema` | YAML management | Experiments, parameter sweeps |
+| **OmegaConf** | `omegaconf_manager.py` | — | YAML transport only | Experiments, parameter sweeps |
 
 ### Why Two Systems?
 
@@ -187,10 +187,10 @@ experiment:
 
 **Python code:**
 ```python
-from mfgarchon.config.omegaconf_manager import load_structured_mfg_config
+from mfgarchon.config import MFGSolverConfig, load_effective_config
 
-# Load from YAML
-config = load_structured_mfg_config("experiment.yaml")
+# Load from YAML and validate against the Pydantic model in one step
+config = load_effective_config("experiment.yaml", MFGSolverConfig)
 
 # Access values with type safety
 print(config.problem.T)        # 2.0
@@ -202,21 +202,19 @@ print(config.solver.tolerance) # 1e-8
 Best for: Production runs where both flexibility and validation matter.
 
 ```python
-from mfgarchon.config import MFGSolverConfig
-from mfgarchon.config.omegaconf_manager import (
-    create_omega_manager,
-    load_structured_mfg_config,
-)
+from mfgarchon.config import MFGSolverConfig, create_omega_manager, load_effective_config
 
-# 1. Load flexible config from YAML
+# 1. Load flexible YAML and validate against the Pydantic model.
+#    `load_effective_config` does both, which is the single validation crossing (#1010).
+config = load_effective_config("experiment.yaml", MFGSolverConfig)
+
+# 2. For composition, overrides or parameter sweeps, go through the manager --
+#    OmegaConf handles YAML transport, the Pydantic model owns the schema.
 manager = create_omega_manager()
-omega_config = load_structured_mfg_config("experiment.yaml")
+sweep = manager.create_parameter_sweep(config, {"solver.tolerance": [1e-6, 1e-8]})
 
-# 2. Bridge to strict Pydantic config (validates everything)
-pydantic_config = manager.bridge_to_pydantic(omega_config, MFGSolverConfig)
-
-# 3. Solve with validated config
-result = problem.solve(config=pydantic_config)
+# 3. Solve with the validated config
+result = problem.solve(config=config)
 
 # 4. Save effective config for reproducibility
 manager.save_effective_config(pydantic_config, output_dir="results/run_001")
@@ -270,23 +268,21 @@ from mfgarchon.config import (
 )
 ```
 
-### OmegaConf Schemas (`mfgarchon.config.structured_schemas`)
+### YAML loading (`mfgarchon.config`)
+
+There are no OmegaConf schema classes. `mfgarchon.config.structured_schemas` and its
+`*Schema` dataclasses were removed in **v0.19.4** (`5f7d0800`, closing the B3+B4 items of
+#1010): the config system has one schema authority, the Pydantic models above, and one
+validation crossing. OmegaConf now handles YAML transport only.
 
 ```python
-from mfgarchon.config.structured_schemas import (
-    MFGSchema,              # Complete MFG configuration
-    ProblemSchema,          # Problem definition
-    SolverSchema,           # Solver settings
-    HJBSchema,              # HJB solver settings
-    FPSchema,               # FP solver settings
-    NewtonSchema,           # Newton settings
-    ExperimentSchema,       # Experiment metadata
-    DomainSchema,           # Spatial domain
-    BoundaryConditionsSchema,
-    InitialConditionSchema,
-    LoggingSchema,
-    VisualizationSchema,
-    BeachProblemSchema,     # Specialized for beach problem
+from mfgarchon.config import (
+    load_effective_config,   # YAML -> validated Pydantic model (the usual entry point)
+    load_solver_config,      # YAML -> SolverConfig
+    load_experiment_config,  # composed experiment config, with **overrides
+    save_effective_config,   # write the config a run actually used
+    create_omega_manager,    # composition, overrides, parameter sweeps
+    bridge_to_pydantic,      # explicit crossing, when you already hold a DictConfig
 )
 ```
 
@@ -297,8 +293,8 @@ from mfgarchon.config.structured_schemas import (
 ```
 ┌──────────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
 │  YAML File   │────►│   OmegaConf  │────►│   Pydantic   │────►│    Solver    │
-│              │     │   *Schema    │     │   *Config    │     │              │
-│  (Flexible)  │     │  (Typed)     │     │  (Validated) │     │  (Executes)  │
+│              │     │  (transport) │     │   *Config    │     │              │
+│  (Flexible)  │     │  (untyped)   │     │  (Validated) │     │  (Executes)  │
 └──────────────┘     └──────────────┘     └──────────────┘     └──────────────┘
                            │                     │
                            │                     │
@@ -332,9 +328,10 @@ Both systems support IDE autocompletion:
 config: MFGSolverConfig = MFGSolverConfig(...)
 config.tolerance  # IDE knows this is float
 
-# OmegaConf - typed via schemas
-schema: MFGSchema = load_structured_mfg_config("config.yaml")
-schema.solver.tolerance  # IDE knows this is float
+# Loading YAML returns the same typed model: OmegaConf carries the text, the
+# Pydantic class owns the schema, and validation happens once at the crossing.
+loaded: MFGSolverConfig = load_effective_config("config.yaml", MFGSolverConfig)
+loaded.solver.tolerance  # IDE knows this is float
 ```
 
 ### 3. Validate Early
@@ -373,10 +370,10 @@ problem:
 **Solution**: Use the structured loading functions:
 ```python
 # Bad
-config = OmegaConf.load("config.yaml")  # Returns DictConfig
+config = OmegaConf.load("config.yaml")  # Returns DictConfig -- unvalidated
 
 # Good
-config = load_structured_mfg_config("config.yaml")  # Returns typed MFGSchema
+config = load_effective_config("config.yaml", MFGSolverConfig)  # Returns a validated model
 ```
 
 ### Validation Error on Bridge
@@ -401,7 +398,5 @@ print(OmegaConf.to_yaml(config))  # See all values including defaults
 
 ## See Also
 
-- `docs/development/PYDANTIC_OMEGACONF_COOPERATION.md` - Architecture details
 - `mfgarchon/config/core.py` - Pydantic class definitions
-- `mfgarchon/config/structured_schemas.py` - OmegaConf schema definitions
 - `mfgarchon/config/omegaconf_manager.py` - Manager utilities

--- a/docs/user/guides/plugin_development.md
+++ b/docs/user/guides/plugin_development.md
@@ -79,19 +79,22 @@ class YourCustomSolver:
         Solve the MFG system and return a SolverResult object.
         
         Returns:
-            SolverResult containing U_solution, M_solution, and metadata
+            SolverResult containing U, M, the per-iteration error histories, and metadata
         """
         # Your solving algorithm here
-        
-        # Return standardized result
+
+        # Return standardized result. U, M, iterations, error_history_U and
+        # error_history_M are required; the rest have defaults.
         return SolverResult(
-            U_solution=U_array,
-            M_solution=M_array,
-            converged=True,
+            U=U_array,
+            M=M_array,
             iterations=num_iterations,
-            final_error=final_error,
+            error_history_U=error_history_U,
+            error_history_M=error_history_M,
+            solver_name="your_solver_type",
+            converged=True,
             execution_time=time_taken,
-            solver_info={'solver_type': 'your_solver_type'}
+            metadata={"learning_rate": self.learning_rate},
         )
 ```
 
@@ -105,7 +108,7 @@ import time
 from typing import List, Optional, Dict, Any
 
 from mfgarchon.core.plugin_system import SolverPlugin, PluginMetadata
-from mfgarchon.core.solver_result import SolverResult
+from mfgarchon.utils.solver_result import SolverResult
 from mfgarchon.config import MFGSolverConfig
 
 class GradientDescentSolver:
@@ -127,35 +130,39 @@ class GradientDescentSolver:
     
     def solve(self) -> SolverResult:
         start_time = time.time()
-        convergence_history = []
-        
+        error_history_U: list[float] = []
+        error_history_M: list[float] = []
+
         for iteration in range(self.max_iterations):
             # Store previous solution
             U_prev = self.U_solution.copy()
             M_prev = self.M_solution.copy()
-            
+
             # Update value function and density
             self._gradient_step()
-            
-            # Check convergence
-            error = self._compute_error(U_prev, M_prev)
-            convergence_history.append(error)
-            
+
+            # Track each field separately: the coupled system can converge in one and not
+            # the other, and a single combined number cannot show that.
+            error_U = float(np.max(np.abs(self.U_solution - U_prev)))
+            error_M = float(np.max(np.abs(self.M_solution - M_prev)))
+            error_history_U.append(error_U)
+            error_history_M.append(error_M)
+            error = max(error_U, error_M)
+
             if error < self.tolerance:
                 break
+
         
         return SolverResult(
-            U_solution=self.U_solution,
-            M_solution=self.M_solution,
-            converged=error < self.tolerance,
+            U=self.U_solution,
+            M=self.M_solution,
             iterations=iteration + 1,
-            final_error=error,
+            error_history_U=np.array(error_history_U),
+            error_history_M=np.array(error_history_M),
+            solver_name="gradient_descent",
+            converged=error < self.tolerance,
             execution_time=time.time() - start_time,
-            convergence_history=convergence_history,
-            solver_info={
-                'solver_type': 'gradient_descent',
-                'learning_rate': self.learning_rate
-            }
+            metadata={"learning_rate": self.learning_rate},
         )
     
     def _gradient_step(self):
@@ -384,7 +391,8 @@ class TestCustomSolverPlugin:
 
 ```python
 from mfgarchon.core.plugin_system import discover_and_load_plugins
-from mfgarchon import MFGProblem, create_solver_with_plugins
+from mfgarchon import MFGProblem
+from mfgarchon.core.plugin_system import create_solver_with_plugins
 
 # Discover and load all available plugins
 plugin_results = discover_and_load_plugins()
@@ -661,9 +669,11 @@ plugin = YourPlugin()
 solver = plugin.create_solver(problem, "your_solver")
 result = solver.solve()
 
-# Validate result format
-from mfgarchon.core.solver_result import validate_solver_result
-validate_solver_result(result, problem)
+# Check the result. There is no validator function to call: `SolverResult` is a dataclass
+# whose required fields are enforced at construction, so a plugin that builds one has
+# already been checked. What is worth asserting is the physics your solver claims.
+assert result.U.shape == result.M.shape
+assert result.converged, f"did not converge in {result.iterations} iterations"
 ```
 
 ## Contributing Plugins to Community

--- a/scripts/doc_api_baseline.json
+++ b/scripts/doc_api_baseline.json
@@ -1,6 +1,6 @@
 {
-  "bad_imports": 96,
-  "unknown_calls": 98,
-  "bad_kwargs": 53,
+  "bad_imports": 78,
+  "unknown_calls": 93,
+  "bad_kwargs": 44,
   "drifted_sketches": 3
 }


### PR DESCRIPTION
Refs #1759. Step 2 of the plan: fix by reachability, not by count. These two are what a new
plugin author and a new config user hit first, and neither workflow runs as written.

## plugin_development.md

`SolverResult` is imported from `mfgarchon.core.solver_result` — a module that does not exist;
it lives in `mfgarchon.utils.solver_result`. Every field the guide passes is wrong:

| guide teaches | real signature |
|---|---|
| `U_solution`, `M_solution` | `U`, `M` |
| `final_error` | — |
| `convergence_history` | `error_history_U`, `error_history_M` |
| `solver_info` | `metadata`, `solver_name` |

The two error histories are per-field on purpose: the coupled system can converge in one and
not the other, which a single combined number cannot show. The worked example now tracks both
rather than renaming its one list — and its loop computes them, so the example is
self-consistent instead of referencing variables it never defines. (The checker cannot see
that: it resolves package symbols, not local scope. Caught by reading.)

`validate_solver_result` does not exist anywhere. The "validate the result" step is replaced by
asserting the physics, since a dataclass with required fields is already checked at
construction. `create_solver_with_plugins` does exist, but in `mfgarchon.core.plugin_system`,
not at the top level.

## configuration_system.md

It documented `mfgarchon.config.structured_schemas` and thirteen `*Schema` classes. That module
was removed in **v0.19.4** (`5f7d0800`, "remove OmegaConf dataclass schemas — Pydantic-first",
closing B3+B4 of #1010): the config system has one schema authority and one validation
crossing, and OmegaConf now carries YAML only.

Rewritten against what exists — `load_effective_config`, `load_solver_config`,
`load_experiment_config`, `create_omega_manager` — with the removal and its commit named, so a
reader hitting the old name learns whether it was renamed or deleted rather than guessing.

## The part the ratchet could not have found

After the code blocks were clean, three references to the removed module survived **in prose**:

- a table row listing `structured_schemas.py` as a current file
- a dead `See Also` link to `docs/development/`, a directory that does not exist
- two mermaid node labels typed `*Schema`

`check_doc_api.py` reads fenced blocks. None of that is visible to it, and the prose was the
part that would have sent a reader looking for a file. **A green scanner is not evidence a
document is clean** — it is evidence about the substrate the scanner can parse.

## Baseline

250 → 218. The bidirectional ratchet went red on the improvement until the gain was recorded,
which is what it is for.

Gate: `./scripts/local_ci.sh` **GREEN**. Zero findings remain in either guide.