### PR TITLE
Stop the built-in Newton from accepting a step that increases the residual

### DIFF
--- a/changelog.d/1745-newton-globalization.changed.md
+++ b/changelog.d/1745-newton-globalization.changed.md
@@ -1,0 +1,8 @@
+`NewtonSolver` no longer accepts a step that increases the residual (#1745). `line_search`
+defaults to `True`, an always-on divergence guard stops the solve when the residual exceeds
+1e4x its initial value (PETSc's `SNESSetDivergenceTolerance` default), and "no acceptable step"
+and "diverged" are now named outcomes in `SolverInfo.extra` rather than an exhausted iteration
+budget. The Armijo condition was also comparing a residual norm against a step norm; it now uses
+the standard `||F(x + a*d)|| <= (1 - c*a)*||F(x)||`. Measured on a 2-D HJB solve, the previous
+default converged to 1.57e-03 in five iterations and then diverged geometrically to 2.42e-01
+because the full step increased the residual where a half step would have quartered it.

--- a/mfgarchon/utils/numerical/nonlinear_solvers.py
+++ b/mfgarchon/utils/numerical/nonlinear_solvers.py
@@ -20,6 +20,7 @@ References:
 
 from __future__ import annotations
 
+import time
 import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
@@ -297,7 +298,8 @@ class NewtonSolver(NonlinearSolver):
         tolerance: float = 1e-6,
         jacobian: Callable[[NDArray], NDArray | sparse.spmatrix] | None = None,
         sparse: bool = True,
-        line_search: bool = False,
+        line_search: bool = True,
+        divergence_tolerance: float = 1e4,
         finite_diff_epsilon: float = 1e-7,
         use_jax_autodiff: bool | Literal["auto"] = "auto",
     ):
@@ -310,7 +312,16 @@ class NewtonSolver(NonlinearSolver):
             jacobian: Optional Jacobian function J: x → ∂F/∂x
                      If None, uses autodiff (if JAX available) or finite differences
             sparse: Use sparse linear solver (for large systems)
-            line_search: Enable backtracking line search
+            line_search: Backtracking line search. **On by default (Issue #1745)** -- a
+                Newton that accepts a step increasing the residual can walk away from a root
+                it had almost reached. Measured on a 2-D HJB solve: the residual converged to
+                1.57e-03 in five iterations, then diverged geometrically to 2.42e-01 because
+                the full step increased it (1.63e-03) where a half step would have quartered
+                it (3.95e-04). No surveyed library -- PETSc, KINSOL, SciPy, Optimistix,
+                Trilinos NOX -- ships an unchecked full step as what a caller gets by
+                omission. Pass False only with a reason.
+            divergence_tolerance: stop when the residual exceeds this multiple of the initial
+                one. Always applied, line search or not (PETSc default, 1e4).
             finite_diff_epsilon: Step size for finite differences
             use_jax_autodiff: Whether to use JAX automatic differentiation:
                 - True: Use JAX autodiff (raises error if JAX not available)
@@ -329,6 +340,8 @@ class NewtonSolver(NonlinearSolver):
         self.jacobian_func = jacobian
         self.use_sparse = sparse
         self.line_search = line_search
+        # PETSc's SNESSetDivergenceTolerance default, and always on there for the same reason.
+        self.divergence_tolerance = divergence_tolerance
         self.epsilon = finite_diff_epsilon
 
         # Configure JAX autodiff
@@ -432,11 +445,47 @@ class NewtonSolver(NonlinearSolver):
             # Solve linear system: J δx = -F
             delta_x = self._solve_linear_system(J, -F_current.flatten(), original_shape)
 
-            # Line search (optional)
+            # Line search (on by default; Issue #1745)
             if self.line_search:
                 alpha = self._backtracking_line_search(F, x_current, delta_x, F_current)
+                if alpha == 0.0:
+                    return self._stop(
+                        x_current,
+                        is_scalar,
+                        iteration,
+                        residual_norm,
+                        residual_history,
+                        start_time,
+                        jacobian_evals,
+                        reason="line_search_failed",
+                        detail=(
+                            "no step along the Newton direction reduced the residual. The "
+                            "direction may be wrong (check the Jacobian) or the iterate may "
+                            "be at a local minimum of ||F|| that is not a root."
+                        ),
+                    )
             else:
                 alpha = 1.0
+
+            # Divergence guard, always on. PETSc keeps SNESSetDivergenceTolerance active
+            # regardless of line search for the same reason: a run that has grown this far past
+            # its starting residual is not going to recover, and the remaining iterations only
+            # delay the diagnosis.
+            if residual_norm > self.divergence_tolerance * residual_history[0]:
+                return self._stop(
+                    x_current,
+                    is_scalar,
+                    iteration,
+                    residual_norm,
+                    residual_history,
+                    start_time,
+                    jacobian_evals,
+                    reason="diverged",
+                    detail=(
+                        f"residual grew to {residual_norm:.3e}, more than "
+                        f"{self.divergence_tolerance:g}x the initial {residual_history[0]:.3e}."
+                    ),
+                )
 
             # Update
             x_current = x_current + alpha * delta_x
@@ -504,6 +553,40 @@ class NewtonSolver(NonlinearSolver):
 
         return delta_x_flat.reshape(original_shape)
 
+    def _stop(
+        self,
+        x_current,
+        is_scalar: bool,
+        iteration: int,
+        residual: float,
+        residual_history: list[float],
+        start_time: float,
+        jacobian_evals: int,
+        *,
+        reason: str,
+        detail: str,
+    ):
+        """Stop with a NAMED outcome rather than exhausting the iteration budget.
+
+        Issue #1745: "no acceptable step" and "diverged" are different from "ran out of
+        iterations", and a caller that cannot tell them apart cannot act on any of them. Every
+        surveyed library types these separately -- PETSc SNES_DIVERGED_LINE_SEARCH /
+        SNES_DIVERGED_DTOL, KINSOL KIN_LINESEARCH_NONCONV. The reason travels in `extra` so the
+        SolverInfo signature is unchanged.
+        """
+        warnings.warn(f"Newton stopped: {reason}. {detail}", RuntimeWarning, stacklevel=3)
+        return (
+            x_current.item() if is_scalar else x_current,
+            SolverInfo(
+                converged=False,
+                iterations=iteration,
+                residual=float(residual),
+                residual_history=residual_history,
+                solver_time=time.time() - start_time,
+                extra={"reason": reason, "detail": detail, "jacobian_evals": jacobian_evals},
+            ),
+        )
+
     def _backtracking_line_search(
         self,
         F: Callable[[NDArray], NDArray],
@@ -521,21 +604,27 @@ class NewtonSolver(NonlinearSolver):
         """
         alpha = alpha_init
         norm_F_x = np.linalg.norm(F_x.flatten())
-        norm_delta = np.linalg.norm(delta_x.flatten())
 
         for _ in range(20):  # Max 20 backtracking steps
             x_trial = x + alpha * delta_x
             F_trial = F(x_trial)
             norm_F_trial = np.linalg.norm(F_trial.flatten())
 
-            # Armijo condition
-            if norm_F_trial <= norm_F_x - c * alpha * norm_delta**2:
+            # Armijo sufficient decrease, in the standard form for a residual norm:
+            #   ||F(x + a*d)|| <= (1 - c*a) * ||F(x)||
+            # The previous form subtracted `c * alpha * ||delta_x||^2` from ||F(x)||, which
+            # compares a residual norm against a STEP norm -- different units, and the term is
+            # so small near a solution that it accepted essentially any decrease.
+            if norm_F_trial <= (1.0 - c * alpha) * norm_F_x:
                 return alpha
 
             alpha *= rho
 
-        # If line search fails, return small step
-        return alpha
+        # No acceptable step. Return 0.0 rather than the last tiny alpha: a step that does not
+        # reduce the residual is not worth taking, and reporting the failure is the caller's
+        # only chance to act on it. PETSc types this as SNES_DIVERGED_LINE_SEARCH rather than
+        # continuing; the previous code returned ~1e-6 and burned the remaining iterations.
+        return 0.0
 
 
 class PolicyIterationSolver(NonlinearSolver):

--- a/mfgarchon/utils/numerical/nonlinear_solvers.py
+++ b/mfgarchon/utils/numerical/nonlinear_solvers.py
@@ -579,11 +579,22 @@ class NewtonSolver(NonlinearSolver):
             x_current.item() if is_scalar else x_current,
             SolverInfo(
                 converged=False,
-                iterations=iteration,
+                # `iteration + 1`, matching the converged and budget-exhausted paths: the
+                # invariant across all three is `iterations == len(residual_history)`. Passing
+                # the raw 0-based index produced "failed to converge after 0 iterations", which
+                # reads as though the solver never ran.
+                iterations=iteration + 1,
                 residual=float(residual),
                 residual_history=residual_history,
                 solver_time=time.time() - start_time,
-                extra={"reason": reason, "detail": detail, "jacobian_evals": jacobian_evals},
+                # Splatted, NOT `extra={...}`. `SolverInfo.__init__` takes `**extra`, so a
+                # keyword literally named `extra` nests one level: callers found
+                # `info.extra["extra"]["reason"]` while every doc said `info.extra["reason"]`.
+                # It also shadowed `jacobian_evals`, so `newton_mfg_solver.py`'s
+                # `extra.get("jacobian_evals", 0)` reported 0 on every stop path.
+                reason=reason,
+                detail=detail,
+                jacobian_evals=jacobian_evals,
             ),
         )
 

--- a/tests/unit/test_utils/test_nonlinear_solvers_stop_reasons.py
+++ b/tests/unit/test_utils/test_nonlinear_solvers_stop_reasons.py
@@ -1,0 +1,61 @@
+r"""The named stop outcomes must be reachable where the docs say they are (#1745).
+
+Review found the whole path unexercised: `grep -rn "info\.extra" tests/` returned nothing, and
+the full suite emitted zero "Newton stopped:" warnings, so `_stop` shipped with its payload
+nested one level under `extra["extra"]` and nobody noticed. These tests are that coverage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.utils.numerical.nonlinear_solvers import NewtonSolver
+
+
+def _rootless(v):
+    """x^2 + 1 has no real root, and a non-singular Jacobian away from the origin."""
+    return v**2 + 1.0
+
+
+def test_a_failed_line_search_names_itself_in_extra():
+    """The changelog promises `SolverInfo.extra["reason"]`. It must be there, not nested.
+
+    `SolverInfo.__init__` takes `**extra`, so passing a keyword literally named `extra` buries
+    the payload at `info.extra["extra"]` while every document says `info.extra["reason"]`.
+    """
+    with pytest.warns(RuntimeWarning, match="Newton stopped"):
+        _, info = NewtonSolver(max_iterations=40, tolerance=1e-10, sparse=False).solve(_rootless, np.array([1.3, 2.7]))
+    assert not info.converged
+    assert info.extra["reason"] == "line_search_failed"
+    assert "extra" not in info.extra, "payload is nested one level; splat it instead"
+
+
+def test_the_stop_path_does_not_shadow_jacobian_evals():
+    """`newton_mfg_solver.py` reads `extra.get("jacobian_evals", 0)`.
+
+    Nesting made that getter return its fallback on every stop path -- a pre-existing field
+    silently reporting 0 where the true count was 20. The `.get()` default absorbed it, so
+    there was no error to notice.
+    """
+    with pytest.warns(RuntimeWarning):
+        _, info = NewtonSolver(max_iterations=40, tolerance=1e-10, sparse=False).solve(_rootless, np.array([1.3, 2.7]))
+    assert info.extra.get("jacobian_evals", 0) > 0
+
+
+def test_iterations_matches_the_residual_history_on_every_exit():
+    """The three exits disagreed: converged returned `iteration + 1`, budget-exhausted returned
+    `max_iterations`, and `_stop` returned the raw 0-based index -- so a stop that had performed
+    a Jacobian and twenty residual evaluations reported "after 0 iterations"."""
+    with pytest.warns(RuntimeWarning):
+        _, stopped = NewtonSolver(max_iterations=40, tolerance=1e-10, sparse=False).solve(
+            _rootless, np.array([1.3, 2.7])
+        )
+    assert stopped.iterations == len(stopped.residual_history)
+
+    _, converged = NewtonSolver(max_iterations=40, tolerance=1e-10, sparse=False).solve(
+        lambda v: v - 1.0, np.array([5.0, -3.0])
+    )
+    assert converged.converged
+    assert converged.iterations == len(converged.residual_history)


### PR DESCRIPTION
Refs #1745. Implements the three things a survey of fourteen solver libraries found to be
**consensus rather than taste**, under the principle that the algorithm choice belongs to the
user but the built-in default must have universal merit.

## What the survey found

| library | default | on residual increase | typed as |
|---|---|---|---|
| PETSc SNES | `SNESNEWTONLS` + `SNESLINESEARCHBT` | backtrack, then fail | `SNES_DIVERGED_LINE_SEARCH`; `divtol=1e4` always on |
| SUNDIALS KINSOL | **refuses to choose** — `strategy` is a required positional arg | backtrack | `KIN_LINESEARCH_NONCONV` |
| deal.II (KINSOL) | `linesearch`, not `newton` | delegates | KINSOL codes |
| DOLFINx | its full-step `NewtonSolver` is **deprecated** | — | — |
| SciPy `least_squares` | trust region, **no unglobalized option** | reject, shrink | — |
| Optimistix `BFGS`/`Dogleg` | `BacktrackingArmijo` / `ClassicalTrustRegion` | step **rejected**, iterate rolled back | `RESULTS` |

None ships an unchecked full step as the omission default. All type "no acceptable step" as a
distinct outcome.

Dissents are narrower than they look. Firedrake overrides PETSc's `bt` back to full step — but
keeps `rtol`, `divtol=1e4` and the NaN guard, so copying the step without those is strictly
worse than what Firedrake ships. NonlinearSolve.jl's polyalgorithm *starts* unglobalized, but a
user who specifies nothing cannot remain there: trust-region rungs sit beneath it.

## The four changes

1. **`line_search` defaults to `True`.** Measured on the 2-D HJB solve: residual converges to
   `1.57e-03` in five iterations, then diverges at ~1.15×/iteration to `2.42e-01`. At the
   turnaround the full step *increases* it (`1.63e-03`) where a half step quarters it
   (`3.95e-04`). The solver took the full step because it never looked.

2. **The Armijo condition was dimensionally wrong.** It compared a residual norm against a step
   norm — `||F(x+ad)|| <= ||F(x)|| - c*a*||dx||^2` — and near a solution the subtracted term is
   small enough that it accepted essentially any decrease. Now `<= (1 - c*a)*||F(x)||`.

3. **A failed line search returned the last backtracked alpha** (~1e-6 after 20 halvings) and
   carried on, spending the whole budget on steps that did nothing. Now stops with
   `reason="line_search_failed"` in `SolverInfo.extra`.

4. **Always-on divergence guard** at 1e4× the initial residual — PETSc's default, and always
   active there for the same reason.

## What this does NOT do

**It does not make the three 2-D capability cells pass.** With globalization on they no longer
diverge, but they do not reach tolerance either, and raising `max_newton_iterations` exposes a
different failure further into the solve that I have not characterised.

I am not tuning the iteration budget to turn the cells green. That would fit the test and leave
the defect.

## Worse than what this fixes, and deliberately not in scope

`base_hjb.py`'s `newton_hjb_step` declares convergence on the **step norm**
(`norm(delta_U) * sqrt(dx)`), never evaluating whether the residual is small — a stalled
iteration produces a small step, and so does a large Jacobian, so that path can return
`converged` at a point that is not a root. Its non-convergence branch is a literal `pass`, and
`converged` is never returned, so no caller can see it.

That path is used by the 1-D solvers. Changing its criterion will move numerical results, so it
needs its own change with its own before/after measurement rather than being folded in here.

## Gate

`./scripts/local_ci.sh` **GREEN** — 5723 passed, 22 skipped, 8 xfailed. Flipping the default
regresses nothing in the suite, which is the main risk this PR carries.