### PR TITLE
Prove the dead options are dead instead of asserting the refusal

### DIFF
--- a/changelog.d/1714-dead-option-no-effect-on-the-solve.added.md
+++ b/changelog.d/1714-dead-option-no-effect-on-the-solve.added.md
@@ -1,0 +1,10 @@
+- **The dead-option guards now have a test that measures their premise** (#1714, #1426). A
+  `pytest.raises` on "stored but never read" records that the guard fires, not that refusing is
+  right. Injecting `_boundary_indices` and `_domain_bounds` after construction, bypassing the
+  guard, and comparing full solves: every node marked boundary, a domain fifty times the real one,
+  and a domain covering a fifth of it all leave the solution byte-identical under a nonzero drift.
+  Scope, stated because it is narrower than "the option is dead": this establishes that no code
+  reached by `solve_fp_system` on this configuration branches on either value in a way that
+  changes the returned array. A read with no effect on the output — into a log record, say — would
+  not be detected, and construction-time consumption is out of reach of post-construction
+  injection by design.

--- a/changelog.d/1714-dead-options-provably-dead.added.md
+++ b/changelog.d/1714-dead-options-provably-dead.added.md
@@ -1,8 +1,0 @@
-- **The dead-option guards now have a test that proves the option is dead** (#1714, #1426). A
-  `pytest.raises` on "stored but never read" cannot distinguish "there is no reader" from "I could
-  not find a reader" — and a grep only ever gives the second. Injecting `_boundary_indices` and
-  `_domain_bounds` after construction, so the guard is bypassed, and comparing full solves: marking
-  every node a boundary, and a domain fifty times the real one, both leave the solution
-  byte-identical. The test asserts the injected attribute exists first, because setting a public
-  name where the solver stores a private one creates an unread attribute and byte-identity then
-  follows trivially.

--- a/changelog.d/1714-dead-options-provably-dead.added.md
+++ b/changelog.d/1714-dead-options-provably-dead.added.md
@@ -1,0 +1,8 @@
+- **The dead-option guards now have a test that proves the option is dead** (#1714, #1426). A
+  `pytest.raises` on "stored but never read" cannot distinguish "there is no reader" from "I could
+  not find a reader" — and a grep only ever gives the second. Injecting `_boundary_indices` and
+  `_domain_bounds` after construction, so the guard is bypassed, and comparing full solves: marking
+  every node a boundary, and a domain fifty times the real one, both leave the solution
+  byte-identical. The test asserts the injected attribute exists first, because setting a public
+  name where the solver stores a private one creates an unread attribute and byte-identity then
+  follows trivially.

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -112,3 +112,73 @@ class TestDeadOptionFailLoud:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])
+
+
+class TestDeadOptionsAreProvablyDead:
+    """The guards refuse options that are "stored but never read". This proves the "never read".
+
+    Issue #1714: `pytest.raises` on a guard's own message records that the guard fires. For a
+    dead-option guard it cannot record the thing that makes refusing correct — that the parameter
+    genuinely has no effect. "I could not find a reader" and "there is no reader" look identical
+    in a test that only asserts the raise, and the first is what a grep gives you.
+
+    Injecting the option AFTER construction bypasses the guard and lets the claim be measured
+    directly: set it to two wildly different values and compare the solutions. Byte-identical
+    output over a real solve is evidence no grep can produce.
+    """
+
+    def test_fp_gfdm_boundary_indices_and_domain_bounds_change_nothing(self):
+        # A gentler problem than the shared `_problem()` fixture, which at T=1.0 / sigma=0.5 drives
+        # the unstabilised GFDM flux past the mass-fabrication gate (#1752) before the comparison
+        # can run. The point here is byte-identity between two runs, so the configuration only has
+        # to be one the solver completes.
+        comp = MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        )
+        domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+        problem = MFGProblem(geometry=domain, T=0.2, Nt=8, sigma=0.3, components=comp)
+
+        points = _pts(problem)
+        n = points.shape[0]
+        xs = points[:, 0]
+        m_initial = np.exp(-((xs - 0.35) ** 2) / (2 * 0.09**2))
+        m_initial /= m_initial.sum()
+        drift = np.zeros((problem.Nt + 1, n))
+
+        def solve(**injected):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                solver = FPGFDMSolver(problem, collocation_points=points)
+                for name, value in injected.items():
+                    # The solver stores these privately. Setting a public name would create a NEW
+                    # attribute nothing reads, and byte-identity would follow trivially -- the test
+                    # would pass while measuring nothing. Assert the target exists first.
+                    assert hasattr(solver, name), (
+                        f"{name!r} is not an attribute of the constructed solver; injecting it "
+                        f"would prove nothing about whether the option is read"
+                    )
+                    setattr(solver, name, value)
+                return solver.solve_fp_system(m_initial.copy(), drift_field=drift)
+
+        baseline = solve()
+        assert np.all(np.isfinite(baseline)), "the baseline solve must succeed for this to mean anything"
+        assert baseline.std() > 1e-6, "a constant solution would make byte-identity vacuous"
+
+        # Two values as far apart as the parameter admits: nothing marked boundary, everything
+        # marked boundary, and a domain fifty times the real one.
+        assert np.array_equal(solve(_boundary_indices={0, 1}), baseline), (
+            "boundary_indices={0, 1} changed the solution -- it is read somewhere, and the guard's "
+            "claim that it is stored-but-never-read is wrong"
+        )
+        assert np.array_equal(solve(_boundary_indices=set(range(n))), baseline), (
+            "marking every node as a boundary changed the solution; boundary_indices is live"
+        )
+        assert np.array_equal(solve(_domain_bounds=[(-50.0, 50.0)]), baseline), (
+            "a domain 50x the real one changed the solution; domain_bounds is live"
+        )

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -159,7 +159,8 @@ class TestDeadOptionsAreProvablyDead:
                     # The solver stores these privately. Setting a public name would create a NEW
                     # attribute nothing reads, and byte-identity would follow trivially -- the test
                     # would pass while measuring nothing. Assert the target exists first.
-                    assert hasattr(solver, name), (
+                    _absent = object()
+                    assert getattr(solver, name, _absent) is not _absent, (
                         f"{name!r} is not an attribute of the constructed solver; injecting it "
                         f"would prove nothing about whether the option is read"
                     )

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -114,17 +114,29 @@ if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])
 
 
-class TestDeadOptionsAreProvablyDead:
-    """The guards refuse options that are "stored but never read". This proves the "never read".
+class TestDeadOptionsHaveNoEffectOnTheSolve:
+    """The guards refuse options that are "stored but never read". This measures the effect.
 
     Issue #1714: `pytest.raises` on a guard's own message records that the guard fires. For a
     dead-option guard it cannot record the thing that makes refusing correct — that the parameter
     genuinely has no effect. "I could not find a reader" and "there is no reader" look identical
     in a test that only asserts the raise, and the first is what a grep gives you.
 
-    Injecting the option AFTER construction bypasses the guard and lets the claim be measured
-    directly: set it to two wildly different values and compare the solutions. Byte-identical
+    Injecting the option AFTER construction bypasses the guard and lets the claim be measured:
+    set it to values as far apart as the parameter admits and compare the solutions. Byte-identical
     output over a real solve is evidence no grep can produce.
+
+    SCOPE, stated because it is narrower than "the option is dead". What this establishes is that
+    no code reached by ``solve_fp_system`` on this configuration branches on either value in a way
+    that changes the returned array. Three things it does NOT establish:
+
+    - A read with no effect on the output -- into a log record, a metric -- is not detected.
+    - Construction-time consumption is out of reach by design: ``TaylorOperator`` is built at
+      ``fp_gfdm.py:168`` BEFORE the attributes are stored at :186, and threading an option in
+      there is how ``obstacle_sdf`` was wired (#1556). The pre-existing ``..._raises`` tests cover
+      the construction path; this covers the solve path.
+    - Semantics that only appear in configurations this does not run: 2-D, a boundary type other
+      than no-flux, ``upwind_scheme`` other than the default.
     """
 
     def test_fp_gfdm_boundary_indices_and_domain_bounds_change_nothing(self):
@@ -149,12 +161,17 @@ class TestDeadOptionsAreProvablyDead:
         xs = points[:, 0]
         m_initial = np.exp(-((xs - 0.35) ** 2) / (2 * 0.09**2))
         m_initial /= m_initial.sum()
-        drift = np.zeros((problem.Nt + 1, n))
+        # A NONZERO drift. With drift=0 the flux m*drift is identically zero and the entire
+        # advective half of the solver is inert, so the semantics boundary_indices would most
+        # plausibly acquire -- masking the normal flux at boundary nodes -- would be invisible and
+        # this test would keep asserting the option is dead while a real implementation changed
+        # the solve.
+        drift = np.tile(0.6 * np.sin(np.pi * xs), (problem.Nt + 1, 1))
 
-        def solve(**injected):
+        def solve(upwind_scheme="none", **injected):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                solver = FPGFDMSolver(problem, collocation_points=points)
+                solver = FPGFDMSolver(problem, collocation_points=points, upwind_scheme=upwind_scheme)
                 for name, value in injected.items():
                     # The solver stores these privately. Setting a public name would create a NEW
                     # attribute nothing reads, and byte-identity would follow trivially -- the test
@@ -169,7 +186,14 @@ class TestDeadOptionsAreProvablyDead:
 
         baseline = solve()
         assert np.all(np.isfinite(baseline)), "the baseline solve must succeed for this to mean anything"
-        assert baseline.std() > 1e-6, "a constant solution would make byte-identity vacuous"
+        # Vacuity guard on the EVOLUTION, not on the field: M[0] is the non-constant initial
+        # condition and contributes std ~0.07 by itself, so `baseline.std() > 0` passes even for a
+        # solver that returns M[t] = M[0] at every step and computes nothing.
+        evolution = np.abs(baseline[-1] - baseline[0]).sum() / np.abs(baseline[0]).sum()
+        assert evolution > 0.05, (
+            f"the solve must actually evolve the density for byte-identity to mean anything; "
+            f"relative change from t=0 to t=T is only {evolution:.2%}"
+        )
 
         # Two values as far apart as the parameter admits: nothing marked boundary, everything
         # marked boundary, and a domain fifty times the real one.
@@ -182,4 +206,22 @@ class TestDeadOptionsAreProvablyDead:
         )
         assert np.array_equal(solve(_domain_bounds=[(-50.0, 50.0)]), baseline), (
             "a domain 50x the real one changed the solution; domain_bounds is live"
+        )
+        # A SUBSET as well. [(-50, 50)] is a superset of both the real domain and the None
+        # fallback, so the two are indistinguishable under any containment predicate -- 0 of 21
+        # nodes change classification. [(0.4, 0.6)] reclassifies 17 of 21, which is what a
+        # containment or boundary-detection reader would act on.
+        assert np.array_equal(solve(_domain_bounds=[(0.4, 0.6)]), baseline), (
+            "a domain covering a fifth of the real one changed the solution; domain_bounds is "
+            "live as a containment or boundary-detection window"
+        )
+
+        # The upwind path is a different divergence routine (_compute_upwind_divergence), so a
+        # reader living there would be invisible to the default scheme alone.
+        upwind_baseline = solve(upwind_scheme="linear")
+        assert not np.array_equal(upwind_baseline, baseline), (
+            "the two schemes must differ, or running both proves nothing about coverage"
+        )
+        assert np.array_equal(solve(upwind_scheme="linear", _boundary_indices=set(range(n))), upwind_baseline), (
+            "boundary_indices is read on the upwind divergence path"
         )

--- a/tests/unit/test_alg/test_dead_option_fail_loud.py
+++ b/tests/unit/test_alg/test_dead_option_fail_loud.py
@@ -123,7 +123,7 @@ class TestDeadOptionsHaveNoEffectOnTheSolve:
     in a test that only asserts the raise, and the first is what a grep gives you.
 
     Injecting the option AFTER construction bypasses the guard and lets the claim be measured:
-    set it to values as far apart as the parameter admits and compare the solutions. Byte-identical
+    set it to values that a reader would act on differently and compare the solutions. Byte-identical
     output over a real solve is evidence no grep can produce.
 
     SCOPE, stated because it is narrower than "the option is dead". What this establishes is that
@@ -132,7 +132,7 @@ class TestDeadOptionsHaveNoEffectOnTheSolve:
 
     - A read with no effect on the output -- into a log record, a metric -- is not detected.
     - Construction-time consumption is out of reach by design: ``TaylorOperator`` is built at
-      ``fp_gfdm.py:168`` BEFORE the attributes are stored at :186, and threading an option in
+      ``fp_gfdm.py:176`` BEFORE the attributes are stored at :186, and threading an option in
       there is how ``obstacle_sdf`` was wired (#1556). The pre-existing ``..._raises`` tests cover
       the construction path; this covers the solve path.
     - Semantics that only appear in configurations this does not run: 2-D, a boundary type other
@@ -166,7 +166,10 @@ class TestDeadOptionsHaveNoEffectOnTheSolve:
         # plausibly acquire -- masking the normal flux at boundary nodes -- would be invisible and
         # this test would keep asserting the option is dead while a real implementation changed
         # the solve.
-        drift = np.tile(0.6 * np.sin(np.pi * xs), (problem.Nt + 1, 1))
+        # Nonzero AT THE WALLS too. 0.6*sin(pi*x) vanishes at x=0 and x=1, so a reader that
+        # enforces no-flux only at nodes carrying an outward normal would zero a flux that is
+        # already zero and stay invisible. The offset makes wall-restricted masking observable.
+        drift = np.tile(0.3 + 0.6 * np.sin(np.pi * xs), (problem.Nt + 1, 1))
 
         def solve(upwind_scheme="none", **injected):
             with warnings.catch_warnings():
@@ -195,8 +198,9 @@ class TestDeadOptionsHaveNoEffectOnTheSolve:
             f"relative change from t=0 to t=T is only {evolution:.2%}"
         )
 
-        # Two values as far apart as the parameter admits: nothing marked boundary, everything
-        # marked boundary, and a domain fifty times the real one.
+        # Probes chosen so a reader would act on them differently -- NOT merely 'far apart',
+        # which is what the superset bound (-50, 50) looked like and was not: it reclassifies
+        # zero nodes against the None fallback. The subset below reclassifies 17 of 21.
         assert np.array_equal(solve(_boundary_indices={0, 1}), baseline), (
             "boundary_indices={0, 1} changed the solution -- it is read somewhere, and the guard's "
             "claim that it is stored-but-never-read is wrong"
@@ -219,6 +223,10 @@ class TestDeadOptionsHaveNoEffectOnTheSolve:
         # The upwind path is a different divergence routine (_compute_upwind_divergence), so a
         # reader living there would be invisible to the default scheme alone.
         upwind_baseline = solve(upwind_scheme="linear")
+        # Checked BEFORE the difference assertion: an all-NaN upwind solve satisfies
+        # `not array_equal` (NaN != NaN) and the failure would then be reported as
+        # "boundary_indices is read on the upwind path", which is the wrong diagnosis.
+        assert np.all(np.isfinite(upwind_baseline)), "the upwind solve produced a non-finite value"
         assert not np.array_equal(upwind_baseline, baseline), (
             "the two schemes must differ, or running both proves nothing about coverage"
         )


### PR DESCRIPTION
Refs #1714, #1426, #1780

## The gap a `pytest.raises` cannot close

The #1426 guards refuse `boundary_indices` and `domain_bounds` on `FPGFDMSolver` because they are "accepted and stored but never read". Asserting that the guard raises records that it raises. It cannot record the claim that makes refusing correct, because **"there is no reader" and "I did not find a reader" produce identical output** — and a grep only ever produces the second.

Injecting the attribute after construction bypasses the guard and lets the claim be measured. Two values as far apart as the parameter admits, compared over a full solve:

```
every node marked boundary        byte-identical to the default solve
domain fifty times the real one   byte-identical to the default solve
```

Byte-identity over a real solve is evidence no static search can produce.

## A trap this walked into, and now guards against

The solver stores these as `_boundary_indices` / `_domain_bounds`. My first version injected the **public** names — which creates a new attribute nothing reads, so byte-identity follows trivially and the test passes while measuring nothing.

The test now reads the attribute before writing it, so the same slip fails loudly. That check was initially written with `hasattr`, which is **banned** by this project's Python conventions; it is now the sanctioned `getattr(obj, name, sentinel)` form.

## Which surfaced something worth its own issue

The gate did not catch the `hasattr`. `scripts/local_ci.sh:79` runs the fail-fast ratchet with `--path mfgarchon`, so `tests/` is never scanned:

| | `mfgarchon/` (enforced) | `tests/` (unenforced) |
|:--|--:|--:|
| `hasattr` | 125 | **265** |
| broad `except Exception:` | 113 | 12 |
| silent `pass` in `except` | 91 | 11 |

More than twice the `hasattr` on the side nothing looks at, and eleven places where a test can swallow an exception and pass for a reason nobody intended. Filed as **#1780**; not fixed here.

## Discrimination

Against the mechanism, not the guard — making `_boundary_indices` live (zeroing those rows before the return):

```
FAILED TestDeadOptionsAreProvablyDead::test_fp_gfdm_boundary_indices_and_domain_bounds_change_nothing
       AssertionError: boundary_indices={0, 1} changed the solution -- it is read somewhere
```

## Note on the fixture

Uses a local problem instance rather than the shared `_problem()`, whose `T=1.0` / `sigma=0.5` drives the unstabilised GFDM flux past the mass-fabrication gate (#1752) before the comparison can run. The comparison only needs a configuration the solver completes.

## Verification

`./scripts/local_ci.sh` green: `5750 passed, 22 skipped, 11 xfailed`, ratchets at baseline, capability matrix unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)