### PR TITLE
Mark alg/neural and alg/reinforcement as FROZEN prototypes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,12 @@ jobs:
         echo "Checking that fenced doc examples resolve against the package..."
         python scripts/check_doc_api.py --path . --check-baseline scripts/doc_api_baseline.json
 
+    - name: Frozen prototype areas (no new tests against alg/neural or alg/reinforcement)
+      timeout-minutes: 1
+      run: |
+        echo "Checking that no test was added against a frozen prototype paradigm..."
+        python scripts/check_frozen_areas.py --check-baseline scripts/frozen_areas_baseline.json
+
   # === PHASE 1: Import Validation ===
   # Note: Ruff formatting, linting, and MyPy checks run in modern_quality.yml workflow
   import-validation:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 ### MFGArchon: Public Infrastructure Package
 Production-ready infrastructure for Mean Field Games research and applications.
 
-**Scope**: ✅ core infrastructure (solvers, backends, config, geometry, workflow, visualization); ✅ classical algorithms (FDM, FEM, GFDM, DGM, PINN, Actor-Critic, PPO); ✅ standard examples (LQ, crowd motion, traffic flow, tutorials).
+**Scope**: ✅ core infrastructure (solvers, backends, config, geometry, workflow, visualization); ✅ classical numerical algorithms (FDM, FEM, GFDM); ⛔ the neural and RL families (DGM, PINN, Actor-Critic, PPO) are **in scope as a direction but FROZEN as code** — see the next section; ✅ standard examples (LQ, crowd motion, traffic flow, tutorials).
 
 ### ⛔ FROZEN: `alg/neural/` and `alg/reinforcement/` — prototype, not under development
 
@@ -142,7 +142,8 @@ The axiom testing discipline governs **what** a test must cover (edge/stress/fai
 | Code type | Changes often? | Public API? | Test type |
 |:----------|:--------------|:------------|:----------|
 | `solve_mfg()`, config system | No | Yes | Unit |
-| New HJB/FP solver, experimental RL | Yes | Maybe/No | Smoke |
+| New HJB/FP solver | Yes | Maybe/No | Smoke |
+| `alg/neural`, `alg/reinforcement` | — | — | **None — frozen, see above** |
 | Visualization | Sometimes | Yes | Smoke |
 | Utility function | No | Internal | Unit or smoke |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,26 @@ Production-ready infrastructure for Mean Field Games research and applications.
 
 **Scope**: ✅ core infrastructure (solvers, backends, config, geometry, workflow, visualization); ✅ classical algorithms (FDM, FEM, GFDM, DGM, PINN, Actor-Critic, PPO); ✅ standard examples (LQ, crowd motion, traffic flow, tutorials).
 
+### ⛔ FROZEN: `alg/neural/` and `alg/reinforcement/` — prototype, not under development
+
+**These two paradigms are design prototypes / placeholders. Do not develop them until told
+otherwise, by name.** That includes: adding features, adding tests, refactoring, fixing
+non-blocking defects, and "improving coverage while I'm here".
+
+What is still allowed without asking:
+- Keeping them **importable** — a change elsewhere that would break `import mfgarchon` must not.
+- A **one-line** fix for something that breaks the gate or the build.
+- **Recording** a defect as a GitHub issue. Filing is free; fixing is not.
+
+Why the ban includes tests, which is the counter-intuitive part: adding tests to a placeholder
+makes it look like it has a pinned contract. A later reader — human or agent — reads coverage as a
+promise that the behaviour is intended and load-bearing, and starts preserving decisions nobody
+made. An untested prototype is honestly labelled; a tested one is not.
+
+If a campaign sweeps the whole repo (a ratchet, an audit, a convention migration), these two
+directories are **out of scope by default** and their exclusion should be stated in the PR rather
+than silently assumed.
+
 ### MFG-Research: Private Research Repository
 Novel/experimental algorithms, unpublished methods. **Key principle**: MFG-Research **imports** MFGArchon but **never modifies** it.
 

--- a/changelog.d/mark-nn-rl-frozen.changed.md
+++ b/changelog.d/mark-nn-rl-frozen.changed.md
@@ -8,3 +8,13 @@
   importable, one-line build fixes, and filing issues remain allowed. The checker counts test
   files importing either package (12 and 2 today) and fails when the count grows; it ships a
   `--self-test` and was verified against a real added test before being wired.
+  Review hardened the checker: it now walks the AST and reads string literals, because the regex
+  form missed `importlib.import_module("mfgarchon.alg.neural.nn")` — the verbatim idiom of one of
+  the two files in its own baseline, which was counted only via an unrelated static import
+  elsewhere in that file — plus `pytest.importorskip`, `patch("...")`, and
+  `from mfgarchon.alg import neural`. It compares file SETS rather than counts, so delete-one-add-one
+  no longer nets to zero, and it runs its own `--self-test` inside `--check-baseline` rather than
+  leaving verification to an opt-in flag nothing invokes. Two docs that advertised the frozen RL
+  package as "Production-Ready ✅" are marked, `CLAUDE.md`'s Scope line no longer lists DGM/PINN/
+  Actor-Critic under ✅ two lines above the ⛔, and four frozen-area issues are labelled
+  `status: blocked` instead of reading as available work.

--- a/changelog.d/mark-nn-rl-frozen.changed.md
+++ b/changelog.d/mark-nn-rl-frozen.changed.md
@@ -18,3 +18,13 @@
   package as "Production-Ready ✅" are marked, `CLAUDE.md`'s Scope line no longer lists DGM/PINN/
   Actor-Critic under ✅ two lines above the ⛔, and four frozen-area issues are labelled
   `status: blocked` instead of reading as available work.
+  A second review found the two branches added to close the first review's blockers had no
+  positive control: the self-test covered exactly the three shapes the original regex already
+  handled, so deleting either new branch left the gate green while reopening the exact blocker.
+  Neither is load-bearing for any of the 14 baselined files -- all 14 carry a static import -- so
+  a baseline regeneration, the full suite and CI would all have passed over it. There is now one
+  fixture per detector branch, each labelled with the branch it exercises, and deleting a branch
+  fails naming it. Four documents teach a frozen package, enumerated with the checker's own prefix
+  matching rather than a grep (which counted `mfgarchon.alg.neural_solvers` as a hit); all four are
+  marked, and every trailing `**Status**` line in them -- one still read "Production-Ready" 435
+  lines under a freeze banner -- now agrees with the header.

--- a/changelog.d/mark-nn-rl-frozen.changed.md
+++ b/changelog.d/mark-nn-rl-frozen.changed.md
@@ -28,3 +28,9 @@
   matching rather than a grep (which counted `mfgarchon.alg.neural_solvers` as a hit); all four are
   marked, and every trailing `**Status**` line in them -- one still read "Production-Ready" 435
   lines under a freeze banner -- now agrees with the header.
+  A third review found the same gap one level up: `--self-test` covers `_references`, the code that
+  turns a source file into a detection, and stops there. The two set differences in `main()` that
+  turn a detection into a failure had no control, and three single-line mutations left
+  `--check-baseline` at exit 0 while `--self-test` printed PASSED -- including one that killed the
+  drop-detection this ratchet is advertised on. `tests/unit/test_check_frozen_areas.py` now pins
+  both directions against a synthetic tree, as `test_check_fail_fast.py` does for its sibling.

--- a/changelog.d/mark-nn-rl-frozen.changed.md
+++ b/changelog.d/mark-nn-rl-frozen.changed.md
@@ -1,0 +1,10 @@
+- **`alg/neural/` and `alg/reinforcement/` are marked FROZEN — design prototypes, not under
+  development.** Three layers, because prose alone does not hold a line here: a section in
+  `CLAUDE.md` (what agents read), a banner in each package docstring (what a human reading the
+  code sees), and `scripts/check_frozen_areas.py` wired into `local_ci.sh` (what fires without
+  being read). The counter-intuitive half of the freeze is that adding TESTS is also out —
+  coverage reads as a promise that behaviour is intended and load-bearing, and on a placeholder
+  that promise is false, so later readers preserve decisions nobody made. Keeping the packages
+  importable, one-line build fixes, and filing issues remain allowed. The checker counts test
+  files importing either package (12 and 2 today) and fails when the count grows; it ships a
+  `--self-test` and was verified against a real added test before being wired.

--- a/docs/user/continuous_environments_guide.md
+++ b/docs/user/continuous_environments_guide.md
@@ -1,8 +1,7 @@
 # [FROZEN 2026-07-30] Continuous MFG Environments User Guide
 
 > ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
-> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". The status line
-> below predates that decision. Treat everything here as illustrative of intent rather than as a
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status, version and readiness marker in this document predates that decision. Treat everything here as illustrative of intent rather than as a
 > supported contract: the behaviour is not pinned, and it may change or be removed without a
 > deprecation cycle.
 

--- a/docs/user/continuous_environments_guide.md
+++ b/docs/user/continuous_environments_guide.md
@@ -1,10 +1,17 @@
-# Continuous MFG Environments User Guide
+# [FROZEN 2026-07-30] Continuous MFG Environments User Guide
+
+> ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". The status line
+> below predates that decision. Treat everything here as illustrative of intent rather than as a
+> supported contract: the behaviour is not pinned, and it may change or be removed without a
+> deprecation cycle.
+
 
 Comprehensive guide to the continuous action space environments in MFGArchon's reinforcement learning framework.
 
 ## Overview
 
-The continuous environments library provides **5 production-ready environments** for benchmarking RL algorithms (DDPG, TD3, SAC) on diverse Mean Field Game problems. Each environment demonstrates different aspects of MFG theory and provides distinct algorithmic challenges.
+The continuous environments library provides **5 prototype environments** (described as production-ready before the freeze) for benchmarking RL algorithms (DDPG, TD3, SAC) on diverse Mean Field Game problems. Each environment demonstrates different aspects of MFG theory and provides distinct algorithmic challenges.
 
 **Package**: `mfgarchon.alg.reinforcement.environments`
 **Base Class**: `ContinuousMFGEnvBase`

--- a/docs/user/guides/maze_generation.md
+++ b/docs/user/guides/maze_generation.md
@@ -1,8 +1,7 @@
 # [FROZEN 2026-07-30] Maze Generation Guide for MFG-RL Research
 
 > ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
-> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status
-> line in this document predates that decision. Treat everything here as illustrative of
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status, version and readiness marker in this document predates that decision. Treat everything here as illustrative of
 > intent rather than as a supported contract: the behaviour is not pinned, and it may change
 > or be removed without a deprecation cycle.
 

--- a/docs/user/guides/maze_generation.md
+++ b/docs/user/guides/maze_generation.md
@@ -1,6 +1,12 @@
-# Maze Generation Guide for MFG-RL Research
+# [FROZEN 2026-07-30] Maze Generation Guide for MFG-RL Research
 
-**Status**: Production-Ready
+> ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status
+> line in this document predates that decision. Treat everything here as illustrative of
+> intent rather than as a supported contract: the behaviour is not pinned, and it may change
+> or be removed without a deprecation cycle.
+
+**Status**: ⛔ Frozen prototype — see the banner at the top of this guide
 **Date**: 2025-10-01
 **Scope**: Comprehensive guide to maze generation algorithms and hybrid methods for MFG research
 
@@ -469,5 +475,5 @@ from mfgarchon.alg.reinforcement.environments import (
 ---
 
 **Last Updated**: 2025-10-01
-**Status**: Production-Ready
+**Status**: ⛔ Frozen prototype — see the banner at the top of this guide
 **Related Issues**: #57 (Advanced Maze Generation), #54 (RL Paradigm Development)

--- a/docs/user/guides/multi_population_quick_start.md
+++ b/docs/user/guides/multi_population_quick_start.md
@@ -1,6 +1,6 @@
 # [FROZEN 2026-07-30] Multi-Population Continuous Control - Quick Start Guide
 
-**Status**: ⛔ Frozen prototype (was: Production-Ready ✅ — that claim predates the freeze)
+**Status**: ⛔ Frozen prototype — see the banner below
 
 > ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
 > development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". The status line
@@ -435,5 +435,5 @@ print(f"Final rewards - Pop 1: {np.mean(stats['episode_rewards'][1][-100:]):.2f}
 ---
 
 **Version**: 1.0
-**Status**: Production-Ready ✅
+**Status**: ⛔ Frozen prototype — see the banner at the top of this guide
 **Last Updated**: October 2025

--- a/docs/user/guides/multi_population_quick_start.md
+++ b/docs/user/guides/multi_population_quick_start.md
@@ -1,6 +1,13 @@
-# Multi-Population Continuous Control - Quick Start Guide
+# [FROZEN 2026-07-30] Multi-Population Continuous Control - Quick Start Guide
 
-**Status**: Production-Ready ✅
+**Status**: ⛔ Frozen prototype (was: Production-Ready ✅ — that claim predates the freeze)
+
+> ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". The status line
+> below predates that decision. Treat everything here as illustrative of intent rather than as a
+> supported contract: the behaviour is not pinned, and it may change or be removed without a
+> deprecation cycle.
+
 **Version**: Phase 3.4
 **Last Updated**: October 2025
 

--- a/docs/user/guides/multi_population_quick_start.md
+++ b/docs/user/guides/multi_population_quick_start.md
@@ -3,8 +3,7 @@
 **Status**: ⛔ Frozen prototype — see the banner below
 
 > ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
-> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". The status line
-> below predates that decision. Treat everything here as illustrative of intent rather than as a
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status, version and readiness marker in this document predates that decision. Treat everything here as illustrative of intent rather than as a
 > supported contract: the behaviour is not pinned, and it may change or be removed without a
 > deprecation cycle.
 

--- a/docs/user/traffic_flow_control_mfg.md
+++ b/docs/user/traffic_flow_control_mfg.md
@@ -1,8 +1,7 @@
 # [FROZEN 2026-07-30] Traffic Flow Control with Mean Field Games
 
 > ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
-> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status
-> line in this document predates that decision. Treat everything here as illustrative of
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status, version and readiness marker in this document predates that decision. Treat everything here as illustrative of
 > intent rather than as a supported contract: the behaviour is not pinned, and it may change
 > or be removed without a deprecation cycle.
 

--- a/docs/user/traffic_flow_control_mfg.md
+++ b/docs/user/traffic_flow_control_mfg.md
@@ -1,7 +1,13 @@
-# Traffic Flow Control with Mean Field Games
+# [FROZEN 2026-07-30] Traffic Flow Control with Mean Field Games
+
+> ⛔ **FROZEN PROTOTYPE.** `mfgarchon.alg.reinforcement` is a design prototype, not under
+> development — see `CLAUDE.md` § "FROZEN: alg/neural/ and alg/reinforcement/". Every status
+> line in this document predates that decision. Treat everything here as illustrative of
+> intent rather than as a supported contract: the behaviour is not pinned, and it may change
+> or be removed without a deprecation cycle.
 
 **Date**: October 2025
-**Status**: Phase 4.2.1 - Real-World Application
+**Status**: ⛔ Frozen prototype (was: Phase 4.2.1 - Real-World Application)
 **Application Domain**: Autonomous Vehicle Coordination
 
 ---
@@ -408,6 +414,6 @@ python examples/advanced/traffic_flow_mfg.py
 - Provides foundation for autonomous vehicle coordination
 - Validates theoretical MFG framework with practical implementation
 
-**Status**: Phase 4.2.1 Complete (October 2025)
+**Status**: ⛔ Frozen prototype (was: Phase 4.2.1 Complete, October 2025)
 
 **Next Application**: Financial Markets MFG (Phase 4.2.2)

--- a/mfgarchon/alg/neural/__init__.py
+++ b/mfgarchon/alg/neural/__init__.py
@@ -1,5 +1,16 @@
 """
+[FROZEN PROTOTYPE — not under development]
+
 Neural paradigm for MFG problems.
+
+⛔ This paradigm is a DESIGN PROTOTYPE / PLACEHOLDER. It is not under active development and
+should not be extended, refactored, or given test coverage without an explicit instruction naming
+it. See CLAUDE.md § "FROZEN: alg/neural/ and alg/reinforcement/".
+
+Adding tests here is discouraged for a reason worth stating: coverage reads as a promise that the
+behaviour is intended and load-bearing. On a placeholder that promise is false, and it makes later
+readers preserve decisions nobody made. Record defects as issues instead — filing is free.
+
 
 This module contains neural network-based approaches for solving Mean Field Games:
 - nn: Neural network architectures (shared by all neural methods)

--- a/mfgarchon/alg/reinforcement/__init__.py
+++ b/mfgarchon/alg/reinforcement/__init__.py
@@ -1,5 +1,16 @@
 """
+[FROZEN PROTOTYPE — not under development]
+
 Reinforcement Learning paradigm for MFG problems.
+
+⛔ This paradigm is a DESIGN PROTOTYPE / PLACEHOLDER. It is not under active development and
+should not be extended, refactored, or given test coverage without an explicit instruction naming
+it. See CLAUDE.md § "FROZEN: alg/neural/ and alg/reinforcement/".
+
+Adding tests here is discouraged for a reason worth stating: coverage reads as a promise that the
+behaviour is intended and load-bearing. On a placeholder that promise is false, and it makes later
+readers preserve decisions nobody made. Record defects as issues instead — filing is free.
+
 
 This module contains agent-based approaches for solving Mean Field Games:
 - core: Base classes and shared infrastructure for MFG-RL

--- a/scripts/check_frozen_areas.py
+++ b/scripts/check_frozen_areas.py
@@ -182,20 +182,43 @@ def self_test() -> int:
             return 1
         baseline.write_text(json.dumps({"counts": dict.fromkeys(FROZEN_PACKAGES, 0), "files": before}) + "\n")
 
-        # The change this exists to catch, in each of the three shapes a test can take.
-        for name, body in (
-            ("test_from.py", "from mfgarchon.alg.reinforcement.algorithms import x\n"),
-            ("test_import.py", "import mfgarchon.alg.neural.nn\n"),
-            ("test_indented.py", "def test_a():\n    from mfgarchon.alg.neural import core\n"),
+        # One fixture per branch of _references. The first version of this list held the three
+        # shapes the ORIGINAL regex already handled, so the two branches added to close the
+        # review's blockers -- the string literal and `from mfgarchon.alg import <frozen>` --
+        # had no positive control: deleting either left the gate green while reopening the exact
+        # blocker, and neither is load-bearing for any file in the current baseline, so nothing
+        # else in the suite would have noticed. Add a branch to _references, add a row here.
+        for branch, name, body in (
+            ("ast.Import", "test_import.py", "import mfgarchon.alg.neural.nn\n"),
+            (
+                "ast.ImportFrom (frozen module)",
+                "test_from.py",
+                "from mfgarchon.alg.reinforcement.algorithms import x\n",
+            ),
+            (
+                "ast.ImportFrom (frozen name off mfgarchon.alg)",
+                "test_pkg_symbol.py",
+                "from mfgarchon.alg import reinforcement\n",
+            ),
+            (
+                "ast.Constant (dynamic import by string)",
+                "test_dynamic.py",
+                'import importlib\n\nmod = importlib.import_module("mfgarchon.alg.neural.nn")\n',
+            ),
+            (
+                "ast.walk reaches function scope",
+                "test_indented.py",
+                "def test_a():\n    from mfgarchon.alg.neural import core\n",
+            ),
         ):
             (root / "unit" / name).write_text(body)
             after = offending_files(root)
-            if not any(after.values()):
-                print(f"SELF-TEST FAILED: {name} was not detected")
-                return 1
             (root / "unit" / name).unlink()
+            if not any(after.values()):
+                print(f"SELF-TEST FAILED: {branch} not detected ({name})")
+                return 1
 
-        print("SELF-TEST PASSED: from-import, plain import, and function-scoped import all detected")
+        print("SELF-TEST PASSED: all 5 detector branches have a positive control")
         return 0
 
 

--- a/scripts/check_frozen_areas.py
+++ b/scripts/check_frozen_areas.py
@@ -12,8 +12,9 @@ into a test anyway on 2026-07-30, because the fail-fast ratchet scans `mfgarchon
 So the freeze gets a counter, not just a paragraph.
 
 WHAT THIS DOES NOT DO. It counts test FILES that import a frozen package; it does not read intent
-and it does not look at line counts. Deleting a frozen test lowers the count and the baseline must
-be regenerated, which is the same ratchet shape as `check_fail_fast.py`. The explicitly allowed
+and it does not look at line counts. Deleting a frozen test drops it from the set and the baseline
+must be regenerated in the same change -- the shape `check_doc_api.py` uses, which hard-fails on
+a drop. (`check_fail_fast.py` only nudges and exits 0; citing it here was wrong.) The explicitly allowed
 actions -- keeping the packages importable, a one-line build fix, filing an issue -- add no test
 file and cannot trip it.
 """
@@ -21,8 +22,8 @@ file and cannot trip it.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -30,23 +31,58 @@ FROZEN_PACKAGES = ("mfgarchon.alg.neural", "mfgarchon.alg.reinforcement")
 
 # Matches `from mfgarchon.alg.neural...` and `import mfgarchon.alg.neural...`, including
 # submodules, and tolerates leading whitespace for imports inside a function or fixture.
-_IMPORT = re.compile(
-    r"^\s*(?:from|import)\s+(" + "|".join(re.escape(p) for p in FROZEN_PACKAGES) + r")\b",
-    re.MULTILINE,
-)
+_PREFIXES = tuple(FROZEN_PACKAGES)
+
+
+def _names_a_frozen_package(text: str) -> bool:
+    """Whether this string names a frozen package or one of its submodules."""
+    return any(text == p or text.startswith(p + ".") for p in _PREFIXES)
+
+
+def _references(path: Path) -> set[str]:
+    """Frozen packages this file reaches, by AST -- imports AND string literals.
+
+    Regex over `from|import <dotted>` was the first form and it missed the idiom this very
+    baseline depends on. `test_mean_field_rl_requires_pop_state_1508.py` reaches three frozen RL
+    algorithms through `@pytest.mark.parametrize` + `importlib.import_module(name)`, and was
+    counted only because of one unrelated static import elsewhere in the file. Lifting its
+    parametrised half into a new file passed the gate.
+
+    So string literals count too. `importlib.import_module("mfgarchon.alg.neural.nn")`,
+    `pytest.importorskip(...)` (20+ uses in this suite) and `patch("mfgarchon.alg.neural.nn.MLP")`
+    are all house style here, not evasion.
+
+    Also handles `from mfgarchon.alg import neural`, where the frozen name is the imported symbol
+    rather than part of the module path -- the shape `mfgarchon/alg/__init__.py` exports and
+    `from mfgarchon.alg import SchemeFamily` already uses in six test files.
+    """
+    found: set[str] = set()
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _names_a_frozen_package(alias.name):
+                    found.add(next(p for p in _PREFIXES if alias.name.startswith(p)))
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if _names_a_frozen_package(node.module):
+                found.add(next(p for p in _PREFIXES if node.module.startswith(p)))
+            else:
+                # `from mfgarchon.alg import neural`
+                for alias in node.names:
+                    dotted = f"{node.module}.{alias.name}"
+                    if _names_a_frozen_package(dotted):
+                        found.add(next(p for p in _PREFIXES if dotted.startswith(p)))
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if _names_a_frozen_package(node.value):
+                found.add(next(p for p in _PREFIXES if node.value.startswith(p)))
+    return found
 
 
 def offending_files(tests_root: Path) -> dict[str, list[str]]:
-    """Test files importing each frozen package, keyed by package."""
+    """Test files reaching each frozen package, keyed by package."""
     found: dict[str, list[str]] = {p: [] for p in FROZEN_PACKAGES}
     for path in sorted(tests_root.rglob("*.py")):
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            # A file that cannot be read cannot be classified; surfacing it is more useful than
-            # skipping it silently, which would let the count drift down for the wrong reason.
-            raise
-        for package in {m.group(1) for m in _IMPORT.finditer(text)}:
+        for package in _references(path):
             found[package].append(str(path))
     return found
 
@@ -86,14 +122,22 @@ def main() -> int:
         return 0
 
     if args.check_baseline:
+        # As check_doc_api.py does: a gate whose self-test is an opt-in flag has its verification
+        # happen once, by hand, and never again.
+        if self_test() != 0:
+            return 1
         baseline = json.loads(Path(args.check_baseline).read_text())
-        recorded = baseline["counts"]
-        grew = {p: (recorded.get(p, 0), counts[p]) for p in counts if counts[p] > recorded.get(p, 0)}
-        if grew:
+        recorded = {p: set(baseline["files"].get(p, [])) for p in FROZEN_PACKAGES}
+        # Sets, not counts. A count nets to zero on delete-one-add-one, which is exactly the shape
+        # of "I removed a frozen test and added a different one" -- the second half is the thing
+        # this gate exists to stop.
+        added = {p: sorted(set(found[p]) - recorded[p]) for p in FROZEN_PACKAGES}
+        added = {p: f for p, f in added.items() if f}
+        if added:
             print("FAIL: new tests added against a FROZEN prototype paradigm.")
-            for package, (was, now) in sorted(grew.items()):
-                print(f"  {package}: {was} -> {now} test file(s)")
-                for path in sorted(set(found[package]) - set(baseline["files"].get(package, []))):
+            for package, files in sorted(added.items()):
+                print(f"  {package}:")
+                for path in files:
                     print(f"      + {path}")
             print(
                 "\nalg/neural and alg/reinforcement are prototypes, not under development "
@@ -103,9 +147,10 @@ def main() -> int:
                 f"{args.check_baseline}"
             )
             return 1
-        shrank = {p: (recorded.get(p, 0), counts[p]) for p in counts if counts[p] < recorded.get(p, 0)}
-        if shrank:
-            print(f"FAIL: frozen-area test count DROPPED {shrank} -- regenerate the baseline.")
+        removed = {p: sorted(recorded[p] - set(found[p])) for p in FROZEN_PACKAGES}
+        removed = {p: f for p, f in removed.items() if f}
+        if removed:
+            print(f"FAIL: frozen-area tests disappeared {removed} -- regenerate the baseline.")
             return 1
         print(f"OK: no new tests against frozen paradigms {counts}")
         return 0
@@ -121,7 +166,14 @@ def self_test() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp) / "tests"
         (root / "unit").mkdir(parents=True)
-        (root / "unit" / "test_clean.py").write_text("from mfgarchon.core import mfg_problem\n")
+        # Positive control on the NEAREST false-positive class: a sibling package under alg/.
+        # A mutant broadening the match to `mfgarchon.alg.*` would flag every numerical test, and
+        # a clean fixture that only imports mfgarchon.core would not notice.
+        (root / "unit" / "test_clean.py").write_text(
+            "from mfgarchon.core import mfg_problem\n"
+            "from mfgarchon.alg.numerical.fp_solvers import fp_fdm\n"
+            'import importlib; importlib.import_module("mfgarchon.alg.numerical")\n'
+        )
         baseline = Path(tmp) / "baseline.json"
 
         before = offending_files(root)

--- a/scripts/check_frozen_areas.py
+++ b/scripts/check_frozen_areas.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fail when a test is added against a frozen prototype paradigm.
+
+`mfgarchon/alg/neural/` and `mfgarchon/alg/reinforcement/` are design prototypes, not under
+development (CLAUDE.md, "FROZEN"). Adding tests to a placeholder is the counter-intuitive half of
+that freeze: coverage reads as a promise that the behaviour is intended and load-bearing, so a
+later reader starts preserving decisions nobody made.
+
+Prose does not stop this. `hasattr` is banned by the project's Python conventions and was written
+into a test anyway on 2026-07-30, because the fail-fast ratchet scans `mfgarchon/` and not
+`tests/` (#1780) -- a rule the checker cannot see is a rule the surrounding code stops teaching.
+So the freeze gets a counter, not just a paragraph.
+
+WHAT THIS DOES NOT DO. It counts test FILES that import a frozen package; it does not read intent
+and it does not look at line counts. Deleting a frozen test lowers the count and the baseline must
+be regenerated, which is the same ratchet shape as `check_fail_fast.py`. The explicitly allowed
+actions -- keeping the packages importable, a one-line build fix, filing an issue -- add no test
+file and cannot trip it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+FROZEN_PACKAGES = ("mfgarchon.alg.neural", "mfgarchon.alg.reinforcement")
+
+# Matches `from mfgarchon.alg.neural...` and `import mfgarchon.alg.neural...`, including
+# submodules, and tolerates leading whitespace for imports inside a function or fixture.
+_IMPORT = re.compile(
+    r"^\s*(?:from|import)\s+(" + "|".join(re.escape(p) for p in FROZEN_PACKAGES) + r")\b",
+    re.MULTILINE,
+)
+
+
+def offending_files(tests_root: Path) -> dict[str, list[str]]:
+    """Test files importing each frozen package, keyed by package."""
+    found: dict[str, list[str]] = {p: [] for p in FROZEN_PACKAGES}
+    for path in sorted(tests_root.rglob("*.py")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # A file that cannot be read cannot be classified; surfacing it is more useful than
+            # skipping it silently, which would let the count drift down for the wrong reason.
+            raise
+        for package in {m.group(1) for m in _IMPORT.finditer(text)}:
+            found[package].append(str(path))
+    return found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tests", default="tests", help="Test root to scan")
+    parser.add_argument("--write-baseline", metavar="FILE")
+    parser.add_argument("--check-baseline", metavar="FILE")
+    parser.add_argument("--self-test", action="store_true", help="Prove the check can fail")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    found = offending_files(Path(args.tests))
+    counts = {package: len(files) for package, files in found.items()}
+
+    if args.write_baseline:
+        Path(args.write_baseline).write_text(
+            json.dumps(
+                {
+                    "_comment": (
+                        "Test files importing a FROZEN prototype paradigm (CLAUDE.md). The count "
+                        "must not grow: adding tests to a placeholder makes it read as a pinned "
+                        "contract. Lowering it by deleting such a test is welcome -- regenerate "
+                        "with --write-baseline in the same change."
+                    ),
+                    "counts": counts,
+                    "files": found,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        print(f"Wrote frozen-area baseline: {counts}")
+        return 0
+
+    if args.check_baseline:
+        baseline = json.loads(Path(args.check_baseline).read_text())
+        recorded = baseline["counts"]
+        grew = {p: (recorded.get(p, 0), counts[p]) for p in counts if counts[p] > recorded.get(p, 0)}
+        if grew:
+            print("FAIL: new tests added against a FROZEN prototype paradigm.")
+            for package, (was, now) in sorted(grew.items()):
+                print(f"  {package}: {was} -> {now} test file(s)")
+                for path in sorted(set(found[package]) - set(baseline["files"].get(package, []))):
+                    print(f"      + {path}")
+            print(
+                "\nalg/neural and alg/reinforcement are prototypes, not under development "
+                "(CLAUDE.md).\nA placeholder with tests reads as a pinned contract. File an issue "
+                "instead, or get an\nexplicit instruction naming the paradigm and regenerate:\n"
+                "  python scripts/check_frozen_areas.py --write-baseline "
+                f"{args.check_baseline}"
+            )
+            return 1
+        shrank = {p: (recorded.get(p, 0), counts[p]) for p in counts if counts[p] < recorded.get(p, 0)}
+        if shrank:
+            print(f"FAIL: frozen-area test count DROPPED {shrank} -- regenerate the baseline.")
+            return 1
+        print(f"OK: no new tests against frozen paradigms {counts}")
+        return 0
+
+    print(json.dumps({"counts": counts, "files": found}, indent=2))
+    return 0
+
+
+def self_test() -> int:
+    """Prove the check fires. A gate that has never been seen to fail is not known to work."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "tests"
+        (root / "unit").mkdir(parents=True)
+        (root / "unit" / "test_clean.py").write_text("from mfgarchon.core import mfg_problem\n")
+        baseline = Path(tmp) / "baseline.json"
+
+        before = offending_files(root)
+        if any(before.values()):
+            print("SELF-TEST FAILED: the clean fixture already reports offenders")
+            return 1
+        baseline.write_text(json.dumps({"counts": dict.fromkeys(FROZEN_PACKAGES, 0), "files": before}) + "\n")
+
+        # The change this exists to catch, in each of the three shapes a test can take.
+        for name, body in (
+            ("test_from.py", "from mfgarchon.alg.reinforcement.algorithms import x\n"),
+            ("test_import.py", "import mfgarchon.alg.neural.nn\n"),
+            ("test_indented.py", "def test_a():\n    from mfgarchon.alg.neural import core\n"),
+        ):
+            (root / "unit" / name).write_text(body)
+            after = offending_files(root)
+            if not any(after.values()):
+                print(f"SELF-TEST FAILED: {name} was not detected")
+                return 1
+            (root / "unit" / name).unlink()
+
+        print("SELF-TEST PASSED: from-import, plain import, and function-scoped import all detected")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/frozen_areas_baseline.json
+++ b/scripts/frozen_areas_baseline.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Test files importing a FROZEN prototype paradigm (CLAUDE.md). The count must not grow: adding tests to a placeholder makes it read as a pinned contract. Lowering it by deleting such a test is welcome -- regenerate with --write-baseline in the same change.",
+  "counts": {
+    "mfgarchon.alg.neural": 12,
+    "mfgarchon.alg.reinforcement": 2
+  },
+  "files": {
+    "mfgarchon.alg.neural": [
+      "tests/unit/test_alg/test_adaptive_training_canonical_mode_1572.py",
+      "tests/unit/test_alg/test_dgm_foundation.py",
+      "tests/unit/test_alg/test_neural_operators.py",
+      "tests/unit/test_alg/test_pinn_all_solvers_construct_1314.py",
+      "tests/unit/test_alg/test_pinn_get_results_1303.py",
+      "tests/unit/test_alg/test_pinn_hjb_diffusion_no_grad.py",
+      "tests/unit/test_alg/test_pinn_hjb_diffusion_single_source_1193.py",
+      "tests/unit/test_alg/test_pinn_hjb_time_sign_1571.py",
+      "tests/unit/test_alg/test_pinn_init_chain_1290.py",
+      "tests/unit/test_alg/test_solver_construction_smoke_887.py",
+      "tests/unit/test_alg/test_training.py",
+      "tests/unit/test_config/test_enum_conversions.py"
+    ],
+    "mfgarchon.alg.reinforcement": [
+      "tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py",
+      "tests/unit/test_alg/test_rl_mean_field_real_1600.py"
+    ]
+  }
+}

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -87,6 +87,15 @@ step "Doc-API ratchet"
 "$PY" scripts/check_doc_api.py --path . --check-baseline scripts/doc_api_baseline.json
 check $? "docs teach no more missing API than the baseline records"
 
+step "Frozen prototype areas"
+# alg/neural and alg/reinforcement are prototypes, not under development (CLAUDE.md). The
+# counter-intuitive half of that freeze is that ADDING TESTS is also out: coverage reads as a
+# promise the behaviour is intended, and on a placeholder that promise is false. Prose alone does
+# not hold this line -- hasattr is banned by the same conventions and was written into a test on
+# 2026-07-30 because the fail-fast ratchet does not scan tests/ (#1780).
+"$PY" scripts/check_frozen_areas.py --check-baseline scripts/frozen_areas_baseline.json
+check $? "no new tests against a frozen prototype paradigm"
+
 if [[ $FAST -eq 0 ]]; then
   # ~40 s. Not in --fast: every cell is a real coupled solve, so this is the one check
   # here that measures the product rather than the source. Counts of tests, issues or

--- a/tests/unit/test_check_frozen_areas.py
+++ b/tests/unit/test_check_frozen_areas.py
@@ -1,0 +1,130 @@
+"""The frozen-area ratchet must fail in BOTH directions, and something must check that it does.
+
+`check_frozen_areas.py --self-test` covers `_references`: every branch that turns a source file
+into a detection has a fixture, and deleting a branch reddens the gate naming it. It stops there.
+The code that turns a detection into a *failure* -- the two set differences in `main()` -- had no
+automated control at all, which is the same defect one level up: three single-line mutations left
+`--check-baseline` at exit 0 while `--self-test` printed PASSED.
+
+    sorted(set(found[p]) - recorded[p]) -> []   an added frozen test passes
+    return 1 inside `if added:`         -> 0    an added frozen test passes
+    sorted(recorded[p] - set(found[p])) -> []   a deleted frozen test passes
+
+The third falsifies the property the ratchet is advertised on -- hard-failing on a drop, the way
+`check_doc_api.py` does and `check_fail_fast.py` does not.
+
+Shaped after `tests/unit/test_check_fail_fast.py`, which pins its sibling ratchet's comparison for
+the same reason. Both directions are exercised against a synthetic tree, so the assertions do not
+depend on what the real baseline happens to contain today.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "check_frozen_areas.py"
+
+
+@pytest.fixture(scope="module")
+def script():
+    spec = importlib.util.spec_from_file_location("check_frozen_areas", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(tests_dir: pathlib.Path, baseline: pathlib.Path) -> subprocess.CompletedProcess:
+    """The gate as CI invokes it: a subprocess, so the exit code is the thing measured."""
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--tests", str(tests_dir), "--check-baseline", str(baseline)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def frozen_tree(tmp_path, script):
+    """A two-file synthetic tree at baseline: one frozen-area test per frozen package."""
+    tests_dir = tmp_path / "tests"
+    (tests_dir / "unit").mkdir(parents=True)
+    (tests_dir / "unit" / "test_neural_pinned.py").write_text("import mfgarchon.alg.neural.nn\n")
+    (tests_dir / "unit" / "test_rl_pinned.py").write_text("from mfgarchon.alg.reinforcement.algorithms import x\n")
+
+    found = script.offending_files(tests_dir)
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"counts": {p: len(f) for p, f in found.items()}, "files": found}) + "\n")
+    return tests_dir, baseline
+
+
+def test_the_tree_starts_green(frozen_tree):
+    """Without this, every assertion below could be satisfied by a gate that always fails."""
+    tests_dir, baseline = frozen_tree
+    result = _run(tests_dir, baseline)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK: no new tests against frozen paradigms" in result.stdout
+
+
+def test_an_added_frozen_test_fails_the_gate_and_is_named(frozen_tree):
+    tests_dir, baseline = frozen_tree
+    added = tests_dir / "unit" / "test_rl_new.py"
+    added.write_text("from mfgarchon.alg.reinforcement.environments import Env\n")
+
+    result = _run(tests_dir, baseline)
+    assert result.returncode == 1, "an added frozen-area test must fail the gate\n" + result.stdout
+    assert "new tests added against a FROZEN prototype paradigm" in result.stdout
+    assert "test_rl_new.py" in result.stdout, "the message must name the file, not just the count"
+    assert "--write-baseline" in result.stdout, "and say how to proceed deliberately"
+
+
+def test_a_deleted_frozen_test_fails_the_gate(frozen_tree):
+    """The drop direction. `check_fail_fast.py` prints a nudge and exits 0 here; this must not.
+
+    A silent drop means the baseline no longer describes the tree, so the next addition is measured
+    against a stale record -- and delete-one-add-one nets to zero under a count comparison, which
+    is the shape this gate uses sets to catch.
+    """
+    tests_dir, baseline = frozen_tree
+    (tests_dir / "unit" / "test_neural_pinned.py").unlink()
+
+    result = _run(tests_dir, baseline)
+    assert result.returncode == 1, "a removed frozen-area test must fail the gate\n" + result.stdout
+    assert "disappeared" in result.stdout
+
+
+def test_delete_one_add_one_does_not_net_to_zero(frozen_tree, script):
+    """The case that motivated comparing sets rather than counts.
+
+    Counts are unchanged here -- one neural file out, one in -- so a count comparison reports no
+    change and the substituted test is never seen.
+    """
+    tests_dir, baseline = frozen_tree
+    (tests_dir / "unit" / "test_neural_pinned.py").unlink()
+    (tests_dir / "unit" / "test_neural_substituted.py").write_text("import mfgarchon.alg.neural.nn\n")
+
+    before = json.loads(baseline.read_text())["counts"]
+    after = {p: len(f) for p, f in script.offending_files(tests_dir).items()}
+    assert before == after, f"the fixture must hold the counts equal, or it tests nothing: {before} vs {after}"
+
+    result = _run(tests_dir, baseline)
+    assert result.returncode == 1, "a substituted frozen test must fail the gate\n" + result.stdout
+    assert "test_neural_substituted.py" in result.stdout
+
+
+def test_a_non_frozen_test_does_not_fail_the_gate(frozen_tree):
+    """Negative control: the gate must be silent about the rest of the suite.
+
+    Without this, every assertion above is satisfied by a gate that fails on any new file.
+    """
+    tests_dir, baseline = frozen_tree
+    (tests_dir / "unit" / "test_ordinary.py").write_text(
+        "from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver\n"
+    )
+
+    result = _run(tests_dir, baseline)
+    assert result.returncode == 0, "a non-frozen test must not trip the gate\n" + result.stdout


### PR DESCRIPTION
These two paradigms are design prototypes / placeholders. They are not under development and should not be extended, refactored, or given test coverage until an instruction names them.

## Three layers, because one is not enough

Earlier today I wrote `hasattr` into a test — banned by this project's own Python conventions — and the gate passed, because the fail-fast ratchet scans `mfgarchon/` and not `tests/` (**#1780**). It was caught by a human reading the diff. **A rule the checker cannot see is a rule the surrounding code stops teaching**, and `tests/` currently carries 265 `hasattr` against `mfgarchon/`'s 125 for exactly that reason.

So the freeze gets a counter, not only a paragraph:

| layer | reader |
|:--|:--|
| `CLAUDE.md` § FROZEN | what an agent loads every session |
| package docstring banners | what a human reading the code sees |
| `scripts/check_frozen_areas.py` in `local_ci.sh` | what fires without being read |

## The counter-intuitive half: tests are also out

Coverage reads as a promise that the behaviour is intended and load-bearing. On a placeholder that promise is false, and a later reader — human or agent — starts preserving decisions nobody made. **An untested prototype is honestly labelled; a tested one is not.**

Still allowed without asking, and none of them can trip the gate, because none adds a test file:

- keeping the packages **importable** — a change elsewhere must not break `import mfgarchon`;
- a **one-line** fix for something that breaks the build or the gate;
- **filing an issue**. Recording a defect is free; fixing it is not.

## The checker was verified before it was wired

Per the rule that building a tool does not exempt the builder from it:

Verbatim, not paraphrased. Adding `tests/unit/test_MUTANT_probe.py` containing
`from mfgarchon.alg.reinforcement.algorithms import mean_field_ddpg`:

```
$ python scripts/check_frozen_areas.py --check-baseline scripts/frozen_areas_baseline.json
SELF-TEST PASSED: all 5 detector branches have a positive control
FAIL: new tests added against a FROZEN prototype paradigm.
  mfgarchon.alg.reinforcement:
      + tests/unit/test_MUTANT_probe.py
```

And the drop direction, moving a baselined file out of the tree:

```
SELF-TEST PASSED: all 5 detector branches have a positive control
FAIL: frozen-area tests disappeared {'mfgarchon.alg.neural': ['tests/unit/test_alg/test_dgm_foundation.py']} -- regenerate the baseline.
```

Both are pinned by `tests/unit/test_check_frozen_areas.py`, which builds a synthetic tree and its
own baseline, so the assertions do not depend on what the real baseline contains today.

Baseline today: `neural` 12 test files, `reinforcement` 2. It is a ratchet in the same shape as `check_doc_api.py`, which hard-fails on a drop — not `check_fail_fast.py`, which prints a nudge on a decrease and exits 0. It compares file **sets**, not counts, so delete-one-add-one no longer nets to zero, and it runs its own `--self-test` inside `--check-baseline` with one fixture per detector branch.

## What this does not claim

It counts **test files that import a frozen package**. It does not read intent, does not look at line counts, and does not prevent someone editing the prototype source directly. It closes the specific hole I nearly walked into today: writing a test for a placeholder because the guard's reasoning was interesting.

## Verification

`./scripts/local_ci.sh` green: ruff, workflow integrity, fail-fast ratchet at baseline, doc-API ratchet, the new frozen-area gate, capability matrix unchanged, `5750 passed, 22 skipped, 11 xfailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

