### PR TITLE
Refuse to forward a kwarg the solver does not name, on both coupling sides

### DIFF
--- a/changelog.d/1783-kwarg-gate-var-keyword.fixed.md
+++ b/changelog.d/1783-kwarg-gate-var-keyword.fixed.md
@@ -1,11 +1,34 @@
 - **The coupling kwarg gate no longer drops `volatility_field` when a solver declares `**kwargs`**
   (#1783). `_build_hjb_kwargs` / `_build_fp_kwargs` asked `inspect.signature` whether the solver
   named the parameter — which answers "does this callable name it", not "can this solver consume
-  it". `MeshlessGalerkinHJBSolver` and `HJBHowardSolver` both declare `(self, *args, **kwargs)`, so
-  the field was dropped on the HJB side while the paired FP solver consumed it: measured with
+  it". `MeshlessGalerkinHJBSolver` delegates through `(*args, use_newton=None, **kwargs)`, so the
+  field was dropped on the HJB side while the paired FP solver consumed it: measured with
   `problem.sigma = 0.3` and a field of mean 0.7, HJB ran at `D = 0.045` against FP's `D = 0.245`, a
   5.4x mismatch with no warning and a converged density for a problem nobody posed. The gate now
-  refuses, matching the `source_term` branch three lines below it (#1424). Both sides route through
-  one `_require_kwarg`, so a fix to one is no longer a fix to one. A scalar equal to `problem.sigma`
-  is exempt — `MFGProblem.volatility_field` defaults to it, so every ordinary solve carries a
-  non-None value that cannot cause a mismatch.
+  refuses, matching the `source_term` branch three lines below it (#1424).
+
+  Review found the same silent drop live on two further sites the issue had not named:
+  `MFGResidual.compute_hjb_output` and `.compute_fp_output`, the Newton coupling path, where the
+  identical 5.4x mismatch was fully reachable through `NewtonMFGSolver`. The four sites each
+  restated the same three-way decision — is this field a hazard, can the solver take it, do we
+  forward it — and the restatement is what let them disagree. All four now call one
+  `resolve_volatility_kwarg`; its guard test scans the whole coupling package for a surviving
+  inline membership test rather than one class, which is why the first version of that guard was
+  green while the two Newton copies were live.
+
+  Two corrections to the first version of this fix. It put the forward inside the hazard branch,
+  so a scalar equal to `problem.sigma` stopped being forwarded at all — silent-wrong in the same
+  way, because `problem.volatility_field` is not always `problem.sigma`: construct with an array
+  sigma and the field is the array while `sigma` is its mean, so a solver falling back through
+  `get_diffusion_coefficient_field(None)` picked up the array instead of the constant asked for.
+  Forwarding is now unconditional whenever the solver names the parameter, and the exemption
+  decides only whether to refuse. The scalar test is `numbers.Real` rather than `(int, float)`, so
+  `np.float32(0.3)` no longer draws a refusal for a solve byte-identical to one that is accepted.
+
+  Known limitation, not addressed here: `MeshlessGalerkinHJBSolver.solve_hjb_system` is a pure
+  delegation to `WeakFormHJBSolver.solve_hjb_system`, which does name `volatility_field` and does
+  consume it (`D = 0.045` without, `D = 0.245` with). The refusal therefore forecloses a capability
+  that solver has; declaring the parameter on the wrapper, or resolving the signature through the
+  delegate, is the better fix. Left to the weak-form work in flight rather than edited underneath
+  it, and tracked separately. Until then the refusal is still the right behaviour — the prior
+  alternative was a silently wrong answer, not a working solve.

--- a/changelog.d/1783-kwarg-gate-var-keyword.fixed.md
+++ b/changelog.d/1783-kwarg-gate-var-keyword.fixed.md
@@ -1,0 +1,11 @@
+- **The coupling kwarg gate no longer drops `volatility_field` when a solver declares `**kwargs`**
+  (#1783). `_build_hjb_kwargs` / `_build_fp_kwargs` asked `inspect.signature` whether the solver
+  named the parameter — which answers "does this callable name it", not "can this solver consume
+  it". `MeshlessGalerkinHJBSolver` and `HJBHowardSolver` both declare `(self, *args, **kwargs)`, so
+  the field was dropped on the HJB side while the paired FP solver consumed it: measured with
+  `problem.sigma = 0.3` and a field of mean 0.7, HJB ran at `D = 0.045` against FP's `D = 0.245`, a
+  5.4x mismatch with no warning and a converged density for a problem nobody posed. The gate now
+  refuses, matching the `source_term` branch three lines below it (#1424). Both sides route through
+  one `_require_kwarg`, so a fix to one is no longer a fix to one. A scalar equal to `problem.sigma`
+  is exempt — `MFGProblem.volatility_field` defaults to it, so every ordinary solve carries a
+  non-None value that cannot cause a mismatch.

--- a/mfgarchon/alg/numerical/coupling/base_mfg.py
+++ b/mfgarchon/alg/numerical/coupling/base_mfg.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import numbers
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -69,6 +70,72 @@ def assert_paired_solver_sigma(hjb_solver: Any, fp_solver: Any, context: str) ->
         )
 
 
+def matches_problem_sigma(problem: Any, volatility_field: Any) -> bool:
+    """Whether this field is indistinguishable from the problem's own sigma.
+
+    Scalars only. An array or callable cannot be shown equivalent to sigma without evaluating it,
+    and guessing there is what #1316 was about, so those are never called indistinguishable.
+    ``numbers.Real`` rather than ``(int, float)``: ``np.float32(0.3)`` is neither, and rejecting it
+    would refuse a solve that is byte-identical to one it accepts.
+    """
+    sigma = getattr(problem, "sigma", None)
+    if not isinstance(volatility_field, numbers.Real) or not isinstance(sigma, numbers.Real):
+        return False
+    return abs(float(volatility_field) - float(sigma)) <= 1e-12
+
+
+def resolve_volatility_kwarg(
+    params: Any, volatility_field: Any, problem: Any, solver_name: str, method: str, side: str
+) -> dict[str, Any]:
+    """The ``volatility_field`` kwarg for ``method``, or ``{}`` when there is nothing to forward.
+
+    One owner for all four coupling call sites -- both Picard sides (:class:`BaseCouplingIterator`)
+    and both Newton sides (:class:`~.mfg_residual.MFGResidual`). Issue #1783 was filed against two
+    of them, and a review of the first fix found the same silent drop still live on the other two.
+    The four sites each restated the same three-way decision, and the restatement is what let them
+    disagree; a fifth site restating it is the next instance, so the decision lives here only.
+
+    Three outcomes, in this order:
+
+    - **The solver names the parameter: forward it, unconditionally.** Including when the field is
+      indistinguishable from ``problem.sigma`` -- it is still the caller's explicit value, and
+      ``problem.volatility_field`` is not always ``problem.sigma``. Construct with an array sigma
+      and the field is the array while ``problem.sigma`` is its mean, so a solver that falls back
+      through ``get_diffusion_coefficient_field(None)`` would pick up the array. Declining to
+      forward an "equivalent" scalar hands the solver a different field than the one asked for.
+      The first fix of #1783 put the forward inside the hazard branch and did exactly that.
+    - **The solver does not name it, and the field is a hazard: raise.** Signature introspection
+      answers "does this callable name the parameter", not "can this solver consume it", and a
+      ``**kwargs`` override makes those two diverge. Measured on the meshless pair, whose HJB
+      wrapper delegates through ``(*args, use_newton=None, **kwargs)``: with ``problem.sigma = 0.3``
+      and a field of mean 0.7, the HJB side ran at D = 0.045 while the paired FP side -- which does
+      name the parameter -- ran at D = 0.245. A 5.4x mismatch, no warning, and a converged density
+      for a problem nobody posed. Treating ``VAR_KEYWORD`` as accept-anything was the other
+      candidate; it assumes a solver consumes what it swallows, the assumption that produced #1316.
+    - **The solver does not name it, and the field is indistinguishable: drop it silently**, because
+      dropping it changes nothing. ``MFGProblem.volatility_field`` defaults to ``problem.sigma``, so
+      the coupling loop hands a non-None value on EVERY ordinary solve; refusing those is a refusal
+      to run at all, which the full suite caught two tests deep in the meshless recipe when the
+      first version of this fix keyed on "is not None".
+    """
+    if volatility_field is None:
+        return {}
+    if "volatility_field" in params:
+        return {"volatility_field": volatility_field}
+    if matches_problem_sigma(problem, volatility_field):
+        return {}
+    other = "FP" if side == "HJB" else "HJB"
+    raise NotImplementedError(
+        f"{solver_name}.{method} does not accept 'volatility_field', but a volatility_field was "
+        f"supplied. Its signature is ({', '.join(sorted(params))}). Dropping it would leave the "
+        f"{side} side on problem.sigma while the {other} side uses the field, so the two equations "
+        f"would be solved with different diffusion and the result would be neither problem "
+        f"(Issue #1783). Either declare volatility_field on the solver's {method}, or remove it "
+        f"from the solve. A solver taking **kwargs does not count as accepting it -- the parameter "
+        f"must be named."
+    )
+
+
 class BaseCouplingIterator(ABC):
     """
     Abstract base class for iterative coupling solvers (Picard, block, fictitious play).
@@ -120,60 +187,6 @@ class BaseCouplingIterator(ABC):
         # Issue #1489 (S1): cache the FP solver's drift-input convention for resolve_fp_drift_kwargs.
         self._fp_drift_convention = getattr(fp_solver, "_drift_convention", None)
 
-    def _matches_problem_sigma(self, volatility_field: Any) -> bool:
-        """Whether this field is indistinguishable from the problem's own sigma.
-
-        ``MFGProblem.volatility_field`` defaults to ``problem.sigma``, so the coupling loop hands a
-        non-None value on EVERY ordinary solve. Refusing those is a refusal to run at all -- the
-        full suite caught exactly that, two tests deep in the meshless recipe, when the first
-        version of this fix keyed on "is not None". The hazard is a field that would make the two
-        sides disagree, not a field that exists.
-
-        Scalars only. An array or callable cannot be shown equivalent to sigma without evaluating
-        it, and guessing there is what #1316 was about, so those always reach the capability check.
-        """
-        # getattr on self too: a caller that borrows this method without a problem (a minimal test
-        # double does exactly that) gets "not equivalent", which routes to the capability check --
-        # the conservative direction, and the one that keeps this method total.
-        sigma = getattr(getattr(self, "problem", None), "sigma", None)
-        if not isinstance(volatility_field, (int, float)) or not isinstance(sigma, (int, float)):
-            return False
-        return abs(float(volatility_field) - float(sigma)) <= 1e-12
-
-    @staticmethod
-    def _require_kwarg(params: Any, name: str, solver_name: str, method: str, consequence: str) -> None:
-        """Refuse to forward a kwarg the solver does not name. One owner for both sides.
-
-        Issue #1783. Signature introspection answers "does this callable name the parameter", not
-        "can this solver consume it", and a ``**kwargs`` override makes those two diverge. The
-        previous form dropped the value silently when the name was absent -- three lines above a
-        branch that raises for exactly the same situation with ``source_term`` (#1424). Two
-        adjacent branches of one function, opposite policies.
-
-        Measured on the meshless pair, whose HJB solver declares ``(self, *args, **kwargs)``:
-        with ``problem.sigma = 0.3`` and a field of mean 0.7, the HJB side ran at D = 0.045 while
-        the paired FP side -- which does name the parameter -- ran at D = 0.245. A 5.4x mismatch,
-        no warning, and a converged density for a problem nobody posed.
-
-        Refusing rather than guessing is deliberate. Treating ``VAR_KEYWORD`` as accept-anything
-        was the other candidate, and it assumes a solver consumes what it swallows -- the
-        assumption that produced #1316.
-
-        Not every non-None value is a hazard. ``problem.volatility_field`` defaults to
-        ``problem.sigma``, so a scalar equal to it changes nothing on either side and refusing it
-        would break every ordinary solve -- the full suite caught exactly that, two tests deep in
-        the meshless recipe. The caller filters those out before asking; this helper answers only
-        the narrow question of whether the parameter can be forwarded at all.
-        """
-        if name in params:
-            return
-        raise NotImplementedError(
-            f"{solver_name}.{method} does not accept {name!r}, but a {name} was supplied. Its "
-            f"signature is ({', '.join(params)}). {consequence} (Issue #1783). Either declare "
-            f"{name} on the solver's {method}, or remove it from the solve. A solver taking "
-            f"**kwargs does not count as accepting it -- the parameter must be named."
-        )
-
     def _build_hjb_kwargs(
         self,
         *,
@@ -189,17 +202,16 @@ class BaseCouplingIterator(ABC):
         params = self._hjb_sig_params
         if params is None:
             return kwargs
-        if volatility_field is not None and not self._matches_problem_sigma(volatility_field):
-            self._require_kwarg(
+        kwargs.update(
+            resolve_volatility_kwarg(
                 params,
-                "volatility_field",
+                volatility_field,
+                self.problem,
                 self._hjb_solver_name,
                 "solve_hjb_system",
-                "Dropping it would leave the HJB side on problem.sigma while the FP side uses the "
-                "field, so the two equations would be solved with different diffusion and the "
-                "result would be neither problem.",
+                "HJB",
             )
-            kwargs["volatility_field"] = volatility_field
+        )
         if source_term is not None:
             if "source_term" not in params:
                 raise NotImplementedError(
@@ -229,17 +241,16 @@ class BaseCouplingIterator(ABC):
             return kwargs
         if "drift_field" in params and drift_field is not None:
             kwargs["drift_field"] = drift_field
-        if volatility_field is not None and not self._matches_problem_sigma(volatility_field):
-            self._require_kwarg(
+        kwargs.update(
+            resolve_volatility_kwarg(
                 params,
-                "volatility_field",
+                volatility_field,
+                self.problem,
                 self._fp_solver_name,
                 "solve_fp_system",
-                "Dropping it would leave the FP side on problem.sigma while the HJB side uses the "
-                "field, so the two equations would be solved with different diffusion and the "
-                "result would be neither problem.",
+                "FP",
             )
-            kwargs["volatility_field"] = volatility_field
+        )
         if source_term is not None:
             if "source_term" not in params:
                 raise NotImplementedError(

--- a/mfgarchon/alg/numerical/coupling/base_mfg.py
+++ b/mfgarchon/alg/numerical/coupling/base_mfg.py
@@ -120,6 +120,60 @@ class BaseCouplingIterator(ABC):
         # Issue #1489 (S1): cache the FP solver's drift-input convention for resolve_fp_drift_kwargs.
         self._fp_drift_convention = getattr(fp_solver, "_drift_convention", None)
 
+    def _matches_problem_sigma(self, volatility_field: Any) -> bool:
+        """Whether this field is indistinguishable from the problem's own sigma.
+
+        ``MFGProblem.volatility_field`` defaults to ``problem.sigma``, so the coupling loop hands a
+        non-None value on EVERY ordinary solve. Refusing those is a refusal to run at all -- the
+        full suite caught exactly that, two tests deep in the meshless recipe, when the first
+        version of this fix keyed on "is not None". The hazard is a field that would make the two
+        sides disagree, not a field that exists.
+
+        Scalars only. An array or callable cannot be shown equivalent to sigma without evaluating
+        it, and guessing there is what #1316 was about, so those always reach the capability check.
+        """
+        # getattr on self too: a caller that borrows this method without a problem (a minimal test
+        # double does exactly that) gets "not equivalent", which routes to the capability check --
+        # the conservative direction, and the one that keeps this method total.
+        sigma = getattr(getattr(self, "problem", None), "sigma", None)
+        if not isinstance(volatility_field, (int, float)) or not isinstance(sigma, (int, float)):
+            return False
+        return abs(float(volatility_field) - float(sigma)) <= 1e-12
+
+    @staticmethod
+    def _require_kwarg(params: Any, name: str, solver_name: str, method: str, consequence: str) -> None:
+        """Refuse to forward a kwarg the solver does not name. One owner for both sides.
+
+        Issue #1783. Signature introspection answers "does this callable name the parameter", not
+        "can this solver consume it", and a ``**kwargs`` override makes those two diverge. The
+        previous form dropped the value silently when the name was absent -- three lines above a
+        branch that raises for exactly the same situation with ``source_term`` (#1424). Two
+        adjacent branches of one function, opposite policies.
+
+        Measured on the meshless pair, whose HJB solver declares ``(self, *args, **kwargs)``:
+        with ``problem.sigma = 0.3`` and a field of mean 0.7, the HJB side ran at D = 0.045 while
+        the paired FP side -- which does name the parameter -- ran at D = 0.245. A 5.4x mismatch,
+        no warning, and a converged density for a problem nobody posed.
+
+        Refusing rather than guessing is deliberate. Treating ``VAR_KEYWORD`` as accept-anything
+        was the other candidate, and it assumes a solver consumes what it swallows -- the
+        assumption that produced #1316.
+
+        Not every non-None value is a hazard. ``problem.volatility_field`` defaults to
+        ``problem.sigma``, so a scalar equal to it changes nothing on either side and refusing it
+        would break every ordinary solve -- the full suite caught exactly that, two tests deep in
+        the meshless recipe. The caller filters those out before asking; this helper answers only
+        the narrow question of whether the parameter can be forwarded at all.
+        """
+        if name in params:
+            return
+        raise NotImplementedError(
+            f"{solver_name}.{method} does not accept {name!r}, but a {name} was supplied. Its "
+            f"signature is ({', '.join(params)}). {consequence} (Issue #1783). Either declare "
+            f"{name} on the solver's {method}, or remove it from the solve. A solver taking "
+            f"**kwargs does not count as accepting it -- the parameter must be named."
+        )
+
     def _build_hjb_kwargs(
         self,
         *,
@@ -135,7 +189,16 @@ class BaseCouplingIterator(ABC):
         params = self._hjb_sig_params
         if params is None:
             return kwargs
-        if "volatility_field" in params and volatility_field is not None:
+        if volatility_field is not None and not self._matches_problem_sigma(volatility_field):
+            self._require_kwarg(
+                params,
+                "volatility_field",
+                self._hjb_solver_name,
+                "solve_hjb_system",
+                "Dropping it would leave the HJB side on problem.sigma while the FP side uses the "
+                "field, so the two equations would be solved with different diffusion and the "
+                "result would be neither problem.",
+            )
             kwargs["volatility_field"] = volatility_field
         if source_term is not None:
             if "source_term" not in params:
@@ -166,7 +229,16 @@ class BaseCouplingIterator(ABC):
             return kwargs
         if "drift_field" in params and drift_field is not None:
             kwargs["drift_field"] = drift_field
-        if "volatility_field" in params and volatility_field is not None:
+        if volatility_field is not None and not self._matches_problem_sigma(volatility_field):
+            self._require_kwarg(
+                params,
+                "volatility_field",
+                self._fp_solver_name,
+                "solve_fp_system",
+                "Dropping it would leave the FP side on problem.sigma while the HJB side uses the "
+                "field, so the two equations would be solved with different diffusion and the "
+                "result would be neither problem.",
+            )
             kwargs["volatility_field"] = volatility_field
         if source_term is not None:
             if "source_term" not in params:

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -28,7 +28,7 @@ import numpy as np
 from mfgarchon.geometry.boundary import no_flux_bc
 from mfgarchon.utils.mfg_logging import get_logger
 
-from .base_mfg import assert_bc_providers_resolvable
+from .base_mfg import assert_bc_providers_resolvable, resolve_volatility_kwarg
 from .fixed_point_utils import resolve_fp_drift_kwargs
 from .source_composition import compose_fp_source, compose_hjb_source
 
@@ -211,8 +211,19 @@ class MFGResidual:
         if self._hjb_sig_params is not None:
             if "show_progress" in self._hjb_sig_params:
                 kwargs["show_progress"] = False
-            if "volatility_field" in self._hjb_sig_params and self.volatility_field is not None:
-                kwargs["volatility_field"] = self.volatility_field
+            # Issue #1783: one owner with Picard. This site carried a private copy that
+            # silently dropped the field for a solver taking **kwargs -- three lines above a
+            # branch already raising for exactly that situation with source_term (#1430).
+            kwargs.update(
+                resolve_volatility_kwarg(
+                    self._hjb_sig_params,
+                    self.volatility_field,
+                    self.problem,
+                    type(self.hjb_solver).__name__,
+                    "solve_hjb_system",
+                    "HJB",
+                )
+            )
             # Issue #1430: fail loud like the Picard path (Issue #1424) instead of silently
             # dropping a composed source the solver cannot accept. Compose unconditionally; if
             # the problem defines a source but this HJB solver's signature lacks source_term,
@@ -262,8 +273,16 @@ class MFGResidual:
         kwargs: dict[str, Any] = {}
         if "show_progress" in params:
             kwargs["show_progress"] = False
-        if "volatility_field" in params and self.volatility_field is not None:
-            kwargs["volatility_field"] = self.volatility_field
+        kwargs.update(
+            resolve_volatility_kwarg(
+                params,
+                self.volatility_field,
+                self.problem,
+                type(self.fp_solver).__name__,
+                "solve_fp_system",
+                "FP",
+            )
+        )
 
         if M is None:
             M = np.broadcast_to(self.M_initial, self.solution_shape) if self.M_initial is not None else U

--- a/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
+++ b/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
@@ -31,12 +31,25 @@ _N = 21
 _SIGMA_LO, _SIGMA_HI = 0.1, 0.5  # mean 0.3
 
 
-class _HJBKwargBuilder:
-    _build_hjb_kwargs = BaseCouplingIterator._build_hjb_kwargs
+class _HJBKwargBuilder(BaseCouplingIterator):
+    """Minimal stand-in for the coupling seam.
+
+    Subclasses rather than borrowing the single method: `_build_hjb_kwargs` now delegates to
+    sibling helpers on the class (`_matches_problem_sigma`, `_require_kwarg`, #1783), and a double
+    that copies one method silently loses them. Inheriting keeps the double honest about what the
+    seam actually depends on.
+    """
 
     def __init__(self):
         self._hjb_sig_params = {"volatility_field"}
         self._hjb_solver_name = "HJBGFDMSolver"
+        self.problem = None  # no problem: a scalar can never be shown equivalent to sigma
+
+    def solve(self, *args, **kwargs):  # pragma: no cover - abstract stub, never called
+        raise NotImplementedError
+
+    def get_results(self, *args, **kwargs):  # pragma: no cover - abstract stub, never called
+        raise NotImplementedError
 
 
 def _problem(sigma=0.3):

--- a/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
+++ b/tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py
@@ -34,10 +34,10 @@ _SIGMA_LO, _SIGMA_HI = 0.1, 0.5  # mean 0.3
 class _HJBKwargBuilder(BaseCouplingIterator):
     """Minimal stand-in for the coupling seam.
 
-    Subclasses rather than borrowing the single method: `_build_hjb_kwargs` now delegates to
-    sibling helpers on the class (`_matches_problem_sigma`, `_require_kwarg`, #1783), and a double
-    that copies one method silently loses them. Inheriting keeps the double honest about what the
-    seam actually depends on.
+    Subclasses rather than borrowing the single method. `_build_hjb_kwargs` reads `self.problem`
+    and delegates to the module-level `resolve_volatility_kwarg` (#1783); a double that copies one
+    method off the class keeps compiling while quietly diverging from what the seam depends on.
+    Inheriting makes that dependency fail loud instead.
     """
 
     def __init__(self):

--- a/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
+++ b/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
@@ -17,12 +17,24 @@ Three lines below, the same function already raised for exactly this situation w
 from __future__ import annotations
 
 import inspect
+import pathlib
+from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
 import numpy as np
 
-from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+from mfgarchon.alg.numerical.coupling import base_mfg
+from mfgarchon.alg.numerical.coupling.base_mfg import resolve_volatility_kwarg
+
+
+@dataclass
+class _Problem:
+    """Only the two attributes the owner reads."""
+
+    sigma: Any
+    volatility_field: Any = None
 
 
 def test_a_var_keyword_override_does_not_count_as_accepting_the_parameter():
@@ -39,13 +51,13 @@ def test_a_var_keyword_override_does_not_count_as_accepting_the_parameter():
     )
 
     with pytest.raises(NotImplementedError, match="does not accept 'volatility_field'"):
-        BaseCouplingIterator._require_kwarg(
-            params, "volatility_field", "FakeSolver", "solve_hjb_system", "Consequence."
-        )
+        resolve_volatility_kwarg(params, 0.7, _Problem(0.3), "FakeSolver", "solve_hjb_system", "HJB")
 
     # And it does NOT refuse when the parameter is named.
     named = inspect.signature(lambda self, volatility_field=None: None).parameters
-    BaseCouplingIterator._require_kwarg(named, "volatility_field", "FakeSolver", "solve_hjb_system", "Consequence.")
+    assert resolve_volatility_kwarg(named, 0.7, _Problem(0.3), "FakeSolver", "solve_hjb_system", "HJB") == {
+        "volatility_field": 0.7
+    }
 
 
 def test_the_message_names_the_signature_and_the_consequence():
@@ -57,13 +69,7 @@ def test_the_message_names_the_signature_and_the_consequence():
     """
     params = inspect.signature(lambda self, *args, **kwargs: None).parameters
     with pytest.raises(NotImplementedError) as exc:
-        BaseCouplingIterator._require_kwarg(
-            params,
-            "volatility_field",
-            "MeshlessGalerkinHJBSolver",
-            "solve_hjb_system",
-            "Dropping it would leave the two equations on different diffusion.",
-        )
+        resolve_volatility_kwarg(params, 0.7, _Problem(0.3), "MeshlessGalerkinHJBSolver", "solve_hjb_system", "HJB")
     message = str(exc.value)
     assert "MeshlessGalerkinHJBSolver.solve_hjb_system" in message
     assert "different diffusion" in message, "the consequence must be stated, not just the refusal"
@@ -72,19 +78,59 @@ def test_the_message_names_the_signature_and_the_consequence():
     )
 
 
-def test_both_coupling_sides_route_through_one_owner():
-    """HJB and FP had two copies of this gate. A fix to one is a fix to one.
+def test_every_coupling_path_routes_through_one_owner():
+    """Four call sites, one decision. Scanned across the package, not one class.
 
-    The repo's dominant defect class is a convention with a private copy on a neighbouring path;
-    this pins that the two sides share an owner rather than agreeing by coincidence.
+    The first version of this test read ``inspect.getsource(BaseCouplingIterator)`` and was green
+    while ``mfg_residual`` -- the Newton coupling path, in the same package -- carried two live
+    inline copies that dropped the field silently. A single-owner guard scoped to one class cannot
+    see the neighbouring path, which is the whole shape it exists to catch.
     """
-    source = inspect.getsource(BaseCouplingIterator)
-    assert source.count("_require_kwarg") >= 3, (
-        "expected one definition and two call sites; a lower count means one side has drifted back to an inline check"
+    package = pathlib.Path(base_mfg.__file__).parent
+    modules = sorted(package.glob("*.py"))
+    assert len(modules) >= 4, f"expected the coupling package, found {len(modules)} files"
+
+    inline = {m.name: m.read_text(encoding="utf-8").count('"volatility_field" in ') for m in modules}
+    assert sum(inline.values()) == 1, (
+        f"exactly one membership test may exist -- the one inside resolve_volatility_kwarg. Found "
+        f"{ {k: v for k, v in inline.items() if v} }. An inline copy is the form that dropped the "
+        f"value silently on both Picard (#1783) and Newton (found reviewing the #1783 fix)."
     )
-    assert source.count('"volatility_field" in params') == 0, (
-        "an inline membership test has reappeared -- that is the form that dropped the value silently"
-    )
+    assert inline["base_mfg.py"] == 1, "the surviving one must be the owner's"
+
+    # Per file, not a total: a total lets one path lose a call site while another gains one.
+    uses = {m.name: m.read_text(encoding="utf-8").count("resolve_volatility_kwarg(") for m in modules}
+    assert uses["base_mfg.py"] == 3, f"Picard: expected the definition + both sides, found {uses['base_mfg.py']}"
+    assert uses["mfg_residual.py"] == 2, f"Newton: expected both sides, found {uses['mfg_residual.py']}"
+
+
+def test_an_exempt_scalar_is_still_forwarded_when_the_solver_names_it():
+    """Indistinguishable from sigma is a reason not to REFUSE, not a reason not to FORWARD.
+
+    The first fix of #1783 put the forward inside the hazard branch, so a scalar equal to
+    ``problem.sigma`` stopped being forwarded at all. That is silent-wrong in the same way the
+    original defect was: ``problem.volatility_field`` is not always ``problem.sigma`` -- construct
+    with an array sigma and the field is the array while ``sigma`` is its mean -- so a solver
+    falling back through ``get_diffusion_coefficient_field(None)`` picks up the array instead of
+    the constant the caller asked for.
+    """
+    named = inspect.signature(lambda self, volatility_field=None: None).parameters
+    array_sigma = _Problem(0.3, volatility_field=np.full(9, 0.3))
+    assert resolve_volatility_kwarg(named, 0.3, array_sigma, "FDM", "solve_hjb_system", "HJB") == {
+        "volatility_field": 0.3
+    }, "an explicit override must reach the solver even when it equals problem.sigma"
+
+    # The exemption still applies where it was needed: a solver that cannot take it, and a field
+    # whose loss changes nothing. Without this branch every ordinary solve would refuse.
+    kw_only = inspect.signature(lambda self, *args, **kwargs: None).parameters
+    assert resolve_volatility_kwarg(kw_only, 0.3, _Problem(0.3), "X", "solve_hjb_system", "HJB") == {}
+
+
+def test_a_numpy_scalar_is_not_a_hazard():
+    """``np.float32(0.3)`` is neither ``int`` nor ``float``; refusing it refuses an identical solve."""
+    kw_only = inspect.signature(lambda self, *args, **kwargs: None).parameters
+    p = _Problem(np.float32(0.3))
+    assert resolve_volatility_kwarg(kw_only, np.float32(0.3), p, "X", "solve_hjb_system", "HJB") == {}
 
 
 def test_the_meshless_pair_is_refused_end_to_end():

--- a/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
+++ b/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
@@ -1,0 +1,143 @@
+"""Issue #1783: the coupling kwarg gate must not be fooled by a ``**kwargs`` override.
+
+``BaseCouplingIterator._build_hjb_kwargs`` / ``_build_fp_kwargs`` decide whether to forward
+``volatility_field`` by asking ``inspect.signature`` whether the solver names the parameter. That
+answers "does this callable name it", not "can this solver consume it", and a subclass declaring
+``(self, *args, **kwargs)`` makes the two diverge.
+
+Before the fix the field was dropped silently on the side that did not name it. Measured on the
+meshless pair with ``problem.sigma = 0.3`` and a field of mean 0.7: the HJB side ran at D = 0.045
+while the paired FP side ran at D = 0.245 -- a 5.4x mismatch, no warning, and a converged density
+for a problem nobody posed.
+
+Three lines below, the same function already raised for exactly this situation with
+``source_term`` (#1424). Two adjacent branches of one function, opposite policies.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
+
+
+def test_a_var_keyword_override_does_not_count_as_accepting_the_parameter():
+    """The gate must refuse, not guess, when the name is absent.
+
+    Treating ``VAR_KEYWORD`` as accept-anything was the other candidate fix. It assumes a solver
+    consumes what it swallows -- which is precisely the assumption that produced #1316, where
+    three HJB solvers declared ``volatility_field`` and ignored it.
+    """
+    params = inspect.signature(lambda self, *args, **kwargs: None).parameters
+    assert "volatility_field" not in params
+    assert any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()), (
+        "the fixture must actually have **kwargs, or it tests nothing about the hole"
+    )
+
+    with pytest.raises(NotImplementedError, match="does not accept 'volatility_field'"):
+        BaseCouplingIterator._require_kwarg(
+            params, "volatility_field", "FakeSolver", "solve_hjb_system", "Consequence."
+        )
+
+    # And it does NOT refuse when the parameter is named.
+    named = inspect.signature(lambda self, volatility_field=None: None).parameters
+    BaseCouplingIterator._require_kwarg(named, "volatility_field", "FakeSolver", "solve_hjb_system", "Consequence.")
+
+
+def test_the_message_names_the_signature_and_the_consequence():
+    """A refusal that does not say what would have gone wrong sends the reader to the wrong fix.
+
+    The natural but wrong response to "solver does not accept volatility_field" is to add
+    ``**kwargs`` to the solver -- which is what caused the defect. The message has to say that
+    explicitly.
+    """
+    params = inspect.signature(lambda self, *args, **kwargs: None).parameters
+    with pytest.raises(NotImplementedError) as exc:
+        BaseCouplingIterator._require_kwarg(
+            params,
+            "volatility_field",
+            "MeshlessGalerkinHJBSolver",
+            "solve_hjb_system",
+            "Dropping it would leave the two equations on different diffusion.",
+        )
+    message = str(exc.value)
+    assert "MeshlessGalerkinHJBSolver.solve_hjb_system" in message
+    assert "different diffusion" in message, "the consequence must be stated, not just the refusal"
+    assert "**kwargs does not count" in message, (
+        "without this the reader's natural fix is to widen the signature, which is the defect"
+    )
+
+
+def test_both_coupling_sides_route_through_one_owner():
+    """HJB and FP had two copies of this gate. A fix to one is a fix to one.
+
+    The repo's dominant defect class is a convention with a private copy on a neighbouring path;
+    this pins that the two sides share an owner rather than agreeing by coincidence.
+    """
+    source = inspect.getsource(BaseCouplingIterator)
+    assert source.count("_require_kwarg") >= 3, (
+        "expected one definition and two call sites; a lower count means one side has drifted back to an inline check"
+    )
+    assert source.count('"volatility_field" in params') == 0, (
+        "an inline membership test has reappeared -- that is the form that dropped the value silently"
+    )
+
+
+def test_the_meshless_pair_is_refused_end_to_end():
+    """The real configuration, through the public constructor.
+
+    `volatility_field` is a CONSTRUCTOR argument of the iterator, not a `solve()` kwarg -- passing
+    it to `solve()` is swallowed by **kwargs and never reaches the gate, which is how a first
+    attempt at this test measured nothing while appearing to pass.
+    """
+    from mfgarchon.alg.numerical.coupling.fixed_point_iterator import FixedPointIterator
+    from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+    from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    n = 21
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(
+        geometry=grid,
+        T=0.2,
+        Nt=5,
+        sigma=0.3,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    points = np.linspace(0.0, 1.0, n).reshape(-1, 1)
+    delta = 2.6 / np.sqrt(n)
+
+    def pair():
+        return (
+            MeshlessGalerkinHJBSolver(problem, points, delta=delta),
+            MeshlessGalerkinFPSolver(problem, points, delta=delta),
+        )
+
+    hjb, _fp = pair()
+    assert "volatility_field" not in inspect.signature(hjb.solve_hjb_system).parameters, (
+        "this solver must be the **kwargs shape, or the test does not exercise the hole"
+    )
+
+    # Without the field, nothing changes -- the refusal must not break ordinary use.
+    FixedPointIterator(problem, *pair()).solve(max_iterations=2, verbose=False)
+
+    with pytest.raises(NotImplementedError, match="does not accept 'volatility_field'"):
+        FixedPointIterator(problem, *pair(), volatility_field=np.linspace(0.5, 0.9, n)).solve(
+            max_iterations=2, verbose=False
+        )

--- a/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
+++ b/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
@@ -187,3 +187,81 @@ def test_the_meshless_pair_is_refused_end_to_end():
         FixedPointIterator(problem, *pair(), volatility_field=np.linspace(0.5, 0.9, n)).solve(
             max_iterations=2, verbose=False
         )
+
+
+def test_the_newton_path_refuses_the_same_pair_the_picard_path_does():
+    """The Newton half of the fix, exercised rather than counted.
+
+    `test_every_coupling_path_routes_through_one_owner` reads source text, so it stays green if a
+    call site keeps the call and passes the wrong argument. Changing `self.volatility_field` to
+    `None` at either `mfg_residual` site leaves every test in this file passing while the Newton
+    gate stops both forwarding and refusing -- strictly worse than the pre-PR behaviour, which at
+    least forwarded to solvers that name the parameter.
+
+    Before this, no test in the repository constructed `MFGResidual` or `NewtonMFGSolver` with a
+    `volatility_field` at all: 26 construction sites, none passing one.
+    """
+    from mfgarchon.alg.numerical.coupling.mfg_residual import MFGResidual
+    from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+    from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    n = 21
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(
+        geometry=grid,
+        T=0.2,
+        Nt=5,
+        sigma=0.3,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (x - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    points = np.linspace(0.0, 1.0, n).reshape(-1, 1)
+    delta = 2.6 / np.sqrt(n)
+    hjb = MeshlessGalerkinHJBSolver(problem, points, delta=delta)
+    fp = MeshlessGalerkinFPSolver(problem, points, delta=delta)
+    assert "volatility_field" not in inspect.signature(hjb.solve_hjb_system).parameters, (
+        "this solver must be the **kwargs shape, or the test does not exercise the hole"
+    )
+
+    shape = (problem.Nt + 1, n)
+    M0 = np.tile(np.ones(n) / n, (problem.Nt + 1, 1))
+    U0 = np.zeros(shape)
+
+    # A field the two sides would disagree about: mean 0.7 against problem.sigma = 0.3.
+    hazard = np.linspace(0.5, 0.9, n)
+    residual = MFGResidual(problem, hjb, fp, volatility_field=hazard)
+    with pytest.raises(NotImplementedError, match="does not accept 'volatility_field'"):
+        residual.compute_hjb_output(M0, U0)
+
+    # And the FP side, which DOES name the parameter, must actually RECEIVE it. Asserting only
+    # that the call returns a well-shaped array leaves the site pinned by nothing: replacing the
+    # forwarded value with None still returns an array, it is just a different problem's array.
+    seen: dict[str, object] = {}
+    inner = fp.solve_fp_system
+
+    def spy(*args, **kwargs):
+        seen.update(kwargs)
+        return inner(*args, **kwargs)
+
+    fp.solve_fp_system = spy
+    try:
+        assert residual.compute_fp_output(U0, M0).shape == shape
+    finally:
+        fp.solve_fp_system = inner
+    assert "volatility_field" in seen, "the FP side names the parameter, so it must be forwarded"
+    assert np.array_equal(seen["volatility_field"], hazard)
+
+    # No field, no refusal -- the Newton path must still run ordinarily.
+    MFGResidual(problem, hjb, fp).compute_hjb_output(M0, U0)

--- a/tests/unit/test_alg/test_source_term_fail_loud.py
+++ b/tests/unit/test_alg/test_source_term_fail_loud.py
@@ -15,9 +15,21 @@ import numpy as np
 from mfgarchon.alg.numerical.coupling.base_mfg import BaseCouplingIterator
 
 
-class _Builder:
-    _build_hjb_kwargs = BaseCouplingIterator._build_hjb_kwargs
-    _build_fp_kwargs = BaseCouplingIterator._build_fp_kwargs
+class _Builder(BaseCouplingIterator):
+    """Subclass, not a method-borrowing double.
+
+    Borrowing `_build_*_kwargs` onto a bare class was green only because these tests never pass
+    `volatility_field`; adding one such case raised `AttributeError` on the seam's other
+    dependencies instead of testing anything (#1783 review). Inheriting keeps the double honest.
+    """
+
+    problem = None
+
+    def solve(self, *args, **kwargs):  # pragma: no cover - abstract stub, never called
+        raise NotImplementedError
+
+    def get_results(self, *args, **kwargs):  # pragma: no cover - abstract stub, never called
+        raise NotImplementedError
 
     def __init__(self, hjb_params, fp_params):
         self._hjb_sig_params = hjb_params
@@ -58,3 +70,14 @@ class TestSourceTermFailLoud:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])
+
+
+def test_the_double_carries_the_whole_seam_not_one_borrowed_method():
+    """Guard on the fixture itself: it must reach every dependency of `_build_hjb_kwargs`.
+
+    A double that borrows one method passes this file's cases and fails the moment an unrelated
+    test adds a `volatility_field`, reporting an `AttributeError` about the fixture rather than a
+    fact about the code. Exercising the other branch here keeps that discoverable in this file.
+    """
+    b = _Builder(hjb_params={"M_density", "U_terminal", "volatility_field"}, fp_params=set())
+    assert b._build_hjb_kwargs(volatility_field=0.42) == {"volatility_field": 0.42}


### PR DESCRIPTION
Fixes #1783

Found while re-verifying #1316 — which is genuinely fixed for the three solvers it names. This is a different, reachable instance of the same class, and it produces a converged answer to a question nobody asked.

## Measured

`FixedPointIterator`, meshless pair, `problem.sigma = 0.3`, `volatility_field` of mean 0.7:

```
HJB D = 0.045    FP D = 0.245     ratio 5.4x, no warning

final density vs the consistent sigma=0.7 MFG   1.01e-01
final density vs the consistent sigma=0.3 MFG   8.86e-01
control, the two consistent MFGs differ by      9.56e-01
```

## Mechanism

The gate asked `inspect.signature(...).parameters` whether the solver names `volatility_field` — which answers *"does this callable name it"*, not *"can this solver consume it"*. Two solvers make those diverge:

```
MeshlessGalerkinHJBSolver   (self, *args, use_newton=None, **kwargs)
```

`HJBHowardSolver` was named here as a second offender in the first revision. That was wrong: its
signature is `(self, M_density, U_terminal, cross_density=None, **_unused)`, one verified instance
and one asserted without a trace. It *is* reachable by the gate — in the hazard case the gate fires
first, because `_build_hjb_kwargs` runs before `solve_hjb_system` is ever called — but it is not a
`**kwargs`-shaped offender, and with an exempt or absent field it falls through to its own
`cross_density` guard. Traced, not inferred:

```
hazard field (0.7 vs sigma 0.3)  -> refused at the gate
exempt field (0.3)               -> {} from the gate, then the cross_density NotImplementedError
```

Three lines below, `source_term` already **raised** for exactly this situation (#1424). Two adjacent branches of one function, opposite policies — so the fix is to make `volatility_field` match, not to loosen the test. Treating `VAR_KEYWORD` as accept-anything was the other candidate; it assumes a solver consumes what it swallows, which is the assumption that produced #1316.

## The gate existed in four copies

The first revision of this PR said two — HJB and FP on the Picard path — and that was false at repo
scope. Review found `MFGResidual.compute_hjb_output` and `.compute_fp_output`, the Newton coupling
path in the same package, carrying two more inline copies, with the identical 5.44x silent mismatch
fully reachable through `NewtonMFGSolver`.

The four sites each restated the same three-way decision — *is this field a hazard, can the solver
take it, do we forward it* — and the restatement is what let them disagree. So the decision itself
now lives in one module-level `resolve_volatility_kwarg`, and the class-local helpers the first
revision added are deleted. Implementations of the membership test in `coupling/`: **4 → 1**,
measured with `git grep -c`.

## Scope correction the full suite forced, and was right to

My first version keyed on `volatility_field is not None`, which refused **every ordinary solve**: `MFGProblem.volatility_field` defaults to `problem.sigma`, so the coupling loop always hands a non-None value. Two meshless tests went red.

A scalar within `1e-12` of `problem.sigma` is now exempt — it cannot make the two sides disagree. **Arrays and callables are never exempt**, because showing one equivalent requires evaluating it, and guessing there is what #1316 was about. The comparison is `numbers.Real`, not `(int, float)`: `np.float32(0.3)` is neither, and refusing it refuses a solve byte-identical to one that is accepted. Mutating `1e-12` to `1e12` reddens two tests.

## Two method notes, both caught here rather than shipped

- My first probe passed `volatility_field` to `solve()`, where it is swallowed by `**kwargs` and never reaches the gate — it is a **constructor** argument of the iterator. The probe reported "fix ineffective" while testing nothing.
- `test_gfdm_batch_spatial_volatility_1725.py` used a double that copied `_build_hjb_kwargs` as a single borrowed method. Once that method delegates to siblings, a copy silently loses them. The double now subclasses the seam, which keeps it honest about what the seam depends on.

## Discrimination

Restoring the silent inline membership test on both sides:

```
restore an inline copy in mfg_residual   -> FAILED test_every_coupling_path_routes_through_one_owner
Newton HJB call site -> None             -> FAILED test_the_newton_path_refuses_the_same_pair...
Newton FP  call site -> None             -> FAILED test_the_newton_path_refuses_the_same_pair...
forward moved back inside hazard branch  -> FAILED test_an_exempt_scalar_is_still_forwarded...
numbers.Real -> (int, float)             -> FAILED test_a_numpy_scalar_is_not_a_hazard
owner never refuses                      -> FAILED 3 tests
```

The Newton rows matter most: the single-owner guard reads source text, so a call site that keeps
the call and passes the wrong argument leaves it green. Before this PR no test in the repository
constructed `MFGResidual` or `NewtonMFGSolver` with a `volatility_field` at all — 26 construction
sites, none passing one — so the Newton half was pinned by nothing until the behavioural test was
added.

## Verification

`./scripts/local_ci.sh` green: ruff, workflow integrity, fail-fast ratchet at baseline, doc-API ratchet, frozen-area gate, capability matrix unchanged, `5755 passed, 22 skipped, 11 xfailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
