### PR TITLE
Surface deprecation-guide name collisions instead of listing both sides silently

### DIFF
--- a/changelog.d/deprecation-guide-name-collisions.fixed.md
+++ b/changelog.d/deprecation-guide-name-collisions.fixed.md
@@ -1,0 +1,21 @@
+- **The deprecation guide no longer tells a reader to migrate to a name it elsewhere deprecates.**
+  `drift_field` is the destination on `FPFDMSolver.solve_fp_system` — replacing `velocity_field`,
+  where it means the optimal control $\alpha^*$ — and is simultaneously deprecated in favour of
+  `potential_field` on eight other FP solvers, where it means the value function $U$. The guide
+  listed all nine rows with nothing marking them as different quantities, so a reader's reasonable
+  conclusion (the name is on its way out everywhere) is the wrong one.
+
+  Both parameters exist on both solver families, so the wrong migration is accepted silently rather
+  than raising. Measured on a 21-point 1D problem, `sigma = 0.3`, `T = 0.2`, constant optimal
+  control `alpha = 1.0`, initial mass centred at 0.3: `drift_field=alpha` transports the centroid
+  to 0.5055, `potential_field=alpha` leaves it at 0.3151 — the solver computes
+  $-c\nabla\alpha = 0$ for a constant control, so the advection vanishes entirely. A 37.7% error
+  in the transported centroid, no exception and no warning.
+
+  The generator now detects the class mechanically — any identifier that is both a deprecated name
+  and a recommended replacement — rather than special-casing this one. It emits a section before
+  the version listings pairing each side with its owning API and its own migration, and flags every
+  affected row inline, including the `velocity_field -> drift_field` row, which is the row that
+  makes the name look canonical and which a check keyed only on deprecated names would leave clean.
+  A collision is a legitimate transient, so this surfaces it rather than deciding it; the naming
+  question itself is #1786. Issues #1043, #1044.

--- a/docs/user/DEPRECATION_MODERNIZATION_GUIDE.md
+++ b/docs/user/DEPRECATION_MODERNIZATION_GUIDE.md
@@ -19,14 +19,36 @@ python -W error::DeprecationWarning -c 'import mfgarchon; ...'
 
 ---
 
+## Do not migrate these across solvers
+
+The identifiers below are **deprecated in one place and the recommended replacement in another**. That is not a mistake in this guide: the same word names different quantities on different solvers, and each row is correct for the API it names.
+
+It does mean a migration you read on one row **does not transfer** to another solver. Both parameters usually exist on both solvers, so applying the wrong one is accepted silently and changes the answer rather than raising. Check the target solver's `solve_*` docstring for what the parameter means there before renaming anything.
+
+### `drift_field`
+
+| in this API | `drift_field` is | migration on that row |
+|---|---|---|
+| `FPFDMSolver.solve_fp_system()` | the destination | `velocity_field` -> `drift_field` |
+| `FPFEMSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+| `FPNetworkSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+| `FPSLAdjointSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+| `FPSLJacobianSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+| `FPSLSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+| `MeshlessGalerkinFPSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+| `NetworkFPSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+| `WeakFormFPSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
+
+---
+
 ## Deprecated since v0.21.0
 
 *2 items*
 
 ### Parameters
 
-- **`drift_field`** in `FPNetworkSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
-- **`drift_field`** in `NetworkFPSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
+- **`drift_field`** in `FPNetworkSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
+- **`drift_field`** in `NetworkFPSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
 
 ---
 
@@ -50,9 +72,9 @@ python -W error::DeprecationWarning -c 'import mfgarchon; ...'
 
 ### Parameters
 
-- **`drift_field`** in `FPFEMSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
-- **`drift_field`** in `MeshlessGalerkinFPSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
-- **`drift_field`** in `WeakFormFPSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
+- **`drift_field`** in `FPFEMSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
+- **`drift_field`** in `MeshlessGalerkinFPSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
+- **`drift_field`** in `WeakFormFPSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
 
 ---
 
@@ -100,10 +122,10 @@ python -W error::DeprecationWarning -c 'import mfgarchon; ...'
 
 ### Parameters
 
-- **`velocity_field`** in `FPFDMSolver.solve_fp_system()` — use `drift_field` instead (remove by v0.25.0)
-- **`drift_field`** in `FPSLAdjointSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
-- **`drift_field`** in `FPSLJacobianSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
-- **`drift_field`** in `FPSLSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0)
+- **`velocity_field`** in `FPFDMSolver.solve_fp_system()` — use `drift_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
+- **`drift_field`** in `FPSLAdjointSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
+- **`drift_field`** in `FPSLJacobianSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
+- **`drift_field`** in `FPSLSolver.solve_fp_system()` — use `potential_field` instead (remove by v0.25.0) [see *Do not migrate these across solvers*: `drift_field`]
 
 ---
 

--- a/scripts/generate_deprecation_guide.py
+++ b/scripts/generate_deprecation_guide.py
@@ -59,12 +59,107 @@ def deduplicate(items: list[dict]) -> list[dict]:
     return unique
 
 
-def format_item(item: dict) -> str:
+def _short_name(item: dict) -> str:
+    """The bare identifier a user types, without the owning class/method path."""
+    return item.get("name", "").split(".")[-1]
+
+
+def find_name_collisions(items: list[dict]) -> dict[str, dict[str, list[str]]]:
+    """Identifiers that are deprecated in one place and the recommended replacement in another.
+
+    A guide that lists both without saying so tells a reader to migrate TO a name on one line and
+    AWAY from it on the next, with nothing marking the two as different quantities. The reader's
+    reasonable conclusion -- that the name is being phased out everywhere -- is the wrong one, and
+    the API accepts the wrong migration without a warning because both parameters exist.
+
+    Measured instance, the one that motivated this (Issue #1043 / #1044): `drift_field` is the
+    replacement for `velocity_field` on `FPFDMSolver`, where it means the optimal control a*, and
+    is simultaneously deprecated in favour of `potential_field` on seven solvers, where it means
+    the value function U. A correct FDM caller who follows the seven rows migrates
+    `drift_field=alpha` to `potential_field=alpha`; the solver then computes -c*grad(alpha), which
+    for a constant control is zero, so the advection vanishes silently. On a 21-point 1D problem
+    with alpha = 1.0 the density centroid moves 0.3 -> 0.5055 correctly and 0.3 -> 0.3151 after
+    the migration: a 37.7% error, no exception, no warning.
+
+    Returns ``{name: {"deprecated_in": [...], "replaces": [...]}}``, each entry carrying the owning
+    ``method`` and the ``other`` name on that side, so a reader can act on one row without
+    reconstructing the pairing. Empty when the guide is unambiguous, which is the state to aim for
+    -- a collision is a legitimate transient, not a permanent design, and this surfaces it rather
+    than deciding it.
+    """
+    collisions: dict[str, dict[str, list[dict]]] = {}
+    replaced_names = {i.get("replacement", "") for i in items}
+    for name in {_short_name(i) for i in items if _short_name(i)}:
+        if name not in replaced_names:
+            continue
+        collisions[name] = {
+            # Where this name is itself on the way out, and what it points at.
+            "deprecated_in": sorted(
+                (
+                    {"method": i.get("name", "").rsplit(".", 1)[0], "other": i.get("replacement", "")}
+                    for i in items
+                    if _short_name(i) == name
+                ),
+                key=lambda d: d["method"],
+            ),
+            # Where this name is the destination, and which name it replaces there.
+            "replaces": sorted(
+                (
+                    {"method": i.get("name", "").rsplit(".", 1)[0], "other": _short_name(i)}
+                    for i in items
+                    if i.get("replacement", "") == name
+                ),
+                key=lambda d: d["method"],
+            ),
+        }
+    return collisions
+
+
+def format_collisions(collisions: dict[str, dict[str, list[dict]]]) -> list[str]:
+    """The warning section. Placed before the version listings, not after."""
+    if not collisions:
+        return []
+    lines = [
+        "## Do not migrate these across solvers",
+        "",
+        "The identifiers below are **deprecated in one place and the recommended replacement in "
+        "another**. That is not a mistake in this guide: the same word names different quantities "
+        "on different solvers, and each row is correct for the API it names.",
+        "",
+        "It does mean a migration you read on one row **does not transfer** to another solver. "
+        "Both parameters usually exist on both solvers, so applying the wrong one is accepted "
+        "silently and changes the answer rather than raising. Check the target solver's `solve_*` "
+        "docstring for what the parameter means there before renaming anything.",
+        "",
+    ]
+    for name, sides in sorted(collisions.items()):
+        lines.append(f"### `{name}`")
+        lines.append("")
+        lines.append("| in this API | `" + name + "` is | migration on that row |")
+        lines.append("|---|---|---|")
+        for row in sides["replaces"]:
+            lines.append(f"| `{row['method']}()` | the destination | `{row['other']}` -> `{name}` |")
+        for row in sides["deprecated_in"]:
+            lines.append(f"| `{row['method']}()` | itself deprecated | `{name}` -> `{row['other']}` |")
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def format_item(item: dict, collisions: dict[str, dict] | None = None) -> str:
     """Format a single deprecation item as markdown."""
     name = item.get("name", "unknown")
     replacement = item.get("replacement", "N/A")
     removal = item.get("removal", "v1.0.0")
     item_type = item.get("type", "unknown")
+    # A reader scanning one row must see the ambiguity without reading the whole guide.
+    flag = ""
+    if collisions:
+        hit = {_short_name(item), replacement} & set(collisions)
+        if hit:
+            flag = " [see *Do not migrate these across solvers*: "
+            flag += ", ".join(f"`{h}`" for h in sorted(hit)) + "]"
 
     if item_type == "parameter":
         # "ClassName.method.param_name" -> extract parts
@@ -72,22 +167,23 @@ def format_item(item: dict) -> str:
         if len(parts) >= 2:
             func_name = ".".join(parts[:-1])
             param = parts[-1]
-            return f"- **`{param}`** in `{func_name}()` — use `{replacement}` instead (remove by {removal})"
-        return f"- **`{name}`** — use `{replacement}` instead (remove by {removal})"
+            return f"- **`{param}`** in `{func_name}()` — use `{replacement}` instead (remove by {removal}){flag}"
+        return f"- **`{name}`** — use `{replacement}` instead (remove by {removal}){flag}"
     elif item_type == "function":
-        return f"- **`{name}()`** — use `{replacement}` instead (remove by {removal})"
+        return f"- **`{name}()`** — use `{replacement}` instead (remove by {removal}){flag}"
     elif item_type == "property":
-        return f"- **`{name}`** (property) — use `{replacement}` instead (remove by {removal})"
+        return f"- **`{name}`** (property) — use `{replacement}` instead (remove by {removal}){flag}"
     elif item_type == "alias":
-        return f"- **`{name}`** (import alias) — use `{replacement}` instead (remove by {removal})"
+        return f"- **`{name}`** (import alias) — use `{replacement}` instead (remove by {removal}){flag}"
     else:
-        return f"- **`{name}`** ({item_type}) — use `{replacement}` instead (remove by {removal})"
+        return f"- **`{name}`** ({item_type}) — use `{replacement}` instead (remove by {removal}){flag}"
 
 
 def generate_guide(items: list[dict]) -> str:
     """Generate the full markdown guide."""
     items = deduplicate(items)
     groups = group_by_version(items)
+    collisions = find_name_collisions(items)
 
     lines = [
         "# Deprecation Modernization Guide",
@@ -112,6 +208,8 @@ def generate_guide(items: list[dict]) -> str:
         "---",
         "",
     ]
+
+    lines.extend(format_collisions(collisions))
 
     for version, version_items in groups.items():
         # Sub-group by type
@@ -138,7 +236,7 @@ def generate_guide(items: list[dict]) -> str:
                 lines.append(f"### {type_labels.get(t, t.title())}")
                 lines.append("")
                 for item in type_items:
-                    lines.append(format_item(item))
+                    lines.append(format_item(item, collisions))
                 lines.append("")
 
         # Any remaining types
@@ -148,7 +246,7 @@ def generate_guide(items: list[dict]) -> str:
                 lines.append(f"### {t.title()}")
                 lines.append("")
                 for item in type_items:
-                    lines.append(format_item(item))
+                    lines.append(format_item(item, collisions))
                 lines.append("")
 
         lines.append("---")

--- a/tests/unit/test_deprecation_guide_name_collisions.py
+++ b/tests/unit/test_deprecation_guide_name_collisions.py
@@ -1,0 +1,125 @@
+"""The deprecation guide must not tell a reader to migrate to a name it elsewhere deprecates.
+
+`drift_field` is the destination on `FPFDMSolver.solve_fp_system` (replacing `velocity_field`,
+where it means the optimal control a*) and is simultaneously deprecated in favour of
+`potential_field` on eight other FP solvers (where it means the value function U). The generated
+guide listed all nine rows with nothing marking them as different quantities, so the reader's
+reasonable conclusion -- that the name is on its way out everywhere -- is the wrong one.
+
+Both parameters exist on both solver families, so the wrong migration is accepted silently.
+Measured on a 21-point 1D problem, sigma = 0.3, T = 0.2, with a constant optimal control
+alpha = 1.0 and initial mass centred at 0.3:
+
+    drift_field=alpha      -> final centroid 0.5055   (correct: the control advects the mass)
+    potential_field=alpha  -> final centroid 0.3151   (the solver computes -c*grad(alpha) = 0,
+                                                       so the advection vanishes; pure diffusion)
+
+A 37.7% error in the transported centroid, no exception and no warning. Issues #1043, #1044.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_GENERATOR = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "generate_deprecation_guide.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("generate_deprecation_guide", _GENERATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gen():
+    return _load()
+
+
+@pytest.fixture(scope="module")
+def registry(gen):
+    """The real deprecation registry, not a synthetic one.
+
+    A hand-built fixture would be generated from this file's *description* of the defect, and the
+    description drops whatever made the defect possible -- here, that the colliding name is a
+    parameter whose owner path has to be split off before the identifiers compare equal.
+    """
+    return gen.deduplicate(gen.scan_all_deprecations())
+
+
+def test_the_live_collision_is_detected(gen, registry):
+    collisions = gen.find_name_collisions(registry)
+    assert "drift_field" in collisions, (
+        "drift_field is the destination on FPFDMSolver and deprecated on eight other FP solvers; "
+        "if this is empty the detector stopped seeing the case it was written for"
+    )
+
+    sides = collisions["drift_field"]
+    destinations = {row["method"] for row in sides["replaces"]}
+    deprecated = {row["method"] for row in sides["deprecated_in"]}
+    assert "FPFDMSolver.solve_fp_system" in destinations
+    assert deprecated >= {"FPSLSolver.solve_fp_system", "WeakFormFPSolver.solve_fp_system"}
+    assert destinations & deprecated == set(), "a method cannot be on both sides for one name"
+
+    # The pairing must survive into the row, or the reader has to reconstruct it.
+    assert {row["other"] for row in sides["replaces"]} == {"velocity_field"}
+    assert {row["other"] for row in sides["deprecated_in"]} == {"potential_field"}
+
+
+def test_an_unambiguous_registry_produces_no_section(gen):
+    """Positive control: the section must be absent when there is nothing to warn about.
+
+    Without this, "the section is present" is satisfied by a detector that flags everything, and
+    the guide would carry a permanent warning that readers learn to skip.
+    """
+    clean = [
+        {"name": "Solver.method.old_name", "replacement": "new_name", "type": "parameter", "since": "v0.1.0"},
+        {"name": "Solver.method.other_old", "replacement": "other_new", "type": "parameter", "since": "v0.1.0"},
+    ]
+    assert gen.find_name_collisions(clean) == {}
+    assert gen.format_collisions({}) == []
+    assert "Do not migrate these across solvers" not in gen.generate_guide(clean)
+
+
+def test_a_name_deprecated_only_at_a_different_owner_still_collides(gen):
+    """The owner path must be split off before comparing, which is what the real case needs.
+
+    `FPFDMSolver.solve_fp_system.drift_field` and `FPSLSolver.solve_fp_system.drift_field` are
+    distinct registry keys; comparing the dotted names finds no collision at all. Mutating
+    `_short_name` to return the full name reddens this.
+    """
+    items = [
+        {"name": "A.solve.velocity_field", "replacement": "drift_field", "type": "parameter", "since": "v0.1.0"},
+        {"name": "B.solve.drift_field", "replacement": "potential_field", "type": "parameter", "since": "v0.1.0"},
+    ]
+    assert set(gen.find_name_collisions(items)) == {"drift_field"}
+
+
+def test_the_guide_carries_the_warning_and_flags_every_affected_row(gen, registry):
+    """The section alone is not enough: a reader scanning one row must see the ambiguity there."""
+    guide = gen.generate_guide(registry)
+    assert "## Do not migrate these across solvers" in guide
+
+    section_at = guide.index("## Do not migrate these across solvers")
+    first_listing = guide.index("## Deprecated since")
+    assert section_at < first_listing, "the warning must precede the rows it qualifies, not follow them"
+
+    rows = [ln for ln in guide.splitlines() if ln.startswith("- **`") and "drift_field" in ln]
+    assert len(rows) >= 9, f"expected the FDM destination row plus eight deprecations, found {len(rows)}"
+    unflagged = [ln for ln in rows if "Do not migrate these across solvers" not in ln]
+    assert not unflagged, "these rows carry the ambiguity with no marker:\n" + "\n".join(unflagged)
+
+
+def test_the_flag_fires_on_the_destination_row_not_only_the_deprecated_ones(gen, registry):
+    """The `velocity_field -> drift_field` row is the one that makes the name look canonical.
+
+    Flagging only the rows whose *deprecated* name collides leaves that row clean, and it is the
+    row a FDM user reads. The check is `{short_name, replacement} & collisions`, not `short_name`.
+    """
+    guide = gen.generate_guide(registry)
+    # The listing row, not the summary table's -- the table names both sides by construction.
+    fdm_row = next(ln for ln in guide.splitlines() if ln.startswith("- **`velocity_field`**") and "FPFDMSolver" in ln)
+    assert "Do not migrate these across solvers" in fdm_row, fdm_row


### PR DESCRIPTION
## The defect

`docs/user/DEPRECATION_MODERNIZATION_GUIDE.md` told a reader to migrate **to** `drift_field` on one row and **away** from it on eight others, with nothing marking the two as different quantities.

```
- **`velocity_field`** in `FPFDMSolver.solve_fp_system()` — use `drift_field` instead
- **`drift_field`**    in `FPSLSolver.solve_fp_system()`  — use `potential_field` instead
- ... seven more of the latter
```

`drift_field` is the destination on `FPFDMSolver`, where it means the optimal control $\alpha^*$, and is deprecated in favour of `potential_field` on eight other FP solvers, where it means the value function $U$. Each row is correct for the API it names. Together they read as "this name is being phased out", which is the wrong conclusion.

## Why it is not just cosmetic

Both parameters exist on both solver families, so the wrong migration is **accepted silently** rather than raising.

Measured — 21-point 1D problem, `sigma = 0.3`, `T = 0.2`, constant optimal control `alpha = 1.0`, mass initially centred at 0.3:

| call | final centroid |
|---|---|
| `drift_field=alpha` (correct today) | **0.5055** |
| `potential_field=alpha` (after applying the guide's rows) | **0.3151** |

$-c\nabla\alpha^* = 0$ for a constant control, so the advection vanishes entirely and only diffusion remains — the centroid barely moves from its initial 0.3. A 37.7% error in the transported quantity, no exception, no warning.

## The fix

The generator detects the **class** — any identifier that is both a deprecated name and a recommended replacement — not this one instance. It emits a section before the version listings:

| in this API | `drift_field` is | migration on that row |
|---|---|---|
| `FPFDMSolver.solve_fp_system()` | the destination | `velocity_field` -> `drift_field` |
| `FPSLSolver.solve_fp_system()` | itself deprecated | `drift_field` -> `potential_field` |
| … | | |

and flags every affected row inline, so a reader scanning one row sees the ambiguity without reading the whole guide.

**Including the `velocity_field -> drift_field` row.** That row is what makes the name look canonical, and it is the row an FDM user reads; a check keyed only on *deprecated* names leaves it clean. The condition is `{short_name, replacement} & collisions`.

## Discrimination

Three production mutations, each reddens:

| mutation | result |
|---|---|
| `_short_name` returns the full dotted name | 4 failed |
| the section is not emitted | 1 failed |
| the flag keys on deprecated names only | 2 failed |

The fixture is the **real registry**, not a synthetic collision — a hand-built one is generated from the *description* of the defect, and the description drops what made it possible (that the colliding name is a parameter whose owner path must be split off before the identifiers compare equal).

There is a positive control for the empty case: an unambiguous registry must produce **no** section. Without it, "the section is present" is satisfied by a detector that flags everything, and readers learn to skip a permanent warning.

## Scope

The generator and its output, plus one test file. No solver, no parameter, no deprecation decorator is touched — a collision is a legitimate transient, and this surfaces it rather than deciding it.

The naming question underneath — two concepts carrying four names, since `DriftConvention` says `VELOCITY`/`VALUE_FUNCTION` while the parameters say `drift_field`/`potential_field` — is filed as #1786 with the field-standard analysis and a recommendation. It is a public-API judgement call and is not made here.

Full suite: 5756 passed, 22 skipped, 11 xfailed. Capability matrix unchanged.

Refs #1043, #1044.