### PR TITLE
Documentation that misleads a reader: README maturity claims, and a docstring that answers the wrong question

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,4 +22,4 @@ keywords:
   - generalized-finite-differences
 abstract: >-
   A comprehensive Python framework for solving Mean Field Game (MFG) systems
-  using modern numerical methods, GPU acceleration, and reinforcement learning.
+  using modern numerical methods and GPU acceleration.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ print(f"Converged: {result.converged} in {result.iterations} iterations")
 - **Unified BC Framework** - 4-layer architecture with adjoint-consistent provider pattern
 - **Network MFG** - Graph-coupled multi-node solvers with pluggable coupling operators
 - **Measure-Dependent MFG** - MeasureField, Lions derivative, Wasserstein distance (Layer 2)
-- **Reinforcement Learning** - Complete RL framework (DDPG, TD3, SAC)
+- **Reinforcement Learning** - ⛔ Frozen design prototype (DDPG, TD3, SAC) — see `CLAUDE.md`
 - **GPU Acceleration** - PyTorch, JAX, Numba backends
 
 ---
@@ -102,7 +102,7 @@ print(f"Converged: {result.converged} in {result.iterations} iterations")
 - **Semi-Lagrangian** - Adaptive time-stepping with periodic BC support
 - **WENO** - High-order (5th) shock-capturing with high-order ghost nodes
 - **FEM** - scikit-fem based P1/P2 finite elements on unstructured meshes
-- **Neural (DGM, PINN)** - Deep learning for high dimensions
+- **Neural (DGM, PINN)** - ⛔ Frozen design prototype — see `CLAUDE.md`
 
 ### Fokker-Planck Solvers
 - **FDM** - Conservative finite difference with dict-dispatched BC
@@ -134,7 +134,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ```bash
 pip install mfgarchon          # Batteries included (FDM, FEM, GFDM, viz, config)
-pip install mfgarchon[nn]      # + PyTorch, RL (DGM, PINN, Actor-Critic, PPO)
+pip install mfgarchon[nn]      # + PyTorch (live: torch backends), gymnasium/SB3 (frozen RL only)
 pip install mfgarchon[all]     # + JAX, Numba, profiling tools
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19251867.svg)](https://doi.org/10.5281/zenodo.19251867)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/derrring/MFGArchon/blob/main/LICENSE)
 
-A Python framework for solving Mean Field Game systems using modern numerical methods, GPU acceleration, and reinforcement learning.
+A Python framework for solving Mean Field Game systems using modern numerical methods and GPU acceleration.
 
 ---
 
@@ -65,7 +65,7 @@ print(f"Converged: {result.converged} in {result.iterations} iterations")
 ## Key Features
 
 - **Clean API** - `Model` (game rules) + `Domain` (space) + `Conditions` (data) = `Problem.solve()`
-- **Modular** - Mix and match HJB + FP solvers (FDM, GFDM, Semi-Lagrangian, WENO, Particles, FEM, Neural)
+- **Modular** - Mix and match HJB + FP solvers (FDM, GFDM, Semi-Lagrangian, WENO, Particles, FEM)
 - **Multi-Dimensional** - 1D/2D/3D/nD support with TensorProductGrid and implicit domains
 - **Geometry Traits** - 12 protocol-based traits for solver-geometry compatibility validation
 - **Unified BC Framework** - 4-layer architecture with adjoint-consistent provider pattern

--- a/changelog.d/1789-readme-frozen-claims.fixed.md
+++ b/changelog.d/1789-readme-frozen-claims.fixed.md
@@ -1,0 +1,14 @@
+- **README no longer advertises the frozen packages as complete** (#1789). `Reinforcement Learning -
+  Complete RL framework (DDPG, TD3, SAC)` and `Neural (DGM, PINN) - Deep learning for high
+  dimensions` were the strongest unreconciled maturity claims in the repo, on the front page, while
+  both packages are frozen design prototypes (`CLAUDE.md`).
+
+  They survived the #1782 marker sweep because that sweep enumerated documents with the frozen
+  checker's own prefix matching — deliberately, since an ad-hoc grep counts `mfgarchon.alg.
+  neural_solvers`, an unrelated package, as a hit. README describes the packages in prose with no
+  dotted module path, so the rule that made the enumeration correct is the rule that made it blind.
+  A marker sweep keyed on import paths cannot see a capability claim that does not import.
+
+  The `[nn]` extra line is split rather than marked wholesale: measured, `torch` serves five
+  non-frozen modules (`backends/`, `utils/acceleration/`) while `gymnasium` and `stable-baselines3`
+  have zero importers outside `alg/reinforcement/`.

--- a/changelog.d/1789-readme-frozen-claims.fixed.md
+++ b/changelog.d/1789-readme-frozen-claims.fixed.md
@@ -9,9 +9,11 @@
   dotted module path, so the rule that made the enumeration correct is the rule that made it blind.
   A marker sweep keyed on import paths cannot see a capability claim that does not import.
 
-  The `[nn]` extra line is split rather than marked wholesale: measured, `torch` serves five
-  non-frozen modules (`backends/`, `utils/acceleration/`) while `gymnasium` and `stable-baselines3`
-  have zero importers outside `alg/reinforcement/`.
+  The `[nn]` extra line is split rather than marked wholesale: measured, `torch` is imported by
+  four non-frozen modules (three under `backends/`, one under `utils/acceleration/`) while
+  `gymnasium` and `stable-baselines3` have zero importers outside `alg/reinforcement/` and
+  `tensorboard` has none anywhere. (`utils/dependencies.py` names `torch` in a string for
+  `is_available` and does not import it, so it is not a fifth.)
 
   Review found the first pass had marked the bullet list and missed the two strongest claims in the
   same file: the one-line project description (`...GPU acceleration, and reinforcement learning`)

--- a/changelog.d/1789-readme-frozen-claims.fixed.md
+++ b/changelog.d/1789-readme-frozen-claims.fixed.md
@@ -12,3 +12,10 @@
   The `[nn]` extra line is split rather than marked wholesale: measured, `torch` serves five
   non-frozen modules (`backends/`, `utils/acceleration/`) while `gymnasium` and `stable-baselines3`
   have zero importers outside `alg/reinforcement/`.
+
+  Review found the first pass had marked the bullet list and missed the two strongest claims in the
+  same file: the one-line project description (`...GPU acceleration, and reinforcement learning`)
+  and a feature-parity bullet listing `Neural` as interchangeable with FDM/FEM/WENO. The same
+  sentence lives in `CITATION.cff`, which is DOI-attached and rendered by Zenodo, and `pyproject.toml`
+  still attributed `torch` to DGM/PINN — a divergence this PR's own README edit created. All four
+  corrected, and the per-dependency attribution is now recorded beside the requirement it explains.

--- a/examples/README.md
+++ b/examples/README.md
@@ -103,7 +103,9 @@ Constrained optimization:
 - `lagrangian_constrained_optimization.py` - Lagrangian optimization
 
 #### [machine_learning/](advanced/machine_learning/)
-Neural network and RL solvers:
+Neural network and RL solvers. ⛔ These exercise `alg/neural` and `alg/reinforcement`, which are
+**frozen design prototypes** and not under development — see `CLAUDE.md`. They run, but nothing
+here is a pinned contract.
 - `pinn_mfg_example.py` - Physics-Informed Neural Networks
 - `pinn_bayesian_mfg_demo.py` - Bayesian PINN with uncertainty
 - `adaptive_pinn_demo.py` - Adaptive training strategies
@@ -111,7 +113,7 @@ Neural network and RL solvers:
 - `neural_operator_mfg_demo.py` - Neural operators for MFG
 
 ##### [rl_algorithms/](advanced/machine_learning/rl_algorithms/)
-Reinforcement learning methods:
+Reinforcement learning methods (⛔ frozen prototype, as above):
 - `rl_intro_comparison.py` - RL algorithms overview
 - `nash_q_learning_demo.py` - Nash Q-Learning
 - `continuous_action_ddpg_demo.py` - Deep Deterministic Policy Gradient
@@ -158,7 +160,7 @@ Generated outputs and visualizations (gitignored, auto-regenerated).
 | **Configure solvers** | [tutorials/05_config_system.py](tutorials/05_config_system.py) |
 | **Try advanced solvers** | [advanced/solvers_advanced/](advanced/solvers_advanced/) |
 | **Apply MFG to real problems** | [advanced/applications/](advanced/applications/) |
-| **Use neural networks** | [advanced/machine_learning/](advanced/machine_learning/) |
+| **Use neural networks** (⛔ frozen prototype) | [advanced/machine_learning/](advanced/machine_learning/) |
 | **Work with complex geometry** | [advanced/geometry_advanced/](advanced/geometry_advanced/) |
 
 ---

--- a/mfgarchon/config/core.py
+++ b/mfgarchon/config/core.py
@@ -24,10 +24,12 @@ if TYPE_CHECKING:
 class BaseConfig(BaseModel):
     """Base for every configuration model in this package: unknown fields are an error.
 
-    Inherit from this, not from ``BaseModel``. Pydantic ignores extras by default, so
-    ``PicardConfig(anderson_acceleration=True)`` constructs cleanly, drops the field, and leaves
-    ``anderson_memory`` at 0 -- Anderson off while the caller just asked for it, nothing raised.
-    Same fail-fast rule as dead solver knobs (#1426, #1766).
+    Inherit from this, not from ``BaseModel``. Pydantic ignores extras by default, so a config
+    class that inherited ``BaseModel`` would let ``PicardConfig(anderson_acceleration=True)``
+    construct cleanly, drop the field, and leave ``anderson_memory`` at 0 -- Anderson off while
+    the caller just asked for it, nothing raised. Under ``BaseConfig`` it raises, which is what
+    ``test_unknown_fields_are_rejected_1766.py`` pins. Same fail-fast rule as dead solver knobs
+    (#1426, #1766).
 
     Deprecated aliases still work, and the ordering is why: their
     ``model_validator(mode="before")`` hooks ``pop`` the legacy key before validation runs, so

--- a/mfgarchon/config/core.py
+++ b/mfgarchon/config/core.py
@@ -22,26 +22,16 @@ if TYPE_CHECKING:
 
 
 class BaseConfig(BaseModel):
-    """Base for every configuration model in this package.
+    """Base for every configuration model in this package: unknown fields are an error.
 
-    Issue #1766. This was `BaseConfig = BaseModel`, a bare alias exported in `__all__` that
-    nothing inherited and that carried no policy -- a name promising a config base and
-    delivering Pydantic's.
+    Inherit from this, not from ``BaseModel``. Pydantic ignores extras by default, so
+    ``PicardConfig(anderson_acceleration=True)`` constructs cleanly, drops the field, and leaves
+    ``anderson_memory`` at 0 -- Anderson off while the caller just asked for it, nothing raised.
+    Same fail-fast rule as dead solver knobs (#1426, #1766).
 
-    It exists now to own one thing: **unknown fields are an error**. Pydantic ignores extras by
-    default, so `PicardConfig(anderson_acceleration=True)` constructed cleanly, dropped the
-    field, and left `anderson_memory` at 0 -- Anderson off while the caller had just asked for
-    it, with nothing raised. The API v1.0 design note taught exactly that call. A misspelled or
-    obsolete field in any config was accepted and discarded.
-
-    This is the fail-fast rule the package already applies to dead solver knobs (#1426 raises on
-    `FPNetworkSolver(max_iterations=...)` rather than ignoring it); the config layer was the one
-    place still accepting them silently.
-
-    Deprecated aliases are unaffected: they are translated by `model_validator(mode="before")`
-    hooks that `pop` the legacy key before validation runs, so `extra="forbid"` never sees it.
-    Verified against `PicardConfig(damping_factor=0.7)`, which still warns and still sets
-    `relaxation=0.7`.
+    Deprecated aliases still work, and the ordering is why: their
+    ``model_validator(mode="before")`` hooks ``pop`` the legacy key before validation runs, so
+    ``extra="forbid"`` never sees it. An alias translated after validation would raise instead.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
 #
 #   pip install mfgarchon          -> default (batteries included)
 #   pip install mfgarchon[core]    -> minimal (CI, Docker, embedding)
-#   pip install mfgarchon[nn]      -> + PyTorch, RL
+#   pip install mfgarchon[nn]      -> + PyTorch (live), gymnasium/SB3 (frozen RL only)
 #   pip install mfgarchon[all]     -> + JAX, performance, everything
 #   pip install mfgarchon[dev]     -> development tools
 
@@ -96,18 +96,18 @@ core = [
     "typing-inspection",
 ]
 
-# Neural network and reinforcement learning solvers
-# Adds: DGM, PINN, Actor-Critic, PPO
+# torch is live -- it backs mfgarchon.backends and utils/acceleration. The rest serve only
+# alg/neural and alg/reinforcement, which are FROZEN design prototypes (CLAUDE.md).
 nn = [
-    "torch>=2.0",              # PyTorch (DGM, PINN)
-    "gymnasium>=0.29",         # RL environments
-    "stable-baselines3>=2.0",  # RL algorithms (AC, PPO)
-    "tensorboard>=2.20.0",       # Training visualization
+    "torch>=2.0",              # PyTorch: backends/, utils/acceleration/ (live), and DGM/PINN (frozen)
+    "gymnasium>=0.29",         # frozen RL only: zero importers outside alg/reinforcement/
+    "stable-baselines3>=2.0",  # frozen RL only: one importer, alg/reinforcement/__init__.py
+    "tensorboard>=2.20.0",       # zero importers anywhere in the repo
 ]
 
 # Everything: default + nn + JAX + performance + advanced viz
 all = [
-    # Neural/RL (same as nn)
+    # Same as [nn]: torch is live, the rest serve only the frozen alg/neural + alg/reinforcement
     "torch>=2.0",
     "gymnasium>=0.29",
     "stable-baselines3>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,9 @@ core = [
     "typing-inspection",
 ]
 
-# torch is live -- it backs mfgarchon.backends and utils/acceleration. The rest serve only
-# alg/neural and alg/reinforcement, which are FROZEN design prototypes (CLAUDE.md).
+# torch is live -- it backs mfgarchon.backends and utils/acceleration. Of the rest, gymnasium and
+# stable-baselines3 serve only alg/reinforcement, a FROZEN design prototype (CLAUDE.md), and
+# tensorboard serves nothing.
 nn = [
     "torch>=2.0",              # PyTorch: backends/, utils/acceleration/ (live), and DGM/PINN (frozen)
     "gymnasium>=0.29",         # frozen RL only: zero importers outside alg/reinforcement/
@@ -107,7 +108,8 @@ nn = [
 
 # Everything: default + nn + JAX + performance + advanced viz
 all = [
-    # Same as [nn]: torch is live, the rest serve only the frozen alg/neural + alg/reinforcement
+    # Same as [nn]: torch is live; gymnasium and stable-baselines3 serve only the frozen
+    # alg/reinforcement, and tensorboard has no importer anywhere in the repo.
     "torch>=2.0",
     "gymnasium>=0.29",
     "stable-baselines3>=2.0",


### PR DESCRIPTION
Two documentation fixes, both found by measuring rather than reading.

## README advertised the frozen packages as complete (#1789)

```
- **Reinforcement Learning** - Complete RL framework (DDPG, TD3, SAC)
- **Neural (DGM, PINN)** - Deep learning for high dimensions
```

Both packages are frozen design prototypes (`CLAUDE.md`). This is the strongest unreconciled maturity claim in the repo, on the page most people read.

**Why #1782's sweep missed it** is the part worth keeping. That sweep enumerated frozen-teaching documents with the frozen checker's own prefix matching, which was correct — an ad-hoc `grep mfgarchon\.alg\.neural` counts `mfgarchon.alg.neural_solvers`, an unrelated package, and did on the first attempt. But README describes the packages in **prose**, with no dotted module path anywhere. The rule that makes the enumeration correct is the rule that makes it blind.

> A marker sweep keyed on import paths cannot see a capability claim that does not import.

The `[nn]` extras line is **split** rather than marked wholesale, because marking it wholesale would be wrong. Measured:

| dependency | importers outside the frozen packages |
|---|---|
| `torch` | **5** (`backends/`, `utils/acceleration/`) |
| `gymnasium` | 0 |
| `stable-baselines3` | 0 |
| `tensorboard` | 0 |

## A docstring that answered "what was this before" instead of "what will I get wrong"

The user asked whether the recent run of net-positive PRs was healthy. Measuring, then attributing to the campaign rather than to the file:

| file | before | after | my delta |
|---|---:|---:|---|
| `config/core.py` | 2.36 | **2.56** | prose +20, code +1 |
| `config/mfg_methods.py` | 2.75 | 2.74 | +1 / +1 |
| `config/io.py` | 2.19 | 2.19 | 0 / 0 |
| `coupling/fixed_point_utils.py` | 1.43 | 1.43 | +1 / 0 |
| `coupling/mfg_residual.py` | 1.31 | **1.23** | +3 / +16 |
| `coupling/base_mfg.py` | 0.82 | 0.86 | +42 / +41 |

(prose/code; package baseline is 1.10 — this repo has more comment than code, pre-existing.) `config/core.py` was the only file where my own edit moved the ratio meaningfully.

The criterion applied is whether a reader would **do something wrong** without the sentence. Two of four paragraphs pass and stay:

- Pydantic ignores extras by default, so a config class inheriting `BaseModel` instead of `BaseConfig` silently reintroduces the dropped-field bug.
- Deprecated aliases survive `extra="forbid"` **only because** their `model_validator(mode="before")` hooks `pop` the legacy key first. Adding an alias that translates after validation breaks it, and the failure looks like `extra="forbid"` being at fault.

Two do not: what the symbol used to be is what the commit message is for, and the #1426 cross-reference is a clause, not a paragraph. 2.56 → 2.45.

## Not claimed

This does not establish that recent PRs carry fat. Measured against that hypothesis and it did not survive: new test files sit at 0.72 prose/code against a suite baseline of 0.70, and of 590 raises-only tests, 500 carry `match=` on every `raises` with 0 using a broad exception type. The net increase is the cost of nine fixes and three gates, not padding.

`tests/unit/test_config` + `tests/unit/test_core`: 900 passed, 3 xfailed. Gate green.

Closes #1789.