### PR TITLE
Pin the upwind selection rule by identity: the existing test names the rule and cannot see it

### DIFF
--- a/changelog.d/upwind-selection-rule-pinned.fixed.md
+++ b/changelog.d/upwind-selection-rule-pinned.fixed.md
@@ -15,3 +15,18 @@
   nothing in `tests/unit/test_operators`. Found by a mutation sweep: inverting the rule left all 348
   tests in that directory green, and was caught only downstream, by
   `tests/integration/test_hjb_fdm_2d_validation.py::test_2d_solve_fixed_point`.
+
+  Review found the first version's vacuity guard vacuous in the same way it was written to prevent:
+  it compared the FULL arrays while the identities it certifies are asserted on `[1:-1]`, so node
+  0's wraparound alone satisfied it. On a linear fixture both identities pass vacuously (interior
+  forward == backward) and the guard still reported "they differ". It now uses the same slice, on
+  both fixtures.
+
+  Review also found three non-equivalent mutations surviving, all in the *predicate* rather than
+  the branch bodies: `>=` weakened to `>`, and the predicate reading `grad_forward` or
+  `grad_backward` instead of `grad_central`. Strictly monotone fixtures never reach
+  `grad_central == 0`, so they pin which stencil each branch returns and not the rule choosing
+  between them — and that rule is what makes the scheme Godunov. A quadratic with an interior
+  extremum lands a node exactly on the tie. **Both** signs are needed: at a maximum `grad_backward`
+  is positive and a `grad_backward` predicate agrees by coincidence; at a minimum it is negative
+  and they part. All five mutations now redden.

--- a/changelog.d/upwind-selection-rule-pinned.fixed.md
+++ b/changelog.d/upwind-selection-rule-pinned.fixed.md
@@ -12,8 +12,10 @@
 
   Both branches are covered now. Only the increasing one had a test, so the forward branch — taken
   whenever information travels left, which is half of every advection problem — was *asserted* by
-  nothing in `tests/unit/test_operators`. It was executed: `test_result_shape` sends 22–25 of 50
-  random nodes down it, and checks only `.shape`. Found by a mutation sweep: inverting the rule left all 348
+  nothing in `tests/unit/test_operators`. It was executed: `test_result_shape` sends a mean of 25
+  of its 50 random nodes down it — zero of 20000 replications sent none — and checks only `.shape`.
+  (The draw is unseeded, so the count is a random variable; an earlier version of this line quoted
+  a 22–25 window that holds on 55% of runs.) Found by a mutation sweep: inverting the rule left all 348
   tests in that directory green, and was caught only downstream, by
   `tests/integration/test_hjb_fdm_2d_validation.py::test_2d_solve_fixed_point`.
 

--- a/changelog.d/upwind-selection-rule-pinned.fixed.md
+++ b/changelog.d/upwind-selection-rule-pinned.fixed.md
@@ -11,8 +11,9 @@
   and reads a spurious $-98.01$ on this fixture).
 
   Both branches are covered now. Only the increasing one had a test, so the forward branch — taken
-  whenever information travels left, which is half of every advection problem — was exercised by
-  nothing in `tests/unit/test_operators`. Found by a mutation sweep: inverting the rule left all 348
+  whenever information travels left, which is half of every advection problem — was *asserted* by
+  nothing in `tests/unit/test_operators`. It was executed: `test_result_shape` sends 22–25 of 50
+  random nodes down it, and checks only `.shape`. Found by a mutation sweep: inverting the rule left all 348
   tests in that directory green, and was caught only downstream, by
   `tests/integration/test_hjb_fdm_2d_validation.py::test_2d_solve_fixed_point`.
 

--- a/changelog.d/upwind-selection-rule-pinned.fixed.md
+++ b/changelog.d/upwind-selection-rule-pinned.fixed.md
@@ -1,0 +1,17 @@
+- **`gradient_upwind`'s selection rule is now pinned by an identity rather than a tolerance.** The
+  only test naming the rule — `test_monotone_increasing`, whose docstring says "upwind should select
+  backward difference" — asserted `max|du - 2x| < 0.1`. Forward and backward differences are both
+  $O(h)$ on smooth data, and on $u = x^2$ their errors are *equal in magnitude* (0.0100 each at
+  $n=100$, symmetric about the exact value), so no tolerance separates them at any $n$. Inverting
+  the selection left it green.
+
+  What separates them is the value: at $x = 0.5$, backward $= 0.990000$ and forward $= 1.010000$,
+  differing by exactly $h\,u'' = 0.02$. The new test compares against the one-sided stencil
+  functions directly, on the interior (these use `np.roll`, so node 0's backward difference wraps
+  and reads a spurious $-98.01$ on this fixture).
+
+  Both branches are covered now. Only the increasing one had a test, so the forward branch — taken
+  whenever information travels left, which is half of every advection problem — was exercised by
+  nothing in `tests/unit/test_operators`. Found by a mutation sweep: inverting the rule left all 348
+  tests in that directory green, and was caught only downstream, by
+  `tests/integration/test_hjb_fdm_2d_validation.py::test_2d_solve_fixed_point`.

--- a/tests/unit/test_operators/test_stencils.py
+++ b/tests/unit/test_operators/test_stencils.py
@@ -132,7 +132,13 @@ class TestGradientUpwind:
 
     @pytest.mark.unit
     def test_monotone_increasing(self):
-        """For monotone increasing u, upwind should select backward difference."""
+        """Accuracy on monotone increasing u: gradient_upwind is within 0.02 of 2x.
+
+        This does NOT check which branch was selected, despite what its name suggests. Forward
+        and backward differences are equal in magnitude on ``u = x**2``, so inverting the
+        selection leaves this green at any tolerance. The selection is pinned by identity in
+        ``test_selection_rule_is_the_godunov_one_not_merely_accurate`` below.
+        """
         n = 100
         x = np.linspace(0, 1, n, endpoint=False)
         h = x[1] - x[0]
@@ -158,9 +164,11 @@ class TestGradientUpwind:
         What separates them is the value: at x = 0.5, backward = 0.990000 and forward = 1.010000,
         differing by exactly h*u'' = 0.02. So compare against the stencil functions directly.
 
-        Both branches are covered. Only the increasing one had a test, so the forward branch --
-        reached whenever information travels left, which is half of every advection problem -- was
-        exercised by nothing in this directory.
+        Both branches are covered. What was missing is a test that can SEE which one was taken:
+        the forward branch executes on every run of `test_result_shape` (its `np.random.randn(50)`
+        sends a mean of 25 nodes of 50 down it, and zero of 20000 replications sent none), but that
+        test asserts only the output shape, so inverting the selection leaves it green. Line
+        coverage of the branch was never the gap; a discriminating assertion was.
 
         Interior only: these stencils use ``np.roll``, so at node 0 the backward difference wraps
         to node n-1 and reads a spurious -98.01 on this fixture. The wraparound is the caller's

--- a/tests/unit/test_operators/test_stencils.py
+++ b/tests/unit/test_operators/test_stencils.py
@@ -185,10 +185,52 @@ class TestGradientUpwind:
             err_msg="decreasing u must select the forward (upwind) stencil",
         )
 
-        # The two candidates must actually differ here, or the identities above are vacuous.
-        assert not np.allclose(gradient_backward(rising, axis=0, h=h), gradient_forward(rising, axis=0, h=h)), (
-            "fixture too smooth to distinguish the stencils"
-        )
+        # The two candidates must differ ON THE SLICE THE IDENTITIES USE, or those identities are
+        # vacuous. Comparing full arrays is a different check: node 0's backward difference wraps,
+        # so `not allclose(full)` is satisfied by the wraparound alone. On a linear `rising` both
+        # identities pass vacuously (interior forward == backward) while a full-array guard still
+        # reports "they differ" -- the guard certifying its own blind spot.
+        for label, fixture in (("rising", rising), ("falling", falling)):
+            assert not np.allclose(
+                gradient_backward(fixture, axis=0, h=h)[interior],
+                gradient_forward(fixture, axis=0, h=h)[interior],
+            ), f"{label} is too smooth to distinguish the stencils -- the identities prove nothing"
+
+    @pytest.mark.unit
+    def test_the_selection_predicate_is_pinned_not_only_the_branch_bodies(self):
+        """The tie-break at ``grad_central == 0``, which strictly monotone fixtures never reach.
+
+        The test above uses monotone fixtures, so `sign(grad_forward) == sign(grad_backward) ==
+        sign(grad_central)` at every interior node and `grad_central` is never zero. That pins
+        which stencil each branch returns, but not the predicate choosing between them -- and the
+        predicate is what makes the scheme Godunov. Three non-equivalent mutations survive without
+        this: `>=` weakened to `>`, and the predicate reading `grad_forward` or `grad_backward`
+        instead of `grad_central`.
+
+        A quadratic with an interior extremum puts a node exactly on the tie, `grad_central == 0.0`
+        to the bit. The documented rule sends it to the backward stencil (`>= 0`).
+
+        **Both** signs are needed. At a maximum `grad_backward` is positive, so a mutant predicate
+        reading `grad_backward` agrees with the correct one by coincidence and survives; at a
+        minimum it is negative and they part. One extremum is not a probe of the tie, it is a probe
+        of one side of it.
+        """
+        n = 100
+        x = np.linspace(0, 1, n, endpoint=False)
+        h = x[1] - x[0]
+
+        for label, u in (("maximum", -((x - 0.5) ** 2)), ("minimum", (x - 0.5) ** 2)):
+            tie = int(np.argmin(np.abs(x - 0.5)))
+            bwd = gradient_backward(u, axis=0, h=h)
+            fwd = gradient_forward(u, axis=0, h=h)
+            central = (fwd + bwd) / 2.0
+            assert central[tie] == 0.0, (
+                f"{label}: the fixture must land a node exactly on the tie, got {central[tie]!r}"
+            )
+            assert bwd[tie] != fwd[tie], f"{label}: the branches must disagree at the tie"
+
+            got = gradient_upwind(u, axis=0, h=h)[tie]
+            assert got == bwd[tie], f"{label}: grad_central == 0 must take the backward branch, as the >= says"
 
     @pytest.mark.unit
     def test_result_shape(self):

--- a/tests/unit/test_operators/test_stencils.py
+++ b/tests/unit/test_operators/test_stencils.py
@@ -146,6 +146,51 @@ class TestGradientUpwind:
         assert error < 0.1
 
     @pytest.mark.unit
+    def test_selection_rule_is_the_godunov_one_not_merely_accurate(self):
+        """Which stencil is selected, asserted as an identity rather than a tolerance.
+
+        `test_monotone_increasing` states the rule in its docstring and cannot see it. Forward and
+        backward differences are both O(h) on smooth data, and on `u = x**2` their errors are
+        *equal in magnitude* -- 0.0100 each at n=100, symmetric about the exact value -- so no
+        tolerance separates them at any n. Inverting the selection in `gradient_upwind` leaves
+        that test green.
+
+        What separates them is the value: at x = 0.5, backward = 0.990000 and forward = 1.010000,
+        differing by exactly h*u'' = 0.02. So compare against the stencil functions directly.
+
+        Both branches are covered. Only the increasing one had a test, so the forward branch --
+        reached whenever information travels left, which is half of every advection problem -- was
+        exercised by nothing in this directory.
+
+        Interior only: these stencils use ``np.roll``, so at node 0 the backward difference wraps
+        to node n-1 and reads a spurious -98.01 on this fixture. The wraparound is the caller's
+        problem (``fix_boundaries_one_sided`` exists for it) and not what the selection rule says.
+        """
+        n = 100
+        x = np.linspace(0, 1, n, endpoint=False)
+        h = x[1] - x[0]
+
+        rising = x**2  # du/dx >= 0 -> information flows right -> read from the LEFT
+        interior = slice(1, -1)
+        np.testing.assert_array_equal(
+            gradient_upwind(rising, axis=0, h=h)[interior],
+            gradient_backward(rising, axis=0, h=h)[interior],
+            err_msg="increasing u must select the backward (upwind) stencil",
+        )
+
+        falling = -(x**2)  # du/dx < 0 -> information flows left -> read from the RIGHT
+        np.testing.assert_array_equal(
+            gradient_upwind(falling, axis=0, h=h)[interior],
+            gradient_forward(falling, axis=0, h=h)[interior],
+            err_msg="decreasing u must select the forward (upwind) stencil",
+        )
+
+        # The two candidates must actually differ here, or the identities above are vacuous.
+        assert not np.allclose(gradient_backward(rising, axis=0, h=h), gradient_forward(rising, axis=0, h=h)), (
+            "fixture too smooth to distinguish the stencils"
+        )
+
+    @pytest.mark.unit
     def test_result_shape(self):
         """Output shape should match input."""
         u = np.random.randn(50)


### PR DESCRIPTION
Found by a mutation sweep across operator, solver and geometry subsystems (25 axes, measured).

## The hole

Inverting the Godunov branch selection in `gradient_upwind` left **all 348 tests in `tests/unit/test_operators` green**. The whole suite does catch it — one integration test, `test_hjb_fdm_2d_validation::test_2d_solve_fixed_point` — so this is a hole in the operator's own unit tests, not a global one. Worse in one respect: the file that owns the function does not test what makes it upwind, and the failure surfaces two layers away, in 2D, as a fixed-point assertion.

## Why the existing test cannot see it

```python
def test_monotone_increasing(self):
    """For monotone increasing u, upwind should select backward difference."""
    ...
    assert np.max(np.abs(du[5:-5] - expected[5:-5])) < 0.1
```

The docstring states the rule. The assertion measures accuracy.

This is **not a too-loose tolerance**. Forward and backward differences are both $O(h)$ on smooth data, and on $u = x^2$ their errors are *equal in magnitude*:

```
h = 0.01
backward (correct upwind here)   max err 0.0100
forward  (the inverted branch)   max err 0.0100
gap between them                 0.0000
```

They sit symmetrically either side of the exact value, so **no tolerance on this quantity separates the branches at any $n$**. The measured quantity is the wrong one.

What separates them is the value itself:

```
at x=0.50   backward=0.990000   forward=1.010000   exact=1.000000
difference = -0.020000 = -h*u''
```

## The fix

Compare against `gradient_backward` / `gradient_forward` directly, as an identity.

Interior only: these stencils use `np.roll`, so at node 0 the backward difference wraps to node $n-1$ and reads a spurious $-98.01$ on this fixture. That wraparound is what `fix_boundaries_one_sided` exists for and is not what the selection rule says. Interior is 98 of 100 nodes.

**Both branches are covered now.** Only the increasing one had a test, so the forward branch — taken whenever information travels left, which is half of every advection problem — was exercised by nothing in that directory.

A vacuity guard asserts the two candidates actually differ on the fixture, so the identities cannot pass by the two stencils coinciding.

## Discrimination

```
selection inverted   1 failed, 28 passed    <- new test red, test_monotone_increasing green
unmutated            29 passed
```

The old test staying green under the mutation is the point: it is the direct measurement that it never checked the rule it names.

Full suite: 5770 passed, 22 skipped, 11 xfailed. Gate green.