### PR TITLE
Give the nightly notifier a closing edge

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -225,3 +225,63 @@ jobs:
               labels: ['automated', 'area: testing', 'priority: high', 'type: bug'],
             });
           }
+
+  # The closing edge. notify-on-failure had only an opening one: it filed or commented when a run
+  # was not green and did nothing when one was, so every issue it created outlived its own cause
+  # until a human swept it. #1703 sat open at `priority: high` through eight consecutive green
+  # nightlies for exactly that reason (Issue #1806).
+  resolve-on-success:
+    needs: [full-test-suite, capability-matrix]
+    # Requires both dependencies to be literally 'success'. NOT `success()` and not "the absence of
+    # failure": notify-on-failure documents why -- a shard that blows the timeout reports
+    # `cancelled`, and treating not-failed as green would close the issue on the runs that most
+    # need it open.
+    if: >-
+      ${{ needs.full-test-suite.result == 'success'
+          && needs.capability-matrix.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v9
+      with:
+        script: |
+          const date = new Date().toISOString().split('T')[0];
+          const title = 'Nightly full test suite is failing';
+          const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+          // Match on title AND the `automated` label, the same pair notify-on-failure creates
+          // with. A human-filed issue that happens to share the title carries no `automated`
+          // label and must survive: a robot closing a person's issue is worse than a stale one.
+          const existing = await github.paginate(github.rest.issues.listForRepo, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'automated',
+            per_page: 100,
+          });
+          const open = existing.find(i => i.title === title);
+          if (!open) {
+            core.info('No open automated nightly-failure issue to resolve.');
+            return;
+          }
+
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: open.number,
+            body: [
+              `Nightly is green as of ${date}; closing.`,
+              '',
+              `Run: ${url}`,
+              '',
+              'Filed and closed by `nightly.yml`. If the suite breaks again a new issue is opened',
+              'rather than this one reopened, so each report carries the run that produced it.',
+            ].join('\n'),
+          });
+          await github.rest.issues.update({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: open.number,
+            state: 'closed',
+            state_reason: 'completed',
+          });
+          core.info(`Closed #${open.number}.`);

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -258,7 +258,10 @@ jobs:
             labels: 'automated',
             per_page: 100,
           });
-          const open = existing.find(i => i.title === title);
+          // `issues.listForRepo` returns pull requests too -- GitHub's REST API treats every
+          // PR as an issue -- and this job CLOSES what it selects, unlike the notifier which
+          // only comments. Identify them by the `pull_request` key and skip them.
+          const open = existing.find(i => i.title === title && !i.pull_request);
           if (!open) {
             core.info('No open automated nightly-failure issue to resolve.');
             return;

--- a/tests/unit/test_nightly_notifier_edges_1806.py
+++ b/tests/unit/test_nightly_notifier_edges_1806.py
@@ -10,7 +10,9 @@ The condition pair is the part worth pinning. Two ways to get it wrong, both sil
   green run leaves the issue open;
 - an overlap -- some combination fires both, so a run files an issue and closes it.
 
-`resolve-on-success` must also require both dependencies to be literally `'success'`. Using
+`resolve-on-success` must also require both dependencies to be literally `'success'`.
+(The evaluator models GitHub's implicit `success()`; see `_fires`. Its unsupported-syntax
+guard catches tokens that are present and unmodelled -- never semantics that are absent.) Using
 `success()` or "not failure" would close the issue on a `cancelled` shard, which is the state
 `notify-on-failure`'s own comment records for 98 of 108 historical runs -- precisely the runs
 that most need it open.
@@ -46,21 +48,54 @@ def _condition(job_name: str) -> str:
     return " ".join(inner.split())
 
 
+STATUS_CHECKS = ("success()", "always()", "cancelled()", "failure()")
+
+
 def _fires(condition: str, results: dict[str, str]) -> bool:
     """Evaluate a GitHub `if:` expression for the subset of syntax these two jobs use.
 
-    Deliberately NOT a general evaluator: it handles `always()`, `needs.X.result`, string
-    literals, `==`, `!=`, `&&`, `||`, and parentheses, and raises on anything else so a
-    future condition using unsupported syntax fails loudly instead of being mis-evaluated.
+    Models GitHub's **implicit status check**, which is the part that bites: per
+    `expressions.md`, *"A default status check of `success()` is applied unless you include
+    one of these functions"* -- `success()`, `always()`, `cancelled()`, `failure()`. So a
+    condition with no status-check function is silently ANDed with "every needed job
+    succeeded".
+
+    An earlier version of this evaluator omitted that rule, and the omission was not inert:
+    deleting `always()` from `notify-on-failure` -- one token -- kept all 20 tests green
+    while the opening edge would have fired 0 of 16 on real GitHub, reinstating exactly the
+    #1658 silent-nightly state. Nothing raised, because the mis-model was in the ABSENCE of
+    a token; there was no unsupported syntax to detect.
+
+    Still deliberately NOT a general evaluator. It handles the status-check functions above,
+    `needs.X.result`, string literals, `==`, `!=`, `&&`, `||` and parentheses, and raises on
+    anything else. Note what that guard can and cannot do: it catches syntax that is
+    PRESENT and unmodelled, never semantics that are absent.
     """
     expr = condition
     for dep, value in results.items():
         expr = expr.replace(f"needs.{dep}.result", repr(value))
-    expr = expr.replace("always()", "True").replace("&&", " and ").replace("||", " or ")
+
+    implicit_success = not any(fn in condition for fn in STATUS_CHECKS)
+    for fn, py in (
+        ("always()", "True"),
+        ("success()", "_ALL_OK"),
+        ("failure()", "_ANY_BAD"),
+        ("cancelled()", "_ANY_CANCELLED"),
+    ):
+        expr = expr.replace(fn, py)
+    expr = expr.replace("&&", " and ").replace("||", " or ")
+
     unresolved = re.findall(r"\b[a-z_]+\(\)|needs\.[\w.-]+", expr)
     if unresolved:
         raise AssertionError(f"unsupported syntax {unresolved} in {condition!r}")
-    return bool(eval(expr))
+
+    env = {
+        "_ALL_OK": all(v == "success" for v in results.values()),
+        "_ANY_BAD": any(v == "failure" for v in results.values()),
+        "_ANY_CANCELLED": any(v == "cancelled" for v in results.values()),
+    }
+    fired = bool(eval(expr, {"__builtins__": {}}, env))  # noqa: S307 - the repo's own workflow file
+    return fired and (env["_ALL_OK"] if implicit_success else True)
 
 
 def test_both_edges_exist():
@@ -105,3 +140,49 @@ def test_closing_edge_and_notifier_agree_on_the_title():
         for name in (NOTIFY, RESOLVE)
     }
     assert titles[NOTIFY] == titles[RESOLVE], f"the closing edge would never find the issue: {titles}"
+
+
+def test_notifier_keeps_a_status_check_function():
+    """Without one, GitHub ANDs the condition with `success()` and the opening edge dies.
+
+    `notify-on-failure` fires precisely when a dependency is NOT 'success', so an implicit
+    `success()` makes its condition unsatisfiable -- 0 of 16 combinations -- and nothing
+    would ever report a red nightly again. That is #1658's state, reachable by deleting one
+    token. Asserted on the text because the consequence is invisible in the truth table
+    unless the evaluator models the implicit check.
+    """
+    cond = _condition(NOTIFY)
+    assert any(fn in cond for fn in STATUS_CHECKS), (
+        f"{NOTIFY} has no status-check function, so GitHub applies success() and the job can "
+        f"never fire on a red run (#1658). Condition: {cond!r}"
+    )
+
+
+def test_closing_edge_actually_closes():
+    """#1806 is 'it comments and does not close'. Pin the close, not just the selection.
+
+    Deleting the `issues.update` call left every other assertion green while the job posted
+    'Nightly is green ...; closing.' and closed nothing -- the defect restored, with the
+    comment now also false.
+    """
+    script = _workflow()["jobs"][RESOLVE]["steps"][0]["with"]["script"]
+    assert "github.rest.issues.update" in script, "the closing edge does not call issues.update"
+    assert "state: 'closed'" in script, "issues.update is called but not with state: 'closed'"
+    assert "state_reason: 'completed'" in script, "closed without a reason"
+
+
+def test_each_job_declares_every_dependency_its_condition_reads():
+    """A `needs.X.result` reference with no matching `needs:` entry silently reads null.
+
+    GitHub's `needs` context holds only DIRECT dependencies, so dropping a job from `needs:`
+    while the condition still names it makes that comparison false forever -- the closing
+    edge would stop firing with nothing to report it.
+    """
+    jobs = _workflow()["jobs"]
+    for name in (NOTIFY, RESOLVE):
+        referenced = set(re.findall(r"needs\.([\w.-]+)\.result", _condition(name)))
+        declared = set(jobs[name]["needs"])
+        assert referenced <= declared, (
+            f"{name}: condition reads {sorted(referenced - declared)} which is not in needs="
+            f"{sorted(declared)}; that reference evaluates to null, not to a job result"
+        )

--- a/tests/unit/test_nightly_notifier_edges_1806.py
+++ b/tests/unit/test_nightly_notifier_edges_1806.py
@@ -94,7 +94,7 @@ def _fires(condition: str, results: dict[str, str]) -> bool:
         "_ANY_BAD": any(v == "failure" for v in results.values()),
         "_ANY_CANCELLED": any(v == "cancelled" for v in results.values()),
     }
-    fired = bool(eval(expr, {"__builtins__": {}}, env))  # noqa: S307 - the repo's own workflow file
+    fired = bool(eval(expr, {"__builtins__": {}}, env))
     return fired and (env["_ALL_OK"] if implicit_success else True)
 
 

--- a/tests/unit/test_nightly_notifier_edges_1806.py
+++ b/tests/unit/test_nightly_notifier_edges_1806.py
@@ -1,0 +1,107 @@
+"""The nightly notifier must have both edges, and exactly one must fire per run (#1806).
+
+`notify-on-failure` had an opening edge and no closing one: it filed or commented when a run
+was not green and did nothing when one was, so every issue it created outlived its cause.
+#1703 stayed open at `priority: high` through eight consecutive green nightlies.
+
+The condition pair is the part worth pinning. Two ways to get it wrong, both silent:
+
+- a gap -- some result combination fires neither job, so a failure goes unreported or a
+  green run leaves the issue open;
+- an overlap -- some combination fires both, so a run files an issue and closes it.
+
+`resolve-on-success` must also require both dependencies to be literally `'success'`. Using
+`success()` or "not failure" would close the issue on a `cancelled` shard, which is the state
+`notify-on-failure`'s own comment records for 98 of 108 historical runs -- precisely the runs
+that most need it open.
+"""
+
+from __future__ import annotations
+
+import itertools
+import pathlib
+import re
+
+import pytest
+import yaml
+
+WORKFLOW = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows" / "nightly.yml"
+
+# Every state GitHub can report for a needed job.
+RESULTS = ("success", "failure", "cancelled", "skipped")
+
+NOTIFY = "notify-on-failure"
+RESOLVE = "resolve-on-success"
+DEPS = ("full-test-suite", "capability-matrix")
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _condition(job_name: str) -> str:
+    """The job's `if:`, stripped of the ${{ }} wrapper and normalised to one line."""
+    raw = _workflow()["jobs"][job_name]["if"]
+    inner = re.sub(r"^\s*\$\{\{\s*|\s*\}\}\s*$", "", raw.strip(), flags=re.S)
+    return " ".join(inner.split())
+
+
+def _fires(condition: str, results: dict[str, str]) -> bool:
+    """Evaluate a GitHub `if:` expression for the subset of syntax these two jobs use.
+
+    Deliberately NOT a general evaluator: it handles `always()`, `needs.X.result`, string
+    literals, `==`, `!=`, `&&`, `||`, and parentheses, and raises on anything else so a
+    future condition using unsupported syntax fails loudly instead of being mis-evaluated.
+    """
+    expr = condition
+    for dep, value in results.items():
+        expr = expr.replace(f"needs.{dep}.result", repr(value))
+    expr = expr.replace("always()", "True").replace("&&", " and ").replace("||", " or ")
+    unresolved = re.findall(r"\b[a-z_]+\(\)|needs\.[\w.-]+", expr)
+    if unresolved:
+        raise AssertionError(f"unsupported syntax {unresolved} in {condition!r}")
+    return bool(eval(expr))
+
+
+def test_both_edges_exist():
+    jobs = _workflow()["jobs"]
+    assert NOTIFY in jobs, "the opening edge is gone"
+    assert RESOLVE in jobs, "the closing edge is missing: an automated issue would outlive its cause, which is #1806"
+
+
+@pytest.mark.parametrize(
+    "results", [dict(zip(DEPS, combo, strict=True)) for combo in itertools.product(RESULTS, repeat=len(DEPS))]
+)
+def test_exactly_one_edge_fires_for_every_result_combination(results):
+    notify = _fires(_condition(NOTIFY), results)
+    resolve = _fires(_condition(RESOLVE), results)
+    all_green = all(v == "success" for v in results.values())
+
+    assert notify != resolve, (
+        f"{results}: notify={notify} resolve={resolve} -- a gap leaves the run unreported or the "
+        "issue stale; an overlap files and closes in the same run"
+    )
+    assert resolve is all_green, f"{results}: the closing edge must fire exactly when both deps are 'success'"
+
+
+def test_closing_edge_does_not_treat_cancelled_as_green():
+    """The specific state that made 98 of 108 historical runs report nothing."""
+    assert not _fires(_condition(RESOLVE), {"full-test-suite": "cancelled", "capability-matrix": "success"})
+    assert _fires(_condition(NOTIFY), {"full-test-suite": "cancelled", "capability-matrix": "success"})
+
+
+def test_closing_edge_matches_the_automated_label_not_the_title_alone():
+    """A human-filed issue sharing the title must survive: it carries no `automated` label."""
+    script = _workflow()["jobs"][RESOLVE]["steps"][0]["with"]["script"]
+    assert "labels: 'automated'" in script, "closing edge must filter on the `automated` label"
+    assert "i.title === title" in script, "closing edge must also match the title"
+
+
+def test_closing_edge_and_notifier_agree_on_the_title():
+    """Two copies of a string that must match, so pin that they do."""
+    jobs = _workflow()["jobs"]
+    titles = {
+        name: re.search(r"const title = '([^']+)'", jobs[name]["steps"][0]["with"]["script"]).group(1)
+        for name in (NOTIFY, RESOLVE)
+    }
+    assert titles[NOTIFY] == titles[RESOLVE], f"the closing edge would never find the issue: {titles}"


### PR DESCRIPTION
Closes #1806. Refs #1658, #1703, #1706.

## The asymmetry

`notify-on-failure` runs only when a run is not green. It files an issue, or comments on an open
one with the same title, and there is **no step on the success path** — so the issue it creates
outlives its own cause until a human sweeps it.

#1703 sat open at `priority: high` through **eight consecutive green nightlies** and was closed by
hand today only because an audit went looking. That is #1706's Class-B shape inside the repo's own
automation: an observable decoupled from the quantity it reports.

## The change

`resolve-on-success` is the mirror: comment with the green run URL, then close. Two details the
opening job already got right, kept rather than re-derived:

- **Both dependencies must be literally `'success'`** — not `success()`, not the absence of
  failure. `notify-on-failure`'s own comment records why: *a shard that blows the timeout reports
  `cancelled`, not `failed`* — 98 of 108 historical runs — so a not-failed test would close the
  issue on exactly the runs that most need it open.
- **Match on title AND the `automated` label**, the pair the notifier creates with. A human-filed
  issue sharing the title carries no such label and survives; a robot closing someone's issue is
  worse than a stale one.

## The pin is over the condition PAIR

Both ways of getting this wrong are silent: a **gap** leaves some result combination firing neither
job (a failure goes unreported, or a green run leaves the issue open); an **overlap** fires both, so
one run files an issue and closes it.

So the test parametrises all 16 combinations of the four states GitHub can report for two
dependencies, and asserts exactly one edge fires — and that the closing one fires exactly when both
are `'success'`.

Mutation-checked, all four killed:

| mutation | result |
|---|---|
| delete `resolve-on-success` | 20 failed |
| close on `!= 'failure'` instead of `== 'success'` | 9 failed |
| let the two jobs' titles diverge | 1 failed |
| drop the `automated` label filter | 1 failed |

## What this test does NOT establish — stated, not glossed

The expression evaluator in the test is **my model of GitHub's `if:` semantics**, and the conditions
are also mine. So these 20 tests verify that *under that model* the two conditions neither overlap
nor leave a gap. They cannot catch "GitHub evaluates this differently than I do."

That structural property is real and worth pinning — it does not depend on the semantic details —
but the only behavioural evidence would be a `workflow_dispatch` run. **This has not been run
end-to-end.** The evaluator raises on any syntax it does not model rather than mis-evaluating it, so
a future condition using unsupported syntax fails loudly instead of being silently mis-checked.

## Gate

`./scripts/local_ci.sh` GREEN: **5762 passed, 22 skipped, 11 xfailed** in 5:52.