### PR TITLE
Stop making "add a test" the default close-out for a fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,35 @@ The axiom testing discipline governs **what** a test must cover (edge/stress/fai
 | Visualization | Sometimes | Yes | Smoke |
 | Utility function | No | Internal | Unit or smoke |
 
+### Closing out a fix ⚠️ — name the oracle, or say there isn't one
+
+"Add a test" is **not** the default close-out for a fix here. Measured on this repo: ~200 kills
+across the six load-bearing conventions the discrimination ratchet tracks, in a 5,683-test suite —
+about **3.5%** of tests react when the physics the library exists to get right is broken; of the
+tests whose *names* claim `single_source` / `cross_path` / `_agree`, **60% are inert** (#1715). And
+the yield runs the other way too: #1660's 17 nightly "failures" resolved as 8 fixture rot from the
+#1442 drift migration, 2 tests measuring the wrong quantity, 7 timeouts — **zero** product
+regressions caught by a test.
+
+So state which of these the fix ends with, in the PR body, in this order of preference:
+
+1. **An external oracle** — a law the scheme must reproduce, computed independently of the scheme.
+   Regime masses against `M(0) @ expm(Qt)`; an LQG analytic solution; a closed form. Cannot go
+   tautological when the two paths are later consolidated, which is what kills agreement tests.
+2. **A mutation-verified convention pin** — the mutation and its kill count stated. Unverified, a
+   pin is a claim about discrimination with no measurement behind it.
+3. **A capability cell** — when the question is "can this configuration solve at all". Deliberately
+   fixed-size: the matrix must not grow with the library.
+4. **A happy-path assertion** — admit it as such, and say what it would not catch.
+
+"There is no oracle for this yet" is an acceptable close-out and a fileable issue. A green suite is
+not evidence: on every defect independent review found in #1802, the full local gate was green
+(5776 and 5781 passed) with the defect present.
+
+Cf. axiom `feedback_net_negative_test_mass` (adding must be indicated by a measurement, not by
+"should test more") and `feedback_test_discrimination_unmeasured` (assert on disagreement, not
+validity — every one of those defects sat on a covered line).
+
 ---
 
 ## 🔧 Development workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,12 @@ The axiom testing discipline governs **what** a test must cover (edge/stress/fai
 
 ### Closing out a fix ⚠️ — name the oracle, or say there isn't one
 
-"Add a test" is **not** the default close-out for a fix here. Measured on this repo: ~200 kills
-across the six load-bearing conventions the discrimination ratchet tracks, in a 5,683-test suite —
-about **3.5%** of tests react when the physics the library exists to get right is broken; of the
-tests whose *names* claim `single_source` / `cross_path` / `_agree`, **60% are inert** (#1715). And
+"Add a test" is **not** the default close-out for a fix here. Measured on this repo: the six load-bearing
+conventions the discrimination ratchet tracks are noticed by **192 distinct tests** out of 5,683 —
+**3.4%** react when the physics the library exists to get right is broken. (The baseline's kill
+counts sum to 200; 8 tests are killed by more than one mutation, so the sum over-counts and the
+honest figure is the lower one.) Of the tests whose *names* claim `single_source` / `cross_path` /
+`_agree`, **60% are inert** (#1715). And
 the yield runs the other way too: #1660's 17 nightly "failures" resolved as 8 fixture rot from the
 #1442 drift migration, 2 tests measuring the wrong quantity, 7 timeouts — **zero** product
 regressions caught by a test.


### PR DESCRIPTION
Adds one section to `CLAUDE.md` § Testing. Repo-scoped deliberately — see the last paragraph.

## Why

Measured on this repo, not asserted:

- `scripts/discrimination_baseline.json` records **~200 kills** across the six load-bearing
  conventions the ratchet tracks, in a **5,683-test** suite. About **3.5%** of tests react when the
  physics the library exists to get right is broken.
- Of the tests whose *names* claim `single_source` / `cross_path` / `_agree`, **60% are inert** (#1715).
- #1660's 17 nightly "failures" resolved as 8 fixture rot from the #1442 drift migration, 2 tests
  measuring the wrong quantity, 7 timeouts — **zero** product regressions caught by a test.
- On every defect independent review found in #1802, the full local gate was **green** (5776 and
  5781 passed) with the defect present.

That last one is the point. A green suite is not evidence, and during rapid change test mass mostly
manufactures work: tests pin the implementation you have, so churn produces false failures rather
than caught regressions.

## What changes

A fix now states which of four things it ends with, in the PR body, in order of preference:

1. **external oracle** — a law the scheme must reproduce, computed independently of the scheme
   (`M(0) @ expm(Qt)` for regime masses; an LQG analytic solution). Cannot go tautological when two
   paths are later consolidated, which is what kills agreement tests.
2. **mutation-verified convention pin** — with the mutation and its kill count stated.
3. **capability cell** — for "can this configuration solve at all". Deliberately fixed-size.
4. **happy-path assertion** — admitted as such, saying what it would not catch.

"There is no oracle for this yet" is an acceptable close-out, and a fileable issue.

## Scope

All the evidence is from mfgarchon, so this lands here rather than in the axiom. This file's own
composition note says a new universal pattern "starts here as a project override and graduates into
the axiom after it recurs across N≥3 repos". It cross-references the two axiom entries it builds on
(`feedback_net_negative_test_mass`, `feedback_test_discrimination_unmeasured`) rather than
restating them.

Docs only; no code paths touched. `./scripts/local_ci.sh` GREEN.