### PR TITLE
Refuse an interpolation_method the SL solver will not honour

### DIFF
--- a/changelog.d/1809-interpolation-method-honoured.fixed.md
+++ b/changelog.d/1809-interpolation-method-honoured.fixed.md
@@ -1,0 +1,14 @@
+- **`HJBSemiLagrangianSolver` refuses an `interpolation_method` it will not honour** (Issues #1809,
+  #1664). The argument was stored unvalidated and both interpolators default to linear for anything
+  they do not recognise, so the declared method and the honoured one could differ silently in two
+  ways. The 1D path is `if method == "cubic": PCHIP else: linear` — it recognises two methods where
+  the nD path recognises five — so `nearest` selected genuinely different interpolants by dimension:
+  measured on `U = [0, 10, 0, 10, 0]` at `x = 0.30`, **8.0 in 1D against 10.0 in nD**, and a typo
+  such as `"cubis"` was accepted at construction and collapsed to linear at both. Separately,
+  `RegularGridInterpolator` needs 4 points per axis for `cubic` and 6 for `quintic` (measured, not
+  read from the docs) and raises below that — the only condition that reaches the RBF fallback,
+  whose chain then substituted `RBF -> nearest neighbour` behind a `logger.debug` for the method the
+  caller asked for. Construction now refuses both, naming the honoured set at that dimension or the
+  axis and the minimum. The honoured sets and per-axis minima are single-sourced in
+  `hjb_sl_interpolation.py`, since the gap between accepted and honoured is what both issues are
+  about. No configuration in the tree is affected: 275 existing semi-Lagrangian tests pass unchanged.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -361,6 +361,14 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             else:
                 logger.info(f"ADI diffusion enabled for nD solve: {adi_msg}")
 
+        # Issues #1809 / #1664: refuse an interpolation_method this solver will not honour, at
+        # THIS problem's dimension and grid. Until now the argument was stored unvalidated and
+        # both interpolators defaulted to linear for anything unrecognised, so `nearest` meant
+        # nearest in nD and linear in 1D (measured: 10.0 against 8.0 on one profile), and a typo
+        # was accepted and silently downgraded. Runs after the dimension/grid branches because
+        # the honoured set and the per-axis minimum both depend on them.
+        self._validate_interpolation_method()
+
         # Setup JAX functions if available
         if self.use_jax:
             self._setup_jax_functions()
@@ -397,6 +405,58 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 )
 
     # _detect_dimension() inherited from BaseNumericalSolver (Issue #633)
+
+    def _validate_interpolation_method(self) -> None:
+        """Refuse an ``interpolation_method`` this solver will not honour here.
+
+        Two ways the declared method used to differ from the honoured one, both silent:
+
+        - **Not implemented at this dimension.** The 1D path is ``if method == "cubic": PCHIP
+          else: linear``, so ``nearest``/``slinear``/``quintic`` reached it and returned linear
+          while the same argument selected a genuinely different interpolant in nD. Measured on
+          ``U = [0, 10, 0, 10, 0]`` at ``x = 0.30``: ``nearest`` gives 8.0 in 1D, 10.0 in nD.
+          An unrecognised string -- a typo -- collapsed to linear at both dimensions (#1809).
+        - **The grid is too small for it.** ``RegularGridInterpolator`` needs 4 points per axis
+          for ``cubic`` and 6 for ``quintic``, and raises otherwise. That raise is the only
+          condition that reaches the RBF fallback, whose chain then degrades the request to
+          ``RBF -> nearest neighbour`` behind ``logger.debug`` (#1664).
+
+        Refusing is the honest disposition for both. Implementing the missing 1D methods is a
+        capability decision, not a bug fix, and silently substituting an interpolant of a
+        different order is precisely what these two issues are about.
+        """
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import (
+            MIN_POINTS_PER_AXIS,
+            honoured_methods,
+        )
+
+        method = self.interpolation_method
+        allowed = honoured_methods(self.dimension)
+        if method not in allowed:
+            extra = (
+                " It is honoured in higher dimensions but not at dimension 1, where this solver "
+                f"implements only {sorted(honoured_methods(1))}; it would have returned linear."
+                if method in MIN_POINTS_PER_AXIS
+                else ""
+            )
+            raise ValueError(
+                f"HJBSemiLagrangianSolver: interpolation_method={method!r} is not honoured at "
+                f"dimension {self.dimension}. Honoured here: {sorted(allowed)}.{extra} An "
+                "unhonoured method used to return a linear interpolant silently (Issue #1809)."
+            )
+
+        need = MIN_POINTS_PER_AXIS.get(method, 1)
+        shape = tuple(self._grid_shape) if self.dimension > 1 else (len(self.x_grid),)
+        short = [(ax, n) for ax, n in enumerate(shape) if n < need]
+        if short:
+            ax, n = short[0]
+            raise ValueError(
+                f"HJBSemiLagrangianSolver: interpolation_method={method!r} needs at least {need} "
+                f"points per axis, but axis {ax} has {n} (grid shape {shape}). The interpolator "
+                "raises on this, and the fallback chain would substitute an RBF or a "
+                "nearest-neighbour value for the method you asked for (Issue #1664). Refine the "
+                f"grid on axis {ax}, or choose a method the grid supports."
+            )
 
     def _setup_jax_functions(self):
         """Setup JAX-accelerated functions for performance."""

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -426,8 +426,9 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         different order is precisely what these two issues are about.
         """
         from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import (
-            MIN_POINTS_PER_AXIS,
+            MIN_POINTS_PER_AXIS_ND,
             honoured_methods,
+            min_points_per_axis,
         )
 
         method = self.interpolation_method
@@ -436,7 +437,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             extra = (
                 " It is honoured in higher dimensions but not at dimension 1, where this solver "
                 f"implements only {sorted(honoured_methods(1))}; it would have returned linear."
-                if method in MIN_POINTS_PER_AXIS
+                if method in MIN_POINTS_PER_AXIS_ND
                 else ""
             )
             raise ValueError(
@@ -445,17 +446,26 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 "unhonoured method used to return a linear interpolant silently (Issue #1809)."
             )
 
-        need = MIN_POINTS_PER_AXIS.get(method, 1)
+        need = min_points_per_axis(method, self.dimension)
         shape = tuple(self._grid_shape) if self.dimension > 1 else (len(self.x_grid),)
         short = [(ax, n) for ax, n in enumerate(shape) if n < need]
         if short:
             ax, n = short[0]
+            # The two paths fail differently, and saying so is the actionable half: nD raises
+            # inside RegularGridInterpolator and falls through the RBF chain, while 1D does not
+            # raise at all -- PCHIP/CubicSpline quietly return the linear value.
+            consequence = (
+                "The interpolator raises on this, and the fallback chain would substitute an RBF "
+                "or a nearest-neighbour value for the method you asked for (Issue #1664)."
+                if self.dimension > 1
+                else "The 1D interpolator does not raise on this -- it returns the LINEAR value, "
+                "so the method would be silently ignored (Issue #1809)."
+            )
             raise ValueError(
                 f"HJBSemiLagrangianSolver: interpolation_method={method!r} needs at least {need} "
-                f"points per axis, but axis {ax} has {n} (grid shape {shape}). The interpolator "
-                "raises on this, and the fallback chain would substitute an RBF or a "
-                "nearest-neighbour value for the method you asked for (Issue #1664). Refine the "
-                f"grid on axis {ax}, or choose a method the grid supports."
+                f"points per axis at dimension {self.dimension}, but axis {ax} has {n} "
+                f"(grid shape {shape}). {consequence} Refine the grid on axis {ax}, or choose a "
+                "method the grid supports."
             )
 
     def _setup_jax_functions(self):

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
@@ -162,6 +162,29 @@ def interpolate_value_nd(
     return float(result[0])
 
 
+# Which interpolation methods each path in this module actually HONOURS, and the minimum
+# points per axis each needs. One owner, because the two paths honour different sets and the
+# gap between "accepted" and "honoured" is the defect both #1809 and #1664 describe:
+#
+#   1D  (interpolate_value_1d)  is `if method == "cubic": PCHIP else: linear` -- it recognises
+#       exactly two. `nearest`/`slinear`/`quintic` reach it and silently return linear, so the
+#       same public argument names a different interpolant than it does in nD (measured: 8.0
+#       against 10.0 for `nearest` on the same profile).
+#   nD  (interpolate_value_nd)  maps onto RegularGridInterpolator, which additionally REFUSES a
+#       grid with fewer points on an axis than the method needs -- 4 for cubic, 6 for quintic,
+#       measured rather than read from the docs. That refusal is the only condition that reaches
+#       the RBF fallback below (#1664); everything else -- out of bounds, NaN, inf, a descending
+#       axis, an unknown method name -- returns silently.
+HONOURED_METHODS_1D = frozenset({"linear", "cubic"})
+HONOURED_METHODS_ND = frozenset({"linear", "slinear", "nearest", "cubic", "quintic"})
+MIN_POINTS_PER_AXIS = {"linear": 2, "slinear": 2, "nearest": 1, "cubic": 4, "quintic": 6}
+
+
+def honoured_methods(dimension: int) -> frozenset[str]:
+    """The interpolation methods this module honours at ``dimension``."""
+    return HONOURED_METHODS_1D if dimension == 1 else HONOURED_METHODS_ND
+
+
 def interpolate_value_rbf_fallback(
     U_values: np.ndarray,
     x_query: np.ndarray,

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
@@ -177,12 +177,35 @@ def interpolate_value_nd(
 #       axis, an unknown method name -- returns silently.
 HONOURED_METHODS_1D = frozenset({"linear", "cubic"})
 HONOURED_METHODS_ND = frozenset({"linear", "slinear", "nearest", "cubic", "quintic"})
-MIN_POINTS_PER_AXIS = {"linear": 2, "slinear": 2, "nearest": 1, "cubic": 4, "quintic": 6}
+
+# Minimum points per axis, PER DIMENSION, because the two paths use different machinery and
+# therefore have different boundaries. Measured, not read from docs:
+#
+#   nD: `RegularGridInterpolator` under THIS module's construction arguments
+#       (`bounds_error=False, fill_value=None`). Those arguments matter -- with scipy's
+#       defaults `linear` and `nearest` measure 2 rather than 1, because querying an interior
+#       point on a one-point axis is then out of bounds and raises for a different reason.
+#       Pinned against scipy directly in the test suite, since for these numbers scipy IS the
+#       external oracle.
+#   1D: `PchipInterpolator` / `CubicSpline`, which never touch RegularGridInterpolator. They do
+#       not raise on a short grid -- they return the LINEAR value, which is the failure this
+#       module is guarding against. Measured on a non-linear profile: at n=2 cubic and linear
+#       agree exactly (so cubic is not honoured), at n=3 they differ (0.7477 vs 0.9256), so the
+#       1D boundary is 3. Applying the nD table here refused a configuration in which cubic was
+#       genuinely honoured -- the inverse of the defect this guard exists to fix.
+MIN_POINTS_PER_AXIS_ND = {"linear": 1, "slinear": 2, "nearest": 1, "cubic": 4, "quintic": 6}
+MIN_POINTS_PER_AXIS_1D = {"linear": 2, "cubic": 3}
 
 
 def honoured_methods(dimension: int) -> frozenset[str]:
     """The interpolation methods this module honours at ``dimension``."""
     return HONOURED_METHODS_1D if dimension == 1 else HONOURED_METHODS_ND
+
+
+def min_points_per_axis(method: str, dimension: int) -> int:
+    """Smallest per-axis point count at which ``method`` is honoured at ``dimension``."""
+    table = MIN_POINTS_PER_AXIS_1D if dimension == 1 else MIN_POINTS_PER_AXIS_ND
+    return table.get(method, 1)
 
 
 def interpolate_value_rbf_fallback(

--- a/mfgarchon/config/mfg_methods.py
+++ b/mfgarchon/config/mfg_methods.py
@@ -271,7 +271,12 @@ class SLConfig(BaseConfig):
 
     Attributes
     ----------
-    interpolation_method : Literal["linear", "cubic", "rbf"]
+    interpolation_method : Literal["linear", "slinear", "nearest", "cubic", "quintic"]
+        Interpolation for the semi-Lagrangian lookup. NOT every value is honoured at
+        every dimension -- 1D honours only "linear" and "cubic" -- and the solver
+        refuses the combinations it would otherwise silently downgrade (Issue #1809).
+        "rbf" was accepted here and is not an interpolation method the solver has ever
+        implemented; it reached the solver and returned linear.
         Interpolation method for foot-of-characteristic (default: cubic)
     rk_order : Literal[1, 2, 3, 4]
         Runge-Kutta order for characteristic tracing (default: 2)
@@ -279,7 +284,7 @@ class SLConfig(BaseConfig):
         CFL number for stability (default: 0.5)
     """
 
-    interpolation_method: Literal["linear", "cubic", "rbf"] = "cubic"
+    interpolation_method: Literal["linear", "slinear", "nearest", "cubic", "quintic"] = "cubic"
     rk_order: Literal[1, 2, 3, 4] = 2
     cfl_number: float = Field(default=0.5, gt=0, le=1.0)
 

--- a/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
+++ b/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
@@ -27,10 +27,12 @@ import numpy as np
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
 from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import (
-    MIN_POINTS_PER_AXIS,
+    HONOURED_METHODS_ND,
+    MIN_POINTS_PER_AXIS_ND,
     honoured_methods,
     interpolate_value_1d,
     interpolate_value_nd,
+    min_points_per_axis,
 )
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
@@ -97,14 +99,17 @@ class TestUnhonouredMethodsAreRefused:
 class TestGridTooSmallForTheMethodIsRefused:
     @pytest.mark.parametrize(("method", "n"), [("cubic", 3), ("quintic", 5)], ids=["cubic-on-3", "quintic-on-5"])
     def test_below_the_per_axis_minimum_is_refused(self, method, n):
-        assert n < MIN_POINTS_PER_AXIS[method], "fixture must actually be below the minimum"
-        with pytest.raises(ValueError, match=r"needs at least \d+ points per axis"):
+        need = min_points_per_axis(method, 2)
+        assert n < need, "fixture must actually be below the minimum"
+        # The stated number, not `\d+`: a message that announces a different minimum than the
+        # one enforced is a silent drift, and `\d+` matched it happily.
+        with pytest.raises(ValueError, match=rf"needs at least {need} points per axis"):
             HJBSemiLagrangianSolver(_problem(2, n), interpolation_method=method)
 
     @pytest.mark.parametrize(("method", "n"), [("cubic", 4), ("quintic", 6)], ids=["cubic-at-4", "quintic-at-6"])
     def test_exactly_at_the_minimum_is_accepted(self, method, n):
         """The boundary of the refusal, on the accepting side -- an off-by-one here refuses valid work."""
-        assert n == MIN_POINTS_PER_AXIS[method]
+        assert n == min_points_per_axis(method, 2)
         HJBSemiLagrangianSolver(_problem(2, n), interpolation_method=method)
 
 
@@ -126,3 +131,94 @@ class TestHonouredConfigurationsStillConstruct:
     def test_every_honoured_combination_constructs(self, dimension, n, method):
         solver = HJBSemiLagrangianSolver(_problem(dimension, n), interpolation_method=method)
         assert solver.interpolation_method == method
+
+
+class TestTheMinimaAreAnchoredToScipy:
+    """For the per-axis minima, scipy IS the external oracle -- so consult it, not our table.
+
+    Every other assertion in this file re-reads the same dict the guard reads, which cannot
+    detect the dict being wrong. If scipy ever changed a minimum, the guard would accept a grid
+    the interpolator then refuses at runtime, and #1664's silent RBF-to-nearest degradation would
+    reopen behind a green suite. This is the one part of the change with a law outside the code.
+    """
+
+    @pytest.mark.parametrize("method", sorted(HONOURED_METHODS_ND))
+    def test_scipy_agrees_with_the_nd_table(self, method):
+        from scipy.interpolate import RegularGridInterpolator
+
+        need = MIN_POINTS_PER_AXIS_ND[method]
+
+        def rgi_works(n: int) -> bool:
+            coords = (np.linspace(0.0, 1.0, n),) * 2
+            try:  # exactly the construction hjb_sl_interpolation uses
+                RegularGridInterpolator(coords, np.zeros((n, n)), method=method, bounds_error=False, fill_value=None)(
+                    np.array([[0.5, 0.5]])
+                )
+            except Exception:
+                return False
+            return True
+
+        assert rgi_works(need), f"table says {method} needs {need} points, scipy refuses that"
+        if need > 1:
+            assert not rgi_works(need - 1), f"table says {method} needs {need}, but scipy accepts {need - 1}"
+
+
+class TestTheRefusalNamesTheRightAxis:
+    """The axis number is what the message tells the user to act on, so pin it.
+
+    Every other refusal fixture is isotropic `(n, n)`, where reporting the first or the last
+    short axis is indistinguishable.
+    """
+
+    # The third case is the discriminating one. With a single short axis, reporting the first or
+    # the last short axis selects the same element, and a mutation swapping them survives. Two
+    # short axes of DIFFERENT lengths separate them: first is (axis 0, n=3), last is (axis 1, n=2).
+    @pytest.mark.parametrize(
+        ("shape", "expected_axis", "expected_n"),
+        [((3, 20), 0, 3), ((20, 3), 1, 3), ((3, 2), 0, 3)],
+        ids=["short-first", "short-last", "both-short-different-lengths"],
+    )
+    def test_the_short_axis_is_identified(self, shape, expected_axis, expected_n):
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0), (0.0, 1.0)],
+                Nx_points=list(shape),
+                boundary_conditions=no_flux_bc(dimension=2),
+            ),
+            T=0.5,
+            Nt=5,
+            sigma=0.3,
+            components=MFGComponents(
+                m_initial=lambda x: 1.0,
+                u_terminal=lambda x: 0.0,
+                hamiltonian=SeparableHamiltonian(
+                    control_cost=QuadraticControlCost(control_cost=1.0),
+                    coupling=lambda m: m,
+                    coupling_dm=lambda m: 1.0,
+                ),
+            ),
+        )
+        with pytest.raises(ValueError, match=rf"axis {expected_axis} has {expected_n}"):
+            HJBSemiLagrangianSolver(problem, interpolation_method="cubic")
+
+
+class TestOneDimensionalMinimaFollowTheTruePathNotRegularGridInterpolator:
+    """1D uses PCHIP/CubicSpline, which never touch RegularGridInterpolator.
+
+    Applying the nD table here refused `cubic` at n=3, where cubic is genuinely honoured --
+    measured on a non-linear profile, PCHIP 0.7477 against linear 0.9256. At n=2 the two agree
+    exactly, so refusing there is right. The 1D boundary is 3.
+    """
+
+    def test_cubic_is_accepted_at_three_points_in_1d(self):
+        assert min_points_per_axis("cubic", 1) == 3
+        HJBSemiLagrangianSolver(_problem(1, 3), interpolation_method="cubic")
+
+    def test_cubic_is_refused_at_two_points_in_1d_where_it_is_linear(self):
+        xg = np.linspace(0.0, 1.0, 2)
+        u = np.array([0.0, 7.0])
+        assert interpolate_value_1d(u, 0.3, xg, method="cubic") == pytest.approx(
+            interpolate_value_1d(u, 0.3, xg, method="linear")
+        ), "at 2 points cubic IS linear, which is why it is refused"
+        with pytest.raises(ValueError, match=r"needs at least 3 points per axis at dimension 1"):
+            HJBSemiLagrangianSolver(_problem(1, 2), interpolation_method="cubic")

--- a/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
+++ b/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
@@ -1,0 +1,128 @@
+"""The SL solver must refuse an interpolation_method it will not honour (#1809, #1664).
+
+`interpolation_method` was stored unvalidated, and both interpolators default to linear for
+anything they do not recognise. Two consequences, both silent:
+
+- **Dimension-dependent meaning.** The 1D path is ``if method == "cubic": PCHIP else: linear``,
+  so it recognises two methods; the nD path recognises five. Measured on
+  ``U = [0, 10, 0, 10, 0]`` at ``x = 0.30`` (nodes at 0.25 and 0.50): ``nearest`` returns
+  **8.0 in 1D** and **10.0 in nD** -- the same public argument naming a different interpolant
+  depending on dimension. A typo collapsed to linear at both.
+- **Grid too small for the method.** ``RegularGridInterpolator`` needs 4 points per axis for
+  ``cubic`` and 6 for ``quintic``. Below that it raises, and the fallback chain substituted
+  ``RBF -> nearest neighbour`` behind ``logger.debug`` -- the caller asked for cubic and could
+  receive nearest (#1664).
+
+The oracle here is not a numerical law, so these are **convention pins**: each is verified by
+mutating the guard and observing it redden, and the accept-cases exist because a guard that
+refuses everything passes every refuse-case and looks correct.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
+from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import (
+    MIN_POINTS_PER_AXIS,
+    honoured_methods,
+    interpolate_value_1d,
+    interpolate_value_nd,
+)
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem(dimension: int, n: int) -> MFGProblem:
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)] * dimension,
+            Nx_points=[n] * dimension,
+            boundary_conditions=no_flux_bc(dimension=dimension),
+        ),
+        T=0.5,
+        Nt=5,
+        sigma=0.3,
+        components=MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+class TestTheDivergenceThatMotivatesTheGuard:
+    """Pin the measured fact itself, so the guard's reason cannot rot away from it."""
+
+    def test_nearest_means_different_things_in_1d_and_nd(self):
+        xg = np.linspace(0.0, 1.0, 5)
+        u = np.array([0.0, 10.0, 0.0, 10.0, 0.0])
+        q = 0.30  # between nodes at 0.25 and 0.50
+
+        assert interpolate_value_1d(u, q, xg, method="nearest") == pytest.approx(8.0), (
+            "the 1D path recognises only 'cubic'; everything else is linear"
+        )
+        u2 = np.repeat(u[:, None], 5, axis=1)
+        assert interpolate_value_nd(u2, np.array([q, 0.5]), (xg, np.linspace(0, 1, 5)), (5, 5), method="nearest") == (
+            pytest.approx(10.0)
+        ), "the nD path honours 'nearest'"
+
+    def test_the_honoured_sets_differ_by_dimension(self):
+        assert honoured_methods(1) < honoured_methods(2), "1D honours strictly fewer methods"
+        assert "nearest" in honoured_methods(2)
+        assert "nearest" not in honoured_methods(1)
+
+
+class TestUnhonouredMethodsAreRefused:
+    @pytest.mark.parametrize("method", ["nearest", "slinear", "quintic"], ids=["nearest", "slinear", "quintic"])
+    def test_an_nd_only_method_is_refused_in_1d(self, method):
+        with pytest.raises(ValueError, match=r"not honoured at dimension 1"):
+            HJBSemiLagrangianSolver(_problem(1, 21), interpolation_method=method)
+
+    @pytest.mark.parametrize("dimension", [1, 2])
+    def test_a_typo_is_refused_rather_than_silently_linear(self, dimension):
+        with pytest.raises(ValueError, match=r"not honoured at dimension"):
+            HJBSemiLagrangianSolver(_problem(dimension, 11), interpolation_method="cubis")
+
+
+class TestGridTooSmallForTheMethodIsRefused:
+    @pytest.mark.parametrize(("method", "n"), [("cubic", 3), ("quintic", 5)], ids=["cubic-on-3", "quintic-on-5"])
+    def test_below_the_per_axis_minimum_is_refused(self, method, n):
+        assert n < MIN_POINTS_PER_AXIS[method], "fixture must actually be below the minimum"
+        with pytest.raises(ValueError, match=r"needs at least \d+ points per axis"):
+            HJBSemiLagrangianSolver(_problem(2, n), interpolation_method=method)
+
+    @pytest.mark.parametrize(("method", "n"), [("cubic", 4), ("quintic", 6)], ids=["cubic-at-4", "quintic-at-6"])
+    def test_exactly_at_the_minimum_is_accepted(self, method, n):
+        """The boundary of the refusal, on the accepting side -- an off-by-one here refuses valid work."""
+        assert n == MIN_POINTS_PER_AXIS[method]
+        HJBSemiLagrangianSolver(_problem(2, n), interpolation_method=method)
+
+
+class TestHonouredConfigurationsStillConstruct:
+    """Negative controls. A guard that raises unconditionally passes every test above."""
+
+    @pytest.mark.parametrize(
+        ("dimension", "n", "method"),
+        [
+            (1, 21, "linear"),
+            (1, 21, "cubic"),
+            (2, 11, "linear"),
+            (2, 11, "slinear"),
+            (2, 11, "nearest"),
+            (2, 11, "cubic"),
+            (2, 11, "quintic"),
+        ],
+    )
+    def test_every_honoured_combination_constructs(self, dimension, n, method):
+        solver = HJBSemiLagrangianSolver(_problem(dimension, n), interpolation_method=method)
+        assert solver.interpolation_method == method


### PR DESCRIPTION
Closes #1809. Refs #1664, #1574.

## How this was found, and a correction to #1664

#1664 reports `interpolate_value_rbf_fallback` entered **0 times in 5177 interpolations** and frames
it as steep gradients being insufficient to trigger the fallback. That framing is wrong: in
`_interpolate_value`, the 1D case returns at the `if` and the fallback lives in the `else` — the nD
path. **A 1D configuration cannot reach it at all**, regardless of the field. Chasing the real
trigger turned up a second, larger defect.

## Two ways the declared method differed from the honoured one, both silent

`interpolation_method` was stored at `hjb_semi_lagrangian.py:224` with **no membership check**.
Downstream, `interpolate_value_nd` defaults to `linear` and overrides only for five known names,
while `interpolate_value_1d` is `if method == "cubic": PCHIP else: linear` — it recognises **two**.

**1. Dimension-dependent meaning.** Measured on `U = [0, 10, 0, 10, 0]` at `x = 0.30`, nodes at
0.25 and 0.50 (analytic: linear `8.0`, nearest `10.0`):

| method | 1D | 2D |
|---|---|---|
| `linear` | 8.0 | 8.0 |
| `nearest` | **8.0** | **10.0** |
| `slinear` | 8.0 | 8.0 |
| `"cubis"` (typo) | 8.0 | 8.0 |

The same public argument names a different interpolant depending on dimension, and construction
accepted the typo outright.

**2. Grid too small for the method.** `RegularGridInterpolator` needs 4 points per axis for `cubic`
and 6 for `quintic` — measured by bisection, not read from the docs — and raises below that. That
raise is the **only** condition reaching the RBF fallback. Everything else I probed returns
silently: a far out-of-bounds query gives `1.005e+09` (`bounds_error=False, fill_value=None`
extrapolate), plus `NaN`, `inf`, a descending axis, and an unknown method name. On that one path the
chain degrades `cubic -> RBF -> nearest neighbour` behind `logger.debug`.

## The change

Construction refuses both, naming either the honoured set at this dimension or the offending axis
and its minimum. Refusing is the honest disposition: implementing the missing 1D methods is a
capability decision rather than a bug fix, and silently substituting an interpolant of a different
order is what both issues are about.

Honoured sets and per-axis minima are single-sourced in `hjb_sl_interpolation.py`, next to the
interpolators that honour them — the gap between *accepted* and *honoured* is the defect itself, so
it gets one owner.

## Close-out: convention pins, and no oracle claimed

Per the rule added in #1808: there is **no external oracle** here. The refusal is a capability
decision, not a law the scheme must reproduce, so these are mutation-verified convention pins and I
am not implying more.

| mutation | result |
|---|---|
| remove the validation call | 7 failed |
| merge the 1D honoured set into the nD one | 4 failed |
| gut the per-axis minimum to 1 | 4 failed |
| make the guard refuse **everything** (negative control) | 12 failed |

The last one matters: a guard that raises unconditionally passes every refuse-case and looks
correct. Boundary cases are pinned on the accepting side too (`cubic` at exactly 4 points, `quintic`
at exactly 6), since an off-by-one there would refuse valid work.

**Blast radius measured before the tests were written**: 275 existing semi-Lagrangian and
interpolation tests pass unchanged, so nothing in the tree used an unhonoured method or an
undersized grid.

## Not done here

With this guard, `use_rbf_fallback` / `rbf_kernel` have no reachable trigger left, so #1664's
option 3 — remove them — is now *determined* rather than a judgement call. They are public
parameters and removal follows the deprecation policy, so that belongs in its own change against
#1664.

`./scripts/local_ci.sh` GREEN: **5823 passed, 22 skipped, 10 xfailed** in 5:17.