### PR TITLE
Give the semi-Lagrangian family one owner for method-to-backend

### DIFF
--- a/changelog.d/sl-interpolation-single-owner.changed.md
+++ b/changelog.d/sl-interpolation-single-owner.changed.md
@@ -9,6 +9,8 @@ not a byte-identical refactor.
 
 `sl_backend()` in `hjb_sl_interpolation` is now the single owner of method-to-backend, taking the
 monotone requirement as an explicit policy argument, and the four private ladders are deleted.
+Only the backend choice changes: both interpolants the batch path previously built extrapolated
+out-of-domain feet, and it still does, so the out-of-bounds policy is untouched.
 
 A monotone scheme overriding the declared method is now disclosed rather than applied silently.
 `diffusion_method="stochastic"` warned only for `cubic`/`quintic`, via a hardcoded pair that was a

--- a/changelog.d/sl-interpolation-single-owner.changed.md
+++ b/changelog.d/sl-interpolation-single-owner.changed.md
@@ -1,8 +1,8 @@
 One solve now commits to one interpolant. `interpolation_method` named four different
 interpolants across the semi-Lagrangian family, and which one ran was decided **per timestep**
 by the CFL number rather than by configuration: one `cubic` solve at `Nx=41, Nt=8` constructed
-`CubicSpline(not-a-knot)` 7 times and `PchipInterpolator` 81 times. The two disagree by ~1.9e-2
-on coarse grids and differ in monotonicity -- the property Issue #583/#1033 replaced
+`CubicSpline(not-a-knot)` 7 times and `PchipInterpolator` 81 times. The two differ in order -- 4 against 2 on smooth
+data, an error ratio that grows without bound in `h` -- and in monotonicity -- the property Issue #583/#1033 replaced
 `CubicSpline` for after the Towel-on-Beach blow-up. Three of the four dispatch sites had taken
 that fix; the default batch path had not, so on that path this is a deliberate numerical change,
 not a byte-identical refactor.
@@ -10,7 +10,12 @@ not a byte-identical refactor.
 `sl_backend()` in `hjb_sl_interpolation` is now the single owner of method-to-backend, taking the
 monotone requirement as an explicit policy argument, and the four private ladders are deleted.
 Only the backend choice changes: both interpolants the batch path previously built extrapolated
-out-of-domain feet, and it still does, so the out-of-bounds policy is untouched.
+out-of-domain feet, and it still does, so the out-of-bounds policy is untouched. Pinned against
+the pre-consolidation output, since an agreement test between the two paths goes tautological once
+they share an owner.
+
+`interpolate_value_nd` now raises for an unrecognised method at nD instead of silently returning
+the linear value. Unreachable through the solver, which validates the method at construction.
 
 A monotone scheme overriding the declared method is now disclosed rather than applied silently.
 `diffusion_method="stochastic"` warned only for `cubic`/`quintic`, via a hardcoded pair that was a

--- a/changelog.d/sl-interpolation-single-owner.changed.md
+++ b/changelog.d/sl-interpolation-single-owner.changed.md
@@ -1,0 +1,17 @@
+One solve now commits to one interpolant. `interpolation_method` named four different
+interpolants across the semi-Lagrangian family, and which one ran was decided **per timestep**
+by the CFL number rather than by configuration: one `cubic` solve at `Nx=41, Nt=8` constructed
+`CubicSpline(not-a-knot)` 7 times and `PchipInterpolator` 81 times. The two disagree by ~1.9e-2
+on coarse grids and differ in monotonicity -- the property Issue #583/#1033 replaced
+`CubicSpline` for after the Towel-on-Beach blow-up. Three of the four dispatch sites had taken
+that fix; the default batch path had not, so on that path this is a deliberate numerical change,
+not a byte-identical refactor.
+
+`sl_backend()` in `hjb_sl_interpolation` is now the single owner of method-to-backend, taking the
+monotone requirement as an explicit policy argument, and the four private ladders are deleted.
+
+A monotone scheme overriding the declared method is now disclosed rather than applied silently.
+`diffusion_method="stochastic"` warned only for `cubic`/`quintic`, via a hardcoded pair that was a
+third restatement of the same policy; `nearest` and `slinear` are honoured at nD, are equally
+non-monotone, and were remapped to linear with no warning at all (measured spread on one 7x7
+profile: `nearest` 0.0688 against `linear` 0.2732).

--- a/changelog.d/sl-interpolation-single-owner.changed.md
+++ b/changelog.d/sl-interpolation-single-owner.changed.md
@@ -14,8 +14,13 @@ out-of-domain feet, and it still does, so the out-of-bounds policy is untouched.
 the pre-consolidation output, since an agreement test between the two paths goes tautological once
 they share an owner.
 
-`interpolate_value_nd` now raises for an unrecognised method at nD instead of silently returning
-the linear value. Unreachable through the solver, which validates the method at construction.
+`interpolate_value_nd` now raises for an unrecognised method at **two or more axes**, instead of
+silently returning the linear value. At a one-axis grid it still returns the linear value, because
+`sl_backend`'s `dimension` argument selects which SL machinery applies and the 1D branch is total
+over method strings -- the same semantics `interpolate_value_1d` has always had, now reached
+through both names instead of the two disagreeing on four of five methods. Unreachable through the
+solver either way: `_grid_shape` is assigned only in the `dimension > 1` branch, so a one-axis
+`grid_shape` cannot arise there.
 
 A monotone scheme overriding the declared method is now disclosed rather than applied silently.
 `diffusion_method="stochastic"` warned only for `cubic`/`quintic`, via a hardcoded pair that was a

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1276,20 +1276,12 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 # at Nx=41, Nt=8). CubicSpline is also the non-monotone object Issue #583 replaced.
                 from scipy.interpolate import PchipInterpolator, interp1d
 
-                # `extrapolate=True`, and `interp1d` rather than `np.interp`, because BOTH
-                # interpolants this site used to build extrapolated and the consolidation must not
-                # change that. It is only the backend that is being unified here.
-                #
-                # This started as a clamp, which was wrong twice over. `reflect_into_domain` rounds
-                # OUTWARD for endpoints that are not exactly representable -- reflect(-0.3) is
-                # 2.8e-17 below x_grid[0] -- and PCHIP with extrapolate=False returns NaN there,
-                # which solve_banded rejects. Clamping did stop the abort, but the only BC that
-                # reaches this site with genuinely out-of-domain feet is PERIODIC, whose fold is
-                # dead (#1739): measured, feet land 0.47 dx below xmin, 4.7e14 times the overshoot
-                # the clamp was written for. Against a fold-repaired reference the clamp cost
-                # 2.04e-2 where extrapolation costs 5.73e-3 -- linear extrapolation across the seam
-                # is a first-order stand-in for the wrapped value, clamping is a zeroth-order one.
-                # It also removed the loud failure that would have surfaced #1739.
+                # Both interpolants must EXTRAPOLATE: only the backend is being unified here, and
+                # both of the ones this site used to build extrapolated. Clamping instead (whether
+                # via np.clip or np.interp's default) is a different out-of-bounds policy, and it
+                # is reachable -- periodic feet leave the domain at every step because that fold is
+                # dead (#1739), landing ~0.5 dx out, where clamping costs 2.04e-2 against 5.73e-3
+                # for extrapolation. Pinned by TestTheLinearPathIsUNCHANGEDByTheConsolidation.
                 backend = sl_backend(self.interpolation_method, 1, monotone_required=False)
                 if backend == "pchip":
                     u_departures = PchipInterpolator(self.x_grid, U_next, extrapolate=True)(x_departures)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -166,7 +166,9 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             problem: MFG problem instance
             interpolation_method: Method for interpolating values
                 - 'linear': Linear interpolation (fastest, C⁰ continuous)
-                - 'cubic': Cubic spline interpolation (slower, C² continuous)
+                - 'cubic': Monotone cubic Hermite (PCHIP) -- slower, C¹, and monotone. NOT a C² spline:
+              Issue #583 replaced CubicSpline to stop the Issue #1033 blow-up, so the accuracy
+              on smooth data is 2nd order here against the 4th order a not-a-knot spline gives.
                 - 'quintic': Quintic interpolation (slowest, highest accuracy, nD only)
                 - 'nearest': Nearest neighbor (for debugging)
             optimization_method: Method for Hamiltonian optimization ('brent', 'golden')
@@ -459,7 +461,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         that restated the monotone policy a third time. It therefore missed the other half:
         ``nearest`` and ``slinear`` are honoured at nD, are equally non-monotone, and were
         remapped to linear with no warning at all -- measured on one 7x7 profile, ``nearest``
-        0.0688 against ``linear`` 0.2732. `monotone_downgrade` is the single owner of which
+        0.0688 against ``linear`` 0.2732. `sl_backend` is the single owner of which
         methods get overridden, so this cannot drift from the dispatch again (#1810, #1811).
 
         The two cases are disclosed differently because they are different: cubic/quintic are
@@ -1276,6 +1278,17 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 # at Nx=41, Nt=8). CubicSpline is also the non-monotone object Issue #583 replaced.
                 from scipy.interpolate import PchipInterpolator
 
+                # Clamp to the grid range before interpolating. `reflect_into_domain` rounds
+                # OUTWARD for endpoints that are not exactly representable -- reflect(-0.3)
+                # is -0.30000000000000004, 2.8e-17 below x_grid[0] -- and PCHIP with
+                # extrapolate=False returns NaN there, which solve_banded then rejects with
+                # "array must not contain infs or NaNs". Both interpolants this site used to
+                # build extrapolated, so the overshoot was harmless; PCHIP does not, which
+                # turned a 1-ULP artefact into an aborted solve on any domain like [-0.3, 1.7].
+                # The pointwise sibling has always clamped (hjb_sl_interpolation.py:73-76);
+                # this is that same semantics, which is what makes the two paths agree.
+                x_departures = np.clip(x_departures, self.x_grid[0], self.x_grid[-1])
+
                 backend = sl_backend(self.interpolation_method, 1, monotone_required=False)
                 if backend == "pchip":
                     u_departures = PchipInterpolator(self.x_grid, U_next, extrapolate=False)(x_departures)
@@ -1630,9 +1643,11 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         algorithm differs, but because collapsing them changes the numerics
         (verified non-byte-identical):
 
-        - **Interpolation backend**: 1D uses ``numpy.interp`` (linear) /
-          ``PchipInterpolator`` (cubic), which *clamp* out-of-bounds feet to
-          the endpoint value; nD uses ``RegularGridInterpolator``, which
+        - **Interpolation backend**: 1D uses ``numpy.interp`` (linear), which *clamps*
+          out-of-bounds feet to the endpoint value, or ``PchipInterpolator`` (cubic), which
+          with ``extrapolate=False`` returns **NaN** -- these are NOT the same policy, and
+          this sentence claimed they were until #1811 traced an aborted solve back to it.
+          nD uses ``RegularGridInterpolator``, which
           *extrapolates* (``fill_value=None``). Under reflect/wrap BC every
           foot is in-bounds and the two agree to ~1 ULP; they diverge only for
           ``clamp`` BC (Dirichlet/none), where clamp vs. extrapolation are

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -1282,7 +1282,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 # is reachable -- periodic feet leave the domain at every step because that fold is
                 # dead (#1739), landing ~0.5 dx out, where clamping costs 2.04e-2 against 5.73e-3
                 # for extrapolation. Pinned by TestTheLinearPathIsUNCHANGEDByTheConsolidation.
-                backend = sl_backend(self.interpolation_method, 1, monotone_required=False)
+                backend = sl_backend(self.interpolation_method, self.dimension, monotone_required=False)
                 if backend == "pchip":
                     u_departures = PchipInterpolator(self.x_grid, U_next, extrapolate=True)(x_departures)
                 else:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -478,8 +478,6 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         if self.diffusion_method != "stochastic":
             return
 
-        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import sl_backend
-
         runs = sl_backend(self.interpolation_method, self.dimension, monotone_required=True)
         would_run = sl_backend(self.interpolation_method, self.dimension, monotone_required=False)
         if runs == would_run == "linear":  # Q1: exactly what Carlini-Silva 2014 covers
@@ -1276,24 +1274,29 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 # pointwise sibling built PchipInterpolator -- and _compute_cfl_and_substeps picks
                 # between the two PER TIMESTEP by CFL, so one solve mixed both (measured 7 and 81
                 # at Nx=41, Nt=8). CubicSpline is also the non-monotone object Issue #583 replaced.
-                from scipy.interpolate import PchipInterpolator
+                from scipy.interpolate import PchipInterpolator, interp1d
 
-                # Clamp to the grid range before interpolating. `reflect_into_domain` rounds
-                # OUTWARD for endpoints that are not exactly representable -- reflect(-0.3)
-                # is -0.30000000000000004, 2.8e-17 below x_grid[0] -- and PCHIP with
-                # extrapolate=False returns NaN there, which solve_banded then rejects with
-                # "array must not contain infs or NaNs". Both interpolants this site used to
-                # build extrapolated, so the overshoot was harmless; PCHIP does not, which
-                # turned a 1-ULP artefact into an aborted solve on any domain like [-0.3, 1.7].
-                # The pointwise sibling has always clamped (hjb_sl_interpolation.py:73-76);
-                # this is that same semantics, which is what makes the two paths agree.
-                x_departures = np.clip(x_departures, self.x_grid[0], self.x_grid[-1])
-
+                # `extrapolate=True`, and `interp1d` rather than `np.interp`, because BOTH
+                # interpolants this site used to build extrapolated and the consolidation must not
+                # change that. It is only the backend that is being unified here.
+                #
+                # This started as a clamp, which was wrong twice over. `reflect_into_domain` rounds
+                # OUTWARD for endpoints that are not exactly representable -- reflect(-0.3) is
+                # 2.8e-17 below x_grid[0] -- and PCHIP with extrapolate=False returns NaN there,
+                # which solve_banded rejects. Clamping did stop the abort, but the only BC that
+                # reaches this site with genuinely out-of-domain feet is PERIODIC, whose fold is
+                # dead (#1739): measured, feet land 0.47 dx below xmin, 4.7e14 times the overshoot
+                # the clamp was written for. Against a fold-repaired reference the clamp cost
+                # 2.04e-2 where extrapolation costs 5.73e-3 -- linear extrapolation across the seam
+                # is a first-order stand-in for the wrapped value, clamping is a zeroth-order one.
+                # It also removed the loud failure that would have surfaced #1739.
                 backend = sl_backend(self.interpolation_method, 1, monotone_required=False)
                 if backend == "pchip":
-                    u_departures = PchipInterpolator(self.x_grid, U_next, extrapolate=False)(x_departures)
+                    u_departures = PchipInterpolator(self.x_grid, U_next, extrapolate=True)(x_departures)
                 else:
-                    u_departures = np.interp(x_departures, self.x_grid, U_next)
+                    u_departures = interp1d(
+                        self.x_grid, U_next, kind="linear", bounds_error=False, fill_value="extrapolate"
+                    )(x_departures)
 
                 # Step 1d: Lax-Oleinik value update (Issue #1413)
                 U_star = self._sl_value_update(u_departures, x_batch, M_next, p_batch, time_idx * self.dt, self.dt)

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -54,6 +54,7 @@ from .hjb_sl_interpolation import (
     interpolate_value_1d,
     interpolate_value_nd,
     interpolate_value_rbf_fallback,
+    sl_backend,
 )
 
 if TYPE_CHECKING:
@@ -240,30 +241,6 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         self.gradient_clip_threshold = gradient_clip_threshold
         self.enable_gradient_monitoring = enable_gradient_monitoring
 
-        # Issue #1049: Carlini-Silva 2014 prove unconditional stability of the
-        # deterministic 2-direction averaging SL scheme (here: diffusion_method=
-        # "stochastic") **specifically for Q1 (linear, monotone) interpolation**.
-        # Cubic interpolation is not covered by the CS 2014 proof and is non-monotone
-        # (Issue #1033 documents the exponential blow-up on Towel-on-Beach).
-        # The previous validation actively rejected the proof-applicable combination.
-        # Now: warn (don't reject) when cubic+stochastic is selected, since that
-        # combination violates the monotone-scheme requirement of CS 2014.
-        if self.diffusion_method == "stochastic" and self.interpolation_method in ("cubic", "quintic"):
-            import warnings
-
-            warnings.warn(
-                f"diffusion_method='stochastic' with interpolation_method='{self.interpolation_method}' "
-                "is NOT covered by the Carlini-Silva 2014 stability proof, which "
-                "requires monotone (Q1/linear) interpolation. Cubic/quintic can "
-                "violate the monotone-scheme requirement of Barles-Souganidis and "
-                "produce exponential blow-up on stiff problems (see Issue #1033). "
-                "Recommended: interpolation_method='linear'. mfgarchon's cubic "
-                "path now uses `PchipInterpolator` (monotonic Hermite) which is "
-                "more stable than `CubicSpline` but still outside the formal proof.",
-                UserWarning,
-                stacklevel=2,
-            )
-
         # Issue #1058: canonical Carlini-Silva SL with implicit-alpha* DPP fixed point.
         # CS 2014's stability proof requires monotone (Q1/linear) interpolation; cubic/quintic
         # are non-monotone and outside the proof (Issue #1033/#1049). Fail fast rather than
@@ -368,6 +345,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # was accepted and silently downgraded. Runs after the dimension/grid branches because
         # the honoured set and the per-axis minimum both depend on them.
         self._validate_interpolation_method()
+        self._disclose_monotone_override()
 
         # Setup JAX functions if available
         if self.use_jax:
@@ -467,6 +445,68 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                 f"(grid shape {shape}). {consequence} Refine the grid on axis {ax}, or choose a "
                 "method the grid supports."
             )
+
+    def _disclose_monotone_override(self) -> None:
+        """Say so when the monotone scheme will not run the interpolant that was asked for.
+
+        ``diffusion_method="stochastic"`` requires a monotone interpolant: Carlini-Silva 2014
+        prove unconditional stability of this two-direction averaging scheme **for Q1 (linear)
+        interpolation**, and Issue #1033 records the exponential Towel-on-Beach blow-up when a
+        non-monotone cubic runs instead. So the path overrides the declared method. The override
+        is correct; performing it silently is not.
+
+        The override was previously announced for ``cubic``/``quintic`` only, by a hardcoded pair
+        that restated the monotone policy a third time. It therefore missed the other half:
+        ``nearest`` and ``slinear`` are honoured at nD, are equally non-monotone, and were
+        remapped to linear with no warning at all -- measured on one 7x7 profile, ``nearest``
+        0.0688 against ``linear`` 0.2732. `monotone_downgrade` is the single owner of which
+        methods get overridden, so this cannot drift from the dispatch again (#1810, #1811).
+
+        The two cases are disclosed differently because they are different: cubic/quintic are
+        replaced by a *different non-proof-covered* interpolant (PCHIP, monotone Hermite), while
+        nearest/slinear are replaced by linear, which IS proof-covered but is not what the caller
+        asked for.
+
+        Both questions are answered by `sl_backend`, and the discriminating question is "is what
+        RUNS the Q1 interpolant the proof covers" -- not "does the monotone flag change anything".
+        Those come apart at 1D cubic, which resolves to PCHIP with or without the flag: the flag
+        changes nothing there, yet PCHIP is still outside the proof and still owes the warning
+        the pre-consolidation code correctly gave it.
+        """
+        if self.diffusion_method != "stochastic":
+            return
+
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import sl_backend
+
+        runs = sl_backend(self.interpolation_method, self.dimension, monotone_required=True)
+        would_run = sl_backend(self.interpolation_method, self.dimension, monotone_required=False)
+        if runs == would_run == "linear":  # Q1: exactly what Carlini-Silva 2014 covers
+            return
+
+        import warnings
+
+        if runs != "linear":
+            detail = (
+                "Cubic/quintic can violate the monotone-scheme requirement of Barles-Souganidis "
+                "and produce exponential blow-up on stiff problems (see Issue #1033). This path "
+                "runs `PchipInterpolator` (monotonic Hermite), which is more stable than "
+                "`CubicSpline` but still outside the formal proof."
+            )
+        else:
+            detail = (
+                f"This path runs {runs!r} instead of {would_run!r}, which IS covered by the proof "
+                "but is not the interpolant you selected -- it used to be substituted with no "
+                "warning at all (Issue #1810)."
+            )
+
+        warnings.warn(
+            f"diffusion_method='stochastic' with interpolation_method="
+            f"'{self.interpolation_method}' is NOT covered by the Carlini-Silva 2014 stability "
+            f"proof, which requires monotone (Q1/linear) interpolation. {detail} "
+            "Recommended: interpolation_method='linear'.",
+            UserWarning,
+            stacklevel=3,
+        )
 
     def _setup_jax_functions(self):
         """Setup JAX-accelerated functions for performance."""
@@ -1229,15 +1269,18 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
                     L = xmax - xmin
                     x_departures = xmin + (x_departures - xmin) % L
 
-                # Step 1b: Batch interpolation
-                from scipy.interpolate import CubicSpline, interp1d
+                # Step 1b: Batch interpolation, through the single owner.
+                # This site used to build CubicSpline(bc_type="not-a-knot") for "cubic" while the
+                # pointwise sibling built PchipInterpolator -- and _compute_cfl_and_substeps picks
+                # between the two PER TIMESTEP by CFL, so one solve mixed both (measured 7 and 81
+                # at Nx=41, Nt=8). CubicSpline is also the non-monotone object Issue #583 replaced.
+                from scipy.interpolate import PchipInterpolator
 
-                if self.interpolation_method == "cubic":
-                    interp_fn = CubicSpline(self.x_grid, U_next, bc_type="not-a-knot")
-                    u_departures = interp_fn(x_departures)
+                backend = sl_backend(self.interpolation_method, 1, monotone_required=False)
+                if backend == "pchip":
+                    u_departures = PchipInterpolator(self.x_grid, U_next, extrapolate=False)(x_departures)
                 else:
-                    interp_fn = interp1d(self.x_grid, U_next, kind="linear", fill_value="extrapolate")
-                    u_departures = interp_fn(x_departures)
+                    u_departures = np.interp(x_departures, self.x_grid, U_next)
 
                 # Step 1d: Lax-Oleinik value update (Issue #1413)
                 U_star = self._sl_value_update(u_departures, x_batch, M_next, p_batch, time_idx * self.dt, self.dt)
@@ -1683,12 +1726,7 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
         # Issue #1033/#1054: monotone dispatch — cubic/quintic → PCHIP (monotone
         # Hermite) to avoid the non-monotone CubicSpline blow-up; linear is the
         # canonical Carlini-Silva interpolant (Issue #1049).
-        if self.interpolation_method == "linear":
-            interp_method = "linear"
-        elif self.interpolation_method in ("cubic", "quintic"):
-            interp_method = "pchip"
-        else:
-            interp_method = "linear"
+        interp_method = sl_backend(self.interpolation_method, d, monotone_required=True)
 
         if d == 1:
             # numpy.interp / PchipInterpolator preserve the 1D clamp-at-boundary

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
@@ -4,8 +4,9 @@ Interpolation Methods for Semi-Lagrangian HJB Solver.
 This module provides interpolation routines for evaluating the value function
 at departure points during characteristic tracing in the semi-Lagrangian scheme.
 
-Supported methods:
-- 1D: scipy.interpolate.interp1d (linear, cubic)
+Supported methods (see `sl_backend`, the single owner of method -> backend):
+- 1D: numpy.interp (linear) / PchipInterpolator (cubic -- monotone Hermite, NOT a C2 spline;
+  Issue #583 replaced CubicSpline to stop the Issue #1033 blow-up)
 - nD: scipy.interpolate.RegularGridInterpolator (linear, cubic, quintic)
 - Fallback: RBF interpolation for boundary cases
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
@@ -5,8 +5,8 @@ This module provides interpolation routines for evaluating the value function
 at departure points during characteristic tracing in the semi-Lagrangian scheme.
 
 Supported methods (see `sl_backend`, the single owner of method -> backend):
-- 1D: numpy.interp (linear) / PchipInterpolator (cubic -- monotone Hermite, NOT a C2 spline;
-  Issue #583 replaced CubicSpline to stop the Issue #1033 blow-up)
+- 1D: scipy.interpolate.interp1d (linear, extrapolating) / PchipInterpolator (cubic -- monotone
+  Hermite, NOT a C2 spline; Issue #583 replaced CubicSpline to stop the Issue #1033 blow-up)
 - nD: scipy.interpolate.RegularGridInterpolator (linear, cubic, quintic)
 - Fallback: RBF interpolation for boundary cases
 
@@ -84,7 +84,7 @@ def interpolate_value_1d(
             interpolator = PchipInterpolator(
                 x_grid,
                 U_values,
-                extrapolate=False,  # Return NaN outside bounds (handled by lines 72-75)
+                extrapolate=False,  # Return NaN outside bounds (the boundary guard above returns first)
             )
         else:
             # Default to linear
@@ -215,7 +215,11 @@ def sl_backend(method: str, dimension: int, *, monotone_required: bool) -> str:
     and the default path did not. There is no configuration in which this owner returns it.
 
     Returns a backend key: ``"linear"``, ``"pchip"``, or a ``RegularGridInterpolator`` method
-    name. 1D callers map ``"linear"`` to ``np.interp`` and ``"pchip"`` to ``PchipInterpolator``.
+    name. It names the interpolant, NOT the out-of-bounds policy -- 1D callers realise ``"linear"``
+    as extrapolating ``interp1d`` on the characteristic paths and as clamping ``np.interp`` in
+    ``_stochastic_sl_step``, which documents its own reason. Do not "align" those: swapping the
+    former for the latter moves a periodic solve by rel 3.6e-2 and is what
+    TestTheLinearPathIsUNCHANGEDByTheConsolidation exists to catch.
     """
     if dimension == 1:
         return "pchip" if method == "cubic" else "linear"

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_interpolation.py
@@ -76,9 +76,10 @@ def interpolate_value_1d(
         return float(U_values[-1])
 
     try:
-        if method == "cubic":
-            # Issue #583 fix: Use PCHIP (monotonicity-preserving cubic Hermite)
-            # instead of cubic splines to prevent Runge oscillations at discontinuities
+        # sl_backend is the one owner of "which interpolant does this method mean" (#1811).
+        # The Issue #583 rationale -- PCHIP rather than a cubic spline, to keep monotonicity and
+        # avoid Runge oscillations at discontinuities -- now lives there rather than here.
+        if sl_backend(method, 1, monotone_required=False) == "pchip":
             interpolator = PchipInterpolator(
                 x_grid,
                 U_values,
@@ -140,14 +141,9 @@ def interpolate_value_nd(
     else:
         U_values_reshaped = U_values
 
-    # Map method name to RegularGridInterpolator format
-    interp_method = "linear"
-    if method == "cubic":
-        interp_method = "cubic"
-    elif method == "quintic":
-        interp_method = "quintic"
-    elif method in ["linear", "nearest", "slinear"]:
-        interp_method = method
+    # One owner for method -> backend (#1811). This block used to be a fourth private copy,
+    # and its catch-all `else` is what silently turned an unrecognised method into linear.
+    interp_method = sl_backend(method, len(grid_shape), monotone_required=False)
 
     interpolator = RegularGridInterpolator(
         grid_coordinates,
@@ -195,6 +191,39 @@ HONOURED_METHODS_ND = frozenset({"linear", "slinear", "nearest", "cubic", "quint
 #       genuinely honoured -- the inverse of the defect this guard exists to fix.
 MIN_POINTS_PER_AXIS_ND = {"linear": 1, "slinear": 2, "nearest": 1, "cubic": 4, "quintic": 6}
 MIN_POINTS_PER_AXIS_1D = {"linear": 2, "cubic": 3}
+
+
+def sl_backend(method: str, dimension: int, *, monotone_required: bool) -> str:
+    """The single answer to "which interpolant does ``method`` mean here".
+
+    Four sites used to decide this independently and disagreed. Measured on
+    ``U = [0, 10, 0, 10, 0]`` at ``x = 0.30``, ``interpolation_method="cubic"`` produced
+    ``7.68`` through ``CubicSpline(bc_type="not-a-knot")`` and ``8.96`` through
+    ``PchipInterpolator`` -- and which one ran was decided **per timestep**, because
+    ``_compute_cfl_and_substeps`` sends a CFL<=1 step down the batch path and a CFL>1 step down
+    the pointwise path. One solve at Nx=41, Nt=8 built 7 of the first and 81 of the second.
+
+    ``monotone_required`` is a real distinction, not a fork, and is why this takes a policy
+    rather than hardcoding a ladder. The Carlini-Silva 2014 stability proof covers monotone
+    interpolation only, so ``diffusion_method='stochastic'`` asks for the monotone backend even
+    when the user said ``quintic`` (Issues #1033, #1049, #1054). What was wrong was that each
+    site re-derived that ladder; the policy is now stated by the caller and applied here.
+
+    In 1D ``cubic`` is ALWAYS PCHIP. ``CubicSpline`` is non-monotone and is precisely what
+    Issue #583 replaced to stop the Issue #1033 blow-up; three of the four sites took that fix
+    and the default path did not. There is no configuration in which this owner returns it.
+
+    Returns a backend key: ``"linear"``, ``"pchip"``, or a ``RegularGridInterpolator`` method
+    name. 1D callers map ``"linear"`` to ``np.interp`` and ``"pchip"`` to ``PchipInterpolator``.
+    """
+    if dimension == 1:
+        return "pchip" if method == "cubic" else "linear"
+    if monotone_required:
+        # Monotone dispatch: anything higher order collapses to the monotone Hermite backend,
+        # anything else to Q1. Note `nearest` and `slinear` land on "linear" here, which is a
+        # genuine downgrade the caller is asking for -- it must be disclosed, not silent.
+        return "pchip" if method in ("cubic", "quintic") else "linear"
+    return method
 
 
 def honoured_methods(dimension: int) -> frozenset[str]:

--- a/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
+++ b/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
@@ -239,6 +239,20 @@ class TestAnUnrecognisedMethodRaisesAtND:
         with pytest.raises(ValueError, match="not defined"):
             interpolate_value_nd(u, np.array([0.30, 0.5]), (xg, xg), (5, 5), method="bogus")
 
+    def test_at_one_axis_it_does_not_raise_and_the_changelog_says_so(self):
+        """The claim above is scoped to >=2 axes, and this is why -- so it cannot silently widen.
+
+        `sl_backend`'s `dimension` selects WHICH SL MACHINERY applies, and the 1D branch is total
+        over method strings, so a one-axis grid takes the characteristic-path pair and absorbs
+        everything RegularGridInterpolator would have refused. That is `interpolate_value_1d`'s
+        long-standing behaviour, now reached through both names rather than the two disagreeing.
+        Unreachable through the solver -- `_grid_shape` exists only when `dimension > 1`.
+        """
+        xg = np.linspace(0.0, 1.0, 5)
+        u = np.array([0.0, 10.0, 0.0, 10.0, 0.0])
+        assert interpolate_value_nd(u, np.array([0.30]), (xg,), (5,), method="bogus") == pytest.approx(8.0)
+        assert interpolate_value_nd(u, np.array([0.30]), (xg,), (5,), method="quintic") == pytest.approx(8.0)
+
     def test_an_honoured_method_still_returns_a_value(self):
         """Negative control: a guard that raises on everything passes the test above."""
         xg = np.linspace(0.0, 1.0, 5)

--- a/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
+++ b/tests/unit/test_alg/test_sl_interpolation_method_honoured_1809.py
@@ -222,3 +222,25 @@ class TestOneDimensionalMinimaFollowTheTruePathNotRegularGridInterpolator:
         ), "at 2 points cubic IS linear, which is why it is refused"
         with pytest.raises(ValueError, match=r"needs at least 3 points per axis at dimension 1"):
             HJBSemiLagrangianSolver(_problem(1, 2), interpolation_method="cubic")
+
+
+class TestAnUnrecognisedMethodRaisesAtND:
+    """The changelog ships this as a behaviour change, so it owes a test (#1814 review, N1).
+
+    `interpolate_value_nd` used to return the LINEAR value for any method it did not recognise --
+    the catch-all `else` that made a typo indistinguishable from a deliberate choice. It now
+    raises. Unreachable through the solver, which validates at construction, so this is the only
+    thing that exercises it.
+    """
+
+    def test_an_unknown_method_raises_rather_than_returning_linear(self):
+        xg = np.linspace(0.0, 1.0, 5)
+        u = np.repeat(np.array([0.0, 10.0, 0.0, 10.0, 0.0])[:, None], 5, axis=1)
+        with pytest.raises(ValueError, match="not defined"):
+            interpolate_value_nd(u, np.array([0.30, 0.5]), (xg, xg), (5, 5), method="bogus")
+
+    def test_an_honoured_method_still_returns_a_value(self):
+        """Negative control: a guard that raises on everything passes the test above."""
+        xg = np.linspace(0.0, 1.0, 5)
+        u = np.repeat(np.array([0.0, 10.0, 0.0, 10.0, 0.0])[:, None], 5, axis=1)
+        assert interpolate_value_nd(u, np.array([0.30, 0.5]), (xg, xg), (5, 5), method="nearest") == pytest.approx(10.0)

--- a/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
+++ b/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
@@ -338,3 +338,85 @@ class TestTheOverrideIsDisclosedRatherThanApplied:
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
             _solver_for(1, "cubic", diffusion_method="explicit_euler")
+
+
+class TestTheLinearPathIsUNCHANGEDByTheConsolidation:
+    """The other half of this change's stated invariant, and the half nothing was pinning.
+
+    The claim is "only the backend choice changes": both interpolants the batch path built
+    extrapolated out-of-domain feet, and it still does. The cubic half is pinned by
+    `test_a_solve_survives_a_non_representable_domain[cubic-(-0.3, 1.7)]`. The linear half was
+    pinned by nothing -- and during this change the batch site's
+    `interp1d(fill_value="extrapolate")` was silently swapped for `np.interp`, which CLAMPS.
+    Reapplying that one-line swap passes 613 SL/HJB tests while moving a periodic linear solve by
+    5.26e-3, eleven times the 4.77e-4 the intended cubic backend swap moves it. The `[linear-*]`
+    fold cases assert only finiteness, and a clamped value is finite.
+
+    Periodic BC is what makes this reachable: its fold is dead (#1739), so feet leave the domain
+    at every step and the out-of-bounds policy is what decides the answer.
+
+    The values below are captured from `main` BEFORE the consolidation. That is deliberate -- an
+    agreement test between the two paths goes tautological the moment they share an owner, which
+    is exactly when this change lands, so the only pin that survives is against the
+    pre-consolidation output. Update it only alongside a stated, measured intent to change the
+    linear path.
+    """
+
+    # Captured on main @ fecbfa1d, before sl_backend existed.
+    MAIN_U0_FIRST5 = (
+        -0.40983509012196784,
+        -0.404058809261078,
+        -0.3982725404248194,
+        -0.3923195952518894,
+        -0.3860645384176972,
+    )
+    MAIN_SUM = -75.51161537275942
+
+    def _periodic_linear_solve(self) -> np.ndarray:
+        from mfgarchon.geometry.boundary import periodic_bc
+
+        problem = MFGProblem(
+            geometry=TensorProductGrid(
+                bounds=[(0.0, 1.0)], Nx_points=[41], boundary_conditions=periodic_bc(dimension=1)
+            ),
+            T=0.4,
+            Nt=8,
+            sigma=0.05,
+            components=MFGComponents(
+                m_initial=lambda x: 1.0,
+                u_terminal=lambda x: 0.05 * np.sin(2 * np.pi * np.asarray(x)),
+                hamiltonian=SeparableHamiltonian(
+                    control_cost=QuadraticControlCost(control_cost=1.0),
+                    coupling=lambda m: m,
+                    coupling_dm=lambda m: 1.0,
+                ),
+            ),
+        )
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method="linear", characteristic_solver="explicit_euler")
+        u = np.zeros((9, 41))
+        u[-1] = problem.get_u_terminal()
+        return solver.solve_hjb_system(np.ones((9, 41)), u[-1], u)
+
+    def test_a_periodic_linear_solve_is_bit_identical_to_pre_consolidation(self):
+        result = self._periodic_linear_solve()
+        assert tuple(float(v) for v in result[0][:5]) == self.MAIN_U0_FIRST5, (
+            "the linear batch path moved. This change is supposed to alter only which CUBIC "
+            "backend runs; if the linear result moved, the out-of-bounds policy changed with it "
+            "(clamp vs extrapolate), which is the boundary policy #1739 owns and this PR defers."
+        )
+        assert float(result.sum()) == self.MAIN_SUM
+
+    def test_the_fixture_actually_sends_feet_out_of_the_domain(self):
+        """Positive control. On a domain where no foot leaves, the pin above is vacuous.
+
+        `periodic` maps to `bc_op == "periodic"`, which no branch handles (#1739), so nothing
+        folds the feet back. If that is ever fixed, this test fails and the pin above must be
+        re-captured rather than quietly kept.
+        """
+        from mfgarchon.geometry.boundary import bc_utils, periodic_bc
+
+        assert bc_utils.bc_type_to_geometric_operation("periodic") != "wrap", (
+            "#1739 is fixed: periodic feet now fold, so the pin above no longer measures the "
+            "out-of-bounds policy and must be re-captured on a fixture that still does"
+        )
+        assert periodic_bc(dimension=1) is not None

--- a/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
+++ b/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
@@ -1,0 +1,273 @@
+"""One solve must not mix interpolants (#1811, #1664, #1809).
+
+`interpolation_method="cubic"` names four different interpolants across the SL family, and
+which one runs is decided **per timestep**, not per configuration: `_compute_cfl_and_substeps`
+routes a CFL<=1 timestep to the batch path and a CFL>1 timestep to the pointwise path, and
+those two paths build different cubics. Measured on `main` before the consolidation, one solve
+at `Nx=41, Nt=8`, terminal `0.05*exp(-300(x-0.5)^2)`:
+
+    CubicSpline(not-a-knot) constructed : 7
+    PchipInterpolator constructed       : 81
+
+The two disagree by ~1.9e-2 on coarse grids (PCHIP 8.96 against not-a-knot 7.68 on
+`U = [0, 10, 0, 10, 0]` at `x = 0.30`), and they differ in the property that matters:
+`CubicSpline` is non-monotone and is what #583/#1033 replaced with PCHIP to stop the
+Towel-on-Beach blow-up. Three of the four sites took that fix; the default path did not.
+
+This is the acceptance criterion for giving the SL family one interpolation owner. It is not a
+convergence check and not an accuracy bound -- it asserts that a single solve commits to a
+single backend, which is a property no tolerance can express.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import numpy as np
+import scipy.interpolate as scipy_interpolate
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+# Interpolant constructors any SL path could reach. Counting CONSTRUCTIONS rather than
+# sabotaging a body: the call sites in this family swallow exceptions, so a sabotaged path
+# reports as passing (recorded in #1664).
+_BACKENDS = ("CubicSpline", "PchipInterpolator", "RegularGridInterpolator", "RBFInterpolator")
+
+
+@pytest.fixture
+def backend_counter(monkeypatch):
+    """Count every backend construction across scipy and the modules that import it by name."""
+    import mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian as solver_mod
+    import mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation as interp_mod
+
+    counts: dict[str, int] = dict.fromkeys(_BACKENDS, 0)
+
+    for name in _BACKENDS:
+        original = getattr(scipy_interpolate, name)
+
+        def make(_name=name, _original=original):
+            def counting(*args, **kwargs):
+                counts[_name] += 1
+                return _original(*args, **kwargs)
+
+            return counting
+
+        counting_fn = make()
+        monkeypatch.setattr(scipy_interpolate, name, counting_fn, raising=False)
+        for module in (solver_mod, interp_mod):
+            if hasattr(module, name):
+                monkeypatch.setattr(module, name, counting_fn, raising=False)
+
+    return counts
+
+
+def _steep_1d_problem(nx: int = 41, nt: int = 8) -> MFGProblem:
+    """Steep terminal data, so some timesteps exceed CFL and substep and some do not.
+
+    That spread is the point: it is what routes different timesteps of ONE solve down the
+    batch and pointwise paths.
+    """
+    return MFGProblem(
+        geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1)),
+        T=0.4,
+        Nt=nt,
+        sigma=0.2,
+        components=MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.05 * np.exp(-300 * (np.asarray(x) - 0.5) ** 2),
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _solver_for(dimension: int, method: str, **solver_kwargs) -> HJBSemiLagrangianSolver:
+    """A solver at the given dimension, on a grid large enough for every honoured method."""
+    problem = MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)] * dimension,
+            Nx_points=[11] * dimension,
+            boundary_conditions=no_flux_bc(dimension=dimension),
+        ),
+        T=0.4,
+        Nt=4,
+        sigma=0.2,
+        components=MFGComponents(
+            m_initial=lambda x: 1.0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    return HJBSemiLagrangianSolver(problem, interpolation_method=method, **solver_kwargs)
+
+
+def _solve(problem: MFGProblem, **solver_kwargs) -> None:
+    solver = HJBSemiLagrangianSolver(problem, **solver_kwargs)
+    nx = problem.geometry.get_grid_shape()[0]
+    m = np.ones((problem.Nt + 1, nx))
+    u = np.zeros((problem.Nt + 1, nx))
+    u[-1] = problem.get_u_terminal()
+    solver.solve_hjb_system(m, u[-1], u)
+
+
+def test_a_cubic_solve_commits_to_one_cubic_backend(backend_counter):
+    """The headline. On main this fails with 7 CubicSpline and 81 PCHIP in one solve."""
+    _solve(_steep_1d_problem(), interpolation_method="cubic", characteristic_solver="explicit_euler")
+
+    cubic_backends = {
+        name: n for name, n in backend_counter.items() if name in ("CubicSpline", "PchipInterpolator") and n
+    }
+    assert len(cubic_backends) <= 1, (
+        f"one solve used more than one cubic backend: {cubic_backends}. Which one runs is decided "
+        "per timestep by the CFL number rather than by configuration, and the two differ in "
+        "monotonicity -- the property #583/#1033 replaced CubicSpline for."
+    )
+
+
+def test_the_cubic_backend_is_the_monotone_one(backend_counter):
+    """Not merely consistent -- consistent with the #583 fix.
+
+    Three of the four sites already use PCHIP and say why. Consolidating onto the
+    non-monotone `CubicSpline` would satisfy the test above and reintroduce the blow-up.
+    """
+    _solve(_steep_1d_problem(), interpolation_method="cubic", characteristic_solver="explicit_euler")
+
+    assert backend_counter["CubicSpline"] == 0, (
+        "the solve constructed CubicSpline(not-a-knot), which is non-monotone and is what "
+        "Issue #583 replaced with PchipInterpolator to stop the Issue #1033 blow-up"
+    )
+    assert backend_counter["PchipInterpolator"] > 0, "no cubic interpolant was built at all"
+
+
+def test_substepping_does_not_change_which_backend_runs(backend_counter):
+    """The mechanism, isolated: with substepping off, only the batch path runs.
+
+    If the two paths agree on the backend, turning substepping off cannot change which one is
+    built. On main it does, which is the defect stated as a difference rather than a count.
+    """
+    _solve(
+        _steep_1d_problem(),
+        interpolation_method="cubic",
+        characteristic_solver="explicit_euler",
+        enable_adaptive_substepping=False,
+    )
+    without = {k: v for k, v in backend_counter.items() if v}
+
+    for key in backend_counter:
+        backend_counter[key] = 0
+    _solve(
+        _steep_1d_problem(),
+        interpolation_method="cubic",
+        characteristic_solver="explicit_euler",
+        enable_adaptive_substepping=True,
+    )
+    with_sub = {k: v for k, v in backend_counter.items() if v}
+
+    assert set(without) == set(with_sub), (
+        f"substepping changed the interpolant backend: without={without}, with={with_sub}. "
+        "The CFL number is selecting the numerical method."
+    )
+
+
+@pytest.mark.parametrize("method", ["linear", "cubic"])
+def test_the_stochastic_path_consults_the_owner(method, monkeypatch):
+    """Coverage gap this file had: every case above uses explicit_euler + adi.
+
+    The stochastic path has its own dispatch line, and when it was first routed through the
+    owner the import was function-local, so that line raised NameError at runtime while all
+    three tests above stayed green. Lint caught it; this test is what should have.
+
+    The assertion is a POSITIVE CONTROL, and the first attempt at it was not. Counting backend
+    constructions reported `{}` here and looked like a pass, because 1D+linear takes `np.interp`
+    -- which is not a counted backend. An empty count had two causes (the line did not run, or
+    the measurement could not see it) and could not separate them. Counting consultations of
+    `sl_backend` itself distinguishes them: 0 means the line never ran.
+    """
+    import mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian as solver_mod
+
+    calls: list[tuple] = []
+    original = solver_mod.sl_backend
+
+    def recording(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(solver_mod, "sl_backend", recording)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)  # the cubic case warns by design
+        _solve(_steep_1d_problem(nx=21, nt=4), interpolation_method=method, diffusion_method="stochastic")
+
+    assert calls, "the stochastic dispatch never consulted sl_backend -- this test cannot see a NameError there"
+    assert all(kw.get("monotone_required") is True for _, kw in calls), (
+        f"the stochastic path must demand a monotone interpolant (Carlini-Silva 2014): {calls}"
+    )
+
+
+class TestTheOverrideIsDisclosedRatherThanApplied:
+    """A monotone scheme silently replacing the caller's interpolant is the #1810 hole.
+
+    The disclosure previously named a hardcoded `("cubic", "quintic")` pair -- a third
+    restatement of the monotone policy, which missed `nearest`/`slinear`. Those are honoured at
+    nD, are equally non-monotone, and were remapped to linear with no warning. Measured spread
+    on one 7x7 profile: nearest 0.0688 against linear 0.2732.
+    """
+
+    def test_the_owner_reports_what_the_monotone_scheme_runs(self):
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import sl_backend
+
+        forced = {m: sl_backend(m, 2, monotone_required=True) for m in ("nearest", "slinear", "quintic", "linear")}
+        assert forced == {"nearest": "linear", "slinear": "linear", "quintic": "pchip", "linear": "linear"}
+
+    def test_one_d_cubic_is_pchip_with_or_without_the_monotone_flag(self):
+        """The case that broke the first version of the disclosure.
+
+        Keyed on "does the monotone flag change anything", 1D cubic answers no -- PCHIP runs
+        either way -- and the warning vanished, silently dropping a disclosure the code had
+        given correctly before the consolidation. The predicate that survives is "is what runs
+        the Q1 interpolant the proof covers".
+        """
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_interpolation import sl_backend
+
+        assert sl_backend("cubic", 1, monotone_required=True) == "pchip"
+        assert sl_backend("cubic", 1, monotone_required=False) == "pchip"
+
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [("cubic", "PchipInterpolator"), ("nearest", "is not the interpolant you selected")],
+        ids=["cubic-is-replaced-by-pchip", "nearest-is-replaced-by-linear"],
+    )
+    def test_a_downgraded_method_warns(self, method, expected):
+        """`nearest` is the case that used to pass in silence."""
+        dimension = 1 if method == "cubic" else 2
+        with pytest.warns(UserWarning, match="Carlini-Silva 2014") as record:
+            _solver_for(dimension, method, diffusion_method="stochastic")
+        assert any(expected in str(w.message) for w in record), (
+            f"the warning must say what actually runs instead: {[str(w.message) for w in record]}"
+        )
+
+    def test_a_monotone_method_does_not_warn(self):
+        """Negative control. A disclosure that fires unconditionally passes every test above."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            _solver_for(1, "linear", diffusion_method="stochastic")
+
+    def test_a_non_monotone_scheme_does_not_warn(self):
+        """Second negative control: the override only happens under the monotone scheme."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            _solver_for(1, "cubic", diffusion_method="explicit_euler")

--- a/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
+++ b/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
@@ -28,6 +28,7 @@ import pytest
 import numpy as np
 import scipy.interpolate as scipy_interpolate
 
+import mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian as solver_mod
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.hjb_solvers import HJBSemiLagrangianSolver
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
@@ -397,26 +398,75 @@ class TestTheLinearPathIsUNCHANGEDByTheConsolidation:
         u[-1] = problem.get_u_terminal()
         return solver.solve_hjb_system(np.ones((9, 41)), u[-1], u)
 
-    def test_a_periodic_linear_solve_is_bit_identical_to_pre_consolidation(self):
+    # Relative, not bit-exact. Bit-exactness made this a scipy-internals pin wearing a policy
+    # pin's name: on scipy 1.13.1 -- which pyproject declares supported -- `interp1d`'s
+    # `_call_linear` differs by 1 ULP on 16 of 42 query points and the pin failed while claiming
+    # the boundary policy had changed. The margin is not close: M8, the mutation this exists for,
+    # moves these values by rel 3.6e-2; the scipy-version noise is rel 5.4e-16. Any tolerance in
+    # [1e-12, 1e-4] keeps ~10 orders of discrimination and drops the library coupling.
+    RTOL = 1e-9
+
+    def test_a_periodic_linear_solve_matches_pre_consolidation(self):
         result = self._periodic_linear_solve()
-        assert tuple(float(v) for v in result[0][:5]) == self.MAIN_U0_FIRST5, (
+        assert tuple(float(v) for v in result[0][:5]) == pytest.approx(self.MAIN_U0_FIRST5, rel=self.RTOL), (
             "the linear batch path moved. This change is supposed to alter only which CUBIC "
-            "backend runs; if the linear result moved, the out-of-bounds policy changed with it "
+            "backend runs; a moved linear result means the out-of-bounds policy moved with it "
             "(clamp vs extrapolate), which is the boundary policy #1739 owns and this PR defers."
         )
-        assert float(result.sum()) == self.MAIN_SUM
+        assert float(result.sum()) == pytest.approx(self.MAIN_SUM, rel=self.RTOL)
 
-    def test_the_fixture_actually_sends_feet_out_of_the_domain(self):
-        """Positive control. On a domain where no foot leaves, the pin above is vacuous.
+    def test_the_fixture_actually_sends_feet_out_of_the_domain(self, monkeypatch):
+        """Positive control: MEASURE the feet, do not infer them from a dispatch string.
 
-        `periodic` maps to `bc_op == "periodic"`, which no branch handles (#1739), so nothing
-        folds the feet back. If that is ever fixed, this test fails and the pin above must be
-        re-captured rather than quietly kept.
+        The first version asserted `bc_type_to_geometric_operation("periodic") != "wrap"`, which
+        is a claim about the producer. #1739 is a defect in the CONSUMER -- three HJB sites compare
+        `bc_op == "wrap"` against a function that returns `"reflect" | "clamp" | "periodic"`, and
+        the FP adjoint already compares against `"periodic"`, so the available fix is to change
+        those three comparisons, not the producer. Constructed, that fix takes out-of-domain feet
+        from 8/328 to 0/328 -- the fixture stops exercising the policy, which is exactly what this
+        control exists to catch -- and the string assertion still PASSED.
+
+        Counting the feet cannot go inert that way: it fails when they stop leaving, whatever the
+        reason. That matters because the pin above is relative, and on a wrapped fixture M8 moves
+        the values by only ~1 ULP, so the pin would be blind and this control is what says so.
         """
-        from mfgarchon.geometry.boundary import bc_utils, periodic_bc
+        import scipy.interpolate as scipy_interpolate
 
-        assert bc_utils.bc_type_to_geometric_operation("periodic") != "wrap", (
-            "#1739 is fixed: periodic feet now fold, so the pin above no longer measures the "
-            "out-of-bounds policy and must be re-captured on a fixture that still does"
+        # Counted through BOTH backends, so this measures where the feet are rather than which
+        # interpolant is built. Counting only interp1d made the control fail under a mutation that
+        # merely switched to np.interp -- a failure about the implementation, not the fixture.
+        outside = []
+
+        def _tally(x, q):
+            lo, hi = float(np.min(x)), float(np.max(x))
+            q_arr = np.atleast_1d(q)
+            outside.append(int(np.sum((q_arr < lo) | (q_arr > hi))))
+
+        original_interp1d = scipy_interpolate.interp1d
+
+        def counting_interp1d(x, y, **kwargs):
+            f = original_interp1d(x, y, **kwargs)
+
+            def wrapped(q):
+                _tally(x, q)
+                return f(q)
+
+            return wrapped
+
+        original_np_interp = np.interp
+
+        def counting_np_interp(q, xp, fp, **kwargs):
+            _tally(xp, q)
+            return original_np_interp(q, xp, fp, **kwargs)
+
+        monkeypatch.setattr(scipy_interpolate, "interp1d", counting_interp1d)
+        monkeypatch.setattr(solver_mod, "interp1d", counting_interp1d, raising=False)
+        monkeypatch.setattr(solver_mod.np, "interp", counting_np_interp)
+        self._periodic_linear_solve()
+
+        assert sum(outside) > 0, (
+            "no departure foot left the domain, so the pin above measures nothing about the "
+            "out-of-bounds policy. Most likely #1739 was fixed and the periodic fold now wraps: "
+            "re-capture the reference on a fixture that still exercises extrapolation, rather "
+            "than keeping a pin that has quietly stopped testing its subject."
         )
-        assert periodic_bc(dimension=1) is not None

--- a/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
+++ b/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
@@ -183,6 +183,60 @@ def test_substepping_does_not_change_which_backend_runs(backend_counter):
     )
 
 
+class TestTheFoldOvershootsAndTheInterpolantMustSurviveIt:
+    """`[0, 1]` is the one domain where this cannot fire, and every fixture above uses it.
+
+    `reflect_into_domain` computes ``xmin + span - |((x - xmin) mod 2*span) - span|``, which
+    rounds OUTWARD when the endpoints are not exactly representable:
+
+        bounds (0.0, 1.0)   reflect(xmin) = 0.0                  exact
+        bounds (-0.3, 1.7)  reflect(xmin) = -0.30000000000000004  2.8e-17 BELOW xmin
+        bounds (0.1, 0.9)   reflect(xmin) = 0.09999999999999998   below xmin
+
+    Both interpolants the batch path used to build extrapolated, so that overshoot cost ~1e-17
+    of error. `PchipInterpolator(extrapolate=False)` returns NaN instead, and `solve_banded`
+    rejects it -- so consolidating onto PCHIP turned a rounding artefact into an aborted solve.
+    Caught in review; the acceptance tests above are all on `[0, 1]` and are structurally
+    incapable of seeing it.
+    """
+
+    @pytest.mark.parametrize("bounds", [(-0.3, 1.7), (0.1, 0.9), (0.0, 1.0)], ids=str)
+    @pytest.mark.parametrize("method", ["cubic", "linear"])
+    def test_a_solve_survives_a_non_representable_domain(self, bounds, method):
+        problem = MFGProblem(
+            geometry=TensorProductGrid(bounds=[bounds], Nx_points=[41], boundary_conditions=no_flux_bc(dimension=1)),
+            T=0.4,
+            Nt=8,
+            sigma=0.2,
+            components=MFGComponents(
+                m_initial=lambda x: 1.0,
+                u_terminal=lambda x: 0.05 * np.exp(-300 * (np.asarray(x) - 0.5) ** 2),
+                hamiltonian=SeparableHamiltonian(
+                    control_cost=QuadraticControlCost(control_cost=1.0),
+                    coupling=lambda m: m,
+                    coupling_dm=lambda m: 1.0,
+                ),
+            ),
+        )
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method=method, characteristic_solver="explicit_euler")
+        u = np.zeros((9, 41))
+        u[-1] = problem.get_u_terminal()
+        result = solver.solve_hjb_system(np.ones((9, 41)), u[-1], u)
+        assert np.all(np.isfinite(result)), (
+            f"non-finite value function on bounds={bounds}, method={method}: the reflect fold "
+            "overshoots by ~1 ULP and the interpolant returned NaN rather than clamping"
+        )
+
+    def test_the_fold_really_does_overshoot(self):
+        """Pin the mechanism, not just the symptom -- otherwise a later 'fix' to the interpolant
+        can hide it while the fold still returns points outside the domain."""
+        from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_characteristics import reflect_into_domain
+
+        lo, hi = -0.3, 1.7
+        folded = reflect_into_domain(np.array([[lo]]), np.array([lo]), np.array([hi]))[0, 0]
+        assert folded < lo, "fixture is stale: this domain no longer exercises the outward rounding"
+
+
 @pytest.mark.parametrize("method", ["linear", "cubic"])
 def test_the_stochastic_path_consults_the_owner(method, monkeypatch):
     """Coverage gap this file had: every case above uses explicit_euler + adi.

--- a/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
+++ b/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
@@ -253,6 +253,18 @@ def test_the_stochastic_path_consults_the_owner(method, monkeypatch):
     """
     import mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian as solver_mod
 
+    # Construct BEFORE patching. The constructor's disclosure also consults the owner, and with
+    # `monotone_required=False` among its calls -- so recording construction too made an `all(...)`
+    # assertion here false, and the version of this test that passed did so only because
+    # `_disclose_monotone_override` re-imported `sl_backend` function-locally and thereby shadowed
+    # the patch. Deleting that redundant import, a pure no-op, turned 18 passed into 2 failed: the
+    # test was pinning an import style rather than a dispatch property. Patching after construction
+    # isolates the solve-time dispatch, which is the thing under test.
+    problem = _steep_1d_problem(nx=21, nt=4)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)  # the cubic case warns by design
+        solver = HJBSemiLagrangianSolver(problem, interpolation_method=method, diffusion_method="stochastic")
+
     calls: list[tuple] = []
     original = solver_mod.sl_backend
 
@@ -262,9 +274,10 @@ def test_the_stochastic_path_consults_the_owner(method, monkeypatch):
 
     monkeypatch.setattr(solver_mod, "sl_backend", recording)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)  # the cubic case warns by design
-        _solve(_steep_1d_problem(nx=21, nt=4), interpolation_method=method, diffusion_method="stochastic")
+    nx = problem.geometry.get_grid_shape()[0]
+    u = np.zeros((problem.Nt + 1, nx))
+    u[-1] = problem.get_u_terminal()
+    solver.solve_hjb_system(np.ones((problem.Nt + 1, nx)), u[-1], u)
 
     assert calls, "the stochastic dispatch never consulted sl_backend -- this test cannot see a NameError there"
     assert all(kw.get("monotone_required") is True for _, kw in calls), (

--- a/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
+++ b/tests/unit/test_alg/test_sl_one_solve_one_interpolant.py
@@ -132,6 +132,9 @@ def test_a_cubic_solve_commits_to_one_cubic_backend(backend_counter):
     cubic_backends = {
         name: n for name, n in backend_counter.items() if name in ("CubicSpline", "PchipInterpolator") and n
     }
+    # An empty count satisfies `<= 1` while measuring nothing -- the same two-causes shape this
+    # file fixed in the stochastic test. Assert the solve built a cubic at all before judging it.
+    assert cubic_backends, "no cubic interpolant was constructed; this assertion would pass vacuously"
     assert len(cubic_backends) <= 1, (
         f"one solve used more than one cubic backend: {cubic_backends}. Which one runs is decided "
         "per timestep by the CFL number rather than by configuration, and the two differ in "
@@ -178,6 +181,9 @@ def test_substepping_does_not_change_which_backend_runs(backend_counter):
     )
     with_sub = {k: v for k, v in backend_counter.items() if v}
 
+    # Two empty dicts are equal. Without this, a solve that built no interpolant at all passes.
+    assert without, f"substepping off built no interpolant: {without}"
+    assert with_sub, f"substepping on built no interpolant: {with_sub}"
     assert set(without) == set(with_sub), (
         f"substepping changed the interpolant backend: without={without}, with={with_sub}. "
         "The CFL number is selecting the numerical method."


### PR DESCRIPTION
## The defect

`interpolation_method` names four different interpolants across the semi-Lagrangian family, and which one runs is decided **per timestep**, not per configuration. `_compute_cfl_and_substeps` routes a CFL<=1 timestep to the batch path and CFL>1 to the pointwise path, and those two build different cubics. Measured on ONE solve, `interpolation_method="cubic"`, `Nx=41, Nt=8`:

```
CubicSpline(not-a-knot) constructed : 7
PchipInterpolator constructed       : 81
```

They disagree by ~1.9e-2 on coarse grids (8.96 against 7.68 on `U = [0, 10, 0, 10, 0]` at `x = 0.30`) and differ in the property that matters:

### Accuracy cost of consolidating onto PCHIP (corrected after review)

The line above understated this. Measured on `0.3*exp(-8(x-0.5)^2)`, 20k random query points:

| Nx | not-a-knot | EOC | PCHIP | EOC | ratio |
|--:|--:|--:|--:|--:|--:|
| 21 | 1.62e-05 | | 4.39e-04 | | 27 |
| 81 | 4.26e-08 | 4.22 | 2.78e-05 | 2.00 | 652 |
| 321 | 1.47e-10 | 4.06 | 1.74e-06 | 2.00 | 11 845 |
| 641 | 8.96e-12 | 4.03 | 4.34e-07 | 2.00 | 48 445 |

**Order 4 -> 2 at the interpolant level, ratio unbounded in `h`.** PCHIP flattens the derivative at nodes bracketing an extremum, which is where an HJB value function lives.

The choice is still defensible -- Barles-Souganidis requires monotonicity and #583/#1033 are what removed `CubicSpline` -- and 81 of the 88 constructions in the measured solve were already PCHIP. But a high-order option for provably smooth data is a real gap this makes visible, and the cost belongs in the body rather than in a review thread.
 `CubicSpline` is non-monotone and is exactly what #583/#1033 replaced with PCHIP to stop the Towel-on-Beach blow-up. Three of the four sites took that fix. The **default** batch path did not.

So on that path this is a **deliberate numerical change, not a byte-identical refactor.**

## The change

`sl_backend(method, dimension, *, monotone_required)` in `hjb_sl_interpolation` is the single owner. The monotone requirement is an explicit policy argument rather than a ladder re-derived per site — the stochastic path's `cubic -> pchip` remap is legitimate (Carlini-Silva 2014 covers monotone interpolation only); what was wrong was four sites each re-deriving it. The four private ladders are deleted.

It also closes the disclosure half. The stochastic path warned only for `cubic`/`quintic` via a hardcoded pair — a third restatement of the same policy — so `nearest` and `slinear`, honoured at nD and equally non-monotone, were remapped to linear **in silence**. Measured spread on one 7x7 profile: `nearest` 0.0688 against `linear` 0.2732. That is #1810's hole, and #1810 is mine from earlier today.

The disclosure is keyed on **whether what RUNS is the Q1 interpolant the proof covers**, not on "does the monotone flag change anything". Those come apart at 1D cubic, which is PCHIP either way: my first version keyed on the flag and silently dropped a warning the pre-consolidation code gave correctly. Pinned by `test_one_d_cubic_is_pchip_with_or_without_the_monotone_flag`.

## Close-out oracle

Per CLAUDE.md § "Closing out a fix": tier 2, **a mutation-verified convention pin**. The acceptance test failed on `main` before the change (3 failed) — it is not a test written to match what the code already did.

| Mutation | Result |
|:--|:--|
| M1 batch path back to `CubicSpline` | KILLED by pins |
| M2 disclosure removed entirely | KILLED by pins |
| M3 disclosure back to the hardcoded `("cubic","quintic")` pair | KILLED by pins |
| M4 stochastic path drops `monotone_required` | KILLED by pins |
| M5 nD monotone policy stops remapping | KILLED by pins |

5/5. A sixth, non-compiling mutant is retained in the harness as the compile gate's own regression case: the first run of this battery reported an `IndentationError` as a `TRUE SURVIVOR`, which is a null result with no positive control. The harness now reports `INVALID: mutant does not compile -- nothing measured`.

The same failure appeared in the tests here and is recorded in the file: the first stochastic-path assertion counted backend constructions, got `{}`, and looked like a pass — 1D+linear takes `np.interp`, which is not a counted backend. It could not have caught the `NameError` it was written for. It now counts consultations of `sl_backend` itself, where 0 means the line never ran.

## Mechanical check (axiom: implementations must drop, net lines must not grow)

- **Decision sites: 12 -> 7.** Backend-mapping ladders specifically **4 -> 1**. The 7 remaining are the owner's own two lines, a different policy (`canonical_cs` fail-fast), a docstring line, two inline smoke asserts, and a JAX capability check.
- **Net lines: +67 in `mfgarchon/` — this half FAILS the check, and I am not going to spin it.** The PR does two things: the consolidation (rivals deleted, roughly line-neutral) and a disclosure that did not exist before (~55 lines). The growth is entirely the latter. The rule's purpose — catching a "consolidation" that adds a layer and leaves rivals standing — is satisfied; the rivals are gone. Splitting into two PRs is reasonable if preferred, though the disclosure is driven by `sl_backend` and cannot land first.

## Gate

**GATE GREEN — 5844 passed, 22 skipped, 10 xfailed** (317s).

Worth stating plainly: I changed the default path from `CubicSpline` to PCHIP and **not one of 5844 tests noticed**. That is a measurement of the suite, not a validation of the change — nothing in it discriminates which cubic runs on the default SL path. The acceptance test in this PR is the first thing that does.

## Not in this PR

The boundary fold and out-of-bounds policy, which is where #1739's dead `bc_op == "wrap"` branch lives, and routing `FPSLSolver` through the same owner (#1812). Both are separate consolidations.

Refs #1811, #1810, #1809, #1664, #583, #1033
