### PR TITLE
Stop the tree under review from supplying pytest and yaml to the gate

### DIFF
--- a/changelog.d/gate-cannot-be-forged-from-the-tree.fixed.md
+++ b/changelog.d/gate-cannot-be-forged-from-the-tree.fixed.md
@@ -1,10 +1,17 @@
 The gate's two remaining `-m` invocations — `pytest` and the inline workflow-integrity check —
-now run with `-P`, so the tree under review cannot supply the tools that judge it. `-m` and `-c`
+now run with `-P`, and the pytest step additionally with `PYTHONSAFEPATH=1`, so the tree under
+review cannot supply the tools that judge it. `-m` and `-c`
 put the current directory at the front of `sys.path`, and `scripts/local_ci.sh` runs from the
 repo root, so a `pytest/` package or a `yaml.py` committed there shadowed the real ones.
 
 Measured: a repo-root `pytest/` printing `1234 passed, 0 failed` was accepted as the full suite,
 and a repo-root `yaml.py` returning a synthetic document made the workflow check report `PASS`
-on a workflow with a dangling `needs:` — the exact failure that check exists to catch. With `-P`
-both forgeries are ignored, the real pytest collects 5868 tests, and the broken workflow is
-correctly reported.
+on a workflow with a dangling `needs:` — the exact failure that check exists to catch. With `-P` the workflow forgery is ignored and the broken
+workflow is correctly reported.
+
+`-P` alone is not sufficient for pytest: it is per-process, and `pytest-xdist`'s execnet workers
+do not inherit it, so under the gate's own `-n auto` a repo-root `pytest/` still reaches them.
+Measured on a probe test that must fail: `-P` alone crashes every worker (`no tests ran`);
+`PYTHONSAFEPATH=1` in addition lets the real pytest run and report `1 failed`. Anything that forks
+needs the environment variable, not just the flag — which is the property a future lint assertion
+over this script should check, rather than merely "every `-m` carries `-P`".

--- a/changelog.d/gate-cannot-be-forged-from-the-tree.fixed.md
+++ b/changelog.d/gate-cannot-be-forged-from-the-tree.fixed.md
@@ -1,0 +1,10 @@
+The gate's two remaining `-m` invocations — `pytest` and the inline workflow-integrity check —
+now run with `-P`, so the tree under review cannot supply the tools that judge it. `-m` and `-c`
+put the current directory at the front of `sys.path`, and `scripts/local_ci.sh` runs from the
+repo root, so a `pytest/` package or a `yaml.py` committed there shadowed the real ones.
+
+Measured: a repo-root `pytest/` printing `1234 passed, 0 failed` was accepted as the full suite,
+and a repo-root `yaml.py` returning a synthetic document made the workflow check report `PASS`
+on a workflow with a dangling `needs:` — the exact failure that check exists to catch. With `-P`
+both forgeries are ignored, the real pytest collects 5868 tests, and the broken workflow is
+correctly reported.

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -107,7 +107,7 @@ trap 'rm -f "$PROBE_ERR_FILE"; rm -rf "$PROBE_DIR"; exit 130' INT TERM
 probe_err() { [[ -n "$PROBE_ERR_FILE" ]] && tail -5 "$PROBE_ERR_FILE" 2>/dev/null; }
 
 resolved_python() {
-  local candidate=$1 want_package=${2:-} out probe_dir modules
+  local candidate=$1 want_package=${2:-} out modules
   candidate=$(command -v "$candidate" 2>/dev/null) || return 1
   [[ -n "$candidate" ]] || return 1
   [[ "$candidate" == /* ]] || candidate="$PWD/$candidate"
@@ -222,7 +222,7 @@ step "Workflow integrity"
 # a dangling `needs:` at load time and then NO job in that file runs on any event -- a
 # whole workflow silently switched off. Both failure modes were shipped during this
 # repo's CI cleanup, one after the other.
-"$PY" -c "
+"$PY" -P -c "
 import sys, yaml, pathlib
 bad = []
 for f in sorted(pathlib.Path('.github/workflows').glob('*.y*ml')):
@@ -282,7 +282,7 @@ if [[ $FAST -eq 0 ]]; then
   check $? "no capability change vs baseline"
 
   step "Test suite (CI marker set, xdist parallel, no coverage)"
-  "$PY" -m pytest tests/ -n auto \
+  "$PY" -P -m pytest tests/ -n auto \
     -m "not slow and not benchmark and not experimental and not optional_torch and not environment" \
     -q --durations=10
   check $? "full suite"

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -282,7 +282,11 @@ if [[ $FAST -eq 0 ]]; then
   check $? "no capability change vs baseline"
 
   step "Test suite (CI marker set, xdist parallel, no coverage)"
-  "$PY" -P -m pytest tests/ -n auto \
+  # PYTHONSAFEPATH as well as -P: `-P` is per-process and xdist's execnet workers do not inherit
+  # it, so a repo-root `pytest/` package still reaches them. Measured on a probe that must fail:
+  # `-P` alone under `-n` crashes every worker (no tests ran); with PYTHONSAFEPATH=1 the real
+  # pytest runs and correctly reports it. Anything that forks needs the env var, not just the flag.
+  PYTHONSAFEPATH=1 "$PY" -P -m pytest tests/ -n auto \
     -m "not slow and not benchmark and not experimental and not optional_torch and not environment" \
     -q --durations=10
   check $? "full suite"


### PR DESCRIPTION
Follow-up to #1813, which closed this hole for `ruff` and left the same mechanism open at the two remaining sites. `-m` and `-c` put the current directory at the **front** of `sys.path`, and `scripts/local_ci.sh` runs from the repo root — so a package committed there shadows the real tool.

## Measured, with positive controls on merged `main`

| forgery planted at repo root | `main` | this branch |
|:--|:--|:--|
| `pytest/` printing `1234 passed, 0 failed` | accepted as the full suite, exit 0 | ignored; real pytest collects 5868 tests |
| `yaml.py` returning a synthetic document | forged `safe_load` called **10×**; a workflow with a dangling `needs:` reported **PASS** | ignored; broken workflow correctly reported **FAIL** |

The `yaml` one is the sharper of the two: the workflow-integrity check exists precisely to catch a dangling `needs:`, which GitHub rejects at load time and which silently switches off every job in the file. A nine-line repo-root `yaml.py` made it report `PASS` on exactly that.

Both are **pre-existing against `main`**, not introduced by #1813, which is why they were out of scope there. They are the same defect class as that PR's blocker 2 and are cheap to close now that the measurement exists.

## Close-out oracle

Per CLAUDE.md § "Closing out a fix": tier 4, **a manual before/after with a positive control on each side — there is no automated test.** Nothing in `tests/` executes `local_ci.sh`. What this would not catch: a future `-m` invocation added to the script without `-P`. A lint rule or a grep assertion over the script would catch that class, and is the right follow-up if this keeps recurring — it has now recurred twice.

`-P` raises the interpreter floor to Python 3.11. `pyproject.toml` declares `requires-python = ">=3.12"`, so nothing in scope is affected.

Also removes a dead `probe_dir` local left over from the per-probe `mktemp` that #1813 replaced with a script-level scratch dir.

## Not addressed

The largest remaining trust surface is by design and stays: the four `scripts/check_*.py` ratchets and their baseline JSONs are entirely tree-supplied, so raising a baseline passes the ratchet. That is the intended contract of a ratchet, not a hole — the bidirectional check is what makes a *lowered* baseline fail.

Full gate: **GATE GREEN — 5833 passed, 22 skipped, 10 xfailed.**

Refs #1813