### PR TITLE
Say why the baseline was red, not just which test

### DIFF
--- a/changelog.d/1817-sweep-refusal-reports-why.fixed.md
+++ b/changelog.d/1817-sweep-refusal-reports-why.fixed.md
@@ -5,5 +5,9 @@
   nothing: the same argv on the same commit gave `5833 passed` locally, which makes the runner's
   own output the only evidence that the failure existed. `Run` now carries the output and both
   `sys.exit` paths append a `_failure_excerpt`, anchored at the `FAILURES` banner so the progress
-  dots do not crowd out the reason, tail-truncated at 120 lines because `-q` puts the short summary
-  last, and explicit about how many lines it dropped.
+  dots do not crowd out the reason, truncated from the **head** to the last 120 lines because `-q`
+  puts the short summary last, and explicit about how many lines it dropped. Both exits are pinned:
+  the `base.failed` branch fires first whenever stdout carries a `FAILED` line, so the collection
+  failure that reaches the second one -- a `--paths` typo -- needs its own test to be covered at all.
+  Note the excerpt carries `proc.stdout` only; pytest writes some usage errors to stderr, which this
+  still discards.

--- a/changelog.d/1817-sweep-refusal-reports-why.fixed.md
+++ b/changelog.d/1817-sweep-refusal-reports-why.fixed.md
@@ -1,0 +1,9 @@
+- **The discrimination sweep's two refusals now print the pytest output they refused on** (Issue
+  #1817). `_pytest` parsed failure names out of `proc.stdout` and discarded the rest, so a weekly
+  run that aborts on a pre-existing failure named the node id and nothing else -- no assertion, no
+  traceback. Diagnosing one red therefore cost a full CI round-trip, and on 2026-08-03 it bought
+  nothing: the same argv on the same commit gave `5833 passed` locally, which makes the runner's
+  own output the only evidence that the failure existed. `Run` now carries the output and both
+  `sys.exit` paths append a `_failure_excerpt`, anchored at the `FAILURES` banner so the progress
+  dots do not crowd out the reason, tail-truncated at 120 lines because `-q` puts the short summary
+  last, and explicit about how many lines it dropped.

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -196,11 +196,8 @@ def _pytest(paths: list[str], timeout: int = 3600) -> Run:
 def _failure_excerpt(output: str, limit: int = 120) -> str:
     """The part of a pytest run that says WHY it failed, bounded.
 
-    The two refusal paths below abort on a run whose stdout was then discarded, so the
-    weekly job reported a node id and nothing else. That is one full CI round-trip per
-    red before anyone learns what the assertion said -- and on 2026-08-03 the failure
-    did not reproduce locally at all (5833 passed under the same argv), which is
-    exactly the case where the runner's own output is the only evidence there is.
+    Both refusal paths below must print this. A weekly red often does not reproduce
+    locally, and then the runner's own output is the only evidence there is.
     """
     banner = re.search(r"^=+ FAILURES =+$", output, re.MULTILINE)
     excerpt = output[banner.start() :] if banner else output

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -153,6 +153,7 @@ class Run:
     returncode: int = 0
     collected: int = 0
     seconds: float = 0.0
+    output: str = ""
 
 
 def _pytest(paths: list[str], timeout: int = 3600) -> Run:
@@ -188,7 +189,27 @@ def _pytest(paths: list[str], timeout: int = 3600) -> Run:
         returncode=proc.returncode,
         collected=_collected(proc.stdout),
         seconds=round(time.perf_counter() - t0, 1),
+        output=proc.stdout,
     )
+
+
+def _failure_excerpt(output: str, limit: int = 120) -> str:
+    """The part of a pytest run that says WHY it failed, bounded.
+
+    The two refusal paths below abort on a run whose stdout was then discarded, so the
+    weekly job reported a node id and nothing else. That is one full CI round-trip per
+    red before anyone learns what the assertion said -- and on 2026-08-03 the failure
+    did not reproduce locally at all (5833 passed under the same argv), which is
+    exactly the case where the runner's own output is the only evidence there is.
+    """
+    banner = re.search(r"^=+ FAILURES =+$", output, re.MULTILINE)
+    excerpt = output[banner.start() :] if banner else output
+    lines = excerpt.splitlines()
+    if len(lines) <= limit:
+        return "\n".join(lines)
+    # Keep the tail: with -q the short summary lands last, and it names every failure
+    # even when a single traceback is long enough to push the others out.
+    return "\n".join([f"... {len(lines) - limit} earlier lines omitted ...", *lines[-limit:]])
 
 
 _COLLECTED = re.compile(r"(\d+) (?:passed|failed|error)")
@@ -411,7 +432,9 @@ def main() -> None:
     if base.failed:
         sys.exit(
             f"Refusing to run: {len(base.failed)} tests already fail before any mutation, so a "
-            f"kill could not be attributed.\n  " + "\n  ".join(sorted(base.failed)[:10])
+            f"kill could not be attributed.\n  "
+            + "\n  ".join(sorted(base.failed)[:10])
+            + f"\n\n--- baseline pytest output ---\n{_failure_excerpt(base.output)}"
         )
     # pytest exits 5 on "no tests collected" and 2/3/4 on usage or internal errors, and in
     # every one of those the FAILED set is empty. Without this, a --paths typo produces a
@@ -422,6 +445,7 @@ def main() -> None:
         sys.exit(
             f"Refusing to run: the baseline pytest exited {base.returncode} having run "
             f"{base.collected} tests. Nothing below would be a measurement."
+            f"\n\n--- baseline pytest output ---\n{_failure_excerpt(base.output)}"
         )
     print(f"  clean, {base.collected} ran, {base.seconds}s\n", flush=True)
 

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -166,13 +166,10 @@ FAILED tests/unit/test_backends/test_backend_factory.py::TestBackendCreationEdge
 
 
 def test_the_refusal_reports_why_the_baseline_was_red(td, monkeypatch):
-    """The node id alone costs a full CI round-trip, and sometimes buys nothing.
+    """Wiring, not the helper: `_failure_excerpt` can be correct while nothing calls it.
 
-    On 2026-08-03 the weekly job refused on one pre-existing failure and printed only
-    its name. The same argv on the same commit locally gave 5833 passed, so the
-    runner's own output was the only evidence that existed -- and the script had
-    discarded it. Wiring, not the helper: `_failure_excerpt` can be correct while
-    nothing calls it, which is the M1 shape above.
+    Same shape as M1 above. A refusal naming the node id but not the assertion costs a
+    full CI round-trip, and buys nothing when the red does not reproduce locally.
     """
 
     class _Proc:
@@ -188,9 +185,7 @@ def test_the_refusal_reports_why_the_baseline_was_red(td, monkeypatch):
     with pytest.raises(SystemExit) as exc:
         td.main()
     message = str(exc.value)
-    assert "assert 0 > 0" in message, (
-        f"the refusal named the test but not the assertion; it said:\n{message}"
-    )
+    assert "assert 0 > 0" in message, f"the refusal named the test but not the assertion; it said:\n{message}"
 
 
 def test_the_excerpt_starts_at_the_failures_banner(td):

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -188,6 +188,39 @@ def test_the_refusal_reports_why_the_baseline_was_red(td, monkeypatch):
     assert "assert 0 > 0" in message, f"the refusal named the test but not the assertion; it said:\n{message}"
 
 
+_EMPTY_BASELINE = """\
+============================= test session starts ==============================
+collected 0 items
+
+============================ no tests ran in 0.01s =============================
+"""
+
+
+def test_the_other_refusal_reports_why_too(td, monkeypatch):
+    """Two exits call the excerpt; one test reaching one of them pins one of them.
+
+    The `base.failed` branch fires first whenever stdout carries a FAILED line, so the test
+    above can never reach this one. A `--paths` typo is the case that gets here -- pytest
+    collects nothing, exits non-zero, and the FAILED set is empty -- and it is the case whose
+    inline comment says an unnoticed one produces six bogus UNCOVERED findings.
+    """
+
+    class _Proc:
+        stdout = _EMPTY_BASELINE
+        returncode = 5
+
+    monkeypatch.setattr(td, "_assert_clean_tree", lambda: None)
+    monkeypatch.setattr(td, "_assert_import_is_the_mutated_tree", lambda: None)
+    monkeypatch.setattr(td.subprocess, "run", lambda cmd, **kw: _Proc())
+    monkeypatch.setattr(td.sys, "argv", ["test_discrimination.py"])
+    with pytest.raises(SystemExit) as exc:
+        td.main()
+    message = str(exc.value)
+    assert "collected 0 items" in message, (
+        f"the second refusal reported the exit code but not the output behind it; it said:\n{message}"
+    )
+
+
 def test_the_excerpt_starts_at_the_failures_banner(td):
     """Everything before the banner is progress dots, which crowd out the reason."""
     assert td._failure_excerpt(_RED_BASELINE).startswith("=")

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -153,6 +153,64 @@ def test_the_sweep_passes_its_self_exclusion_to_pytest(td, monkeypatch):
     )
 
 
+_RED_BASELINE = """\
+............F...........                                                 [100%]
+=================================== FAILURES ===================================
+____________ TestBackendCreationEdgeCases.test_auto_selection_logging ____________
+>       assert len(captured.out) > 0
+E       assert 0 > 0
+=========================== short test summary info ============================
+FAILED tests/unit/test_backends/test_backend_factory.py::TestBackendCreationEdgeCases::test_auto_selection_logging
+1 failed, 23 passed
+"""
+
+
+def test_the_refusal_reports_why_the_baseline_was_red(td, monkeypatch):
+    """The node id alone costs a full CI round-trip, and sometimes buys nothing.
+
+    On 2026-08-03 the weekly job refused on one pre-existing failure and printed only
+    its name. The same argv on the same commit locally gave 5833 passed, so the
+    runner's own output was the only evidence that existed -- and the script had
+    discarded it. Wiring, not the helper: `_failure_excerpt` can be correct while
+    nothing calls it, which is the M1 shape above.
+    """
+
+    class _Proc:
+        stdout = _RED_BASELINE
+        returncode = 1
+
+    # The two startup guards shell out to git, and this test replaces subprocess
+    # wholesale; they have their own pins above and are not what is under test here.
+    monkeypatch.setattr(td, "_assert_clean_tree", lambda: None)
+    monkeypatch.setattr(td, "_assert_import_is_the_mutated_tree", lambda: None)
+    monkeypatch.setattr(td.subprocess, "run", lambda cmd, **kw: _Proc())
+    monkeypatch.setattr(td.sys, "argv", ["test_discrimination.py"])
+    with pytest.raises(SystemExit) as exc:
+        td.main()
+    message = str(exc.value)
+    assert "assert 0 > 0" in message, (
+        f"the refusal named the test but not the assertion; it said:\n{message}"
+    )
+
+
+def test_the_excerpt_starts_at_the_failures_banner(td):
+    """Everything before the banner is progress dots, which crowd out the reason."""
+    assert td._failure_excerpt(_RED_BASELINE).startswith("=")
+    assert "[100%]" not in td._failure_excerpt(_RED_BASELINE)
+
+
+def test_a_long_excerpt_keeps_the_tail_and_says_what_it_dropped(td):
+    """With -q the short summary lands last, so truncating the head is the safe end.
+
+    Silent truncation would read as "that was the whole failure" -- the shape this
+    repo files under a silent instrument.
+    """
+    long_output = "=" * 3 + " FAILURES " + "=" * 3 + "\n" + "\n".join(f"line {i}" for i in range(500))
+    excerpt = td._failure_excerpt(long_output, limit=10)
+    assert excerpt.splitlines()[-1] == "line 499", "the tail, where the summary is, was dropped"
+    assert "omitted" in excerpt, "truncation was silent"
+
+
 # ---------------------------------------------------------------------------
 # The mutation anchors -- literal source text, so they rot when the source moves
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1817. **Not** `Closes` — this makes the next red diagnosable; it does not fix the red.

## What was wrong

`_pytest` ran `_FAILED` over `proc.stdout`, kept the names, the returncode and the counts, and
discarded the rest. Both `Refusing to run:` exits then reported a node id and nothing else — no
assertion, no traceback — so diagnosing one weekly red cost a full CI round-trip.

On 2026-08-03 it cost more than that. The run refused on one pre-existing failure
(`test_auto_selection_logging`). The same argv on the same commit gives **5833 passed** locally, so
the runner's own output was the only evidence the failure existed anywhere — and the script had
already thrown it away.

## The change

`Run` carries `output`; both `sys.exit` paths append `_failure_excerpt`, which:

- anchors at the `FAILURES` banner, so progress dots do not crowd out the reason;
- truncates from the **head**, because `-q` puts the short summary last and that summary names
  every failure even when one traceback is long;
- states how many lines it dropped, so truncation cannot read as "that was the whole failure".

## Oracle for the close-out

**(2) A mutation-verified convention pin.** Three mutations, run against the new tests; each kills
exactly one, and only one:

| Mutation | Killed |
|---|---|
| refusal drops the excerpt (wiring, not helper) | `test_the_refusal_reports_why_the_baseline_was_red` |
| excerpt starts before the `FAILURES` banner | `test_the_excerpt_starts_at_the_failures_banner` |
| truncation stops saying it truncated | `test_a_long_excerpt_keeps_the_tail_and_says_what_it_dropped` |

The wiring test is the load-bearing one: M1 in this same file records that pinning a constant while
leaving its wiring unpinned left all 19 pins green while the defect returned.

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, exit 0, `5859 passed, 22 skipped, 10 xfailed` in 5:21.

## Not in scope here

`test_auto_selection_logging` asserts `capfd` stdout is non-empty for a `logger.info` whose handler
is attached once at first `get_logger` and bound to whatever `sys.stdout` was at that moment, with
`propagate = False` (measured: `caplog.records == []`). Its verdict is a property of logging
configuration rather than of backend auto-selection, which is the #1706 Class B shape. That wants
its own issue, not a quiet fix inside this PR.

Independent adversarial review has **not** been run — required before merge per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)