### PR TITLE
Measure the periodic capability claim instead of trusting it

### DIFF
--- a/changelog.d/1822-periodic-capability-ratchet.added.md
+++ b/changelog.d/1822-periodic-capability-ratchet.added.md
@@ -1,0 +1,13 @@
+- **A ratchet on the periodic-BC capability claim** (Issue #1822). `tests/unit/test_alg/test_periodic_capability_invariant_1822.py`
+  runs one solve from exactly periodic data through every solver that declares `BCType.PERIODIC`
+  and asserts the output is still periodic -- `x_min` and `x_max` are the same physical point on an
+  endpoint-inclusive grid, so the seam is zero in exact arithmetic. **Nine of the eleven declaring
+  solvers fail it**; `FPFVMSolver` (2.2e-16) and `FPGFDMSolver` (2.2e-11) are the two that honour
+  the claim. `HJBGFDMSolver` is a distinct case: it declares PERIODIC and raises
+  `NotImplementedError` for it.
+  Each failure carries `xfail(strict=True)`, so repairing a solver turns its XFAIL into an XPASS and
+  fails the suite until the marker is removed in the same change -- the count can only go down.
+  Coverage is guarded from an independent source: an AST walk over `mfgarchon/alg/numerical/` for
+  declaration sites, rather than the import list the matrix is built from, because comparing the
+  matrix against its own source is tautological and was measured passing while the matrix silently
+  stopped covering a solver.

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -1,0 +1,215 @@
+"""Every solver that declares PERIODIC must return a periodic field. Issue #1822.
+
+`TensorProductGrid(bounds=[(0, 1)], Nx_points=[21])` is endpoint-inclusive, so under a periodic
+boundary condition `x[0]` and `x[-1]` are the same physical point and any field a solver returns
+must agree there. This is a property of the continuous problem; no discretisation may violate it
+at O(1).
+
+This file is a **ratchet, not a bug report**. Nine of the eleven declaring solvers fail it today;
+`FPFVMSolver` (2.2e-16) and `FPGFDMSolver` (2.2e-11) are the two that honour it. Each failure is
+marked `xfail(strict=True)` with the issue that owns it, so:
+
+- fixing a solver turns its XFAIL into an XPASS, which `strict=True` reports as a failure, forcing
+  the marker to be removed in the same change -- the count can only go down;
+- a solver that starts declaring PERIODIC without honouring it is caught by the coverage test
+  below rather than by nobody.
+
+The order matters and is stated in #1822: this test comes first precisely so per-solver repair has
+a number to move. Patching the eight in eight PRs without it is how the class stayed invisible
+through #1257 and #1739, each of which fixed one stage of one solver.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import periodic_bc
+from mfgarchon.geometry.boundary.types import BCType
+
+NX = 21
+NT = 10
+SEAM_TOL = 1e-9  # exact zero in exact arithmetic; this admits round-off and meshless quadrature
+
+# The modules searched for PERIODIC-declaring solvers. Listed rather than walked, because a walk
+# imports optional-backend modules as a side effect; `test_the_matrix_covers_every_declaring_solver`
+# is what stops this list going stale.
+_SEARCHED = (
+    "mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian",
+    "mfgarchon.alg.numerical.hjb_solvers.hjb_weno",
+    "mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm",
+    "mfgarchon.alg.numerical.hjb_solvers.hjb_fdm",
+    "mfgarchon.alg.numerical.fp_solvers.fp_fdm",
+    "mfgarchon.alg.numerical.fp_solvers.fp_fvm",
+    "mfgarchon.alg.numerical.fp_solvers.fp_gfdm",
+    "mfgarchon.alg.numerical.fp_solvers.fp_particle",
+    "mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian",
+    "mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint",
+)
+
+# name -> (kind, owning issue) for the solvers measured as NOT honouring PERIODIC on ebfc5c96.
+# Measured seams, 1D, Nx=21, sigma=0.3, T=0.5, Nt=10, exactly periodic input:
+#   HJBSemiLagrangianSolver 7.68e-01   FPParticleSolver   5.78e-01
+#   HJBWENOSolver           1.77e-01   FPSLAdjointSolver  1.25e-01
+#   HJBFDMSolver            1.53e-01   FPSLSolver         1.25e-01
+#   FPFDMSolver             1.11e-01
+# HJBGFDMSolver is separate: it declares PERIODIC and raises NotImplementedError for it.
+KNOWN_NOT_HONOURED = {
+    "HJBSemiLagrangianSolver": "#1820",
+    "HJBWENOSolver": "#1822",
+    "HJBFDMSolver": "#1822",
+    "HJBGFDMSolver": "#1822 (declares PERIODIC, raises NotImplementedError for it)",
+    "FPFDMSolver": "#1822",
+    "FPParticleSolver": "#1822",
+    "FPSLAdjointSolver": "#1822",
+    "FPSLSolver": "#1822",
+    "FPSLJacobianSolver": "#1822 (deprecated, retirement tracked in #1756)",
+}
+
+
+def _declaring_solvers() -> dict[str, type]:
+    """Every class in the searched modules whose `_SUPPORTED_BC_TYPES` contains PERIODIC."""
+    found: dict[str, type] = {}
+    for module_name in _SEARCHED:
+        module = importlib.import_module(module_name)
+        for name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module_name:
+                continue
+            declared = getattr(cls, "_SUPPORTED_BC_TYPES", None)
+            if declared and BCType.PERIODIC in declared:
+                found[name] = cls
+    return found
+
+
+def _periodic_problem() -> MFGProblem:
+    return MFGProblem(
+        geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=periodic_bc(dimension=1)),
+        T=0.5,
+        Nt=NT,
+        sigma=0.3,
+        components=MFGComponents(
+            m_initial=lambda z: 1.0 + 0.5 * np.cos(2 * np.pi * np.asarray(z)),
+            u_terminal=lambda z: np.sin(2 * np.pi * np.asarray(z)),
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _seam(field: np.ndarray) -> float:
+    arr = np.asarray(field)
+    if arr.ndim == 1:
+        arr = arr[None, :]
+    return float(np.abs(arr[:, 0] - arr[:, -1]).max())
+
+
+def _solve_periodic(cls: type) -> np.ndarray:
+    """Run one solve from exactly periodic data and return the field it produced."""
+    x = np.linspace(0.0, 1.0, NX)
+    u_periodic = np.sin(2 * np.pi * x)
+    m_periodic = 1.0 + 0.5 * np.cos(2 * np.pi * x)
+    assert _seam(u_periodic) < 1e-15, "the u input itself must be periodic, or the output tells us nothing"
+    assert _seam(m_periodic) < 1e-15, "the m input itself must be periodic, or the output tells us nothing"
+
+    problem = _periodic_problem()
+    kwargs = {}
+    if "collocation_points" in inspect.signature(cls.__init__).parameters:
+        kwargs["collocation_points"] = x.reshape(-1, 1)
+    solver = cls(problem, **kwargs)
+
+    if hasattr(solver, "solve_hjb_system"):
+        return solver.solve_hjb_system(np.tile(m_periodic, (NT + 1, 1)), u_periodic, np.zeros((NT + 1, NX)))
+    return solver.solve_fp_system(m_periodic, np.tile(u_periodic, (NT + 1, 1)))
+
+
+def _parametrised():
+    for name, cls in sorted(_declaring_solvers().items()):
+        marks = []
+        if name in KNOWN_NOT_HONOURED:
+            marks.append(
+                pytest.mark.xfail(
+                    strict=True,
+                    reason=f"{name} declares PERIODIC and does not honour it ({KNOWN_NOT_HONOURED[name]})",
+                )
+            )
+        yield pytest.param(name, cls, marks=marks, id=name)
+
+
+@pytest.mark.parametrize(("name", "cls"), list(_parametrised()))
+def test_a_periodic_solve_returns_a_periodic_field(name, cls):
+    """x_min and x_max are the same point, so the solver's own output must agree there."""
+    field = _solve_periodic(cls)
+    assert np.isfinite(np.asarray(field)).all(), f"{name} produced non-finite values"
+    seam = _seam(field)
+    assert seam < SEAM_TOL, (
+        f"{name} declares BCType.PERIODIC but returned a field with a seam of {seam:.4e} between "
+        f"x_min and x_max, which are the same physical point on a periodic domain"
+    )
+
+
+def _declaring_solvers_from_source() -> set[str]:
+    """The same question answered from the package's SOURCE TEXT, not from imports.
+
+    Deliberately a second mechanism. The obvious coverage test -- compare `_parametrised()` against
+    `_declaring_solvers()` -- is tautological, because both derive from `_SEARCHED`: dropping a
+    module from that tuple removes it from each side and the comparison still passes. Measured:
+    deleting `fp_fvm` from `_SEARCHED` left that version of this test green while the matrix
+    silently stopped covering a solver. An AST walk over the files cannot be narrowed by editing
+    `_SEARCHED`, which is the whole point.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3] / "mfgarchon" / "alg" / "numerical"
+    names: set[str] = set()
+    for path in sorted(root.rglob("*.py")):
+        source = path.read_text()
+        if "_SUPPORTED_BC_TYPES" not in source:
+            continue
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for stmt in node.body:
+                targets = [stmt.target] if isinstance(stmt, ast.AnnAssign) else getattr(stmt, "targets", [])
+                if not any(isinstance(t, ast.Name) and t.id == "_SUPPORTED_BC_TYPES" for t in targets):
+                    continue
+                if stmt.value is not None and "PERIODIC" in ast.get_source_segment(source, stmt.value):
+                    names.add(node.name)
+    return names
+
+
+def test_the_matrix_covers_every_declaring_solver():
+    """A new solver cannot declare PERIODIC and quietly sit outside this ratchet.
+
+    Without this, the file measures whatever it happens to list, and a solver added later is
+    absent rather than failing -- which reads identically to passing.
+    """
+    from_source = _declaring_solvers_from_source()
+    parametrised = {p.id for p in _parametrised()}
+    uncovered = from_source - parametrised
+    assert not uncovered, (
+        f"these classes declare PERIODIC in their source and are not in this matrix: "
+        f"{sorted(uncovered)}. Add them, or the ratchet measures whatever it happens to list."
+    )
+    # The reverse direction is deliberately NOT asserted. A subclass inherits the declaration
+    # without restating it -- `FPSLAdjointSolver` is the deprecated alias of `FPSLSolver` (#710)
+    # and reaches a user as a PERIODIC-declaring solver while defining no `_SUPPORTED_BC_TYPES` of
+    # its own. It belongs in the matrix and will never appear in an AST walk of declaration sites.
+
+
+def test_the_known_broken_list_names_only_solvers_that_exist():
+    """A stale entry here would silently xfail nothing and hide a regression elsewhere."""
+    declaring = set(_declaring_solvers())
+    stale = set(KNOWN_NOT_HONOURED) - declaring
+    assert not stale, f"KNOWN_NOT_HONOURED names solvers that no longer declare PERIODIC: {sorted(stale)}"


### PR DESCRIPTION
Step 1 of the order proposed in #1822. **This adds the measurement, not the repairs.**

## What it measures

`TensorProductGrid(bounds=[(0,1)], Nx_points=[21])` is endpoint-inclusive, so under a periodic BC
`x[0]` and `x[-1]` are the same physical point and any returned field must agree there. Exact zero
in exact arithmetic. One solve from exactly periodic input (`seam 2.2e-16`) through every solver
declaring `BCType.PERIODIC`:

| solver | seam | |
|---|---|---|
| `HJBSemiLagrangianSolver` | 7.68e-01 | xfail (#1820) |
| `FPParticleSolver` | 5.78e-01 | xfail |
| `HJBWENOSolver` | 1.77e-01 | xfail |
| `HJBFDMSolver` | 1.53e-01 | xfail |
| `FPSLSolver` / `FPSLAdjointSolver` | 1.25e-01 | xfail |
| `FPFDMSolver` | 1.11e-01 | xfail |
| `FPSLJacobianSolver` | — | xfail (deprecated, #1756) |
| `HJBGFDMSolver` | raises `NotImplementedError` for PERIODIC | xfail |
| `FPFVMSolver` | 2.22e-16 | honours it |
| `FPGFDMSolver` | 2.24e-11 | honours it |

**Nine of eleven.** `HJBGFDMSolver` is the sharpest case: the declaration contradicts its own code,
which a check could have caught the day it was written.

## Why a ratchet rather than eight fixes

`_SUPPORTED_BC_TYPES` is read by the dispatcher to decide whether to **refuse**, and by nothing to
decide whether the code **honours**. So the claim costs nothing to make and nothing to break. #1257
fixed the periodic seam of one diffusion sub-step of one solver; #1739 fixed one departure fold of
another. Both are green. The class was never measured, and the sweep still returns nine.

`xfail(strict=True)` makes the count monotone: repairing a solver turns XFAIL into XPASS, which
fails the suite until the marker is removed in the same change.

## The two guards, and one of them was wrong first

- **Coverage** is checked from an **AST walk over `mfgarchon/alg/numerical/`** for declaration
  sites, not from the import list the matrix is built from. My first version compared the matrix
  against `_declaring_solvers()` — both derive from `_SEARCHED`, so deleting a module from that
  tuple removed it from *both sides* and the test stayed green while coverage silently shrank. I
  found that by mutating it, not by reading it; the independent-source version fails as it should.
- **The reverse direction is deliberately not asserted.** `FPSLAdjointSolver` inherits the
  declaration from `FPSLSolver` (#710) without restating it, so it reaches a user as a
  PERIODIC-declaring solver and can never appear in a walk of declaration sites.

## Oracle

**(1) An external oracle** — periodicity is a property of the continuous problem, computed
independently of every scheme here, so it cannot go tautological when these solvers are later
consolidated.

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, exit 0.

Independent adversarial review has **not** been run.

Refs #1822, #1574, #1820, #1739, #1257, #1756.