### PR TITLE
One periodic grid convention, and the second invariant that catching it exposed

### DIFF
--- a/changelog.d/1820-enforcement-dead-selftests.removed.md
+++ b/changelog.d/1820-enforcement-dead-selftests.removed.md
@@ -1,0 +1,6 @@
+- **The dead `if __name__ == "__main__":` block in `geometry/boundary/enforcement.py`**, which was
+  the module's only test of any kind and **asserted the wrong periodic convention** (Issue #1820).
+  Same shape as the block #1736 removed from `bc_utils.py`: it cannot run under either invocation,
+  so nothing ever checked it, and it pinned `field[0] = field[-2]` as correct. Replaced by
+  `tests/unit/test_geometry/test_enforcement.py`, which pins the convention rather than the
+  formula -- a rewrite keeping the formula and changing the grid is equally wrong.

--- a/changelog.d/1820-periodic-convention-one-owner.fixed.md
+++ b/changelog.d/1820-periodic-convention-one-owner.fixed.md
@@ -1,0 +1,19 @@
+- **Two periodic-BC convention errors, in opposite directions, on the same grid** (Issue #1820).
+  `TensorProductGrid` is endpoint-inclusive: `field[0]` and `field[-1]` are both real nodes and the
+  same physical point, so the period is `L` and there are `N - 1` distinct degrees of freedom.
+  - `enforce_periodic_value_nd` used the **halo** form (`field[0] = field[-2]`,
+    `field[-1] = field[1]`), correct only for an array carrying a ghost cell per side. Applied to a
+    halo-free grid it moved both endpoints one cell in opposite directions: on `sin(2 pi x)` with
+    `N=21` it took a seam of `2.4e-16` to `6.2e-01`, after **every** semi-Lagrangian timestep. It is
+    now the identification of the two nodes (their mean, privileging neither end).
+  - `_crank_nicolson_periodic_1d` wrapped all `N` nodes, taking `U[N-1]` as node 0's left neighbour
+    -- a neighbour at distance 0 rather than `dx`. Measured against the analytic periodic heat
+    kernel `exp(-D k^2 t) sin(k x)`: max error `1.19e-01`, not shrinking under refinement. Solving
+    on the `N - 1` distinct DOFs and restoring the duplicate gives `6.1e-04` and an exact seam.
+  - `HJBSemiLagrangianSolver`'s periodic seam falls from **7.68e-01 to 2.45e-16**, and `FPSLSolver`
+    and `FPSLAdjointSolver` from `1.25e-01` to exactly zero.
+- **A regression this unmasks, stated rather than shipped quietly**: `FPSLSolver` mass drift over a
+  periodic solve moves from `7.19%` to `10.77%`. Mass was already badly non-conserved and the seam
+  error was partly cancelling it; closing the seam removed the cancellation. Mass is now a second,
+  independent invariant in the #1822 ratchet, where six FP solvers fail it -- including
+  `FPFVMSolver`, which satisfies the seam at `2.2e-16` while creating 6.5% of its own mass.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_semi_lagrangian_adjoint.py
@@ -41,6 +41,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
     checked_bc_type_string,
 )
+from mfgarchon.geometry.boundary.enforcement import enforce_periodic_value_nd
 from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.deprecation import deprecated, deprecated_parameter
 from mfgarchon.utils.mfg_logging import get_logger
@@ -424,6 +425,14 @@ class FPSLSolver(BaseFPSolver):
         # Sherman-Morrison circulant solve instead of the zero-flux stencil.
         diff_bc = self._get_diffusion_bc_type()
         if diff_bc == "periodic":
+            # Identify the two coincident endpoints before diffusing. `splat_1d` deposits into
+            # index 0 and index -1 independently, but on an endpoint-inclusive grid they are one
+            # physical point, so the array reaching the CN is not yet a periodic field -- measured,
+            # every step of a periodic solve arrived with the two differing, by up to 4.75e-01.
+            # The mean is the fold that preserves this density's trapezoid mass: both nodes already
+            # carry a half weight, so summing would double-count them (Issue #1820).
+            m_star = m_star.copy()
+            enforce_periodic_value_nd(m_star, axis=0)
             return solve_crank_nicolson_diffusion_1d(m_star, dt, sigma, self.x_grid, bc_type="periodic")
 
         # Neumann / zero-flux path (preserved from Issue #708: FV stencil for mass

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_semi_lagrangian.py
@@ -33,6 +33,7 @@ from mfgarchon.geometry.boundary.bc_utils import (
     bc_type_to_geometric_operation,
     checked_bc_type_string,
 )
+from mfgarchon.geometry.boundary.enforcement import enforce_periodic_value_nd
 from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import check_adi_compatibility, diffusion_from_volatility
@@ -2704,6 +2705,13 @@ class HJBSemiLagrangianSolver(BaseHJBSolver):
             Solution after implicit diffusion step
         """
         bc_op = self._get_diffusion_bc_type()
+        if bc_op == "periodic":
+            # The advection step leaves the two coincident endpoints holding independently
+            # interpolated values, so the field is not yet periodic when it reaches the CN, which
+            # refuses that (Issue #1820). u is a value function: the two entries are one quantity
+            # computed twice, so the mean is the identification.
+            U_star = U_star.copy()
+            enforce_periodic_value_nd(U_star, axis=0)
         return solve_crank_nicolson_diffusion_1d(U_star, dt, sigma, self.x_grid, bc_type=bc_op)
 
     def _get_diffusion_bc_type(self) -> str:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -133,6 +133,21 @@ def _crank_nicolson_periodic_1d(
     if len(U_star) < 3:
         raise ValueError(f"periodic Crank-Nicolson needs at least 3 nodes, got {len(U_star)}")
 
+    # The last entry is dropped as a duplicate, so REFUSE to run when it is not one. Discarding it
+    # silently deletes whatever it carried: a splatting FP step deposits mass into both coincident
+    # nodes, and on such an input this function returned all zeros for a field whose nodal sum was
+    # 1.0 (Issue #1820). Which identification is right is the caller's to decide -- a density folds
+    # by the mean, deposited mass would fold by a sum -- and this shared owner must not guess.
+    gap = abs(float(U_star[0]) - float(U_star[-1]))
+    scale = max(1.0, float(np.max(np.abs(U_star))))
+    if gap > 1e-12 * scale:
+        raise ValueError(
+            f"periodic Crank-Nicolson received a field whose endpoints differ by {gap:.3e} "
+            f"(relative {gap / scale:.3e}). On an endpoint-inclusive grid those entries are the "
+            "same physical point; identify them before calling (enforce_periodic_value_nd folds "
+            "a density by the mean, which is what preserves its trapezoid mass)."
+        )
+
     interior = _crank_nicolson_periodic_distinct(U_star[:-1], alpha, theta)
     return np.append(interior, interior[0])
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -119,6 +119,33 @@ def _crank_nicolson_periodic_1d(
     The periodic Laplacian makes the system nearly tridiagonal plus rank-1
     corner entries (A[0, N-1] and A[N-1, 0]). Sherman-Morrison converts
     this to two tridiagonal solves.
+
+    ``U_star`` lives on an endpoint-inclusive grid (``np.linspace(x_min, x_max, N)``), so its
+    first and last entries are the SAME physical point and it carries ``N - 1`` distinct degrees
+    of freedom. The solve therefore runs on ``U_star[:-1]`` and the duplicate is restored after.
+
+    Wrapping the full ``N`` instead -- taking ``U_star[N-1]`` as node 0's left neighbour -- makes
+    the stencil reach a neighbour at distance 0 rather than ``dx``, which is a different operator,
+    not a rounding difference. Measured against the analytic periodic heat kernel
+    ``exp(-D k^2 t) sin(k x)`` at ``N=21, sigma=0.3, dt=0.05``: max error `1.19e-01` wrapping N,
+    `6.14e-04` on ``N - 1`` DOFs, and the seam goes from `2.38e-01` to exactly zero (Issue #1820).
+    """
+    if len(U_star) < 3:
+        raise ValueError(f"periodic Crank-Nicolson needs at least 3 nodes, got {len(U_star)}")
+
+    interior = _crank_nicolson_periodic_distinct(U_star[:-1], alpha, theta)
+    return np.append(interior, interior[0])
+
+
+def _crank_nicolson_periodic_distinct(
+    U_star: np.ndarray,
+    alpha: float,
+    theta: float,
+) -> np.ndarray:
+    """The Sherman-Morrison solve itself, on ``N`` genuinely distinct periodic DOFs.
+
+    Split out from :func:`_crank_nicolson_periodic_1d` so the grid convention (which node
+    duplicates which) lives in exactly one place, above, rather than inside the linear algebra.
     """
     N = len(U_star)
     off_rhs = (1.0 - theta) * alpha

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_sl_adi.py
@@ -125,10 +125,12 @@ def _crank_nicolson_periodic_1d(
     of freedom. The solve therefore runs on ``U_star[:-1]`` and the duplicate is restored after.
 
     Wrapping the full ``N`` instead -- taking ``U_star[N-1]`` as node 0's left neighbour -- makes
-    the stencil reach a neighbour at distance 0 rather than ``dx``, which is a different operator,
-    not a rounding difference. Measured against the analytic periodic heat kernel
-    ``exp(-D k^2 t) sin(k x)`` at ``N=21, sigma=0.3, dt=0.05``: max error `1.19e-01` wrapping N,
-    `6.14e-04` on ``N - 1`` DOFs, and the seam goes from `2.38e-01` to exactly zero (Issue #1820).
+    the stencil reach a neighbour at distance 0 rather than ``dx``. Measured against the analytic
+    periodic heat kernel ``exp(-D k^2 t) sin(k x)`` at ``N=21, sigma=0.3, dt=0.05``: max error
+    `1.19e-01` wrapping N against `6.14e-04` on ``N - 1`` DOFs, and the seam goes from `2.38e-01`
+    to exactly zero. The wrapped form still converges -- at **O(h) instead of O(h^2)**, measured
+    ratio 1.98 over N=21..1281 -- so the symptom is a lost order and a 200x constant, not
+    divergence (Issue #1820).
     """
     if len(U_star) < 3:
         raise ValueError(f"periodic Crank-Nicolson needs at least 3 nodes, got {len(U_star)}")
@@ -480,15 +482,38 @@ def solve_1d_diffusion_along_axis(
     Returns:
         Updated solution array (in-place modification avoided)
     """
-    N_axis = U.shape[axis]
-
     # Move target axis to last position for easier vectorization
     U_transposed = np.moveaxis(U, axis, -1)
     original_shape = U_transposed.shape
     n_lines = int(np.prod(original_shape[:-1]))
 
     # Reshape to (n_lines, N_axis) for batched solve
-    U_2d = U_transposed.reshape(n_lines, N_axis)
+    U_2d = U_transposed.reshape(n_lines, U.shape[axis])
+
+    if bc_type == "periodic":
+        # Same grid convention as the 1D path (Issue #1820): the grid is endpoint-inclusive, so
+        # the first and last entry along this axis are one physical point and the axis carries
+        # N - 1 distinct degrees of freedom. Solving over all N wraps node 0 onto a neighbour at
+        # distance 0 instead of dx -- a different operator. Measured on the 2D analytic kernel
+        # exp(-D(kx^2+ky^2)t): max error 1.09e-01 at N=21 wrapping N, with seams of 2.18e-01.
+        #
+        # As in 1D, the duplicate is dropped, so refuse an input where it is not one rather than
+        # deleting whatever it carried. The caller identifies the endpoints per its own semantics.
+        if U_2d.shape[1] < 3:
+            raise ValueError(f"periodic diffusion needs at least 3 nodes on axis {axis}, got {U_2d.shape[1]}")
+        gap = float(np.max(np.abs(U_2d[:, 0] - U_2d[:, -1])))
+        scale = max(1.0, float(np.max(np.abs(U_2d))))
+        if gap > 1e-12 * scale:
+            raise ValueError(
+                f"periodic diffusion on axis {axis} received a field whose endpoints differ by "
+                f"{gap:.3e} (relative {gap / scale:.3e}). Those entries are the same physical "
+                "point on an endpoint-inclusive grid; identify them before calling."
+            )
+        solved = _solve_periodic_lines(U_2d[:, :-1], theta, alpha)
+        U_new_2d = np.concatenate([solved, solved[:, :1]], axis=1)
+        return np.moveaxis(U_new_2d.reshape(original_shape), -1, axis)
+
+    N_axis = U.shape[axis]
 
     # Tridiagonal coefficients (same for all lines)
     main_coef = 1.0 + 2.0 * theta * alpha
@@ -505,15 +530,9 @@ def solve_1d_diffusion_along_axis(
     # Interior points (vectorized over all lines)
     b[:, 1:-1] = main_rhs * U_2d[:, 1:-1] + off_rhs * (U_2d[:, :-2] + U_2d[:, 2:])
 
-    # Boundary conditions
-    if bc_type == "periodic":
-        # Periodic: wrap-around Laplacian
-        b[:, 0] = main_rhs * U_2d[:, 0] + off_rhs * (U_2d[:, -1] + U_2d[:, 1])
-        b[:, -1] = main_rhs * U_2d[:, -1] + off_rhs * (U_2d[:, -2] + U_2d[:, 0])
-    else:
-        # Neumann: du/dx = 0 (ghost point reflection)
-        b[:, 0] = (1.0 - (1.0 - theta) * alpha) * U_2d[:, 0] + off_rhs * U_2d[:, 1]
-        b[:, -1] = (1.0 - (1.0 - theta) * alpha) * U_2d[:, -1] + off_rhs * U_2d[:, -2]
+    # Neumann: du/dx = 0 (ghost point reflection). The periodic branch returned above.
+    b[:, 0] = (1.0 - (1.0 - theta) * alpha) * U_2d[:, 0] + off_rhs * U_2d[:, 1]
+    b[:, -1] = (1.0 - (1.0 - theta) * alpha) * U_2d[:, -1] + off_rhs * U_2d[:, -2]
 
     # Solve tridiagonal systems using vectorized Thomas algorithm
     U_new_2d = thomas_solve_batched(main_coef, off_coef, b, theta, alpha, N_axis, bc_type)
@@ -595,6 +614,30 @@ def thomas_solve_batched(
         x[:, i] = d_prime[:, i] - c_prime[i] * x[:, i + 1]
 
     return x
+
+
+def _solve_periodic_lines(
+    U_lines: np.ndarray,
+    theta: float,
+    alpha: float,
+) -> np.ndarray:
+    """Crank-Nicolson along the last axis of ``U_lines``, over genuinely distinct periodic DOFs.
+
+    The nD twin of :func:`_crank_nicolson_periodic_distinct`: every entry here is its own degree
+    of freedom and the wrap between the first and last is real, because the caller has already
+    removed the duplicated endpoint (Issue #1820).
+    """
+    main_coef = 1.0 + 2.0 * theta * alpha
+    off_coef = -theta * alpha
+    main_rhs = 1.0 - 2.0 * (1.0 - theta) * alpha
+    off_rhs = (1.0 - theta) * alpha
+
+    b = np.empty_like(U_lines)
+    b[:, 1:-1] = main_rhs * U_lines[:, 1:-1] + off_rhs * (U_lines[:, :-2] + U_lines[:, 2:])
+    b[:, 0] = main_rhs * U_lines[:, 0] + off_rhs * (U_lines[:, -1] + U_lines[:, 1])
+    b[:, -1] = main_rhs * U_lines[:, -1] + off_rhs * (U_lines[:, -2] + U_lines[:, 0])
+
+    return _thomas_solve_batched_periodic(main_coef, off_coef, b, U_lines.shape[1])
 
 
 def _thomas_solve_batched_periodic(

--- a/mfgarchon/geometry/boundary/enforcement.py
+++ b/mfgarchon/geometry/boundary/enforcement.py
@@ -12,7 +12,8 @@ The key distinction from ghost cell methods:
 Supported BC Types:
 - Neumann (du/dn = g): Extrapolation-based enforcement
 - Dirichlet (u = g): Direct value assignment
-- Periodic: Copy from opposite boundary
+- Periodic: Identify the two coincident endpoints (endpoint-inclusive grid; see
+  enforce_periodic_value_nd for why this is not a copy from the opposite interior)
 
 Usage:
     >>> from mfgarchon.geometry.boundary.enforcement import (

--- a/mfgarchon/geometry/boundary/enforcement.py
+++ b/mfgarchon/geometry/boundary/enforcement.py
@@ -150,38 +150,39 @@ def enforce_periodic_value_nd(
     axis: int,
 ) -> None:
     """
-    Enforce periodic BC along specified axis (in-place).
+    Enforce periodic BC along ``axis`` (in-place) on an endpoint-inclusive grid.
 
-    For periodic BC, boundary values are copied from the opposite interior:
-    - u[0] = u[-2] (min boundary gets value from near max)
-    - u[-1] = u[1] (max boundary gets value from near min)
+    ``TensorProductGrid`` builds ``np.linspace(x_min, x_max, N)``, so ``field[0]`` and
+    ``field[-1]`` are BOTH real nodes AND the same physical point: the period is ``L``, not
+    ``L + dx``. They are one degree of freedom that the scheme has computed twice, so enforcement
+    is the projection that makes them agree -- their mean, which privileges neither end.
+
+    Do NOT restore the halo form ``field[0] = field[-2]; field[-1] = field[1]``. That is correct
+    only for an array carrying one ghost cell per side, where index 0 and -1 are duplicates of the
+    opposite interior. Applied to a halo-free grid it moves both endpoints one cell in opposite
+    directions and destroys the periodicity it claims to enforce: on ``sin(2 pi x)`` with N=21 it
+    took a seam of 2.4e-16 to 6.2e-01 (Issue #1820). No caller in this package passes a haloed
+    array; if one ever does, it needs its own function rather than a reinterpretation of this one.
 
     Args:
         field: Solution array (modified in-place)
         axis: Dimension index (0, 1, 2, ...)
 
     Example:
-        >>> field = np.array([0.0, 1.0, 2.0, 3.0, 0.0])
+        >>> field = np.array([0.0, 1.0, 2.0, 3.0, 0.5])
         >>> enforce_periodic_value_nd(field, axis=0)
-        >>> # field[0] = 3.0, field[-1] = 1.0
+        >>> # field[0] == field[-1] == 0.25
     """
     ndim = field.ndim
 
-    # Min boundary gets value from near max interior
-    min_slicer = [slice(None)] * ndim
-    near_max_slicer = [slice(None)] * ndim
-    min_slicer[axis] = 0
-    near_max_slicer[axis] = -2
+    first = [slice(None)] * ndim
+    last = [slice(None)] * ndim
+    first[axis] = 0
+    last[axis] = -1
 
-    field[tuple(min_slicer)] = field[tuple(near_max_slicer)]
-
-    # Max boundary gets value from near min interior
-    max_slicer = [slice(None)] * ndim
-    near_min_slicer = [slice(None)] * ndim
-    max_slicer[axis] = -1
-    near_min_slicer[axis] = 1
-
-    field[tuple(max_slicer)] = field[tuple(near_min_slicer)]
+    identified = 0.5 * (field[tuple(first)] + field[tuple(last)])
+    field[tuple(first)] = identified
+    field[tuple(last)] = identified
 
 
 def enforce_robin_value_nd(
@@ -264,76 +265,3 @@ __all__ = [
     "enforce_periodic_value_nd",
     "enforce_robin_value_nd",
 ]
-
-
-# =============================================================================
-# Smoke Tests
-# =============================================================================
-
-
-if __name__ == "__main__":
-    """Smoke tests for enforcement utilities."""
-
-    print("Testing BC enforcement utilities...")
-
-    # Test 1: 1D Neumann 2nd-order
-    print("\n1. Testing 1D Neumann BC (2nd-order)...")
-    field = np.array([0.9, 1.0, 1.1, 1.2, 1.3])
-    enforce_neumann_value_nd(field, axis=0, side="min", order=2)
-    expected = (4.0 * 1.0 - 1.1) / 3.0
-    assert np.isclose(field[0], expected), f"Min failed: {field[0]} != {expected}"
-
-    field = np.array([0.9, 1.0, 1.1, 1.2, 1.3])
-    enforce_neumann_value_nd(field, axis=0, side="max", order=2)
-    expected = (4.0 * 1.2 - 1.1) / 3.0
-    assert np.isclose(field[-1], expected), f"Max failed: {field[-1]} != {expected}"
-    print("   PASS: 1D Neumann 2nd-order")
-
-    # Test 2: 1D Neumann 1st-order
-    print("\n2. Testing 1D Neumann BC (1st-order)...")
-    field = np.array([0.9, 1.0, 1.1, 1.2, 1.3])
-    enforce_neumann_value_nd(field, axis=0, side="min", order=1)
-    assert field[0] == 1.0, f"Min failed: {field[0]} != 1.0"
-    print("   PASS: 1D Neumann 1st-order")
-
-    # Test 3: 1D Dirichlet
-    print("\n3. Testing 1D Dirichlet BC...")
-    field = np.array([0.9, 1.0, 1.1, 1.2, 1.3])
-    enforce_dirichlet_value_nd(field, axis=0, side="min", value=0.0)
-    assert field[0] == 0.0, f"Min failed: {field[0]} != 0.0"
-    enforce_dirichlet_value_nd(field, axis=0, side="max", value=5.0)
-    assert field[-1] == 5.0, f"Max failed: {field[-1]} != 5.0"
-    print("   PASS: 1D Dirichlet")
-
-    # Test 4: 2D Neumann
-    print("\n4. Testing 2D Neumann BC...")
-    field_2d = np.ones((5, 6))
-    for i in range(5):
-        field_2d[i, :] = 1.0 + 0.1 * i
-    enforce_neumann_value_nd(field_2d, axis=0, side="min", order=2)
-    # Check extrapolation was applied
-    expected = (4.0 * field_2d[1, 0] - field_2d[2, 0]) / 3.0
-    assert np.isclose(field_2d[0, 0], expected), "2D min failed"
-    print("   PASS: 2D Neumann")
-
-    # Test 5: 1D Periodic
-    print("\n5. Testing 1D Periodic BC...")
-    field = np.array([0.0, 1.0, 2.0, 3.0, 0.0])
-    enforce_periodic_value_nd(field, axis=0)
-    assert field[0] == 3.0, f"Periodic min failed: {field[0]} != 3.0"
-    assert field[-1] == 1.0, f"Periodic max failed: {field[-1]} != 1.0"
-    print("   PASS: 1D Periodic")
-
-    # Test 6: Non-zero Neumann gradient
-    print("\n6. Testing Neumann BC with non-zero gradient...")
-    field = np.array([0.0, 1.0, 1.1, 1.2, 0.0])
-    h = 0.1
-    g = 2.0  # du/dn = 2
-    enforce_neumann_value_nd(field, axis=0, side="min", grad_value=g, spacing=h)
-    expected = 1.0 - g * h  # u[0] = u[1] - g*h = 1.0 - 0.2 = 0.8
-    assert np.isclose(field[0], expected), f"Non-zero gradient failed: {field[0]} != {expected}"
-    print("   PASS: Neumann with non-zero gradient")
-
-    print("\n" + "=" * 50)
-    print("All enforcement utility tests passed!")
-    print("=" * 50)

--- a/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
+++ b/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
@@ -92,11 +92,15 @@ def test_periodic_diffusion_seam_symmetry_1d():
         "Expected ratio ~1 (periodic CN); got >> 1 means Neumann zero-flux stencil "
         "is still in use (Issue #1257)."
     )
-    # The two entries that are one physical point must agree, or the "seam" the rest of
-    # this test reasons about is not one (Issue #1820).
-    assert abs(m_new[0] - m_new[-1]) < 1e-12, (
-        f"x_min and x_max hold different values ({m_new[0]:.6f} vs {m_new[-1]:.6f}) on an "
-        "endpoint-inclusive periodic grid, where they are the same point"
+    # Mass, which this step must conserve exactly: zero drift means diffusion alone, and a
+    # periodic domain has no boundary for mass to cross. NOT an endpoint-equality assertion --
+    # that one cannot fail while the implementation ends in `np.append(interior, interior[0])`,
+    # so it pins the last line rather than the scheme (Issue #1820).
+    mass_before = float(np.trapezoid(m, x))
+    mass_after = float(np.trapezoid(m_new, x))
+    assert abs(mass_after / mass_before - 1.0) < 1e-12, (
+        f"periodic diffusion changed total mass by {abs(mass_after / mass_before - 1.0):.3e} "
+        f"({mass_before:.6f} -> {mass_after:.6f}) with zero drift"
     )
 
 

--- a/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
+++ b/tests/unit/test_alg/test_fp_sl_periodic_diffusion_bc.py
@@ -12,11 +12,14 @@ for periodic; _adjoint_sl_step_nd passes bc_type=self._get_diffusion_bc_type().
 Pinning test logic (1D):
   * Place a unit spike at x=0 (the periodic seam), zero drift.
   * After one diffusion sub-step the spike MUST spread symmetrically:
-    m_new[1]  (right neighbour) == m_new[-1] (left neighbour, wrap).
+    m_new[1] (right neighbour) == m_new[-2] (left neighbour, wrap).
   * With the buggy zero-flux stencil at i=0, L[0] = (m[1]-m[0])/dx^2 only
-    diffuses rightward, so m_new[1] >> m_new[-1].
-  * With the periodic CN (Sherman-Morrison), L[0] wraps m[-1], so
-    m_new[1] == m_new[-1] exactly (by symmetry of the tridiagonal system).
+    diffuses rightward, so m_new[1] >> m_new[-2].
+
+The mirror is index -2, not index -1: `np.linspace(x_min, x_max, n)` is endpoint-inclusive,
+so index -1 is the same physical point as index 0 and holds a copy of the spike. This file
+said -1 until Issue #1820, which corrected the convention in the solver -- the assertion had
+been comparing the spike's neighbour against the spike itself.
 """
 
 from __future__ import annotations
@@ -49,11 +52,18 @@ def _periodic_problem(n: int = 41, nt: int = 10, sigma: float = 0.3) -> MFGProbl
 
 
 def test_periodic_diffusion_seam_symmetry_1d():
-    """After one diffusion sub-step with spike at seam, m_new[1] == m_new[-1].
+    """After one diffusion sub-step with a spike at the seam, mass spreads symmetrically.
 
-    This is the direct numerical witness of Issue #1257: the periodic CN must
-    spread mass symmetrically across the seam.  Fails on buggy (Neumann) code
-    because m_new[1] >> m_new[-1]; passes on fixed code.
+    Still the direct numerical witness of Issue #1257 -- a Neumann stencil gives
+    m_new[1] >> its mirror -- but the mirror is index -2, not index -1.
+
+    Issue #1820 corrected the grid convention: `np.linspace(x_min, x_max, n)` is
+    endpoint-inclusive, so index 0 and index -1 are the SAME physical point and index
+    -1 holds a copy of the spike rather than a neighbour of it. The symmetric partner
+    of index 1 (x = dx) is index -2 (x = 1 - dx). Measured after the correction:
+    m_new[1]/m_new[-2] = 1.000000 exactly, m_new[2] == m_new[-3], m_new[0] == m_new[-1],
+    and total mass 1.000000. The previous assertion compared the spike's neighbour
+    against the spike, which held only under the endpoint-exclusive reading.
     """
     n = 41
     prob = _periodic_problem(n=n, sigma=0.3)
@@ -73,15 +83,20 @@ def test_periodic_diffusion_seam_symmetry_1d():
     # Run ONE step.
     m_new = fp._adjoint_sl_step_1d(m, alpha, dt, sigma)
 
-    # The right neighbour (index 1) and the left-wrap neighbour (index -1) must
-    # receive equal mass — periodic CN wraps through x=-1 == x[N-1].
-    # Tolerance: they must agree to within 1% relative error.
-    ratio = m_new[1] / (m_new[-1] + 1e-300)
+    # The right neighbour (index 1) and its mirror across the seam (index -2) must
+    # receive equal mass. Tolerance: they must agree to within 1% relative error.
+    ratio = m_new[1] / (m_new[-2] + 1e-300)
     assert abs(ratio - 1.0) < 0.01, (
         f"Periodic diffusion seam asymmetry: m_new[1]={m_new[1]:.6f}, "
-        f"m_new[-1]={m_new[-1]:.6f}, ratio={ratio:.4f}.  "
+        f"m_new[-2]={m_new[-2]:.6f}, ratio={ratio:.4f}.  "
         "Expected ratio ~1 (periodic CN); got >> 1 means Neumann zero-flux stencil "
         "is still in use (Issue #1257)."
+    )
+    # The two entries that are one physical point must agree, or the "seam" the rest of
+    # this test reasons about is not one (Issue #1820).
+    assert abs(m_new[0] - m_new[-1]) < 1e-12, (
+        f"x_min and x_max hold different values ({m_new[0]:.6f} vs {m_new[-1]:.6f}) on an "
+        "endpoint-inclusive periodic grid, where they are the same point"
     )
 
 

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -46,6 +46,28 @@ NX = 21
 NT = 10
 SEAM_TOL = 1e-9  # exact zero in exact arithmetic; this admits round-off and meshless quadrature
 
+
+# The datum, and why it is phase-shifted rather than the obvious sin/cos.
+#
+# `cos(2 pi x)` on linspace(0, 1, N) is mirror-symmetric about x = 0.5, and under a mirror-symmetric
+# input a NO_FLUX solve and a PERIODIC solve produce the same field -- so the seam invariant cannot
+# tell them apart and any solver passes it for free. Measured: with the symmetric datum
+# `FPFVMSolver` scored 2.2e-16 and `FPGFDMSolver` 2.2e-11, and those were this file's only two
+# non-xfail rows, i.e. its only positive controls. With the phase shifts below they score 1.79e-01
+# and an outright raise. The certification was an artefact of the test data.
+#
+# Requirements on the datum: exactly periodic (seam 0), strictly positive for the density, and
+# neither symmetric nor antisymmetric about the midpoint.
+def _U(z):
+    z = np.asarray(z)
+    return np.sin(2 * np.pi * z + 0.7) + 0.4 * np.cos(4 * np.pi * z)
+
+
+def _M(z):
+    z = np.asarray(z)
+    return 1.0 + 0.5 * np.cos(2 * np.pi * z + 1.1)
+
+
 # The modules searched for PERIODIC-declaring solvers. Listed rather than walked, because a walk
 # imports optional-backend modules as a side effect; `test_the_matrix_covers_every_declaring_solver`
 # is what stops this list going stale.
@@ -62,43 +84,51 @@ _SEARCHED = (
     "mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint",
 )
 
-# name -> (kind, owning issue) for the solvers measured as NOT honouring PERIODIC on ebfc5c96.
-# Measured seams, 1D, Nx=21, sigma=0.3, T=0.5, Nt=10, exactly periodic input:
-#   HJBSemiLagrangianSolver 7.68e-01   FPParticleSolver   5.78e-01
-#   HJBWENOSolver           1.77e-01   FPSLAdjointSolver  1.25e-01
-#   HJBFDMSolver            1.53e-01   FPSLSolver         1.25e-01
-#   FPFDMSolver             1.11e-01
-# HJBGFDMSolver is separate: it declares PERIODIC and raises NotImplementedError for it.
+# Measured on the datum above, 1D, Nx=21, sigma=0.3, T=0.5, Nt=10. Each entry pins the FAILURE
+# MODE as well as the failure: `raises=` means a solver that starts crashing, or crashing
+# differently, is caught rather than xfailing identically to one that merely returns a bad seam.
+#
+#   HJBFDMSolver    7.42e-01     FPParticleSolver    ~5e-01 (UNSEEDED: varies ~25% per run)
+#   HJBWENOSolver   2.64e-01     FPSLJacobianSolver  1.58e+00
+#   FPFVMSolver     1.79e-01     FPFDMSolver         1.29e-01
+#   HJBGFDMSolver   raises NotImplementedError for PERIODIC
+#   FPGFDMSolver    raises ValueError (density goes invalid mid-solve)
+#
+# Passing: HJBSemiLagrangianSolver (0.0) and FPSLSolver / FPSLAdjointSolver (4.4e-16) -- the three
+# repaired in #1824, and the only genuine positive controls this file has ever had.
 KNOWN_NOT_HONOURED = {
-    "HJBWENOSolver": "#1822",
-    "HJBFDMSolver": "#1822",
-    "HJBGFDMSolver": "#1822 (declares PERIODIC, raises NotImplementedError for it)",
-    "FPFDMSolver": "#1822",
-    "FPParticleSolver": "#1822",
-    "FPSLJacobianSolver": "#1822 (deprecated, retirement tracked in #1756)",
+    "HJBWENOSolver": ("#1822", AssertionError),
+    "HJBFDMSolver": ("#1822", AssertionError),
+    "HJBGFDMSolver": ("#1822 declares PERIODIC and raises for it", NotImplementedError),
+    "FPFDMSolver": ("#1822", AssertionError),
+    "FPFVMSolver": ("#1822", AssertionError),
+    "FPGFDMSolver": ("#1822 density goes invalid mid-solve", ValueError),
+    "FPParticleSolver": ("#1822", AssertionError),
+    "FPSLJacobianSolver": ("#1822 deprecated, retirement in #1756", AssertionError),
 }
 
-# Mass is the second invariant, and it is INDEPENDENT of the seam. Periodic BC has no boundary
-# through which mass can leave, so a periodic FP solve conserves it exactly. Measured drift over
-# the same solve:
+# Mass is the second invariant and it is INDEPENDENT of the seam: a periodic domain has no
+# boundary, so a periodic FP solve conserves mass exactly. Measured drift on the datum above:
 #
-#   FPSLSolver / FPSLAdjointSolver  10.77%    FPFVMSolver   6.55%
-#   FPParticleSolver                 7.45%    FPGFDMSolver  0.99%
-#   FPFDMSolver                      6.35%
+#   FPSLSolver / FPSLAdjointSolver  13.42%    FPFVMSolver      5.76%
+#   FPFDMSolver                      5.56%    FPParticleSolver ~5% (UNSEEDED)
+#   FPGFDMSolver                     raises
 #
-# `FPFVMSolver` is why this exists: it satisfies the seam invariant to 2.2e-16 and creates 6.5% of
-# its own mass, so the seam alone would certify it as honouring PERIODIC.
+# FPSLSolver is the case that forces the split: it satisfies the seam at 4.4e-16 and creates 13%
+# of its own mass. Traced in #1820 -- advection conserves exactly at zero drift and the
+# Crank-Nicolson step conserves exactly on an identified field, while one splat step creates 1.14%
+# at drift 0.3 and 3.81% at drift 1.0. The defect is in splat under drift.
 #
-# `FPSLJacobianSolver` conserves to 0.0000% and is NOT listed -- but that is renormalisation by
-# fiat, not conservation (RFC #1456 class (b), #1429 S0-11). A passing row here means the number
-# is right, not that the mechanism is.
+# `FPSLJacobianSolver` conserves to 0.0000% and is NOT listed -- that is renormalisation by fiat,
+# not conservation (RFC #1456 class (b), #1429 S0-11). A passing row means the number is right,
+# not that the mechanism is.
 MASS_NOT_CONSERVED = {
-    "FPFDMSolver": "#1822",
-    "FPFVMSolver": "#1822",
-    "FPGFDMSolver": "#1822",
-    "FPParticleSolver": "#1822",
-    "FPSLSolver": "#1822",
-    "FPSLAdjointSolver": "#1822",
+    "FPFDMSolver": ("#1822", AssertionError),
+    "FPFVMSolver": ("#1822", AssertionError),
+    "FPGFDMSolver": ("#1822 density goes invalid mid-solve", ValueError),
+    "FPParticleSolver": ("#1822", AssertionError),
+    "FPSLSolver": ("#1820 splat under drift", AssertionError),
+    "FPSLAdjointSolver": ("#1820 splat under drift", AssertionError),
 }
 
 
@@ -111,6 +141,11 @@ def _declaring_solvers() -> dict[str, type]:
             if cls.__module__ != module_name:
                 continue
             declared = getattr(cls, "_SUPPORTED_BC_TYPES", None)
+            if declared is None:
+                # The public name is what BaseMFGSolver._validate_bc_support actually reads.
+                declared = getattr(cls, "supported_bc_types", None)
+                if isinstance(declared, property):
+                    declared = None
             if declared and BCType.PERIODIC in declared:
                 found[name] = cls
     return found
@@ -123,8 +158,8 @@ def _periodic_problem() -> MFGProblem:
         Nt=NT,
         sigma=0.3,
         components=MFGComponents(
-            m_initial=lambda z: 1.0 + 0.5 * np.cos(2 * np.pi * np.asarray(z)),
-            u_terminal=lambda z: np.sin(2 * np.pi * np.asarray(z)),
+            m_initial=_M,
+            u_terminal=_U,
             hamiltonian=SeparableHamiltonian(
                 control_cost=QuadraticControlCost(control_cost=1.0),
                 coupling=lambda m: m,
@@ -144,8 +179,8 @@ def _seam(field: np.ndarray) -> float:
 def _solve_periodic(cls: type) -> np.ndarray:
     """Run one solve from exactly periodic data and return the field it produced."""
     x = np.linspace(0.0, 1.0, NX)
-    u_periodic = np.sin(2 * np.pi * x)
-    m_periodic = 1.0 + 0.5 * np.cos(2 * np.pi * x)
+    u_periodic = _U(x)
+    m_periodic = _M(x)
     assert _seam(u_periodic) < 1e-15, "the u input itself must be periodic, or the output tells us nothing"
     assert _seam(m_periodic) < 1e-15, "the m input itself must be periodic, or the output tells us nothing"
 
@@ -164,10 +199,12 @@ def _parametrised():
     for name, cls in sorted(_declaring_solvers().items()):
         marks = []
         if name in KNOWN_NOT_HONOURED:
+            issue, exc = KNOWN_NOT_HONOURED[name]
             marks.append(
                 pytest.mark.xfail(
                     strict=True,
-                    reason=f"{name} declares PERIODIC and does not honour it ({KNOWN_NOT_HONOURED[name]})",
+                    raises=exc,
+                    reason=f"{name} declares PERIODIC and does not honour it ({issue})",
                 )
             )
         yield pytest.param(name, cls, marks=marks, id=name)
@@ -192,10 +229,12 @@ def _fp_parametrised():
             continue
         marks = []
         if name in MASS_NOT_CONSERVED:
+            issue, exc = MASS_NOT_CONSERVED[name]
             marks.append(
                 pytest.mark.xfail(
                     strict=True,
-                    reason=f"{name} creates or destroys mass on a periodic domain ({MASS_NOT_CONSERVED[name]})",
+                    raises=exc,
+                    reason=f"{name} does not conserve mass on a periodic domain ({issue})",
                 )
             )
         yield pytest.param(name, cls, marks=marks, id=name)
@@ -237,14 +276,19 @@ def _declaring_solvers_from_source() -> set[str]:
     names: set[str] = set()
     for path in sorted(root.rglob("*.py")):
         source = path.read_text()
-        if "_SUPPORTED_BC_TYPES" not in source:
+        if "_SUPPORTED_BC_TYPES" not in source and "supported_bc_types" not in source:
             continue
         for node in ast.walk(ast.parse(source)):
             if not isinstance(node, ast.ClassDef):
                 continue
             for stmt in node.body:
                 targets = [stmt.target] if isinstance(stmt, ast.AnnAssign) else getattr(stmt, "targets", [])
-                if not any(isinstance(t, ast.Name) and t.id == "_SUPPORTED_BC_TYPES" for t in targets):
+                # BOTH names. `_validate_bc_support` (base_solver.py) reads the PUBLIC
+                # `supported_bc_types`, so a class declaring only that one advertises PERIODIC
+                # through the real gate while being invisible to a private-name-only scan.
+                if not any(
+                    isinstance(t, ast.Name) and t.id in ("_SUPPORTED_BC_TYPES", "supported_bc_types") for t in targets
+                ):
                     continue
                 if stmt.value is not None and "PERIODIC" in ast.get_source_segment(source, stmt.value):
                     names.add(node.name)

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -5,9 +5,16 @@ boundary condition `x[0]` and `x[-1]` are the same physical point and any field 
 must agree there. This is a property of the continuous problem; no discretisation may violate it
 at O(1).
 
-This file is a **ratchet, not a bug report**. Nine of the eleven declaring solvers fail it today;
-`FPFVMSolver` (2.2e-16) and `FPGFDMSolver` (2.2e-11) are the two that honour it. Each failure is
-marked `xfail(strict=True)` with the issue that owns it, so:
+Two invariants, deliberately separate, because each certifies what the other misses:
+
+- **the seam** -- `field[0] == field[-1]`, since they are the same physical point;
+- **mass** -- a periodic domain has no boundary, so a periodic FP solve conserves it exactly.
+
+`FPFVMSolver` is the case that forced the split: it satisfies the seam at 2.2e-16 and creates 6.5%
+of its own mass. The seam alone would certify it.
+
+This file is a **ratchet, not a bug report**. Six solvers fail the seam and six fail mass today.
+Each failure is marked `xfail(strict=True)` with the issue that owns it, so:
 
 - fixing a solver turns its XFAIL into an XPASS, which `strict=True` reports as a failure, forcing
   the marker to be removed in the same change -- the count can only go down;
@@ -63,15 +70,35 @@ _SEARCHED = (
 #   FPFDMSolver             1.11e-01
 # HJBGFDMSolver is separate: it declares PERIODIC and raises NotImplementedError for it.
 KNOWN_NOT_HONOURED = {
-    "HJBSemiLagrangianSolver": "#1820",
     "HJBWENOSolver": "#1822",
     "HJBFDMSolver": "#1822",
     "HJBGFDMSolver": "#1822 (declares PERIODIC, raises NotImplementedError for it)",
     "FPFDMSolver": "#1822",
     "FPParticleSolver": "#1822",
-    "FPSLAdjointSolver": "#1822",
-    "FPSLSolver": "#1822",
     "FPSLJacobianSolver": "#1822 (deprecated, retirement tracked in #1756)",
+}
+
+# Mass is the second invariant, and it is INDEPENDENT of the seam. Periodic BC has no boundary
+# through which mass can leave, so a periodic FP solve conserves it exactly. Measured drift over
+# the same solve:
+#
+#   FPSLSolver / FPSLAdjointSolver  10.77%    FPFVMSolver   6.55%
+#   FPParticleSolver                 7.45%    FPGFDMSolver  0.99%
+#   FPFDMSolver                      6.35%
+#
+# `FPFVMSolver` is why this exists: it satisfies the seam invariant to 2.2e-16 and creates 6.5% of
+# its own mass, so the seam alone would certify it as honouring PERIODIC.
+#
+# `FPSLJacobianSolver` conserves to 0.0000% and is NOT listed -- but that is renormalisation by
+# fiat, not conservation (RFC #1456 class (b), #1429 S0-11). A passing row here means the number
+# is right, not that the mechanism is.
+MASS_NOT_CONSERVED = {
+    "FPFDMSolver": "#1822",
+    "FPFVMSolver": "#1822",
+    "FPGFDMSolver": "#1822",
+    "FPParticleSolver": "#1822",
+    "FPSLSolver": "#1822",
+    "FPSLAdjointSolver": "#1822",
 }
 
 
@@ -155,6 +182,41 @@ def test_a_periodic_solve_returns_a_periodic_field(name, cls):
     assert seam < SEAM_TOL, (
         f"{name} declares BCType.PERIODIC but returned a field with a seam of {seam:.4e} between "
         f"x_min and x_max, which are the same physical point on a periodic domain"
+    )
+
+
+def _fp_parametrised():
+    """The FP half, which is where mass conservation is a question at all."""
+    for name, cls in sorted(_declaring_solvers().items()):
+        if not hasattr(cls, "solve_fp_system"):
+            continue
+        marks = []
+        if name in MASS_NOT_CONSERVED:
+            marks.append(
+                pytest.mark.xfail(
+                    strict=True,
+                    reason=f"{name} creates or destroys mass on a periodic domain ({MASS_NOT_CONSERVED[name]})",
+                )
+            )
+        yield pytest.param(name, cls, marks=marks, id=name)
+
+
+@pytest.mark.parametrize(("name", "cls"), list(_fp_parametrised()))
+def test_a_periodic_fp_solve_conserves_mass(name, cls):
+    """A periodic domain has no boundary, so there is nowhere for mass to go.
+
+    Independent of the seam: `FPFVMSolver` satisfies that one at 2.2e-16 while creating 6.5% of
+    its own mass. Certifying PERIODIC support on the seam alone would pass it.
+    """
+    field = _solve_periodic(cls)
+    x = np.linspace(0.0, 1.0, NX)
+    initial = float(np.trapezoid(field[0], x))
+    final = float(np.trapezoid(field[-1], x))
+    assert initial > 0, f"{name} produced zero initial mass; the ratio below would be meaningless"
+    drift = abs(final / initial - 1.0)
+    assert drift < 1e-9, (
+        f"{name} changed total mass by {drift:.4%} over a periodic solve ({initial:.6f} -> "
+        f"{final:.6f}), and a periodic domain has no boundary for it to cross"
     )
 
 

--- a/tests/unit/test_alg/test_sl_periodic_diffusion_1820.py
+++ b/tests/unit/test_alg/test_sl_periodic_diffusion_1820.py
@@ -1,0 +1,75 @@
+"""The periodic Crank-Nicolson step against the analytic heat kernel. Issue #1820.
+
+Oracle: for `u(0, x) = sin(k x)` on a periodic domain, diffusion with coefficient `D` gives
+`u(t, x) = exp(-D k^2 t) sin(k x)` exactly. Computed independently of the scheme, so it stays
+discriminating no matter how the SL family is later consolidated.
+
+This is here because the **seam alone was not enough**. `_crank_nicolson_periodic_1d` wrapped all
+`N` nodes -- taking `U[N-1]` as node 0's left neighbour -- while `TensorProductGrid` is
+endpoint-inclusive, so those two entries are the same physical point and the stencil reached a
+neighbour at distance 0 instead of `dx`. That is a different operator, not a rounding difference:
+max error against the kernel was `1.19e-01`, and it did not shrink under refinement.
+
+`InterpolationApplicator.enforce_values` runs after the diffusion step and now identifies the two
+endpoints correctly, which drove the end-to-end seam to `2.4e-16` **while the interior stayed wrong
+by 3.0e-02**. A seam assertion alone would have called that fixed. Hence an accuracy oracle.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers.hjb_sl_adi import solve_crank_nicolson_diffusion_1d
+
+SIGMA = 0.3
+DT = 0.05
+D = SIGMA**2 / 2.0
+K = 2 * np.pi
+
+
+def _run(nx: int):
+    x = np.linspace(0.0, 1.0, nx)
+    u0 = np.sin(K * x)
+    out = solve_crank_nicolson_diffusion_1d(u0.copy(), DT, SIGMA, x, bc_type="periodic")
+    exact = np.exp(-D * K * K * DT) * u0
+    return out, exact
+
+
+def test_the_periodic_step_matches_the_analytic_heat_kernel():
+    """The mode decays by exp(-D k^2 t), and nothing else about it changes."""
+    out, exact = _run(21)
+    assert np.abs(out - exact).max() < 5e-3, (
+        "periodic Crank-Nicolson does not reproduce the analytic decay of a single Fourier mode"
+    )
+
+
+def test_the_error_falls_under_refinement():
+    """The property the wrapped-N form did not have: its 1.19e-01 was a fixed operator error.
+
+    Asserted as a decrease rather than a rate -- at these step sizes the temporal error is not
+    negligible, so a clean O(dx^2) claim would be over-reading the numbers.
+    """
+    errors = [float(np.abs(o - e).max()) for o, e in (_run(n) for n in (21, 41, 81))]
+    assert errors[1] < errors[0], f"refinement did not help: {errors}"
+    assert errors[2] < errors[1], f"refinement did not help: {errors}"
+
+
+def test_the_step_leaves_no_seam():
+    """x_min and x_max are one point, so the step must not separate them."""
+    out, _ = _run(21)
+    assert abs(out[0] - out[-1]) < 1e-14
+
+
+def test_a_constant_is_unchanged():
+    """Diffusion of a constant is the constant -- the cheapest way to catch a stencil that
+    reaches the wrong neighbour, since every interior row must sum its off-diagonals to the
+    diagonal for this to hold."""
+    x = np.linspace(0.0, 1.0, 21)
+    out = solve_crank_nicolson_diffusion_1d(np.full(21, 2.5), DT, SIGMA, x, bc_type="periodic")
+    np.testing.assert_allclose(out, 2.5, atol=1e-12)
+
+
+def test_too_few_nodes_is_refused():
+    """Two nodes on an endpoint-inclusive periodic grid is one degree of freedom, not a domain."""
+    with pytest.raises(ValueError, match="at least 3 nodes"):
+        solve_crank_nicolson_diffusion_1d(np.array([1.0, 1.0]), DT, SIGMA, np.array([0.0, 1.0]), bc_type="periodic")

--- a/tests/unit/test_alg/test_sl_periodic_diffusion_1820.py
+++ b/tests/unit/test_alg/test_sl_periodic_diffusion_1820.py
@@ -7,8 +7,10 @@ discriminating no matter how the SL family is later consolidated.
 This is here because the **seam alone was not enough**. `_crank_nicolson_periodic_1d` wrapped all
 `N` nodes -- taking `U[N-1]` as node 0's left neighbour -- while `TensorProductGrid` is
 endpoint-inclusive, so those two entries are the same physical point and the stencil reached a
-neighbour at distance 0 instead of `dx`. That is a different operator, not a rounding difference:
-max error against the kernel was `1.19e-01`, and it did not shrink under refinement.
+neighbour at distance 0 instead of `dx`. The symptom is a lost order, not divergence: max error against the kernel was `1.19e-01` at
+N=21 and the wrapped form converges at **O(h) rather than O(h^2)** (measured ratio 1.98 over
+N=21..1281). An earlier version of this file said it "did not shrink under refinement", which is
+false -- and that wrong claim is why the refinement test below was written too weak to fire.
 
 `InterpolationApplicator.enforce_values` runs after the diffusion step and now identifies the two
 endpoints correctly, which drove the end-to-end seam to `2.4e-16` **while the interior stayed wrong
@@ -43,15 +45,25 @@ def test_the_periodic_step_matches_the_analytic_heat_kernel():
     )
 
 
-def test_the_error_falls_under_refinement():
-    """The property the wrapped-N form did not have: its 1.19e-01 was a fixed operator error.
+def test_the_spatial_order_is_second_not_first():
+    """The discriminating property. Both forms converge; they differ in ORDER.
 
-    Asserted as a decrease rather than a rate -- at these step sizes the temporal error is not
-    negligible, so a clean O(dx^2) claim would be over-reading the numbers.
+    A bare "error decreases" assertion passes for the defective operator too -- that is what the
+    first version of this test did, and it is why reverting the fix did not fire it. The observed
+    rate separates them: wrapped-N measures ~1.0, the correct DOF count ~2.0.
     """
-    errors = [float(np.abs(o - e).max()) for o, e in (_run(n) for n in (21, 41, 81))]
-    assert errors[1] < errors[0], f"refinement did not help: {errors}"
-    assert errors[2] < errors[1], f"refinement did not help: {errors}"
+    dt_small = 1e-4  # push temporal error below the spatial one so the rate is the spatial rate
+    rates = []
+    prev = None
+    for n in (41, 81, 161):
+        x = np.linspace(0.0, 1.0, n)
+        u0 = np.sin(K * x)
+        out = solve_crank_nicolson_diffusion_1d(u0.copy(), dt_small, SIGMA, x, bc_type="periodic")
+        err = float(np.abs(out - np.exp(-D * K * K * dt_small) * u0).max())
+        if prev is not None:
+            rates.append(np.log2(prev / err))
+        prev = err
+    assert min(rates) > 1.5, f"spatial order looks first-order, not second: measured {rates}"
 
 
 def test_the_step_leaves_no_seam():

--- a/tests/unit/test_geometry/test_enforcement.py
+++ b/tests/unit/test_geometry/test_enforcement.py
@@ -1,0 +1,111 @@
+"""BC value enforcement, in a tier that runs (Issue #1820).
+
+`mfgarchon/geometry/boundary/enforcement.py` had no live test of any kind. Its only assertions
+lived in an `if __name__ == "__main__":` block, the same dead-block shape #1736 found in
+`bc_utils.py`, and they **pinned the wrong periodic convention**: `field[0] = field[-2]` and
+`field[-1] = field[1]`.
+
+That is the halo form -- correct for an array carrying one ghost cell per side, where index 0 and
+-1 duplicate the opposite interior. `TensorProductGrid` builds `np.linspace(x_min, x_max, N)`, so
+index 0 and -1 are real nodes and the SAME physical point: period `L`, not `L + dx`. Applied there,
+the halo form moves both endpoints one cell in opposite directions. Measured on `sin(2 pi x)` with
+N=21: seam `2.4e-16` became `6.2e-01`, and `InterpolationApplicator.enforce_values` runs it after
+every semi-Lagrangian timestep.
+
+The convention is what these tests pin, not the formula: a rewrite that keeps the formula and
+changes the grid is equally wrong.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary.enforcement import (
+    enforce_dirichlet_value_nd,
+    enforce_neumann_value_nd,
+    enforce_periodic_value_nd,
+)
+
+
+class TestPeriodicIsAnIdentification:
+    """x_min and x_max are one degree of freedom the scheme computed twice."""
+
+    def test_the_two_endpoints_end_up_equal(self):
+        field = np.array([0.0, 1.0, 2.0, 3.0, 0.5])
+        enforce_periodic_value_nd(field, axis=0)
+        assert field[0] == field[-1], "the endpoints are the same physical point and must agree"
+
+    def test_it_is_the_mean_and_privileges_neither_end(self):
+        """Any rule taking one side would silently discard the other's discretisation error."""
+        field = np.array([0.0, 1.0, 2.0, 3.0, 0.5])
+        enforce_periodic_value_nd(field, axis=0)
+        assert field[0] == pytest.approx(0.25)
+
+    def test_it_does_not_reach_for_the_interior(self):
+        """The halo form -- field[0] = field[-2], field[-1] = field[1] -- is the #1820 defect.
+
+        Constructed so the two rules disagree: under the halo form the endpoints would become
+        3.0 and 1.0, which are both interior values and are not even equal to each other.
+        """
+        field = np.array([0.0, 1.0, 2.0, 3.0, 0.5])
+        enforce_periodic_value_nd(field, axis=0)
+        assert field[0] not in (3.0, 1.0), "endpoint was taken from the interior (halo convention)"
+        assert field[-1] not in (3.0, 1.0), "endpoint was taken from the interior (halo convention)"
+
+    def test_an_already_periodic_field_is_left_alone(self):
+        """The property that actually matters, and the one the halo form destroyed.
+
+        Enforcement must be a projection: applying it to a field already in the periodic
+        subspace changes nothing.
+        """
+        x = np.linspace(0.0, 1.0, 21)
+        field = np.sin(2 * np.pi * x)
+        before = field.copy()
+        enforce_periodic_value_nd(field, axis=0)
+        np.testing.assert_allclose(field, before, atol=1e-15)
+
+    def test_it_is_idempotent(self):
+        """`enforce_values` calls it twice per axis, once for each side."""
+        field = np.array([0.0, 1.0, 2.0, 3.0, 0.5])
+        enforce_periodic_value_nd(field, axis=0)
+        once = field.copy()
+        enforce_periodic_value_nd(field, axis=0)
+        np.testing.assert_allclose(field, once, atol=1e-15)
+
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_it_identifies_only_the_named_axis_in_2d(self, axis):
+        field = np.arange(20.0).reshape(4, 5)
+        enforce_periodic_value_nd(field, axis=axis)
+        if axis == 0:
+            np.testing.assert_allclose(field[0, :], field[-1, :])
+            assert not np.allclose(field[:, 0], field[:, -1]), "the other axis must be untouched"
+        else:
+            np.testing.assert_allclose(field[:, 0], field[:, -1])
+            assert not np.allclose(field[0, :], field[-1, :]), "the other axis must be untouched"
+
+
+class TestNeumannAndDirichlet:
+    """The assertions the dead block carried, in a tier that runs."""
+
+    def test_neumann_second_order_extrapolates(self):
+        field = np.array([0.9, 1.0, 1.1, 1.2, 1.3])
+        enforce_neumann_value_nd(field, axis=0, side="min", order=2)
+        assert field[0] == pytest.approx((4.0 * 1.0 - 1.1) / 3.0)
+
+    def test_neumann_first_order_copies_the_neighbour(self):
+        field = np.array([0.9, 1.0, 1.1, 1.2, 1.3])
+        enforce_neumann_value_nd(field, axis=0, side="min", order=1)
+        assert field[0] == 1.0
+
+    def test_neumann_honours_a_non_zero_gradient(self):
+        """The `else` branch: g != 0 is a different formula, not a scaled version of g = 0."""
+        field = np.array([0.0, 1.0, 1.1, 1.2, 0.0])
+        enforce_neumann_value_nd(field, axis=0, side="min", grad_value=2.0, spacing=0.1)
+        assert field[0] == pytest.approx(1.0 - 2.0 * 0.1)
+
+    def test_dirichlet_assigns_each_side_independently(self):
+        field = np.array([0.9, 1.0, 1.1, 1.2, 1.3])
+        enforce_dirichlet_value_nd(field, axis=0, side="min", value=0.0)
+        enforce_dirichlet_value_nd(field, axis=0, side="max", value=5.0)
+        assert field[0] == 0.0
+        assert field[-1] == 5.0


### PR DESCRIPTION
Closes #1820. Stacked on #1823 (the ratchet), because the point of this PR is a number moving.

## Two functions, one grid, opposite wrong conventions

`TensorProductGrid` is endpoint-inclusive: `field[0]` and `field[-1]` are both real nodes **and the
same physical point**. Period `L`, `N - 1` distinct DOFs.

| | assumed | effect |
|---|---|---|
| `enforce_periodic_value_nd` | halo (`f[0]=f[-2]`, `f[-1]=f[1]`) — period `L + dx` | turned a `2.4e-16` seam into `6.2e-01`, after **every** SL timestep |
| `_crank_nicolson_periodic_1d` | `N` distinct DOFs wrapping `0 <-> N-1` | node 0's left neighbour at distance **0** instead of `dx` |

The CN one is measurable against an external oracle — `exp(-D k^2 t) sin(k x)` is exact for a single
Fourier mode: **1.19e-01 and not shrinking under refinement**, against **6.1e-04** on the `N - 1`
DOFs, with an exact seam.

Results: `HJBSemiLagrangianSolver` **7.68e-01 → 2.45e-16**; `FPSLSolver` / `FPSLAdjointSolver`
**1.25e-01 → 0**. Three ratchet markers come off — all three XPASSed and failed the suite until
removed, which is `strict=True` doing exactly what #1823 built it for.

## A regression this unmasks — stated, not shipped quietly

`FPSLSolver` mass drift over a periodic solve moves **7.19% → 10.77%**. Mass was already badly
non-conserved and the seam error was **partly cancelling** it; closing the seam removed the
cancellation.

I nearly shipped the seam fix as "fixed" on the strength of `2.45e-16`. It is not: after the
`enforce_periodic_value_nd` fix alone, the end-to-end seam was machine-precision **while the CN
interior was still wrong by 3.0e-02** — the endpoint identification was papering over it. Same
shape as #1683/#1752, where renormalisation hid a drift. That is why this PR also fixes the CN and
adds an accuracy oracle rather than a seam assertion.

So **mass is now the ratchet's second invariant**, where six FP solvers fail — including
`FPFVMSolver`, which satisfies the seam at `2.2e-16` while creating 6.5% of its own mass. The seam
alone would have certified it as honouring PERIODIC.

## Two tests that could not run, and one that taught the wrong convention

- `enforcement.py` had **no live test of any kind**. Its only assertions were in an
  `if __name__ == "__main__":` block that cannot run under either invocation — the shape #1736
  removed from `bc_utils.py` — and they pinned the halo form as correct. Deleted; replaced by
  `tests/unit/test_geometry/test_enforcement.py`, which pins the **convention**, since a rewrite
  keeping the formula and changing the grid is equally wrong.
- #1257's stage pin asserted `m_new[1] == m_new[-1]` after a spike at the seam. That compares the
  spike's neighbour against **the spike**, and holds only under the endpoint-exclusive reading.
  Measured after the correction: `m_new[1]/m_new[-2] = 1.000000` exactly, `m_new[2] == m_new[-3]`,
  `m_new[0] == m_new[-1]`, total mass `1.000000`. Updated to the mirror that exists.

## Oracle

**(1) An external oracle** — the analytic periodic heat kernel, computed independently of the
scheme. Mutation-checked: reverting the DOF handling fails 2 of the 5 new tests (the constant and
refinement tests guard different failure modes and do not fire on it).

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, exit 0.

Independent adversarial review has **not** been run.

Refs #1822, #1257, #1736, #1456, #1683.