### PR TITLE
Give the periodic wrap a stated grid convention instead of an assumed one

### DIFF
--- a/changelog.d/1822-periodic-grid-convention.fixed.md
+++ b/changelog.d/1822-periodic-grid-convention.fixed.md
@@ -1,0 +1,50 @@
+- **A periodic wrap assumed a node layout, and two different ones were in use** (Issues #1822, #1825).
+  `TensorProductGrid` builds `np.linspace(lo, hi, N)`, so `x[0]` and `x[-1]` are the same physical
+  point; the operator layer (`LaplacianOperator`, `IsotropicDiffusion`) builds
+  `np.linspace(lo, hi, N, endpoint=False)`, where every node is distinct. Both reach the same ghost
+  applicator, which hard-coded the second — in two separate copies, one per dispatch path.
+  On an endpoint-inclusive grid that puts the duplicated node into the ghost and shifts every
+  periodic stencil one cell. Measured against the analytic continuation of `sin(2 pi x)` at `Nx=21`:
+  the ghost was wrong by **3.09e-01 at ghost depths 1, 2 and 3**. Downstream, `HJBWENOSolver`
+  returned a seam of **2.63e-01** from exactly periodic input, and `ImplicitHeatSolver`'s seam
+  stalled at ~1.5e-02 under refinement instead of vanishing (#1825) — refinement could not close a
+  fixed one-cell offset.
+  `PeriodicGridConvention` now names the two layouts and travels on the periodic `BoundaryConditions`,
+  which is the one carrier that reaches every wrapping site — a wrap happens *only* because that
+  object says PERIODIC — so nothing had to be threaded through the 31 call sites that pad or
+  construct. `HJBWENOSolver`'s seam is now exactly **0** and both xfails are gone rather than
+  silenced. Closes #1825.
+- **Unstated means what this package always did, and a grid completes it** (Issue #1822).
+  The convention is `None` by default, and `None` wraps the historical way — all `N` nodes distinct
+  — so adding the field changed no existing caller's numbers. `TensorProductGrid` **binds** the
+  convention it measures from its own coordinates onto any periodic BC it is handed, the way it
+  already binds `dimension`, and refuses one that contradicts them. A BC that never meets a grid is
+  completed at the three places that receive both — `get_laplacian_operator`, `get_gradient_operator`
+  and the solver BC resolution chain — so no solver declares anything, and a caller with no grid at
+  all (the operator layer) keeps the historical layout unless it says otherwise.
+  Defaulting to the *other* convention was tried first and reverted under review: it silently
+  reinterprets every BC that already meant exclusive, and took the operator layer's own Laplacian
+  from **1.3e-02 to 6.3e+02** of error with nothing going red.
+- **`LaplacianOperator`'s matrix and its matvec wrapped differently** (Issue #1822).
+  `as_scipy_sparse()` hard-coded `(i - 1 + n) % n` while `__call__` padded through the ghost
+  applicator. Once the convention was carried on the BC the two paths described different operators,
+  disagreeing by **1.9e+02** on an inclusive grid. The sparse assembly now reads the same
+  convention; dense and sparse agree to 2.5e-12 under both layouts, pinned by a test that reddens
+  when the wrap is reverted — review found the divergence once, then found that fixing it pinned
+  nothing.
+  Stated limitation: stepping over the duplicated node leaves column `n-1` referenced by nothing but
+  its own diagonal, so the inclusive matrix is asymmetric (`|A - A^T| = 900` at `n=31`, against 0.0
+  before). No wrong answer follows on seam-consistent input and mass is conserved under the correct
+  inclusive trapezoid weights (7e-15), but a future consumer assuming self-adjointness would be
+  misled. Filed as #1832; the fix is to carry `n-1` DOFs, as #1829 did for the periodic
+  Crank-Nicolson.
+- **Two tests were pinning the defect, and are now measured against calculus** (Issue #1822).
+  `test_periodic_gradient_byte_identical_to_legacy` asserted that the BC-aware gradient equalled the
+  legacy `%Nx` wrap "so periodic baselines do not move". They had to move: that wrap takes the left
+  neighbour of `x[0]` to be `x[-1]`, which *is* `x[0]`, so it reads across a separation of `dx` while
+  dividing by `2*dx`. Against the analytic `d/dx sin(2 pi x) = 2 pi` at `x=0`: legacy **3.0902**
+  (error 3.19), fixed **6.1803** (error 0.10, the interior's own O(h^2)). It now compares to the
+  analytic derivative, which cannot go stale when a stencil is replaced. The same one-node error set
+  the expected `-1.5` in `test_gradient_uses_periodic_override_not_noflux_geometry`; the correct
+  value on its `linspace(0, 4, 5)` grid is `-1.0`, and the periodic-vs-no-flux discrimination the
+  test exists for is untouched.

--- a/mfgarchon/alg/base_solver.py
+++ b/mfgarchon/alg/base_solver.py
@@ -16,6 +16,7 @@ BC Integration (Issue #527):
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -196,7 +197,7 @@ class BaseMFGSolver(ABC):
         # Priority 1: Check for instance attribute (solvers may cache BCs)
         try:
             if self._boundary_conditions is not None:
-                return self._boundary_conditions
+                return self._with_geometry_periodic_convention(self._boundary_conditions)
         except AttributeError:
             pass
 
@@ -204,7 +205,7 @@ class BaseMFGSolver(ABC):
         try:
             bc = self.problem.geometry.boundary_conditions
             if bc is not None:
-                return bc
+                return self._with_geometry_periodic_convention(bc)
         except AttributeError:
             pass
 
@@ -212,7 +213,7 @@ class BaseMFGSolver(ABC):
         try:
             bc = self.problem.geometry.get_boundary_conditions()
             if bc is not None:
-                return bc
+                return self._with_geometry_periodic_convention(bc)
         except AttributeError:
             pass
 
@@ -220,7 +221,7 @@ class BaseMFGSolver(ABC):
         try:
             bc = self.problem.boundary_conditions
             if bc is not None:
-                return bc
+                return self._with_geometry_periodic_convention(bc)
         except AttributeError:
             pass
 
@@ -228,12 +229,37 @@ class BaseMFGSolver(ABC):
         try:
             bc = self.problem.get_boundary_conditions()
             if bc is not None:
-                return bc
+                return self._with_geometry_periodic_convention(bc)
         except AttributeError:
             pass
 
         # No BC found
         return None
+
+    def _with_geometry_periodic_convention(self, bc):
+        """Complete a periodic BC with the node layout of the geometry actually being solved on.
+
+        Issue #1822. A grid binds this when a BC is attached to it, but Priority 1 above is a BC
+        the CALLER handed the solver -- it never met the grid, so its convention is unstated and
+        would wrap the historical way (all N nodes distinct) on a grid where the two endpoints are
+        one point. Measured on that path: the periodic gradient at the seam came out -1.5 where the
+        grid's own layout gives -1.0.
+
+        Only fills a gap; a stated convention is left alone, and the grid refuses one that
+        contradicts it at attachment time.
+        """
+        # Local import: this module is imported from mfgarchon.alg.__init__, and reaching
+        # geometry.boundary at module scope closes an import cycle.
+        from mfgarchon.geometry.boundary.types import BCType
+
+        if getattr(bc, "periodic_convention", None) is not None:
+            return bc
+        if not any(getattr(seg, "bc_type", None) is BCType.PERIODIC for seg in getattr(bc, "segments", [])):
+            return bc
+        measured = getattr(getattr(self.problem, "geometry", None), "periodic_convention", None)
+        if measured is None:
+            return bc
+        return replace(bc, periodic_convention=measured)
 
     #: Issue #1686: does this solver apply the *value* attached to a NEUMANN segment, or only
     #: its type? Every FP family currently reads the type and drops the value, so they override

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -353,6 +353,9 @@ class HJBWENOSolver(BaseHJBSolver):
             domain_bounds=domain_bounds,
             ghost_depth=self.ghost_depth,
             order=self.ghost_order,  # High-order ghost cells for WENO5
+            # No periodic_convention= here on purpose (Issue #1822): the BC carries it, and a
+            # second declaration beside the one that already arrives is exactly the duplicated
+            # convention this change removed from the applicator.
         )
 
     def _get_boundary_conditions(self):

--- a/mfgarchon/geometry/boundary/__init__.py
+++ b/mfgarchon/geometry/boundary/__init__.py
@@ -88,6 +88,7 @@ from .types import (
     BCType,
     BoundaryEntity,
     BoundaryFace,
+    PeriodicGridConvention,
     create_standard_boundary_names,
     parse_boundary_face,
 )
@@ -107,6 +108,7 @@ from .types import (
 __all__ = [
     # Layer 1: Specification
     "BCType",
+    "PeriodicGridConvention",
     "BCSegment",
     "BoundaryConditions",
     "BoundaryEntity",

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -93,7 +93,7 @@ from .conditions import BoundaryConditions
 from .enforcement import enforce_dirichlet_value_nd, enforce_neumann_value_nd
 from .fdm_bc_1d import BoundaryConditions as BoundaryConditions1DFDM
 from .ghost_cells import GhostCellConfig
-from .types import BCSegment, BCType, BoundaryFace, parse_boundary_face
+from .types import BCSegment, BCType, BoundaryFace, PeriodicGridConvention, parse_boundary_face
 
 logger = get_logger(__name__)
 
@@ -789,6 +789,45 @@ if TYPE_CHECKING:
     from .applicator_base import BoundaryCalculator, Topology
 
 
+def _periodic_ghost_slices(
+    axis: int, side: str, d: int, g: int, convention: PeriodicGridConvention
+) -> tuple[tuple[slice, ...], tuple[slice, ...]]:
+    """Where a periodic ghost cell reads from. Issue #1822.
+
+    The two conventions differ by exactly one node, and which one applies is a property of the
+    grid that nothing here can see -- see ``PeriodicGridConvention`` for the measurements. Hence
+    the required argument: there is no reading of ``buf`` that distinguishes them.
+
+    Both ghost paths in this module previously carried their own copy of the exclusive arithmetic,
+    so an inclusive grid got every periodic stencil shifted one cell. #1829 fixed the same
+    confusion in ``enforce_periodic_value_nd`` and called itself one owner for the convention;
+    this module was a second owner, twice over. Both copies now route here.
+
+    Args:
+        axis: Axis being filled.
+        side: ``"min"`` fills the low ghosts, ``"max"`` the high ones.
+        d: Number of dimensions of the padded buffer.
+        g: Ghost depth.
+        convention: Which grid this is. No default -- see the class docstring.
+
+    Returns:
+        ``(ghost, source)``, both indexable into the PADDED buffer, whose layout along ``axis`` is
+        ``[ghost_lo (g) | interior (N) | ghost_hi (g)]``.
+    """
+    ghost: list[slice] = [slice(None)] * d
+    source: list[slice] = [slice(None)] * d
+    # On an inclusive grid the shared endpoint is a duplicate and must be stepped over; on an
+    # exclusive one every node is distinct and the wrap starts at the last one.
+    skip = 1 if convention is PeriodicGridConvention.ENDPOINT_INCLUSIVE else 0
+    if side == "min":
+        ghost[axis] = slice(0, g)
+        source[axis] = slice(-2 * g - skip, -g - skip)
+    else:
+        ghost[axis] = slice(-g, None)
+        source[axis] = slice(g + skip, 2 * g + skip)
+    return tuple(ghost), tuple(source)
+
+
 # =============================================================================
 # Pre-allocated Ghost Cell Buffer (Legacy Interface - Zero-Copy Design)
 # =============================================================================
@@ -840,6 +879,7 @@ class PreallocatedGhostBuffer:
         order: int = 2,
         config: GhostCellConfig | None = None,
         geometry: object | None = None,
+        periodic_convention: PeriodicGridConvention | None = None,
     ):
         """
         Initialize pre-allocated ghost buffer.
@@ -872,6 +912,10 @@ class PreallocatedGhostBuffer:
         self._domain_bounds = domain_bounds
         self._config = config if config is not None else GhostCellConfig()
         self._geometry = geometry  # For region_name resolution (Issue #577 Phase 3)
+        # Issue #1822. An override for a buffer built from a bare BoundaryConditions; normally
+        # the convention arrives ON the BC, bound there by the grid. Consulted only where PERIODIC
+        # is actually filled, so callers using any other BC never meet it.
+        self._periodic_convention = periodic_convention
 
         # Compute padded shape
         self._padded_shape = tuple(s + 2 * ghost_depth for s in interior_shape)
@@ -917,6 +961,30 @@ class PreallocatedGhostBuffer:
     def ghost_depth(self) -> int:
         """Number of ghost cells per side."""
         return self._ghost_depth
+
+    def _periodic_convention_in_force(self) -> PeriodicGridConvention:
+        """Which grid this buffer wraps under. Issue #1822.
+
+        Read off the BOUNDARY CONDITION, because a periodic fill happens only because the BC says
+        PERIODIC -- so the BC is the one carrier that reaches every wrapping site without a new
+        argument threaded through the 31 that construct or pad. An earlier revision of this change
+        required each caller to pass it and reddened 74 tests, most in paths with no periodic
+        content, which is what a grid property looks like when it is put on the call sites.
+
+        An explicit ``periodic_convention=`` still wins, for a buffer built directly from a bare
+        ``BoundaryConditions`` in a test.
+
+        Unstated means ENDPOINT_EXCLUSIVE, which is how this package wrapped before #1822, so a
+        caller that says nothing gets exactly the numbers it got before. The other choice was
+        measured and reverted: defaulting to INCLUSIVE reinterprets every BC that already meant
+        exclusive, and took the operator layer's own Laplacian from 1.3e-02 to 6.3e+02 error with
+        no test going red. A grid binds the right one in on attachment, so solver paths do not
+        rely on this fallback.
+        """
+        if self._periodic_convention is not None:
+            return self._periodic_convention
+        declared = getattr(self._boundary_conditions, "periodic_convention", None)
+        return declared if declared is not None else PeriodicGridConvention.ENDPOINT_EXCLUSIVE
 
     def update_ghosts(self, time: float = 0.0) -> None:
         """
@@ -1008,21 +1076,11 @@ class PreallocatedGhostBuffer:
             v = value if value is not None else 0.0
 
         if bc_type == BCType.PERIODIC:
-            # Periodic: ghost = opposite interior
+            convention = self._periodic_convention_in_force()
             for axis in range(d):
-                # Low ghost = high interior
-                lo_ghost = [slice(None)] * d
-                lo_ghost[axis] = slice(0, g)
-                hi_interior = [slice(None)] * d
-                hi_interior[axis] = slice(-2 * g, -g)
-                buf[tuple(lo_ghost)] = buf[tuple(hi_interior)]
-
-                # High ghost = low interior
-                hi_ghost = [slice(None)] * d
-                hi_ghost[axis] = slice(-g, None)
-                lo_interior = [slice(None)] * d
-                lo_interior[axis] = slice(g, 2 * g)
-                buf[tuple(hi_ghost)] = buf[tuple(lo_interior)]
+                for side in ("min", "max"):
+                    ghost, source = _periodic_ghost_slices(axis, side, d, g, convention)
+                    buf[ghost] = buf[source]
 
         elif bc_type == BCType.DIRICHLET:
             # Dirichlet: u_ghost = 2*g - u_interior
@@ -1536,14 +1594,8 @@ class PreallocatedGhostBuffer:
 
         # Apply ghost cell formula based on BC type
         if bc_type == BCType.PERIODIC:
-            # Periodic: ghost = opposite interior
-            if side == "min":
-                opposite_interior = [slice(None)] * d
-                opposite_interior[axis] = slice(-2 * g, -g)
-            else:
-                opposite_interior = [slice(None)] * d
-                opposite_interior[axis] = slice(g, 2 * g)
-            buf[tuple(ghost_slices)] = buf[tuple(opposite_interior)]
+            ghost, source = _periodic_ghost_slices(axis, side, d, g, self._periodic_convention_in_force())
+            buf[ghost] = buf[source]
 
         elif bc_type == BCType.DIRICHLET:
             # Dirichlet: u_ghost = 2*g - u_interior
@@ -1701,6 +1753,7 @@ def pad_array_with_ghosts(
     ghost_depth: int = 1,
     time: float = 0.0,
     geometry: object | None = None,
+    periodic_convention: PeriodicGridConvention | None = None,
 ) -> NDArray[np.floating]:
     """
     Pad array with ghost cells based on boundary conditions.
@@ -1715,6 +1768,9 @@ def pad_array_with_ghosts(
         time: Current time for time-dependent BC values
         geometry: Geometry object for region_name resolution (Issue #577 Phase 3).
                  Required if BC segments use region_name.
+        periodic_convention: Overrides the convention carried on ``bc`` (see
+                 ``PeriodicGridConvention``). Normally unnecessary: a grid binds the right one onto
+                 the BC, and unstated means the historical layout.
 
     Returns:
         New array with ghost cells added on all boundaries
@@ -1737,6 +1793,7 @@ def pad_array_with_ghosts(
         domain_bounds=domain_bounds,
         ghost_depth=ghost_depth,
         geometry=geometry,
+        periodic_convention=periodic_convention,
     )
     # Copy array into interior view and update ghosts
     buffer.interior[:] = array

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -37,7 +37,7 @@ from mfgarchon.geometry.protocols import SupportsRegionMarking
 from mfgarchon.utils.deprecation import deprecated
 
 from .tolerances import BOUNDARY_REL_TOL, BOUNDARY_TOL, SDF_BOUNDARY_TOL
-from .types import BCSegment, BCType, BoundaryFace, _compute_sdf_gradient
+from .types import BCSegment, BCType, BoundaryFace, PeriodicGridConvention, _compute_sdf_gradient
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -110,6 +110,18 @@ class BoundaryConditions:
     # Corner handling (important for Lipschitz domains with re-entrant corners)
     corner_strategy: Literal["priority", "average", "mollify"] = "priority"
     corner_mollification_radius: float = 0.1
+    # Issue #1822. Rides on the BC because a periodic wrap happens ONLY because this object says
+    # PERIODIC, so this is the one carrier that reaches every wrapping site without threading a
+    # new argument through the 31 that pad or construct.
+    #
+    # ``None`` means UNSTATED, and unstated wraps the way this package always wrapped -- N
+    # distinct nodes -- so attaching this field changes no existing caller's numbers. Defaulting
+    # it to the other convention instead was measured and reverted: it silently reinterprets every
+    # BC that already meant exclusive, and took the operator layer's own Laplacian from 1.3e-02 to
+    # 6.3e+02 with nothing red. A grid does not leave it unstated for long -- ``TensorProductGrid``
+    # BINDS the convention it measures from its own coordinates when a periodic BC is attached, the
+    # same way it binds ``dimension``, and refuses one that contradicts them.
+    periodic_convention: PeriodicGridConvention | None = None
 
     def __post_init__(self):
         """Sort segments by priority (highest first)."""
@@ -911,7 +923,11 @@ def uniform_bc(
     )
 
 
-def periodic_bc(dimension: int | None = None, domain_bounds: np.ndarray | None = None) -> BoundaryConditions:
+def periodic_bc(
+    dimension: int | None = None,
+    domain_bounds: np.ndarray | None = None,
+    convention: PeriodicGridConvention | None = None,
+) -> BoundaryConditions:
     """
     Create periodic boundary conditions.
 
@@ -919,11 +935,22 @@ def periodic_bc(dimension: int | None = None, domain_bounds: np.ndarray | None =
         dimension: Spatial dimension. If None, dimension will be inferred when
             BC is attached to a Geometry (lazy binding).
         domain_bounds: Optional domain bounds
+        convention: Where the last node sits (Issue #1822). ``None`` leaves it unstated, which
+            wraps as this package always has -- ``np.linspace(lo, hi, N, endpoint=False)``, all N
+            nodes distinct. Attaching this BC to a ``TensorProductGrid`` binds the convention that
+            grid measures from its own coordinates (``ENDPOINT_INCLUSIVE``: ``x[0]`` and ``x[-1]``
+            are one physical point), so solver paths need not state it. State it here for a grid
+            the BC never meets -- the operator layer holds no grid object. The two differ by
+            exactly one node, and a wrap under the wrong one returns a finite, plausible field
+            with every stencil shifted a cell; a stated convention that contradicts the grid it is
+            attached to is refused rather than silently overridden.
 
     Returns:
         Uniform periodic BC
     """
-    return uniform_bc(BCType.PERIODIC, value=0.0, dimension=dimension, domain_bounds=domain_bounds)
+    bc = uniform_bc(BCType.PERIODIC, value=0.0, dimension=dimension, domain_bounds=domain_bounds)
+    bc.periodic_convention = convention
+    return bc
 
 
 def dirichlet_bc(

--- a/mfgarchon/geometry/boundary/types.py
+++ b/mfgarchon/geometry/boundary/types.py
@@ -80,6 +80,43 @@ def _compute_sdf_gradient(
     return grad
 
 
+class PeriodicGridConvention(Enum):
+    """Which periodic grid a wrap-around operation is acting on. Issue #1822.
+
+    ``BCType.PERIODIC`` says the domain wraps. It does NOT say where the last node sits, and the
+    two answers give different neighbours for the same index:
+
+    ``ENDPOINT_INCLUSIVE``
+        ``np.linspace(x_min, x_max, N)`` -- what ``TensorProductGrid`` builds. ``x[0]`` and
+        ``x[-1]`` are the same physical point counted twice, so the period is ``L``, the spacing
+        is ``L / (N - 1)``, and the node one step left of ``x[0]`` is ``x[-2]``.
+
+    ``ENDPOINT_EXCLUSIVE``
+        ``np.linspace(x_min, x_max, N, endpoint=False)`` -- what the operator layer
+        (``LaplacianOperator``, ``IsotropicDiffusion``) builds. ``N`` distinct nodes, spacing
+        ``L / N``, and the node one step left of ``x[0]`` is ``x[-1]``.
+
+    Both are live in this package, they differ by exactly one node, and a wrap that assumes the
+    wrong one shifts every periodic stencil by a cell while still returning a finite, plausible
+    field. Measured both ways on ``Nx=21``: wrapping an inclusive grid as exclusive gave
+    ``HJBWENOSolver`` a periodic seam of 2.63e-01 from exactly periodic input and stalled
+    ``ImplicitHeatSolver``'s seam at 1.5e-02 under refinement (#1825); wrapping an exclusive grid
+    as inclusive took the operator layer's Laplacian from 1.3e-02 to 6.3e+02 of error. Neither
+    raises, which is why this is carried rather than guessed at each site.
+
+    **How it gets decided.** The choice rides on the periodic ``BoundaryConditions``, since a wrap
+    happens only because that object says PERIODIC. Left unstated (``None``) it means
+    ``ENDPOINT_EXCLUSIVE`` -- how this package wrapped before #1822 -- so adding it changed no
+    existing caller's numbers. ``TensorProductGrid`` binds the convention it measures from its own
+    coordinates onto any periodic BC attached to it, the way it binds ``dimension``, and refuses
+    one that contradicts them. So solver paths are correct without declaring anything, and a
+    caller with no grid (the operator layer) states it or keeps the historical layout.
+    """
+
+    ENDPOINT_INCLUSIVE = "endpoint_inclusive"
+    ENDPOINT_EXCLUSIVE = "endpoint_exclusive"
+
+
 class BCType(Enum):
     """
     Boundary condition types (dimension-agnostic).

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -19,12 +19,14 @@ References:
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from mfgarchon.geometry.base import CartesianGrid, nearest_point_on_box_boundary
 from mfgarchon.geometry.boundary.tolerances import ONWALL_TOL
+from mfgarchon.geometry.boundary.types import BCType, PeriodicGridConvention
 from mfgarchon.geometry.protocol import GeometryType
 from mfgarchon.geometry.protocols import (
     SupportsAdvection,
@@ -274,7 +276,12 @@ class TensorProductGrid(
         self.bounds = list(bounds)
         self.spacing_type = spacing_type
 
-        # Create coordinate arrays
+        # Create coordinate arrays.
+        #
+        # Issue #1822: `np.linspace(lo, hi, N)` INCLUDES both endpoints, which is what makes
+        # `periodic_convention` below ENDPOINT_INCLUSIVE. The two facts must move together --
+        # switching to `endpoint=False` here without changing that property would leave every
+        # periodic ghost stencil one cell off, silently.
         if spacing_type == "uniform":
             self.coordinates = [
                 np.linspace(bounds[i][0], bounds[i][1], self._Nx_points[i]) for i in range(self._dimension)
@@ -314,6 +321,7 @@ class TensorProductGrid(
             )
         # bind_dimension returns a new BC with dimension set, or validates if already set
         boundary_conditions = boundary_conditions.bind_dimension(dimension)
+        boundary_conditions = self._bind_periodic_convention(boundary_conditions)
         self._boundary_conditions = boundary_conditions
 
         # Cache for flattened grid (computed lazily, perf optimization)
@@ -332,6 +340,80 @@ class TensorProductGrid(
     def geometry_type(self) -> GeometryType:
         """Type of geometry (always CARTESIAN_GRID for tensor product grids)."""
         return GeometryType.CARTESIAN_GRID
+
+    def _bind_periodic_convention(self, bc):
+        """Complete a periodic BC with the node layout this grid measures. Issue #1822.
+
+        The convention travels on the BC, because that is what reaches solvers and operators. An
+        unstated one wraps as the package always did (all N nodes distinct), which is wrong for
+        THIS grid -- so binding it here is what makes solver paths correct without any of them
+        declaring anything, exactly as ``bind_dimension`` completes the BC's dimension.
+
+        A BC that states a convention is not overridden: it is checked, and a contradiction raises.
+        Silently replacing a caller's explicit statement would be the same silence this whole
+        change removes, one level up.
+
+        Returns the BC to store -- a completed copy when it was unstated, otherwise the original.
+        """
+        if not any(seg.bc_type is BCType.PERIODIC for seg in getattr(bc, "segments", [])):
+            return bc
+        measured = self.periodic_convention
+        declared = getattr(bc, "periodic_convention", None)
+        if declared is None:
+            return replace(bc, periodic_convention=measured)
+        if declared is not measured:
+            axis = self._first_axis_with_convention(measured)
+            raise ValueError(
+                f"This grid's coordinates are {measured.name} on axis {axis} "
+                f"(x[-1] = {self.coordinates[axis][-1]!r} against an upper bound of "
+                f"{self.bounds[axis][1]!r}), but the periodic boundary condition declares "
+                f"{declared.name}. They differ by exactly one node, so wrapping under the declared "
+                f"one would shift every periodic stencil by a cell and still return a finite field. "
+                f"Build the BC with periodic_bc(..., convention=PeriodicGridConvention."
+                f"{measured.name}), or build the grid to match (Issue #1822)."
+            )
+        return bc
+
+    def _first_axis_with_convention(self, convention: PeriodicGridConvention) -> int:
+        """The axis the verdict came from, so the evidence in the message is that axis's.
+
+        Reporting axis 0's coordinates for a verdict reached on axis 1 prints a parenthetical that
+        contradicts its own conclusion.
+        """
+        for axis, coords in enumerate(self.coordinates):
+            if len(coords) >= 2 and self._axis_convention(axis) is convention:
+                return axis
+        return 0
+
+    def _axis_convention(self, axis: int) -> PeriodicGridConvention:
+        """Where the last node sits on one axis, measured."""
+        coords = self.coordinates[axis]
+        hi = self.bounds[axis][1]
+        if abs(coords[-1] - hi) > 0.5 * abs(coords[-1] - coords[-2]):
+            return PeriodicGridConvention.ENDPOINT_EXCLUSIVE
+        return PeriodicGridConvention.ENDPOINT_INCLUSIVE
+
+    @property
+    def periodic_convention(self) -> PeriodicGridConvention:
+        """Where the last node sits, MEASURED from the coordinates this grid actually built.
+
+        Issue #1822. Derived rather than asserted, so that changing how ``coordinates`` is
+        constructed cannot leave a stale claim behind: the whole defect class here is a wrap that
+        believes something about the node layout which stopped being true.
+
+        A periodic ``BoundaryConditions`` carries this too -- that is what reaches solvers and
+        operators, which hold no grid -- and ``__init__`` refuses a BC that contradicts what is
+        measured here.
+        """
+        # Inclusive iff the last node sits ON the upper bound, on every axis. The tolerance is
+        # relative to the spacing because the alternative sits exactly one dx below it -- the two
+        # are never close by accident.
+        for axis, coords in enumerate(self.coordinates):
+            if len(coords) < 2:
+                continue
+            if self._axis_convention(axis) is PeriodicGridConvention.ENDPOINT_EXCLUSIVE:
+                return PeriodicGridConvention.ENDPOINT_EXCLUSIVE
+        return PeriodicGridConvention.ENDPOINT_INCLUSIVE
 
     @property
     def num_spatial_points(self) -> int:
@@ -698,6 +780,7 @@ class TensorProductGrid(
         if bc is not None:
             # Validate dimension if BC has one set
             bc = bc.bind_dimension(self._dimension)
+            bc = self._bind_periodic_convention(bc)
         self._boundary_conditions = bc
 
     @property
@@ -1520,9 +1603,11 @@ class TensorProductGrid(
         """
         from mfgarchon.operators import LaplacianOperator
 
-        # Use grid's BC if not provided
-        if bc is None:
-            bc = self.get_boundary_conditions()
+        # Use grid's BC if not provided. A supplied one never went through attachment, so its
+        # periodic node layout is unstated and would wrap the historical way on a grid whose two
+        # endpoints are one point -- the operator returned here must use THIS grid's layout,
+        # whoever supplied the boundary condition (Issue #1822, and #1825's stalled seam).
+        bc = self.get_boundary_conditions() if bc is None else self._bind_periodic_convention(bc)
 
         return LaplacianOperator(
             spacings=self.spacing,
@@ -1572,7 +1657,11 @@ class TensorProductGrid(
         # Use caller-supplied BC if provided, otherwise fall back to grid's own BC.
         # Matches the pattern of get_laplacian_operator (tensor_grid.py:1474).
         # Issue #1255 (A), 2026-06-10 audit.
-        bc = bc if bc is not None else self.get_boundary_conditions()
+        # A caller-supplied BC never met this grid, so its periodic convention is unstated and
+        # would wrap the historical way on a grid whose two endpoints are one point. Complete it
+        # the same way attachment does (Issue #1822): the operator this returns must use THIS
+        # grid's node layout, whoever supplied the boundary condition.
+        bc = self._bind_periodic_convention(bc) if bc is not None else self.get_boundary_conditions()
 
         # Create operator(s)
         if direction is not None:

--- a/mfgarchon/operators/differential/laplacian.py
+++ b/mfgarchon/operators/differential/laplacian.py
@@ -184,6 +184,18 @@ class LaplacianOperator(LinearOperator):
         # Return flattened
         return Lu.ravel()
 
+    def _periodic_convention_is_inclusive(self) -> bool:
+        """Whether this operator's periodic wrap identifies the two endpoints. Issue #1822.
+
+        Read off the same BC that `__call__`'s ghost padding reads, so the matrix and the matvec
+        cannot describe different operators. Unstated means the layout this package always used --
+        all N nodes distinct -- which is what the operator layer's own grids are.
+        """
+        from mfgarchon.geometry.boundary.types import PeriodicGridConvention
+
+        declared = getattr(self.bc, "periodic_convention", None)
+        return declared is PeriodicGridConvention.ENDPOINT_INCLUSIVE
+
     def __call__(self, u: NDArray) -> NDArray:
         """
         Apply Laplacian to field (preserves shape).
@@ -388,9 +400,20 @@ class LaplacianOperator(LinearOperator):
                 cols_list.append(all_idx)
                 vals_list.append(np.full(N, -2.0 / h2))
 
+                # The wrap has to use the SAME node layout as `__call__`, which pads through the
+                # ghost applicator and reads the convention off the BC (Issue #1822). A hard-coded
+                # `% n_d` here is the exclusive layout; against an inclusive grid that made the
+                # dense and sparse paths of one operator disagree by 1.9e+02 -- a cross-path
+                # divergence in a quantity computed twice, which is the class this convention was
+                # named to close.
+                #
+                # On an inclusive grid node n-1 IS node 0, so the wrap skips it: the left neighbour
+                # of node 0 is n-2 and the right neighbour of node n-1 is 1.
+                span = n_d - 1 if self._periodic_convention_is_inclusive() else n_d
+
                 # Left neighbor (wrapped for periodic)
                 left_idx = multi_indices.copy()
-                left_idx[:, d] = (i_d - 1 + n_d) % n_d
+                left_idx[:, d] = (i_d - 1 + span) % span if span > 0 else i_d
                 left_flat = np.ravel_multi_index(left_idx.T, self.field_shape)
                 rows_list.append(all_idx)
                 cols_list.append(left_flat)
@@ -398,7 +421,7 @@ class LaplacianOperator(LinearOperator):
 
                 # Right neighbor (wrapped for periodic)
                 right_idx = multi_indices.copy()
-                right_idx[:, d] = (i_d + 1) % n_d
+                right_idx[:, d] = (i_d + 1) % span if span > 0 else i_d
                 right_flat = np.ravel_multi_index(right_idx.T, self.field_shape)
                 rows_list.append(all_idx)
                 cols_list.append(right_flat)

--- a/tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py
+++ b/tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py
@@ -120,10 +120,16 @@ class TestGradientBCOverrideThreaded:
         grads = solver._compute_gradient_nd(u, spacings, use_backend=False)
 
         grad_x = grads[0]
-        # Periodic: at x=0, du/dx = (u[1] - u[4])/(2*1) = (1-4)/2 = -1.5
-        # No-flux: at x=0, du/dx = (u[1] - u[0])/(2*1) = (1-0)/2 = 0.5
-        assert abs(grad_x[0] - (-1.5)) < 1e-9, (
-            f"Expected -1.5 (periodic override), got {grad_x[0]:.4f}. "
+        # The grid is np.linspace(0, 4, 5), so x[0] and x[4] are the SAME physical point under a
+        # periodic BC and the node left of x[0] is x[3] (Issue #1822):
+        #   Periodic: at x=0, du/dx = (u[1] - u[3])/(2*1) = (1-3)/2 = -1.0
+        #   No-flux:  at x=0, du/dx = (u[1] - u[0])/(2*1) = (1-0)/2 = 0.5
+        # This expected -1.5 = (u[1] - u[4])/2 until #1822, which is the wrap that treats the two
+        # coincident endpoints as distinct nodes -- it reads across a separation of dx while
+        # dividing by 2*dx. The discrimination this test exists for is untouched: no-flux still
+        # gives 0.5, and the two remain far apart.
+        assert abs(grad_x[0] - (-1.0)) < 1e-9, (
+            f"Expected -1.0 (periodic override), got {grad_x[0]:.4f}. "
             "Bug: geometry's no-flux BC was used instead of solver's periodic override."
         )
 

--- a/tests/unit/test_alg/test_hjb_fdm_solver.py
+++ b/tests/unit/test_alg/test_hjb_fdm_solver.py
@@ -1119,20 +1119,50 @@ class TestBoundaryGradientBCAware1384:
         assert abs(bc_aware[0] - legacy[0]) > 1.0
         assert abs(bc_aware[-1] - legacy[-1]) > 1.0
 
-    def test_periodic_gradient_byte_identical_to_legacy(self):
-        """Mechanism: for PERIODIC BC the BC-aware gradient equals the legacy %Nx stencil
-        (Δ <= 1 ULP everywhere) — the discrimination the fix relies on, so periodic
-        baselines do not move."""
+    def test_periodic_gradient_matches_the_analytic_derivative_at_the_seam(self):
+        """The periodic endpoint gradient is measured against calculus, not against the legacy stencil.
+
+        This test used to assert byte-identity with ``_legacy_periodic_grad`` on the grounds that
+        "periodic baselines do not move". They had to move: on an endpoint-inclusive grid the
+        legacy ``%Nx`` wrap takes the left neighbour of ``x[0]`` to be ``x[-1]``, which IS ``x[0]``,
+        so it reads across a separation of ``dx`` while dividing by ``2*dx`` -- a factor-of-two
+        error at both endpoints and nowhere else. Measured on ``sin(2 pi x)``, ``Nx=21``, where the
+        analytic derivative at ``x=0`` is ``2 pi = 6.2832``:
+
+            legacy %Nx wrap   3.0902   error 3.19
+            inclusive wrap    6.1803   error 0.10   (O(h^2), as a central difference should be)
+
+        So the old assertion pinned the defect, and #1822 is what moved the baseline. Comparing to
+        the analytic derivative instead cannot go stale that way: it is external to both stencils.
+        """
         from mfgarchon.alg.numerical.hjb_solvers import base_hjb
         from mfgarchon.geometry.boundary import periodic_bc as _pb
+        from mfgarchon.geometry.boundary.types import PeriodicGridConvention
 
         Nx = 21
         x = np.linspace(0.0, 1.0, Nx)
         dx = x[1] - x[0]
         U = np.sin(2 * np.pi * x)
-        legacy = self._legacy_periodic_grad(U, dx)
-        bc_aware = base_hjb._compute_gradient_array_1d(U, dx, bc=_pb(dimension=1), upwind=False)
-        assert np.max(np.abs(bc_aware - legacy)) <= 1e-12
+        analytic = 2 * np.pi * np.cos(2 * np.pi * x)
+
+        # The field lives on np.linspace(0, 1, Nx) -- endpoint-inclusive -- and this BC is built
+        # bare, so it says which layout it is for; a grid would otherwise bind that (Issue #1822).
+        bc = _pb(dimension=1, convention=PeriodicGridConvention.ENDPOINT_INCLUSIVE)
+        bc_aware = base_hjb._compute_gradient_array_1d(U, dx, bc=bc, upwind=False)
+
+        # A central difference on this grid is O(h^2); at Nx=21 that is ~0.10 for this field, and
+        # the tolerance is set from the INTERIOR error so the endpoints cannot hide behind a
+        # tolerance sized for them.
+        interior_error = np.max(np.abs(bc_aware[1:-1] - analytic[1:-1]))
+        assert np.abs(bc_aware[0] - analytic[0]) <= 1.5 * interior_error, (
+            f"the periodic seam gradient is {bc_aware[0]:.4f} against an analytic {analytic[0]:.4f}; "
+            f"the interior of the same field is accurate to {interior_error:.4f}, so the endpoint is "
+            f"using a different stencil width -- the %Nx wrap reads x[-1], which is x[0] itself"
+        )
+        assert np.abs(bc_aware[-1] - analytic[-1]) <= 1.5 * interior_error
+
+        # And the two coincident nodes must agree with each other, which is what periodicity means.
+        assert np.abs(bc_aware[0] - bc_aware[-1]) < 1e-12
 
     def test_dirichlet_steep_terminal_converges(self):
         """Dirichlet with a steep terminal: making only the residual BC-aware while the FD

--- a/tests/unit/test_alg/test_implicit_heat.py
+++ b/tests/unit/test_alg/test_implicit_heat.py
@@ -159,12 +159,12 @@ class TestImplicitHeatSolver1D:
         relative_diff = np.linalg.norm(T_cn - T_be) / np.linalg.norm(T_cn)
         assert relative_diff < 0.05, f"CN and BE solutions too different: {relative_diff:.2%}"
 
-    @pytest.mark.xfail(
-        strict=True,
-        raises=AssertionError,
-        reason="ImplicitHeatSolver does not honour periodic BC: seam stalls at ~1.5e-02 under "
-        "refinement rather than vanishing (Issue #1825)",
-    )
+    # The #1825 xfail is GONE, not silenced. That seam stalled at ~1.5e-02 under refinement
+    # because the periodic ghost fill read the last g interior entries -- which on this
+    # endpoint-inclusive grid includes the node that IS x[0] -- so every periodic stencil sat one
+    # cell off and no amount of refinement could close it. Fixed in
+    # applicator_fdm._periodic_ghost_slices, which now takes the convention from the BC
+    # (Issue #1822). Closes #1825.
     def test_periodic_bc(self):
         """Test periodic boundary conditions."""
         grid = TensorProductGrid(bounds=[(0, 1)], Nx=[100], boundary_conditions=neumann_bc(dimension=1))

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -105,7 +105,11 @@ _SEARCHED = (
 # Passing: HJBSemiLagrangianSolver (0.0) and FPSLSolver / FPSLAdjointSolver (4.4e-16) -- the three
 # repaired in #1824, and the only genuine positive controls this file has ever had.
 KNOWN_NOT_HONOURED = {
-    "HJBWENOSolver": ("#1822", AssertionError),
+    # HJBWENOSolver is GONE from this roster, not silenced: its ghost buffer read the last g
+    # interior entries, which on an endpoint-inclusive grid includes the node that IS x[0], so
+    # every periodic stencil sat one cell off. Fixed in applicator_fdm._periodic_ghost_slices;
+    # seam 2.63e-01 -> exactly 0. The ghost fill itself is pinned against the analytic continuation
+    # in tests/unit/test_geometry/test_periodic_ghost_fill_1822.py.
     "HJBFDMSolver": ("#1822", AssertionError),
     "HJBGFDMSolver": ("#1822 declares PERIODIC and raises for it", NotImplementedError),
     "FPFDMSolver": ("#1822", AssertionError),

--- a/tests/unit/test_geometry/test_periodic_ghost_fill_1822.py
+++ b/tests/unit/test_geometry/test_periodic_ghost_fill_1822.py
@@ -1,0 +1,164 @@
+"""A periodic ghost cell must hold the analytic periodic continuation, at every ghost depth.
+
+`TensorProductGrid` is endpoint-inclusive, so `x[0]` and `x[-1]` are the same physical point and
+the node one step left of `x[0]` is `x[-2]`. Both ghost paths in `applicator_fdm.py` -- the uniform
+one and the mixed one, each with its own copy of the arithmetic -- read the last `g` interior
+entries instead, which is the halo convention (N distinct DOFs over a period of `L + dx`). That
+puts the duplicated node in the ghost and shifts the stencil by one cell.
+
+Measured before the fix, against `sin(2 pi x)` on `Nx=21`: the ghost was wrong by **3.09e-01 at
+g = 1, 2 and 3**, and `HJBWENOSolver` turned exactly periodic data (seam 2.4e-16) into a field with
+a seam of 2.63e-01. After: ghost error ~5e-16 and the solver's seam is exactly 0.
+
+The oracle is EXTERNAL -- `sin(2 pi x)` evaluated off-grid at the ghost coordinates -- not a second
+implementation of the fill, so it cannot go tautological if the fill is later rewritten. It is also
+what a same-side pin would have missed: `slice(-2g, -g)` and the correct `slice(-2g-1, -g-1)` agree
+on nothing, but "ghost equals some interior value" is true of both.
+
+Issue #1822; same convention #1829 settled for `enforce_periodic_value_nd`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
+from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
+from mfgarchon.geometry.boundary.types import PeriodicGridConvention
+
+NX = 21
+BOUNDS = (0.0, 1.0)
+
+
+def _periodic_bc(uniform: bool) -> BoundaryConditions:
+    """One segment takes `update_ghosts`' uniform path; two take the mixed one.
+
+    Both are exercised because both carried the defect. A single-path test passed over the other
+    for as long as the two copies existed.
+    """
+    # Stated, because these BCs are built bare and never attached to a grid: unstated means the
+    # historical layout, and a grid is what would otherwise bind the inclusive one here.
+    if uniform:
+        return BoundaryConditions(
+            segments=[BCSegment(name="all", bc_type=BCType.PERIODIC)],
+            dimension=1,
+            periodic_convention=PeriodicGridConvention.ENDPOINT_INCLUSIVE,
+        )
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="lo", bc_type=BCType.PERIODIC, boundary="x_min"),
+            BCSegment(name="hi", bc_type=BCType.PERIODIC, boundary="x_max"),
+        ],
+        dimension=1,
+        periodic_convention=PeriodicGridConvention.ENDPOINT_INCLUSIVE,
+    )
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+@pytest.mark.parametrize("uniform", [True, False], ids=["uniform-path", "mixed-path"])
+def test_periodic_ghosts_hold_the_analytic_continuation(ghost_depth, uniform):
+    """The inclusive grid: x[0] and x[-1] coincide, so the wrap steps over the shared node."""
+    x = np.linspace(*BOUNDS, NX)
+    dx = x[1] - x[0]
+    field = np.sin(2 * np.pi * x)
+    assert abs(field[0] - field[-1]) < 1e-15, "the input must be periodic, or the ghosts prove nothing"
+
+    bc = _periodic_bc(uniform)
+    assert bc.is_uniform is uniform, "this test selects the dispatch path by is_uniform; it moved"
+    assert bc.periodic_convention is PeriodicGridConvention.ENDPOINT_INCLUSIVE, (
+        "this case measures the inclusive continuation; the BC default moved out from under it"
+    )
+
+    buf = PreallocatedGhostBuffer(
+        interior_shape=(NX,),
+        boundary_conditions=bc,
+        domain_bounds=np.array([list(BOUNDS)]),
+        ghost_depth=ghost_depth,
+        order=2,
+    )
+    buf.interior[...] = field
+    buf.update_ghosts()
+    padded = np.asarray(buf.padded)
+
+    g = ghost_depth
+    want_low = np.sin(2 * np.pi * (x[0] - dx * np.arange(g, 0, -1)))
+    want_high = np.sin(2 * np.pi * (x[-1] + dx * np.arange(1, g + 1)))
+
+    np.testing.assert_allclose(
+        padded[:g],
+        want_low,
+        atol=1e-14,
+        err_msg=(
+            f"low ghosts (depth {g}) are not the periodic continuation. Reading the last {g} "
+            f"interior entries includes x[-1], which IS x[0] on an endpoint-inclusive grid, and "
+            f"shifts the stencil one cell"
+        ),
+    )
+    np.testing.assert_allclose(padded[-g:], want_high, atol=1e-14, err_msg=f"high ghosts (depth {g}) likewise")
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+def test_the_exclusive_convention_wraps_without_skipping_a_node(ghost_depth):
+    """The other grid, and the reason the fill cannot hard-code either one.
+
+    ``np.linspace(lo, hi, N, endpoint=False)`` -- what the operator layer builds -- has N distinct
+    nodes, so the node one step left of ``x[0]`` is ``x[-1]`` and nothing is stepped over. This
+    case and the inclusive one above differ by exactly one node, and each is the other's defect:
+    filling an inclusive grid this way gave `HJBWENOSolver` a seam of 2.63e-01, and filling an
+    exclusive grid the inclusive way put 0.5 of error into the operator layer's Laplacian.
+    """
+    n = NX
+    x = np.linspace(*BOUNDS, n, endpoint=False)
+    dx = x[1] - x[0]
+    field = np.sin(2 * np.pi * x / (BOUNDS[1] - BOUNDS[0]))
+
+    bc = BoundaryConditions(
+        segments=[BCSegment(name="all", bc_type=BCType.PERIODIC)],
+        dimension=1,
+        periodic_convention=PeriodicGridConvention.ENDPOINT_EXCLUSIVE,
+    )
+    buf = PreallocatedGhostBuffer(
+        interior_shape=(n,),
+        boundary_conditions=bc,
+        domain_bounds=np.array([list(BOUNDS)]),
+        ghost_depth=ghost_depth,
+        order=2,
+    )
+    buf.interior[...] = field
+    buf.update_ghosts()
+    padded = np.asarray(buf.padded)
+
+    g = ghost_depth
+    period = BOUNDS[1] - BOUNDS[0]
+    want_low = np.sin(2 * np.pi * (x[0] - dx * np.arange(g, 0, -1)) / period)
+    want_high = np.sin(2 * np.pi * (x[-1] + dx * np.arange(1, g + 1)) / period)
+
+    np.testing.assert_allclose(padded[:g], want_low, atol=1e-14, err_msg="low ghosts, exclusive grid")
+    np.testing.assert_allclose(padded[-g:], want_high, atol=1e-14, err_msg="high ghosts, exclusive grid")
+
+
+@pytest.mark.parametrize("uniform", [True, False], ids=["uniform-path", "mixed-path"])
+def test_a_constant_field_is_unchanged_by_the_periodic_fill(uniform):
+    """Negative control: a constant has no continuation to get wrong.
+
+    The defect above is invisible here -- every candidate source slice holds the same number -- so
+    this passing while the parametrised test fails is the expected pattern, and it is the reason a
+    constant or symmetric fixture cannot be the pin for this class.
+    """
+    buf = PreallocatedGhostBuffer(
+        interior_shape=(NX,),
+        boundary_conditions=_periodic_bc(uniform),
+        domain_bounds=np.array([list(BOUNDS)]),
+        ghost_depth=2,
+        order=2,
+    )
+    buf.interior[...] = 3.25
+    buf.update_ghosts()
+
+    np.testing.assert_allclose(np.asarray(buf.padded), 3.25, atol=1e-15)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_operators/test_laplacian.py
+++ b/tests/unit/test_operators/test_laplacian.py
@@ -217,6 +217,35 @@ class TestLaplacianSparse:
         np.testing.assert_allclose(Lu_sparse, Lu_matvec, atol=1e-10)
 
     @pytest.mark.unit
+    def test_sparse_matches_matvec_on_an_endpoint_inclusive_periodic_grid(self):
+        """The matrix and the matvec must describe ONE operator under either node layout.
+
+        The case above uses an `endpoint=False` grid, which is the layout `as_scipy_sparse`'s wrap
+        was hard-coded for, so it passed either way. `__call__` pads through the ghost applicator
+        and reads the convention off the BC, while the sparse assembly wrapped with a fixed
+        `% n`; on a `TensorProductGrid` — where `x[0]` and `x[-1]` are one physical point — the two
+        described different operators and disagreed by **1.9e+02** (Issue #1822).
+
+        Independent review found that divergence, and then found that fixing it pinned nothing:
+        reverting the sparse wrap left 1243 tests green. This is that pin. The BC is bound by the
+        grid rather than stated here, so it also covers the binding that makes solver paths correct.
+        """
+        from mfgarchon.geometry import TensorProductGrid
+
+        n = 31
+        grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=periodic_bc(dimension=1))
+        bc = grid.boundary_conditions
+        assert bc.periodic_convention is not None, "the grid must bind the convention, or this proves nothing"
+
+        x = np.asarray(grid.coordinates[0])
+        dx = x[1] - x[0]
+        u = np.sin(2 * np.pi * x)
+        assert abs(u[0] - u[-1]) < 1e-15, "seam-consistent input: the only legitimate field on this grid"
+
+        L = LaplacianOperator(spacings=[dx], field_shape=(n,), bc=bc)
+        np.testing.assert_allclose(L.as_scipy_sparse() @ u.ravel(), L @ u.ravel(), atol=1e-10)
+
+    @pytest.mark.unit
     def test_sparse_2d_neumann(self):
         """2D sparse export should match matvec at interior for Neumann BC."""
         X, Y, dx, dy = _2d_grid(20, 20)


### PR DESCRIPTION
Closes #1825. First per-solver repair under #1822 step 3.

## The defect

`TensorProductGrid` builds `np.linspace(lo, hi, N)`, so `x[0]` and `x[-1]` are the **same physical
point**. The operator layer (`LaplacianOperator`, `IsotropicDiffusion`) builds
`np.linspace(lo, hi, N, endpoint=False)`, where every node is distinct. Both reach the same ghost
applicator, which hard-coded the second — in two separate copies, one per dispatch path.

On an inclusive grid that puts the duplicated node into the ghost and shifts every periodic stencil
one cell. Measured against the analytic continuation of `sin(2 pi x)` at `Nx=21`:

| | ghost error |
|---|---|
| ghost depth 1, 2 and 3 | **3.09e-01** each |

Downstream: `HJBWENOSolver` returned a seam of **2.63e-01** from exactly periodic input, and
`ImplicitHeatSolver`'s seam **stalled at ~1.5e-02 under refinement** instead of vanishing (#1825) —
no refinement closes a fixed one-cell offset.

## This answers #1822's open question

> *"Open question I did not settle: whether any of these solvers internally assume an
> endpoint-**exclusive** periodic grid, in which case its seam is not a defect but a convention
> disagreement."*

Both conventions are genuinely live, and hard-coding the other one is equally wrong — it took the
operator layer's own Laplacian from 1.3e-02 to **6.3e+02** of error. No fixed rule serves both grids.

## The fix

`PeriodicGridConvention` names the two layouts and travels on the periodic `BoundaryConditions` —
the one carrier that reaches every wrapping site, since a wrap happens *only* because that object
says PERIODIC. Nothing is threaded through the 31 sites that pad or construct a buffer. An earlier
revision required every caller to declare and reddened **74** tests, most with no periodic content.

**Unstated means the historical layout**, so adding the field changed no existing caller's numbers.
A grid does not leave it unstated: `TensorProductGrid` **binds** the convention it *measures* from
its own coordinates — derived, not asserted, so changing that `linspace` cannot leave a stale claim
— and refuses one that contradicts them. A BC that never meets a grid is completed at the places
holding both: `get_laplacian_operator`, `get_gradient_operator`, and the solver BC resolution chain.
**No solver declares anything.**

`HJBWENOSolver`'s seam is now exactly **0**. Both xfails are removed, not silenced.

## What review caught, across two passes

Three findings, each a real defect I had shipped:

1. **The default silently reinterpreted every existing BC.** Defaulting to the inclusive layout
   changed the meaning of every `periodic_bc()` that already meant exclusive: the operator layer's
   Laplacian went **1.3e-02 → 6.3e+02** with nothing red, because three *tests* had been taught the
   new convention while production had not. My changelog claim "the operator layer declares
   ENDPOINT_EXCLUSIVE" was false — `grep` over `mfgarchon/operators/` returned nothing. The default
   is now the historical layout.
2. **`LaplacianOperator`'s matrix and matvec described different operators.** `as_scipy_sparse()`
   hard-coded its own `% n` wrap — a third copy — so once the BC carried a convention the two
   disagreed by **1.9e+02** on an inclusive grid. Fixed; they now agree to 2.5e-12 under both.
3. **That fix was itself unpinned.** Reverting it left **1243 tests green**. It now has a
   dense-vs-sparse test on a grid-bound inclusive BC that reddens under exactly that mutation.

Also deleted: an `ImplicitHeatSolver` binding that was dead code whose comment claimed credit for
closing #1825. The counterfactual puts that on `get_laplacian_operator` (mutate it → `test_periodic_bc`
fails; remove the dead lines → nothing moves), and the dead version used `getattr` duck-typing.

## Two tests were pinning the defect

`test_periodic_gradient_byte_identical_to_legacy` asserted equality with the legacy `%Nx` wrap "so
periodic baselines do not move". They had to move: that wrap takes `x[0]`'s left neighbour to be
`x[-1]`, which **is** `x[0]`, reading across `dx` while dividing by `2*dx`. Against analytic
`d/dx sin(2 pi x) = 2 pi` at `x=0`:

| | value | error |
|---|---|---|
| legacy `%Nx` | 3.0902 | 3.19 |
| fixed | **6.1803** | 0.10 — the interior's own O(h²) |

Both tests now measure against calculus, which cannot go stale when a stencil is replaced. The same
one-node error set the expected `-1.5` in the particle gradient override test; on its
`linspace(0, 4, 5)` grid the correct value is `-1.0`, and the periodic-vs-no-flux discrimination
that test exists for is unchanged.

## Stated limitation

Stepping over the duplicated node leaves column `n-1` referenced by nothing but its own diagonal, so
the inclusive matrix is asymmetric (`|A - A^T| = 900` at `n=31`, against 0.0 before). No wrong answer
follows on seam-consistent input, `L @ ones = 0` exactly, and mass conserves to 7e-15 under inclusive
trapezoid weights — but a consumer assuming self-adjointness would be misled. Filed as **#1832**; the
fix is to carry `n-1` DOFs, as #1829 did for the periodic Crank-Nicolson.

## Still xfailed, untouched

Four distinct mechanisms remain under #1822, each measured and none of them this one:
`HJBFDMSolver` (stalls Newton **only** under PERIODIC), `FPFDMSolver` / `FPFVMSolver` (seam enters at
the first timestep), `FPParticleSolver` (KDE edge bins), and the GFDM pair (raise rather than return).

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, `5806 passed, 26 skipped, 28 xfailed` in 5:47.
