### PR TITLE
Solve the periodic FP problem on the torus the grid describes, not one cell longer

### DIFF
--- a/changelog.d/1822-fp-periodic-torus.fixed.md
+++ b/changelog.d/1822-fp-periodic-torus.fixed.md
@@ -1,0 +1,41 @@
+`FPFDMSolver` and `FPFVMSolver` now solve on the torus the grid actually describes. Both wrapped
+cell `N-1` to cell `0`, which on the endpoint-inclusive grid `TensorProductGrid` builds treats the
+repeated endpoint as its own cell and puts the solve on a torus of length `1 + dx`. Against the
+analytic heat kernel at `Nx=21` that was 8.7e-02 of relative error; it is now 9.3e-03, converging
+to 2.4e-03 at `Nx=81`. Nothing raised, the density stayed positive, and under a datum symmetric
+about the midpoint the periodic seam stayed at 2e-15 while the mode's amplitude came out 8.7% off
+the analytic value (a decay rate 9.4% low) -- so the `#1822` seam invariant could not see it, and
+the new pin is against the heat kernel and a rigid translation instead
+(`tests/unit/test_alg/test_periodic_torus_oracle_1822.py`).
+
+The same wrap reached three further paths, each of which would otherwise have disagreed with the
+fixed ones: a periodic BC supplied through the constructor or through `components` rather than
+through the geometry (both solvers resolve the BC themselves, shadowing the base-class property
+that binds the grid's layout), and `AdvectionOperator`'s wrap face, which the callable-`drift_field`
+route uses -- that route returned a seam of 3.9e-02 from exactly periodic data and lost 0.54% of
+the torus mass.
+
+The wrap arithmetic had 12 live copies across the four FP-FDM advection schemes, the ghost
+applicator and the Laplacian assembly; all now route through
+`boundary.conditions.periodic_axis_span` and `boundary.types.repeated_endpoint_count`, and the
+copies are deleted. Four more remain in `FPFDMSolver._solve_fp_1d`, which has no callers and is
+already scheduled for removal by v0.25.0; they are left untouched rather than changed unverified.
+
+Three mass-conservation tests measured mass with a rectangle rule that counts the shared node twice
+(it read 1.035 for a density of mass 1 even at `t=0`, so it was never measuring mass on this grid)
+and now use the quadrature `invariants.mass_drift` already owned; the same solves conserve to
+1.2e-14 under it, and the discrepancy the rectangle rule reported equals `m[0]*dx` to ten digits.
+
+Unstated conventions are untouched, so no caller that never met a grid has its numbers moved:
+`bc=None` and an unstated periodic BC remain byte-identical to before, in 1D, 2D and 3D, for
+`no_flux`, `neumann`, `dirichlet`, `robin` and mixed alike. Only a periodic BC that has met a grid
+changes.
+
+**One 2D configuration that used to run now refuses.** A 2D periodic FP solve driven through the
+tensor-diffusion route with a strong drift trips the positivity guard where it previously completed
+(`Nt=40` and `Nt=160` completed before; they now raise). This is the correct direction and not a
+lost capability: measured on a smooth, strictly positive, exactly periodic 2D datum under the
+`N-1`-cell quadrature, the old path **created 6.3% of its own mass and did not converge away**
+(6.486%, 6.324%, 6.285% at `Nt=10/40/160`), while the new one conserves to 1e-15 and closes both
+seams exactly. So what used to complete was silently wrong, and what now raises is fail-loud. The
+underlying 2D defect is #1835 and predates this change.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -252,6 +252,15 @@ class FPFDMSolver(BaseFPSolver):
 
                 self.boundary_conditions = no_flux_bc(dimension=self.dimension)
 
+        # This resolution shadows BaseMFGSolver.boundary_conditions, which is where a periodic BC
+        # normally picks up the node layout of the grid being solved on (#1822). Without this line
+        # a BC handed to the constructor -- or reached through components -- keeps an unstated
+        # convention and wraps the historical way, while the same solve through the geometry gets
+        # the grid's layout: measured 8.7e-02 against 9.3e-03 of heat-kernel error on one problem,
+        # from one library, depending only on which channel supplied the BC. Applied once, after
+        # both branches, so no channel can be added below it and miss it.
+        self.boundary_conditions = self._with_geometry_periodic_convention(self.boundary_conditions)
+
         # Issue #1456: fail loud now if the resolved BC requests a type FP-FDM cannot honor
         # (Robin has no stencil; Reflecting/Extrapolation are not field-BC types), instead of
         # silently assembling a default (no-flux) wall.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_centered.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_centered.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.geometry.boundary.conditions import periodic_axis_span
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
@@ -107,13 +108,6 @@ def add_interior_entries_divergence_centered(
     # Diffusion coefficient D = sigma^2/2
     D = diffusion_from_volatility(sigma)
 
-    # Check for periodic BC
-    # Issue #543 Phase 2: Replace hasattr with try/except
-    try:
-        is_periodic = boundary_conditions.is_uniform and boundary_conditions.type == "periodic"
-    except AttributeError:
-        is_periodic = False
-
     # For each dimension, add flux-based advection + diffusion contributions
     for d in range(ndim):
         dx = spacing[d]
@@ -126,10 +120,13 @@ def add_interior_entries_divergence_centered(
         multi_idx_plus[d] = multi_idx[d] + 1
         multi_idx_minus[d] = multi_idx[d] - 1
 
-        # Handle periodic wrapping
+        # Handle periodic wrapping. `span` is shape[d] only on an endpoint-exclusive grid;
+        # see periodic_axis_span for why (Issue #1822).
+        span = periodic_axis_span(boundary_conditions, shape[d])
+        is_periodic = span is not None
         if is_periodic:
-            multi_idx_plus[d] = multi_idx_plus[d] % shape[d]
-            multi_idx_minus[d] = multi_idx_minus[d] % shape[d]
+            multi_idx_plus[d] = multi_idx_plus[d] % span
+            multi_idx_minus[d] = multi_idx_minus[d] % span
 
         # Check if neighbors exist (non-periodic case)
         has_plus = multi_idx_plus[d] < shape[d]
@@ -172,7 +169,7 @@ def add_interior_entries_divergence_centered(
             multi_idx_plus2 = list(multi_idx)
             multi_idx_plus2[d] = multi_idx[d] + 2
             if is_periodic:
-                multi_idx_plus2[d] = multi_idx_plus2[d] % shape[d]
+                multi_idx_plus2[d] = multi_idx_plus2[d] % span
 
             if multi_idx_plus2[d] < shape[d] or is_periodic:
                 flat_idx_plus2 = grid.get_index(tuple(multi_idx_plus2))
@@ -190,7 +187,7 @@ def add_interior_entries_divergence_centered(
             multi_idx_minus2 = list(multi_idx)
             multi_idx_minus2[d] = multi_idx[d] - 2
             if is_periodic:
-                multi_idx_minus2[d] = multi_idx_minus2[d] % shape[d]
+                multi_idx_minus2[d] = multi_idx_minus2[d] % span
 
             if multi_idx_minus2[d] >= 0 or is_periodic:
                 flat_idx_minus2 = grid.get_index(tuple(multi_idx_minus2))

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_upwind.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_upwind.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.geometry.boundary.conditions import periodic_axis_span
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
@@ -100,16 +101,13 @@ def add_interior_entries_divergence_upwind(
         multi_idx_plus[d] = multi_idx[d] + 1
         multi_idx_minus[d] = multi_idx[d] - 1
 
-        # Handle boundary wrapping for periodic BC
-        # Issue #543 Phase 2: Replace hasattr with try/except
-        try:
-            is_periodic = boundary_conditions.is_uniform and boundary_conditions.type == "periodic"
-        except AttributeError:
-            is_periodic = False
-
+        # Handle boundary wrapping for periodic BC. `span` is shape[d] only on an
+        # endpoint-exclusive grid; see periodic_axis_span for why (Issue #1822).
+        span = periodic_axis_span(boundary_conditions, shape[d])
+        is_periodic = span is not None
         if is_periodic:
-            multi_idx_plus[d] = multi_idx_plus[d] % shape[d]
-            multi_idx_minus[d] = multi_idx_minus[d] % shape[d]
+            multi_idx_plus[d] = multi_idx_plus[d] % span
+            multi_idx_minus[d] = multi_idx_minus[d] % span
 
         # Check if neighbors exist (non-periodic case)
         has_plus = multi_idx_plus[d] < shape[d]

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_centered.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_centered.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.geometry.boundary.conditions import periodic_axis_span
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
 if TYPE_CHECKING:
@@ -101,13 +102,6 @@ def add_interior_entries_gradient_centered(
     # Diffusion coefficient D = sigma^2/2 (Issue #1189: single source)
     D = diffusion_from_volatility(sigma)
 
-    # Check for periodic BC
-    # Issue #543 Phase 2: Replace hasattr with try/except
-    try:
-        is_periodic = boundary_conditions.is_uniform and boundary_conditions.type == "periodic"
-    except AttributeError:
-        is_periodic = False
-
     # For each dimension, add advection + diffusion contributions
     for d in range(ndim):
         dx = spacing[d]
@@ -120,10 +114,13 @@ def add_interior_entries_gradient_centered(
         multi_idx_plus[d] = multi_idx[d] + 1
         multi_idx_minus[d] = multi_idx[d] - 1
 
-        # Handle periodic wrapping
+        # Handle periodic wrapping. `span` is shape[d] only on an endpoint-exclusive grid;
+        # see periodic_axis_span for why (Issue #1822).
+        span = periodic_axis_span(boundary_conditions, shape[d])
+        is_periodic = span is not None
         if is_periodic:
-            multi_idx_plus[d] = multi_idx_plus[d] % shape[d]
-            multi_idx_minus[d] = multi_idx_minus[d] % shape[d]
+            multi_idx_plus[d] = multi_idx_plus[d] % span
+            multi_idx_minus[d] = multi_idx_minus[d] % span
 
         # Check if neighbors exist (non-periodic case)
         has_plus = multi_idx_plus[d] < shape[d]

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_gradient_upwind.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mfgarchon.geometry.boundary.conditions import periodic_axis_span
 from mfgarchon.utils.aux_func import npart, ppart
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
@@ -125,17 +126,13 @@ def add_interior_entries_gradient_upwind(
         multi_idx_plus[d] = multi_idx[d] + 1
         multi_idx_minus[d] = multi_idx[d] - 1
 
-        # Handle boundary wrapping for periodic BC
-        # Issue #543 Phase 2: Replace hasattr with try/except
-        try:
-            is_periodic = boundary_conditions.is_uniform and boundary_conditions.type == "periodic"
-        except AttributeError:
-            # For BoundaryConditionManager2D or unknown types, default to non-periodic
-            is_periodic = False
-
+        # Handle boundary wrapping for periodic BC. `span` is shape[d] only on an
+        # endpoint-exclusive grid; see periodic_axis_span for why (Issue #1822).
+        span = periodic_axis_span(boundary_conditions, shape[d])
+        is_periodic = span is not None
         if is_periodic:
-            multi_idx_plus[d] = multi_idx_plus[d] % shape[d]
-            multi_idx_minus[d] = multi_idx_minus[d] % shape[d]
+            multi_idx_plus[d] = multi_idx_plus[d] % span
+            multi_idx_minus[d] = multi_idx_minus[d] % span
 
         # Check if neighbors exist (non-periodic case)
         has_plus = multi_idx_plus[d] < shape[d]

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -65,6 +65,7 @@ from mfgarchon.geometry.boundary import no_flux_bc
 from mfgarchon.geometry.boundary.applicator_base import (
     LinearConstraint,
 )
+from mfgarchon.geometry.boundary.conditions import repeated_endpoint_mirror
 from mfgarchon.geometry.boundary.types import BoundaryFace
 from mfgarchon.utils.numerical import clip_nonnegative_or_raise, mass_fabricated_by_clip
 from mfgarchon.utils.pde_coefficients import (
@@ -1247,10 +1248,27 @@ def solve_timestep_full_nd(
                 "Use 'no_flux' or 'neumann' for zero-flux (reflecting) walls. (Issue #1250)"
             )
 
+    # Nodes that an inclusive periodic wrap makes duplicates of another node (Issue #1822).
+    # They get a constraint row instead of a stencil row: they are not unknowns.
+    repeated_rows: list[int] = []
+
     # Build matrix by iterating over all grid points
     for flat_idx in range(N_total):
         # Convert flat index to multi-index (i, j, k, ...)
         multi_idx = grid.get_multi_index(flat_idx)
+
+        # On an endpoint-inclusive periodic grid the last node along a wrapping axis IS the first
+        # one. Assembling a stencil row for it solves for one cell too many on a torus one cell too
+        # long, and the duplicated pair drifts apart because their neighbourhoods differ -- the
+        # #1822 seam. Constrain it to the node it repeats and move on.
+        mirror = repeated_endpoint_mirror(boundary_conditions, multi_idx, shape)
+        if mirror is not None:
+            mirror_flat = grid.get_index(tuple(mirror))
+            row_indices.extend((flat_idx, flat_idx))
+            col_indices.extend((flat_idx, mirror_flat))
+            data_values.extend((1.0, -1.0))
+            repeated_rows.append(flat_idx)
+            continue
 
         # Extract local diffusion coefficient (scalar or from spatially varying array)
         if isinstance(sigma, np.ndarray):
@@ -1370,6 +1388,12 @@ def solve_timestep_full_nd(
     # Add source term to RHS (MMS verification)
     if source_term is not None:
         b_rhs = b_rhs + source_term
+
+    # The repeated-endpoint rows assembled above read `m[i] - m[mirror] = 0`. Zeroed last so a
+    # source term cannot re-enter a row that carries a constraint rather than a balance.
+    if repeated_rows:
+        b_rhs = b_rhs.copy()
+        b_rhs[repeated_rows] = 0.0
 
     # Solve linear system
     m_next_flat = sparse.linalg.spsolve(A_matrix, b_rhs)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
@@ -62,6 +62,7 @@ from scipy.sparse.linalg import splu
 from mfgarchon.alg.base_solver import SchemeFamily
 from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver, DriftConvention
 from mfgarchon.alg.numerical.fp_solvers.fp_fvm_flux import advective_divergence
+from mfgarchon.geometry.boundary.conditions import periodic_axis_span
 from mfgarchon.geometry.boundary.types import BCType
 from mfgarchon.operators.differential.laplacian import LaplacianOperator
 from mfgarchon.utils.mfg_logging import get_logger
@@ -161,7 +162,19 @@ class FPFVMSolver(BaseFPSolver):
     # Setup helpers
     # ------------------------------------------------------------------
     def _resolve_boundary_conditions(self, boundary_conditions: BoundaryConditions | None) -> BoundaryConditions:
-        """Resolve BC using the same hierarchy as FPFDMSolver (explicit > components > geometry)."""
+        """Resolve BC using the same hierarchy as FPFDMSolver (explicit > components > geometry).
+
+        Every return goes through ``_with_geometry_periodic_convention``: this method shadows
+        ``BaseMFGSolver.boundary_conditions``, which is where a periodic BC normally picks up the
+        node layout of the grid being solved on (#1822). Without it, a BC supplied by the caller
+        keeps an unstated convention and wraps the historical way while the geometry channel gets
+        the grid's -- 8.7e-02 against 9.3e-03 of heat-kernel error on one problem, decided only by
+        which channel supplied the BC.
+        """
+        return self._with_geometry_periodic_convention(self._boundary_conditions_source(boundary_conditions))
+
+    def _boundary_conditions_source(self, boundary_conditions: BoundaryConditions | None) -> BoundaryConditions:
+        """Which object supplies the BC, before the grid's periodic layout is bound onto it."""
         if boundary_conditions is not None:
             return boundary_conditions
 
@@ -230,11 +243,13 @@ class FPFVMSolver(BaseFPSolver):
         if diffusion == 0.0:
             return None
         spacing = list(self.problem.geometry.get_grid_spacing())
-        # Periodic Laplacian closure is requested via bc=None (wrap); otherwise pass the BC so
-        # the conservative finite-volume no-flux/Neumann closure (1^T L = 0) is used.
-        lap_bc = None if all(t == "periodic" for t in self._bc_types) else self.boundary_conditions
+        # Always pass the BC. `bc=None` also selects the wrap closure, but it discards which
+        # periodic grid this is: the operator then reads no convention and wraps the exclusive way
+        # (Issue #1822), which on the endpoint-inclusive grid TensorProductGrid builds puts the
+        # diffusion half of this solver on a torus one cell too long. The periodic branch of
+        # as_scipy_sparse is the same either way; `mass_conservative` gates only no-flux/Neumann.
         laplacian = LaplacianOperator(
-            spacings=spacing, field_shape=shape, bc=lap_bc, mass_conservative=True
+            spacings=spacing, field_shape=shape, bc=self.boundary_conditions, mass_conservative=True
         ).as_scipy_sparse()
         n_total = int(np.prod(shape))
         system = sparse.eye(n_total, format="csc") - dt * diffusion * laplacian
@@ -400,7 +415,15 @@ class FPFVMSolver(BaseFPSolver):
         n_sub = max(1, math.ceil(dt_adv * amax / (cfl * dx_min)))
         dt_sub = dt_adv / n_sub
         for _ in range(n_sub):
-            div = advective_divergence(m, alpha_faces, alpha_wrap, spacing, self.reconstruction, self._bc_types)
+            div = advective_divergence(
+                m,
+                alpha_faces,
+                alpha_wrap,
+                spacing,
+                self.reconstruction,
+                self._bc_types,
+                spans=[periodic_axis_span(self.boundary_conditions, n) for n in m.shape],
+            )
             m = m - dt_sub * div
         return m
 

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fvm_flux.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fvm_flux.py
@@ -89,6 +89,7 @@ def axis_flux_divergence(
     scheme: str,
     bc_type: str,
     alpha_wrap: np.ndarray | None = None,
+    span: int | None = None,
 ) -> np.ndarray:
     r"""Advective flux divergence ``(F_{i+1/2} - F_{i-1/2})/dx`` along one axis.
 
@@ -111,7 +112,16 @@ def axis_flux_divergence(
         ``reflecting``) or ``periodic``.
     alpha_wrap : np.ndarray | None
         Interface velocity at the periodic wrap face (between cell ``N-1`` and cell ``0``);
-        required iff ``bc_type == "periodic"``. Shape = ``m`` with ``axis`` removed.
+        required iff ``bc_type == "periodic"`` on an endpoint-exclusive axis. Ignored when
+        ``span < N``: see below. Shape = ``m`` with ``axis`` removed.
+    span : int | None
+        Number of DISTINCT cells along ``axis`` (Issue #1822). ``None`` or ``N`` is the
+        endpoint-exclusive layout this module was written for. On an endpoint-inclusive axis
+        ``span = N - 1``, because cell ``N-1`` is cell ``0`` under another index -- and then the
+        wrap face is already one of the supplied interior faces (``alpha_int[..., span-1]`` sits
+        between cell ``span-1`` and cell ``N-1``, which IS cell 0), so ``alpha_wrap`` is degenerate
+        and is not read. Treating the repeat as its own cell puts the solve on a torus one cell
+        too long and the duplicated pair drifts apart.
 
     Returns
     -------
@@ -121,6 +131,13 @@ def axis_flux_divergence(
     mm = np.moveaxis(m, axis, -1)
     ai = np.moveaxis(alpha_int, axis, -1)
     periodic = bc_type == "periodic"
+    n_full = mm.shape[-1]
+    repeats = periodic and span is not None and span < n_full
+    if repeats:
+        # Drop the repeated cell and take the wrap velocity from the face that already spans it.
+        alpha_wrap = ai[..., span - 1]
+        mm = mm[..., :span]
+        ai = ai[..., : span - 1]
     n = mm.shape[-1]
 
     if scheme == "muscl":
@@ -159,6 +176,11 @@ def axis_flux_divergence(
         )
 
     div = (f_full[..., 1:] - f_full[..., :-1]) / dx
+    if repeats:
+        # Restore the caller's shape: the repeated cell carries cell 0's divergence, because it
+        # IS cell 0. Written back rather than left stale so the field stays periodic by
+        # construction instead of by a later copy nobody can see from here.
+        div = np.concatenate([div, div[..., : n_full - n]], axis=-1)
     return np.moveaxis(div, -1, axis)
 
 
@@ -169,6 +191,7 @@ def advective_divergence(
     spacing: list[float],
     scheme: str,
     bc_types: list[str],
+    spans: list[int | None] | None = None,
 ) -> np.ndarray:
     """Total advective flux divergence ``sum_d (F^d_{+} - F^d_{-})/dx_d`` over all axes.
 
@@ -179,5 +202,14 @@ def advective_divergence(
     ndim = m.ndim
     div = np.zeros_like(m, dtype=float)
     for d in range(ndim):
-        div += axis_flux_divergence(m, alpha_faces[d], d, spacing[d], scheme, bc_types[d], alpha_wrap[d])
+        div += axis_flux_divergence(
+            m,
+            alpha_faces[d],
+            d,
+            spacing[d],
+            scheme,
+            bc_types[d],
+            alpha_wrap[d],
+            span=None if spans is None else spans[d],
+        )
     return div

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -93,7 +93,14 @@ from .conditions import BoundaryConditions
 from .enforcement import enforce_dirichlet_value_nd, enforce_neumann_value_nd
 from .fdm_bc_1d import BoundaryConditions as BoundaryConditions1DFDM
 from .ghost_cells import GhostCellConfig
-from .types import BCSegment, BCType, BoundaryFace, PeriodicGridConvention, parse_boundary_face
+from .types import (
+    BCSegment,
+    BCType,
+    BoundaryFace,
+    PeriodicGridConvention,
+    parse_boundary_face,
+    repeated_endpoint_count,
+)
 
 logger = get_logger(__name__)
 
@@ -818,7 +825,7 @@ def _periodic_ghost_slices(
     source: list[slice] = [slice(None)] * d
     # On an inclusive grid the shared endpoint is a duplicate and must be stepped over; on an
     # exclusive one every node is distinct and the wrap starts at the last one.
-    skip = 1 if convention is PeriodicGridConvention.ENDPOINT_INCLUSIVE else 0
+    skip = repeated_endpoint_count(convention)
     if side == "min":
         ghost[axis] = slice(0, g)
         source[axis] = slice(-2 * g - skip, -g - skip)

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -37,7 +37,14 @@ from mfgarchon.geometry.protocols import SupportsRegionMarking
 from mfgarchon.utils.deprecation import deprecated
 
 from .tolerances import BOUNDARY_REL_TOL, BOUNDARY_TOL, SDF_BOUNDARY_TOL
-from .types import BCSegment, BCType, BoundaryFace, PeriodicGridConvention, _compute_sdf_gradient
+from .types import (
+    BCSegment,
+    BCType,
+    BoundaryFace,
+    PeriodicGridConvention,
+    _compute_sdf_gradient,
+    repeated_endpoint_count,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -951,6 +958,50 @@ def periodic_bc(
     bc = uniform_bc(BCType.PERIODIC, value=0.0, dimension=dimension, domain_bounds=domain_bounds)
     bc.periodic_convention = convention
     return bc
+
+
+def periodic_axis_span(bc: Any, n: int) -> int | None:
+    """How many DISTINCT cells an axis of ``n`` nodes has, or ``None`` if it does not wrap.
+
+    Issue #1822. A wrap needs two facts, and reading only the first is what every periodic
+    stencil in this package got wrong: ``bc`` says the axis wraps, and ``bc.periodic_convention``
+    says whether the last node is a *new* cell or the first one under another index. Under
+    ``ENDPOINT_INCLUSIVE`` -- what ``TensorProductGrid`` builds -- it is the latter, so ``i-1``
+    from node 0 is node ``n-2`` and the modular arithmetic must divide by ``n-1``.
+
+    Dividing by ``n`` there solves the problem on a torus one cell too long. Measured on the
+    FP-FDM family at ``Nx=21``: 8.7e-02 of relative error against the analytic heat kernel, where
+    the same scheme on the equivalent ``n-1``-cell torus gives 9.3e-03. Nothing raises either way.
+
+    Returns ``None`` -- not ``n`` -- for a non-periodic axis, so a caller cannot use the number
+    without having decided what to do about the wrap.
+    """
+    try:
+        wraps = bool(bc.is_uniform) and bc.type == "periodic"
+    except AttributeError:
+        # Legacy fdm_bc_1d BoundaryConditions1D: has .type but no .is_uniform, and this assembly
+        # does not honour its 'periodic' anyway (see the Issue #1559 note in fp_fdm_time_stepping).
+        return None
+    if not wraps:
+        return None
+    return n - repeated_endpoint_count(getattr(bc, "periodic_convention", None))
+
+
+def repeated_endpoint_mirror(bc: Any, multi_idx: tuple[int, ...], shape: tuple[int, ...]) -> tuple[int, ...] | None:
+    """The node ``multi_idx`` duplicates under an inclusive wrap, or ``None`` if it duplicates none.
+
+    Issue #1822. On an inclusive periodic axis the last node is not an unknown: it is node 0 under
+    another index. An assembly that gives it a stencil row of its own is solving for one cell too
+    many, and the duplicated pair then drifts apart because their neighbourhoods differ.
+    """
+    mirrored = list(multi_idx)
+    duplicated = False
+    for d in range(len(shape)):
+        span = periodic_axis_span(bc, shape[d])
+        if span is not None and span < shape[d] and multi_idx[d] >= span:
+            mirrored[d] = multi_idx[d] - span
+            duplicated = True
+    return tuple(mirrored) if duplicated else None
 
 
 def dirichlet_bc(

--- a/mfgarchon/geometry/boundary/types.py
+++ b/mfgarchon/geometry/boundary/types.py
@@ -117,6 +117,21 @@ class PeriodicGridConvention(Enum):
     ENDPOINT_EXCLUSIVE = "endpoint_exclusive"
 
 
+def repeated_endpoint_count(convention: PeriodicGridConvention | None) -> int:
+    """How many trailing nodes of a periodic axis repeat a node the array already holds.
+
+    One under ``ENDPOINT_INCLUSIVE`` (``x[-1]`` *is* ``x[0]``), zero otherwise; unstated means the
+    exclusive layout this package wrapped with before #1822.
+
+    Every periodic wrap in the package is one of two expressions of this single number, which is
+    why it is a function and not two constants: a ghost fill steps over the repeat
+    (``skip``), and a modular neighbour index divides by the count of distinct cells
+    (``span = N - repeated_endpoint_count(...)``). Written out separately at each site they drift,
+    and the drift is silent -- both readings return a finite, plausible field.
+    """
+    return 1 if convention is PeriodicGridConvention.ENDPOINT_INCLUSIVE else 0
+
+
 class BCType(Enum):
     """
     Boundary condition types (dimension-agnostic).

--- a/mfgarchon/operators/differential/advection.py
+++ b/mfgarchon/operators/differential/advection.py
@@ -313,6 +313,7 @@ class AdvectionOperator(LinearOperator):
         FP use case); other BCs would need an inflow flux and should not opt in.
         """
         from mfgarchon.geometry.boundary import BCType, BoundaryConditions
+        from mfgarchon.geometry.boundary.conditions import periodic_axis_span
 
         # Issue #1428: an explicit periodic BoundaryConditions object must be treated like
         # bc=None (wrap-face telescoping), not rejected — previously only bc=None counted as
@@ -334,6 +335,18 @@ class AdvectionOperator(LinearOperator):
             h = self.spacings[d]
             md = np.moveaxis(m, d, -1)
             vd = np.moveaxis(self.velocity_field[d], d, -1)
+            # On an endpoint-inclusive periodic axis the last cell IS the first one, so it is not
+            # its own control volume and the wrap face sits one cell earlier (#1822). Wrapping all
+            # N cells there telescopes over a torus of length L + h: measured on the callable-drift
+            # FP path, a seam of 3.9e-02 from exactly periodic data and 0.54% of the mass lost.
+            # `bc=None` means periodic with no convention stated, i.e. the exclusive layout, and
+            # `periodic_axis_span` returns None for it -- so that path is untouched.
+            n_full = md.shape[-1]
+            span = periodic_axis_span(self.bc, n_full) if periodic else None
+            repeats = span is not None and span < n_full
+            if repeats:
+                md = md[..., :span]
+                vd = vd[..., :span]
             # Upwind flux on interior faces i+1/2 (i = 0 .. N-2), velocity averaged to the face.
             v_face = 0.5 * (vd[..., :-1] + vd[..., 1:])
             flux = np.where(v_face >= 0.0, v_face * md[..., :-1], v_face * md[..., 1:])
@@ -344,6 +357,9 @@ class AdvectionOperator(LinearOperator):
                 dvar[..., 0] = (flux[..., 0] - flux_wrap) / h
                 dvar[..., 1:-1] = (flux[..., 1:] - flux[..., :-1]) / h
                 dvar[..., -1] = (flux_wrap - flux[..., -1]) / h
+                if repeats:
+                    # The repeated cell carries cell 0's divergence, because it IS cell 0.
+                    dvar = np.concatenate([dvar, dvar[..., : n_full - span]], axis=-1)
             else:
                 # No-flux walls: zero flux through both boundary faces.
                 dvar[..., 0] = flux[..., 0] / h

--- a/mfgarchon/operators/differential/laplacian.py
+++ b/mfgarchon/operators/differential/laplacian.py
@@ -184,17 +184,16 @@ class LaplacianOperator(LinearOperator):
         # Return flattened
         return Lu.ravel()
 
-    def _periodic_convention_is_inclusive(self) -> bool:
-        """Whether this operator's periodic wrap identifies the two endpoints. Issue #1822.
+    def _repeated_endpoints(self) -> int:
+        """How many nodes this operator's periodic wrap must step over. Issue #1822.
 
         Read off the same BC that `__call__`'s ghost padding reads, so the matrix and the matvec
         cannot describe different operators. Unstated means the layout this package always used --
         all N nodes distinct -- which is what the operator layer's own grids are.
         """
-        from mfgarchon.geometry.boundary.types import PeriodicGridConvention
+        from mfgarchon.geometry.boundary.types import repeated_endpoint_count
 
-        declared = getattr(self.bc, "periodic_convention", None)
-        return declared is PeriodicGridConvention.ENDPOINT_INCLUSIVE
+        return repeated_endpoint_count(getattr(self.bc, "periodic_convention", None))
 
     def __call__(self, u: NDArray) -> NDArray:
         """
@@ -409,7 +408,7 @@ class LaplacianOperator(LinearOperator):
                 #
                 # On an inclusive grid node n-1 IS node 0, so the wrap skips it: the left neighbour
                 # of node 0 is n-2 and the right neighbour of node n-1 is 1.
-                span = n_d - 1 if self._periodic_convention_is_inclusive() else n_d
+                span = n_d - self._repeated_endpoints()
 
                 # Left neighbor (wrapped for periodic)
                 left_idx = multi_indices.copy()

--- a/tests/unit/test_alg/test_fp_fdm_solver.py
+++ b/tests/unit/test_alg/test_fp_fdm_solver.py
@@ -926,14 +926,27 @@ class TestFPFDMSolverTensorDiffusion:
         assert np.all(M >= 0)
 
     def test_tensor_with_drift(self):
-        """Test tensor diffusion combined with drift field."""
+        """Test tensor diffusion combined with drift field.
+
+        The BC matches the geometry (#1822). It was `periodic_bc(dimension=1)` on this 2D grid --
+        a dimension mismatch, and one this test asserts nothing about: its subject is tensor
+        diffusion plus drift. It was also not doing what its name said. Measured on the code before
+        #1822, that BC left a seam of 4.63e-02, i.e. the periodicity it requested was never
+        honoured; the solve passed because the wrap was loose, not because it was right.
+
+        Making that path genuinely periodic -- the BC now carries the grid's layout and the
+        advection operator honours it -- trips the positivity guard here. That IS a narrowing: this
+        configuration completed before at Nt=40 and Nt=160. It is still the right direction, because
+        what completed before created 6.3% of its own mass and did not converge away, where the new
+        path conserves to 1e-15 and closes both seams. Both states are wrong; #1835 holds the work
+        of making 2D periodic actually solve, and this test is not the place to carry it.
+        """
         domain = TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[26, 26], boundary_conditions=no_flux_bc(dimension=2)
         )
         problem = MFGProblem(geometry=domain, T=0.05, Nt=10, sigma=0.1, components=_default_components_2d())
 
-        boundary_conditions = periodic_bc(dimension=1)
-        solver = FPFDMSolver(problem, boundary_conditions=boundary_conditions)
+        solver = FPFDMSolver(problem, boundary_conditions=no_flux_bc(dimension=2))
 
         Nx, Ny = domain.num_points[0], domain.num_points[1]
         Nt = problem.Nt + 1

--- a/tests/unit/test_alg/test_fp_matrix_conservation.py
+++ b/tests/unit/test_alg/test_fp_matrix_conservation.py
@@ -28,6 +28,7 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import neumann_bc, no_flux_bc, periodic_bc, robin_bc
+from mfgarchon.geometry.boundary.invariants import mass_drift
 
 
 def _zero_drift_density_evolution(bc, n=41, nt=40, T=0.2, sigma=0.5):
@@ -60,9 +61,18 @@ class TestFPProductionConservation:
     """Mass + positivity of the real FPFDMSolver implicit step (not a shadow matrix)."""
 
     def test_mass_conserved_periodic_zero_drift(self):
-        M, dx = _zero_drift_density_evolution(periodic_bc(dimension=1))
-        mass = M.sum(axis=1) * dx
-        relerr = abs(mass[-1] - mass[0]) / mass[0]
+        """Quadrature is `trapezoid`, not `sum`, because the grid is endpoint-inclusive (#1822).
+
+        `M.sum(axis=1) * dx` counts the shared node twice -- it read 1.035 for a datum of mass 1
+        even at t=0. That was consistent while the solver treated the repeat as its own cell on a
+        torus of length 1 + dx; now that it does not, the rectangle rule is measuring a quantity
+        the solve does not conserve, and the drift it reports is one cell's worth of density
+        (verified: the gap equals `m[0]*dx` to ten digits). Under the owner's quadrature the same
+        solve conserves mass to 1.2e-14.
+        """
+        M, _dx = _zero_drift_density_evolution(periodic_bc(dimension=1))
+        x = np.linspace(0.0, 1.0, M.shape[1])
+        relerr = mass_drift(M, x)
         assert relerr < 1e-12, f"periodic zero-drift mass not conserved: relerr {relerr:.2e}"
 
     def test_mass_conserved_no_flux_zero_drift(self):

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -110,10 +110,22 @@ KNOWN_NOT_HONOURED = {
     # every periodic stencil sat one cell off. Fixed in applicator_fdm._periodic_ghost_slices;
     # seam 2.63e-01 -> exactly 0. The ghost fill itself is pinned against the analytic continuation
     # in tests/unit/test_geometry/test_periodic_ghost_fill_1822.py.
-    "HJBFDMSolver": ("#1822", AssertionError),
+    # FPFDMSolver and FPFVMSolver are GONE from this roster for one shared reason, the same one
+    # that removed HJBWENOSolver: both wrapped cell N-1 to cell 0, which on an endpoint-inclusive
+    # grid treats the repeated endpoint as its own cell and solves on a torus one cell too long.
+    # The seam was the visible half; the invisible half was worse. Against the analytic heat
+    # kernel at Nx=21 they were 8.7e-02 of relative error and are now 9.3e-03, converging
+    # 9.3e-03 -> 3.8e-03 -> 2.4e-03 over 21/41/81 -- and under the SYMMETRIC datum that error sat
+    # behind a seam of 2e-15, so this file's own invariant could not have found it. Fixed in
+    # conditions.periodic_axis_span (one owner, four scheme modules and the FVM wrap face route
+    # through it) plus the repeated-endpoint constraint row in fp_fdm_time_stepping. Pinned
+    # against the heat kernel and a rigid translation, not against the seam, in
+    # tests/unit/test_alg/test_periodic_torus_oracle_1822.py.
+    # Reason is a pointer, not a diagnosis: the evidence for what produces this seam (the seam
+    # enters at the stalled timestep and decays backward, and the stall is periodic-specific) is
+    # in #1834, and nothing in THIS change tests it.
+    "HJBFDMSolver": ("#1834", AssertionError),
     "HJBGFDMSolver": ("#1822 declares PERIODIC and raises for it", NotImplementedError),
-    "FPFDMSolver": ("#1822", AssertionError),
-    "FPFVMSolver": ("#1822", AssertionError),
     "FPGFDMSolver": ("#1822 density goes invalid mid-solve", ValueError),
     "FPParticleSolver": ("#1822", AssertionError),
     "FPSLJacobianSolver": ("#1822 deprecated, retirement in #1756", AssertionError),
@@ -392,9 +404,11 @@ BC_FACTORIES = {
 # without identifying the coincident nodes, and that is a weaker claim than the seam test above
 # makes, not a violated one.
 #
-#   converge:   FPFVMSolver 1.79e-01 9.00e-02 4.25e-02   HJBWENOSolver 2.63e-01 2.08e-01 1.34e-01
-#               HJBFDMSolver 7.42e-01 6.51e-01 4.72e-01  FPFDMSolver (same shape)
-#   exact:      HJBSemiLagrangianSolver 0, FPSLSolver / FPSLAdjointSolver 4.4e-16
+#   converge:   HJBFDMSolver 7.42e-01 6.51e-01 4.72e-01
+#   exact:      HJBSemiLagrangianSolver 0, FPSLSolver / FPSLAdjointSolver 4.4e-16,
+#               HJBWENOSolver (was 2.63e-01 2.08e-01 1.34e-01 before its ghost fill was fixed),
+#               FPFVMSolver and FPFDMSolver (were 1.79e-01 9.00e-02 4.25e-02 and the same shape,
+#               before the wrap was put on the right torus -- #1822)
 #   NOT:        FPParticleSolver 5.64e-01 2.08e-01 2.63e-01 (up at 81)
 #               FPSLJacobianSolver 1.58e+00 7.64e-03 1.16e-02 (up at 81)
 # Unseeded solvers cannot be classified here at all: measured over three trials, FPParticleSolver

--- a/tests/unit/test_alg/test_periodic_torus_oracle_1822.py
+++ b/tests/unit/test_alg/test_periodic_torus_oracle_1822.py
@@ -1,0 +1,331 @@
+"""A periodic FP solve must reproduce the torus the grid describes. Issue #1822.
+
+The seam invariant in ``test_periodic_capability_invariant_1822.py`` asks whether ``m[0]`` and
+``m[-1]`` agree. That is necessary and it is not sufficient: under a datum symmetric about the
+midpoint, ``FPFDMSolver`` and ``FPFVMSolver`` both returned a seam of **2e-15** while the mode's
+amplitude came out **8.7% off** the analytic value -- a decay rate 9.4% low. They wrapped cell
+``N-1`` to cell ``0`` on an endpoint-inclusive grid, which solves the problem on a torus one cell too long, and symmetry keeps the duplicated pair
+equal all the way to the end. A seam test cannot see that, so this file measures against laws
+computed independently of any discretisation:
+
+- **the heat kernel** -- with zero drift the FP equation is ``dm/dt = D m_xx``, ``D = sigma^2/2``,
+  and the mode ``cos(2 pi x)`` decays by exactly ``exp(-D (2 pi)^2 T)`` on the unit torus;
+- **rigid translation** -- with zero diffusion and a constant velocity ``v``, ``m(T, .)`` is
+  ``m0(. - vT)``, wrapped.
+
+Both are stated by the PDE, so neither can go tautological when the two solvers are later
+consolidated onto shared machinery -- which is the failure mode that kills path-A-vs-path-B
+agreement tests once the consolidation they were written for succeeds.
+
+Grid, and why only this one is measured. ``TensorProductGrid(bounds=[(0, 1)], Nx_points=[N])``
+always builds ``linspace(0, 1, N)``: endpoint-INCLUSIVE, ``dx = 1/(N-1)``, ``N-1`` distinct cells,
+torus length exactly 1. Asking for an exclusive layout by passing ``x[-1] = 0.95`` does NOT produce
+one -- it produces an inclusive grid over ``[0, 0.95]``, whose 21-cell torus comes out at 0.9975
+and matches the oracle by accident. That accident is how the first version of this measurement
+certified the unfixed solvers; the exclusive layout belongs to the operator layer, which builds its
+own coordinates and is covered in ``test_operators/test_laplacian.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.alg.numerical.fp_solvers.fp_fvm import FPFVMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import periodic_bc
+
+T_FINAL = 0.5
+NT = 200  # fine in time on purpose: what is under test is the SPACE wrap, not the time error
+AMP = 0.3
+SIGMA = 0.3
+D = SIGMA**2 / 2
+
+SOLVERS = {"FPFDMSolver": FPFDMSolver, "FPFVMSolver": FPFVMSolver}
+
+
+def _datum(z, k=1.0):
+    """Exactly 1-periodic and strictly positive, so it is a legal density on the unit torus."""
+    return 1.0 + AMP * np.cos(2 * np.pi * k * np.asarray(z))
+
+
+def _problem(nx, sigma, k=1.0):
+    return MFGProblem(
+        geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=periodic_bc(dimension=1)),
+        T=T_FINAL,
+        Nt=NT,
+        sigma=sigma,
+        components=MFGComponents(
+            m_initial=lambda z: _datum(z, k),
+            u_terminal=lambda z: np.zeros_like(np.asarray(z)),
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _diffuse(name, nx, sigma=SIGMA, k=1.0, scheme=None):
+    """Zero drift: the optimal control vanishes and FP reduces to the heat equation."""
+    kwargs = {"advection_scheme": scheme} if scheme else {}
+    solver = SOLVERS[name](_problem(nx, sigma, k), **kwargs)
+    x = np.linspace(0.0, 1.0, nx)
+    return np.asarray(solver.solve_fp_system(_datum(x, k), np.zeros((NT + 1, nx)))), x
+
+
+def _mode_amplitude(m, x, k=1.0):
+    """Projection onto ``cos(2 pi k x)``, with the repeated endpoint weighted once.
+
+    ``x[-1]`` IS ``x[0]``; counting it twice biases ``<phi, phi>`` by 1/(N-1) and would show up as
+    a solver error of the same size.
+    """
+    phi = np.cos(2 * np.pi * k * x)
+    w = np.ones_like(x)
+    w[-1] = 0.0
+    return float(np.sum(w * m * phi) / np.sum(w * phi * phi))
+
+
+@pytest.mark.parametrize("name", sorted(SOLVERS))
+def test_a_periodic_solve_reproduces_the_heat_kernel(name):
+    """The decay rate of a Fourier mode is fixed by the PDE, and by the torus length.
+
+    Wrapping N-1 to 0 on this grid stretches the torus from 1 to 1 + dx, which slows the decay --
+    measured 8.7e-02 of relative error at Nx=21 before the fix, where the number below is 9.3e-03.
+    The failure is silent: nothing raises, the density stays positive, the seam stays at round-off.
+    """
+    oracle = AMP * np.exp(-D * (2 * np.pi) ** 2 * T_FINAL)
+    errors = []
+    for nx in (21, 41, 81):
+        m, x = _diffuse(name, nx)
+        assert np.isfinite(m).all(), f"{name} produced non-finite values"
+        errors.append(abs(_mode_amplitude(m[-1], x) - oracle) / oracle)
+
+    trend = ", ".join(f"{e:.3e}" for e in errors)
+    assert errors[0] < 3e-2, (
+        f"{name} decayed cos(2 pi x) at the wrong rate on the unit torus: relative error "
+        f"{errors[0]:.3e} at Nx=21 ({trend} at 21/41/81). A wrap that treats the repeated endpoint "
+        f"as its own cell puts the solve on a torus of length 1 + dx and lands near 8.7e-02 here"
+    )
+    assert errors[2] < errors[0], f"{name} heat-kernel error did not improve under refinement: {trend}"
+
+
+@pytest.mark.parametrize("name", sorted(SOLVERS))
+def test_zero_diffusion_and_zero_drift_do_not_move_the_density(name):
+    """Positive control for the test above: with nothing driving it, the datum must be untouched.
+
+    Without this, `test_a_periodic_solve_reproduces_the_heat_kernel` has two ways to pass -- the
+    scheme is right, or the solve did nothing and the amplitude never changed. This separates them:
+    here doing nothing is the correct answer and any evolution is a defect.
+    """
+    m, x = _diffuse(name, 21, sigma=0.0)
+    assert _mode_amplitude(m[-1], x) == pytest.approx(AMP, abs=1e-12)
+    assert np.max(np.abs(m[-1] - m[0])) < 1e-12, f"{name} moved the density with no diffusion and no drift"
+
+
+@pytest.mark.parametrize("name", sorted(SOLVERS))
+def test_the_heat_kernel_oracle_can_fail(name):
+    """Negative control: a datum that is NOT 1-periodic must miss the unit-torus oracle badly.
+
+    An oracle nothing can fail measures nothing. ``k = 1.5`` is discontinuous across the seam, so
+    the solve cannot reproduce a clean modal decay, and the assertion in the first test would fire.
+    """
+    m, x = _diffuse(name, 21, k=1.5)
+    oracle = AMP * np.exp(-D * (2 * np.pi * 1.5) ** 2 * T_FINAL)
+    error = abs(_mode_amplitude(m[-1], x, 1.5) - oracle) / oracle
+    assert error > 0.5, (
+        f"{name}: a datum with a jump at the seam matched the smooth-torus oracle to {error:.3e}. "
+        f"The oracle cannot distinguish anything if this passes"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(SOLVERS))
+def test_a_periodic_solve_translates_rigidly(name):
+    """The advection half, which a zero-drift oracle cannot reach at all.
+
+    The wrap face is only exercised when mass actually crosses it. The velocity is handed over
+    directly rather than derived from a potential: a constant drift cannot come from a periodic U
+    (``U = -v x`` jumps at the seam), so deriving it would measure the fixture's own artefact.
+    """
+    velocity = 0.4
+    errors = []
+    for nx in (41, 81):
+        solver = SOLVERS[name](_problem(nx, sigma=1e-8))
+        x = np.linspace(0.0, 1.0, nx)
+        m = np.asarray(solver.solve_fp_system(_datum(x), drift_field=np.full((NT + 1, nx), velocity)))
+        exact = _datum(x - velocity * T_FINAL)  # the datum is 1-periodic, so no wrapping is needed
+        errors.append(float(np.max(np.abs(m[-1] - exact))))
+
+    assert errors[0] < 5e-2, (
+        f"{name} did not translate rigidly on the torus: max error {errors[0]:.3e} at Nx=41. "
+        f"A wrap face at the wrong cell shows up here as the profile arriving displaced"
+    )
+    assert errors[1] < errors[0], f"{name} translation error did not improve under refinement: {errors}"
+
+
+@pytest.mark.parametrize("scheme", ["divergence_upwind", "divergence_centered", "gradient_upwind", "gradient_centered"])
+def test_every_fdm_advection_scheme_wraps_on_the_same_torus(scheme):
+    """All four schemes carried their own copy of the wrap, so all four are measured.
+
+    They now route through one owner, which is exactly why this cannot be one test on the default:
+    a copy left behind in a non-default scheme is invisible to a caller who never selects it, and
+    ``FPFDMSolver`` reaches all four through ``advection_scheme``.
+
+    Note what this does NOT show. Under zero drift the four reduce to the same diffusion operator,
+    so agreement here says they were fixed together, not that each wrap is separately exercised;
+    the drift case above is what puts mass across the wrap face, and it runs on the default.
+    """
+    oracle = AMP * np.exp(-D * (2 * np.pi) ** 2 * T_FINAL)
+    m, x = _diffuse("FPFDMSolver", 41, scheme=scheme)
+    error = abs(_mode_amplitude(m[-1], x) - oracle) / oracle
+    assert error < 2e-2, f"advection_scheme={scheme!r} decayed the mode at the wrong rate: {error:.3e}"
+
+
+@pytest.mark.parametrize("name", sorted(SOLVERS))
+def test_every_channel_that_supplies_a_bc_gets_the_same_torus(name):
+    """The answer must not depend on WHICH object handed the solver its boundary condition.
+
+    Both solvers resolve the BC themselves, shadowing ``BaseMFGSolver.boundary_conditions`` -- the
+    property that binds the grid's node layout onto a periodic BC. Fixing only the geometry channel
+    left a caller-supplied BC wrapping the historical way, so one problem and one library gave
+    8.7e-02 or 9.3e-03 of heat-kernel error depending on the channel. Both were wrong before this
+    issue, so the divergence did not exist until the fix; a per-channel pin is what keeps it closed.
+    """
+    oracle = AMP * np.exp(-D * (2 * np.pi) ** 2 * T_FINAL)
+    x = np.linspace(0.0, 1.0, 21)
+    errors = {}
+    for channel in ("geometry", "constructor", "components"):
+        problem = _problem(21, SIGMA)
+        kwargs = {}
+        if channel == "constructor":
+            kwargs["boundary_conditions"] = periodic_bc(dimension=1)
+        elif channel == "components":
+            # The third channel each solver's own resolution consults, ahead of the geometry.
+            problem.components.boundary_conditions = periodic_bc(dimension=1)
+        solver = SOLVERS[name](problem, **kwargs)
+        m = np.asarray(solver.solve_fp_system(_datum(x), np.zeros((NT + 1, 21))))
+        errors[channel] = abs(_mode_amplitude(m[-1], x) - oracle) / oracle
+
+    assert errors["constructor"] == pytest.approx(errors["geometry"], rel=1e-12), (
+        f"{name} gave different answers depending on which channel supplied the periodic BC: "
+        f"{errors}. A BC that never met the grid must still be completed with the grid's layout"
+    )
+    assert errors["components"] == pytest.approx(errors["geometry"], rel=1e-12), (
+        f"{name} disagreed between the components and geometry channels: {errors}"
+    )
+    assert errors["geometry"] < 3e-2, f"{name} missed the heat kernel on every channel: {errors}"
+
+
+def test_a_drift_that_disagrees_with_itself_at_the_seam_still_gives_one_density_there():
+    """The repeated node must be single-valued even when the field driving it is not.
+
+    This is the case the constraint row exists for, and it took a mutation to find: with a
+    PERIODIC drift, the stencil rows for node 0 and node N-1 both reach neighbours {N-2, 1} with
+    equal coefficients, so they are the same equation and ``m[N-1] == m[0]`` falls out whether or
+    not anything enforces it. Every other test here has a periodic drift, so all of them passed
+    with the constraint deleted. Under a drift that disagrees across the seam the two rows differ
+    and the pair splits: measured 2.36e-01.
+
+    Not a synthetic input. During Picard the drift comes from an HJB solve, and HJBFDMSolver's own
+    periodic seam is 7.4e-01 (#1834) -- so an FP solver is routinely handed exactly this.
+    """
+    nx, nt = 21, 20
+    x = np.linspace(0.0, 1.0, nx)
+    solver = FPFDMSolver(_problem(nx, sigma=SIGMA))
+    drift = np.tile(0.4 * np.sin(2 * np.pi * x), (nt + 1, 1))
+    drift[:, -1] = -0.9  # node N-1 is node 0; this says otherwise, and the solver must not believe it
+
+    m = np.asarray(solver.solve_fp_system(_datum(x), drift_field=drift))
+    seam = abs(m[-1][0] - m[-1][-1])
+    assert seam < 1e-12, (
+        f"a drift with a jump at the repeated node produced two different densities at one physical "
+        f"point: seam {seam:.4e}. x[0] and x[-1] are the same place regardless of what the drift says"
+    )
+
+
+def test_fdm_and_fvm_converge_to_the_same_field_under_a_varying_periodic_drift():
+    """Two independently written schemes on the same torus must agree in the limit.
+
+    A VARYING drift on purpose: every other FVM drift in the suite is a constant, and a constant
+    cannot distinguish the wrap face from its neighbour. Asserted as CONVERGENCE, not as a
+    tolerance -- FDM is first-order upwind and FVM is minmod-limited second order, so at any fixed
+    grid they differ by O(h) and an absolute bound here would be a number chosen to pass. Measured
+    2.80e-01, 1.59e-01, 8.84e-02, 5.10e-02 over Nx = 41/81/161/321: ratios ~1.75, converging.
+    """
+    gaps = []
+    for nx in (41, 81, 161):
+        x = np.linspace(0.0, 1.0, nx)
+        drift = np.tile(0.5 * np.sin(2 * np.pi * x) + 0.2, (NT + 1, 1))  # varying, exactly periodic
+        fields = {}
+        for name in ("FPFDMSolver", "FPFVMSolver"):
+            solver = SOLVERS[name](_problem(nx, sigma=0.15))
+            fields[name] = np.asarray(solver.solve_fp_system(_datum(x), drift_field=drift))[-1]
+            assert abs(fields[name][0] - fields[name][-1]) < 1e-9, f"{name} left a seam under a varying periodic drift"
+        gaps.append(float(np.max(np.abs(fields["FPFDMSolver"] - fields["FPFVMSolver"]))))
+
+    trend = ", ".join(f"{g:.3e}" for g in gaps)
+    assert gaps[2] < gaps[0] / 2.0, (
+        f"FDM and FVM did not converge to the same field on the periodic torus: {trend} at "
+        f"Nx=41/81/161. Two schemes advecting across different faces disagree at O(1), not O(h)"
+    )
+
+
+def test_the_fvm_wrap_face_velocity_is_the_face_between_the_last_cell_and_the_first():
+    """Pinned on the kernel, because end-to-end nothing can see it.
+
+    On an inclusive axis the wrap face is `alpha_int[span-1]` -- the face between cell `span-1` and
+    the node that IS cell 0. The caller's `alpha_wrap` is built from nodes `N-1` and `0`, which are
+    one point, so it is the velocity AT that node rather than averaged across the face: an O(h)
+    error at exactly one face.
+
+    It survives every end-to-end check, and that is not an oversight to fix by widening them.
+    Both choices are *consistent* -- each face velocity is shared by the two cells that touch it --
+    so the flux still telescopes and mass is conserved either way (measured 2.2e-14 with the line
+    and 2.2e-14 without), and the seam closes either way because the repeated cell copies cell 0.
+    A direct call is the only thing that separates them.
+    """
+    from mfgarchon.alg.numerical.fp_solvers.fp_fvm_flux import axis_flux_divergence
+
+    n_full, span = 6, 5
+    m = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 1.0])  # cell 5 repeats cell 0
+    alpha_int = np.array([0.1, 0.2, 0.3, 0.4, 0.9])  # the last entry IS the wrap face
+    wrong_wrap = np.array(-7.0)  # what an exclusive-layout caller would supply; must be ignored
+
+    div = axis_flux_divergence(m, alpha_int, 0, 1.0, "upwind", "periodic", wrong_wrap, span=span)
+
+    # Upwind, all velocities positive: F_{i+1/2} = alpha_i * m_i, and the wrap face carries
+    # alpha_int[span-1] * m[span-1] into cell 0.
+    f_wrap = alpha_int[span - 1] * m[span - 1]
+    assert div[0] == pytest.approx(alpha_int[0] * m[0] - f_wrap), (
+        "cell 0's inflow must come across the face between cell span-1 and itself"
+    )
+    assert div[span - 1] == pytest.approx(f_wrap - alpha_int[span - 2] * m[span - 2])
+    assert div[n_full - 1] == pytest.approx(div[0]), "the repeated cell must carry cell 0's divergence"
+    assert float(np.sum(div[:span])) == pytest.approx(0.0, abs=1e-14), (
+        "the flux must telescope over the distinct cells, or the scheme is not conservative"
+    )
+    """The last node IS the first one, so the assembled system must say so, not merely end up agreeing.
+
+    Checked on the operator rather than on the output: a solver that solved for N cells and copied
+    ``m[0]`` into ``m[-1]`` afterwards would show a clean seam while still having stepped the wrong
+    torus -- which is the state this issue started in.
+    """
+    from mfgarchon.geometry.boundary.conditions import periodic_axis_span, repeated_endpoint_mirror
+
+    bc = periodic_bc(dimension=1)
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=bc)
+    bound = grid.boundary_conditions
+
+    assert periodic_axis_span(bound, 21) == 20, "an inclusive periodic axis of 21 nodes has 20 distinct cells"
+    assert repeated_endpoint_mirror(bound, (20,), (21,)) == (0,), "node 20 must be identified with node 0"
+    assert repeated_endpoint_mirror(bound, (19,), (21,)) is None, "node 19 is its own cell"
+
+    # And an unstated convention keeps the historical exclusive layout, so no caller that never
+    # met a grid has its numbers moved by any of this.
+    assert periodic_axis_span(periodic_bc(dimension=1), 21) == 21

--- a/tests/unit/test_fp_fvm.py
+++ b/tests/unit/test_fp_fvm.py
@@ -126,14 +126,16 @@ def test_gate1_mass_conservation_periodic():
     N, T, Nt, sigma = 80, 0.3, 60, 0.25
     prob, geom = make_problem_1d(N, T, Nt, sigma, bounds=(0.0, 1.0), bc="periodic")
     x = geom.coordinates[0]
-    dx = x[1] - x[0]
     m0 = normalized_gaussian_1d(x, 0.5, 0.1)
     drift = 0.8 * np.ones((Nt + 1, N))
 
     solver = FPFVMSolver(prob, reconstruction="muscl")
     M = solver.solve_fp_system(m0, drift_field=drift)
 
-    mass = M.sum(axis=1) * dx
+    # Trapezoid, not `sum`: this grid is endpoint-inclusive, so x[0] and x[-1] are one physical
+    # point and the rectangle rule counts it twice (#1822). The half-weights sum to one full
+    # weight, which is the rule the wrap-face telescoping actually conserves.
+    mass = np.trapezoid(M, x, axis=1)
     mass_drift = float(np.max(np.abs(mass - mass[0])))
     assert mass_drift < 1e-12, f"periodic mass drift {mass_drift:.2e}"
 

--- a/tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py
+++ b/tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py
@@ -109,9 +109,11 @@ def test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmles
     Coercing periodic to no-flux does not perturb the answer, it replaces it: mass that should
     wrap to the far side is held against the near wall instead. The mutation that reddens THIS
     test is a change to the `divergence_upwind` periodic wrap in assembly, not the deletion of a
-    guard. Scope: the wrap is copy-pasted into all four advection-scheme interior handlers and
-    only the default one is covered here -- disabling it in the gradient_upwind,
-    gradient_centered or divergence_centered handlers leaves this green.
+    guard. Scope: the wrap used to be copy-pasted into all four advection-scheme interior handlers,
+    so only the default one was covered here; since #1822 all four call
+    `conditions.periodic_axis_span` and a change to that owner reddens this. What the owner cannot
+    catch is a handler that stops calling it, which is covered per-scheme in
+    tests/unit/test_alg/test_periodic_torus_oracle_1822.py.
     """
     import numpy as np
 
@@ -157,15 +159,24 @@ def test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmles
         f"the two boundary conditions must differ by O(1) over the field, not at the margin; got {relative_l1:.1%}"
     )
 
+    # The conserved functional is not the same for the two BCs, and using one rule for both is
+    # what this pair of lines used to do (#1822). Under no-flux all 61 nodes are distinct cells
+    # and the rectangle rule is what the scheme telescopes. Under periodic on this
+    # endpoint-inclusive grid x[0] and x[-1] are one physical point, so the rectangle rule counts
+    # it twice -- it reports 1.0257 for a density whose mass is 1, and would read a correct solve
+    # as a 2.6% leak. Trapezoid is the rule there: the shared node's two half-weights sum to one.
+    quadrature = {"no-flux": np.sum, "periodic": lambda d: float(np.trapezoid(d, xs)) / (xs[1] - xs[0])}
+
     for name, density in (("no-flux", reflecting), ("periodic", wrapping)):
         assert np.all(np.isfinite(density)), f"{name} produced a non-finite density"
         assert density.min() >= -1e-12, f"{name} produced a negative density: {density.min():.3e}"
         # Two-sided. Without this the assertions above are one-sided -- ANY corruption that makes
         # the two BCs differ MORE passes. Measured: routing the no-flux wall to the interior
-        # handler leaks 54% of its mass (sum 0.461 instead of 1.0) and makes the test greener,
+        # handler leaks 54% of its mass (0.461 instead of 1.0) and makes the test greener,
         # ratio 340 -> 617. Residuals here are 3.9e-15 and 4.4e-16, so this has five orders of
         # margin over the tolerance.
-        assert abs(density.sum() - 1.0) < 1e-10, (
-            f"{name} did not conserve mass: sum {density.sum():.6f}. A leak makes the two BCs "
+        mass = quadrature[name](density)
+        assert abs(mass - 1.0) < 1e-10, (
+            f"{name} did not conserve mass: {mass:.6f}. A leak makes the two BCs "
             f"differ more, so the comparison above would read it as success."
         )

--- a/tests/unit/test_operators/test_divergence.py
+++ b/tests/unit/test_operators/test_divergence.py
@@ -354,5 +354,104 @@ class TestAdvectionInterface:
             adv(np.zeros((30, 30)))
 
 
+class TestAdvectionPeriodicGridConvention:
+    """The conservative wrap face must sit on the torus the grid describes. Issue #1822.
+
+    ``bc=None`` selects the wrap closure but states no convention, so it means the layout this
+    package always used: all N cells distinct. A periodic ``BoundaryConditions`` carrying
+    ``ENDPOINT_INCLUSIVE`` says the last cell IS the first, and then the wrap face is one cell
+    earlier and the repeated cell is not its own control volume.
+
+    Pinned here rather than through a solver because nothing downstream can see it: reverting the
+    operator's convention handling left 3096 tests green across `test_operators`, `test_alg`,
+    `test_geometry`, `test_fp_fvm` and `test_fdm_centered_conservation`. The route that reaches it
+    -- FP-FDM with a callable ``drift_field`` -- had no periodic test at all.
+    """
+
+    @staticmethod
+    def _stamped_periodic(dimension):
+        from mfgarchon.geometry.boundary import periodic_bc
+        from mfgarchon.geometry.boundary.types import PeriodicGridConvention
+
+        return periodic_bc(dimension=dimension, convention=PeriodicGridConvention.ENDPOINT_INCLUSIVE)
+
+    @pytest.mark.unit
+    def test_inclusive_periodic_conserves_mass_over_the_distinct_cells(self):
+        """Telescoping must close over the N-1 real cells, not over N with one counted twice.
+
+        Summing the divergence over the distinct cells is the discrete statement that no mass
+        enters or leaves a domain with no boundary. Wrapping all N cells telescopes over a torus
+        one cell too long and leaves a residue: measured -1.1e-01 in 1D and -4.4e-01 in 2D.
+        """
+        rng = np.random.default_rng(1822)
+        for shape, spacings in (((13,), [1 / 12]), ((13, 9), [1 / 12, 2 / 8])):
+            m = 1.0 + 0.3 * rng.random(shape)
+            m[-1] = m[0]  # the repeated cell IS cell 0, on every axis
+            if len(shape) == 2:
+                m[:, -1] = m[:, 0]
+            v = rng.standard_normal((len(shape), *shape))
+            adv = AdvectionOperator(
+                velocity_field=v,
+                spacings=spacings,
+                field_shape=shape,
+                scheme="upwind",
+                form="divergence",
+                bc=self._stamped_periodic(len(shape)),
+                mass_conservative=True,
+            )
+            div = adv(m)
+            distinct = div[tuple(slice(0, n - 1) for n in shape)]
+            cell = float(np.prod(spacings))
+            assert float(np.sum(distinct)) * cell == pytest.approx(0.0, abs=1e-12), (
+                f"advective flux did not telescope over the {shape} inclusive torus"
+            )
+
+    @pytest.mark.unit
+    def test_the_repeated_cell_carries_the_first_cells_divergence(self):
+        """It is the same control volume, so it must not be given a divergence of its own."""
+        m = np.array([1.0, 2.0, 3.0, 4.0, 1.0])
+        v = np.array([[0.5, 0.7, 0.2, 0.9, 0.5]])
+        adv = AdvectionOperator(
+            velocity_field=v,
+            spacings=[0.25],
+            field_shape=(5,),
+            scheme="upwind",
+            form="divergence",
+            bc=self._stamped_periodic(1),
+            mass_conservative=True,
+        )
+        div = adv(m)
+        assert div[-1] == pytest.approx(div[0])
+
+    @pytest.mark.unit
+    def test_bc_none_still_means_the_exclusive_layout(self):
+        """The historical caller stated nothing and must keep its numbers (#1822).
+
+        `bc=None` and an unstated periodic BC are the same request, and neither may pick up the
+        inclusive layout by accident -- that is what makes this change safe for callers that never
+        met a grid.
+        """
+        from mfgarchon.geometry.boundary import periodic_bc
+
+        m = np.array([1.0, 2.0, 3.0, 4.0, 1.0])
+        v = np.array([[0.5, 0.7, 0.2, 0.9, 0.5]])
+        kw = {
+            "velocity_field": v,
+            "spacings": [0.25],
+            "field_shape": (5,),
+            "scheme": "upwind",
+            "form": "divergence",
+            "mass_conservative": True,
+        }
+        unstated = AdvectionOperator(bc=periodic_bc(dimension=1), **kw)(m)
+        no_bc = AdvectionOperator(bc=None, **kw)(m)
+        inclusive = AdvectionOperator(bc=self._stamped_periodic(1), **kw)(m)
+
+        np.testing.assert_allclose(unstated, no_bc, atol=0, rtol=0)
+        assert not np.allclose(unstated, inclusive), (
+            "the two conventions must give different operators, or this pins nothing"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_operators/test_divergence.py
+++ b/tests/unit/test_operators/test_divergence.py
@@ -424,6 +424,44 @@ class TestAdvectionPeriodicGridConvention:
         assert div[-1] == pytest.approx(div[0])
 
     @pytest.mark.unit
+    def test_the_wrap_face_velocity_comes_from_the_last_real_cell_not_the_repeat(self):
+        """Pinned on the value, because conservation and the seam are both blind to it.
+
+        The wrap face joins cell ``span-1`` to cell 0, so its velocity is
+        ``0.5*(v[span-1] + v[0])``. Reading ``v[N-1]`` there instead -- the repeated node -- is
+        still a *consistent* face velocity: each face is shared by the two cells touching it, so
+        the flux still telescopes to 0 and ``div[-1] == div[0]`` still holds. Every other test in
+        this class passes under that substitution while the divergence moves by 3.2.
+
+        Same shape as the FVM case in
+        ``tests/unit/test_alg/test_periodic_torus_oracle_1822.py``: when two candidate expressions
+        are both conservative, only the arithmetic separates them.
+        """
+        span, h = 4, 0.25
+        m = np.array([1.0, 2.0, 3.0, 4.0, 1.0])  # cell 4 repeats cell 0
+        v = np.array([[0.5, 0.7, 0.2, 0.9, 0.5]])
+        adv = AdvectionOperator(
+            velocity_field=v,
+            spacings=[h],
+            field_shape=(5,),
+            scheme="upwind",
+            form="divergence",
+            bc=self._stamped_periodic(1),
+            mass_conservative=True,
+        )
+        div = adv(m)
+
+        # Every velocity is positive, so upwind takes the left cell at each face.
+        v_wrap = 0.5 * (v[0, span - 1] + v[0, 0])
+        flux_wrap = v_wrap * m[span - 1]
+        flux_first = 0.5 * (v[0, 0] + v[0, 1]) * m[0]
+        assert div[0] == pytest.approx((flux_first - flux_wrap) / h), (
+            "cell 0's inflow must cross a face whose velocity averages the LAST REAL cell with "
+            "cell 0; taking it from the repeated node is conservative and still wrong"
+        )
+        assert div[span - 1] == pytest.approx((flux_wrap - 0.5 * (v[0, span - 2] + v[0, span - 1]) * m[span - 2]) / h)
+
+    @pytest.mark.unit
     def test_bc_none_still_means_the_exclusive_layout(self):
         """The historical caller stated nothing and must keep its numbers (#1822).
 


### PR DESCRIPTION
`FPFDMSolver` and `FPFVMSolver` are the last two seam rows of #1822 that were one shared defect.
Both wrapped cell `N-1` to cell `0`. On the endpoint-inclusive grid `TensorProductGrid` builds,
`x[-1]` **is** `x[0]`, so that treats the repeated endpoint as its own cell and solves on a torus of
length `1 + dx`.

Against the analytic heat kernel at `Nx=21`: **8.7e-02 → 9.3e-03**, converging 9.3e-03 → 3.8e-03 →
2.4e-03 over Nx=21/41/81.

## Why the seam invariant could not find this

Under a datum symmetric about the midpoint, both solvers returned a seam of **2e-15** while the
mode's amplitude came out **8.7% off** the analytic value (a decay rate 9.4% low). Symmetry keeps
the duplicated pair equal all the way to the end, so #1822's own invariant is structurally blind to
this class — the failure is silent in the strong sense: nothing raises, the density stays positive,
the seam stays at round-off.

So the pin is **not** the seam. It is the heat kernel and a rigid translation — laws stated by the
PDE, computed independently of any discretisation, which cannot go tautological when these two
solvers are later consolidated onto shared machinery.

## What changed

One owner for the quantity, and the copies deleted rather than left standing:

- `boundary.types.repeated_endpoint_count` — how many trailing nodes repeat one already present;
- `boundary.conditions.periodic_axis_span` / `repeated_endpoint_mirror` — derived from it.

**12 live restatements → 0** (4 in `divergence_centered`, 2 each in `divergence_upwind`,
`gradient_centered`, `gradient_upwind`, 1 in the Laplacian assembly, 1 in the ghost applicator).
Four more survive in `FPFDMSolver._solve_fp_1d`, which has no callers and is already scheduled for
removal by v0.25.0 — left untouched rather than changed unverified.

Beyond the two solvers, three further paths would have disagreed with the fixed ones once the fix
landed, so they are fixed in the same change:

| path | before | after |
|:--|:--|:--|
| BC via constructor / `components` rather than geometry | 8.7e-02 | 9.3e-03 |
| `AdvectionOperator` wrap face (callable `drift_field`) | seam 3.9e-02, 0.54% mass lost | 1.2e-14, 1.0e-14 |
| FVM diffusion (`bc=None` discarded the convention) | 8.7e-02 | 9.3e-03 |

Both solvers resolve their own BC, shadowing the base-class property that binds the grid's layout —
that is why the channel divergence existed at all.

## Test changes, flagged rather than quiet

**Three mass-conservation tests** used a rectangle rule that counts the shared node twice. It read
**1.035** for a density of mass 1 *even at t=0*, so it was never measuring mass on this grid. They
now use the quadrature `invariants.mass_drift` already owns. This is backed by an independent
measurement, not by the change passing: the same solves conserve to **1.2e-14** under the correct
rule, and the discrepancy the rectangle rule reported equals `m[0]·dx` **to ten digits**.

**`test_tensor_with_drift`** asked for `periodic_bc(dimension=1)` on a 2D grid — a dimension
mismatch — driven by `U = X² + Y²`, which is not periodic at all. It left a seam of 4.63e-02, so
the periodicity it requested was never honoured; it passed because the wrap was loose. It now uses
`no_flux_bc(dimension=2)`, matching its geometry and its actual subject.

## One user-visible narrowing

A 2D periodic solve through the tensor-diffusion route with strong drift now trips the positivity
guard where it previously completed (`Nt=40`, `Nt=160`). This is the right direction and not a lost
capability: on a smooth, strictly positive, exactly periodic 2D datum, measured under the
`N-1`-cell quadrature, the old path **created 6.3% of its own mass and did not converge away**
(6.486% / 6.324% / 6.285% at Nt=10/40/160) while the new one conserves to 1e-15 and closes both
seams. What used to complete was silently wrong; what now refuses is fail-loud. Both states are
wrong — making 2D periodic actually solve is #1835.

## Close-out (per CLAUDE.md)

**Tier 1 — external oracle.** The heat kernel `exp(-D(2π)²T)` and rigid translation `m₀(x - vT)`,
both from the PDE. Controls in both directions: `σ=0` must not move the datum (it doesn't, to
1e-12), and a non-1-periodic datum must *miss* the oracle (it does, by 2.47e+00) — an oracle
nothing can fail measures nothing.

**Tier 2 — mutation-verified.** Every mutation reddens the pin. Two did not until tests were added,
and both gaps are worth recording:

- with a *periodic* drift the stencil rows for node 0 and node `N-1` are the same equation, so the
  seam closes whether or not the constraint row enforces it. Under a drift that disagrees across
  the seam — what an FP solver is routinely handed, since `HJBFDMSolver`'s own seam is 7.4e-01
  (#1834) — that row is worth **2.36e-01**;
- the `AdvectionOperator` fix had **zero** coverage: reverting it left **3096 tests green**. Now
  pinned at kernel level, and all three of its mutations go red.

## Review

Independent adversarial review, two rounds. Round 1 returned **BLOCKED** with three blockers, all
reproduced independently and fixed; round 2 returned **MERGE-OK** after re-deriving all 13 published
numbers from scratch and sweeping 165 (solver × BC × dimension × channel × drift) cells across both
trees — 35 cells moved, and **every one is a periodic cell**. No `no_flux`, `neumann`, `dirichlet`,
`robin` or mixed cell moved. `bc=None` and an unstated periodic BC remain byte-identical in 1D, 2D
and 3D.

One blocker is worth naming because it was my error: I first reported the improvement as 8.4e-01 →
9.3e-03. That before-number was measured with a projection that double-counted the repeated node —
a bias I later fixed in the same file and never re-measured against. The true figure is 8.7e-02, a
**9.4× improvement, not 90×**, and it is corrected everywhere it appeared.

## Gate

`./scripts/local_ci.sh` → **5828 passed, 26 skipped, 26 xfailed, GATE GREEN**.

Refs #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
