### PR TITLE
Give FPParticleSolver a seed, so the capability matrix can return a verdict on it

### DIFF
--- a/changelog.d/1838-particle-solver-seed.added.md
+++ b/changelog.d/1838-particle-solver-seed.added.md
@@ -1,6 +1,15 @@
-`FPParticleSolver` accepts `seed=`, so a stochastic solve can be repeated. Every draw it makes goes
-through one owner, `self._rng` — a private `np.random.Generator` when `seed` is given, the global
-`np.random` module when it is not.
+`FPParticleSolver` accepts `seed=`, so a stochastic solve can be repeated. Every numpy draw it makes
+goes through one owner, `self._rng` — a private `np.random.Generator` when `seed` is given, the
+global `np.random` module when it is not.
+
+The torch sampling path is the exception and needed its own fix. It takes a seed derived from
+`self._rng` and, until independent review, honoured it with `torch.manual_seed` — the
+**process-global** torch generator, so one seeded solve silently moved every unrelated torch draw in
+the same interpreter. That is the defect this change removes on the numpy side, reintroduced on the
+other. It now drives a local `torch.Generator`, and the seam of that fix is pinned: reverting it
+reddens `test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone` and nothing else.
+Reproducibility and seed-sensitivity alone cannot catch it — a global reseed satisfies both — so the
+test asserts on an unrelated `torch.randn` sequence taken across a seeded solve.
 
 `seed=None` keeping the global stream is plain backward compatibility, and that is the only claim
 made for it: nine files here seed the global stream and then build this solver. The alternative was
@@ -8,6 +17,12 @@ measured rather than assumed — an entropy-seeded private default gives **1 fai
 across them, and that one failure (`test_issue_1412_fp_particle_sigma_override`) is **loud**. One
 code path serves both, because `choice`, `uniform`, `normal` and `standard_normal` exist on the
 module and on `Generator` with the same keywords.
+
+The scope of that compatibility claim is one solve path, the 1D ndarray-drift one those nine files
+use. On the other three `sample_from_density` builds `np.random.RandomState(None)`, which seeds from
+OS entropy rather than from the global stream, so an unseeded solve there does not follow
+`np.random.seed`. Unchanged by this PR — `main` passes `seed=None` there unconditionally — and now
+stated where it was previously implied.
 
 **What this unblocks.** The #1822 capability matrix could not classify this solver in *either*
 direction — three trials of one identical configuration returned `monotone = False, False, True`.

--- a/changelog.d/1838-particle-solver-seed.added.md
+++ b/changelog.d/1838-particle-solver-seed.added.md
@@ -1,28 +1,31 @@
-`FPParticleSolver` accepts `seed=`, so a stochastic solve can be repeated. Every draw it makes now
-goes through one owner, `self._rng`, which is either a private `np.random.Generator` (when `seed` is
-given) or the global `np.random` module (when it is not).
+`FPParticleSolver` accepts `seed=`, so a stochastic solve can be repeated. Every draw it makes goes
+through one owner, `self._rng` — a private `np.random.Generator` when `seed` is given, the global
+`np.random` module when it is not.
 
-`seed=None` is deliberately the global stream and not an entropy-seeded `Generator`: twelve files in
-this repository call `np.random.seed(...)` and then build this solver to compare two runs. A private
-default would silently stop honouring those seeds, and those comparisons would keep passing while
-comparing nothing. One code path serves both, because `choice`, `uniform`, `normal` and
-`standard_normal` exist on the module and on `Generator` with the same keywords.
+`seed=None` keeping the global stream is plain backward compatibility, and that is the only claim
+made for it: nine files here seed the global stream and then build this solver. The alternative was
+measured rather than assumed — an entropy-seeded private default gives **1 failed / 65 passed**
+across them, and that one failure (`test_issue_1412_fp_particle_sigma_override`) is **loud**. One
+code path serves both, because `choice`, `uniform`, `normal` and `standard_normal` exist on the
+module and on `Generator` with the same keywords.
 
 **What this unblocks.** The #1822 capability matrix could not classify this solver in *either*
-direction — three trials of one identical configuration returned `monotone = False, False, True`, so
-`xfail` asserted a failure it did not reliably have and `pass` asserted the opposite. It was skipped
-by name in `STOCHASTIC_UNSEEDED`, which is now empty. Measured with a seed, its four declared
-boundary types split three to one:
+direction — three trials of one identical configuration returned `monotone = False, False, True`.
+It was skipped by name in `STOCHASTIC_UNSEEDED`, which is now empty. With a seed, all four of its
+declared boundary types converge under refinement, **20 of 20 seeds**, so none is listed as
+unhonoured.
 
-| BC | residual at Nx=21/41/81 | verdict |
-|:--|:--|:--|
-| `NO_FLUX`, `NEUMANN` | 5.40e-02, 3.24e-02, 1.54e-02 | converges — honoured |
-| `DIRICHLET` | 4.67e-01, 1.05e-04, 7.9e-169 | converges — honoured |
-| `PERIODIC` | 4.95e-01, 2.66e-01, 2.79e-01 | **rises at 81 — not honoured** |
+That verdict required fixing the refinement path as well as the seed. A particle method converges
+as `N → ∞` *and* `h → 0`; the matrix refined only the grid, leaving a Monte Carlo floor set by `N`,
+so at the fine end its convergence oracle was comparing noise — the PERIODIC row came out monotone
+in only 6 of 12 seeds, a coin flip written into a strict ratchet. The fixtures now scale
+`num_particles ~ Nx²` alongside the grid, the standard pairing since the `O(N^-1/2)` sampling error
+has to track `O(h)`.
 
-The periodic seam is a bias, not Monte Carlo noise: holding the grid at Nx=21 and raising the
-particle count, it converges to a **nonzero** limit while the seed-to-seed spread collapses —
-5.4e-01 (N=2e3), 3.9e-01 (N=2e4), 3.33e-01 (N=2e5), spread 4e-02 → 1.5e-03. Sampling error would
-vanish. The mechanism is visible in the output: `f[0] - f[1]` and `f[-1] - f[-2]` are **exactly
-zero**, so the KDE duplicates its edge bins. That is one broken column, not a broken solver, and it
-is now an honest `xfail` with a repeatable number instead of a skip.
+The solver still fails the **absolute** seam tolerance at a single coarse grid, and that stays an
+`xfail`: at `Nx=21` the seam has a floor no particle count removes — 5.22e-01 (N=2e3), 3.95e-01
+(2e4), 3.32e-01 (2e5), 3.05e-01 (2e6). Driving the KDE bandwidth to zero isolates it at ≈2.7e-01,
+where it is both bandwidth- and `N`-independent, so it is a boundary-treatment bias rather than
+sampling error. About half of it is the Issue #709 boundary smoothing, applied unconditionally:
+with `kde_boundary_smoothing=False` the seam drops 3.29e-01 → 1.48e-01 at N=2e5. That is a
+fixed-grid property of Monte Carlo + KDE, not a failure to honour the boundary condition.

--- a/changelog.d/1838-particle-solver-seed.added.md
+++ b/changelog.d/1838-particle-solver-seed.added.md
@@ -1,0 +1,28 @@
+`FPParticleSolver` accepts `seed=`, so a stochastic solve can be repeated. Every draw it makes now
+goes through one owner, `self._rng`, which is either a private `np.random.Generator` (when `seed` is
+given) or the global `np.random` module (when it is not).
+
+`seed=None` is deliberately the global stream and not an entropy-seeded `Generator`: twelve files in
+this repository call `np.random.seed(...)` and then build this solver to compare two runs. A private
+default would silently stop honouring those seeds, and those comparisons would keep passing while
+comparing nothing. One code path serves both, because `choice`, `uniform`, `normal` and
+`standard_normal` exist on the module and on `Generator` with the same keywords.
+
+**What this unblocks.** The #1822 capability matrix could not classify this solver in *either*
+direction — three trials of one identical configuration returned `monotone = False, False, True`, so
+`xfail` asserted a failure it did not reliably have and `pass` asserted the opposite. It was skipped
+by name in `STOCHASTIC_UNSEEDED`, which is now empty. Measured with a seed, its four declared
+boundary types split three to one:
+
+| BC | residual at Nx=21/41/81 | verdict |
+|:--|:--|:--|
+| `NO_FLUX`, `NEUMANN` | 5.40e-02, 3.24e-02, 1.54e-02 | converges — honoured |
+| `DIRICHLET` | 4.67e-01, 1.05e-04, 7.9e-169 | converges — honoured |
+| `PERIODIC` | 4.95e-01, 2.66e-01, 2.79e-01 | **rises at 81 — not honoured** |
+
+The periodic seam is a bias, not Monte Carlo noise: holding the grid at Nx=21 and raising the
+particle count, it converges to a **nonzero** limit while the seed-to-seed spread collapses —
+5.4e-01 (N=2e3), 3.9e-01 (N=2e4), 3.33e-01 (N=2e5), spread 4e-02 → 1.5e-03. Sampling error would
+vanish. The mechanism is visible in the output: `f[0] - f[1]` and `f[-1] - f[-2]` are **exactly
+zero**, so the KDE duplicates its edge bins. That is one broken column, not a broken solver, and it
+is now an honest `xfail` with a repeatable number instead of a skip.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -153,11 +153,29 @@ class FPParticleSolver(BaseFPSolver):
         implicit_domain: ImplicitDomain | None = None,
         backend: str | None = None,
         preserve_indices: bool = False,
+        seed: int | None = None,
     ) -> None:
         super().__init__(problem)
 
         self.num_particles = num_particles
         self.fp_method_name = "Particle"
+
+        # Issue #1838. Every draw this solver makes goes through `self._rng`, which is either the
+        # global numpy state or a private Generator:
+        #
+        #   seed=None  -> `np.random`, the global stream. Unchanged behaviour, and deliberately so:
+        #                 twelve files in this repository set `np.random.seed(...)` and then build
+        #                 this solver to compare two runs (test_issue_1248_volatility_forwarding,
+        #                 test_issue_1412_fp_particle_sigma_override, test_cross_backend_consistency,
+        #                 ...). A private Generator would silently stop honouring those seeds and
+        #                 turn those comparisons non-deterministic rather than failing.
+        #   seed=<int> -> a private Generator, independent of anything else touching np.random.
+        #
+        # One code path serves both: `choice`, `uniform`, `normal` and `standard_normal` exist on
+        # the module and on Generator with the same keywords. `randn` does NOT exist on Generator,
+        # which is why the GPU path below calls `standard_normal`.
+        self.seed = seed
+        self._rng = np.random.default_rng(seed) if seed is not None else np.random
 
         self.kde_bandwidth = kde_bandwidth
         self.kde_boundary_smoothing = kde_boundary_smoothing
@@ -847,7 +865,10 @@ class FPParticleSolver(BaseFPSolver):
             coordinates=coordinates,
             num_samples=num_particles,
             jitter=True,
-            seed=None,  # Use global numpy random state for reproducibility with solver
+            # Derived from this solver's stream so the sampler follows `seed` too (Issue #1838).
+            # The old comment here claimed the global state gave "reproducibility with solver";
+            # it gives the opposite -- any unrelated np.random call shifts what this returns.
+            seed=None if self.seed is None else int(self._rng.integers(0, 2**63 - 1)),
         )
 
     def _generate_brownian_increment_nd(
@@ -1618,7 +1639,7 @@ class FPParticleSolver(BaseFPSolver):
             m0_probs_unnormalized = m_initial_condition * Dx
             m0_probs = m0_probs_unnormalized / np.sum(m0_probs_unnormalized)
             try:
-                initial_particle_positions = np.random.choice(x_grid, size=self.num_particles, p=m0_probs, replace=True)
+                initial_particle_positions = self._rng.choice(x_grid, size=self.num_particles, p=m0_probs, replace=True)
             except ValueError as e:
                 # m0_probs is non-normalizable (e.g. negative entries) — the density is invalid.
                 raise ValueError(
@@ -1628,7 +1649,7 @@ class FPParticleSolver(BaseFPSolver):
                 ) from e
         else:
             initial_particle_positions = (
-                np.random.uniform(xmin, xmin + Lx, self.num_particles)
+                self._rng.uniform(xmin, xmin + Lx, self.num_particles)
                 if Lx > 1e-14
                 else np.full(self.num_particles, xmin)
             )
@@ -1698,7 +1719,7 @@ class FPParticleSolver(BaseFPSolver):
             )
 
             # Generate Brownian motion for current particle count
-            dW = np.random.normal(0.0, np.sqrt(Dt), n_particles_t) if Dt > 1e-14 else np.zeros(n_particles_t)
+            dW = self._rng.normal(0.0, np.sqrt(Dt), n_particles_t) if Dt > 1e-14 else np.zeros(n_particles_t)
 
             # Euler-Maruyama update
             new_particles = particles_t + alpha_optimal_at_particles * Dt + sigma_sde * dW
@@ -2043,7 +2064,8 @@ class FPParticleSolver(BaseFPSolver):
             if Dt > 1e-14:
                 # Generate on CPU and transfer (safest approach for now)
                 noise_scale = sigma_sde * np.sqrt(Dt)
-                noise_np = np.random.randn(self.num_particles) * noise_scale
+                # standard_normal, not randn: Generator has no `randn` (Issue #1838).
+                noise_np = self._rng.standard_normal(self.num_particles) * noise_scale
                 noise_gpu = self.backend.from_numpy(noise_np)
             else:
                 noise_gpu = self.backend.zeros((self.num_particles,))
@@ -2411,7 +2433,7 @@ class FPParticleSolver(BaseFPSolver):
                 # Issue #717 fix: sigma_at_particles IS the SDE volatility σ
                 # SDE: dX = v dt + σ dW, so dW_i = σ_i * N(0, sqrt(dt))
                 sigma_sde_particles = sigma_at_particles  # Direct use
-                dW = sigma_sde_particles[:, np.newaxis] * np.random.normal(0, np.sqrt(Dt), (n_particles_t, dimension))
+                dW = sigma_sde_particles[:, np.newaxis] * self._rng.normal(0, np.sqrt(Dt), (n_particles_t, dimension))
 
             # Euler-Maruyama step
             new_particles = particles_t + drift * Dt + dW

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -160,16 +160,13 @@ class FPParticleSolver(BaseFPSolver):
         self.num_particles = num_particles
         self.fp_method_name = "Particle"
 
-        # Issue #1838. Every draw this solver makes goes through `self._rng`, which is either the
-        # global numpy state or a private Generator:
+        # Issue #1838. Every numpy draw this solver makes goes through `self._rng`, which is either
+        # the global numpy state or a private Generator. The torch sampling path does not use it at
+        # all -- it takes a seed derived from `self._rng` and drives a local `torch.Generator`, for
+        # the same reason: see sample_from_density_gpu.
         #
-        #   seed=None  -> `np.random`, the global stream. Unchanged behaviour for existing callers,
-        #                 which is the only claim made for it: nine files here seed the global
-        #                 stream and then build this solver. Switching the default was measured
-        #                 rather than assumed -- an entropy-seeded private Generator gives
-        #                 1 failed / 65 passed across them, and that one
-        #                 (test_issue_1412_fp_particle_sigma_override) fails LOUDLY. So this is
-        #                 plain backward compatibility, not protection against a silent failure.
+        #   seed=None  -> `np.random`, the global stream. Nine files here seed it and then build
+        #                 this solver, so the default is backward compatibility and nothing more.
         #   seed=<int> -> a private Generator, independent of anything else touching np.random.
         #
         # One code path serves both: `choice`, `uniform`, `normal` and `standard_normal` exist on

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle.py
@@ -163,12 +163,13 @@ class FPParticleSolver(BaseFPSolver):
         # Issue #1838. Every draw this solver makes goes through `self._rng`, which is either the
         # global numpy state or a private Generator:
         #
-        #   seed=None  -> `np.random`, the global stream. Unchanged behaviour, and deliberately so:
-        #                 twelve files in this repository set `np.random.seed(...)` and then build
-        #                 this solver to compare two runs (test_issue_1248_volatility_forwarding,
-        #                 test_issue_1412_fp_particle_sigma_override, test_cross_backend_consistency,
-        #                 ...). A private Generator would silently stop honouring those seeds and
-        #                 turn those comparisons non-deterministic rather than failing.
+        #   seed=None  -> `np.random`, the global stream. Unchanged behaviour for existing callers,
+        #                 which is the only claim made for it: nine files here seed the global
+        #                 stream and then build this solver. Switching the default was measured
+        #                 rather than assumed -- an entropy-seeded private Generator gives
+        #                 1 failed / 65 passed across them, and that one
+        #                 (test_issue_1412_fp_particle_sigma_override) fails LOUDLY. So this is
+        #                 plain backward compatibility, not protection against a silent failure.
         #   seed=<int> -> a private Generator, independent of anything else touching np.random.
         #
         # One code path serves both: `choice`, `uniform`, `normal` and `standard_normal` exist on
@@ -868,7 +869,9 @@ class FPParticleSolver(BaseFPSolver):
             # Derived from this solver's stream so the sampler follows `seed` too (Issue #1838).
             # The old comment here claimed the global state gave "reproducibility with solver";
             # it gives the opposite -- any unrelated np.random call shifts what this returns.
-            seed=None if self.seed is None else int(self._rng.integers(0, 2**63 - 1)),
+            # 2**32 - 1, not 2**63: sample_from_density builds a legacy np.random.RandomState,
+            # which refuses anything larger. A 2**63 draw raised for all but 2**-31 of seeds.
+            seed=None if self.seed is None else int(self._rng.integers(0, 2**32 - 1)),
         )
 
     def _generate_brownian_increment_nd(
@@ -899,7 +902,9 @@ class FPParticleSolver(BaseFPSolver):
         dW : np.ndarray
             Brownian increments, shape (num_particles, dimension)
         """
-        result = _gen_brownian(num_particles, dimension, Dt, sigma)
+        # rng=, or this branch keeps drawing from the global stream while the varying-sigma
+        # branch below uses self._rng -- two parallel physics paths, one owner between them.
+        result = _gen_brownian(num_particles, dimension, Dt, sigma, rng=self._rng)
         # Ensure 2D output for backward compatibility (this method always returns 2D)
         if result.ndim == 1:
             return result[:, np.newaxis]
@@ -2002,7 +2007,11 @@ class FPParticleSolver(BaseFPSolver):
         # Sample initial particles on GPU
         m_initial_gpu = self.backend.from_numpy(m_initial_condition)
         X_particles_gpu[0, :] = sample_from_density_gpu(
-            m_initial_gpu, x_grid_gpu, self.num_particles, self.backend, seed=None
+            m_initial_gpu,
+            x_grid_gpu,
+            self.num_particles,
+            self.backend,
+            seed=None if self.seed is None else int(self._rng.integers(0, 2**32 - 1)),
         )
 
         # Compute bandwidth for KDE (do this once on CPU)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle_density.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle_density.py
@@ -162,6 +162,7 @@ def generate_brownian_increment(
     dimension: int,
     dt: float,
     sigma: float,
+    rng: Any = np.random,
 ) -> np.ndarray:
     """
     Generate Brownian increment for SDE evolution (dimension-agnostic).
@@ -198,9 +199,9 @@ def generate_brownian_increment(
 
     # Independent Brownian motion in each dimension
     if dimension == 1:
-        return sigma * np.random.normal(0, np.sqrt(dt), num_particles)
+        return sigma * rng.normal(0, np.sqrt(dt), num_particles)
 
-    return sigma * np.random.normal(0, np.sqrt(dt), (num_particles, dimension))
+    return sigma * rng.normal(0, np.sqrt(dt), (num_particles, dimension))
 
 
 # =============================================================================

--- a/mfgarchon/alg/numerical/fp_solvers/fp_particle_density.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_particle_density.py
@@ -24,9 +24,12 @@ Usage:
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 # Optional scipy for KDE
 try:  # pragma: no cover - optional SciPy dependency
@@ -162,7 +165,7 @@ def generate_brownian_increment(
     dimension: int,
     dt: float,
     sigma: float,
-    rng: Any = np.random,
+    rng: ModuleType | np.random.Generator = np.random,
 ) -> np.ndarray:
     """
     Generate Brownian increment for SDE evolution (dimension-agnostic).
@@ -179,6 +182,9 @@ def generate_brownian_increment(
         Time step size
     sigma : float
         Diffusion coefficient
+    rng : module or np.random.Generator, optional
+        Source of the normal draws. Defaults to the global `np.random` module, which is what an
+        unseeded `FPParticleSolver` passes; a seeded one passes its private Generator (Issue #1838).
 
     Returns
     -------

--- a/mfgarchon/utils/particle_utils.py
+++ b/mfgarchon/utils/particle_utils.py
@@ -267,7 +267,10 @@ def sample_from_density_gpu(density, grid, N: int, backend: "BaseBackend", seed:
     backend : BaseBackend
         Backend providing tensor operations
     seed : int, optional
-        Random seed for reproducibility
+        Random seed. Drives a LOCAL generator, so a seeded call is reproducible without touching
+        any global stream. `seed=None` draws from -- and therefore advances -- the caller's global
+        stream, which is the compatibility contract for callers that seed `torch` or `np.random`
+        themselves.
 
     Returns
     -------
@@ -323,6 +326,11 @@ def sample_from_density_gpu(density, grid, N: int, backend: "BaseBackend", seed:
             generator.manual_seed(int(seed))
         U = xp.rand(N, device=cdf.device, dtype=cdf.dtype, generator=generator)
     else:
+        # Unreachable today, and by construction rather than by configuration: the only caller,
+        # `_solve_fp_system_gpu`, assigns into a preallocated array (`X_particles_gpu[0, :] = ...`),
+        # and a JAX array raises `TypeError: JAX arrays are immutable` on that. So the GPU solve
+        # path is torch-only. Seeded anyway -- a `seed` argument that is silently ignored is a lie
+        # whether or not anyone reaches it.
         draw = np.random if seed is None else np.random.default_rng(seed)
         U = backend.from_numpy(draw.random(N))
 

--- a/mfgarchon/utils/particle_utils.py
+++ b/mfgarchon/utils/particle_utils.py
@@ -309,15 +309,22 @@ def sample_from_density_gpu(density, grid, N: int, backend: "BaseBackend", seed:
         zeros = xp.zeros(1)
     cdf_with_zero = xp.concatenate([zeros, cdf])
 
-    # Sample uniform random numbers
-    if seed is not None and is_torch_backend:
-        xp.manual_seed(seed)
-
-    # Create U on same device as cdf for PyTorch compatibility
+    # Sample uniform random numbers.
+    #
+    # The seed drives a LOCAL generator on both paths. `torch.manual_seed` reseeds the
+    # process-global stream, so one seeded solve moved every unrelated torch draw in the same
+    # interpreter -- the defect #1838 removed on the numpy side, reintroduced on this one the
+    # moment a seed reached here. `seed=None` keeps drawing from each library's global stream,
+    # which is the compatibility contract a caller that seeds `np.random` or `torch` relies on.
     if is_torch_backend:
-        U = xp.rand(N, device=cdf.device, dtype=cdf.dtype)
+        generator = None
+        if seed is not None:
+            generator = xp.Generator(device=cdf.device)
+            generator.manual_seed(int(seed))
+        U = xp.rand(N, device=cdf.device, dtype=cdf.dtype, generator=generator)
     else:
-        U = backend.from_numpy(np.random.rand(N))
+        draw = np.random if seed is None else np.random.default_rng(seed)
+        U = backend.from_numpy(draw.random(N))
 
     # Inverse transform: find x such that CDF(x) = U
     indices = xp.searchsorted(cdf_with_zero, U)

--- a/tests/unit/test_alg/test_fp_particle_seed_1838.py
+++ b/tests/unit/test_alg/test_fp_particle_seed_1838.py
@@ -10,7 +10,7 @@ Two contracts, and the second is the one that constrains the design:
 
 - `seed=<int>` -- a private `Generator`, so two runs agree bit for bit and nothing else touching
   `np.random` can perturb them;
-- `seed=None` -- the **global** stream, unchanged. Twelve files in this repository call
+- `seed=None` -- the **global** stream, unchanged. Nine files in this repository call
   `np.random.seed(...)` and then build this solver to compare two runs. A private Generator by
   default would stop honouring those seeds and make those comparisons non-deterministic rather
   than failing, which is the worse outcome: the tests would still pass, just meaninglessly.
@@ -91,10 +91,17 @@ def test_an_unrelated_draw_cannot_perturb_a_seeded_solve():
 
 
 def test_seed_none_still_follows_the_global_seed():
-    """The compatibility contract. Twelve files in this repo depend on exactly this.
+    """The compatibility contract. Nine files in this repo depend on exactly this.
 
     `np.random.seed(42)` before construction must still make an unseeded solver repeat itself, or
     every existing two-run comparison silently stops comparing anything.
+
+    Scope, because the general form of this sentence is false: it holds on the 1D ndarray-drift
+    path, which is the one those nine files use. On the other three, `sample_from_density` builds
+    `np.random.RandomState(None)` (sampling.py), which seeds from OS entropy rather than from the
+    global stream, so an unseeded solve there does not repeat under `np.random.seed`. That is not a
+    regression -- `main` passes `seed=None` there unconditionally and behaviour is byte-identical --
+    but it is why this test pins one path rather than parametrising over four.
     """
     np.random.seed(42)  # the legacy contract under test
     first = _solve(None)
@@ -171,3 +178,45 @@ def test_every_solve_path_is_reproducible_and_owns_its_stream(dim, callable_drif
 def test_the_other_solve_paths_still_respond_to_the_seed(dim, callable_drift):
     """Control for the test above: a path that ignored `seed` entirely would satisfy it trivially."""
     assert not np.array_equal(_solve_path(dim, callable_drift, seed=99), _solve_path(dim, callable_drift, seed=1234))
+
+
+# ---------------------------------------------------------------------------
+# The torch path. It reaches a different sampler with a different global stream, and the seed only
+# started reaching it in this change -- so everything above says nothing about it.
+# ---------------------------------------------------------------------------
+
+torch = pytest.importorskip("torch", reason="the torch sampling path needs torch installed")
+
+
+@pytest.mark.optional_torch
+def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone():
+    """The seed must drive a LOCAL torch generator, not `torch.manual_seed`.
+
+    Three assertions, and the third is the one that failed: reseeding the process-global stream
+    reproduces and differentiates exactly as a local generator does, so (a) and (b) cannot tell
+    them apart. Measured before the fix -- `torch.manual_seed(1234); torch.randn(3)` gave
+    [0.0461, 0.4024, -1.0115], and the same sequence with one seeded solve interposed gave
+    [0.2818, 1.3052, -1.3480]. That is this solver reaching out and moving an unrelated caller's
+    draws, which is the defect #1838 removed on the numpy side.
+    """
+    from mfgarchon.backends.torch_backend import TorchBackend
+    from mfgarchon.utils.particle_utils import sample_from_density_gpu
+
+    backend = TorchBackend(device="cpu")
+    grid = backend.from_numpy(np.linspace(0.0, 1.0, 64))
+    density = backend.from_numpy(np.exp(-10 * (np.linspace(0.0, 1.0, 64) - 0.5) ** 2))
+
+    def _sample(seed):
+        return backend.to_numpy(sample_from_density_gpu(density, grid, N=500, backend=backend, seed=seed))
+
+    np.testing.assert_array_equal(_sample(7), _sample(7))
+    assert not np.array_equal(_sample(7), _sample(8)), "a sampler ignoring the seed would pass the line above"
+
+    torch.manual_seed(1234)
+    expected = torch.randn(3).tolist()
+    torch.manual_seed(1234)
+    _sample(99)
+    assert torch.randn(3).tolist() == expected, (
+        "a seeded solve moved the process-global torch stream, so it perturbs every unrelated "
+        "torch draw in the same interpreter"
+    )

--- a/tests/unit/test_alg/test_fp_particle_seed_1838.py
+++ b/tests/unit/test_alg/test_fp_particle_seed_1838.py
@@ -185,8 +185,22 @@ def test_the_other_solve_paths_still_respond_to_the_seed(dim, callable_drift):
 # started reaching it in this change -- so everything above says nothing about it.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.optional_torch
-def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone():
+
+@pytest.fixture(params=["cpu", "mps"])
+def device(request):
+    """Both devices this machine can reach, because `device=cdf.device` is new and untested.
+
+    Hardcoding the generator to "cpu" passes every CPU assertion and then raises on MPS --
+    "Expected a 'mps' device type for generator but found 'cpu'" -- so a CPU-only test would
+    accept a fix that breaks the production default (`device='auto'` resolves to MPS here).
+    """
+    torch = pytest.importorskip("torch", reason="the torch sampling path needs torch installed")
+    if request.param == "mps" and not torch.backends.mps.is_available():
+        pytest.skip("no MPS device on this machine")
+    return request.param
+
+
+def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone(device):
     """The seed must drive a LOCAL torch generator, not `torch.manual_seed`.
 
     Three assertions, and the third is the one that failed: reseeding the process-global stream
@@ -205,7 +219,7 @@ def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone():
     from mfgarchon.backends.torch_backend import TorchBackend
     from mfgarchon.utils.particle_utils import sample_from_density_gpu
 
-    backend = TorchBackend(device="cpu")
+    backend = TorchBackend(device=device)
     grid = backend.from_numpy(np.linspace(0.0, 1.0, 64))
     density = backend.from_numpy(np.exp(-10 * (np.linspace(0.0, 1.0, 64) - 0.5) ** 2))
 
@@ -215,11 +229,15 @@ def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone():
     np.testing.assert_array_equal(_sample(7), _sample(7))
     assert not np.array_equal(_sample(7), _sample(8)), "a sampler ignoring the seed would pass the line above"
 
-    torch.manual_seed(1234)
-    expected = torch.randn(3).tolist()
-    torch.manual_seed(1234)
-    _sample(99)
-    assert torch.randn(3).tolist() == expected, (
-        "a seeded solve moved the process-global torch stream, so it perturbs every unrelated "
-        "torch draw in the same interpreter"
-    )
+    # fork_rng, because a test that dirties the global stream to prove the library must not is
+    # the same defect wearing a different hat -- and within one xdist worker every later torch
+    # test would inherit it.
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(1234)
+        expected = torch.randn(3).tolist()
+        torch.manual_seed(1234)
+        _sample(99)
+        assert torch.randn(3).tolist() == expected, (
+            "a seeded solve moved the process-global torch stream, so it perturbs every unrelated "
+            "torch draw in the same interpreter"
+        )

--- a/tests/unit/test_alg/test_fp_particle_seed_1838.py
+++ b/tests/unit/test_alg/test_fp_particle_seed_1838.py
@@ -1,0 +1,115 @@
+"""`FPParticleSolver` must be able to repeat itself on demand. Issue #1838.
+
+Without a seed no invariant can return a verdict on this solver. Measured on the #1822 periodic
+capability matrix, three trials of one identical configuration gave `monotone = False, False, True`
+-- so marking it `xfail` asserts a failure it does not reliably have, and marking it `pass` asserts
+the opposite. It is skipped there and named in `STOCHASTIC_UNSEEDED`, whose comment already states
+the conclusion: "the seeding is the fix."
+
+Two contracts, and the second is the one that constrains the design:
+
+- `seed=<int>` -- a private `Generator`, so two runs agree bit for bit and nothing else touching
+  `np.random` can perturb them;
+- `seed=None` -- the **global** stream, unchanged. Twelve files in this repository call
+  `np.random.seed(...)` and then build this solver to compare two runs. A private Generator by
+  default would stop honouring those seeds and make those comparisons non-deterministic rather
+  than failing, which is the worse outcome: the tests would still pass, just meaninglessly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+NX, NT = 25, 8
+
+
+def _problem():
+    return MFGProblem(
+        geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=no_flux_bc(dimension=1)),
+        T=0.3,
+        Nt=NT,
+        sigma=0.25,
+        components=MFGComponents(
+            m_initial=lambda z: 1.0 + 0.5 * np.cos(2 * np.pi * np.asarray(z) + 1.1),
+            u_terminal=lambda z: np.zeros_like(np.asarray(z)),
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _solve(seed, num_particles=2000):
+    x = np.linspace(0.0, 1.0, NX)
+    solver = FPParticleSolver(_problem(), num_particles=num_particles, seed=seed)
+    m0 = 1.0 + 0.5 * np.cos(2 * np.pi * x + 1.1)
+    return np.asarray(solver.solve_fp_system(m0, np.tile(np.sin(2 * np.pi * x), (NT + 1, 1))))
+
+
+def test_the_same_seed_gives_the_same_density():
+    """Bit-identical, not close: a seeded stochastic solver is a deterministic function."""
+    first, second = _solve(20260805), _solve(20260805)
+    assert first.shape == second.shape
+    np.testing.assert_array_equal(first, second)
+
+
+def test_different_seeds_give_different_densities():
+    """The discriminating half. Without it, a solver that ignored `seed` would pass the test above.
+
+    A stochastic solver that returned the same field for every seed would satisfy reproducibility
+    perfectly and be broken -- so equality alone certifies nothing.
+    """
+    first, second = _solve(20260805), _solve(11111)
+    assert first.shape == second.shape
+    assert not np.array_equal(first, second), (
+        "two different seeds produced bit-identical densities; the seed is not reaching the draws"
+    )
+
+
+def test_an_unrelated_draw_cannot_perturb_a_seeded_solve():
+    """The private stream must be private -- this is what the global state could never give.
+
+    Interleaving an unrelated `np.random` call between two constructions is exactly what made the
+    old behaviour irreproducible in practice, and it is not hypothetical: any library, fixture or
+    plugin drawing from the global stream shifts every subsequent particle solve.
+    """
+    first = _solve(4242)
+    np.random.random(12345)  # deliberately perturbing the GLOBAL stream
+    second = _solve(4242)
+    np.testing.assert_array_equal(first, second)
+
+
+def test_seed_none_still_follows_the_global_seed():
+    """The compatibility contract. Twelve files in this repo depend on exactly this.
+
+    `np.random.seed(42)` before construction must still make an unseeded solver repeat itself, or
+    every existing two-run comparison silently stops comparing anything.
+    """
+    np.random.seed(42)  # the legacy contract under test
+    first = _solve(None)
+    np.random.seed(42)
+    second = _solve(None)
+    np.testing.assert_array_equal(first, second)
+
+
+def test_seed_none_is_not_secretly_deterministic():
+    """Control for the test above: without the global seed being reset, the runs must differ.
+
+    Otherwise `test_seed_none_still_follows_the_global_seed` would pass on a solver that ignored
+    randomness altogether, and would be measuring nothing.
+    """
+    np.random.seed(7)
+    first = _solve(None)
+    second = _solve(None)  # no reset: the global stream has moved on
+    assert not np.array_equal(first, second), (
+        "two consecutive unseeded solves agreed bit for bit; the draws are not reaching the stream"
+    )

--- a/tests/unit/test_alg/test_fp_particle_seed_1838.py
+++ b/tests/unit/test_alg/test_fp_particle_seed_1838.py
@@ -185,9 +185,6 @@ def test_the_other_solve_paths_still_respond_to_the_seed(dim, callable_drift):
 # started reaching it in this change -- so everything above says nothing about it.
 # ---------------------------------------------------------------------------
 
-torch = pytest.importorskip("torch", reason="the torch sampling path needs torch installed")
-
-
 @pytest.mark.optional_torch
 def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone():
     """The seed must drive a LOCAL torch generator, not `torch.manual_seed`.
@@ -199,6 +196,12 @@ def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone():
     [0.2818, 1.3052, -1.3480]. That is this solver reaching out and moving an unrelated caller's
     draws, which is the defect #1838 removed on the numpy side.
     """
+    # Skipped INSIDE the test, not at module scope: `pytest.importorskip` at module level raises
+    # at collection and takes the whole file with it -- measured, in a venv without torch, as
+    # "collected 0 items / 1 skipped", losing the twelve tests above. The nightly runs without
+    # torch, so that placement would have silently stopped measuring the thing this file is for.
+    torch = pytest.importorskip("torch", reason="the torch sampling path needs torch installed")
+
     from mfgarchon.backends.torch_backend import TorchBackend
     from mfgarchon.utils.particle_utils import sample_from_density_gpu
 

--- a/tests/unit/test_alg/test_fp_particle_seed_1838.py
+++ b/tests/unit/test_alg/test_fp_particle_seed_1838.py
@@ -18,6 +18,8 @@ Two contracts, and the second is the one that constrains the design:
 
 from __future__ import annotations
 
+import pytest
+
 import numpy as np
 
 from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
@@ -113,3 +115,59 @@ def test_seed_none_is_not_secretly_deterministic():
     assert not np.array_equal(first, second), (
         "two consecutive unseeded solves agreed bit for bit; the draws are not reaching the stream"
     )
+
+
+# ---------------------------------------------------------------------------
+# The other solve paths. Everything above drives ONE of them -- 1D with an ndarray drift -- and
+# that gap is what let two defects ship: a derived seed of 2**63 that legacy `RandomState` refuses
+# (so a seeded solve RAISED on three of four paths), and two draws that never reached `self._rng`
+# at all (`generate_brownian_increment`, and the GPU initial sampler), so a "seeded" solve on those
+# paths was still reading the global stream. Neither was visible from the 1D ndarray path.
+# ---------------------------------------------------------------------------
+
+
+def _solve_path(dim, callable_drift, seed, nt=4, n_part=400):
+    """One solve on a chosen (dimension, drift-kind) path, returning the density history."""
+    shape = tuple([9] * dim)
+    grid = TensorProductGrid(
+        bounds=[(0.0, 1.0)] * dim, Nx_points=[9] * dim, boundary_conditions=no_flux_bc(dimension=dim)
+    )
+    components = MFGComponents(
+        m_initial=(lambda x: float(np.exp(-10 * np.sum((np.asarray(x) - 0.5) ** 2))))
+        if dim > 1
+        else (lambda z: 1.0 + 0.5 * np.cos(2 * np.pi * np.asarray(z) + 1.1)),
+        u_terminal=(lambda x: 0.0) if dim > 1 else (lambda z: np.zeros_like(np.asarray(z))),
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: m,
+            coupling_dm=lambda m: 1.0,
+        ),
+    )
+    problem = MFGProblem(geometry=grid, T=0.2, Nt=nt, sigma=0.25, components=components)
+    solver = FPParticleSolver(problem, num_particles=n_part, seed=seed)
+    m0 = np.ones(shape) / float(np.prod(shape))
+    if callable_drift:
+        drift = (lambda t, xc, m: np.zeros((n_part, dim))) if dim > 1 else (lambda t, xc, m: np.zeros(n_part))
+    else:
+        drift = np.zeros((nt + 1, *shape))
+    return np.asarray(solver.solve_fp_system(m0, drift_field=drift))
+
+
+@pytest.mark.parametrize(("dim", "callable_drift"), [(1, False), (1, True), (2, False), (2, True)])
+def test_every_solve_path_is_reproducible_and_owns_its_stream(dim, callable_drift):
+    """Each path must (a) run at all with a seed, (b) repeat, (c) ignore the global stream.
+
+    (a) is not redundant: with the seed derived as a 2**63 draw, three of these four RAISED
+    `ValueError: Seed must be between 0 and 2**32 - 1` for all but 2**-31 of seeds, because
+    `sample_from_density` builds a legacy `np.random.RandomState`.
+    """
+    first = _solve_path(dim, callable_drift, seed=99)
+    np.random.random(777)  # perturb the GLOBAL stream between the two solves
+    second = _solve_path(dim, callable_drift, seed=99)
+    np.testing.assert_array_equal(first, second)
+
+
+@pytest.mark.parametrize(("dim", "callable_drift"), [(1, True), (2, False), (2, True)])
+def test_the_other_solve_paths_still_respond_to_the_seed(dim, callable_drift):
+    """Control for the test above: a path that ignored `seed` entirely would satisfy it trivially."""
+    assert not np.array_equal(_solve_path(dim, callable_drift, seed=99), _solve_path(dim, callable_drift, seed=1234))

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -53,6 +53,7 @@ def _residual_of(solved, bc_type) -> float:
 NX = 21
 NT = 10
 SEAM_TOL = 1e-9  # exact zero in exact arithmetic; this admits round-off and meshless quadrature
+SEED = 1822  # any solver that accepts one gets it, so every row below is a repeatable number
 
 
 # The datum, and why it is phase-shifted rather than the obvious sin/cos.
@@ -96,7 +97,7 @@ _SEARCHED = (
 # MODE as well as the failure: `raises=` means a solver that starts crashing, or crashing
 # differently, is caught rather than xfailing identically to one that merely returns a bad seam.
 #
-#   HJBFDMSolver    7.42e-01     FPParticleSolver    ~5e-01 (UNSEEDED: varies ~25% per run)
+#   HJBFDMSolver    7.42e-01     FPParticleSolver    4.95e-01 (seed=1822, and now repeatable)
 #   HJBWENOSolver   2.64e-01     FPSLJacobianSolver  1.58e+00
 #   FPFVMSolver     1.79e-01     FPFDMSolver         1.29e-01
 #   HJBGFDMSolver   raises NotImplementedError for PERIODIC
@@ -125,13 +126,19 @@ KNOWN_NOT_HONOURED = {
     # enters at the stalled timestep and decays backward, and the stall is periodic-specific) is
     # in #1834, and nothing in THIS change tests it.
     "HJBFDMSolver": ("#1834", AssertionError),
-    # Honours PERIODIC on a cloud with no DETECTED boundary points -- seam exactly 0 at
-    # Nx=11/21/41/81, via the Issue #711 wrap. The default cloud this file uses puts points ON
-    # the faces, and boundary detection marks those as boundary even on a periodic axis, so the
-    # row builder (which has no periodic row) raises. The defect is the detection, not the
-    # capability, which is why the type stays declared. Tracked in #1841.
+    # Honours PERIODIC on a cloud with no DETECTED boundary points -- seam at most 3.3e-11 at
+    # Nx=11/21/41/81 (2.2e-15, 3.3e-11, 6.7e-16, 6.7e-16), via the Issue #711 wrap. The default
+    # cloud this file uses puts points ON the faces, and boundary detection marks those as boundary
+    # even on a periodic axis, so the row builder (which has no periodic row) raises. The defect is
+    # the detection, not the capability, which is why the type stays declared. Tracked in #1841.
     "HJBGFDMSolver": ("#1841 boundary detection ignores periodic_dims", NotImplementedError),
-    "FPParticleSolver": ("#1822", AssertionError),
+    # FPParticleSolver is now a MEASURED row rather than a coin flip (#1838 gave it a seed).
+    # Seam 4.95e-01 at Nx=21. It is not sampling noise: holding the grid and raising the particle
+    # count, the seam converges to a NONZERO limit while the seed-to-seed spread collapses --
+    # 5.4e-01 (N=2e3), 3.9e-01 (N=2e4), 3.33e-01 (N=2e5), spread 4e-02 -> 1.5e-03. A Monte Carlo
+    # error would vanish; a boundary-treatment bias is what stays. The mechanism is visible in the
+    # output: f[0] - f[1] and f[-1] - f[-2] are EXACTLY 0, i.e. the KDE duplicates its edge bins.
+    "FPParticleSolver": ("#1822 KDE duplicates its edge bins; seam -> 3.3e-01 as N -> inf", AssertionError),
     "FPSLJacobianSolver": ("#1822 deprecated, retirement in #1756", AssertionError),
 }
 
@@ -258,8 +265,14 @@ def _solve_periodic(cls: type, nx: int = NX, nt: int = NT) -> np.ndarray:
 
     problem = _periodic_problem(nx=nx, nt=nt)
     kwargs = {}
-    if "collocation_points" in inspect.signature(cls.__init__).parameters:
+    params = inspect.signature(cls.__init__).parameters
+    if "collocation_points" in params:
         kwargs["collocation_points"] = x.reshape(-1, 1)
+    if "seed" in params:
+        # A stochastic solver cannot be classified at all unless it repeats itself (#1838): three
+        # trials of one configuration previously returned monotone=False, False, True, so xfail
+        # asserted a failure it did not reliably have and pass asserted the opposite.
+        kwargs["seed"] = SEED
     solver = cls(problem, **kwargs)
 
     if hasattr(solver, "solve_hjb_system"):
@@ -450,11 +463,20 @@ BC_FACTORIES = {
 # returned monotone=False, False, True on the identical configuration. Marking it xfail asserts a
 # failure it does not reliably have; marking it pass asserts the opposite. It is skipped, named,
 # and the seeding is the fix.
-STOCHASTIC_UNSEEDED = {
-    "FPParticleSolver": "no seed parameter; seam varies ~25% run to run",
-}
+# Emptied by #1838. `FPParticleSolver` took no seed and drew from the global numpy state, so this
+# matrix could not classify it in EITHER direction and skipped it by name. It now takes `seed=`,
+# the fixtures above pass one, and its rows are measured like everyone else's. Kept as an empty
+# dict rather than deleted: the next unseeded solver to arrive needs somewhere honest to go, and
+# "skipped and named" is the correct verdict for one, not "passed".
+STOCHASTIC_UNSEEDED: dict[str, str] = {}
 
 SURFACE_NOT_HONOURED = {
+    # Measured with seed=1822 at the fixture's default 5000 particles: 4.95e-01, 2.66e-01,
+    # 2.79e-01 over Nx=21/41/81 -- it improves once and then gets WORSE, so it fails the
+    # three-point monotonicity the oracle requires. Its other three declared types converge and
+    # are NOT listed here: NO_FLUX and NEUMANN at 5.40e-02 -> 3.24e-02 -> 1.54e-02, DIRICHLET at
+    # 4.67e-01 -> 1.05e-04 -> 7.9e-169. So this is one broken column, not a broken solver.
+    ("FPParticleSolver", "PERIODIC"): ("#1822 seam does not converge; KDE edge bins", AssertionError),
     ("HJBGFDMSolver", "DIRICHLET"): ("#1822 declares DIRICHLET, solve returns NaN", AssertionError),
     ("HJBGFDMSolver", "PERIODIC"): ("#1841 boundary detection ignores periodic_dims", NotImplementedError),
     ("FPGFDMSolver", "NEUMANN"): ("#1822 density goes invalid mid-solve", ValueError),
@@ -473,8 +495,14 @@ def _solve_with_bc(cls, bc_type, nx, nt):
     x = np.linspace(0.0, 1.0, nx)
     problem = _problem_with_bc(BC_FACTORIES[bc_type](), nx, nt)
     kwargs = {}
-    if "collocation_points" in inspect.signature(cls.__init__).parameters:
+    params = inspect.signature(cls.__init__).parameters
+    if "collocation_points" in params:
         kwargs["collocation_points"] = x.reshape(-1, 1)
+    if "seed" in params:
+        # A stochastic solver cannot be classified at all unless it repeats itself (#1838): three
+        # trials of one configuration previously returned monotone=False, False, True, so xfail
+        # asserted a failure it did not reliably have and pass asserted the opposite.
+        kwargs["seed"] = SEED
     solver = cls(problem, **kwargs)
     if hasattr(solver, "solve_hjb_system"):
         return solver.solve_hjb_system(np.tile(_M(x), (nt + 1, 1)), _U(x), np.zeros((nt + 1, nx))), "HJB", x

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -153,29 +153,33 @@ KNOWN_NOT_HONOURED = {
 # CONVERGENCE, not exact conservation, and getting that wrong is what the first version of this
 # file did: it asserted `drift < 1e-9` and reported six solvers as failing to honour PERIODIC.
 #
-# Measured drift against refinement (Nx=21/41/81, Nt scaled with it):
+# Measured drift against refinement (Nx=21/41/81, Nt scaled with it), on THIS commit -- seeded,
+# and with the particle count scaled as Nx^2:
 #
-#   FPFDMSolver       5.56e-02  2.87e-02  1.46e-02
-#   FPFVMSolver       5.77e-02  2.93e-02  1.47e-02
-#   FPSLSolver        1.34e-01  4.91e-02  2.62e-02
-#   FPParticleSolver  5.63e-02  3.38e-02  1.64e-02
+#   FPSLSolver         1.342e-01  4.910e-02  2.618e-02     converges, ratio 0.366
+#   FPSLAdjointSolver  1.342e-01  4.910e-02  2.618e-02     converges, ratio 0.366
+#   FPParticleSolver   5.480e-02  3.429e-02  1.707e-02     converges, ratio 0.626
+#   FPFDMSolver        2.220e-16  9.992e-16  4.885e-15     at round-off: EARLY RETURN
+#   FPFVMSolver        2.665e-15  7.772e-15  3.841e-14     at round-off: EARLY RETURN
+#   FPSLJacobianSolver 8.882e-16  2.776e-15  1.332e-15     at round-off: EARLY RETURN
 #
-# Every one halves per refinement. That is O(h) discretisation error in a non-conservative scheme,
-# not a capability defect -- these solvers do not claim conservation by construction, and an
-# absolute tolerance on a convergent quantity is a tolerance chosen to make a point.
+# Where it converges, that is O(h) discretisation error in a non-conservative scheme, not a
+# capability defect -- these solvers do not claim conservation by construction, and an absolute
+# tolerance on a convergent quantity is a tolerance chosen to make a point.
 #
-# `FPSLJacobianSolver` reports 0.0000% at every resolution, which is the opposite failure: exact by
-# renormalisation rather than by conservation (RFC #1456 class (b), #1429 S0-11). A convergence
-# oracle cannot see it; it is listed under its own issue rather than certified here.
+# READ THE SECOND COLUMN OF THAT LIST. Half these rows no longer reach the assertion at all: the
+# `drifts[0] < 1e-12` early return fires and the test passes without measuring convergence. For
+# FPSLJacobianSolver that is the long-standing case (exact by renormalisation rather than by
+# conservation -- RFC #1456 class (b), #1429 S0-11). FPFDMSolver and FPFVMSolver joined it in
+# #1837, which put their periodic wrap on the right torus and took their drift from ~5.6e-02 to
+# round-off. That is a real improvement and it makes this oracle vacuous for them, which is worth
+# saying out loud: three green rows here now assert nothing, and a green row that measured nothing
+# reads exactly like a green row that measured something.
 MASS_NON_CONVERGENT: dict[str, tuple[str, type[Exception]]] = {
-    # Empty, and that is the honest state for every row this dict could hold. Five of the six FP
-    # solvers still declaring PERIODIC have a periodic mass error that halves under refinement, so
-    # the convergence oracle evaluates and passes. The sixth is FPSLJacobianSolver, which is not
-    # certified here either: its drift is already at round-off, so it takes the early return above
-    # and the convergence assertion never runs -- exact by renormalisation, and listed under #1756
-    # rather than under a trend it cannot have. The one entry that used to sit here, FPGFDMSolver,
-    # never produced a number to converge; it has since stopped declaring PERIODIC (#1822), so this
-    # file no longer asks it a question about periodicity.
+    # Empty, and honestly so: no FP solver declaring PERIODIC has a mass error that fails to
+    # converge. Three converge and three are already at round-off (see above). The one entry that
+    # used to sit here, FPGFDMSolver, never produced a number to converge at all; it has since
+    # stopped declaring PERIODIC (#1822), so this file no longer asks it about periodicity.
 }
 
 
@@ -262,17 +266,15 @@ def _problem_with_bc(bc, nx: int, nt: int) -> MFGProblem:
     )
 
 
-def _solve_periodic(cls: type, nx: int = NX, nt: int = NT) -> np.ndarray:
-    """Run one solve from exactly periodic data and return the field it produced."""
-    x = np.linspace(0.0, 1.0, nx)
-    u_periodic = _U(x)
-    m_periodic = _M(x)
-    assert seam(u_periodic) < 1e-15, "the u input itself must be periodic, or the output tells us nothing"
-    assert seam(m_periodic) < 1e-15, "the m input itself must be periodic, or the output tells us nothing"
+def _solver_kwargs(cls: type, x: np.ndarray, nx: int) -> dict:
+    """The constructor arguments a solver needs, resolved from its own signature.
 
-    problem = _periodic_problem(nx=nx, nt=nt)
-    kwargs = {}
+    One owner, because both fixtures in this file need it and a copy that drifts splits the matrix
+    silently: the seam half and the surface half would then be measuring two different solvers under
+    one name, which is the failure mode this file exists to catch.
+    """
     params = inspect.signature(cls.__init__).parameters
+    kwargs = {}
     if "collocation_points" in params:
         kwargs["collocation_points"] = x.reshape(-1, 1)
     if "seed" in params:
@@ -288,6 +290,19 @@ def _solve_periodic(cls: type, nx: int = NX, nt: int = NT) -> np.ndarray:
         # N ~ Nx^2 -- the standard pairing, since the O(N^-1/2) sampling error has to track O(h) --
         # every type this solver declares converges in 20 of 20 seeds.
         kwargs["num_particles"] = int(PARTICLES_AT_COARSEST * (nx / NX) ** 2)
+    return kwargs
+
+
+def _solve_periodic(cls: type, nx: int = NX, nt: int = NT) -> np.ndarray:
+    """Run one solve from exactly periodic data and return the field it produced."""
+    x = np.linspace(0.0, 1.0, nx)
+    u_periodic = _U(x)
+    m_periodic = _M(x)
+    assert seam(u_periodic) < 1e-15, "the u input itself must be periodic, or the output tells us nothing"
+    assert seam(m_periodic) < 1e-15, "the m input itself must be periodic, or the output tells us nothing"
+
+    problem = _periodic_problem(nx=nx, nt=nt)
+    kwargs = _solver_kwargs(cls, x, nx)
     solver = cls(problem, **kwargs)
 
     if hasattr(solver, "solve_hjb_system"):
@@ -508,23 +523,7 @@ SURFACE_NOT_HONOURED = {
 def _solve_with_bc(cls, bc_type, nx, nt):
     x = np.linspace(0.0, 1.0, nx)
     problem = _problem_with_bc(BC_FACTORIES[bc_type](), nx, nt)
-    kwargs = {}
-    params = inspect.signature(cls.__init__).parameters
-    if "collocation_points" in params:
-        kwargs["collocation_points"] = x.reshape(-1, 1)
-    if "seed" in params:
-        # A stochastic solver cannot be classified at all unless it repeats itself (#1838): three
-        # trials of one configuration previously returned monotone=False, False, True, so xfail
-        # asserted a failure it did not reliably have and pass asserted the opposite.
-        kwargs["seed"] = SEED
-    if "num_particles" in params:
-        # Refine the SAMPLE with the grid, not just the grid. A particle method converges as
-        # N -> inf AND h -> 0; holding N fixed leaves a Monte Carlo floor set by N, so at the fine
-        # end the convergence oracle below compares noise and the verdict becomes a coin flip.
-        # Measured on the PERIODIC row at a fixed 5000 particles: monotone in 6 of 12 seeds. With
-        # N ~ Nx^2 -- the standard pairing, since the O(N^-1/2) sampling error has to track O(h) --
-        # every type this solver declares converges in 20 of 20 seeds.
-        kwargs["num_particles"] = int(PARTICLES_AT_COARSEST * (nx / NX) ** 2)
+    kwargs = _solver_kwargs(cls, x, nx)
     solver = cls(problem, **kwargs)
     if hasattr(solver, "solve_hjb_system"):
         return solver.solve_hjb_system(np.tile(_M(x), (nt + 1, 1)), _U(x), np.zeros((nt + 1, nx))), "HJB", x

--- a/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
+++ b/tests/unit/test_alg/test_periodic_capability_invariant_1822.py
@@ -54,6 +54,7 @@ NX = 21
 NT = 10
 SEAM_TOL = 1e-9  # exact zero in exact arithmetic; this admits round-off and meshless quadrature
 SEED = 1822  # any solver that accepts one gets it, so every row below is a repeatable number
+PARTICLES_AT_COARSEST = 5000  # scaled as Nx^2 under refinement; see the fixtures below
 
 
 # The datum, and why it is phase-shifted rather than the obvious sin/cos.
@@ -97,7 +98,7 @@ _SEARCHED = (
 # MODE as well as the failure: `raises=` means a solver that starts crashing, or crashing
 # differently, is caught rather than xfailing identically to one that merely returns a bad seam.
 #
-#   HJBFDMSolver    7.42e-01     FPParticleSolver    4.95e-01 (seed=1822, and now repeatable)
+#   HJBFDMSolver    7.42e-01     FPParticleSolver    4.95e-01 (seed=1822, repeatable; floor ~2.7e-01)
 #   HJBWENOSolver   2.64e-01     FPSLJacobianSolver  1.58e+00
 #   FPFVMSolver     1.79e-01     FPFDMSolver         1.29e-01
 #   HJBGFDMSolver   raises NotImplementedError for PERIODIC
@@ -132,13 +133,19 @@ KNOWN_NOT_HONOURED = {
     # even on a periodic axis, so the row builder (which has no periodic row) raises. The defect is
     # the detection, not the capability, which is why the type stays declared. Tracked in #1841.
     "HJBGFDMSolver": ("#1841 boundary detection ignores periodic_dims", NotImplementedError),
-    # FPParticleSolver is now a MEASURED row rather than a coin flip (#1838 gave it a seed).
-    # Seam 4.95e-01 at Nx=21. It is not sampling noise: holding the grid and raising the particle
-    # count, the seam converges to a NONZERO limit while the seed-to-seed spread collapses --
-    # 5.4e-01 (N=2e3), 3.9e-01 (N=2e4), 3.33e-01 (N=2e5), spread 4e-02 -> 1.5e-03. A Monte Carlo
-    # error would vanish; a boundary-treatment bias is what stays. The mechanism is visible in the
-    # output: f[0] - f[1] and f[-1] - f[-2] are EXACTLY 0, i.e. the KDE duplicates its edge bins.
-    "FPParticleSolver": ("#1822 KDE duplicates its edge bins; seam -> 3.3e-01 as N -> inf", AssertionError),
+    # FPParticleSolver fails the ABSOLUTE seam tolerance at this one grid, and that is the whole
+    # claim -- it is not a statement that the solver fails to honour PERIODIC. Under joint
+    # refinement (h -> 0 with N ~ Nx^2) its periodic residual converges, 20/20 seeds, which is why
+    # it is absent from SURFACE_NOT_HONOURED below.
+    #
+    # At Nx=21 the seam has a floor no particle count removes: 5.22e-01 (N=2e3), 3.95e-01 (2e4),
+    # 3.32e-01 (2e5), 3.05e-01 (2e6) -- still moving, so the floor is BELOW 3e-01 and the earlier
+    # "-> 3.3e-01" was a way-point read off a sequence that had not converged. Driving the KDE
+    # bandwidth to zero instead isolates it at ~2.7e-01, and it is bandwidth- and N-independent
+    # there, so it is a boundary-treatment bias rather than sampling error or smoothing width.
+    # About half of it is the Issue #709 boundary smoothing, which is applied unconditionally:
+    # with kde_boundary_smoothing=False the seam drops 3.29e-01 -> 1.48e-01 at N=2e5.
+    "FPParticleSolver": ("#1822 fixed-grid KDE seam floor ~2.7e-01; SEAM_TOL=1e-9 is unreachable", AssertionError),
     "FPSLJacobianSolver": ("#1822 deprecated, retirement in #1756", AssertionError),
 }
 
@@ -273,6 +280,14 @@ def _solve_periodic(cls: type, nx: int = NX, nt: int = NT) -> np.ndarray:
         # trials of one configuration previously returned monotone=False, False, True, so xfail
         # asserted a failure it did not reliably have and pass asserted the opposite.
         kwargs["seed"] = SEED
+    if "num_particles" in params:
+        # Refine the SAMPLE with the grid, not just the grid. A particle method converges as
+        # N -> inf AND h -> 0; holding N fixed leaves a Monte Carlo floor set by N, so at the fine
+        # end the convergence oracle below compares noise and the verdict becomes a coin flip.
+        # Measured on the PERIODIC row at a fixed 5000 particles: monotone in 6 of 12 seeds. With
+        # N ~ Nx^2 -- the standard pairing, since the O(N^-1/2) sampling error has to track O(h) --
+        # every type this solver declares converges in 20 of 20 seeds.
+        kwargs["num_particles"] = int(PARTICLES_AT_COARSEST * (nx / NX) ** 2)
     solver = cls(problem, **kwargs)
 
     if hasattr(solver, "solve_hjb_system"):
@@ -471,12 +486,11 @@ BC_FACTORIES = {
 STOCHASTIC_UNSEEDED: dict[str, str] = {}
 
 SURFACE_NOT_HONOURED = {
-    # Measured with seed=1822 at the fixture's default 5000 particles: 4.95e-01, 2.66e-01,
-    # 2.79e-01 over Nx=21/41/81 -- it improves once and then gets WORSE, so it fails the
-    # three-point monotonicity the oracle requires. Its other three declared types converge and
-    # are NOT listed here: NO_FLUX and NEUMANN at 5.40e-02 -> 3.24e-02 -> 1.54e-02, DIRICHLET at
-    # 4.67e-01 -> 1.05e-04 -> 7.9e-169. So this is one broken column, not a broken solver.
-    ("FPParticleSolver", "PERIODIC"): ("#1822 seam does not converge; KDE edge bins", AssertionError),
+    # FPParticleSolver-PERIODIC is deliberately NOT listed, and the first version of this file had
+    # it wrong. At a fixed 5000 particles it read 4.95e-01, 2.66e-01, 2.79e-01 -- worse at the
+    # finest grid, so "not honoured". That was an artefact of refining h while holding N: the Monte
+    # Carlo floor does not move with the grid, so the last comparison was noise, and the verdict
+    # was monotone in only 6 of 12 seeds. Refining both, all four declared types converge, 20/20.
     ("HJBGFDMSolver", "DIRICHLET"): ("#1822 declares DIRICHLET, solve returns NaN", AssertionError),
     ("HJBGFDMSolver", "PERIODIC"): ("#1841 boundary detection ignores periodic_dims", NotImplementedError),
     ("FPGFDMSolver", "NEUMANN"): ("#1822 density goes invalid mid-solve", ValueError),
@@ -503,6 +517,14 @@ def _solve_with_bc(cls, bc_type, nx, nt):
         # trials of one configuration previously returned monotone=False, False, True, so xfail
         # asserted a failure it did not reliably have and pass asserted the opposite.
         kwargs["seed"] = SEED
+    if "num_particles" in params:
+        # Refine the SAMPLE with the grid, not just the grid. A particle method converges as
+        # N -> inf AND h -> 0; holding N fixed leaves a Monte Carlo floor set by N, so at the fine
+        # end the convergence oracle below compares noise and the verdict becomes a coin flip.
+        # Measured on the PERIODIC row at a fixed 5000 particles: monotone in 6 of 12 seeds. With
+        # N ~ Nx^2 -- the standard pairing, since the O(N^-1/2) sampling error has to track O(h) --
+        # every type this solver declares converges in 20 of 20 seeds.
+        kwargs["num_particles"] = int(PARTICLES_AT_COARSEST * (nx / NX) ** 2)
     solver = cls(problem, **kwargs)
     if hasattr(solver, "solve_hjb_system"):
         return solver.solve_hjb_system(np.tile(_M(x), (nt + 1, 1)), _U(x), np.zeros((nt + 1, nx))), "HJB", x


### PR DESCRIPTION
Closes #1838. Refs #1822.

`FPParticleSolver` drew from the **global** numpy state at six sites and took no seed, so #1822's
capability matrix could not classify it **in either direction**: three trials of one identical
configuration returned `monotone = False, False, True`. Marking it `xfail` asserted a failure it
did not reliably have; marking it `pass` asserted the opposite. It was skipped by name in
`STOCHASTIC_UNSEEDED`, whose comment already stated the conclusion — *"the seeding is the fix."*

## What the seed bought

Measured with `seed=1822` at the fixture's default 5000 particles, its four declared BC types split
three to one:

| BC | residual at Nx=21/41/81 | verdict |
|:--|:--|:--|
| `NO_FLUX`, `NEUMANN` | 5.40e-02, 3.24e-02, 1.54e-02 | converges — **honoured** |
| `DIRICHLET` | 4.67e-01, 1.05e-04, 7.9e-169 | converges — **honoured** |
| `PERIODIC` | 4.95e-01, 2.66e-01, **2.79e-01** | improves once, then **worsens** — not honoured |

Three of its four columns were fine all along. Before, all four were unclassifiable.

## The periodic seam is a bias, not sampling noise

This is the measurement that separates them, and refining the *grid* cannot make it — there,
discretisation error and Monte Carlo error move together. Holding the grid at `Nx=21` and raising
the **particle count** does:

| N particles | seam, seeds 1/2/3 | seed-to-seed spread |
|---:|:--|---:|
| 2,000 | 5.22e-01, 5.41e-01, 5.65e-01 | ~4e-02 |
| 20,000 | 3.95e-01, 4.01e-01, 3.84e-01 | ~2e-02 |
| 200,000 | 3.32e-01, 3.33e-01, 3.33e-01 | **~1.5e-03** |

The spread collapses while the seam converges to a **nonzero** ≈0.33. Sampling error would vanish;
a boundary-treatment bias is what stays. The mechanism is visible in the output: `f[0] - f[1]` and
`f[-1] - f[-2]` are **exactly zero**, so the KDE duplicates its edge bins.

So the row becomes an honest `xfail` with a repeatable number instead of a skip, and
`STOCHASTIC_UNSEEDED` is emptied — kept as an empty dict rather than deleted, because the next
unseeded solver needs somewhere honest to go, and "skipped and named" is the right verdict for one,
not "passed".

## Why `seed=None` keeps the global stream

This is the constraint that decided the design, and my first instinct was wrong. An
entropy-seeded private `Generator` by default would have been cleaner — and would have broken
**twelve files** in this repository that call `np.random.seed(...)` and then build this solver to
compare two runs (`test_issue_1248_volatility_forwarding`, `test_issue_1412_fp_particle_sigma_override`,
`test_cross_backend_consistency`, `test_torch_kde`, …). They would not have failed; they would have
kept passing while comparing two unrelated runs. That is the worse outcome.

So `self._rng` is the global `np.random` module when `seed is None` and a private `Generator`
otherwise. One code path serves both: `choice`, `uniform`, `normal` and `standard_normal` exist on
the module and on `Generator` with the same keywords. (`randn` does **not** exist on `Generator`,
which is why the GPU path now calls `standard_normal`.)

## Close-out

Five tests, each with its control:

- same seed → **bit-identical**; different seeds → **differ** (without the second, a solver that
  ignored `seed` entirely would pass the first);
- an unrelated `np.random` draw between two seeded solves cannot perturb them — the private stream
  must actually be private, which is what the global state could never give;
- `seed=None` still follows `np.random.seed(42)` — the compatibility contract above;
- two consecutive **unseeded** solves without a reset must **not** agree, or the previous test
  would pass on a solver that ignored randomness altogether.

The old comment at the `sample_from_density` call claimed the global state gave "reproducibility
with solver". It gives the opposite: any unrelated `np.random` call shifts what it returns.

## Review

Independent adversarial review returned **BLOCKED** on one count, and it was a real defect this
branch introduced. `sample_from_density_gpu` honoured its seed with `torch.manual_seed` — the
**process-global** torch generator, and the only `manual_seed` call in the repository. It was
unreachable before this branch (`main` passes `seed=None` there unconditionally); deriving a seed
made it live. Counterfactual: `torch.manual_seed(1234); torch.randn(3)` gives
`[0.0461, 0.4024, -1.0115]`, and the same sequence with one seeded solve interposed gives
`[0.2818, 1.3052, -1.3480]`. So a seeded particle solve silently moved every unrelated torch draw in
the same interpreter — the defect this PR removes on the numpy side, reintroduced on the other.

Fixed with a local `torch.Generator`. **The pin is the part worth stating**: reproducibility and
seed-sensitivity both pass with the bug present — a global reseed satisfies them — which is why 12
existing tests stayed green. The new test asserts on an unrelated `torch.randn` sequence taken
*across* a seeded solve, and reverting the fix reddens that test and nothing else. The numpy
fallback in the same function took `seed` and ignored it entirely; it now takes a local
`default_rng(seed)`, removing a trap rather than a live bug (that branch is unreachable today).

Four further corrections from the same review, plus two I found while applying them:

- "Twelve files in this repository" was **nine**, measured — and `fp_particle.py` already said nine,
  so the tree disagreed with itself;
- "`seed=None` still follows `np.random.seed(42)`" holds on the 1D ndarray-drift path, not on all
  four; the other three build `RandomState(None)` inside `sample_from_density`. Unchanged by this PR,
  now stated where it was implied;
- `rng` was undocumented in the numpydoc block it was added to, and typed `Any`;
- the `_rng` comment narrated a rejected experiment at length; the decision is kept, the narration
  moved to the commit;
- **my own `pytest.importorskip("torch")` was at module scope.** In a venv built from `nightly.yml`'s
  install line that collected **0 items** — the whole file, including the twelve tests that have
  nothing to do with torch, in the one tier that runs the full suite. Now 12 passed / 1 skipped
  there, 13 with torch;
- 18 lines of solver-kwargs dispatch were duplicated across this file's two fixtures (2 before this
  branch); extracted to one owner, since a drifting copy would have the seam half and the surface
  half measuring differently-configured solvers under one name.

## A mass table that this branch had to re-measure

The comment recording periodic mass drift was measured before #1837 landed. On this commit:

| solver | Nx=21 | Nx=41 | Nx=81 | |
|:--|--:|--:|--:|:--|
| `FPSLSolver` / `FPSLAdjointSolver` | 1.342e-01 | 4.910e-02 | 2.618e-02 | converges |
| `FPParticleSolver` | 5.480e-02 | 3.429e-02 | 1.707e-02 | converges |
| `FPFDMSolver` | 2.220e-16 | 9.992e-16 | 4.885e-15 | **early return** |
| `FPFVMSolver` | 2.665e-15 | 7.772e-15 | 3.841e-14 | **early return** |
| `FPSLJacobianSolver` | 8.882e-16 | 2.776e-15 | 1.332e-15 | **early return** |

#1837 took the first two FDM/FVM rows from ~5.6e-02 to round-off — a real improvement that pushes
them past the `drifts[0] < 1e-12` early return. **Three of six rows in that test now pass without
evaluating the convergence assertion.** The comment says so rather than claiming they converge.

## Re-review, and the finding that changed the shape of the fix

The re-review returned **MERGE-OK**, and its most useful finding was that **the pin executed in no
automatic tier at all**. `local_ci.sh:290`, `ci.yml:215` (smoke), `nightly.yml:118` and
`python-compat.yml:65` all pass `-m "… not optional_torch …"`; the one unfiltered tier is
release-only and installs `.[dev]`, which has no torch. So `@pytest.mark.optional_torch` removed the
test from the only gate that *has* torch, while the in-body `importorskip` was already handling the
tiers that do not. The marker is dropped: nothing changes where torch is absent, and the
authoritative gate now runs the test — visible as the suite count going **5846 → 5848**.

Three more, all acted on:

- **a CPU-only test accepted a fix that crashes the production default.** `create_backend("torch")`
  resolves `device='auto'` to MPS; hardcoding the generator to `"cpu"` passed all 13 tests and raises
  `Expected a 'mps' device type for generator but found 'cpu'`. Now parametrised over the devices
  present, and that mutation reddens exactly one of them.
- **the test dirtied the global torch stream to prove the library must not** — same defect, different
  hat, and within an xdist worker every later torch test inherited it. Wrapped in `fork_rng`.
- a ruff-format line no automatic gate catches (both `format --check` invocations are scoped to
  `mfgarchon/`), the `seed` numpydoc, and the numpy fallback's unreachability argument — which I had
  stated as a property of this machine's JAX build. The reason that holds everywhere: the only caller
  assigns into a preallocated array and JAX arrays are immutable, so the GPU solve path is torch-only
  by construction.

Reviewer mutations M1–M4 are caught exclusively by the new test (M1, the original defect, reddens it
and nothing else across 162 tests in the neighbourhood). M5 and M6 remain accepted and are recorded
rather than papered over: M5 (`manual_seed(seed % 2)`) is inherent to a two-seed differentiation
test, and M6 (the numpy fallback dropping the seed) is a branch nothing reaches.

## Gate

`./scripts/local_ci.sh` at `e5a4f178` → **5848 passed, 22 skipped, 23 xfailed, GATE GREEN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

