### PR TITLE
Let the backstop tier read the live library, and say what it cannot read

### DIFF
--- a/.github/workflows/discrimination.yml
+++ b/.github/workflows/discrimination.yml
@@ -45,10 +45,14 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
 
+    # numba for the same measured reason nightly.yml and deprecation-check.yml carry it: without
+    # it `mfgarchon.backends.numba_backend` -- LIVE library, not a frozen paradigm -- cannot be
+    # imported, and the deprecation-guide tests refuse a tree whose live half they cannot read
+    # (#1836). This tier runs `pytest tests` in full, so it hits exactly the same three errors.
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev,numerical]"
+        pip install -e ".[dev,numerical]" numba
 
     # NOTE: --paths defaults to `tests`, which includes tests/unit/test_backends and
     # tests/unit/test_visualization. nightly.yml deliberately --ignores both (see its

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,10 +63,16 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    # `numba` is here for the same measured reason deprecation-check.yml carries it, and torch is
+    # still NOT: of the 20 modules this environment cannot import, 19 live under the frozen
+    # paradigms (CLAUDE.md) and the twentieth is `backends/numba_backend.py`, which raises a
+    # deliberate ImportError without numba. That one is LIVE library, so the backstop tier could
+    # not read the library end to end -- measured on b88b4781. torch stays out: it is a 2 GB wheel
+    # on a tier that already deselects `optional_torch` and ignores tests/unit/test_backends/.
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev,numerical]"
+        pip install -e ".[dev,numerical]" numba
 
     - name: Assert the shard matrix covers every tests/ subdirectory
       # tests/regression was silently dropped from an earlier three-shard matrix -- it holds the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,11 +64,12 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     # `numba` is here for the same measured reason deprecation-check.yml carries it, and torch is
-    # still NOT: of the 20 modules this environment cannot import, 19 live under the frozen
-    # paradigms (CLAUDE.md) and the twentieth is `backends/numba_backend.py`, which raises a
-    # deliberate ImportError without numba. That one is LIVE library, so the backstop tier could
-    # not read the library end to end -- measured on b88b4781. torch stays out: it is a 2 GB wheel
-    # on a tier that already deselects `optional_torch` and ignores tests/unit/test_backends/.
+    # still NOT. WITHOUT numba this environment cannot import 20 modules: 19 under the frozen
+    # paradigms (CLAUDE.md), and `backends/numba_backend.py`, which raises a deliberate ImportError
+    # without it. That twentieth is LIVE library, so the backstop tier could not read the library
+    # end to end -- measured on b88b4781. Installing numba leaves the 19 frozen ones, which is a
+    # state the deprecation-guide tests are entitled to skip on. torch stays out: it is a 2 GB
+    # wheel on a tier that already deselects `optional_torch` and ignores tests/unit/test_backends/.
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/changelog.d/1836-guide-scan-env.fixed.md
+++ b/changelog.d/1836-guide-scan-env.fixed.md
@@ -9,9 +9,16 @@
   paradigms, and `mfgarchon.backends.numba_backend`, which raises a deliberate `ImportError`
   without numba. The twentieth is live library, so the only automatic full-suite tier could not read
   the package end to end — the nightly now installs `numba`, for the same measured reason
-  `deprecation-check.yml` already carried it, and still not torch. The fixture skips with the reason
+  `deprecation-check.yml` already carried it, and still not torch. `discrimination.yml` — the weekly
+  sweep, and a second automatic tier that runs `pytest tests` in full — had the identical hole and
+  gets the same one-word fix. The fixture skips with the reason
   and the remedy, and only when every unreadable module is inside a frozen paradigm: a live module
   that will not import still raises, since turning a real breakage into a skip is how a suite goes
   quiet about what it was built to catch. The scope rule is read from the ratchet that owns it
   (`check_internal_deprecation.FROZEN`) rather than restated, and both branches of the guard are
   pinned against the nightly's own 20-module failure.
+  Installing numba is not inert: `USE_NUMBA` flips to True and three `@njit` kernels become
+  compiled. Measured rather than assumed — collection is identical in all four shards with and
+  without it, and no test in the nightly's marker selection branches on numba availability, so
+  the change moves that tier toward the local gate, whose environment already has it.
+

--- a/changelog.d/1836-guide-scan-env.fixed.md
+++ b/changelog.d/1836-guide-scan-env.fixed.md
@@ -1,0 +1,17 @@
+- **The nightly can read the live library end to end, and the deprecation-guide tests state the
+  environment they need instead of erroring in it** (Issue #1836, refs #1830, #1713). Reading the
+  runtime registry made a complete walk a precondition: `scan_all_deprecations` refuses a partial
+  one, because the guide is user-facing and a guide generated from half a tree teaches half an API
+  as if it were the whole one. From #1830 the `registry` fixture therefore raised
+  `IncompleteScanError` at setup and three tests errored every night, while the local gate — which
+  runs in a complete environment — stayed green. Measured on `b88b4781` in a fresh
+  `.[dev,numerical]` environment, the walk cannot import **20** modules: 19 under the frozen
+  paradigms, and `mfgarchon.backends.numba_backend`, which raises a deliberate `ImportError`
+  without numba. The twentieth is live library, so the only automatic full-suite tier could not read
+  the package end to end — the nightly now installs `numba`, for the same measured reason
+  `deprecation-check.yml` already carried it, and still not torch. The fixture skips with the reason
+  and the remedy, and only when every unreadable module is inside a frozen paradigm: a live module
+  that will not import still raises, since turning a real breakage into a skip is how a suite goes
+  quiet about what it was built to catch. The scope rule is read from the ratchet that owns it
+  (`check_internal_deprecation.FROZEN`) rather than restated, and both branches of the guard are
+  pinned against the nightly's own 20-module failure.

--- a/tests/unit/test_deprecation_guide_name_collisions.py
+++ b/tests/unit/test_deprecation_guide_name_collisions.py
@@ -23,6 +23,7 @@ import importlib.util
 import pathlib
 
 import pytest
+from _pytest.outcomes import Skipped
 
 _SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
 
@@ -47,6 +48,30 @@ def _live_holes(unimportable: dict[str, str]) -> list[str]:
     return sorted(module for module in unimportable if not _RATCHET.is_frozen(module))
 
 
+def _scan_or_skip(scan):
+    """Run `scan`, and turn an incomplete-but-frozen-only tree into a skip rather than an error.
+
+    A free function rather than an inline `try` in the fixture, so a test can drive it with a
+    fabricated `IncompleteScanError` and check BOTH branches. Inline, the two ways this can rot --
+    skipping unconditionally, or refusing unconditionally -- are invisible: independent review
+    mutated each of them and every environment stayed green, including the authoritative gate.
+    That is the failure this guard exists to prevent, one level up from where it prevents it.
+    """
+    from mfgarchon.utils.deprecation import IncompleteScanError
+
+    try:
+        return scan()
+    except IncompleteScanError as exc:
+        if _live_holes(exc.unimportable):
+            raise
+        pytest.skip(
+            f"the package cannot be read in full here, so the shipped guide cannot be generated: "
+            f"{len(exc.unimportable)} frozen-paradigm module(s) need optional extras. "
+            f"Install `.[nn]` to run this, or rely on ./scripts/local_ci.sh, the authoritative "
+            f"gate, which runs in a complete environment."
+        )
+
+
 @pytest.fixture(scope="module")
 def gen():
     return _load("generate_deprecation_guide")
@@ -69,21 +94,9 @@ def registry(gen):
 
     The hole has to be entirely inside the frozen paradigms. A LIVE module that will not import is
     a real breakage, and turning that into a skip is how a suite goes quiet about the thing it was
-    built to catch.
+    built to catch. That decision lives in `_scan_or_skip`, where a test can reach it.
     """
-    from mfgarchon.utils.deprecation import IncompleteScanError
-
-    try:
-        return gen.deduplicate(gen.scan_all_deprecations())
-    except IncompleteScanError as exc:
-        if _live_holes(exc.unimportable):
-            raise
-        pytest.skip(
-            f"the package cannot be read in full here, so the shipped guide cannot be generated: "
-            f"{len(exc.unimportable)} frozen-paradigm module(s) need optional extras. "
-            f"Install `.[nn]` to run this, or rely on ./scripts/local_ci.sh, the authoritative "
-            f"gate, which runs in a complete environment."
-        )
+    return gen.deduplicate(_scan_or_skip(gen.scan_all_deprecations))
 
 
 def test_the_live_collision_is_detected(gen, registry):
@@ -120,25 +133,68 @@ def test_an_unambiguous_registry_produces_no_section(gen):
     assert "Do not migrate these across solvers" not in gen.generate_guide(clean)
 
 
-def test_the_scan_guard_skips_for_the_frozen_paradigms_and_not_for_a_live_module():
-    """A guard that turns every unreadable tree into a skip reports nothing when it matters.
+def _raising(unimportable):
+    """A stand-in for `scan_all_deprecations` that fails the way the real one does."""
+    from mfgarchon.utils.deprecation import IncompleteScanError
 
-    Both halves are the instance that motivated it: the nightly's `IncompleteScanError` named 20
-    modules and every one of them sat under a frozen paradigm (`.core.networks`, `.core.utils`,
-    `.nn.feedforward`, ...), which is the environment `registry` is entitled to skip on. Add one
-    live module to the same dict and the skip must not fire -- that tree is broken, not merely
-    partially installed.
+    def scan():
+        raise IncompleteScanError(unimportable)
+
+    return scan
+
+
+# The nightly's own failure, minus the module that made it interesting. `.[dev,numerical]` cannot
+# import 20 modules; nineteen are frozen and the twentieth, `backends/numba_backend`, is LIVE -- it
+# is why this branch installs numba rather than only guarding the test. These three are from the
+# traceback's own "(+17 more)" prefix, built from FROZEN because check_frozen_areas.py counts
+# literals naming a frozen package.
+_FROZEN_ONLY = {
+    f"{_RATCHET.FROZEN[0]}.core.networks": "ModuleNotFoundError: No module named 'torch'",
+    f"{_RATCHET.FROZEN[0]}.core.utils": "ModuleNotFoundError: No module named 'torch'",
+    f"{_RATCHET.FROZEN[0]}.nn.feedforward": "ModuleNotFoundError: No module named 'torch'",
+}
+_LIVE_HOLE = "mfgarchon.backends.numba_backend"
+
+
+def test_the_scan_guard_classifies_the_holes():
+    """The classifier alone: frozen holes are not live ones, and a live hole is reported."""
+    assert _live_holes(_FROZEN_ONLY) == []
+    assert _live_holes({**_FROZEN_ONLY, _LIVE_HOLE: "ImportError: Numba required"}) == [_LIVE_HOLE]
+
+
+def test_the_scan_guard_skips_on_a_frozen_only_tree():
+    """Driving the guard, not the classifier under it.
+
+    Asserting on `_live_holes` alone leaves the `try/except` untested, and independent review
+    measured what that costs: mutating the guard to skip unconditionally -- the exact degradation
+    this file's docstrings warn about -- left every environment green, the authoritative gate
+    included.
     """
-    frozen = _RATCHET.FROZEN[0]
-    nightly = {
-        f"{frozen}.core.networks": "ModuleNotFoundError: No module named 'torch'",
-        f"{frozen}.core.utils": "ModuleNotFoundError: No module named 'torch'",
-        f"{frozen}.nn.feedforward": "ModuleNotFoundError: No module named 'torch'",
-    }
-    assert _live_holes(nightly) == []
+    with pytest.raises(Skipped):
+        _scan_or_skip(_raising(_FROZEN_ONLY))
 
-    live = "mfgarchon.utils.numerical"
-    assert _live_holes({**nightly, live: "ImportError: cannot import name 'solve'"}) == [live]
+
+def test_the_scan_guard_refuses_a_tree_with_a_live_hole():
+    """The half that must NOT be a skip, asserted so that a skip fails rather than passes.
+
+    `pytest.raises(IncompleteScanError)` is the obvious spelling and it is not enough: under a
+    guard that skips unconditionally, `Skipped` propagates out of this call and pytest records the
+    test as SKIPPED -- exit 0, invisible in the summary, which is what the mutation would exploit.
+    So the skip is caught explicitly and turned into a failure.
+    """
+    from mfgarchon.utils.deprecation import IncompleteScanError
+
+    scan = _raising({**_FROZEN_ONLY, _LIVE_HOLE: "ImportError: Numba required for Numba backend"})
+    try:
+        _scan_or_skip(scan)
+    except Skipped:
+        pytest.fail(
+            f"the guard skipped a tree whose live library it could not read ({_LIVE_HOLE}); a real "
+            f"breakage is now reported as 'not installed', which is how a suite goes quiet"
+        )
+    except IncompleteScanError:
+        return
+    pytest.fail("the guard neither raised nor skipped on an unreadable tree")
 
 
 def test_a_name_deprecated_only_at_a_different_owner_still_collides(gen):

--- a/tests/unit/test_deprecation_guide_name_collisions.py
+++ b/tests/unit/test_deprecation_guide_name_collisions.py
@@ -24,19 +24,32 @@ import pathlib
 
 import pytest
 
-_GENERATOR = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "generate_deprecation_guide.py"
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
 
 
-def _load():
-    spec = importlib.util.spec_from_file_location("generate_deprecation_guide", _GENERATOR)
+def _load(stem: str):
+    spec = importlib.util.spec_from_file_location(stem, _SCRIPTS / f"{stem}.py")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
+# The ratchet owns the frozen-paradigm scope rule (`FROZEN`, `is_frozen`); this file reads it
+# rather than restating it. Module scope, because `_live_holes` is called from a fixture and from
+# a test, and every frozen module name below is BUILT from `FROZEN` -- check_frozen_areas.py counts
+# string literals naming a frozen package, so spelling one here would register as a new test
+# against a frozen prototype (CLAUDE.md).
+_RATCHET = _load("check_internal_deprecation")
+
+
+def _live_holes(unimportable: dict[str, str]) -> list[str]:
+    """The modules in an incomplete scan that the live library needed, frozen paradigms excluded."""
+    return sorted(module for module in unimportable if not _RATCHET.is_frozen(module))
+
+
 @pytest.fixture(scope="module")
 def gen():
-    return _load()
+    return _load("generate_deprecation_guide")
 
 
 @pytest.fixture(scope="module")
@@ -46,8 +59,31 @@ def registry(gen):
     A hand-built fixture would be generated from this file's *description* of the defect, and the
     description drops whatever made the defect possible -- here, that the colliding name is a
     parameter whose owner path has to be split off before the identifiers compare equal.
+
+    Which is why this needs a tree it can read in FULL, and says so instead of erroring. The guide
+    is user-facing, so `scan_all_deprecations` refuses a partial walk outright (#1713) -- in an
+    environment without `[nn]` the document under test cannot be produced at all, and asserting
+    about the one a partial walk would yield answers a question nobody ships. The nightly runs
+    `.[dev,numerical]` on purpose, keeping a 2 GB wheel off the critical path (deprecation-check.yml),
+    and errored here every night from #1830 until this guard (#1836).
+
+    The hole has to be entirely inside the frozen paradigms. A LIVE module that will not import is
+    a real breakage, and turning that into a skip is how a suite goes quiet about the thing it was
+    built to catch.
     """
-    return gen.deduplicate(gen.scan_all_deprecations())
+    from mfgarchon.utils.deprecation import IncompleteScanError
+
+    try:
+        return gen.deduplicate(gen.scan_all_deprecations())
+    except IncompleteScanError as exc:
+        if _live_holes(exc.unimportable):
+            raise
+        pytest.skip(
+            f"the package cannot be read in full here, so the shipped guide cannot be generated: "
+            f"{len(exc.unimportable)} frozen-paradigm module(s) need optional extras. "
+            f"Install `.[nn]` to run this, or rely on ./scripts/local_ci.sh, the authoritative "
+            f"gate, which runs in a complete environment."
+        )
 
 
 def test_the_live_collision_is_detected(gen, registry):
@@ -82,6 +118,27 @@ def test_an_unambiguous_registry_produces_no_section(gen):
     assert gen.find_name_collisions(clean) == {}
     assert gen.format_collisions({}) == []
     assert "Do not migrate these across solvers" not in gen.generate_guide(clean)
+
+
+def test_the_scan_guard_skips_for_the_frozen_paradigms_and_not_for_a_live_module():
+    """A guard that turns every unreadable tree into a skip reports nothing when it matters.
+
+    Both halves are the instance that motivated it: the nightly's `IncompleteScanError` named 20
+    modules and every one of them sat under a frozen paradigm (`.core.networks`, `.core.utils`,
+    `.nn.feedforward`, ...), which is the environment `registry` is entitled to skip on. Add one
+    live module to the same dict and the skip must not fire -- that tree is broken, not merely
+    partially installed.
+    """
+    frozen = _RATCHET.FROZEN[0]
+    nightly = {
+        f"{frozen}.core.networks": "ModuleNotFoundError: No module named 'torch'",
+        f"{frozen}.core.utils": "ModuleNotFoundError: No module named 'torch'",
+        f"{frozen}.nn.feedforward": "ModuleNotFoundError: No module named 'torch'",
+    }
+    assert _live_holes(nightly) == []
+
+    live = "mfgarchon.utils.numerical"
+    assert _live_holes({**nightly, live: "ImportError: cannot import name 'solve'"}) == [live]
 
 
 def test_a_name_deprecated_only_at_a_different_owner_still_collides(gen):


### PR DESCRIPTION
Refs #1836, #1830, #1713, #1774.

The nightly has errored on three tests every night since #1830, and the local gate cannot see it,
because the two environments differ in a way nothing declared.

## What actually fails

Reading the runtime registry made a **complete** walk of the package a precondition.
`scan_all_deprecations` refuses a partial one on purpose — the guide is user-facing, and one
generated from half a tree teaches half an API as if it were the whole one (#1713). The `registry`
fixture in `tests/unit/test_deprecation_guide_name_collisions.py` inherited that precondition
without declaring it, so `IncompleteScanError` came out of fixture **setup** as three ERRORs rather
than as a statement about the environment.

## The measurement that changed the fix

In a venv built from `nightly.yml`'s own install line (`.[dev,numerical]`, Python 3.12), the walk
cannot import **20** modules. Nineteen are under the frozen paradigms (CLAUDE.md). The twentieth:

```
LIVE holes: ['mfgarchon.backends.numba_backend']
   why: ImportError: Numba required for Numba backend. Install with: pip install numba
```

That is **live library**, unreadable in the only automatic full-suite tier. So a test-side guard
alone would not have turned the nightly green — it would have refused to skip, correctly. Both
halves are needed, and the second is a finding in its own right rather than a means to the first.

## Two halves

1. **`nightly.yml` installs `numba`**, for the same measured reason `deprecation-check.yml` already
   carries it (its comment: numba is the only optional distribution the live library needs to be
   readable end to end). Still **not** torch: a 2 GB wheel on a tier that already deselects
   `optional_torch` and ignores `tests/unit/test_backends/` buys nothing.
2. **The `registry` fixture skips with the reason and the remedy — and only when every unreadable
   module is inside a frozen paradigm.** A live module that will not import still raises. A guard
   that turns any unreadable tree into a skip reports nothing on the day it matters, and this one
   had a live hole in it from the start.

The scope rule is read from the ratchet that owns it (`check_internal_deprecation.FROZEN`), not
restated, and every frozen module name in the new test is **built** from it — `check_frozen_areas.py`
counts string literals naming a frozen package, so spelling one would register as a new test against
a frozen prototype.

## Verified in all three environments, which is the whole dispatch surface

| environment | result |
|:--|:--|
| `.[dev,numerical]`, no numba | **3 passed, 3 errors** — a live hole exists, so the guard refuses to skip |
| `.[dev,numerical]` + numba (what the nightly becomes) | **3 passed, 3 skipped**, with the reason |
| full env with torch (the local gate) | **6 passed** — the assertions actually run |

The middle row is the nightly after this change; the bottom row is why the detector is still
exercised on every push, since `./scripts/local_ci.sh` is the authoritative gate and runs complete.

Both branches of the guard are pinned by `test_the_scan_guard_skips_for_the_frozen_paradigms_and_not_for_a_live_module`,
using the three module names the nightly's own traceback printed.

## What this does not claim

**Not "Closes #1836"** — though for a narrower reason than this section first gave. I wrote that the
2026-08-07 integration failure was unattributable. Independent review found the evidence I had
stopped looking for: the log blob is gone, but the check-run annotation survives.

```
gh api repos/derrring/MFGArchon/check-runs/92774534568/annotations
→ failure: The hosted runner lost communication with the server. Anything in your workflow that
  terminates the runner process, starves it for CPU/Memory, or blocks its network access can
  cause this error.
```

So that shard failed on **infrastructure, not on the tree**, which removes the one reason to expect
the nightly to stay red after this. The unit shard is fully attributed: all three red nights report
`5219 passed, 54 skipped, 23 xfailed, 3 errors` — those three and nothing else.

It still says *Refs*, because "the nightly is green" is a claim only a nightly run can make.
`nightly.yml` closes this issue itself via `resolve-on-success` (#1806); a manual `workflow_dispatch`
after merge is what should settle it.

## Review

Independent adversarial review returned **BLOCKED**, and its blocker was on the part I was most
confident about: **the control test pinned `_live_holes`, a pure classifier, and never reached the
`try/except` that decides skip-versus-raise.** Measured by the reviewer, both degradations were
invisible:

| mutation | before | after |
|:--|:--|:--|
| guard → skip unconditionally | green in **all three** environments | **1 FAILED** in both |
| guard → raise unconditionally | green in the local gate; nightly only, a day later | **1 FAILED** in both |

The first is the exact failure this file's own docstrings warn about — so the guard was protecting
the suite from a defect its own test could not see, which is #1774's recorded shape one level down.

The decision now lives in `_scan_or_skip`, a free function a test can drive with a fabricated
`IncompleteScanError`. The live-hole half asserts by catching `Skipped` and failing on it, **not** by
`pytest.raises(IncompleteScanError)`: under the skip-everything mutation the obvious spelling records
the test as SKIPPED — exit 0, invisible in the summary — which is precisely what that mutation would
exploit.

Three more from the same review:

- the control's docstring claimed all 20 unimportable modules were frozen, contradicting this
  branch's entire finding. Nineteen are; the twentieth is the live `numba_backend`, and the
  fabricated dict now uses that module by name for the live case;
- **`discrimination.yml` has the identical hole** — `.[dev,numerical]`, no numba — and it runs
  `pytest tests` in full, so it hits the same three errors. That also makes "the only automatic
  full-suite tier" wrong as a description of the nightly. Same one-word fix, applied here;
- installing numba is not inert: `USE_NUMBA` flips and three `@njit` kernels compile. Collection is
  identical across all four shards with and without it, so this moves that tier *toward* the local
  gate, whose environment already has numba.

## Gate

`./scripts/local_ci.sh` → **5833 passed, 26 skipped, 23 xfailed, GATE GREEN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
