### PR TITLE
Test the particle solver's coupling to time, which no fixture could see

### DIFF
--- a/changelog.d/1792-particle-time-level.added.md
+++ b/changelog.d/1792-particle-time-level.added.md
@@ -1,0 +1,17 @@
+- **The particle solver's coupling to time is now tested, on both the 1D and the nD path**
+  (Issue #1792). The FP sweep runs forward while the HJB sweep runs backward, and that pairing is
+  what makes the MFG fixed point mean anything — but reading `U[T - t_n]` instead of `U[t_n]`
+  survived a 25-axis mutation sweep against the entire marker-filtered suite (5770 passed, 0
+  failed). Negative indexing keeps every access in range for any `Nt`, so nothing raises and nothing
+  warns while the density tracks the control's journey backwards. The gap was structural rather than
+  a missing assertion: every `U_solution` the particle tests build is `np.zeros((Nt, Nx))` or
+  `np.tile(f(x), (Nt, 1))`, i.e. time-constant, which makes `U[n]` and `U[-1-n]` the same array and
+  the mutation a no-op by construction — no assertion added to such a fixture could have helped.
+  The new test drives a well whose centre travels 0.2 → 0.8 and measures the correlation between the
+  density's centroid and the well's position over the whole trajectory: **+0.9917 (k=2) and +0.9981
+  (k=5) correct, against −0.0143 and −0.6194 for the mirrored read**. Both indexing sites are
+  covered (`U_solution_for_drift[n_time_idx]` on the 1D path, `[t_idx]` on the nD one); the issue
+  named only the first. The under-driven-fixture trap it warns about — where neither run tracks
+  anything, the gap is 1%, and a null result reads as a small effect — is an explicit control rather
+  than a tuned threshold. Determinism comes from the seed added in #1838; without it this comparison
+  is a statement about the Monte Carlo draw rather than about the solver.

--- a/changelog.d/1792-particle-time-level.added.md
+++ b/changelog.d/1792-particle-time-level.added.md
@@ -2,7 +2,9 @@
   (Issue #1792). The FP sweep runs forward while the HJB sweep runs backward, and that pairing is
   what makes the MFG fixed point mean anything — but reading `U[T - t_n]` instead of `U[t_n]`
   survived a 25-axis mutation sweep against the entire marker-filtered suite (5770 passed, 0
-  failed). Negative indexing keeps every access in range for any `Nt`, so nothing raises and nothing
+  failed, as reported in the issue). Re-measured directly: with both index sites mirrored, all 23
+  test files mentioning `FPParticleSolver` return 322 passed / 13 xfailed — byte for byte the
+  unmutated result. Negative indexing keeps every access in range for any `Nt`, so nothing raises and nothing
   warns while the density tracks the control's journey backwards. The gap was structural rather than
   a missing assertion: every `U_solution` the particle tests build is `np.zeros((Nt, Nx))` or
   `np.tile(f(x), (Nt, 1))`, i.e. time-constant, which makes `U[n]` and `U[-1-n]` the same array and
@@ -12,6 +14,12 @@
   (k=5) correct, against −0.0143 and −0.6194 for the mirrored read**. Both indexing sites are
   covered (`U_solution_for_drift[n_time_idx]` on the 1D path, `[t_idx]` on the nD one); the issue
   named only the first. The under-driven-fixture trap it warns about — where neither run tracks
-  anything, the gap is 1%, and a null result reads as a small effect — is an explicit control rather
-  than a tuned threshold. Determinism comes from the seed added in #1838; without it this comparison
+  anything, the gap is 1%, and a null result reads as a small effect — is an explicit control. That
+  control IS a tuned threshold, unlike the correlation: the mirrored read lags 0.168 at k=2 and
+  passes it, so the k=2 row is carried by the correlation alone. Determinism comes from the seed added in #1838; without it this comparison
   is a statement about the Monte Carlo draw rather than about the solver.
+  Scoped deliberately: the observable detects the DIRECTION of the time coupling, not the exact
+  level. A pure shift `U[i+s]` survives for s from −8 to +20 — with finite drift the mass trails a
+  moving well, so reading ahead compensates the lag instead of exposing it — and an off-by-one is
+  therefore not caught. The white-box spy used on the FDM side would catch it; that seam does not
+  exist on the particle path. The docstring says so rather than implying the stronger claim.

--- a/tests/unit/test_alg/test_fp_particle_time_level_1792.py
+++ b/tests/unit/test_alg/test_fp_particle_time_level_1792.py
@@ -1,12 +1,14 @@
-"""`FPParticleSolver` must read the value function at the time level it is stepping. Issue #1792.
+"""`FPParticleSolver` must read the value function forward in time. Issue #1792.
 
 The FP sweep runs FORWARD while the HJB sweep runs backward, and the pairing of the two is what
 makes the MFG fixed point mean anything. Reading `U[T - t_n]` instead of `U[t_n]` keeps every index
 in range for any `Nt` -- negative indexing wraps -- so nothing raises and nothing warns, while the
 density tracks the control's journey backwards.
 
-That mutation survived a 25-axis sweep against the entire marker-filtered suite: 5770 passed, 0
-failed. The reason is structural rather than a missing assertion. Every `U_solution` the particle
+That mutation survived a 25-axis sweep against the entire marker-filtered suite -- 5770 passed, 0
+failed, reported in #1792 and not re-measured here. What IS re-measured: with both index sites
+mirrored, all 23 test files that mention `FPParticleSolver` return 322 passed / 13 xfailed, byte for
+byte the unmutated result. The reason is structural rather than a missing assertion. Every `U_solution` the particle
 tests build is `np.zeros((Nt, Nx))` or `np.tile(f(x), (Nt, 1))` -- time-CONSTANT, so `U[n]` and
 `U[-1-n]` are literally the same array and the mutation is a no-op by construction. A fixture where
 time does not vary cannot test a coupling to time, and no assertion added to one would help.
@@ -23,7 +25,18 @@ available to each: `fp_particle.py` reads `U_solution_for_drift[n_time_idx]` on 
 `U_solution_for_drift[t_idx]` on the nD one.
 
 The seed comes from #1838. Without it this is a coin flip on the Monte Carlo draw rather than a
-statement about the solver.
+statement about the solver. Measured across 12 seeds the correlation moves in the fourth decimal
+(+0.9916 to +0.9917 correct, -0.0159 to -0.0141 mirrored), so the verdict is the solver's and not
+the draw's.
+
+SCOPE, because the stronger claim would be false. This measures the DIRECTION of the time coupling,
+not the exact level. A pure shift `U[i + s]` survives for every s from -8 to +20, and the lag is
+SMALLER at s = +10 (0.0054) than at the correct s = 0 (0.1139): with finite drift the mass
+physically trails a moving well, so reading ahead compensates that lag rather than exposing it. An
+off-by-one is therefore not caught here. The white-box form used on the FDM side
+(`test_hjb_fdm_nd_coupling_time_level.py`) spies the index sequence and would catch it, but that
+seam does not exist on this path -- the coupling runs through the drift computation. So this closes
+the defect #1792 names, a reversed read that no fixture in the suite could see, and claims no more.
 """
 
 from __future__ import annotations
@@ -50,6 +63,10 @@ MASS_START = 0.2
 TRACKS = 0.9
 # ...and the control: correlation alone is satisfied by a mass that follows the well loosely from
 # far away, so the run also has to get NEAR it. Correct is 0.114 (k=2) and 0.054 (k=5).
+#
+# This one is a genuine threshold, unlike TRACKS. The mirrored read gives 0.168 at k=2 -- which
+# PASSES it -- and 0.246 at k=5. So the control is carried by the correlation on the k=2 row and by
+# both on k=5; it is not a second independent detector, and calling it untuned would be wrong.
 MAX_LAG = 0.2
 
 
@@ -142,12 +159,15 @@ def test_the_density_follows_the_well_forward_in_time(dim, nx, particles, k):
     assert correlation > TRACKS, (
         f"the density does not follow the moving well through time (corr {correlation:+.4f}, "
         f"mean|centroid - well| {lag:.4f}). The FP sweep steps FORWARD, so it must read the value "
-        f"function at t_n, not at T - t_n; a mirrored read gives corr -0.01 to -0.62 here. "
-        f"(If the correlation is near zero rather than negative, check the fixture drives at all "
-        f"before concluding the time level is wrong.)"
+        f"function at t_n, not at T - t_n; a mirrored read gives corr -0.01 (k=2) to -0.62 (k=5) "
+        f"here, so a value near zero is the k=2 signature of exactly that defect and not a reason "
+        f"to suspect the fixture."
     )
     assert lag < MAX_LAG, (
         f"the density correlates with the well but never gets near it (mean|centroid - well| "
-        f"{lag:.4f}, corr {correlation:+.4f}): the fixture is under-driven, so the assertion above "
-        f"is passing on a drift that follows the well only in the loosest sense"
+        f"{lag:.4f}, corr {correlation:+.4f}). Two causes reach here and this assertion cannot "
+        f"separate them: an under-driven fixture, where nothing tracks and the correlation above "
+        f"is passing on a drift that follows the well only in the loosest sense; or a solver "
+        f"reading U at a COMPRESSED time level (U[n//2] lands here at 0.2098, correlating +0.99 "
+        f"while lagging the well). Check that the correct run tracks before blaming the fixture."
     )

--- a/tests/unit/test_alg/test_fp_particle_time_level_1792.py
+++ b/tests/unit/test_alg/test_fp_particle_time_level_1792.py
@@ -1,0 +1,153 @@
+"""`FPParticleSolver` must read the value function at the time level it is stepping. Issue #1792.
+
+The FP sweep runs FORWARD while the HJB sweep runs backward, and the pairing of the two is what
+makes the MFG fixed point mean anything. Reading `U[T - t_n]` instead of `U[t_n]` keeps every index
+in range for any `Nt` -- negative indexing wraps -- so nothing raises and nothing warns, while the
+density tracks the control's journey backwards.
+
+That mutation survived a 25-axis sweep against the entire marker-filtered suite: 5770 passed, 0
+failed. The reason is structural rather than a missing assertion. Every `U_solution` the particle
+tests build is `np.zeros((Nt, Nx))` or `np.tile(f(x), (Nt, 1))` -- time-CONSTANT, so `U[n]` and
+`U[-1-n]` are literally the same array and the mutation is a no-op by construction. A fixture where
+time does not vary cannot test a coupling to time, and no assertion added to one would help.
+
+So the datum is a well whose centre MOVES, 0.2 -> 0.8 over [0, T], and the observable is the
+correlation between where the mass is and where the well is, over the whole trajectory rather than
+at the endpoint alone. Measured here:
+
+    k = 2.0    correct +0.9917    mirrored -0.0143
+    k = 5.0    correct +0.9981    mirrored -0.6194
+
+Both indexing sites are covered, because they are separate code paths with the same defect
+available to each: `fp_particle.py` reads `U_solution_for_drift[n_time_idx]` on the 1D path and
+`U_solution_for_drift[t_idx]` on the nD one.
+
+The seed comes from #1838. Without it this is a coin flip on the Monte Carlo draw rather than a
+statement about the solver.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+NT, T = 40, 2.0
+SIGMA = 0.02
+SEED = 1792
+WELL_START, WELL_END = 0.2, 0.8
+MASS_START = 0.2
+
+# The correlation the correct solver achieves is +0.99; the mirrored read gives -0.01 at k=2.0 and
+# -0.62 at k=5.0. Anywhere in between is not a threshold anyone has to tune.
+TRACKS = 0.9
+# ...and the control: correlation alone is satisfied by a mass that follows the well loosely from
+# far away, so the run also has to get NEAR it. Correct is 0.114 (k=2) and 0.054 (k=5).
+MAX_LAG = 0.2
+
+
+def _centres() -> np.ndarray:
+    return np.linspace(WELL_START, WELL_END, NT + 1)
+
+
+def _travelling_well(k: float, nx: int, dim: int) -> np.ndarray:
+    """U(t, x) = k/2 * |x - c(t)|^2, with the well centre c travelling WELL_START -> WELL_END.
+
+    Quadratic because the drift it induces, -grad U, is then linear in the distance to the centre:
+    the mass tracks c(t) rather than merely being pushed against a wall, so "where is the mass"
+    answers "where does the solver think the well is" and nothing else.
+    """
+    x = np.linspace(0.0, 1.0, nx)
+    if dim == 1:
+        return 0.5 * k * (x[None, :] - _centres()[:, None]) ** 2
+    grids = np.meshgrid(*([x] * dim), indexing="ij")
+    # Only the first axis moves; the others are a stationary well, so the centroid along axis 0 is
+    # the whole signal and the other axes cannot contribute to it.
+    return np.stack([0.5 * k * ((grids[0] - c) ** 2 + sum(g**2 for g in grids[1:])) for c in _centres()])
+
+
+def _initial_density(nx: int, dim: int) -> np.ndarray:
+    x = np.linspace(0.0, 1.0, nx)
+    if dim == 1:
+        m0 = np.exp(-200.0 * (x - MASS_START) ** 2)
+    else:
+        grids = np.meshgrid(*([x] * dim), indexing="ij")
+        m0 = np.exp(-200.0 * ((grids[0] - MASS_START) ** 2 + sum(g**2 for g in grids[1:])))
+    return m0 / m0.sum()
+
+
+def _problem(nx: int, dim: int) -> MFGProblem:
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)] * dim, Nx_points=[nx] * dim, boundary_conditions=no_flux_bc(dimension=dim)
+        ),
+        T=T,
+        Nt=NT,
+        sigma=SIGMA,
+        components=MFGComponents(
+            # *coords: the nD path calls these with one argument per axis.
+            m_initial=lambda *c: np.exp(
+                -200.0 * ((np.asarray(c[0]) - MASS_START) ** 2 + sum(np.asarray(a) ** 2 for a in c[1:]))
+            ),
+            u_terminal=lambda *c: np.zeros_like(np.asarray(c[0])),
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _centroid_trajectory(k: float, nx: int, dim: int, particles: int) -> np.ndarray:
+    """Where the mass sits along axis 0, at every time level."""
+    x = np.linspace(0.0, 1.0, nx)
+    solver = FPParticleSolver(_problem(nx, dim), num_particles=particles, seed=SEED)
+    density = np.asarray(
+        solver.solve_fp_system(_initial_density(nx, dim), potential_field=_travelling_well(k, nx, dim))
+    )
+    along_axis0 = density.reshape(density.shape[0], nx, -1).sum(axis=2)
+    weight = along_axis0.sum(axis=1)
+    return (along_axis0 * x).sum(axis=1) / weight
+
+
+@pytest.mark.parametrize(
+    ("dim", "nx", "particles", "k"), [(1, 41, 20000, 2.0), (1, 41, 20000, 5.0), (2, 21, 20000, 5.0)]
+)
+def test_the_density_follows_the_well_forward_in_time(dim, nx, particles, k):
+    """The density must track the well's journey in the direction the journey actually runs.
+
+    The correlation is the load-bearing assertion and it comes first, because it is the one whose
+    failure has a single likely cause. Under `U[-1 - n]` it collapses from +0.99 to -0.01 (k=2) or
+    -0.62 (k=5) -- the mass is following the mirrored journey.
+
+    The lag assertion below is the CONTROL, and the issue this test closes is explicit about why it
+    is needed: a first attempt measured a 1% gap because the fixture was under-driven and neither
+    run tracked anything, which is a null result that reads as a small effect. Correlation alone
+    does not rule that out -- a mass drifting loosely in the same general direction correlates well
+    while never going near the well.
+    """
+    centroids = _centroid_trajectory(k, nx, dim, particles)
+    centres = _centres()
+    correlation = float(np.corrcoef(centroids, centres)[0, 1])
+    lag = float(np.mean(np.abs(centroids - centres)))
+
+    assert correlation > TRACKS, (
+        f"the density does not follow the moving well through time (corr {correlation:+.4f}, "
+        f"mean|centroid - well| {lag:.4f}). The FP sweep steps FORWARD, so it must read the value "
+        f"function at t_n, not at T - t_n; a mirrored read gives corr -0.01 to -0.62 here. "
+        f"(If the correlation is near zero rather than negative, check the fixture drives at all "
+        f"before concluding the time level is wrong.)"
+    )
+    assert lag < MAX_LAG, (
+        f"the density correlates with the well but never gets near it (mean|centroid - well| "
+        f"{lag:.4f}, corr {correlation:+.4f}): the fixture is under-driven, so the assertion above "
+        f"is passing on a drift that follows the well only in the loosest sense"
+    )


### PR DESCRIPTION
Closes #1792.

Reading the value function at the mirrored time level survived a 25-axis mutation sweep against the
entire marker-filtered suite: **5770 passed, 0 failed**. The FP sweep steps forward and the HJB sweep
steps backward, and that pairing is what makes the fixed point mean anything — but `U[-1 - n]` keeps
every access in range for any `Nt`, so nothing raises, nothing warns, and the density simply tracks
the control's journey backwards.

## The gap was the fixture, not a missing assertion

Every `U_solution` the particle tests build is `np.zeros((Nt, Nx))` or `np.tile(f(x), (Nt, 1))` —
**time-constant**, which makes `U[n]` and `U[-1-n]` literally the same array and the mutation a no-op
by construction. Verified across the particle test files: the largest one builds `U_solution` twelve
times and every instance is one of those two shapes.

So no assertion added to those fixtures could have closed this. The datum had to change.

## What the test measures

A well whose centre travels 0.2 → 0.8 over `[0, T]`, and the observable is the correlation between
the density's centroid and the well's position **across the whole trajectory** rather than at the
endpoint:

| | correct | mirrored `U[T - t]` |
|:--|--:|--:|
| k = 2.0 | **+0.9917** | −0.0143 |
| k = 5.0 | **+0.9981** | −0.6194 |

**Both indexing sites are covered**, and mutating them one at a time discriminates exactly per path:

| mutation | outcome |
|:--|:--|
| 1D site, `U_solution_for_drift[n_time_idx]` → mirrored | **2 failed**, 1 passed (the 2D row is unaffected) |
| nD site, `U_solution_for_drift[t_idx]` → mirrored | **1 failed**, 2 passed (the 1D rows are unaffected) |

The issue names only the first site; the nD path has the identical defect available to it and the
same absence of coverage.

## An endpoint assertion was written first and discarded

It does redden under the mutation — but on the **control** assertion, with the message "the fixture
is under-driven", which points a reader at the fixture rather than at the solver. A test that fails
for the right reason with the wrong diagnosis costs more than it saves.

The correlation fails on the load-bearing assertion instead, and the control that remains
(`mean|centroid − well| < 0.2`) is the one this issue explicitly warns about: its own first attempt
measured a 1% gap because neither run tracked anything — a null result that reads as a small effect.
Neither threshold is tuned; the correct/mirrored values are separated by a full order of magnitude
and a sign change.

## Dependency

Determinism comes from the seed added in #1838 / #1839, merged earlier today. Without it this
compares two Monte Carlo draws rather than two solvers, which is exactly why the #1822 capability
matrix could not classify this solver at all before it was seeded.

## Gate

`./scripts/local_ci.sh` → **5851 passed, 22 skipped, 23 xfailed, GATE GREEN** (5848 before, +3 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
