### PR TITLE
Stop eight sites asking for extras that do not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
       timeout-minutes: 5
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[performance]
+        pip install -e .
 
     - name: Memory usage validation
       timeout-minutes: 10
@@ -413,7 +413,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[test,performance]
+        pip install -e .
 
     - name: Run integration tests
       run: |

--- a/.github/workflows/modern_quality.yml
+++ b/.github/workflows/modern_quality.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[performance]  # Use pyproject.toml performance dependencies
+        pip install -e .
 
     - name: Memory usage validation
       run: |
@@ -115,7 +115,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[performance]
+        pip install -e .
 
     - name: Performance regression test
       run: |
@@ -169,7 +169,7 @@ jobs:
     - name: Install performance tools
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[performance]
+        pip install -e .
 
     - name: Quick performance test
       run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install safety bandit semgrep pip-audit
-        pip install -e .[dev,test]
+        pip install -e .[dev]
 
     - name: Run Safety (dependency vulnerability scan)
       run: |

--- a/changelog.d/1831-nonexistent-extras.fixed.md
+++ b/changelog.d/1831-nonexistent-extras.fixed.md
@@ -1,0 +1,17 @@
+- **Six CI jobs stop asking for extras that do not exist** (Issue #1831). `pip install -e
+  .[performance]` and `.[test,...]` name extras `pyproject.toml` never declared. pip does not treat
+  that as an error — measured: `WARNING: mfgarchon 0.22.0.dev0 does not provide the extra
+  'performance'`, **exit code 0** — so five jobs in `ci.yml` / `modern_quality.yml` and one in
+  `security.yml` ran on base dependencies while their install line said otherwise, and stayed green
+  the whole time. The references are deleted rather than the extras declared, because measured
+  against what those jobs actually execute nothing was missing: `psutil` is a base dependency, not a
+  performance extra, and none of the six imports numba, polars, joblib or either profiler, nor runs
+  pytest — all six drive `python -c` scripts. So this changes nothing at runtime by construction; it
+  removes a claim that was false. `security.yml` keeps `[dev]`, which exists, and drops only the
+  `test` half.
+  Two more instances outside the workflows go with them: `scripts/setup_development.sh` installs
+  `".[dev,test,interactive]"` on both its uv and pip branches, and `interactive` does not exist
+  either — so the documented developer-onboarding path has been handing every new contributor a
+  silent partial install. `uv` behaves like pip here, warning and exiting 0. A tree-wide sweep
+  after this change finds no remaining install site naming an undeclared extra.
+

--- a/scripts/setup_development.sh
+++ b/scripts/setup_development.sh
@@ -59,7 +59,7 @@ setup_uv_environment() {
 
     # Install package in development mode
     log_info "Installing MFGarchon in development mode..."
-    uv pip install -e ".[dev,test,interactive]"
+    uv pip install -e ".[dev]"
 
     # Install pre-commit hooks
     if command_exists pre-commit; then
@@ -84,7 +84,7 @@ setup_pip_environment() {
 
     # Install package in development mode
     log_info "Installing MFGarchon in development mode..."
-    pip install -e ".[dev,test,interactive]"
+    pip install -e ".[dev]"
 
     # Install pre-commit hooks
     if command_exists pre-commit; then


### PR DESCRIPTION
Closes #1831. Refs #1846.

`pip install -e .[performance]` names an extra `pyproject.toml` never declared. Neither pip nor uv
treats that as an error — measured on a throwaway package:

```
pip 26.1.2 : WARNING: ... does not provide the extra 'performance'    -> exit 0
uv  0.12.1 : warning: ... does not have an extra named 'performance'  -> exit 0
```

So five jobs in `ci.yml` / `modern_quality.yml` and one in `security.yml` have been running on base
dependencies while their install line said otherwise, green the whole time.

## Deleted, not declared — and that is measured, not a preference

Before removing them I checked what those jobs execute: `psutil`, the only non-core import any of
them makes, is a **base** dependency; none imports numba, polars, joblib or either profiler; none
runs `pytest` — all six drive `python -c` scripts, so `[test]` was never needed either. Nothing was
missing, so declaring the extras would add dependencies to satisfy a line rather than a need. The
change is a **no-op at runtime by construction**, and what it removes is a false claim.

| file | was | now |
|:--|:--|:--|
| `ci.yml:270` | `.[performance]` | `.` |
| `ci.yml:416` | `.[test,performance]` | `.` |
| `modern_quality.yml:57` | `.[performance]` + a comment claiming pyproject provides it | `.` |
| `modern_quality.yml:118` | `.[performance]` | `.` |
| `modern_quality.yml:172` | `.[performance]` | `.` |
| `security.yml:47` | `.[dev,test]` | `.[dev]` |
| `setup_development.sh:62` (uv branch) | `.[dev,test,interactive]` | `.[dev]` |
| `setup_development.sh:87` (pip branch) | `.[dev,test,interactive]` | `.[dev]` |

**The last two came from independent review, and they are the worst placed of the eight.** That is
the documented onboarding path (`scripts/README.md`), so every new contributor following it has been
getting a silent partial install — and `interactive` does not exist either. A tree-wide sweep after
this change finds **no** install site naming an undeclared extra.

## The mechanism is deliberately NOT fixed here

I wrote a guard for it — a per-line regex over `.github/workflows/` wired into `local_ci.sh`'s
workflow-integrity check — and withdrew it after review measured it. It **misses** backslash
continuations, a second spec on the same line, `pip3`, package-name-rather-than-dot forms, and
anything outside the workflow glob — which is where the two live instances turned out to be. It also
goes **RED on legal content**: a YAML comment naming the string, and `".[${{ matrix.extras }}]"`.

A guard that reads as covering the tree while seeing one anchor on one physical line is the defect it
exists to refuse. It goes to **#1846** with the measured coverage table as its spec, including the
requirement this repo already applies to two of its five gates: an unconditional self-test that
exercises the holes rather than the happy path.

## Gate

`./scripts/local_ci.sh` → **5848 passed, 22 skipped, 23 xfailed, GATE GREEN** (measured on the
version that still carried the guard; this one touches no Python at all — workflows, one shell
script, one changelog fragment — and re-runs green on `--fast`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)