### PR TITLE
docs: plan management — replace the single-slot rule with a pointer to the Joplin process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,55 +249,39 @@ Why: the full suite is ~141 s locally and **exceeded a 25-minute step budget** o
 | Content | Location |
 |---------|----------|
 | User docs (tutorials, guides, API) | `mfgarchon/docs/user/` (public, future book) |
-| Theory & design, architecture, roadmaps | **Joplin MFG notebook** (private) |
+| Theory & design, architecture | **Joplin MFG notebook** (private) |
+| **The** roadmap — cross-Plan ordering, and what is deliberately not being done | Joplin `Dev`, see § Development Plan Management |
+| **A** roadmap — one subsystem's implementation sequence (BC, FEEC, …) | with its topic: Joplin, or `archon-notes/` per `docs/README.md` |
 | Development guides (coding style, CI/CD, tooling) | `mfg-research/docs/archon-notes/development/` |
 | Research notes (experiments, analysis) | `mfg-research/docs/`, `experiments/*/docs/` |
 | Completed/historical | `mfg-research/docs/archon-notes/archive/` |
 
 **Joplin ↔ archon-notes split**: see the Joplin Dev `[Principle]` note "Joplin MFG vs archon-notes — doc division of labor" (Joplin = evergreen knowledge-graph; archon-notes = git-versioned chronicle + dev handbook). Rules: never create `docs/theory|development|architecture/` in mfgarchon; never put internal planning/theory in the public repo; never create markdown design docs in repos — use Joplin. Cross-repo: design in Joplin → GitHub issue → implement with issue ref → update user docs if user-facing → bidirectional-link Joplin + issue.
 
-### Development Plan Management ⚠️ CRITICAL — **[试行 2026-08-08 → 复审 2026-09-19]**
+### Development Plan Management — agent-facing contract
+**[PROVISIONAL 2026-08-08 — examine 2026-09-19.** Not an expiry: absent an examination this
+section stays in force unchanged, and the examination is what may change it.**]**
 
-Three objects, one owner each. **Roadmap** says *should this be worked on now*; **Plan** says
-*why this order, and where it stands*; **issue** says *what to do*. Nothing restates another
-layer's state — if a line can be recomputed from the Plans, it is a view, not roadmap content.
+The process this serves — Now/Next/Later, appetite, WIP, the monthly read — is **the maintainer's**,
+and lives in Joplin `Dev` `[Principle] Joplin MFG vs archon-notes` § Plan management. Below is only
+what an agent working in this repo must know, because an agent executes none of it.
 
-- **Roadmap** — one note, Joplin `Dev`. Three buckets, **Now / Next / Later**, no dates: the
-  argument is whether an item moves between buckets, not whether it ships in Q2 or Q3. Also holds
-  what no single Plan can: cross-Plan ordering and dependency, and **what is deliberately not
-  being done, with the reason**. Carries no per-Plan progress.
-- **Plan** — Joplin `Dev`, named `{焦点} Plan — {appetite}`. **Appetite, not estimate**: start
-  from the time you are willing to spend and design something that fits; when it does not fit,
-  **cut scope, do not extend**. Fixed time, variable scope. Status prefix is mandatory and is the
-  single owner of state: `[ACTIVE]` / `[COMPLETED]` / `[SUPERSEDED by …]`.
-- **`[PITCH]` — shaped, not started, does not count against WIP.** A Plan that exists but has not
-  been bet on. It carries an appetite and a scope; its unresolved rabbit holes must be closed
-  *before* it becomes `[ACTIVE]`, not during. Betting on it = changing the prefix. Missing from the
-  first draft of this clause, which had no state between "does not exist" and "in progress"
-  [ADDED 2026-08-08].
-- **`[ACTIVE]` means a Plan is being worked on. Nothing else may use it.** A document that is
-  merely still correct carries **no status tag at all** — absence is currency, and tags are for
-  what has left it (`[SUPERSEDED by …]`, `[ARCHIVED]`). Measured 2026-08-08: fifteen notes declared
-  ACTIVE, and eleven were architecture overviews, capability matrices and notation standards
-  saying "this doc still holds". A word meaning two things makes the monthly read return noise,
-  and a marker on almost everything discriminates nothing — the same way this repo's 5 tags and
-  84 `[UNREVIEWED]` stamps died.
-- **WIP limit 4**, observed not chosen — and got there by being wrong twice. ~~3~~ counted notes
-  *carrying* the prefix and missed a live Plan with no prefix; the recount then caught eleven
-  non-Plans using the same word. **Counting labels is not counting states.** At the limit, start
-  nothing new: finish one, or demote one to `Later` and say so.
-- **Ageing prompts, it never decides.** A Plan past its appetite shows as `[ACTIVE · 逾期]`. That
-  is a fact, not a verdict: retirement stays a judgement someone makes. Same footing as
-  *never judge guidance by a counter or a clock* — a Plan is a mechanism with a self-declared
-  scope, so its own deadline may prompt a look; it may not archive anything by itself.
-- **No backlog.** `Later` may be deleted freely. An idea worth doing will be re-proposed; an idea
-  that is never re-proposed was not worth carrying. This is what stops the notebook thickening.
-- **Cadence — the only real forcing function, and the weakest part.** **First working session of
-  each month: read `Now` and every `[ACTIVE]` Plan, and decide.** Nothing above works without it.
+- **Plans live in Joplin `Dev`**, named `{焦点} Plan — {appetite} (started YYYY-MM-DD)`. Appetite is
+  one of **2 weeks / 6 weeks / 3 months**, and it is what gets cut to, never extended. The start
+  date is there because "past its appetite" is otherwise not computable from the name.
+- **Status prefix is mandatory and is the single owner of state**: `[PITCH]` shaped but not bet on,
+  does not count toward WIP · `[ACTIVE]` being worked on · `[COMPLETED]` · `[SUPERSEDED by …]`.
+  A Plan that stops being worked on returns to `[PITCH]`; it does not lose its prefix.
+- **`[ACTIVE]` is a Plan status and nothing else may use it.** A document that is merely still
+  correct carries **no status tag at all** — absence is currency, tags are for what has left it.
+  Eleven notes in `Dev` currently violate this, using `Status: Active` to mean "this doc still
+  holds"; until they are cleaned, searching `[ACTIVE]` returns noise.
+- **Do not create a second roadmap, and do not write plan markdown into this repo.** There is one
+  cross-Plan roadmap (Joplin `Dev`); a per-subsystem implementation sequence is a different object
+  and belongs with its topic.
 
-`[Principle]` prefix = permanent design-philosophy doc, never archived, outside all of the above.
-~~Scope 2–4 months; **only 1 active Plan**~~ replaced 2026-08-08 — why, and the sources it came
-from: Joplin `Dev` `[Principle] Joplin MFG vs archon-notes` § Plan management.
+~~Scope 2–4 months; **only 1 active Plan**~~ replaced 2026-08-08 — why, and the sources:
+Joplin `Dev` `[Principle] Joplin MFG vs archon-notes` § Plan management.
 
 ### Progressive logging ⚠️
 Log incrementally, summarize at milestones only. During work: technical notes + TodoWrite, no frequent summaries. Bugs → GitHub issues (`gh issue create`), not `docs/bugs/*.md`. Create a summary only at phase completion / milestone / investigation conclusion — and **ask first**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,20 +249,17 @@ Why: the full suite is ~141 s locally and **exceeded a 25-minute step budget** o
 | Content | Location |
 |---------|----------|
 | User docs (tutorials, guides, API) | `mfgarchon/docs/user/` (public, future book) |
-| Theory & design, architecture, roadmaps | **Joplin MFG notebook** (private), except the archon-notes planning set — see § Development Plan Management |
+| Theory & design, architecture, roadmaps | **Joplin MFG notebook** (private) |
 | Development guides (coding style, CI/CD, tooling) | `mfg-research/docs/archon-notes/development/` |
 | Research notes (experiments, analysis) | `mfg-research/docs/`, `experiments/*/docs/` |
 | Completed/historical | `mfg-research/docs/archon-notes/archive/` |
 
 **Joplin ↔ archon-notes split**: see the Joplin Dev `[Principle]` note "Joplin MFG vs archon-notes — doc division of labor" (Joplin = evergreen knowledge-graph; archon-notes = git-versioned chronicle + dev handbook). Rules: never create `docs/theory|development|architecture/` in mfgarchon; never put internal planning/theory in the public repo; never create markdown design docs in repos — use Joplin. Cross-repo: design in Joplin → GitHub issue → implement with issue ref → update user docs if user-facing → bidirectional-link Joplin + issue.
 
-### Development Plan Management [PROVISIONAL 2026-08-08]
-Examination: #1857 — absent it, this stays in force. Naming, status prefixes and lifecycle are the
-maintainer's process, in Joplin `Dev Principles` → `[Principle] Joplin MFG vs archon-notes` § Plan
-management. **For an agent, the whole rule is: do not create Plan or roadmap markdown in a repo,
-and do not start a second cross-Plan roadmap.** Everything else in that process is executed by a
-human and is not checkable from here — three review rounds of #1856 each produced a false claim
-about external state written into this file, which is what a longer version of this section costs.
+### Development Plan Management
+Plans, their naming, status prefixes and lifecycle: Joplin `MFG/Dev/Dev Principles` →
+`[Principle] Joplin MFG vs archon-notes — doc division of labor` § Plan management.
+Agent-facing rule not already stated above: do not start a second cross-Plan roadmap.
 
 ### Progressive logging ⚠️
 Log incrementally, summarize at milestones only. During work: technical notes + TodoWrite, no frequent summaries. Bugs → GitHub issues (`gh issue create`), not `docs/bugs/*.md`. Create a summary only at phase completion / milestone / investigation conclusion — and **ask first**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,8 +256,35 @@ Why: the full suite is ~141 s locally and **exceeded a 25-minute step budget** o
 
 **Joplin ↔ archon-notes split**: see the Joplin Dev `[Principle]` note "Joplin MFG vs archon-notes — doc division of labor" (Joplin = evergreen knowledge-graph; archon-notes = git-versioned chronicle + dev handbook). Rules: never create `docs/theory|development|architecture/` in mfgarchon; never put internal planning/theory in the public repo; never create markdown design docs in repos — use Joplin. Cross-repo: design in Joplin → GitHub issue → implement with issue ref → update user docs if user-facing → bidirectional-link Joplin + issue.
 
-### Development Plan Management ⚠️ CRITICAL
-Plans live in Joplin **Dev** folder. Naming `{焦点} Plan — {日期范围}`. Scope 2–4 months (longer → split). **Only 1 active Plan** at a time. On completion → `[COMPLETED]` + move to Archive; on replacement → `[SUPERSEDED by …]` + Archive. Plan explains *why this order*; issues define *what to do*. `[Principle]` prefix = permanent design-philosophy doc (never archived).
+### Development Plan Management ⚠️ CRITICAL — **[试行 2026-08-08 → 复审 2026-09-19]**
+
+Three objects, one owner each. **Roadmap** says *should this be worked on now*; **Plan** says
+*why this order, and where it stands*; **issue** says *what to do*. Nothing restates another
+layer's state — if a line can be recomputed from the Plans, it is a view, not roadmap content.
+
+- **Roadmap** — one note, Joplin `Dev`. Three buckets, **Now / Next / Later**, no dates: the
+  argument is whether an item moves between buckets, not whether it ships in Q2 or Q3. Also holds
+  what no single Plan can: cross-Plan ordering and dependency, and **what is deliberately not
+  being done, with the reason**. Carries no per-Plan progress.
+- **Plan** — Joplin `Dev`, named `{焦点} Plan — {appetite}`. **Appetite, not estimate**: start
+  from the time you are willing to spend and design something that fits; when it does not fit,
+  **cut scope, do not extend**. Fixed time, variable scope. Status prefix is mandatory and is the
+  single owner of state: `[ACTIVE]` / `[COMPLETED]` / `[SUPERSEDED by …]`.
+- **WIP limit 3.** Measured 2026-08-08: three notes carried `[ACTIVE]` (agent_axiom v4, Route B,
+  Route audit), so 3 is the observed sustainable concurrency, not a target. At the limit, start
+  nothing new — finish, or explicitly demote one to `Later`.
+- **Ageing prompts, it never decides.** A Plan past its appetite shows as `[ACTIVE · 逾期]`. That
+  is a fact, not a verdict: retirement stays a judgement someone makes. Same footing as
+  *never judge guidance by a counter or a clock* — a Plan is a mechanism with a self-declared
+  scope, so its own deadline may prompt a look; it may not archive anything by itself.
+- **No backlog.** `Later` may be deleted freely. An idea worth doing will be re-proposed; an idea
+  that is never re-proposed was not worth carrying. This is what stops the notebook thickening.
+- **Cadence — the only real forcing function, and the weakest part.** **First working session of
+  each month: read `Now` and every `[ACTIVE]` Plan, and decide.** Nothing above works without it.
+
+`[Principle]` prefix = permanent design-philosophy doc, never archived, outside all of the above.
+~~Scope 2–4 months; **only 1 active Plan**~~ replaced 2026-08-08 — why, and the sources it came
+from: Joplin `Dev` `[Principle] Joplin MFG vs archon-notes` § Plan management.
 
 ### Progressive logging ⚠️
 Log incrementally, summarize at milestones only. During work: technical notes + TodoWrite, no frequent summaries. Bugs → GitHub issues (`gh issue create`), not `docs/bugs/*.md`. Create a summary only at phase completion / milestone / investigation conclusion — and **ask first**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,34 +249,20 @@ Why: the full suite is ~141 s locally and **exceeded a 25-minute step budget** o
 | Content | Location |
 |---------|----------|
 | User docs (tutorials, guides, API) | `mfgarchon/docs/user/` (public, future book) |
-| Theory & design, architecture | **Joplin MFG notebook** (private) |
-| **The** roadmap — cross-Plan ordering, and what is deliberately not being done | Joplin `Dev`, see § Development Plan Management |
-| **A** roadmap — one subsystem's implementation sequence (BC, FEEC, …) | Joplin, with its subsystem |
+| Theory & design, architecture, roadmaps | **Joplin MFG notebook** (private), except the archon-notes planning set — see § Development Plan Management |
 | Development guides (coding style, CI/CD, tooling) | `mfg-research/docs/archon-notes/development/` |
 | Research notes (experiments, analysis) | `mfg-research/docs/`, `experiments/*/docs/` |
 | Completed/historical | `mfg-research/docs/archon-notes/archive/` |
 
 **Joplin ↔ archon-notes split**: see the Joplin Dev `[Principle]` note "Joplin MFG vs archon-notes — doc division of labor" (Joplin = evergreen knowledge-graph; archon-notes = git-versioned chronicle + dev handbook). Rules: never create `docs/theory|development|architecture/` in mfgarchon; never put internal planning/theory in the public repo; never create markdown design docs in repos — use Joplin. Cross-repo: design in Joplin → GitHub issue → implement with issue ref → update user docs if user-facing → bidirectional-link Joplin + issue.
 
-### Development Plan Management — agent-facing contract
-On trial; #1857 owns the examination. The process itself is the maintainer's and lives in Joplin
-`Dev Principles` `[Principle] Joplin MFG vs archon-notes — doc division of labor` § Plan
-management. Below is what an agent must know.
-
-- **Plans live in Joplin, with their topic** (`Dev`, `Variational MFG`, `agent_axiom`, …). The one
-  cross-Plan roadmap lives in Joplin `Dev`. A per-subsystem implementation sequence is a different
-  object and stays with its subsystem.
-- **Naming, for Plans created from 2026-08-08**: `{焦点} Plan — {appetite} (started YYYY-MM-DD)`,
-  appetite one of 2 weeks / 6 weeks / 3 months. Earlier Plans are grandfathered until next touched,
-  so "past its appetite" is not computable for them.
-- **Status prefix is mandatory and is the single owner of state**: `[PITCH]` shaped, not started ·
-  `[ACTIVE]` being worked on · `[COMPLETED]` · `[SUPERSEDED <date>]` with `SUPERSEDED-BY: <ref>`.
-  A Plan that stops returns to `[PITCH]` and must re-clear its open questions before going
-  `[ACTIVE]` again.
-- **`[ACTIVE]` is a Plan status; nothing else may use it.** A document that is merely still correct
-  carries no status tag — absence is currency, tags are for what has left it. Legacy
-  `**Status**: Active` headers in `Dev` make an `[ACTIVE]` search noisy until cleaned.
-- **Do not create a second roadmap, and do not write plan markdown into this repo.**
+### Development Plan Management [PROVISIONAL 2026-08-08]
+Examination: #1857 — absent it, this stays in force. Naming, status prefixes and lifecycle are the
+maintainer's process, in Joplin `Dev Principles` → `[Principle] Joplin MFG vs archon-notes` § Plan
+management. **For an agent, the whole rule is: do not create Plan or roadmap markdown in a repo,
+and do not start a second cross-Plan roadmap.** Everything else in that process is executed by a
+human and is not checkable from here — three review rounds of #1856 each produced a false claim
+about external state written into this file, which is what a longer version of this section costs.
 
 ### Progressive logging ⚠️
 Log incrementally, summarize at milestones only. During work: technical notes + TodoWrite, no frequent summaries. Bugs → GitHub issues (`gh issue create`), not `docs/bugs/*.md`. Create a summary only at phase completion / milestone / investigation conclusion — and **ask first**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,9 +270,17 @@ layer's state — if a line can be recomputed from the Plans, it is a view, not 
   from the time you are willing to spend and design something that fits; when it does not fit,
   **cut scope, do not extend**. Fixed time, variable scope. Status prefix is mandatory and is the
   single owner of state: `[ACTIVE]` / `[COMPLETED]` / `[SUPERSEDED by …]`.
-- **WIP limit 3.** Measured 2026-08-08: three notes carried `[ACTIVE]` (agent_axiom v4, Route B,
-  Route audit), so 3 is the observed sustainable concurrency, not a target. At the limit, start
-  nothing new — finish, or explicitly demote one to `Later`.
+- **`[ACTIVE]` means a Plan is being worked on. Nothing else may use it.** A document that is
+  merely still correct carries **no status tag at all** — absence is currency, and tags are for
+  what has left it (`[SUPERSEDED by …]`, `[ARCHIVED]`). Measured 2026-08-08: fifteen notes declared
+  ACTIVE, and eleven were architecture overviews, capability matrices and notation standards
+  saying "this doc still holds". A word meaning two things makes the monthly read return noise,
+  and a marker on almost everything discriminates nothing — the same way this repo's 5 tags and
+  84 `[UNREVIEWED]` stamps died.
+- **WIP limit 4**, observed not chosen — and got there by being wrong twice. ~~3~~ counted notes
+  *carrying* the prefix and missed a live Plan with no prefix; the recount then caught eleven
+  non-Plans using the same word. **Counting labels is not counting states.** At the limit, start
+  nothing new: finish one, or demote one to `Later` and say so.
 - **Ageing prompts, it never decides.** A Plan past its appetite shows as `[ACTIVE · 逾期]`. That
   is a fact, not a verdict: retirement stays a judgement someone makes. Same footing as
   *never judge guidance by a counter or a clock* — a Plan is a mechanism with a self-declared

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,11 @@ layer's state — if a line can be recomputed from the Plans, it is a view, not 
   from the time you are willing to spend and design something that fits; when it does not fit,
   **cut scope, do not extend**. Fixed time, variable scope. Status prefix is mandatory and is the
   single owner of state: `[ACTIVE]` / `[COMPLETED]` / `[SUPERSEDED by …]`.
+- **`[PITCH]` — shaped, not started, does not count against WIP.** A Plan that exists but has not
+  been bet on. It carries an appetite and a scope; its unresolved rabbit holes must be closed
+  *before* it becomes `[ACTIVE]`, not during. Betting on it = changing the prefix. Missing from the
+  first draft of this clause, which had no state between "does not exist" and "in progress"
+  [ADDED 2026-08-08].
 - **`[ACTIVE]` means a Plan is being worked on. Nothing else may use it.** A document that is
   merely still correct carries **no status tag at all** — absence is currency, and tags are for
   what has left it (`[SUPERSEDED by …]`, `[ARCHIVED]`). Measured 2026-08-08: fifteen notes declared

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ Why: the full suite is ~141 s locally and **exceeded a 25-minute step budget** o
 | User docs (tutorials, guides, API) | `mfgarchon/docs/user/` (public, future book) |
 | Theory & design, architecture | **Joplin MFG notebook** (private) |
 | **The** roadmap — cross-Plan ordering, and what is deliberately not being done | Joplin `Dev`, see § Development Plan Management |
-| **A** roadmap — one subsystem's implementation sequence (BC, FEEC, …) | with its topic: Joplin, or `archon-notes/` per `docs/README.md` |
+| **A** roadmap — one subsystem's implementation sequence (BC, FEEC, …) | Joplin, with its subsystem |
 | Development guides (coding style, CI/CD, tooling) | `mfg-research/docs/archon-notes/development/` |
 | Research notes (experiments, analysis) | `mfg-research/docs/`, `experiments/*/docs/` |
 | Completed/historical | `mfg-research/docs/archon-notes/archive/` |
@@ -259,29 +259,24 @@ Why: the full suite is ~141 s locally and **exceeded a 25-minute step budget** o
 **Joplin ↔ archon-notes split**: see the Joplin Dev `[Principle]` note "Joplin MFG vs archon-notes — doc division of labor" (Joplin = evergreen knowledge-graph; archon-notes = git-versioned chronicle + dev handbook). Rules: never create `docs/theory|development|architecture/` in mfgarchon; never put internal planning/theory in the public repo; never create markdown design docs in repos — use Joplin. Cross-repo: design in Joplin → GitHub issue → implement with issue ref → update user docs if user-facing → bidirectional-link Joplin + issue.
 
 ### Development Plan Management — agent-facing contract
-**[PROVISIONAL 2026-08-08 — examine 2026-09-19.** Not an expiry: absent an examination this
-section stays in force unchanged, and the examination is what may change it.**]**
+On trial; #1857 owns the examination. The process itself is the maintainer's and lives in Joplin
+`Dev Principles` `[Principle] Joplin MFG vs archon-notes — doc division of labor` § Plan
+management. Below is what an agent must know.
 
-The process this serves — Now/Next/Later, appetite, WIP, the monthly read — is **the maintainer's**,
-and lives in Joplin `Dev` `[Principle] Joplin MFG vs archon-notes` § Plan management. Below is only
-what an agent working in this repo must know, because an agent executes none of it.
-
-- **Plans live in Joplin `Dev`**, named `{焦点} Plan — {appetite} (started YYYY-MM-DD)`. Appetite is
-  one of **2 weeks / 6 weeks / 3 months**, and it is what gets cut to, never extended. The start
-  date is there because "past its appetite" is otherwise not computable from the name.
-- **Status prefix is mandatory and is the single owner of state**: `[PITCH]` shaped but not bet on,
-  does not count toward WIP · `[ACTIVE]` being worked on · `[COMPLETED]` · `[SUPERSEDED by …]`.
-  A Plan that stops being worked on returns to `[PITCH]`; it does not lose its prefix.
-- **`[ACTIVE]` is a Plan status and nothing else may use it.** A document that is merely still
-  correct carries **no status tag at all** — absence is currency, tags are for what has left it.
-  Eleven notes in `Dev` currently violate this, using `Status: Active` to mean "this doc still
-  holds"; until they are cleaned, searching `[ACTIVE]` returns noise.
-- **Do not create a second roadmap, and do not write plan markdown into this repo.** There is one
-  cross-Plan roadmap (Joplin `Dev`); a per-subsystem implementation sequence is a different object
-  and belongs with its topic.
-
-~~Scope 2–4 months; **only 1 active Plan**~~ replaced 2026-08-08 — why, and the sources:
-Joplin `Dev` `[Principle] Joplin MFG vs archon-notes` § Plan management.
+- **Plans live in Joplin, with their topic** (`Dev`, `Variational MFG`, `agent_axiom`, …). The one
+  cross-Plan roadmap lives in Joplin `Dev`. A per-subsystem implementation sequence is a different
+  object and stays with its subsystem.
+- **Naming, for Plans created from 2026-08-08**: `{焦点} Plan — {appetite} (started YYYY-MM-DD)`,
+  appetite one of 2 weeks / 6 weeks / 3 months. Earlier Plans are grandfathered until next touched,
+  so "past its appetite" is not computable for them.
+- **Status prefix is mandatory and is the single owner of state**: `[PITCH]` shaped, not started ·
+  `[ACTIVE]` being worked on · `[COMPLETED]` · `[SUPERSEDED <date>]` with `SUPERSEDED-BY: <ref>`.
+  A Plan that stops returns to `[PITCH]` and must re-clear its open questions before going
+  `[ACTIVE]` again.
+- **`[ACTIVE]` is a Plan status; nothing else may use it.** A document that is merely still correct
+  carries no status tag — absence is currency, tags are for what has left it. Legacy
+  `**Status**: Active` headers in `Dev` make an `[ACTIVE]` search noisy until cleaned.
+- **Do not create a second roadmap, and do not write plan markdown into this repo.**
 
 ### Progressive logging ⚠️
 Log incrementally, summarize at milestones only. During work: technical notes + TodoWrite, no frequent summaries. Bugs → GitHub issues (`gh issue create`), not `docs/bugs/*.md`. Create a summary only at phase completion / milestone / investigation conclusion — and **ask first**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,4 @@ jupyter-book build .     # Static HTML build
 
 ## Internal development notes
 
-Internal development notes — architecture, roadmaps, issue analysis — are split between the private `mfg-research` repo (`docs/archon-notes/`) and Joplin. Which goes where: `CLAUDE.md` § Development Plan Management.
+Architecture design, roadmaps, and issue analysis are in the private `mfg-research` repository under `docs/archon-notes/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,4 @@ jupyter-book build .     # Static HTML build
 
 ## Internal development notes
 
-Architecture design and issue analysis are in the private `mfg-research` repository under `docs/archon-notes/`. **Roadmaps are in Joplin**, not here — the cross-Plan roadmap in `Dev`, a subsystem's implementation sequence with its subsystem. [CORRECTED 2026-08-08: this said roadmaps live in `archon-notes/`; both existing ones are in Joplin.]
+Internal development notes — architecture, roadmaps, issue analysis — are split between the private `mfg-research` repo (`docs/archon-notes/`) and Joplin. Which goes where: `CLAUDE.md` § Development Plan Management.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,4 @@ jupyter-book build .     # Static HTML build
 
 ## Internal development notes
 
-Architecture design, roadmaps, and issue analysis are in the private `mfg-research` repository under `docs/archon-notes/`.
+Architecture design and issue analysis are in the private `mfg-research` repository under `docs/archon-notes/`. **Roadmaps are in Joplin**, not here — the cross-Plan roadmap in `Dev`, a subsystem's implementation sequence with its subsystem. [CORRECTED 2026-08-08: this said roadmaps live in `archon-notes/`; both existing ones are in Joplin.]


### PR DESCRIPTION
Replaces the `Only 1 active Plan` clause in `CLAUDE.md` § Development Plan Management with a pointer to the Joplin process. **`CLAUDE.md` only, +4 / −2.**

```markdown
### Development Plan Management
Plans, their naming, status prefixes and lifecycle: Joplin `MFG/Dev/Dev Principles` →
`[Principle] Joplin MFG vs archon-notes — doc division of labor` § Plan management.
Agent-facing rule not already stated above: do not start a second cross-Plan roadmap.
```

## Why `main`'s clause had to change

Two statements in it are wrong or rejected:

- *"Plans live in Joplin **Dev** folder"* — false of three of four live `[ACTIVE]` Plans, which are in `Variational MFG` and `CS/agent_axiom`.
- *"**Only 1 active Plan** at a time"* — rejected by the maintainer 2026-08-07. It broke on three counts: plans do not complete linearly, there is never only one, and they do not finish on schedule.

The single slot was also the only thing that ever retired a Plan, so removing it needed a replacement. That replacement — Now/Next/Later, appetite over estimate, a circuit breaker (past its appetite, re-bet or demote to `[PITCH]`, never a second cycle unchanged), a monthly read that appends a dated line — is **the maintainer's process and lives in Joplin**, where the repo's own `CLAUDE.md:257` already says such documents belong. An agent executes none of it.

So the repo keeps a pointer, plus the one agent-facing rule that is new and stated nowhere else.

## History

This started as a 43-line section and took **four independent adversarial review rounds** to get to three lines. Each round found defects inside the previous round's fixes, including four consecutive false claims about external state — the last of them a UTC-versus-local timezone error in round 3's own correction of round 2.

The rounds are in the comments below, with the commands that falsify each claim. The examination of the trial is owned by #1857, which also states the default: absent examination, the clause stays in force.

**Nothing in this PR asserts a count, a location, or a state that cannot be checked from inside this repository.** That property is what the four rounds were spent buying.
