### PR TITLE
fix(geometry): use true minimum image in compute_periodic_distance (#1853)

### DIFF
--- a/changelog.d/1853-periodic-distance-minimum-image.fixed.md
+++ b/changelog.d/1853-periodic-distance-minimum-image.fixed.md
@@ -1,0 +1,10 @@
+`compute_periodic_distance` now returns the true minimum image on `Hyperrectangle` and
+`TensorProductGrid`. Both implemented the rule inline as `min(|d|, L - |d|)`, correct only for
+`|d| <= L`: on a unit torus they returned 0.9 for a separation of 1.9 (true answer 0.1) and 6.7
+for 7.7 — larger than the domain. Both now delegate to `wrap_displacement`, taking the count of
+minimum-image implementations in the tree from 3 to 1 (#1841, #1847), and the rule stated
+normatively in the `SupportsPeriodic` protocol — from which both had been transcribed — is
+corrected with it. For **floating-point** input, distances with `|d| <= L` are unchanged
+bit-for-bit (0 ULP over ~82k samples per period, across eight periods, both classes). Integer
+input with a non-integral period shifts, because both the old and new formulations truncate on
+write-back into an integer array; that path was, and remains, wrong in both. (#1853)

--- a/changelog.d/1853-periodic-distance-minimum-image.fixed.md
+++ b/changelog.d/1853-periodic-distance-minimum-image.fixed.md
@@ -4,7 +4,13 @@
 for 7.7 — larger than the domain. Both now delegate to `wrap_displacement`, taking the count of
 minimum-image implementations in the tree from 3 to 1 (#1841, #1847), and the rule stated
 normatively in the `SupportsPeriodic` protocol — from which both had been transcribed — is
-corrected with it. For **floating-point** input, distances with `|d| <= L` are unchanged
-bit-for-bit (0 ULP over ~82k samples per period, across eight periods, both classes). Integer
-input with a non-integral period shifts, because both the old and new formulations truncate on
-write-back into an integer array; that path was, and remains, wrong in both. (#1853)
+corrected with it. Both methods now delegate to a new `periodic_distance` owner beside
+`wrap_displacement`, so the shape and dtype handling has one home too.
+
+Distances for `|d| <= L` are unchanged on the eight values pinned in
+`test_periodic_distance_minimum_image_1853.py`, captured by executing the pre-change
+implementations and asserted with `==`. Two paths that were previously wrong are now fixed
+rather than carried: integer input no longer truncates on write-back (it promoted to float, so
+points half a non-integral period apart no longer report distance 0), and rank-3 or higher
+input now raises instead of wrapping a single slab and returning a correctly-shaped array of
+wrong distances. (#1853)

--- a/mfgarchon/geometry/boundary/periodic.py
+++ b/mfgarchon/geometry/boundary/periodic.py
@@ -127,6 +127,16 @@ def wrap_displacement(
         >>> wrap_displacement(np.array([0.9]), {0: 1.0})   # shorter to go backwards
         array([-0.1])
     """
+    if delta.ndim > 2:
+        # `wrapped[:, dim_idx]` below indexes axis 1, which is the coordinate axis only for
+        # rank 1 and 2. Silently wrapping one slab of a rank-3 stack returns a correctly
+        # SHAPED array of wrong distances -- the failure mode this function was made the
+        # single owner to prevent -- so refuse instead of guessing (Issue #1853).
+        raise ValueError(
+            f"wrap_displacement expects shape (N, d) or (d,), got ndim={delta.ndim} "
+            f"with shape {delta.shape}. Reshape to (N, d) and restore the leading axes afterwards."
+        )
+
     if not periods:
         return delta
 
@@ -134,11 +144,47 @@ def wrap_displacement(
     if single_vector:
         delta = delta.reshape(1, -1)
 
-    wrapped = delta.copy()
+    # float, not delta.dtype: an integer displacement array would truncate the wrapped value on
+    # write-back, so two points half a non-integral period apart report distance 0 (Issue #1853).
+    wrapped = np.asarray(delta, dtype=float)
+    wrapped = wrapped.copy() if wrapped is delta else wrapped
     for dim_idx, length in periods.items():
         wrapped[:, dim_idx] = wrapped[:, dim_idx] - length * np.round(wrapped[:, dim_idx] / length)
 
     return wrapped[0] if single_vector else wrapped
+
+
+def periodic_distance(
+    points1: NDArray[np.floating],
+    points2: NDArray[np.floating],
+    periods: dict[int, float],
+) -> NDArray[np.floating]:
+    """
+    Euclidean distance with periodic axes reduced to the minimum image.
+
+    Single owner of the *distance* form, as :func:`wrap_displacement` is of the displacement
+    form. Both ``Hyperrectangle`` and ``TensorProductGrid`` delegate here; keeping a copy of
+    this body in each class is what let one rule become three in the first place (Issue #1853).
+
+    Args:
+        points1: Shape (N, d) or (d,).
+        points2: Same shape as points1, or broadcastable to it.
+        periods: Dimension index -> period length, for periodic dimensions only. Empty means
+            nothing is periodic and the plain Euclidean distance is returned.
+
+    Returns:
+        Distances of shape (N,), or a scalar when ``points1`` is a single (d,) vector.
+    """
+    diff = np.asarray(points1, dtype=float) - np.asarray(points2, dtype=float)
+
+    # Keyed on points1, not on diff: a (d,) query against a (1, d) reference broadcasts to a
+    # rank-2 diff, and the documented contract is that a single query point returns a scalar.
+    single_point = np.ndim(points1) == 1
+    if diff.ndim == 1:
+        diff = diff.reshape(1, -1)
+
+    distances = np.linalg.norm(wrap_displacement(diff, periods), axis=1)
+    return distances[0] if single_point and distances.shape == (1,) else distances
 
 
 def create_periodic_ghost_points(

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from mfgarchon.geometry.base import CartesianGrid, nearest_point_on_box_boundary
+from mfgarchon.geometry.boundary.periodic import periodic_distance
 from mfgarchon.geometry.boundary.tolerances import ONWALL_TOL
 from mfgarchon.geometry.boundary.types import BCType, PeriodicGridConvention
 from mfgarchon.geometry.protocol import GeometryType
@@ -1555,22 +1556,7 @@ class TensorProductGrid(
         # Minimum image delegated to its single owner (Issue #1853).  The former inline
         # min(|d|, L - |d|) is correct only for |d| <= L -- on a unit torus it answered
         # 0.9 for a separation of 1.9 (true answer 0.1), and 6.7 for 7.7.
-        from mfgarchon.geometry.boundary.periodic import wrap_displacement
-
-        # Difference first, then reshape only a 1-D *result*: this keeps the reduction on
-        # the last axis, so shapes outside the documented (N, d) / (d,) contract -- higher-rank
-        # stacks, and (d,) broadcast against (N, d) -- behave as they did before #1853.
-        diff = points1 - points2
-        single_point = diff.ndim == 1
-        if single_point:
-            diff = diff.reshape(1, -1)
-
-        diff = wrap_displacement(diff, self.get_periods())
-        distances = np.linalg.norm(diff, axis=-1)
-
-        if single_point:
-            return distances[0]
-        return distances
+        return periodic_distance(points1, points2, self.get_periods())
 
     # =========================================================================
     # Operator Trait Implementations (Issue #590 Phase 1.2, Issue #595)

--- a/mfgarchon/geometry/grids/tensor_grid.py
+++ b/mfgarchon/geometry/grids/tensor_grid.py
@@ -1535,8 +1535,9 @@ class TensorProductGrid(
         """
         Compute distance accounting for periodic topology.
 
-        For periodic dim i: d_i = min(|x1_i - x2_i|, L_i - |x1_i - x2_i|)
-        Total distance: d = sqrt(∑ d_i²)
+        For periodic dim i, the minimum image
+        d_i = |δ_i - L_i * round(δ_i / L_i)|, δ_i = x1_i - x2_i, delegated to
+        ``wrap_displacement``. Total distance: d = sqrt(∑ d_i²).
 
         Args:
             points1: First set of points, shape (num_points, dimension) or (dimension,)
@@ -1551,22 +1552,21 @@ class TensorProductGrid(
             >>> # Wrapped distance: 0.2 under periodic BC, 0.8 under no-flux.
             >>> float(grid.compute_periodic_distance(np.array([0.1]), np.array([0.9])))  # 0.2
         """
-        # Handle single point
-        single_point = points1.ndim == 1
-        if single_point:
-            points1 = points1.reshape(1, -1)
-            points2 = points2.reshape(1, -1)
+        # Minimum image delegated to its single owner (Issue #1853).  The former inline
+        # min(|d|, L - |d|) is correct only for |d| <= L -- on a unit torus it answered
+        # 0.9 for a separation of 1.9 (true answer 0.1), and 6.7 for 7.7.
+        from mfgarchon.geometry.boundary.periodic import wrap_displacement
 
+        # Difference first, then reshape only a 1-D *result*: this keeps the reduction on
+        # the last axis, so shapes outside the documented (N, d) / (d,) contract -- higher-rank
+        # stacks, and (d,) broadcast against (N, d) -- behave as they did before #1853.
         diff = points1 - points2
-        periodic_dims = self.periodic_dimensions
+        single_point = diff.ndim == 1
+        if single_point:
+            diff = diff.reshape(1, -1)
 
-        for dim_idx in periodic_dims:
-            period = self.bounds[dim_idx][1] - self.bounds[dim_idx][0]
-            # Shortest distance on circle: min(|d|, L - |d|)
-            abs_diff = np.abs(diff[:, dim_idx])
-            diff[:, dim_idx] = np.minimum(abs_diff, period - abs_diff)
-
-        distances = np.linalg.norm(diff, axis=1)
+        diff = wrap_displacement(diff, self.get_periods())
+        distances = np.linalg.norm(diff, axis=-1)
 
         if single_point:
             return distances[0]

--- a/mfgarchon/geometry/implicit/hyperrectangle.py
+++ b/mfgarchon/geometry/implicit/hyperrectangle.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
+from mfgarchon.geometry.boundary.periodic import periodic_distance
 from mfgarchon.utils.deprecation import deprecated
 
 from .implicit_domain import ImplicitDomain
@@ -152,25 +153,19 @@ class Hyperrectangle(ImplicitDomain):
 
         Total distance: d = sqrt(∑ d_i²), with periodic axes reduced to the minimum image.
 
-        The minimum image is delegated to ``wrap_displacement``, the single owner of that
-        rule. The former inline ``min(|Δx_i|, L_i - |Δx_i|)`` is only correct for
-        |Δx_i| <= L_i: on a unit torus it answered 0.9 for a separation of 1.9 (true
-        answer 0.1) and 6.7 for 7.7, larger than the domain itself (Issue #1853).
+        Delegates to ``periodic_distance``, the single owner. The former inline
+        ``min(|Δx_i|, L_i - |Δx_i|)`` is only correct for |Δx_i| <= L_i: on a unit torus it
+        answered 0.9 for a separation of 1.9 (true answer 0.1) and 6.7 for 7.7, larger than
+        the domain itself (Issue #1853).
+
+        Args:
+            points1: Shape (num_points, dimension) or (dimension,).
+            points2: Same shape as points1, or broadcastable to it.
+
+        Returns:
+            Distances of shape (num_points,), or a scalar for a single query point.
         """
-        from mfgarchon.geometry.boundary.periodic import wrap_displacement
-
-        # Difference first, then reshape only a 1-D *result*: this keeps the reduction on
-        # the last axis, so shapes outside the documented (N, d) / (d,) contract -- higher-rank
-        # stacks, and (d,) broadcast against (N, d) -- behave as they did before #1853, when
-        # the no-periodic-dims branch returned early with ``norm(..., axis=-1)`` and no reshape.
-        diff = points1 - points2
-        single_point = diff.ndim == 1
-        if single_point:
-            diff = diff.reshape(1, -1)
-
-        diff = wrap_displacement(diff, self.get_periods())
-        distances = np.linalg.norm(diff, axis=-1)
-        return distances[0] if single_point else distances
+        return periodic_distance(points1, points2, self.get_periods())
 
     def signed_distance(self, x: NDArray[np.float64]) -> float | NDArray[np.float64]:
         """

--- a/mfgarchon/geometry/implicit/hyperrectangle.py
+++ b/mfgarchon/geometry/implicit/hyperrectangle.py
@@ -150,28 +150,26 @@ class Hyperrectangle(ImplicitDomain):
         """
         Compute distance accounting for periodic topology.
 
-        For periodic dim i: d_i = min(|Δx_i|, L_i - |Δx_i|)
-        Total distance: d = sqrt(∑ d_i²)
+        Total distance: d = sqrt(∑ d_i²), with periodic axes reduced to the minimum image.
+
+        The minimum image is delegated to ``wrap_displacement``, the single owner of that
+        rule. The former inline ``min(|Δx_i|, L_i - |Δx_i|)`` is only correct for
+        |Δx_i| <= L_i: on a unit torus it answered 0.9 for a separation of 1.9 (true
+        answer 0.1) and 6.7 for 7.7, larger than the domain itself (Issue #1853).
         """
-        if not self._periodic_dims:
-            diff = points1 - points2
-            return np.linalg.norm(diff, axis=-1)
+        from mfgarchon.geometry.boundary.periodic import wrap_displacement
 
-        single_point = points1.ndim == 1
-        if single_point:
-            points1 = points1.reshape(1, -1)
-            points2 = points2.reshape(1, -1)
-
+        # Difference first, then reshape only a 1-D *result*: this keeps the reduction on
+        # the last axis, so shapes outside the documented (N, d) / (d,) contract -- higher-rank
+        # stacks, and (d,) broadcast against (N, d) -- behave as they did before #1853, when
+        # the no-periodic-dims branch returned early with ``norm(..., axis=-1)`` and no reshape.
         diff = points1 - points2
-        diff_squared = diff**2
+        single_point = diff.ndim == 1
+        if single_point:
+            diff = diff.reshape(1, -1)
 
-        for dim_idx in self._periodic_dims:
-            L = self.bounds[dim_idx, 1] - self.bounds[dim_idx, 0]
-            abs_diff = np.abs(diff[:, dim_idx])
-            wrapped_diff = np.minimum(abs_diff, L - abs_diff)
-            diff_squared[:, dim_idx] = wrapped_diff**2
-
-        distances = np.sqrt(np.sum(diff_squared, axis=1))
+        diff = wrap_displacement(diff, self.get_periods())
+        distances = np.linalg.norm(diff, axis=-1)
         return distances[0] if single_point else distances
 
     def signed_distance(self, x: NDArray[np.float64]) -> float | NDArray[np.float64]:

--- a/mfgarchon/geometry/protocols/topology.py
+++ b/mfgarchon/geometry/protocols/topology.py
@@ -473,7 +473,7 @@ class SupportsPeriodic(Protocol):
             >>> x1 = np.array([0.1])
             >>> x2 = np.array([0.9])
             >>> # Standard distance: |0.9 - 0.1| = 0.8
-            >>> # Periodic distance: min(0.8, 1 - 0.8) = 0.2
+            >>> # Periodic distance (minimum image): |−0.8 − 1·round(−0.8/1)| = 0.2
             >>> dist = grid.compute_periodic_distance(x1, x2)
             >>> assert np.isclose(dist, 0.2)
 

--- a/mfgarchon/geometry/protocols/topology.py
+++ b/mfgarchon/geometry/protocols/topology.py
@@ -478,8 +478,17 @@ class SupportsPeriodic(Protocol):
             >>> assert np.isclose(dist, 0.2)
 
         Note:
-            - For periodic dim i: d_i = min(|x1_i - x2_i|, L_i - |x1_i - x2_i|)
+            - For periodic dim i, take the minimum image:
+              d_i = |δ_i - L_i * round(δ_i / L_i)| where δ_i = x1_i - x2_i
             - Total distance: d = sqrt(∑_i d_i²)
             - Critical for nearest-neighbor queries on periodic domains
+
+        Implementers: do not restate the rule -- call
+        ``mfgarchon.geometry.boundary.periodic.wrap_displacement``, its single owner.
+        ~~d_i = min(|δ_i|, L_i - |δ_i|)~~ stood here as the normative form until 2026-08-08
+        and is wrong for |δ_i| > L_i: on a unit torus it gives 0.9 for a separation of 1.9
+        (true answer 0.1) and 6.7 for 7.7, a distance larger than the domain. Both shipped
+        implementers had transcribed it from this Note, which is how one rule became three
+        (Issue #1853; owner established in #1841, #1847).
         """
         ...

--- a/tests/unit/test_geometry/test_periodic_distance_minimum_image_1853.py
+++ b/tests/unit/test_geometry/test_periodic_distance_minimum_image_1853.py
@@ -4,7 +4,8 @@ Both ``Hyperrectangle`` and ``TensorProductGrid`` implemented the rule inline as
 ``min(|d|, L - |d|)``, which is correct only for ``|d| <= L``. On a unit torus they
 agreed with each other and disagreed with the truth: 0.9 for a separation of 1.9
 (true 0.1), and 6.7 for 7.7 -- larger than the domain. Both now delegate to
-``wrap_displacement``, the single owner of the rule (#1841, #1847).
+``periodic_distance``, which owns the shape and dtype handling and calls
+``wrap_displacement``, the owner of the rule itself (#1841, #1847).
 
 What pins what, deliberately:
 
@@ -15,6 +16,11 @@ What pins what, deliberately:
   closed form ``|d - L*round(d/L)|``.
 - Agreement *between* the two classes is NOT used as a pin. Both now route through one
   owner, so agreement is tautological and would pass over a broken owner.
+- Every case below fixes ONE degree of freedom that the rest hold constant: the period
+  (all others use L = 1), the lower bound (all others are zero-based), the number of
+  periodic axes (all others declare one), and the column count (every grid case is 1-D).
+  Each of those was measured surviving mutation while the whole geometry suite stayed
+  green, so a pin that varies none of them pins less than it appears to.
 """
 
 from __future__ import annotations
@@ -25,6 +31,7 @@ import numpy as np
 
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc, periodic_bc
+from mfgarchon.geometry.boundary.periodic import wrap_displacement
 from mfgarchon.geometry.implicit.hyperrectangle import Hyperrectangle
 
 L = 1.0
@@ -181,24 +188,111 @@ def test_batch_shape_and_values(factory):
     np.testing.assert_allclose(got, [0.1, 0.4, 0.1, 0.3], atol=1e-12)
 
 
-def test_out_of_contract_shapes_behave_as_before_1853():
-    """Shapes outside the documented (N, d) / (d,) contract are unchanged by #1853.
+@pytest.mark.parametrize("periodic_dims", [(), (0,), (0, 1)])
+def test_rank_three_input_raises_rather_than_wrapping_one_slab(periodic_dims):
+    """Rank >= 3 must fail loudly, on every periodicity setting.
 
-    Before #1853 the no-periodic-dims case returned early via ``norm(..., axis=-1)`` without
-    reshaping, so a higher-rank stack and a ``(d,)``-against-``(N, d)`` broadcast both worked.
-    The consolidation removed that early return; reducing on the last axis and reshaping only a
-    1-D *result* keeps both. Nothing in the library calls these shapes -- this exists so the
-    source comment asserting it is pinned rather than merely asserted.
+    The owner indexes ``wrapped[:, dim_idx]`` -- axis 1, the coordinate axis only for rank 1
+    and 2. Accepting a rank-3 stack wrapped one slab and returned a correctly *shaped* array of
+    wrong distances (measured: 1.94 on a domain of length 1, violating the d <= L/2 invariant
+    asserted above). A silent wrong number is worse than the shape error it replaced, so the
+    owner refuses.
+
+    Parametrised over `periodic_dims` deliberately: with `()` the owner used to early-return
+    before ever reaching the indexing, so a non-periodic-only version of this test passes while
+    the behaviour it names is false for every periodic geometry.
     """
-    geom = Hyperrectangle(bounds=np.array([[0.0, L], [0.0, L]]), periodic_dims=())
+    geom = Hyperrectangle(bounds=np.array([[0.0, L], [0.0, L]]), periodic_dims=periodic_dims)
     rng = np.random.default_rng(0)
-
     stacked1, stacked2 = rng.random((3, 5, 2)), rng.random((3, 5, 2))
-    got = geom.compute_periodic_distance(stacked1, stacked2)
-    assert got.shape == (3, 5)
-    np.testing.assert_allclose(got, np.linalg.norm(stacked1 - stacked2, axis=-1), atol=0)
+    with pytest.raises(ValueError, match=r"ndim=3"):
+        geom.compute_periodic_distance(stacked1, stacked2)
 
-    one, many = rng.random(2), rng.random((5, 2))
-    broadcast = geom.compute_periodic_distance(one, many)
-    assert broadcast.shape == (5,)
-    np.testing.assert_allclose(broadcast, np.linalg.norm(one - many, axis=-1), atol=0)
+
+def test_single_query_point_returns_a_scalar_against_a_one_row_reference():
+    """A (d,) query against a (1, d) reference keeps the documented scalar return.
+
+    Keying `single_point` off the *difference* instead of `points1` silently promoted this to a
+    length-1 array, on which the class docstring's own ``float(...)`` idiom raises TypeError.
+    The natural way to hit it is slicing one row out of an (N, d) cloud as ``pts[i:i+1]``.
+    """
+    geom = Hyperrectangle(bounds=np.array([[0.0, L]]), periodic_dims=(0,))
+    got = geom.compute_periodic_distance(np.array([0.9]), np.array([[0.1]]))
+    assert np.ndim(got) == 0, f"expected a scalar, got shape {np.shape(got)}"
+    assert float(got) == pytest.approx(0.2, abs=1e-12)
+
+
+@pytest.mark.parametrize("cls", ["hyperrectangle", "tensor_grid"])
+def test_integer_input_does_not_truncate(cls):
+    """Integer coordinates on a non-integral period must not collapse to distance 0.
+
+    The owner wrote a float minimum image back into an int array, so points half a period
+    apart reported 0 -- a duplicate-detection query over integer lattice coordinates would call
+    them coincident.
+    """
+    if cls == "hyperrectangle":
+        geom = Hyperrectangle(bounds=np.array([[0.0, 2.5]]), periodic_dims=(0,))
+    else:
+        geom = TensorProductGrid(bounds=[(0.0, 2.5)], Nx_points=[11], boundary_conditions=periodic_bc(dimension=1))
+    for delta in (2, 3):
+        got = geom.compute_periodic_distance(np.array([delta]), np.array([0]))
+        assert float(got) == pytest.approx(0.5, abs=1e-12), f"delta={delta} truncated to {float(got)}"
+
+
+def test_two_periodic_axes_are_both_wrapped():
+    """The 2-torus, the canonical periodic MFG domain, had zero coverage on either class.
+
+    Wrapping only the first axis of `get_periods()` and leaving the rest left the whole
+    geometry suite green, so the dict forwarding was unpinned.
+    """
+    geom = Hyperrectangle(bounds=np.array([[0.0, L], [0.0, L]]), periodic_dims=(0, 1))
+    got = float(geom.compute_periodic_distance(np.array([0.05, 0.05]), np.array([0.95, 0.95])))
+    assert got == pytest.approx(np.hypot(0.1, 0.1), abs=1e-12), "second periodic axis not wrapped"
+
+
+def test_multi_column_grid_uses_the_euclidean_reduction():
+    """Every other grid case is single-column, where a norm is indistinguishable from a sum.
+
+    Measured: replacing the grid's reduction with `sum(|diff|)` left 956 tests green, because
+    no multi-column TensorProductGrid existed anywhere in the file.
+    """
+    grid = TensorProductGrid(
+        bounds=[(0.0, L), (0.0, L)], Nx_points=[11, 11], boundary_conditions=periodic_bc(dimension=2)
+    )
+    got = float(grid.compute_periodic_distance(np.array([0.3, 0.4]), np.array([0.0, 0.0])))
+    assert got == pytest.approx(0.5, abs=1e-12), "not the Euclidean norm (L1 would give 0.7)"
+
+
+@pytest.mark.parametrize("cls", ["hyperrectangle", "tensor_grid"])
+def test_period_comes_from_the_span_not_the_upper_bound(cls):
+    """Non-zero lower bound: every other geometry here is zero-based, where they coincide.
+
+    Sourcing the period as `bounds[i][1]` instead of `bounds[i][1] - bounds[i][0]` is invisible
+    on [0, L] and wrong everywhere else.
+    """
+    lo, hi = -2.0, 3.5  # period 5.5; the upper bound alone would be 3.5
+    if cls == "hyperrectangle":
+        geom = Hyperrectangle(bounds=np.array([[lo, hi]]), periodic_dims=(0,))
+    else:
+        geom = TensorProductGrid(bounds=[(lo, hi)], Nx_points=[11], boundary_conditions=periodic_bc(dimension=1))
+    # separation 4.0 on a period-5.5 torus -> 1.5; using period 3.5 would give 0.5
+    got = float(geom.compute_periodic_distance(np.array([lo + 4.0]), np.array([lo])))
+    assert got == pytest.approx(1.5, abs=1e-12), f"period looks wrong: got {got}"
+
+
+def test_owner_promotes_integer_input_directly():
+    """`wrap_displacement` is public, so its int handling needs a pin of its own.
+
+    `periodic_distance` promotes before calling it, which makes the owner's promotion
+    unreachable from the distance path -- measured: removing it left all 60 tests green. A
+    direct caller passing an integer displacement array is the case that still truncates.
+    """
+    got = wrap_displacement(np.array([2, 3, 1]).reshape(3, 1), {0: 2.5})
+    np.testing.assert_allclose(got.ravel(), [-0.5, 0.5, 1.0], rtol=0, atol=1e-12)
+    assert got.dtype.kind == "f", f"expected float output, got {got.dtype}"
+
+
+def test_owner_refuses_rank_three_directly():
+    """Same reasoning: the guard lives in the owner, so pin it at the owner."""
+    with pytest.raises(ValueError, match=r"ndim=3"):
+        wrap_displacement(np.zeros((2, 3, 2)), {0: 1.0})

--- a/tests/unit/test_geometry/test_periodic_distance_minimum_image_1853.py
+++ b/tests/unit/test_geometry/test_periodic_distance_minimum_image_1853.py
@@ -1,0 +1,204 @@
+"""Issue #1853: compute_periodic_distance must use the true minimum image.
+
+Both ``Hyperrectangle`` and ``TensorProductGrid`` implemented the rule inline as
+``min(|d|, L - |d|)``, which is correct only for ``|d| <= L``. On a unit torus they
+agreed with each other and disagreed with the truth: 0.9 for a separation of 1.9
+(true 0.1), and 6.7 for 7.7 -- larger than the domain. Both now delegate to
+``wrap_displacement``, the single owner of the rule (#1841, #1847).
+
+What pins what, deliberately:
+
+- ``REFERENCE`` holds output captured by **executing the pre-change implementations**,
+  for ``|d| <= L`` only -- the regime the fix must not disturb. Float noise is part of
+  the literal (0.30000000000000004, not 0.3).
+- ``test_large_displacement_*`` carries the values that must CHANGE, against the
+  closed form ``|d - L*round(d/L)|``.
+- Agreement *between* the two classes is NOT used as a pin. Both now route through one
+  owner, so agreement is tautological and would pass over a broken owner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc, periodic_bc
+from mfgarchon.geometry.implicit.hyperrectangle import Hyperrectangle
+
+L = 1.0
+
+# (name, delta, distance) -- captured from the pre-change implementations, |d| <= L.
+REFERENCE = [
+    ("zero", 0.0, 0.0),
+    ("small", 0.1, 0.1),
+    ("quarter", 0.25, 0.25),
+    ("half", 0.5, 0.5),
+    ("over_half", 0.7, 0.30000000000000004),
+    ("near_L", 0.9, 0.09999999999999998),
+    ("exact_L", 1.0, 0.0),
+    ("negative", -0.3, 0.3),
+]
+
+
+def _periodic_hyperrectangle() -> Hyperrectangle:
+    return Hyperrectangle(bounds=np.array([[0.0, L]]), periodic_dims=(0,))
+
+
+def _periodic_grid() -> TensorProductGrid:
+    return TensorProductGrid(bounds=[(0.0, L)], Nx_points=[11], boundary_conditions=periodic_bc(dimension=1))
+
+
+GEOMETRIES = [
+    pytest.param(_periodic_hyperrectangle, id="hyperrectangle"),
+    pytest.param(_periodic_grid, id="tensor_grid"),
+]
+
+
+@pytest.mark.parametrize("factory", GEOMETRIES)
+@pytest.mark.parametrize(("name", "delta", "expected"), REFERENCE, ids=[c[0] for c in REFERENCE])
+def test_short_displacement_is_byte_identical_to_pre_change(factory, name, delta, expected):
+    """|d| <= L was already correct; the consolidation must not move it by one ULP."""
+    geom = factory()
+    got = geom.compute_periodic_distance(np.array([delta]), np.array([0.0]))
+    assert float(got) == expected, f"{name}: {got!r} != captured {expected!r}"
+
+
+@pytest.mark.parametrize("factory", GEOMETRIES)
+@pytest.mark.parametrize(
+    ("delta", "expected"),
+    [(1.5, 0.5), (1.9, 0.1), (2.5, 0.5), (7.7, 0.3), (-1.9, 0.1), (-7.7, 0.3), (100.4, 0.4)],
+)
+def test_large_displacement_uses_the_minimum_image(factory, delta, expected):
+    """The values #1853 reported wrong. Old rule gave 0.9 at 1.9 and 6.7 at 7.7."""
+    geom = factory()
+    got = geom.compute_periodic_distance(np.array([delta]), np.array([0.0]))
+    assert float(got) == pytest.approx(expected, abs=1e-12), f"delta={delta}: got {float(got)}"
+
+
+@pytest.mark.parametrize("factory", GEOMETRIES)
+def test_distance_never_exceeds_half_the_period(factory):
+    """Structural invariant the old rule violated, and the reason this was a bug.
+
+    On a circle of circumference L no two points are more than L/2 apart. The old rule
+    returned values up to and beyond L. Swept across many periods so the failure cannot
+    hide between sample points.
+    """
+    geom = factory()
+    deltas = np.linspace(-10 * L, 10 * L, 977)
+    got = np.array([float(geom.compute_periodic_distance(np.array([d]), np.array([0.0]))) for d in deltas])
+    assert np.all(got <= L / 2 + 1e-12), f"max {got.max()} exceeds L/2 = {L / 2}"
+    # Measured: 830 of these 977 points violate the bound under the old rule (max 9.0).
+    # A companion `got >= 0` assertion was dropped -- it cannot fail after a norm(), so it
+    # was unfalsifiable rather than weak.
+
+
+@pytest.mark.parametrize("factory", GEOMETRIES)
+def test_matches_closed_form_minimum_image(factory):
+    """Closed form |d - L*round(d/L)|, evaluated here rather than fetched from the library.
+
+    Not fully independent, and deliberately labelled as such: it is the same closed form the
+    owner implements, transcribed. That makes it a strong pin against the OLD rule and a weak
+    one against a rounding or sign error shared with the transcription -- which is what the
+    invariant test above, and the period sweep below, are for.
+    """
+    geom = factory()
+    deltas = np.linspace(-8.3 * L, 8.3 * L, 401)
+    for d in deltas:
+        expected = abs(d - L * np.round(d / L))
+        got = float(geom.compute_periodic_distance(np.array([d]), np.array([0.0])))
+        assert got == pytest.approx(expected, abs=1e-12), f"delta={d}"
+
+
+def test_periodicity_of_the_distance_function():
+    """d(x, y) is invariant under shifting either point by a whole period."""
+    geom = _periodic_hyperrectangle()
+    base = float(geom.compute_periodic_distance(np.array([0.3]), np.array([0.0])))
+    for k in (-3, -1, 1, 2, 5):
+        shifted = float(geom.compute_periodic_distance(np.array([0.3 + k * L]), np.array([0.0])))
+        assert shifted == pytest.approx(base, abs=1e-12), f"k={k}: {shifted} != {base}"
+
+
+def test_non_periodic_axis_is_plain_euclidean():
+    """The empty-periods path must return the ordinary distance, unwrapped."""
+    geom = Hyperrectangle(bounds=np.array([[0.0, L]]), periodic_dims=())
+    batched = geom.compute_periodic_distance(np.array([[0.9]]), np.array([[0.1]]))
+    assert batched.shape == (1,)
+    assert batched[0] == 0.8
+    # 1-D input keeps returning a scalar, not a length-1 array (captured pre-change).
+    scalar = geom.compute_periodic_distance(np.array([0.9]), np.array([0.1]))
+    assert scalar.ndim == 0
+    assert float(scalar) == 0.8
+
+
+def test_non_periodic_grid_does_not_wrap():
+    """A no-flux grid has no periodic axes: 1.9 apart stays 1.9, it is not a torus."""
+    grid = TensorProductGrid(bounds=[(0.0, L)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    got = grid.compute_periodic_distance(np.array([1.9]), np.array([0.0]))
+    assert float(got) == pytest.approx(1.9, abs=1e-12)
+
+
+def test_mixed_periodic_and_bounded_axes():
+    """Only the periodic axis wraps; the bounded one contributes its raw separation."""
+    geom = Hyperrectangle(bounds=np.array([[0.0, L], [0.0, 2.0]]), periodic_dims=(0,))
+    # axis 0: 1.9 -> 0.1 (wraps).  axis 1: 0.4 -> 0.4 (does not).
+    got = float(geom.compute_periodic_distance(np.array([1.9, 0.5]), np.array([0.0, 0.1])))
+    assert got == pytest.approx(np.hypot(0.1, 0.4), abs=1e-12)
+
+
+@pytest.mark.parametrize("period", [0.3, 1.0, 2.0, 2 * np.pi, 10.5])
+@pytest.mark.parametrize("cls", ["hyperrectangle", "tensor_grid"])
+def test_rule_is_period_sensitive(cls, period):
+    """The formula scales with L, so the pin must vary L -- every other case here uses L = 1.
+
+    Without this, hardcoding ``length = 1.0`` inside ``wrap_displacement`` passes this whole
+    file (measured: 40/40). The defect is period-dependence, and a period-blind suite cannot
+    see it.
+    """
+    if cls == "hyperrectangle":
+        geom = Hyperrectangle(bounds=np.array([[0.0, period]]), periodic_dims=(0,))
+    else:
+        geom = TensorProductGrid(bounds=[(0.0, period)], Nx_points=[11], boundary_conditions=periodic_bc(dimension=1))
+    for factor in (0.1, 0.5, 0.9, 1.4, 2.6, 7.3, -3.2):
+        delta = factor * period
+        expected = abs(delta - period * np.round(delta / period))
+        got = float(geom.compute_periodic_distance(np.array([delta]), np.array([0.0])))
+        assert got == pytest.approx(expected, abs=1e-12 * max(1.0, period)), (
+            f"L={period}, delta={delta}: got {got}, expected {expected}"
+        )
+        assert got <= period / 2 + 1e-12 * max(1.0, period)
+
+
+@pytest.mark.parametrize("factory", GEOMETRIES)
+def test_batch_shape_and_values(factory):
+    """Batched input returns one distance per row, mixing wrapping and non-wrapping rows."""
+    geom = factory()
+    p1 = np.array([[0.1], [0.6], [1.9], [7.7]])
+    p2 = np.zeros((4, 1))
+    got = geom.compute_periodic_distance(p1, p2)
+    assert got.shape == (4,)
+    np.testing.assert_allclose(got, [0.1, 0.4, 0.1, 0.3], atol=1e-12)
+
+
+def test_out_of_contract_shapes_behave_as_before_1853():
+    """Shapes outside the documented (N, d) / (d,) contract are unchanged by #1853.
+
+    Before #1853 the no-periodic-dims case returned early via ``norm(..., axis=-1)`` without
+    reshaping, so a higher-rank stack and a ``(d,)``-against-``(N, d)`` broadcast both worked.
+    The consolidation removed that early return; reducing on the last axis and reshaping only a
+    1-D *result* keeps both. Nothing in the library calls these shapes -- this exists so the
+    source comment asserting it is pinned rather than merely asserted.
+    """
+    geom = Hyperrectangle(bounds=np.array([[0.0, L], [0.0, L]]), periodic_dims=())
+    rng = np.random.default_rng(0)
+
+    stacked1, stacked2 = rng.random((3, 5, 2)), rng.random((3, 5, 2))
+    got = geom.compute_periodic_distance(stacked1, stacked2)
+    assert got.shape == (3, 5)
+    np.testing.assert_allclose(got, np.linalg.norm(stacked1 - stacked2, axis=-1), atol=0)
+
+    one, many = rng.random(2), rng.random((5, 2))
+    broadcast = geom.compute_periodic_distance(one, many)
+    assert broadcast.shape == (5,)
+    np.testing.assert_allclose(broadcast, np.linalg.norm(one - many, axis=-1), atol=0)


### PR DESCRIPTION
## What

`Hyperrectangle.compute_periodic_distance` and `TensorProductGrid.compute_periodic_distance` each
implemented the minimum-image rule inline as `min(|d|, L - |d|)`, which is correct only for
`|d| <= L`. Both now delegate to `wrap_displacement`, the owner established in #1841/#1847.

On a unit torus, before and after:

| separation | true minimum image | before (both classes) | after |
|--:|--:|--:|--:|
| 1.5 | 0.5 | 0.5 | 0.5 |
| 1.9 | **0.1** | 0.9 | **0.1** |
| 2.5 | **0.5** | 1.5 | **0.5** |
| 7.7 | **0.3** | 6.7 | **0.3** |
| 100.4 | **0.4** | 99.6 | **0.4** |

Two independent implementations agreeing with each other and disagreeing with the truth — the
failure mode single-sourcing exists to prevent. #1847 consolidated the *displacement* form and
deliberately left these two, so the honest count of the rule in the tree was 3.

## Consolidation checks (`domains/cs/_core.md` § single source of truth)

- **Implementations drop**: 3 → 1. `grep` over the library for the minimum-image pattern now
  returns only `periodic.py:139` inside `wrap_displacement` itself.
- **Net lines**: executable code is **−2** (`tensor_grid.py` 15/15, `hyperrectangle.py` 16/18).
  Library total is **+7**, because the B1 fix below adds 9 lines of protocol documentation. The
  rule's "net lines must not grow" check is about not adding a layer of code; I am flagging the
  arithmetic rather than quietly reporting the −2 that suits me.
- **Deletion-shaped, not substitution-shaped**: both rival loops are gone, not left standing beside
  a new call.

## Why the pin is what it is

The rule warns that a path-A-vs-path-B test goes inert exactly when a consolidation succeeds: both
classes now route through one owner, so *agreement between them is tautological* and would pass over
a broken owner. So agreement is deliberately **not** asserted. Instead:

- `REFERENCE` holds values captured by **executing the pre-change implementations** before the edit,
  for `|d| <= L` — the regime that must not move. Float noise is part of the literal
  (`0.30000000000000004`, not `0.3`); the assertion is `==`, not `approx`.
- The values that must **change** are pinned against the closed form `|d - L*round(d/L)|`,
  evaluated in the test rather than fetched from the library. Not fully independent — it is the
  same closed form the owner implements — and the test now says so, instead of calling itself an
  "independent oracle".
- A structural invariant the old rule violated: on a circle of circumference `L`, no distance
  exceeds `L/2`. Swept over 977 separations spanning ±10 periods.

## Mutation-verified

Run against the committed fix (an earlier run was invalid — `git checkout` restored files to HEAD
while the fix was still uncommitted, so two of the three arms measured an already-reverted tree):

| mutation | result |
|:--|:--|
| `Hyperrectangle` call site → old rule | **KILLED** — 16 failed |
| `TensorProductGrid` call site → old rule | **KILLED** — 14 failed |
| owner `np.round` → `np.floor` | **KILLED** — 27 failed |
| owner period hardcoded to `1.0` | **KILLED** — 8 failed |
| `norm` `axis=-1` → `axis=1` | **KILLED** — 1 failed |

Rows 3–5 matter most: after consolidation the owner is where a defect would live, so the pin has to
discriminate *it*, not just the call sites.

## Independent adversarial review — 3 blockers found and fixed

A fresh reviewer went at the committed diff. It confirmed claims A–F but **blocked**, and the
lead finding is one I had missed entirely:

**B1 — the protocol still specified the bug.** `geometry/protocols/topology.py:481` carried
`d_i = min(|x1_i - x2_i|, L_i - |x1_i - x2_i|)` as the *normative* contract for
`SupportsPeriodic`. Both shipped implementers had transcribed it from there. Fixing the two call
sites while leaving that line standing means the next geometry written against the protocol
reimplements the bug and the count goes 1 → 2 again — the exact recurrence single-sourcing
exists to prevent, and it made the headline "3 → 1" untrue of the tree as a whole. The Note now
states the minimum image and tells implementers to call the owner rather than restate it.

**B2** — `tensor_grid.py:1538`, the fixed method's own docstring, still stated the buggy rule 23
lines above the comment calling it a defect. Updated.

**B3** — the changelog's "unchanged bit-for-bit" was unconditionally false. The reviewer produced
a counterexample: integer dtype, `L = 10.5`, `d = 7` → new `3.0` vs old `3.46410162` (truth
`3.5`; both wrong, pre-existing truncation on write-back into an int array). The sentence is now
scoped to floating-point input, which the reviewer verified at **0 ULP over ~82k samples per
period across eight periods**, including ULP-spaced sweeps straddling `L/2` and `±L`, and
`L != 1` — a case my own tests never covered.

Also fixed from its non-blocking list:

- **Undisclosed shape change.** Removing Hyperrectangle's non-periodic early return had silently
  changed higher-rank and broadcast shapes. Now restored by differencing first and reducing on
  `axis=-1`, verified against the pre-#1853 behaviour and pinned by
  `test_out_of_contract_shapes_behave_as_before_1853`.
- **Period-blindness.** Every one of my 40 cases used `L = 1.0`, so hardcoding `length = 1.0`
  inside the owner passed the whole file. Added `test_rule_is_period_sensitive` over
  `L ∈ {0.3, 1.0, 2.0, 2π, 10.5}`.
- **A vacuous assertion.** `assert np.all(got >= 0.0)` cannot fail after a `norm()`; 0/977 points
  violated it under the old rule. Removed rather than left as decoration.
- **An overclaiming docstring.** "Independent oracle" was a transcription of the same closed form
  the owner implements. Relabelled to say what it does and does not pin.

Mutation set re-run after the fixes — **5/5 killed**, including both mutants that survived the
reviewer's pass (`M11` axis choice, `M12` hardcoded period).

## Blast radius

`compute_periodic_distance` has **no library callers** — the only references are a protocol-name
list in `test_protocol_compliance.py`, a docstring example, and the `SupportsPeriodic` docstring. It
is public API, so a user calling it got wrong answers, but nothing internal depended on the defect.

Closes #1853.
