### PR TITLE
fix(geometry): GKS sparse path must read the end of the spectrum its criterion tests (#1859)

### DIFF
--- a/changelog.d/1859-gks-sparse-spectrum-end.fixed.md
+++ b/changelog.d/1859-gks-sparse-spectrum-end.fixed.md
@@ -1,0 +1,8 @@
+`check_gks_stability` no longer reports every operator stable once `N > 100`. The sparse branch
+asked `eigs` for `which="LM"` (largest magnitude) while the parabolic criterion is on the largest
+real part; for a discretized Laplacian the largest-magnitude eigenvalues are the most negative
+ones, so the near-zero eigenvalues that decide stability were never returned. An operator with
+`max Re(λ) = +0.1` was reported stable at N = 101, 201 and 401, and correctly unstable at N = 61
+only because that took the dense path. The end of the spectrum sampled is now chosen by the
+criterion being applied. Sparse-branch tests added — every pre-existing test in the file used
+N = 50 or N = 5, so that branch had never been executed. (#1859)

--- a/mfgarchon/geometry/boundary/validation/gks.py
+++ b/mfgarchon/geometry/boundary/validation/gks.py
@@ -152,15 +152,31 @@ def check_gks_stability(
     if num_eigenvalues is None:
         num_eigenvalues = min(50, N - 2)  # Leave margin for eigs() safety
 
-    # Compute eigenvalues
-    # Note: eigs() computes largest magnitude by default, use which='LM'
+    # Which end of the spectrum to sample is decided by the criterion, not by convention:
+    # `eigs` returns only `num_eigenvalues` of N, so asking for the wrong end silently omits
+    # exactly the eigenvalues the test is about (Issue #1859).
+    #
+    # parabolic tests max Re(lambda), so it needs the largest REAL part ('LR'). Under the
+    # previous 'LM' the returned values were the most negative ones (~ -4/dx^2 for a
+    # discretized Laplacian), so max_real_part came back large and negative and `stable` was
+    # True for every operator once N > 100 -- including one with Re(lambda) = +0.1.
+    #
+    # hyperbolic consumes max|lambda| as `operator_norm`, which is what 'LM' returns, so it
+    # keeps 'LM'. (Its criterion has a separate problem, reported on #1859: |Im z| <= |z|
+    # holds for every complex number, so the comparison can never fail. Not fixed here.)
+    #
+    # elliptic asks whether all eigenvalues share a sign, which needs BOTH ends and is
+    # therefore not answerable from one truncated call at all -- also reported, not fixed,
+    # because it needs a second solve rather than a different `which`.
+    which = "LR" if pde_type == "parabolic" else "LM"
+
     try:
         if N <= 100:
             # For small problems, use dense eigenvalue solver (more reliable)
             eigenvalues = np.linalg.eigvals(operator.toarray())
         else:
             # For large problems, use sparse solver
-            eigenvalues, _ = eigs(operator, k=num_eigenvalues, which="LM", tol=1e-6)
+            eigenvalues, _ = eigs(operator, k=num_eigenvalues, which=which, tol=1e-6)
     except Exception:
         # If sparse solver fails (common for small N or ill-conditioned), use dense
         logger.warning("Sparse eigensolver failed for N=%d, falling back to dense solver", N)

--- a/tests/validation/test_gks_conditions.py
+++ b/tests/validation/test_gks_conditions.py
@@ -12,7 +12,7 @@ Created: 2026-01-18 (Issue #593 Phase 4.2)
 import pytest
 
 import numpy as np
-from scipy.sparse import csr_matrix, diags
+from scipy.sparse import csr_matrix, diags, eye
 
 from mfgarchon.geometry.boundary.validation.gks import (
     GKSResult,
@@ -273,6 +273,82 @@ class TestGKSEdgeCases:
 
         # Should convert to sparse internally
         assert isinstance(result.eigenvalues, np.ndarray)
+
+
+class TestGKSSparseBranchReadsTheRightEndOfTheSpectrum:
+    """Issue #1859: the N > 100 branch had zero coverage, and was unconditionally stable.
+
+    ``check_gks_stability`` dispatches on size: dense ``eigvals`` for N <= 100, sparse ``eigs``
+    above it. Every pre-existing test in this file uses N = 50 or N = 5, so the sparse branch
+    was never executed. It asked ``eigs`` for ``which="LM"`` -- largest MAGNITUDE -- while the
+    parabolic criterion is on the largest REAL part. For a discretized Laplacian the
+    largest-magnitude eigenvalues are the most negative ones (about -4/dx^2), so the near-zero
+    eigenvalues that decide stability were never returned and ``stable`` was True for every
+    operator once N > 100.
+    """
+
+    @staticmethod
+    def _laplacian_with_growth(N: int, delta: float) -> csr_matrix:
+        """1D Neumann Laplacian plus delta*I.
+
+        ``d_t u = Laplacian(u) + delta*u`` grows exponentially for delta > 0, so max Re(lambda)
+        is exactly delta and a correct parabolic check must report unstable.
+        """
+        h = 1.0 / (N - 1)
+        L = (diags([1.0, -2.0, 1.0], [-1, 0, 1], shape=(N, N)) / h**2).tolil()
+        L[0, 1] = 2 / h**2
+        L[-1, -2] = 2 / h**2
+        if delta:
+            L = L + delta * eye(N)
+        return L.tocsr()
+
+    @pytest.mark.parametrize("N", [101, 201, 401])
+    def test_growing_operator_is_reported_unstable_on_the_sparse_branch(self, N):
+        """The regression. Under ``which="LM"`` this returned stable=True at every N."""
+        operator = self._laplacian_with_growth(N, delta=0.1)
+        result = check_gks_stability(operator, pde_type="parabolic", bc_description=f"N={N}")
+
+        # This test is ABOUT the sparse branch, so assert it was actually taken: the sparse call
+        # returns min(50, N-2) eigenvalues where the dense path returns all N. Without this, a
+        # change to the size threshold would silently redirect these cases to the dense solver
+        # and they would keep passing while covering nothing (measured: raising the threshold
+        # leaves all 16 tests green).
+        assert len(result.eigenvalues) == min(50, N - 2), (
+            f"N={N}: expected the sparse branch (min(50, N-2) eigenvalues), "
+            f"got {len(result.eigenvalues)} -- dense path taken, so this test no longer covers "
+            f"what it names"
+        )
+        assert not result.stable, (
+            f"N={N}: operator with max Re(lambda) = +0.1 reported stable; max_real_part={result.max_real_part:.3e}"
+        )
+        assert result.max_real_part == pytest.approx(0.1, abs=1e-6), (
+            f"N={N}: expected the near-zero end of the spectrum, got {result.max_real_part:.3e}"
+        )
+
+    @pytest.mark.parametrize("N", [101, 401])
+    def test_dissipative_operator_is_still_reported_stable(self, N):
+        """The other half: sampling a different end must not manufacture false alarms."""
+        operator = self._laplacian_with_growth(N, delta=0.0)
+        result = check_gks_stability(operator, pde_type="parabolic", bc_description=f"N={N}")
+
+        assert result.stable, f"N={N}: pure Laplacian reported unstable ({result.max_real_part:.3e})"
+        assert result.max_real_part <= 1e-8
+
+    def test_dense_and_sparse_branches_agree_across_the_dispatch_boundary(self):
+        """N=100 and N=101 take different code paths and must not disagree about stability.
+
+        This is the check that would have caught the defect without knowing its mechanism: the
+        answer must not depend on which side of an internal size threshold the input lands on.
+        """
+        dense = check_gks_stability(self._laplacian_with_growth(100, 0.1), pde_type="parabolic")
+        sparse = check_gks_stability(self._laplacian_with_growth(101, 0.1), pde_type="parabolic")
+
+        assert dense.stable == sparse.stable is False, (
+            f"dispatch boundary disagrees: N=100 stable={dense.stable} "
+            f"(Re={dense.max_real_part:.3e}), N=101 stable={sparse.stable} "
+            f"(Re={sparse.max_real_part:.3e})"
+        )
+        assert sparse.max_real_part == pytest.approx(dense.max_real_part, abs=1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes defect 1 of #1859. Defect 2 (`ghost_cell_neumann` vs `ghost_cell_robin`) is untouched here
and gets its own PR — different module, different risk, and a revert of either should not take out
the other.

## What

`check_gks_stability` dispatches on size — dense `eigvals` for `N <= 100`, sparse `eigs` above it —
and the sparse call asked for `which="LM"` (largest **magnitude**) while the parabolic criterion is
on the largest **real part**. For a discretized Laplacian the largest-magnitude eigenvalues are the
most negative ones (about `-4/dx²`), so the near-zero eigenvalues that decide stability were never
returned: `max_real_part` came back large and negative and `stable` was `True` for every operator
once `N > 100`.

Reproduced on `∂ₜu = Δu + 0.1·u`, whose true `max Re(λ)` is exactly `+0.1`:

| N | path | true | reported before | before | reported after | after |
|--:|:--|--:|--:|:--|--:|:--|
| 61 | dense | +1.000e-01 | +1.000e-01 | unstable ✓ | +1.000e-01 | unstable ✓ |
| 101 | sparse | +1.000e-01 | −2.063e+04 | **stable ✗** | +1.000e-01 | unstable ✓ |
| 201 | sparse | +1.000e-01 | −1.375e+05 | **stable ✗** | +1.000e-01 | unstable ✓ |
| 401 | sparse | +1.000e-01 | −6.166e+05 | **stable ✗** | +1.000e-01 | unstable ✓ |

The other half also holds: a pure Laplacian still reports stable at N = 101/401/1001/4001, so
sampling a different end does not manufacture false alarms. N = 4001 takes 2.9 s.

## Why `which` is now chosen per criterion rather than changed outright

The issue proposes `"LM"` → `"LR"`, which is right for the criterion it demonstrates. But `which`
is shared by three `pde_type` branches and only the parabolic one was measured, so a blanket change
would disturb the other two:

- **parabolic** → `"LR"`. This is the fix.
- **hyperbolic** keeps `"LM"`, because it consumes `max|λ|` as its `operator_norm`, which is exactly
  what `"LM"` returns. Changing it would silently degrade that number.
- **elliptic** keeps `"LM"`, because "do all eigenvalues share a sign" needs *both* ends and is not
  answerable from one truncated call at all. That is a different fix, not a different `which`.

Two further defects in the same function surfaced while establishing that, both the same shape as
the ones filed. **Neither is fixed here** — they are reported on #1859 instead, because neither is
in the scope this PR was opened for and each needs its own decision.

## Tests

Every pre-existing test in `tests/validation/test_gks_conditions.py` uses `N = 50` or `N = 5`, so
the `N > 100` branch had **never been executed**. Added:

- the regression itself, at N = 101/201/401;
- the converse, that a dissipative operator is still reported stable;
- a **dispatch-boundary** case asserting N = 100 and N = 101 agree — the check that would have
  caught this without knowing the mechanism, since an answer must not depend on which side of an
  internal size threshold the input lands on.

Each sparse test also asserts it *actually took the sparse branch* (`len(eigenvalues) ==
min(50, N-2)`, versus `N` on the dense path). Without that, raising the size threshold silently
redirects these cases to the dense solver and they keep passing while covering nothing — measured:
all 16 stay green. That is the same vacuity a reviewer found in my #1853 test this morning, where a
fixture built with `periodic_dims=()` meant the code under test was never reached.

## Mutation-verified

Run against the committed fix, 4/4 killed:

| mutation | result |
|:--|:--|
| revert to `which="LM"` (the original defect) | **KILLED** — 4 failed |
| `which="SR"` (the other wrong end) | **KILLED** — 4 failed |
| size threshold raised so nothing takes the sparse path | **KILLED** — 3 failed |
| parabolic criterion forced to `True` | **KILLED** — 4 failed |

Full gate green: 5879 passed.

## Blast radius

`check_gks_stability` has **no internal callers** — the only references are this test file and the
`validation/__init__.py` re-export. It is developer-facing validation, so the defect misled
whoever ran it rather than corrupting a solve.
