### PR TITLE
fix(numerical): the FD Jacobian must not straddle a kink (#1745)

### DIFF
--- a/changelog.d/1745-central-difference-jacobian.fixed.md
+++ b/changelog.d/1745-central-difference-jacobian.fixed.md
@@ -1,0 +1,14 @@
+- **`NewtonSolver`'s finite-difference Jacobian no longer straddles a kink** (Issue #1745). An
+  upwind HJB residual selects between two one-sided differences, so it is non-differentiable where
+  they tie, and symmetric initial data puts nodes exactly there rather than near there: on the 2-D
+  smoke problem the grid centre's neighbours agree to 9e-11 and `dF[60]/dU[59]` is `+13.395` from
+  one side and `-7.9998` from the other. The forward quotient reported only the branch on its own
+  side, and the resulting step was one the line search cut to ~0.03 -- the inner solve creeped to
+  its 30-iteration budget at `1.17e-05` and needed 67 iterations to reach a `1e-6` tolerance. The
+  symmetric quotient reports the mean of the two branch slopes and reaches `3.14e-09` in 5. On the
+  2-D FDM coupled solve, twelve of the thirteen inner solves now converge in 4-7 iterations with
+  final residuals from `4.9e-12` to `7.4e-07`, where before the fifth stalled. The cost is `2n`
+  residual evaluations per Jacobian instead of `n`. No capability cell changes status: the 2-D cells
+  still fail, the thirteenth inner solve being where the coupled iteration has already diverged
+  (Issue #1865) -- for `fdm_upwind_2d` and `fvm_muscl_2d` that failure is still reported by the
+  inner Newton, while `fdm_centered_2d` now gets far enough to fail in the FP step instead.

--- a/mfgarchon/utils/numerical/nonlinear_solvers.py
+++ b/mfgarchon/utils/numerical/nonlinear_solvers.py
@@ -435,11 +435,11 @@ class NewtonSolver(NonlinearSolver):
                         RuntimeWarning,
                         stacklevel=2,
                     )
-                    J = self._finite_difference_jacobian(F, x_current, F_current)
+                    J = self._finite_difference_jacobian(F, x_current)
                     jacobian_evals += 1
             else:
                 # Fallback: finite difference Jacobian (O(N) complexity)
-                J = self._finite_difference_jacobian(F, x_current, F_current)
+                J = self._finite_difference_jacobian(F, x_current)
                 jacobian_evals += 1
 
             # Solve linear system: J δx = -F
@@ -509,15 +509,33 @@ class NewtonSolver(NonlinearSolver):
         self,
         F: Callable[[NDArray], NDArray],
         x: NDArray,
-        F_x: NDArray,
     ) -> NDArray | sparse.spmatrix:
         """
-        Compute Jacobian via forward finite differences.
+        Compute Jacobian via central finite differences.
 
-        J[i,j] ≈ (F(x + ε·e_j)[i] - F(x)[i]) / ε
+        J[i,j] ≈ (F(x + ε·e_j)[i] - F(x - ε·e_j)[i]) / (2ε)
+
+        Central, not one-sided, because the residuals this solver is handed are only
+        piecewise smooth, and the iterate can sit exactly on a kink (Issue #1745). An
+        upwind HJB residual selects between two one-sided differences, so it is
+        non-differentiable wherever they tie -- and symmetric initial data puts nodes
+        exactly there rather than near there. Measured on the 2-D smoke problem at the
+        stalled iterate: at the grid centre the two neighbours agree to 9e-11 (both
+        -1.32946871 to eight decimals), and dF[60]/dU[59] is +13.395 approached from
+        one side and -7.9998 from the other -- both read at eps 1e-5; at this solver's own
+        default of 1e-7 the second side reads -7.98. A one-sided quotient reports whichever
+        branch lies on the +eps side; that branch governs half a neighbourhood, and the
+        step built from it is one the line search then has to cut to ~0.03. The symmetric
+        quotient reports the mean of the two branch slopes. Same inner solve, same x0:
+        forward reaches 1.17e-05 in 30 iterations and needs 67 to reach tolerance,
+        central reaches 3.14e-09 in 5.
+
+        The cost is 2n evaluations of F per Jacobian rather than n. That is the wrong
+        thing to economise on: a solver spending O(n) residual evaluations per iteration
+        is already the expensive path, and on the case that motivated this the cheaper
+        quotient bought 13.4x the iterations -- 6.7x the residual evaluations net.
         """
         x_flat = x.flatten()
-        F_flat = F_x.flatten()
         n = len(x_flat)
 
         if self.use_sparse:
@@ -527,15 +545,16 @@ class NewtonSolver(NonlinearSolver):
             J = np.zeros((n, n), dtype=np.float64)
 
         for j in range(n):
-            # Perturb j-th component
-            x_pert = x_flat.copy()
-            x_pert[j] += self.epsilon
+            # Perturb j-th component either side
+            x_plus = x_flat.copy()
+            x_minus = x_flat.copy()
+            x_plus[j] += self.epsilon
+            x_minus[j] -= self.epsilon
 
-            # Evaluate F at perturbed point
-            F_pert = F(x_pert.reshape(x.shape)).flatten()
+            F_plus = F(x_plus.reshape(x.shape)).flatten()
+            F_minus = F(x_minus.reshape(x.shape)).flatten()
 
-            # Finite difference
-            J[:, j] = (F_pert - F_flat) / self.epsilon
+            J[:, j] = (F_plus - F_minus) / (2.0 * self.epsilon)
 
         return J.tocsr() if self.use_sparse else J
 

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -11,10 +11,10 @@
     },
     "fdm_centered_2d/mass_conservation": {
       "artifact": {
-        "exception": "ConvergenceError",
-        "message": "newton solver failed to converge after 30 iterations (residual: 1.17e-05)"
+        "exception": "ValueError",
+        "message": "FP solver: at timestep 2/6, advection_scheme='divergence_centered': density went to -6.618e-01. Clipping it to zero would fabricate 2.329% of the total mass, so the solve is stopped rather than report"
       },
-      "intended": "DEFECT \u2014 #1745. One bug, three cells: FDM_CENTERED, FDM_UPWIND and FVM_MUSCL fail with an identical residual 1.17e-05 because they share HJBFDMSolver; SL_LINEAR does not and passes. The inner Newton's tolerance is 1e-6 and its budget is 30 iterations, so this is 11.7x the tolerance -- it is not diverging, it fails to close the last order of magnitude in the budget. Start with the convergence rate and the iteration budget rather than the Jacobian: at max_iterations=400 the recorded solve does converge, at iteration 67 (9.685e-07). But it is not settled -- the NEXT Newton in the same cell then stops after 2 iterations at 4.568e+01 with reason='line_search_failed' and the solver's own detail 'the direction may be wrong (check the Jacobian)'. The Jacobian on this path is finite-difference (hjb_fdm.py:312 passes jacobian=None) and the observed rate is q-linear ~0.87, not quadratic. #1763's own body disclosed that raising the budget 'exposes a different failure further into the solve that I have not characterised'; that is still true. (Before #1763 this cell recorded 2.42e-01. That WAS a residual, not a step norm: `git show 005a10f5~1` has `residual_norm = np.linalg.norm(F_current.flatten())`, and #1763's own body records the residual converging to 1.57e-03 in five iterations and then diverging geometrically to 2.42e-01 because the full step increased it where a half step would have quartered it. #1763 fixed that by defaulting line_search=True. #1764 changed the convergence test in base_hjb.py, which is NOT on this cell's path -- it reaches NewtonSolver via hjb_fdm.py. Do not read the old number as a bad criterion; it recorded a real divergence that is now fixed.)",
+      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered.",
       "status": "UNSUPPORTED"
     },
     "fdm_upwind/mass_conservation": {
@@ -31,9 +31,9 @@
     "fdm_upwind_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
-        "message": "newton solver failed to converge after 30 iterations (residual: 1.17e-05)"
+        "message": "newton solver failed to converge after 30 iterations (residual: 2.95e+01)"
       },
-      "intended": "DEFECT \u2014 #1745, same defect as fdm_centered_2d: identical residual 1.17e-05, shared HJBFDMSolver.",
+      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one.",
       "status": "UNSUPPORTED"
     },
     "fvm_muscl/mass_conservation": {
@@ -49,9 +49,9 @@
     "fvm_muscl_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
-        "message": "newton solver failed to converge after 30 iterations (residual: 1.17e-05)"
+        "message": "newton solver failed to converge after 30 iterations (residual: 1.15e+02)"
       },
-      "intended": "DEFECT \u2014 #1745, same defect as fdm_centered_2d: identical residual 1.17e-05, shared HJBFDMSolver.",
+      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes.",
       "status": "UNSUPPORTED"
     },
     "fvm_vs_fdm/agreement": {
@@ -94,7 +94,7 @@
         ],
         "tolerance": 1e-06
       },
-      "intended": "DEFECT — #1798, and NOT the defect this cell recorded before. The solve now RUNS: #1681 is fixed and both regime densities are strictly positive (min 8.4e-04), where this cell previously raised at the mass-fabrication gate every run. What fails is the cell's own oracle, which gates PER-REGIME mass drift at 1e-6. A regime's mass is not conserved in a Markov-switching model -- the generator transfers it. For this cell's Q the stationary distribution is [2/3, 1/3] against equal initial masses, so the measured 8.9%/8.6% is approximately RIGHT, not approximately wrong; integrating the FP system over the no-flux domain leaves M(t) = M(0) expm(Qt), and the run tracks it to 2.2e-03. The conserved quantity is the sum over regimes: 1.4e-03 here, 8.0e-04 by 30 Picard iterations, 6.7e-04 at Nt=80. Do NOT turn this PASS by relaxing 1e-6 to fit the measurement -- #1767 named that route as one the matrix exists to catch; #1798 records the three honest replacements. Note for the next regeneration: this is the first FAIL cell, so _note_still_applies drops this annotation as soon as any of these floats move, exactly as that function's docstring predicts. That is the safe direction, but it means the note is not durable here the way an exception-shaped one is.",
+      "intended": "DEFECT \u2014 #1798, and NOT the defect this cell recorded before. The solve now RUNS: #1681 is fixed and both regime densities are strictly positive (min 8.4e-04), where this cell previously raised at the mass-fabrication gate every run. What fails is the cell's own oracle, which gates PER-REGIME mass drift at 1e-6. A regime's mass is not conserved in a Markov-switching model -- the generator transfers it. For this cell's Q the stationary distribution is [2/3, 1/3] against equal initial masses, so the measured 8.9%/8.6% is approximately RIGHT, not approximately wrong; integrating the FP system over the no-flux domain leaves M(t) = M(0) expm(Qt), and the run tracks it to 2.2e-03. The conserved quantity is the sum over regimes: 1.4e-03 here, 8.0e-04 by 30 Picard iterations, 6.7e-04 at Nt=80. Do NOT turn this PASS by relaxing 1e-6 to fit the measurement -- #1767 named that route as one the matrix exists to catch; #1798 records the three honest replacements. Note for the next regeneration: this is the first FAIL cell, so _note_still_applies drops this annotation as soon as any of these floats move, exactly as that function's docstring predicts. That is the safe direction, but it means the note is not durable here the way an exception-shaped one is.",
       "status": "FAIL"
     },
     "sl_linear/mass_conservation": {

--- a/tests/unit/test_utils/test_nonlinear_solvers_kink_jacobian.py
+++ b/tests/unit/test_utils/test_nonlinear_solvers_kink_jacobian.py
@@ -1,0 +1,137 @@
+r"""The finite-difference Jacobian must not straddle a kink (#1745).
+
+An upwind HJB residual selects between two one-sided differences, so it is
+non-differentiable where they tie -- and symmetric initial data puts nodes exactly there.
+Measured on the 2-D smoke problem at the stalled iterate: the grid centre's two
+neighbours agree to 9e-11, and dF[60]/dU[59] is +13.395 approached from one side and
+-7.9998 from the other. A one-sided quotient reports only the branch on its own side; the
+step built from it is one the line search then cuts to ~0.03, and the solve creeps to its
+iteration budget instead of converging.
+
+The system below is that structure in four unknowns, evaluated at the tie. It is built to
+four **structural** properties rather than to a list of mutants, because a mutant list is
+what the author already imagined:
+
+1. **Every row and every column separates the two quotients.** Row 0 and row 2 through a
+   quadratic (forward reads `2a + h`, central reads `2a`), row 1 through the kink itself,
+   row 3 through `u[1]**2` in a column that is otherwise flat. A Jacobian that is central
+   on some rows or columns and one-sided on the rest is therefore visible somewhere. An
+   earlier revision was linear on rows 0 and 2, and "forward on the even rows" passed the
+   whole file while collapsing the real solve from 13 inner solves to 3.
+2. **The entries bracket the real Jacobian's dynamic range.** Measured over the 84
+   Jacobians the `fdm_upwind_2d` capability cell builds: smallest nonzero `|J| = 0.0356`,
+   largest `= 449.78`. Here the range is `1e-4` to `2000`, so any clipping bound or
+   sparsification threshold that could alter the real solve falls inside what these
+   assertions pin. An earlier revision topped out at 20, and clipping to +-25 -- which
+   kills the real cell in one iteration -- passed.
+3. **One entry's value depends on the step size.** The central quotient of a cubic is
+   `3a^2 + h^2` exactly, so `J[3,3]` reports the epsilon in force. Against a piecewise
+   linear system every quotient is exact at every step size and an epsilon test certifies
+   nothing.
+4. **Each row's residual magnitude is kept near its pinned entries.** Cancellation in a
+   quotient scales with `|F_i|`, not with `|J[i,j]|`, so the small `1e-4` entry sits in
+   row 1 (`|F| ~ 1`), not beside the 2000 in row 2 (`|F| ~ 1000`). Worst realized error is
+   0.36 of its tolerance.
+
+**What no fixed-size miniature can catch:** a mutation keyed on the system's size or
+bandwidth. "Forward when n > 8", "forward when n is odd" and "forward outside bandwidth 3"
+all pass here and return the real cell to its pre-fix defect, because n = 4 puts every
+entry in band. Those are a limit of this oracle; the capability cell is what covers them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.utils.numerical.nonlinear_solvers import NewtonSolver
+
+# u[0] and u[2] are equidistant from u[1], so the two candidate differences tie and the
+# selection is a coin flip -- the configuration the 2-D solve reaches on its own.
+TIE = np.array([1.0, 0.0, 1.0, 2.0])
+
+# Analytic Jacobian at TIE, with the kink row carrying the mean of its two branch slopes.
+# [3,3] is 3*u[3]**2 = 12, plus the central quotient's exact h**2 term.
+EXPECTED = np.array(
+    [
+        [20.0, 0.0, 3.0, 0.0],
+        [0.5, -1.0, 0.5, 1e-4],
+        [0.0, 0.0, 2000.0, 0.0],
+        [0.0, 0.0, 0.0, 12.0],
+    ]
+)
+
+
+def _selecting(u: np.ndarray) -> np.ndarray:
+    return np.array(
+        [
+            10.0 * u[0] ** 2 + 3.0 * u[2],
+            max(u[0] - u[1], u[2] - u[1]) + 1e-4 * u[3],
+            1000.0 * u[2] ** 2,
+            u[3] ** 3 + u[1] ** 2,
+        ]
+    )
+
+
+def _jacobian(sparse: bool, epsilon: float = 1e-7) -> np.ndarray:
+    J = NewtonSolver(sparse=sparse, finite_diff_epsilon=epsilon)._finite_difference_jacobian(_selecting, TIE)
+    return np.asarray(J.toarray() if sparse else J)
+
+
+# Both branches ship: hjb_fdm.py builds its solver with sparse=True, and the sparse
+# assembly is a separate code path from the dense one.
+@pytest.mark.parametrize("sparse", [False, True])
+def test_the_jacobian_at_a_tie_reports_both_branches_not_one(sparse):
+    """The kink row's two live columns must carry the mean of the branch slopes, 0.5.
+
+    Perturbing u[0] upwards makes `u[0] - u[1]` the winner (slope 1 in that component);
+    perturbing it downwards hands the max to `u[2] - u[1]`, whose slope in u[0] is 0. A
+    forward quotient sees only the first and returns 1.
+    """
+    J = _jacobian(sparse)
+
+    assert np.isclose(J[1, 0], 0.5, rtol=0, atol=1e-6), f"column 0 straddles the kink: {J[1, 0]} (forward gives 1.0)"
+    assert np.isclose(J[1, 2], 0.5, rtol=0, atol=1e-6), f"column 2 straddles the kink: {J[1, 2]} (forward gives 1.0)"
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+def test_every_entry_matches_the_analytic_jacobian(sparse):
+    """Whole-matrix, not a handful of scalars: an unpinned entry is where a mutant lives.
+
+    `atol` governs the structurally-zero entries, where the two evaluations are
+    bit-identical and the quotient is exactly 0, so a one-sided value of order `h` shows
+    up. `rtol` governs the large ones, whose realized error is set by `|F_i|` and not by
+    the entry.
+    """
+    J = _jacobian(sparse)
+
+    assert J.shape == EXPECTED.shape
+    worst = int(np.argmax(np.abs(J - EXPECTED)))
+    assert np.allclose(J, EXPECTED, rtol=1e-8, atol=1e-8), (
+        f"entry {divmod(worst, 4)} is {J.flat[worst]}, expected {EXPECTED.flat[worst]}\ngot:\n{J}"
+    )
+
+
+def test_the_kink_columns_are_not_an_artefact_of_one_epsilon():
+    """A truncation effect shrinks with epsilon. A kink does not: 0.5 at every step size."""
+    for eps in (1e-4, 1e-6, 1e-8):
+        J = _jacobian(sparse=False, epsilon=eps)
+        assert np.isclose(J[1, 0], 0.5, rtol=0, atol=1e-6), f"eps={eps:g} gave {J[1, 0]}"
+
+
+def test_the_step_size_used_is_the_one_it_was_given():
+    """`J[3,3]` is 3*u[3]**2 + eps**2 exactly, so it reports the epsilon in force.
+
+    The range stops at 1e-4 for DISCRIMINATION, not for noise: the signal being asserted
+    is eps**2, so at eps = 1e-5 it is 1e-10, below this atol, and a solver ignoring
+    `finite_diff_epsilon` would pass. Cancellation is the looser bound -- 8.9e-16/eps,
+    still 5.6x under atol at 1e-5 -- and does not bind until 1e-6.
+    """
+    for eps in (1e-2, 1e-3, 1e-4):
+        J = _jacobian(sparse=False, epsilon=eps)
+        expected = 12.0 + eps**2
+        assert np.isclose(J[3, 3], expected, rtol=0, atol=1e-9), (
+            f"eps={eps:g}: J[3,3] = {J[3, 3]!r}, expected {expected!r} -- "
+            "the solver is not using the epsilon it was handed"
+        )


### PR DESCRIPTION
Refs #1745. Fixes the inner-solver half of it; the capability the issue is named for is **not**
delivered here and #1745 stays open.

## The defect

`NewtonSolver` built its Jacobian from forward differences. The residuals it is handed are only
piecewise smooth: an upwind HJB residual selects between two one-sided differences and is
non-differentiable where they tie — and symmetric initial data puts nodes exactly there, not near
there.

Measured on the 2-D smoke problem at the stalled iterate:

- the grid centre's two neighbours agree to 9e-11 (`U[5,4]` and `U[5,6]`, both `-1.32946871`)
- `dF[60]/dU[59]` is `+13.395` approached from one side, `-7.9998` from the other — both read at
  eps `1e-5`; at the solver's own default of `1e-7` the second side reads `-7.98`
- **44 entries** of `J+` and `J-` disagree by more than `1.0`, and it is the *same 44 entries* at
  every epsilon from `1e-5` to `1e-9` (set equality checked, not just the count). Counted instead
  against a relative threshold of `1e-6·max|Jc|` the count runs `385 / 165 / 44 / 44 / 44` over that
  range — a truncation halo shrinking around a fixed core. Truncation moves with epsilon; the core
  does not, and that is what says kink rather than error. (An earlier revision also quoted the
  relative Frobenius norm at the two endpoints. Two independent measurements of it disagreed
  because they were taken at different stalled iterates, so the number is gone and the set identity,
  which all three measurements reproduce, carries the claim.)

The forward quotient reports only the branch on its own side. The step built from it is one the
Armijo search then cuts to ~0.03, so the solve creeps to its budget:

| | iterations to tolerance | where it ends in 30 |
|---|---|---|
| forward (before) | 67 | `1.17e-05`, not converged |
| central (after) | 5 | `3.14e-09`, converged |

Across the 2-D FDM coupled solve, **twelve of the thirteen** inner solves now converge in 4–7
iterations with final residuals from `4.9e-12` to `7.4e-07`. Before, the fifth stalled and the solve
raised there.

## This is the live path

JAX is installed here, so `use_jax_autodiff="auto"` tries autodiff first — and it raises
`TracerArrayConversionError` on this residual once per inner solve and falls back to finite
differences. Forcing `use_jax_autodiff=False` reproduces the residual history digit for digit, so
the FD path is what runs and not a dead branch.

## Cost

`2n` residual evaluations per Jacobian instead of `n` — exact, verified by counting (242 against
121 at `n=121`). Net on the case that motivated this: the cheaper quotient bought 13.4x the
iterations, so 6.7x the evaluations. Aggregate, measured:

The cell it was aimed at is where the cost lands and it reproduces across two independent
measurements: `fdm_upwind_2d` goes from 1.69–1.73 s to 3.07–3.18 s, **+77% to +86%**.

**The suite-level figure is not resolvable on this machine and is therefore not claimed.** An
earlier revision of this PR asserted +10.6% on `./scripts/local_ci.sh` from one run per arm; a clean
back-to-back re-measurement got +0.9%, and the spread *within* the PR arm alone across runs was 23%.
One sample per arm is not a trend, and the effect is under the noise.

A solver already spending O(n) residual evaluations per Jacobian is the expensive path by
construction; anyone at a size where 2n hurts should be supplying an analytic Jacobian, which the
`jacobian=` parameter already accepts.

## Oracle: a mutation-verified pin

`tests/unit/test_utils/test_nonlinear_solvers_kink_jacobian.py` puts the same structure in four
unknowns, evaluated at the tie. It is built to four **structural** properties rather than to a list
of mutants — a mutant list is what the author already imagined, and review has now twice found the
one he did not:

1. **Every row and every column separates the two quotients**, so a Jacobian that is central on some
   rows or columns and one-sided on the rest shows up somewhere.
2. **The entries bracket the real Jacobian's dynamic range** — measured over the 84 Jacobians the
   `fdm_upwind_2d` cell builds, smallest nonzero `|J| = 0.0356`, largest `= 449.78`; the miniature
   spans `1e-4` to `2000`. Any clipping bound or sparsification threshold that could alter the real
   solve therefore falls inside what the assertions pin.
3. **One entry's value depends on the step size** (`J[3,3] = 3a² + h²`), so a solver ignoring
   `finite_diff_epsilon` is visible. Against a piecewise-linear system every quotient is exact at
   every step size and an epsilon test certifies nothing.
4. **Each row's residual magnitude is kept near its pinned entries**, since cancellation scales with
   `|F_i|` and not with `|J[i,j]|`. Worst realized error is **0.049** of its tolerance.

**Twenty-five quotient-only mutations, 22 killed** (signature preserved throughout — a signature
mutation dies of `TypeError` and pins nothing):

```
forward (pre-PR)  6/6   backward          6/6   wrong denominator  6/6   sign flip        6/6
zero matrix       6/6   transposed        5/6   half of forward    3/6   symmetrised fwd  3/6
one-sided at kink 6/6   fwd on odd cols   3/6   clip +-10          3/6   hard-coded eps   1/6
additive 1e-7     3/6   col scaling       3/6   sparsify 1e-3      2/6   sparsify 1e-2    2/6
fwd on even ROWS  2/6   fwd on rows i%3   2/6   clip +-25          2/6   clip +-100       2/6
clip +-1000       2/6
```

**The three survivors, stated rather than hidden:**

- `sparsify |J| < 1e-5` survives and **cannot** affect the real solve: the real Jacobian's smallest
  nonzero entry is 0.0356, four orders above that threshold. Property 2 predicts this — the pin
  covers the range that matters, not every conceivable threshold.
- `forward when n > 8` and `forward when n is odd` survive **by construction**. No fixed-size
  miniature closes a size-keyed mutation, and both return the real cell to its pre-fix defect
  (residual `1.17e-05`). The capability cell is what covers that class; this file cannot.

Both `sparse` branches are covered, since `hjb_fdm.py` builds its solver with `sparse=True`.

## The baseline is regenerated in the same change

No cell changes status, but all three 2-D artifacts move (`1.17e-05` → `2.95e+01`, `1.15e+02`, and
a `ValueError` from the FP solver). `_note_still_applies` drops an `intended` note whose artifact no
longer matches, so leaving the baseline alone would have left three notes citing evidence the code
no longer produces — one of them advising the next reader to *"start with the convergence rate and
the iteration budget rather than the Jacobian"*, which is exactly what this PR refutes. That is the
failure `_note_still_applies` was written for, and its docstring names this issue's own note as the
motivating case. The three notes are rewritten against the new artifacts and point at #1865.

## What this does NOT do

**No capability cell changes status.** `fdm_upwind_2d`, `fdm_centered_2d` and `fvm_muscl_2d` still
fail. The thirteenth inner solve is where the coupled Picard iteration has already diverged
(`max|U|` 1.86 → 37.35, peak density 34.9 → 101 over two sweeps) and has no root within reach —
`scipy.optimize.least_squares(method="trf")` fails on the same residual too. For `fdm_upwind_2d` and
`fvm_muscl_2d` that failure is still reported by the inner Newton; `fdm_centered_2d` now gets far
enough to fail in the FP step instead, on `divergence_centered`'s negative density, which is what
its 1-D sibling already reports. All of that is #1865.

## Recorded, not fixed here

- `NewtonMFGSolver` packs the density into the Newton state, so the `-eps` side of the symmetric
  quotient now evaluates at a slightly negative density where `m < 1e-7`. Measured: 33 of 44 density
  entries are below the FD epsilon on one fixture, the Jacobian stays finite, no evaluation raises,
  and negative densities already reach that residual pre-PR (min `-1.109` forward against `-2.662`
  central) with nothing in the stack refusing them. Risk with no failing instance; recording rather
  than asserting.
- `finite_diff_epsilon` defaults to `1e-7`, near-optimal for a forward quotient and about **60x**
  below optimal for a central one (`macheps^(1/3) = 6.055e-06`, so 60.6x — an earlier revision said
  20x). Not revisited here: changing two things at once would confound the measurement, and
  `3.14e-09` in 5 iterations says it does not bite. The new epsilon test does pin that the solver
  uses the epsilon it is handed, so a later change to this default is a one-line change with a
  guard behind it.

## Review

**Round 1** — three independent adversarial reviewers, worktree-isolated, all MERGE-BLOCKED, none on
the code. They changed: the pin's miniature (a symmetrised-forward mutant passed the whole file
while reproducing the original stall), the capability baseline, `sparse` coverage, decorative `atol`
(`np.isclose`'s default `rtol=1e-5` made a written `atol=1e-9` four orders looser than it reads),
and four false or imprecise numbers in prose — including a commit message attesting `5927 passed`,
which is **main's** count from a gate run that predated this change's own tests.

**Round 2** — re-review of the fixes, MERGE-BLOCKED again, and right twice more. It found a *tenth*
surviving mutant and proved it a real defect: with a 3x3 miniature, column 1 was the only odd column
and forward equalled central there, so "central on some columns, forward on others" was invisible to
every assertion while collapsing the real solve from 13 inner solves to 3. It also showed the
epsilon test was vacuous by construction — a piecewise-linear system's quotient is exact at every
step size, so the test could not detect a solver that ignores `finite_diff_epsilon` entirely. Both
are closed above, and the count of quotient-only mutants went 9 → 15 with no survivors.

It also refused to certify a number I had asserted: the relative Frobenius endpoint `8.11e-02` could
not be reproduced under ten normalizations, and the +10.6% gate figure did not survive a clean
back-to-back re-run. Both are removed rather than restated.

**Round 3** — MERGE-BLOCKED again, on three counts, and the third is the one worth reading. It ran
an **ablation**: drop each term of the miniature, rebuild `EXPECTED` analytically for the reduced
system, and re-run the mutant that term was credited with killing. Three of the five "this term
exists because that mutant survived without it" claims were **false** — the mutants were being
killed by other terms. The justifications have been replaced with the structural properties above,
which are checkable rather than anecdotal.

Its other two blockers: the round-2 fix closed the *column* axis only, leaving rows 0 and 2 exactly
linear, where forward and central agree bit-for-bit — only 4 of 16 entries discriminated, and
"forward on the even rows" passed while collapsing the real solve 13 → 3. And the clip window
`[20, 450)` still survived, because the miniature's largest entry was 20 while the real Jacobian
reaches 449.78; `clip[-25, 25]` kills the real cell in one iteration and passed the file. Both are
closed by construction now, and property 2 states the bound it is built against.

It also found two must-fix numbers in the capability note. `max|U| 1.86 → 37.35` did not reproduce
through the iterator's `iteration_callback`, which reports `0.93 → 19.14`. Both are correct: the
callback reports the **damped** iterate and the note was quoting the undamped HJB output handed to
the FP solve, exactly half at damping 0.5 — verified, `(37.3533 + 0.930)/2 = 19.14`. The note now
names its instrument. And "sigma 0.5 is a bound" was budget-dependent: at `max_iterations=5`, sigma
0.50 fails too (residual `9.88e+00`) and the bound is 0.55. Both stated.

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, 5933 passed, 22 skipped, 21 xfailed, measured on this tree after both rounds of review fixes. Pushed with
`--no-verify` per #1804: the pre-push gate outlives the SSH connection git has already opened, so
every gated push fails transport and the documented path is to run the gate by hand and attest it
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
