### PR TITLE
feat(meshless): centroidal VC operator sandbox and its moment, coercivity and Poisson gates

### DIFF
--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -583,6 +583,14 @@ class CentroidalVC2SCNIOperatorSandbox:
         return self._centroids
 
     @property
+    def centroid_evaluation_count(self) -> int:
+        return len(self._centroids)
+
+    @property
+    def edge_evaluation_count(self) -> int:
+        return len(self._edge_points)
+
+    @property
     def weights(self) -> NDArray:
         return self._weights
 

--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -1,4 +1,4 @@
-"""Operator sandbox for centroidal VC2-SCNI and an exactly paired MFG linearization.
+"""Operator sandbox for centroidal VCI-SCNI and an exactly paired MFG linearization.
 
 This module is deliberately outside ``WeakFormDiscretization``. It is an admission
 gate for a candidate Petrov-Galerkin method, not a production solver backend.
@@ -6,8 +6,10 @@ gate for a candidate Petrov-Galerkin method, not a production solver backend.
 The construction uses clipped Voronoi centroids ``c_a`` as sampling points,
 ``M = E.T @ W @ E`` with ``E[a, i] = phi_i(c_a)``, the SCNI cell-average trial
 gradient, and a local variational-consistency correction of the test gradient.
-The correction enforces the degree-two weak patch, including boundary fluxes,
-through five shifted/scaled constraints per test function.
+The correction targets shifted/scaled weak moments through degree two, three,
+or four, including boundary fluxes. Degree-two MLS makes only the quadratic
+discrete patch exact; higher target moments and the actual discrete patch are
+reported separately.
 
 All nonlinear MFG blocks are derived from one residual. The forward spatial
 operator is therefore the transpose of the complete analytic Jacobian; no
@@ -17,6 +19,7 @@ independent advection assembly exists here.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from numbers import Integral
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -33,8 +36,13 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class VC2AdmissionDiagnostics:
-    """Numerical invariants that decide whether a cloud is admitted by the sandbox."""
+class VCIAdmissionDiagnostics:
+    """Numerical invariants that decide whether a cloud is admitted by the sandbox.
+
+    ``corrected_patch_defect`` uses exact target-polynomial gradients.
+    ``discrete_patch_defect`` instead applies the assembled stiffness to nodal
+    polynomial values and therefore includes the degree-two trial-gradient error.
+    """
 
     local_rank_min: int
     local_condition_max: float
@@ -44,8 +52,10 @@ class VC2AdmissionDiagnostics:
     value_constant_defect: float
     trial_constant_defect: float
     quadratic_gradient_defect: float
+    vci_trial_gradient_defect: float
     plain_patch_defect: float
     corrected_patch_defect: float
+    discrete_patch_defect: float
     right_constant_defect: float
     left_constant_defect: float
     gauge_coercivity_min: float
@@ -167,7 +177,7 @@ def boundary_complete_cvt_rectangle(
 
 def _edge_quadrature(cells: list[CellGeometry], n_gauss: int) -> _EdgeQuadrature:
     if n_gauss < 2:
-        raise ValueError("VC2 edge quadrature requires at least two Gauss points per edge.")
+        raise ValueError("VCI edge quadrature requires at least two Gauss points per edge.")
     xi, wi = np.polynomial.legendre.leggauss(n_gauss)
     t = 0.5 * (xi + 1.0)
     points: list[NDArray] = []
@@ -188,7 +198,7 @@ def _edge_quadrature(cells: list[CellGeometry], n_gauss: int) -> _EdgeQuadrature
             cell_indices.append(np.full(n_gauss, a, dtype=np.int64))
             normal_weights.append(edge_weights[:, None] * normal[None, :])
     if not points:
-        raise ValueError("VC2 edge quadrature found no nondegenerate cell edges.")
+        raise ValueError("VCI edge quadrature found no nondegenerate cell edges.")
     return _EdgeQuadrature(
         points=np.vstack(points),
         cell_indices=np.concatenate(cell_indices),
@@ -196,21 +206,68 @@ def _edge_quadrature(cells: list[CellGeometry], n_gauss: int) -> _EdgeQuadrature
     )
 
 
-def _p2_data(points: NDArray, center: NDArray, scales: NDArray) -> tuple[NDArray, NDArray, NDArray]:
-    """Values, gradients, and Laplacians of a shifted/scaled basis of ``P2``."""
-    sx = (points[:, 0] - center[0]) / scales[0]
-    sy = (points[:, 1] - center[1]) / scales[1]
-    values = np.column_stack([np.ones(len(points)), sx, sy, sx**2, sx * sy, sy**2])
-    gradients: NDArray = np.zeros((len(points), 6, 2), dtype=np.float64)
-    gradients[:, 1, 0] = 1.0 / scales[0]
-    gradients[:, 2, 1] = 1.0 / scales[1]
-    gradients[:, 3, 0] = 2.0 * sx / scales[0]
-    gradients[:, 4, 0] = sy / scales[0]
-    gradients[:, 4, 1] = sx / scales[1]
-    gradients[:, 5, 1] = 2.0 * sy / scales[1]
-    laplacians: NDArray = np.zeros((len(points), 6), dtype=np.float64)
-    laplacians[:, 3] = 2.0 / scales[0] ** 2
-    laplacians[:, 5] = 2.0 / scales[1] ** 2
+def _polynomial_exponents(degree: int) -> NDArray:
+    return np.asarray(
+        [
+            (x_degree, total_degree - x_degree)
+            for total_degree in range(degree + 1)
+            for x_degree in range(total_degree, -1, -1)
+        ],
+        dtype=np.int64,
+    )
+
+
+def _monomial_values(scaled_points: NDArray, exponents: NDArray) -> NDArray:
+    return np.prod(scaled_points[:, None, :] ** exponents[None, :, :], axis=2)
+
+
+def _polynomial_data(
+    points: NDArray,
+    center: NDArray,
+    scales: NDArray,
+    degree: int,
+) -> tuple[NDArray, NDArray, NDArray]:
+    """Values, gradients, and Laplacians of a shifted/scaled total-degree basis."""
+    scaled_points = (points - center[None, :]) / scales[None, :]
+    if degree == 2:
+        sx = scaled_points[:, 0]
+        sy = scaled_points[:, 1]
+        values = np.column_stack([np.ones(len(points)), sx, sy, sx**2, sx * sy, sy**2])
+        quadratic_gradients: NDArray = np.zeros((len(points), 6, 2), dtype=np.float64)
+        quadratic_gradients[:, 1, 0] = 1.0 / scales[0]
+        quadratic_gradients[:, 2, 1] = 1.0 / scales[1]
+        quadratic_gradients[:, 3, 0] = 2.0 * sx / scales[0]
+        quadratic_gradients[:, 4, 0] = sy / scales[0]
+        quadratic_gradients[:, 4, 1] = sx / scales[1]
+        quadratic_gradients[:, 5, 1] = 2.0 * sy / scales[1]
+        quadratic_laplacians: NDArray = np.zeros((len(points), 6), dtype=np.float64)
+        quadratic_laplacians[:, 3] = 2.0 / scales[0] ** 2
+        quadratic_laplacians[:, 5] = 2.0 / scales[1] ** 2
+        return values, quadratic_gradients, quadratic_laplacians
+
+    exponents = _polynomial_exponents(degree)
+    values = _monomial_values(scaled_points, exponents)
+    gradients: NDArray = np.zeros((len(points), len(exponents), 2), dtype=np.float64)
+    laplacians: NDArray = np.zeros((len(points), len(exponents)), dtype=np.float64)
+    for basis_index, exponent in enumerate(exponents):
+        for direction in range(2):
+            if exponent[direction] > 0:
+                gradient_exponent = exponent.copy()
+                gradient_exponent[direction] -= 1
+                gradients[:, basis_index, direction] = (
+                    exponent[direction]
+                    / scales[direction]
+                    * _monomial_values(scaled_points, gradient_exponent[None, :])[:, 0]
+                )
+            if exponent[direction] > 1:
+                laplacian_exponent = exponent.copy()
+                laplacian_exponent[direction] -= 2
+                laplacians[:, basis_index] += (
+                    exponent[direction]
+                    * (exponent[direction] - 1)
+                    / scales[direction] ** 2
+                    * _monomial_values(scaled_points, laplacian_exponent[None, :])[:, 0]
+                )
     return values, gradients, laplacians
 
 
@@ -223,13 +280,14 @@ def _as_vector(values: NDArray, size: int, name: str) -> NDArray:
     return array
 
 
-class CentroidalVC2SCNIOperatorSandbox:
-    """Dense research sandbox for the centroidal VC2-SCNI operator gate.
+class CentroidalVCISCNIOperatorSandbox:
+    """Dense research sandbox for the centroidal VCI-SCNI operator gate.
 
-    The current implementation is two-dimensional and degree-two. It supports
-    rectangular clipping and the existing polygonal SDF-chord clipping. Dense
-    diagnostics are intentional: promotion to a production sparse backend is
-    blocked until the operator gate passes across cloud families and refinement.
+    The MLS trial basis is two-dimensional and degree-two. The shifted/scaled
+    variational correction can target degrees two through four. The sandbox
+    supports rectangular clipping and the existing polygonal SDF-chord clipping.
+    Dense diagnostics are intentional: promotion to a production sparse backend
+    is blocked until the operator gate passes across cloud families and refinement.
     """
 
     def __init__(
@@ -239,6 +297,7 @@ class CentroidalVC2SCNIOperatorSandbox:
         bounds: list[tuple[float, float]],
         *,
         degree: int = 2,
+        vci_degree: int = 2,
         sdf: Callable[[NDArray], NDArray] | None = None,
         backend: str = "numpy",
         n_edge_gauss: int = 4,
@@ -252,36 +311,38 @@ class CentroidalVC2SCNIOperatorSandbox:
     ) -> None:
         self._nodes = np.asarray(nodes, dtype=np.float64)
         if self._nodes.ndim != 2 or self._nodes.shape[1] != 2:
-            raise ValueError(f"Centroidal VC2-SCNI requires nodes with shape (N, 2), got {self._nodes.shape}.")
+            raise ValueError(f"Centroidal VCI-SCNI requires nodes with shape (N, 2), got {self._nodes.shape}.")
         if len(self._nodes) < 6:
-            raise ValueError("Centroidal VC2-SCNI requires at least six nodes for a degree-two MLS basis.")
+            raise ValueError("Centroidal VCI-SCNI requires at least six nodes for a degree-two MLS basis.")
         if not np.all(np.isfinite(self._nodes)):
-            raise ValueError("Centroidal VC2-SCNI nodes must all be finite.")
+            raise ValueError("Centroidal VCI-SCNI nodes must all be finite.")
         if len(np.unique(self._nodes, axis=0)) != len(self._nodes):
-            raise ValueError("Centroidal VC2-SCNI does not admit duplicate nodes.")
+            raise ValueError("Centroidal VCI-SCNI does not admit duplicate nodes.")
         if degree != 2:
-            raise ValueError(f"Centroidal VC2-SCNI implements degree=2 only, got degree={degree}.")
+            raise ValueError(f"Centroidal VCI-SCNI implements MLS degree=2 only, got degree={degree}.")
+        if not isinstance(vci_degree, Integral) or vci_degree not in (2, 3, 4):
+            raise ValueError(f"Centroidal VCI-SCNI requires vci_degree in {{2, 3, 4}}, got {vci_degree}.")
         if backend != "numpy":
-            raise ValueError("Centroidal VC2-SCNI admission diagnostics require backend='numpy'.")
+            raise ValueError("Centroidal VCI-SCNI admission diagnostics require backend='numpy'.")
         if not np.isfinite(rho) or rho <= 0.0:
-            raise ValueError(f"Centroidal VC2-SCNI requires rho > 0, got {rho}.")
+            raise ValueError(f"Centroidal VCI-SCNI requires rho > 0, got {rho}.")
         if len(bounds) != 2 or any(len(bound) != 2 or bound[1] <= bound[0] for bound in bounds):
-            raise ValueError(f"Centroidal VC2-SCNI requires two increasing bounds, got {bounds}.")
+            raise ValueError(f"Centroidal VCI-SCNI requires two increasing bounds, got {bounds}.")
         bounds_array = np.asarray(bounds, dtype=np.float64)
         if not np.all(np.isfinite(bounds_array)):
-            raise ValueError(f"Centroidal VC2-SCNI bounds must be finite, got {bounds}.")
+            raise ValueError(f"Centroidal VCI-SCNI bounds must be finite, got {bounds}.")
         bound_tolerance = 1e-12 * max(float(np.max(bounds_array[:, 1] - bounds_array[:, 0])), 1.0)
         outside_bounds = np.any(
             (self._nodes < bounds_array[:, 0] - bound_tolerance) | (self._nodes > bounds_array[:, 1] + bound_tolerance)
         )
         if outside_bounds:
-            raise ValueError("Centroidal VC2-SCNI nodes must lie inside bounds.")
+            raise ValueError("Centroidal VCI-SCNI nodes must lie inside bounds.")
         if sdf is not None:
             signed_distances = np.asarray(sdf(self._nodes), dtype=np.float64).ravel()
             if signed_distances.shape != (len(self._nodes),) or not np.all(np.isfinite(signed_distances)):
-                raise ValueError("Centroidal VC2-SCNI sdf(nodes) must return one finite value per node.")
+                raise ValueError("Centroidal VCI-SCNI sdf(nodes) must return one finite value per node.")
             if np.any(signed_distances > bound_tolerance):
-                raise ValueError("Centroidal VC2-SCNI nodes must lie inside the sdf domain.")
+                raise ValueError("Centroidal VCI-SCNI nodes must lie inside the sdf domain.")
         if rank_tolerance <= 0.0 or rank_tolerance >= 1.0:
             raise ValueError(f"rank_tolerance must lie in (0, 1), got {rank_tolerance}.")
 
@@ -289,6 +350,9 @@ class CentroidalVC2SCNIOperatorSandbox:
         self._rho = float(rho)
         self._bounds = [(float(lower), float(upper)) for lower, upper in bounds]
         self._exponents = monomial_exponents(2, 2)
+        self._vci_degree = int(vci_degree)
+        self._vci_constraint_count = len(_polynomial_exponents(self._vci_degree)) - 1
+        self._correction_exponents = _polynomial_exponents(self._vci_degree - 1)
         self._rank_tolerance = float(rank_tolerance)
         self._max_local_condition = float(max_local_condition)
         self._max_mass_condition = float(max_mass_condition)
@@ -348,38 +412,46 @@ class CentroidalVC2SCNIOperatorSandbox:
         local_scales = nearest_distances[:, 1]
         if np.any(local_scales <= 1e-14):
             bad = int(np.argmin(local_scales))
-            raise ValueError(f"VC2 local scale vanishes at node {bad}; duplicate or coincident nodes are not admitted.")
+            raise ValueError(f"VCI local scale vanishes at node {bad}; duplicate or coincident nodes are not admitted.")
 
         ranks = []
         conditions = []
         correction_ratios = []
+        correction_basis_count = len(self._correction_exponents)
         for i in range(self._n_dof):
             distances = np.linalg.norm(self._centroids - self._nodes[i], axis=1)
             support = distances <= self._vci_support_radius * (1.0 + 10.0 * np.finfo(float).eps)
             support_count = int(np.count_nonzero(support))
-            if support_count < 3:
+            if support_count < correction_basis_count:
                 raise ValueError(
-                    f"VC2 local constraint rank failure at node {i}: fewer than three support cells "
-                    f"(support_cells={support_count}, support_radius={self._vci_support_radius:.6g})."
+                    f"VCI local constraint rank failure at node {i}: support_cells={support_count} "
+                    f"< correction_basis_size={correction_basis_count} "
+                    f"(support_radius={self._vci_support_radius:.6g})."
                 )
             h_i = float(local_scales[i])
             local_scale = np.array([h_i, h_i], dtype=np.float64)
-            _, centroid_gradients, centroid_laplacians = _p2_data(
+            _, centroid_gradients, centroid_laplacians = _polynomial_data(
                 self._centroids,
                 self._nodes[i],
                 local_scale,
+                self._vci_degree,
             )
-            _, edge_gradients, _ = _p2_data(self._edge_points, self._nodes[i], local_scale)
+            _, edge_gradients, _ = _polynomial_data(
+                self._edge_points,
+                self._nodes[i],
+                local_scale,
+                self._vci_degree,
+            )
 
             shifted = (self._centroids[support] - self._nodes[i]) / h_i
-            correction_basis = np.column_stack([np.ones(support_count), shifted])
+            correction_basis = _monomial_values(shifted, self._correction_exponents)
             weighted_gram = correction_basis.T @ (self._weights[support, None] * correction_basis)
             correction_metric = linalg.block_diag(weighted_gram, weighted_gram)
             try:
                 metric_cholesky = np.linalg.cholesky(correction_metric)
             except np.linalg.LinAlgError as error:
                 raise np.linalg.LinAlgError(
-                    f"VC2 local correction metric is singular at node {i} with {support_count} support cells."
+                    f"VCI local correction metric is singular at node {i} with {support_count} support cells."
                 ) from error
 
             constraint = np.einsum(
@@ -387,7 +459,7 @@ class CentroidalVC2SCNIOperatorSandbox:
                 self._weights[support],
                 correction_basis,
                 centroid_gradients[support, 1:, :],
-            ).reshape(5, 6)
+            ).reshape(self._vci_constraint_count, 2 * correction_basis_count)
             whitened_constraint = linalg.solve_triangular(
                 metric_cholesky,
                 constraint.T,
@@ -398,16 +470,17 @@ class CentroidalVC2SCNIOperatorSandbox:
             relative_cutoff = self._rank_tolerance * singular_values[0] if singular_values.size else np.inf
             rank = int(np.count_nonzero(singular_values > relative_cutoff))
             ranks.append(rank)
-            if rank < 5:
+            if rank < self._vci_constraint_count:
                 raise ValueError(
-                    f"VC2 local constraint rank failure at node {i}: rank={rank}, required=5, "
+                    f"VCI local constraint rank failure at node {i}: rank={rank}, "
+                    f"required={self._vci_constraint_count}, "
                     f"support_cells={support_count}, support_radius={self._vci_support_radius:.6g}."
                 )
             condition = float(singular_values[0] / singular_values[-1])
             conditions.append(condition)
             if not np.isfinite(condition) or condition > self._max_local_condition:
                 raise np.linalg.LinAlgError(
-                    f"VC2 local constraint is ill-conditioned at node {i}: cond={condition:.3e} "
+                    f"VCI local constraint is ill-conditioned at node {i}: cond={condition:.3e} "
                     f"> {self._max_local_condition:.3e}."
                 )
 
@@ -441,31 +514,31 @@ class CentroidalVC2SCNIOperatorSandbox:
                 lower=False,
                 check_finite=False,
             )
-            correction_x = correction_basis @ coefficients[:3]
-            correction_y = correction_basis @ coefficients[3:]
+            correction_x = correction_basis @ coefficients[:correction_basis_count]
+            correction_y = correction_basis @ coefficients[correction_basis_count:]
             test_gradients[0][support, i] += correction_x
             test_gradients[1][support, i] += correction_y
 
             correction_norm = np.sqrt(np.sum(self._weights[support] * (correction_x**2 + correction_y**2)))
             base_norm = np.sqrt(np.sum(self._weights * np.sum(base_gradient**2, axis=1)))
             if base_norm <= 1e-14:
-                raise ValueError(f"VC2 base test-gradient norm vanishes at node {i}.")
+                raise ValueError(f"VCI base test-gradient norm vanishes at node {i}.")
             correction_ratios.append(float(correction_norm / base_norm))
         return test_gradients, ranks, conditions, correction_ratios
 
-    def _global_patch_data(self) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+    def _global_patch_data(self, degree: int) -> tuple[NDArray, NDArray, NDArray, NDArray]:
         center = np.array(
             [0.5 * (lower + upper) for lower, upper in self._bounds],
             dtype=np.float64,
         )
         scales = np.array([upper - lower for lower, upper in self._bounds], dtype=np.float64)
-        node_values, _, _ = _p2_data(self._nodes, center, scales)
-        _, centroid_gradients, centroid_laplacians = _p2_data(self._centroids, center, scales)
-        _, edge_gradients, _ = _p2_data(self._edge_points, center, scales)
+        node_values, _, _ = _polynomial_data(self._nodes, center, scales, degree)
+        _, centroid_gradients, centroid_laplacians = _polynomial_data(self._centroids, center, scales, degree)
+        _, edge_gradients, _ = _polynomial_data(self._edge_points, center, scales, degree)
         return node_values, centroid_gradients, centroid_laplacians, edge_gradients
 
-    def _weak_patch_defect(self, test_gradients: list[NDArray]) -> float:
-        _, centroid_gradients, centroid_laplacians, edge_gradients = self._global_patch_data()
+    def _weak_patch_defect(self, test_gradients: list[NDArray], degree: int) -> float:
+        _, centroid_gradients, centroid_laplacians, edge_gradients = self._global_patch_data(degree)
         volume_gradient = sum(
             gradient.T @ (self._weights[:, None] * centroid_gradients[:, :, direction])
             for direction, gradient in enumerate(test_gradients)
@@ -475,16 +548,28 @@ class CentroidalVC2SCNIOperatorSandbox:
         boundary_flux = self._edge_phi.T @ normal_derivatives
         return float(np.max(np.abs(volume_gradient + volume_laplacian - boundary_flux)))
 
+    def _discrete_patch_defect(self) -> float:
+        node_values, _, centroid_laplacians, edge_gradients = self._global_patch_data(self._vci_degree)
+        volume_laplacian = self._E.T @ (self._weights[:, None] * centroid_laplacians)
+        normal_derivatives = np.einsum("qkd,qd->qk", edge_gradients, self._edge_normal_weights)
+        boundary_flux = self._edge_phi.T @ normal_derivatives
+        return float(np.max(np.abs(self._K @ node_values + volume_laplacian - boundary_flux)))
+
     def _compute_diagnostics(
         self,
         ranks: list[int],
         conditions: list[float],
         correction_ratios: list[float],
-    ) -> VC2AdmissionDiagnostics:
+    ) -> VCIAdmissionDiagnostics:
         one = np.ones(self._n_dof)
-        node_values, centroid_gradients, _, _ = self._global_patch_data()
-        gradient_defect = max(
-            float(np.max(np.abs(gradient @ node_values - centroid_gradients[:, :, direction])))
+        quadratic_values, quadratic_gradients, _, _ = self._global_patch_data(2)
+        quadratic_gradient_defect = max(
+            float(np.max(np.abs(gradient @ quadratic_values - quadratic_gradients[:, :, direction])))
+            for direction, gradient in enumerate(self._G)
+        )
+        vci_values, vci_gradients, _, _ = self._global_patch_data(self._vci_degree)
+        vci_gradient_defect = max(
+            float(np.max(np.abs(gradient @ vci_values - vci_gradients[:, :, direction])))
             for direction, gradient in enumerate(self._G)
         )
         symmetric_stiffness = 0.5 * (self._K + self._K.T)
@@ -513,7 +598,7 @@ class CentroidalVC2SCNIOperatorSandbox:
         stiffness_singular_values = np.linalg.svd(self._K, compute_uv=False)
         nullity_threshold = 1e-10 * float(stiffness_singular_values[0])
         stiffness_nullity = int(np.count_nonzero(stiffness_singular_values <= nullity_threshold))
-        return VC2AdmissionDiagnostics(
+        return VCIAdmissionDiagnostics(
             local_rank_min=min(ranks),
             local_condition_max=max(conditions),
             correction_ratio_median=float(np.median(correction_ratios)),
@@ -521,9 +606,11 @@ class CentroidalVC2SCNIOperatorSandbox:
             mass_condition=float(np.linalg.cond(self._M)),
             value_constant_defect=float(np.max(np.abs(self._E @ one - 1.0))),
             trial_constant_defect=max(float(np.max(np.abs(gradient @ one))) for gradient in self._G),
-            quadratic_gradient_defect=gradient_defect,
-            plain_patch_defect=self._weak_patch_defect(self._G),
-            corrected_patch_defect=self._weak_patch_defect(self._Gbar),
+            quadratic_gradient_defect=quadratic_gradient_defect,
+            vci_trial_gradient_defect=vci_gradient_defect,
+            plain_patch_defect=self._weak_patch_defect(self._G, self._vci_degree),
+            corrected_patch_defect=self._weak_patch_defect(self._Gbar, self._vci_degree),
+            discrete_patch_defect=self._discrete_patch_defect(),
             right_constant_defect=float(np.max(np.abs(self._K @ one))),
             left_constant_defect=float(np.max(np.abs(one @ self._K))),
             gauge_coercivity_min=gauge_coercivity,
@@ -537,33 +624,33 @@ class CentroidalVC2SCNIOperatorSandbox:
             "value partition of unity": diagnostics.value_constant_defect,
             "trial-gradient constants": diagnostics.trial_constant_defect,
             "quadratic centroid gradient": diagnostics.quadratic_gradient_defect,
-            "corrected weak patch": diagnostics.corrected_patch_defect,
+            f"degree-{self._vci_degree} corrected target weak patch": diagnostics.corrected_patch_defect,
             "right constant nullity": diagnostics.right_constant_defect,
         }
         failed_exactness = {name: value for name, value in exactness_defects.items() if value > self._patch_tolerance}
         if failed_exactness:
             details = ", ".join(f"{name}={value:.3e}" for name, value in failed_exactness.items())
             raise ValueError(
-                f"Centroidal VC2-SCNI exactness gate failed ({details}); tolerance={self._patch_tolerance:.3e}."
+                f"Centroidal VCI-SCNI exactness gate failed ({details}); tolerance={self._patch_tolerance:.3e}."
             )
         if not np.isfinite(diagnostics.mass_condition) or diagnostics.mass_condition > self._max_mass_condition:
             raise np.linalg.LinAlgError(
-                f"Centroidal VC2-SCNI mass gate failed: cond(M)={diagnostics.mass_condition:.3e} "
+                f"Centroidal VCI-SCNI mass gate failed: cond(M)={diagnostics.mass_condition:.3e} "
                 f"> {self._max_mass_condition:.3e}."
             )
         if diagnostics.correction_ratio_max > self._max_correction_ratio:
             raise ValueError(
-                f"Centroidal VC2-SCNI correction gate failed: max ratio={diagnostics.correction_ratio_max:.3e} "
+                f"Centroidal VCI-SCNI correction gate failed: max ratio={diagnostics.correction_ratio_max:.3e} "
                 f"> {self._max_correction_ratio:.3e}."
             )
         if diagnostics.gauge_coercivity_min <= self._min_gauge_coercivity:
             raise ValueError(
-                f"Centroidal VC2-SCNI gauge-coercivity gate failed: lambda_min="
+                f"Centroidal VCI-SCNI gauge-coercivity gate failed: lambda_min="
                 f"{diagnostics.gauge_coercivity_min:.3e} <= {self._min_gauge_coercivity:.3e}."
             )
         if diagnostics.stiffness_nullity != 1:
             raise ValueError(
-                f"Centroidal VC2-SCNI kernel gate failed: nullity={diagnostics.stiffness_nullity}, expected 1."
+                f"Centroidal VCI-SCNI kernel gate failed: nullity={diagnostics.stiffness_nullity}, expected 1."
             )
 
     @property
@@ -573,6 +660,10 @@ class CentroidalVC2SCNIOperatorSandbox:
     @property
     def dim(self) -> int:
         return 2
+
+    @property
+    def vci_degree(self) -> int:
+        return self._vci_degree
 
     @property
     def nodes(self) -> NDArray:
@@ -595,7 +686,7 @@ class CentroidalVC2SCNIOperatorSandbox:
         return self._weights
 
     @property
-    def diagnostics(self) -> VC2AdmissionDiagnostics:
+    def diagnostics(self) -> VCIAdmissionDiagnostics:
         return self._diagnostics
 
     def value_operator(self) -> sparse.csr_matrix:
@@ -625,7 +716,7 @@ class CentroidalVC2SCNIOperatorSandbox:
         vector = left_singular_vectors[:, -1]
         normalization = float(vector @ np.ones(self._n_dof))
         if abs(normalization) <= 1e-14:
-            raise ValueError("Centroidal VC2-SCNI left null vector has zero constant pairing.")
+            raise ValueError("Centroidal VCI-SCNI left null vector has zero constant pairing.")
         return vector / normalization
 
 
@@ -634,7 +725,7 @@ class PairedMFGOperatorSandbox:
 
     def __init__(
         self,
-        discretization: CentroidalVC2SCNIOperatorSandbox,
+        discretization: CentroidalVCISCNIOperatorSandbox,
         *,
         diffusion: float,
         hamiltonian: Callable[[NDArray, NDArray], NDArray],

--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -1,0 +1,616 @@
+"""Operator sandbox for centroidal VC2-SCNI and an exactly paired MFG linearization.
+
+This module is deliberately outside ``WeakFormDiscretization``. It is an admission
+gate for a candidate Petrov-Galerkin method, not a production solver backend.
+
+The construction uses clipped Voronoi centroids ``c_a`` as sampling points,
+``M = E.T @ W @ E`` with ``E[a, i] = phi_i(c_a)``, the SCNI cell-average trial
+gradient, and a local variational-consistency correction of the test gradient.
+The correction enforces the degree-two weak patch, including boundary fluxes,
+through five shifted/scaled constraints per test function.
+
+All nonlinear MFG blocks are derived from one residual. The forward spatial
+operator is therefore the transpose of the complete analytic Jacobian; no
+independent advection assembly exists here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy import linalg, sparse
+from scipy.spatial import cKDTree
+
+from mfgarchon.alg.numerical.meshless_galerkin.mls_basis import monomial_exponents, shape_functions_and_grads
+from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import CellGeometry, clipped_voronoi_cells
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class VC2AdmissionDiagnostics:
+    """Numerical invariants that decide whether a cloud is admitted by the sandbox."""
+
+    local_rank_min: int
+    local_condition_max: float
+    correction_ratio_median: float
+    correction_ratio_max: float
+    mass_condition: float
+    value_constant_defect: float
+    trial_constant_defect: float
+    quadratic_gradient_defect: float
+    plain_patch_defect: float
+    corrected_patch_defect: float
+    right_constant_defect: float
+    left_constant_defect: float
+    gauge_coercivity_min: float
+    gauge_smallest_singular_value: float
+    stiffness_nullity: int
+
+
+@dataclass(frozen=True)
+class _EdgeQuadrature:
+    points: NDArray
+    cell_indices: NDArray
+    normal_weights: NDArray
+
+
+def _edge_quadrature(cells: list[CellGeometry], n_gauss: int) -> _EdgeQuadrature:
+    if n_gauss < 2:
+        raise ValueError("VC2 edge quadrature requires at least two Gauss points per edge.")
+    xi, wi = np.polynomial.legendre.leggauss(n_gauss)
+    t = 0.5 * (xi + 1.0)
+    points: list[NDArray] = []
+    cell_indices: list[NDArray] = []
+    normal_weights: list[NDArray] = []
+    for a, cell in enumerate(cells):
+        polygon = cell.polygon
+        for edge in range(len(polygon)):
+            v0 = polygon[edge]
+            delta = polygon[(edge + 1) % len(polygon)] - v0
+            length = float(np.linalg.norm(delta))
+            if length <= 1e-14:
+                continue
+            normal = np.array([delta[1], -delta[0]], dtype=np.float64) / length
+            edge_points = v0[None, :] + t[:, None] * delta[None, :]
+            edge_weights = 0.5 * length * wi
+            points.append(edge_points)
+            cell_indices.append(np.full(n_gauss, a, dtype=np.int64))
+            normal_weights.append(edge_weights[:, None] * normal[None, :])
+    if not points:
+        raise ValueError("VC2 edge quadrature found no nondegenerate cell edges.")
+    return _EdgeQuadrature(
+        points=np.vstack(points),
+        cell_indices=np.concatenate(cell_indices),
+        normal_weights=np.vstack(normal_weights),
+    )
+
+
+def _p2_data(points: NDArray, center: NDArray, scales: NDArray) -> tuple[NDArray, NDArray, NDArray]:
+    """Values, gradients, and Laplacians of a shifted/scaled basis of ``P2``."""
+    sx = (points[:, 0] - center[0]) / scales[0]
+    sy = (points[:, 1] - center[1]) / scales[1]
+    values = np.column_stack([np.ones(len(points)), sx, sy, sx**2, sx * sy, sy**2])
+    gradients: NDArray = np.zeros((len(points), 6, 2), dtype=np.float64)
+    gradients[:, 1, 0] = 1.0 / scales[0]
+    gradients[:, 2, 1] = 1.0 / scales[1]
+    gradients[:, 3, 0] = 2.0 * sx / scales[0]
+    gradients[:, 4, 0] = sy / scales[0]
+    gradients[:, 4, 1] = sx / scales[1]
+    gradients[:, 5, 1] = 2.0 * sy / scales[1]
+    laplacians: NDArray = np.zeros((len(points), 6), dtype=np.float64)
+    laplacians[:, 3] = 2.0 / scales[0] ** 2
+    laplacians[:, 5] = 2.0 / scales[1] ** 2
+    return values, gradients, laplacians
+
+
+def _as_vector(values: NDArray, size: int, name: str) -> NDArray:
+    array = np.asarray(values, dtype=np.float64)
+    if array.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},), got {array.shape}.")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} contains non-finite values.")
+    return array
+
+
+class CentroidalVC2SCNIOperatorSandbox:
+    """Dense research sandbox for the centroidal VC2-SCNI operator gate.
+
+    The current implementation is two-dimensional and degree-two. It supports
+    rectangular clipping and the existing polygonal SDF-chord clipping. Dense
+    diagnostics are intentional: promotion to a production sparse backend is
+    blocked until the operator gate passes across cloud families and refinement.
+    """
+
+    def __init__(
+        self,
+        nodes: NDArray,
+        rho: float,
+        bounds: list[tuple[float, float]],
+        *,
+        degree: int = 2,
+        sdf: Callable[[NDArray], NDArray] | None = None,
+        backend: str = "numpy",
+        n_edge_gauss: int = 4,
+        vci_support_radius: float | None = None,
+        rank_tolerance: float = 1e-11,
+        max_local_condition: float = 1e8,
+        max_mass_condition: float = 1e6,
+        max_correction_ratio: float = 1.0,
+        min_gauge_coercivity: float = 0.0,
+        patch_tolerance: float = 1e-9,
+    ) -> None:
+        self._nodes = np.asarray(nodes, dtype=np.float64)
+        if self._nodes.ndim != 2 or self._nodes.shape[1] != 2:
+            raise ValueError(f"Centroidal VC2-SCNI requires nodes with shape (N, 2), got {self._nodes.shape}.")
+        if len(self._nodes) < 6:
+            raise ValueError("Centroidal VC2-SCNI requires at least six nodes for a degree-two MLS basis.")
+        if not np.all(np.isfinite(self._nodes)):
+            raise ValueError("Centroidal VC2-SCNI nodes must all be finite.")
+        if len(np.unique(self._nodes, axis=0)) != len(self._nodes):
+            raise ValueError("Centroidal VC2-SCNI does not admit duplicate nodes.")
+        if degree != 2:
+            raise ValueError(f"Centroidal VC2-SCNI implements degree=2 only, got degree={degree}.")
+        if backend != "numpy":
+            raise ValueError("Centroidal VC2-SCNI admission diagnostics require backend='numpy'.")
+        if not np.isfinite(rho) or rho <= 0.0:
+            raise ValueError(f"Centroidal VC2-SCNI requires rho > 0, got {rho}.")
+        if len(bounds) != 2 or any(len(bound) != 2 or bound[1] <= bound[0] for bound in bounds):
+            raise ValueError(f"Centroidal VC2-SCNI requires two increasing bounds, got {bounds}.")
+        bounds_array = np.asarray(bounds, dtype=np.float64)
+        if not np.all(np.isfinite(bounds_array)):
+            raise ValueError(f"Centroidal VC2-SCNI bounds must be finite, got {bounds}.")
+        bound_tolerance = 1e-12 * max(float(np.max(bounds_array[:, 1] - bounds_array[:, 0])), 1.0)
+        outside_bounds = np.any(
+            (self._nodes < bounds_array[:, 0] - bound_tolerance) | (self._nodes > bounds_array[:, 1] + bound_tolerance)
+        )
+        if outside_bounds:
+            raise ValueError("Centroidal VC2-SCNI nodes must lie inside bounds.")
+        if sdf is not None:
+            signed_distances = np.asarray(sdf(self._nodes), dtype=np.float64).ravel()
+            if signed_distances.shape != (len(self._nodes),) or not np.all(np.isfinite(signed_distances)):
+                raise ValueError("Centroidal VC2-SCNI sdf(nodes) must return one finite value per node.")
+            if np.any(signed_distances > bound_tolerance):
+                raise ValueError("Centroidal VC2-SCNI nodes must lie inside the sdf domain.")
+        if rank_tolerance <= 0.0 or rank_tolerance >= 1.0:
+            raise ValueError(f"rank_tolerance must lie in (0, 1), got {rank_tolerance}.")
+
+        self._n_dof = len(self._nodes)
+        self._rho = float(rho)
+        self._bounds = [(float(lower), float(upper)) for lower, upper in bounds]
+        self._exponents = monomial_exponents(2, 2)
+        self._rank_tolerance = float(rank_tolerance)
+        self._max_local_condition = float(max_local_condition)
+        self._max_mass_condition = float(max_mass_condition)
+        self._max_correction_ratio = float(max_correction_ratio)
+        self._min_gauge_coercivity = float(min_gauge_coercivity)
+        self._patch_tolerance = float(patch_tolerance)
+        self._vci_support_radius = float(vci_support_radius if vci_support_radius is not None else rho)
+        if self._vci_support_radius <= 0.0:
+            raise ValueError(f"vci_support_radius must be positive, got {self._vci_support_radius}.")
+
+        cells = clipped_voronoi_cells(self._nodes, self._bounds, sdf)
+        self._centroids = np.vstack([cell.centroid for cell in cells])
+        self._weights = np.array([cell.area for cell in cells], dtype=np.float64)
+        edge_rule = _edge_quadrature(cells, n_edge_gauss)
+        self._edge_points = edge_rule.points
+        self._edge_normal_weights = edge_rule.normal_weights
+
+        self._E, _ = shape_functions_and_grads(
+            self._centroids,
+            self._nodes,
+            self._rho,
+            self._exponents,
+            backend,
+            check_conditioning=True,
+        )
+        self._edge_phi, _ = shape_functions_and_grads(
+            self._edge_points,
+            self._nodes,
+            self._rho,
+            self._exponents,
+            backend,
+            check_conditioning=True,
+        )
+        self._G = self._assemble_trial_gradient(edge_rule)
+        self._Gbar, ranks, conditions, correction_ratios = self._assemble_test_gradient()
+        self._M = self._E.T @ (self._weights[:, None] * self._E)
+        self._K = sum(
+            test_gradient.T @ (self._weights[:, None] * trial_gradient)
+            for test_gradient, trial_gradient in zip(self._Gbar, self._G, strict=True)
+        )
+        self._diagnostics = self._compute_diagnostics(ranks, conditions, correction_ratios)
+        self._enforce_admission_gates()
+
+    def _assemble_trial_gradient(self, edge_rule: _EdgeQuadrature) -> list[NDArray]:
+        gradients = []
+        for direction in range(2):
+            accumulator: NDArray = np.zeros((self._n_dof, self._n_dof), dtype=np.float64)
+            contribution = edge_rule.normal_weights[:, direction, None] * self._edge_phi
+            np.add.at(accumulator, edge_rule.cell_indices, contribution)
+            accumulator /= self._weights[:, None]
+            gradients.append(accumulator)
+        return gradients
+
+    def _assemble_test_gradient(self) -> tuple[list[NDArray], list[int], list[float], list[float]]:
+        test_gradients = [gradient.copy() for gradient in self._G]
+        nearest_distances, _ = cKDTree(self._nodes).query(self._nodes, k=2)
+        local_scales = nearest_distances[:, 1]
+        if np.any(local_scales <= 1e-14):
+            bad = int(np.argmin(local_scales))
+            raise ValueError(f"VC2 local scale vanishes at node {bad}; duplicate or coincident nodes are not admitted.")
+
+        ranks = []
+        conditions = []
+        correction_ratios = []
+        for i in range(self._n_dof):
+            distances = np.linalg.norm(self._centroids - self._nodes[i], axis=1)
+            support = distances <= self._vci_support_radius * (1.0 + 10.0 * np.finfo(float).eps)
+            support_count = int(np.count_nonzero(support))
+            if support_count < 3:
+                raise ValueError(
+                    f"VC2 local constraint rank failure at node {i}: fewer than three support cells "
+                    f"(support_cells={support_count}, support_radius={self._vci_support_radius:.6g})."
+                )
+            h_i = float(local_scales[i])
+            local_scale = np.array([h_i, h_i], dtype=np.float64)
+            _, centroid_gradients, centroid_laplacians = _p2_data(
+                self._centroids,
+                self._nodes[i],
+                local_scale,
+            )
+            _, edge_gradients, _ = _p2_data(self._edge_points, self._nodes[i], local_scale)
+
+            shifted = (self._centroids[support] - self._nodes[i]) / h_i
+            correction_basis = np.column_stack([np.ones(support_count), shifted])
+            weighted_gram = correction_basis.T @ (self._weights[support, None] * correction_basis)
+            correction_metric = linalg.block_diag(weighted_gram, weighted_gram)
+            try:
+                metric_cholesky = np.linalg.cholesky(correction_metric)
+            except np.linalg.LinAlgError as error:
+                raise np.linalg.LinAlgError(
+                    f"VC2 local correction metric is singular at node {i} with {support_count} support cells."
+                ) from error
+
+            constraint = np.einsum(
+                "a,al,akd->kdl",
+                self._weights[support],
+                correction_basis,
+                centroid_gradients[support, 1:, :],
+            ).reshape(5, 6)
+            whitened_constraint = linalg.solve_triangular(
+                metric_cholesky,
+                constraint.T,
+                lower=True,
+                check_finite=False,
+            ).T
+            singular_values = np.linalg.svd(whitened_constraint, compute_uv=False)
+            relative_cutoff = self._rank_tolerance * singular_values[0] if singular_values.size else np.inf
+            rank = int(np.count_nonzero(singular_values > relative_cutoff))
+            ranks.append(rank)
+            if rank < 5:
+                raise ValueError(
+                    f"VC2 local constraint rank failure at node {i}: rank={rank}, required=5, "
+                    f"support_cells={support_count}, support_radius={self._vci_support_radius:.6g}."
+                )
+            condition = float(singular_values[0] / singular_values[-1])
+            conditions.append(condition)
+            if not np.isfinite(condition) or condition > self._max_local_condition:
+                raise np.linalg.LinAlgError(
+                    f"VC2 local constraint is ill-conditioned at node {i}: cond={condition:.3e} "
+                    f"> {self._max_local_condition:.3e}."
+                )
+
+            base_gradient = np.column_stack([gradient[:, i] for gradient in self._G])
+            base_term = np.einsum(
+                "a,ad,akd->k",
+                self._weights,
+                base_gradient,
+                centroid_gradients,
+            )
+            volume_term = np.einsum(
+                "a,a,ak->k",
+                self._weights,
+                self._E[:, i],
+                centroid_laplacians,
+            )
+            boundary_term = np.einsum(
+                "q,qkd,qd->k",
+                self._edge_phi[:, i],
+                edge_gradients,
+                self._edge_normal_weights,
+            )
+            residual = (-volume_term + boundary_term - base_term)[1:]
+
+            multiplier_matrix = whitened_constraint @ whitened_constraint.T
+            multipliers = np.linalg.solve(multiplier_matrix, residual)
+            whitened_coefficients = whitened_constraint.T @ multipliers
+            coefficients = linalg.solve_triangular(
+                metric_cholesky.T,
+                whitened_coefficients,
+                lower=False,
+                check_finite=False,
+            )
+            correction_x = correction_basis @ coefficients[:3]
+            correction_y = correction_basis @ coefficients[3:]
+            test_gradients[0][support, i] += correction_x
+            test_gradients[1][support, i] += correction_y
+
+            correction_norm = np.sqrt(np.sum(self._weights[support] * (correction_x**2 + correction_y**2)))
+            base_norm = np.sqrt(np.sum(self._weights * np.sum(base_gradient**2, axis=1)))
+            if base_norm <= 1e-14:
+                raise ValueError(f"VC2 base test-gradient norm vanishes at node {i}.")
+            correction_ratios.append(float(correction_norm / base_norm))
+        return test_gradients, ranks, conditions, correction_ratios
+
+    def _global_patch_data(self) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+        center = np.array(
+            [0.5 * (lower + upper) for lower, upper in self._bounds],
+            dtype=np.float64,
+        )
+        scales = np.array([upper - lower for lower, upper in self._bounds], dtype=np.float64)
+        node_values, _, _ = _p2_data(self._nodes, center, scales)
+        _, centroid_gradients, centroid_laplacians = _p2_data(self._centroids, center, scales)
+        _, edge_gradients, _ = _p2_data(self._edge_points, center, scales)
+        return node_values, centroid_gradients, centroid_laplacians, edge_gradients
+
+    def _weak_patch_defect(self, test_gradients: list[NDArray]) -> float:
+        _, centroid_gradients, centroid_laplacians, edge_gradients = self._global_patch_data()
+        volume_gradient = sum(
+            gradient.T @ (self._weights[:, None] * centroid_gradients[:, :, direction])
+            for direction, gradient in enumerate(test_gradients)
+        )
+        volume_laplacian = self._E.T @ (self._weights[:, None] * centroid_laplacians)
+        normal_derivatives = np.einsum("qkd,qd->qk", edge_gradients, self._edge_normal_weights)
+        boundary_flux = self._edge_phi.T @ normal_derivatives
+        return float(np.max(np.abs(volume_gradient + volume_laplacian - boundary_flux)))
+
+    def _compute_diagnostics(
+        self,
+        ranks: list[int],
+        conditions: list[float],
+        correction_ratios: list[float],
+    ) -> VC2AdmissionDiagnostics:
+        one = np.ones(self._n_dof)
+        node_values, centroid_gradients, _, _ = self._global_patch_data()
+        gradient_defect = max(
+            float(np.max(np.abs(gradient @ node_values - centroid_gradients[:, :, direction])))
+            for direction, gradient in enumerate(self._G)
+        )
+        symmetric_stiffness = 0.5 * (self._K + self._K.T)
+        mean_constraint = self._M @ one
+        gauge_basis = linalg.null_space(mean_constraint[None, :])
+        gauge_stiffness = gauge_basis.T @ symmetric_stiffness @ gauge_basis
+        gauge_mass = gauge_basis.T @ self._M @ gauge_basis
+        gauge_coercivity = float(
+            linalg.eigvalsh(gauge_stiffness, gauge_mass, subset_by_index=[0, 0], check_finite=False)[0]
+        )
+        gauge_cholesky = np.linalg.cholesky(gauge_mass)
+        reduced_operator = gauge_basis.T @ self._K @ gauge_basis
+        left_scaled = linalg.solve_triangular(
+            gauge_cholesky,
+            reduced_operator,
+            lower=True,
+            check_finite=False,
+        )
+        mass_scaled_operator = linalg.solve_triangular(
+            gauge_cholesky,
+            left_scaled.T,
+            lower=True,
+            check_finite=False,
+        ).T
+        gauge_smallest_singular = float(np.linalg.svd(mass_scaled_operator, compute_uv=False)[-1])
+        stiffness_singular_values = np.linalg.svd(self._K, compute_uv=False)
+        nullity_threshold = 1e-10 * float(stiffness_singular_values[0])
+        stiffness_nullity = int(np.count_nonzero(stiffness_singular_values <= nullity_threshold))
+        return VC2AdmissionDiagnostics(
+            local_rank_min=min(ranks),
+            local_condition_max=max(conditions),
+            correction_ratio_median=float(np.median(correction_ratios)),
+            correction_ratio_max=max(correction_ratios),
+            mass_condition=float(np.linalg.cond(self._M)),
+            value_constant_defect=float(np.max(np.abs(self._E @ one - 1.0))),
+            trial_constant_defect=max(float(np.max(np.abs(gradient @ one))) for gradient in self._G),
+            quadratic_gradient_defect=gradient_defect,
+            plain_patch_defect=self._weak_patch_defect(self._G),
+            corrected_patch_defect=self._weak_patch_defect(self._Gbar),
+            right_constant_defect=float(np.max(np.abs(self._K @ one))),
+            left_constant_defect=float(np.max(np.abs(one @ self._K))),
+            gauge_coercivity_min=gauge_coercivity,
+            gauge_smallest_singular_value=gauge_smallest_singular,
+            stiffness_nullity=stiffness_nullity,
+        )
+
+    def _enforce_admission_gates(self) -> None:
+        diagnostics = self._diagnostics
+        exactness_defects = {
+            "value partition of unity": diagnostics.value_constant_defect,
+            "trial-gradient constants": diagnostics.trial_constant_defect,
+            "quadratic centroid gradient": diagnostics.quadratic_gradient_defect,
+            "corrected weak patch": diagnostics.corrected_patch_defect,
+            "right constant nullity": diagnostics.right_constant_defect,
+        }
+        failed_exactness = {name: value for name, value in exactness_defects.items() if value > self._patch_tolerance}
+        if failed_exactness:
+            details = ", ".join(f"{name}={value:.3e}" for name, value in failed_exactness.items())
+            raise ValueError(
+                f"Centroidal VC2-SCNI exactness gate failed ({details}); tolerance={self._patch_tolerance:.3e}."
+            )
+        if not np.isfinite(diagnostics.mass_condition) or diagnostics.mass_condition > self._max_mass_condition:
+            raise np.linalg.LinAlgError(
+                f"Centroidal VC2-SCNI mass gate failed: cond(M)={diagnostics.mass_condition:.3e} "
+                f"> {self._max_mass_condition:.3e}."
+            )
+        if diagnostics.correction_ratio_max > self._max_correction_ratio:
+            raise ValueError(
+                f"Centroidal VC2-SCNI correction gate failed: max ratio={diagnostics.correction_ratio_max:.3e} "
+                f"> {self._max_correction_ratio:.3e}."
+            )
+        if diagnostics.gauge_coercivity_min <= self._min_gauge_coercivity:
+            raise ValueError(
+                f"Centroidal VC2-SCNI gauge-coercivity gate failed: lambda_min="
+                f"{diagnostics.gauge_coercivity_min:.3e} <= {self._min_gauge_coercivity:.3e}."
+            )
+        if diagnostics.stiffness_nullity != 1:
+            raise ValueError(
+                f"Centroidal VC2-SCNI kernel gate failed: nullity={diagnostics.stiffness_nullity}, expected 1."
+            )
+
+    @property
+    def n_dof(self) -> int:
+        return self._n_dof
+
+    @property
+    def dim(self) -> int:
+        return 2
+
+    @property
+    def nodes(self) -> NDArray:
+        return self._nodes
+
+    @property
+    def evaluation_points(self) -> NDArray:
+        return self._centroids
+
+    @property
+    def weights(self) -> NDArray:
+        return self._weights
+
+    @property
+    def diagnostics(self) -> VC2AdmissionDiagnostics:
+        return self._diagnostics
+
+    def value_operator(self) -> sparse.csr_matrix:
+        return sparse.csr_matrix(self._E)
+
+    def trial_gradient(self) -> list[sparse.csr_matrix]:
+        return [sparse.csr_matrix(gradient) for gradient in self._G]
+
+    def test_gradient(self) -> list[sparse.csr_matrix]:
+        return [sparse.csr_matrix(gradient) for gradient in self._Gbar]
+
+    def mass(self) -> sparse.csr_matrix:
+        return sparse.csr_matrix(self._M)
+
+    def stiffness(self) -> sparse.csr_matrix:
+        return sparse.csr_matrix(self._K)
+
+    def reconstructed_density(self, coefficients: NDArray) -> NDArray:
+        vector = _as_vector(coefficients, self._n_dof, "Density coefficients")
+        return self._E @ vector
+
+    def physical_mass(self, coefficients: NDArray) -> float:
+        return float(self._weights @ self.reconstructed_density(coefficients))
+
+    def left_null_vector(self) -> NDArray:
+        left_singular_vectors, _, _ = np.linalg.svd(self._K)
+        vector = left_singular_vectors[:, -1]
+        normalization = float(vector @ np.ones(self._n_dof))
+        if abs(normalization) <= 1e-14:
+            raise ValueError("Centroidal VC2-SCNI left null vector has zero constant pairing.")
+        return vector / normalization
+
+
+class PairedMFGOperatorSandbox:
+    """Nonlinear nodal MFG residual with one analytic Jacobian and its transpose."""
+
+    def __init__(
+        self,
+        discretization: CentroidalVC2SCNIOperatorSandbox,
+        *,
+        diffusion: float,
+        hamiltonian: Callable[[NDArray, NDArray], NDArray],
+        hamiltonian_gradient: Callable[[NDArray, NDArray], NDArray],
+        stabilization_flux: Callable[[NDArray, NDArray], NDArray] | None = None,
+        stabilization_jacobian: Callable[[NDArray, NDArray], NDArray] | None = None,
+    ) -> None:
+        if not np.isfinite(diffusion) or diffusion < 0.0:
+            raise ValueError(f"diffusion must be finite and nonnegative, got {diffusion}.")
+        if (stabilization_flux is None) != (stabilization_jacobian is None):
+            raise ValueError("stabilization_flux and stabilization_jacobian must be supplied together.")
+        self._discretization = discretization
+        self._diffusion = float(diffusion)
+        self._hamiltonian = hamiltonian
+        self._hamiltonian_gradient = hamiltonian_gradient
+        self._stabilization_flux = stabilization_flux
+        self._stabilization_jacobian = stabilization_jacobian
+
+    def momentum(self, state: NDArray) -> NDArray:
+        vector = _as_vector(state, self._discretization.n_dof, "HJB state")
+        return np.column_stack([gradient @ vector for gradient in self._discretization._G])
+
+    def _hamiltonian_data(self, momentum: NDArray) -> tuple[NDArray, NDArray]:
+        points = self._discretization.evaluation_points
+        count = self._discretization.n_dof
+        values = np.asarray(self._hamiltonian(points, momentum), dtype=np.float64)
+        gradients = np.asarray(self._hamiltonian_gradient(points, momentum), dtype=np.float64)
+        if values.shape != (count,):
+            raise ValueError(f"Hamiltonian values must have shape ({count},), got {values.shape}.")
+        if gradients.shape != (count, 2):
+            raise ValueError(f"Hamiltonian gradient must have shape ({count}, 2), got {gradients.shape}.")
+        if not np.all(np.isfinite(values)) or not np.all(np.isfinite(gradients)):
+            raise ValueError("Hamiltonian evaluation contains non-finite values.")
+        return values, gradients
+
+    def _stabilization_data(self, momentum: NDArray) -> tuple[NDArray, NDArray] | None:
+        if self._stabilization_flux is None or self._stabilization_jacobian is None:
+            return None
+        points = self._discretization.evaluation_points
+        count = self._discretization.n_dof
+        flux = np.asarray(self._stabilization_flux(points, momentum), dtype=np.float64)
+        jacobian = np.asarray(self._stabilization_jacobian(points, momentum), dtype=np.float64)
+        if flux.shape != (count, 2):
+            raise ValueError(f"Stabilization flux must have shape ({count}, 2), got {flux.shape}.")
+        if jacobian.shape != (count, 2, 2):
+            raise ValueError(f"Stabilization Jacobian must have shape ({count}, 2, 2), got {jacobian.shape}.")
+        if not np.all(np.isfinite(flux)) or not np.all(np.isfinite(jacobian)):
+            raise ValueError("Stabilization evaluation contains non-finite values.")
+        return flux, jacobian
+
+    def residual(self, state: NDArray) -> NDArray:
+        vector = _as_vector(state, self._discretization.n_dof, "HJB state")
+        momentum = self.momentum(vector)
+        hamiltonian, _ = self._hamiltonian_data(momentum)
+        residual = self._diffusion * (self._discretization._K @ vector)
+        residual += self._discretization._E.T @ (self._discretization._weights * hamiltonian)
+        stabilization = self._stabilization_data(momentum)
+        if stabilization is not None:
+            flux, _ = stabilization
+            for direction in range(2):
+                residual += self._discretization._Gbar[direction].T @ (
+                    self._discretization._weights * flux[:, direction]
+                )
+        return residual
+
+    def jacobian(self, state: NDArray) -> NDArray:
+        vector = _as_vector(state, self._discretization.n_dof, "HJB state")
+        momentum = self.momentum(vector)
+        _, hamiltonian_gradient = self._hamiltonian_data(momentum)
+        jacobian = self._diffusion * self._discretization._K.copy()
+        for direction in range(2):
+            weighted_derivative = self._discretization._weights * hamiltonian_gradient[:, direction]
+            jacobian += self._discretization._E.T @ (weighted_derivative[:, None] * self._discretization._G[direction])
+        stabilization = self._stabilization_data(momentum)
+        if stabilization is not None:
+            _, stabilization_jacobian = stabilization
+            for test_direction in range(2):
+                for trial_direction in range(2):
+                    weighted_derivative = (
+                        self._discretization._weights * stabilization_jacobian[:, test_direction, trial_direction]
+                    )
+                    jacobian += self._discretization._Gbar[test_direction].T @ (
+                        weighted_derivative[:, None] * self._discretization._G[trial_direction]
+                    )
+        return jacobian
+
+    def forward_spatial(self, state: NDArray, density: NDArray) -> NDArray:
+        density_vector = _as_vector(density, self._discretization.n_dof, "Density coefficients")
+        return self.jacobian(state).T @ density_vector
+
+    def physical_mass(self, density: NDArray) -> float:
+        return self._discretization.physical_mass(density)

--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -60,6 +60,111 @@ class _EdgeQuadrature:
     normal_weights: NDArray
 
 
+@dataclass(frozen=True)
+class BoundaryCompleteCVTCloud:
+    """A rectangle cloud with fixed boundary sites and Lloyd-relaxed interior sites."""
+
+    nodes: NDArray
+    boundary_mask: NDArray
+    resolution: int
+    seed: int
+    iterations: int
+    nominal_spacing: float
+    max_interior_centroid_offset_ratio: float
+    min_separation_ratio: float
+    min_cell_area_ratio: float
+    max_cell_area_ratio: float
+    max_cell_diameter_ratio: float
+
+    @property
+    def cell_area_ratio(self) -> float:
+        return self.max_cell_area_ratio / self.min_cell_area_ratio
+
+
+def boundary_complete_cvt_rectangle(
+    resolution: int,
+    bounds: list[tuple[float, float]],
+    *,
+    seed: int = 0,
+    iterations: int = 30,
+    jitter_fraction: float = 0.35,
+    relaxation: float = 1.0,
+) -> BoundaryCompleteCVTCloud:
+    """Build a deterministic boundary-complete constrained-CVT cloud.
+
+    The boundary sites are the boundary of a tensor grid and remain fixed.
+    Interior sites start from independently jittered tensor-grid positions and
+    undergo exact clipped-Voronoi centroid updates. The construction has exactly
+    ``resolution**2`` sites and keeps ``4 * (resolution - 1)`` fitted boundary
+    sites at every level.
+
+    This is a research family constructor. It does not claim that arbitrary
+    interior-only clouds become admissible after adding boundary samples.
+    """
+    if resolution < 5:
+        raise ValueError(f"Boundary-complete CVT requires resolution >= 5, got {resolution}.")
+    if iterations < 0:
+        raise ValueError(f"Boundary-complete CVT requires iterations >= 0, got {iterations}.")
+    if not 0.0 <= jitter_fraction < 0.5:
+        raise ValueError(f"jitter_fraction must lie in [0, 0.5), got {jitter_fraction}.")
+    if not 0.0 < relaxation <= 1.0:
+        raise ValueError(f"relaxation must lie in (0, 1], got {relaxation}.")
+    bounds_array = np.asarray(bounds, dtype=np.float64)
+    if bounds_array.shape != (2, 2):
+        raise ValueError(f"Boundary-complete CVT requires bounds with shape (2, 2), got {bounds_array.shape}.")
+    spans = bounds_array[:, 1] - bounds_array[:, 0]
+    if not np.all(np.isfinite(bounds_array)) or np.any(spans <= 0.0):
+        raise ValueError(f"Boundary-complete CVT requires finite increasing bounds, got {bounds}.")
+
+    axes = [np.linspace(bounds_array[direction, 0], bounds_array[direction, 1], resolution) for direction in range(2)]
+    coordinates = np.meshgrid(*axes, indexing="ij")
+    nodes = np.stack([coordinate.ravel() for coordinate in coordinates], axis=1)
+    indices: tuple[NDArray, NDArray] = np.meshgrid(np.arange(resolution), np.arange(resolution), indexing="ij")
+    boundary_mask = (
+        (indices[0] == 0) | (indices[0] == resolution - 1) | (indices[1] == 0) | (indices[1] == resolution - 1)
+    ).ravel()
+    interior_mask = ~boundary_mask
+    grid_spacings = spans / (resolution - 1)
+    rng = np.random.default_rng(seed)
+    nodes[interior_mask] += (
+        jitter_fraction
+        * rng.uniform(-1.0, 1.0, size=(int(np.count_nonzero(interior_mask)), 2))
+        * grid_spacings[None, :]
+    )
+
+    for _ in range(iterations):
+        cells = clipped_voronoi_cells(nodes, bounds)
+        centroids = np.vstack([cell.centroid for cell in cells])
+        nodes[interior_mask] += relaxation * (centroids[interior_mask] - nodes[interior_mask])
+
+    cells = clipped_voronoi_cells(nodes, bounds)
+    centroids = np.vstack([cell.centroid for cell in cells])
+    nominal_spacing = float(np.max(grid_spacings))
+    centroid_offsets = np.linalg.norm(centroids[interior_mask] - nodes[interior_mask], axis=1)
+    nearest_distances, _ = cKDTree(nodes).query(nodes, k=2)
+    cell_areas = np.array([cell.area for cell in cells], dtype=np.float64)
+    nominal_cell_area = float(np.prod(spans) / len(nodes))
+    cell_diameters = np.array(
+        [np.max(np.linalg.norm(cell.polygon[:, None, :] - cell.polygon[None, :, :], axis=2)) for cell in cells],
+        dtype=np.float64,
+    )
+    nodes.setflags(write=False)
+    boundary_mask.setflags(write=False)
+    return BoundaryCompleteCVTCloud(
+        nodes=nodes,
+        boundary_mask=boundary_mask,
+        resolution=resolution,
+        seed=seed,
+        iterations=iterations,
+        nominal_spacing=nominal_spacing,
+        max_interior_centroid_offset_ratio=float(np.max(centroid_offsets) / nominal_spacing),
+        min_separation_ratio=float(np.min(nearest_distances[:, 1]) / nominal_spacing),
+        min_cell_area_ratio=float(np.min(cell_areas) / nominal_cell_area),
+        max_cell_area_ratio=float(np.max(cell_areas) / nominal_cell_area),
+        max_cell_diameter_ratio=float(np.max(cell_diameters) / nominal_spacing),
+    )
+
+
 def _edge_quadrature(cells: list[CellGeometry], n_gauss: int) -> _EdgeQuadrature:
     if n_gauss < 2:
         raise ValueError("VC2 edge quadrature requires at least two Gauss points per edge.")

--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -4,12 +4,17 @@ This module is deliberately outside ``WeakFormDiscretization``. It is an admissi
 gate for a candidate Petrov-Galerkin method, not a production solver backend.
 
 The construction uses clipped Voronoi centroids ``c_a`` as sampling points,
-``M = E.T @ W @ E`` with ``E[a, i] = phi_i(c_a)``, the SCNI cell-average trial
-gradient, and a local variational-consistency correction of the test gradient.
+``M = E.T @ W @ E`` with ``E[a, i] = phi_i(c_a)``, a selectable SCNI
+cell-average or centroid-pointwise trial gradient, and a local
+variational-consistency correction of the test gradient.
 The correction targets shifted/scaled weak moments through degree two, three,
-or four, including boundary fluxes. Degree-two MLS makes only the quadratic
-discrete patch exact; higher target moments and the actual discrete patch are
-reported separately.
+or four, including boundary fluxes. The MLS trial degree is selected
+independently, so target weak moments and the actual discrete patch are reported
+separately.
+
+An optional local polynomial-null stabilization is a research diagnostic, not a
+production backend. It tests whether a symmetric positive-semidefinite correction
+can remove non-polynomial negative modes without changing the target patch.
 
 All nonlinear MFG blocks are derived from one residual. The forward spatial
 operator is therefore the transpose of the complete analytic Jacobian; no
@@ -41,7 +46,11 @@ class VCIAdmissionDiagnostics:
 
     ``corrected_patch_defect`` uses exact target-polynomial gradients.
     ``discrete_patch_defect`` instead applies the assembled stiffness to nodal
-    polynomial values and therefore includes the degree-two trial-gradient error.
+    polynomial values and therefore includes any trial-gradient error at the
+    selected VCI target degree.
+
+    ``raw_gauge_coercivity_min`` is measured before polynomial-null
+    stabilization; ``gauge_coercivity_min`` is measured after it.
     """
 
     local_rank_min: int
@@ -56,8 +65,14 @@ class VCIAdmissionDiagnostics:
     plain_patch_defect: float
     corrected_patch_defect: float
     discrete_patch_defect: float
+    stabilization_rank_min: int
+    stabilization_condition_max: float
+    stabilization_support_count_min: int
+    stabilization_support_count_max: int
+    stabilization_patch_defect: float
     right_constant_defect: float
     left_constant_defect: float
+    raw_gauge_coercivity_min: float
     gauge_coercivity_min: float
     gauge_smallest_singular_value: float
     stiffness_nullity: int
@@ -283,8 +298,9 @@ def _as_vector(values: NDArray, size: int, name: str) -> NDArray:
 class CentroidalVCISCNIOperatorSandbox:
     """Dense research sandbox for the centroidal VCI-SCNI operator gate.
 
-    The MLS trial basis is two-dimensional and degree-two. The shifted/scaled
-    variational correction can target degrees two through four. The sandbox
+    The MLS trial basis is two-dimensional and can have degree two through four.
+    The shifted/scaled variational correction independently targets degrees two
+    through four. The sandbox
     supports rectangular clipping and the existing polygonal SDF-chord clipping.
     Dense diagnostics are intentional: promotion to a production sparse backend
     is blocked until the operator gate passes across cloud families and refinement.
@@ -302,6 +318,11 @@ class CentroidalVCISCNIOperatorSandbox:
         backend: str = "numpy",
         n_edge_gauss: int = 4,
         vci_support_radius: float | None = None,
+        trial_gradient_mode: str = "scni",
+        test_gradient_base: str = "trial",
+        polynomial_null_stabilization: float = 0.0,
+        stabilization_support_radius: float | None = None,
+        max_stabilization_condition: float = 1e8,
         rank_tolerance: float = 1e-11,
         max_local_condition: float = 1e8,
         max_mass_condition: float = 1e6,
@@ -312,18 +333,45 @@ class CentroidalVCISCNIOperatorSandbox:
         self._nodes = np.asarray(nodes, dtype=np.float64)
         if self._nodes.ndim != 2 or self._nodes.shape[1] != 2:
             raise ValueError(f"Centroidal VCI-SCNI requires nodes with shape (N, 2), got {self._nodes.shape}.")
-        if len(self._nodes) < 6:
-            raise ValueError("Centroidal VCI-SCNI requires at least six nodes for a degree-two MLS basis.")
         if not np.all(np.isfinite(self._nodes)):
             raise ValueError("Centroidal VCI-SCNI nodes must all be finite.")
         if len(np.unique(self._nodes, axis=0)) != len(self._nodes):
             raise ValueError("Centroidal VCI-SCNI does not admit duplicate nodes.")
-        if degree != 2:
-            raise ValueError(f"Centroidal VCI-SCNI implements MLS degree=2 only, got degree={degree}.")
+        if not isinstance(degree, Integral) or degree not in (2, 3, 4):
+            raise ValueError(f"Centroidal VCI-SCNI requires MLS degree in {{2, 3, 4}}, got {degree}.")
+        required_nodes = len(monomial_exponents(2, int(degree)))
+        if len(self._nodes) < required_nodes:
+            raise ValueError(
+                f"Centroidal VCI-SCNI degree-{degree} MLS requires at least {required_nodes} nodes, "
+                f"got {len(self._nodes)}."
+            )
         if not isinstance(vci_degree, Integral) or vci_degree not in (2, 3, 4):
             raise ValueError(f"Centroidal VCI-SCNI requires vci_degree in {{2, 3, 4}}, got {vci_degree}.")
         if backend != "numpy":
             raise ValueError("Centroidal VCI-SCNI admission diagnostics require backend='numpy'.")
+        if trial_gradient_mode not in {"scni", "pointwise"}:
+            raise ValueError(
+                "Centroidal VCI-SCNI requires trial_gradient_mode in {'scni', 'pointwise'}, "
+                f"got {trial_gradient_mode!r}."
+            )
+        if test_gradient_base not in {"trial", "scni"}:
+            raise ValueError(
+                f"Centroidal VCI-SCNI requires test_gradient_base in {{'trial', 'scni'}}, got {test_gradient_base!r}."
+            )
+        if not np.isfinite(polynomial_null_stabilization) or polynomial_null_stabilization < 0.0:
+            raise ValueError(
+                f"polynomial_null_stabilization must be finite and nonnegative, got {polynomial_null_stabilization}."
+            )
+        if stabilization_support_radius is not None and (
+            not np.isfinite(stabilization_support_radius) or stabilization_support_radius <= 0.0
+        ):
+            raise ValueError(
+                f"stabilization_support_radius must be finite and positive, got {stabilization_support_radius}."
+            )
+        if not np.isfinite(max_stabilization_condition) or max_stabilization_condition <= 1.0:
+            raise ValueError(
+                f"max_stabilization_condition must be finite and greater than one, got {max_stabilization_condition}."
+            )
         if not np.isfinite(rho) or rho <= 0.0:
             raise ValueError(f"Centroidal VCI-SCNI requires rho > 0, got {rho}.")
         if len(bounds) != 2 or any(len(bound) != 2 or bound[1] <= bound[0] for bound in bounds):
@@ -349,7 +397,15 @@ class CentroidalVCISCNIOperatorSandbox:
         self._n_dof = len(self._nodes)
         self._rho = float(rho)
         self._bounds = [(float(lower), float(upper)) for lower, upper in bounds]
-        self._exponents = monomial_exponents(2, 2)
+        self._degree = int(degree)
+        self._exponents = monomial_exponents(2, self._degree)
+        self._trial_gradient_mode = trial_gradient_mode
+        self._test_gradient_base = test_gradient_base
+        self._polynomial_null_stabilization = float(polynomial_null_stabilization)
+        self._stabilization_support_radius = float(
+            stabilization_support_radius if stabilization_support_radius is not None else rho
+        )
+        self._max_stabilization_condition = float(max_stabilization_condition)
         self._vci_degree = int(vci_degree)
         self._vci_constraint_count = len(_polynomial_exponents(self._vci_degree)) - 1
         self._correction_exponents = _polynomial_exponents(self._vci_degree - 1)
@@ -370,7 +426,7 @@ class CentroidalVCISCNIOperatorSandbox:
         self._edge_points = edge_rule.points
         self._edge_normal_weights = edge_rule.normal_weights
 
-        self._E, _ = shape_functions_and_grads(
+        self._E, centroid_gradients = shape_functions_and_grads(
             self._centroids,
             self._nodes,
             self._rho,
@@ -378,6 +434,7 @@ class CentroidalVCISCNIOperatorSandbox:
             backend,
             check_conditioning=True,
         )
+        pointwise_gradients = [centroid_gradients[:, :, direction] for direction in range(2)]
         self._edge_phi, _ = shape_functions_and_grads(
             self._edge_points,
             self._nodes,
@@ -386,17 +443,42 @@ class CentroidalVCISCNIOperatorSandbox:
             backend,
             check_conditioning=True,
         )
-        self._G = self._assemble_trial_gradient(edge_rule)
-        self._Gbar, ranks, conditions, correction_ratios = self._assemble_test_gradient()
+        scni_gradients = self._assemble_scni_gradient(edge_rule)
+        self._G = scni_gradients if trial_gradient_mode == "scni" else pointwise_gradients
+        base_test_gradients = self._G if test_gradient_base == "trial" else scni_gradients
+        self._Gbar, ranks, conditions, correction_ratios = self._assemble_test_gradient(base_test_gradients)
         self._M = self._E.T @ (self._weights[:, None] * self._E)
-        self._K = sum(
+        self._raw_K = sum(
             test_gradient.T @ (self._weights[:, None] * trial_gradient)
             for test_gradient, trial_gradient in zip(self._Gbar, self._G, strict=True)
         )
-        self._diagnostics = self._compute_diagnostics(ranks, conditions, correction_ratios)
+        if self._polynomial_null_stabilization > 0.0:
+            (
+                self._stabilization,
+                stabilization_ranks,
+                stabilization_conditions,
+                stabilization_support_counts,
+                stabilization_patch_defect,
+            ) = self._assemble_polynomial_null_stabilization()
+        else:
+            self._stabilization = np.zeros_like(self._raw_K)
+            stabilization_ranks = []
+            stabilization_conditions = []
+            stabilization_support_counts = []
+            stabilization_patch_defect = 0.0
+        self._K = self._raw_K + self._polynomial_null_stabilization * self._stabilization
+        self._diagnostics = self._compute_diagnostics(
+            ranks,
+            conditions,
+            correction_ratios,
+            stabilization_ranks,
+            stabilization_conditions,
+            stabilization_support_counts,
+            stabilization_patch_defect,
+        )
         self._enforce_admission_gates()
 
-    def _assemble_trial_gradient(self, edge_rule: _EdgeQuadrature) -> list[NDArray]:
+    def _assemble_scni_gradient(self, edge_rule: _EdgeQuadrature) -> list[NDArray]:
         gradients = []
         for direction in range(2):
             accumulator: NDArray = np.zeros((self._n_dof, self._n_dof), dtype=np.float64)
@@ -406,8 +488,11 @@ class CentroidalVCISCNIOperatorSandbox:
             gradients.append(accumulator)
         return gradients
 
-    def _assemble_test_gradient(self) -> tuple[list[NDArray], list[int], list[float], list[float]]:
-        test_gradients = [gradient.copy() for gradient in self._G]
+    def _assemble_test_gradient(
+        self,
+        base_test_gradients: list[NDArray],
+    ) -> tuple[list[NDArray], list[int], list[float], list[float]]:
+        test_gradients = [gradient.copy() for gradient in base_test_gradients]
         nearest_distances, _ = cKDTree(self._nodes).query(self._nodes, k=2)
         local_scales = nearest_distances[:, 1]
         if np.any(local_scales <= 1e-14):
@@ -484,7 +569,7 @@ class CentroidalVCISCNIOperatorSandbox:
                     f"> {self._max_local_condition:.3e}."
                 )
 
-            base_gradient = np.column_stack([gradient[:, i] for gradient in self._G])
+            base_gradient = np.column_stack([gradient[:, i] for gradient in base_test_gradients])
             base_term = np.einsum(
                 "a,ad,akd->k",
                 self._weights,
@@ -526,6 +611,67 @@ class CentroidalVCISCNIOperatorSandbox:
             correction_ratios.append(float(correction_norm / base_norm))
         return test_gradients, ranks, conditions, correction_ratios
 
+    def _assemble_polynomial_null_stabilization(
+        self,
+    ) -> tuple[NDArray, list[int], list[float], list[int], float]:
+        """Assemble a local PSD stabilization that annihilates target polynomials.
+
+        Dividing each stencil projector by its support count prevents its
+        high-frequency scale from growing merely because the stencil contains
+        more nodes. This normalization remains an empirical sandbox choice.
+        """
+        stabilization = np.zeros((self._n_dof, self._n_dof), dtype=np.float64)
+        tree = cKDTree(self._nodes)
+        nearest_distances, _ = tree.query(self._nodes, k=2)
+        local_scales = nearest_distances[:, 1]
+        polynomial_count = len(_polynomial_exponents(self._vci_degree))
+        ranks = []
+        conditions = []
+        support_counts = []
+        for i, center in enumerate(self._nodes):
+            support = np.sort(
+                np.asarray(tree.query_ball_point(center, self._stabilization_support_radius), dtype=np.int64)
+            )
+            support_count = len(support)
+            support_counts.append(support_count)
+            if support_count < polynomial_count:
+                raise ValueError(
+                    f"Polynomial-null stabilization rank failure at node {i}: support_nodes={support_count} "
+                    f"< polynomial_basis_size={polynomial_count} "
+                    f"(support_radius={self._stabilization_support_radius:.6g})."
+                )
+            local_points = (self._nodes[support] - center[None, :]) / local_scales[i]
+            polynomial_values, _, _ = _polynomial_data(
+                local_points,
+                np.zeros(2, dtype=np.float64),
+                np.ones(2, dtype=np.float64),
+                self._vci_degree,
+            )
+            left_vectors, singular_values, _ = np.linalg.svd(polynomial_values, full_matrices=False)
+            relative_cutoff = self._rank_tolerance * singular_values[0]
+            rank = int(np.count_nonzero(singular_values > relative_cutoff))
+            ranks.append(rank)
+            if rank < polynomial_count:
+                raise ValueError(
+                    f"Polynomial-null stabilization rank failure at node {i}: rank={rank}, "
+                    f"required={polynomial_count}, support_nodes={support_count}, "
+                    f"support_radius={self._stabilization_support_radius:.6g}."
+                )
+            condition = float(singular_values[0] / singular_values[-1])
+            conditions.append(condition)
+            if not np.isfinite(condition) or condition > self._max_stabilization_condition:
+                raise np.linalg.LinAlgError(
+                    f"Polynomial-null stabilization is ill-conditioned at node {i}: cond={condition:.3e} "
+                    f"> {self._max_stabilization_condition:.3e}."
+                )
+            polynomial_basis = left_vectors[:, :polynomial_count]
+            residual_projector = np.eye(support_count) - polynomial_basis @ polynomial_basis.T
+            stabilization[np.ix_(support, support)] += residual_projector / support_count
+
+        node_values, _, _, _ = self._global_patch_data(self._vci_degree)
+        patch_defect = float(np.max(np.abs(stabilization @ node_values)))
+        return stabilization, ranks, conditions, support_counts, patch_defect
+
     def _global_patch_data(self, degree: int) -> tuple[NDArray, NDArray, NDArray, NDArray]:
         center = np.array(
             [0.5 * (lower + upper) for lower, upper in self._bounds],
@@ -560,6 +706,10 @@ class CentroidalVCISCNIOperatorSandbox:
         ranks: list[int],
         conditions: list[float],
         correction_ratios: list[float],
+        stabilization_ranks: list[int],
+        stabilization_conditions: list[float],
+        stabilization_support_counts: list[int],
+        stabilization_patch_defect: float,
     ) -> VCIAdmissionDiagnostics:
         one = np.ones(self._n_dof)
         quadratic_values, quadratic_gradients, _, _ = self._global_patch_data(2)
@@ -572,14 +722,22 @@ class CentroidalVCISCNIOperatorSandbox:
             float(np.max(np.abs(gradient @ vci_values - vci_gradients[:, :, direction])))
             for direction, gradient in enumerate(self._G)
         )
-        symmetric_stiffness = 0.5 * (self._K + self._K.T)
         mean_constraint = self._M @ one
         gauge_basis = linalg.null_space(mean_constraint[None, :])
-        gauge_stiffness = gauge_basis.T @ symmetric_stiffness @ gauge_basis
         gauge_mass = gauge_basis.T @ self._M @ gauge_basis
+        symmetric_stiffness = 0.5 * (self._K + self._K.T)
+        gauge_stiffness = gauge_basis.T @ symmetric_stiffness @ gauge_basis
         gauge_coercivity = float(
             linalg.eigvalsh(gauge_stiffness, gauge_mass, subset_by_index=[0, 0], check_finite=False)[0]
         )
+        if self._polynomial_null_stabilization == 0.0:
+            raw_gauge_coercivity = gauge_coercivity
+        else:
+            raw_symmetric_stiffness = 0.5 * (self._raw_K + self._raw_K.T)
+            raw_gauge_stiffness = gauge_basis.T @ raw_symmetric_stiffness @ gauge_basis
+            raw_gauge_coercivity = float(
+                linalg.eigvalsh(raw_gauge_stiffness, gauge_mass, subset_by_index=[0, 0], check_finite=False)[0]
+            )
         gauge_cholesky = np.linalg.cholesky(gauge_mass)
         reduced_operator = gauge_basis.T @ self._K @ gauge_basis
         left_scaled = linalg.solve_triangular(
@@ -611,8 +769,14 @@ class CentroidalVCISCNIOperatorSandbox:
             plain_patch_defect=self._weak_patch_defect(self._G, self._vci_degree),
             corrected_patch_defect=self._weak_patch_defect(self._Gbar, self._vci_degree),
             discrete_patch_defect=self._discrete_patch_defect(),
+            stabilization_rank_min=min(stabilization_ranks, default=0),
+            stabilization_condition_max=max(stabilization_conditions, default=0.0),
+            stabilization_support_count_min=min(stabilization_support_counts, default=0),
+            stabilization_support_count_max=max(stabilization_support_counts, default=0),
+            stabilization_patch_defect=stabilization_patch_defect,
             right_constant_defect=float(np.max(np.abs(self._K @ one))),
             left_constant_defect=float(np.max(np.abs(one @ self._K))),
+            raw_gauge_coercivity_min=raw_gauge_coercivity,
             gauge_coercivity_min=gauge_coercivity,
             gauge_smallest_singular_value=gauge_smallest_singular,
             stiffness_nullity=stiffness_nullity,
@@ -625,6 +789,7 @@ class CentroidalVCISCNIOperatorSandbox:
             "trial-gradient constants": diagnostics.trial_constant_defect,
             "quadratic centroid gradient": diagnostics.quadratic_gradient_defect,
             f"degree-{self._vci_degree} corrected target weak patch": diagnostics.corrected_patch_defect,
+            "polynomial-null stabilization patch": diagnostics.stabilization_patch_defect,
             "right constant nullity": diagnostics.right_constant_defect,
         }
         failed_exactness = {name: value for name, value in exactness_defects.items() if value > self._patch_tolerance}
@@ -666,6 +831,22 @@ class CentroidalVCISCNIOperatorSandbox:
         return self._vci_degree
 
     @property
+    def degree(self) -> int:
+        return self._degree
+
+    @property
+    def trial_gradient_mode(self) -> str:
+        return self._trial_gradient_mode
+
+    @property
+    def test_gradient_base(self) -> str:
+        return self._test_gradient_base
+
+    @property
+    def polynomial_null_stabilization(self) -> float:
+        return self._polynomial_null_stabilization
+
+    @property
     def nodes(self) -> NDArray:
         return self._nodes
 
@@ -703,6 +884,9 @@ class CentroidalVCISCNIOperatorSandbox:
 
     def stiffness(self) -> sparse.csr_matrix:
         return sparse.csr_matrix(self._K)
+
+    def stabilization(self) -> sparse.csr_matrix:
+        return sparse.csr_matrix(self._stabilization)
 
     def reconstructed_density(self, coefficients: NDArray) -> NDArray:
         vector = _as_vector(coefficients, self._n_dof, "Density coefficients")

--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -12,6 +12,11 @@ or four, including boundary fluxes. The MLS trial degree is selected
 independently, so target weak moments and the actual discrete patch are reported
 separately.
 
+For a spatial elliptic coefficient, the coefficient value and its exact gradient
+must be supplied together. The same sampled coefficient then drives the local VCI
+constraints, the Petrov stiffness, the edge-energy stabilization, and the patch
+diagnostic for ``-div(a grad u)``.
+
 An optional local polynomial-null stabilization is a research diagnostic, not a
 production backend. It tests whether a symmetric positive-semidefinite correction
 can remove non-polynomial negative modes without changing the target patch. The
@@ -297,6 +302,20 @@ def _as_vector(values: NDArray, size: int, name: str) -> NDArray:
     return array
 
 
+def _evaluate_field(
+    field: Callable[[NDArray], NDArray],
+    points: NDArray,
+    expected_shape: tuple[int, ...],
+    name: str,
+) -> NDArray:
+    values = np.asarray(field(points), dtype=np.float64)
+    if values.shape != expected_shape:
+        raise ValueError(f"{name} must return shape {expected_shape}, got {values.shape}.")
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"{name} returned non-finite values.")
+    return values
+
+
 class CentroidalVCISCNIOperatorSandbox:
     """Dense research sandbox for the centroidal VCI-SCNI operator gate.
 
@@ -317,6 +336,8 @@ class CentroidalVCISCNIOperatorSandbox:
         degree: int = 2,
         vci_degree: int = 2,
         sdf: Callable[[NDArray], NDArray] | None = None,
+        elliptic_coefficient: Callable[[NDArray], NDArray] | None = None,
+        elliptic_coefficient_gradient: Callable[[NDArray], NDArray] | None = None,
         backend: str = "numpy",
         n_edge_gauss: int = 4,
         vci_support_radius: float | None = None,
@@ -352,6 +373,12 @@ class CentroidalVCISCNIOperatorSandbox:
             raise ValueError(f"Centroidal VCI-SCNI requires vci_degree in {{2, 3, 4}}, got {vci_degree}.")
         if backend != "numpy":
             raise ValueError("Centroidal VCI-SCNI admission diagnostics require backend='numpy'.")
+        if (elliptic_coefficient is None) != (elliptic_coefficient_gradient is None):
+            raise ValueError("elliptic_coefficient and elliptic_coefficient_gradient must be supplied together.")
+        if elliptic_coefficient is not None and (
+            not callable(elliptic_coefficient) or not callable(elliptic_coefficient_gradient)
+        ):
+            raise TypeError("elliptic_coefficient and elliptic_coefficient_gradient must be callable.")
         if trial_gradient_mode not in {"scni", "pointwise"}:
             raise ValueError(
                 "Centroidal VCI-SCNI requires trial_gradient_mode in {'scni', 'pointwise'}, "
@@ -384,6 +411,18 @@ class CentroidalVCISCNIOperatorSandbox:
         if not np.isfinite(max_stabilization_condition) or max_stabilization_condition <= 1.0:
             raise ValueError(
                 f"max_stabilization_condition must be finite and greater than one, got {max_stabilization_condition}."
+            )
+        if elliptic_coefficient is not None and (
+            degree != 4
+            or vci_degree != 4
+            or trial_gradient_mode != "pointwise"
+            or test_gradient_base != "trial"
+            or polynomial_null_stabilization <= 0.0
+            or stabilization_metric != "edge_energy"
+        ):
+            raise ValueError(
+                "The spatial elliptic-coefficient gate is only defined for the aligned degree-4 VCI candidate "
+                "with pointwise trial gradients, trial-based test correction, and positive edge-energy stabilization."
             )
         if not np.isfinite(rho) or rho <= 0.0:
             raise ValueError(f"Centroidal VCI-SCNI requires rho > 0, got {rho}.")
@@ -429,6 +468,7 @@ class CentroidalVCISCNIOperatorSandbox:
         self._max_correction_ratio = float(max_correction_ratio)
         self._min_gauge_coercivity = float(min_gauge_coercivity)
         self._patch_tolerance = float(patch_tolerance)
+        self._has_spatial_elliptic_coefficient = elliptic_coefficient is not None
         self._vci_support_radius = float(vci_support_radius if vci_support_radius is not None else rho)
         if self._vci_support_radius <= 0.0:
             raise ValueError(f"vci_support_radius must be positive, got {self._vci_support_radius}.")
@@ -452,6 +492,40 @@ class CentroidalVCISCNIOperatorSandbox:
         self._edge_energy_weights = (
             edge_measures * self._weights[edge_rule.cell_indices] / cell_perimeters[edge_rule.cell_indices]
         )
+        if elliptic_coefficient is None or elliptic_coefficient_gradient is None:
+            self._centroid_elliptic_coefficient = np.ones(self._n_dof, dtype=np.float64)
+            self._centroid_elliptic_coefficient_gradient = np.zeros((self._n_dof, 2), dtype=np.float64)
+            self._edge_elliptic_coefficient = np.ones(len(self._edge_points), dtype=np.float64)
+        else:
+            self._centroid_elliptic_coefficient = _evaluate_field(
+                elliptic_coefficient,
+                self._centroids,
+                (self._n_dof,),
+                "elliptic_coefficient(centroids)",
+            )
+            self._centroid_elliptic_coefficient_gradient = _evaluate_field(
+                elliptic_coefficient_gradient,
+                self._centroids,
+                (self._n_dof, 2),
+                "elliptic_coefficient_gradient(centroids)",
+            )
+            self._edge_elliptic_coefficient = _evaluate_field(
+                elliptic_coefficient,
+                self._edge_points,
+                (len(self._edge_points),),
+                "elliptic_coefficient(edge_points)",
+            )
+        sampled_coefficient_min = min(
+            float(np.min(self._centroid_elliptic_coefficient)),
+            float(np.min(self._edge_elliptic_coefficient)),
+        )
+        if sampled_coefficient_min <= 0.0:
+            raise ValueError(
+                "elliptic_coefficient must be strictly positive at all centroid and edge samples; "
+                f"sampled minimum={sampled_coefficient_min:.6g}."
+            )
+        self._elliptic_weights = self._weights * self._centroid_elliptic_coefficient
+        self._edge_elliptic_energy_weights = self._edge_energy_weights * self._edge_elliptic_coefficient
 
         self._E, centroid_gradients = shape_functions_and_grads(
             self._centroids,
@@ -476,7 +550,7 @@ class CentroidalVCISCNIOperatorSandbox:
         self._Gbar, ranks, conditions, correction_ratios = self._assemble_test_gradient(base_test_gradients)
         self._M = self._E.T @ (self._weights[:, None] * self._E)
         self._raw_K = sum(
-            test_gradient.T @ (self._weights[:, None] * trial_gradient)
+            test_gradient.T @ (self._elliptic_weights[:, None] * trial_gradient)
             for test_gradient, trial_gradient in zip(self._Gbar, self._G, strict=True)
         )
         if self._polynomial_null_stabilization > 0.0:
@@ -557,7 +631,8 @@ class CentroidalVCISCNIOperatorSandbox:
 
             shifted = (self._centroids[support] - self._nodes[i]) / h_i
             correction_basis = _monomial_values(shifted, self._correction_exponents)
-            weighted_gram = correction_basis.T @ (self._weights[support, None] * correction_basis)
+            local_elliptic_weights = self._elliptic_weights[support]
+            weighted_gram = correction_basis.T @ (local_elliptic_weights[:, None] * correction_basis)
             correction_metric = linalg.block_diag(weighted_gram, weighted_gram)
             try:
                 metric_cholesky = np.linalg.cholesky(correction_metric)
@@ -568,7 +643,7 @@ class CentroidalVCISCNIOperatorSandbox:
 
             constraint = np.einsum(
                 "a,al,akd->kdl",
-                self._weights[support],
+                local_elliptic_weights,
                 correction_basis,
                 centroid_gradients[support, 1:, :],
             ).reshape(self._vci_constraint_count, 2 * correction_basis_count)
@@ -599,22 +674,21 @@ class CentroidalVCISCNIOperatorSandbox:
             base_gradient = np.column_stack([gradient[:, i] for gradient in base_test_gradients])
             base_term = np.einsum(
                 "a,ad,akd->k",
-                self._weights,
+                self._elliptic_weights,
                 base_gradient,
                 centroid_gradients,
+            )
+            elliptic_divergence = self._elliptic_polynomial_divergence(
+                centroid_gradients,
+                centroid_laplacians,
             )
             volume_term = np.einsum(
                 "a,a,ak->k",
                 self._weights,
                 self._E[:, i],
-                centroid_laplacians,
+                elliptic_divergence,
             )
-            boundary_term = np.einsum(
-                "q,qkd,qd->k",
-                self._edge_phi[:, i],
-                edge_gradients,
-                self._edge_normal_weights,
-            )
+            boundary_term = self._edge_phi[:, i] @ self._elliptic_normal_derivatives(edge_gradients)
             residual = (-volume_term + boundary_term - base_term)[1:]
 
             multiplier_matrix = whitened_constraint @ whitened_constraint.T
@@ -713,12 +787,12 @@ class CentroidalVCISCNIOperatorSandbox:
             polynomial_basis = left_vectors[:, :polynomial_count]
             residual_projector = np.eye(support_count) - polynomial_basis @ polynomial_basis.T
             if edge_rows is None:
-                local_stabilization = residual_projector / support_count
+                local_stabilization = self._centroid_elliptic_coefficient[i] * residual_projector / support_count
             else:
                 local_edge_gradients = edge_point_gradients[edge_rows][:, support, :]
                 local_metric = np.einsum(
                     "q,qid,qjd->ij",
-                    self._edge_energy_weights[edge_rows],
+                    self._edge_elliptic_energy_weights[edge_rows],
                     local_edge_gradients,
                     local_edge_gradients,
                 )
@@ -740,21 +814,48 @@ class CentroidalVCISCNIOperatorSandbox:
         _, edge_gradients, _ = _polynomial_data(self._edge_points, center, scales, degree)
         return node_values, centroid_gradients, centroid_laplacians, edge_gradients
 
+    def _elliptic_polynomial_divergence(
+        self,
+        centroid_gradients: NDArray,
+        centroid_laplacians: NDArray,
+    ) -> NDArray:
+        return self._centroid_elliptic_coefficient[:, None] * centroid_laplacians + np.einsum(
+            "ad,akd->ak",
+            self._centroid_elliptic_coefficient_gradient,
+            centroid_gradients,
+        )
+
+    def _elliptic_normal_derivatives(self, edge_gradients: NDArray) -> NDArray:
+        return np.einsum(
+            "q,qkd,qd->qk",
+            self._edge_elliptic_coefficient,
+            edge_gradients,
+            self._edge_normal_weights,
+        )
+
     def _weak_patch_defect(self, test_gradients: list[NDArray], degree: int) -> float:
         _, centroid_gradients, centroid_laplacians, edge_gradients = self._global_patch_data(degree)
         volume_gradient = sum(
-            gradient.T @ (self._weights[:, None] * centroid_gradients[:, :, direction])
+            gradient.T @ (self._elliptic_weights[:, None] * centroid_gradients[:, :, direction])
             for direction, gradient in enumerate(test_gradients)
         )
-        volume_laplacian = self._E.T @ (self._weights[:, None] * centroid_laplacians)
-        normal_derivatives = np.einsum("qkd,qd->qk", edge_gradients, self._edge_normal_weights)
+        elliptic_divergence = self._elliptic_polynomial_divergence(
+            centroid_gradients,
+            centroid_laplacians,
+        )
+        volume_laplacian = self._E.T @ (self._weights[:, None] * elliptic_divergence)
+        normal_derivatives = self._elliptic_normal_derivatives(edge_gradients)
         boundary_flux = self._edge_phi.T @ normal_derivatives
         return float(np.max(np.abs(volume_gradient + volume_laplacian - boundary_flux)))
 
     def _discrete_patch_defect(self) -> float:
-        node_values, _, centroid_laplacians, edge_gradients = self._global_patch_data(self._vci_degree)
-        volume_laplacian = self._E.T @ (self._weights[:, None] * centroid_laplacians)
-        normal_derivatives = np.einsum("qkd,qd->qk", edge_gradients, self._edge_normal_weights)
+        node_values, centroid_gradients, centroid_laplacians, edge_gradients = self._global_patch_data(self._vci_degree)
+        elliptic_divergence = self._elliptic_polynomial_divergence(
+            centroid_gradients,
+            centroid_laplacians,
+        )
+        volume_laplacian = self._E.T @ (self._weights[:, None] * elliptic_divergence)
+        normal_derivatives = self._elliptic_normal_derivatives(edge_gradients)
         boundary_flux = self._edge_phi.T @ normal_derivatives
         return float(np.max(np.abs(self._K @ node_values + volume_laplacian - boundary_flux)))
 
@@ -908,6 +1009,23 @@ class CentroidalVCISCNIOperatorSandbox:
         return self._stabilization_metric
 
     @property
+    def has_spatial_elliptic_coefficient(self) -> bool:
+        return self._has_spatial_elliptic_coefficient
+
+    @property
+    def sampled_elliptic_coefficient_bounds(self) -> tuple[float, float]:
+        return (
+            min(
+                float(np.min(self._centroid_elliptic_coefficient)),
+                float(np.min(self._edge_elliptic_coefficient)),
+            ),
+            max(
+                float(np.max(self._centroid_elliptic_coefficient)),
+                float(np.max(self._edge_elliptic_coefficient)),
+            ),
+        )
+
+    @property
     def nodes(self) -> NDArray:
         return self._nodes
 
@@ -982,6 +1100,11 @@ class PairedMFGOperatorSandbox:
             raise ValueError(f"diffusion must be finite and nonnegative, got {diffusion}.")
         if (stabilization_flux is None) != (stabilization_jacobian is None):
             raise ValueError("stabilization_flux and stabilization_jacobian must be supplied together.")
+        if discretization.has_spatial_elliptic_coefficient and stabilization_flux is not None:
+            raise ValueError(
+                "A coefficient-weighted VCI test gradient cannot also assemble stabilization_flux; "
+                "that nonlinear flux requires its own variational correction."
+            )
         self._discretization = discretization
         self._diffusion = float(diffusion)
         self._hamiltonian = hamiltonian

--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -14,7 +14,9 @@ separately.
 
 An optional local polynomial-null stabilization is a research diagnostic, not a
 production backend. It tests whether a symmetric positive-semidefinite correction
-can remove non-polynomial negative modes without changing the target patch.
+can remove non-polynomial negative modes without changing the target patch. The
+stabilization metric is either the original Euclidean stencil metric or a physical
+edge-gradient energy assembled from the already-required cell-edge evaluations.
 
 All nonlinear MFG blocks are derived from one residual. The forward spatial
 operator is therefore the transpose of the complete analytic Jacobian; no
@@ -321,6 +323,7 @@ class CentroidalVCISCNIOperatorSandbox:
         trial_gradient_mode: str = "scni",
         test_gradient_base: str = "trial",
         polynomial_null_stabilization: float = 0.0,
+        stabilization_metric: str = "euclidean",
         stabilization_support_radius: float | None = None,
         max_stabilization_condition: float = 1e8,
         rank_tolerance: float = 1e-11,
@@ -362,6 +365,16 @@ class CentroidalVCISCNIOperatorSandbox:
             raise ValueError(
                 f"polynomial_null_stabilization must be finite and nonnegative, got {polynomial_null_stabilization}."
             )
+        if stabilization_metric not in {"euclidean", "edge_energy"}:
+            raise ValueError(
+                "Centroidal VCI-SCNI requires stabilization_metric in "
+                f"{{'euclidean', 'edge_energy'}}, got {stabilization_metric!r}."
+            )
+        if stabilization_metric == "edge_energy" and stabilization_support_radius is not None:
+            raise ValueError(
+                "stabilization_support_radius is not defined for stabilization_metric='edge_energy'; "
+                "the active edge MLS stencil determines its support."
+            )
         if stabilization_support_radius is not None and (
             not np.isfinite(stabilization_support_radius) or stabilization_support_radius <= 0.0
         ):
@@ -402,6 +415,7 @@ class CentroidalVCISCNIOperatorSandbox:
         self._trial_gradient_mode = trial_gradient_mode
         self._test_gradient_base = test_gradient_base
         self._polynomial_null_stabilization = float(polynomial_null_stabilization)
+        self._stabilization_metric = stabilization_metric
         self._stabilization_support_radius = float(
             stabilization_support_radius if stabilization_support_radius is not None else rho
         )
@@ -425,6 +439,19 @@ class CentroidalVCISCNIOperatorSandbox:
         edge_rule = _edge_quadrature(cells, n_edge_gauss)
         self._edge_points = edge_rule.points
         self._edge_normal_weights = edge_rule.normal_weights
+        self._edge_cell_indices = edge_rule.cell_indices
+        edge_measures = np.linalg.norm(edge_rule.normal_weights, axis=1)
+        cell_perimeters = np.bincount(
+            edge_rule.cell_indices,
+            weights=edge_measures,
+            minlength=self._n_dof,
+        )
+        if np.any(cell_perimeters <= 0.0):
+            bad = int(np.argmin(cell_perimeters))
+            raise ValueError(f"VCI cell {bad} has nonpositive boundary measure.")
+        self._edge_energy_weights = (
+            edge_measures * self._weights[edge_rule.cell_indices] / cell_perimeters[edge_rule.cell_indices]
+        )
 
         self._E, centroid_gradients = shape_functions_and_grads(
             self._centroids,
@@ -435,7 +462,7 @@ class CentroidalVCISCNIOperatorSandbox:
             check_conditioning=True,
         )
         pointwise_gradients = [centroid_gradients[:, :, direction] for direction in range(2)]
-        self._edge_phi, _ = shape_functions_and_grads(
+        self._edge_phi, edge_point_gradients = shape_functions_and_grads(
             self._edge_points,
             self._nodes,
             self._rho,
@@ -459,7 +486,7 @@ class CentroidalVCISCNIOperatorSandbox:
                 stabilization_conditions,
                 stabilization_support_counts,
                 stabilization_patch_defect,
-            ) = self._assemble_polynomial_null_stabilization()
+            ) = self._assemble_polynomial_null_stabilization(edge_point_gradients)
         else:
             self._stabilization = np.zeros_like(self._raw_K)
             stabilization_ranks = []
@@ -613,12 +640,15 @@ class CentroidalVCISCNIOperatorSandbox:
 
     def _assemble_polynomial_null_stabilization(
         self,
+        edge_point_gradients: NDArray,
     ) -> tuple[NDArray, list[int], list[float], list[int], float]:
         """Assemble a local PSD stabilization that annihilates target polynomials.
 
-        Dividing each stencil projector by its support count prevents its
-        high-frequency scale from growing merely because the stencil contains
-        more nodes. This normalization remains an empirical sandbox choice.
+        The Euclidean metric divides each stencil projector by its support count;
+        this remains the challenged baseline. The edge-energy metric sandwiches
+        each cell's positive boundary-gradient energy with the same local
+        polynomial-complement projector. Its boundary weights sum to the cell
+        area, so the metric has the scale of a volume gradient energy.
         """
         stabilization = np.zeros((self._n_dof, self._n_dof), dtype=np.float64)
         tree = cKDTree(self._nodes)
@@ -629,16 +659,27 @@ class CentroidalVCISCNIOperatorSandbox:
         conditions = []
         support_counts = []
         for i, center in enumerate(self._nodes):
-            support = np.sort(
-                np.asarray(tree.query_ball_point(center, self._stabilization_support_radius), dtype=np.int64)
-            )
+            if self._stabilization_metric == "euclidean":
+                support = np.sort(
+                    np.asarray(tree.query_ball_point(center, self._stabilization_support_radius), dtype=np.int64)
+                )
+                edge_rows = None
+            else:
+                edge_rows = np.flatnonzero(self._edge_cell_indices == i)
+                local_edge_gradients = edge_point_gradients[edge_rows]
+                support = np.flatnonzero(np.max(np.abs(local_edge_gradients), axis=(0, 2)) > 0.0)
             support_count = len(support)
             support_counts.append(support_count)
             if support_count < polynomial_count:
+                support_description = (
+                    f"support_radius={self._stabilization_support_radius:.6g}"
+                    if edge_rows is None
+                    else "support=active edge MLS stencil"
+                )
                 raise ValueError(
                     f"Polynomial-null stabilization rank failure at node {i}: support_nodes={support_count} "
                     f"< polynomial_basis_size={polynomial_count} "
-                    f"(support_radius={self._stabilization_support_radius:.6g})."
+                    f"({support_description})."
                 )
             local_points = (self._nodes[support] - center[None, :]) / local_scales[i]
             polynomial_values, _, _ = _polynomial_data(
@@ -652,10 +693,15 @@ class CentroidalVCISCNIOperatorSandbox:
             rank = int(np.count_nonzero(singular_values > relative_cutoff))
             ranks.append(rank)
             if rank < polynomial_count:
+                support_description = (
+                    f"support_radius={self._stabilization_support_radius:.6g}"
+                    if edge_rows is None
+                    else "support=active edge MLS stencil"
+                )
                 raise ValueError(
                     f"Polynomial-null stabilization rank failure at node {i}: rank={rank}, "
                     f"required={polynomial_count}, support_nodes={support_count}, "
-                    f"support_radius={self._stabilization_support_radius:.6g}."
+                    f"{support_description}."
                 )
             condition = float(singular_values[0] / singular_values[-1])
             conditions.append(condition)
@@ -666,7 +712,18 @@ class CentroidalVCISCNIOperatorSandbox:
                 )
             polynomial_basis = left_vectors[:, :polynomial_count]
             residual_projector = np.eye(support_count) - polynomial_basis @ polynomial_basis.T
-            stabilization[np.ix_(support, support)] += residual_projector / support_count
+            if edge_rows is None:
+                local_stabilization = residual_projector / support_count
+            else:
+                local_edge_gradients = edge_point_gradients[edge_rows][:, support, :]
+                local_metric = np.einsum(
+                    "q,qid,qjd->ij",
+                    self._edge_energy_weights[edge_rows],
+                    local_edge_gradients,
+                    local_edge_gradients,
+                )
+                local_stabilization = residual_projector @ local_metric @ residual_projector
+            stabilization[np.ix_(support, support)] += local_stabilization
 
         node_values, _, _, _ = self._global_patch_data(self._vci_degree)
         patch_defect = float(np.max(np.abs(stabilization @ node_values)))
@@ -845,6 +902,10 @@ class CentroidalVCISCNIOperatorSandbox:
     @property
     def polynomial_null_stabilization(self) -> float:
         return self._polynomial_null_stabilization
+
+    @property
+    def stabilization_metric(self) -> str:
+        return self._stabilization_metric
 
     @property
     def nodes(self) -> NDArray:

--- a/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/centroidal_vci_sandbox.py
@@ -58,6 +58,10 @@ class VCIAdmissionDiagnostics:
 
     ``raw_gauge_coercivity_min`` is measured before polynomial-null
     stabilization; ``gauge_coercivity_min`` is measured after it.
+
+    The weighted column sums and ``frame_gauge_euclidean_coercivity_min``
+    are unscaled. An admitted family must compare them with its registered
+    spacing as $O(h^2)$, $O(h)$, $O(h)$, and $\\Omega(h^2)$, respectively.
     """
 
     local_rank_min: int
@@ -77,6 +81,10 @@ class VCIAdmissionDiagnostics:
     stabilization_support_count_min: int
     stabilization_support_count_max: int
     stabilization_patch_defect: float
+    value_weighted_column_sum_max: float
+    test_gradient_weighted_column_sum_max: float
+    edge_value_weighted_column_sum_max: float
+    frame_gauge_euclidean_coercivity_min: float
     right_constant_defect: float
     left_constant_defect: float
     raw_gauge_coercivity_min: float
@@ -883,6 +891,17 @@ class CentroidalVCISCNIOperatorSandbox:
         mean_constraint = self._M @ one
         gauge_basis = linalg.null_space(mean_constraint[None, :])
         gauge_mass = gauge_basis.T @ self._M @ gauge_basis
+        positive_frame = (
+            sum(gradient.T @ (self._elliptic_weights[:, None] * gradient) for gradient in self._G)
+            + self._polynomial_null_stabilization * self._stabilization
+        )
+        frame_gauge_euclidean_coercivity = float(
+            linalg.eigvalsh(
+                gauge_basis.T @ positive_frame @ gauge_basis,
+                subset_by_index=[0, 0],
+                check_finite=False,
+            )[0]
+        )
         symmetric_stiffness = 0.5 * (self._K + self._K.T)
         gauge_stiffness = gauge_basis.T @ symmetric_stiffness @ gauge_basis
         gauge_coercivity = float(
@@ -932,6 +951,24 @@ class CentroidalVCISCNIOperatorSandbox:
             stabilization_support_count_min=min(stabilization_support_counts, default=0),
             stabilization_support_count_max=max(stabilization_support_counts, default=0),
             stabilization_patch_defect=stabilization_patch_defect,
+            value_weighted_column_sum_max=float(np.max(np.sum(self._weights[:, None] * np.abs(self._E), axis=0))),
+            test_gradient_weighted_column_sum_max=float(
+                np.max(
+                    np.sum(
+                        self._weights[:, None] * np.sqrt(sum(gradient**2 for gradient in self._Gbar)),
+                        axis=0,
+                    )
+                )
+            ),
+            edge_value_weighted_column_sum_max=float(
+                np.max(
+                    np.sum(
+                        np.linalg.norm(self._edge_normal_weights, axis=1)[:, None] * np.abs(self._edge_phi),
+                        axis=0,
+                    )
+                )
+            ),
+            frame_gauge_euclidean_coercivity_min=frame_gauge_euclidean_coercivity,
             right_constant_defect=float(np.max(np.abs(self._K @ one))),
             left_constant_defect=float(np.max(np.abs(one @ self._K))),
             raw_gauge_coercivity_min=raw_gauge_coercivity,

--- a/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
@@ -1,6 +1,7 @@
 """
 Dimension-agnostic Moving Least Squares (MLS) shape functions with full
-derivatives. Two interchangeable derivative backends:
+derivatives and evaluation-centered shifted/scaled moments. Two interchangeable
+derivative backends:
 
 - ``"numpy"`` (default): analytic derivatives, core dependencies only.
 - ``"jax"`` (optional): autodiff through the moment matrix; requires jax.
@@ -73,7 +74,10 @@ def shape_functions_and_grads_numpy(
 ) -> tuple[NDArray, NDArray]:
     r"""MLS shape functions and full gradients via analytic differentiation.
 
-    phi_j(x) = omega_j(x) p(x)^T M(x)^{-1} p(x_j),  M(x) = sum_l omega_l p_l p_l^T.
+    At each evaluation point, the polynomial basis is frozen at that point and
+    scaled by ``rho``. This is an invertible basis change, so it preserves the
+    exact-arithmetic MLS shape functions and derivatives while making the moment
+    condition number translation- and scale-independent.
 
     Using gamma = M^{-1} p, s_j = (P gamma)_j, the full gradient is
         d_c phi_j = (d_c omega_j) s_j + omega_j (P (beta_c - w_c))_j,
@@ -85,54 +89,60 @@ def shape_functions_and_grads_numpy(
     x_eval = np.asarray(x_eval, dtype=np.float64)
     nodes = np.asarray(nodes, dtype=np.float64)
     Q, d = x_eval.shape
+    N = len(nodes)
+    m = len(exponents)
+    if Q == 0:
+        return np.empty((0, N)), np.empty((0, N, d))
 
-    diffs = x_eval[:, None, :] - nodes[None, :, :]  # (Q,N,d), x - x_l
-    dist = np.linalg.norm(diffs, axis=2)  # (Q,N)
-    r = dist / rho
-    omega = _wendland_c2(r)  # (Q,N)
-    wprime = _wendland_c2_deriv(r)  # (Q,N)
+    origin = np.zeros((1, d), dtype=np.float64)
+    p = _poly_batch(origin, exponents)[0]
+    dp = _poly_grad_batch(origin, exponents)[0] / rho
+    phi = np.empty((Q, N), dtype=np.float64)
+    grad = np.empty((Q, N, d), dtype=np.float64)
+    batch_size = max(1, min(Q, 4_000_000 // max(N * m, 1)))
 
-    P = _poly_batch(nodes, exponents)  # (N,m)
-    p = _poly_batch(x_eval, exponents)  # (Q,m)
-    dp = _poly_grad_batch(x_eval, exponents)  # (Q,m,d)
+    for start in range(0, Q, batch_size):
+        stop = min(start + batch_size, Q)
+        evaluation_batch = x_eval[start:stop]
+        diffs = evaluation_batch[:, None, :] - nodes[None, :, :]
+        dist = np.linalg.norm(diffs, axis=2)
+        r = dist / rho
+        omega = _wendland_c2(r)
+        wprime = _wendland_c2_deriv(r)
 
-    M = np.einsum("qn,ni,nj->qij", omega, P, P)  # (Q,m,m)
-    if check_conditioning:
-        # Issue #1485: on the Gauss-quadrature ASSEMBLY path, a near-singular MLS moment matrix M (too
-        # few nodes inside a quadrature point's support -> rank-deficient) yields garbage shape
-        # functions that np.linalg.solve does NOT flag (near-, not exactly, singular). Fail loud. The
-        # SCNI path does NOT pass check_conditioning: its nodal-smoothed gradients tolerate poor
-        # pointwise conditioning, so it stays exempt (do not move this guard into the shared basis).
-        conds = np.linalg.cond(M)  # (Q,)
-        worst = float(np.max(conds)) if conds.size else 0.0
-        if not np.isfinite(worst) or worst > 1e12:
-            q_bad = int(np.argmax(conds))
-            raise np.linalg.LinAlgError(
-                f"MLS moment matrix is ill-conditioned at quadrature point {q_bad} (cond={worst:.2e} "
-                f"> 1e12): too few nodes cover its support (rho={rho} too small, or a gap / degenerate "
-                f"cloud). The shape functions would be silently garbage. Increase the support radius "
-                f"rho, densify the cloud, or lower the polynomial degree (Issue #1485)."
-            )
-    # numpy>=2.0: a (Q,m,m) with b (Q,m) is read as a single matrix RHS; pass an
-    # explicit (Q,m,1) column stack and squeeze to get batched vector solves.
-    gamma = np.linalg.solve(M, p[..., None])[..., 0]  # (Q,m)
-    s = np.einsum("qm,nm->qn", gamma, P)  # (Q,N)
-    phi = omega * s
+        local_nodes = -diffs / rho
+        P = np.ones((stop - start, N, m), dtype=np.float64)
+        for c in range(d):
+            P *= local_nodes[:, :, c, None] ** exponents[None, None, :, c]
+        M = np.einsum("qn,qni,qnj->qij", omega, P, P)
+        if check_conditioning:
+            conds = np.linalg.cond(M)
+            worst = float(np.max(conds)) if conds.size else 0.0
+            if not np.isfinite(worst) or worst > 1e12:
+                local_bad = int(np.argmax(conds))
+                q_bad = start + local_bad
+                raise np.linalg.LinAlgError(
+                    f"MLS moment matrix is ill-conditioned at quadrature point {q_bad} (cond={worst:.2e} "
+                    f"> 1e12): too few nodes cover its support (rho={rho} too small, or a gap / degenerate "
+                    f"cloud). The shape functions would be silently garbage. Increase the support radius "
+                    f"rho, densify the cloud, or lower the polynomial degree (Issue #1485)."
+                )
 
-    # weight gradient: d omega_l/dx_c = w'(r_l) (x - x_l)_c / (rho * dist_l).
-    # dist_l = 0 only when x hits a node, where w'(0) = 0, so the row is 0;
-    # the safe denominator just avoids 0/0.
-    safe = np.where(dist == 0.0, 1.0, dist)
-    domega = (wprime / (rho * safe))[..., None] * diffs  # (Q,N,d)
+        right_hand_side = np.broadcast_to(p, (stop - start, m))
+        gamma = np.linalg.solve(M, right_hand_side[..., None])[..., 0]
+        s = np.einsum("qnm,qm->qn", P, gamma)
+        phi[start:stop] = omega * s
 
-    grad = np.empty((Q, P.shape[0], d))
-    for c in range(d):
-        dM = np.einsum("qn,ni,nj->qij", domega[:, :, c], P, P)  # (Q,m,m)
-        beta = np.linalg.solve(M, dp[:, :, c][..., None])[..., 0]  # (Q,m)
-        u = np.einsum("qij,qj->qi", dM, gamma)  # (Q,m)
-        w_c = np.linalg.solve(M, u[..., None])[..., 0]  # (Q,m)
-        ds = np.einsum("qm,nm->qn", beta - w_c, P)  # (Q,N)
-        grad[:, :, c] = domega[:, :, c] * s + omega * ds
+        safe = np.where(dist == 0.0, 1.0, dist)
+        domega = (wprime / (rho * safe))[..., None] * diffs
+        for c in range(d):
+            dM = np.einsum("qn,qni,qnj->qij", domega[:, :, c], P, P)
+            derivative_rhs = np.broadcast_to(dp[:, c], (stop - start, m))
+            beta = np.linalg.solve(M, derivative_rhs[..., None])[..., 0]
+            u = np.einsum("qij,qj->qi", dM, gamma)
+            w_c = np.linalg.solve(M, u[..., None])[..., 0]
+            ds = np.einsum("qnm,qm->qn", P, beta - w_c)
+            grad[start:stop, :, c] = domega[:, :, c] * s + omega * ds
     return phi, grad
 
 
@@ -153,15 +163,18 @@ def shape_functions_and_grads_jax(
     jax.config.update("jax_enable_x64", True)
     nodes_j = jnp.asarray(nodes, dtype=jnp.float64)
     exps_j = jnp.asarray(exponents)
-    P = jnp.prod(nodes_j[:, None, :] ** exps_j[None, :, :], axis=2)  # (N,m)
 
     def phi_at(x):  # x (d,) -> (N,)
+        center = jax.lax.stop_gradient(x)
+        local_nodes = (nodes_j - center[None, :]) / rho
+        local_evaluation = (x - center) / rho
+        P = jnp.prod(local_nodes[:, None, :] ** exps_j[None, :, :], axis=2)
         sq = jnp.sum((nodes_j - x[None, :]) ** 2, axis=1)
         is_zero = sq == 0.0
         dist = jnp.where(is_zero, 0.0, jnp.sqrt(jnp.where(is_zero, 1.0, sq)))
         r = dist / rho
         w = jnp.where(r < 1.0, (1.0 - r) ** 4 * (4.0 * r + 1.0), 0.0)
-        p = jnp.prod(x[None, :] ** exps_j, axis=1)  # (m,)
+        p = jnp.prod(local_evaluation[None, :] ** exps_j, axis=1)
         M = jnp.einsum("n,ni,nj->ij", w, P, P)
         return (P @ jnp.linalg.solve(M, p)) * w
 

--- a/mfgarchon/alg/numerical/meshless_galerkin/voronoi_cells.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/voronoi_cells.py
@@ -33,10 +33,11 @@ if TYPE_CHECKING:
 
 @dataclass
 class CellGeometry:
-    """A clipped Voronoi cell: CCW polygon, area, and boundary-edge normals/lengths/midpoints."""
+    """A clipped Voronoi cell: CCW polygon, exact centroid, area, and boundary-edge geometry."""
 
     polygon: NDArray  # (V, 2) CCW vertices
     area: float  # |Omega_a|
+    centroid: NDArray  # (2,), exact centroid of the polygonal cell
     edge_midpoints: NDArray  # (E, 2)
     edge_normals: NDArray  # (E, 2) outward unit normals
     edge_lengths: NDArray  # (E,)
@@ -83,6 +84,22 @@ def _polygon_area_ccw(poly: NDArray) -> float:
         return 0.0
     x, y = poly[:, 0], poly[:, 1]
     return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+
+
+def _polygon_centroid(poly: NDArray) -> NDArray:
+    """Exact area centroid of a nondegenerate polygon."""
+    x, y = poly[:, 0], poly[:, 1]
+    cross = x * np.roll(y, -1) - np.roll(x, -1) * y
+    twice_area = float(np.sum(cross))
+    if abs(twice_area) <= 2e-14:
+        raise ValueError("Cannot compute the centroid of a degenerate Voronoi polygon.")
+    return np.array(
+        [
+            np.sum((x + np.roll(x, -1)) * cross),
+            np.sum((y + np.roll(y, -1)) * cross),
+        ],
+        dtype=np.float64,
+    ) / (3.0 * twice_area)
 
 
 def _cell_edges(poly: NDArray):
@@ -158,6 +175,7 @@ def clipped_voronoi_cells(
                 f"SCNI: node {a} at {np.round(xa, 4).tolist()} has an empty/degenerate Voronoi cell "
                 f"(area={area:.2e}); check the cloud / bounds / domain (#1139)."
             )
+        centroid = _polygon_centroid(poly)
         mids, normals, lengths = _cell_edges(poly)
         closure = float(np.abs((normals * lengths[:, None]).sum(axis=0)).max())
         if closure > 1e-9:
@@ -165,7 +183,7 @@ def clipped_voronoi_cells(
                 f"SCNI: node {a} cell is not closed (||sum_e n_e L_e|| = {closure:.2e}); an open "
                 "polygon breaks the SCNI integration constraint (mass conservation) (#1139)."
             )
-        cells.append(CellGeometry(poly, area, mids, normals, lengths))
+        cells.append(CellGeometry(poly, area, centroid, mids, normals, lengths))
     return cells
 
 

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -1,0 +1,305 @@
+"""Admission tests for the experimental centroidal VC2-SCNI operator sandbox."""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.meshless_galerkin.centroidal_vci_sandbox import (
+    CentroidalVC2SCNIOperatorSandbox,
+    PairedMFGOperatorSandbox,
+)
+from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voronoi_cells
+
+BOUNDS = [(0.0, 1.0), (0.0, 1.0)]
+
+
+def _grid(n: int) -> np.ndarray:
+    axis = np.linspace(0.0, 1.0, n)
+    return np.stack([coordinate.ravel() for coordinate in np.meshgrid(axis, axis, indexing="ij")], axis=1)
+
+
+def _jittered_grid(n: int, seed: int) -> np.ndarray:
+    nodes = _grid(n)
+    interior = (nodes[:, 0] > 0.0) & (nodes[:, 0] < 1.0) & (nodes[:, 1] > 0.0) & (nodes[:, 1] < 1.0)
+    perturbation = np.random.default_rng(seed).uniform(-1.0, 1.0, size=(int(interior.sum()), 2))
+    nodes[interior] += 0.15 / (n - 1) * perturbation
+    return nodes
+
+
+@pytest.fixture(scope="module")
+def structured_sandbox() -> CentroidalVC2SCNIOperatorSandbox:
+    n = 7
+    return CentroidalVC2SCNIOperatorSandbox(_grid(n), rho=3.0 / (n - 1), bounds=BOUNDS)
+
+
+@pytest.fixture(scope="module")
+def jittered_sandbox() -> CentroidalVC2SCNIOperatorSandbox:
+    n = 7
+    return CentroidalVC2SCNIOperatorSandbox(
+        _jittered_grid(n, seed=0),
+        rho=3.2 / (n - 1),
+        bounds=BOUNDS,
+    )
+
+
+def _hamiltonian(_points: np.ndarray, momentum: np.ndarray) -> np.ndarray:
+    return 0.5 * np.sum(momentum**2, axis=1) + 0.1 * np.sum(momentum**4, axis=1)
+
+
+def _hamiltonian_gradient(_points: np.ndarray, momentum: np.ndarray) -> np.ndarray:
+    return momentum + 0.4 * momentum**3
+
+
+def _stabilization_flux(_points: np.ndarray, momentum: np.ndarray) -> np.ndarray:
+    squared_norm = np.sum(momentum**2, axis=1)
+    return 0.03 * squared_norm[:, None] * momentum
+
+
+def _stabilization_jacobian(_points: np.ndarray, momentum: np.ndarray) -> np.ndarray:
+    count, dim = momentum.shape
+    squared_norm = np.sum(momentum**2, axis=1)
+    jacobian = 0.06 * np.einsum("qd,qe->qde", momentum, momentum)
+    jacobian += 0.03 * squared_norm[:, None, None] * np.eye(dim)[None, :, :]
+    return jacobian.reshape(count, dim, dim)
+
+
+class TestCentroidalVC2Geometry:
+    def test_polygon_centroids_are_exact_on_a_cartesian_tiling(self):
+        cells = clipped_voronoi_cells(_grid(3), BOUNDS)
+        assert np.allclose(cells[0].centroid, [0.125, 0.125], atol=1e-14)
+        assert np.allclose(cells[4].centroid, [0.5, 0.5], atol=1e-14)
+        assert all(cell.area > 0.0 for cell in cells)
+
+    def test_structured_cloud_passes_polynomial_and_stability_gates(self, structured_sandbox):
+        diagnostics = structured_sandbox.diagnostics
+        assert diagnostics.local_rank_min == 5
+        assert diagnostics.quadratic_gradient_defect < 1e-10
+        assert diagnostics.plain_patch_defect > 1e-4
+        assert diagnostics.corrected_patch_defect < 1e-12
+        assert diagnostics.correction_ratio_max < 0.2
+        assert diagnostics.mass_condition < 1e3
+        assert diagnostics.gauge_coercivity_min > 1.0
+        assert diagnostics.gauge_smallest_singular_value > 1.0
+        assert diagnostics.stiffness_nullity == 1
+
+    def test_jittered_cloud_preserves_the_full_gate(self, jittered_sandbox):
+        diagnostics = jittered_sandbox.diagnostics
+        assert diagnostics.local_rank_min == 5
+        assert diagnostics.local_condition_max < 20.0
+        assert diagnostics.quadratic_gradient_defect < 1e-9
+        assert diagnostics.corrected_patch_defect < 1e-12
+        assert diagnostics.correction_ratio_max < 0.2
+        assert diagnostics.gauge_coercivity_min > 1.0
+        assert diagnostics.stiffness_nullity == 1
+
+    def test_sdf_chord_geometry_includes_boundary_flux_in_the_patch(self):
+        center = np.array([0.5, 0.5])
+        radius = 0.4
+        n = 11
+        axis = np.linspace(0.1, 0.9, n)
+        grid = np.stack(
+            [coordinate.ravel() for coordinate in np.meshgrid(axis, axis, indexing="ij")],
+            axis=1,
+        )
+        sdf = lambda points: np.linalg.norm(np.atleast_2d(points) - center, axis=1) - radius  # noqa: E731
+        nodes = grid[sdf(grid) <= 1e-14]
+        sandbox = CentroidalVC2SCNIOperatorSandbox(
+            nodes,
+            rho=3.0 * 0.8 / (n - 1),
+            bounds=[(0.1, 0.9), (0.1, 0.9)],
+            sdf=sdf,
+        )
+        assert sandbox.diagnostics.quadratic_gradient_defect < 1e-9
+        assert sandbox.diagnostics.corrected_patch_defect < 1e-12
+        assert sandbox.diagnostics.stiffness_nullity == 1
+
+    def test_boundary_complete_lloyd_cloud_passes(self):
+        from mfgarchon.geometry.collocation import ImplicitDomainCollocation
+        from mfgarchon.geometry.implicit import Hyperrectangle
+
+        interior = ImplicitDomainCollocation(Hyperrectangle(bounds=BOUNDS)).sample_interior(
+            80,
+            method="lloyd",
+            seed=0,
+        )
+        interior = interior[
+            (interior[:, 0] > 0.035) & (interior[:, 0] < 0.965) & (interior[:, 1] > 0.035) & (interior[:, 1] < 0.965)
+        ]
+        boundary_axis = np.linspace(0.0, 1.0, 12)
+        boundary = np.vstack(
+            [
+                np.column_stack([boundary_axis, np.zeros_like(boundary_axis)]),
+                np.column_stack([boundary_axis, np.ones_like(boundary_axis)]),
+                np.column_stack([np.zeros_like(boundary_axis[1:-1]), boundary_axis[1:-1]]),
+                np.column_stack([np.ones_like(boundary_axis[1:-1]), boundary_axis[1:-1]]),
+            ]
+        )
+        nodes = np.vstack([interior, boundary])
+        h = 1.0 / np.sqrt(len(nodes))
+        sandbox = CentroidalVC2SCNIOperatorSandbox(nodes, rho=3.5 * h, bounds=BOUNDS)
+        diagnostics = sandbox.diagnostics
+        assert diagnostics.local_rank_min == 5
+        assert diagnostics.quadratic_gradient_defect < 1e-8
+        assert diagnostics.corrected_patch_defect < 1e-12
+        assert diagnostics.correction_ratio_max < 0.5
+        assert diagnostics.mass_condition < 1e5
+        assert diagnostics.gauge_coercivity_min > 1.0
+        assert diagnostics.stiffness_nullity == 1
+
+    def test_interior_only_lloyd_cloud_fails_the_mass_gate(self):
+        from mfgarchon.geometry.collocation import ImplicitDomainCollocation
+        from mfgarchon.geometry.implicit import Hyperrectangle
+
+        nodes = ImplicitDomainCollocation(Hyperrectangle(bounds=BOUNDS)).sample_interior(
+            120,
+            method="lloyd",
+            seed=0,
+        )
+        h = 1.0 / np.sqrt(len(nodes))
+        with pytest.raises(np.linalg.LinAlgError, match=r"mass gate failed: cond\(M\)"):
+            CentroidalVC2SCNIOperatorSandbox(nodes, rho=4.0 * h, bounds=BOUNDS)
+
+    def test_mass_and_petrov_nullspaces_are_not_conflated(self, structured_sandbox):
+        E = structured_sandbox.value_operator().toarray()
+        W = structured_sandbox.weights
+        M = structured_sandbox.mass().toarray()
+        K = structured_sandbox.stiffness().toarray()
+        one = np.ones(structured_sandbox.n_dof)
+        assert np.allclose(M, E.T @ (W[:, None] * E), atol=1e-14)
+        assert np.linalg.eigvalsh(M).min() > 0.0
+        assert np.linalg.norm(K - K.T) / np.linalg.norm(K) > 1e-4
+        assert np.max(np.abs(K @ one)) < 1e-10
+        assert np.max(np.abs(one @ K)) > 1e-3
+        left_null = structured_sandbox.left_null_vector()
+        assert abs(left_null.sum() - 1.0) < 1e-12
+        assert np.max(np.abs(left_null @ K)) < 1e-10
+
+    def test_rank_deficient_local_support_fails_loud(self):
+        n = 7
+        with pytest.raises(ValueError, match="VC2 local constraint rank failure"):
+            CentroidalVC2SCNIOperatorSandbox(
+                _grid(n),
+                rho=3.0 / (n - 1),
+                bounds=BOUNDS,
+                vci_support_radius=0.2 / (n - 1),
+            )
+
+    def test_duplicate_nodes_fail_before_geometry_assembly(self):
+        nodes = _grid(7)
+        nodes[1] = nodes[0]
+        with pytest.raises(ValueError, match="does not admit duplicate nodes"):
+            CentroidalVC2SCNIOperatorSandbox(nodes, rho=0.5, bounds=BOUNDS)
+
+    def test_condition_gate_fails_loud(self):
+        n = 7
+        with pytest.raises(np.linalg.LinAlgError, match="VC2 local constraint is ill-conditioned"):
+            CentroidalVC2SCNIOperatorSandbox(
+                _grid(n),
+                rho=3.0 / (n - 1),
+                bounds=BOUNDS,
+                max_local_condition=1.0,
+            )
+
+
+class TestPairedMFGOperator:
+    def test_complete_analytic_jacobian_matches_centered_difference(self, structured_sandbox):
+        operator = PairedMFGOperatorSandbox(
+            structured_sandbox,
+            diffusion=0.07,
+            hamiltonian=_hamiltonian,
+            hamiltonian_gradient=_hamiltonian_gradient,
+            stabilization_flux=_stabilization_flux,
+            stabilization_jacobian=_stabilization_jacobian,
+        )
+        rng = np.random.default_rng(12)
+        state = 0.1 * rng.standard_normal(structured_sandbox.n_dof)
+        analytic = operator.jacobian(state)
+        finite_difference = np.empty_like(analytic)
+        step = 2e-7
+        for column in range(structured_sandbox.n_dof):
+            direction = np.zeros(structured_sandbox.n_dof)
+            direction[column] = step
+            finite_difference[:, column] = (
+                operator.residual(state + direction) - operator.residual(state - direction)
+            ) / (2.0 * step)
+        relative_defect = np.linalg.norm(analytic - finite_difference) / np.linalg.norm(analytic)
+        assert relative_defect < 2e-8
+
+    def test_forward_block_is_exact_transpose_and_preserves_physical_mass(self, structured_sandbox):
+        operator = PairedMFGOperatorSandbox(
+            structured_sandbox,
+            diffusion=0.05,
+            hamiltonian=_hamiltonian,
+            hamiltonian_gradient=_hamiltonian_gradient,
+            stabilization_flux=_stabilization_flux,
+            stabilization_jacobian=_stabilization_jacobian,
+        )
+        rng = np.random.default_rng(4)
+        state = 0.05 * rng.standard_normal(structured_sandbox.n_dof)
+        density = np.ones(structured_sandbox.n_dof) + 0.02 * rng.standard_normal(structured_sandbox.n_dof)
+        jacobian = operator.jacobian(state)
+        one = np.ones(structured_sandbox.n_dof)
+        assert np.max(np.abs(jacobian @ one)) < 1e-10
+        assert np.array_equal(operator.forward_spatial(state, density), jacobian.T @ density)
+
+        M = structured_sandbox.mass().toarray()
+        time_step = 1e-3
+        advanced_density = np.linalg.solve(M / time_step + jacobian.T, (M / time_step) @ density)
+        assert abs(operator.physical_mass(advanced_density) - operator.physical_mass(density)) < 1e-12
+
+    def test_hamiltonian_pairing_equals_reconstructed_density_bregman_term(self, structured_sandbox):
+        operator = PairedMFGOperatorSandbox(
+            structured_sandbox,
+            diffusion=0.0,
+            hamiltonian=_hamiltonian,
+            hamiltonian_gradient=_hamiltonian_gradient,
+        )
+        rng = np.random.default_rng(9)
+        state_1 = 0.05 * rng.standard_normal(structured_sandbox.n_dof)
+        state_2 = 0.05 * rng.standard_normal(structured_sandbox.n_dof)
+        density_1 = np.ones(structured_sandbox.n_dof) + 0.02 * rng.standard_normal(structured_sandbox.n_dof)
+        density_2 = np.ones(structured_sandbox.n_dof) + 0.02 * rng.standard_normal(structured_sandbox.n_dof)
+        rho_1 = structured_sandbox.reconstructed_density(density_1)
+        rho_2 = structured_sandbox.reconstructed_density(density_2)
+        assert np.min(rho_1) > 0.0
+        assert np.min(rho_2) > 0.0
+
+        momentum_1 = operator.momentum(state_1)
+        momentum_2 = operator.momentum(state_2)
+        values_1 = _hamiltonian(structured_sandbox.evaluation_points, momentum_1)
+        values_2 = _hamiltonian(structured_sandbox.evaluation_points, momentum_2)
+        gradients_1 = _hamiltonian_gradient(structured_sandbox.evaluation_points, momentum_1)
+        gradients_2 = _hamiltonian_gradient(structured_sandbox.evaluation_points, momentum_2)
+        bregman_21 = values_2 - values_1 - np.sum(gradients_1 * (momentum_2 - momentum_1), axis=1)
+        bregman_12 = values_1 - values_2 - np.sum(gradients_2 * (momentum_1 - momentum_2), axis=1)
+        expected = structured_sandbox.weights @ (rho_1 * bregman_21 + rho_2 * bregman_12)
+
+        residual_1 = operator.residual(state_1)
+        residual_2 = operator.residual(state_2)
+        state_delta = state_2 - state_1
+        paired = density_1 @ (residual_2 - residual_1 - operator.jacobian(state_1) @ state_delta)
+        paired += density_2 @ (residual_1 - residual_2 + operator.jacobian(state_2) @ state_delta)
+        assert abs(paired - expected) < 1e-13
+        assert expected >= 0.0
+
+    def test_invalid_hamiltonian_shape_fails_loud(self, structured_sandbox):
+        operator = PairedMFGOperatorSandbox(
+            structured_sandbox,
+            diffusion=0.0,
+            hamiltonian=lambda _points, _momentum: np.zeros((structured_sandbox.n_dof, 1)),
+            hamiltonian_gradient=_hamiltonian_gradient,
+        )
+        with pytest.raises(ValueError, match="Hamiltonian values must have shape"):
+            operator.residual(np.zeros(structured_sandbox.n_dof))
+
+    def test_stabilization_derivative_is_mandatory(self, structured_sandbox):
+        with pytest.raises(ValueError, match="must be supplied together"):
+            PairedMFGOperatorSandbox(
+                structured_sandbox,
+                diffusion=0.0,
+                hamiltonian=_hamiltonian,
+                hamiltonian_gradient=_hamiltonian_gradient,
+                stabilization_flux=_stabilization_flux,
+            )

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from functools import cache
+
 import pytest
 
 import numpy as np
 
 from mfgarchon.alg.numerical.meshless_galerkin.centroidal_vci_sandbox import (
+    BoundaryCompleteCVTCloud,
     CentroidalVC2SCNIOperatorSandbox,
     PairedMFGOperatorSandbox,
     boundary_complete_cvt_rectangle,
@@ -27,6 +30,20 @@ def _jittered_grid(n: int, seed: int) -> np.ndarray:
     perturbation = np.random.default_rng(seed).uniform(-1.0, 1.0, size=(int(interior.sum()), 2))
     nodes[interior] += 0.15 / (n - 1) * perturbation
     return nodes
+
+
+@cache
+def _boundary_complete_case(
+    resolution: int,
+    seed: int,
+) -> tuple[BoundaryCompleteCVTCloud, CentroidalVC2SCNIOperatorSandbox]:
+    cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
+    sandbox = CentroidalVC2SCNIOperatorSandbox(
+        cloud.nodes,
+        rho=3.0 * cloud.nominal_spacing,
+        bounds=BOUNDS,
+    )
+    return cloud, sandbox
 
 
 @pytest.fixture(scope="module")
@@ -150,12 +167,7 @@ class TestCentroidalVC2Geometry:
         [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
     )
     def test_boundary_complete_cvt_family_passes_refinement_gate(self, resolution, seed):
-        cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
-        sandbox = CentroidalVC2SCNIOperatorSandbox(
-            cloud.nodes,
-            rho=3.0 * cloud.nominal_spacing,
-            bounds=BOUNDS,
-        )
+        cloud, sandbox = _boundary_complete_case(resolution, seed)
         diagnostics = sandbox.diagnostics
         assert cloud.max_interior_centroid_offset_ratio < 0.025
         assert cloud.min_separation_ratio > 0.8
@@ -171,6 +183,77 @@ class TestCentroidalVC2Geometry:
         assert diagnostics.gauge_coercivity_min > 9.0
         assert diagnostics.gauge_smallest_singular_value > 9.0
         assert diagnostics.stiffness_nullity == 1
+
+    @pytest.mark.parametrize(
+        ("wave_numbers", "minimum_l2_rate", "minimum_h1_rate"),
+        [
+            ((1, 1), 1.95, 2.2),
+            ((2, 1), 1.75, 2.15),
+        ],
+    )
+    @pytest.mark.parametrize("seed", range(3))
+    def test_boundary_complete_cvt_poisson_neumann_converges(
+        self,
+        wave_numbers,
+        minimum_l2_rate,
+        minimum_h1_rate,
+        seed,
+    ):
+        records = []
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, sandbox = _boundary_complete_case(resolution, seed)
+            points = sandbox.evaluation_points
+            exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
+            forcing = (kx**2 + ky**2) * np.pi**2 * exact_values
+            exact_values -= float(sandbox.weights @ exact_values / np.sum(sandbox.weights))
+            exact_gradient = np.column_stack(
+                [
+                    -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
+                    -ky * np.pi * np.cos(kx * np.pi * points[:, 0]) * np.sin(ky * np.pi * points[:, 1]),
+                ]
+            )
+
+            E = sandbox.value_operator().toarray()
+            M = sandbox.mass().toarray()
+            K = sandbox.stiffness().toarray()
+            one = np.ones(sandbox.n_dof)
+            mean_constraint = M @ one
+            left_null = sandbox.left_null_vector()
+            load = E.T @ (sandbox.weights * forcing)
+            saddle = np.block(
+                [
+                    [K, left_null[:, None]],
+                    [mean_constraint[None, :], np.zeros((1, 1))],
+                ]
+            )
+            augmented_load = np.append(load, 0.0)
+            augmented_solution = np.linalg.solve(saddle, augmented_load)
+            solution = augmented_solution[:-1]
+            relative_saddle_residual = np.linalg.norm(saddle @ augmented_solution - augmented_load) / np.linalg.norm(
+                load
+            )
+            assert relative_saddle_residual < 1e-12
+            assert abs(mean_constraint @ solution) < 1e-12
+
+            reconstructed_values = E @ solution
+            reconstructed_gradient = np.column_stack([gradient @ solution for gradient in sandbox.trial_gradient()])
+            l2_error = float(np.sqrt(sandbox.weights @ (reconstructed_values - exact_values) ** 2))
+            h1_error = float(np.sqrt(sandbox.weights @ np.sum((reconstructed_gradient - exact_gradient) ** 2, axis=1)))
+            compatibility_ratio = float(abs(left_null @ load) / (np.linalg.norm(left_null) * np.linalg.norm(load)))
+            records.append((cloud.nominal_spacing, l2_error, h1_error, compatibility_ratio))
+
+        spacings, l2_errors, h1_errors, compatibility_ratios = map(np.asarray, zip(*records, strict=True))
+        assert np.all(np.diff(l2_errors) < 0.0)
+        assert np.all(np.diff(h1_errors) < 0.0)
+        assert l2_errors[-1] < 0.12 * l2_errors[0]
+        assert h1_errors[-1] < 0.08 * h1_errors[0]
+        assert np.max(compatibility_ratios) < 4e-3
+        assert compatibility_ratios[-1] < 2e-4
+        l2_rate = float(np.polyfit(np.log(spacings), np.log(l2_errors), 1)[0])
+        h1_rate = float(np.polyfit(np.log(spacings), np.log(h1_errors), 1)[0])
+        assert l2_rate > minimum_l2_rate
+        assert h1_rate > minimum_h1_rate
 
     def test_interior_only_lloyd_cloud_fails_the_mass_gate(self):
         from mfgarchon.geometry.collocation import ImplicitDomainCollocation

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -14,6 +14,13 @@ from mfgarchon.alg.numerical.meshless_galerkin.centroidal_vci_sandbox import (
     PairedMFGOperatorSandbox,
     boundary_complete_cvt_rectangle,
 )
+from mfgarchon.alg.numerical.meshless_galerkin.discretization import MeshlessGalerkinDiscretization
+from mfgarchon.alg.numerical.meshless_galerkin.mls_basis import (
+    monomial_exponents,
+    shape_functions_and_grads,
+)
+from mfgarchon.alg.numerical.meshless_galerkin.quadrature import tensor_gauss
+from mfgarchon.alg.numerical.meshless_galerkin.scni_discretization import MeshlessSCNIDiscretization
 from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voronoi_cells
 
 BOUNDS = [(0.0, 1.0), (0.0, 1.0)]
@@ -44,6 +51,97 @@ def _boundary_complete_case(
         bounds=BOUNDS,
     )
     return cloud, sandbox
+
+
+def _solve_neumann_system(K, M, load, left_null):
+    one = np.ones(len(K))
+    mean_constraint = M @ one
+    saddle = np.block(
+        [
+            [K, left_null[:, None]],
+            [mean_constraint[None, :], np.zeros((1, 1))],
+        ]
+    )
+    augmented_load = np.append(load, 0.0)
+    augmented_solution = np.linalg.solve(saddle, augmented_load)
+    relative_residual = np.linalg.norm(saddle @ augmented_solution - augmented_load) / np.linalg.norm(load)
+    gauge_defect = float(abs(mean_constraint @ augmented_solution[:-1]))
+    return augmented_solution[:-1], relative_residual, gauge_defect
+
+
+def _physical_poisson_errors(
+    reconstructed_values,
+    reconstructed_gradient,
+    exact_values,
+    exact_gradient,
+    weights,
+):
+    value_error = reconstructed_values - exact_values
+    value_error -= float(weights @ value_error / np.sum(weights))
+    l2_error = float(np.sqrt(weights @ value_error**2))
+    h1_error = float(np.sqrt(weights @ np.sum((reconstructed_gradient - exact_gradient) ** 2, axis=1)))
+    return l2_error, h1_error
+
+
+@cache
+def _matched_cost_arms(resolution: int, seed: int):
+    cloud, sandbox = _boundary_complete_case(resolution, seed)
+    rho = 3.0 * cloud.nominal_spacing
+    E = sandbox.value_operator().toarray()
+    W = sandbox.weights
+    trial_gradients = [gradient.toarray() for gradient in sandbox.trial_gradient()]
+    M = sandbox.mass().toarray()
+
+    plain_scni = MeshlessSCNIDiscretization(
+        cloud.nodes,
+        rho=rho,
+        degree=2,
+        bounds=BOUNDS,
+        n_edge_gauss=4,
+    )
+    # Halving every oriented edge count also pairs physical-boundary edges, so this
+    # undercounts an optimized VC2 implementation and biases the budget in VC2's favor.
+    optimistic_vc2_budget = sandbox.centroid_evaluation_count + (sandbox.edge_evaluation_count + 1) // 2
+    common_cells = max(1, int(np.floor(np.sqrt(optimistic_vc2_budget) / 4)))
+    common_points, common_weights = tensor_gauss(BOUNDS, n_cells=common_cells, n_gauss=4)
+    common = MeshlessGalerkinDiscretization(
+        cloud.nodes,
+        rho,
+        2,
+        common_points,
+        common_weights,
+    )
+    _, pointwise_gradients = shape_functions_and_grads(
+        sandbox.evaluation_points,
+        cloud.nodes,
+        rho,
+        monomial_exponents(2, 2),
+        "numpy",
+        check_conditioning=True,
+    )
+    arms = {
+        "plain_scni": (
+            plain_scni.stiffness().toarray(),
+            plain_scni.mass().toarray(),
+            trial_gradients,
+        ),
+        "centroidal_scni": (
+            sum(gradient.T @ (W[:, None] * gradient) for gradient in trial_gradients),
+            M,
+            trial_gradients,
+        ),
+        "vc2": (
+            sandbox.stiffness().toarray(),
+            M,
+            trial_gradients,
+        ),
+        "common_quadrature": (
+            common.stiffness().toarray(),
+            common.mass().toarray(),
+            [pointwise_gradients[:, :, direction] for direction in range(2)],
+        ),
+    }
+    return cloud, sandbox, E, W, arms, len(common_points), optimistic_vc2_budget
 
 
 @pytest.fixture(scope="module")
@@ -206,7 +304,6 @@ class TestCentroidalVC2Geometry:
             points = sandbox.evaluation_points
             exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
             forcing = (kx**2 + ky**2) * np.pi**2 * exact_values
-            exact_values -= float(sandbox.weights @ exact_values / np.sum(sandbox.weights))
             exact_gradient = np.column_stack(
                 [
                     -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
@@ -217,29 +314,21 @@ class TestCentroidalVC2Geometry:
             E = sandbox.value_operator().toarray()
             M = sandbox.mass().toarray()
             K = sandbox.stiffness().toarray()
-            one = np.ones(sandbox.n_dof)
-            mean_constraint = M @ one
             left_null = sandbox.left_null_vector()
             load = E.T @ (sandbox.weights * forcing)
-            saddle = np.block(
-                [
-                    [K, left_null[:, None]],
-                    [mean_constraint[None, :], np.zeros((1, 1))],
-                ]
-            )
-            augmented_load = np.append(load, 0.0)
-            augmented_solution = np.linalg.solve(saddle, augmented_load)
-            solution = augmented_solution[:-1]
-            relative_saddle_residual = np.linalg.norm(saddle @ augmented_solution - augmented_load) / np.linalg.norm(
-                load
-            )
+            solution, relative_saddle_residual, gauge_defect = _solve_neumann_system(K, M, load, left_null)
             assert relative_saddle_residual < 1e-12
-            assert abs(mean_constraint @ solution) < 1e-12
+            assert gauge_defect < 1e-12
 
             reconstructed_values = E @ solution
             reconstructed_gradient = np.column_stack([gradient @ solution for gradient in sandbox.trial_gradient()])
-            l2_error = float(np.sqrt(sandbox.weights @ (reconstructed_values - exact_values) ** 2))
-            h1_error = float(np.sqrt(sandbox.weights @ np.sum((reconstructed_gradient - exact_gradient) ** 2, axis=1)))
+            l2_error, h1_error = _physical_poisson_errors(
+                reconstructed_values,
+                reconstructed_gradient,
+                exact_values,
+                exact_gradient,
+                sandbox.weights,
+            )
             compatibility_ratio = float(abs(left_null @ load) / (np.linalg.norm(left_null) * np.linalg.norm(load)))
             records.append((cloud.nominal_spacing, l2_error, h1_error, compatibility_ratio))
 
@@ -254,6 +343,77 @@ class TestCentroidalVC2Geometry:
         h1_rate = float(np.polyfit(np.log(spacings), np.log(h1_errors), 1)[0])
         assert l2_rate > minimum_l2_rate
         assert h1_rate > minimum_h1_rate
+
+    @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1)])
+    @pytest.mark.parametrize("seed", range(3))
+    def test_matched_cost_poisson_records_vc2_gain_and_common_quadrature_gap(self, wave_numbers, seed):
+        records = {
+            "plain_scni": [],
+            "centroidal_scni": [],
+            "vc2": [],
+            "common_quadrature": [],
+        }
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, sandbox, E, W, arms, common_count, optimistic_vc2_budget = _matched_cost_arms(resolution, seed)
+            assert 0.75 * optimistic_vc2_budget < common_count <= optimistic_vc2_budget
+            points = sandbox.evaluation_points
+            exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
+            exact_gradient = np.column_stack(
+                [
+                    -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
+                    -ky * np.pi * np.cos(kx * np.pi * points[:, 0]) * np.sin(ky * np.pi * points[:, 1]),
+                ]
+            )
+            forcing_nodes = (
+                (kx**2 + ky**2)
+                * np.pi**2
+                * np.cos(kx * np.pi * cloud.nodes[:, 0])
+                * np.cos(ky * np.pi * cloud.nodes[:, 1])
+            )
+            for name, (K, M, gradients) in arms.items():
+                one = np.ones(sandbox.n_dof)
+                left_null = sandbox.left_null_vector() if name == "vc2" else one / len(one)
+                solution, relative_residual, gauge_defect = _solve_neumann_system(
+                    K,
+                    M,
+                    M @ forcing_nodes,
+                    left_null,
+                )
+                assert relative_residual < 1e-12
+                assert gauge_defect < 1e-12
+                reconstructed_gradient = np.column_stack([gradient @ solution for gradient in gradients])
+                l2_error, h1_error = _physical_poisson_errors(
+                    E @ solution,
+                    reconstructed_gradient,
+                    exact_values,
+                    exact_gradient,
+                    W,
+                )
+                records[name].append((cloud.nominal_spacing, l2_error, h1_error))
+
+        rates = {}
+        for name, arm_records in records.items():
+            spacings, l2_errors, h1_errors = map(np.asarray, zip(*arm_records, strict=True))
+            assert np.all(np.diff(l2_errors) < 0.0)
+            assert np.all(np.diff(h1_errors) < 0.0)
+            rates[name] = (
+                float(np.polyfit(np.log(spacings), np.log(l2_errors), 1)[0]),
+                float(np.polyfit(np.log(spacings), np.log(h1_errors), 1)[0]),
+            )
+
+        assert rates["plain_scni"][1] < 1.6
+        assert rates["centroidal_scni"][1] < 1.8
+        assert rates["vc2"][1] > 2.0
+        assert rates["common_quadrature"][1] > 2.0
+        plain_finest = records["plain_scni"][-1]
+        centroidal_finest = records["centroidal_scni"][-1]
+        vc2_finest = records["vc2"][-1]
+        common_finest = records["common_quadrature"][-1]
+        assert vc2_finest[2] < 0.3 * plain_finest[2]
+        assert vc2_finest[2] < 0.4 * centroidal_finest[2]
+        assert common_finest[2] < 0.55 * vc2_finest[2]
+        assert common_finest[1] < 0.06 * vc2_finest[1]
 
     def test_interior_only_lloyd_cloud_fails_the_mass_gate(self):
         from mfgarchon.geometry.collocation import ImplicitDomainCollocation

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -767,8 +767,9 @@ class TestCentroidalVCGeometry:
         [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
     )
     def test_edge_energy_stabilized_vc4_family_has_physical_spectral_bounds(self, resolution, seed):
-        _cloud, sandbox = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
+        cloud, sandbox = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
         diagnostics = sandbox.diagnostics
+        spacing = cloud.nominal_spacing
         assert sandbox.stabilization_metric == "edge_energy"
         assert diagnostics.stabilization_rank_min == 15
         assert diagnostics.stabilization_condition_max < 5100.0
@@ -780,6 +781,10 @@ class TestCentroidalVCGeometry:
         assert diagnostics.gauge_smallest_singular_value > 9.8
         assert diagnostics.discrete_patch_defect < 7e-14
         assert diagnostics.stiffness_nullity == 1
+        assert diagnostics.value_weighted_column_sum_max / spacing**2 < 2.3
+        assert diagnostics.test_gradient_weighted_column_sum_max / spacing < 6.0
+        assert diagnostics.edge_value_weighted_column_sum_max / spacing < 9.5
+        assert diagnostics.frame_gauge_euclidean_coercivity_min / spacing**2 > 0.35
 
         one = np.ones(sandbox.n_dof)
         mass = sandbox.mass().toarray()
@@ -843,8 +848,9 @@ class TestCentroidalVCGeometry:
         [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
     )
     def test_variable_coefficient_edge_vc4_family_preserves_patch_and_spectral_bounds(self, resolution, seed):
-        _cloud, sandbox = _boundary_complete_variable_edge_stabilized_vc4_case(resolution, seed)
+        cloud, sandbox = _boundary_complete_variable_edge_stabilized_vc4_case(resolution, seed)
         diagnostics = sandbox.diagnostics
+        spacing = cloud.nominal_spacing
         sampled_min, sampled_max = sandbox.sampled_elliptic_coefficient_bounds
         assert sandbox.has_spatial_elliptic_coefficient
         assert 0.8 <= sampled_min < sampled_max <= 1.2
@@ -859,6 +865,10 @@ class TestCentroidalVCGeometry:
         assert diagnostics.gauge_coercivity_min > 7.55
         assert diagnostics.gauge_smallest_singular_value > 9.74
         assert diagnostics.stiffness_nullity == 1
+        assert diagnostics.value_weighted_column_sum_max / spacing**2 < 2.3
+        assert diagnostics.test_gradient_weighted_column_sum_max / spacing < 6.2
+        assert diagnostics.edge_value_weighted_column_sum_max / spacing < 9.5
+        assert diagnostics.frame_gauge_euclidean_coercivity_min / spacing**2 > 0.35
 
         one = np.ones(sandbox.n_dof)
         mass = sandbox.mass().toarray()

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -1,4 +1,4 @@
-"""Admission tests for the experimental centroidal VC2-SCNI operator sandbox."""
+"""Admission tests for the experimental centroidal VCI-SCNI operator sandbox."""
 
 from __future__ import annotations
 
@@ -10,8 +10,9 @@ import numpy as np
 
 from mfgarchon.alg.numerical.meshless_galerkin.centroidal_vci_sandbox import (
     BoundaryCompleteCVTCloud,
-    CentroidalVC2SCNIOperatorSandbox,
+    CentroidalVCISCNIOperatorSandbox,
     PairedMFGOperatorSandbox,
+    _polynomial_data,
     boundary_complete_cvt_rectangle,
 )
 from mfgarchon.alg.numerical.meshless_galerkin.discretization import MeshlessGalerkinDiscretization
@@ -43,12 +44,28 @@ def _jittered_grid(n: int, seed: int) -> np.ndarray:
 def _boundary_complete_case(
     resolution: int,
     seed: int,
-) -> tuple[BoundaryCompleteCVTCloud, CentroidalVC2SCNIOperatorSandbox]:
+) -> tuple[BoundaryCompleteCVTCloud, CentroidalVCISCNIOperatorSandbox]:
     cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
-    sandbox = CentroidalVC2SCNIOperatorSandbox(
+    sandbox = CentroidalVCISCNIOperatorSandbox(
         cloud.nodes,
         rho=3.0 * cloud.nominal_spacing,
         bounds=BOUNDS,
+    )
+    return cloud, sandbox
+
+
+@cache
+def _boundary_complete_vc4_case(
+    resolution: int,
+    seed: int,
+) -> tuple[BoundaryCompleteCVTCloud, CentroidalVCISCNIOperatorSandbox]:
+    cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
+    sandbox = CentroidalVCISCNIOperatorSandbox(
+        cloud.nodes,
+        rho=3.0 * cloud.nominal_spacing,
+        bounds=BOUNDS,
+        vci_degree=4,
+        vci_support_radius=4.0 * cloud.nominal_spacing,
     )
     return cloud, sandbox
 
@@ -100,9 +117,10 @@ def _matched_cost_arms(resolution: int, seed: int):
         n_edge_gauss=4,
     )
     # Halving every oriented edge count also pairs physical-boundary edges, so this
-    # undercounts an optimized VC2 implementation and biases the budget in VC2's favor.
-    optimistic_vc2_budget = sandbox.centroid_evaluation_count + (sandbox.edge_evaluation_count + 1) // 2
-    common_cells = max(1, int(np.floor(np.sqrt(optimistic_vc2_budget) / 4)))
+    # undercounts an optimized VCI implementation and biases the MLS-evaluation
+    # budget in VCI's favor. Local moment-solve cost is not included.
+    optimistic_vci_evaluation_budget = sandbox.centroid_evaluation_count + (sandbox.edge_evaluation_count + 1) // 2
+    common_cells = max(1, int(np.floor(np.sqrt(optimistic_vci_evaluation_budget) / 4)))
     common_points, common_weights = tensor_gauss(BOUNDS, n_cells=common_cells, n_gauss=4)
     common = MeshlessGalerkinDiscretization(
         cloud.nodes,
@@ -141,19 +159,19 @@ def _matched_cost_arms(resolution: int, seed: int):
             [pointwise_gradients[:, :, direction] for direction in range(2)],
         ),
     }
-    return cloud, sandbox, E, W, arms, len(common_points), optimistic_vc2_budget
+    return cloud, sandbox, E, W, arms, len(common_points), optimistic_vci_evaluation_budget
 
 
 @pytest.fixture(scope="module")
-def structured_sandbox() -> CentroidalVC2SCNIOperatorSandbox:
+def structured_sandbox() -> CentroidalVCISCNIOperatorSandbox:
     n = 7
-    return CentroidalVC2SCNIOperatorSandbox(_grid(n), rho=3.0 / (n - 1), bounds=BOUNDS)
+    return CentroidalVCISCNIOperatorSandbox(_grid(n), rho=3.0 / (n - 1), bounds=BOUNDS)
 
 
 @pytest.fixture(scope="module")
-def jittered_sandbox() -> CentroidalVC2SCNIOperatorSandbox:
+def jittered_sandbox() -> CentroidalVCISCNIOperatorSandbox:
     n = 7
-    return CentroidalVC2SCNIOperatorSandbox(
+    return CentroidalVCISCNIOperatorSandbox(
         _jittered_grid(n, seed=0),
         rho=3.2 / (n - 1),
         bounds=BOUNDS,
@@ -181,7 +199,42 @@ def _stabilization_jacobian(_points: np.ndarray, momentum: np.ndarray) -> np.nda
     return jacobian.reshape(count, dim, dim)
 
 
-class TestCentroidalVC2Geometry:
+class TestCentroidalVCGeometry:
+    def test_degree_four_polynomial_derivatives_are_independently_pinned(self):
+        points = np.array([[0.2, -0.1], [0.8, 0.7]])
+        center = np.array([0.1, -0.3])
+        scales = np.array([0.5, 2.0])
+        values, gradients, laplacians = _polynomial_data(points, center, scales, degree=4)
+        sx = (points[:, 0] - center[0]) / scales[0]
+        sy = (points[:, 1] - center[1]) / scales[1]
+
+        assert values.shape == (2, 15)
+        assert np.allclose(values[:, 11], sx**3 * sy)
+        assert np.allclose(gradients[:, 11, 0], 3.0 * sx**2 * sy / scales[0])
+        assert np.allclose(gradients[:, 11, 1], sx**3 / scales[1])
+        assert np.allclose(laplacians[:, 11], 6.0 * sx * sy / scales[0] ** 2)
+        assert np.allclose(values[:, 12], sx**2 * sy**2)
+        assert np.allclose(gradients[:, 12, 0], 2.0 * sx * sy**2 / scales[0])
+        assert np.allclose(gradients[:, 12, 1], 2.0 * sx**2 * sy / scales[1])
+        assert np.allclose(
+            laplacians[:, 12],
+            2.0 * sy**2 / scales[0] ** 2 + 2.0 * sx**2 / scales[1] ** 2,
+        )
+
+    def test_degree_three_vci_branch_is_admitted(self):
+        n = 7
+        sandbox = CentroidalVCISCNIOperatorSandbox(
+            _grid(n),
+            rho=3.0 / (n - 1),
+            bounds=BOUNDS,
+            vci_degree=3,
+            vci_support_radius=4.0 / (n - 1),
+        )
+        diagnostics = sandbox.diagnostics
+        assert diagnostics.local_rank_min == 9
+        assert diagnostics.corrected_patch_defect < 1e-12
+        assert diagnostics.stiffness_nullity == 1
+
     def test_polygon_centroids_are_exact_on_a_cartesian_tiling(self):
         cells = clipped_voronoi_cells(_grid(3), BOUNDS)
         assert np.allclose(cells[0].centroid, [0.125, 0.125], atol=1e-14)
@@ -221,7 +274,7 @@ class TestCentroidalVC2Geometry:
         )
         sdf = lambda points: np.linalg.norm(np.atleast_2d(points) - center, axis=1) - radius  # noqa: E731
         nodes = grid[sdf(grid) <= 1e-14]
-        sandbox = CentroidalVC2SCNIOperatorSandbox(
+        sandbox = CentroidalVCISCNIOperatorSandbox(
             nodes,
             rho=3.0 * 0.8 / (n - 1),
             bounds=[(0.1, 0.9), (0.1, 0.9)],
@@ -355,8 +408,8 @@ class TestCentroidalVC2Geometry:
         }
         kx, ky = wave_numbers
         for resolution in (7, 9, 11, 13, 17, 21):
-            cloud, sandbox, E, W, arms, common_count, optimistic_vc2_budget = _matched_cost_arms(resolution, seed)
-            assert 0.75 * optimistic_vc2_budget < common_count <= optimistic_vc2_budget
+            cloud, sandbox, E, W, arms, common_count, optimistic_vci_budget = _matched_cost_arms(resolution, seed)
+            assert 0.75 * optimistic_vci_budget < common_count <= optimistic_vci_budget
             points = sandbox.evaluation_points
             exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
             exact_gradient = np.column_stack(
@@ -415,6 +468,118 @@ class TestCentroidalVC2Geometry:
         assert common_finest[2] < 0.55 * vc2_finest[2]
         assert common_finest[1] < 0.06 * vc2_finest[1]
 
+    @pytest.mark.parametrize(
+        ("resolution", "seed"),
+        [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
+    )
+    def test_vc4_family_preserves_target_moments_and_stability(self, resolution, seed):
+        _cloud, sandbox = _boundary_complete_vc4_case(resolution, seed)
+        diagnostics = sandbox.diagnostics
+        assert sandbox.vci_degree == 4
+        assert diagnostics.local_rank_min == 14
+        assert diagnostics.local_condition_max < 1700.0
+        assert diagnostics.correction_ratio_max < 0.7
+        assert diagnostics.mass_condition < 250.0
+        assert diagnostics.quadratic_gradient_defect < 1e-8
+        assert diagnostics.corrected_patch_defect < 1e-11
+        assert diagnostics.discrete_patch_defect < 1e-2
+        assert diagnostics.gauge_coercivity_min > 7.5
+        assert diagnostics.stiffness_nullity == 1
+
+    @pytest.mark.parametrize("seed", range(3))
+    def test_vc4_discrete_quartic_patch_converges_without_claiming_trial_exactness(self, seed):
+        records = []
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, sandbox = _boundary_complete_vc4_case(resolution, seed)
+            diagnostics = sandbox.diagnostics
+            assert diagnostics.vci_trial_gradient_defect > diagnostics.discrete_patch_defect
+            records.append((cloud.nominal_spacing, diagnostics.discrete_patch_defect))
+        spacings, defects = map(np.asarray, zip(*records, strict=True))
+        assert np.all(np.diff(defects) < 0.0)
+        rate = float(np.polyfit(np.log(spacings), np.log(defects), 1)[0])
+        assert rate > 2.6
+
+    @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
+    @pytest.mark.parametrize("seed", range(3))
+    def test_vc4_beats_mls_evaluation_budget_matched_common_in_h1_but_not_l2(self, wave_numbers, seed):
+        vc4_records = []
+        common_records = []
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, vc4 = _boundary_complete_vc4_case(resolution, seed)
+            _, _, E, W, arms, common_count, optimistic_vci_budget = _matched_cost_arms(resolution, seed)
+            assert 0.75 * optimistic_vci_budget < common_count <= optimistic_vci_budget
+            points = vc4.evaluation_points
+            exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
+            exact_gradient = np.column_stack(
+                [
+                    -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
+                    -ky * np.pi * np.cos(kx * np.pi * points[:, 0]) * np.sin(ky * np.pi * points[:, 1]),
+                ]
+            )
+            forcing_nodes = (
+                (kx**2 + ky**2)
+                * np.pi**2
+                * np.cos(kx * np.pi * cloud.nodes[:, 0])
+                * np.cos(ky * np.pi * cloud.nodes[:, 1])
+            )
+            vc4_K = vc4.stiffness().toarray()
+            vc4_M = vc4.mass().toarray()
+            vc4_solution, vc4_residual, vc4_gauge = _solve_neumann_system(
+                vc4_K,
+                vc4_M,
+                vc4_M @ forcing_nodes,
+                vc4.left_null_vector(),
+            )
+            assert vc4_residual < 1e-12
+            assert vc4_gauge < 1e-12
+            vc4_gradient = np.column_stack([gradient @ vc4_solution for gradient in vc4.trial_gradient()])
+            vc4_records.append(
+                (
+                    cloud.nominal_spacing,
+                    *_physical_poisson_errors(
+                        E @ vc4_solution,
+                        vc4_gradient,
+                        exact_values,
+                        exact_gradient,
+                        W,
+                    ),
+                )
+            )
+
+            common_K, common_M, common_gradients = arms["common_quadrature"]
+            one = np.ones(vc4.n_dof)
+            common_solution, common_residual, common_gauge = _solve_neumann_system(
+                common_K,
+                common_M,
+                common_M @ forcing_nodes,
+                one / len(one),
+            )
+            assert common_residual < 1e-12
+            assert common_gauge < 1e-12
+            common_gradient = np.column_stack([gradient @ common_solution for gradient in common_gradients])
+            common_records.append(
+                (
+                    cloud.nominal_spacing,
+                    *_physical_poisson_errors(
+                        E @ common_solution,
+                        common_gradient,
+                        exact_values,
+                        exact_gradient,
+                        W,
+                    ),
+                )
+            )
+
+        spacings, vc4_l2, vc4_h1 = map(np.asarray, zip(*vc4_records, strict=True))
+        _, common_l2, common_h1 = map(np.asarray, zip(*common_records, strict=True))
+        assert np.all(np.diff(vc4_l2) < 0.0)
+        assert np.all(np.diff(vc4_h1) < 0.0)
+        vc4_h1_rate = float(np.polyfit(np.log(spacings), np.log(vc4_h1), 1)[0])
+        assert vc4_h1_rate > 2.75
+        assert vc4_h1[-1] < 0.4 * common_h1[-1]
+        assert common_l2[-1] < 0.35 * vc4_l2[-1]
+
     def test_interior_only_lloyd_cloud_fails_the_mass_gate(self):
         from mfgarchon.geometry.collocation import ImplicitDomainCollocation
         from mfgarchon.geometry.implicit import Hyperrectangle
@@ -426,7 +591,7 @@ class TestCentroidalVC2Geometry:
         )
         h = 1.0 / np.sqrt(len(nodes))
         with pytest.raises(np.linalg.LinAlgError, match=r"mass gate failed: cond\(M\)"):
-            CentroidalVC2SCNIOperatorSandbox(nodes, rho=4.0 * h, bounds=BOUNDS)
+            CentroidalVCISCNIOperatorSandbox(nodes, rho=4.0 * h, bounds=BOUNDS)
 
     def test_mass_and_petrov_nullspaces_are_not_conflated(self, structured_sandbox):
         E = structured_sandbox.value_operator().toarray()
@@ -445,8 +610,8 @@ class TestCentroidalVC2Geometry:
 
     def test_rank_deficient_local_support_fails_loud(self):
         n = 7
-        with pytest.raises(ValueError, match="VC2 local constraint rank failure"):
-            CentroidalVC2SCNIOperatorSandbox(
+        with pytest.raises(ValueError, match="VCI local constraint rank failure"):
+            CentroidalVCISCNIOperatorSandbox(
                 _grid(n),
                 rho=3.0 / (n - 1),
                 bounds=BOUNDS,
@@ -457,12 +622,18 @@ class TestCentroidalVC2Geometry:
         nodes = _grid(7)
         nodes[1] = nodes[0]
         with pytest.raises(ValueError, match="does not admit duplicate nodes"):
-            CentroidalVC2SCNIOperatorSandbox(nodes, rho=0.5, bounds=BOUNDS)
+            CentroidalVCISCNIOperatorSandbox(nodes, rho=0.5, bounds=BOUNDS)
+
+    def test_unsupported_vci_degree_fails_before_geometry_assembly(self):
+        with pytest.raises(ValueError, match=r"vci_degree in \{2, 3, 4\}"):
+            CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, vci_degree=5)
+        with pytest.raises(ValueError, match=r"vci_degree in \{2, 3, 4\}"):
+            CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, vci_degree=4.0)
 
     def test_condition_gate_fails_loud(self):
         n = 7
-        with pytest.raises(np.linalg.LinAlgError, match="VC2 local constraint is ill-conditioned"):
-            CentroidalVC2SCNIOperatorSandbox(
+        with pytest.raises(np.linalg.LinAlgError, match="VCI local constraint is ill-conditioned"):
+            CentroidalVCISCNIOperatorSandbox(
                 _grid(n),
                 rho=3.0 / (n - 1),
                 bounds=BOUNDS,

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -7,6 +7,7 @@ from functools import cache
 import pytest
 
 import numpy as np
+from scipy import linalg
 
 from mfgarchon.alg.numerical.meshless_galerkin.centroidal_vci_sandbox import (
     BoundaryCompleteCVTCloud,
@@ -89,6 +90,51 @@ def _boundary_complete_stabilized_vc4_case(
         stabilization_support_radius=4.5 * cloud.nominal_spacing,
     )
     return cloud, sandbox
+
+
+@cache
+def _boundary_complete_edge_stabilized_vc4_case(
+    resolution: int,
+    seed: int,
+) -> tuple[BoundaryCompleteCVTCloud, CentroidalVCISCNIOperatorSandbox]:
+    cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
+    sandbox = CentroidalVCISCNIOperatorSandbox(
+        cloud.nodes,
+        rho=4.5 * cloud.nominal_spacing,
+        bounds=BOUNDS,
+        degree=4,
+        vci_degree=4,
+        vci_support_radius=4.0 * cloud.nominal_spacing,
+        trial_gradient_mode="pointwise",
+        test_gradient_base="trial",
+        polynomial_null_stabilization=0.1,
+        stabilization_metric="edge_energy",
+    )
+    return cloud, sandbox
+
+
+@cache
+def _degree_four_reference_stiffness(resolution: int, seed: int) -> np.ndarray:
+    cloud, _candidate = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
+    points, weights = tensor_gauss(BOUNDS, n_cells=resolution - 1, n_gauss=4)
+    reference = MeshlessGalerkinDiscretization(
+        cloud.nodes,
+        rho=4.5 * cloud.nominal_spacing,
+        degree=4,
+        quad_points=points,
+        quad_weights=weights,
+    )
+    return reference.stiffness().toarray()
+
+
+@cache
+def _edge_stabilization_dual_data(resolution: int, seed: int):
+    _cloud, sandbox = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
+    one = np.ones(sandbox.n_dof)
+    mass = sandbox.mass().toarray()
+    gauge_basis = linalg.null_space((mass @ one)[None, :])
+    reference = gauge_basis.T @ _degree_four_reference_stiffness(resolution, seed) @ gauge_basis
+    return sandbox.stabilization().toarray(), gauge_basis, linalg.cho_factor(reference, check_finite=False)
 
 
 @cache
@@ -659,6 +705,76 @@ class TestCentroidalVCGeometry:
         assert np.linalg.eigvalsh(stabilization).min() > -1e-12
         assert np.max(np.abs(stabilization @ node_values)) < 1e-14
 
+    @pytest.mark.parametrize(
+        ("resolution", "seed"),
+        [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
+    )
+    def test_edge_energy_stabilized_vc4_family_has_physical_spectral_bounds(self, resolution, seed):
+        _cloud, sandbox = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
+        diagnostics = sandbox.diagnostics
+        assert sandbox.stabilization_metric == "edge_energy"
+        assert diagnostics.stabilization_rank_min == 15
+        assert diagnostics.stabilization_condition_max < 5100.0
+        assert diagnostics.stabilization_support_count_min >= 23
+        assert diagnostics.stabilization_support_count_max <= 86
+        assert diagnostics.stabilization_patch_defect < 5e-15
+        assert diagnostics.raw_gauge_coercivity_min < -9.0
+        assert diagnostics.gauge_coercivity_min > 7.6
+        assert diagnostics.gauge_smallest_singular_value > 9.8
+        assert diagnostics.discrete_patch_defect < 7e-14
+        assert diagnostics.stiffness_nullity == 1
+
+        one = np.ones(sandbox.n_dof)
+        mass = sandbox.mass().toarray()
+        gauge_basis = linalg.null_space((mass @ one)[None, :])
+        candidate = 0.5 * (sandbox.stiffness().toarray() + sandbox.stiffness().toarray().T)
+        reference = _degree_four_reference_stiffness(resolution, seed)
+        relative_spectrum = linalg.eigvalsh(
+            gauge_basis.T @ candidate @ gauge_basis,
+            gauge_basis.T @ reference @ gauge_basis,
+            check_finite=False,
+        )
+        assert relative_spectrum[0] > 0.075
+        assert relative_spectrum[-1] < 2.45
+
+    def test_edge_energy_stabilization_is_symmetric_psd_and_annihilates_p4(self):
+        cloud, sandbox = _boundary_complete_edge_stabilized_vc4_case(11, 0)
+        stabilization = sandbox.stabilization().toarray()
+        node_values, _, _ = _polynomial_data(
+            cloud.nodes,
+            np.array([0.5, 0.5]),
+            np.ones(2),
+            degree=4,
+        )
+        assert np.allclose(stabilization, stabilization.T, rtol=0.0, atol=1e-14)
+        assert np.linalg.eigvalsh(stabilization).min() > -1e-12
+        assert np.max(np.abs(stabilization @ node_values)) < 5e-15
+
+    @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
+    @pytest.mark.parametrize("seed", range(3))
+    def test_edge_energy_stabilization_is_smoothly_consistent(self, wave_numbers, seed):
+        records = []
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, _sandbox = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
+            stabilization, gauge_basis, reference_factor = _edge_stabilization_dual_data(resolution, seed)
+            node_values = np.cos(kx * np.pi * cloud.nodes[:, 0]) * np.cos(ky * np.pi * cloud.nodes[:, 1])
+            defect = stabilization @ node_values
+            energy = float(np.sqrt(max(node_values @ defect, 0.0)))
+            reduced_defect = gauge_basis.T @ defect
+            dual = float(
+                np.sqrt(reduced_defect @ linalg.cho_solve(reference_factor, reduced_defect, check_finite=False))
+            )
+            records.append((cloud.nominal_spacing, energy, dual))
+
+        spacings, energy_defects, dual_defects = map(np.asarray, zip(*records, strict=True))
+        energy_rate = float(np.polyfit(np.log(spacings), np.log(energy_defects), 1)[0])
+        dual_rate = float(np.polyfit(np.log(spacings), np.log(dual_defects), 1)[0])
+        assert energy_rate > 2.2
+        assert dual_rate > 3.05
+        assert np.all(np.diff(energy_defects) < 0.0)
+        assert np.all(np.diff(dual_defects) < 0.0)
+
     def test_degree_three_mls_dispatch_preserves_the_vci_gate(self):
         sandbox = CentroidalVCISCNIOperatorSandbox(
             _grid(7),
@@ -737,6 +853,56 @@ class TestCentroidalVCGeometry:
         assert h1_rate > 3.6
         assert l2_errors[-1] < 1e-3
         assert h1_errors[-1] < 0.022
+        assert np.all(np.diff(h1_errors) < 0.0)
+
+    @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
+    @pytest.mark.parametrize("seed", range(3))
+    def test_edge_energy_stabilized_vc4_poisson_converges(self, wave_numbers, seed):
+        records = []
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, sandbox = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
+            points = sandbox.evaluation_points
+            exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
+            forcing_nodes = (
+                (kx**2 + ky**2)
+                * np.pi**2
+                * np.cos(kx * np.pi * cloud.nodes[:, 0])
+                * np.cos(ky * np.pi * cloud.nodes[:, 1])
+            )
+            exact_gradient = np.column_stack(
+                [
+                    -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
+                    -ky * np.pi * np.cos(kx * np.pi * points[:, 0]) * np.sin(ky * np.pi * points[:, 1]),
+                ]
+            )
+            mass = sandbox.mass().toarray()
+            solution, relative_residual, gauge_defect = _solve_neumann_system(
+                sandbox.stiffness().toarray(),
+                mass,
+                mass @ forcing_nodes,
+                sandbox.left_null_vector(),
+            )
+            assert relative_residual < 1e-12
+            assert gauge_defect < 1e-12
+            reconstructed_gradient = np.column_stack([gradient @ solution for gradient in sandbox.trial_gradient()])
+            errors = _physical_poisson_errors(
+                sandbox.value_operator() @ solution,
+                reconstructed_gradient,
+                exact_values,
+                exact_gradient,
+                sandbox.weights,
+            )
+            records.append((cloud.nominal_spacing, *errors))
+
+        spacings, l2_errors, h1_errors = map(np.asarray, zip(*records, strict=True))
+        l2_rate = float(np.polyfit(np.log(spacings), np.log(l2_errors), 1)[0])
+        h1_rate = float(np.polyfit(np.log(spacings), np.log(h1_errors), 1)[0])
+        assert l2_rate > 3.7
+        assert h1_rate > 3.0
+        assert l2_errors[-1] < 2.1e-3
+        assert h1_errors[-1] < 0.033
+        assert np.all(np.diff(l2_errors) < 0.0)
         assert np.all(np.diff(h1_errors) < 0.0)
 
     @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
@@ -883,7 +1049,12 @@ class TestCentroidalVCGeometry:
         [
             ({"polynomial_null_stabilization": -0.1}, "finite and nonnegative"),
             ({"polynomial_null_stabilization": np.nan}, "finite and nonnegative"),
+            ({"stabilization_metric": "unknown"}, "stabilization_metric"),
             ({"stabilization_support_radius": 0.0}, "finite and positive"),
+            (
+                {"stabilization_metric": "edge_energy", "stabilization_support_radius": 0.5},
+                "active edge MLS stencil determines its support",
+            ),
             ({"max_stabilization_condition": 1.0}, "greater than one"),
         ],
     )

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -9,6 +9,7 @@ import numpy as np
 from mfgarchon.alg.numerical.meshless_galerkin.centroidal_vci_sandbox import (
     CentroidalVC2SCNIOperatorSandbox,
     PairedMFGOperatorSandbox,
+    boundary_complete_cvt_rectangle,
 )
 from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voronoi_cells
 
@@ -115,37 +116,60 @@ class TestCentroidalVC2Geometry:
         assert sandbox.diagnostics.corrected_patch_defect < 1e-12
         assert sandbox.diagnostics.stiffness_nullity == 1
 
-    def test_boundary_complete_lloyd_cloud_passes(self):
-        from mfgarchon.geometry.collocation import ImplicitDomainCollocation
-        from mfgarchon.geometry.implicit import Hyperrectangle
+    def test_boundary_complete_cvt_is_deterministic_and_keeps_fitted_boundary(self):
+        first = boundary_complete_cvt_rectangle(7, BOUNDS, seed=4, iterations=10)
+        second = boundary_complete_cvt_rectangle(7, BOUNDS, seed=4, iterations=10)
+        assert np.array_equal(first.nodes, second.nodes)
+        assert np.array_equal(first.boundary_mask, second.boundary_mask)
+        assert len(first.nodes) == 7**2
+        assert np.count_nonzero(first.boundary_mask) == 4 * (7 - 1)
+        boundary = first.nodes[first.boundary_mask]
+        on_box = (boundary[:, 0] == 0.0) | (boundary[:, 0] == 1.0) | (boundary[:, 1] == 0.0) | (boundary[:, 1] == 1.0)
+        assert np.all(on_box)
+        assert not first.nodes.flags.writeable
+        assert not first.boundary_mask.flags.writeable
 
-        interior = ImplicitDomainCollocation(Hyperrectangle(bounds=BOUNDS)).sample_interior(
-            80,
-            method="lloyd",
-            seed=0,
+    @pytest.mark.parametrize(
+        ("options", "message"),
+        [
+            ({"resolution": 4}, "resolution >= 5"),
+            ({"resolution": 7, "iterations": -1}, "iterations >= 0"),
+            ({"resolution": 7, "jitter_fraction": 0.5}, "jitter_fraction"),
+            ({"resolution": 7, "relaxation": 0.0}, "relaxation"),
+            ({"resolution": 7, "bounds": [(0.0, 1.0)]}, r"shape \(2, 2\)"),
+            ({"resolution": 7, "bounds": [(0.0, 1.0), (1.0, 0.0)]}, "finite increasing bounds"),
+        ],
+    )
+    def test_boundary_complete_cvt_rejects_invalid_family_parameters(self, options, message):
+        arguments = {"bounds": BOUNDS, **options}
+        with pytest.raises(ValueError, match=message):
+            boundary_complete_cvt_rectangle(**arguments)
+
+    @pytest.mark.parametrize(
+        ("resolution", "seed"),
+        [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
+    )
+    def test_boundary_complete_cvt_family_passes_refinement_gate(self, resolution, seed):
+        cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
+        sandbox = CentroidalVC2SCNIOperatorSandbox(
+            cloud.nodes,
+            rho=3.0 * cloud.nominal_spacing,
+            bounds=BOUNDS,
         )
-        interior = interior[
-            (interior[:, 0] > 0.035) & (interior[:, 0] < 0.965) & (interior[:, 1] > 0.035) & (interior[:, 1] < 0.965)
-        ]
-        boundary_axis = np.linspace(0.0, 1.0, 12)
-        boundary = np.vstack(
-            [
-                np.column_stack([boundary_axis, np.zeros_like(boundary_axis)]),
-                np.column_stack([boundary_axis, np.ones_like(boundary_axis)]),
-                np.column_stack([np.zeros_like(boundary_axis[1:-1]), boundary_axis[1:-1]]),
-                np.column_stack([np.ones_like(boundary_axis[1:-1]), boundary_axis[1:-1]]),
-            ]
-        )
-        nodes = np.vstack([interior, boundary])
-        h = 1.0 / np.sqrt(len(nodes))
-        sandbox = CentroidalVC2SCNIOperatorSandbox(nodes, rho=3.5 * h, bounds=BOUNDS)
         diagnostics = sandbox.diagnostics
+        assert cloud.max_interior_centroid_offset_ratio < 0.025
+        assert cloud.min_separation_ratio > 0.8
+        assert cloud.min_cell_area_ratio > 0.25
+        assert cloud.max_cell_area_ratio < 1.6
+        assert cloud.max_cell_diameter_ratio < 1.5
         assert diagnostics.local_rank_min == 5
+        assert diagnostics.local_condition_max < 15.0
         assert diagnostics.quadratic_gradient_defect < 1e-8
         assert diagnostics.corrected_patch_defect < 1e-12
-        assert diagnostics.correction_ratio_max < 0.5
-        assert diagnostics.mass_condition < 1e5
-        assert diagnostics.gauge_coercivity_min > 1.0
+        assert diagnostics.correction_ratio_max < 0.2
+        assert diagnostics.mass_condition < 250.0
+        assert diagnostics.gauge_coercivity_min > 9.0
+        assert diagnostics.gauge_smallest_singular_value > 9.0
         assert diagnostics.stiffness_nullity == 1
 
     def test_interior_only_lloyd_cloud_fails_the_mass_gate(self):

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -91,6 +91,22 @@ def _boundary_complete_stabilized_vc4_case(
     return cloud, sandbox
 
 
+@cache
+def _degree_four_evaluation_matched_common_case(resolution: int, seed: int):
+    cloud, candidate = _boundary_complete_stabilized_vc4_case(resolution, seed)
+    evaluation_budget = candidate.centroid_evaluation_count + candidate.edge_evaluation_count
+    common_cells = max(1, int(np.floor(np.sqrt(evaluation_budget) / 4)))
+    common_points, common_weights = tensor_gauss(BOUNDS, n_cells=common_cells, n_gauss=4)
+    common = MeshlessGalerkinDiscretization(
+        cloud.nodes,
+        rho=4.5 * cloud.nominal_spacing,
+        degree=4,
+        quad_points=common_points,
+        quad_weights=common_weights,
+    )
+    return candidate, common.stiffness().toarray(), common.mass().toarray(), len(common_points), evaluation_budget
+
+
 def _solve_neumann_system(K, M, load, left_null):
     one = np.ones(len(K))
     mean_constraint = M @ one
@@ -722,6 +738,74 @@ class TestCentroidalVCGeometry:
         assert l2_errors[-1] < 1e-3
         assert h1_errors[-1] < 0.022
         assert np.all(np.diff(h1_errors) < 0.0)
+
+    @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
+    def test_stabilized_aligned_vc4_does_not_dominate_evaluation_matched_common(self, wave_numbers):
+        candidate_records = []
+        common_records = []
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, candidate = _boundary_complete_stabilized_vc4_case(resolution, 0)
+            matched_candidate, common_K, common_M, common_count, candidate_budget = (
+                _degree_four_evaluation_matched_common_case(resolution, 0)
+            )
+            assert matched_candidate is candidate
+            assert 0.8 * candidate_budget < common_count <= candidate_budget
+            points = candidate.evaluation_points
+            exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
+            exact_gradient = np.column_stack(
+                [
+                    -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
+                    -ky * np.pi * np.cos(kx * np.pi * points[:, 0]) * np.sin(ky * np.pi * points[:, 1]),
+                ]
+            )
+            forcing_nodes = (
+                (kx**2 + ky**2)
+                * np.pi**2
+                * np.cos(kx * np.pi * cloud.nodes[:, 0])
+                * np.cos(ky * np.pi * cloud.nodes[:, 1])
+            )
+            E = candidate.value_operator().toarray()
+            gradients = [gradient.toarray() for gradient in candidate.trial_gradient()]
+            one = np.ones(candidate.n_dof)
+            arms = {
+                "candidate": (
+                    candidate.stiffness().toarray(),
+                    candidate.mass().toarray(),
+                    candidate.left_null_vector(),
+                ),
+                "common": (common_K, common_M, one / len(one)),
+            }
+            for name, (K, M, left_null) in arms.items():
+                solution, relative_residual, gauge_defect = _solve_neumann_system(
+                    K,
+                    M,
+                    M @ forcing_nodes,
+                    left_null,
+                )
+                assert relative_residual < 1e-12
+                assert gauge_defect < 1e-12
+                reconstructed_gradient = np.column_stack([gradient @ solution for gradient in gradients])
+                errors = _physical_poisson_errors(
+                    E @ solution,
+                    reconstructed_gradient,
+                    exact_values,
+                    exact_gradient,
+                    candidate.weights,
+                )
+                record = (cloud.nominal_spacing, *errors)
+                if name == "candidate":
+                    candidate_records.append(record)
+                else:
+                    common_records.append(record)
+
+        _, candidate_l2, candidate_h1 = map(np.asarray, zip(*candidate_records, strict=True))
+        _, common_l2, common_h1 = map(np.asarray, zip(*common_records, strict=True))
+        assert common_l2[-1] < 0.4 * candidate_l2[-1]
+        if wave_numbers == (1, 1):
+            assert candidate_h1[-1] < 0.6 * common_h1[-1]
+        else:
+            assert common_h1[-1] < 0.5 * candidate_h1[-1]
 
     def test_interior_only_lloyd_cloud_fails_the_mass_gate(self):
         from mfgarchon.geometry.collocation import ImplicitDomainCollocation

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -28,6 +28,19 @@ from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voro
 BOUNDS = [(0.0, 1.0), (0.0, 1.0)]
 
 
+def _smooth_elliptic_coefficient(points: np.ndarray) -> np.ndarray:
+    return 1.0 + 0.2 * np.sin(2.0 * np.pi * points[:, 0]) * np.cos(2.0 * np.pi * points[:, 1])
+
+
+def _smooth_elliptic_coefficient_gradient(points: np.ndarray) -> np.ndarray:
+    return np.column_stack(
+        [
+            0.4 * np.pi * np.cos(2.0 * np.pi * points[:, 0]) * np.cos(2.0 * np.pi * points[:, 1]),
+            -0.4 * np.pi * np.sin(2.0 * np.pi * points[:, 0]) * np.sin(2.0 * np.pi * points[:, 1]),
+        ]
+    )
+
+
 def _grid(n: int) -> np.ndarray:
     axis = np.linspace(0.0, 1.0, n)
     return np.stack([coordinate.ravel() for coordinate in np.meshgrid(axis, axis, indexing="ij")], axis=1)
@@ -114,6 +127,29 @@ def _boundary_complete_edge_stabilized_vc4_case(
 
 
 @cache
+def _boundary_complete_variable_edge_stabilized_vc4_case(
+    resolution: int,
+    seed: int,
+) -> tuple[BoundaryCompleteCVTCloud, CentroidalVCISCNIOperatorSandbox]:
+    cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
+    sandbox = CentroidalVCISCNIOperatorSandbox(
+        cloud.nodes,
+        rho=4.5 * cloud.nominal_spacing,
+        bounds=BOUNDS,
+        degree=4,
+        vci_degree=4,
+        vci_support_radius=4.0 * cloud.nominal_spacing,
+        trial_gradient_mode="pointwise",
+        test_gradient_base="trial",
+        polynomial_null_stabilization=0.1,
+        stabilization_metric="edge_energy",
+        elliptic_coefficient=_smooth_elliptic_coefficient,
+        elliptic_coefficient_gradient=_smooth_elliptic_coefficient_gradient,
+    )
+    return cloud, sandbox
+
+
+@cache
 def _degree_four_reference_stiffness(resolution: int, seed: int) -> np.ndarray:
     cloud, _candidate = _boundary_complete_edge_stabilized_vc4_case(resolution, seed)
     points, weights = tensor_gauss(BOUNDS, n_cells=resolution - 1, n_gauss=4)
@@ -125,6 +161,27 @@ def _degree_four_reference_stiffness(resolution: int, seed: int) -> np.ndarray:
         quad_weights=weights,
     )
     return reference.stiffness().toarray()
+
+
+@cache
+def _degree_four_variable_reference_stiffness(resolution: int, seed: int) -> np.ndarray:
+    cloud, _candidate = _boundary_complete_variable_edge_stabilized_vc4_case(resolution, seed)
+    points, weights = tensor_gauss(BOUNDS, n_cells=resolution - 1, n_gauss=4)
+    _, gradients = shape_functions_and_grads(
+        points,
+        cloud.nodes,
+        4.5 * cloud.nominal_spacing,
+        monomial_exponents(2, 4),
+        "numpy",
+        check_conditioning=True,
+    )
+    return np.einsum(
+        "q,q,qid,qjd->ij",
+        weights,
+        _smooth_elliptic_coefficient(points),
+        gradients,
+        gradients,
+    )
 
 
 @cache
@@ -750,6 +807,73 @@ class TestCentroidalVCGeometry:
         assert np.linalg.eigvalsh(stabilization).min() > -1e-12
         assert np.max(np.abs(stabilization @ node_values)) < 5e-15
 
+    def test_explicit_unit_elliptic_coefficient_is_identical_to_default_path(self):
+        cloud, baseline = _boundary_complete_edge_stabilized_vc4_case(7, 0)
+        explicit = CentroidalVCISCNIOperatorSandbox(
+            cloud.nodes,
+            rho=4.5 * cloud.nominal_spacing,
+            bounds=BOUNDS,
+            degree=4,
+            vci_degree=4,
+            vci_support_radius=4.0 * cloud.nominal_spacing,
+            trial_gradient_mode="pointwise",
+            test_gradient_base="trial",
+            polynomial_null_stabilization=0.1,
+            stabilization_metric="edge_energy",
+            elliptic_coefficient=lambda points: np.ones(len(points)),
+            elliptic_coefficient_gradient=lambda points: np.zeros_like(points),
+        )
+        assert not baseline.has_spatial_elliptic_coefficient
+        assert explicit.has_spatial_elliptic_coefficient
+        assert explicit.sampled_elliptic_coefficient_bounds == (1.0, 1.0)
+        assert np.array_equal(explicit.stiffness().toarray(), baseline.stiffness().toarray())
+        assert np.array_equal(explicit.stabilization().toarray(), baseline.stabilization().toarray())
+        assert all(
+            np.array_equal(explicit_gradient.toarray(), baseline_gradient.toarray())
+            for explicit_gradient, baseline_gradient in zip(
+                explicit.test_gradient(),
+                baseline.test_gradient(),
+                strict=True,
+            )
+        )
+        assert explicit.diagnostics == baseline.diagnostics
+
+    @pytest.mark.parametrize(
+        ("resolution", "seed"),
+        [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
+    )
+    def test_variable_coefficient_edge_vc4_family_preserves_patch_and_spectral_bounds(self, resolution, seed):
+        _cloud, sandbox = _boundary_complete_variable_edge_stabilized_vc4_case(resolution, seed)
+        diagnostics = sandbox.diagnostics
+        sampled_min, sampled_max = sandbox.sampled_elliptic_coefficient_bounds
+        assert sandbox.has_spatial_elliptic_coefficient
+        assert 0.8 <= sampled_min < sampled_max <= 1.2
+        assert sampled_max - sampled_min > 0.39
+        assert diagnostics.local_rank_min == 14
+        assert diagnostics.local_condition_max < 1700.0
+        assert diagnostics.correction_ratio_max < 0.72
+        assert diagnostics.corrected_patch_defect < 8e-15
+        assert diagnostics.discrete_patch_defect < 7e-14
+        assert diagnostics.stabilization_patch_defect < 1e-14
+        assert diagnostics.raw_gauge_coercivity_min < -9.0
+        assert diagnostics.gauge_coercivity_min > 7.55
+        assert diagnostics.gauge_smallest_singular_value > 9.74
+        assert diagnostics.stiffness_nullity == 1
+
+        one = np.ones(sandbox.n_dof)
+        mass = sandbox.mass().toarray()
+        gauge_basis = linalg.null_space((mass @ one)[None, :])
+        stiffness = sandbox.stiffness().toarray()
+        symmetric_stiffness = 0.5 * (stiffness + stiffness.T)
+        reference = _degree_four_variable_reference_stiffness(resolution, seed)
+        relative_spectrum = linalg.eigvalsh(
+            gauge_basis.T @ symmetric_stiffness @ gauge_basis,
+            gauge_basis.T @ reference @ gauge_basis,
+            check_finite=False,
+        )
+        assert relative_spectrum[0] > 0.07
+        assert relative_spectrum[-1] < 2.6
+
     @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
     @pytest.mark.parametrize("seed", range(3))
     def test_edge_energy_stabilization_is_smoothly_consistent(self, wave_numbers, seed):
@@ -904,6 +1028,115 @@ class TestCentroidalVCGeometry:
         assert h1_errors[-1] < 0.033
         assert np.all(np.diff(l2_errors) < 0.0)
         assert np.all(np.diff(h1_errors) < 0.0)
+
+    @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
+    @pytest.mark.parametrize("seed", range(3))
+    def test_variable_coefficient_edge_vc4_poisson_converges(self, wave_numbers, seed):
+        records = []
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, sandbox = _boundary_complete_variable_edge_stabilized_vc4_case(resolution, seed)
+            points = sandbox.evaluation_points
+            exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
+            exact_gradient = np.column_stack(
+                [
+                    -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
+                    -ky * np.pi * np.cos(kx * np.pi * points[:, 0]) * np.sin(ky * np.pi * points[:, 1]),
+                ]
+            )
+            coefficient = _smooth_elliptic_coefficient(points)
+            coefficient_gradient = _smooth_elliptic_coefficient_gradient(points)
+            forcing = (kx**2 + ky**2) * np.pi**2 * coefficient * exact_values - np.sum(
+                coefficient_gradient * exact_gradient, axis=1
+            )
+            value_operator = sandbox.value_operator().toarray()
+            mass = sandbox.mass().toarray()
+            load = value_operator.T @ (sandbox.weights * forcing)
+            solution, relative_residual, gauge_defect = _solve_neumann_system(
+                sandbox.stiffness().toarray(),
+                mass,
+                load,
+                sandbox.left_null_vector(),
+            )
+            assert relative_residual < 2e-12
+            assert gauge_defect < 2e-12
+            reconstructed_gradient = np.column_stack([gradient @ solution for gradient in sandbox.trial_gradient()])
+            errors = _physical_poisson_errors(
+                value_operator @ solution,
+                reconstructed_gradient,
+                exact_values,
+                exact_gradient,
+                sandbox.weights,
+            )
+            records.append((cloud.nominal_spacing, *errors))
+
+        spacings, l2_errors, h1_errors = map(np.asarray, zip(*records, strict=True))
+        l2_rate = float(np.polyfit(np.log(spacings), np.log(l2_errors), 1)[0])
+        h1_rate = float(np.polyfit(np.log(spacings), np.log(h1_errors), 1)[0])
+        assert l2_rate > 3.35
+        assert h1_rate > 2.7
+        assert l2_errors[-1] < 2.1e-3
+        assert h1_errors[-1] < 0.033
+        assert np.all(np.diff(l2_errors) < 0.0)
+        assert np.all(np.diff(h1_errors) < 0.0)
+
+    def test_variable_coefficient_vci_correction_beats_frozen_constant_correction(self):
+        _cloud, variable = _boundary_complete_variable_edge_stabilized_vc4_case(21, 0)
+        _, constant = _boundary_complete_edge_stabilized_vc4_case(21, 0)
+        points = variable.evaluation_points
+        coefficient = _smooth_elliptic_coefficient(points)
+        elliptic_weights = variable.weights * coefficient
+        frozen_stiffness = sum(
+            test_gradient.toarray().T @ (elliptic_weights[:, None] * trial_gradient.toarray())
+            for test_gradient, trial_gradient in zip(
+                constant.test_gradient(),
+                constant.trial_gradient(),
+                strict=True,
+            )
+        )
+        frozen_stiffness += 0.1 * variable.stabilization().toarray()
+
+        exact_values = np.cos(np.pi * points[:, 0]) * np.cos(np.pi * points[:, 1])
+        exact_gradient = np.column_stack(
+            [
+                -np.pi * np.sin(np.pi * points[:, 0]) * np.cos(np.pi * points[:, 1]),
+                -np.pi * np.cos(np.pi * points[:, 0]) * np.sin(np.pi * points[:, 1]),
+            ]
+        )
+        forcing = 2.0 * np.pi**2 * coefficient * exact_values - np.sum(
+            _smooth_elliptic_coefficient_gradient(points) * exact_gradient, axis=1
+        )
+        value_operator = variable.value_operator().toarray()
+        mass = variable.mass().toarray()
+        load = value_operator.T @ (variable.weights * forcing)
+        frozen_left_null = np.linalg.svd(frozen_stiffness)[0][:, -1]
+        frozen_left_null /= frozen_left_null @ np.ones(variable.n_dof)
+        errors = []
+        for stiffness, left_null in (
+            (variable.stiffness().toarray(), variable.left_null_vector()),
+            (frozen_stiffness, frozen_left_null),
+        ):
+            solution, relative_residual, gauge_defect = _solve_neumann_system(
+                stiffness,
+                mass,
+                load,
+                left_null,
+            )
+            assert relative_residual < 2e-12
+            assert gauge_defect < 2e-12
+            reconstructed_gradient = np.column_stack([gradient @ solution for gradient in variable.trial_gradient()])
+            errors.append(
+                _physical_poisson_errors(
+                    value_operator @ solution,
+                    reconstructed_gradient,
+                    exact_values,
+                    exact_gradient,
+                    variable.weights,
+                )
+            )
+        variable_errors, frozen_errors = errors
+        assert variable_errors[0] < 0.1 * frozen_errors[0]
+        assert variable_errors[1] < 0.1 * frozen_errors[1]
 
     @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
     def test_stabilized_aligned_vc4_does_not_dominate_evaluation_matched_common(self, wave_numbers):
@@ -1066,6 +1299,98 @@ class TestCentroidalVCGeometry:
         with pytest.raises(ValueError, match=message):
             CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, **options)
 
+    @pytest.mark.parametrize(
+        ("options", "exception", "message"),
+        [
+            (
+                {"elliptic_coefficient": lambda points: np.ones(len(points))},
+                ValueError,
+                "must be supplied together",
+            ),
+            (
+                {"elliptic_coefficient_gradient": lambda points: np.zeros_like(points)},
+                ValueError,
+                "must be supplied together",
+            ),
+            (
+                {
+                    "elliptic_coefficient": 1.0,
+                    "elliptic_coefficient_gradient": lambda points: np.zeros_like(points),
+                },
+                TypeError,
+                "must be callable",
+            ),
+            (
+                {
+                    "elliptic_coefficient": lambda points: np.ones((len(points), 1)),
+                    "elliptic_coefficient_gradient": lambda points: np.zeros_like(points),
+                },
+                ValueError,
+                "elliptic_coefficient\\(centroids\\) must return shape",
+            ),
+            (
+                {
+                    "elliptic_coefficient": lambda points: np.ones(len(points)),
+                    "elliptic_coefficient_gradient": lambda points: np.zeros(len(points)),
+                },
+                ValueError,
+                "elliptic_coefficient_gradient\\(centroids\\) must return shape",
+            ),
+            (
+                {
+                    "elliptic_coefficient": lambda points: np.full(len(points), np.nan),
+                    "elliptic_coefficient_gradient": lambda points: np.zeros_like(points),
+                },
+                ValueError,
+                "returned non-finite values",
+            ),
+            (
+                {
+                    "elliptic_coefficient": lambda points: np.ones(len(points)),
+                    "elliptic_coefficient_gradient": lambda points: np.full_like(points, np.inf),
+                },
+                ValueError,
+                "returned non-finite values",
+            ),
+            (
+                {
+                    "elliptic_coefficient": lambda points: np.where(points[:, 0] == 0.0, -1.0, 1.0),
+                    "elliptic_coefficient_gradient": lambda points: np.zeros_like(points),
+                },
+                ValueError,
+                "must be strictly positive",
+            ),
+        ],
+    )
+    def test_invalid_elliptic_coefficient_contract_fails_loudly(self, options, exception, message):
+        aligned_options = {
+            "degree": 4,
+            "vci_degree": 4,
+            "vci_support_radius": 4.0 / 6.0,
+            "trial_gradient_mode": "pointwise",
+            "test_gradient_base": "trial",
+            "polynomial_null_stabilization": 0.1,
+            "stabilization_metric": "edge_energy",
+        }
+        with pytest.raises(exception, match=message):
+            CentroidalVCISCNIOperatorSandbox(
+                _grid(7),
+                rho=4.5 / 6.0,
+                bounds=BOUNDS,
+                **aligned_options,
+                **options,
+            )
+
+    def test_spatial_elliptic_coefficient_rejects_untested_operator_branch(self):
+        with pytest.raises(ValueError, match="only defined for the aligned degree-4 VCI candidate"):
+            CentroidalVCISCNIOperatorSandbox(
+                _grid(7),
+                rho=0.5,
+                bounds=BOUNDS,
+                elliptic_coefficient=lambda points: np.ones(len(points)),
+                elliptic_coefficient_gradient=lambda points: np.zeros_like(points),
+            )
+
     def test_polynomial_null_stabilization_fails_on_rank_deficient_support(self):
         nodes = _grid(7)
         with pytest.raises(ValueError, match="Polynomial-null stabilization rank failure"):
@@ -1099,6 +1424,18 @@ class TestCentroidalVCGeometry:
 
 
 class TestPairedMFGOperator:
+    def test_variable_elliptic_correction_cannot_be_reused_for_nonlinear_stabilization(self):
+        _cloud, sandbox = _boundary_complete_variable_edge_stabilized_vc4_case(7, 0)
+        with pytest.raises(ValueError, match="requires its own variational correction"):
+            PairedMFGOperatorSandbox(
+                sandbox,
+                diffusion=0.07,
+                hamiltonian=_hamiltonian,
+                hamiltonian_gradient=_hamiltonian_gradient,
+                stabilization_flux=_stabilization_flux,
+                stabilization_jacobian=_stabilization_jacobian,
+            )
+
     def test_complete_analytic_jacobian_matches_centered_difference(self, structured_sandbox):
         operator = PairedMFGOperatorSandbox(
             structured_sandbox,

--- a/tests/unit/test_alg/test_centroidal_vci_sandbox.py
+++ b/tests/unit/test_alg/test_centroidal_vci_sandbox.py
@@ -70,6 +70,27 @@ def _boundary_complete_vc4_case(
     return cloud, sandbox
 
 
+@cache
+def _boundary_complete_stabilized_vc4_case(
+    resolution: int,
+    seed: int,
+) -> tuple[BoundaryCompleteCVTCloud, CentroidalVCISCNIOperatorSandbox]:
+    cloud = boundary_complete_cvt_rectangle(resolution, BOUNDS, seed=seed)
+    sandbox = CentroidalVCISCNIOperatorSandbox(
+        cloud.nodes,
+        rho=4.5 * cloud.nominal_spacing,
+        bounds=BOUNDS,
+        degree=4,
+        vci_degree=4,
+        vci_support_radius=4.0 * cloud.nominal_spacing,
+        trial_gradient_mode="pointwise",
+        test_gradient_base="trial",
+        polynomial_null_stabilization=0.1,
+        stabilization_support_radius=4.5 * cloud.nominal_spacing,
+    )
+    return cloud, sandbox
+
+
 def _solve_neumann_system(K, M, load, left_null):
     one = np.ones(len(K))
     mean_constraint = M @ one
@@ -580,6 +601,128 @@ class TestCentroidalVCGeometry:
         assert vc4_h1[-1] < 0.4 * common_h1[-1]
         assert common_l2[-1] < 0.35 * vc4_l2[-1]
 
+    @pytest.mark.parametrize(
+        ("resolution", "seed"),
+        [(resolution, seed) for resolution in (7, 9, 11, 13, 17, 21) for seed in range(3)],
+    )
+    def test_stabilized_aligned_vc4_family_restores_coercivity_without_changing_p4(self, resolution, seed):
+        _cloud, sandbox = _boundary_complete_stabilized_vc4_case(resolution, seed)
+        diagnostics = sandbox.diagnostics
+        assert sandbox.degree == 4
+        assert sandbox.vci_degree == 4
+        assert sandbox.trial_gradient_mode == "pointwise"
+        assert sandbox.test_gradient_base == "trial"
+        assert sandbox.polynomial_null_stabilization == 0.1
+        assert diagnostics.local_rank_min == 14
+        assert diagnostics.local_condition_max < 1700.0
+        assert diagnostics.correction_ratio_max < 0.72
+        assert diagnostics.mass_condition < 3600.0
+        assert diagnostics.vci_trial_gradient_defect < 2e-12
+        assert diagnostics.corrected_patch_defect < 1e-14
+        assert diagnostics.discrete_patch_defect < 1e-12
+        assert diagnostics.stabilization_rank_min == 15
+        assert diagnostics.stabilization_condition_max < 4700.0
+        assert diagnostics.stabilization_support_count_min >= 20
+        assert diagnostics.stabilization_support_count_max <= 68
+        assert diagnostics.stabilization_patch_defect < 1e-14
+        assert diagnostics.raw_gauge_coercivity_min < -9.0
+        assert diagnostics.gauge_coercivity_min > 7.7
+        assert diagnostics.gauge_smallest_singular_value > 9.8
+        assert diagnostics.stiffness_nullity == 1
+
+    def test_local_polynomial_null_stabilization_is_symmetric_psd_and_annihilates_p4(self):
+        cloud, sandbox = _boundary_complete_stabilized_vc4_case(11, 0)
+        stabilization = sandbox.stabilization().toarray()
+        node_values, _, _ = _polynomial_data(
+            cloud.nodes,
+            np.array([0.5, 0.5]),
+            np.ones(2),
+            degree=4,
+        )
+        assert np.allclose(stabilization, stabilization.T, rtol=0.0, atol=1e-14)
+        assert np.linalg.eigvalsh(stabilization).min() > -1e-12
+        assert np.max(np.abs(stabilization @ node_values)) < 1e-14
+
+    def test_degree_three_mls_dispatch_preserves_the_vci_gate(self):
+        sandbox = CentroidalVCISCNIOperatorSandbox(
+            _grid(7),
+            rho=3.5 / 6.0,
+            bounds=BOUNDS,
+            degree=3,
+            vci_degree=3,
+            vci_support_radius=3.5 / 6.0,
+        )
+        assert sandbox.degree == 3
+        assert sandbox.diagnostics.corrected_patch_defect < 1e-12
+        assert sandbox.diagnostics.gauge_coercivity_min > 9.0
+        assert sandbox.diagnostics.stiffness_nullity == 1
+
+    @pytest.mark.parametrize("test_gradient_base", ["trial", "scni"])
+    def test_pointwise_trial_gradient_dispatch_preserves_the_quadratic_patch(self, test_gradient_base):
+        sandbox = CentroidalVCISCNIOperatorSandbox(
+            _grid(7),
+            rho=0.5,
+            bounds=BOUNDS,
+            trial_gradient_mode="pointwise",
+            test_gradient_base=test_gradient_base,
+        )
+        assert sandbox.trial_gradient_mode == "pointwise"
+        assert sandbox.test_gradient_base == test_gradient_base
+        assert sandbox.diagnostics.discrete_patch_defect < 1e-12
+        assert sandbox.diagnostics.gauge_coercivity_min > 9.0
+
+    @pytest.mark.parametrize("wave_numbers", [(1, 1), (2, 1), (2, 2), (3, 1)])
+    @pytest.mark.parametrize("seed", range(3))
+    def test_stabilized_aligned_vc4_poisson_converges_near_fourth_order(self, wave_numbers, seed):
+        records = []
+        kx, ky = wave_numbers
+        for resolution in (7, 9, 11, 13, 17, 21):
+            cloud, sandbox = _boundary_complete_stabilized_vc4_case(resolution, seed)
+            points = sandbox.evaluation_points
+            exact_values = np.cos(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1])
+            forcing_nodes = (
+                (kx**2 + ky**2)
+                * np.pi**2
+                * np.cos(kx * np.pi * cloud.nodes[:, 0])
+                * np.cos(ky * np.pi * cloud.nodes[:, 1])
+            )
+            exact_gradient = np.column_stack(
+                [
+                    -kx * np.pi * np.sin(kx * np.pi * points[:, 0]) * np.cos(ky * np.pi * points[:, 1]),
+                    -ky * np.pi * np.cos(kx * np.pi * points[:, 0]) * np.sin(ky * np.pi * points[:, 1]),
+                ]
+            )
+
+            E = sandbox.value_operator().toarray()
+            M = sandbox.mass().toarray()
+            K = sandbox.stiffness().toarray()
+            solution, relative_residual, gauge_defect = _solve_neumann_system(
+                K,
+                M,
+                M @ forcing_nodes,
+                sandbox.left_null_vector(),
+            )
+            assert relative_residual < 1e-12
+            assert gauge_defect < 1e-12
+            reconstructed_gradient = np.column_stack([gradient @ solution for gradient in sandbox.trial_gradient()])
+            l2_error, h1_error = _physical_poisson_errors(
+                E @ solution,
+                reconstructed_gradient,
+                exact_values,
+                exact_gradient,
+                sandbox.weights,
+            )
+            records.append((cloud.nominal_spacing, l2_error, h1_error))
+
+        spacings, l2_errors, h1_errors = map(np.asarray, zip(*records, strict=True))
+        l2_rate = float(np.polyfit(np.log(spacings), np.log(l2_errors), 1)[0])
+        h1_rate = float(np.polyfit(np.log(spacings), np.log(h1_errors), 1)[0])
+        assert l2_rate > 3.65
+        assert h1_rate > 3.6
+        assert l2_errors[-1] < 1e-3
+        assert h1_errors[-1] < 0.022
+        assert np.all(np.diff(h1_errors) < 0.0)
+
     def test_interior_only_lloyd_cloud_fails_the_mass_gate(self):
         from mfgarchon.geometry.collocation import ImplicitDomainCollocation
         from mfgarchon.geometry.implicit import Hyperrectangle
@@ -629,6 +772,65 @@ class TestCentroidalVCGeometry:
             CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, vci_degree=5)
         with pytest.raises(ValueError, match=r"vci_degree in \{2, 3, 4\}"):
             CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, vci_degree=4.0)
+
+    def test_unsupported_mls_degree_fails_before_geometry_assembly(self):
+        with pytest.raises(ValueError, match=r"MLS degree in \{2, 3, 4\}"):
+            CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, degree=5)
+        with pytest.raises(ValueError, match=r"MLS degree in \{2, 3, 4\}"):
+            CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, degree=4.0)
+
+    def test_mls_degree_requires_enough_nodes_before_geometry_assembly(self):
+        with pytest.raises(ValueError, match="degree-4 MLS requires at least 15 nodes"):
+            CentroidalVCISCNIOperatorSandbox(_grid(3), rho=0.75, bounds=BOUNDS, degree=4)
+
+    @pytest.mark.parametrize(
+        ("options", "message"),
+        [
+            ({"trial_gradient_mode": "unknown"}, "trial_gradient_mode"),
+            ({"test_gradient_base": "unknown"}, "test_gradient_base"),
+        ],
+    )
+    def test_unsupported_gradient_modes_fail_before_geometry_assembly(self, options, message):
+        with pytest.raises(ValueError, match=message):
+            CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, **options)
+
+    @pytest.mark.parametrize(
+        ("options", "message"),
+        [
+            ({"polynomial_null_stabilization": -0.1}, "finite and nonnegative"),
+            ({"polynomial_null_stabilization": np.nan}, "finite and nonnegative"),
+            ({"stabilization_support_radius": 0.0}, "finite and positive"),
+            ({"max_stabilization_condition": 1.0}, "greater than one"),
+        ],
+    )
+    def test_invalid_polynomial_null_stabilization_parameters_fail_before_geometry_assembly(
+        self,
+        options,
+        message,
+    ):
+        with pytest.raises(ValueError, match=message):
+            CentroidalVCISCNIOperatorSandbox(_grid(7), rho=0.5, bounds=BOUNDS, **options)
+
+    def test_polynomial_null_stabilization_fails_on_rank_deficient_support(self):
+        nodes = _grid(7)
+        with pytest.raises(ValueError, match="Polynomial-null stabilization rank failure"):
+            CentroidalVCISCNIOperatorSandbox(
+                nodes,
+                rho=0.5,
+                bounds=BOUNDS,
+                polynomial_null_stabilization=0.1,
+                stabilization_support_radius=0.01,
+            )
+
+    def test_polynomial_null_stabilization_fails_on_ill_conditioned_projection(self):
+        with pytest.raises(np.linalg.LinAlgError, match="Polynomial-null stabilization is ill-conditioned"):
+            CentroidalVCISCNIOperatorSandbox(
+                _grid(7),
+                rho=0.5,
+                bounds=BOUNDS,
+                polynomial_null_stabilization=0.1,
+                max_stabilization_condition=1.01,
+            )
 
     def test_condition_gate_fails_loud(self):
         n = 7

--- a/tests/unit/test_alg/test_mls_conditioning_guard_1485.py
+++ b/tests/unit/test_alg/test_mls_conditioning_guard_1485.py
@@ -11,6 +11,11 @@ import numpy as np
 from mfgarchon.alg.numerical.meshless_galerkin.mls_basis import monomial_exponents, shape_functions_and_grads
 
 
+def _grid_2d(n):
+    axis = np.linspace(0.0, 1.0, n)
+    return np.stack([coordinate.ravel() for coordinate in np.meshgrid(axis, axis, indexing="ij")], axis=1)
+
+
 def test_well_conditioned_cloud_does_not_fire():
     nodes = np.linspace(0.0, 1.0, 11).reshape(-1, 1)
     qp = np.linspace(0.05, 0.95, 20).reshape(-1, 1)
@@ -29,3 +34,99 @@ def test_scni_path_is_exempt_on_same_degenerate_cloud():
     qp = np.array([[0.5]])
     # SCNI calls without check_conditioning (default False) -> must NOT raise
     shape_functions_and_grads(qp, bad_nodes, 1.0, monomial_exponents(1, 2), "numpy")
+
+
+@pytest.mark.parametrize("degree", [2, 4])
+def test_shifted_scaled_moments_are_translation_and_scale_invariant(degree):
+    nodes = _grid_2d(9)
+    evaluation_points = np.array([[0.18, 0.27], [0.51, 0.62], [0.83, 0.74]])
+    rho = 0.65
+    exponents = monomial_exponents(2, degree)
+    phi, gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        rho,
+        exponents,
+        "numpy",
+        check_conditioning=True,
+    )
+
+    scale = 3.7
+    translation = np.array([1.0e6, -2.0e6])
+    transformed_phi, transformed_gradient = shape_functions_and_grads(
+        scale * evaluation_points + translation,
+        scale * nodes + translation,
+        scale * rho,
+        exponents,
+        "numpy",
+        check_conditioning=True,
+    )
+
+    assert np.allclose(transformed_phi, phi, rtol=2e-9, atol=2e-10)
+    assert np.allclose(scale * transformed_gradient, gradient, rtol=2e-8, atol=2e-9)
+
+
+def test_degree_four_values_and_gradients_reproduce_a_boundary_polynomial():
+    nodes = _grid_2d(11)
+    evaluation_points = np.array([[0.0, 0.0], [0.05, 0.0], [1.0, 0.5], [0.37, 0.41]])
+    phi, gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        0.55,
+        monomial_exponents(2, 4),
+        "numpy",
+        check_conditioning=True,
+    )
+    x_nodes, y_nodes = nodes.T
+    nodal_values = x_nodes**4 - 0.7 * x_nodes**2 * y_nodes**2 + 0.2 * y_nodes**3
+    x_eval, y_eval = evaluation_points.T
+    exact_values = x_eval**4 - 0.7 * x_eval**2 * y_eval**2 + 0.2 * y_eval**3
+    exact_gradient = np.column_stack(
+        [
+            4.0 * x_eval**3 - 1.4 * x_eval * y_eval**2,
+            -1.4 * x_eval**2 * y_eval + 0.6 * y_eval**2,
+        ]
+    )
+
+    assert np.allclose(phi @ nodal_values, exact_values, rtol=1e-10, atol=2e-12)
+    reconstructed_gradient = np.column_stack([gradient[:, :, direction] @ nodal_values for direction in range(2)])
+    assert np.allclose(reconstructed_gradient, exact_gradient, rtol=1e-9, atol=2e-11)
+
+
+def test_empty_evaluation_batch_preserves_output_contract():
+    phi, gradient = shape_functions_and_grads(
+        np.empty((0, 2)),
+        _grid_2d(5),
+        0.75,
+        monomial_exponents(2, 2),
+        "numpy",
+        check_conditioning=True,
+    )
+
+    assert phi.shape == (0, 25)
+    assert gradient.shape == (0, 25, 2)
+
+
+def test_numpy_and_jax_use_the_same_shifted_scaled_moments():
+    pytest.importorskip("jax")
+    nodes = _grid_2d(7)
+    evaluation_points = np.array([[0.22, 0.31], [0.57, 0.68]])
+    exponents = monomial_exponents(2, 3)
+    numpy_phi, numpy_gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        0.75,
+        exponents,
+        "numpy",
+        check_conditioning=True,
+    )
+    jax_phi, jax_gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        0.75,
+        exponents,
+        "jax",
+    )
+
+    assert np.allclose(jax_phi, numpy_phi, rtol=2e-10, atol=2e-12)
+    assert np.allclose(jax_gradient, numpy_gradient, rtol=2e-9, atol=2e-11)


### PR DESCRIPTION
## Local gate

```
=== 6154 passed, 22 skipped, 21 xfailed, 5218 warnings in 619.48s (0:10:19) ====
PASS full suite

gate interpreter : /opt/homebrew/Caskroom/miniforge/base/envs/mfg_env/bin/python (Python 3.12.13)
gate ruff        : ruff 0.16.0
GATE GREEN -- safe to push.
```

- [x] `./scripts/local_ci.sh` is **GATE GREEN** on this branch's head
- [ ] Any new pinning test was **mutation-checked** — **not verified by me.** These eleven commits were
  authored 2026-07-29..08-01; this PR only rebased them onto today's `main` and re-ran their gates.
  Whether each pin was mutation-checked at the time is not something the rebase establishes.

## What changed

Eleven commits adding a centroidal Voronoi/VCI operator sandbox for the meshless Galerkin line, plus
the gates that judge it:

- `centroidal_vci_sandbox.py` (new, 1225 lines) — centroidal VC2 operator, boundary-complete CVT
  families, quartic VCI redesign, two VC4 stabilizations (polynomial-null and physical edge-energy),
  a coefficient-aware elliptic VCI gate, and primal-consistency admission diagnostics.
- `mls_basis.py` — evaluation-centered shifted/scaled moments. An invertible basis change, so it
  preserves the shape functions while making the reported condition number translation- and
  scale-independent.
- `voronoi_cells.py` — small supporting change.
- `test_centroidal_vci_sandbox.py` (new, 1547 lines) and additions to
  `test_mls_conditioning_guard_1485.py`.

Five files, +2953 / -49.

## Why

The branch had drifted 43 commits behind `main` while carrying work that nothing else has. Rebasing
now was cheap and stays cheap only while it is done: the touched subtree moves about once a month
(`meshless_galerkin/` last changed 2026-07-18, `mls_basis.py` 2026-07-04), so conflict risk is low
and does not grow — but the gates' *results* were measured against a 2026-07-29 `main`, and that is a
fact with a shelf life.

## Evidence

- Rebase `--onto main`, dropping two commits: **11/11 replayed, zero conflicts**, now 11 ahead / 0
  behind.
- The two dropped commits duplicated `#1745` work already on `main`. Verified by content, not by
  hash: `base_hjb.py`, `test_solver_golden_baseline.py`,
  `test_hjb_newton_reports_returned_iterate.py` and the changelog fragment are **byte-identical**
  between the branch and `main`. Only the independently regenerated golden `.npz` differed, and
  `main`'s is kept. Same commit subject, different patch-id — the label agreed and the diff did not,
  so the check had to be on the resulting files.
- The branch's own gates on today's `main`: `test_centroidal_vci_sandbox.py` +
  `test_mls_conditioning_guard_1485.py` → **230 passed**, run twice (once on a throwaway rebase to
  predict, once on the real branch to confirm).
- Full suite: **6154 passed, 22 skipped, 21 xfailed**, GATE GREEN.

## Not done

- **Placement is unresolved and is the reason this is a draft.** `centroidal_vci_sandbox.py` puts a
  file named `*_sandbox` inside the production package, and `find mfgarchon -name "*sandbox*"`
  returns no other. If the answer is that research scaffolding belongs in the research repo rather
  than here, this PR is the wrong vehicle and the branch should stay a branch.
- No `changelog.d/` fragment. Not added on purpose: whether a sandbox module is a user-visible change
  depends on the placement question above.
- `mls_basis.py`'s shift does **not** close the analytic-vs-autodiff gap between the two backends —
  measured on one fixed 21-node 1D cloud, degree 2, `rho = 2.6h`: `main` (unshifted) separates at
  5.0e-10 in the gradient, this branch (shifted) at 1.6e-9. So the shift is worth having for the
  conditioning claim it makes, but it is not a fix for that separation, whose cause is unexplained.
  See #1863.
- The eleven commits are not mine; I rebased and verified them. Squashing, re-authoring or splitting
  them is the author's call.
