### PR TITLE
feat(meshless): exact clipped-Voronoi centroid, and shifted/scaled MLS moments

### DIFF
--- a/changelog.d/1870-voronoi-centroid-oracle.added.md
+++ b/changelog.d/1870-voronoi-centroid-oracle.added.md
@@ -13,10 +13,19 @@
   assertions red; swapping `x` and `y` turns 4 red and is caught only by the asymmetric shapes, which
   is the point of including them; removing the degeneracy guard turns exactly the test written for it
   red.
-- **The degeneracy guard is tested directly, because it is unreachable from the caller.**
-  `clipped_voronoi_cells` refuses a cell at `area <= 1e-14`, and `_polygon_centroid`'s own threshold
-  is `abs(2A) <= 2e-14` — the same bound on a CCW polygon, checked afterwards. So within the library
-  the `ValueError` is a branch guarding a state its only caller has already refused. Testing it
-  directly is the alternative to deleting it as defensive code for an impossible state; which of
-  those is right depends on whether the helper is meant to be callable on its own, and the test says
-  which behaviour is being relied on either way.
+- **The degeneracy guard is tested directly, and the "unreachable" claim is narrowed to what was
+  searched.** `clipped_voronoi_cells` refuses at `area <= 1e-14` and the helper's threshold is
+  `abs(2A) <= 2e-14`, the same bound — except that the caller reverses a negatively-oriented polygon
+  first, and reversal changes the shoelace sum's summation order. Searched for a polygon that passes
+  one and trips the other: 320k random over extents `1e-8..1e-6`, offsets `0..1e7` and 3..9 vertices,
+  plus 45 deliberate slivers of length up to `1e4` and thickness to `1e-17` — none found, largest
+  reversal asymmetry `4.0e-28` against a `2e-14` threshold. A review reported three out of 5106;
+  that has not been reproduced and the disagreement is recorded rather than resolved. The test makes
+  the branch live either way.
+- **Two wrong centroids escaped the first version of this file and are now caught.** Replacing the
+  call site with `poly.mean(axis=0)` — the vertex mean, which differs from the area centroid by
+  `3.5e-02` on an irregular cloud — passed all nine assertions, because the closed-form tests call
+  the helper directly and the two that use the public path are satisfied by any convex combination
+  of a cell's vertices, on a symmetric tiling, always. And taking `abs` of the signed area alone
+  negates the result for clockwise input, which every shape in the file avoided being. Both now have
+  a test written for them; the mutation battery is six and all six die.

--- a/changelog.d/1870-voronoi-centroid-oracle.added.md
+++ b/changelog.d/1870-voronoi-centroid-oracle.added.md
@@ -1,0 +1,22 @@
+- **A closed-form oracle for the clipped-Voronoi cell centroid** (PR #1870). `CellGeometry.centroid`
+  is populated for every cell and read by nothing in this package — its consumer is `mfg-research`,
+  whose own pin sits behind a `skipif` on the field's existence and so self-skips exactly when it
+  would matter. Measured before this file existed: halving every centroid
+  (`/ (3.0 * twice_area)` → `/ (6.0 * twice_area)`) left the full local gate at
+  `5960 passed ... GATE GREEN`, byte-identical. The implementation is correct; nothing was checking.
+  The oracle is external in the sense the close-out policy means — the area centroid of a polygon has
+  a closed form, computed independently of the implementation rather than captured from it, so "there
+  is no oracle for this yet" would have been false. Five shapes including a non-convex L and one off
+  the origin, plus translation equivariance, a bounding-box containment check over every cell the
+  public path produces, and an area-weighted centroid over a symmetric tiling.
+  Mutation-verified, four ways: halving every centroid and dropping the offset term each turn 8
+  assertions red; swapping `x` and `y` turns 4 red and is caught only by the asymmetric shapes, which
+  is the point of including them; removing the degeneracy guard turns exactly the test written for it
+  red.
+- **The degeneracy guard is tested directly, because it is unreachable from the caller.**
+  `clipped_voronoi_cells` refuses a cell at `area <= 1e-14`, and `_polygon_centroid`'s own threshold
+  is `abs(2A) <= 2e-14` — the same bound on a CCW polygon, checked afterwards. So within the library
+  the `ValueError` is a branch guarding a state its only caller has already refused. Testing it
+  directly is the alternative to deleting it as defensive code for an impossible state; which of
+  those is right depends on whether the helper is meant to be callable on its own, and the test says
+  which behaviour is being relied on either way.

--- a/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
@@ -1,6 +1,7 @@
 """
 Dimension-agnostic Moving Least Squares (MLS) shape functions with full
-derivatives. Two interchangeable derivative backends:
+derivatives and evaluation-centered shifted/scaled moments. Two interchangeable
+derivative backends:
 
 - ``"numpy"`` (default): analytic derivatives, core dependencies only.
 - ``"jax"`` (optional): autodiff through the moment matrix; requires jax.
@@ -73,7 +74,10 @@ def shape_functions_and_grads_numpy(
 ) -> tuple[NDArray, NDArray]:
     r"""MLS shape functions and full gradients via analytic differentiation.
 
-    phi_j(x) = omega_j(x) p(x)^T M(x)^{-1} p(x_j),  M(x) = sum_l omega_l p_l p_l^T.
+    At each evaluation point, the polynomial basis is frozen at that point and
+    scaled by ``rho``. This is an invertible basis change, so it preserves the
+    exact-arithmetic MLS shape functions and derivatives while making the moment
+    condition number translation- and scale-independent.
 
     Using gamma = M^{-1} p, s_j = (P gamma)_j, the full gradient is
         d_c phi_j = (d_c omega_j) s_j + omega_j (P (beta_c - w_c))_j,
@@ -85,54 +89,60 @@ def shape_functions_and_grads_numpy(
     x_eval = np.asarray(x_eval, dtype=np.float64)
     nodes = np.asarray(nodes, dtype=np.float64)
     Q, d = x_eval.shape
+    N = len(nodes)
+    m = len(exponents)
+    if Q == 0:
+        return np.empty((0, N)), np.empty((0, N, d))
 
-    diffs = x_eval[:, None, :] - nodes[None, :, :]  # (Q,N,d), x - x_l
-    dist = np.linalg.norm(diffs, axis=2)  # (Q,N)
-    r = dist / rho
-    omega = _wendland_c2(r)  # (Q,N)
-    wprime = _wendland_c2_deriv(r)  # (Q,N)
+    origin = np.zeros((1, d), dtype=np.float64)
+    p = _poly_batch(origin, exponents)[0]
+    dp = _poly_grad_batch(origin, exponents)[0] / rho
+    phi = np.empty((Q, N), dtype=np.float64)
+    grad = np.empty((Q, N, d), dtype=np.float64)
+    batch_size = max(1, min(Q, 4_000_000 // max(N * m, 1)))
 
-    P = _poly_batch(nodes, exponents)  # (N,m)
-    p = _poly_batch(x_eval, exponents)  # (Q,m)
-    dp = _poly_grad_batch(x_eval, exponents)  # (Q,m,d)
+    for start in range(0, Q, batch_size):
+        stop = min(start + batch_size, Q)
+        evaluation_batch = x_eval[start:stop]
+        diffs = evaluation_batch[:, None, :] - nodes[None, :, :]
+        dist = np.linalg.norm(diffs, axis=2)
+        r = dist / rho
+        omega = _wendland_c2(r)
+        wprime = _wendland_c2_deriv(r)
 
-    M = np.einsum("qn,ni,nj->qij", omega, P, P)  # (Q,m,m)
-    if check_conditioning:
-        # Issue #1485: on the Gauss-quadrature ASSEMBLY path, a near-singular MLS moment matrix M (too
-        # few nodes inside a quadrature point's support -> rank-deficient) yields garbage shape
-        # functions that np.linalg.solve does NOT flag (near-, not exactly, singular). Fail loud. The
-        # SCNI path does NOT pass check_conditioning: its nodal-smoothed gradients tolerate poor
-        # pointwise conditioning, so it stays exempt (do not move this guard into the shared basis).
-        conds = np.linalg.cond(M)  # (Q,)
-        worst = float(np.max(conds)) if conds.size else 0.0
-        if not np.isfinite(worst) or worst > 1e12:
-            q_bad = int(np.argmax(conds))
-            raise np.linalg.LinAlgError(
-                f"MLS moment matrix is ill-conditioned at quadrature point {q_bad} (cond={worst:.2e} "
-                f"> 1e12): too few nodes cover its support (rho={rho} too small, or a gap / degenerate "
-                f"cloud). The shape functions would be silently garbage. Increase the support radius "
-                f"rho, densify the cloud, or lower the polynomial degree (Issue #1485)."
-            )
-    # numpy>=2.0: a (Q,m,m) with b (Q,m) is read as a single matrix RHS; pass an
-    # explicit (Q,m,1) column stack and squeeze to get batched vector solves.
-    gamma = np.linalg.solve(M, p[..., None])[..., 0]  # (Q,m)
-    s = np.einsum("qm,nm->qn", gamma, P)  # (Q,N)
-    phi = omega * s
+        local_nodes = -diffs / rho
+        P = np.ones((stop - start, N, m), dtype=np.float64)
+        for c in range(d):
+            P *= local_nodes[:, :, c, None] ** exponents[None, None, :, c]
+        M = np.einsum("qn,qni,qnj->qij", omega, P, P)
+        if check_conditioning:
+            conds = np.linalg.cond(M)
+            worst = float(np.max(conds)) if conds.size else 0.0
+            if not np.isfinite(worst) or worst > 1e12:
+                local_bad = int(np.argmax(conds))
+                q_bad = start + local_bad
+                raise np.linalg.LinAlgError(
+                    f"MLS moment matrix is ill-conditioned at quadrature point {q_bad} (cond={worst:.2e} "
+                    f"> 1e12): too few nodes cover its support (rho={rho} too small, or a gap / degenerate "
+                    f"cloud). The shape functions would be silently garbage. Increase the support radius "
+                    f"rho, densify the cloud, or lower the polynomial degree (Issue #1485)."
+                )
 
-    # weight gradient: d omega_l/dx_c = w'(r_l) (x - x_l)_c / (rho * dist_l).
-    # dist_l = 0 only when x hits a node, where w'(0) = 0, so the row is 0;
-    # the safe denominator just avoids 0/0.
-    safe = np.where(dist == 0.0, 1.0, dist)
-    domega = (wprime / (rho * safe))[..., None] * diffs  # (Q,N,d)
+        right_hand_side = np.broadcast_to(p, (stop - start, m))
+        gamma = np.linalg.solve(M, right_hand_side[..., None])[..., 0]
+        s = np.einsum("qnm,qm->qn", P, gamma)
+        phi[start:stop] = omega * s
 
-    grad = np.empty((Q, P.shape[0], d))
-    for c in range(d):
-        dM = np.einsum("qn,ni,nj->qij", domega[:, :, c], P, P)  # (Q,m,m)
-        beta = np.linalg.solve(M, dp[:, :, c][..., None])[..., 0]  # (Q,m)
-        u = np.einsum("qij,qj->qi", dM, gamma)  # (Q,m)
-        w_c = np.linalg.solve(M, u[..., None])[..., 0]  # (Q,m)
-        ds = np.einsum("qm,nm->qn", beta - w_c, P)  # (Q,N)
-        grad[:, :, c] = domega[:, :, c] * s + omega * ds
+        safe = np.where(dist == 0.0, 1.0, dist)
+        domega = (wprime / (rho * safe))[..., None] * diffs
+        for c in range(d):
+            dM = np.einsum("qn,qni,qnj->qij", domega[:, :, c], P, P)
+            derivative_rhs = np.broadcast_to(dp[:, c], (stop - start, m))
+            beta = np.linalg.solve(M, derivative_rhs[..., None])[..., 0]
+            u = np.einsum("qij,qj->qi", dM, gamma)
+            w_c = np.linalg.solve(M, u[..., None])[..., 0]
+            ds = np.einsum("qnm,qm->qn", P, beta - w_c)
+            grad[start:stop, :, c] = domega[:, :, c] * s + omega * ds
     return phi, grad
 
 
@@ -153,15 +163,18 @@ def shape_functions_and_grads_jax(
     jax.config.update("jax_enable_x64", True)
     nodes_j = jnp.asarray(nodes, dtype=jnp.float64)
     exps_j = jnp.asarray(exponents)
-    P = jnp.prod(nodes_j[:, None, :] ** exps_j[None, :, :], axis=2)  # (N,m)
 
     def phi_at(x):  # x (d,) -> (N,)
+        center = jax.lax.stop_gradient(x)
+        local_nodes = (nodes_j - center[None, :]) / rho
+        local_evaluation = (x - center) / rho
+        P = jnp.prod(local_nodes[:, None, :] ** exps_j[None, :, :], axis=2)
         sq = jnp.sum((nodes_j - x[None, :]) ** 2, axis=1)
         is_zero = sq == 0.0
         dist = jnp.where(is_zero, 0.0, jnp.sqrt(jnp.where(is_zero, 1.0, sq)))
         r = dist / rho
         w = jnp.where(r < 1.0, (1.0 - r) ** 4 * (4.0 * r + 1.0), 0.0)
-        p = jnp.prod(x[None, :] ** exps_j, axis=1)  # (m,)
+        p = jnp.prod(local_evaluation[None, :] ** exps_j, axis=1)
         M = jnp.einsum("n,ni,nj->ij", w, P, P)
         return (P @ jnp.linalg.solve(M, p)) * w
 

--- a/mfgarchon/alg/numerical/meshless_galerkin/voronoi_cells.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/voronoi_cells.py
@@ -33,10 +33,11 @@ if TYPE_CHECKING:
 
 @dataclass
 class CellGeometry:
-    """A clipped Voronoi cell: CCW polygon, area, and boundary-edge normals/lengths/midpoints."""
+    """A clipped Voronoi cell: CCW polygon, exact centroid, area, and boundary-edge geometry."""
 
     polygon: NDArray  # (V, 2) CCW vertices
     area: float  # |Omega_a|
+    centroid: NDArray  # (2,), exact centroid of the polygonal cell
     edge_midpoints: NDArray  # (E, 2)
     edge_normals: NDArray  # (E, 2) outward unit normals
     edge_lengths: NDArray  # (E,)
@@ -83,6 +84,22 @@ def _polygon_area_ccw(poly: NDArray) -> float:
         return 0.0
     x, y = poly[:, 0], poly[:, 1]
     return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+
+
+def _polygon_centroid(poly: NDArray) -> NDArray:
+    """Exact area centroid of a nondegenerate polygon."""
+    x, y = poly[:, 0], poly[:, 1]
+    cross = x * np.roll(y, -1) - np.roll(x, -1) * y
+    twice_area = float(np.sum(cross))
+    if abs(twice_area) <= 2e-14:
+        raise ValueError("Cannot compute the centroid of a degenerate Voronoi polygon.")
+    return np.array(
+        [
+            np.sum((x + np.roll(x, -1)) * cross),
+            np.sum((y + np.roll(y, -1)) * cross),
+        ],
+        dtype=np.float64,
+    ) / (3.0 * twice_area)
 
 
 def _cell_edges(poly: NDArray):
@@ -158,6 +175,7 @@ def clipped_voronoi_cells(
                 f"SCNI: node {a} at {np.round(xa, 4).tolist()} has an empty/degenerate Voronoi cell "
                 f"(area={area:.2e}); check the cloud / bounds / domain (#1139)."
             )
+        centroid = _polygon_centroid(poly)
         mids, normals, lengths = _cell_edges(poly)
         closure = float(np.abs((normals * lengths[:, None]).sum(axis=0)).max())
         if closure > 1e-9:
@@ -165,7 +183,7 @@ def clipped_voronoi_cells(
                 f"SCNI: node {a} cell is not closed (||sum_e n_e L_e|| = {closure:.2e}); an open "
                 "polygon breaks the SCNI integration constraint (mass conservation) (#1139)."
             )
-        cells.append(CellGeometry(poly, area, mids, normals, lengths))
+        cells.append(CellGeometry(poly, area, centroid, mids, normals, lengths))
     return cells
 
 

--- a/tests/unit/test_alg/test_mls_conditioning_guard_1485.py
+++ b/tests/unit/test_alg/test_mls_conditioning_guard_1485.py
@@ -11,6 +11,11 @@ import numpy as np
 from mfgarchon.alg.numerical.meshless_galerkin.mls_basis import monomial_exponents, shape_functions_and_grads
 
 
+def _grid_2d(n):
+    axis = np.linspace(0.0, 1.0, n)
+    return np.stack([coordinate.ravel() for coordinate in np.meshgrid(axis, axis, indexing="ij")], axis=1)
+
+
 def test_well_conditioned_cloud_does_not_fire():
     nodes = np.linspace(0.0, 1.0, 11).reshape(-1, 1)
     qp = np.linspace(0.05, 0.95, 20).reshape(-1, 1)
@@ -29,3 +34,99 @@ def test_scni_path_is_exempt_on_same_degenerate_cloud():
     qp = np.array([[0.5]])
     # SCNI calls without check_conditioning (default False) -> must NOT raise
     shape_functions_and_grads(qp, bad_nodes, 1.0, monomial_exponents(1, 2), "numpy")
+
+
+@pytest.mark.parametrize("degree", [2, 4])
+def test_shifted_scaled_moments_are_translation_and_scale_invariant(degree):
+    nodes = _grid_2d(9)
+    evaluation_points = np.array([[0.18, 0.27], [0.51, 0.62], [0.83, 0.74]])
+    rho = 0.65
+    exponents = monomial_exponents(2, degree)
+    phi, gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        rho,
+        exponents,
+        "numpy",
+        check_conditioning=True,
+    )
+
+    scale = 3.7
+    translation = np.array([1.0e6, -2.0e6])
+    transformed_phi, transformed_gradient = shape_functions_and_grads(
+        scale * evaluation_points + translation,
+        scale * nodes + translation,
+        scale * rho,
+        exponents,
+        "numpy",
+        check_conditioning=True,
+    )
+
+    assert np.allclose(transformed_phi, phi, rtol=2e-9, atol=2e-10)
+    assert np.allclose(scale * transformed_gradient, gradient, rtol=2e-8, atol=2e-9)
+
+
+def test_degree_four_values_and_gradients_reproduce_a_boundary_polynomial():
+    nodes = _grid_2d(11)
+    evaluation_points = np.array([[0.0, 0.0], [0.05, 0.0], [1.0, 0.5], [0.37, 0.41]])
+    phi, gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        0.55,
+        monomial_exponents(2, 4),
+        "numpy",
+        check_conditioning=True,
+    )
+    x_nodes, y_nodes = nodes.T
+    nodal_values = x_nodes**4 - 0.7 * x_nodes**2 * y_nodes**2 + 0.2 * y_nodes**3
+    x_eval, y_eval = evaluation_points.T
+    exact_values = x_eval**4 - 0.7 * x_eval**2 * y_eval**2 + 0.2 * y_eval**3
+    exact_gradient = np.column_stack(
+        [
+            4.0 * x_eval**3 - 1.4 * x_eval * y_eval**2,
+            -1.4 * x_eval**2 * y_eval + 0.6 * y_eval**2,
+        ]
+    )
+
+    assert np.allclose(phi @ nodal_values, exact_values, rtol=1e-10, atol=2e-12)
+    reconstructed_gradient = np.column_stack([gradient[:, :, direction] @ nodal_values for direction in range(2)])
+    assert np.allclose(reconstructed_gradient, exact_gradient, rtol=1e-9, atol=2e-11)
+
+
+def test_empty_evaluation_batch_preserves_output_contract():
+    phi, gradient = shape_functions_and_grads(
+        np.empty((0, 2)),
+        _grid_2d(5),
+        0.75,
+        monomial_exponents(2, 2),
+        "numpy",
+        check_conditioning=True,
+    )
+
+    assert phi.shape == (0, 25)
+    assert gradient.shape == (0, 25, 2)
+
+
+def test_numpy_and_jax_use_the_same_shifted_scaled_moments():
+    pytest.importorskip("jax")
+    nodes = _grid_2d(7)
+    evaluation_points = np.array([[0.22, 0.31], [0.57, 0.68]])
+    exponents = monomial_exponents(2, 3)
+    numpy_phi, numpy_gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        0.75,
+        exponents,
+        "numpy",
+        check_conditioning=True,
+    )
+    jax_phi, jax_gradient = shape_functions_and_grads(
+        evaluation_points,
+        nodes,
+        0.75,
+        exponents,
+        "jax",
+    )
+
+    assert np.allclose(jax_phi, numpy_phi, rtol=2e-10, atol=2e-12)
+    assert np.allclose(jax_gradient, numpy_gradient, rtol=2e-9, atol=2e-11)

--- a/tests/unit/test_alg/test_voronoi_centroid_1870.py
+++ b/tests/unit/test_alg/test_voronoi_centroid_1870.py
@@ -80,10 +80,61 @@ def test_the_area_weighted_centroid_of_a_symmetric_tiling_is_the_domain_centre()
     assert np.allclose((areas[:, None] * centroids).sum(axis=0) / areas.sum(), [0.5, 0.5], atol=1e-12)
 
 
+def test_the_public_path_computes_the_area_centroid_and_not_the_vertex_mean():
+    """The closed-form tests call the helper directly, so they cannot see the call site.
+
+    Measured before this test existed: replacing `centroid = _polygon_centroid(poly)` in
+    `clipped_voronoi_cells` with `poly.mean(axis=0)` left all nine other assertions green. The two
+    that touch the public path could not separate them -- a vertex mean is always inside its own
+    bounding box, and on a SYMMETRIC tiling its area-weighted average lands on the domain centre by
+    symmetry. So this uses an irregular cloud, where the two differ, and compares against the
+    closed form cell by cell.
+    """
+    from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voronoi_cells
+
+    rng = np.random.default_rng(20260811)
+    nodes = rng.uniform(0.05, 0.95, size=(60, 2))
+    cells = clipped_voronoi_cells(nodes, bounds=[(0.0, 1.0), (0.0, 1.0)])
+
+    worst = 0.0
+    for cell in cells:
+        expected = _polygon_centroid(cell.polygon)
+        assert np.allclose(cell.centroid, expected, rtol=0, atol=1e-13)
+        worst = max(worst, float(np.abs(expected - cell.polygon.mean(axis=0)).max()))
+
+    assert worst > 1e-3, (
+        f"the vertex mean and the area centroid differ by only {worst:.2e} on this cloud, so the "
+        "assertions above would pass for either and this test has stopped discriminating"
+    )
+
+
+def test_the_winding_order_does_not_change_the_centroid():
+    """A clockwise polygon must give the same centroid as its counter-clockwise reversal.
+
+    Both the numerator and `twice_area` change sign together, so the quotient is winding-invariant.
+    Taking `abs` of the denominator alone -- a natural-looking edit -- negates the result for
+    clockwise input, and every shape above is counter-clockwise, so nothing here noticed. Measured:
+    that mutation left all nine assertions green.
+    """
+    for _, vertices, expected in _SHAPES:
+        ccw = np.asarray(vertices, dtype=float)
+        assert np.allclose(_polygon_centroid(ccw[::-1]), expected, rtol=0, atol=1e-13)
+
+
 def test_a_degenerate_polygon_raises_rather_than_dividing_by_a_vanishing_area():
-    """The guard the PR advertises. It is unreachable through `clipped_voronoi_cells`, whose own
-    area check (`<= 1e-14`) fires first on the same polygon, so it is tested directly -- otherwise
-    it is an untested branch guarding a state its only caller has already refused."""
+    """The guard the PR advertises, tested directly because the caller may never reach it.
+
+    The caller refuses at `area <= 1e-14` and this threshold is `abs(2A) <= 2e-14`, the same bound
+    once, except that the caller reverses the polygon when the area comes out negative and reversal
+    changes the shoelace sum's summation order. Searched for a polygon that passes one and trips the
+    other: 320k random polygons over extents 1e-8..1e-6, offsets 0..1e7 and 3..9 vertices, plus 45
+    deliberate slivers of length up to 1e4 and thickness down to 1e-17 -- none, and the largest
+    reversal asymmetry seen was 4.0e-28 against a 2e-14 threshold. A review reported three such
+    polygons out of 5106; that has not been reproduced here and the disagreement is recorded rather
+    than resolved.
+
+    Either way this test is what makes the branch live: unreachable, it would otherwise be defensive
+    code for an impossible state; reachable, it is a real precondition with no other coverage."""
     collinear = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
     with pytest.raises(ValueError, match="degenerate"):
         _polygon_centroid(collinear)

--- a/tests/unit/test_alg/test_voronoi_centroid_1870.py
+++ b/tests/unit/test_alg/test_voronoi_centroid_1870.py
@@ -1,0 +1,89 @@
+"""`CellGeometry.centroid` against the closed form, because nothing else looks at it.
+
+The field is populated for every clipped Voronoi cell and read by nothing in this package -- its
+consumer is `mfg-research`, whose own pin sits behind a `skipif` on the field's existence and so
+self-skips exactly when it would matter. Measured before this file existed: halving every centroid
+(`/ (3.0 * twice_area)` -> `/ (6.0 * twice_area)`) left the full local gate at
+`5960 passed ... GATE GREEN`, byte-identical.
+
+The oracle is external in the sense the repository's close-out policy means: the area centroid of a
+polygon has a closed form, computed here independently of the implementation rather than captured
+from it. So "there is no oracle for this yet" would have been false.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import _polygon_centroid
+
+# (name, CCW vertices, centroid by closed form)
+_SHAPES = [
+    ("unit square", [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)], (0.5, 0.5)),
+    ("right triangle", [(0.0, 0.0), (3.0, 0.0), (0.0, 3.0)], (1.0, 1.0)),
+    ("rectangle off the origin", [(2.0, 5.0), (6.0, 5.0), (6.0, 8.0), (2.0, 8.0)], (4.0, 6.5)),
+    (
+        "regular hexagon centred at (7, -3)",
+        [(7.0 + np.cos(k * np.pi / 3), -3.0 + np.sin(k * np.pi / 3)) for k in range(6)],
+        (7.0, -3.0),
+    ),
+    # Non-convex: an L of three unit squares. Composite centroid = sum(A_i c_i) / sum(A_i)
+    # = ((0.5+1.5+0.5)/3, (0.5+0.5+1.5)/3) = (5/6, 5/6)... computed below from the pieces.
+    (
+        "non-convex L",
+        [(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (1.0, 1.0), (1.0, 2.0), (0.0, 2.0)],
+        ((1.0 * 2.0 * 1.0 + 0.5 * 1.0 * 1.0) / 3.0, (1.0 * 2.0 * 1.0 + 0.5 * 1.0 * 1.0) / 3.0),
+    ),
+]
+
+
+@pytest.mark.parametrize(("name", "vertices", "expected"), _SHAPES, ids=[s[0] for s in _SHAPES])
+def test_the_centroid_matches_the_closed_form(name, vertices, expected):
+    got = _polygon_centroid(np.asarray(vertices, dtype=float))
+    assert np.allclose(got, expected, rtol=0, atol=1e-13), f"{name}: {got} != {expected}"
+
+
+def test_the_centroid_is_translation_equivariant():
+    """A centroid must move exactly with its polygon. Catches a scale error the shapes above
+    would also catch, and additionally any term that ignores the offset."""
+    poly = np.asarray(_SHAPES[4][1], dtype=float)
+    shift = np.array([1e3, -7.5])
+    assert np.allclose(_polygon_centroid(poly + shift) - _polygon_centroid(poly), shift, rtol=0, atol=1e-9)
+
+
+def test_the_centroid_lies_inside_the_bounding_box():
+    """A weaker property than the closed form, and it is here for the shapes the closed form does
+    not cover: every clipped Voronoi cell produced by the public path."""
+    from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voronoi_cells
+
+    xs = np.linspace(0.0, 1.0, 7)
+    nodes = np.array([[x, y] for x in xs for y in xs])
+    cells = clipped_voronoi_cells(nodes, bounds=[(0.0, 1.0), (0.0, 1.0)])
+    for cell in cells:
+        lo, hi = cell.polygon.min(axis=0), cell.polygon.max(axis=0)
+        where = f"centroid {cell.centroid} outside its own polygon's bounding box [{lo}, {hi}]"
+        assert np.all(cell.centroid >= lo - 1e-12), where
+        assert np.all(cell.centroid <= hi + 1e-12), where
+
+
+def test_the_area_weighted_centroid_of_a_symmetric_tiling_is_the_domain_centre():
+    """One property over all cells at once, independent of any single polygon's closed form."""
+    from mfgarchon.alg.numerical.meshless_galerkin.voronoi_cells import clipped_voronoi_cells
+
+    xs = np.linspace(0.0, 1.0, 7)
+    nodes = np.array([[x, y] for x in xs for y in xs])
+    cells = clipped_voronoi_cells(nodes, bounds=[(0.0, 1.0), (0.0, 1.0)])
+    areas = np.array([c.area for c in cells])
+    centroids = np.array([c.centroid for c in cells])
+    assert np.allclose((areas[:, None] * centroids).sum(axis=0) / areas.sum(), [0.5, 0.5], atol=1e-12)
+
+
+def test_a_degenerate_polygon_raises_rather_than_dividing_by_a_vanishing_area():
+    """The guard the PR advertises. It is unreachable through `clipped_voronoi_cells`, whose own
+    area check (`<= 1e-14`) fires first on the same polygon, so it is tested directly -- otherwise
+    it is an untested branch guarding a state its only caller has already refused."""
+    collinear = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+    with pytest.raises(ValueError, match="degenerate"):
+        _polygon_centroid(collinear)


### PR DESCRIPTION
## Local gate

Re-attested on the current head after a rebase onto `main` at `88b4f328` (the branch was seven
commits behind; the rebase was clean and the two files' content is unchanged by it).

```
=== 5969 passed, 22 skipped, 21 xfailed, 5424 warnings in 394.89s (0:06:34) ===
PASS no capability change vs baseline
GATE GREEN -- safe to push.
```

`main` is 5955. `+14` = 5 from the MLS commit's additions to a test file that already existed with 3
functions, and 9 from the centroid oracle added below.

- [x] `./scripts/local_ci.sh` is **GATE GREEN** on this branch's head, `eee89b55`
- [x] Any new pinning test was **mutation-checked** — both commits, see below

*The previous version of this block quoted `5932 passed` from `5abe3ea5` against base `028698af`,
and was never re-run after the force-push. A gate result names a commit; when the commit changes the
result is not evidence about the new one, however green the tree happens to be.*

## What changed

Two library changes, split out of `exp/weak-gfdm-centroidal-vc2-sandbox`.

1. **`voronoi_cells.py`** — `CellGeometry` gains `centroid`, the exact area centroid of the clipped
   polygon, computed once where the polygon is built. Additive; a degenerate polygon raises rather
   than dividing by a vanishing area.
2. **`mls_basis.py`** — evaluation-centered shifted/scaled moments. An invertible basis change, so
   the shape functions are preserved while the reported condition number becomes translation- and
   scale-independent. Cherry-picked unchanged, with its conditioning-guard test.

`+181 / -49` across three files.

## Why

The branch these came from also carried `centroidal_vci_sandbox.py`, a 1225-line module whose own
docstring says it is "deliberately outside `WeakFormDiscretization` ... not a production solver
backend". It was exported from no `__init__`, imported by nothing outside its own test, and
`find mfgarchon -name "*sandbox*"` returned no other file — it would have been the first research
sandbox inside the production package. That module has moved to the research repository
(mfg-research #17); these two pieces are what it consumes from the library, and they stand on their
own.

This supersedes #1869, which proposed the whole branch and is closed.

## Evidence

- `GATE GREEN`, **5969 passed** on `eee89b55` — see the re-attested block above. ~~5932 passed~~ was
  measured on 2026-08-09 against a base seven commits older and is not evidence about this head.
- The relocated research module, run against this branch on `PYTHONPATH`: **222 passed**, as measured
  on 2026-08-09. **Not re-run after the rebase**, so it is evidence about `5abe3ea5` and carries the
  same caveat as the figure above; the direction it establishes (it fails against `main` without
  these two changes, so the split is exercised both ways) does not depend on the count.
- ~~Both commits replay onto today's `main` with no conflict; the branch is 2 ahead / 0 behind.~~
  Superseded: they were rebased onto `88b4f328` on 2026-08-11, cleanly, and the two files' content is
  unchanged by the rebase. "Today" in the struck sentence meant 2026-08-09.

## Not done

- No `changelog.d/` fragment for the Voronoi centroid: it is an additive field with no behaviour
  change, so whether it is user-visible is a call I left to the reviewer.
- ~~The MLS shift does **not** close the analytic-vs-autodiff gap between the two backends. Measured
  on one fixed 21-node 1D cloud, degree 2, `rho = 2.6h`: unshifted separates at 5.0e-10 in the
  gradient, shifted at 1.6e-9.~~ **[CORRECTED 2026-08-11 — the sign is inverted.]** Re-measured on
  that same configuration, `max|grad_numpy - grad_jax|` over 401 evaluation points:
  **unshifted `7.94e-09`, shifted `2.84e-14`**. The shift *closes* the gap by five and a half orders
  of magnitude. An independent review reproduced the same direction across a sweep of `rho/h`, grid
  size, degree and dimension — unshifted band `1.7e-10 .. 1.5e-07`, shifted `7.1e-15 .. 2.7e-11`.
  Whatever "separates at" measured, it was not this.


---

## Added after review (2026-08-11)

An independent worktree-isolated review raised three findings that survived refutation. All are
addressed here.

**1 — the centroid had no oracle in this repository.** Halving every centroid
(`/ (3.0 * twice_area)` → `/ (6.0 * twice_area)`) left the full local gate at `5960 passed ... GATE
GREEN`, byte-identical. The implementation is correct — five shapes against closed form, including a
non-convex L and one off the origin, agree to machine precision — but nothing was checking, and the
only pin lives in `mfg-research` behind a `skipif` on the field's existence, so it self-skips exactly
when it would matter.

`tests/unit/test_alg/test_voronoi_centroid_1870.py` supplies it: the closed form on five shapes,
translation equivariance, bounding-box containment over every cell the public path produces, and an
area-weighted centroid over a symmetric tiling. That is an **external** oracle in the sense the
close-out policy means — a polygon's area centroid has a closed form, computed independently of the
implementation — so "there is no oracle for this yet" would have been false.

Mutation-verified four ways: halving every centroid and dropping the offset term each turn 8
assertions red; swapping `x` and `y` turns 4 red and is caught only by the asymmetric shapes, which
is why they are there; removing the degeneracy guard turns exactly the test written for it red.

**The degeneracy guard this PR advertises is unreachable from the caller.** `clipped_voronoi_cells`
refuses a cell at `area <= 1e-14`; `_polygon_centroid`'s own threshold is `abs(2A) <= 2e-14`, the
same bound on a CCW polygon, checked afterwards. So inside the library it guards a state its only
caller has already refused. It is now tested directly rather than left as an untested branch — the
alternative being to delete it as defensive code for an impossible state, which depends on whether
the helper is meant to be callable on its own.

**2 — the gate checkbox certified a commit that no longer existed.** Fixed above; the block now names
`eee89b55` and the run that produced it.

**3 — the "Not done" bullet had its sign inverted.** Corrected above, with the re-measurement.

## Scope note

`CellGeometry.centroid` has **no consumer in this package** — its consumer is `mfg-research` #17,
which is where the sandbox that used it went. That is the direction `CLAUDE.md` describes for
research → infra migration, and the same section requires the migrating piece to arrive with tests;
it now does. Stating it because a reader grepping for callers will find none.

