### PR TITLE
feat(capability): record whether the coupled solve converged (#1871)

### DIFF
--- a/changelog.d/1871-capability-picard-verdict.added.md
+++ b/changelog.d/1871-capability-picard-verdict.added.md
@@ -1,0 +1,22 @@
+- **The capability matrix records whether the coupled solve converged** (Issue #1871). Its mass
+  oracles could not see it, and not because a tolerance was loose: mass conservation is a property
+  of the FP time-stepping, which holds on whatever drift field it is handed, converged or not.
+  Measured when this landed, three of the five PASS cells run exactly to their iteration budget
+  without converging — `fdm_upwind` and `sl_linear` at 5, `sl_linear_2d` at 3, the last being the
+  cell cited throughout #1745 as the control that works where the FDM family fails. In the other
+  direction, a deliberately under-relaxed run (`picard.relaxation=0.1`, 3 sweeps) reports
+  `converged=False` with mass drift `1.8e-16` and is a **PASS** under the old verdict, so two of the
+  UNSUPPORTED cells — `fdm_upwind_2d` and `fvm_muscl_2d` — could have been turned green by a config
+  change that leaves the solve further from a fixed point. (`fdm_centered_2d` could not: it raises
+  inside the first FP solve, which relaxation of the outer iterate cannot reach.) Every cell holding
+  a solver result now carries `picard_converged` and `picard_iterations` in its baseline artifact.
+  **Recorded, not gated**: gating today turns three long-standing greens red, and two of those still
+  do not converge at 100 sweeps for different reasons — for `fdm_upwind` exactly one of the four
+  criterion inputs blocks, the value function's absolute error (rises to 287, ends at `2.3e-04`),
+  while for `sl_linear` all four are above tolerance, the density worst and not descending (never
+  below `0.357`, ends at `8.2e-01`). That is Issue #1873. No cell changes status.
+  Guarded by a source-level test: a cell function that binds a `.solve(...)` result must mention
+  `_picard_verdict`, which is structural and so needs no exemption list. An earlier version of that
+  test compared recorded artifacts instead and stayed green when a call site was deleted — the
+  baseline still carried the field from the last regeneration — which is the same defect class the
+  field itself exists to expose, one level up.

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -24,6 +24,8 @@
         "mass_t0": 1.0000000000000002,
         "max_drift": 1.2212453270876722e-15,
         "min_density": 0.007498923710795448,
+        "picard_converged": false,
+        "picard_iterations": 5,
         "tolerance": 1.0000000000000003e-09
       },
       "status": "PASS"
@@ -42,6 +44,8 @@
         "mass_t0": 0.9999999999999998,
         "max_rel_drift": 2.2204460492503136e-16,
         "min_density": 7.271016423279045e-05,
+        "picard_converged": true,
+        "picard_iterations": 18,
         "tolerance": 1e-06
       },
       "status": "PASS"
@@ -57,6 +61,10 @@
     "fvm_vs_fdm/agreement": {
       "artifact": {
         "all_finite": true,
+        "fdm_picard_converged": true,
+        "fdm_picard_iterations": 17,
+        "fvm_picard_converged": true,
+        "fvm_picard_iterations": 18,
         "rel_l2_M": 0.04890580973631817,
         "rel_l2_M_terminal": 0.04285356047380676,
         "rel_l2_U": 0.027229780657619235,
@@ -78,6 +86,8 @@
         "all_finite": true,
         "max_rel_drift": 0.0888200989332657,
         "min_density": 0.0008425476627731638,
+        "picard_converged": false,
+        "picard_iterations": 3,
         "regimes": [
           {
             "all_finite": true,
@@ -104,6 +114,8 @@
         "mass_t0": 1.0000000000000002,
         "max_drift": 4.440892098500626e-16,
         "min_density": 0.00466345594426523,
+        "picard_converged": false,
+        "picard_iterations": 5,
         "tolerance": 1.0000000000000003e-09
       },
       "status": "PASS"
@@ -114,6 +126,8 @@
         "mass_t0": 1.2100000000000002,
         "max_rel_drift": 3.670158759091426e-16,
         "min_density": 3.5346848535299638e-06,
+        "picard_converged": false,
+        "picard_iterations": 3,
         "tolerance": 1e-09
       },
       "status": "PASS"

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -200,6 +200,44 @@ def _mass_drift(result, problem) -> dict:
     }
 
 
+def _picard_verdict(result, prefix: str = "") -> dict:
+    """What the coupled iteration said about itself, recorded beside the oracle (#1871).
+
+    Deliberately NOT part of any cell's ``ok``. Measured when this was added: three of the
+    five PASS cells run exactly to their iteration budget without converging --
+    ``fdm_upwind`` and ``sl_linear`` at 5, ``sl_linear_2d`` at 3 -- so gating on it today
+    turns three long-standing greens red. Two of those still do not converge at 100 sweeps,
+    and for different reasons, which is why the gate is not a one-line follow-up:
+
+    - ``fdm_upwind``: the value function's Picard error rises from 0.496 to 287, oscillates
+      (13.5 at sweep 10, back to 235 at sweep 19) and ends at 2.3e-04. The density gets to
+      9.5e-10 by sweep 85 but rises on 35 of 99 steps and ends 40x higher, at 3.9e-08.
+    - ``sl_linear``: BOTH are above tolerance, so neither fix alone would turn it green.
+      The density is the worse of the two and is not descending -- never below 0.357,
+      ending at 8.2e-01, O(1) after 100 sweeps -- while the value function ends at 5.9e-02
+      and is still coming down.
+
+    ``sl_linear_2d`` is the one a budget fixes -- it converges at 35 sweeps in ~3s.
+
+    A mass oracle cannot see any of this, and not because its tolerance is loose: mass
+    conservation is a property of the FP time-stepping, which holds on whatever drift it is
+    handed, converged or not. So this field is what makes the difference visible in the
+    baseline and diffable across changes, before anyone argues about the gate. The
+    non-convergence itself is #1873.
+
+    ``picard_iterations`` is the count of sweeps performed, in both result types -- but the
+    two reach it differently, and the asymmetry runs opposite to the one you would guess.
+    ``RegimeSwitchingIterator`` exits early only on convergence, so a non-converged run has
+    always executed the full budget and its count equals it by construction.
+    ``FixedPointIterator`` has three non-converged breaks besides, so its count is the one
+    that can fall short of the budget without having converged.
+    """
+    return {
+        f"{prefix}picard_converged": bool(result.converged),
+        f"{prefix}picard_iterations": int(result.iterations),
+    }
+
+
 def _rel_l2(a: np.ndarray, b: np.ndarray, dx: float) -> float:
     return float(np.sqrt(dx * np.sum((a - b) ** 2)) / np.sqrt(dx * np.sum(b**2)))
 
@@ -288,6 +326,7 @@ def _mass_conservation_cell(scheme_name: str):
 
         def verdict():
             art = _mass_drift(result, problem)
+            art |= _picard_verdict(result)
             art["tolerance"] = MASS_RTOL * max(abs(art["mass_t0"]), 1.0)
             ok = art["all_finite"] and art["max_drift"] <= art["tolerance"]
             return ("PASS" if ok else "FAIL"), art
@@ -325,6 +364,7 @@ def _mass_conservation_2d_cell(scheme_name: str):
                 "all_finite": bool(np.isfinite(M).all()),
                 "tolerance": 1e-9,
             }
+            art |= _picard_verdict(result)
             ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-9
             return ("PASS" if ok else "FAIL"), art
 
@@ -405,6 +445,7 @@ def _fvm_fdm_agreement_cell():
                 ),
                 "tolerance": AGREEMENT_RTOL,
             }
+            art |= _picard_verdict(r_fvm, "fvm_") | _picard_verdict(r_fdm, "fdm_")
             if not art["all_finite"]:
                 art["worst"] = None
                 return "FAIL", art
@@ -437,6 +478,7 @@ def _fvm_mass_cell():
                 "all_finite": bool(np.isfinite(M).all()),
                 "tolerance": 1e-6,
             }
+            art |= _picard_verdict(result)
             ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
             return ("PASS" if ok else "FAIL"), art
 
@@ -540,6 +582,7 @@ def _regime_switching_cell():
                 "all_finite": all(r["all_finite"] for r in per_regime),
                 "tolerance": 1e-6,
             }
+            art |= _picard_verdict(result)
             ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
             return ("PASS" if ok else "FAIL"), art
 

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -16,6 +16,7 @@ These tests exercise the comparison and mutation logic directly. They do not sol
 anything: the cells themselves are exercised by running the script.
 """
 
+import ast
 import importlib.util
 import json
 import sys
@@ -688,3 +689,42 @@ def test_the_unexplained_count_is_derived_not_asserted(cm, monkeypatch, tmp_path
     assert "1 non-PASS cell(s) with no recorded reason" in report, report
     assert "b/bare" in report
     assert "a/annotated" not in report.split("no recorded reason")[-1]
+
+
+def test_every_cell_that_solves_records_the_picard_verdict():
+    """A cell that solves must say whether the solve converged (#1871).
+
+    The field exists because the mass oracles cannot see convergence -- mass is conserved on
+    whatever drift field the FP step is handed. It is recorded, not gated: nothing in
+    `--check-baseline` reacts to it, and a `_picard_verdict` returning constants leaves the
+    full gate green (verified by mutation). This test is the only oracle over the field.
+
+    It reads the SOURCE, not the baseline. The first version of this test compared recorded
+    artifacts, and deleting a `_picard_verdict` call left it green -- the baseline still
+    carried the field from the last regeneration, so the test pinned a record rather than
+    the code that writes it. That is the same defect class the field itself exists to
+    expose, one level up.
+
+    The rule is structural, so there is no exemption list to keep in sync: a cell function
+    that binds the result of a `.solve(...)` call must mention `_picard_verdict`. Cells that
+    only construct a solver -- `_gfdm_rbf_cell` -- bind no result and are exempt by shape,
+    which matters because it is why "no exception implies a verdict" cannot be the rule.
+    """
+    tree = ast.parse(_SCRIPT.read_text())
+
+    def solves(node: ast.FunctionDef) -> bool:
+        return any(
+            isinstance(n, ast.Assign)
+            and isinstance(n.value, ast.Call)
+            and isinstance(n.value.func, ast.Attribute)
+            and n.value.func.attr == "solve"
+            for n in ast.walk(node)
+        )
+
+    solving = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and solves(n)]
+    assert solving, "no cell binds a solve result -- the rule below would be vacuous"
+
+    missing = sorted(
+        n.name for n in solving if "_picard_verdict" not in ast.dump(n) and "_picard_verdict" not in ast.unparse(n)
+    )
+    assert not missing, f"these solve a problem and never record whether it converged: {missing}"


### PR DESCRIPTION
Closes the first half of #1871. Purely additive: **no cell changes status**.

## What the oracle could not see

Mass conservation is a property of the FP time-stepping — it holds on whatever drift field the
solver is handed, converged or not. So `max_rel_drift <= 1e-9` is not a weak test of whether the
configuration solves; it is not a test of it at all. `grep -c converged scripts/capability_matrix.py`
returned **0**: none of the eleven cells read the solver's own verdict.

## What that was hiding, measured

```
fdm_upwind/mass_conservation      PASS  converged=False iters=5    <- budget 5, exhausted
sl_linear/mass_conservation       PASS  converged=False iters=5    <- budget 5, exhausted
sl_linear_2d/mass_conservation    PASS  converged=False iters=3    <- budget 3, exhausted
fvm_muscl/mass_conservation       PASS  converged=True  iters=18
fvm_vs_fdm/agreement              PASS  converged=True  iters=18; 17
```

Three of five greens never converged. `sl_linear_2d` is the cell cited throughout #1745 as the
control — "SL_LINEAR passes at 3.67e-16 while the FDM family fails" — and it has never converged in
that comparison.

And in the other direction: `picard.relaxation=0.1` with 3 sweeps **returns** rather than raising,
with mass drift `1.8e-16`, `min M = 3.5e-06`, all finite, `converged=False`. Fed to the 2-D cell's
own verdict logic that artifact is a **PASS**. **Two** of the UNSUPPORTED cells — `fdm_upwind_2d` and `fvm_muscl_2d` — could have been turned green
by a config change that leaves the solve further from a fixed point than the default. (`fdm_centered_2d`
could not: it raises inside the first FP solve, and relaxation damps the outer iterate after the
sub-solves, so it never reaches that failure. An earlier revision of this PR said three.)

## The change

One owner, `_picard_verdict(result, prefix="")`, at five call sites covering the six cells that hold
a solver result — rather than six inline dict edits that would drift apart. `fvm_vs_fdm` holds two
results and records both under `fvm_`/`fdm_` prefixes. Six of the eleven artifacts carry the fields;
the other five are four cells that raise before producing a result — their call sites are wired all
the same — plus `gfdm_rbf`, which constructs a solver and never solves, so it has no result to
record and no call site. That last one is why "no `exception` key implies a verdict" cannot be the
invariant, and why the test above keys on binding a solve result instead.

## Recorded, not gated — and why that is measured, not deferred

Gating today turns three long-standing greens red, and two of those still do not converge at **100
sweeps** (5 and 100 are the budgets measured; "any budget" would be an extrapolation):

```
cell                                   budget  iters  converged  seconds
fdm_upwind/mass_conservation   (1-D)      100    100      False     16.5
sl_linear/mass_conservation    (1-D)      100    100      False      9.3
sl_linear_2d/mass_conservation (2-D)      100     35      True       2.8
```

And they fail for **different reasons**, which is why the gate is not a one-line follow-up:

- `fdm_upwind` stalls in the **value function**: its Picard error rises from `0.4957` to `287`,
  oscillates — `13.5` at sweep 10, back to `235.0` at sweep 19 — and ends at `2.2983e-04`. Its
  density reaches `9.5459e-10` by sweep 85 but rises on 35 of 99 steps and ends 40x higher, at
  `3.8868e-08`. Not monotone, which an earlier revision of this PR claimed.
- `sl_linear` stalls in the **density**: `M` never goes below `0.357` and ends at `8.1517e-01`, O(1)
  after 100 sweeps. Carrying `fdm_upwind`'s diagnosis onto it, as an earlier revision did here and
  in #1873, is wrong — a fix aimed at the value function would leave this cell red.

That is a defect in the solver, not in the gate: **#1873**, rescoped accordingly. `sl_linear_2d` is
the one a budget fixes (35 sweeps, ~3 s), so raising it is available whenever the gate lands.

Recording first makes the difference visible and diffable in the baseline immediately, and separates
"the matrix cannot see this" from "the solver does this" — which are two fixes with two owners.

## Baseline

Regenerated in the same change, since every artifact moved. `git diff --numstat b6df8bd4..HEAD` on
`scripts/capability_baseline.json` is **`14 0`** — fourteen additions, zero deletions. That single
number independently confirms three claims at once: no cell changed status, no previously recorded
artifact value moved under the regeneration, and `regime_switching`'s note is byte-identical rather
than rewritten. `_note_still_applies` dropped
`regime_switching`'s `intended` note for that reason alone — its content is unaffected by this PR —
so it is restored **verbatim from HEAD** rather than rewritten, which is the honest form when the
note did not become wrong.

## Oracle

A **mutation-verified source-level check**: `test_every_cell_that_solves_records_the_picard_verdict`
parses `capability_matrix.py` and requires that any cell function binding a `.solve(...)` result
mentions `_picard_verdict`. Structural, so there is no exemption list — `_gfdm_rbf_cell` binds no
result and is exempt by shape. Deleting the call from the 1-D mass cell, the 2-D mass cell or the
`fvm_vs_fdm` cell each turns it red; each mutation was checked to have actually applied before its
result was read.

**It reads the source, not the baseline, and that was not the first attempt.** The first version
compared recorded artifacts and stayed green when a call site was deleted, because the baseline
still carried the field from the last regeneration — it pinned a record rather than the code that
writes it. That is the same defect class this whole PR exists to expose, one level up.

**What it does not cover, stated plainly**: it checks that the verdict is *recorded*, not that it is
*right*. A `_picard_verdict` returning constants passes it, and passes the full gate — verified by
mutation, `GATE GREEN`, identical counts. `compare_to_baseline` compares status only, so nothing
reacts to the value. Making the value load-bearing is the gate, and the gate is the second half of
#1871.

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, 5933 passed, 22 skipped, 21 xfailed. Pushed with
`--no-verify` per #1804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
