### PR TITLE
fix(convergence): the U error must not measure an additive function of time (#1873)

### DIFF
--- a/changelog.d/1873-convergence-gauge.fixed.md
+++ b/changelog.d/1873-convergence-gauge.fixed.md
@@ -1,0 +1,16 @@
+- **The U convergence metric ignores an additive function of time** (Issue #1873). `u` reaches the
+  density only through `grad(u)` — the drift is `-grad(u)/c` — so adding a constant to a whole time
+  slice changes nothing the coupled system can observe. It does change `||u||` and `||du||`, and on
+  a real problem it dominates both: measured on the 1-D smoke fixture, **99.77% of `||U||`'s energy
+  is that mode**, and 99.71% of the per-sweep change. The error was therefore mostly a quantity
+  nothing in the game depends on, in both directions — the mode inflates the absolute error, so a
+  converged solve reads as not converged, and it inflates the denominator of the relative error, so
+  a solve reads as converged for an unrelated reason: at the sweep where the raw relative error
+  first passed `1e-6`, the gauge-free part was still moving at `8.0e-6` and the drift field at
+  `9.7e-6`. `M` is deliberately not projected; its level is mass, which is observable and conserved.
+  No capability cell changes status; two PASS cells take one to two more Picard sweeps under the
+  now-stricter measurement (`fvm_muscl` 18 → 19, `fvm_vs_fdm` 17/18 → 19/19) and the baseline is
+  regenerated in the same change. The convergence criterion itself still compares one number
+  against both a relative and an absolute error, which is the remaining half of #1873 and is
+  deliberately not bundled here — measured, making the arms alternatives while the metric still
+  carried the gauge mode reported convergence on a sweep the old form was right to refuse.

--- a/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_utils.py
@@ -197,11 +197,21 @@ def check_convergence_criteria(
     tol_picard: float,
 ) -> tuple[bool, str]:
     """
-    Check if fixed-point iteration has converged.
+    Check if the fixed-point iteration has converged.
 
-    Convergence criteria (both must be satisfied):
-    1. Relative errors: max(l2distu_rel, l2distm_rel) < tol_picard
-    2. Absolute errors: max(l2distu_abs, l2distm_abs) < tol_picard
+    Both the relative and the absolute error must be below `tol_picard`, for both variables.
+
+    Known and NOT fixed here (#1873): one number serves as both a relative and an absolute
+    tolerance, so which arm binds is decided by the size of the solution rather than by the
+    caller. For a value function of norm 1.5e+03 in the grid-scaled norm the absolute arm
+    demands 6.6e-10 relative; for a solution of norm 1e-03 the relative arm would demand
+    1e-09 absolute. Separating rtol from atol is the standard fix and is what this repo
+    already did one layer down for the inner Newton (#1745). It is deliberately not done in
+    the same change as the gauge fix in `calculate_l2_convergence_metrics`, because making
+    the arms alternatives while the U error still measured an additive gauge mode reported
+    convergence on a sweep where the drift field was still moving at 9.7x the requested
+    tolerance -- the looser criterion and the honest measurement have to arrive in that
+    order.
 
     Args:
         l2distu_rel: Relative L2 error for U
@@ -211,22 +221,22 @@ def check_convergence_criteria(
         tol_picard: Convergence tolerance
 
     Returns:
-        Tuple of (converged: bool, reason: str)
-
-    Example:
-        >>> converged, reason = check_convergence_criteria(1e-7, 1e-8, 1e-6, 1e-7, 1e-6)
-        >>> print(converged)  # True
-        >>> print(reason)  # "Converged: Rel err 1.0e-07, Abs err 1.0e-06 < tol 1.0e-06"
+        Tuple of (converged: bool, reason: str). The reason is non-empty on failure too,
+        naming the arm that blocked and both variables' errors; it was the empty string
+        before, so a caller could not tell which criterion refused, or by how much.
     """
     max_rel_err = max(l2distu_rel, l2distm_rel)
     max_abs_err = max(l2distu_abs, l2distm_abs)
 
-    # Both relative and absolute errors must be below tolerance
     if max_rel_err < tol_picard and max_abs_err < tol_picard:
-        reason = f"Converged: Rel err {max_rel_err:.1e}, Abs err {max_abs_err:.1e} < tol {tol_picard:.1e}"
-        return True, reason
-    else:
-        return False, ""
+        return True, f"Converged: rel {max_rel_err:.1e}, abs {max_abs_err:.1e} < tol {tol_picard:.1e}"
+
+    blocked = "relative" if max_rel_err >= tol_picard else "absolute"
+    return False, (
+        f"Not converged on the {blocked} criterion: "
+        f"U (rel {l2distu_rel:.1e}, abs {l2distu_abs:.1e}), "
+        f"M (rel {l2distm_rel:.1e}, abs {l2distm_abs:.1e}) vs tol {tol_picard:.1e}"
+    )
 
 
 def preserve_initial_condition(

--- a/mfgarchon/utils/convergence/convergence_metrics.py
+++ b/mfgarchon/utils/convergence/convergence_metrics.py
@@ -342,6 +342,27 @@ def calculate_error(
     }
 
 
+def _without_additive_gauge(U: np.ndarray) -> np.ndarray:
+    """Strip the additive function of time from a value function before measuring it.
+
+    `u` reaches the density only through `grad(u)` -- the drift is `-grad(u)/c` -- so adding
+    a constant to a whole time slice changes nothing the coupled system can observe. It does
+    change `||u||` and `||du||`, and on a real problem it dominates both: measured on the 1-D
+    smoke fixture (#1873), 99.77% of `||U||`'s energy is that mode, and 99.71% of the
+    per-sweep change. Measuring `u` raw therefore reports a convergence error that is mostly
+    a quantity nothing in the game depends on -- in both directions, since the inflated
+    denominator also makes a RELATIVE error look small for a reason unrelated to the solve:
+    at the sweep where the raw relative error first passes 1e-6, the gauge-free part is
+    still moving at 8e-6 and the drift field at 9.7e-6.
+
+    M is deliberately left alone. Its absolute level is mass, which is observable and
+    conserved; there is no additive freedom to remove.
+    """
+    U = np.asarray(U, dtype=float)
+    axes = tuple(range(1, U.ndim)) if U.ndim > 1 else (0,)
+    return U - U.mean(axis=axes, keepdims=True)
+
+
 def calculate_l2_convergence_metrics(
     U_new: np.ndarray,
     U_old: np.ndarray,
@@ -380,7 +401,7 @@ def calculate_l2_convergence_metrics(
         The normalization factor sqrt(Dx * Dt) accounts for grid discretization,
         making errors comparable across different grid resolutions.
     """
-    u_error = calculate_error(U_new, U_old, dx=Dx, dt=Dt, norm="l2")
+    u_error = calculate_error(_without_additive_gauge(U_new), _without_additive_gauge(U_old), dx=Dx, dt=Dt, norm="l2")
     m_error = calculate_error(M_new, M_old, dx=Dx, dt=Dt, norm="l2")
 
     return {

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -45,7 +45,7 @@
         "max_rel_drift": 2.2204460492503136e-16,
         "min_density": 7.271016423279045e-05,
         "picard_converged": true,
-        "picard_iterations": 18,
+        "picard_iterations": 19,
         "tolerance": 1e-06
       },
       "status": "PASS"
@@ -62,14 +62,14 @@
       "artifact": {
         "all_finite": true,
         "fdm_picard_converged": true,
-        "fdm_picard_iterations": 17,
+        "fdm_picard_iterations": 19,
         "fvm_picard_converged": true,
-        "fvm_picard_iterations": 18,
-        "rel_l2_M": 0.04890580973631817,
-        "rel_l2_M_terminal": 0.04285356047380676,
-        "rel_l2_U": 0.027229780657619235,
+        "fvm_picard_iterations": 19,
+        "rel_l2_M": 0.048917185838740516,
+        "rel_l2_M_terminal": 0.04287252636861601,
+        "rel_l2_U": 0.027278425431498336,
         "tolerance": 0.07,
-        "worst": 0.04890580973631817
+        "worst": 0.048917185838740516
       },
       "status": "PASS"
     },

--- a/tests/unit/test_utils/test_convergence_gauge_invariance.py
+++ b/tests/unit/test_utils/test_convergence_gauge_invariance.py
@@ -1,0 +1,128 @@
+r"""The U convergence metric must ignore an additive function of time (#1873).
+
+`u` reaches the density only through `grad(u)`; the drift is `-grad(u)/c`. So adding a
+constant to a whole time slice changes nothing the coupled system can observe -- but it
+changes `||u||` and `||du||`, and on a real problem it dominates both. Measured on the 1-D
+smoke fixture: 99.77% of `||U||`'s energy is that mode, and 99.71% of the per-sweep change.
+
+Both directions of the error matter, which is why this is measured rather than argued. The
+mode inflates the ABSOLUTE error, so a converged solve is reported as not converged. It
+also inflates the DENOMINATOR of the relative error, so a solve is reported as converged
+for a reason unrelated to the solve: at the sweep where the raw relative error first passed
+1e-6, the gauge-free part was still moving at 8.0e-6 and the drift field at 9.7e-6.
+
+M is deliberately not projected. Its level is mass -- observable, conserved, and with no
+additive freedom to remove -- so one test here pins that the asymmetry is intended.
+
+No test name in this file may contain "large", "slow" or "benchmark": tests/conftest.py:100
+marks any such test slow and the gate excludes slow. The first version of the pure-gauge
+case below was called "..._not_a_large_one" and was silently absent from the authoritative
+suite -- in the same change that filed #1875 for that rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.utils.convergence.convergence_metrics import calculate_l2_convergence_metrics
+
+NT, NX = 11, 21
+DX, DT = 1.0 / (NX - 1), 1.0 / (NT - 1)
+RNG = np.random.default_rng(1873)
+
+
+def _fields():
+    U_old = RNG.standard_normal((NT, NX))
+    U_new = U_old + 1e-3 * RNG.standard_normal((NT, NX))
+    M_old = np.abs(RNG.standard_normal((NT, NX))) + 0.1
+    M_new = M_old + 1e-3 * RNG.standard_normal((NT, NX))
+    return U_new, U_old, M_new, M_old
+
+
+@pytest.mark.parametrize(("offset_scale", "tolerance"), [(1.0, 1e-9), (1e3, 1e-9), (1e6, 1e-6)])
+def test_the_u_error_is_unchanged_by_an_additive_function_of_time(offset_scale, tolerance):
+    """A per-slice constant is invisible to the density, so it must be invisible here.
+
+    The offsets differ between the two iterates as well as across time -- a gauge that
+    only moved with the iteration would be caught by a metric that merely subtracted a
+    single global constant.
+
+    The tolerance loosens at 1e6 because the projection is subtraction, and subtraction of
+    a 1e+06 offset from an O(1) field spends six of float64's sixteen digits. That is a real
+    limit of removing the mode this way rather than never forming it: invariance holds to
+    about `offset_scale * eps / ||U||`. It is recorded here rather than hidden by dropping
+    the case, because a caller whose value function genuinely carries an offset that large
+    should know the metric goes soft, not silently wrong.
+    """
+    U_new, U_old, M_new, M_old = _fields()
+    base = calculate_l2_convergence_metrics(U_new, U_old, M_new, M_old, DX, DT)
+
+    off_new = offset_scale * RNG.standard_normal((NT, 1))
+    off_old = offset_scale * RNG.standard_normal((NT, 1))
+    shifted = calculate_l2_convergence_metrics(U_new + off_new, U_old + off_old, M_new, M_old, DX, DT)
+
+    assert shifted["l2distu_abs"] == pytest.approx(base["l2distu_abs"], rel=tolerance), (
+        f"an offset of scale {offset_scale:g} moved the absolute U error"
+    )
+    assert shifted["l2distu_rel"] == pytest.approx(base["l2distu_rel"], rel=tolerance), (
+        f"an offset of scale {offset_scale:g} moved the relative U error"
+    )
+
+
+def test_a_pure_gauge_change_is_zero_error_not_a_big_one():
+    """Two iterates differing ONLY by a per-slice constant have converged in U.
+
+    This is the sharp form: the raw metric would report an error of the size of the offset
+    -- here 1e+03 -- on a pair whose drift fields are identical.
+    """
+    U_old = RNG.standard_normal((NT, NX))
+    U_new = U_old + 1e3 * RNG.standard_normal((NT, 1))
+    M = np.abs(RNG.standard_normal((NT, NX))) + 0.1
+
+    m = calculate_l2_convergence_metrics(U_new, U_old, M, M, DX, DT)
+
+    assert m["l2distu_abs"] < 1e-9, f"a pure gauge change reported {m['l2distu_abs']:.3e}"
+    assert np.allclose(np.gradient(U_new, axis=1), np.gradient(U_old, axis=1)), "the fixture is not a pure gauge change"
+
+
+def test_a_real_change_still_registers():
+    """The projection must not swallow the signal along with the gauge.
+
+    Without this, returning a zero matrix would satisfy every assertion above.
+    """
+    U_old = RNG.standard_normal((NT, NX))
+    U_new = U_old + 1e-2 * np.sin(np.linspace(0, np.pi, NX))[None, :]
+    M = np.abs(RNG.standard_normal((NT, NX))) + 0.1
+
+    m = calculate_l2_convergence_metrics(U_new, U_old, M, M, DX, DT)
+
+    assert m["l2distu_abs"] > 1e-4, f"a spatially varying change of 1e-2 reported {m['l2distu_abs']:.3e}"
+
+
+def test_the_density_metric_is_not_projected():
+    """M's level is mass. Shifting it is a real change and must be reported as one.
+
+    The asymmetry between the two variables is the point, not an oversight: there is no
+    additive freedom in `m` to remove.
+    """
+    U = RNG.standard_normal((NT, NX))
+    M_old = np.abs(RNG.standard_normal((NT, NX))) + 0.1
+    M_new = M_old + 0.5  # a uniform shift in density is a change in mass
+
+    m = calculate_l2_convergence_metrics(U, U, M_new, M_old, DX, DT)
+
+    assert m["l2distm_abs"] > 1e-2, f"a uniform density shift reported {m['l2distm_abs']:.3e}"
+
+
+def test_the_projection_survives_a_two_dimensional_field():
+    """The nD path passes (Nt, Nx, Ny); the mean must be over space, not over one axis."""
+    U_old = RNG.standard_normal((NT, 7, 5))
+    U_new = U_old + 1e-3 * RNG.standard_normal((NT, 7, 5))
+    M = np.abs(RNG.standard_normal((NT, 7, 5))) + 0.1
+
+    base = calculate_l2_convergence_metrics(U_new, U_old, M, M, DX, DT)
+    shifted = calculate_l2_convergence_metrics(U_new + 1e4 * RNG.standard_normal((NT, 1, 1)), U_old, M, M, DX, DT)
+
+    assert shifted["l2distu_abs"] == pytest.approx(base["l2distu_abs"], rel=1e-9)


### PR DESCRIPTION
> **This PR was rewritten after review.** Its first version made the convergence criterion's two
> arms alternatives; review refuted that on this same fixture. The branch name still says
> `picard-tolerance-arms`. What follows is what actually lands.

Fixes the measurement half of #1873. **No capability cell changes status.**

## The defect

`u` reaches the density only through `grad(u)` — the drift is `-grad(u)/c` — so adding a constant
to a whole time slice changes nothing the coupled system can observe. It does change `||u||` and
`||du||`, and on a real problem it dominates both.

Measured on the 1-D smoke fixture, the repository's simplest:

```
||U||                      = 2.1275e+04
  of which the constant mode = 2.1250e+04   (99.77% of the energy)
  with physical content      = 1.0222e+03
per-slice constants:  -2047.45  -1944.82  -1842.24  -1739.66   (a linear ramp in t)
99.71% of the per-sweep change in U is that same mode
```

It misled in **both** directions:

- The mode inflates the **absolute** error, so a converged solve reads as not converged. This
  fixture was reported not converged at 100, 200 and 400 sweeps.
- It inflates the **denominator** of the relative error, so a solve reads as converged for a reason
  unrelated to the solve. At the sweep where the raw relative error first passes `1e-6`, the
  gauge-free part is still moving at `8.0e-6` and the drift field at `9.7e-6`.

`M` is deliberately not projected — its level is mass, observable and conserved, with no additive
freedom to remove. The asymmetry has its own test.

## What this replaced, and why the order matters

The first version of this branch made the criterion's arms alternatives, arguing the relative arm
was the honest measure. **Review refuted it**: with the metric still carrying the gauge mode, the
looser criterion declared convergence at sweep 38 — where the drift field was moving at 9.7x the
requested tolerance — and it fires on **21 of 100 sweeps** of an oscillating iteration, so the
verdict was a statement about where you stopped rather than about the solve.

The criterion's real defect — one number serving as both a relative and an absolute tolerance — is
recorded in its docstring and left to the second half of #1873. **A looser criterion has to arrive
after an honest measurement, not before it.** Kept from that version: the failure reason, which was
the empty string and now names the arm that blocked and both variables' errors.

## Oracle

Seven tests in `tests/unit/test_utils/test_convergence_gauge_invariance.py`. Removing the
projection turns **five** red; the two survivors are the negative controls — a real spatially
varying change must still register, and `M` must still see a uniform shift — true either way by
design.

The `1e6`-offset case carries a looser tolerance and says why: the projection is subtraction, so
invariance holds to about `offset * eps / ||U||`. A caller whose value function genuinely carries an
offset that large should know the metric goes soft, not silently wrong — so the case stays, with the
limit written down, rather than being dropped for passing awkwardly.

## Baseline

Two PASS cells take more Picard sweeps under the now-stricter measurement — `fvm_muscl` 18 → 19,
`fvm_vs_fdm` 17/18 → 19/19, with three `rel_l2` values moving in their last digits — and the
baseline is **regenerated in the same change**. That drift is invisible to `--check-baseline`,
which compares status only. It was measured before pushing rather than after, which is the part
the previous PR got wrong.

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, 5941 passed, 22 skipped, 21 xfailed. Collected
`5977 -> 5984` and passed `5934 -> 5941`, +7 both.

That arithmetic caught something worth recording: at +6, one of these tests —
`test_a_pure_gauge_change_is_zero_error_not_a_large_one`, the sharpest one in the file — was being
silently excluded by #1875's rule, because its name contains "large". In the change that documents
#1875. Twice now, which is the argument for the mechanical fix proposed there rather than for
remembering the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
