### PR TITLE
fix(capability): the harness must hear the library it measures (#1879)

### DIFF
--- a/changelog.d/1879-capability-hears-the-library.fixed.md
+++ b/changelog.d/1879-capability-hears-the-library.fixed.md
@@ -12,3 +12,30 @@
   configuration solves. **Recorded, not gated** — `--check-baseline` still compares status only, and
   no cell changes status; the field's purpose is that the next regeneration shows this in a diff
   instead of requiring a five-hour investigation to find.
+- **The exclusion is by message as well as by category, after adversarial review.** The first
+  version excluded import and deprecation warnings only, on the reasoning that what remained —
+  including the JAX-autodiff fallback, which fires only where JAX is importable — was "capability
+  information rather than noise". Measured, it is not: forcing `_JAX_AVAILABLE = False` leaves the
+  numeric half of all three affected 2-D cells byte-identical, so the entry says what is installed,
+  not whether the configuration solves. Recorded, it made this committed baseline machine-dependent,
+  and via `_note_still_applies` a regeneration on a JAX-free machine **silently dropped three
+  `intended` notes**, including the ~1500-character #1865 investigation record — which
+  `--check-baseline` cannot catch, because it compares status only.
+- **Numbers are collapsed, hyphens are not.** The normalising regex `[-+0-9][0-9.eE+-]*` also ate the
+  hyphen inside ordinary words, folding `non-negativity` to `nonNnegativity` and
+  `stable-baselines3` to `stableNbaselinesN` — merging warnings that differ in their text rather
+  than in their numbers.
+- **Per-cell attribution is now tested.** Every original test monkeypatched `CELLS` to a *single*
+  stub, so the field's actual claim — that a cell carries its own warnings and no one else's — was
+  unverified by construction: hoisting `catch_warnings` out of the per-cell loop, which credits each
+  cell with its predecessors' output, passed all five. Verified on a real two-cell run to credit
+  `gfdm_rbf/construction` with two non-convergence warnings emitted by `fdm_centered`. A two-cell
+  test now kills it, and kills nothing else.
+- **The import-time guard's structural half was scoped wrong in both directions.** It tested
+  `category is Warning and module is None`, which missed `simplefilter("ignore")` (whose `module` is
+  `""`) and `filterwarnings("ignore", category=UserWarning)` — the latter reopens the process-wide
+  trap for one category and left every test green. Widening it to any `Warning` subclass then
+  flagged CPython's own always-installed defaults. It now asks the only question that matters:
+  would this filter swallow a category the harness records.
+  Five mutations, each asserted to apply before it ran and each killed by exactly the test written
+  for it; both files restored and SHA-256-verified afterwards.

--- a/changelog.d/1879-capability-hears-the-library.fixed.md
+++ b/changelog.d/1879-capability-hears-the-library.fixed.md
@@ -1,0 +1,14 @@
+- **The capability harness no longer silences the library it measures** (Issue #1879).
+  `scripts/capability_matrix.py` carried a bare, uncommented `warnings.filterwarnings("ignore")` at
+  import — process-wide, so anything importing it inherited the deafness. While the matrix decided
+  whether a configuration can solve at all, the library could tell it nothing. What that hid,
+  measured the moment it was removed: `fdm_upwind/mass_conservation`, PASS on every run, emits **39**
+  warnings reading *"the value function returned for this timestep is not a root of the discrete
+  HJB, and the outer iteration will consume it as if it were"*, and `regime_switching` emits **42**
+  (Issue #1878). Each cell now runs under `catch_warnings` and what the library said lands in its
+  artifact as `library_said`, folded by category and message with digits collapsed so near-identical
+  warnings count rather than repeat. Import and deprecation warnings are excluded: they differ
+  between machines and would fake a baseline diff, and they are not statements about whether the
+  configuration solves. **Recorded, not gated** — `--check-baseline` still compares status only, and
+  no cell changes status; the field's purpose is that the next regeneration shows this in a diff
+  instead of requiring a five-hour investigation to find.

--- a/changelog.d/1879-capability-hears-the-library.fixed.md
+++ b/changelog.d/1879-capability-hears-the-library.fixed.md
@@ -39,3 +39,18 @@
   would this filter swallow a category the harness records.
   Five mutations, each asserted to apply before it ran and each killed by exactly the test written
   for it; both files restored and SHA-256-verified afterwards.
+- **The baseline is now a fixed point of its own generator, and a test says so.** The `_comment`
+  paragraph documenting `library_said` and the environment exclusion was appended to
+  `capability_baseline.json` by hand, but that field is emitted from a literal in
+  `capability_matrix.py` — so the next `--write-baseline` deleted it, taking with it the only place a
+  future regenerator learns why `_ENVIRONMENT_MARKERS` exists, which makes that list read as
+  arbitrary and the obvious thing to remove. Nothing caught it: `--check-baseline` compares status
+  only, and the gate is green either way. The paragraph now lives in the generator; the file was
+  regenerated in place and verified **SHA-256 identical across a second regeneration**, which is the
+  property that was missing. A hand-restored key order (`artifact, status, intended` against the
+  generator's `sort_keys=True`) went with it, so the next regeneration no longer produces a cosmetic
+  diff in exactly the four cells whose notes had been restored by hand.
+  Guarded by `test_the_baseline_comment_is_what_the_generator_writes`, an AST comparison that needs
+  no solve. Mutation-verified in both directions and calibrated: appending to the JSON alone (the
+  defect as it actually happened) fails it; editing the generator's literal without regenerating
+  fails it; editing a cell's `intended` note, which is legitimately hand-maintained, does not.

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -4,6 +4,9 @@
     "fdm_centered/mass_conservation": {
       "artifact": {
         "exception": "ValueError",
+        "library_said": {
+          "RuntimeWarning: HJB inner Newton did not converge at t_idx=N: residual stopped decreasing after N iterations, residual N again": 2
+        },
         "message": "FP solver: at timestep 2/10, advection_scheme='divergence_centered': density went to -2.762e-01. Clipping it to zero would fabricate 5.722% of the total mass, so the solve is stopped rather than repor"
       },
       "intended": "INTENDED \u2014 not a defect. The mass-fabrication gate (#1683) correctly refuses this configuration: divergence_centered at this cell Peclet is not positivity-preserving and the clip would fabricate 5.722% of the mass. Turning this PASS by loosening the gate is the defect that campaign removed. Fix by picking a well-posed configuration, or leave it.",
@@ -12,6 +15,9 @@
     "fdm_centered_2d/mass_conservation": {
       "artifact": {
         "exception": "ValueError",
+        "library_said": {
+          "RuntimeWarning: JAX autodiff failed: TracerArrayConversionError('The numpy.ndarray conversion method __array__() was called on": 6
+        },
         "message": "FP solver: at timestep 2/6, advection_scheme='divergence_centered': density went to -6.618e-01. Clipping it to zero would fabricate 2.329% of the total mass, so the solve is stopped rather than report"
       },
       "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered.",
@@ -20,6 +26,9 @@
     "fdm_upwind/mass_conservation": {
       "artifact": {
         "all_finite": true,
+        "library_said": {
+          "RuntimeWarning: HJB inner Newton did not converge at t_idx=N: residual stopped decreasing after N iterations, residual N again": 39
+        },
         "mass_max": 1.0000000000000002,
         "mass_t0": 1.0000000000000002,
         "max_drift": 1.2212453270876722e-15,
@@ -33,6 +42,9 @@
     "fdm_upwind_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
+        "library_said": {
+          "RuntimeWarning: JAX autodiff failed: TracerArrayConversionError('The numpy.ndarray conversion method __array__() was called on": 13
+        },
         "message": "newton solver failed to converge after 30 iterations (residual: 2.95e+01)"
       },
       "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one.",
@@ -53,6 +65,9 @@
     "fvm_muscl_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
+        "library_said": {
+          "RuntimeWarning: JAX autodiff failed: TracerArrayConversionError('The numpy.ndarray conversion method __array__() was called on": 8
+        },
         "message": "newton solver failed to converge after 30 iterations (residual: 1.15e+02)"
       },
       "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes.",
@@ -76,6 +91,10 @@
     "gfdm_rbf/construction": {
       "artifact": {
         "exception": "NotImplementedError",
+        "library_said": {
+          "UserWarning: HJBGFDMSolver: no `monotonicity_scheme` specified; defaulting to 'none' (no QP correction). This produces bare": 2,
+          "UserWarning: Hybrid neighborhood: N/N points (N%) had fewer than k=N neighbors within delta=N Used kNNN fallback.": 1
+        },
         "message": "HJBGFDMSolver derivative_method='rbf' is not supported (Issue #1553): since #1526 the RBF branch has no working differentiation-weight builder and would reopen the #1124 obstacle seam. Use derivative_"
       },
       "intended": "ABSENT BY DESIGN \u2014 not a regression. `HJBGFDMSolver(derivative_method='rbf')` raises NotImplementedError at construction since PR #1619, which closed #1553 by converting an AttributeError crash into a loud refusal. Do not read #1553 as the tracker for this cell: it is CLOSED and tracked the crash, not the absence. Reinstating RBF has NO open issue \u2014 the cell exists so that doing so cannot land unnoticed.",
@@ -84,6 +103,9 @@
     "regime_switching/non_negativity": {
       "artifact": {
         "all_finite": true,
+        "library_said": {
+          "RuntimeWarning: HJB inner Newton did not converge at t_idx=N: residual stopped decreasing after N iterations, residual N again": 42
+        },
         "max_rel_drift": 0.0888200989332657,
         "min_density": 0.0008425476627731638,
         "picard_converged": false,

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -17,8 +17,8 @@
         "exception": "ValueError",
         "message": "FP solver: at timestep 2/6, advection_scheme='divergence_centered': density went to -6.618e-01. Clipping it to zero would fabricate 2.329% of the total mass, so the solve is stopped rather than report"
       },
-      "status": "UNSUPPORTED",
-      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered."
+      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered.",
+      "status": "UNSUPPORTED"
     },
     "fdm_upwind/mass_conservation": {
       "artifact": {
@@ -41,8 +41,8 @@
         "exception": "ConvergenceError",
         "message": "newton solver failed to converge after 30 iterations (residual: 2.95e+01)"
       },
-      "status": "UNSUPPORTED",
-      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one."
+      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one.",
+      "status": "UNSUPPORTED"
     },
     "fvm_muscl/mass_conservation": {
       "artifact": {
@@ -61,8 +61,8 @@
         "exception": "ConvergenceError",
         "message": "newton solver failed to converge after 30 iterations (residual: 1.15e+02)"
       },
-      "status": "UNSUPPORTED",
-      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes."
+      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes.",
+      "status": "UNSUPPORTED"
     },
     "fvm_vs_fdm/agreement": {
       "artifact": {
@@ -88,8 +88,8 @@
         },
         "message": "HJBGFDMSolver derivative_method='rbf' is not supported (Issue #1553): since #1526 the RBF branch has no working differentiation-weight builder and would reopen the #1124 obstacle seam. Use derivative_"
       },
-      "status": "UNSUPPORTED",
-      "intended": "ABSENT BY DESIGN \u2014 not a regression. `HJBGFDMSolver(derivative_method='rbf')` raises NotImplementedError at construction since PR #1619, which closed #1553 by converting an AttributeError crash into a loud refusal. Do not read #1553 as the tracker for this cell: it is CLOSED and tracked the crash, not the absence. Reinstating RBF has NO open issue \u2014 the cell exists so that doing so cannot land unnoticed."
+      "intended": "ABSENT BY DESIGN \u2014 not a regression. `HJBGFDMSolver(derivative_method='rbf')` raises NotImplementedError at construction since PR #1619, which closed #1553 by converting an AttributeError crash into a loud refusal. Do not read #1553 as the tracker for this cell: it is CLOSED and tracked the crash, not the absence. Reinstating RBF has NO open issue \u2014 the cell exists so that doing so cannot land unnoticed.",
+      "status": "UNSUPPORTED"
     },
     "regime_switching/non_negativity": {
       "artifact": {

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Executed capability of the solve surface. --check-baseline compares STATUS only, in BOTH directions: a recovered cell must be recorded here in the same change that recovers it. The artifact blocks are a record for diffing by a human reviewer, NOT a gate -- a cell can degrade within its own tolerance (fvm_vs_fdm at 4.891% could reach 6.99%) and the status check stays green. Regenerate with --write-baseline. A non-PASS cell may carry an `intended` note saying WHY it is not PASS; cells without one are unexplained and are the actual backlog.",
+  "_comment": "Executed capability of the solve surface. --check-baseline compares STATUS only, in BOTH directions: a recovered cell must be recorded here in the same change that recovers it. The artifact blocks are a record for diffing by a human reviewer, NOT a gate -- a cell can degrade within its own tolerance (fvm_vs_fdm at 4.891% could reach 6.99%) and the status check stays green. Regenerate with --write-baseline. A non-PASS cell may carry an `intended` note saying WHY it is not PASS; cells without one are unexplained and are the actual backlog. A cell's artifact may also carry `library_said`: the warnings the library emitted while that cell ran, folded by category and message with numbers collapsed. Warnings about the machine rather than about whether the configuration solves (import, deprecation, and the JAX-autodiff fallback) are excluded by design -- recording them makes this file machine-dependent and silently drops the `intended` notes of every cell whose artifact moves. A cell that emitted nothing carries no field at all.",
   "cells": {
     "fdm_centered/mass_conservation": {
       "artifact": {
@@ -15,13 +15,10 @@
     "fdm_centered_2d/mass_conservation": {
       "artifact": {
         "exception": "ValueError",
-        "library_said": {
-          "RuntimeWarning: JAX autodiff failed: TracerArrayConversionError('The numpy.ndarray conversion method __array__() was called on": 6
-        },
         "message": "FP solver: at timestep 2/6, advection_scheme='divergence_centered': density went to -6.618e-01. Clipping it to zero would fabricate 2.329% of the total mass, so the solve is stopped rather than report"
       },
-      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered.",
-      "status": "UNSUPPORTED"
+      "status": "UNSUPPORTED",
+      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered."
     },
     "fdm_upwind/mass_conservation": {
       "artifact": {
@@ -42,13 +39,10 @@
     "fdm_upwind_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
-        "library_said": {
-          "RuntimeWarning: JAX autodiff failed: TracerArrayConversionError('The numpy.ndarray conversion method __array__() was called on": 13
-        },
         "message": "newton solver failed to converge after 30 iterations (residual: 2.95e+01)"
       },
-      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one.",
-      "status": "UNSUPPORTED"
+      "status": "UNSUPPORTED",
+      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one."
     },
     "fvm_muscl/mass_conservation": {
       "artifact": {
@@ -65,13 +59,10 @@
     "fvm_muscl_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
-        "library_said": {
-          "RuntimeWarning: JAX autodiff failed: TracerArrayConversionError('The numpy.ndarray conversion method __array__() was called on": 8
-        },
         "message": "newton solver failed to converge after 30 iterations (residual: 1.15e+02)"
       },
-      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes.",
-      "status": "UNSUPPORTED"
+      "status": "UNSUPPORTED",
+      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes."
     },
     "fvm_vs_fdm/agreement": {
       "artifact": {
@@ -93,12 +84,12 @@
         "exception": "NotImplementedError",
         "library_said": {
           "UserWarning: HJBGFDMSolver: no `monotonicity_scheme` specified; defaulting to 'none' (no QP correction). This produces bare": 2,
-          "UserWarning: Hybrid neighborhood: N/N points (N%) had fewer than k=N neighbors within delta=N Used kNNN fallback.": 1
+          "UserWarning: Hybrid neighborhood: N/N points (N%) had fewer than k=N neighbors within delta=N Used k-NN fallback.": 1
         },
         "message": "HJBGFDMSolver derivative_method='rbf' is not supported (Issue #1553): since #1526 the RBF branch has no working differentiation-weight builder and would reopen the #1124 obstacle seam. Use derivative_"
       },
-      "intended": "ABSENT BY DESIGN \u2014 not a regression. `HJBGFDMSolver(derivative_method='rbf')` raises NotImplementedError at construction since PR #1619, which closed #1553 by converting an AttributeError crash into a loud refusal. Do not read #1553 as the tracker for this cell: it is CLOSED and tracked the crash, not the absence. Reinstating RBF has NO open issue \u2014 the cell exists so that doing so cannot land unnoticed.",
-      "status": "UNSUPPORTED"
+      "status": "UNSUPPORTED",
+      "intended": "ABSENT BY DESIGN \u2014 not a regression. `HJBGFDMSolver(derivative_method='rbf')` raises NotImplementedError at construction since PR #1619, which closed #1553 by converting an AttributeError crash into a loud refusal. Do not read #1553 as the tracker for this cell: it is CLOSED and tracked the crash, not the absence. Reinstating RBF has NO open issue \u2014 the cell exists so that doing so cannot land unnoticed."
     },
     "regime_switching/non_negativity": {
       "artifact": {

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -37,6 +37,16 @@ What ``--check-baseline`` compares is STATUS, not the recorded artifacts. The ar
 blocks in the baseline are a record for a human diffing a PR; a cell can degrade well
 within its own tolerance and the gate stays green.
 
+An artifact may carry ``library_said``: what the library warned about while that cell ran,
+folded by category and message with numbers collapsed, and absent entirely from a cell that
+warned about nothing. It records capability the oracles cannot see -- `fdm_upwind` passes its
+mass oracle while saying 39 times that the value function it returned is not a root of the
+discrete HJB. Warnings that describe the machine rather than the solve are excluded: import
+and deprecation by category, the JAX-autodiff fallback by message. That exclusion is not
+tidiness. An entry that appears only where an optional package is installed makes this
+committed baseline machine-dependent, and a regeneration elsewhere both fakes a diff and
+drops the ``intended`` note of every cell whose artifact moved.
+
 Every cell but one drives the public API. ``regime_switching/non_negativity`` reaches
 through the deep module path because ``RegimeSwitchingIterator`` is exported from no
 package ``__init__`` -- recorded in that cell rather than treated as a reason to leave
@@ -69,8 +79,9 @@ import numpy as np
 # returned "is not a root of the discrete HJB, and the outer iteration will consume it as
 # if it were". That is a statement about capability, made by the code under test, to the
 # instrument that exists to record capability, and it went to /dev/null for the life of
-# this file. What replaces it is `_recorded`: each cell runs under `catch_warnings`, and
-# what the library said lands in the artifact where a baseline diff can show it.
+# this file. What replaces it is `_warning_summary`: each cell runs under `catch_warnings`,
+# and what the library said lands in the artifact as `library_said`, where a baseline diff
+# can show it.
 
 # Set by --self-test. Applied to every density this module measures, so a mass oracle
 # that does not read the density it claims to read stays green and the self-test
@@ -632,26 +643,44 @@ MASS_ORACLE_CELLS = {
 }
 
 
+# Substrings that identify a warning as a report about the machine rather than about whether
+# the configuration solves. Category alone does not separate these: the JAX-autodiff fallback
+# is a RuntimeWarning, and it fires only where JAX is importable.
+_ENVIRONMENT_MARKERS = (
+    "JAX autodiff failed",
+    "Falling back to finite-difference Jacobian",
+)
+
+
 def _warning_summary(caught) -> dict:
     """Fold a cell's warnings into something a baseline can carry and a diff can show.
 
     Keyed by category and a normalised prefix -- digits collapsed -- because the useful
     signal is "this cell emitted 39 non-convergence warnings", not 39 near-identical
-    strings differing in a time index and a residual. Counts are stable: the solvers are
-    deterministic (verified for HJB and FP separately), and `simplefilter("always")` means
-    the count does not depend on Python's once-per-location registry.
+    strings differing in a time index and a residual. Counts are stable against Python's
+    once-per-location registry, because `simplefilter("always")` defeats it; a library that
+    keeps its own warn-once set (`backends/__init__.py` has one) is not covered by that
+    argument, and no cell here selects a configuration that reaches it.
     """
     seen: dict[str, int] = {}
     for w in caught:
-        # ImportWarning and DeprecationWarning are about the environment and the API, not
-        # about whether this configuration solves, and they differ between machines --
-        # recording "requires POT" would make a regeneration elsewhere produce a false diff.
-        # What survives can still be environment-sensitive (the JAX-autodiff fallback fires
-        # only where JAX is installed), and that is capability information rather than noise.
+        # Environment, not capability. These say what is installed on the machine that ran
+        # the harness, so recording them makes the committed baseline machine-dependent:
+        # a regeneration elsewhere produces a false diff, and -- worse -- `_note_still_applies`
+        # drops the `intended` note attached to every cell whose artifact moved. Measured on
+        # the JAX-autodiff fallback: forcing `_JAX_AVAILABLE = False` changes no number in
+        # three 2-D cells (the numeric half is byte-identical) yet destroys three notes,
+        # including the ~1500-character #1865 investigation record. A statement that holds
+        # with and without a package installed is not a statement about the package.
         if issubclass(w.category, (ImportWarning, DeprecationWarning, PendingDeprecationWarning)):
             continue
         text = " ".join(str(w.message).split())
-        norm = re.sub(r"[-+0-9][0-9.eE+-]*", "N", text)[:110]
+        if any(marker in text for marker in _ENVIRONMENT_MARKERS):
+            continue
+        # Collapse numbers so near-identical warnings fold, but only tokens that START with a
+        # digit or a signed digit: `[-+0-9][0-9.eE+-]*` also ate the hyphen in ordinary words
+        # ("non-negativity" -> "nonNnegativity"), which is not what "digits collapsed" means.
+        norm = re.sub(r"(?<![\w.])[-+]?\d[\d.eE]*(?:[-+]\d+)?", "N", text)[:110]
         seen[f"{w.category.__name__}: {norm}"] = seen.get(f"{w.category.__name__}: {norm}", 0) + 1
     return dict(sorted(seen.items()))
 

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -977,6 +977,13 @@ def main() -> None:
                 "Regenerate with --write-baseline. A non-PASS cell may carry an `intended` "
                 "note saying WHY it is not PASS; cells without one are unexplained and are the "
                 "actual backlog."
+                " A cell's artifact may also carry `library_said`: the warnings the library"
+                " emitted while that cell ran, folded by category and message with numbers"
+                " collapsed. Warnings about the machine rather than about whether the"
+                " configuration solves (import, deprecation, and the JAX-autodiff fallback) are"
+                " excluded by design -- recording them makes this file machine-dependent and"
+                " silently drops the `intended` notes of every cell whose artifact moves. A cell"
+                " that emitted nothing carries no field at all."
             ),
             "cells": {
                 k: (

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -55,6 +55,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import sys
 import time
 import traceback
@@ -62,7 +63,14 @@ import warnings
 
 import numpy as np
 
-warnings.filterwarnings("ignore")
+# No blanket `warnings.filterwarnings("ignore")` here. There was one until #1879, and it
+# silenced the library while this file measured it -- including the warning base_hjb raises
+# 39 times in the fdm_upwind cell, saying in as many words that the value function it
+# returned "is not a root of the discrete HJB, and the outer iteration will consume it as
+# if it were". That is a statement about capability, made by the code under test, to the
+# instrument that exists to record capability, and it went to /dev/null for the life of
+# this file. What replaces it is `_recorded`: each cell runs under `catch_warnings`, and
+# what the library said lands in the artifact where a baseline diff can show it.
 
 # Set by --self-test. Applied to every density this module measures, so a mass oracle
 # that does not read the density it claims to read stays green and the self-test
@@ -624,42 +632,75 @@ MASS_ORACLE_CELLS = {
 }
 
 
+def _warning_summary(caught) -> dict:
+    """Fold a cell's warnings into something a baseline can carry and a diff can show.
+
+    Keyed by category and a normalised prefix -- digits collapsed -- because the useful
+    signal is "this cell emitted 39 non-convergence warnings", not 39 near-identical
+    strings differing in a time index and a residual. Counts are stable: the solvers are
+    deterministic (verified for HJB and FP separately), and `simplefilter("always")` means
+    the count does not depend on Python's once-per-location registry.
+    """
+    seen: dict[str, int] = {}
+    for w in caught:
+        # ImportWarning and DeprecationWarning are about the environment and the API, not
+        # about whether this configuration solves, and they differ between machines --
+        # recording "requires POT" would make a regeneration elsewhere produce a false diff.
+        # What survives can still be environment-sensitive (the JAX-autodiff fallback fires
+        # only where JAX is installed), and that is capability information rather than noise.
+        if issubclass(w.category, (ImportWarning, DeprecationWarning, PendingDeprecationWarning)):
+            continue
+        text = " ".join(str(w.message).split())
+        norm = re.sub(r"[-+0-9][0-9.eE+-]*", "N", text)[:110]
+        seen[f"{w.category.__name__}: {norm}"] = seen.get(f"{w.category.__name__}: {norm}", 0) + 1
+    return dict(sorted(seen.items()))
+
+
 def evaluate(only: list[str] | None = None) -> dict:
     results = {}
     for name, run in CELLS.items():
         if only and name not in only:
             continue
         t0 = time.perf_counter()
-        try:
-            status, artifact = run()
-        # A HarnessError names its own phase: construct or measure, never the solve.
-        except HarnessError as exc:
-            status = "ERROR"
-            artifact = {
-                "exception": "HarnessError",
-                "message": " ".join(str(exc).split())[:200],
-                "traceback_tail": traceback.format_exc().strip().splitlines()[-1],
-            }
-        # Broad by design: classifying the refusal IS the measurement here. Anything
-        # reaching this point came out of the solve phase.
-        except Exception as exc:
-            status = "UNSUPPORTED"
-            artifact = {
-                "exception": type(exc).__name__,
-                "message": " ".join(str(exc).split())[:200],
-            }
-            # Second net, for exception classes that cannot come from a library
-            # refusal no matter which phase raised them.
-            if type(exc).__name__ in {
-                "ImportError",
-                "ModuleNotFoundError",
-                "AttributeError",
-                "TypeError",
-                "AssertionError",
-                "KeyError",
-            }:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                status, artifact = run()
+            # A HarnessError names its own phase: construct or measure, never the solve.
+            except HarnessError as exc:
                 status = "ERROR"
-                artifact["traceback_tail"] = traceback.format_exc().strip().splitlines()[-1]
+                artifact = {
+                    "exception": "HarnessError",
+                    "message": " ".join(str(exc).split())[:200],
+                    "traceback_tail": traceback.format_exc().strip().splitlines()[-1],
+                }
+            # Broad by design: classifying the refusal IS the measurement here. Anything
+            # reaching this point came out of the solve phase.
+            except Exception as exc:
+                status = "UNSUPPORTED"
+                artifact = {
+                    "exception": type(exc).__name__,
+                    "message": " ".join(str(exc).split())[:200],
+                }
+                # Second net, for exception classes that cannot come from a library
+                # refusal no matter which phase raised them.
+                if type(exc).__name__ in {
+                    "ImportError",
+                    "ModuleNotFoundError",
+                    "AttributeError",
+                    "TypeError",
+                    "AssertionError",
+                    "KeyError",
+                }:
+                    status = "ERROR"
+                    artifact["traceback_tail"] = traceback.format_exc().strip().splitlines()[-1]
+        # Recorded, not gated (#1879). A cell that emits 39 "not a root of the discrete
+        # HJB" warnings has said something about its capability; the status alone cannot
+        # carry it, and `--check-baseline` compares status only, so this shows up where a
+        # human diffing a regeneration will see it.
+        said = _warning_summary(caught)
+        if said:
+            artifact["library_said"] = said
         results[name] = {
             "status": status,
             "artifact": artifact,

--- a/tests/unit/test_capability_warnings.py
+++ b/tests/unit/test_capability_warnings.py
@@ -235,3 +235,41 @@ def test_the_shipped_baseline_records_the_non_convergence_it_was_hiding():
     assert cells["fdm_upwind/mass_conservation"]["status"] == "PASS", (
         "the cell is PASS while its inner solves fail; if that changed, #1878 moved"
     )
+
+
+def test_the_baseline_comment_is_what_the_generator_writes():
+    """The committed baseline must be a fixed point of its own generator.
+
+    `_comment` is emitted from a literal in `capability_matrix.py`, so a paragraph appended to the
+    JSON by hand survives exactly until the next `--write-baseline` and then vanishes. That happened:
+    the paragraph explaining why the JAX-autodiff entries are excluded was added to the JSON only, and
+    the next in-place regeneration deleted it -- taking with it the only place a future regenerator
+    learns why `_ENVIRONMENT_MARKERS` exists, which makes that list read as arbitrary and the obvious
+    thing to remove.
+
+    Nothing else catches it. `--check-baseline` compares status only, no other test reads `_comment`,
+    and the gate is green either way. Compared by AST rather than by running the generator, so this
+    costs nothing and cannot be defeated by the solve.
+    """
+    import ast
+    import json
+
+    source = _SCRIPT.read_text()
+    baseline = json.loads((_SCRIPT.parent / "capability_baseline.json").read_text())
+
+    literals = [
+        ast.literal_eval(value)
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Dict)
+        for key, value in zip(node.keys, node.values, strict=True)
+        if isinstance(key, ast.Constant) and key.value == "_comment"
+    ]
+    assert len(literals) == 1, f"expected exactly one `_comment` literal in the generator, found {len(literals)}"
+
+    assert literals[0] == baseline["_comment"], (
+        "the committed baseline's `_comment` is not what the generator writes, so the next "
+        "`--write-baseline` will silently replace it. Put the text in the generator's literal, "
+        "not in the JSON.\n"
+        f"  generator: {len(literals[0])} chars\n"
+        f"  committed: {len(baseline['_comment'])} chars"
+    )

--- a/tests/unit/test_capability_warnings.py
+++ b/tests/unit/test_capability_warnings.py
@@ -1,0 +1,134 @@
+r"""The capability harness must not be deaf to the library it measures (#1879).
+
+`scripts/capability_matrix.py` carried a bare `warnings.filterwarnings("ignore")` at import.
+While it measured, the library could tell it nothing -- including the warning `base_hjb`
+raises 39 times in the `fdm_upwind` cell, saying in as many words that the value function
+returned "is not a root of the discrete HJB, and the outer iteration will consume it as if
+it were" (#1878). That cell has been PASS on every run, because the mass oracle measures a
+property of the FP time-stepping that holds on whatever drift field it is handed.
+
+The suppression was also process-wide: anything importing this module inherited it, which
+is a trap for the instrumentation someone would write to investigate a cell.
+
+Recorded, not gated. Nothing here decides a status; `--check-baseline` still compares
+status only. What the field buys is that the next regeneration shows it in a diff.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import warnings
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "capability_matrix.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("capability_matrix_warn", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_importing_the_harness_does_not_silence_the_process():
+    """The suppression was global and survived the import, so this is the load-bearing check.
+
+    Deliberately NO `simplefilter` inside the context. The first version of this test called
+    `simplefilter("always")`, which resets the filters and so overrode the very suppression it
+    was meant to detect -- restoring the `filterwarnings("ignore")` line left all five tests
+    green. The setup masked the defect, which is the failure mode this whole file is about.
+    Here the ambient filter state, as the import left it, is what governs.
+    """
+    _load()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.warn("a library would like to say something", RuntimeWarning, stacklevel=1)
+
+    assert len(caught) == 1, "importing the capability harness suppressed a later warning"
+
+    # And structurally, since the behavioural check above depends on this process not having
+    # been silenced by something else first: no blanket entry may sit in the filter list.
+    blanket = [f for f in warnings.filters if f[0] == "ignore" and f[1] is None and f[2] is Warning and f[3] is None]
+    assert not blanket, f"a blanket ignore is installed: {blanket}"
+
+
+def test_a_cell_records_what_the_library_said():
+    """A cell that provokes warnings must carry them into its artifact.
+
+    Uses a stub cell rather than a real solve: this is about the harness's plumbing, and
+    the real solves take minutes. The kill for the removed suppression is the test above.
+    """
+    cm = _load()
+
+    def noisy():
+        warnings.warn("HJB inner Newton did not converge at t_idx=3: residual 6.6e+05", RuntimeWarning, stacklevel=1)
+        warnings.warn("HJB inner Newton did not converge at t_idx=4: residual 1.2e+05", RuntimeWarning, stacklevel=1)
+        return "PASS", {"all_finite": True}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cm, "CELLS", {"stub/noisy": noisy})
+        out = cm.evaluate()
+
+    said = out["stub/noisy"]["artifact"]["library_said"]
+    assert sum(said.values()) == 2, said
+    key = next(iter(said))
+    assert key.startswith("RuntimeWarning: "), key
+    assert "t_idx=N" in key, f"digits should be collapsed so two near-identical warnings fold: {key}"
+    assert said[key] == 2
+
+
+def test_environment_noise_is_not_recorded():
+    """Import and deprecation warnings differ between machines and would fake a baseline diff.
+
+    They are also not statements about whether the configuration solves, which is the only
+    question this file asks.
+    """
+    cm = _load()
+
+    def noisy():
+        warnings.warn("Optimal transport solvers require POT", ImportWarning, stacklevel=1)
+        warnings.warn("Legacy MFGProblem(...) is deprecated", DeprecationWarning, stacklevel=1)
+        warnings.warn("something the solver said", RuntimeWarning, stacklevel=1)
+        return "PASS", {"all_finite": True}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cm, "CELLS", {"stub/mixed": noisy})
+        out = cm.evaluate()
+
+    said = out["stub/mixed"]["artifact"]["library_said"]
+    assert sum(said.values()) == 1, f"only the solve-time warning should be recorded: {said}"
+    assert next(iter(said)).startswith("RuntimeWarning: ")
+
+
+def test_a_quiet_cell_carries_no_field_at_all():
+    """Absence is currency: a cell with nothing to report must not carry an empty dict."""
+    cm = _load()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cm, "CELLS", {"stub/quiet": lambda: ("PASS", {"all_finite": True})})
+        out = cm.evaluate()
+
+    assert "library_said" not in out["stub/quiet"]["artifact"]
+
+
+def test_the_shipped_baseline_records_the_non_convergence_it_was_hiding():
+    """The point of the change, pinned against the artifact it produced.
+
+    `fdm_upwind/mass_conservation` is PASS and emits 39 non-convergence warnings. If a
+    future change makes the solve produce roots the count drops and this test must be
+    updated -- deliberately, since that is exactly the event #1878 tracks and it should not
+    pass silently.
+    """
+    import json
+
+    cells = json.loads((_SCRIPT.parent / "capability_baseline.json").read_text())["cells"]
+    said = cells["fdm_upwind/mass_conservation"]["artifact"]["library_said"]
+
+    newton = {k: v for k, v in said.items() if "inner Newton did not converge" in k}
+    assert newton, f"the recorded warnings no longer mention the inner Newton: {said}"
+    assert sum(newton.values()) == 39, f"expected 39 non-convergence warnings (#1878), got {newton}"
+    assert cells["fdm_upwind/mass_conservation"]["status"] == "PASS", (
+        "the cell is PASS while its inner solves fail; if that changed, #1878 moved"
+    )

--- a/tests/unit/test_capability_warnings.py
+++ b/tests/unit/test_capability_warnings.py
@@ -50,8 +50,23 @@ def test_importing_the_harness_does_not_silence_the_process():
 
     # And structurally, since the behavioural check above depends on this process not having
     # been silenced by something else first: no blanket entry may sit in the filter list.
-    blanket = [f for f in warnings.filters if f[0] == "ignore" and f[1] is None and f[2] is Warning and f[3] is None]
-    assert not blanket, f"a blanket ignore is installed: {blanket}"
+    #
+    # The test is whether a filter would swallow a category this harness has to hear, not what
+    # shape it has. Two earlier forms were wrong in opposite directions. `f[2] is Warning and
+    # f[3] is None` missed `simplefilter("ignore")` (whose `module` is `""`, not `None`) and
+    # `filterwarnings("ignore", category=UserWarning)`, which reopens this file's trap for one
+    # category and left every test green. Widening it to any `Warning` subclass then flagged
+    # CPython's own defaults -- Deprecation, PendingDeprecation, Import, Resource -- which are
+    # always installed and are exactly the categories `_warning_summary` discards anyway.
+    silences = [
+        f
+        for f in warnings.filters
+        if f[0] == "ignore"
+        and f[1] is None
+        and f[3] in (None, "")
+        and (issubclass(RuntimeWarning, f[2]) or issubclass(UserWarning, f[2]))
+    ]
+    assert not silences, f"a filter is installed that would swallow what the harness records: {silences}"
 
 
 def test_a_cell_records_what_the_library_said():
@@ -100,6 +115,94 @@ def test_environment_noise_is_not_recorded():
     said = out["stub/mixed"]["artifact"]["library_said"]
     assert sum(said.values()) == 1, f"only the solve-time warning should be recorded: {said}"
     assert next(iter(said)).startswith("RuntimeWarning: ")
+
+
+def test_each_cell_carries_only_its_own_warnings():
+    """Attribution is the whole claim, and a single-cell fixture cannot test it.
+
+    "This cell said 39 things" is what the field asserts. Every other test here monkeypatches
+    `CELLS` to ONE stub, so hoisting `catch_warnings` out of the per-cell loop -- which makes
+    `caught` accumulate and credits every cell with its predecessors' output -- is invisible to
+    all of them by construction. Measured: that mutation leaves all five green, and on a real
+    two-cell run it credited `gfdm_rbf/construction` with two non-convergence warnings emitted
+    by `fdm_centered/mass_conservation`.
+
+    Two cells, each with a distinguishable message, and each must carry its own and nothing else.
+    """
+    cm = _load()
+
+    def first():
+        warnings.warn("alpha said something at t_idx=1", RuntimeWarning, stacklevel=1)
+        return "PASS", {"all_finite": True}
+
+    def second():
+        warnings.warn("beta said something at t_idx=2", RuntimeWarning, stacklevel=1)
+        warnings.warn("beta said something at t_idx=3", RuntimeWarning, stacklevel=1)
+        return "PASS", {"all_finite": True}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cm, "CELLS", {"stub/alpha": first, "stub/beta": second})
+        out = cm.evaluate()
+
+    alpha = out["stub/alpha"]["artifact"]["library_said"]
+    beta = out["stub/beta"]["artifact"]["library_said"]
+
+    assert sum(alpha.values()) == 1, f"alpha must carry exactly its own one warning: {alpha}"
+    assert sum(beta.values()) == 2, f"beta must carry exactly its own two warnings: {beta}"
+    assert all("alpha" in k for k in alpha), alpha
+    assert all("beta" in k for k in beta), beta
+    # The direction the hoist breaks: beta running second must not inherit alpha's.
+    assert not any("alpha" in k for k in beta), f"beta was credited with alpha's warnings: {beta}"
+
+
+def test_an_environment_report_is_not_recorded_even_as_a_runtime_warning():
+    """The category filter is not enough: the JAX-autodiff fallback is a `RuntimeWarning`.
+
+    It fires only where JAX is importable, and forcing `_JAX_AVAILABLE = False` leaves every
+    number in the affected cells byte-identical -- so it describes the machine, not whether the
+    configuration solves. Recorded, it makes the committed baseline machine-dependent and, via
+    `_note_still_applies`, drops the `intended` note of every cell whose artifact moved.
+    """
+    cm = _load()
+
+    def noisy():
+        warnings.warn(
+            "JAX autodiff failed: TracerArrayConversionError(...). Falling back to "
+            "finite-difference Jacobian (O(N) complexity).",
+            RuntimeWarning,
+            stacklevel=1,
+        )
+        warnings.warn("HJB inner Newton did not converge at t_idx=3", RuntimeWarning, stacklevel=1)
+        return "PASS", {"all_finite": True}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cm, "CELLS", {"stub/jax": noisy})
+        out = cm.evaluate()
+
+    said = out["stub/jax"]["artifact"]["library_said"]
+    assert sum(said.values()) == 1, f"only the solve-time warning should survive: {said}"
+    assert "did not converge" in next(iter(said)), said
+
+
+def test_number_collapsing_does_not_eat_hyphens_in_words():
+    """`[-+0-9][0-9.eE+-]*` matched the hyphen inside ordinary words.
+
+    "non-negativity" folded to "nonNnegativity" and "stable-baselines3" to "stableNbaselinesN",
+    which silently merges warnings that differ in their text, not in their numbers.
+    """
+    cm = _load()
+
+    def noisy():
+        warnings.warn("mass non-negativity violated at t_idx=7", RuntimeWarning, stacklevel=1)
+        return "PASS", {"all_finite": True}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cm, "CELLS", {"stub/hyphen": noisy})
+        out = cm.evaluate()
+
+    key = next(iter(out["stub/hyphen"]["artifact"]["library_said"]))
+    assert "non-negativity" in key, f"the hyphen was consumed as a sign: {key}"
+    assert "t_idx=N" in key, f"the digit should still collapse: {key}"
 
 
 def test_a_quiet_cell_carries_no_field_at_all():


### PR DESCRIPTION
Fixes #1879. **Recorded, not gated — no cell changes status.**

## The line

`scripts/capability_matrix.py:65`, bare and uncommented:

```python
warnings.filterwarnings("ignore")
```

The matrix decides whether a configuration can solve at all, and its verdicts feed the baseline, the
local gate and nightly. While it measured, the library could tell it nothing.

## What it hid, measured the moment it was removed

```
fdm_upwind/mass_conservation      PASS    39x  HJB inner Newton did not converge ... "the value
                                                function returned for this timestep is not a root
                                                of the discrete HJB, and the outer iteration will
                                                consume it as if it were"
regime_switching/non_negativity   FAIL    42x  the same
fdm_centered/mass_conservation    UNSUP    2x  the same
fdm_upwind_2d / fvm_muscl_2d / fdm_centered_2d   13x / 8x / 6x  JAX autodiff fell back to FD
```

The first line is the point: that cell has been PASS on every run, and the sentence it was emitting
39 times was written by earlier #1745 work for precisely this situation. The mass oracle cannot see
it either — mass conservation is a property of the FP time-stepping and holds on whatever drift
field it is handed — so between the suppression and the oracle, nothing in the pipeline could
report it. It took a long investigation to find instead (#1878), and `regime_switching`'s 42 were
not found at all until this ran.

The suppression was also **process-wide**: `filterwarnings` mutates the interpreter's global list,
so anything importing this module inherited the deafness — a trap for exactly the instrumentation
someone would write to investigate a cell.

## The change

Each cell runs under `catch_warnings(record=True)`, and what the library said lands in the artifact
as `library_said` — keyed by category and message with digits collapsed, so 39 warnings differing in
a time index and a residual fold into one line with a count.

`ImportWarning` and `DeprecationWarning` are excluded: they differ between machines (POT, gmsh,
stable-baselines) and would fake a baseline diff on a regeneration elsewhere, and neither is a
statement about whether the configuration solves. What survives can still be environment-sensitive —
the JAX fallback fires only where JAX is installed — and that is capability information rather than
noise.

## Oracle

Five tests, each mutation-verified: restoring the `filterwarnings("ignore")` line turns the first
red; removing the environment-category filter turns the third red.

The first test earned its keep the hard way. Its initial version called `simplefilter("always")`
inside its own `catch_warnings`, which resets the filters and so **overrode the very suppression it
was meant to detect** — the mutation left all five tests green. It now installs no filter of its own
and additionally asserts that no blanket entry sits in `warnings.filters`. The setup masking the
defect is the same failure mode this whole PR is about, one level up.

## Baseline

Regenerated here. All six `intended` notes were dropped by `_note_still_applies` because every
non-PASS artifact gained a field; their content is unaffected, so they are restored **verbatim from
HEAD** rather than rewritten. That is the third time in this sequence that adding an artifact field
has cost a note rewrite — the mechanism is working as designed, but the cost is worth naming.

## Gate

`./scripts/local_ci.sh` — **GATE GREEN**, 5939 passed, 22 skipped, 21 xfailed. Collected
`5977 -> 5982` and passed `5934 -> 5939`, +5 both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
