### PR TITLE
refactor(hjb): name the grid-scaled residual norm

### DIFF
--- a/changelog.d/1878-hjb-residual-norm-owner.changed.md
+++ b/changelog.d/1878-hjb-residual-norm-owner.changed.md
@@ -1,0 +1,19 @@
+- **`hjb_residual_norm` names the grid-scaled HJB residual norm** — `||F||_2 * sqrt(dx)`, previously
+  an inline expression in `newton_hjb_step` (Issue #1878). Behaviour is unchanged, pinned on a
+  configuration chosen because it is *not* quiet: `Nx=1601`, `FDM_UPWIND`, 2 sweeps, where 95 of
+  627592 finite-difference Jacobian probes exceed the `1e6` p-value clip limit, so the clip is
+  actively firing while the comparison runs. `U` and `M` are bit-identical across the change
+  (`np.array_equal` True, max difference `0.0`), with each run printing whether the module under it
+  defines the new function — a before/after in which both sides are the same build is the failure
+  mode this control exists to catch, and it caught one.
+  The reason it is a function is measured. A second caller written during #1878 restated the norm and
+  dropped the `sqrt(dx)`; at `Nx=21` that is a factor of 4.5, and the two paths were being compared
+  against each other, so the caller's Armijo test demanded a 4.5x reduction to score as "no worse",
+  rejected every step, and returned its input while reporting the residual at the *starting* iterate.
+  It presented as a five-order-of-magnitude improvement and as 11 red tests elsewhere.
+- **This is a naming, not yet a consolidation, and the docstring says so.** `HJBFDMSolver`'s nD path
+  and `HJBGFDMSolver` compare an **unscaled** 2-norm against `DEFAULT_NEWTON_TOLERANCE` — the same
+  constant the scaled norm here is tested against — so one tolerance means different things on
+  different paths, by a factor of `sqrt(dx)`. Routing them through this function is a behaviour
+  change on those paths and is not attempted here. Correcting an earlier version of this entry: it
+  claimed "implementations of the quantity 2 -> 1", which does not reproduce — the count is 5.

--- a/changelog.d/1878-hjb-residual-norm-owner.changed.md
+++ b/changelog.d/1878-hjb-residual-norm-owner.changed.md
@@ -1,8 +1,12 @@
 - **`hjb_residual_norm` names the grid-scaled HJB residual norm** — `||F||_2 * sqrt(dx)`, previously
   an inline expression in `newton_hjb_step` (Issue #1878). Behaviour is unchanged, pinned on a
-  configuration chosen because it is *not* quiet: `Nx=1601`, `FDM_UPWIND`, 2 sweeps, where 95 of
-  627592 finite-difference Jacobian probes exceed the `1e6` p-value clip limit, so the clip is
-  actively firing while the comparison runs. `U` and `M` are bit-identical across the change
+  configuration chosen because it is *not* quiet: `Nx=1601`, `FDM_UPWIND`, 2 sweeps, where **570 of
+  537936** finite-difference Jacobian probes exceed the `1e6` p-value clip limit, so the clip is
+  actively firing while the comparison runs. (An earlier version of this entry said "95 of 627592",
+  which paired a numerator from one population with a denominator from another: 627592 is *every*
+  `_calculate_derivatives` call, and 95 is the over-limit count among the 89656 of them that pass
+  `clip=False`, where the clip by definition does not fire. Both numbers were real and neither
+  described the quantity the sentence names.) `U` and `M` are bit-identical across the change
   (`np.array_equal` True, max difference `0.0`), with each run printing whether the module under it
   defines the new function — a before/after in which both sides are the same build is the failure
   mode this control exists to catch, and it caught one.

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -1054,6 +1054,26 @@ def compute_hjb_jacobian(
     return Jac.tocsr()
 
 
+def hjb_residual_norm(residual: np.ndarray, dx: float) -> float:
+    """The one owner of "how large is this HJB residual".
+
+    The grid-scaled discrete L2 norm, ``||F||_2 * sqrt(dx)``, so the number does not change
+    meaning under refinement. It is a function rather than an inline expression because the
+    ``sqrt(dx)`` is load-bearing and silently omissible: a second caller that drops it compares
+    its own residual against this one on a scale 4.5x apart at Nx=21, and on the wrong side of
+    that comparison an iteration rejects every step, returns its input unchanged, and reports
+    the residual at the starting iterate -- which reads as a five-order-of-magnitude
+    improvement. Measured, during #1878.
+
+    NOT yet the only site. ``HJBFDMSolver``'s nD path and ``HJBGFDMSolver`` compare an
+    UNSCALED 2-norm against ``DEFAULT_NEWTON_TOLERANCE``, the same constant this scaled norm is
+    tested against -- so the same tolerance means different things on different paths. Closing
+    that is a behaviour change on those paths and is tracked separately; this docstring is here
+    so the next reader does not assume the consolidation is finished.
+    """
+    return float(np.linalg.norm(residual) * np.sqrt(dx))
+
+
 def newton_hjb_step(
     U_n_current_newton_iterate: np.ndarray,  # U_new_n_tmp in notebook
     U_n_plus_1_from_hjb_step: np.ndarray,  # U_new_np1 in notebook
@@ -1096,7 +1116,7 @@ def newton_hjb_step(
     # Issue #1745: the residual at the CURRENT iterate is already in hand for the linear
     # solve. Returning it costs nothing and gives the caller the quantity that actually says
     # whether this is a root; the step norm below says only that the iteration stopped moving.
-    residual_norm = float(np.linalg.norm(residual_F_U) * np.sqrt(dx_norm))
+    residual_norm = hjb_residual_norm(residual_F_U, dx_norm)
 
     if has_nan_or_inf(residual_F_U, backend):
         return U_n_current_newton_iterate, np.inf, np.inf


### PR DESCRIPTION
Part of #1878. **Rewritten after adversarial review** — the original version of this PR was wrong
about its own central claim, and what remains is the half that survived.

## What lands

`hjb_residual_norm(residual, dx) -> ||residual||_2 * sqrt(dx)`, extracted from `newton_hjb_step`
where it was inline, and called from there. `+21 / -1`. Nothing else.

## Oracle

A bit-identity pin captured across the change on a configuration chosen because it is **not** quiet:
`Nx=1601`, `FDM_UPWIND`, 2 sweeps, where 95 of 627592 finite-difference Jacobian probes exceed the
`1e6` p-value clip limit, so the clip is actively firing while the comparison runs.

```
BEFORE (947ac79e)  controls {has_new_fn: false, has_clip: true}   U_inf = 1885.6054131643573
AFTER  (this PR)   controls {has_new_fn: true,  has_clip: true}   U_inf = 1885.6054131643573
U bit-identical: True   max|dU| = 0.000e+00
M bit-identical: True   max|dM| = 0.000e+00
```

The `controls` line is not decoration. The first attempt at this measurement used `git stash` to
produce the "before" build, which reverts to branch HEAD rather than to `main`; the controls printed
`{has_new_fn: true, has_clip: false}` and the run was discarded. A before/after where both sides are
the same build reports `identical` for the same reason a correct one does.

Gate: `./scripts/local_ci.sh` — `5934 passed, 22 skipped, 21 xfailed`, `PASS no capability change vs
baseline`, `GATE GREEN`. Same count as `main`; this adds no tests.

## Why a function rather than an inline expression

Measured, during #1878. A second caller restated the norm and dropped the `sqrt(dx)`. At `Nx=21` that
is a factor of 4.5, and the two paths were compared against each other: the caller's Armijo test
demanded a 4.5x reduction to score as "no worse", rejected every step, broke at iteration 0, and
returned its input while reporting the residual at the *starting* iterate. It presented as a
five-order-of-magnitude improvement, and as 11 red tests in unrelated files.

## What this PR previously claimed, and does not claim now

The first version also deleted the FD-Jacobian `clip` machinery, described as dead code on two
grounds. Both were false, and an independent worktree-isolated review established it:

- **"No caller anywhere in the repo passed `clip=True`."** There were six, all in
  `compute_hjb_jacobian`'s FD-fallback branch — the branch the default single-population 1-D FDM path
  takes — and this PR's own diff deleted them. `git grep -c "clip=True" 947ac79e` returns 6;
  the positive control `clip=False` returns 1. The claim came from grepping *after* the same session
  had already edited those six sites to `clip=False`: the deadness was manufactured and then
  reported as pre-existing.
- **"Changes no number."** False. Isolated exactly: `PR-head` vs `main` with
  `P_VALUE_CLIP_LIMIT_FD_JAC = np.inf` is bit-identical, and `main` vs the same is not — so the clip
  removal was the entire mechanism and the norm extraction contributed zero. On the fixture unchanged
  except for `Nx=1601`: 1344 probes over the limit, `U_inf` 1885.61 -> 2602.08, `max|dU| = 1.9e3`.
  The margin on the unrefined fixture is 1.18x, so it was inert there by luck.
- **"0 of 5796 calls triggered."** One short run of one fixture, stated as a property of the code.

The clip should still go — a library must not silently substitute a nearby bounded problem — but as a
**behaviour change** with a before/after and a decision about what replaces it. That is **#1884**.

Also corrected: the claim "implementations of the quantity 2 -> 1" does not reproduce; the count is
5, because the nD and GFDM Newton paths compare an *unscaled* 2-norm against the same
`DEFAULT_NEWTON_TOLERANCE`. This PR is therefore a naming, not a consolidation, and says so in the
docstring rather than leaving a future reader to assume the work is finished. That divergence is
**#1885**.

Numbers corrected elsewhere from the same review: the step-cap firing rates and the SL comparison on
#1878, and the Jacobian monotonicity counts on #1882.
