### PR TITLE
test(bc): move the region-BC overhead measurement out of the gated suite

### DIFF
--- a/benchmarks/benchmark_region_bc_overhead.py
+++ b/benchmarks/benchmark_region_bc_overhead.py
@@ -1,0 +1,104 @@
+"""How much does a region-based boundary condition cost against a plain one?
+
+This was `tests/integration/test_region_based_bc.py::TestRegionBasedBCPerformance`
+until #1877, where it failed the nightly full suite at "overhead 12.3% exceeds 10%".
+It was measuring the runner, not the code.
+
+The original estimator timed 100 standard applications, then 100 region applications, and
+divided. Those blocks run at different moments, so anything the machine does in between is
+charged to the region path. Measured over 21 repeats on a loaded machine: min -59.5%, median
+1.0%, max +105.3%, sd 34.7pp, exceeding its own 10% bound 24% of the time. An overhead of
+-59.5% is not a number the region path can produce.
+
+Interleaving the two variants so machine drift cancels -- same machine, same load, same work,
+only the estimator changed -- gives min -4.3%, median 0.4%, max 4.2%, sd 2.0pp. That isolates
+the estimator's structure as the cause rather than the environment.
+
+Interleaving alone is still not enough to gate on. In a fresh short-lived process the FIRST
+repeat is systematically the worst (14.5%, 9.5%, 11.0% in three of six runs), and individual
+repeats excurse to -35% even after warmup; medians of 5 above 5% do occur under heavy
+contention. The true overhead is 0.1-1%, so no threshold both admits the truth and survives the
+noise. Hence a benchmark, run deliberately, rather than a test that gates a merge.
+
+    python benchmarks/benchmark_region_bc_overhead.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    FDMApplicator,
+    mixed_bc_from_regions,
+    no_flux_bc,
+)
+
+N_ITERATIONS = 100
+N_REPEATS = 9
+N_WARMUP = 3
+
+
+def _build():
+    geometry = TensorProductGrid(
+        bounds=[(0, 1), (0, 1)], boundary_conditions=no_flux_bc(dimension=2), Nx_points=[101, 101]
+    )
+    bc_standard = BoundaryConditions(
+        dimension=2,
+        segments=[BCSegment(name="all", bc_type=BCType.DIRICHLET, value=0.0, boundary=None)],
+    )
+    geometry.mark_region("all_domain", predicate=lambda x: np.ones(x.shape[0], dtype=bool))
+    bc_region = mixed_bc_from_regions(
+        geometry,
+        {"all_domain": BCSegment(name="all_bc", bc_type=BCType.DIRICHLET, value=0.0)},
+    )
+    return geometry, bc_standard, bc_region
+
+
+def measure() -> tuple[float, list[float]]:
+    """Median relative overhead in percent, and the per-repeat values behind it."""
+    geometry, bc_standard, bc_region = _build()
+    field = np.random.randn(101, 101)
+    domain_bounds = np.array([[0, 1], [0, 1]])
+    applicator = FDMApplicator(dimension=2)
+
+    # The first repeat is systematically the worst in a cold process, so warm up properly
+    # rather than letting the statistic absorb it.
+    for _ in range(N_WARMUP):
+        for _ in range(N_ITERATIONS):
+            applicator.apply(field, bc_standard, domain_bounds=domain_bounds)
+            applicator.apply(field, bc_region, domain_bounds=domain_bounds, geometry=geometry)
+
+    overheads = []
+    for _ in range(N_REPEATS):
+        t_standard = 0.0
+        t_region = 0.0
+        for _ in range(N_ITERATIONS):
+            start = time.perf_counter()
+            applicator.apply(field, bc_standard, domain_bounds=domain_bounds)
+            t_standard += time.perf_counter() - start
+
+            start = time.perf_counter()
+            applicator.apply(field, bc_region, domain_bounds=domain_bounds, geometry=geometry)
+            t_region += time.perf_counter() - start
+        overheads.append((t_region - t_standard) / t_standard * 100)
+
+    return float(np.median(overheads)), overheads
+
+
+def main() -> None:
+    median, overheads = measure()
+    print(f"Region-based BC overhead, {N_ITERATIONS} interleaved applications x {N_REPEATS} repeats")
+    print(f"  per repeat: {[f'{o:.1f}%' for o in overheads]}")
+    print(f"  median:     {median:.2f}%")
+    print(f"  spread:     min {min(overheads):.1f}%  max {max(overheads):.1f}%")
+    print("\nRead the median. A single repeat carries the machine's noise, not the code's cost.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_region_bc_overhead.py
+++ b/benchmarks/benchmark_region_bc_overhead.py
@@ -1,30 +1,36 @@
 """How much does a region-based boundary condition cost against a plain one?
 
-This was `tests/integration/test_region_based_bc.py::TestRegionBasedBCPerformance`
-until #1877, where it failed the nightly full suite at "overhead 12.3% exceeds 10%".
-It was measuring the runner, not the code.
+This was `tests/integration/test_region_based_bc.py::TestRegionBasedBCPerformance` until #1877,
+where it failed the nightly full suite at "overhead 12.3% exceeds 10%". No wall-clock ratio of
+these two paths reaches that precision, so the assertion could not have been satisfied reliably by
+any threshold near its own bound.
 
-The original estimator timed 100 standard applications, then 100 region applications, and
-divided. Those blocks run at different moments, so anything the machine does in between is
-charged to the region path. Measured over 21 repeats on a loaded machine: min -59.5%, median
-1.0%, max +105.3%, sd 34.7pp, exceeding its own 10% bound 24% of the time. An overhead of
--59.5% is not a number the region path can produce.
+The original estimator timed 100 standard applications, then 100 region applications, and divided.
+Those blocks run at different moments, so anything the machine does in between is charged to the
+region path. Over 21 repeats on a loaded machine: min -59.5%, median 1.0%, max +105.3%, sd 34.7pp,
+exceeding its own 10% bound 24% of the time. An overhead of -59.5% is not a cost the region path
+can have.
 
-Interleaving the two variants so machine drift cancels -- same machine, same load, same work,
-only the estimator changed -- gives min -4.3%, median 0.4%, max 4.2%, sd 2.0pp. That isolates
-the estimator's structure as the cause rather than the environment.
+Interleaving the two variants fixes that particular defect -- within one process, 11 repeats give
+min -4.3%, median 0.4%, max 4.2%, sd 2.0pp. **That figure does not transfer to a fresh process,
+and an earlier version of this file implied it did.** Repeats inside one process share warm caches,
+one allocation layout and one core assignment; the ratio itself shifts between processes. Measured
+across 14 fresh invocations of this script at load average 2.0 -- an idle machine -- the headline
+median-of-9 ran from -13.33% to +13.25%, sd 5.50, with 86% of invocations outside the 0.1-1% band
+that repeated measurement puts the true cost in. Taking the ratio of per-variant MINIMA instead of
+the median of ratios, on the theory that noise is one-sided, does not help: 16 fresh processes gave
+sd 5.60 against the median's 5.58.
 
-Interleaving alone is still not enough to gate on. In a fresh short-lived process the FIRST
-repeat is systematically the worst (14.5%, 9.5%, 11.0% in three of six runs), and individual
-repeats excurse to -35% even after warmup; medians of 5 above 5% do occur under heavy
-contention. The true overhead is 0.1-1%, so no threshold both admits the truth and survives the
-noise. Hence a benchmark, run deliberately, rather than a test that gates a merge.
+So: the central estimate is that the region path costs about **1% or less**, and a single
+invocation of this script carries roughly +/-14 points around it. Compare builds by running it many
+times, not once.
 
     python benchmarks/benchmark_region_bc_overhead.py
 """
 
 from __future__ import annotations
 
+import os
 import time
 
 import numpy as np
@@ -94,10 +100,16 @@ def measure() -> tuple[float, list[float]]:
 def main() -> None:
     median, overheads = measure()
     print(f"Region-based BC overhead, {N_ITERATIONS} interleaved applications x {N_REPEATS} repeats")
-    print(f"  per repeat: {[f'{o:.1f}%' for o in overheads]}")
-    print(f"  median:     {median:.2f}%")
-    print(f"  spread:     min {min(overheads):.1f}%  max {max(overheads):.1f}%")
-    print("\nRead the median. A single repeat carries the machine's noise, not the code's cost.")
+    print(f"  load average: {os.getloadavg()[0]:.1f}")
+    print(f"  per repeat:   {[f'{o:.1f}%' for o in overheads]}")
+    print(f"  median:       {median:.2f}%")
+    print(f"  spread:       min {min(overheads):.1f}%  max {max(overheads):.1f}%")
+    print(
+        "\nOne invocation is not an answer. These repeats share a process, so they share caches, "
+        "\nallocation layout and core assignment; measured across 14 fresh invocations on an idle "
+        "\nmachine the median above ranged -13.3% to +13.2% (sd 5.5). The central estimate from "
+        "\nrepeated running is about 1% or less. Compare builds over many invocations."
+    )
 
 
 if __name__ == "__main__":

--- a/changelog.d/1877-region-bc-overhead-benchmark.changed.md
+++ b/changelog.d/1877-region-bc-overhead-benchmark.changed.md
@@ -1,0 +1,32 @@
+- **A wall-clock performance assertion no longer gates the suite** (Issue #1877).
+  `test_region_based_bc.py::TestRegionBasedBCPerformance::test_region_lookup_overhead` failed the
+  nightly full run at *"Region-based BC overhead 12.3% exceeds 10%"*. It was measuring the runner.
+  The estimator timed 100 standard BC applications, then 100 region-based ones, and divided — two
+  blocks separated in time, so anything the machine did in between was charged to the region path.
+  Measured over 21 repeats: min **-59.5%**, median 1.0%, max **+105.3%**, sd 34.7pp, exceeding its
+  own 10% bound **24%** of the time. An overhead of -59.5% is not a number the region path can
+  produce, which is what identifies the estimator rather than the code as the subject.
+  The counterfactual — same machine, same load (load average 42), same work, only the estimator
+  interleaved so drift cancels — gives min -4.3%, median **0.4%**, max 4.2%, sd 2.0pp. So the
+  variance came from the estimator's structure, and loosening the threshold would have hidden that
+  rather than fixed it. (The assertion had drifted from its own docstring in the other direction
+  already: the docstring promised `<5%` and the assertion allowed `10%`, from the first commit.)
+  Interleaving is still not enough to gate on. In a fresh short-lived process the **first** repeat is
+  systematically the worst — 14.5%, 9.5%, 11.0% in three of six runs — and single repeats excurse to
+  `-35%` and `+713%` even after warmup, so medians above 5% do occur under contention. The true
+  overhead is **0.1-1%**; no threshold both admits that and survives the noise. The measurement moved
+  to `benchmarks/benchmark_region_bc_overhead.py`, warmed up properly and reporting a median over 9
+  repeats, and the test is gone.
+  **The local gate never ran it.** It carries the `slow` marker, so `-m "not slow"` deselects it and
+  `./scripts/local_ci.sh` skips it; verified by listing the selected set, and by the counts moving
+  `6384 -> 6383` collected while the *selected* count stayed at `6226` and deselected went
+  `158 -> 157`. Nightly is the only tier that runs `@slow`, so it is the only tier that could have
+  failed — the local gate was never lucky, it was structurally blind. (Where the `slow` marker comes
+  from is unresolved: `tests/conftest.py:100` adds it only on the name substrings `large`/`slow`/
+  `benchmark`, none of which `test_region_lookup_overhead` contains, the file carries no
+  `@pytest.mark.slow`, and neutering that conftest branch leaves the test deselected. Noted rather
+  than guessed at.)
+  **What the suite loses**: nothing it was reliably providing — a 24% false-positive rate against a
+  real signal of 1% is not a regression detector. **What is now unguarded**: a change that makes the
+  region path materially slower. Nothing catches that automatically any more, and the benchmark has
+  to be run deliberately — stated here rather than left for someone to discover.

--- a/changelog.d/1877-region-bc-overhead-benchmark.changed.md
+++ b/changelog.d/1877-region-bc-overhead-benchmark.changed.md
@@ -3,30 +3,31 @@
   nightly full run at *"Region-based BC overhead 12.3% exceeds 10%"*. It was measuring the runner.
   The estimator timed 100 standard BC applications, then 100 region-based ones, and divided — two
   blocks separated in time, so anything the machine did in between was charged to the region path.
-  Measured over 21 repeats: min **-59.5%**, median 1.0%, max **+105.3%**, sd 34.7pp, exceeding its
-  own 10% bound **24%** of the time. An overhead of -59.5% is not a number the region path can
-  produce, which is what identifies the estimator rather than the code as the subject.
-  The counterfactual — same machine, same load (load average 42), same work, only the estimator
-  interleaved so drift cancels — gives min -4.3%, median **0.4%**, max 4.2%, sd 2.0pp. So the
-  variance came from the estimator's structure, and loosening the threshold would have hidden that
-  rather than fixed it. (The assertion had drifted from its own docstring in the other direction
-  already: the docstring promised `<5%` and the assertion allowed `10%`, from the first commit.)
-  Interleaving is still not enough to gate on. In a fresh short-lived process the **first** repeat is
-  systematically the worst — 14.5%, 9.5%, 11.0% in three of six runs — and single repeats excurse to
-  `-35%` and `+713%` even after warmup, so medians above 5% do occur under contention. The true
-  overhead is **0.1-1%**; no threshold both admits that and survives the noise. The measurement moved
-  to `benchmarks/benchmark_region_bc_overhead.py`, warmed up properly and reporting a median over 9
-  repeats, and the test is gone.
-  **The local gate never ran it.** It carries the `slow` marker, so `-m "not slow"` deselects it and
-  `./scripts/local_ci.sh` skips it; verified by listing the selected set, and by the counts moving
-  `6384 -> 6383` collected while the *selected* count stayed at `6226` and deselected went
-  `158 -> 157`. Nightly is the only tier that runs `@slow`, so it is the only tier that could have
-  failed — the local gate was never lucky, it was structurally blind. (Where the `slow` marker comes
-  from is unresolved: `tests/conftest.py:100` adds it only on the name substrings `large`/`slow`/
-  `benchmark`, none of which `test_region_lookup_overhead` contains, the file carries no
-  `@pytest.mark.slow`, and neutering that conftest branch leaves the test deselected. Noted rather
-  than guessed at.)
-  **What the suite loses**: nothing it was reliably providing — a 24% false-positive rate against a
-  real signal of 1% is not a regression detector. **What is now unguarded**: a change that makes the
-  region path materially slower. Nothing catches that automatically any more, and the benchmark has
-  to be run deliberately — stated here rather than left for someone to discover.
+  Over 21 repeats: min **-59.5%**, median 1.0%, max **+105.3%**, sd 34.7pp, exceeding its own 10%
+  bound **24%** of the time. An overhead of -59.5% is not a cost the region path can have, which is
+  what identifies the estimator rather than the code as the subject. (The assertion had never matched
+  its own docstring either: `"""...<5% overhead"""` over `assert overhead < 10`, from the first
+  commit.)
+- **No form of this measurement reaches the precision the assertion needed.** Interleaving the two
+  variants fixes the drift defect — within one process, 11 repeats give min -4.3%, median 0.4%, max
+  4.2%, sd 2.0pp. That figure does not transfer: repeats inside one process share warm caches, one
+  allocation layout and one core assignment, and the ratio itself shifts between processes. Across
+  **14 fresh invocations at load average 2.0**, an idle machine, the median-of-9 headline ran from
+  **-13.33% to +13.25%**, sd 5.50, with 86% of invocations outside the 0.1-1% band that repeated
+  measurement puts the true cost in. Taking the ratio of per-variant minima instead, on the theory
+  that noise is one-sided, does not help either: 16 fresh processes, sd 5.60 against the median's
+  5.58. So the 10% threshold was unreachable by any statistic, and loosening it would have been
+  guesswork rather than a fix.
+  The measurement moved to `benchmarks/benchmark_region_bc_overhead.py`, which prints the load
+  average, the per-repeat values and the between-process spread, and says in as many words that one
+  invocation is not an answer. The test is gone.
+- **The local gate never ran it.** The test carried `@pytest.mark.slow` (`test_region_based_bc.py:278`,
+  removed by this diff along with the test), so `-m "not slow"` deselected it and
+  `./scripts/local_ci.sh` skipped it; nightly is the only tier that runs `@slow`. Confirmed by the
+  counts: collected `6384 -> 6383` while the *selected* count stayed at `6226` and deselected went
+  `158 -> 157`. The local gate was not lucky — it was structurally blind, which is the whole reason
+  the failure could only appear at night.
+- **What the suite loses**: nothing it was reliably providing — a 24% false-positive rate against a
+  real signal near 1% is not a regression detector. **What is now unguarded**: a change that makes
+  the region path materially slower. Nothing catches that automatically any more, and the benchmark
+  must be run deliberately and repeatedly. Stated here rather than left to be discovered.

--- a/tests/integration/test_region_based_bc.py
+++ b/tests/integration/test_region_based_bc.py
@@ -14,8 +14,6 @@ Test scenarios:
 - Performance validation (<5% overhead)
 """
 
-import time
-
 import pytest
 
 import numpy as np
@@ -270,65 +268,6 @@ class TestRegionBasedBC2D:
         point_bottom = np.array([0.5, 0.3])
         segment = bc.get_bc_at_point(point_bottom, None, geometry=geometry)
         assert segment.name == "bottom_bc"
-
-
-class TestRegionBasedBCPerformance:
-    """Performance tests for region-based BC application."""
-
-    @pytest.mark.slow
-    def test_region_lookup_overhead(self):
-        """Test that region-based BC has <5% overhead vs standard BC."""
-        # Create moderately sized 2D grid
-        geometry = TensorProductGrid(
-            bounds=[(0, 1), (0, 1)], boundary_conditions=no_flux_bc(dimension=2), Nx_points=[101, 101]
-        )
-
-        # Standard BC (no regions)
-        bc_standard = BoundaryConditions(
-            dimension=2,
-            segments=[BCSegment(name="all", bc_type=BCType.DIRICHLET, value=0.0, boundary=None)],
-        )
-
-        # Region-based BC
-        geometry.mark_region("all_domain", predicate=lambda x: np.ones(x.shape[0], dtype=bool))
-        bc_region = mixed_bc_from_regions(
-            geometry,
-            {"all_domain": BCSegment(name="all_bc", bc_type=BCType.DIRICHLET, value=0.0)},
-        )
-
-        field = np.random.randn(101, 101)
-        applicator = FDMApplicator(dimension=2)
-        domain_bounds = np.array([[0, 1], [0, 1]])
-
-        # Warmup
-        applicator.apply(field, bc_standard, domain_bounds=domain_bounds)
-        applicator.apply(field, bc_region, domain_bounds=domain_bounds, geometry=geometry)
-
-        # Benchmark standard BC
-        n_iterations = 100
-        start = time.perf_counter()
-        for _ in range(n_iterations):
-            applicator.apply(field, bc_standard, domain_bounds=domain_bounds)
-        time_standard = time.perf_counter() - start
-
-        # Benchmark region-based BC
-        start = time.perf_counter()
-        for _ in range(n_iterations):
-            applicator.apply(field, bc_region, domain_bounds=domain_bounds, geometry=geometry)
-        time_region = time.perf_counter() - start
-
-        # Calculate overhead
-        overhead = (time_region - time_standard) / time_standard * 100
-
-        print(f"\nPerformance comparison ({n_iterations} iterations):")
-        print(f"  Standard BC: {time_standard * 1000:.2f} ms")
-        print(f"  Region BC:   {time_region * 1000:.2f} ms")
-        print(f"  Overhead:    {overhead:.1f}%")
-
-        # Assert <5% overhead
-        # Note: This is a loose bound for CI environments
-        # In practice, overhead should be <1%
-        assert overhead < 10, f"Region-based BC overhead {overhead:.1f}% exceeds 10%"
 
 
 class TestRegionBasedBCEdgeCases:


### PR DESCRIPTION
Closes #1877.

The nightly full suite failed at *"Region-based BC overhead 12.3% exceeds 10%"*. Not a regression —
the test was measuring the runner.

## The estimator

It timed 100 standard BC applications, then 100 region-based ones, and divided. Two blocks separated
in time, so anything the machine does in between is charged to the region path.

| estimator | reps | min | median | max | sd | over its own bound |
|:--|--:|--:|--:|--:|--:|--:|
| as written (sequential blocks) | 21 | **-59.5%** | 1.0% | **+105.3%** | 34.7pp | 24% |
| interleaved (drift cancels) | 11 | -4.3% | **0.4%** | 4.2% | 2.0pp | 0% |

Same machine, same load (load average 42), same work — only the estimator changed. That is the
counterfactual: the variance is structural, not environmental, so loosening the threshold would have
hidden the defect rather than fixed it. An overhead of `-59.5%` is not a number the region path can
produce, which is what identifies the estimator rather than the code as the subject.

The assertion had also never matched its own docstring: `"""...<5% overhead"""` over
`assert overhead < 10`, from the first commit.

## Why not just fix the estimator in place

Tried, measured, rejected — and the first attempt at rejecting it was itself under-measured.

Interleaving fixes the drift defect *within one process*: 11 repeats give min -4.3%, median 0.4%,
max 4.2%, sd 2.0pp. **That figure does not transfer to a fresh process**, and repeats inside one
process share warm caches, one allocation layout and one core assignment. Across **14 fresh
invocations of the shipped script at load average 2.0** — an idle machine, so this is not a
contention artefact — the median-of-9 headline ran **-13.33% to +13.25%**, sd **5.50**, with 86% of
invocations outside the 0.1-1% band that repeated measurement puts the true cost in.

The obvious repair fails too. On the theory that timing noise is one-sided, the ratio of per-variant
**minima** should beat a median of ratios; across 16 fresh processes it does not — sd 5.60 against
5.58, max 14.27% against 14.54%. What drifts between processes is the *ratio itself*.

So no statistic tried reaches the precision a 10% threshold needs. The original assertion was
unsatisfiable by construction, and loosening it would have been another guess rather than a fix —
which is the argument for taking it out of the gate rather than tuning it.

## The local gate never ran it

`test_region_lookup_overhead` carried `@pytest.mark.slow` at `test_region_based_bc.py:278`, one line
above its `def` — this diff removes both. So `-m "not slow"` deselected it and
`./scripts/local_ci.sh` skipped it; nightly is the only tier that runs `@slow`, which is why the
failure could only appear at night. Confirmed by the counts: collected `6384 -> 6383` while
**selected stayed at 6226**, and deselected went `158 -> 157`.

*An earlier version of this PR said the marker's source was "unresolved" and that the file carried no
`@pytest.mark.slow`. That was wrong, and the mechanism is duller than the plugin-or-hook-ordering
theory it invited: the search was `grep -n "mark\|pytestmark" | head`, ten `mark_region` hits filled
the window, and line 278 was cut off. The truncation was read as the answer.*

## What is now unguarded

A change that makes the region path materially slower. Nothing catches that automatically any more,
and the benchmark must be run deliberately. Stated here rather than left to be discovered.

## Gate

`./scripts/local_ci.sh` — `5934 passed, 22 skipped, 21 xfailed`, `PASS no capability change vs
baseline`, `GATE GREEN`. Unchanged from `main`, because the deleted test was never in the selected
set.

