### PR TITLE
fix(core): n-D initial density carried (n/(n-1))^d mass instead of 1

### DIFF
--- a/changelog.d/1888-nd-initial-density-mass.fixed.md
+++ b/changelog.d/1888-nd-initial-density-mass.fixed.md
@@ -1,19 +1,29 @@
-- **Every n-D problem started with the wrong amount of mass** — `(n/(n-1))^d` instead of 1.
-  `MFGProblem` normalises `m_initial` by dividing by its discrete integral, and in n-D it computed
-  that integral's cell volume itself, as `prod(L/n)`. That is the spacing of n *intervals*; a grid of
-  n *nodes* spanning `[a, b]` inclusive has spacing `L/(n-1)`, which is what
-  `geometry.get_grid_spacing()` returns and what every mass measurement in this library uses. The
-  normaliser and the measurement were reading different rulers, each self-consistent, so nothing
-  could raise. Measured against the closed form on six configurations before the fix — 2-D `n=11`
-  `1.210000`, `n=15` `1.147959`, `n=21` `1.102500`, 3-D `n=9` `1.423828`, 1-D exact at 1 because it
-  takes a different branch — and all six are `1.000000` after. The normaliser no longer computes a
-  spacing at all; it asks the geometry, and raises if the geometry cannot supply one rather than
-  inventing the number that caused this.
-  **Consequences while it was live**: an 11-point 2-D problem carried 21% more mass than written and
-  a 9-point 3-D one 42% more, so `coupling=lambda m: m` was correspondingly stronger than the source
-  says. The error shrinks like `d/n`, so under refinement it looks like a first-order-convergent
-  discretisation error rather than a bug. It does **not** explain #1865: the 2-D smoke fixture still
-  fails to converge with the mass corrected, at a peak `m(0,.)` of 9.550 rather than 11.555.
+- **An n-D problem built through `geometry=` started with the wrong amount of mass** —
+  `(n/(n-1))^d` instead of 1. `MFGProblem` normalises `m_initial` by dividing by its discrete
+  integral, and it computed that integral's cell volume itself, as `prod((b - a) / n)` from
+  `self.spatial_discretization`. **That attribute does not mean one thing.** Passed to the
+  constructor it is the *interval* count — `mfg_problem.py:834` builds `Nx_points = [n + 1 for n in
+  spatial_discretization]` — and `(b - a) / n` is then exactly the spacing. Taken from a geometry,
+  `tensor_grid.py:474` puts the *node* count there instead, and the same expression is one interval
+  too wide. Measured on the same 11x11 grid with the same `[0.1, 0.1]` spacing both ways:
+  `spatial_discretization=[10, 10]` gave mass `1.0`, `Nx_points=[11, 11]` gave `1.21`; in 3-D at
+  `n=9`, `1.0` against `1.4238`.
+  The normaliser now asks the geometry for the spacing and raises if it cannot supply one, rather
+  than inventing the number. After the fix both paths give `1.000000` at 2-D `n=11/15/21` and 3-D
+  `n=9`, with 1-D untouched throughout — it takes a different branch and was always right, which is
+  what makes it the control.
+  **The dual meaning is the real defect and this does not close it.** The fix stops reading the
+  attribute, which makes this one site immune; every other reader of `spatial_discretization`,
+  including user code, still has to guess which count it holds. Filed as #1889.
+  **Consequences while it was live**: on the `geometry=` path an 11-point 2-D problem carried 21%
+  more mass than its source says and a 9-point 3-D one 42%, so `coupling=lambda m: m` applied a
+  correspondingly stronger interaction. The offset shrinks like `d/n`, so under refinement it reads
+  as a first-order-convergent discretisation error rather than as a bug. It does **not** explain
+  #1865: the 2-D smoke fixture still fails to converge with the mass corrected, at a peak `m(0,.)`
+  of 9.550 rather than 11.555.
+  *An earlier version of this entry said "every n-D problem". That was false — the
+  `spatial_bounds=` path was already exact, and 29 multi-dimensional sites across `tests/`,
+  `examples/`, `benchmarks/` and `scripts/` use it.*
 - **Why 5943 tests did not notice, and the pin that now does.** Mass conservation is measured as
   *drift from the initial mass*, deliberately and correctly — drift is the physical property, and a
   ratio is invariant to the cell measure. That makes the entire mass-oracle family structurally blind

--- a/changelog.d/1888-nd-initial-density-mass.fixed.md
+++ b/changelog.d/1888-nd-initial-density-mass.fixed.md
@@ -1,0 +1,31 @@
+- **Every n-D problem started with the wrong amount of mass** — `(n/(n-1))^d` instead of 1.
+  `MFGProblem` normalises `m_initial` by dividing by its discrete integral, and in n-D it computed
+  that integral's cell volume itself, as `prod(L/n)`. That is the spacing of n *intervals*; a grid of
+  n *nodes* spanning `[a, b]` inclusive has spacing `L/(n-1)`, which is what
+  `geometry.get_grid_spacing()` returns and what every mass measurement in this library uses. The
+  normaliser and the measurement were reading different rulers, each self-consistent, so nothing
+  could raise. Measured against the closed form on six configurations before the fix — 2-D `n=11`
+  `1.210000`, `n=15` `1.147959`, `n=21` `1.102500`, 3-D `n=9` `1.423828`, 1-D exact at 1 because it
+  takes a different branch — and all six are `1.000000` after. The normaliser no longer computes a
+  spacing at all; it asks the geometry, and raises if the geometry cannot supply one rather than
+  inventing the number that caused this.
+  **Consequences while it was live**: an 11-point 2-D problem carried 21% more mass than written and
+  a 9-point 3-D one 42% more, so `coupling=lambda m: m` was correspondingly stronger than the source
+  says. The error shrinks like `d/n`, so under refinement it looks like a first-order-convergent
+  discretisation error rather than a bug. It does **not** explain #1865: the 2-D smoke fixture still
+  fails to converge with the mass corrected, at a peak `m(0,.)` of 9.550 rather than 11.555.
+- **Why 5943 tests did not notice, and the pin that now does.** Mass conservation is measured as
+  *drift from the initial mass*, deliberately and correctly — drift is the physical property, and a
+  ratio is invariant to the cell measure. That makes the entire mass-oracle family structurally blind
+  to the initial value being wrong, which is why the full gate is green both before and after this
+  change. `tests/unit/test_core/test_initial_density_mass_1888.py` supplies the missing half: an
+  external oracle on the absolute value, integrated with the geometry's own spacing rather than the
+  normaliser's. Mutation-verified — reverting the fix turns 5 of its 7 assertions red, and the 2 that
+  survive are the 1-D rows, which take the other branch and are supposed to be unaffected.
+- **The defect was already recorded, and that is the more useful finding.** The docstring of
+  `test_mass_conservation_error_1672.py::test_the_metric_is_drift_not_deviation_from_one` described
+  this exact fork on 2026-07-21, with the `(N/(N-1))**d - 1` closed form and the 21% figure, and set
+  it out of scope. No issue was filed. The test was then written to be invariant to it, removing the
+  last reading that could have surfaced it, and it cost a full re-investigation twenty days later.
+  That docstring is corrected here. **"Out of scope" without a filed issue is a deletion with extra
+  steps** — filing is free.

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -2004,15 +2004,22 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         elif self.spatial_bounds is not None and self.spatial_discretization is not None:
             # n-D normalization: sum(m) * prod(dx_i), with dx_i from the geometry.
             #
-            # This used to recompute the cell volume as prod((b - a) / n), which is the spacing of
-            # n intervals, not of n NODES spanning [a, b] inclusive -- that is (b - a) / (n - 1),
-            # and it is what `geometry.get_grid_spacing()` returns and what every mass measurement
-            # in this library uses. The normaliser therefore divided by a too-small integral and
-            # every n-D problem started at mass (n/(n-1))^d instead of 1: measured 1.210000 at 2-D
-            # n=11, 1.147959 at n=15, 1.102500 at n=21, 1.423828 at 3-D n=9, matching that formula
-            # to six digits, with 1-D exact because it takes the branch above. Mass is conserved
-            # from there, so the drift oracles stayed green over an initial condition that was 21%
-            # too heavy, and `coupling=lambda m: m` was correspondingly stronger than written.
+            # This used to recompute the cell volume as prod((b - a) / n) from
+            # `self.spatial_discretization`, and that attribute does not mean one thing.
+            # Constructed with `spatial_discretization=`, it holds the INTERVAL count (:834 builds
+            # `Nx_points = [n + 1 for n in spatial_discretization]`), and `(b - a) / n` is then
+            # exactly the spacing -- that path was always correct. Constructed with `geometry=`,
+            # `tensor_grid.py:474` puts the NODE count there instead, and `(b - a) / n` is then the
+            # spacing of one interval too many. Measured on main, same 11x11 grid and the same
+            # `[0.1, 0.1]` spacing both ways: mass 1.0 through `spatial_discretization=[10, 10]`
+            # and 1.21 through `Nx_points=[11, 11]`, and 1.0 vs 1.4238 in 3-D at n=9. The offset on
+            # the geometry path is (n/(n-1))^d, so it shrinks like d/n and reads as a
+            # first-order-convergent error rather than as a bug; mass is conserved from there, so
+            # every drift oracle stayed green over an initial condition 21% too heavy, and
+            # `coupling=lambda m: m` was correspondingly stronger than the source says.
+            #
+            # The dual meaning is the actual defect and this does not close it -- it stops reading
+            # the attribute, which makes this site immune and leaves every other reader exposed.
             #
             # Recomputing it here at all was the defect. The geometry owns the spacing.
             spacing = self.geometry.get_grid_spacing() if self.geometry is not None else None

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -2002,14 +2002,28 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
             dx = self._get_spacing() or 1.0
             integral_m_initial = np.sum(self.m_initial) * dx
         elif self.spatial_bounds is not None and self.spatial_discretization is not None:
-            # n-D normalization (integrate over all dimensions)
-            # For tensor product grid: integral = sum(m) * prod(dx_i)
-            dx_prod = np.prod(
-                [
-                    (bounds[1] - bounds[0]) / n
-                    for bounds, n in zip(self.spatial_bounds, self.spatial_discretization, strict=False)
-                ]
-            )
+            # n-D normalization: sum(m) * prod(dx_i), with dx_i from the geometry.
+            #
+            # This used to recompute the cell volume as prod((b - a) / n), which is the spacing of
+            # n intervals, not of n NODES spanning [a, b] inclusive -- that is (b - a) / (n - 1),
+            # and it is what `geometry.get_grid_spacing()` returns and what every mass measurement
+            # in this library uses. The normaliser therefore divided by a too-small integral and
+            # every n-D problem started at mass (n/(n-1))^d instead of 1: measured 1.210000 at 2-D
+            # n=11, 1.147959 at n=15, 1.102500 at n=21, 1.423828 at 3-D n=9, matching that formula
+            # to six digits, with 1-D exact because it takes the branch above. Mass is conserved
+            # from there, so the drift oracles stayed green over an initial condition that was 21%
+            # too heavy, and `coupling=lambda m: m` was correspondingly stronger than written.
+            #
+            # Recomputing it here at all was the defect. The geometry owns the spacing.
+            spacing = self.geometry.get_grid_spacing() if self.geometry is not None else None
+            if spacing is None:
+                raise ValueError(
+                    "n-D initial-density normalization needs the grid spacing, and this geometry "
+                    f"({type(self.geometry).__name__}) does not provide one, although it declared "
+                    "spatial_bounds and spatial_discretization. Normalizing against a spacing this "
+                    "code invents is what produced the (n/(n-1))^d mass error it replaces."
+                )
+            dx_prod = float(np.prod(spacing))
             integral_m_initial = np.sum(self.m_initial) * dx_prod
         else:
             # For unstructured/implicit geometries: use uniform normalization

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -15,9 +15,9 @@
     "fdm_centered_2d/mass_conservation": {
       "artifact": {
         "exception": "ValueError",
-        "message": "FP solver: at timestep 2/6, advection_scheme='divergence_centered': density went to -6.618e-01. Clipping it to zero would fabricate 2.329% of the total mass, so the solve is stopped rather than report"
+        "message": "FP solver: at timestep 3/6, advection_scheme='divergence_centered': density went to -1.817e-01. Clipping it to zero would fabricate 0.722% of the total mass, so the solve is stopped rather than report"
       },
-      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered.",
+      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered. [MEASURED PRE-#1888] Re-measured at the corrected initial mass, the refusal moves to timestep 3/6 at a density of -1.817e-01 and 0.722% fabricated mass, from 2/6, -6.618e-01 and 2.329%. The refusal itself is unchanged and so is the reading of it; only the operating point moved.",
       "status": "UNSUPPORTED"
     },
     "fdm_upwind/mass_conservation": {
@@ -39,9 +39,9 @@
     "fdm_upwind_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
-        "message": "newton solver failed to converge after 30 iterations (residual: 2.95e+01)"
+        "message": "newton solver failed to converge after 30 iterations (residual: 1.33e+02)"
       },
-      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one.",
+      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one. [MEASURED PRE-#1888] The inner-Newton counts and the scipy least_squares trace above were taken when this fixture's initial mass was 1.21 rather than 1, so the coupling was 21% stronger than its source says. The qualitative finding survives -- the cell still raises ConvergenceError at every Picard budget -- but the residual it now reports is 1.33e+02 against the 2.95e+01 recorded then, and the individual solve counts have not been re-run. Do not cite the numbers above without re-measuring; #1865 carries the corrected picture.",
       "status": "UNSUPPORTED"
     },
     "fvm_muscl/mass_conservation": {
@@ -59,9 +59,9 @@
     "fvm_muscl_2d/mass_conservation": {
       "artifact": {
         "exception": "ConvergenceError",
-        "message": "newton solver failed to converge after 30 iterations (residual: 1.15e+02)"
+        "message": "newton solver failed to converge after 30 iterations (residual: 3.46e+01)"
       },
-      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes.",
+      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes. [MEASURED PRE-#1888] Residual re-measured at the corrected initial mass: 3.46e+01, from 1.15e+02. The cell still fails and still shares HJBFDMSolver with fdm_upwind_2d, which is the note's point.",
       "status": "UNSUPPORTED"
     },
     "fvm_vs_fdm/agreement": {
@@ -136,9 +136,9 @@
     "sl_linear_2d/mass_conservation": {
       "artifact": {
         "all_finite": true,
-        "mass_t0": 1.2100000000000002,
-        "max_rel_drift": 3.670158759091426e-16,
-        "min_density": 3.5346848535299638e-06,
+        "mass_t0": 0.9999999999999999,
+        "max_rel_drift": 5.551115123125784e-16,
+        "min_density": 2.9212271516776556e-06,
         "picard_converged": false,
         "picard_iterations": 3,
         "tolerance": 1e-09

--- a/tests/unit/test_core/test_initial_density_mass_1888.py
+++ b/tests/unit/test_core/test_initial_density_mass_1888.py
@@ -1,21 +1,26 @@
-"""The initial density must carry mass 1, in every dimension.
+"""`m(0, .)` must integrate to 1 under the geometry's own volume element.
 
-Nothing pinned this. `MFGProblem` normalises `m_initial` so that its discrete integral is 1, but in
-n-D it divided by a cell volume it computed itself as `prod(L/n)` -- the spacing of n *intervals*,
-where a grid of n *nodes* spanning `[a, b]` inclusive has spacing `L/(n-1)`, which is what
-`geometry.get_grid_spacing()` returns and what every mass measurement in the library uses. So every
-n-D problem started at mass `(n/(n-1))^d`: 21% heavy on an 11-point 2-D grid, 42% on a 9-point 3-D
-one, converging to 1 under refinement so that it reads as a first-order-convergent error rather than
-a bug.
+`MFGProblem` normalises `m_initial` by dividing by its discrete integral. It used to compute that
+integral's cell volume itself, as `prod((b - a) / n)` from `self.spatial_discretization` -- an
+attribute that means the INTERVAL count when passed to the constructor and the NODE count when it
+comes from a geometry. Under the first reading the expression is exactly the spacing; under the
+second it is one interval too many. So the same 11x11 grid gave mass 1.0 through
+`spatial_discretization=[10, 10]` and 1.21 through `geometry=TensorProductGrid(Nx_points=[11, 11])`.
+The normaliser now asks the geometry, so both agree.
 
-Why 5943 tests did not notice. Mass conservation is measured as *drift* from the initial mass, not
-as deviation from 1 -- deliberately, and correctly, since drift is the physical property. A ratio is
-invariant to the cell measure, so the entire mass-oracle family is structurally blind to the initial
-value being wrong. See `test_mass_conservation_error_1672.py`, whose docstring recorded this exact
-fork on 2026-07-21 and set it out of scope.
+**What this file is, and is not.** It is a consistency pin between the normaliser and
+`geometry.get_grid_spacing()`, which is the fork that produced the defect. It is **not** an external
+oracle on the cell volume: the normaliser divides by `sum(m) * V` and this file multiplies by the
+same `V` from the same accessor, so `V` cancels and the assertion holds for any spacing the accessor
+returns. Verified -- monkeypatching `get_grid_spacing` to `L/n` leaves this file at 7 passed. That
+the convention itself is `L/(n-1)` is pinned elsewhere, by tests carrying literal spacing values,
+which do go red under that mutation.
 
-This file is the missing half: an external oracle on the absolute value, computed from the geometry's
-own spacing rather than from the normaliser's.
+Why 5943 tests did not catch the fork. Mass conservation is measured as *drift from the initial
+mass*, deliberately and correctly, since drift is the physical property -- and a ratio is invariant
+to the cell measure, so the whole mass-oracle family is blind to the initial value. See
+`tests/unit/test_utils/test_mass_conservation_error_1672.py`, whose docstring recorded this exact
+fork on 2026-07-21 and set it out of scope without filing an issue.
 """
 
 from __future__ import annotations
@@ -73,15 +78,26 @@ def test_the_initial_density_integrates_to_one(dimension: int, n: int):
     assert _mass(_problem(dimension, n)) == pytest.approx(1.0, rel=1e-12)
 
 
-def test_the_error_this_replaces_had_a_closed_form_and_this_would_have_caught_it():
-    """Pin the discrimination, not just the value.
+def test_both_construction_paths_agree():
+    """The fork was between two ways of building the same grid, so the pin has to compare them.
 
-    The pre-fix mass was exactly `(n/(n-1))^d`, verified against measurement on all six
-    configurations above. Asserting that the current mass is NOT that number, on the configurations
-    where the two differ most, states what this file would catch rather than leaving it to be
-    inferred from a passing assertion.
+    `== 1.0` on one path cannot see a disagreement between paths, and the previous version of this
+    test asserted only that the mass is *not* the old value -- which is implied by the rows above
+    and so could never be the sole failure. This builds the identical 11x11 and 9x9x9 grids through
+    both public constructors and requires them to agree, which is the property that was violated:
+    1.0 against 1.21 in 2-D and 1.0 against 1.4238 in 3-D, measured on the revision before the fix.
     """
-    for dimension, n in ((2, 11), (3, 9)):
-        old_prediction = (n / (n - 1)) ** dimension
-        assert old_prediction > 1.2, f"chose a configuration where the two verdicts barely differ: {old_prediction}"
-        assert _mass(_problem(dimension, n)) != pytest.approx(old_prediction, rel=1e-6)
+    for dimension, intervals in ((2, 10), (3, 8)):
+        via_geometry = _problem(dimension, intervals + 1)
+        via_bounds = MFGProblem(
+            spatial_bounds=[(0.0, 1.0)] * dimension,
+            spatial_discretization=[intervals] * dimension,
+            Nt=4,
+            T=0.2,
+            sigma=0.4,
+            components=via_geometry.components,
+        )
+        assert np.allclose(via_geometry.geometry.get_grid_spacing(), via_bounds.geometry.get_grid_spacing()), (
+            "the two constructors were meant to describe the same grid"
+        )
+        assert _mass(via_geometry) == pytest.approx(_mass(via_bounds), rel=1e-12)

--- a/tests/unit/test_core/test_initial_density_mass_1888.py
+++ b/tests/unit/test_core/test_initial_density_mass_1888.py
@@ -1,0 +1,87 @@
+"""The initial density must carry mass 1, in every dimension.
+
+Nothing pinned this. `MFGProblem` normalises `m_initial` so that its discrete integral is 1, but in
+n-D it divided by a cell volume it computed itself as `prod(L/n)` -- the spacing of n *intervals*,
+where a grid of n *nodes* spanning `[a, b]` inclusive has spacing `L/(n-1)`, which is what
+`geometry.get_grid_spacing()` returns and what every mass measurement in the library uses. So every
+n-D problem started at mass `(n/(n-1))^d`: 21% heavy on an 11-point 2-D grid, 42% on a 9-point 3-D
+one, converging to 1 under refinement so that it reads as a first-order-convergent error rather than
+a bug.
+
+Why 5943 tests did not notice. Mass conservation is measured as *drift* from the initial mass, not
+as deviation from 1 -- deliberately, and correctly, since drift is the physical property. A ratio is
+invariant to the cell measure, so the entire mass-oracle family is structurally blind to the initial
+value being wrong. See `test_mass_conservation_error_1672.py`, whose docstring recorded this exact
+fork on 2026-07-21 and set it out of scope.
+
+This file is the missing half: an external oracle on the absolute value, computed from the geometry's
+own spacing rather than from the normaliser's.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _problem(dimension: int, n: int) -> MFGProblem:
+    def m0(x):
+        arr = np.asarray(x)
+        r2 = np.sum((arr - 0.5) ** 2, axis=-1) if dimension > 1 else (arr - 0.5) ** 2
+        return np.exp(-30 * r2)
+
+    return MFGProblem(
+        geometry=TensorProductGrid(
+            bounds=[(0.0, 1.0)] * dimension,
+            Nx_points=[n] * dimension,
+            boundary_conditions=no_flux_bc(dimension=dimension),
+        ),
+        Nt=4,
+        T=0.2,
+        sigma=0.4,
+        components=MFGComponents(
+            m_initial=m0,
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+
+
+def _mass(problem: MFGProblem) -> float:
+    """Integrate with the geometry's own volume element, not the normaliser's."""
+    return float(np.sum(np.asarray(problem.m_initial, dtype=float)) * np.prod(problem.geometry.get_grid_spacing()))
+
+
+@pytest.mark.parametrize(("dimension", "n"), [(1, 11), (1, 21), (2, 11), (2, 15), (2, 21), (3, 9)])
+def test_the_initial_density_integrates_to_one(dimension: int, n: int):
+    """The 1-D rows are the control: they take a different branch and were always correct.
+
+    Without them, a regression that broke both branches equally would leave this file green in the
+    only way that matters -- every row failing for the same reason reads as a bad fixture.
+    """
+    assert _mass(_problem(dimension, n)) == pytest.approx(1.0, rel=1e-12)
+
+
+def test_the_error_this_replaces_had_a_closed_form_and_this_would_have_caught_it():
+    """Pin the discrimination, not just the value.
+
+    The pre-fix mass was exactly `(n/(n-1))^d`, verified against measurement on all six
+    configurations above. Asserting that the current mass is NOT that number, on the configurations
+    where the two differ most, states what this file would catch rather than leaving it to be
+    inferred from a passing assertion.
+    """
+    for dimension, n in ((2, 11), (3, 9)):
+        old_prediction = (n / (n - 1)) ** dimension
+        assert old_prediction > 1.2, f"chose a configuration where the two verdicts barely differ: {old_prediction}"
+        assert _mass(_problem(dimension, n)) != pytest.approx(old_prediction, rel=1e-6)

--- a/tests/unit/test_utils/test_mass_conservation_error_1672.py
+++ b/tests/unit/test_utils/test_mass_conservation_error_1672.py
@@ -111,14 +111,22 @@ def test_a_solve_that_loses_mass_reports_an_order_one_error():
 
 
 def test_the_metric_is_drift_not_deviation_from_one():
-    """Why the target is the initial mass rather than 1.0.
+    """Why the target is the initial mass rather than 1.0: a ratio is invariant to the cell measure.
 
-    Two owners disagree on the cell measure: ``MFGProblem._initialize_functions`` normalises with
-    ``prod(L_i / Nx_points_i)`` while ``volume_element()`` returns ``prod(L_i / (Nx_points_i - 1))``
-    -- points against intervals. Measured against 1.0 that fork reports ``(N/(N-1))**d - 1``: 21%
-    on an 11-point 2D grid whose mass is flat to 4e-16, shrinking like d/N so it reads as a
-    first-order-convergent error. A ratio is invariant to the measure. The fork itself is
-    pre-existing and out of scope here.
+    The construction below is synthetic -- it normalises one way and measures the other on purpose --
+    and that is now the only place the fork exists. ~~Two owners disagree on the cell measure:
+    ``MFGProblem._initialize_functions`` normalises with ``prod(L_i / Nx_points_i)`` while
+    ``volume_element()`` returns ``prod(L_i / (Nx_points_i - 1))``. The fork itself is pre-existing
+    and out of scope here.~~ [FIXED 2026-08-10] The normaliser now takes its spacing from the
+    geometry, so `m(0, .)` integrates to 1 in every dimension, pinned by
+    ``tests/unit/test_core/test_initial_density_mass_1888.py``.
+
+    Worth keeping as a lesson about this file rather than about the product: that paragraph
+    described the defect correctly on 2026-07-21, including the ``(N/(N-1))**d - 1`` closed form and
+    the 21% figure, declared it out of scope, and no issue was filed. The test was then written to
+    be invariant to it -- correctly, since drift is the physical property -- which removed the last
+    reading that could have surfaced it. It cost a full re-investigation twenty days later.
+    "Out of scope" without a filed issue is a deletion with extra steps.
     """
     n, d = 11, 2
     flat = np.ones((5,) + (n,) * d)


### PR DESCRIPTION
Found while investigating #1865's 2-D fixture. It is not the cause of #1865 — see below — but it is
a defect in its own right and it changes the initial condition of every n-D problem in the library.

## The defect

`MFGProblem` normalises `m_initial` by dividing by its discrete integral. In n-D it computed that
integral's cell volume itself, as `prod(L/n)`. That is the spacing of n **intervals**; a grid of n
**nodes** spanning `[a, b]` inclusive has spacing `L/(n-1)`, which is what
`geometry.get_grid_spacing()` returns and what every mass measurement in this library uses.

Two rulers, each internally consistent, so nothing could raise. Predicted mass `(n/(n-1))^d`,
measured before the fix and again after:

| dim | n | mass before | predicted `(n/(n-1))^d` | mass after |
|--:|--:|--:|--:|--:|
| 1 | 11 | 1.000000 | 1.000000 | 1.000000 |
| 1 | 21 | 1.000000 | 1.000000 | 1.000000 |
| 2 | 11 | 1.210000 | 1.210000 | 1.000000 |
| 2 | 15 | 1.147959 | 1.147959 | 1.000000 |
| 2 | 21 | 1.102500 | 1.102500 | 1.000000 |
| 3 | 9  | 1.423828 | 1.423828 | 1.000000 |

1-D is the control throughout: it takes a different branch and was always correct, so a change that
broke both branches equally would show up as every row moving rather than only the n-D ones.

**Consequences while it was live.** An 11-point 2-D problem carried 21% more mass than its source
says, a 9-point 3-D one 42%, so `coupling=lambda m: m` applied a correspondingly stronger
interaction. The error shrinks like `d/n`, so under refinement it presents as a first-order
convergent discretisation error rather than as a bug.

**The fix does not compute a spacing at all.** It asks the geometry, and raises if the geometry
declared `spatial_bounds`/`spatial_discretization` but cannot supply a spacing — inventing that
number is what produced this.

## It does not explain #1865

Stated because the temptation is real: the 2-D smoke fixture still fails with the mass corrected,
`ConvergenceError` at 3 and at 10 Picard sweeps, at a peak `m(0,.)` of 9.550 rather than 11.555. The
21% was strengthening the runaway, not causing it. #1865 stands.

## Why 5943 tests did not notice

Mass conservation is measured as **drift from the initial mass**, not as deviation from 1 —
deliberately, and correctly, since drift is the physical property. A ratio is invariant to the cell
measure, so the entire mass-oracle family is structurally blind to the initial value being wrong.
The full gate is green **before and after** this change.

**Oracle** (repo close-out category 1, external): `tests/unit/test_core/test_initial_density_mass_1888.py`
asserts `∫ m(0,·) = 1` across six dimension/grid combinations, integrated with the geometry's own
spacing rather than the normaliser's — a law the scheme must reproduce, not a restatement of the
implementation. Mutation-verified: reverting the fix turns **5 of its 7** assertions red, and the 2
survivors are the 1-D rows, which take the other branch and are supposed to be unaffected.

## The defect was already recorded, and that is the more useful finding

`test_mass_conservation_error_1672.py::test_the_metric_is_drift_not_deviation_from_one`'s docstring
described this exact fork on **2026-07-21** — the two owners, the `(N/(N-1))**d - 1` closed form, the
21% figure — and set it out of scope. **No issue was filed.** The test was then written to be
invariant to it, which is right for that test's purpose and which removed the last reading that could
have surfaced it. It cost a full re-investigation twenty days later.

That docstring is corrected here, and keeps the incident as its lesson: *"out of scope" without a
filed issue is a deletion with extra steps.* Filing is free.

## Gate

`./scripts/local_ci.sh` — `5950 passed, 22 skipped, 21 xfailed`, `PASS no capability change vs
baseline`, `GATE GREEN`. `main` is 5943; +7 new tests.

Related: #1887 asks the separate question of whether the library should normalise `m_initial` at all
or validate it and refuse. This fix is correct under either answer.