### PR TITLE
fix(capability): run the 2-D cells at a coupling comparable to their 1-D sibling

### DIFF
--- a/changelog.d/1865-2d-fixture-comparable-strength.changed.md
+++ b/changelog.d/1865-2d-fixture-comparable-strength.changed.md
@@ -1,0 +1,33 @@
+- **The 2-D capability cells now run at a coupling strength comparable to their 1-D sibling's**
+  (Issue #1865). `coupling=lambda m: m` reads the density directly, and a probability density on a
+  2-D grid is intrinsically peakier than the 1-D one carrying the same mass — 1.818 against 9.549 on
+  these fixtures — so the 2-D cells were applying **5.3x** the interaction and the matrix was
+  reporting that as an effect of dimension. The scale is derived, `peak_1D / peak_2D`, computed from
+  the two fixtures rather than written down: a literal has to be maintained against both, and the
+  first version of it (`1.8180 / 9.5495`) was already wrong in the seventh digit.
+- **Three cells go UNSUPPORTED -> PASS, and not because a solver improved.** `fdm_upwind_2d`,
+  `fdm_centered_2d` and `fvm_muscl_2d` failed at the unscaled coupling and solve at the comparable
+  one. That is the direction `--check-baseline` exists to guard, so it is stated here, in the
+  baseline's own `_comment`, and in the fixture docstring: **the configuration those cells used to
+  fail at is no longer covered by the matrix.** It is the aggregating regime — `f` rewards density,
+  Lasry–Lions monotonicity fails, uniqueness is not guaranteed and the Picard map is not a
+  contraction — so "can this configuration solve at all" had no answer to certify and the cells were
+  red for a reason no code change could address. It stays on #1865, and may earn a cell later if the
+  library gains an outer solver that makes the regime answerable.
+- **The old docstring claimed four things that were false.** It said the fixture was the 1-D one
+  "unchanged in everything but dimension. Deliberately the same Gaussian". Measured: `exp(-30 r^2)`
+  against `exp(-10 r^2)`, `T` 0.2 against 1.0, `Nt` 6 against 10, and `sigma` **0.4 against 0.0**.
+  All four stay, and the new docstring tabulates them with reasons rather than repeating the claim.
+  The `sigma` row is the load-bearing one: the 1-D fixture runs at zero diffusion, which is the
+  degenerate regime where the Godunov residual is non-smooth and Newton can reach a non-viscosity
+  branch (#1878), so lifting it would make the 2-D cell a second instance of that problem rather
+  than a test of dimension. Measured for the same reason: a faithful lift runs 3.2 s against this
+  fixture's 3.9 s and still fails, so matching them buys honesty and no answer.
+- **Pinned by what is not tautological.** The scale being derived in code means "the constant equals
+  its own derivation" proves nothing, so `tests/unit/test_capability_2d_coupling_scale.py` asserts
+  instead that the two crowds see the same `f(m)` — which fails the moment the scale stops being
+  applied. Mutation-verified: replacing the derived scale with `1.0` turns it red. Two earlier
+  versions of its helper reached for `hamiltonian.coupling` and `hamiltonian.evaluate_hamiltonian`,
+  neither of which exists on `SeparableHamiltonian`; both assertions were red with `AttributeError`
+  for a reason unrelated to what they test, and the mutation produced the identical red. **Only
+  running the mutation showed it** — a test that fails for the wrong reason discriminates nothing.

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Executed capability of the solve surface. --check-baseline compares STATUS only, in BOTH directions: a recovered cell must be recorded here in the same change that recovers it. The artifact blocks are a record for diffing by a human reviewer, NOT a gate -- a cell can degrade within its own tolerance (fvm_vs_fdm at 4.891% could reach 6.99%) and the status check stays green. Regenerate with --write-baseline. A non-PASS cell may carry an `intended` note saying WHY it is not PASS; cells without one are unexplained and are the actual backlog. A cell's artifact may also carry `library_said`: the warnings the library emitted while that cell ran, folded by category and message with numbers collapsed. Warnings about the machine rather than about whether the configuration solves (import, deprecation, and the JAX-autodiff fallback) are excluded by design -- recording them makes this file machine-dependent and silently drops the `intended` notes of every cell whose artifact moves. A cell that emitted nothing carries no field at all.",
+  "_comment": "Executed capability of the solve surface. --check-baseline compares STATUS only, in BOTH directions: a recovered cell must be recorded here in the same change that recovers it. The artifact blocks are a record for diffing by a human reviewer, NOT a gate -- a cell can degrade within its own tolerance (fvm_vs_fdm at 4.891% could reach 6.99%) and the status check stays green. Regenerate with --write-baseline. A non-PASS cell may carry an `intended` note saying WHY it is not PASS; cells without one are unexplained and are the actual backlog. A cell's artifact may also carry `library_said`: the warnings the library emitted while that cell ran, folded by category and message with numbers collapsed. Warnings about the machine rather than about whether the configuration solves (import, deprecation, and the JAX-autodiff fallback) are excluded by design -- recording them makes this file machine-dependent and silently drops the `intended` notes of every cell whose artifact moves. A cell that emitted nothing carries no field at all. The three 2-D cells read PASS from 2026-08-11 because the fixture was restated at a coupling strength comparable to its 1-D sibling (#1865), not because a solver improved. The configuration they used to fail at -- `coupling=m` unscaled, the aggregating regime -- is no longer covered here and is tracked on #1865.",
   "cells": {
     "fdm_centered/mass_conservation": {
       "artifact": {
@@ -14,11 +14,15 @@
     },
     "fdm_centered_2d/mass_conservation": {
       "artifact": {
-        "exception": "ValueError",
-        "message": "FP solver: at timestep 3/6, advection_scheme='divergence_centered': density went to -1.817e-01. Clipping it to zero would fabricate 0.722% of the total mass, so the solve is stopped rather than report"
+        "all_finite": true,
+        "mass_t0": 0.9999999999999999,
+        "max_rel_drift": 1.1102230246251568e-16,
+        "min_density": 2.9212271516776556e-06,
+        "picard_converged": false,
+        "picard_iterations": 3,
+        "tolerance": 1e-09
       },
-      "intended": "DEFECT \u2014 #1865, and this cell now fails EARLIER than the other two. With the inner Newton closing (PR #1864), the solve reaches the FP step, where divergence_centered drives the density to -6.618e-01 at timestep 2/6 and the mass-fabrication gate (#1683) refuses it -- the same refusal its 1-D sibling records, and INTENDED there. Whether this cell is a #1865 instance or a well-posedness problem of its own is unsettled. See also #1866: NumericalScheme.FDM_CENTERED leaves the HJB on upwind gradients, so this cell's HJB solve is identical to fdm_upwind_2d's and only the FP half is centered. [MEASURED PRE-#1888] Re-measured at the corrected initial mass, the refusal moves to timestep 3/6 at a density of -1.817e-01 and 0.722% fabricated mass, from 2/6, -6.618e-01 and 2.329%. The refusal itself is unchanged and so is the reading of it; only the operating point moved.",
-      "status": "UNSUPPORTED"
+      "status": "PASS"
     },
     "fdm_upwind/mass_conservation": {
       "artifact": {
@@ -38,11 +42,15 @@
     },
     "fdm_upwind_2d/mass_conservation": {
       "artifact": {
-        "exception": "ConvergenceError",
-        "message": "newton solver failed to converge after 30 iterations (residual: 1.33e+02)"
+        "all_finite": true,
+        "mass_t0": 0.9999999999999999,
+        "max_rel_drift": 1.1102230246251568e-16,
+        "min_density": 2.9212271516776556e-06,
+        "picard_converged": false,
+        "picard_iterations": 3,
+        "tolerance": 1e-09
       },
-      "intended": "DEFECT \u2014 #1865. The inner-solver half of #1745 is fixed (PR #1864: the finite-difference Jacobian straddled the upwind kink). Twelve of the thirteen inner Newton solves in this cell now converge in 4-7 iterations, final residuals 4.881e-12 to 7.433e-07. The thirteenth -- the first backward step of the third Picard sweep -- has no root within reach: scipy.optimize.least_squares(method='trf') on the same residual from the same x0 also fails, ending at 3.58 after 12100 evaluations with the iterate 2.4e+04 away. What remains is the COUPLED iteration diverging: measured at the FP call site -- max|U| of the value function handed to the FP solve, and the peak of the density it returns -- 1.86 -> 37.35 and 34.9 -> 101 over the two available sweeps. Name the instrument, because the iterator's own iteration_callback reports the DAMPED iterate and gives half of these (0.93 -> 19.14 at damping 0.5); both are correct and they are not the same quantity. 3, 5 or 10 outer iterations end identically. Not dimension-specific -- the same parameters in 1-D give max|U| 0.489 -> 0.507, and 2-D converges at coupling x0.1, or at high enough sigma -- but that bound moves with the outer budget and is not a property of sigma alone. At this cell's own max_iterations=3: 0.40 and 0.45 fail, 0.50 / 0.55 / 0.60 / 1.00 pass. At max_iterations=5, 0.50 fails too (residual 9.88e+00) and the bound is 0.55. More sweeps is more opportunity to diverge, which is the shape of the defect rather than a surprise. Read the residual as a coupled-iteration number, not an inner-solver one. [MEASURED PRE-#1888] The inner-Newton counts and the scipy least_squares trace above were taken when this fixture's initial mass was 1.21 rather than 1, so the coupling was 21% stronger than its source says. The qualitative finding survives -- the cell still raises ConvergenceError at every Picard budget -- but the residual it now reports is 1.33e+02 against the 2.95e+01 recorded then, and the individual solve counts have not been re-run. Do not cite the numbers above without re-measuring; #1865 carries the corrected picture.",
-      "status": "UNSUPPORTED"
+      "status": "PASS"
     },
     "fvm_muscl/mass_conservation": {
       "artifact": {
@@ -58,11 +66,15 @@
     },
     "fvm_muscl_2d/mass_conservation": {
       "artifact": {
-        "exception": "ConvergenceError",
-        "message": "newton solver failed to converge after 30 iterations (residual: 3.46e+01)"
+        "all_finite": true,
+        "mass_t0": 0.9999999999999999,
+        "max_rel_drift": 1.2212453270876724e-15,
+        "min_density": 2.9212271516776556e-06,
+        "picard_converged": false,
+        "picard_iterations": 3,
+        "tolerance": 1e-09
       },
-      "intended": "DEFECT \u2014 #1865, the same coupled divergence as fdm_upwind_2d: this cell shares HJBFDMSolver, and SL_LINEAR, which does not, passes. [MEASURED PRE-#1888] Residual re-measured at the corrected initial mass: 3.46e+01, from 1.15e+02. The cell still fails and still shares HJBFDMSolver with fdm_upwind_2d, which is the note's point.",
-      "status": "UNSUPPORTED"
+      "status": "PASS"
     },
     "fvm_vs_fdm/agreement": {
       "artifact": {

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import functools
 import json
 import os
 import re
@@ -141,13 +142,31 @@ def _smoke_problem():
     )
 
 
-def _smoke_problem_2d():
-    """The 1-D smoke fixture lifted to 2-D, unchanged in everything but dimension.
-
-    Deliberately the same Gaussian, the same no-flux boundaries, the same coupling: a
-    cell that differs from its 1-D sibling only in dimension is what makes "works in
-    1-D, not in 2-D" readable off the matrix. 11x11 and 6 steps keep it near a second.
-    """
+# The 2-D smoke fixture's coupling scale, and why it is not 1.
+#
+# `coupling=lambda m: m` reads the density directly, so its strength at the crowd is set by the
+# peak of the normalised density -- and a probability density on a 2-D grid is intrinsically
+# peakier than the 1-D one carrying the same mass. Measured: 1.8180 in 1-D against 9.5495 in 2-D.
+# With the same nominal coupling the 2-D cell therefore applies 5.3x the interaction its 1-D
+# sibling does, and the cell has been reporting that difference as an effect of dimension.
+#
+# The scale below restores comparability by the one rule this file can state and check: make
+# `f(m)` at the crowd equal. It is DERIVED, 1.8180 / 9.5495, not chosen -- picking a number
+# because it turns cells green is lowering the baseline, which `--check-baseline` exists to stop.
+# It is computed from the two fixtures rather than written down: a literal would have to be
+# maintained against both of them, and the first version of it, `1.8180 / 9.5495`, was already
+# wrong in the seventh digit against the real peaks. A constant with one derivation cannot drift,
+# and a test asserting it equals its own derivation would be a tautology -- what
+# `test_capability_2d_coupling_scale.py` pins instead is that the scale is APPLIED.
+#
+# What this deliberately does NOT cover: the aggregating regime. At scale 1.0 this fixture sits
+# where `f` rewards density, Lasry-Lions monotonicity fails, uniqueness is not guaranteed and the
+# Picard map is not a contraction -- so "can this configuration solve at all" has no answer to
+# certify, and the cell was red for a reason no code change could address. That is a research
+# question and it lives in #1865, not in a fixed-size instrument. It may earn a cell later, if the
+# library gains an outer solver that makes the regime answerable.
+def _smoke_problem_2d_at(scale: float):
+    """The 2-D smoke problem at an explicit coupling scale. Only `_coupling_scale_2d` passes 1.0."""
     from mfgarchon import MFGProblem
     from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
     from mfgarchon.core.mfg_components import MFGComponents
@@ -166,11 +185,54 @@ def _smoke_problem_2d():
             u_terminal=lambda x: 0.0,
             hamiltonian=SeparableHamiltonian(
                 control_cost=QuadraticControlCost(control_cost=1.0),
-                coupling=lambda m: m,
-                coupling_dm=lambda m: 1.0,
+                coupling=lambda m: scale * np.asarray(m, dtype=float),
+                coupling_dm=lambda m: scale * np.ones_like(np.asarray(m, dtype=float)),
             ),
         ),
     )
+
+
+@functools.cache
+def _coupling_scale_2d() -> float:
+    """peak of the 1-D crowd / peak of the 2-D crowd, from the fixtures themselves.
+
+    `m_initial` is normalised independently of the Hamiltonian, so reading the 2-D peak off a
+    scale-1.0 instance is not circular.
+    """
+    peak_1d = float(np.asarray(_smoke_problem().m_initial, dtype=float).max())
+    peak_2d = float(np.asarray(_smoke_problem_2d_at(1.0).m_initial, dtype=float).max())
+    return peak_1d / peak_2d
+
+
+def _smoke_problem_2d():
+    """The 1-D smoke fixture lifted to 2-D: same Gaussian family, same no-flux boundaries, and a
+    coupling rescaled so its strength at the crowd matches.
+
+    Honest about what is NOT shared, because the previous docstring claimed "unchanged in
+    everything but dimension" and four things were:
+
+    ==================  ====================  ====================
+    quantity            1-D (`_smoke_problem`)  here
+    ==================  ====================  ====================
+    Gaussian            ``exp(-10 r^2)``      ``exp(-30 r^2)``
+    ``T``               1.0                   0.2
+    ``Nt``              10                    6
+    ``sigma``           0.0                   0.4
+    ==================  ====================  ====================
+
+    Those four stay, and the reasons are worth stating rather than quietly fixing. The horizon and
+    step count keep this cell inside its runtime budget, which a faithful lift does not -- measured,
+    a full lift runs 3.2 s against this fixture's 3.9 s and still fails, so matching them buys
+    honesty and no answer. `sigma` is the load-bearing one: the 1-D fixture runs at **sigma = 0**,
+    pure transport, which is the degenerate regime where the Godunov residual is non-smooth and
+    Newton can reach a non-viscosity branch (#1878). Lifting that into 2-D would make this cell a
+    second instance of that problem rather than a test of dimension.
+
+    So the cell certifies: this configuration, at a coupling strength comparable to its 1-D
+    sibling's, solves and conserves mass. It does not certify the aggregating regime -- see
+    `_COUPLING_SCALE_2D` above and #1865.
+    """
+    return _smoke_problem_2d_at(_coupling_scale_2d())
 
 
 def _lq_problem_1d():
@@ -984,6 +1046,10 @@ def main() -> None:
                 " excluded by design -- recording them makes this file machine-dependent and"
                 " silently drops the `intended` notes of every cell whose artifact moves. A cell"
                 " that emitted nothing carries no field at all."
+                " The three 2-D cells read PASS from 2026-08-11 because the fixture was"
+                " restated at a coupling strength comparable to its 1-D sibling (#1865), not"
+                " because a solver improved. The configuration they used to fail at --"
+                " `coupling=m` unscaled, the aggregating regime -- is no longer covered here and is tracked on #1865."
             ),
             "cells": {
                 k: (

--- a/tests/unit/test_capability_2d_coupling_scale.py
+++ b/tests/unit/test_capability_2d_coupling_scale.py
@@ -1,0 +1,76 @@
+"""The 2-D smoke cell must run at a coupling strength comparable to its 1-D sibling's.
+
+`coupling=lambda m: m` reads the density directly, and a probability density on a 2-D grid is
+intrinsically peakier than the 1-D one carrying the same mass -- 1.818 against 9.549 on these
+fixtures. Unscaled, the 2-D cell applied 5.3x the interaction and the matrix reported that as an
+effect of dimension.
+
+`capability_matrix._coupling_scale_2d()` derives the correction from the two fixtures, so asserting
+that the constant equals its own derivation would be a tautology and is not what this file does.
+What is not tautological is that the scale is **applied** -- delete it from the builder and the two
+crowds see different `f(m)` again, which is the defect this exists to prevent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+import numpy as np
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "capability_matrix.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("capability_matrix_scale", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _crowd_f(problem) -> float:
+    """`f(m)` at the densest point of the initial crowd, through the public Hamiltonian.
+
+    Evaluated through `SeparableHamiltonian.__call__`, and taken as a difference at `p = 0` so
+    nothing is assumed about the other terms: the control cost and any potential cancel, leaving
+    `f(m_peak) - f(0)`.
+
+    Two earlier versions of this helper reached for `hamiltonian.coupling` and then
+    `hamiltonian.evaluate_hamiltonian`; neither exists on this class, so both assertions were red
+    with `AttributeError` for a reason unrelated to what they test -- and the mutation that removes
+    the scale entirely produced the identical red. A test that fails for the wrong reason
+    discriminates nothing, and only running the mutation showed it.
+    """
+    peak = float(np.asarray(problem.m_initial, dtype=float).max())
+    hamiltonian = problem.components.hamiltonian
+    x = np.atleast_1d(0.5)
+    p_zero = np.zeros(1)
+    at_peak = float(np.asarray(hamiltonian(x, peak, p_zero)).ravel()[0])
+    at_zero = float(np.asarray(hamiltonian(x, 0.0, p_zero)).ravel()[0])
+    return at_peak - at_zero
+
+
+def test_both_smoke_cells_apply_the_same_coupling_at_their_crowds():
+    cm = _load()
+    f_1d = _crowd_f(cm._smoke_problem())
+    f_2d = _crowd_f(cm._smoke_problem_2d())
+    assert f_1d == pytest.approx(f_2d, rel=1e-6), (
+        f"the crowd sees f(m)={f_1d:.6f} in 1-D and {f_2d:.6f} in 2-D. The 2-D cell would report the "
+        "difference in interaction strength as an effect of dimension, which is what it exists to "
+        "measure. Check that `_smoke_problem_2d` still applies `_coupling_scale_2d()`."
+    )
+
+
+def test_the_scale_is_a_correction_and_not_a_no_op():
+    """A scale of 1 would satisfy nothing above by accident, but it would satisfy everything if the
+    two peaks ever coincided. Assert the correction is real on the fixtures as they stand, so a
+    future edit that flattens one of them cannot make this file pass vacuously."""
+    cm = _load()
+    scale = cm._coupling_scale_2d()
+    assert 0.05 < scale < 0.5, (
+        f"the derived 2-D coupling scale is {scale:.6f}. Outside this range the two fixtures' crowds "
+        "are no longer the several-fold apart that motivates the correction, and the comparability "
+        "argument in `_smoke_problem_2d`'s docstring needs re-deriving rather than the bound relaxing."
+    )


### PR DESCRIPTION
Part of #1865, implementing the disposition agreed there: restate the 2-D capability fixture at a
coupling strength comparable to its 1-D sibling, so the cell measures what its docstring claims.

## Read this part first

**Three cells go `UNSUPPORTED` -> `PASS`, and no solver improved.** `fdm_upwind_2d`,
`fdm_centered_2d` and `fvm_muscl_2d` failed at the unscaled coupling and solve at the comparable
one. That is exactly the direction `--check-baseline`'s both-ways comparison exists to guard, so it
is stated in three places a future reader will meet it: this body, the baseline's own `_comment`, and
the fixture docstring.

**The configuration those cells used to fail at is no longer covered by the matrix.** It is the
aggregating regime — `f` rewards density, Lasry–Lions monotonicity fails, uniqueness is not
guaranteed, the Picard map is not a contraction — so "can this configuration solve at all" had no
answer to certify and the cells were red for a reason no code change could address. It stays on
#1865 and may earn a cell later, if the library gains an outer solver that makes the regime
answerable.

## What was wrong

`coupling=lambda m: m` reads the density directly. A probability density on a 2-D grid is
intrinsically peakier than the 1-D one carrying the same mass: **1.818 against 9.549** on these
fixtures. So the 2-D cells applied **5.3x** the interaction their 1-D sibling did, and the matrix
reported that difference as an effect of dimension — the one thing the cell exists to isolate.

The scale is `peak_1D / peak_2D`, **derived in code from the two fixtures**, not written down. A
literal would have to be maintained against both, and the first version of it, `1.8180 / 9.5495`,
was already wrong in the seventh digit — caught by the pin on its first run.

## The docstring claimed four false things

It said the fixture was the 1-D one *"unchanged in everything but dimension. Deliberately the same
Gaussian"*. Measured:

| quantity | 1-D | 2-D |
|:--|:--|:--|
| Gaussian | `exp(-10 r^2)` | `exp(-30 r^2)` |
| `T` | 1.0 | 0.2 |
| `Nt` | 10 | 6 |
| `sigma` | **0.0** | **0.4** |

All four stay; the new docstring tabulates them with reasons instead of repeating the claim. The
`sigma` row is load-bearing: the 1-D fixture runs at **zero diffusion**, the degenerate regime where
the Godunov residual is non-smooth and Newton can reach a non-viscosity branch (#1878). Lifting it
would make this cell a second instance of that problem rather than a test of dimension. Measured for
the same reason: a faithful lift runs `3.2 s` against this fixture's `3.9 s` and **still fails**, so
matching them buys honesty and no answer.

## Oracle

Deriving the scale in code makes "the constant equals its own derivation" a tautology, so
`tests/unit/test_capability_2d_coupling_scale.py` does not assert that. It asserts the property the
scale exists for — both crowds see the same `f(m)` — which fails the moment the scale stops being
applied. Mutation-verified: replacing the derived scale with `1.0` turns it red.

Worth recording because it nearly shipped green-looking and inert: two earlier versions of that
test's helper called `hamiltonian.coupling` and then `hamiltonian.evaluate_hamiltonian`, **neither of
which exists on `SeparableHamiltonian`**. Both assertions were red with `AttributeError` — for a
reason unrelated to what they test — and the mutation that removes the scale entirely produced the
*identical* red. Only running the mutation showed it. A test that fails for the wrong reason
discriminates nothing.

## Gate

`./scripts/local_ci.sh` — `5952 passed, 22 skipped, 21 xfailed`, `PASS no capability change vs
baseline`, `GATE GREEN`. `main` is 5950; +2 new tests. Baseline regenerated in this commit and
verified SHA-256 identical across a second regeneration.