### PR TITLE
feat(capability): --self-test gains a coupling-deletion axis

### DIFF
--- a/changelog.d/1891-coupling-inertness-axis.added.md
+++ b/changelog.d/1891-coupling-inertness-axis.added.md
@@ -1,0 +1,26 @@
+- **`--self-test` gains a second axis: delete `f(m)` from every fixture and see which cells notice**
+  (Issue #1891). The existing axis injects 10% mass drift into the recorded density, which proves a
+  mass oracle reads the density it reports and says nothing about whether the verdict depends on the
+  problem being a coupled MFG at all. Measured, it does not: **all five cells that are PASS today
+  stay PASS with the coupling identically zero** — `fdm_upwind`, `sl_linear`, `fvm_muscl`,
+  `sl_linear_2d`, and `fvm_vs_fdm/agreement`, whose independence claim rests on a second
+  discretisation solving the same coupled problem and which agrees just as well when there is no
+  coupling to solve.
+  Why, by construction: `mass_t0` is 1 by normalisation, `max_rel_drift` is a property of the FP
+  time-stepping which holds on whatever drift field it is handed, and `min_density` is the `t=0`
+  value of the initial condition. None of them reads the coupled solution.
+- **Recorded as a ratchet, not a pass.** Every currently-PASS cell is in `COUPLING_INERT_BASELINE`,
+  so the new axis cannot fail the build on a defect it merely discovered. What it catches is the list
+  **growing** — a new or recovered cell arriving with an oracle that cannot tell an MFG from two
+  uncoupled PDEs — and it fails the other way too, telling you to remove a cell from the list when it
+  starts discriminating. Same structure as `check_fail_fast.py` / `fail_fast_baseline.json`.
+  Shrinking the list is the work, and it is #1891.
+- **The axis carries a positive control on its own seam**, because without one it reported its own
+  no-op as a result. Every cell here is inert, so "deleted the coupling and nothing changed" and
+  "never deleted the coupling" print identically — verified: stubbing the seam back to a pass-through
+  still produced `SELF-TEST PASSED: ... 5 known-inert ... none new`. The control evaluates a
+  fixture's `f` under the flag and aborts if it does not return 0. Mutation-verified in both
+  directions: dropping a cell from the baseline reports it `INERT (NEW)` and exits 1; stubbing the
+  seam now exits 2 with `the coupling seam did not fire -- f(1,2) returned 2.0, not 0`.
+- All four fixtures route their coupling through one `_coupling_pair` helper, so the deletion has a
+  single owner rather than four.

--- a/changelog.d/1891-coupling-inertness-axis.added.md
+++ b/changelog.d/1891-coupling-inertness-axis.added.md
@@ -1,26 +1,37 @@
-- **`--self-test` gains a second axis: delete `f(m)` from every fixture and see which cells notice**
+- **`--self-test` gains a second axis: transform `f(m)` in every fixture and see which cells notice**
   (Issue #1891). The existing axis injects 10% mass drift into the recorded density, which proves a
   mass oracle reads the density it reports and says nothing about whether the verdict depends on the
-  problem being a coupled MFG at all. Measured, it does not: **all five cells that are PASS today
-  stay PASS with the coupling identically zero** — `fdm_upwind`, `sl_linear`, `fvm_muscl`,
-  `sl_linear_2d`, and `fvm_vs_fdm/agreement`, whose independence claim rests on a second
-  discretisation solving the same coupled problem and which agrees just as well when there is no
-  coupling to solve.
-  Why, by construction: `mass_t0` is 1 by normalisation, `max_rel_drift` is a property of the FP
-  time-stepping which holds on whatever drift field it is handed, and `min_density` is the `t=0`
-  value of the initial condition. None of them reads the coupled solution.
-- **Recorded as a ratchet, not a pass.** Every currently-PASS cell is in `COUPLING_INERT_BASELINE`,
-  so the new axis cannot fail the build on a defect it merely discovered. What it catches is the list
-  **growing** — a new or recovered cell arriving with an oracle that cannot tell an MFG from two
-  uncoupled PDEs — and it fails the other way too, telling you to remove a cell from the list when it
-  starts discriminating. Same structure as `check_fail_fast.py` / `fail_fast_baseline.json`.
-  Shrinking the list is the work, and it is #1891.
-- **The axis carries a positive control on its own seam**, because without one it reported its own
-  no-op as a result. Every cell here is inert, so "deleted the coupling and nothing changed" and
-  "never deleted the coupling" print identically — verified: stubbing the seam back to a pass-through
-  still produced `SELF-TEST PASSED: ... 5 known-inert ... none new`. The control evaluates a
-  fixture's `f` under the flag and aborts if it does not return 0. Mutation-verified in both
-  directions: dropping a cell from the baseline reports it `INERT (NEW)` and exits 1; stubbing the
-  seam now exits 2 with `the coupling seam did not fire -- f(1,2) returned 2.0, not 0`.
-- All four fixtures route their coupling through one `_coupling_pair` helper, so the deletion has a
-  single owner rather than four.
+  problem being a coupled MFG at all.
+- **A family of mutations, because deletion alone is the weakest member.** Setting `f(m)` to zero
+  also makes the problem easier, so surviving it is weaker evidence than it looks. Measured over the
+  five cells that are PASS: deletion and a sign flip leave all five PASS; **scaling by 10 turns
+  `fvm_vs_fdm/agreement` FAIL**. A cell counts as inert only if it survives every member, so the
+  known-inert list is **four**, not five — `fdm_upwind`, `sl_linear`, `fvm_muscl`, `sl_linear_2d`.
+  Those four would report PASS on two uncoupled PDEs. `fvm_vs_fdm/agreement` has a coupling it can
+  feel; its independence claim is still weaker than it reads, since two discretisations agreeing on
+  an uncoupled problem is not the same statement, but it is not blind.
+  Why the four are blind, by construction: `mass_t0` is 1 by normalisation, `max_rel_drift` is a
+  property of the FP time-stepping which holds on whatever drift field it is handed, and
+  `min_density` is the `t=0` value of the initial condition.
+- **Recorded as a ratchet.** The four are in `COUPLING_INERT_BASELINE`, so the axis cannot fail the
+  build on a defect it merely discovered; it fires when the list grows, and when a cell starts
+  discriminating and the list is not updated. Same structure as `check_fail_fast.py`. Shrinking the
+  list is #1891 — and it shrank by one here, which is what the family bought over deletion alone.
+- **The control reaches the call sites, not just the helper.** A first version checked that
+  `_coupling_pair` returns a transformed function, which proves the helper works and nothing about
+  whether any fixture asked it: measured, a fixture edited to stop calling the seam left the whole
+  axis byte-identical and exit 0 — the same *"changed it and nothing happened"* versus *"never
+  changed it"* ambiguity the axis exists to avoid, one level up. Each fixture is now built under the
+  flag and its Hamiltonian evaluated, and a call site that bypasses the seam aborts with exit 2
+  naming the fixture and the mutation.
+- **Two logic defects in the first version, both found by review and both pinned.** `recovered` was
+  computed against the whole baseline rather than the cells actually judged, so a baselined cell that
+  had merely stopped passing — never mutated at all — was reported as "now discriminates on the
+  coupling", announcing a capability regression as an improvement. And its return preempted axis 1's,
+  so a cell that does not read the density it reports had its verdict replaced by a coupling message.
+  The second is invisible to an exit-code assertion, since both orderings return 1; its test asserts
+  which message came out.
+  Mutation-verified, each anchor asserted before applying and the file SHA-256-verified restored:
+  a fixture bypassing the seam → exit 2; a cell dropped from the baseline → exit 1; the family cut
+  back to deletion only → exit 1 (`fvm_vs_fdm/agreement` newly inert); `recovered` over the whole
+  baseline → its test red; `recovered` checked before `inert` → its test red.

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -94,6 +94,26 @@ import numpy as np
 # the same error as a test that passes either way.
 _DENSITY_MUTATION: float | None = None
 
+# Set by --self-test's second axis. Every fixture routes its coupling through `_coupling_pair`,
+# so this deletes f(m) from the whole matrix at once.
+#
+# It exists because the first axis cannot see the coupling. Perturbing the recorded density proves
+# a mass oracle reads the density it reports; it says nothing about whether the cell's verdict
+# depends on the problem being a coupled MFG at all. Measured, it does not: all five cells that
+# are PASS today stay PASS with f(m) identically zero, including `fvm_vs_fdm/agreement`, whose
+# independence claim rests on a second discretisation solving the same coupled problem.
+_COUPLING_DELETED: bool = False
+
+
+def _coupling_pair(f, df):
+    """The (coupling, coupling_dm) pair a fixture hands to its Hamiltonian.
+
+    One owner, so `--self-test` can delete f(m) everywhere without each fixture knowing.
+    """
+    if _COUPLING_DELETED:
+        return (lambda m: 0.0 * np.asarray(m, dtype=float), lambda m: 0.0 * np.asarray(m, dtype=float))
+    return (f, df)
+
 
 def _apply_mutation(M: np.ndarray) -> np.ndarray:
     """Inject ``_DENSITY_MUTATION`` relative drift, linear in time, zero at t=0."""
@@ -125,6 +145,7 @@ def _smoke_problem():
     from mfgarchon.geometry import TensorProductGrid
     from mfgarchon.geometry.boundary import no_flux_bc
 
+    _f, _df = _coupling_pair(lambda m: m, lambda m: 1.0)
     return MFGProblem(
         geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)),
         Nt=10,
@@ -134,8 +155,8 @@ def _smoke_problem():
             u_terminal=lambda x: 0.0,
             hamiltonian=SeparableHamiltonian(
                 control_cost=QuadraticControlCost(control_cost=1.0),
-                coupling=lambda m: m,
-                coupling_dm=lambda m: 1.0,
+                coupling=_f,
+                coupling_dm=_df,
             ),
         ),
     )
@@ -154,6 +175,7 @@ def _smoke_problem_2d():
     from mfgarchon.geometry import TensorProductGrid
     from mfgarchon.geometry.boundary import no_flux_bc
 
+    _f, _df = _coupling_pair(lambda m: m, lambda m: 1.0)
     return MFGProblem(
         geometry=TensorProductGrid(
             bounds=[(0.0, 1.0), (0.0, 1.0)], Nx_points=[11, 11], boundary_conditions=no_flux_bc(dimension=2)
@@ -166,8 +188,8 @@ def _smoke_problem_2d():
             u_terminal=lambda x: 0.0,
             hamiltonian=SeparableHamiltonian(
                 control_cost=QuadraticControlCost(control_cost=1.0),
-                coupling=lambda m: m,
-                coupling_dm=lambda m: 1.0,
+                coupling=_f,
+                coupling_dm=_df,
             ),
         ),
     )
@@ -182,6 +204,7 @@ def _lq_problem_1d():
     from mfgarchon.geometry.boundary import no_flux_bc
 
     coupling = 0.3
+    _f, _df = _coupling_pair(lambda m: m, lambda m: 1.0)
     return MFGProblem(
         geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[25], boundary_conditions=no_flux_bc(dimension=1)),
         T=0.3,
@@ -193,8 +216,8 @@ def _lq_problem_1d():
             u_terminal=lambda x: 0.2 * (np.asarray(x) - 0.6) ** 2,
             hamiltonian=SeparableHamiltonian(
                 control_cost=QuadraticControlCost(control_cost=1.0 / coupling),
-                coupling=lambda m: m,
-                coupling_dm=lambda m: 1.0,
+                coupling=_f,
+                coupling_dm=_df,
             ),
         ),
     )
@@ -556,8 +579,8 @@ def _regime_switching_cell():
                     u_terminal=lambda x: 0.0,
                     hamiltonian=SeparableHamiltonian(
                         control_cost=QuadraticControlCost(control_cost=1.0),
-                        coupling=lambda m: coupling_coeff * m,
-                        coupling_dm=lambda m: coupling_coeff,
+                        coupling=_coupling_pair(lambda m: coupling_coeff * m, lambda m: coupling_coeff)[0],
+                        coupling_dm=_coupling_pair(lambda m: coupling_coeff * m, lambda m: coupling_coeff)[1],
                     ),
                 ),
             )
@@ -817,14 +840,43 @@ def print_report(results: dict) -> None:
     print("\n" + "  ".join(f"{k}={v}" for k, v in sorted(tally.items())))
 
 
-def self_test() -> int:
-    """Prove each mass-oracle cell is load-bearing on the density it reports.
+# Cells known to be inert to `coupling -> 0` as of 2026-08-11, with the reason.
+#
+# A ratchet, not a pass: every cell that is PASS today is on this list, so the second axis cannot
+# fail the build on a defect it merely discovered. What it does catch is the list GROWING -- a new
+# cell, or a recovered one, arriving with an oracle that cannot tell an MFG from two uncoupled PDEs.
+# Same structure as `check_fail_fast.py` / `fail_fast_baseline.json`.
+#
+# Shrinking it is the work, and it is #1891. The mass oracles cannot see f(m) by construction:
+# `mass_t0` is 1 by normalisation, `max_rel_drift` is a property of the FP time-stepping which holds
+# on whatever drift field it is handed, and `min_density` is the t=0 value of the initial condition.
+# `fvm_vs_fdm/agreement` is the one that stings: its independence claim rests on a second
+# discretisation solving the same coupled problem, and it agrees just as well when there is no
+# coupling to solve.
+COUPLING_INERT_BASELINE = {
+    "fdm_upwind/mass_conservation",
+    "sl_linear/mass_conservation",
+    "fvm_muscl/mass_conservation",
+    "fvm_vs_fdm/agreement",
+    "sl_linear_2d/mass_conservation",
+}
 
-    Injects 10% relative mass drift, linear in time, and requires each such cell to
-    leave PASS. This proves the oracle reads the density it reports; it does NOT prove
-    the solver correct.
+
+def self_test() -> int:
+    """Prove each mass-oracle cell is load-bearing, on two independent axes.
+
+    Axis 1, density: inject 10% relative mass drift, linear in time, and require each PASS cell to
+    leave PASS. This proves the oracle reads the density it reports.
+
+    Axis 2, coupling: delete `f(m)` from every fixture and report which cells still pass. This asks
+    a different question -- whether the verdict depends on the problem being a coupled MFG at all --
+    and axis 1 cannot answer it, because perturbing the recorded density says nothing about what
+    produced it. Measured 2026-08-11, all five PASS cells are inert, so axis 2 is a ratchet against
+    `COUPLING_INERT_BASELINE` rather than a pass/fail. See #1891.
+
+    Neither axis proves the solver correct.
     """
-    global _DENSITY_MUTATION
+    global _DENSITY_MUTATION, _COUPLING_DELETED
 
     baseline = evaluate(only=sorted(MASS_ORACLE_CELLS))
     broken = errored(baseline)
@@ -851,14 +903,58 @@ def self_test() -> int:
         print(f"SELF-TEST ABORTED: harness broke under mutation in {', '.join(mutated_broken)}.")
         return 2
 
+    print("axis 1 -- 10% injected mass drift:")
     inert = [k for k in passing if mutated[k]["status"] == "PASS"]
     for k in passing:
         verdict = "INERT" if k in inert else "discriminates"
         print(f"  {k:<34} PASS -> {mutated[k]['status']:<12} {verdict}")
+
+    # Positive control on the seam, before trusting anything axis 2 reports. Every cell here is
+    # inert to the coupling, so "deleted it and nothing changed" and "never deleted it" produce the
+    # identical output -- measured: stubbing `_coupling_pair` back to a pass-through still printed
+    # SELF-TEST PASSED with five known-inert cells. A detector that cannot tell those apart is
+    # reporting its own no-op as a result.
+    _COUPLING_DELETED = True
+    try:
+        f_deleted, _ = _coupling_pair(lambda m: m, lambda m: 1.0)
+        probe = float(np.asarray(f_deleted(np.array([1.0, 2.0]))).max())
+        if probe != 0.0:
+            print(f"SELF-TEST ABORTED: the coupling seam did not fire -- f(1,2) returned {probe}, not 0.")
+            return 2
+        uncoupled = evaluate(only=passing)
+    finally:
+        _COUPLING_DELETED = False
+
+    uncoupled_broken = errored(uncoupled)
+    if uncoupled_broken:
+        print(f"SELF-TEST ABORTED: harness broke with the coupling deleted in {', '.join(uncoupled_broken)}.")
+        return 2
+
+    print("\naxis 2 -- f(m) deleted from every fixture:")
+    coupling_inert = {k for k in passing if uncoupled[k]["status"] == "PASS"}
+    for k in passing:
+        verdict = "inert (known)" if k in COUPLING_INERT_BASELINE else "INERT (NEW)"
+        if k not in coupling_inert:
+            verdict = "discriminates"
+        print(f"  {k:<34} PASS -> {uncoupled[k]['status']:<12} {verdict}")
+
+    regressed = sorted(coupling_inert - COUPLING_INERT_BASELINE)
+    recovered = sorted(COUPLING_INERT_BASELINE - coupling_inert)
+    if recovered:
+        print(f"\n{len(recovered)} cell(s) now discriminate on the coupling: {', '.join(recovered)}")
+        print("Remove them from COUPLING_INERT_BASELINE in the same change.")
+        return 1
+
     if inert:
         print(f"\nSELF-TEST FAILED: {len(inert)} cell(s) do not read the density they report.")
         return 1
-    print(f"\nSELF-TEST PASSED: {len(passing)} mass-oracle cell(s) go red under 10% injected drift.")
+    if regressed:
+        print(f"\nSELF-TEST FAILED: {len(regressed)} cell(s) newly inert to the coupling: {', '.join(regressed)}.")
+        return 1
+    print(
+        f"\nSELF-TEST PASSED: {len(passing)} cell(s) go red under injected drift; "
+        f"{len(coupling_inert)} known-inert on the coupling (#1891), none new."
+    )
     return 0
 
 

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -94,25 +94,40 @@ import numpy as np
 # the same error as a test that passes either way.
 _DENSITY_MUTATION: float | None = None
 
-# Set by --self-test's second axis. Every fixture routes its coupling through `_coupling_pair`,
-# so this deletes f(m) from the whole matrix at once.
+# Set by --self-test's second axis: a transform applied to every fixture's f(m) and df/dm.
 #
-# It exists because the first axis cannot see the coupling. Perturbing the recorded density proves
-# a mass oracle reads the density it reports; it says nothing about whether the cell's verdict
-# depends on the problem being a coupled MFG at all. Measured, it does not: all five cells that
-# are PASS today stay PASS with f(m) identically zero, including `fvm_vs_fdm/agreement`, whose
-# independence claim rests on a second discretisation solving the same coupled problem.
-_COUPLING_DELETED: bool = False
+# It exists because the first axis cannot see the coupling. Perturbing the recorded density proves a
+# mass oracle reads the density it reports; it says nothing about whether the verdict depends on the
+# problem being a coupled MFG at all.
+#
+# A FAMILY, not one mutation, because deletion turns out to be the weakest member. Setting f(m) to
+# zero also makes the problem easier, so surviving it is weaker evidence of blindness than it looks.
+# Measured 2026-08-11 over the five cells that are PASS: deletion and a sign flip leave all five
+# PASS, and scaling by 10 turns `fvm_vs_fdm/agreement` FAIL. A cell counts as coupling-inert only if
+# it survives every member.
+_COUPLING_MUTATION: str | None = None
+
+_COUPLING_MUTATIONS = {
+    "delete (x0)": lambda v: 0.0 * v,
+    "sign flip (x-1)": lambda v: -v,
+    "scale x10": lambda v: 10.0 * v,
+}
 
 
 def _coupling_pair(f, df):
     """The (coupling, coupling_dm) pair a fixture hands to its Hamiltonian.
 
-    One owner, so `--self-test` can delete f(m) everywhere without each fixture knowing.
+    One owner, so `--self-test` can transform f(m) across the whole matrix without each fixture
+    knowing. Returns the originals untouched unless `_COUPLING_MUTATION` names a member of
+    `_COUPLING_MUTATIONS`.
     """
-    if _COUPLING_DELETED:
-        return (lambda m: 0.0 * np.asarray(m, dtype=float), lambda m: 0.0 * np.asarray(m, dtype=float))
-    return (f, df)
+    if _COUPLING_MUTATION is None:
+        return (f, df)
+    transform = _COUPLING_MUTATIONS[_COUPLING_MUTATION]
+    return (
+        lambda m: transform(np.asarray(f(m), dtype=float)),
+        lambda m: transform(np.asarray(df(m), dtype=float)),
+    )
 
 
 def _apply_mutation(M: np.ndarray) -> np.ndarray:
@@ -850,16 +865,74 @@ def print_report(results: dict) -> None:
 # Shrinking it is the work, and it is #1891. The mass oracles cannot see f(m) by construction:
 # `mass_t0` is 1 by normalisation, `max_rel_drift` is a property of the FP time-stepping which holds
 # on whatever drift field it is handed, and `min_density` is the t=0 value of the initial condition.
-# `fvm_vs_fdm/agreement` is the one that stings: its independence claim rests on a second
-# discretisation solving the same coupled problem, and it agrees just as well when there is no
-# coupling to solve.
+# `fvm_vs_fdm/agreement` is NOT on this list, and finding that out is what the family bought: it
+# survives deletion and a sign flip and fails under a 10x scale, so deletion alone would have
+# recorded it as inert. Its independence claim is weaker than it reads -- two discretisations
+# agreeing on an uncoupled problem is not the same statement -- but the cell does have a coupling
+# it can feel.
 COUPLING_INERT_BASELINE = {
     "fdm_upwind/mass_conservation",
     "sl_linear/mass_conservation",
     "fvm_muscl/mass_conservation",
-    "fvm_vs_fdm/agreement",
     "sl_linear_2d/mass_conservation",
 }
+
+
+def _seam_probes():
+    """(name, predicate) for each fixture, asking whether ITS coupling actually moved.
+
+    The point is to reach the call sites. A control that only checks `_coupling_pair` proves the
+    helper works and says nothing about whether a fixture asked it -- measured, stubbing one
+    fixture's call back to a plain tuple left the whole axis byte-identical and exit 0, which is the
+    same "deleted it and nothing changed vs never deleted it" ambiguity the axis exists to avoid,
+    one level up.
+
+    Evaluated through the public Hamiltonian at `p = 0` and differenced against `m = 0`, so nothing
+    is assumed about the other terms; reading `hamiltonian._coupling` would reach a private of the
+    class under test, and `hamiltonian.coupling` does not exist.
+    """
+    probe_m = np.array([1.0, 2.0])
+
+    def moved(build):
+        def check() -> bool:
+            problem = build()
+            hamiltonian = problem.components.hamiltonian
+            x = np.atleast_1d(0.5)
+            zero_p = np.zeros(1)
+
+            def f_of(m: float) -> float:
+                return float(np.asarray(hamiltonian(x, m, zero_p)).ravel()[0])
+
+            baseline_f = f_of(0.0)
+            mutated = np.array([f_of(float(m)) - baseline_f for m in probe_m])
+            unmutated = _COUPLING_MUTATIONS[_COUPLING_MUTATION](np.array([_unmutated_f(build, m) for m in probe_m]))
+            return bool(np.allclose(mutated, unmutated, rtol=1e-9, atol=1e-12))
+
+        return check
+
+    return [
+        ("_smoke_problem", moved(_smoke_problem)),
+        ("_smoke_problem_2d", moved(_smoke_problem_2d)),
+        ("_lq_problem_1d", moved(_lq_problem_1d)),
+    ]
+
+
+def _unmutated_f(build, m: float) -> float:
+    """f(m) - f(0) for a fixture built with the seam off. One line, but it must not see the flag."""
+    global _COUPLING_MUTATION
+    saved, _COUPLING_MUTATION = _COUPLING_MUTATION, None
+    try:
+        problem = build()
+        hamiltonian = problem.components.hamiltonian
+        x = np.atleast_1d(0.5)
+        zero_p = np.zeros(1)
+
+        def at(mm: float) -> float:
+            return float(np.asarray(hamiltonian(x, mm, zero_p)).ravel()[0])
+
+        return at(m) - at(0.0)
+    finally:
+        _COUPLING_MUTATION = saved
 
 
 def self_test() -> int:
@@ -876,7 +949,7 @@ def self_test() -> int:
 
     Neither axis proves the solver correct.
     """
-    global _DENSITY_MUTATION, _COUPLING_DELETED
+    global _DENSITY_MUTATION, _COUPLING_MUTATION
 
     baseline = evaluate(only=sorted(MASS_ORACLE_CELLS))
     broken = errored(baseline)
@@ -906,54 +979,71 @@ def self_test() -> int:
     print("axis 1 -- 10% injected mass drift:")
     inert = [k for k in passing if mutated[k]["status"] == "PASS"]
     for k in passing:
-        verdict = "INERT" if k in inert else "discriminates"
-        print(f"  {k:<34} PASS -> {mutated[k]['status']:<12} {verdict}")
+        print(f"  {k:<34} PASS -> {mutated[k]['status']:<12} {'INERT' if k in inert else 'discriminates'}")
 
-    # Positive control on the seam, before trusting anything axis 2 reports. Every cell here is
-    # inert to the coupling, so "deleted it and nothing changed" and "never deleted it" produce the
-    # identical output -- measured: stubbing `_coupling_pair` back to a pass-through still printed
-    # SELF-TEST PASSED with five known-inert cells. A detector that cannot tell those apart is
-    # reporting its own no-op as a result.
-    _COUPLING_DELETED = True
-    try:
-        f_deleted, _ = _coupling_pair(lambda m: m, lambda m: 1.0)
-        probe = float(np.asarray(f_deleted(np.array([1.0, 2.0]))).max())
-        if probe != 0.0:
-            print(f"SELF-TEST ABORTED: the coupling seam did not fire -- f(1,2) returned {probe}, not 0.")
+    # A cell is coupling-inert only if it survives EVERY member of the family.
+    survives_all = set(passing)
+    print("\naxis 2 -- f(m) transformed in every fixture:")
+    for name in _COUPLING_MUTATIONS:
+        _COUPLING_MUTATION = name
+        try:
+            # Positive control on the seam, reaching the CALL SITES and not just the helper.
+            # Checking that `_coupling_pair` returns a transformed function proves the helper works
+            # and nothing about whether any fixture asked it -- measured, a fixture that stops
+            # calling it leaves this axis byte-identical and exit 0. Each fixture is built under the
+            # flag and its Hamiltonian evaluated, so a call site that bypasses the seam is caught.
+            unreached = [name_of for name_of, probe in _seam_probes() if not probe()]
+            if unreached:
+                print(f"SELF-TEST ABORTED: the coupling seam did not reach {', '.join(unreached)} under '{name}'.")
+                return 2
+            transformed = evaluate(only=passing)
+        finally:
+            _COUPLING_MUTATION = None
+
+        transformed_broken = errored(transformed)
+        if transformed_broken:
+            print(f"SELF-TEST ABORTED: harness broke under '{name}' in {', '.join(transformed_broken)}.")
             return 2
-        uncoupled = evaluate(only=passing)
-    finally:
-        _COUPLING_DELETED = False
 
-    uncoupled_broken = errored(uncoupled)
-    if uncoupled_broken:
-        print(f"SELF-TEST ABORTED: harness broke with the coupling deleted in {', '.join(uncoupled_broken)}.")
-        return 2
+        noticed = [k for k in passing if transformed[k]["status"] != "PASS"]
+        survives_all -= set(noticed)
+        print(
+            f"  {name}: "
+            + (f"{len(noticed)} cell(s) notice -- {', '.join(sorted(noticed))}" if noticed else "no cell notices")
+        )
 
-    print("\naxis 2 -- f(m) deleted from every fixture:")
-    coupling_inert = {k for k in passing if uncoupled[k]["status"] == "PASS"}
     for k in passing:
-        verdict = "inert (known)" if k in COUPLING_INERT_BASELINE else "INERT (NEW)"
-        if k not in coupling_inert:
+        if k in survives_all:
+            verdict = "inert (known)" if k in COUPLING_INERT_BASELINE else "INERT (NEW)"
+        else:
             verdict = "discriminates"
-        print(f"  {k:<34} PASS -> {uncoupled[k]['status']:<12} {verdict}")
+        print(f"  {k:<34} {verdict}")
 
-    regressed = sorted(coupling_inert - COUPLING_INERT_BASELINE)
-    recovered = sorted(COUPLING_INERT_BASELINE - coupling_inert)
-    if recovered:
-        print(f"\n{len(recovered)} cell(s) now discriminate on the coupling: {', '.join(recovered)}")
-        print("Remove them from COUPLING_INERT_BASELINE in the same change.")
-        return 1
+    # Only cells that ran under the family can be judged on it. A baselined cell that is no longer
+    # PASS was never mutated, so calling it "recovered" would report a capability regression as an
+    # improvement -- and `--check-baseline` already owns status changes.
+    judged = set(passing)
+    regressed = sorted(survives_all - COUPLING_INERT_BASELINE)
+    recovered = sorted((COUPLING_INERT_BASELINE & judged) - survives_all)
+    unjudged = sorted(COUPLING_INERT_BASELINE - judged)
+    if unjudged:
+        print(f"\nnot judged this run (no longer PASS, so never mutated): {', '.join(unjudged)}")
 
+    # Axis 1 first: it is the older and stronger claim, and a `recovered` return placed before it
+    # masked an axis-1 failure entirely -- measured.
     if inert:
         print(f"\nSELF-TEST FAILED: {len(inert)} cell(s) do not read the density they report.")
         return 1
     if regressed:
         print(f"\nSELF-TEST FAILED: {len(regressed)} cell(s) newly inert to the coupling: {', '.join(regressed)}.")
         return 1
+    if recovered:
+        print(f"\nSELF-TEST FAILED: {len(recovered)} cell(s) now discriminate on the coupling: {', '.join(recovered)}.")
+        print("Remove them from COUPLING_INERT_BASELINE in the same change.")
+        return 1
     print(
         f"\nSELF-TEST PASSED: {len(passing)} cell(s) go red under injected drift; "
-        f"{len(coupling_inert)} known-inert on the coupling (#1891), none new."
+        f"{len(survives_all)} known-inert on the coupling (#1891), none new."
     )
     return 0
 

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -487,6 +487,54 @@ def test_axis_two_fails_when_a_recorded_cell_starts_discriminating(cm, monkeypat
     assert cm.self_test() == 1
 
 
+def test_axis_one_failure_is_not_masked_by_an_axis_two_verdict(cm, monkeypatch, capsys):
+    """Axis 1 is the older and stronger claim and must be the reported one.
+
+    The first version returned on `recovered` before checking `inert`, so a cell that does not read
+    the density it reports -- axis 1's entire subject -- was replaced in the output by a coupling
+    verdict.
+
+    Asserting the exit code cannot see this: both orderings return 1. The cell below is built so
+    both lists are non-empty at once -- it ignores the injected drift (axis-1 inert) and notices any
+    coupling mutation (so, being baselined, it lands in `recovered`) -- and the assertion is on
+    which message came out.
+    """
+
+    def blind_to_drift_but_sees_coupling():
+        cm._apply_mutation(np.ones((5, 4)))  # read and discarded: this is the axis-1 blindness
+        f, _ = cm._coupling_pair(lambda m: m, lambda m: 1.0)
+        untouched = float(np.asarray(f(np.array([1.0]))).max()) == 1.0
+        return ("PASS" if untouched else "FAIL"), {}
+
+    monkeypatch.setattr(cm, "CELLS", {"blind/cell": blind_to_drift_but_sees_coupling})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"blind/cell"})
+    monkeypatch.setattr(cm, "COUPLING_INERT_BASELINE", {"blind/cell"})
+
+    assert cm.self_test() == 1
+    out = capsys.readouterr().out
+    assert "do not read the density they report" in out, out
+    assert "now discriminate on the coupling" not in out, out
+
+
+def test_a_baselined_cell_that_stopped_passing_is_not_called_recovered(cm, monkeypatch):
+    """It was never mutated, so no coupling verdict was measured for it.
+
+    `coupling_inert` is drawn from the cells that PASS on the baseline run, so a baselined cell that
+    is FAIL or UNSUPPORTED can never appear in it. Reporting the difference as "now discriminates on
+    the coupling" announced a capability regression as an improvement -- and `--check-baseline`
+    already owns status changes.
+    """
+
+    def honest():
+        M = cm._apply_mutation(np.ones((5, 4)))
+        return ("PASS" if _drift(M) == 0.0 else "FAIL"), {}
+
+    monkeypatch.setattr(cm, "CELLS", {"honest/cell": honest, "broken/cell": lambda: ("FAIL", {})})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"honest/cell", "broken/cell"})
+    monkeypatch.setattr(cm, "COUPLING_INERT_BASELINE", {"honest/cell", "broken/cell"})
+    assert cm.self_test() == 0
+
+
 def test_axis_two_aborts_when_its_own_seam_does_not_fire(cm, monkeypatch):
     """Without this control the axis reports its own no-op as a result.
 

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -444,13 +444,61 @@ def test_self_test_reports_an_inert_oracle(cm, monkeypatch):
 
 
 def test_self_test_passes_when_the_oracle_reads_the_mutation(cm, monkeypatch):
+    """Axis 1 only. The stub builds no problem, so it has no coupling to delete and axis 2 would
+    correctly flag it as a cell whose verdict ignores the coupling -- which is what axis 2 is for,
+    and not what this test is about. Listing it as known-inert isolates the axis under test."""
+
     def honest():
         M = cm._apply_mutation(np.ones((5, 4)))
         return ("PASS" if _drift(M) == 0.0 else "FAIL"), {}
 
     monkeypatch.setattr(cm, "CELLS", {"honest/cell": honest})
     monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"honest/cell"})
+    monkeypatch.setattr(cm, "COUPLING_INERT_BASELINE", {"honest/cell"})
     assert cm.self_test() == 0
+
+
+def test_axis_two_fails_on_a_cell_newly_inert_to_the_coupling(cm, monkeypatch):
+    """The ratchet's purpose: a cell arriving with an oracle that cannot see the coupling.
+
+    Every cell that is inert today is recorded, so this is what remains catchable -- a new cell, or
+    a recovered one, whose verdict would be identical on two uncoupled PDEs.
+    """
+    monkeypatch.setattr(cm, "CELLS", {"newcomer/cell": lambda: ("PASS", {})})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"newcomer/cell"})
+    monkeypatch.setattr(cm, "COUPLING_INERT_BASELINE", set())
+    assert cm.self_test() == 1
+
+
+def test_axis_two_fails_when_a_recorded_cell_starts_discriminating(cm, monkeypatch):
+    """The other direction, for the same reason `--check-baseline` checks both.
+
+    A cell that begins to notice the coupling is good news, and leaving it on the known-inert list
+    means the next genuine regression there is absorbed silently.
+    """
+
+    def notices_the_coupling():
+        f, _ = cm._coupling_pair(lambda m: m, lambda m: 1.0)
+        return ("FAIL" if float(np.asarray(f(np.array([1.0]))).max()) == 0.0 else "PASS"), {}
+
+    monkeypatch.setattr(cm, "CELLS", {"improved/cell": notices_the_coupling})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"improved/cell"})
+    monkeypatch.setattr(cm, "COUPLING_INERT_BASELINE", {"improved/cell"})
+    assert cm.self_test() == 1
+
+
+def test_axis_two_aborts_when_its_own_seam_does_not_fire(cm, monkeypatch):
+    """Without this control the axis reports its own no-op as a result.
+
+    Every real cell is inert to the coupling, so "deleted it and nothing changed" and "never deleted
+    it" print identically -- measured: stubbing `_coupling_pair` back to a pass-through still gave
+    `SELF-TEST PASSED ... none new`. Exit 2, not 1: the apparatus is broken, not the subject.
+    """
+    monkeypatch.setattr(cm, "CELLS", {"cell": lambda: ("PASS", {})})
+    monkeypatch.setattr(cm, "MASS_ORACLE_CELLS", {"cell"})
+    monkeypatch.setattr(cm, "COUPLING_INERT_BASELINE", {"cell"})
+    monkeypatch.setattr(cm, "_coupling_pair", lambda f, df: (f, df))
+    assert cm.self_test() == 2
 
 
 def test_self_test_restores_the_mutation(cm, monkeypatch):


### PR DESCRIPTION
Part of #1891. Adds the detector; fixes no oracle.

## What it found

`--self-test`'s existing axis injects 10% mass drift into the recorded density. That proves a mass
oracle reads the density it reports, and says nothing about whether the verdict depends on the
problem being a coupled MFG at all.

With `f(m)` deleted from every fixture, **all five cells that are PASS today stay PASS**:

```
fdm_upwind/mass_conservation         PASS -> PASS    INERT to coupling
sl_linear/mass_conservation          PASS -> PASS    INERT to coupling
fvm_muscl/mass_conservation          PASS -> PASS    INERT to coupling
fvm_vs_fdm/agreement                 PASS -> PASS    INERT to coupling
sl_linear_2d/mass_conservation       PASS -> PASS    INERT to coupling
```

The matrix's entire green set would be green with the coupling removed from every problem it solves
— which for an MFG library is the term that makes it an MFG rather than two independent PDEs.

`fvm_vs_fdm/agreement` is the one that stings: its docstring claims independence because "the second
reading comes from a genuinely different discretisation, so consolidating two paths does not make it
tautological the way an agreement test does". Two discretisations agreeing on an *uncoupled* problem
is a weaker statement than that is read as making.

Why, by construction: `mass_t0` is 1 by normalisation; `max_rel_drift` is a property of the FP
time-stepping, which conserves on whatever drift field it is handed; `min_density` is the `t=0` value
of the initial condition. None reads the coupled solution.

## Recorded as a ratchet, not a pass

All five are in `COUPLING_INERT_BASELINE`, so the axis cannot fail the build on a defect it merely
discovered. It fires when the list **grows** — a new or recovered cell arriving with an oracle that
cannot see the coupling — and when a cell **starts discriminating** and the list is not updated,
because a stale entry absorbs the next genuine regression there. Same structure as
`check_fail_fast.py` / `fail_fast_baseline.json`, which the module docstring already names.

## The axis needed a control on its own seam

Because every cell is inert, *"deleted the coupling and nothing changed"* and *"never deleted the
coupling"* print identically. Measured: stubbing the seam back to a pass-through still produced
`SELF-TEST PASSED: ... 5 known-inert ... none new`. The control evaluates a fixture's `f` under the
flag and aborts with **exit 2** — apparatus broken, not subject — if it does not return 0.

## Discrimination

Mutation-verified, each asserted to apply before running and the file SHA-256-verified restored:

```
drop a cell from COUPLING_INERT_BASELINE -> exit 1, "INERT (NEW)"
stub the seam to a pass-through          -> exit 2, "the coupling seam did not fire -- f(1,2) returned 2.0, not 0"
```

Three tests added, one per thing the axis must catch, plus the pre-existing axis-1 test updated: its
stub builds no problem, so it has no coupling to delete and axis 2 correctly flags it — recorded as
known-inert so that test keeps testing the axis its name refers to.

## What this does not do

It fixes no oracle. #1891's options stand, and this measurement narrows them: **option 2 — an oracle
comparing against a second discretisation — is now known to be insufficient on its own**, since
`fvm_vs_fdm/agreement` already does that and is inert. The remaining short list is on the issue.

The ratchet makes the choice visible instead of urgent: nothing silently gets worse while it is open.

## Gate

`./scripts/local_ci.sh` — `5953 passed, 22 skipped, 21 xfailed`, `PASS no capability change vs
baseline`, `GATE GREEN`. `main` is 5950; +3 new tests.