### PR TITLE
fix(capability): a cell must require the coupled iteration to have converged

### DIFF
--- a/changelog.d/1891-gate-picard-converged.changed.md
+++ b/changelog.d/1891-gate-picard-converged.changed.md
@@ -5,11 +5,17 @@
   First, #1865 had already required it in as many words: *"any restatement of the 2-D fixture must
   assert convergence, or the cell measures whether the FP time-stepper conserves mass (which it does
   regardless) rather than whether the configuration solves."*
-  Second, and new: it is **the only recorded field measured to depend on the coupling**. Under the
-  mutation family added in #1892, deleting `f(m)` makes `fdm_upwind` and `sl_linear` converge in
-  **one** sweep against five, and a 10x coupling stops `fvm_vs_fdm/agreement` converging at all (40
-  sweeps) — while `mass_t0`, `max_rel_drift` and `min_density` do not move at all. A verdict without
-  it cannot tell an MFG from two uncoupled PDEs, which is what #1891 is about.
+  Second: a solve that has not reached a fixed point has not solved, which is what a cell claims to
+  certify.
+  *An earlier version of this entry argued that `picard_converged` is "the only recorded field
+  measured to depend on the coupling", with `mass_t0`, `max_rel_drift` and `min_density` "not moving
+  at all". That was asserted from measuring one field. A full-artifact diff over the mutation family
+  shows `min_density` moving in **four** cells against this field's two, and `max_drift`, `mass_max`,
+  `max_rel_drift`, `rel_l2_*` and `worst` moving as well. The narrower true statement: of the fields
+  a verdict reads, only `worst` — in the agreement cell, at 10x — ever crosses its own threshold, so
+  four of the five coupled cells had a verdict no coupling mutation could move. Gating does not make
+  those four coupling-sensitive; it makes three of them honestly red. The coupling-sensitivity
+  argument was wrong and is withdrawn; the correctness argument stands on its own.*
 - **Three cells go PASS -> FAIL, and they are honestly red.** `fdm_upwind` (5 sweeps),
   `sl_linear` (5) and `sl_linear_2d` (3, its budget) all record `picard_converged: false`. Each
   carries an `intended` note with what is known: `fdm_upwind` does not converge at 100, 200 or 400
@@ -26,3 +32,19 @@
   as `inert (known)` instead.
 - One helper, `_solved`, owns the new conjunct across all four verdicts. Absent means not applicable:
   a cell that runs no coupled iteration carries no such field and is unaffected.
+- **The fifth coupled cell was left out and is now included.** `fvm_vs_fdm/agreement` runs two
+  coupled iterations and records both flags, and its verdict was `worst < AGREEMENT_RTOL` alone — so
+  it could certify PASS with neither iteration converged, demonstrated by cutting its budget to 2
+  (`PASS`, `worst=0.0343`, both flags `false`). It now carries the conjunct too. This also makes
+  `_solved`'s prefixed-field branches reachable: before, all four call sites passed the unprefixed
+  name and the `fdm_picard_converged` fallback and `fvm_picard_converged` conjunct were dead code
+  written for an artifact shape nothing sent them.
+- **The self-test's "not judged this run" line never printed.** It computed
+  `COUPLING_INERT_BASELINE - judged`, and pruning the waiver list to one entry removed exactly the
+  cells the prose said it named. It is now computed over `MASS_ORACLE_CELLS - judged`, which is the
+  right set anyway: a cell that is not PASS has no coupling verdict this run whether or not it was
+  ever waived. Eight cells now appear there.
+- **The `sl_linear_2d` note said "unmeasured" about something this file already answers.** It
+  converges at iteration 32 given a budget of 35 or 60, and `capability_matrix.py`'s module docstring
+  says so twenty lines above the helper that gates the cell. The note is corrected: the cell is red
+  on its 3-sweep budget rather than on the scheme.

--- a/changelog.d/1891-gate-picard-converged.changed.md
+++ b/changelog.d/1891-gate-picard-converged.changed.md
@@ -1,0 +1,28 @@
+- **A capability cell now requires the coupled iteration to have converged** (Issue #1891).
+  `picard_converged` was recorded but left out of the verdict by #1871, on the stated ground that
+  gating it "turns three long-standing greens red" — a transition cost, not a correctness argument.
+  Two things settle it now.
+  First, #1865 had already required it in as many words: *"any restatement of the 2-D fixture must
+  assert convergence, or the cell measures whether the FP time-stepper conserves mass (which it does
+  regardless) rather than whether the configuration solves."*
+  Second, and new: it is **the only recorded field measured to depend on the coupling**. Under the
+  mutation family added in #1892, deleting `f(m)` makes `fdm_upwind` and `sl_linear` converge in
+  **one** sweep against five, and a 10x coupling stops `fvm_vs_fdm/agreement` converging at all (40
+  sweeps) — while `mass_t0`, `max_rel_drift` and `min_density` do not move at all. A verdict without
+  it cannot tell an MFG from two uncoupled PDEs, which is what #1891 is about.
+- **Three cells go PASS -> FAIL, and they are honestly red.** `fdm_upwind` (5 sweeps),
+  `sl_linear` (5) and `sl_linear_2d` (3, its budget) all record `picard_converged: false`. Each
+  carries an `intended` note with what is known: `fdm_upwind` does not converge at 100, 200 or 400
+  sweeps either and its inner half is #1878; `sl_linear` fails on all four criterion arms with the
+  density arm not descending (#1880); `sl_linear_2d` exhausts a 3-sweep budget, which is also why it
+  is the one cell whose convergence flag cannot move under the coupling mutations. `--check-baseline`
+  records the change in the same commit and reports **0 of 9 non-PASS cells unexplained**.
+- **The known-inert list falls from four to one.** Only `fvm_muscl/mass_conservation` remains: it
+  converges (18 sweeps) and its verdict still survives every member of the family. The three that
+  left are no longer PASS, so they are never mutated and cannot be judged — reported as such by the
+  self-test rather than folded into a verdict, which is the `recovered` defect #1892 fixed, working
+  on a real case. They are deliberately **not** kept listed against their return: a cell coming back
+  green should have to prove its oracle can see the coupling, and staying listed would let it arrive
+  as `inert (known)` instead.
+- One helper, `_solved`, owns the new conjunct across all four verdicts. Absent means not applicable:
+  a cell that runs no coupled iteration carries no such field and is unaffected.

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -145,7 +145,7 @@
         "picard_iterations": 3,
         "tolerance": 1e-09
       },
-      "intended": "DEFECT -- #1865. `picard_converged: false` at its 3-sweep budget, and the budget is why this cell is the one member of the family whose convergence flag does not move under the coupling mutations of #1892 -- it exhausts the budget at every scale. Whether it would converge given more sweeps is unmeasured, and measuring it is the next step on #1865. Red from 2026-08-11.",
+      "intended": "DEFECT -- #1865. `picard_converged: false` at its 3-sweep budget, and the budget is why this cell is the one member of the family whose convergence flag does not move under the coupling mutations of #1892 -- it exhausts the budget at every scale. Red from 2026-08-11. It DOES converge given more sweeps: measured here, converged=True at iteration 32 with budgets of 35 and 60, which `capability_matrix.py`'s own module docstring already recorded as \"the one a budget fixes -- it converges at 35 sweeps in ~3s\". An earlier version of this note called that unmeasured; it was measured, twenty lines above the helper that gates this cell. So the cell is red on its budget rather than on the scheme, and raising the budget is a deliberate decision about what the matrix costs -- #1865.",
       "status": "FAIL"
     }
   }

--- a/scripts/capability_baseline.json
+++ b/scripts/capability_baseline.json
@@ -34,7 +34,8 @@
         "picard_iterations": 5,
         "tolerance": 1.0000000000000003e-09
       },
-      "status": "PASS"
+      "intended": "DEFECT -- #1873/#1878. Mass is conserved to 1.2e-15, but the coupled iteration does not reach a fixed point: `picard_converged: false` after 5 sweeps, and it does not converge at 100, 200 or 400 either (final errors 2.3e-04, 4.1e-03, 4.0e-03, not descending). Red from 2026-08-11, when `picard_converged` entered the verdict (#1891). It was PASS before that on the mass oracle alone, which holds on whatever drift field the FP step is handed. The inner Newton's half is #1878; the residual there has more than one root and a line search converges to a non-viscosity branch.",
+      "status": "FAIL"
     },
     "fdm_upwind_2d/mass_conservation": {
       "artifact": {
@@ -131,7 +132,8 @@
         "picard_iterations": 5,
         "tolerance": 1.0000000000000003e-09
       },
-      "status": "PASS"
+      "intended": "DEFECT -- #1873/#1880. `picard_converged: false` after 5 sweeps; unlike its FDM sibling all four criterion arms are above tolerance and the density arm is not descending (never below 0.357). #1880 has the mechanism: SL_LINEAR amplifies asymmetry 2.75x per sweep on a symmetric fixture. Red from 2026-08-11 for the same reason as the row above.",
+      "status": "FAIL"
     },
     "sl_linear_2d/mass_conservation": {
       "artifact": {
@@ -143,7 +145,8 @@
         "picard_iterations": 3,
         "tolerance": 1e-09
       },
-      "status": "PASS"
+      "intended": "DEFECT -- #1865. `picard_converged: false` at its 3-sweep budget, and the budget is why this cell is the one member of the family whose convergence flag does not move under the coupling mutations of #1892 -- it exhausts the budget at every scale. Whether it would converge given more sweeps is unmeasured, and measuring it is the next step on #1865. Red from 2026-08-11.",
+      "status": "FAIL"
     }
   }
 }

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -257,6 +257,28 @@ def _mass_drift(result, problem) -> dict:
     }
 
 
+def _solved(art: dict) -> bool:
+    """Did the coupled iteration reach a fixed point? A cell's `ok` must include this.
+
+    Without it a cell asks whether the FP time-stepping conserves mass, which it does on whatever
+    drift field it is handed, converged or not -- #1871 recorded the field for exactly that reason
+    and left it out of the verdict, and #1865 then required any 2-D restatement to assert
+    convergence or stop claiming the configuration solves.
+
+    It is also the only field measured to depend on the coupling. Under the mutation family in
+    #1892, deleting f(m) makes `fdm_upwind` and `sl_linear` converge in ONE sweep against five, and
+    a 10x coupling stops `fvm_vs_fdm/agreement` converging at all -- while every other recorded
+    field stays put. A verdict that ignores this one cannot tell an MFG from two uncoupled PDEs.
+
+    Absent means not applicable rather than not converged: cells that run no coupled iteration
+    (construction checks) carry no such field and are unaffected.
+    """
+    for field in ("picard_converged", "fdm_picard_converged"):
+        if field in art:
+            return bool(art[field]) and bool(art.get("fvm_picard_converged", True))
+    return True
+
+
 def _picard_verdict(result, prefix: str = "") -> dict:
     """What the coupled iteration said about itself, recorded beside the oracle (#1871).
 
@@ -385,7 +407,7 @@ def _mass_conservation_cell(scheme_name: str):
             art = _mass_drift(result, problem)
             art |= _picard_verdict(result)
             art["tolerance"] = MASS_RTOL * max(abs(art["mass_t0"]), 1.0)
-            ok = art["all_finite"] and art["max_drift"] <= art["tolerance"]
+            ok = art["all_finite"] and art["max_drift"] <= art["tolerance"] and _solved(art)
             return ("PASS" if ok else "FAIL"), art
 
         return _measure("mass drift", verdict)
@@ -422,7 +444,7 @@ def _mass_conservation_2d_cell(scheme_name: str):
                 "tolerance": 1e-9,
             }
             art |= _picard_verdict(result)
-            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-9
+            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-9 and _solved(art)
             return ("PASS" if ok else "FAIL"), art
 
         return _measure("2-D mass drift", verdict)
@@ -536,7 +558,7 @@ def _fvm_mass_cell():
                 "tolerance": 1e-6,
             }
             art |= _picard_verdict(result)
-            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
+            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6 and _solved(art)
             return ("PASS" if ok else "FAIL"), art
 
         return _measure("FVM mass drift", verdict)
@@ -640,7 +662,7 @@ def _regime_switching_cell():
                 "tolerance": 1e-6,
             }
             art |= _picard_verdict(result)
-            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6
+            ok = art["all_finite"] and art["min_density"] >= -1e-12 and art["max_rel_drift"] <= 1e-6 and _solved(art)
             return ("PASS" if ok else "FAIL"), art
 
         return _measure("regime mass/non-negativity", verdict)
@@ -862,7 +884,13 @@ def print_report(results: dict) -> None:
 # cell, or a recovered one, arriving with an oracle that cannot tell an MFG from two uncoupled PDEs.
 # Same structure as `check_fail_fast.py` / `fail_fast_baseline.json`.
 #
-# Shrinking it is the work, and it is #1891. The mass oracles cannot see f(m) by construction:
+# Shrinking it is the work, and it is #1891. It went 5 -> 4 when the mutation family replaced plain
+# deletion, and 4 -> 1 when `picard_converged` entered the verdict: the three cells that left are no
+# longer PASS, so they are never mutated and cannot be judged. They are deliberately NOT kept here
+# against their return. A cell coming back green should have to prove its oracle can see the
+# coupling, and leaving it listed would let it arrive as `inert (known)` instead -- the mirror of
+# why `MASS_ORACLE_CELLS` does keep its non-PASS members, where listing is what makes the proof
+# happen rather than what waives it. The mass oracles cannot see f(m) by construction:
 # `mass_t0` is 1 by normalisation, `max_rel_drift` is a property of the FP time-stepping which holds
 # on whatever drift field it is handed, and `min_density` is the t=0 value of the initial condition.
 # `fvm_vs_fdm/agreement` is NOT on this list, and finding that out is what the family bought: it
@@ -871,10 +899,7 @@ def print_report(results: dict) -> None:
 # agreeing on an uncoupled problem is not the same statement -- but the cell does have a coupling
 # it can feel.
 COUPLING_INERT_BASELINE = {
-    "fdm_upwind/mass_conservation",
-    "sl_linear/mass_conservation",
     "fvm_muscl/mass_conservation",
-    "sl_linear_2d/mass_conservation",
 }
 
 

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -265,10 +265,18 @@ def _solved(art: dict) -> bool:
     and left it out of the verdict, and #1865 then required any 2-D restatement to assert
     convergence or stop claiming the configuration solves.
 
-    It is also the only field measured to depend on the coupling. Under the mutation family in
-    #1892, deleting f(m) makes `fdm_upwind` and `sl_linear` converge in ONE sweep against five, and
-    a 10x coupling stops `fvm_vs_fdm/agreement` converging at all -- while every other recorded
-    field stays put. A verdict that ignores this one cannot tell an MFG from two uncoupled PDEs.
+    It moves under the coupling: deleting f(m) makes `fdm_upwind` and `sl_linear` converge in ONE
+    sweep against five, and a 10x coupling stops `fvm_vs_fdm/agreement` converging at all.
+
+    ~~It is also the only field measured to depend on the coupling ... while every other recorded
+    field stays put.~~ [CORRECTED 2026-08-11] That was asserted from measuring this field alone. A
+    full-artifact diff over the family shows `min_density` moving in FOUR cells against this field's
+    two, and `max_drift`, `mass_max`, `max_rel_drift`, `rel_l2_*` and `worst` moving as well. What is
+    true, and what matters, is narrower: of the fields a verdict reads, only `worst` (in the
+    agreement cell, at 10x) ever crosses its own threshold, so before this change four of the five
+    coupled cells had a verdict no coupling mutation could move. Gating this field does not make
+    those four coupling-sensitive either -- it makes three of them honestly red, which is the
+    argument for it. The coupling-sensitivity argument was mine and it was wrong.
 
     Absent means not applicable rather than not converged: cells that run no coupled iteration
     (construction checks) carry no such field and are unaffected.
@@ -532,7 +540,7 @@ def _fvm_fdm_agreement_cell():
             art["rel_l2_U"] = _rel_l2(U_fvm, U_fdm, dx)
             art["rel_l2_M_terminal"] = _rel_l2(M_fvm[-1], M_fdm[-1], dx)
             art["worst"] = max(art["rel_l2_M"], art["rel_l2_U"], art["rel_l2_M_terminal"])
-            return ("PASS" if art["worst"] < AGREEMENT_RTOL else "FAIL"), art
+            return ("PASS" if art["worst"] < AGREEMENT_RTOL and _solved(art) else "FAIL"), art
 
         return _measure("FVM/FDM agreement", verdict)
 
@@ -1050,9 +1058,13 @@ def self_test() -> int:
     judged = set(passing)
     regressed = sorted(survives_all - COUPLING_INERT_BASELINE)
     recovered = sorted((COUPLING_INERT_BASELINE & judged) - survives_all)
-    unjudged = sorted(COUPLING_INERT_BASELINE - judged)
+    # Over MASS_ORACLE_CELLS, not over the waiver list: a cell that is no longer PASS is never
+    # mutated and so has no coupling verdict this run, and that is worth saying whether or not it
+    # was ever waived. Computing it as `COUPLING_INERT_BASELINE - judged` printed nothing at all
+    # once the waiver list was pruned -- which is exactly the three cells the prose claimed it named.
+    unjudged = sorted(MASS_ORACLE_CELLS - judged)
     if unjudged:
-        print(f"\nnot judged this run (no longer PASS, so never mutated): {', '.join(unjudged)}")
+        print(f"\nnot judged this run (not PASS, so never mutated): {', '.join(unjudged)}")
 
     # Axis 1 first: it is the older and stronger claim, and a `recovered` return placed before it
     # masked an axis-1 failure entirely -- measured.

--- a/tests/unit/test_capability_warnings.py
+++ b/tests/unit/test_capability_warnings.py
@@ -217,23 +217,36 @@ def test_a_quiet_cell_carries_no_field_at_all():
 
 
 def test_the_shipped_baseline_records_the_non_convergence_it_was_hiding():
-    """The point of the change, pinned against the artifact it produced.
+    """The point of #1879, pinned against the artifact it produced.
 
-    `fdm_upwind/mass_conservation` is PASS and emits 39 non-convergence warnings. If a
-    future change makes the solve produce roots the count drops and this test must be
-    updated -- deliberately, since that is exactly the event #1878 tracks and it should not
-    pass silently.
+    `fdm_upwind/mass_conservation` emits 39 non-convergence warnings, and the harness silenced every
+    one of them until #1879. The count is what this file exists to keep visible.
+
+    The cell is now **FAIL**, and not because the solve improved: `picard_converged` entered the
+    verdict on 2026-08-11 (#1891), so a cell that does not reach a fixed point stops being PASS. It
+    was PASS on the mass oracle alone, which holds on whatever drift field the FP step is handed --
+    the same fact these 39 warnings state in words. An earlier version of this test asserted
+    `status == "PASS"` and said "if that changed, #1878 moved"; #1878 has not moved, the verdict did,
+    and the two are worth keeping apart. The pin below is written so the interesting event -- the
+    warnings going away, which IS #1878 moving -- still fails it.
     """
     import json
 
     cells = json.loads((_SCRIPT.parent / "capability_baseline.json").read_text())["cells"]
-    said = cells["fdm_upwind/mass_conservation"]["artifact"]["library_said"]
+    cell = cells["fdm_upwind/mass_conservation"]
+    said = cell["artifact"]["library_said"]
 
     newton = {k: v for k, v in said.items() if "inner Newton did not converge" in k}
     assert newton, f"the recorded warnings no longer mention the inner Newton: {said}"
     assert sum(newton.values()) == 39, f"expected 39 non-convergence warnings (#1878), got {newton}"
-    assert cells["fdm_upwind/mass_conservation"]["status"] == "PASS", (
-        "the cell is PASS while its inner solves fail; if that changed, #1878 moved"
+
+    assert cell["artifact"]["picard_converged"] is False, (
+        "the coupled solve now converges; that is #1878/#1873 moving and this file must be updated "
+        "deliberately rather than adjusted to match"
+    )
+    assert cell["status"] != "PASS", (
+        "the cell is PASS while recording 39 inner-Newton failures and picard_converged=False -- "
+        "the verdict has stopped requiring convergence (#1891)"
     )
 
 


### PR DESCRIPTION
Closes #1891. Approved disposition: gate, three cells go red with `intended` notes.

## Why now

`picard_converged` has been recorded since #1871 and left out of the verdict, on the stated ground
that gating it *"turns three long-standing greens red"* — a transition cost, not a correctness
argument. Two things settle it.

**#1865 had already required it**, in that thread's first comment: *"any restatement of the 2-D
fixture must assert convergence, or the cell measures whether the FP time-stepper conserves mass
(which it does regardless) rather than whether the configuration solves."*

**~~And it is the only recorded field measured to depend on the coupling.~~**
**[WITHDRAWN 2026-08-11 — this argument was wrong.]** It was asserted from measuring that one field.
A full-artifact diff over the mutation family shows `min_density` moving in **four** cells against
this field's two, and `max_drift`, `mass_max`, `max_rel_drift`, `rel_l2_*` and `worst` moving as
well. The narrower true statement is that of the fields a *verdict reads*, only `worst` — in the
agreement cell, at 10x — ever crosses its own threshold. So gating does **not** make the other four
coupling-sensitive; it makes three of them honestly red.

The table below is still what it says it is, and is worth keeping for what it shows about the
solver — deleting the coupling makes `fdm_upwind` and `sl_linear` converge in **one** sweep against
five — but it does not support the claim it was put under.

| cell | unmutated | `x0` | `x-1` | `x10` |
|:--|:--|:--|:--|:--|
| `fdm_upwind` | False / 5 | **True / 1** | False / 5 | False / 5 |
| `sl_linear` | False / 5 | **True / 1** | False / 5 | False / 5 |
| `fvm_muscl` | True / 18 | True / 12 | True / 14 | True / 34 |
| `fvm_vs_fdm` | True / 17 | True / 12 | True / 14 | **False / 40** |
| `sl_linear_2d` | False / 3 | False / 3 | False / 3 | False / 3 |

**What the PR rests on now** is the correctness argument alone, which does not need the other:
a solve that has not reached a fixed point has not solved, and #1865 required a cell to assert it.

## Three further findings from the same review, all fixed

- **The fifth coupled cell was left out.** `fvm_vs_fdm/agreement` runs two coupled iterations and
  records both flags; its verdict was `worst < AGREEMENT_RTOL` alone, so it could certify PASS with
  neither converged — demonstrated by cutting its budget to 2 (`PASS`, `worst=0.0343`, both flags
  `false`). Now gated. This also makes `_solved`'s prefixed-field branches reachable: before, all
  four call sites passed the unprefixed name and those branches were dead code written for an
  artifact shape nothing sent them.
- **The self-test's "not judged this run" line never printed.** It computed
  `COUPLING_INERT_BASELINE - judged`, and pruning the waiver list to one entry removed exactly the
  cells the prose claimed it named. Now computed over `MASS_ORACLE_CELLS - judged` — the right set
  regardless, since a non-PASS cell has no coupling verdict this run whether or not it was waived.
  Eight cells now appear there.
- **The `sl_linear_2d` note called "unmeasured" something this file already answers.** It converges
  at iteration 32 given a budget of 35 or 60, and `capability_matrix.py`'s module docstring records
  exactly that twenty lines above the helper this PR adds. Corrected: the cell is red on its 3-sweep
  budget rather than on the scheme.

## What turns red

`fdm_upwind` (5 sweeps), `sl_linear` (5), `sl_linear_2d` (3). Each gets an `intended` note carrying
what is known — `fdm_upwind` does not converge at 100, 200 or 400 either and its inner half is #1878;
`sl_linear` fails all four criterion arms with the density arm not descending (#1880); `sl_linear_2d`
exhausts its budget, which is also why its flag cannot move under the mutations. `--check-baseline`
records the change in this commit and reports **0 of 9 non-PASS cells unexplained**.

## The known-inert list falls 4 -> 1

Only `fvm_muscl` remains: it converges in 18 sweeps and its verdict still survives every member of
the family. The three that left are no longer PASS, so they are never mutated and cannot be judged —
reported by the self-test as *"not judged this run"* rather than folded into a coupling verdict,
which is #1892's `recovered` fix working on a real case rather than a synthetic one.

They are deliberately **not** kept listed against their return. A cell coming back green should have
to prove its oracle can see the coupling; staying listed would let it arrive as `inert (known)`. This
is the mirror of `MASS_ORACLE_CELLS`, which *does* keep its non-PASS members — there, listing is what
makes the proof happen; here it would waive it. Both are now written down.

## One test changed, and not by adjusting it to match

`test_the_shipped_baseline_records_the_non_convergence_it_was_hiding` asserted `status == "PASS"`
with the message *"if that changed, #1878 moved"*. #1878 has **not** moved: the 39 inner-Newton
warnings are unchanged and `picard_converged` is still `false`. The verdict moved. The test now pins
those two facts and requires `status != "PASS"`, so the event it was written to catch — the warnings
going away — still fails it.

Mutation-checked in both directions: flipping the baseline status back to `PASS` turns it red; making
the 39 warnings disappear turns it red.

## Gate

`./scripts/local_ci.sh` — `5955 passed, 22 skipped, 21 xfailed`, `PASS no capability change vs
baseline`, `GATE GREEN`. Same count as `main`; this adds no tests.
