### PR TITLE
fix(hjb): build the Jacobian's advection block from the residual's own gradient

### DIFF
--- a/changelog.d/1896-jacobian-advection-block.fixed.md
+++ b/changelog.d/1896-jacobian-advection-block.fixed.md
@@ -22,9 +22,12 @@
   fixed the diffusion block of the same function and was identically absent at `σ = 0`.
 
 - **The branch was also selected by a second rule** (item 3). `gradient_upwind` selects on
-  `sign(central)`; the Jacobian selected on `sign(grad_upwind)`. They coincide only where the two
-  share a sign — measured to disagree at **8 of 41 nodes** on a random field, 2 of 41 on
-  `sin(4πx)`, 1 of 41 on `|x-0.5|`, and **0 of 41 on the monotone `x²`** that the tests used.
+  `sign(central)`; the Jacobian selected on `sign(grad_upwind)`. How far they part on a noisy field
+  is a random variable — at `Nx=41`, median **10 of 41**, range 6–16 over 200 seeds. (#1896's
+  inventory quoted "8 of 41" from a single unseeded draw; that draw is inside this range, so the
+  number was not wrong, but stating it as a constant was.) Deterministic fixtures: 2 of 41 on
+  `sin(4πx)`, 1 of 41 on `|x-0.5|`, and **0 of 41 on the monotone `x²`** that the tests used —
+  which is the load-bearing half and reproduces exactly.
 
 - **Extracted, not restated — and for upwind, not extractable either.** The upwind gradient is not
   linear in `U`, and probing it does not merely lose accuracy: at a node where the branch is
@@ -40,49 +43,78 @@
   ```
 
   exact identities of the ghost-padded stencils, walls included — measured at `1.4e-14` over seven
-  BCs (no-flux, Dirichlet, Neumann, periodic, three Robin parameter sets) and three states, and
-  pinned at `1e-12`. Which
-  branch holds at a row is then **observed** rather than restated, which is what closes item 3:
-  observation cannot disagree with the residual, because it is a measurement of it.
+  BCs (no-flux, Dirichlet, Neumann, periodic, three Robin parameter sets) × three states, and pinned
+  at `1e-12`, since it is the premise the whole construction rests on.
 
-- **Observing the branch takes two steps, and the second one was found by measurement.** Comparing
-  `grad_upwind(U)` against both reconstructions is exact where they differ in value — but they agree
-  in value on every locally linear stretch, and the two *rows* still differ there. Reading values
-  alone put the whole Jacobian one column across on a piecewise-linear state: `4.000e+01`,
-  ε-independent, against a column-wise finite difference at `Nx=21`. Those rows are now decided by
-  how `grad_upwind` **moves** under an alternating probe, whose central difference vanishes at every
-  interior node and so cannot move the branch it is measuring. Where the probe is inconclusive the
-  branch is switching at `U`, and both rows are admissible.
+- **Which branch holds is measured, wherever a measurement exists.** Where forward and backward
+  differ in value, `grad_upwind(U)` equals exactly one of them and the branch is read off it. That
+  is what closes item 3, and it covers every row where the two rules could have parted: a rule
+  disagreement that does not change the value cannot change which stencil produced it either. Where
+  they agree in value — every locally linear stretch, so not a rare coincidence — the two *rows*
+  still differ and nothing observable separates them, so `sign(central)` decides. Choosing by the
+  tie alone was worth `4.000e+01`, ε-independent, at `Nx=21`.
 
-- **Result**, column-wise finite difference against the assembled Jacobian, `Nx=21`, over 3 BCs × 2
+- **Result**, column-wise finite difference against the assembled Jacobian, `Nx=21`, over 4 BCs × 2
   schemes × 4 states: every wall row and every interior row agrees to `< 1e-5`, worst `1.19e-07`
-  (Dirichlet, central, monotone), which is the finite difference's own truncation floor. The two residual disagreements are the instrument, not the Jacobian, and each was
-  measured rather than assumed: at a switching node the two-sided difference averages two one-sided
-  operators and equals neither (the Jacobian row converges to one of them exactly, `4e-1 → 4e-2 →
-  4e-3` as the isolating tilt shrinks 10× each time, while the branches stay `2e+01` apart); and at
-  the flat state `u ≡ 0` the advection term is quadratic in `p`, so the difference leaves an O(ε)
-  tail — `1e-2 → 1e-4 → 1e-6` at ε = `1e-4 / 1e-6 / 1e-8`.
+  (Dirichlet, central, monotone), which is the finite difference's own truncation floor. The two
+  residual disagreements are the **instrument**, not the Jacobian, and each was measured rather than
+  assumed: at a switching node the two-sided difference averages two one-sided operators and equals
+  neither (the Jacobian row converges to one of them exactly, `4e-1 → 4e-2 → 4e-3` as the isolating
+  tilt shrinks 10× each time, while the branches stay `2e+01` apart); and at the flat state `u ≡ 0`
+  the advection term is quadratic in `p`, so the difference leaves an O(ε) tail — `1e-2 → 1e-4 →
+  1e-6` at ε = `1e-4 / 1e-6 / 1e-8`.
 
-- **Cost**: the analytic path stays O(Nx) and is ~2.0× slower — `3.6 → 7.3` ms at `Nx=1601`,
-  `1.9 → 3.9` ms at 801, `0.35 → 0.76` ms at 21 — the ratio flat across `Nx`, so no complexity
-  regression. The Laplacian bands are extracted once per Jacobian and shared by both blocks; before
-  that they were extracted twice, worth `10.9 → 7.3` ms at `Nx=1601`. The FD fallback path is
-  untouched. #1607's reason for the analytic path survives: the alternative is O(Nx²).
+- **Cost**: the analytic path stays O(Nx) and is ~2.1× slower — `3.6 → 7.4` ms at `Nx=1601`,
+  `1.9 → 3.8` ms at 801, `0.35 → 0.73` ms at 21 — the ratio flat across `Nx`, so no complexity
+  regression, and the probe count is constant in `Nx` for every BC. The Laplacian bands are
+  extracted once per Jacobian and shared by both blocks; before that they were extracted twice,
+  worth `10.9 → 7.4` ms at `Nx=1601`. The FD fallback path is untouched. #1607's reason for the
+  analytic path survives: the alternative is O(Nx²).
 
 - **Oracle**: `tests/unit/test_alg/test_hjb_jacobian_advection_1896.py`, external — a column-wise
   finite difference of the residual is a law the Jacobian must reproduce, computed independently of
-  it. Mutation-verified, seven mutations, all killed: neutering the tie-break probe (3 tests),
-  restating the branch rule as `sign(grad_upwind)` (15), inverting the mask (20), dropping the
-  per-row sign on the wrap entries (6), dropping the wrap entries (7), using central bands for
-  upwind (20), and removing the identity guard (1). Reverting the whole change turns 34 of 84 red.
-  The file also carries its own positive controls: that the states it calls smooth have no switching
-  node (otherwise the exclusion would silently make every assertion vacuous), and that the two
-  branch-selection rules actually part on the fixture (otherwise item 3's test proves nothing).
+  it. Mutation-verified, ten mutations, all killed:
 
-- **The analytic block is opt-in.** It is reached only when `backend is None`, which is
-  `HJBFDMSolver(analytic_jacobian=True)` (#1607); the default routes to the per-point FD fallback.
-  An earlier measurement of this fix passed a NumPy backend and reproduced the baseline byte for
-  byte — it had been measuring the other path.
+  | mutation | tests killed |
+  |:--|--:|
+  | restate the branch rule as `sign(grad_upwind)` (item 3) | 20 |
+  | invert the mask | 29 |
+  | use central bands for upwind | 27 |
+  | drop the wrap entries entirely | 8 |
+  | drop the per-row sign on the wrap entries | 7 |
+  | revert the tie-break to bare backward-preference | 5 |
+  | invert the tie-break predicate | 5 |
+  | let the tie-break decide every row (measurement never fires) | 1 |
+  | keep cancelled wrap entries instead of dropping them | 1 |
+  | skip the identity guard | 1 |
+
+  Reverting the whole change turns 34 of 84 red. The file carries its own positive controls: that
+  the states it calls smooth have no switching node (otherwise the exclusion silently makes every
+  assertion vacuous), and that the two branch-selection rules actually part on the fixture
+  (otherwise item 3's test proves nothing).
+
+- **What review changed, and it was not cosmetic.** The first version resolved tied rows by probing
+  how `grad_upwind` *moves* under an alternating direction, on the principle that observing beats
+  restating. Review found that probe **structurally blind at a Robin wall with `alpha == beta`**: the
+  ghost is `u_ghost = a·u[0] + c` with `a = (2 + α/β)/(2 − α/β)`, so `a = 3` exactly there, and the
+  probe's separation at row 0 is `|a − 3|/dx` — identically zero, for every state. On a state whose
+  Laplacian also vanishes at the wall the value comparison ties too, and both blind gave the wrong
+  branch on a row that is *not* a switching node: `2.0000e+01`, reproduced independently.
+
+  Fixing that made the probe redundant, and the mutation suite said so — neutering it killed zero
+  tests. A sweep over **27,345** tied rows (9 grid sizes × 4 spacings × 13 BCs × 36 states) found the
+  probe and `sign(central)` never once deciding a row differently, so it was deleted: 14 lines, four
+  operator applications, and three magic constants. Deleting it did **not** measurably change
+  runtime (`7.31 → 7.44` ms at `Nx=1601`, within noise); it bought simplicity and removed the blind
+  spot.
+
+- **The remaining restatement is pinned by a test, not by an argument.** On every configuration this
+  repo can build, measuring the branch and restating `sign(central) >= 0` agree — so no ordinary test
+  separates them, and "let the tie-break decide everything" killed nothing. The difference only
+  appears when the rule *changes*, which is precisely what item 3 was. So
+  `test_the_jacobian_follows_a_changed_selection_rule_without_being_told` inverts `gradient_upwind`
+  itself and asserts the Jacobian still linearises the residual. A Jacobian that measures follows;
+  one that restates cannot.
 
 - **One reference test moved, and was not adjusted to match.**
   `test_jacobian_byte_identical_to_inline_assembly` (#1071) rebuilt the Jacobian from a hand-written
@@ -92,3 +124,16 @@
   diffusion bands. Both stencil halves are tautological there now and are pinned externally instead.
   What the test still discriminates is `dH/dp` — verified, not assumed: perturbing the assembled
   `dH_dp` by one part in 10⁵ turns it red.
+
+- **The analytic block is opt-in.** It is reached only when `backend is None`, which is
+  `HJBFDMSolver(analytic_jacobian=True)` (#1607); the default routes to the per-point FD fallback.
+  An earlier measurement of this fix passed a NumPy backend and reproduced the baseline byte for
+  byte — it had been measuring the other path. The FD fallback remains wrong at periodic row 0
+  (`4.145e+01`) and on upwind interior rows (`7.814e+01`) at `Nx=21`; pre-existing, measured during
+  review, not addressed by this change.
+
+- **Corrected while here**: `_extract_bands`' docstring claimed its O(Nx²) tier was "reached in
+  practice rather than defensively" because obstacle masks, nonlocal terms and Robin BCs defeat the
+  comb. Measured false — tier 1 succeeds for every BC constructible in this repo, at a constant 9
+  probes for every `Nx`, and nothing in-tree builds a banded-plus-something operator. The claim is
+  struck rather than deleted, with the measurement in its place.

--- a/changelog.d/1896-jacobian-advection-block.fixed.md
+++ b/changelog.d/1896-jacobian-advection-block.fixed.md
@@ -73,13 +73,14 @@
 
 - **Oracle**: `tests/unit/test_alg/test_hjb_jacobian_advection_1896.py`, external — a column-wise
   finite difference of the residual is a law the Jacobian must reproduce, computed independently of
-  it. Mutation-verified, ten mutations, all killed:
+  it. Mutation-verified across three files (122 tests) — twelve mutations, eleven killed and one
+  proved equivalent:
 
   | mutation | tests killed |
   |:--|--:|
-  | restate the branch rule as `sign(grad_upwind)` (item 3) | 20 |
-  | invert the mask | 29 |
-  | use central bands for upwind | 27 |
+  | invert the mask | 30 |
+  | use central bands for upwind | 28 |
+  | restate the branch rule as `sign(grad_upwind)` (item 3) | 21 |
   | drop the wrap entries entirely | 8 |
   | drop the per-row sign on the wrap entries | 7 |
   | revert the tie-break to bare backward-preference | 5 |
@@ -87,8 +88,10 @@
   | let the tie-break decide every row (measurement never fires) | 1 |
   | keep cancelled wrap entries instead of dropping them | 1 |
   | skip the identity guard | 1 |
+  | revert the identity-guard scale to the survivor only (F1) | 1 |
+  | freeze `current_time` to 0 in the advection call | **equivalent — see below** |
 
-  Reverting the whole change turns 34 of 84 red. The file carries its own positive controls: that
+  Reverting the whole change turns 52 of 95 red. The file carries its own positive controls: that
   the states it calls smooth have no switching node (otherwise the exclusion silently makes every
   assertion vacuous), and that the two branch-selection rules actually part on the fixture
   (otherwise item 3's test proves nothing).
@@ -137,3 +140,62 @@
   comb. Measured false — tier 1 succeeds for every BC constructible in this repo, at a constant 9
   probes for every `Nx`, and nothing in-tree builds a banded-plus-something operator. The claim is
   struck rather than deleted, with the measurement in its place.
+
+- **Second review round — MERGE-OK, three findings, all taken.**
+
+  **F1, introduced.** The identity guard scaled its tolerance by the *survivor* while its error is
+  set by the *cancelled* terms. `forward`/`backward` recover a small number by cancelling `g_c`
+  against `(dx/2)·laplacian`, so the reconstruction's rounding floor is `eps ×` the cancelled
+  magnitude, while `atol` was `1e-9 × max(|g_up|, 1)` — and an inhomogeneous wall points both end
+  rows' gradient inward, so a large ghost never reaches `g_up` at all. Reproduced independently: at
+  `Nx=51` with a Dirichlet value of `1e6`, mismatch `4.172e-09` against an atol of `1.98e-09` with
+  the cancelled terms at `5e+07`. It escapes to the user — `compute_hjb_jacobian` is called outside
+  the `try` in `newton_hjb_step`. A false alarm rather than a missed detection: where it tripped,
+  `|forward − backward|` is 2× the cancelled magnitude while the error is `eps` times it, so the
+  branch measurement is immune by `1/eps` to the very error being flagged. The scale now includes
+  the cancelled magnitudes; pinned by `test_a_large_wall_value_does_not_trip_the_identity_guard`.
+
+  **F2 — my own correction was wrong, and wrong in the class it was documenting.** The
+  `[CORRECTED 2026-08-12]` note in `_extract_bands` claimed tier 1 succeeds "at a constant 9 probes
+  for every Nx" and that the fallback "is reached by no in-tree configuration". Both halves false.
+  Measured: 4 / 5 / 6 probes at `Nx = 3 / 4 / 5`, **12 at `Nx = 6`**, a flat **8** for every
+  `Nx ≥ 7`. At `Nx=6`, `edges` takes `{0,1,4,5}` leaving `interior=[2,3]`, whose length below 3
+  collapses `stride` to 1, so the single comb probes two *adjacent* columns and the control vector
+  correctly fails. `tests/conftest.py`'s `tiny_problem` is `Nx=6`, so it fires in-tree on every run.
+  The "9" was lifted from the first review, which had measured `Nx ∈ {9,21,101,401}`, and restated
+  as a universal without carrying its population — a verdict without its denominator, written into
+  the correction that was documenting exactly that. Now pinned by
+  `test_nx_6_degenerates_the_comb_and_that_is_recorded_rather_than_assumed_away`, which also asserts
+  the bands are still exact there (tier 2 is exact for any structure), so this records a cost of 8
+  extra applies on the smallest grid in the tree, not a defect.
+
+  **F3, nit.** `test_the_flat_state_the_repo_defaults_to_is_a_total_branch_degeneracy` cannot see
+  the advection block at all: at `u ≡ 0`, `max|dH/dp| = 0`, and review showed that replacing the
+  entire output of `_advection_bands` with zero bands changes the assembled Jacobian by exactly
+  `0.0` there. The docstring already said the true derivative is zero; only the *name* overclaimed.
+  Renamed to `test_the_flat_state_leaves_an_eps_tail_not_a_defect`, and the degeneracy is now a
+  **measured premise** (`assert max|dH_dp| == 0`) rather than an implication of the title. The tie
+  case it appeared to cover is covered for real by `piecewise_linear` and by
+  `test_a_tied_wall_row_...`, both tied in value with `dH/dp ≠ 0`.
+
+- **A coverage gap that turned out to be an equivalent mutation.** Review flagged that freezing
+  `current_time` to `0.0` in the `_advection_bands` call survives the whole suite, and named it the
+  cheapest gap to close. It is not a gap: a BC value enters the ghost as an affine **offset**, and
+  `_advection_bands` subtracts the zero-state, so the offset cancels by construction. Measured over
+  time-dependent Dirichlet, Neumann and Robin, both schemes: `max|bands(t=0) − bands(t=0.6)|` is
+  `0.0` to `1.4e-14`. Only `alpha`/`beta` could move a coefficient and no constructor makes those
+  time-dependent, so the threading **cannot** affect this function's output for any BC constructible
+  today. `test_a_time_dependent_boundary_reaches_the_advection_block` is kept anyway, because
+  `dH/dp` *does* vary with time and the end-to-end property (the Jacobian linearises the residual at
+  the time it was handed) is real. Its fixture carries the sign lesson: with a large **positive**
+  wall value, `central < 0` at both walls, upwinding selects the branch that never reads the ghost,
+  and the test would have asserted nothing while looking fine — caught by its own control.
+
+- **Five findings were refuted** by the second round's skeptics, including one filed as a blocker:
+  that the test advertised as pinning the `sign(central)` restatement pins nothing. Direct mutation
+  says otherwise — replacing the whole recovery with `took_backward = g_c >= 0` gives 1 failed, and
+  the single failure *is* that test; the proposed "safe" fix turns it red at `4.000e+01`. Also
+  refuted: that the probe deletion removed a real discriminator (two independent sweeps, 239,138 and
+  160,280 tied rows, zero disagreements — roughly 10× this PR's own 27,345), and that the
+  linearisation point is unpinned (behaviourally real, but `main` carries the identical unpinning at
+  `e3fdd10c:1005`, so pre-existing).

--- a/changelog.d/1896-jacobian-advection-block.fixed.md
+++ b/changelog.d/1896-jacobian-advection-block.fixed.md
@@ -1,0 +1,94 @@
+- **The 1-D FDM Jacobian's advection block is now built from the gradient the residual applies**
+  (Issue #1896, items 3 and 4). It restated the stencil by hand — central as `[-1/2dx, 0, +1/2dx]`,
+  upwind as a one-sided pair — which is right in the interior and wrong at both walls under every
+  BC. Measured by column-wise finite difference of `compute_hjb_residual` at `Nx=9`:
+
+  | BC | scheme | true row 0 | hardcoded row 0 |
+  |:--|:--|:--|:--|
+  | no_flux | central | `{0: -4, 1: +4}` | `{1: +4}` |
+  | dirichlet | central | `{0: +4, 1: +4}` | `{1: +4}` |
+  | periodic | central | `{1: +4, 8: -4}` | `{1: +4}` |
+  | no_flux | upwind | `{}` | `{0: +8}` |
+  | dirichlet | upwind | `{0: +16}` | `{0: +8}` |
+  | periodic | upwind | `{0: -8, 1: +8}` | `{0: +8}` |
+
+  The missing central entry has the **opposite sign** between no-flux and Dirichlet, so no single
+  correction to the hardcoded row could have covered both.
+
+- **Why nothing caught it.** `use_upwind=True` is the default, and the no-flux upwind row is the one
+  cell where the defect is invisible: the true row is empty *and* the BC forces `p = 0` at the wall,
+  so `dH/dp` multiplies the spurious diagonal away. That is the configuration the `fdm_upwind`
+  capability fixture runs. Under Dirichlet or periodic nothing masks it. Same shape as #1894, which
+  fixed the diffusion block of the same function and was identically absent at `σ = 0`.
+
+- **The branch was also selected by a second rule** (item 3). `gradient_upwind` selects on
+  `sign(central)`; the Jacobian selected on `sign(grad_upwind)`. They coincide only where the two
+  share a sign — measured to disagree at **8 of 41 nodes** on a random field, 2 of 41 on
+  `sin(4πx)`, 1 of 41 on `|x-0.5|`, and **0 of 41 on the monotone `x²`** that the tests used.
+
+- **Extracted, not restated — and for upwind, not extractable either.** The upwind gradient is not
+  linear in `U`, and probing it does not merely lose accuracy: at a node where the branch is
+  switching, the directional difference disagrees with itself and the extractor raises (9 of 15
+  measured wall cells at `Nx=9`, one-sided differences as well as two-sided). That is not an
+  implementation fault — the map is nondifferentiable there and no Jacobian exists, only a Clarke
+  generalised Jacobian. So the bands are assembled from the two operators that *are* linear and
+  already have owners:
+
+  ```
+  forward  = central + (dx/2) * laplacian
+  backward = central - (dx/2) * laplacian
+  ```
+
+  exact identities of the ghost-padded stencils, walls included — measured at `1.4e-14` over seven
+  BCs (no-flux, Dirichlet, Neumann, periodic, three Robin parameter sets) and three states, and
+  pinned at `1e-12`. Which
+  branch holds at a row is then **observed** rather than restated, which is what closes item 3:
+  observation cannot disagree with the residual, because it is a measurement of it.
+
+- **Observing the branch takes two steps, and the second one was found by measurement.** Comparing
+  `grad_upwind(U)` against both reconstructions is exact where they differ in value — but they agree
+  in value on every locally linear stretch, and the two *rows* still differ there. Reading values
+  alone put the whole Jacobian one column across on a piecewise-linear state: `4.000e+01`,
+  ε-independent, against a column-wise finite difference at `Nx=21`. Those rows are now decided by
+  how `grad_upwind` **moves** under an alternating probe, whose central difference vanishes at every
+  interior node and so cannot move the branch it is measuring. Where the probe is inconclusive the
+  branch is switching at `U`, and both rows are admissible.
+
+- **Result**, column-wise finite difference against the assembled Jacobian, `Nx=21`, over 3 BCs × 2
+  schemes × 4 states: every wall row and every interior row agrees to `< 1e-5`, worst `1.19e-07`
+  (Dirichlet, central, monotone), which is the finite difference's own truncation floor. The two residual disagreements are the instrument, not the Jacobian, and each was
+  measured rather than assumed: at a switching node the two-sided difference averages two one-sided
+  operators and equals neither (the Jacobian row converges to one of them exactly, `4e-1 → 4e-2 →
+  4e-3` as the isolating tilt shrinks 10× each time, while the branches stay `2e+01` apart); and at
+  the flat state `u ≡ 0` the advection term is quadratic in `p`, so the difference leaves an O(ε)
+  tail — `1e-2 → 1e-4 → 1e-6` at ε = `1e-4 / 1e-6 / 1e-8`.
+
+- **Cost**: the analytic path stays O(Nx) and is ~2.0× slower — `3.6 → 7.3` ms at `Nx=1601`,
+  `1.9 → 3.9` ms at 801, `0.35 → 0.76` ms at 21 — the ratio flat across `Nx`, so no complexity
+  regression. The Laplacian bands are extracted once per Jacobian and shared by both blocks; before
+  that they were extracted twice, worth `10.9 → 7.3` ms at `Nx=1601`. The FD fallback path is
+  untouched. #1607's reason for the analytic path survives: the alternative is O(Nx²).
+
+- **Oracle**: `tests/unit/test_alg/test_hjb_jacobian_advection_1896.py`, external — a column-wise
+  finite difference of the residual is a law the Jacobian must reproduce, computed independently of
+  it. Mutation-verified, seven mutations, all killed: neutering the tie-break probe (3 tests),
+  restating the branch rule as `sign(grad_upwind)` (15), inverting the mask (20), dropping the
+  per-row sign on the wrap entries (6), dropping the wrap entries (7), using central bands for
+  upwind (20), and removing the identity guard (1). Reverting the whole change turns 34 of 84 red.
+  The file also carries its own positive controls: that the states it calls smooth have no switching
+  node (otherwise the exclusion would silently make every assertion vacuous), and that the two
+  branch-selection rules actually part on the fixture (otherwise item 3's test proves nothing).
+
+- **The analytic block is opt-in.** It is reached only when `backend is None`, which is
+  `HJBFDMSolver(analytic_jacobian=True)` (#1607); the default routes to the per-point FD fallback.
+  An earlier measurement of this fix passed a NumPy backend and reproduced the baseline byte for
+  byte — it had been measuring the other path.
+
+- **One reference test moved, and was not adjusted to match.**
+  `test_jacobian_byte_identical_to_inline_assembly` (#1071) rebuilt the Jacobian from a hand-written
+  advection stencil selected by `grad >= 0` on the **upwind** gradient — carrying both defects at
+  once, so it pinned them rather than its own subject. That subject is the inline `dp` form; the
+  reference now takes its advection bands from the same owner, exactly as #1894 did for its
+  diffusion bands. Both stencil halves are tautological there now and are pinned externally instead.
+  What the test still discriminates is `dH/dp` — verified, not assumed: perturbing the assembled
+  `dH_dp` by one part in 10⁵ turns it red.

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -795,10 +795,10 @@ def compute_hjb_residual(
 def _extract_bands(Nx: int, apply, label: str):
     """Bands of a linear operator, recovered by probing it. `apply(vec)` is that operator.
 
-    Shared by every band extraction in this module so the machinery has one owner: the Laplacian
-    (linear in U, probed directly) and the advection gradient (linearised at the current iterate by
-    a directional difference) differ only in what `apply` does. A second copy of this would be the
-    same defect class the extraction exists to close.
+    Shared by every band extraction in this module so the machinery has one owner: the Laplacian and
+    the central gradient differ only in what `apply` does, and the upwind gradient -- which is not
+    linear and has no bands to probe -- is built from those two by `_advection_bands`. A second copy
+    of this would be the same defect class the extraction exists to close.
 
         Returns ``(sub, diag, sup)`` with ``sub[i] = L[i, i-1]``, ``diag[i] = L[i, i]``,
         ``sup[i] = L[i, i+1]`` -- the convention `J_L`/`J_D`/`J_U` use.
@@ -914,7 +914,7 @@ def _bc_laplacian_bands(Nx: int, dx: float, bc, time: float):
     return _extract_bands(Nx, apply, "BC-aware Laplacian")
 
 
-def _advection_bands(U: np.ndarray, dx: float, bc, time: float, upwind: bool):
+def _advection_bands(U: np.ndarray, dx: float, bc, time: float, upwind: bool, laplacian_bands):
     """Bands of ``d(grad U)/dU``, linearised at ``U`` by probing the residual's own gradient.
 
     The advection block used to restate the stencil by hand -- central as ``[-1/2dx, 0, +1/2dx]``,
@@ -932,21 +932,123 @@ def _advection_bands(U: np.ndarray, dx: float, bc, time: float, upwind: bool):
     there, so ``dH/dp`` is zero and the spurious diagonal is multiplied away. Under Dirichlet or
     periodic nothing masks it.
 
-    Unlike the Laplacian, the upwind gradient is NOT linear in U -- the branch selection depends on
-    it. This linearises at the current iterate, which is what a Jacobian is and what semismooth
-    Newton wants: at a node where the branch is switching, the value returned is one element of the
-    Clarke generalised Jacobian, the same choice the residual makes.
+    Central is linear in U, so it is probed directly. Upwind is not, and probing it does not merely
+    lose accuracy -- at a node where the branch is switching the two-sided directional difference
+    disagrees with itself, so `_extract_bands` raises instead of returning a Jacobian (9 of 15
+    measured wall cells at Nx=9, for one-sided differences as well as two-sided). That is not an
+    implementation fault: the upwind gradient is nondifferentiable there and no Jacobian exists,
+    only a Clarke generalised Jacobian.
+
+    So the upwind bands are assembled from the two operators that ARE linear::
+
+        forward  = central + (dx / 2) * laplacian
+        backward = central - (dx / 2) * laplacian
+
+    exact identities of the ghost-padded stencils, boundaries included -- measured at 1.4e-14 or
+    better over seven BCs (no-flux, Dirichlet, Neumann, periodic, three Robin parameter sets) and
+    three states, and pinned there, since it is the premise the whole construction rests on. Robin
+    is the case that would break it, by padding the Laplacian differently from the gradient.
+
+    Which branch holds at row ``i`` is then **observed**, never restated.
+    Restating it is #1896 item 3: the residual selects on ``sign(central)`` while the Jacobian
+    selected on ``sign(grad_upwind)``, which disagree at 8 of 41 nodes on a random field and at 0 of
+    41 on the monotone states every test used.
+
+    Observation is in two parts, because value and row do not carry the same information:
+
+    1. Where forward and backward differ in VALUE, ``grad_upwind(U)`` equals exactly one of them and
+       the branch is read off directly.
+    2. Where they agree in value -- any locally linear stretch, so not a rare coincidence -- the
+       ROWS still differ, and picking wrong puts the Jacobian one column across. Those rows are
+       decided by how ``grad_upwind`` MOVES under an alternating probe, whose central difference
+       vanishes at every interior node and so cannot move the branch being measured.
+    3. Where the probe is inconclusive, the branch is switching at ``U``: both rows are elements of
+       the Clarke generalised Jacobian and either is admissible.
+
+    ``laplacian_bands`` is passed in rather than extracted here because the caller already holds it
+    for the diffusion block, and extracting it twice per Jacobian build is the same quantity
+    computed on two paths -- cheap to avoid, and measured at roughly half the added cost of the
+    upwind branch.
     """
     U = np.asarray(U, dtype=float)
     Nx = len(U)
-    step = 1e-6 * max(float(np.abs(U).max()), 1.0)
+
+    zero = _compute_gradient_array_1d(np.zeros(Nx), dx, bc=bc, upwind=False, time=time)
 
     def apply(vec):
-        plus = _compute_gradient_array_1d(U + step * vec, dx, bc=bc, upwind=upwind, time=time)
-        minus = _compute_gradient_array_1d(U - step * vec, dx, bc=bc, upwind=upwind, time=time)
-        return (plus - minus) / (2.0 * step)
+        return _compute_gradient_array_1d(vec, dx, bc=bc, upwind=False, time=time) - zero
 
-    return _extract_bands(Nx, apply, "gradient operator")
+    central = _extract_bands(Nx, apply, "central gradient operator")
+    if not upwind:
+        return central
+
+    half = dx / 2.0
+    c_sub, c_diag, c_sup, c_extras = central
+    l_sub, l_diag, l_sup, l_extras = laplacian_bands
+
+    g_up = _compute_gradient_array_1d(U, dx, bc=bc, upwind=True, time=time)
+    g_c = _compute_gradient_array_1d(U, dx, bc=bc, upwind=False, time=time)
+    lap = _compute_laplacian_1d(U, dx, bc=bc, time=time)
+    forward, backward = g_c + half * lap, g_c - half * lap
+
+    took_backward = np.abs(g_up - backward) <= np.abs(g_up - forward)
+    # Fail loudly if the identity above does not hold: the mask is then recovered by picking the
+    # closer of two wrong reconstructions, which is silent and produces a plausible Jacobian. A BC
+    # whose Laplacian pads differently from its gradient would land exactly here.
+    picked = np.where(took_backward, backward, forward)
+    scale = max(float(np.abs(g_up).max()), 1.0)
+    if not np.allclose(picked, g_up, rtol=1e-9, atol=1e-9 * scale):
+        raise ValueError(
+            "the upwind gradient is not one of central +/- (dx/2)*laplacian, so its branch cannot "
+            f"be read off (max mismatch {float(np.abs(picked - g_up).max()):.3e}). #1896."
+        )
+
+    # That comparison is blind wherever forward == backward in VALUE -- which is every locally
+    # linear stretch, not a rare coincidence. The two ROWS still differ there, so the tie is not
+    # harmless: read off values alone it put the whole Jacobian one column across on a
+    # piecewise-linear state, 4.000e+01 against a column-wise finite difference at Nx=21, and
+    # eps-independent. Resolve it by probing how the residual's own gradient MOVES.
+    #
+    # The probe direction is alternating. Its central difference vanishes at every interior node
+    # (v[i+1] == v[i-1]), so it cannot move the branch it is measuring, while its Laplacian is
+    # maximal at -4v/dx^2, separating the two candidate rows by 4/dx. That property is exact in the
+    # interior and only approximate at the walls, where ghost padding is not the interior stencil --
+    # so the probe is trusted per row, and only where one candidate clearly wins.
+    probe = np.empty(Nx)
+    probe[::2], probe[1::2] = 1.0, -1.0
+    step = 1e-7 * max(float(np.abs(U).max()), 1.0)
+    moved = (
+        _compute_gradient_array_1d(U + step * probe, dx, bc=bc, upwind=True, time=time)
+        - _compute_gradient_array_1d(U - step * probe, dx, bc=bc, upwind=True, time=time)
+    ) / (2.0 * step)
+    zero_lap = _compute_laplacian_1d(np.zeros(Nx), dx, bc=bc, time=time)
+    c_probe = _compute_gradient_array_1d(probe, dx, bc=bc, upwind=False, time=time) - zero
+    l_probe = _compute_laplacian_1d(probe, dx, bc=bc, time=time) - zero_lap
+    to_backward, to_forward = np.abs(moved - (c_probe - half * l_probe)), np.abs(moved - (c_probe + half * l_probe))
+    gap = np.abs(dx * l_probe)
+    # A row whose branch the probe did move lands between the two candidates rather than on one of
+    # them; leave those to the value comparison above. They are the nodes where the branch is
+    # switching at U, and there both rows are elements of the Clarke generalised Jacobian.
+    decided = np.minimum(to_backward, to_forward) < 0.25 * gap
+    took_backward = np.where(decided, to_backward <= to_forward, took_backward)
+
+    sign = np.where(took_backward, -1.0, 1.0)
+    sub = c_sub + sign * half * l_sub
+    diag = c_diag + sign * half * l_diag
+    sup = c_sup + sign * half * l_sup
+
+    merged: dict[tuple[int, int], float] = {}
+    for i, j, value in c_extras:
+        merged[(i, j)] = merged.get((i, j), 0.0) + value
+    for i, j, value in l_extras:
+        merged[(i, j)] = merged.get((i, j), 0.0) + float(sign[i]) * half * value
+    # The wrap entry cancels exactly on the branch that does not reach across it -- row 0's forward
+    # difference reads U[1], not the wrap column -- so drop what cancelled rather than carry a
+    # rounding-scale entry that changes nnz without changing the operator.
+    band_scale = max(float(np.abs(np.concatenate([sub, diag, sup])).max()), 1.0)
+    extras = [(i, j, v) for (i, j), v in sorted(merged.items()) if abs(v) > 1e-12 * band_scale]
+
+    return sub, diag, sup, extras
 
 
 def compute_hjb_jacobian(
@@ -1015,6 +1117,11 @@ def compute_hjb_jacobian(
     if has_nan_or_inf(U_n_current_newton_iterate, backend):
         return sparse.diags([np.full(Nx, np.nan)], [0], shape=(Nx, Nx)).tocsr()
 
+    # Extracted once. Both blocks below need this operator -- diffusion applies it, advection builds
+    # the one-sided gradients out of it -- and extracting it twice is the same quantity on two paths
+    # for no reason, at roughly half the cost of the whole advection extraction.
+    _lap_bands = _bc_laplacian_bands(Nx, dx, bc, current_time) if abs(dx) > 1e-14 and Nx > 1 else None
+
     # Time derivative part: d/dU_n_current[j] of (U_n_current[i] - U_{n+1}[i])/dt
     if abs(dt) > 1e-14:
         J_D += 1.0 / dt
@@ -1027,7 +1134,7 @@ def compute_hjb_jacobian(
         # 1/dx^2 -- exactly proportional to sigma^2, absent at sigma=0, which is why every
         # measurement taken on the sigma=0 fixture missed it (#1894).
         _diffusion = diffusion_from_volatility(sigma, kind="field")
-        _sub, _diag, _sup, _extras = _bc_laplacian_bands(Nx, dx, bc, current_time)
+        _sub, _diag, _sup, _extras = _lap_bands
         J_D += -_diffusion * _diag
         J_L += -_diffusion * _sub
         J_U += -_diffusion * _sup
@@ -1041,7 +1148,7 @@ def compute_hjb_jacobian(
         # (1/dt)*I -- a plausible wrong answer, not a crash. The bands above already do this right
         # by elementwise broadcast; only the off-band entries needed the explicit row index.
         _D_row = np.broadcast_to(np.asarray(_diffusion, dtype=float), (Nx,))
-        J_extras = [(i, j, -float(_D_row[i]) * v) for i, j, v in _extras]
+        J_extras += [(i, j, -float(_D_row[i]) * v) for i, j, v in _extras]
         # Note: For spatially varying σ(x), this assumes σ is smooth.
         # More accurate treatment would include ∂σ/∂x terms (Phase 3 extension)
 
@@ -1077,24 +1184,19 @@ def compute_hjb_jacobian(
             HEvalState(x=x_grid, p=p_grid, m=m_grid, t=current_time)
         ).ravel()  # (Nx,) — squeeze the 1D momentum dimension
 
-        # Stencil coefficients: dp_i/dU_j depends on upwind direction
-        # Godunov upwind: p >= 0 uses backward (U_i - U_{i-1})/dx,
-        #                 p < 0  uses forward  (U_{i+1} - U_i)/dx
-        inv_dx = 1.0 / dx
-        if use_upwind:
-            backward_mask = precomputed_grad >= 0  # (Nx,)
-            # Diagonal: dp_i/dU_i
-            J_D += dH_dp * np.where(backward_mask, inv_dx, -inv_dx)
-            # Lower: dp_i/dU_{i-1} (backward stencil only)
-            J_L += dH_dp * np.where(backward_mask, -inv_dx, 0.0)
-            # Upper: dp_i/dU_{i+1} (forward stencil only)
-            J_U += dH_dp * np.where(backward_mask, 0.0, inv_dx)
-        else:
-            # Central difference: p_i = (U_{i+1} - U_{i-1}) / (2*dx)
-            half_inv_dx = inv_dx / 2.0
-            # dp_i/dU_i = 0 (central difference has no diagonal stencil)
-            J_L += dH_dp * (-half_inv_dx)
-            J_U += dH_dp * half_inv_dx
+        # dp_i/dU_j: row i of the SAME gradient operator the residual applied, extracted rather than
+        # restated. Restating it wrote the interior stencil into the wall rows, which are one-sided
+        # under every BC: central row 0 is {0: -4, 1: +4} under no-flux and {0: +4, 1: +4} under
+        # Dirichlet against the hardcoded {1: +4} -- wrong in magnitude, and in sign between the two.
+        # The upwind branch was restated too, selecting on sign(grad_upwind) where the residual
+        # selects on sign(central); they part at 8 of 41 nodes on a random field and at none on a
+        # monotone one, which is what every test used (#1896 items 3 and 4).
+        _g_sub, _g_diag, _g_sup, _g_extras = _advection_bands(U_n_np, dx, bc, current_time, use_upwind, _lap_bands)
+        J_D += dH_dp * _g_diag
+        J_L += dH_dp * _g_sub
+        J_U += dH_dp * _g_sup
+        # Row-index dH_dp for the same reason the diffusion block row-indexes sigma (#1894 B1).
+        J_extras += [(i, j, float(dH_dp[i]) * v) for i, j, v in _g_extras]
     else:
         # Fallback: per-point numerical FD Jacobian for backend or no H_class
         for i in range(Nx):

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -816,10 +816,22 @@ def _extract_bands(Nx: int, apply, label: str):
         built from decides whether that held, and one probe per column -- exact for any structure --
         is used when it did not. ~~Obstacle masks, nonlocal terms and Robin BCs all produce operators
         the comb cannot attribute, so the fallback is reached in practice rather than defensively.~~
-        [CORRECTED 2026-08-12] Measured over every BC constructible in this repo, including Robin:
-        tier 1 succeeds for all of them, at a constant 9 probes for every Nx. The fallback exists for
-        an operator that is banded-plus-something -- an obstacle mask or a nonlocal term would be one
-        -- and nothing in the repo builds one today, so it is reached by no in-tree configuration.
+        [CORRECTED 2026-08-12, and the correction was itself wrong -- see below] Measured over every
+        BC constructible in this repo, including Robin: tier 1 succeeds for all of them. Probe counts
+        are 4 / 5 / 6 at Nx = 3 / 4 / 5, **12 at Nx = 6**, and a flat 8 for every Nx >= 7, identically
+        under no-flux, Dirichlet and periodic.
+
+        Nx = 6 is the one size where the comb degenerates: `edges` takes {0, 1, 4, 5}, leaving
+        `interior = [2, 3]`, whose length below 3 collapses `stride` to 1 -- so the single comb probes
+        two ADJACENT columns, `pack` cannot attribute them, the control vector fails, and tier 2 runs.
+        It is not a BC effect; a hand-built pure tridiagonal operator pays it too. The bands are still
+        exact there, because tier 2 is exact for any structure. `tests/conftest.py`'s `tiny_problem`
+        is Nx = 6, so this fires in-tree on every run.
+
+        ~~at a constant 9 probes for every Nx ... reached by no in-tree configuration~~ was written
+        here on 2026-08-12 and is false on both halves. The "9" was lifted from a review that had
+        measured Nx in {9, 21, 101, 401} and restated as a universal without carrying its population;
+        the true count on that set is 8. This is the defect class the correction was documenting.
     """
 
     def column(cols) -> np.ndarray:
@@ -996,7 +1008,17 @@ def _advection_bands(U: np.ndarray, dx: float, bc, time: float, upwind: bool, la
     lap = _compute_laplacian_1d(U, dx, bc=bc, time=time)
     forward, backward = g_c + half * lap, g_c - half * lap
 
-    scale = max(float(np.abs(g_up).max()), 1.0)
+    # Scale the tolerance by the CANCELLED magnitudes, not only by the survivor. `forward` and
+    # `backward` recover a small number by cancelling `g_c` against `(dx/2)*lap`, so the
+    # reconstruction's rounding floor is set by those terms, while `g_up` can be orders of
+    # magnitude smaller -- an inhomogeneous wall points both end rows' gradient inward, so a large
+    # ghost never reaches `g_up` at all. Scaling by `g_up` alone made the guard raise on bands it
+    # was about to build exactly right: at Nx=51 with a Dirichlet value of 1e6, mismatch 4.172e-09
+    # against an atol of 1.98e-09, where the cancelled terms are 5e+07 and eps*5e+07 is 1.1e-08.
+    # Found by review. It is a false alarm rather than a missed detection in that regime: where it
+    # tripped, |forward - backward| is 2x the cancelled magnitude while the reconstruction error is
+    # eps times it, so the branch measurement is immune by a factor 1/eps to the very error flagged.
+    scale = max(float(np.abs(g_up).max()), float(np.abs(g_c).max()), float(np.abs(half * lap).max()), 1.0)
     # Where the two candidates differ in VALUE, the branch is MEASURED: grad_upwind equals exactly
     # one of them. That is the part that closes #1896 item 3, and it covers every row where the two
     # rules could have parted -- a rule disagreement that changes nothing about the value changes

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -814,8 +814,12 @@ def _extract_bands(Nx: int, apply, label: str):
 
     Two tiers. Comb probes recover a banded operator in O(Nx); a control vector none of them was
         built from decides whether that held, and one probe per column -- exact for any structure --
-        is used when it did not. Obstacle masks, nonlocal terms and Robin BCs all produce operators the
-        comb cannot attribute, so the fallback is reached in practice rather than defensively.
+        is used when it did not. ~~Obstacle masks, nonlocal terms and Robin BCs all produce operators
+        the comb cannot attribute, so the fallback is reached in practice rather than defensively.~~
+        [CORRECTED 2026-08-12] Measured over every BC constructible in this repo, including Robin:
+        tier 1 succeeds for all of them, at a constant 9 probes for every Nx. The fallback exists for
+        an operator that is banded-plus-something -- an obstacle mask or a nonlocal term would be one
+        -- and nothing in the repo builds one today, so it is reached by no in-tree configuration.
     """
 
     def column(cols) -> np.ndarray:
@@ -949,21 +953,22 @@ def _advection_bands(U: np.ndarray, dx: float, bc, time: float, upwind: bool, la
     three states, and pinned there, since it is the premise the whole construction rests on. Robin
     is the case that would break it, by padding the Laplacian differently from the gradient.
 
-    Which branch holds at row ``i`` is then **observed**, never restated.
-    Restating it is #1896 item 3: the residual selects on ``sign(central)`` while the Jacobian
-    selected on ``sign(grad_upwind)``, which disagree at 8 of 41 nodes on a random field and at 0 of
-    41 on the monotone states every test used.
+    Which branch holds at row ``i`` is then **measured wherever a measurement exists**. Restating it
+    instead is #1896 item 3: the residual selects on ``sign(central)`` while the Jacobian selected on
+    ``sign(grad_upwind)``. How far they part is a random variable -- at Nx=41 on ``0.4 sin(4pi x)``
+    plus noise, median 10 nodes over 200 seeds, range 6 to 16 -- but it is exactly 0 of 41 on the
+    monotone ``x^2`` that every test used, and that is the half that matters.
 
-    Observation is in two parts, because value and row do not carry the same information:
+    Value and row do not carry the same information, so recovery is in two parts:
 
     1. Where forward and backward differ in VALUE, ``grad_upwind(U)`` equals exactly one of them and
-       the branch is read off directly.
+       the branch is read off it. This is what closes item 3, and it covers every row where the two
+       rules could have parted: a rule disagreement that does not change the value cannot change
+       which one-sided stencil produced it either.
     2. Where they agree in value -- any locally linear stretch, so not a rare coincidence -- the
-       ROWS still differ, and picking wrong puts the Jacobian one column across. Those rows are
-       decided by how ``grad_upwind`` MOVES under an alternating probe, whose central difference
-       vanishes at every interior node and so cannot move the branch being measured.
-    3. Where the probe is inconclusive, the branch is switching at ``U``: both rows are elements of
-       the Clarke generalised Jacobian and either is admissible.
+       ROWS still differ and nothing observable separates them, so ``sign(central)`` decides.
+       Picking wrong here puts the Jacobian one column across: 4.000e+01 against a column-wise
+       finite difference at Nx=21, eps-independent, before the case was handled at all.
 
     ``laplacian_bands`` is passed in rather than extracted here because the caller already holds it
     for the diffusion block, and extracting it twice per Jacobian build is the same quantity
@@ -991,46 +996,35 @@ def _advection_bands(U: np.ndarray, dx: float, bc, time: float, upwind: bool, la
     lap = _compute_laplacian_1d(U, dx, bc=bc, time=time)
     forward, backward = g_c + half * lap, g_c - half * lap
 
-    took_backward = np.abs(g_up - backward) <= np.abs(g_up - forward)
+    scale = max(float(np.abs(g_up).max()), 1.0)
+    # Where the two candidates differ in VALUE, the branch is MEASURED: grad_upwind equals exactly
+    # one of them. That is the part that closes #1896 item 3, and it covers every row where the two
+    # rules could have parted -- a rule disagreement that changes nothing about the value changes
+    # nothing about the row either.
+    #
+    # Where they agree in value -- every locally linear stretch, so not a rare coincidence -- the
+    # two ROWS still differ and nothing observable separates them, so `sign(central)` decides. That
+    # is a second statement of `gradient_upwind`'s rule, which is the defect this function exists to
+    # close, and it is tolerable only because of where it sits: it never runs on a row any
+    # measurement could decide, and if the rule ever changes to something that is not one of these
+    # two stencils, the check below raises rather than letting it quietly disagree.
+    #
+    # An earlier version resolved these rows by probing how grad_upwind MOVES under an alternating
+    # direction, on the principle that observing beats restating. Deleted after measurement: over
+    # 27345 such rows (9 grid sizes x 4 spacings x 13 BCs x 36 states) the probe never once decided
+    # a row differently from `sign(central)`, and it was structurally blind at a Robin wall with
+    # alpha == beta, where its separation |a - 3|/dx is identically zero.
+    value_decides = np.abs(forward - backward) > 1e-12 * scale
+    took_backward = np.where(value_decides, np.abs(g_up - backward) <= np.abs(g_up - forward), g_c >= 0)
     # Fail loudly if the identity above does not hold: the mask is then recovered by picking the
     # closer of two wrong reconstructions, which is silent and produces a plausible Jacobian. A BC
     # whose Laplacian pads differently from its gradient would land exactly here.
     picked = np.where(took_backward, backward, forward)
-    scale = max(float(np.abs(g_up).max()), 1.0)
     if not np.allclose(picked, g_up, rtol=1e-9, atol=1e-9 * scale):
         raise ValueError(
             "the upwind gradient is not one of central +/- (dx/2)*laplacian, so its branch cannot "
             f"be read off (max mismatch {float(np.abs(picked - g_up).max()):.3e}). #1896."
         )
-
-    # That comparison is blind wherever forward == backward in VALUE -- which is every locally
-    # linear stretch, not a rare coincidence. The two ROWS still differ there, so the tie is not
-    # harmless: read off values alone it put the whole Jacobian one column across on a
-    # piecewise-linear state, 4.000e+01 against a column-wise finite difference at Nx=21, and
-    # eps-independent. Resolve it by probing how the residual's own gradient MOVES.
-    #
-    # The probe direction is alternating. Its central difference vanishes at every interior node
-    # (v[i+1] == v[i-1]), so it cannot move the branch it is measuring, while its Laplacian is
-    # maximal at -4v/dx^2, separating the two candidate rows by 4/dx. That property is exact in the
-    # interior and only approximate at the walls, where ghost padding is not the interior stencil --
-    # so the probe is trusted per row, and only where one candidate clearly wins.
-    probe = np.empty(Nx)
-    probe[::2], probe[1::2] = 1.0, -1.0
-    step = 1e-7 * max(float(np.abs(U).max()), 1.0)
-    moved = (
-        _compute_gradient_array_1d(U + step * probe, dx, bc=bc, upwind=True, time=time)
-        - _compute_gradient_array_1d(U - step * probe, dx, bc=bc, upwind=True, time=time)
-    ) / (2.0 * step)
-    zero_lap = _compute_laplacian_1d(np.zeros(Nx), dx, bc=bc, time=time)
-    c_probe = _compute_gradient_array_1d(probe, dx, bc=bc, upwind=False, time=time) - zero
-    l_probe = _compute_laplacian_1d(probe, dx, bc=bc, time=time) - zero_lap
-    to_backward, to_forward = np.abs(moved - (c_probe - half * l_probe)), np.abs(moved - (c_probe + half * l_probe))
-    gap = np.abs(dx * l_probe)
-    # A row whose branch the probe did move lands between the two candidates rather than on one of
-    # them; leave those to the value comparison above. They are the nodes where the branch is
-    # switching at U, and there both rows are elements of the Clarke generalised Jacobian.
-    decided = np.minimum(to_backward, to_forward) < 0.25 * gap
-    took_backward = np.where(decided, to_backward <= to_forward, took_backward)
 
     sign = np.where(took_backward, -1.0, 1.0)
     sub = c_sub + sign * half * l_sub
@@ -1189,8 +1183,9 @@ def compute_hjb_jacobian(
         # under every BC: central row 0 is {0: -4, 1: +4} under no-flux and {0: +4, 1: +4} under
         # Dirichlet against the hardcoded {1: +4} -- wrong in magnitude, and in sign between the two.
         # The upwind branch was restated too, selecting on sign(grad_upwind) where the residual
-        # selects on sign(central); they part at 8 of 41 nodes on a random field and at none on a
-        # monotone one, which is what every test used (#1896 items 3 and 4).
+        # selects on sign(central); they part at a median 10 of 41 nodes on a noisy field (200
+        # seeds, range 6 to 16) and at none at all on a monotone one, which is what every test
+        # used (#1896 items 3 and 4).
         _g_sub, _g_diag, _g_sup, _g_extras = _advection_bands(U_n_np, dx, bc, current_time, use_upwind, _lap_bands)
         J_D += dH_dp * _g_diag
         J_L += dH_dp * _g_sub

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -792,8 +792,13 @@ def compute_hjb_residual(
     return Phi_U
 
 
-def _bc_laplacian_bands(Nx: int, dx: float, bc, time: float):
-    """Bands of the BC-aware Laplacian, extracted from the operator `compute_hjb_residual` applies.
+def _extract_bands(Nx: int, apply, label: str):
+    """Bands of a linear operator, recovered by probing it. `apply(vec)` is that operator.
+
+    Shared by every band extraction in this module so the machinery has one owner: the Laplacian
+    (linear in U, probed directly) and the advection gradient (linearised at the current iterate by
+    a directional difference) differ only in what `apply` does. A second copy of this would be the
+    same defect class the extraction exists to close.
 
         Returns ``(sub, diag, sup)`` with ``sub[i] = L[i, i-1]``, ``diag[i] = L[i, i]``,
         ``sup[i] = L[i, i+1]`` -- the convention `J_L`/`J_D`/`J_U` use.
@@ -812,12 +817,11 @@ def _bc_laplacian_bands(Nx: int, dx: float, bc, time: float):
         is used when it did not. Obstacle masks, nonlocal terms and Robin BCs all produce operators the
         comb cannot attribute, so the fallback is reached in practice rather than defensively.
     """
-    zero = _compute_laplacian_1d(np.zeros(Nx), dx, bc=bc, time=time)
 
     def column(cols) -> np.ndarray:
         probe = np.zeros(Nx)
         probe[cols] = 1.0
-        return _compute_laplacian_1d(probe, dx, bc=bc, time=time) - zero
+        return apply(probe)
 
     def pack(columns, isolated) -> tuple:
         """Bands plus off-band (row, col, value) triples, from a map of column index -> its column.
@@ -857,7 +861,7 @@ def _bc_laplacian_bands(Nx: int, dx: float, bc, time: float):
 
     # Control vector no probe was built from.
     check = np.linspace(-1.0, 1.0, Nx) + 0.37
-    want = _compute_laplacian_1d(check, dx, bc=bc, time=time) - zero
+    want = apply(check)
     scale = max(float(np.abs(want).max()), 1.0)
 
     # Tier 1: comb probes, O(Nx). Exact when the operator is banded, which is the common case --
@@ -887,10 +891,62 @@ def _bc_laplacian_bands(Nx: int, dx: float, bc, time: float):
     packed = pack({j: column([j]) for j in range(Nx)}, isolated=set(range(Nx)))
     if not np.allclose(reconstruct(*packed, check), want, rtol=1e-9, atol=1e-9 * scale):
         raise ValueError(
-            "the BC-aware Laplacian is not linear in U, so it has no Jacobian to extract (max "
-            f"mismatch {float(np.abs(reconstruct(*packed, check) - want).max()):.3e}). #1894."
+            f"the {label} is not linear in U, so it has no Jacobian to extract (max mismatch "
+            f"{float(np.abs(reconstruct(*packed, check) - want).max()):.3e}). #1894."
         )
     return packed
+
+
+def _bc_laplacian_bands(Nx: int, dx: float, bc, time: float):
+    """Bands of the BC-aware Laplacian, extracted from the operator `compute_hjb_residual` applies.
+
+    The Jacobian used to write the interior three-point stencil by hand, which is right in the
+    interior and wrong at both ends: the true end rows are ``[-1, 1]/dx^2`` under no-flux and
+    ``[-3, 1]/dx^2`` under Dirichlet against the hardcoded ``[-2, 1]/dx^2``. That is #1894, and a
+    second implementation of this operator is what caused it. Under periodic BC the operator is
+    *cyclic* tridiagonal, so the corners come back as ``extras`` and the caller carries them.
+    """
+    zero = _compute_laplacian_1d(np.zeros(Nx), dx, bc=bc, time=time)
+
+    def apply(vec):
+        return _compute_laplacian_1d(vec, dx, bc=bc, time=time) - zero
+
+    return _extract_bands(Nx, apply, "BC-aware Laplacian")
+
+
+def _advection_bands(U: np.ndarray, dx: float, bc, time: float, upwind: bool):
+    """Bands of ``d(grad U)/dU``, linearised at ``U`` by probing the residual's own gradient.
+
+    The advection block used to restate the stencil by hand -- central as ``[-1/2dx, 0, +1/2dx]``,
+    upwind as a one-sided pair chosen by ``sign(precomputed_grad)``. Measured against the residual's
+    actual operator at Nx=9, both wall rows are wrong for every BC and both schemes (#1896 item 4):
+
+        no_flux   central  true {0: -4, 1: +4}      hardcoded {1: +4}
+        dirichlet central  true {0: +4, 1: +4}      hardcoded {1: +4}     <- opposite sign
+        periodic  central  true {1: +4, 8: -4}      hardcoded {1: +4}     <- wrap omitted
+        no_flux   upwind   true {}                  hardcoded {0: +8}     <- spurious diagonal
+        dirichlet upwind   true {0: +16}            hardcoded {0: +8}
+        periodic  upwind   true {0: -8, 1: +8}      hardcoded {0: +8}
+
+    The no-flux upwind row is why this survived: its true row is empty AND the BC forces ``p=0``
+    there, so ``dH/dp`` is zero and the spurious diagonal is multiplied away. Under Dirichlet or
+    periodic nothing masks it.
+
+    Unlike the Laplacian, the upwind gradient is NOT linear in U -- the branch selection depends on
+    it. This linearises at the current iterate, which is what a Jacobian is and what semismooth
+    Newton wants: at a node where the branch is switching, the value returned is one element of the
+    Clarke generalised Jacobian, the same choice the residual makes.
+    """
+    U = np.asarray(U, dtype=float)
+    Nx = len(U)
+    step = 1e-6 * max(float(np.abs(U).max()), 1.0)
+
+    def apply(vec):
+        plus = _compute_gradient_array_1d(U + step * vec, dx, bc=bc, upwind=upwind, time=time)
+        minus = _compute_gradient_array_1d(U - step * vec, dx, bc=bc, upwind=upwind, time=time)
+        return (plus - minus) / (2.0 * step)
+
+    return _extract_bands(Nx, apply, "gradient operator")
 
 
 def compute_hjb_jacobian(

--- a/tests/unit/test_alg/test_hamiltonian_single_source_1071.py
+++ b/tests/unit/test_alg/test_hamiltonian_single_source_1071.py
@@ -230,20 +230,29 @@ def test_jacobian_byte_identical_to_inline_assembly():
     # subject. That subject is the inline `dp` form below (#1071); the diffusion half is now
     # tautological here and is pinned externally by
     # tests/unit/test_alg/test_hjb_jacobian_matches_residual_1894.py.
-    from mfgarchon.alg.numerical.hjb_solvers.base_hjb import _bc_laplacian_bands
+    from mfgarchon.alg.numerical.hjb_solvers.base_hjb import _advection_bands, _bc_laplacian_bands
     from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 
-    _sub, _diag, _sup, _extras = _bc_laplacian_bands(nx, dx, bc, 0.0)
+    lap_bands = _bc_laplacian_bands(nx, dx, bc, t)
+    _sub, _diag, _sup, _extras = lap_bands
     _diffusion = diffusion_from_volatility(sigma, kind="field")
     assert not _extras, "this fixture is not periodic; the reference has no place for wrap entries"
     J_D += -_diffusion * _diag
     J_L += -_diffusion * _sub
     J_U += -_diffusion * _sup
-    inv_dx = 1.0 / dx
-    backward = grad >= 0
-    J_D += dH_dp * np.where(backward, inv_dx, -inv_dx)
-    J_L += dH_dp * np.where(backward, -inv_dx, 0.0)
-    J_U += dH_dp * np.where(backward, 0.0, inv_dx)
+    # Advection from the same operator too, for the same reason and one issue later. This reference
+    # used to restate the one-sided pair and select it with `grad >= 0` on the UPWIND gradient --
+    # two defects at once, since the residual selects on the CENTRAL gradient (#1896 item 3) and the
+    # interior stencil is wrong at both walls (#1896 item 4). So it pinned those rather than its own
+    # subject. That subject is the inline `dp` form above (#1071); both stencil halves are now
+    # tautological here and are pinned externally by
+    # tests/unit/test_alg/test_hjb_jacobian_advection_1896.py against a finite difference of the
+    # residual.
+    _g_sub, _g_diag, _g_sup, _g_extras = _advection_bands(u_cur, dx, bc, t, True, lap_bands)
+    assert not _g_extras, "this fixture is not periodic; the reference has no place for wrap entries"
+    J_D += dH_dp * _g_diag
+    J_L += dH_dp * _g_sub
+    J_U += dH_dp * _g_sup
     j_l_roll = np.roll(J_L, -1)
     j_u_roll = np.roll(J_U, 1)
     ref = sparse.spdiags([j_l_roll, J_D, j_u_roll], [-1, 0, 1], nx, nx, format="csr").tocsr()

--- a/tests/unit/test_alg/test_hjb_jacobian_advection_1896.py
+++ b/tests/unit/test_alg/test_hjb_jacobian_advection_1896.py
@@ -36,7 +36,7 @@ from mfgarchon.alg.numerical.hjb_solvers.base_hjb import (
     compute_hjb_jacobian,
     compute_hjb_residual,
 )
-from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.hamiltonian import HEvalState, QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import dirichlet_bc, neumann_bc, no_flux_bc, periodic_bc, robin_bc
@@ -232,16 +232,34 @@ def test_a_switching_node_gets_a_clarke_element_not_an_average():
     assert nearest < 0.2 * coarse, f"gap does not shrink with the tilt: {coarse:.3e} -> {nearest:.3e}"
 
 
-def test_the_flat_state_the_repo_defaults_to_is_a_total_branch_degeneracy():
+def test_the_flat_state_leaves_an_eps_tail_not_a_defect():
     """`u_terminal = 0` is this repo's own default, and it makes every node a tie.
 
-    Forward and backward agree in value everywhere (both zero), so the value comparison decides
-    nothing at any row. The residual's advection term is quadratic in p, so the true derivative is
+    Read the name carefully: this pins the FINITE-DIFFERENCE tail, not the branch recovery. At this
+    state `dH/dp` is identically zero, so the advection block is multiplied away entirely -- review
+    (#1899) showed that replacing the whole output of `_advection_bands` with zero bands changes the
+    assembled Jacobian by exactly 0.0 here. No mutation confined to the branch recovery can move
+    this assertion, and the earlier name ("a total branch degeneracy") implied otherwise.
+
+    The tie case IS covered, by `piecewise_linear` in `test_every_row_linearises_the_residual` and
+    by `test_a_tied_wall_row_...`, both of which are tied in value with `dH/dp != 0`.
+
+    What this does test: the residual's advection term is quadratic in p, so the true derivative is
     zero and the two-sided FD leaves an O(eps) tail rather than a defect -- pinned by its scaling,
-    since a fixed tolerance here would pass over a genuinely wrong row of the same size.
+    since a fixed tolerance would pass over a genuinely wrong row of the same size.
     """
     problem, bc, m = _fixture("no_flux")
     u = np.zeros(NX)
+    # The premise, measured rather than implied by the name.
+    x_grid = problem.geometry.get_spatial_grid()
+    grad = _compute_gradient_array_1d(u, DX, bc=bc, upwind=True, time=0.0)
+    dh_dp = problem.hamiltonian_class.evaluate_dp(
+        HEvalState(x=x_grid, p=grad.reshape(-1, 1), m=np.asarray(m, dtype=float), t=0.0)
+    ).ravel()
+    assert np.abs(dh_dp).max() == 0.0, (
+        f"dH/dp is no longer identically zero here ({np.abs(dh_dp).max():.3e}); this test would then "
+        f"be reachable by the advection block and its name should say so"
+    )
     jac = _jacobian(problem, bc, m, u, True)
     residual = _residual(problem, bc, m, True)
     coarse = float(np.abs(jac - _fd_columns(residual, u, eps=1e-4)).max())
@@ -438,3 +456,87 @@ def test_the_jacobian_follows_a_changed_selection_rule_without_being_told(monkey
 
     err = np.abs(_jacobian(problem, bc, m, u, True) - _fd_columns(_residual(problem, bc, m, True), u))
     assert err.max() < 1e-5, f"the Jacobian did not follow the rule change: {err.max():.3e}"
+
+
+@pytest.mark.parametrize("upwind", [False, True])
+def test_a_time_dependent_boundary_reaches_the_advection_block(upwind: bool):
+    """`time` is threaded into all three operator calls, and nothing varied it on this path.
+
+    Review (#1899) found that mutating `current_time` to 0.0 inside the `_advection_bands` call
+    survives the whole suite: every fixture in this file uses a time-independent BC, so the
+    threading was carried by no assertion. A BC whose value moves with `t` makes the wall rows
+    depend on it, and the Jacobian must linearise the residual *at that time*, not at zero.
+    """
+    # The SIGN matters, and the control below is what caught it. With a large POSITIVE wall value
+    # the ghost is far above the interior, so `central < 0` at both walls and upwinding selects the
+    # branch that never reads the ghost -- the upwind gradient is then genuinely independent of the
+    # BC value, and a test built on it would assert nothing while looking fine.
+    bc = dirichlet_bc(dimension=1, value=lambda t: -(2.0 + 5.0 * t))
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=bc)
+    problem = MFGProblem(
+        geometry=grid,
+        Nt=10,
+        T=1.0,
+        sigma=0.3,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    m = np.exp(-10 * (X - 0.5) ** 2)
+    m /= m.sum() * DX
+    u = SMOOTH_STATES["bump_off_node"]
+    u_next = np.zeros(NX)
+    t = 0.6
+
+    # Control: the BC must actually differ between t=0 and t, or the test cannot see the threading.
+    at_zero = _compute_gradient_array_1d(u, DX, bc=bc, upwind=upwind, time=0.0)
+    at_t = _compute_gradient_array_1d(u, DX, bc=bc, upwind=upwind, time=t)
+    assert np.abs(at_zero - at_t).max() > 1.0, "the BC is not time-dependent on this fixture"
+
+    def residual(state):
+        return np.asarray(
+            compute_hjb_residual(
+                state, u_next, m, problem, 5, None, None, upwind, bc=bc, domain_bounds=BOUNDS, current_time=t
+            ),
+            dtype=float,
+        )
+
+    jac = compute_hjb_jacobian(
+        u, u, m, problem, 5, None, None, upwind, bc=bc, domain_bounds=BOUNDS, current_time=t
+    ).toarray()
+    assert float(np.abs(jac - _fd_columns(residual, u)).max()) < 1e-5
+
+
+@pytest.mark.parametrize("nx", [21, 51, 201])
+def test_a_large_wall_value_does_not_trip_the_identity_guard(nx: int):
+    """The guard must not raise on bands it is about to build exactly right.
+
+    `forward`/`backward` recover a small number by cancelling `g_c` against `(dx/2)*lap`, so the
+    reconstruction's rounding floor is set by those CANCELLED terms. Scaling the tolerance by
+    `g_up` alone made the guard fire whenever a wall value was large enough that the cancelled
+    magnitude exceeded it by ~1/eps: at Nx=51 with a Dirichlet value of 1e6, mismatch 4.172e-09
+    against an atol of 1.98e-09 while the cancelled terms were 5e+07. Found by review (#1899).
+
+    It escapes to the user: `compute_hjb_jacobian` is called OUTSIDE the `try` in
+    `newton_hjb_step`, so the ValueError propagates out of the solve.
+    """
+    dx = 1.0 / (nx - 1)
+    x = np.linspace(0.0, 1.0, nx)
+    u = x**2
+    for value in (7.0, 1.0e4, 1.0e6):
+        bc = dirichlet_bc(dimension=1, value=value)
+        lap_bands = _bc_laplacian_bands(nx, dx, bc, 0.0)
+        cancelled = float(np.abs(dx / 2 * _compute_laplacian_1d(u, dx, bc=bc, time=0.0)).max())
+        survivor = float(np.abs(_compute_gradient_array_1d(u, dx, bc=bc, upwind=True, time=0.0)).max())
+        # Control: this fixture must actually exercise the regime, or it asserts nothing.
+        if value == 1.0e6:
+            assert cancelled > 1e6 * max(survivor, 1.0), (
+                f"nx={nx}: cancelled {cancelled:.3e} vs survivor {survivor:.3e} -- no longer the trip regime"
+            )
+        _advection_bands(u, dx, bc, 0.0, True, lap_bands)  # must not raise

--- a/tests/unit/test_alg/test_hjb_jacobian_advection_1896.py
+++ b/tests/unit/test_alg/test_hjb_jacobian_advection_1896.py
@@ -7,8 +7,9 @@ reference to the Jacobian), pointed at the other block. Two defects, both measur
     {0: -4, 1: +4} and the Jacobian wrote {1: +4}; under Dirichlet the true row is {0: +4, 1: +4},
     so the missing entry has the OPPOSITE SIGN between two BCs of the same scheme.
   item 3 -- the branch was selected by a second rule. The residual selects on sign(central), the
-    Jacobian selected on sign(grad_upwind); they part at 8 of 41 nodes on a random field and at
-    none on a monotone one, which is what every test used.
+    Jacobian selected on sign(grad_upwind); they part at a median 10 of 41 nodes on a noisy field
+    (200 seeds, range 6 to 16) and at none at all on a monotone one, which is what every test
+    used.
 
 Why it hid, beyond that: `use_upwind=True` is the default, and under no-flux upwind the true wall
 row is EMPTY while the BC forces p=0 there, so `dH/dp` multiplies the spurious diagonal away. The
@@ -49,6 +50,11 @@ BC_FACTORIES = {
     "no_flux": lambda: no_flux_bc(dimension=1),
     "dirichlet": lambda: dirichlet_bc(dimension=1, value=0.0),
     "periodic": lambda: periodic_bc(dimension=1),
+    # Robin is the BC most likely to break the forward/backward identity, by padding the Laplacian
+    # differently from the gradient. alpha == beta specifically: the ghost is u_ghost = a*u[0] + c
+    # with a = (2 + alpha/beta)/(2 - alpha/beta), so a == 3 there, and that is the wall where review
+    # found the wrong branch being chosen -- 2.0000e+01 at row 0.
+    "robin_alpha_eq_beta": lambda: robin_bc(dimension=1, alpha=1.0, beta=1.0, value=0.0),
 }
 
 
@@ -114,7 +120,7 @@ def _switching_nodes(u, bc, upwind: bool):
     return np.abs(g_c) < 1e-9
 
 
-# States with no switching node under any of the three BCs; `_no_switching_states_are_actually_smooth`
+# States with no switching node under any BC above; `test_no_switching_states_are_actually_smooth`
 # is the control that keeps that claim honest as the fixture changes.
 SMOOTH_STATES = {
     "monotone": 2.0 * X**2,
@@ -125,16 +131,15 @@ SMOOTH_STATES = {
 
 
 @pytest.mark.parametrize("bc_name", list(BC_FACTORIES))
-@pytest.mark.parametrize("upwind", [False, True])
 @pytest.mark.parametrize("state", list(SMOOTH_STATES))
-def test_no_switching_states_are_actually_smooth(bc_name: str, upwind: bool, state: str):
+def test_no_switching_states_are_actually_smooth(bc_name: str, state: str):
     """Positive control for the exclusion below: these states must have nothing to exclude.
 
     Without this, `_switching_nodes` growing to cover every row would make every assertion in this
     file vacuous while the suite stayed green -- the exclusion would be laundering the measurement.
     """
     _, bc, _ = _fixture(bc_name)
-    switching = _switching_nodes(SMOOTH_STATES[state], bc, upwind)
+    switching = _switching_nodes(SMOOTH_STATES[state], bc, True)
     assert not switching.any(), f"{state} under {bc_name}: switching at rows {np.nonzero(switching)[0].tolist()}"
 
 
@@ -344,3 +349,92 @@ def test_the_legacy_no_bc_path_linearises_its_own_residual_too(upwind: bool):
 
     jac = compute_hjb_jacobian(u, u, m, problem, 5, None, None, upwind, bc=None).toarray()
     assert float(np.abs(jac - _fd_columns(residual, u)).max()) < 1e-5
+
+
+def test_a_tied_wall_row_that_is_not_a_switching_node_still_gets_the_right_branch():
+    """The fallback's hardest customer: the branch is well defined, and unmeasurable.
+
+    A linear state has zero Laplacian, so forward and backward agree in VALUE and the measurement
+    ties. In the interior that happens under every BC — `test_every_row_linearises_the_residual`
+    covers it with `piecewise_linear`. At a WALL it depends on the ghost rule, and the Robin
+    `alpha == beta` ghost is the case where it happens: `a = (2 + alpha/beta)/(2 - alpha/beta) = 3`
+    extends a linear state exactly, so `lap[0] = 0` too.
+
+    `central[0]` is nowhere near zero there, so this is NOT a switching node — the residual takes
+    one specific branch, the two ROWS differ, and choosing by the tie alone was worth `2.0000e+01`.
+    Found by review; no other BC in this file reaches it, which is why it is written out separately
+    rather than parametrised.
+
+    Asserted as a measurement against the residual, not by inspecting which part of the recovery
+    fired, so it survives a reimplementation of the branch recovery.
+    """
+    problem, bc, m = _fixture("robin_alpha_eq_beta")
+    u = -1.0 * (X - DX / 2)
+    assert abs(_compute_laplacian_1d(u, DX, bc=bc, time=0.0)[0]) < 1e-9, "the wall row no longer ties"
+    central = _compute_gradient_array_1d(u, DX, bc=bc, upwind=False, time=0.0)
+    assert abs(central[0]) > 0.1, f"row 0 is a switching node ({central[0]:.3e}); the test proves nothing"
+
+    err = np.abs(_jacobian(problem, bc, m, u, True) - _fd_columns(_residual(problem, bc, m, True), u))
+    assert err[0].max() < 1e-5, f"row 0: {err[0].max():.3e}"
+
+
+def test_a_cancelled_wrap_entry_is_dropped_rather_than_kept_at_rounding_scale():
+    """Pins the sparsity, which the agreement tests cannot see: they compare dense arrays.
+
+    Under periodic upwind, row 0's forward difference reads `U[1]`, not the wrap column, so the
+    central and Laplacian contributions to that entry cancel exactly. Keeping the residue would
+    leave a `~1e-16` entry in the matrix — numerically invisible, but it changes `nnz` and so
+    changes what every downstream sparse solve is handed.
+    """
+    _, bc, _ = _fixture("periodic")
+    lap_bands = _bc_laplacian_bands(NX, DX, bc, 0.0)
+    # A strictly monotone state cannot be periodic, so the branch is pinned at row 0 only: the wrap
+    # ghost makes `central[0]` follow the sign of `u[1] - u[-1]`. These two differ there and agree
+    # nowhere else that matters, which is exactly the discriminating pair.
+    takes_forward, takes_backward = -np.sin(2 * np.pi * X), np.sin(2 * np.pi * X)
+    assert _compute_gradient_array_1d(takes_forward, DX, bc=bc, upwind=False, time=0.0)[0] < 0
+    assert _compute_gradient_array_1d(takes_backward, DX, bc=bc, upwind=False, time=0.0)[0] > 0
+
+    _, _, _, fwd_extras = _advection_bands(takes_forward, DX, bc, 0.0, True, lap_bands)
+    _, _, _, back_extras = _advection_bands(takes_backward, DX, bc, 0.0, True, lap_bands)
+    scale = 1.0 / DX
+    assert all(abs(v) > 1e-6 * scale for _, _, v in fwd_extras), f"a cancelled entry survived: {fwd_extras}"
+    assert all(abs(v) > 1e-6 * scale for _, _, v in back_extras), f"a cancelled entry survived: {back_extras}"
+
+    fwd_cells = {(i, j) for i, j, _ in fwd_extras}
+    back_cells = {(i, j) for i, j, _ in back_extras}
+    assert fwd_cells != back_cells, "both branches reach the same wrap columns; the drop is invisible here"
+    assert 0 not in {i for i, _ in fwd_cells}, f"row 0 took forward, so it must not reach a wrap column: {fwd_extras}"
+
+
+def test_the_jacobian_follows_a_changed_selection_rule_without_being_told(monkeypatch):
+    """The reason the branch is measured rather than restated, made testable.
+
+    On every configuration this repo can build, measuring which one-sided form `grad_upwind`
+    returned and restating `sign(central) >= 0` give the same answer — so no ordinary test can tell
+    a measurement from a second copy of the rule, and the mutation "let the fallback decide
+    everything" kills nothing. The difference only appears when the rule CHANGES, which is exactly
+    the failure #1896 item 3 is: a second copy that silently stopped agreeing.
+
+    So change it. `gradient_upwind` is inverted here — forward where it took backward — and both the
+    residual and the Jacobian go through it. A Jacobian that measures follows; one that restates
+    `sign(central)` is now wrong on every non-tied row and cannot pass.
+    """
+    from mfgarchon.operators.stencils.finite_difference import gradient_backward, gradient_forward
+
+    def inverted(u, axis, h, xp=np):
+        fwd, bwd = gradient_forward(u, axis, h, xp), gradient_backward(u, axis, h, xp)
+        return xp.where((fwd + bwd) / 2.0 >= 0, fwd, bwd)  # the OPPOSITE of Godunov
+
+    monkeypatch.setattr(base_hjb, "gradient_upwind", inverted)
+
+    problem, bc, m = _fixture("no_flux")
+    u = SMOOTH_STATES["rough"]
+    # Control: the inverted rule must actually differ from the real one on this state, or the
+    # monkeypatch proves nothing.
+    central = _compute_gradient_array_1d(u, DX, bc=bc, upwind=False, time=0.0)
+    assert (central > 0).any(), "state does not exercise the backward branch"
+    assert (central < 0).any(), "state does not exercise the forward branch"
+
+    err = np.abs(_jacobian(problem, bc, m, u, True) - _fd_columns(_residual(problem, bc, m, True), u))
+    assert err.max() < 1e-5, f"the Jacobian did not follow the rule change: {err.max():.3e}"

--- a/tests/unit/test_alg/test_hjb_jacobian_advection_1896.py
+++ b/tests/unit/test_alg/test_hjb_jacobian_advection_1896.py
@@ -1,0 +1,346 @@
+"""The Jacobian's advection block must be the derivative of the gradient the residual applied.
+
+Same external oracle as #1894 (a finite difference of `compute_hjb_residual`, computed without
+reference to the Jacobian), pointed at the other block. Two defects, both measured on this fixture:
+
+  item 4 -- the wall rows were the interior stencil. Under no-flux the true central row 0 is
+    {0: -4, 1: +4} and the Jacobian wrote {1: +4}; under Dirichlet the true row is {0: +4, 1: +4},
+    so the missing entry has the OPPOSITE SIGN between two BCs of the same scheme.
+  item 3 -- the branch was selected by a second rule. The residual selects on sign(central), the
+    Jacobian selected on sign(grad_upwind); they part at 8 of 41 nodes on a random field and at
+    none on a monotone one, which is what every test used.
+
+Why it hid, beyond that: `use_upwind=True` is the default, and under no-flux upwind the true wall
+row is EMPTY while the BC forces p=0 there, so `dH/dp` multiplies the spurious diagonal away. The
+one configuration the capability fixture runs is the one configuration that masks the defect.
+
+The analytic block is reached only when `backend is None` (`HJBFDMSolver(analytic_jacobian=True)`,
+#1607). Passing a NumPy backend routes to the per-point FD fallback instead -- a different code
+path, whose agreement says nothing about this one. Every test here passes `backend=None`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon import MFGProblem
+from mfgarchon.alg.numerical.hjb_solvers import base_hjb
+from mfgarchon.alg.numerical.hjb_solvers.base_hjb import (
+    _advection_bands,
+    _bc_laplacian_bands,
+    _compute_gradient_array_1d,
+    _compute_laplacian_1d,
+    compute_hjb_jacobian,
+    compute_hjb_residual,
+)
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import dirichlet_bc, neumann_bc, no_flux_bc, periodic_bc, robin_bc
+
+NX = 21
+DX = 1.0 / (NX - 1)
+X = np.linspace(0.0, 1.0, NX)
+BOUNDS = np.array([[0.0, 1.0]])
+
+BC_FACTORIES = {
+    "no_flux": lambda: no_flux_bc(dimension=1),
+    "dirichlet": lambda: dirichlet_bc(dimension=1, value=0.0),
+    "periodic": lambda: periodic_bc(dimension=1),
+}
+
+
+def _fixture(bc_name: str, sigma: float = 0.3):
+    bc = BC_FACTORIES[bc_name]()
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=bc)
+    problem = MFGProblem(
+        geometry=grid,
+        Nt=10,
+        T=1.0,
+        sigma=sigma,
+        components=MFGComponents(
+            m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+            u_terminal=lambda x: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: m,
+                coupling_dm=lambda m: 1.0,
+            ),
+        ),
+    )
+    m = np.exp(-10 * (X - 0.5) ** 2)
+    m /= m.sum() * DX
+    return problem, bc, m
+
+
+def _residual(problem, bc, m, upwind: bool):
+    u_next = np.zeros(NX)
+
+    def call(state):
+        return np.asarray(
+            compute_hjb_residual(state, u_next, m, problem, 5, None, None, upwind, bc=bc, domain_bounds=BOUNDS),
+            dtype=float,
+        )
+
+    return call
+
+
+def _jacobian(problem, bc, m, u, upwind: bool):
+    return compute_hjb_jacobian(u, u, m, problem, 5, None, None, upwind, bc=bc, domain_bounds=BOUNDS).toarray()
+
+
+def _fd_columns(residual, u, eps: float = 1e-6):
+    """dF/dU by a two-sided difference, one column at a time. Independent of the Jacobian code."""
+    out = np.zeros((NX, NX))
+    for j in range(NX):
+        e = np.zeros(NX)
+        e[j] = 1.0
+        out[:, j] = (residual(u + eps * e) - residual(u - eps * e)) / (2.0 * eps)
+    return out
+
+
+def _switching_nodes(u, bc, upwind: bool):
+    """Rows where the upwind branch is switching -- the residual is not differentiable there.
+
+    A two-sided FD across such a row averages two different one-sided operators and equals neither,
+    so it is not a valid oracle at those rows. Central differencing has no branch, hence no
+    switching nodes. Returned so every test can say out loud which rows it is not asserting on.
+    """
+    if not upwind:
+        return np.zeros(NX, dtype=bool)
+    g_c = _compute_gradient_array_1d(np.asarray(u, dtype=float), DX, bc=bc, upwind=False, time=0.0)
+    return np.abs(g_c) < 1e-9
+
+
+# States with no switching node under any of the three BCs; `_no_switching_states_are_actually_smooth`
+# is the control that keeps that claim honest as the fixture changes.
+SMOOTH_STATES = {
+    "monotone": 2.0 * X**2,
+    "bump_off_node": -3.0 * np.exp(-8 * (X - 0.53) ** 2),
+    "rough": 0.4 * np.sin(4 * np.pi * X) + 0.1 * np.random.default_rng(1896).standard_normal(NX),
+    "piecewise_linear": np.abs(X - 0.53),
+}
+
+
+@pytest.mark.parametrize("bc_name", list(BC_FACTORIES))
+@pytest.mark.parametrize("upwind", [False, True])
+@pytest.mark.parametrize("state", list(SMOOTH_STATES))
+def test_no_switching_states_are_actually_smooth(bc_name: str, upwind: bool, state: str):
+    """Positive control for the exclusion below: these states must have nothing to exclude.
+
+    Without this, `_switching_nodes` growing to cover every row would make every assertion in this
+    file vacuous while the suite stayed green -- the exclusion would be laundering the measurement.
+    """
+    _, bc, _ = _fixture(bc_name)
+    switching = _switching_nodes(SMOOTH_STATES[state], bc, upwind)
+    assert not switching.any(), f"{state} under {bc_name}: switching at rows {np.nonzero(switching)[0].tolist()}"
+
+
+@pytest.mark.parametrize("bc_name", list(BC_FACTORIES))
+@pytest.mark.parametrize("upwind", [False, True])
+def test_the_wall_rows_are_the_residuals_own_stencil(bc_name: str, upwind: bool):
+    """#1896 item 4, all six cells. These are the rows the hardcoded interior stencil got wrong.
+
+    Before the fix, at Nx=9: central row 0 read {1: +4} against a true {0: -4, 1: +4} (no-flux) and
+    {0: +4, 1: +4} (Dirichlet), and the periodic wrap entry was absent entirely.
+    """
+    problem, bc, m = _fixture(bc_name)
+    u = SMOOTH_STATES["bump_off_node"]
+    err = np.abs(_jacobian(problem, bc, m, u, upwind) - _fd_columns(_residual(problem, bc, m, upwind), u))
+    assert err[0].max() < 1e-5, f"row 0: {err[0].max():.3e}"
+    assert err[-1].max() < 1e-5, f"row -1: {err[-1].max():.3e}"
+
+
+@pytest.mark.parametrize("bc_name", list(BC_FACTORIES))
+@pytest.mark.parametrize("upwind", [False, True])
+@pytest.mark.parametrize("state", list(SMOOTH_STATES))
+def test_every_row_linearises_the_residual(bc_name: str, upwind: bool, state: str):
+    """The whole matrix, not just the ends -- item 3's divergence is interior.
+
+    `piecewise_linear` is the discriminating case for how the branch is recovered: forward and
+    backward agree in VALUE on every linear stretch, so reading the branch off values alone is
+    blind there while the two ROWS still differ. That failure measured 4.000e+01, eps-independent.
+    """
+    problem, bc, m = _fixture(bc_name)
+    u = SMOOTH_STATES[state]
+    err = np.abs(_jacobian(problem, bc, m, u, upwind) - _fd_columns(_residual(problem, bc, m, upwind), u))
+    worst = int(np.argmax(err.max(axis=1)))
+    assert err.max() < 1e-5, f"worst row {worst}: {err.max():.3e}"
+
+
+def test_the_two_branch_selection_rules_actually_disagree_on_this_fixture():
+    """Positive control for item 3: without a state where they part, the test above proves nothing.
+
+    The residual selects on sign(central); the superseded Jacobian selected on sign(grad_upwind).
+    On a monotone state they agree at every node, which is why this was invisible.
+    """
+    _, bc, _ = _fixture("no_flux")
+    rough = SMOOTH_STATES["rough"]
+    central = _compute_gradient_array_1d(rough, DX, bc=bc, upwind=False, time=0.0)
+    upwind_grad = _compute_gradient_array_1d(rough, DX, bc=bc, upwind=True, time=0.0)
+    parted = (central >= 0) != (upwind_grad >= 0)
+    assert parted.sum() >= 2, f"the rules agree everywhere on `rough` ({parted.sum()} nodes differ)"
+
+    monotone = SMOOTH_STATES["monotone"]
+    c_mono = _compute_gradient_array_1d(monotone, DX, bc=bc, upwind=False, time=0.0)
+    u_mono = _compute_gradient_array_1d(monotone, DX, bc=bc, upwind=True, time=0.0)
+    assert not ((c_mono >= 0) != (u_mono >= 0)).any(), "monotone was supposed to be the blind case"
+
+
+def test_a_switching_node_gets_a_clarke_element_not_an_average():
+    """Where the residual is not differentiable, the row must still be one of the admissible ones.
+
+    The two-sided FD is not the oracle here -- it averages the two one-sided operators and equals
+    neither. So each branch is isolated instead: tilt the two neighbours antisymmetrically to pin
+    the selection to one side without moving the node's own value, and take the FD there. The
+    Jacobian row must converge to ONE of the two as the tilt shrinks, and the two must stay far
+    apart (otherwise "matches a branch" is satisfied by anything).
+    """
+    problem, bc, m = _fixture("no_flux")
+    row = NX // 2
+    u = np.abs(X - 0.5)  # kink exactly on `row`: central gradient there is 0
+    assert _switching_nodes(u, bc, True)[row], "fixture no longer switches at this row"
+
+    jac = _jacobian(problem, bc, m, u, True)
+    residual = _residual(problem, bc, m, True)
+
+    def branch_row(direction: float, tilt: float) -> np.ndarray:
+        shifted = u.copy()
+        shifted[row - 1] -= direction * tilt
+        shifted[row + 1] += direction * tilt
+        return _fd_columns(residual, shifted)[row]
+
+    forward, backward = branch_row(-1.0, 1e-5), branch_row(+1.0, 1e-5)
+    separation = float(np.abs(forward - backward).max())
+    nearest = min(float(np.abs(jac[row] - forward).max()), float(np.abs(jac[row] - backward).max()))
+    assert separation > 1.0, f"the two branches coincide ({separation:.3e}); nothing is being tested"
+    assert nearest < 0.05 * separation, f"row {row} matches neither branch: {nearest:.3e} vs {separation:.3e}"
+
+    # The tilt is a perturbation of the state, so `nearest` is O(tilt), not zero. Shrinking it by
+    # 10x must shrink the gap by ~10x -- that is what says the row IS a branch rather than near one.
+    coarse = min(
+        float(np.abs(jac[row] - branch_row(-1.0, 1e-4)).max()),
+        float(np.abs(jac[row] - branch_row(+1.0, 1e-4)).max()),
+    )
+    assert nearest < 0.2 * coarse, f"gap does not shrink with the tilt: {coarse:.3e} -> {nearest:.3e}"
+
+
+def test_the_flat_state_the_repo_defaults_to_is_a_total_branch_degeneracy():
+    """`u_terminal = 0` is this repo's own default, and it makes every node a tie.
+
+    Forward and backward agree in value everywhere (both zero), so the value comparison decides
+    nothing at any row. The residual's advection term is quadratic in p, so the true derivative is
+    zero and the two-sided FD leaves an O(eps) tail rather than a defect -- pinned by its scaling,
+    since a fixed tolerance here would pass over a genuinely wrong row of the same size.
+    """
+    problem, bc, m = _fixture("no_flux")
+    u = np.zeros(NX)
+    jac = _jacobian(problem, bc, m, u, True)
+    residual = _residual(problem, bc, m, True)
+    coarse = float(np.abs(jac - _fd_columns(residual, u, eps=1e-4)).max())
+    fine = float(np.abs(jac - _fd_columns(residual, u, eps=1e-6)).max())
+    assert fine < 0.02 * coarse, f"eps-independent error at the flat state: {coarse:.3e} -> {fine:.3e}"
+
+
+@pytest.mark.parametrize("bc_name", list(BC_FACTORIES))
+def test_a_volatility_field_does_not_disturb_the_advection_block(bc_name: str):
+    """Row-indexed sigma is #1894's B1; the advection block row-indexes dH/dp for the same reason.
+
+    An (Nx,) coefficient written whole into an off-band entry raises ValueError, and the assembly's
+    pre-existing handler answers that by replacing the entire Jacobian with (1/dt)*I -- a plausible
+    wrong answer rather than a crash. Periodic is the case that has off-band entries at all.
+    """
+    problem, bc, m = _fixture(bc_name)
+    sigma_field = 0.2 + 0.3 * np.sin(np.pi * X) ** 2
+    u = SMOOTH_STATES["bump_off_node"]
+    jac = compute_hjb_jacobian(u, u, m, problem, 5, None, sigma_field, True, bc=bc, domain_bounds=BOUNDS).toarray()
+    assert not np.allclose(jac, np.eye(NX) / problem.dt), "the Jacobian collapsed to (1/dt)*I"
+
+    u_next = np.zeros(NX)
+
+    def residual(state):
+        return np.asarray(
+            compute_hjb_residual(state, u_next, m, problem, 5, None, sigma_field, True, bc=bc, domain_bounds=BOUNDS),
+            dtype=float,
+        )
+
+    assert float(np.abs(jac - _fd_columns(residual, u)).max()) < 1e-5
+
+
+# The premise the whole upwind construction rests on. Every BC this repo can build must satisfy it,
+# because the bands are assembled from `central` and `laplacian` and never from a one-sided stencil.
+IDENTITY_BCS = {
+    "no_flux": lambda: no_flux_bc(dimension=1),
+    "dirichlet": lambda: dirichlet_bc(dimension=1, value=0.7),
+    "neumann": lambda: neumann_bc(dimension=1, value=0.3),
+    "periodic": lambda: periodic_bc(dimension=1),
+    "robin_mixed": lambda: robin_bc(dimension=1, alpha=1.0, beta=1.0, value=0.5),
+    "robin_neumann_like": lambda: robin_bc(dimension=1, alpha=0.0, beta=1.0, value=0.0),
+    "robin_sign_flipped": lambda: robin_bc(dimension=1, alpha=2.0, beta=-1.0, value=1.0),
+}
+
+
+@pytest.mark.parametrize("bc_name", list(IDENTITY_BCS))
+@pytest.mark.parametrize(
+    "state",
+    ["smooth", "random", "linear"],
+)
+def test_the_one_sided_stencils_are_algebra_on_the_two_operators_that_have_owners(bc_name: str, state: str):
+    """forward = central + (dx/2)*laplacian, backward = central - (dx/2)*laplacian, walls included.
+
+    This is why the upwind Jacobian needs no third stencil of its own: both one-sided operators are
+    combinations of two the residual already owns. Robin is in the list because it is the BC most
+    likely to pad the Laplacian differently from the gradient, which is the one way this breaks.
+    """
+    bc = IDENTITY_BCS[bc_name]()
+    u = {
+        "smooth": -3.0 * np.exp(-8 * (X - 0.53) ** 2),
+        "random": np.random.default_rng(1896).standard_normal(NX),
+        "linear": 2.0 * X + 0.3,
+    }[state]
+    central = _compute_gradient_array_1d(u, DX, bc=bc, upwind=False, time=0.0)
+    lap = _compute_laplacian_1d(u, DX, bc=bc, time=0.0)
+    upwind = _compute_gradient_array_1d(u, DX, bc=bc, upwind=True, time=0.0)
+    forward, backward = central + DX / 2 * lap, central - DX / 2 * lap
+    residual = float(np.minimum(np.abs(upwind - forward), np.abs(upwind - backward)).max())
+    assert residual < 1e-12, f"{bc_name}/{state}: grad_upwind is neither one-sided form ({residual:.3e})"
+    assert float(np.abs(forward - backward).max()) > 1e-9, "the two forms coincide; nothing is discriminated"
+
+
+def test_a_broken_identity_raises_instead_of_picking_the_closer_wrong_answer(monkeypatch):
+    """The failure mode this guards is silent, so the guard is part of the contract.
+
+    If some future BC padded the Laplacian differently from the gradient, the branch would be
+    recovered by taking the nearer of two wrong reconstructions -- a plausible Jacobian, no error,
+    and Newton merely converging badly. No BC in the repo breaks the identity today (all seven
+    above hold to 1e-14), so it is broken here deliberately.
+    """
+    bc = no_flux_bc(dimension=1)
+    u = -3.0 * np.exp(-8 * (X - 0.53) ** 2)
+    bands = _bc_laplacian_bands(NX, DX, bc, 0.0)
+    real = base_hjb._compute_laplacian_1d
+    monkeypatch.setattr(base_hjb, "_compute_laplacian_1d", lambda *a, **k: real(*a, **k) * 3.0 + 1.0)
+
+    with pytest.raises(ValueError, match="#1896"):
+        _advection_bands(u, DX, bc, 0.0, True, bands)
+
+
+@pytest.mark.parametrize("upwind", [False, True])
+def test_the_legacy_no_bc_path_linearises_its_own_residual_too(upwind: bool):
+    """`bc=None` is a separate dispatch branch: both operators fall back to the periodic %Nx roll.
+
+    The parametrised cases above all pass a real BC object, so none of them reaches it. It matters
+    because the residual takes the same branch -- whatever operator `bc=None` selects, the Jacobian
+    has to be the derivative of that one and not of the BC-aware one.
+    """
+    problem, _, m = _fixture("no_flux")
+    u = SMOOTH_STATES["bump_off_node"]
+    u_next = np.zeros(NX)
+
+    def residual(state):
+        return np.asarray(compute_hjb_residual(state, u_next, m, problem, 5, None, None, upwind, bc=None), dtype=float)
+
+    jac = compute_hjb_jacobian(u, u, m, problem, 5, None, None, upwind, bc=None).toarray()
+    assert float(np.abs(jac - _fd_columns(residual, u)).max()) < 1e-5

--- a/tests/unit/test_alg/test_hjb_jacobian_matches_residual_1894.py
+++ b/tests/unit/test_alg/test_hjb_jacobian_matches_residual_1894.py
@@ -23,7 +23,7 @@ from mfgarchon.backends import create_backend
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.geometry import TensorProductGrid
-from mfgarchon.geometry.boundary import no_flux_bc, periodic_bc
+from mfgarchon.geometry.boundary import dirichlet_bc, no_flux_bc, periodic_bc
 
 
 def _problem(sigma: float, nx: int) -> MFGProblem:
@@ -227,6 +227,61 @@ def test_the_comb_tier_actually_fires_for_a_banded_operator(nx):
             )
     finally:
         base_hjb._compute_laplacian_1d = original
+
+
+def test_nx_6_degenerates_the_comb_and_that_is_recorded_rather_than_assumed_away():
+    """Nx=6 is the one size where the comb cannot fire, and it is an in-tree fixture.
+
+    `edges` takes {0, 1, 4, 5}, leaving `interior = [2, 3]`; a length below 3 collapses `stride` to
+    1, so the single comb probes two ADJACENT columns, `pack` cannot attribute them, the control
+    vector fails and tier 2 runs. Not a BC effect -- it is arithmetic on the index sets, identical
+    under every BC.
+
+    Pinned because the test above parametrises nx over [9, 21, 201, 801] and a docstring in
+    `_extract_bands` generalised that population to "a constant 9 probes for every Nx", which is
+    false twice over: the count on that set is 8, and Nx=6 costs 12. `tests/conftest.py`'s
+    `tiny_problem` is Nx=6, so the fallback fires in-tree on every run. Found by review (#1899).
+
+    The bands are still exact at Nx=6 -- tier 2 is exact for any structure -- so this records a
+    cost, not a defect.
+    """
+    from mfgarchon.alg.numerical.hjb_solvers import base_hjb
+
+    original = base_hjb._compute_laplacian_1d
+
+    def count_for(nx, bc):
+        calls = []
+
+        def counting(*args, **kwargs):
+            calls.append(1)
+            return original(*args, **kwargs)
+
+        base_hjb._compute_laplacian_1d = counting
+        try:
+            bands = base_hjb._bc_laplacian_bands(nx, 1.0 / (nx - 1), bc, 0.0)
+        finally:
+            base_hjb._compute_laplacian_1d = original
+        return len(calls), bands
+
+    for bc in (no_flux_bc(dimension=1), dirichlet_bc(dimension=1, value=0.0), periodic_bc(dimension=1)):
+        n6, bands6 = count_for(6, bc)
+        n7, _ = count_for(7, bc)
+        assert n6 > 9, f"Nx=6 no longer degenerates ({n6} probes); the recorded cost is stale"
+        assert n7 <= 9, f"Nx=7 should still comb ({n7} probes)"
+
+        # ...and the answer is still right, which is why this is a cost and not a defect.
+        nx, dx = 6, 1.0 / 5
+        zero = base_hjb._compute_laplacian_1d(np.zeros(nx), dx, bc=bc, time=0.0)
+        reference = np.zeros((nx, nx))
+        for j in range(nx):
+            e = np.zeros(nx)
+            e[j] = 1.0
+            reference[:, j] = base_hjb._compute_laplacian_1d(e, dx, bc=bc, time=0.0) - zero
+        sub, diag, sup, extras = bands6
+        rebuilt = np.diag(diag) + np.diag(sub[1:], -1) + np.diag(sup[:-1], 1)
+        for i, j, v in extras:
+            rebuilt[i, j] += v
+        assert np.abs(rebuilt - reference).max() < 1e-12, "tier 2 did not extract Nx=6 exactly"
 
 
 @pytest.mark.parametrize("bc_name", ["no_flux", "periodic", "periodic_endpoint_inclusive"])


### PR DESCRIPTION
Refs #1896 — closes **items 3 and 4** only. Items 2, 5, 6, 7, 8 remain open, so this PR does **not** close the issue.

> ⚠️ The commit body says "Closes #1896 items 3 and 4". GitHub will read the `Closes #1896` and auto-close the issue on merge. **Edit the squash-merge message to `Refs #1896` before merging**, or reopen the issue afterwards.

## What was wrong

The advection block restated the gradient stencil by hand. Measured by column-wise finite difference of `compute_hjb_residual` at `Nx=9`:

| BC | scheme | true row 0 | hardcoded row 0 |
|:--|:--|:--|:--|
| no_flux | central | `{0: -4, 1: +4}` | `{1: +4}` |
| dirichlet | central | `{0: +4, 1: +4}` | `{1: +4}` |
| periodic | central | `{1: +4, 8: -4}` | `{1: +4}` |
| no_flux | upwind | `{}` | `{0: +8}` |
| dirichlet | upwind | `{0: +16}` | `{0: +8}` |
| periodic | upwind | `{0: -8, 1: +8}` | `{0: +8}` |

The missing central entry has the **opposite sign** between no-flux and Dirichlet, so no single correction to the hardcoded row covers both. Separately (item 3), the branch was selected on `sign(grad_upwind)` while the residual selects on `sign(central)`: they part at **8 of 41** nodes on a random field and at **0 of 41** on the monotone state every test used.

**Why nothing caught it.** `use_upwind=True` is the default, and no-flux upwind is the one cell where the defect is invisible — the true row is empty *and* the BC forces `p = 0`, so `dH/dp` multiplies the spurious diagonal away. That is what the `fdm_upwind` capability fixture runs. Same shape as #1894, which fixed the diffusion block of the same function and was identically absent at `σ = 0`.

## The fix

Upwind is not linear in `U`, and probing it does not merely lose accuracy — at a switching node the directional difference disagrees with itself and the extractor raises (9 of 15 measured wall cells at `Nx=9`). That is correct: the map is nondifferentiable there and no Jacobian exists, only a Clarke generalised Jacobian.

So the bands come from the two operators that *are* linear and already have owners:

```
forward  = central + (dx/2) * laplacian
backward = central - (dx/2) * laplacian
```

exact to `1.4e-14` over seven BCs (no-flux, Dirichlet, Neumann, periodic, three Robin parameter sets) × three states. Which branch holds is then **observed**, which is what closes item 3 — observation cannot disagree with the residual, because it is a measurement of it.

Observation needs two steps, and the second was found by measurement rather than reasoning: values are blind wherever forward and backward agree — every locally linear stretch — while the two *rows* still differ. Reading values alone put the Jacobian one column across on a piecewise-linear state, `4.000e+01`, ε-independent. Those rows are decided by how `grad_upwind` **moves** under an alternating probe, whose central difference vanishes at every interior node and so cannot move the branch it is measuring.

## Result

Column-wise FD vs the assembled Jacobian, `Nx=21`, 3 BCs × 2 schemes × 4 states: worst `1.19e-07`, the FD truncation floor. Two residual disagreements are the **instrument**, each measured rather than assumed:

- at a switching node the two-sided FD averages two one-sided operators and equals neither. The Jacobian row converges to one of them exactly — `4e-1 → 4e-2 → 4e-3` as the isolating tilt shrinks 10× — while the branches stay `2e+01` apart.
- at `u ≡ 0` the advection term is quadratic in `p`, so the FD leaves an O(ε) tail: `1e-2 → 1e-4 → 1e-6` at ε = `1e-4 / 1e-6 / 1e-8`.

**Cost**: analytic path stays O(Nx), ~2.0× slower (`3.6 → 7.3` ms at `Nx=1601`), ratio flat across `Nx`. The Laplacian bands are now extracted once and shared by both blocks — worth `10.9 → 7.3` ms at `Nx=1601`. FD fallback untouched.

## Oracle

`tests/unit/test_alg/test_hjb_jacobian_advection_1896.py` — external. Mutation-verified, seven mutations, all killed:

| mutation | tests killed |
|:--|--:|
| neuter the tie-break probe | 3 |
| restate the branch rule as `sign(grad_upwind)` | 15 |
| invert the mask | 20 |
| drop the per-row sign on the wrap entries | 6 |
| drop the wrap entries entirely | 7 |
| use central bands for upwind | 20 |
| remove the identity guard | 1 |

Reverting the whole change turns **34 of 84** red. The file carries its own positive controls: that the states it calls smooth have no switching node (otherwise the exclusion silently makes every assertion vacuous), and that the two branch-selection rules actually part on the fixture (otherwise item 3's test proves nothing).

## Two things a reviewer should push on

- **`test_jacobian_byte_identical_to_inline_assembly` (#1071) was changed, not adjusted to pass.** Its reference rebuilt the Jacobian from the same hand-written stencil, so it pinned both defects rather than its own subject. Both stencil halves are tautological there now — verified it still discriminates `dH/dp`: a 1-part-in-10⁵ perturbation turns it red. But the test is weaker than it was, and that is worth arguing about.
- **The analytic block is opt-in**: reached only when `backend is None`, i.e. `HJBFDMSolver(analytic_jacobian=True)` (#1607). The default routes to the per-point FD fallback, which is untouched — and which is still wrong at periodic row 0 and on upwind interior rows (pre-existing, measured, not addressed here).

## Gate

`./scripts/local_ci.sh` → **6090 passed, 22 skipped, 21 xfailed** in 156s, `GATE GREEN`. Single-source counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)