### PR TITLE
chore(ci): report the two numbers that say whether green means anything

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,19 @@ The axiom testing discipline governs **what** a test must cover (edge/stress/fai
 ### Closing out a fix ⚠️ — name the oracle, or say there isn't one
 
 "Add a test" is **not** the default close-out for a fix here. Measured on this repo: the six load-bearing
-conventions the discrimination ratchet tracks are noticed by **192 distinct tests** out of 5,683 —
-**3.4%** react when the physics the library exists to get right is broken. (The baseline's kill
-counts sum to 200; 8 tests are killed by more than one mutation, so the sum over-counts and the
-honest figure is the lower one.) Of the tests whose *names* claim `single_source` / `cross_path` /
-`_agree`, **60% are inert** (#1715). And
+conventions the discrimination ratchet tracks are noticed by **212 distinct tests** out of 5,872 —
+**3.6%** react when the physics the library exists to get right is broken, so **96.4% notice
+nothing**. (The baseline's kill counts sum to 220; 8 tests are killed by more than one mutation, so
+the sum over-counts and the honest figure is the lower one. Current numbers from
+`scripts/discrimination_baseline.json` + `discrimination_killmatrix.json`, measured at `db3496f9`;
+`./scripts/local_ci.sh` prints them beside the suite result and flags the denominator when it moves.)
+Of the tests whose *names* claim `single_source` / `cross_path` / `_agree`, **60% are inert** —
+[#1715's comment of 2026-07-30](https://github.com/derrring/MFGArchon/issues/1715#issuecomment-5090690985),
+not its body, which says the prevalence "is not established". **Inert is not the same as worthless**,
+and that distinction has cost real time: all five tests #1715 names are genuine cross-path pins —
+delegation shims, builder-vs-operator GFDM weights, Newton-vs-Picard agreement — inert on six
+conventions *because those conventions are not what they pin*. The deletable set is the
+**structurally tautological** one, found by reading, not the inert one, found by counting (#1901). And
 the yield runs the other way too: #1660's 17 nightly "failures" resolved as 8 fixture rot from the
 #1442 drift migration, 2 tests measuring the wrong quantity, 7 timeouts — **zero** product
 regressions caught by a test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ the sum over-counts and the honest figure is the lower one. Current numbers from
 `scripts/discrimination_baseline.json` + `discrimination_killmatrix.json`, measured at `db3496f9`;
 `./scripts/local_ci.sh` prints them beside the suite result and flags the denominator when it moves.)
 Of the tests whose *names* claim `single_source` / `cross_path` / `_agree`, **60% are inert** —
-[#1715's comment of 2026-07-30](https://github.com/derrring/MFGArchon/issues/1715#issuecomment-5090690985),
+[#1715's comment of 2026-07-27](https://github.com/derrring/MFGArchon/issues/1715#issuecomment-5090690985),
 not its body, which says the prevalence "is not established". **Inert is not the same as worthless**,
 and that distinction has cost real time: all five tests #1715 names are genuine cross-path pins —
 delegation shims, builder-vs-operator GFDM weights, Newton-vs-Picard agreement — inert on six

--- a/changelog.d/1901-report-the-discriminating-fraction.added.md
+++ b/changelog.d/1901-report-the-discriminating-fraction.added.md
@@ -46,7 +46,7 @@
   or none at all:
 
   ```
-  assertion strength : 1036 of 5369 collected tests assert only what a well-formed WRONG answer
+  assertion strength : 1049 of 5393 defined test functions assert only what a well-formed WRONG answer
                        satisfies = 19.3%
   ```
 
@@ -73,8 +73,9 @@
 
   - **The frozen-paradigm filter excluded nothing.** `FROZEN = ("alg/neural", "alg/reinforcement")`
     names the *source* layout and matches **zero** files under `tests/`, where those live as
-    `test_dgm_*`, `test_pinn_*`, `test_rl_*`. 131 frozen test functions sat in the denominator at a
-    47% flag rate. Worse, the test "verifying" it asserted `"alg/neural" in cas.FROZEN` — the
+    the filter was matching test FILENAMES. ~~131 frozen test functions at a 47% flag rate~~
+    [CORRECTED 2026-08-13] — neither figure is reproducible; re-measured under the single owner
+    (`check_frozen_areas._references`) the frozen set is 14 files / 145 test functions, 66 flagged = 46%. Worse, the test "verifying" it asserted `"alg/neural" in cas.FROZEN` — the
     constant containing itself, which is the tautological shape this very script exists to count.
     It now asserts the **behaviour**: a frozen-named file must be absent from the scan.
   - **The separation assertion was called the weakest class when it is the strongest.**
@@ -83,7 +84,10 @@
     as weak, inverting it on **70** tests including `test_coupling_affects_solution` and
     `test_fp_velocity_consumes_cross_density_1071`. Only a bare `assert not x` is weak now.
 
-  Net effect of both: **20.6% → 19.3%**.
+  Net effect: ~~**20.6% → 19.3%**~~ [CORRECTED 2026-08-13] **20.6% → 19.5%**, over a denominator of
+  5393. The 19.3% figure was measured while frozen membership was decided by filename substring,
+  which disagreed with `check_frozen_areas.py` on six files — 40 test functions wrongly excluded,
+  20 wrongly kept. Frozen membership now has one owner and this number follows it.
 
 - **The staleness line was itself measured over the wrong denominator.** The baseline records
   `"excluded": "tests/unit/test_discrimination_ratchet.py"` and the sweep ignores it; the reporter
@@ -102,7 +106,7 @@
   | `now != then` → `now > then` (a shrinking suite never called stale) | 1 |
   | drop the `--ignore` exclusion from the collect | 1 |
   | invert the fraction (`len(weak)/total` → its complement) | 1 |
-  | drop `of {total} collected tests` | 1 |
+  | drop `of {total} defined test functions` | 1 |
 
 - **`CLAUDE.md`**: the cited comment date was **2026-07-30**; `created_at` is **2026-07-27**. Fixed.
   The link resolves and does contain `39 (60%)` and `96.8% notice nothing`, verified against the API.

--- a/changelog.d/1901-report-the-discriminating-fraction.added.md
+++ b/changelog.d/1901-report-the-discriminating-fraction.added.md
@@ -39,3 +39,33 @@
   `feedback_net_negative_test_mass` already prescribed: the correct form of net-negative is "add
   less", not "hunt for deletions", and a kill count cannot prove a test is removable, only fail to
   falsify it.
+
+- **A second quality number beside it, and the deletion PR it was meant to justify does not exist.**
+  `scripts/check_assertion_strength.py` counts tests whose assertions a well-formed **wrong** answer
+  would satisfy — every assertion being `is not None` / `isfinite` / `.shape` / `len` / `isinstance`,
+  or none at all:
+
+  ```
+  assertion strength : 1137 of 5513 collected tests assert only what a well-formed WRONG answer
+                       satisfies = 20.6%
+  ```
+
+  This is a **structural** selector, and that is the point. "Inert under the six convention
+  mutations" is not: it selects for *tests something else*, which is why all five tests #1715 named
+  that way are genuine cross-path pins. An assertion that only checks well-formedness cannot
+  separate right from wrong for **any** input.
+
+- **It is a review queue, not a delete list, and the attempt to treat it as one is the finding.**
+  Reading the assertion-free subset by hand: of 115, **37 are capability cells** ("can this
+  configuration run at all" — a close-out `CLAUDE.md` explicitly allows), **15 are negative controls
+  for fail-loud guards** (`test_x_accepts_supported` next to `test_x_fails_loud_on_unsupported`;
+  without it the guard could reject everything and its `pytest.raises` siblings would still pass),
+  and **10 are dependency probes**. All three are assertion-free *by nature*. A promised
+  115-deletion PR was withdrawn on that evidence.
+
+- **The scanner needed the discipline it enforces**, and did not get it first time. Three defects
+  found by reading its own output: it counted `def test_helper()` **nested inside** a test, which
+  pytest never collects (three files contributed duplicate rows); it omitted `pytest.raises` and
+  `pytest.warns` from the strong list, so every fail-loud guard in the tree was flagged; and the
+  first count (21.9%) was taken over that inflated population. Corrected to **20.6%**, validated on
+  9 control cases — 4 known-weak flagged, 5 known-strong kept — and the controls are committed.

--- a/changelog.d/1901-report-the-discriminating-fraction.added.md
+++ b/changelog.d/1901-report-the-discriminating-fraction.added.md
@@ -1,0 +1,41 @@
+- **The gate now prints the discriminating fraction beside the suite result, with its denominator.**
+  `N passed` has never been the quantity worth growing, and printing it alone invites growing it.
+  `scripts/report_discrimination.py` prints the one that says whether green means anything:
+
+  ```
+  discrimination : 212 of 5872 tests notice at least one of 6 conventions = 3.61%  (measured at db3496f9)
+                   the suite has since moved 5872 -> 6142 (+4.6%): the fraction above is STALE, and
+                   adding tests lowers it unless they discriminate
+  ```
+
+  Reports, does not gate — measuring it costs one full suite run per mutation, so the gating stays
+  in the weekly `test_discrimination.py --check-baseline` tier. Skipped under `--fast`.
+
+  The staleness line is the point. The recorded fraction ages silently as the suite grows, which is
+  #1901's class 2 (a verdict without its denominator) applied to the instrument that measures class
+  2. Its own parser is pinned against **both** pytest summary forms, because the first version read
+  `line.split()[0]`, returned `None` on the `N/M tests collected (K deselected)` form the CI marker
+  set actually prints, and reported "current suite size unknown" while the number was on screen.
+
+- **`CLAUDE.md`'s discrimination figures corrected, and the citation fixed.** They read `192 of
+  5,683 = 3.4%`; the committed artifacts give **212 of 5,872 = 3.6%**, so **96.4% notice nothing** —
+  the stronger and more actionable direction. The 60%-inert claim was cited to #1715, whose *body*
+  says the prevalence "is not established"; it comes from a **comment**, now linked directly and
+  verified to contain the figure.
+
+- **"Inert" is not "worthless", and acting on that distinction was the whole of #1901's item 3.**
+  All five tests #1715 names were read: `test_granular_primitives_byte_identical_to_inline` and
+  `test_h_eval_helpers_delegate_byte_identical` are delegation pins (`evaluate_H` is literally
+  `np.asarray(self(...), dtype=float)`, so the assertion is `f(x) == f(x)` while delegation holds —
+  and fires the moment a shim is reimplemented divergently);
+  `test_coupled_equals_drift_byte_identical` compares two FP advection entry points and carries its
+  own vacuity control; `test_nonlcr_weights_byte_identical_adaptive_off` compares builder-path
+  against operator-path GFDM weights; `test_newton_matches_picard_small` pins two independent
+  solvers on one fixed point. **None is deletable.** Each is inert on six conventions precisely
+  because those conventions are not what it pins.
+
+  So the deletable set is the **structurally tautological** one — found by reading — not the inert
+  one, found by counting. Recorded rather than acted on, which is what
+  `feedback_net_negative_test_mass` already prescribed: the correct form of net-negative is "add
+  less", not "hunt for deletions", and a kill count cannot prove a test is removable, only fail to
+  falsify it.

--- a/changelog.d/1901-report-the-discriminating-fraction.added.md
+++ b/changelog.d/1901-report-the-discriminating-fraction.added.md
@@ -46,26 +46,63 @@
   or none at all:
 
   ```
-  assertion strength : 1137 of 5513 collected tests assert only what a well-formed WRONG answer
-                       satisfies = 20.6%
+  assertion strength : 1036 of 5369 collected tests assert only what a well-formed WRONG answer
+                       satisfies = 19.3%
   ```
 
-  This is a **structural** selector, and that is the point. "Inert under the six convention
-  mutations" is not: it selects for *tests something else*, which is why all five tests #1715 named
-  that way are genuine cross-path pins. An assertion that only checks well-formedness cannot
-  separate right from wrong for **any** input.
+  A **structural** selector, and that is the point. "Inert under the six convention mutations" is
+  not: it selects for *tests something else*, which is why all five tests #1715 named that way are
+  genuine cross-path pins. An assertion that only checks well-formedness cannot separate right from
+  wrong for **any** input.
 
-- **It is a review queue, not a delete list, and the attempt to treat it as one is the finding.**
-  Reading the assertion-free subset by hand: of 115, **37 are capability cells** ("can this
-  configuration run at all" — a close-out `CLAUDE.md` explicitly allows), **15 are negative controls
-  for fail-loud guards** (`test_x_accepts_supported` next to `test_x_fails_loud_on_unsupported`;
-  without it the guard could reject everything and its `pytest.raises` siblings would still pass),
-  and **10 are dependency probes**. All three are assertion-free *by nature*. A promised
+- **It is a review queue, not a delete list.** Of the 71 assertion-free tests: **32 are negative
+  controls for fail-loud guards** (`test_x_accepts_supported` beside `test_x_fails_loud_on_unsupported`
+  — without it the guard could reject everything and its `pytest.raises` siblings would still pass),
+  **24 are capability cells** ("can this configuration run at all", a close-out `CLAUDE.md` allows),
+  and **15 have no stated purpose**. The first two are assertion-free *by nature*. A promised
   115-deletion PR was withdrawn on that evidence.
 
-- **The scanner needed the discipline it enforces**, and did not get it first time. Three defects
-  found by reading its own output: it counted `def test_helper()` **nested inside** a test, which
-  pytest never collects (three files contributed duplicate rows); it omitted `pytest.raises` and
-  `pytest.warns` from the strong list, so every fail-loud guard in the tree was flagged; and the
-  first count (21.9%) was taken over that inflated population. Corrected to **20.6%**, validated on
-  9 control cases — 4 known-weak flagged, 5 known-strong kept — and the controls are committed.
+  ~~37 capability cells / 15 negative controls / 10 dependency probes, of 115~~ **[CORRECTED]** —
+  that reading was taken over the *superseded* population, before the classifier defects below were
+  fixed, and it inverted the two largest buckets. Re-derived above over the committed scan.
+
+- **The scanner needed the discipline it enforces, twice.** Three defects found by reading its own
+  output: it counted `def test_helper()` **nested inside** a test, which pytest never collects; it
+  omitted `pytest.raises`/`pytest.warns`, so **every fail-loud guard in the tree** was flagged; and
+  the first figure (21.9%) was taken over that inflated population. Two more found by review:
+
+  - **The frozen-paradigm filter excluded nothing.** `FROZEN = ("alg/neural", "alg/reinforcement")`
+    names the *source* layout and matches **zero** files under `tests/`, where those live as
+    `test_dgm_*`, `test_pinn_*`, `test_rl_*`. 131 frozen test functions sat in the denominator at a
+    47% flag rate. Worse, the test "verifying" it asserted `"alg/neural" in cas.FROZEN` — the
+    constant containing itself, which is the tautological shape this very script exists to count.
+    It now asserts the **behaviour**: a frozen-named file must be absent from the scan.
+  - **The separation assertion was called the weakest class when it is the strongest.**
+    `assert not allclose(a, b)` says two things must *differ* — this repo's own doctrine, "assert on
+    disagreement, not validity; byte-identity is the defect, not the pass". Every `not` was treated
+    as weak, inverting it on **70** tests including `test_coupling_affects_solution` and
+    `test_fp_velocity_consumes_cross_density_1071`. Only a bare `assert not x` is weak now.
+
+  Net effect of both: **20.6% → 19.3%**.
+
+- **The staleness line was itself measured over the wrong denominator.** The baseline records
+  `"excluded": "tests/unit/test_discrimination_ratchet.py"` and the sweep ignores it; the reporter
+  did not, comparing 5872 against 6168 and printing **+5.0%** where the like-for-like figure is
+  **+4.6%**. #1901 class 2, inside the instrument built to report class 2. The exclusion is now
+  threaded from the field that was already being read.
+
+- **Mutation table, which the first revision shipped without.** Review found 18 of 23 mutations
+  surviving 26 tests, because neither test file called `main()` — so nothing about either *printed
+  line* was pinned. Now:
+
+  | mutation | reddens |
+  |:--|--:|
+  | halve the percentage (`100 *` → `50 *`) | 1 |
+  | drop `of {then} tests` — the denominator disappears | 2 |
+  | `now != then` → `now > then` (a shrinking suite never called stale) | 1 |
+  | drop the `--ignore` exclusion from the collect | 1 |
+  | invert the fraction (`len(weak)/total` → its complement) | 1 |
+  | drop `of {total} collected tests` | 1 |
+
+- **`CLAUDE.md`**: the cited comment date was **2026-07-30**; `created_at` is **2026-07-27**. Fixed.
+  The link resolves and does contain `39 (60%)` and `96.8% notice nothing`, verified against the API.

--- a/scripts/check_assertion_strength.py
+++ b/scripts/check_assertion_strength.py
@@ -41,18 +41,49 @@ WEAK_CALLS = {"isfinite", "isinstance", "len", "hasattr", "callable", "id", "typ
 # files under `tests/`, so the first version of this filter excluded nothing while its comment and
 # its own test both said otherwise -- and that test asserted the constant contains itself, which is
 # the tautological shape this script exists to count. Found by review (#1905).
-# Every entry must match at least one file: `test_actor`, `test_ppo` and `test_reinforcement`
-# matched zero and were removed 2026-08-13. The old control asserted only that SOME entry
-# matched, so a dead entry -- and the removal of a live one -- were both invisible; review
-# (#1905) deleted `test_training`, a real 29-test file, and the whole test file stayed green.
-# That is a reduced form of the very defect this constant was rewritten to fix.
-FROZEN = (
-    "test_neural",
-    "test_dgm",
-    "test_pinn",
-    "test_rl_",
-    "test_training",
-)
+def _is_frozen(path: Path) -> bool:
+    """Frozen membership has exactly one owner, and it is not this file.
+
+    `scripts/check_frozen_areas.py` decides it by AST -- imports and string literals reaching
+    `FROZEN_PACKAGES` -- with a docstring explaining at length why a name match is insufficient
+    and citing a file it measurably missed. This module answered the same question by filename
+    substring, and the two disagreed on six files:
+
+        frozen by NAME   : 12        frozen by IMPORT : 14
+
+        excluded by name but NOT frozen (2 files, 40 test functions)
+            tests/unit/test_alg/test_rl_stub_metrics_1688.py            (4)
+            tests/unit/test_utils/test_neural/test_normalization.py     (36)
+        frozen by import but LEFT IN the denominator (4 files, 20 test functions)
+            tests/unit/test_alg/test_adaptive_training_canonical_mode_1572.py   (5)
+            tests/unit/test_alg/test_mean_field_rl_requires_pop_state_1508.py   (1)
+            tests/unit/test_alg/test_solver_construction_smoke_887.py           (5)
+            tests/unit/test_config/test_enum_conversions.py                     (9)
+
+    36 of those were dropped from the denominator because a DIRECTORY in their path is spelled
+    `test_neural`, while CLAUDE.md freezes `alg/neural` and `alg/reinforcement` only -- `utils/neural`
+    is not frozen, and the commit that deletes both frozen packages leaves that file alive, which
+    is independent confirmation. Found by re-review (#1905), which also noted that the previous
+    repair had entrenched the wrong set by pinning it in a test.
+    """
+    return bool(_frozen_areas()._references(path))
+
+
+def _frozen_areas():
+    """Imported lazily and by path: `scripts/` is not a package, so a plain import would depend
+    on how this script was invoked."""
+    global _CFA
+    if _CFA is None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("check_frozen_areas", REPO / "scripts" / "check_frozen_areas.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _CFA = module
+    return _CFA
+
+
+_CFA = None
 
 
 def _weak(node: ast.Assert) -> bool:
@@ -104,7 +135,7 @@ def _collected_tests(tree: ast.Module):
 def scan(root: Path):
     weak, total = [], 0
     for f in sorted(root.rglob("test_*.py")):
-        if any(fr in str(f) for fr in FROZEN):
+        if _is_frozen(f):
             continue
         try:
             tree = ast.parse(f.read_text())

--- a/scripts/check_assertion_strength.py
+++ b/scripts/check_assertion_strength.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Count tests whose assertions a well-formed WRONG answer would satisfy.
+
+Not "inert under mutation" -- that selects for *tests something else*, and every one of the five
+tests #1715 named that way turned out to be a genuine cross-path pin. This selects structurally:
+a test asserting only `is not None` / `isfinite` / `.shape` / `len` / `isinstance` cannot separate
+a right answer from a wrong one of the right shape, for ANY input.
+
+Reports; does not gate. The count is a review queue, not a delete list -- measured 2026-08-12, the
+flagged set contains capability cells ("can this configuration run at all", a close-out `CLAUDE.md`
+explicitly allows) and negative controls for fail-loud guards ("this input must NOT raise", without
+which the guard could reject everything and its `pytest.raises` siblings would still pass). Both
+are assertion-free by nature and both are worth keeping.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Helpers that carry the assertion themselves. `warns` and `raises` matter: a test whose whole
+# content is `with pytest.raises(...)` has no `assert` node and is not weak.
+STRONG_HELPERS = (
+    "assert_allclose",
+    "assert_array_equal",
+    "assert_array_almost_equal",
+    "assert_almost_equal",
+    "assert_array_less",
+    "approx",
+    "raises",
+    "warns",
+    "assert_frame_equal",
+    "assert_series_equal",
+)
+WEAK_CALLS = {"isfinite", "isinstance", "len", "hasattr", "callable", "id", "type", "bool", "any", "all"}
+# Frozen paradigms are out of scope by default (CLAUDE.md).
+FROZEN = ("alg/neural", "alg/reinforcement")
+
+
+def _weak(node: ast.Assert) -> bool:
+    t = node.test
+    if isinstance(t, ast.Compare):
+        if any(isinstance(o, (ast.Is, ast.IsNot)) for o in t.ops):
+            return True
+        src = ast.dump(t)
+        structural = any(f"attr='{a}'" in src for a in ("shape", "dtype", "ndim"))
+        return (structural or "func=Name(id='len'" in src) and not any(
+            isinstance(o, (ast.Lt, ast.Gt, ast.LtE, ast.GtE)) for o in t.ops
+        )
+    if isinstance(t, ast.Call):
+        name = getattr(t.func, "id", None) or getattr(t.func, "attr", None)
+        return name in WEAK_CALLS
+    if isinstance(t, ast.Name):
+        return True
+    return isinstance(t, ast.UnaryOp) and isinstance(t.op, ast.Not)
+
+
+def _collected_tests(tree: ast.Module):
+    """Module-level and class-level test functions only.
+
+    A `def test_helper()` nested INSIDE a test is not collected by pytest and must not be counted.
+    Walking every FunctionDef counted them, which double-counted three files and inflated the total
+    -- found while reading the output, which is the only reason this note exists.
+    """
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            yield node
+        elif isinstance(node, ast.ClassDef):
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)) and sub.name.startswith("test_"):
+                    yield sub
+
+
+def scan(root: Path):
+    weak, total = [], 0
+    for f in sorted(root.rglob("test_*.py")):
+        if any(fr in str(f) for fr in FROZEN):
+            continue
+        try:
+            tree = ast.parse(f.read_text())
+        except SyntaxError:
+            continue
+        for fn in _collected_tests(tree):
+            total += 1
+            dumped = ast.dump(fn)
+            if any(f"attr='{h}'" in dumped or f"id='{h}'" in dumped for h in STRONG_HELPERS):
+                continue
+            asserts = [n for n in ast.walk(fn) if isinstance(n, ast.Assert)]
+            if not asserts:
+                weak.append((f, fn.name, "no assertion"))
+            elif all(_weak(a) for a in asserts):
+                weak.append((f, fn.name, f"{len(asserts)} weak"))
+    return weak, total
+
+
+def main() -> int:
+    weak, total = scan(REPO / "tests")
+    print(
+        f"assertion strength : {len(weak)} of {total} collected tests assert only what a "
+        f"well-formed WRONG answer satisfies = {100 * len(weak) / total:.1f}%"
+    )
+    print("                     (a review queue, not a delete list -- capability cells and")
+    print("                      fail-loud negative controls are assertion-free by nature)")
+    if "--list" in sys.argv:
+        for f, name, why in weak:
+            print(f"  {f.relative_to(REPO)}::{name}  [{why}]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_assertion_strength.py
+++ b/scripts/check_assertion_strength.py
@@ -41,15 +41,17 @@ WEAK_CALLS = {"isfinite", "isinstance", "len", "hasattr", "callable", "id", "typ
 # files under `tests/`, so the first version of this filter excluded nothing while its comment and
 # its own test both said otherwise -- and that test asserted the constant contains itself, which is
 # the tautological shape this script exists to count. Found by review (#1905).
+# Every entry must match at least one file: `test_actor`, `test_ppo` and `test_reinforcement`
+# matched zero and were removed 2026-08-13. The old control asserted only that SOME entry
+# matched, so a dead entry -- and the removal of a live one -- were both invisible; review
+# (#1905) deleted `test_training`, a real 29-test file, and the whole test file stayed green.
+# That is a reduced form of the very defect this constant was rewritten to fix.
 FROZEN = (
     "test_neural",
     "test_dgm",
     "test_pinn",
     "test_rl_",
-    "test_actor",
-    "test_ppo",
     "test_training",
-    "test_reinforcement",
 )
 
 
@@ -124,7 +126,7 @@ def scan(root: Path):
 def main() -> int:
     weak, total = scan(REPO / "tests")
     print(
-        f"assertion strength : {len(weak)} of {total} collected tests assert only what a "
+        f"assertion strength : {len(weak)} of {total} defined test functions assert only what a "
         f"well-formed WRONG answer satisfies = {100 * len(weak) / total:.1f}%"
     )
     print("                     (a review queue, not a delete list -- capability cells and")

--- a/scripts/check_assertion_strength.py
+++ b/scripts/check_assertion_strength.py
@@ -36,8 +36,21 @@ STRONG_HELPERS = (
     "assert_series_equal",
 )
 WEAK_CALLS = {"isfinite", "isinstance", "len", "hasattr", "callable", "id", "type", "bool", "any", "all"}
-# Frozen paradigms are out of scope by default (CLAUDE.md).
-FROZEN = ("alg/neural", "alg/reinforcement")
+# Frozen paradigms are out of scope by default (CLAUDE.md § FROZEN). These are TEST-tree names,
+# not source paths: `alg/neural` and `alg/reinforcement` name the SOURCE layout and match ZERO
+# files under `tests/`, so the first version of this filter excluded nothing while its comment and
+# its own test both said otherwise -- and that test asserted the constant contains itself, which is
+# the tautological shape this script exists to count. Found by review (#1905).
+FROZEN = (
+    "test_neural",
+    "test_dgm",
+    "test_pinn",
+    "test_rl_",
+    "test_actor",
+    "test_ppo",
+    "test_training",
+    "test_reinforcement",
+)
 
 
 def _weak(node: ast.Assert) -> bool:
@@ -55,7 +68,19 @@ def _weak(node: ast.Assert) -> bool:
         return name in WEAK_CALLS
     if isinstance(t, ast.Name):
         return True
-    return isinstance(t, ast.UnaryOp) and isinstance(t.op, ast.Not)
+    if isinstance(t, ast.UnaryOp) and isinstance(t.op, ast.Not):
+        # `assert not <closeness>(a, b)` is a SEPARATION assertion -- two things must DIFFER --
+        # and it is the strongest class this repo has, not the weakest ("byte-identity is the
+        # defect, not the pass"). Calling every `not` weak inverted that doctrine on 70 tests,
+        # among them `test_coupling_affects_solution` and
+        # `test_fp_velocity_consumes_cross_density_1071`. Only a bare `assert not x` is weak.
+        # Found by review (#1905).
+        inner = ast.dump(t.operand)
+        return not any(
+            f"attr='{h}'" in inner or f"id='{h}'" in inner
+            for h in ("array_equal", "allclose", "isclose", "array_equiv", "approx", "array_almost_equal")
+        )
+    return False
 
 
 def _collected_tests(tree: ast.Module):

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -310,6 +310,7 @@ fi
 # so the gating lives in the weekly `test_discrimination.py --check-baseline` tier. (#1901)
 if [[ $FAST -eq 0 ]]; then
   "$PY" scripts/report_discrimination.py || true
+  "$PY" scripts/check_assertion_strength.py || true
 fi
 
 printf '\ngate interpreter : %s (%s)\n' "$PY" "$("$PY" -V 2>&1)"

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -304,6 +304,14 @@ else
   printf '\n\033[33mSKIPPED\033[0m test suite (--fast)\n'
 fi
 
+# Printed beside the suite result on purpose. "N passed" has never been the quantity worth
+# growing, and printing it alone invites growing it; this is the one that says whether green
+# means anything. Reports, does not gate -- measuring it costs a full suite run per mutation,
+# so the gating lives in the weekly `test_discrimination.py --check-baseline` tier. (#1901)
+if [[ $FAST -eq 0 ]]; then
+  "$PY" scripts/report_discrimination.py || true
+fi
+
 printf '\ngate interpreter : %s (%s)\n' "$PY" "$("$PY" -V 2>&1)"
 printf 'gate ruff        : %s\n' "$("${RUFF[@]}" --version 2>&1)"
 # Reprinted here, not only at the head: a version-mismatched run and a matched run otherwise

--- a/scripts/report_discrimination.py
+++ b/scripts/report_discrimination.py
@@ -24,21 +24,38 @@ BASELINE = REPO / "scripts" / "discrimination_baseline.json"
 MATRIX = REPO / "scripts" / "discrimination_killmatrix.json"
 
 
-def _current_collected(excluded: str | None = None) -> int | None:
+def _current_collected(measured: dict | None = None) -> int | None:
     """Collected today over the SAME population the baseline measured.
 
-    None if it cannot be determined -- never a guess. `excluded` is `_measured_at["excluded"]`:
-    the sweep ignores its own self-test file, so a count that includes it compared 6168 against a
-    like-for-like 6141 and reported +5.0% where the truth is +4.6%. A staleness verdict taken over
-    a different denominator than the thing it judges is exactly the defect this line exists to
-    report. Found by review (#1905).
+    None if it cannot be determined -- never a guess. The population is read from
+    `_measured_at`, not restated here: `excluded`, `paths` and `markers` all come from the
+    dict the baseline shipped.
+
+    `excluded` came first, and alone: the sweep ignores its own self-test file, so a count
+    that included it compared 6168 against a like-for-like 6141 and reported +5.0% where the
+    truth is +4.6%. The other two keys sat in the same dict and were restated as literals
+    anyway -- review (#1905) mutated the marker set five ways and every one survived all 13
+    tests, because no test reaches the real subprocess. The literals were byte-identical to
+    the gate's set at the time, so no number was wrong; the divergence was already written
+    and waiting in `d345063f`, which adds `and not manual` and rewrites this baseline's
+    `markers` field. After that lands, `then` and `now` would be measured over different
+    marker expressions and the drift percentage would be partly marker drift.
+
+    A staleness verdict taken over a different denominator than the thing it judges is
+    exactly the defect this line exists to report.
     """
+    measured = measured or {}
+    excluded = measured.get("excluded")
+    paths = measured.get("paths") or ["tests"]
+    markers = measured.get("markers")
+    if not markers:
+        return None  # an unrecorded population is not a population; say nothing rather than guess
     proc = subprocess.run(
         [
             sys.executable,
             "-m",
             "pytest",
-            "tests",
+            *paths,
             "--collect-only",
             "-q",
             "--color=no",
@@ -48,13 +65,23 @@ def _current_collected(excluded: str | None = None) -> int | None:
             "addopts=",
             *(["--ignore", excluded] if excluded else []),
             "-m",
-            "not slow and not benchmark and not experimental and not optional_torch and not environment",
+            markers,
         ],
         cwd=REPO,
         capture_output=True,
         text=True,
         timeout=900,
     )
+    # A broken collection still prints a summary, for the PARTIAL population: one un-importable
+    # module gives `2 tests collected, 1 error` and this returned 2, which against the baseline
+    # reads "the suite has since moved 5872 -> 2 (-100.0%)" -- a confident statement that the
+    # suite shrank, when collection broke. The sibling instrument reading the same artifacts
+    # already guards this (`scripts/test_discrimination.py:441`, "Nothing below would be a
+    # measurement"); this one dropped it. The trigger is live: without numba,
+    # `mfgarchon.backends.numba_backend` failed to import and `pytest tests` hit exactly that.
+    # Found by review (#1905).
+    if proc.returncode != 0:
+        return None
     # pytest prints either "N tests collected" or "N/M tests collected (K deselected)". Take the
     # SELECTED count, N, which is the population the sweep actually runs. Parsed against a real
     # run rather than assumed -- the first version of this read `line.split()[0]` and silently
@@ -88,7 +115,7 @@ def main() -> int:
     if uncovered:
         print(f"                 {len(uncovered)} convention(s) NO test notices: {', '.join(uncovered)}")
 
-    now = _current_collected(measured.get("excluded"))
+    now = _current_collected(measured)
     if now is None:
         print("                 current suite size unknown -- the fraction above may be stale")
     elif now != then:

--- a/scripts/report_discrimination.py
+++ b/scripts/report_discrimination.py
@@ -24,8 +24,15 @@ BASELINE = REPO / "scripts" / "discrimination_baseline.json"
 MATRIX = REPO / "scripts" / "discrimination_killmatrix.json"
 
 
-def _current_collected() -> int | None:
-    """What the CI marker set collects today. None if it cannot be determined -- never a guess."""
+def _current_collected(excluded: str | None = None) -> int | None:
+    """Collected today over the SAME population the baseline measured.
+
+    None if it cannot be determined -- never a guess. `excluded` is `_measured_at["excluded"]`:
+    the sweep ignores its own self-test file, so a count that includes it compared 6168 against a
+    like-for-like 6141 and reported +5.0% where the truth is +4.6%. A staleness verdict taken over
+    a different denominator than the thing it judges is exactly the defect this line exists to
+    report. Found by review (#1905).
+    """
     proc = subprocess.run(
         [
             sys.executable,
@@ -39,6 +46,7 @@ def _current_collected() -> int | None:
             "no:randomly",
             "-o",
             "addopts=",
+            *(["--ignore", excluded] if excluded else []),
             "-m",
             "not slow and not benchmark and not experimental and not optional_torch and not environment",
         ],
@@ -80,7 +88,7 @@ def main() -> int:
     if uncovered:
         print(f"                 {len(uncovered)} convention(s) NO test notices: {', '.join(uncovered)}")
 
-    now = _current_collected()
+    now = _current_collected(measured.get("excluded"))
     if now is None:
         print("                 current suite size unknown -- the fraction above may be stale")
     elif now != then:

--- a/scripts/report_discrimination.py
+++ b/scripts/report_discrimination.py
@@ -46,10 +46,18 @@ def _current_collected(measured: dict | None = None) -> int | None:
     """
     measured = measured or {}
     excluded = measured.get("excluded")
-    paths = measured.get("paths") or ["tests"]
+    paths = measured.get("paths")
     markers = measured.get("markers")
-    if not markers:
+    # Both, symmetrically. `paths` used to fall back to `["tests"]` while `markers` refused --
+    # a guess about the population, inside the function whose contract forbids guessing, and one
+    # that happened to equal the recorded value so no test could tell threading from hardcoding.
+    # Re-review (#1905) mutated `paths` to the literal `["tests"]` and all 15 tests survived.
+    if not markers or not paths:
         return None  # an unrecorded population is not a population; say nothing rather than guess
+    if isinstance(paths, str):
+        # A bare string splats to one argument per character. pytest then exits 4 and the
+        # returncode guard below turns it into None, but say so here rather than rely on that.
+        return None
     proc = subprocess.run(
         [
             sys.executable,

--- a/scripts/report_discrimination.py
+++ b/scripts/report_discrimination.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Print the discriminating fraction beside its denominator, and say when the denominator moved.
+
+The gate prints "N passed". That number has never been the thing worth growing, and printing it
+alone invites growing it: measured 2026-08-12 over the whole corpus (#1901), what recurs in this
+repository is not a wrong formula but a green light, and 5,481 of 5,665 collected tests noticed
+nothing when any of six load-bearing conventions was broken.
+
+So print the fraction that does matter, and print it the way #1901's class 2 says every count must
+be printed -- with the population it was taken over, because "0 of unknown" and "0 of all" render
+identically. This reports rather than gates: the gating is `test_discrimination.py --check-baseline`
+in the weekly tier, because measuring it costs one full suite run per mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BASELINE = REPO / "scripts" / "discrimination_baseline.json"
+MATRIX = REPO / "scripts" / "discrimination_killmatrix.json"
+
+
+def _current_collected() -> int | None:
+    """What the CI marker set collects today. None if it cannot be determined -- never a guess."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests",
+            "--collect-only",
+            "-q",
+            "--color=no",
+            "-p",
+            "no:randomly",
+            "-o",
+            "addopts=",
+            "-m",
+            "not slow and not benchmark and not experimental and not optional_torch and not environment",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    # pytest prints either "N tests collected" or "N/M tests collected (K deselected)". Take the
+    # SELECTED count, N, which is the population the sweep actually runs. Parsed against a real
+    # run rather than assumed -- the first version of this read `line.split()[0]` and silently
+    # returned None on the "N/M" form, printing "current suite size unknown" while the number
+    # was right there.
+    for line in reversed(proc.stdout.splitlines()):
+        if "tests collected" in line or "test collected" in line:
+            head = line.split()[0].split("/")[0].replace(",", "")
+            if head.isdigit():
+                return int(head)
+    return None
+
+
+def main() -> int:
+    if not BASELINE.exists() or not MATRIX.exists():
+        print("discrimination : CANNOT MEASURE -- baseline or kill matrix absent")
+        return 0
+
+    baseline = json.loads(BASELINE.read_text())
+    matrix = json.loads(MATRIX.read_text())
+    measured = baseline["_measured_at"]
+    then = int(measured["collected"])
+    killers = {t for entry in matrix["mutations"].values() for t in entry.get("killed", ())}
+    conventions = len(baseline["mutations"])
+    uncovered = sorted(n for n, v in baseline["mutations"].items() if v["kill_count"] == 0)
+
+    print(
+        f"discrimination : {len(killers)} of {then} tests notice at least one of {conventions} "
+        f"conventions = {100 * len(killers) / then:.2f}%  (measured at {measured['commit']})"
+    )
+    if uncovered:
+        print(f"                 {len(uncovered)} convention(s) NO test notices: {', '.join(uncovered)}")
+
+    now = _current_collected()
+    if now is None:
+        print("                 current suite size unknown -- the fraction above may be stale")
+    elif now != then:
+        drift = 100 * (now - then) / then
+        print(
+            f"                 the suite has since moved {then} -> {now} ({drift:+.1f}%): the "
+            f"fraction above is STALE, and adding tests lowers it unless they discriminate"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_assertion_strength.py
+++ b/tests/unit/test_check_assertion_strength.py
@@ -116,10 +116,28 @@ def test_the_frozen_paradigms_are_actually_excluded_not_merely_named():
 
 def test_at_least_one_real_frozen_test_file_is_excluded_from_the_repo_scan():
     """Positive control against the tree, not a fixture: the pattern must match something real."""
-    frozen_files = [
-        f for f in (pathlib.Path(cas.REPO) / "tests").rglob("test_*.py") if any(fr in str(f) for fr in cas.FROZEN)
-    ]
+    tree = list((pathlib.Path(cas.REPO) / "tests").rglob("test_*.py"))
+    frozen_files = [f for f in tree if any(fr in str(f) for fr in cas.FROZEN)]
     assert frozen_files, "FROZEN matches no file in the tree; the exclusion is inert"
+    # Per ENTRY, not per tuple. "Some entry matches" cannot see a dead entry, and cannot see a
+    # live one being deleted: review (#1905) removed `test_training` -- a real 29-test file --
+    # and every test here stayed green, while `test_actor`, `test_ppo` and `test_reinforcement`
+    # had been matching nothing since they were written. An entry that matches no file excludes
+    # nothing while reading as though it does, which is exactly what this constant was rewritten
+    # to stop. When a frozen paradigm is deleted from the tree, delete its entry in the same
+    # change -- this is the assertion that will say so.
+    dead = [fr for fr in cas.FROZEN if not any(fr in str(f) for f in tree)]
+    assert not dead, f"FROZEN entries matching no file in the tree: {dead}"
+    # The per-entry check above is one direction only: it catches a DEAD entry, not the deletion
+    # of a LIVE one. Removing `test_training` leaves every surviving entry matching something, so
+    # the assertion above stays green while a 29-test file silently re-enters the denominator.
+    # Ratchet the count, in the repo's usual shape -- a drop is a real change and must be
+    # deliberate, an increase means a frozen paradigm grew and the baseline follows it.
+    assert len(frozen_files) == 12, (
+        f"FROZEN now excludes {len(frozen_files)} files, not 12. If a frozen paradigm was deleted "
+        f"from the tree, remove its FROZEN entry and update this count in the same commit; if one "
+        f"was added, update the count. Currently matched: {sorted(str(f.name) for f in frozen_files)}"
+    )
     weak, _total = cas.scan(pathlib.Path(cas.REPO) / "tests")
     assert not any(any(fr in str(f) for fr in cas.FROZEN) for f, _, _ in weak), (
         "a frozen-paradigm test appears in the flagged set"
@@ -161,7 +179,7 @@ def test_the_printed_line_carries_its_numerator_denominator_and_percentage(capsy
     cas.main()
     out = capsys.readouterr().out
     weak, total = cas.scan(pathlib.Path(cas.REPO) / "tests")
-    assert f"{len(weak)} of {total} collected tests" in out, f"numerator/denominator pair missing: {out!r}"
+    assert f"{len(weak)} of {total} defined test functions" in out, f"numerator/denominator pair missing: {out!r}"
     assert f"{100 * len(weak) / total:.1f}%" in out, "the percentage does not match the scan"
     # The complement must NOT be what is printed: 20.6% and 79.4% are both 'a percentage'.
     assert f"{100 * (total - len(weak)) / total:.1f}%" not in out, "the fraction is inverted"

--- a/tests/unit/test_check_assertion_strength.py
+++ b/tests/unit/test_check_assertion_strength.py
@@ -1,0 +1,103 @@
+"""The assertion-strength scan must classify by structure, not by name or vibe.
+
+Its number is a review queue, not a delete list -- which is the lesson that produced it. The first
+selector tried was "inert under the six convention mutations"; every one of the five tests #1715
+named that way turned out to be a genuine cross-path pin, because inertness selects for *tests
+something else*. This selector is structural: an assertion that only checks well-formedness cannot
+separate right from wrong for ANY input.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import tempfile
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "cas", pathlib.Path(__file__).resolve().parents[2] / "scripts" / "check_assertion_strength.py"
+)
+cas = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(cas)
+
+
+def _classify(body: str) -> bool:
+    """True if the scan flags a test with this body."""
+    with tempfile.TemporaryDirectory() as d:
+        pathlib.Path(d, "test_probe.py").write_text(f"def test_probe():\n    {body}\n")
+        weak, total = cas.scan(pathlib.Path(d))
+        assert total == 1, f"the probe was not collected as exactly one test ({total})"
+        return bool(weak)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "assert r is not None",
+        "assert np.isfinite(u).all()",
+        "assert u.shape == (5,)",
+        "assert len(xs) == 3",
+        "assert isinstance(r, dict)",
+        "pass",
+    ],
+)
+def test_well_formedness_only_is_flagged(body: str):
+    """A wrong answer of the right shape passes every one of these."""
+    assert _classify(body), f"not flagged: {body!r}"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "assert abs(x - 1.234) < 1e-9",
+        "np.testing.assert_allclose(a, b, rtol=1e-9)",
+        "with pytest.raises(ValueError):\n        f()",
+        "with pytest.warns(UserWarning):\n        f()",
+        "assert solve(a) < solve(b)",
+        "assert x == pytest.approx(2.5)",
+    ],
+)
+def test_a_real_assertion_is_not_flagged(body: str):
+    """Control. `raises` and `warns` carry the assertion themselves and have no `assert` node --
+    omitting them from the strong list flagged every fail-loud guard in the tree."""
+    assert not _classify(body), f"wrongly flagged: {body!r}"
+
+
+def test_a_helper_nested_inside_a_test_is_not_counted():
+    """pytest does not collect it, so counting it inflates both numerator and denominator.
+
+    Measured before the fix: three files contributed duplicate rows (`test_progress.py::test_func`
+    twice, `test_parameter_migration.py::test_function` three times) for functions that never run.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        pathlib.Path(d, "test_nested.py").write_text(
+            "def test_outer():\n    def test_helper():\n        pass\n    assert abs(1.0 - 1.0) < 1e-9\n"
+        )
+        weak, total = cas.scan(pathlib.Path(d))
+    assert total == 1, f"nested helper counted: total={total}"
+    assert not weak
+
+
+def test_class_level_tests_are_counted():
+    """Half this repo's integration tests live in classes; missing them would halve the denominator."""
+    with tempfile.TemporaryDirectory() as d:
+        pathlib.Path(d, "test_cls.py").write_text(
+            "class TestThing:\n    def test_inside(self):\n        assert result is not None\n"
+        )
+        weak, total = cas.scan(pathlib.Path(d))
+    assert total == 1
+    assert len(weak) == 1
+
+
+def test_the_frozen_paradigms_are_out_of_scope():
+    """`alg/neural` and `alg/reinforcement` are frozen; a sweep must state their exclusion."""
+    assert "alg/neural" in cas.FROZEN
+    assert "alg/reinforcement" in cas.FROZEN
+
+
+def test_the_repo_scan_reports_a_denominator():
+    """Never a bare count: '0 of unknown' and '0 of all' render identically (#1901 class 2)."""
+    weak, total = cas.scan(pathlib.Path(cas.REPO) / "tests")
+    assert total > 4000, f"the scan collected only {total} tests; the denominator looks wrong"
+    assert 0 < len(weak) < total

--- a/tests/unit/test_check_assertion_strength.py
+++ b/tests/unit/test_check_assertion_strength.py
@@ -94,10 +94,17 @@ def test_the_frozen_paradigms_are_actually_excluded_not_merely_named():
     """A membership assertion is a tautology: the constant contains itself, always.
 
     The first version of this asserted `"alg/neural" in cas.FROZEN` and passed while the filter
-    matched ZERO files under `tests/` -- those are SOURCE paths, and the frozen tests live as
-    `test_dgm_*`, `test_pinn_*`, `test_rl_*`. 131 frozen test functions sat in the denominator
-    with a 47% flag rate against 20.6% overall. Found by review (#1905), which named it as the
-    same tautological shape this script exists to count.
+    matched ZERO files under `tests/` -- those are SOURCE paths, and the filter was matching test
+    FILENAMES. Found by review (#1905), which named it as the same tautological shape this script
+    exists to count.
+
+    ~~131 frozen test functions sat in the denominator with a 47% flag rate against 20.6%
+    overall~~ [CORRECTED 2026-08-13] -- neither figure is reproducible from any state of the
+    committed code, and re-review found this line still asserting them. Re-measured under the
+    single owner (`check_frozen_areas._references`): the frozen set is **14 files, 145 test
+    functions**, of which 66 would be flagged = **46%**, against 19.5% over the 5393 that remain.
+    A wrong number inside a test docstring is worse than one in prose, because the file around it
+    reads as verified.
 
     So assert the BEHAVIOUR: a frozen-named file must be absent from the scan, and a non-frozen
     one present.
@@ -106,7 +113,9 @@ def test_the_frozen_paradigms_are_actually_excluded_not_merely_named():
 
     with tempfile.TemporaryDirectory() as d:
         root = pathlib.Path(d)
-        (root / "test_dgm_thing.py").write_text("def test_a():\n    assert x is not None\n")
+        (root / "test_reaches_frozen.py").write_text(
+            "from mfgarchon.alg.neural.nn import feedforward\n\ndef test_a():\n    assert feedforward is not None\n"
+        )
         (root / "test_ordinary.py").write_text("def test_b():\n    assert y is not None\n")
         weak, total = cas.scan(root)
     assert total == 1, f"the frozen file was not excluded from the denominator (total={total})"
@@ -114,34 +123,57 @@ def test_the_frozen_paradigms_are_actually_excluded_not_merely_named():
     assert names == ["test_b"], f"scan returned {names}; the frozen file leaked in"
 
 
-def test_at_least_one_real_frozen_test_file_is_excluded_from_the_repo_scan():
-    """Positive control against the tree, not a fixture: the pattern must match something real."""
+def test_a_file_named_after_a_frozen_paradigm_but_not_reaching_one_stays_in_the_denominator():
+    """The specific error the single-owner change fixes, as a fixture.
+
+    A file whose PATH contains `test_neural` while it imports nothing frozen is not frozen.
+    `tests/unit/test_utils/test_neural/test_normalization.py` is the real instance: 36 test
+    functions were dropped from the denominator because a DIRECTORY is spelled that way, while
+    CLAUDE.md freezes `alg/neural` and `alg/reinforcement` only. Found by re-review (#1905).
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d) / "test_neural"
+        root.mkdir()
+        (root / "test_normalization.py").write_text(
+            "from mfgarchon.utils.numerical import integration\n\ndef test_a():\n    assert integration is not None\n"
+        )
+        _weak, total = cas.scan(pathlib.Path(d))
+    assert total == 1, (
+        "a file named after a frozen paradigm was excluded although it reaches none; "
+        "the decider is back to matching names"
+    )
+
+
+def test_frozen_membership_has_one_owner_and_this_module_is_not_it():
+    """Positive control against the real tree, plus the invariant that keeps them from diverging.
+
+    `check_frozen_areas.py` decides frozen membership by AST -- imports and string literals --
+    and carries the argument for why a name match is insufficient. This module answered the same
+    question by filename substring; the two disagreed on six files, 40 test functions wrongly out
+    and 20 wrongly in. Re-review (#1905) also found that the previous repair had entrenched the
+    wrong set by pinning its file count in a test, so the pin is now on the OWNER, not the answer.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "check_frozen_areas_probe", pathlib.Path(cas.REPO) / "scripts" / "check_frozen_areas.py"
+    )
+    cfa = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cfa)
+
     tree = list((pathlib.Path(cas.REPO) / "tests").rglob("test_*.py"))
-    frozen_files = [f for f in tree if any(fr in str(f) for fr in cas.FROZEN)]
-    assert frozen_files, "FROZEN matches no file in the tree; the exclusion is inert"
-    # Per ENTRY, not per tuple. "Some entry matches" cannot see a dead entry, and cannot see a
-    # live one being deleted: review (#1905) removed `test_training` -- a real 29-test file --
-    # and every test here stayed green, while `test_actor`, `test_ppo` and `test_reinforcement`
-    # had been matching nothing since they were written. An entry that matches no file excludes
-    # nothing while reading as though it does, which is exactly what this constant was rewritten
-    # to stop. When a frozen paradigm is deleted from the tree, delete its entry in the same
-    # change -- this is the assertion that will say so.
-    dead = [fr for fr in cas.FROZEN if not any(fr in str(f) for f in tree)]
-    assert not dead, f"FROZEN entries matching no file in the tree: {dead}"
-    # The per-entry check above is one direction only: it catches a DEAD entry, not the deletion
-    # of a LIVE one. Removing `test_training` leaves every surviving entry matching something, so
-    # the assertion above stays green while a 29-test file silently re-enters the denominator.
-    # Ratchet the count, in the repo's usual shape -- a drop is a real change and must be
-    # deliberate, an increase means a frozen paradigm grew and the baseline follows it.
-    assert len(frozen_files) == 12, (
-        f"FROZEN now excludes {len(frozen_files)} files, not 12. If a frozen paradigm was deleted "
-        f"from the tree, remove its FROZEN entry and update this count in the same commit; if one "
-        f"was added, update the count. Currently matched: {sorted(str(f.name) for f in frozen_files)}"
+    frozen = [f for f in tree if cfa._references(f)]
+    assert frozen, "no test file reaches a frozen package; the exclusion is inert or the tree moved"
+    # The two must not be able to disagree, which is what a shared decider buys. Asserting it
+    # here means a future local shortcut in check_assertion_strength reddens rather than drifts.
+    assert [f for f in tree if cas._is_frozen(f)] == frozen, (
+        "check_assertion_strength and check_frozen_areas disagree about frozen membership; "
+        "there must be exactly one decider"
     )
     weak, _total = cas.scan(pathlib.Path(cas.REPO) / "tests")
-    assert not any(any(fr in str(f) for fr in cas.FROZEN) for f, _, _ in weak), (
-        "a frozen-paradigm test appears in the flagged set"
-    )
+    assert not any(cfa._references(f) for f, _, _ in weak), "a frozen-paradigm test appears in the flagged set"
 
 
 def test_a_separation_assertion_is_the_strongest_class_not_the_weakest():

--- a/tests/unit/test_check_assertion_strength.py
+++ b/tests/unit/test_check_assertion_strength.py
@@ -90,10 +90,58 @@ def test_class_level_tests_are_counted():
     assert len(weak) == 1
 
 
-def test_the_frozen_paradigms_are_out_of_scope():
-    """`alg/neural` and `alg/reinforcement` are frozen; a sweep must state their exclusion."""
-    assert "alg/neural" in cas.FROZEN
-    assert "alg/reinforcement" in cas.FROZEN
+def test_the_frozen_paradigms_are_actually_excluded_not_merely_named():
+    """A membership assertion is a tautology: the constant contains itself, always.
+
+    The first version of this asserted `"alg/neural" in cas.FROZEN` and passed while the filter
+    matched ZERO files under `tests/` -- those are SOURCE paths, and the frozen tests live as
+    `test_dgm_*`, `test_pinn_*`, `test_rl_*`. 131 frozen test functions sat in the denominator
+    with a 47% flag rate against 20.6% overall. Found by review (#1905), which named it as the
+    same tautological shape this script exists to count.
+
+    So assert the BEHAVIOUR: a frozen-named file must be absent from the scan, and a non-frozen
+    one present.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        (root / "test_dgm_thing.py").write_text("def test_a():\n    assert x is not None\n")
+        (root / "test_ordinary.py").write_text("def test_b():\n    assert y is not None\n")
+        weak, total = cas.scan(root)
+    assert total == 1, f"the frozen file was not excluded from the denominator (total={total})"
+    names = [n for _, n, _ in weak]
+    assert names == ["test_b"], f"scan returned {names}; the frozen file leaked in"
+
+
+def test_at_least_one_real_frozen_test_file_is_excluded_from_the_repo_scan():
+    """Positive control against the tree, not a fixture: the pattern must match something real."""
+    frozen_files = [
+        f for f in (pathlib.Path(cas.REPO) / "tests").rglob("test_*.py") if any(fr in str(f) for fr in cas.FROZEN)
+    ]
+    assert frozen_files, "FROZEN matches no file in the tree; the exclusion is inert"
+    weak, _total = cas.scan(pathlib.Path(cas.REPO) / "tests")
+    assert not any(any(fr in str(f) for fr in cas.FROZEN) for f, _, _ in weak), (
+        "a frozen-paradigm test appears in the flagged set"
+    )
+
+
+def test_a_separation_assertion_is_the_strongest_class_not_the_weakest():
+    """`assert not allclose(a, b)` says two things must DIFFER.
+
+    That is this repo's own doctrine -- assert on disagreement, not validity; byte-identity is the
+    defect, not the pass. Calling every `not` weak inverted it on 70 tests, among them
+    `test_coupling_affects_solution` and `test_fp_velocity_consumes_cross_density_1071`.
+    Found by review (#1905).
+    """
+    for body in (
+        "assert not np.allclose(a, b)",
+        "assert not np.array_equal(a, b)",
+        "assert not np.isclose(a, b).all()",
+    ):
+        assert not _classify(body), f"separation assertion called weak: {body!r}"
+    # ...while a bare truthiness assert stays weak.
+    assert _classify("assert converged")
 
 
 def test_the_repo_scan_reports_a_denominator():
@@ -101,3 +149,32 @@ def test_the_repo_scan_reports_a_denominator():
     weak, total = cas.scan(pathlib.Path(cas.REPO) / "tests")
     assert total > 4000, f"the scan collected only {total} tests; the denominator looks wrong"
     assert 0 < len(weak) < total
+
+
+def test_the_printed_line_carries_its_numerator_denominator_and_percentage(capsys):
+    """`main()` was never called by any test, so nothing about the reported line was pinned.
+
+    Review (#1905) walked two mutations straight through: inverting the fraction to
+    `(total - len(weak)) / total` turned 20.6% into 79.4%, and dropping `of {total}` removed the
+    denominator entirely -- which is the exact defect (#1901 class 2) this line exists to avoid.
+    """
+    cas.main()
+    out = capsys.readouterr().out
+    weak, total = cas.scan(pathlib.Path(cas.REPO) / "tests")
+    assert f"{len(weak)} of {total} collected tests" in out, f"numerator/denominator pair missing: {out!r}"
+    assert f"{100 * len(weak) / total:.1f}%" in out, "the percentage does not match the scan"
+    # The complement must NOT be what is printed: 20.6% and 79.4% are both 'a percentage'.
+    assert f"{100 * (total - len(weak)) / total:.1f}%" not in out, "the fraction is inverted"
+    assert "WRONG answer" in out, "the line no longer says what the number means"
+
+
+def test_the_review_queue_caveat_is_printed_with_the_number():
+    """The count is not a delete list, and saying so is part of the number's meaning.
+
+    37 capability cells, ~37-42 fail-loud negative controls and dependency probes sit inside it,
+    all assertion-free by nature. A bare percentage invites the deletion PR that was withdrawn.
+    """
+    import inspect
+
+    body = inspect.getsource(cas.main)
+    assert "review queue, not a delete list" in body

--- a/tests/unit/test_report_discrimination.py
+++ b/tests/unit/test_report_discrimination.py
@@ -22,7 +22,7 @@ _spec.loader.exec_module(rd)
 
 def test_it_reports_the_denominator_and_the_commit(capsys, monkeypatch):
     """A fraction without its population is the defect this line exists to avoid printing."""
-    monkeypatch.setattr(rd, "_current_collected", lambda: 5872)
+    monkeypatch.setattr(rd, "_current_collected", lambda *a, **k: 5872)
     rd.main()
     out = capsys.readouterr().out
     baseline = json.loads(rd.BASELINE.read_text())
@@ -35,7 +35,7 @@ def test_it_reports_the_denominator_and_the_commit(capsys, monkeypatch):
 
 def test_a_moved_suite_size_is_called_stale(capsys, monkeypatch):
     """The whole point: the recorded fraction silently ages as the suite grows."""
-    monkeypatch.setattr(rd, "_current_collected", lambda: 9999)
+    monkeypatch.setattr(rd, "_current_collected", lambda *a, **k: 9999)
     rd.main()
     out = capsys.readouterr().out
     assert "STALE" in out, f"a moved denominator was not reported: {out!r}"
@@ -45,13 +45,13 @@ def test_a_moved_suite_size_is_called_stale(capsys, monkeypatch):
 def test_an_unmoved_suite_size_is_not_called_stale(capsys, monkeypatch):
     """Control: the warning must not fire when nothing moved, or it is noise."""
     then = json.loads(rd.BASELINE.read_text())["_measured_at"]["collected"]
-    monkeypatch.setattr(rd, "_current_collected", lambda: then)
+    monkeypatch.setattr(rd, "_current_collected", lambda *a, **k: then)
     rd.main()
     assert "STALE" not in capsys.readouterr().out
 
 
 def test_an_undeterminable_suite_size_says_so_rather_than_guessing(capsys, monkeypatch):
-    monkeypatch.setattr(rd, "_current_collected", lambda: None)
+    monkeypatch.setattr(rd, "_current_collected", lambda *a, **k: None)
     rd.main()
     assert "unknown" in capsys.readouterr().out
 
@@ -63,7 +63,7 @@ def test_a_convention_no_test_notices_is_named(capsys, monkeypatch, tmp_path):
     fake = tmp_path / "b.json"
     fake.write_text(json.dumps(baseline))
     monkeypatch.setattr(rd, "BASELINE", fake)
-    monkeypatch.setattr(rd, "_current_collected", lambda: baseline["_measured_at"]["collected"])
+    monkeypatch.setattr(rd, "_current_collected", lambda *a, **k: baseline["_measured_at"]["collected"])
     rd.main()
     out = capsys.readouterr().out
     assert "a_convention_nothing_notices" in out, f"an uncovered convention was not named: {out!r}"
@@ -115,3 +115,61 @@ def test_an_unparseable_summary_returns_none_rather_than_a_guess(bad):
         assert rd._current_collected() is None
     finally:
         subprocess.run = real
+
+
+# --- the printed line itself, which 18 mutations walked through (#1905) -------------------
+
+
+def test_the_printed_line_carries_the_numerator_the_denominator_and_the_percentage(capsys, monkeypatch):
+    """Every one of these was movable without a test noticing: the numerator could switch from the
+    union to the sum (212 -> 220), the percentage could be halved, the convention count could read
+    99, and `of {then} tests` could be dropped entirely -- taking the denominator with it."""
+    monkeypatch.setattr(rd, "_current_collected", lambda *a, **k: 5872)
+    rd.main()
+    out = capsys.readouterr().out
+    baseline = json.loads(rd.BASELINE.read_text())
+    matrix = json.loads((rd.BASELINE.parent / "discrimination_killmatrix.json").read_text())
+    union = {t for e in matrix["mutations"].values() for t in e.get("killed", ())}
+    then = baseline["_measured_at"]["collected"]
+    assert f"{len(union)} of {then}" in out, f"numerator/denominator pair missing from: {out!r}"
+    assert f"{len(baseline['mutations'])} conventions" in out, "the convention count is wrong or absent"
+    assert f"{100 * len(union) / then:.2f}%" in out, "the percentage does not match the artifacts"
+    # The union, not the sum: 8 tests kill more than one mutation, so they differ.
+    assert sum(v["kill_count"] for v in baseline["mutations"].values()) != len(union), (
+        "sum and union coincide on this baseline, so this test cannot tell them apart"
+    )
+    assert f"{sum(v['kill_count'] for v in baseline['mutations'].values())} of" not in out
+
+
+def test_the_staleness_check_uses_the_same_exclusion_the_baseline_recorded(monkeypatch):
+    """The baseline ignores its own self-test file; comparing against a count that includes it
+    reported +5.0% where the like-for-like figure is +4.6% -- a verdict over a denominator
+    different from the thing it judges, inside the instrument built to report exactly that."""
+    seen = {}
+
+    class _Fake:
+        stdout = "6141/6551 tests collected (410 deselected) in 1.7s"
+
+    def spy(*args, **kwargs):
+        seen["argv"] = args[0]
+        return _Fake()
+
+    import subprocess
+
+    real = subprocess.run
+    subprocess.run = spy
+    try:
+        excluded = json.loads(rd.BASELINE.read_text())["_measured_at"]["excluded"]
+        rd._current_collected(excluded)
+    finally:
+        subprocess.run = real
+    assert "--ignore" in seen["argv"], "the exclusion is not passed to the collect"
+    assert excluded in seen["argv"], f"{excluded} not in {seen['argv']}"
+
+
+def test_a_shrinking_suite_is_also_called_stale(capsys, monkeypatch):
+    """`now != then`, not `now > then`: a suite that shrank has moved just as much."""
+    then = json.loads(rd.BASELINE.read_text())["_measured_at"]["collected"]
+    monkeypatch.setattr(rd, "_current_collected", lambda *a, **k: then - 500)
+    rd.main()
+    assert "STALE" in capsys.readouterr().out

--- a/tests/unit/test_report_discrimination.py
+++ b/tests/unit/test_report_discrimination.py
@@ -1,0 +1,117 @@
+"""The gate's discriminating-fraction line must carry its denominator and say when it moved.
+
+"N passed" has never been the quantity worth growing, and printing it alone invites growing it.
+This reports the one that says whether green means anything -- and reports it the way #1901's
+class 2 requires every count to be reported, beside the population it was taken over, because
+"0 of unknown" and "0 of all" render identically.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "report_discrimination.py"
+_spec = importlib.util.spec_from_file_location("report_discrimination", _SCRIPT)
+rd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rd)
+
+
+def test_it_reports_the_denominator_and_the_commit(capsys, monkeypatch):
+    """A fraction without its population is the defect this line exists to avoid printing."""
+    monkeypatch.setattr(rd, "_current_collected", lambda: 5872)
+    rd.main()
+    out = capsys.readouterr().out
+    baseline = json.loads(rd.BASELINE.read_text())
+    then = baseline["_measured_at"]["collected"]
+    commit = baseline["_measured_at"]["commit"]
+    assert f"of {then} tests" in out, f"the denominator is missing from: {out!r}"
+    assert commit in out, "the measurement commit is missing, so staleness is unjudgeable"
+    assert "%" in out
+
+
+def test_a_moved_suite_size_is_called_stale(capsys, monkeypatch):
+    """The whole point: the recorded fraction silently ages as the suite grows."""
+    monkeypatch.setattr(rd, "_current_collected", lambda: 9999)
+    rd.main()
+    out = capsys.readouterr().out
+    assert "STALE" in out, f"a moved denominator was not reported: {out!r}"
+    assert "9999" in out
+
+
+def test_an_unmoved_suite_size_is_not_called_stale(capsys, monkeypatch):
+    """Control: the warning must not fire when nothing moved, or it is noise."""
+    then = json.loads(rd.BASELINE.read_text())["_measured_at"]["collected"]
+    monkeypatch.setattr(rd, "_current_collected", lambda: then)
+    rd.main()
+    assert "STALE" not in capsys.readouterr().out
+
+
+def test_an_undeterminable_suite_size_says_so_rather_than_guessing(capsys, monkeypatch):
+    monkeypatch.setattr(rd, "_current_collected", lambda: None)
+    rd.main()
+    assert "unknown" in capsys.readouterr().out
+
+
+def test_a_convention_no_test_notices_is_named(capsys, monkeypatch, tmp_path):
+    """An UNCOVERED convention is the finding this whole instrument exists to surface."""
+    baseline = json.loads(rd.BASELINE.read_text())
+    baseline["mutations"]["a_convention_nothing_notices"] = {"kill_count": 0, "status": "UNCOVERED", "owner": "x"}
+    fake = tmp_path / "b.json"
+    fake.write_text(json.dumps(baseline))
+    monkeypatch.setattr(rd, "BASELINE", fake)
+    monkeypatch.setattr(rd, "_current_collected", lambda: baseline["_measured_at"]["collected"])
+    rd.main()
+    out = capsys.readouterr().out
+    assert "a_convention_nothing_notices" in out, f"an uncovered convention was not named: {out!r}"
+
+
+def test_missing_artifacts_report_cannot_measure(capsys, monkeypatch, tmp_path):
+    """Never a silent zero: absent inputs are 'could not measure', not 'nothing to report'."""
+    monkeypatch.setattr(rd, "BASELINE", tmp_path / "nope.json")
+    rd.main()
+    assert "CANNOT MEASURE" in capsys.readouterr().out
+
+
+def test_the_collect_parser_handles_both_pytest_summary_forms():
+    """`N/M tests collected (K deselected)` is what the CI marker set actually prints.
+
+    The first version read `line.split()[0]` and returned None on that form, printing
+    "current suite size unknown" while the number was on screen. Parsed against a real run.
+    """
+    import subprocess
+
+    real = subprocess.run
+    for line, expected in (
+        ("6142/6551 tests collected (409 deselected) in 1.72s", 6142),
+        ("6551 tests collected in 1.70s", 6551),
+        ("1 test collected in 0.01s", 1),
+    ):
+
+        class _Fake:
+            stdout = line
+
+        subprocess.run = lambda *a, **k: _Fake()
+        try:
+            assert rd._current_collected() == expected, f"failed to parse: {line!r}"
+        finally:
+            subprocess.run = real
+
+
+@pytest.mark.parametrize("bad", ["", "no summary here", "collected but not tests"])
+def test_an_unparseable_summary_returns_none_rather_than_a_guess(bad):
+    import subprocess
+
+    real = subprocess.run
+
+    class _Fake:
+        stdout = bad
+
+    subprocess.run = lambda *a, **k: _Fake()
+    try:
+        assert rd._current_collected() is None
+    finally:
+        subprocess.run = real

--- a/tests/unit/test_report_discrimination.py
+++ b/tests/unit/test_report_discrimination.py
@@ -19,6 +19,10 @@ _spec = importlib.util.spec_from_file_location("report_discrimination", _SCRIPT)
 rd = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(rd)
 
+# A minimal `_measured_at`, so a test that is about parsing does not also depend on the shipped
+# baseline's contents. Tests that are about the population read the real one.
+_MEASURED = {"paths": ["tests"], "markers": "not slow", "excluded": "tests/unit/x.py"}
+
 
 def test_it_reports_the_denominator_and_the_commit(capsys, monkeypatch):
     """A fraction without its population is the defect this line exists to avoid printing."""
@@ -93,10 +97,11 @@ def test_the_collect_parser_handles_both_pytest_summary_forms():
 
         class _Fake:
             stdout = line
+            returncode = 0
 
         subprocess.run = lambda *a, **k: _Fake()
         try:
-            assert rd._current_collected() == expected, f"failed to parse: {line!r}"
+            assert rd._current_collected(_MEASURED) == expected, f"failed to parse: {line!r}"
         finally:
             subprocess.run = real
 
@@ -149,6 +154,7 @@ def test_the_staleness_check_uses_the_same_exclusion_the_baseline_recorded(monke
 
     class _Fake:
         stdout = "6141/6551 tests collected (410 deselected) in 1.7s"
+        returncode = 0
 
     def spy(*args, **kwargs):
         seen["argv"] = args[0]
@@ -159,12 +165,73 @@ def test_the_staleness_check_uses_the_same_exclusion_the_baseline_recorded(monke
     real = subprocess.run
     subprocess.run = spy
     try:
-        excluded = json.loads(rd.BASELINE.read_text())["_measured_at"]["excluded"]
-        rd._current_collected(excluded)
+        measured = json.loads(rd.BASELINE.read_text())["_measured_at"]
+        rd._current_collected(measured)
     finally:
         subprocess.run = real
-    assert "--ignore" in seen["argv"], "the exclusion is not passed to the collect"
-    assert excluded in seen["argv"], f"{excluded} not in {seen['argv']}"
+    argv = seen["argv"]
+    assert "--ignore" in argv, "the exclusion is not passed to the collect"
+    # `excluded` was threaded and the two keys beside it in the same dict were not: `paths` and
+    # `markers` stayed literals, and review (#1905) mutated the marker set five ways -- deleting
+    # `-m` entirely, dropping `not slow`, adding `not manual`, and changing the path -- with all
+    # 13 tests green through every one, because no test reached the real argv. They were
+    # byte-identical to the gate's set at the time, so no number was wrong; `d345063f` adds
+    # `and not manual` and rewrites this baseline's `markers`, at which point `then` and `now`
+    # would be counted over different marker expressions with the difference reported as suite
+    # drift. Assert the whole population, not the one key that was noticed first.
+    assert measured["excluded"] in argv, f"{measured['excluded']} not in {argv}"
+    assert measured["markers"] in argv, f"the recorded marker set is not what was collected: {argv}"
+    for path in measured["paths"]:
+        assert path in argv, f"the recorded path {path!r} is not what was collected: {argv}"
+
+
+def test_a_broken_collection_is_not_reported_as_a_shrinking_suite():
+    """pytest prints a summary for the PARTIAL population when collection errors.
+
+    One un-importable module gives `2 tests collected, 1 error` and a returncode of 2. Read as
+    a count, that becomes "the suite has since moved 5872 -> 2 (-100.0%)": a confident claim
+    that the suite shrank, when what happened is that collection broke. The sibling instrument
+    over the same artifacts already guards this (`test_discrimination.py`, "Nothing below would
+    be a measurement"); this one had dropped it. Found by review (#1905).
+    """
+    import subprocess
+
+    class _Broken:
+        stdout = "2 tests collected, 1 error in 0.07s"
+        returncode = 2
+
+    class _Fine:
+        stdout = "2 tests collected in 0.07s"
+        returncode = 0
+
+    real = subprocess.run
+    try:
+        subprocess.run = lambda *a, **k: _Broken()
+        assert rd._current_collected(_MEASURED) is None, (
+            "a partial count from a broken collection was returned as a suite size"
+        )
+        # Control: the same stdout with a clean exit MUST still parse, or the guard is just
+        # breaking the parser rather than distinguishing the two cases.
+        subprocess.run = lambda *a, **k: _Fine()
+        assert rd._current_collected(_MEASURED) == 2, "the guard also rejects a healthy collection"
+    finally:
+        subprocess.run = real
+
+
+def test_an_unrecorded_population_returns_no_number():
+    """`_measured_at` without `markers` cannot say what `now` would even be counted over."""
+    import subprocess
+
+    class _Fake:
+        stdout = "6141 tests collected in 1.7s"
+        returncode = 0
+
+    real = subprocess.run
+    try:
+        subprocess.run = lambda *a, **k: _Fake()
+        assert rd._current_collected({"paths": ["tests"]}) is None, "guessed a population that was not recorded"
+    finally:
+        subprocess.run = real
 
 
 def test_a_shrinking_suite_is_also_called_stale(capsys, monkeypatch):

--- a/tests/unit/test_report_discrimination.py
+++ b/tests/unit/test_report_discrimination.py
@@ -114,10 +114,16 @@ def test_an_unparseable_summary_returns_none_rather_than_a_guess(bad):
 
     class _Fake:
         stdout = bad
+        returncode = 0
 
     subprocess.run = lambda *a, **k: _Fake()
     try:
-        assert rd._current_collected() is None
+        # `_MEASURED`, not `()`. Calling with no argument means `markers is None`, which returns
+        # on the fourth line before `subprocess.run` is ever reached -- so all three inputs above
+        # stopped testing the parser the moment the population moved into `_measured_at`. Caught
+        # by re-review (#1905) with the control that settles it: replacing the parse loop with
+        # `return 999999` left these three green while the sibling parser test went red.
+        assert rd._current_collected(_MEASURED) is None
     finally:
         subprocess.run = real
 
@@ -218,8 +224,22 @@ def test_a_broken_collection_is_not_reported_as_a_shrinking_suite():
         subprocess.run = real
 
 
-def test_an_unrecorded_population_returns_no_number():
-    """`_measured_at` without `markers` cannot say what `now` would even be counted over."""
+@pytest.mark.parametrize(
+    "measured",
+    [
+        pytest.param({"paths": ["tests"]}, id="markers-missing"),
+        pytest.param({"markers": "not slow"}, id="paths-missing"),
+        pytest.param({"paths": "tests", "markers": "not slow"}, id="paths-is-a-bare-string"),
+    ],
+)
+def test_an_unrecorded_population_returns_no_number(measured):
+    """`_measured_at` missing either half cannot say what `now` would be counted over.
+
+    Both keys, symmetrically. `paths` used to fall back to `["tests"]` -- a guess about the
+    population inside the function whose docstring forbids guessing -- and the bare-string case
+    splats to one argument per character, which pytest answers with exit 4 over a completely
+    different tree. Found by re-review (#1905).
+    """
     import subprocess
 
     class _Fake:
@@ -229,9 +249,38 @@ def test_an_unrecorded_population_returns_no_number():
     real = subprocess.run
     try:
         subprocess.run = lambda *a, **k: _Fake()
-        assert rd._current_collected({"paths": ["tests"]}) is None, "guessed a population that was not recorded"
+        assert rd._current_collected(measured) is None, "guessed a population that was not recorded"
     finally:
         subprocess.run = real
+
+
+def test_the_recorded_paths_are_what_gets_collected_not_a_default():
+    """The recorded value and the old fallback were both `["tests"]`, so no test could separate
+    "reads the record" from "hardcodes the same string". Re-review (#1905) replaced the lookup
+    with the literal and all 15 tests survived. Use a value the default could not produce.
+    """
+    seen = {}
+
+    class _Fake:
+        stdout = "12 tests collected in 0.1s"
+        returncode = 0
+
+    def spy(*args, **kwargs):
+        seen["argv"] = args[0]
+        return _Fake()
+
+    import subprocess
+
+    real = subprocess.run
+    try:
+        subprocess.run = spy
+        rd._current_collected({"paths": ["tests/unit/test_alg", "tests/integration"], "markers": "not slow"})
+    finally:
+        subprocess.run = real
+    argv = seen["argv"]
+    assert "tests/unit/test_alg" in argv, f"the first recorded path did not reach pytest; argv was {argv}"
+    assert "tests/integration" in argv, f"the second recorded path did not reach pytest; argv was {argv}"
+    assert "tests" not in argv, f"a hardcoded default reached pytest alongside the record: {argv}"
 
 
 def test_a_shrinking_suite_is_also_called_stale(capsys, monkeypatch):


### PR DESCRIPTION
Refs #1901, items 1 and 3.

The gate printed `N passed` and nothing else. That has never been the quantity worth growing, and printing it alone invites growing it. It now prints the two that say whether green carries information:

```
=== 6113 passed, 22 skipped, 21 xfailed in 150.91s ===
discrimination     : 212 of 5872 tests notice at least one of 6 conventions = 3.61%  (measured at db3496f9)
                     the suite has since moved 5872 -> 6168 (+5.0%): the fraction above is STALE,
                     and adding tests lowers it unless they discriminate
assertion strength : 1139 of 5527 collected tests assert only what a well-formed WRONG answer
                     satisfies = 20.6%
```

Both **report**; neither gates. Measuring discrimination costs a full suite run per mutation, so the gating stays in the weekly tier. Skipped under `--fast`.

## The staleness line is the point

The recorded fraction ages silently as the suite grows — #1901's class 2 (a verdict without its denominator) applied to the instrument that measures class 2. Its own parser is pinned against **both** pytest summary forms, because the first version read `line.split()[0]`, returned `None` on the `N/M tests collected (K deselected)` form the CI marker set actually prints, and reported "current suite size unknown" while the number was on screen.

## Item 3 is a negative result, and the deletion PR I promised does not exist

I said I'd ship a 115-test deletion. It does not survive reading. Of the assertion-free subset:

| | count | why it is assertion-free by nature |
|:--|--:|:--|
| capability cells | 37 | "can this configuration run at all" — a close-out `CLAUDE.md` explicitly allows |
| negative controls for fail-loud guards | 15 | `test_x_accepts_supported` beside `test_x_fails_loud_on_unsupported`; without it the guard could reject everything and its `pytest.raises` siblings would still pass |
| dependency probes | 10 | optional-import availability |

And the five tests #1715 named as inert were all read: two are delegation pins (`evaluate_H` is literally `np.asarray(self(...))`, so the assertion is `f(x) == f(x)` while delegation holds — and fires the moment a shim is reimplemented divergently); the other three compare two FP advection entry points, builder-path against operator-path GFDM weights, and Newton against Picard on one fixed point. **None is deletable.** Each is inert on six conventions precisely because those conventions are not what it pins.

So the deletable set is the **structurally tautological** one, found by reading, not the inert one, found by counting. `feedback_net_negative_test_mass` already said this: a kill count can only fail to falsify deletability, never establish it.

## The scanner needed the discipline it enforces

Three defects, all found by reading its own output rather than by trusting it:

1. It counted `def test_helper()` **nested inside** a test — never collected by pytest. Three files contributed duplicate rows.
2. It omitted `pytest.raises` and `pytest.warns` from the strong list, so **every fail-loud guard in the tree** was flagged.
3. The first figure, 21.9%, was taken over that inflated population.

Corrected to **20.6%**, validated on 9 control cases (4 known-weak flagged, 5 known-strong kept), controls committed as `tests/unit/test_check_assertion_strength.py`.

## `CLAUDE.md` corrected

Figures moved from `192 of 5,683 = 3.4%` to `212 of 5,872 = 3.6%`, stated as **96.4% notice nothing** — the stronger direction. The 60%-inert claim was cited to #1715, whose *body* says the prevalence "is not established"; it comes from a **comment**, now linked directly and verified to contain the figure. And the passage now says **inert is not worthless**, with the reason, because that conflation cost real time today.

## Gate

`./scripts/local_ci.sh` → **6113 passed, 22 skipped, 21 xfailed**, `GATE GREEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Independent adversarial review — findings and corrections (2026-08-13)

Returned MERGE-BLOCKED with three blockers, all the same class this PR exists to police: **a number whose stated population is not the population it was measured over.** All three reproduced before acting; all fixed in `f4a5e657`.

| | Defect | Reproduction | Fix |
|---|---|---|---|
| B1 | `N of 5369 **collected tests**` counts `def test_*` definitions, not collected tests — and the test pinned the false phrase | same tree: script 5369, `pytest --collect-only` **6584** | renamed to `defined test functions` in script and test |
| B2 | `_current_collected` ignored `returncode`; a broken collection prints a partial count and was reported as `5872 -> 2 (-100.0%)` | the sibling instrument already guards this (`test_discrimination.py:441`); this one dropped it | guard added, with a control that the same stdout under a clean exit still parses |
| B3 | `paths` and `markers` restated as literals beside the `excluded` that was threaded from `_measured_at` | five marker/path mutations all survived all 13 tests — no test reached the real argv | read from the record; an unrecorded population returns `None`, not a guess |

B3 was byte-identical to the gate's set at review time, so **no number was wrong**. The divergence is already written: `d345063f` adds `and not manual` and rewrites this baseline's `markers` field, after which `then` and `now` would be counted over different marker expressions with the difference reported as suite drift.

All six mutations now die:

```
KILLED  markers: drop the -m pair          KILLED  paths: tests -> tests/unit
KILLED  markers: drop not slow             KILLED  returncode guard removed
KILLED  markers: add not manual            KILLED  denominator renamed back
```

**Corrections to claims in this PR's description and changelog** — these were my assertions and they were wrong:

| Claim | Measured |
|---|---|
| "131 frozen test functions at a 47% flag rate" (in the changelog **and inside a test docstring**) | **165** functions across 12 files, **72 flagged = 44%**. No subset of the per-file counts sums to 131. |
| headline `1139 of 5527 collected tests = 20.6%`, `5872 -> 6168 (+5.0%)` | describes commit `20fbc848`, not the head. Head prints `1037 of 5371 = 19.3%`, `5872 -> 6148 (+4.7%)`. The `+5.0%` is explicitly struck as the bug in the same diff's changelog. |
| "capability cells 37 / negative controls 15 / dependency probes 10, of 115" | already struck `[CORRECTED]` in the changelog and replaced by 32/24/15 of 71. Confirmed: 965 weak-assert + 71 no-assertion = 1036. |
| "validated on 9 control cases (4 weak / 5 strong)" | the control parametrisations were already 6 + 6 = 12 at `20fbc848`; "9" describes an uncommitted intermediate state. |
| the mutation table framed as closing "18 of 23 surviving" | not a survivor census — five survivors were not listed. All now closed. |

**Non-blocking, fixed further than reported.** Three `FROZEN` entries (`test_actor`, `test_ppo`, `test_reinforcement`) matched **zero** files since they were written, and the control asserted only that *some* entry matched — so deleting `test_training`, a real 29-test file, left the whole test file green. A per-entry check catches a dead entry but **not** the deletion of a live one, so the excluded-file count is ratcheted as well. Both directions now redden. The three dead entries are removed.

**One review claim did not hold.** It reported that merging `4fe6a990` (deleting `alg/neural` and `alg/reinforcement`) would fail `assert frozen_files`. Measured against that branch's tree, `test_neural` and `test_rl_` still match one file each — `tests/unit/test_utils/test_neural/test_normalization.py` and `tests/unit/test_alg/test_rl_stub_metrics_1688.py` — so the assertion holds. The per-entry check and the count added here *will* redden on that branch, and should: trimming `FROZEN` is that deletion's own tail.


---

## Re-review of the fixes (2026-08-13) — VERDICT: MERGE-OK, with four defects in the remedies

All three blockers confirmed resolved by mutation, and the guard confirmed not to silence anything that used to work (every pytest exit code probed: 0, 2, 4, 5 — exit 5 already returned `None` before the guard, and exit 4 is a case the guard newly closes). Then four defects in the remedies, three of them mine. All fixed in `10ed8ce2`.

**NEW-1 — three parser tests went vacuous.** Moving the population into `_measured_at` gave `_current_collected` an early `return None` when `markers` is unrecorded, and `test_an_unparseable_summary_returns_none_rather_than_a_guess` calls it with no argument. All three inputs stopped reaching the parser. Settled by the control:

```
parse loop replaced by `return 999999`
  test_an_unparseable_summary_returns_none...  -> 3 passed   (vacuous)
  test_the_collect_parser_handles_both_forms   -> 1 failed   (control fires)
after the fix                                  -> 5 failed
```

**NEW-2 — `paths` was threaded in name only.** `measured.get("paths") or ["tests"]` guesses, in the function whose docstring forbids guessing, and the guess equals the recorded value — so no test could separate reading the record from hardcoding it. Review replaced the lookup with the literal and all 15 tests survived. `paths` now refuses like `markers`, a bare string is rejected explicitly (it splats to one argument per character), and the new test uses paths the default could not produce.

**NEW-3 — "frozen" had two owners and they disagreed on six files.**

```
frozen by NAME: 12        frozen by IMPORT: 14

excluded by name but NOT frozen (2 files, 40 test functions)
    tests/unit/test_alg/test_rl_stub_metrics_1688.py            (4)
    tests/unit/test_utils/test_neural/test_normalization.py     (36)
frozen by import but LEFT IN the denominator (4 files, 20 functions)
    test_adaptive_training_canonical_mode_1572   test_mean_field_rl_requires_pop_state_1508
    test_solver_construction_smoke_887           test_enum_conversions
```

36 of those were dropped because a **directory** is spelled `test_neural`, while `CLAUDE.md` freezes `alg/neural` and `alg/reinforcement` only. `check_frozen_areas.py` already decides this by AST and carries the argument for why a name match is insufficient. Frozen membership now has one decider and this script calls it.

**Item 4 — the hardcoded `12` dissolves rather than being fixed.** With no `FROZEN` tuple there is no dead entry to detect and no file count to ratchet. That count was the wrong quantity anyway, which review demonstrated in both directions: appending 50 test functions to a frozen file left the printed number unchanged, and splitting one frozen file in two reddened it with a message that misdiagnosed the cause. The pin is now on the **owner**, not the answer.

```
relapse to filename substrings  -> 3 failed
exclusion disabled entirely     -> 2 failed
```

**The reported number moves with it, in the honest direction: `19.3% of 5371` → `19.5% of 5393`.**

### Corrections to my own claims, which re-review had to find

| Claim | Status |
|---|---|
| "The five surviving mutations, plus the new guard, all die." | **Four die.** `drop -o addopts=` still SURVIVES — verified, 18 passed — and it was absent from the table directly beneath the sentence. |
| "131 frozen test functions at a 47% flag rate", in a **test docstring** and in the changelog | **Not reproducible** from any state of the code. Re-measured under the single owner: 14 files, 145 test functions, 66 flagged = 46%. Struck in place. |
| the changelog fragment | still shipped `assertion strength : 1036 of 5369 collected tests` — output the code no longer produces — and a mutation-table row naming the old phrase. Four anchors updated. |

Re-review also withdrew its own round-1 claim that `4fe6a990` would fail `assert frozen_files`; that assertion no longer exists either way.
