### PR TITLE
fix(workflow): stop writing to the caller's working directory at import

### DIFF
--- a/changelog.d/1917-no-writes-at-import.fixed.md
+++ b/changelog.d/1917-no-writes-at-import.fixed.md
@@ -1,0 +1,13 @@
+Importing `mfgarchon` or `mfgarchon.workflow` no longer writes to the caller's working
+directory.
+
+`import mfgarchon.workflow` ran an initialiser that built a workflow manager anchored to
+`Path.cwd()`, created `.mfg_workflows/`, and persisted an example workflow as a side effect of
+reading the module; `import mfgarchon` separately created `performance_data/` from a
+module-level `PerformanceMonitor()` whose constructor called `mkdir`. Constructing a `Workflow`
+or a `WorkflowManager` also created directories. 21,498 empty directories had accumulated in the
+development tree, and on a read-only working directory the import raised `PermissionError`.
+
+Paths are now computed at construction and the directory is created at the point of an actual
+write. `initialize_default_workspace()` and `_create_example_workflows()` are removed with the
+initialiser that was their only caller. (#1917, #1674)

--- a/changelog.d/1917-no-writes-at-import.fixed.md
+++ b/changelog.d/1917-no-writes-at-import.fixed.md
@@ -8,6 +8,10 @@ module-level `PerformanceMonitor()` whose constructor called `mkdir`. Constructi
 or a `WorkflowManager` also created directories. 21,498 empty directories had accumulated in the
 development tree, and on a read-only working directory the import raised `PermissionError`.
 
-Paths are now computed at construction and the directory is created at the point of an actual
-write. `initialize_default_workspace()` and `_create_example_workflows()` are removed with the
-initialiser that was their only caller. (#1917, #1674)
+`Workflow`, `WorkflowManager` and `PerformanceMonitor` now compute their paths at construction
+and create the directory at the point of an actual write. `initialize_default_workspace()` and
+`_create_example_workflows()` are removed with the initialiser that was their only caller.
+
+The same constructor-time pattern survives in `Experiment`, `ExperimentTracker` and
+`SweepConfiguration`, which still create directories under the current working directory when
+they are constructed; those are tracked in #1929. (#1917, #1674)

--- a/mfgarchon/utils/performance/monitoring.py
+++ b/mfgarchon/utils/performance/monitoring.py
@@ -110,8 +110,12 @@ class PerformanceMonitor:
         Args:
             storage_path: Path to store performance data (default: ./performance_data)
         """
+        # No mkdir here. `global_performance_monitor = PerformanceMonitor()` runs at module
+        # level, so this constructor created `performance_data/` in the CALLER's working
+        # directory as a side effect of `import mfgarchon`. `_load_stored_data` below only
+        # reads, and guards on `.exists()`; `_save_data` is the one path that needs the
+        # directory, and it creates it. #1674, same shape as #1917.
         self.storage_path = storage_path or Path("performance_data")
-        self.storage_path.mkdir(exist_ok=True)
 
         self.metrics_history: dict[str, list[PerformanceMetrics]] = {}
         self.baselines: dict[str, PerformanceBaseline] = {}
@@ -144,6 +148,7 @@ class PerformanceMonitor:
     def _save_data(self) -> None:
         """Save performance data to storage."""
         try:
+            self.storage_path.mkdir(parents=True, exist_ok=True)
             # Save baselines
             baseline_file = self.storage_path / "baselines.json"
             baseline_data = {}

--- a/mfgarchon/workflow/__init__.py
+++ b/mfgarchon/workflow/__init__.py
@@ -23,7 +23,6 @@ Components:
 
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 from .common import ExecutionStatus
@@ -244,20 +243,14 @@ __all__ = [
 ]
 
 
-# Initialize workflow system
-def _initialize_workflow_system():
-    """Initialize the workflow system with default configuration."""
-    try:
-        # Set up default workspace if needed
-        import os
-
-        if not os.getenv("MFG_WORKFLOW_INITIALIZED"):
-            manager = get_workflow_manager()
-            manager.initialize_default_workspace()
-            os.environ["MFG_WORKFLOW_INITIALIZED"] = "true"
-    except Exception as e:
-        warnings.warn(f"Could not initialize workflow system: {e}", stacklevel=2)
-
-
-# Initialize on import
-_initialize_workflow_system()
+# [REMOVED 2026-08-14] `_initialize_workflow_system()` ran at import and is gone. It built the
+# global manager, created `.mfg_workflows/` under the CALLER's working directory, and persisted an
+# example workflow -- `example_parameter_study`, with a step -- as a side effect of reading the
+# module. The `MFG_WORKFLOW_INITIALIZED` env guard only suppressed a repeat within one process, so
+# every process contributed a fresh UUID directory: 20,322 accumulated in this repository in two
+# weeks, and a sample of 500 were all empty. Nothing in the survey that found them was using the
+# workflow system; they came from test collection and from `import mfgarchon`.
+#
+# `initialize_default_workspace()` and `_create_example_workflows()` were unreachable once this
+# call went, and are deleted with it -- the change's own tail. Example content belongs in
+# `examples/`, not in a directory the library invents under someone else's cwd. #1917

--- a/mfgarchon/workflow/__init__.py
+++ b/mfgarchon/workflow/__init__.py
@@ -247,9 +247,18 @@ __all__ = [
 # global manager, created `.mfg_workflows/` under the CALLER's working directory, and persisted an
 # example workflow -- `example_parameter_study`, with a step -- as a side effect of reading the
 # module. The `MFG_WORKFLOW_INITIALIZED` env guard only suppressed a repeat within one process, so
-# every process contributed a fresh UUID directory: 20,322 accumulated in this repository in two
-# weeks, and a sample of 500 were all empty. Nothing in the survey that found them was using the
-# workflow system; they came from test collection and from `import mfgarchon`.
+# every process contributed fresh UUID directories: 21,498 accumulated in this repository in two
+# weeks, 800 sampled and all empty. Nothing that produced them was using the workflow system;
+# they came from test collection and from `import mfgarchon`.
+#
+# The producer was `_load_existing_workflows`, not the example builder. ~~`if not self.workflows`
+# is always true in a fresh process, so every import created a directory and wrote nothing~~
+# [CORRECTED 2026-08-14] -- that is self-contradictory, as review pointed out: were it true there
+# would be 21,498 metadata.json files, not one. Traced instead: the loader constructs a
+# `Workflow(...)` for each metadata-bearing directory it finds, that constructor mkdir'd a FRESH
+# uuid directory, and the next line reassigned `workflow_dir` and orphaned it. Measured on main
+# with one seeded workflow: dirs = 2, 3, 4 over three imports while metadata files stayed at 1.
+# So the growth was one orphan PER already-persisted workflow per import, not a flat one.
 #
 # `initialize_default_workspace()` and `_create_example_workflows()` were unreachable once this
 # call went, and are deleted with it -- the change's own tail. Example content belongs in

--- a/mfgarchon/workflow/common.py
+++ b/mfgarchon/workflow/common.py
@@ -9,7 +9,6 @@ Issue #621: Consolidate duplicate patterns in workflow/ module.
 from __future__ import annotations
 
 import logging
-import os
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -74,59 +73,45 @@ def setup_workflow_logging(
 ) -> logging.Logger:
     """Configure a logger with an optional file handler and optional console handler.
 
-    All five ``_setup_logging()`` methods across the workflow module follow the
-    same pattern. This function consolidates that pattern.
+    `log_file` is optional so a caller that does not yet own a directory can still get a logger;
+    `Workflow` and `WorkflowManager` construct theirs before any directory exists (#1917).
 
-    Args:
-        name: Logger name passed to :func:`get_logger`.
-        log_file: Path to the log file, or ``None`` for console only. `None` is what a
-            caller passes before it owns a directory to write into -- attach the file
-            later with :func:`attach_log_file`.
-        console: If ``True``, also attach a :class:`~logging.StreamHandler`.
+    The `if not logger.handlers:` guard is deliberate and is restored here after a review found
+    that lifting it revived a path dead since #621 (`d424be1d`, 2026-02-06). `get_logger` always
+    attaches a StreamHandler before returning, so this branch has been False for every caller
+    since then and no `FileHandler` has been constructed. An earlier revision of this change
+    moved the file handler outside the guard; the result wrote `parameter_sweep.log` and
+    `experiment.log` into the caller's working directory, and -- because `mfg_workflow_manager`,
+    `mfg_experiment_tracker` and `mfg_parameter_sweep` are FIXED logger names -- appended a new
+    handler per instance, so records from 126 distinct output directories landed in one file at
+    this repository's root, 298 KB of them during the gate run that reviewed the change.
 
-    Returns:
-        Configured :class:`~logging.Logger`.
+    Reviving workflow file logging is a separate decision from stopping import-time writes, and
+    it needs the shared-name loggers fixed first. Tracked separately; not done here.
     """
     logger = get_logger(name)
     logger.setLevel(logging.INFO)
 
     if not logger.handlers:
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+        if log_file is not None:
+            file_handler = logging.FileHandler(log_file)
+            file_handler.setLevel(logging.DEBUG)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+
         if console:
             console_handler = logging.StreamHandler()
             console_handler.setLevel(logging.INFO)
-            console_handler.setFormatter(_FORMATTER)
+            console_handler.setFormatter(formatter)
             logger.addHandler(console_handler)
-
-    if log_file is not None:
-        attach_log_file(logger, log_file)
 
     return logger
 
 
-_FORMATTER = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-
-def attach_log_file(logger: logging.Logger, log_file: Path) -> None:
-    """Attach a file handler, once, to a logger that may already have one.
-
-    `delay=True` matters: `logging.FileHandler` opens its file in `__init__` by default, so
-    constructing the handler is itself a write. Deferring means the file appears when a record
-    is actually emitted, which is the same moment the caller has committed to owning the
-    directory. #1917.
-    """
-    resolved = os.path.abspath(str(log_file))
-    for handler in logger.handlers:
-        if isinstance(handler, logging.FileHandler) and handler.baseFilename == resolved:
-            return
-    file_handler = logging.FileHandler(log_file, delay=True)
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(_FORMATTER)
-    logger.addHandler(file_handler)
-
-
 __all__ = [
     "ExecutionStatus",
-    "attach_log_file",
     "serialize_value",
     "setup_workflow_logging",
 ]

--- a/mfgarchon/workflow/common.py
+++ b/mfgarchon/workflow/common.py
@@ -83,8 +83,11 @@ def setup_workflow_logging(
     moved the file handler outside the guard; the result wrote `parameter_sweep.log` and
     `experiment.log` into the caller's working directory, and -- because `mfg_workflow_manager`,
     `mfg_experiment_tracker` and `mfg_parameter_sweep` are FIXED logger names -- appended a new
-    handler per instance, so records from 126 distinct output directories landed in one file at
-    this repository's root, 298 KB of them during the gate run that reviewed the change.
+    handler per instance, so records from **37** distinct output directories landed in one file at
+    this repository's root during a single gate run -- 298 KB of it. (~~126~~ [CORRECTED] was the
+    whole file's 128 minus a bad extraction: 91 of those predate #621 disabling the logging and
+    have nothing to do with handler accumulation. Attributing a nine-month total to a 14-minute
+    run overstated the mechanism by 3.5x. Found by re-review.)
 
     Reviving workflow file logging is a separate decision from stopping import-time writes, and
     it needs the shared-name loggers fixed first. Tracked separately; not done here.

--- a/mfgarchon/workflow/common.py
+++ b/mfgarchon/workflow/common.py
@@ -78,16 +78,24 @@ def setup_workflow_logging(
 
     The `if not logger.handlers:` guard is deliberate and is restored here after a review found
     that lifting it revived a path dead since #621 (`d424be1d`, 2026-02-06). `get_logger` always
-    attaches a StreamHandler before returning, so this branch has been False for every caller
-    since then and no `FileHandler` has been constructed. An earlier revision of this change
-    moved the file handler outside the guard; the result wrote `parameter_sweep.log` and
-    `experiment.log` into the caller's working directory, and -- because `mfg_workflow_manager`,
-    `mfg_experiment_tracker` and `mfg_parameter_sweep` are FIXED logger names -- appended a new
-    handler per instance, so records from **37** distinct output directories landed in one file at
-    this repository's root during a single gate run -- 298 KB of it. (~~126~~ [CORRECTED] was the
-    whole file's 128 minus a bad extraction: 91 of those predate #621 disabling the logging and
-    have nothing to do with handler accumulation. Attributing a nine-month total to a 14-minute
-    run overstated the mechanism by 3.5x. Found by re-review.)
+    attaches a StreamHandler before returning, so for any caller that obtains its logger through
+    `get_logger` this branch is False and no `FileHandler` is constructed. (~~for any caller~~
+    [CORRECTED 2026-08-14] -- `tests/unit/test_workflow/test_common.py` patches `get_logger` to
+    return a bare logger, so the guard is True there and a real FileHandler IS built. That is why
+    that test is the second one to redden when the guard is lifted. The operative claim is about
+    production callers; the universal was false.)
+
+    An earlier revision of this change moved the file handler outside the guard; the result wrote
+    `parameter_sweep.log` and `experiment.log` into the caller's working directory, and -- because
+    `mfg_workflow_manager`, `mfg_experiment_tracker` and `mfg_parameter_sweep` are FIXED logger
+    names -- appended a new handler per instance, so records from **37** distinct output
+    directories landed in one file at this repository's root, 298,009 bytes of it. 37 counts the
+    directories named by the `Saved complete results to` records dated 2026-08-14; a figure that
+    moves with the extraction rule is not settled, so the rule is stated. (~~126~~ [CORRECTED
+    2026-08-14] -- the whole file holds 128 across 2025-10-09..2026-08-14, of which 91 predate
+    #621 disabling the logging, with zero overlap. Attributing that total to the 2026-08-14
+    window overstated the mechanism ~3.5x. The window spans 01:08:43..01:22:18 with gaps, so
+    whether it is one gate run or several is not established.)
 
     Reviving workflow file logging is a separate decision from stopping import-time writes, and
     it needs the shared-name loggers fixed first. Tracked separately; not done here.

--- a/mfgarchon/workflow/common.py
+++ b/mfgarchon/workflow/common.py
@@ -9,6 +9,7 @@ Issue #621: Consolidate duplicate patterns in workflow/ module.
 from __future__ import annotations
 
 import logging
+import os
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -67,18 +68,20 @@ def serialize_value(value: Any, name: str = "") -> Any:
 
 def setup_workflow_logging(
     name: str,
-    log_file: Path,
+    log_file: Path | None = None,
     *,
     console: bool = False,
 ) -> logging.Logger:
-    """Configure a logger with a file handler and optional console handler.
+    """Configure a logger with an optional file handler and optional console handler.
 
     All five ``_setup_logging()`` methods across the workflow module follow the
     same pattern. This function consolidates that pattern.
 
     Args:
         name: Logger name passed to :func:`get_logger`.
-        log_file: Path to the log file.
+        log_file: Path to the log file, or ``None`` for console only. `None` is what a
+            caller passes before it owns a directory to write into -- attach the file
+            later with :func:`attach_log_file`.
         console: If ``True``, also attach a :class:`~logging.StreamHandler`.
 
     Returns:
@@ -88,24 +91,42 @@ def setup_workflow_logging(
     logger.setLevel(logging.INFO)
 
     if not logger.handlers:
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-        file_handler = logging.FileHandler(log_file)
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
-
         if console:
             console_handler = logging.StreamHandler()
             console_handler.setLevel(logging.INFO)
-            console_handler.setFormatter(formatter)
+            console_handler.setFormatter(_FORMATTER)
             logger.addHandler(console_handler)
+
+    if log_file is not None:
+        attach_log_file(logger, log_file)
 
     return logger
 
 
+_FORMATTER = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+
+def attach_log_file(logger: logging.Logger, log_file: Path) -> None:
+    """Attach a file handler, once, to a logger that may already have one.
+
+    `delay=True` matters: `logging.FileHandler` opens its file in `__init__` by default, so
+    constructing the handler is itself a write. Deferring means the file appears when a record
+    is actually emitted, which is the same moment the caller has committed to owning the
+    directory. #1917.
+    """
+    resolved = os.path.abspath(str(log_file))
+    for handler in logger.handlers:
+        if isinstance(handler, logging.FileHandler) and handler.baseFilename == resolved:
+            return
+    file_handler = logging.FileHandler(log_file, delay=True)
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(_FORMATTER)
+    logger.addHandler(file_handler)
+
+
 __all__ = [
     "ExecutionStatus",
+    "attach_log_file",
     "serialize_value",
     "setup_workflow_logging",
 ]

--- a/mfgarchon/workflow/workflow_manager.py
+++ b/mfgarchon/workflow/workflow_manager.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .common import ExecutionStatus, attach_log_file, serialize_value, setup_workflow_logging
+from .common import ExecutionStatus, serialize_value, setup_workflow_logging
 
 if TYPE_CHECKING:
     import logging
@@ -135,12 +135,14 @@ class Workflow:
         self.current_result: WorkflowResult | None = None
 
         # Storage
-        # No mkdir here, and no file handler. Constructing a Workflow used to create
-        # `.mfg_workflows/workflow_<uuid>/` and open `workflow.log` inside it -- so merely
-        # naming a workflow wrote to the caller's working directory. Combined with an
-        # import-time initialiser (deleted with this change) that produced 20,322 empty
-        # directories in this repository in two weeks. The directory is created by
-        # `_materialise()`, which every writing path calls and no constructor does. #1917
+        # No mkdir here. Constructing a Workflow used to create `.mfg_workflows/workflow_<uuid>/`,
+        # so merely NAMING a workflow wrote to the caller's working directory. ~~and open
+        # `workflow.log` inside it~~ [CORRECTED 2026-08-14] -- it did not: `setup_workflow_logging`
+        # guards on `if not logger.handlers:` and `get_logger` always attaches a StreamHandler
+        # first, so no FileHandler has been constructed since #621 (2026-02-06). The 21,498
+        # directories being ALL EMPTY is the proof, and it was in hand when the wrong claim was
+        # written. The directory is created by `_materialise()`, which every writing path calls
+        # and no constructor does. #1917
         self.workspace_path = workspace_path or Path.cwd() / ".mfg_workflows"
         self.workflow_dir = self.workspace_path / f"workflow_{self.id}"
         self._materialised = False
@@ -481,7 +483,6 @@ class Workflow:
         """
         if not self._materialised:
             self.workflow_dir.mkdir(parents=True, exist_ok=True)
-            attach_log_file(self.logger, self.workflow_dir / "workflow.log")
             self._materialised = True
         return self.workflow_dir
 
@@ -627,7 +628,6 @@ class WorkflowManager:
         `__init__`. #1917"""
         if not self._materialised:
             self.workspace_path.mkdir(parents=True, exist_ok=True)
-            attach_log_file(self.logger, self.workspace_path / "workflow_manager.log")
             self._materialised = True
         return self.workspace_path
 

--- a/mfgarchon/workflow/workflow_manager.py
+++ b/mfgarchon/workflow/workflow_manager.py
@@ -490,8 +490,10 @@ class Workflow:
         """Console only, and no file handler is attached anywhere.
 
         `setup_workflow_logging` builds its FileHandler inside `if not logger.handlers:`, and
-        `get_logger` always attaches a StreamHandler first -- so no FileHandler has been
-        constructed for any caller since #621 (2026-02-06). Passing a path here would not create
+        `get_logger` always attaches a StreamHandler first -- so for any caller that obtains
+        its logger through `get_logger`, no FileHandler has been constructed since #621
+        (2026-02-06). `test_common.py` patches `get_logger` and does build one, which is
+        why it reddens alongside this when the guard is lifted. Passing a path here would not create
         a directory either; it would simply be discarded, which is what main did. Reviving
         workflow file logging needs the fixed-name loggers dealt with first: #1929."""
         return setup_workflow_logging(f"mfg_workflow.{self.id}", console=True)

--- a/mfgarchon/workflow/workflow_manager.py
+++ b/mfgarchon/workflow/workflow_manager.py
@@ -475,7 +475,7 @@ class Workflow:
         }
 
     def _materialise(self) -> Path:
-        """Create the workflow directory and attach its log file. Idempotent.
+        """Create the workflow directory. Idempotent. Attaches no log file -- see `_setup_logging`.
 
         Every path that writes calls this; no constructor does. That split is the whole fix
         for #1917 -- the directory now appears when a workflow is persisted, not when one is
@@ -487,8 +487,13 @@ class Workflow:
         return self.workflow_dir
 
     def _setup_logging(self) -> logging.Logger:
-        """Console only. The file handler is attached by `_materialise()`, because attaching
-        it here would create the directory this change exists to stop creating."""
+        """Console only, and no file handler is attached anywhere.
+
+        `setup_workflow_logging` builds its FileHandler inside `if not logger.handlers:`, and
+        `get_logger` always attaches a StreamHandler first -- so no FileHandler has been
+        constructed for any caller since #621 (2026-02-06). Passing a path here would not create
+        a directory either; it would simply be discarded, which is what main did. Reviving
+        workflow file logging needs the fixed-name loggers dealt with first: #1929."""
         return setup_workflow_logging(f"mfg_workflow.{self.id}", console=True)
 
 
@@ -624,16 +629,15 @@ class WorkflowManager:
             json.dump(metadata, f, indent=2)
 
     def _materialise(self) -> Path:
-        """Create the workspace and attach its log file. Idempotent; never called by
-        `__init__`. #1917"""
+        """Create the workspace. Idempotent; never called by `__init__`. Attaches no log file --
+        see `Workflow._setup_logging` for why none is attached anywhere. #1917"""
         if not self._materialised:
             self.workspace_path.mkdir(parents=True, exist_ok=True)
             self._materialised = True
         return self.workspace_path
 
     def _setup_logging(self) -> logging.Logger:
-        """Console only until `_materialise()` runs -- naming the log file here would
-        require the directory that this change exists to stop creating."""
+        """Console only. `_materialise()` does not change logging; see `Workflow._setup_logging`."""
         return setup_workflow_logging("mfg_workflow_manager")
 
 

--- a/mfgarchon/workflow/workflow_manager.py
+++ b/mfgarchon/workflow/workflow_manager.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .common import ExecutionStatus, serialize_value, setup_workflow_logging
+from .common import ExecutionStatus, attach_log_file, serialize_value, setup_workflow_logging
 
 if TYPE_CHECKING:
     import logging
@@ -135,9 +135,15 @@ class Workflow:
         self.current_result: WorkflowResult | None = None
 
         # Storage
+        # No mkdir here, and no file handler. Constructing a Workflow used to create
+        # `.mfg_workflows/workflow_<uuid>/` and open `workflow.log` inside it -- so merely
+        # naming a workflow wrote to the caller's working directory. Combined with an
+        # import-time initialiser (deleted with this change) that produced 20,322 empty
+        # directories in this repository in two weeks. The directory is created by
+        # `_materialise()`, which every writing path calls and no constructor does. #1917
         self.workspace_path = workspace_path or Path.cwd() / ".mfg_workflows"
         self.workflow_dir = self.workspace_path / f"workflow_{self.id}"
-        self.workflow_dir.mkdir(parents=True, exist_ok=True)
+        self._materialised = False
 
         # Logging
         self.logger = self._setup_logging()
@@ -378,7 +384,7 @@ class Workflow:
 
     def save_result(self, result: WorkflowResult):
         """Save workflow result to disk."""
-        result_file = self.workflow_dir / "result.json"
+        result_file = self._materialise() / "result.json"
 
         # Save main result metadata
         with open(result_file, "w") as f:
@@ -466,13 +472,23 @@ class Workflow:
             "context": self.context,
         }
 
+    def _materialise(self) -> Path:
+        """Create the workflow directory and attach its log file. Idempotent.
+
+        Every path that writes calls this; no constructor does. That split is the whole fix
+        for #1917 -- the directory now appears when a workflow is persisted, not when one is
+        named.
+        """
+        if not self._materialised:
+            self.workflow_dir.mkdir(parents=True, exist_ok=True)
+            attach_log_file(self.logger, self.workflow_dir / "workflow.log")
+            self._materialised = True
+        return self.workflow_dir
+
     def _setup_logging(self) -> logging.Logger:
-        """Set up logging for the workflow."""
-        return setup_workflow_logging(
-            f"mfg_workflow.{self.id}",
-            self.workflow_dir / "workflow.log",
-            console=True,
-        )
+        """Console only. The file handler is attached by `_materialise()`, because attaching
+        it here would create the directory this change exists to stop creating."""
+        return setup_workflow_logging(f"mfg_workflow.{self.id}", console=True)
 
 
 class WorkflowManager:
@@ -490,8 +506,9 @@ class WorkflowManager:
         Args:
             workspace_path: Path to workspace directory
         """
+        # Same split as Workflow above: naming a manager must not create a directory. #1917
         self.workspace_path = workspace_path or Path.cwd() / ".mfg_workflows"
-        self.workspace_path.mkdir(parents=True, exist_ok=True)
+        self._materialised = False
 
         self.workflows: dict[str, Workflow] = {}
         self.logger = self._setup_logging()
@@ -503,7 +520,7 @@ class WorkflowManager:
 
     def create_workflow(self, name: str, description: str = "", **kwargs) -> Workflow:
         """Create a new workflow."""
-        workflow = Workflow(name, description, self.workspace_path)
+        workflow = Workflow(name, description, self._materialise())
         self.workflows[workflow.id] = workflow
 
         # Save workflow metadata
@@ -562,45 +579,6 @@ class WorkflowManager:
 
         return workflow.execute(**kwargs)
 
-    def initialize_default_workspace(self):
-        """Initialize default workspace with example workflows."""
-        self.logger.info("Initializing default workspace")
-
-        # Create workspace structure
-        (self.workspace_path / "templates").mkdir(exist_ok=True)
-        (self.workspace_path / "shared").mkdir(exist_ok=True)
-        (self.workspace_path / "exports").mkdir(exist_ok=True)
-
-        # Create example workflows if none exist
-        if not self.workflows:
-            self._create_example_workflows()
-
-    def _create_example_workflows(self):
-        """Create example workflows for demonstration."""
-        # Example 1: Simple parameter study
-        workflow1 = self.create_workflow("example_parameter_study", "Example parameter study workflow")
-
-        def example_solve(sigma, Nx=20, Nt=10):
-            from mfgarchon import MFGProblem
-            from mfgarchon.geometry import TensorProductGrid
-            from mfgarchon.geometry.boundary import no_flux_bc
-
-            geometry = TensorProductGrid(
-                bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
-            )
-            problem = MFGProblem(geometry=geometry, sigma=sigma, Nt=Nt)
-            result = problem.solve()
-            return {
-                "converged": getattr(result, "converged", False),
-                "iterations": getattr(result, "iterations", 0),
-                "final_error": getattr(result, "final_error", 0.0),
-                "execution_time": getattr(result, "execution_time", 0.0),
-            }
-
-        workflow1.add_step("solve_problem", example_solve, inputs={"sigma": 0.5, "Nx": 20, "Nt": 10})
-
-        self.logger.info("Created example workflows")
-
     def _load_existing_workflows(self):
         """Load existing workflows from workspace."""
         if not self.workspace_path.exists():
@@ -631,7 +609,7 @@ class WorkflowManager:
 
     def _save_workflow_metadata(self, workflow: Workflow):
         """Save workflow metadata to disk."""
-        metadata_file = workflow.workflow_dir / "metadata.json"
+        metadata_file = workflow._materialise() / "metadata.json"
 
         metadata = {
             "id": workflow.id,
@@ -644,12 +622,19 @@ class WorkflowManager:
         with open(metadata_file, "w") as f:
             json.dump(metadata, f, indent=2)
 
+    def _materialise(self) -> Path:
+        """Create the workspace and attach its log file. Idempotent; never called by
+        `__init__`. #1917"""
+        if not self._materialised:
+            self.workspace_path.mkdir(parents=True, exist_ok=True)
+            attach_log_file(self.logger, self.workspace_path / "workflow_manager.log")
+            self._materialised = True
+        return self.workspace_path
+
     def _setup_logging(self) -> logging.Logger:
-        """Set up logging for the workflow manager."""
-        return setup_workflow_logging(
-            "mfg_workflow_manager",
-            self.workspace_path / "workflow_manager.log",
-        )
+        """Console only until `_materialise()` runs -- naming the log file here would
+        require the directory that this change exists to stop creating."""
+        return setup_workflow_logging("mfg_workflow_manager")
 
 
 # Export main classes

--- a/scripts/fail_fast_baseline.json
+++ b/scripts/fail_fast_baseline.json
@@ -1,6 +1,6 @@
 {
   "bare_except": 0,
-  "broad_except": 109,
+  "broad_except": 108,
   "hasattr": 109,
   "silent_pass": 90
 }

--- a/tests/unit/test_no_writes_at_import.py
+++ b/tests/unit/test_no_writes_at_import.py
@@ -153,8 +153,9 @@ def test_using_the_workflow_machinery_writes_no_log_into_the_working_directory()
     """A guard against reviving workflow file logging by accident.
 
     `setup_workflow_logging` has an `if not logger.handlers:` guard, and `get_logger` always
-    attaches a StreamHandler before returning -- so no `FileHandler` has been constructed for any
-    caller since #621 (2026-02-06). An earlier revision of #1917 lifted that guard while
+    attaches a StreamHandler before returning -- so for any caller that obtains its logger
+    through `get_logger`, no `FileHandler` has been constructed since #621 (2026-02-06).
+    (`test_workflow/test_common.py` patches `get_logger` and does build one.) An earlier revision of #1917 lifted that guard while
     restructuring the helper, which revived the path. Because `mfg_workflow_manager`,
     `mfg_experiment_tracker` and `mfg_parameter_sweep` are FIXED logger names, each new instance
     appended another handler rather than replacing one: records from 37 distinct output
@@ -173,7 +174,11 @@ def test_using_the_workflow_machinery_writes_no_log_into_the_working_directory()
         "from mfgarchon.workflow.experiment_tracker import ExperimentTracker\n"
         "cfg = SweepConfiguration({'a': [1, 2]}, output_dir=Path('out'))\n"
         "ParameterSweep({'a': [1, 2]}, cfg)\n"
-        "WorkflowManager(workspace_path=Path('ws'))\n"
+        # `.create_workflow(...)`, not a bare manager: without it `ws/` is never created,
+        # `_load_existing_workflows` returns early and `Workflow._materialise` is never
+        # reached -- so re-adding the file handler THERE, which is literally what 05ee9058
+        # did, passed all 216 tests. Measured by re-review.
+        "WorkflowManager(workspace_path=Path('ws')).create_workflow('w', '')\n"
         # ExperimentTracker has its own _setup_logging and its own fixed logger name, so a
         # revival there bypasses the helper entirely. Re-review measured it: without this line
         # the mutant writes exp/experiment_tracker.log and all 216 tests pass.

--- a/tests/unit/test_no_writes_at_import.py
+++ b/tests/unit/test_no_writes_at_import.py
@@ -1,14 +1,17 @@
 """Importing this package writes nothing to the caller's working directory.
 
-#1917 measured 20,322 UUID-named directories accumulated in this repository in two weeks, a
-sample of 500 of them empty. `import mfgarchon.workflow` ran an initialiser that built a manager
+#1917 measured 21,498 UUID-named directories accumulated in this repository in two weeks, 800
+sampled and all empty. (The issue text says 20,322 / 500; that was the count at filing, three
+days earlier. Both are real measurements at different times -- the later one is used throughout.) `import mfgarchon.workflow` ran an initialiser that built a manager
 anchored to `Path.cwd()`, created `.mfg_workflows/`, and persisted an example workflow -- with a
-step -- as a side effect of reading the module. `import mfgarchon` separately created
+step -- as a side effect of reading the module. The directories then multiplied through
+`_load_existing_workflows`, which constructs a `Workflow` per persisted metadata file and whose
+constructor mkdir'd a fresh uuid directory that the next line orphaned. `import mfgarchon` separately created
 `performance_data/`, because `global_performance_monitor = PerformanceMonitor()` runs at module
 level and that constructor called `mkdir`. Neither needed a user to do anything.
 
 The reason this file exists rather than just the fixes: #1674 filed the `performance_data/` half
-BEFORE those 20,322 directories were created, and it stayed open while they accumulated. A fix
+BEFORE those 21,498 directories were created, and it stayed open while they accumulated. A fix
 with no test is what that looks like from the outside. What is asserted here is the whole
 directory listing, not the two names that are known to have gone wrong -- a filter would pass over
 the next site rather than catch it.
@@ -85,7 +88,7 @@ def test_importing_writes_nothing_to_the_working_directory(module, tmp_path):
 
 def test_naming_a_workflow_writes_nothing():
     """Constructing a `Workflow` used to `mkdir` and open a log file inside it, so the test
-    suite's own `Workflow(name="test")` calls were part of the 20,322."""
+    suite's own `Workflow(name="test")` calls were part of the 21,498."""
     code = "from mfgarchon.workflow import Workflow\nw = Workflow(name='probe')\nassert w.name == 'probe'\n"
     import tempfile
 
@@ -136,3 +139,36 @@ def test_saving_a_result_does_create_the_directory():
         after, proc = _listing_after(code, cwd)
     assert proc.returncode == 0, f"the persistence path is broken:\n{proc.stderr[-1500:]}"
     assert after == {"ws"}, f"expected only the workspace the caller named, got {sorted(after)}"
+
+
+def test_using_the_workflow_machinery_writes_no_log_into_the_working_directory():
+    """A guard against reviving workflow file logging by accident.
+
+    `setup_workflow_logging` has an `if not logger.handlers:` guard, and `get_logger` always
+    attaches a StreamHandler before returning -- so no `FileHandler` has been constructed for any
+    caller since #621 (2026-02-06). An earlier revision of #1917 lifted that guard while
+    restructuring the helper, which revived the path. Because `mfg_workflow_manager`,
+    `mfg_experiment_tracker` and `mfg_parameter_sweep` are FIXED logger names, each new instance
+    appended another handler rather than replacing one: records from 126 distinct output
+    directories ended up in a single file at this repository's root, 298 KB of them written
+    during the gate run that was reviewing the change. Found by independent review.
+
+    Reviving that logging is a separate decision and needs the shared-name loggers fixed first.
+    Until then this asserts it stays off, because nothing else in the suite reacts to it.
+    """
+    code = (
+        "from pathlib import Path\n"
+        "from mfgarchon.workflow.parameter_sweep import ParameterSweep, SweepConfiguration\n"
+        "from mfgarchon.workflow import WorkflowManager\n"
+        "cfg = SweepConfiguration({'a': [1, 2]}, output_dir=Path('out'))\n"
+        "ParameterSweep({'a': [1, 2]}, cfg)\n"
+        "WorkflowManager(workspace_path=Path('ws'))\n"
+    )
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        cwd = Path(d)
+        _after, proc = _listing_after(code, cwd)
+        logs = sorted(str(p.relative_to(cwd)) for p in cwd.rglob("*.log"))
+    assert proc.returncode == 0, f"the probe never ran, so it measured nothing:\n{proc.stderr[-1500:]}"
+    assert not logs, f"workflow file logging is live again and writing to the caller's cwd: {logs}"

--- a/tests/unit/test_no_writes_at_import.py
+++ b/tests/unit/test_no_writes_at_import.py
@@ -1,8 +1,10 @@
 """Importing this package writes nothing to the caller's working directory.
 
 #1917 measured 21,498 UUID-named directories accumulated in this repository in two weeks, 800
-sampled and all empty. (The issue text says 20,322 / 500; that was the count at filing, three
-days earlier. Both are real measurements at different times -- the later one is used throughout.) `import mfgarchon.workflow` ran an initialiser that built a manager
+sampled and all empty. (The issue text says 20,322 / 500 -- the count when it was filed
+at 2026-08-13T12:54Z, against 21,498 / 800 recounted at 17:19Z. ~~three days earlier~~ [CORRECTED
+2026-08-14]: the interval is about four and a half hours, and that is the more telling number --
+**+1,176 directories in under six hours of ordinary work.**) `import mfgarchon.workflow` ran an initialiser that built a manager
 anchored to `Path.cwd()`, created `.mfg_workflows/`, and persisted an example workflow -- with a
 step -- as a side effect of reading the module. The directories then multiplied through
 `_load_existing_workflows`, which constructs a `Workflow` per persisted metadata file and whose
@@ -87,8 +89,14 @@ def test_importing_writes_nothing_to_the_working_directory(module, tmp_path):
 
 
 def test_naming_a_workflow_writes_nothing():
-    """Constructing a `Workflow` used to `mkdir` and open a log file inside it, so the test
-    suite's own `Workflow(name="test")` calls were part of the 21,498."""
+    """Constructing a `Workflow` used to `mkdir`, so the test suite's own `Workflow(name="test")`
+    calls were part of the 21,498.
+
+    ~~and open a log file inside it~~ [CORRECTED 2026-08-14] -- it never opened one. No FileHandler
+    has been constructed for any caller since #621 (2026-02-06), because `setup_workflow_logging`
+    guards on `if not logger.handlers:` and `get_logger` always attaches a StreamHandler first.
+    The 21,498 directories being ALL EMPTY is the proof, and it was in hand when the claim was
+    written."""
     code = "from mfgarchon.workflow import Workflow\nw = Workflow(name='probe')\nassert w.name == 'probe'\n"
     import tempfile
 
@@ -149,9 +157,11 @@ def test_using_the_workflow_machinery_writes_no_log_into_the_working_directory()
     caller since #621 (2026-02-06). An earlier revision of #1917 lifted that guard while
     restructuring the helper, which revived the path. Because `mfg_workflow_manager`,
     `mfg_experiment_tracker` and `mfg_parameter_sweep` are FIXED logger names, each new instance
-    appended another handler rather than replacing one: records from 126 distinct output
-    directories ended up in a single file at this repository's root, 298 KB of them written
-    during the gate run that was reviewing the change. Found by independent review.
+    appended another handler rather than replacing one: records from 37 distinct output
+    directories ended up in a single file at this repository's root, 298 KB written during the
+    gate run that was reviewing the change. (~~126~~ [CORRECTED 2026-08-14] -- that misread the
+    whole file's nine-month total of 128; 91 of those predate #621 disabling the logging, with
+    zero overlap, so attributing them to a 14-minute run overstated the mechanism 3.5x.)
 
     Reviving that logging is a separate decision and needs the shared-name loggers fixed first.
     Until then this asserts it stays off, because nothing else in the suite reacts to it.
@@ -160,9 +170,14 @@ def test_using_the_workflow_machinery_writes_no_log_into_the_working_directory()
         "from pathlib import Path\n"
         "from mfgarchon.workflow.parameter_sweep import ParameterSweep, SweepConfiguration\n"
         "from mfgarchon.workflow import WorkflowManager\n"
+        "from mfgarchon.workflow.experiment_tracker import ExperimentTracker\n"
         "cfg = SweepConfiguration({'a': [1, 2]}, output_dir=Path('out'))\n"
         "ParameterSweep({'a': [1, 2]}, cfg)\n"
         "WorkflowManager(workspace_path=Path('ws'))\n"
+        # ExperimentTracker has its own _setup_logging and its own fixed logger name, so a
+        # revival there bypasses the helper entirely. Re-review measured it: without this line
+        # the mutant writes exp/experiment_tracker.log and all 216 tests pass.
+        "ExperimentTracker(workspace_path=Path('exp')).create_experiment('p', 'd')\n"
     )
     import tempfile
 

--- a/tests/unit/test_no_writes_at_import.py
+++ b/tests/unit/test_no_writes_at_import.py
@@ -1,0 +1,138 @@
+"""Importing this package writes nothing to the caller's working directory.
+
+#1917 measured 20,322 UUID-named directories accumulated in this repository in two weeks, a
+sample of 500 of them empty. `import mfgarchon.workflow` ran an initialiser that built a manager
+anchored to `Path.cwd()`, created `.mfg_workflows/`, and persisted an example workflow -- with a
+step -- as a side effect of reading the module. `import mfgarchon` separately created
+`performance_data/`, because `global_performance_monitor = PerformanceMonitor()` runs at module
+level and that constructor called `mkdir`. Neither needed a user to do anything.
+
+The reason this file exists rather than just the fixes: #1674 filed the `performance_data/` half
+BEFORE those 20,322 directories were created, and it stayed open while they accumulated. A fix
+with no test is what that looks like from the outside. What is asserted here is the whole
+directory listing, not the two names that are known to have gone wrong -- a filter would pass over
+the next site rather than catch it.
+
+Each test runs the import in a subprocess with a fresh interpreter, because by the time this file
+is collected the package is already imported and the side effect, if any, has already happened in
+the pytest process's cwd.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Entry points a user or a tool actually reaches for. `mfgarchon.workflow` is the site #1917
+# measured; the others are here because the defect was never specific to it -- any module-level
+# singleton whose constructor writes has the same shape.
+IMPORTS = [
+    "mfgarchon",
+    "mfgarchon.workflow",
+    "mfgarchon.utils.performance",
+    "mfgarchon.geometry",
+    "mfgarchon.backends",
+]
+
+
+def _listing_after(code: str, cwd: Path) -> tuple[set[str], subprocess.CompletedProcess]:
+    """Run `code` with `cwd` as the working directory and report what appeared there.
+
+    HOME points somewhere else on purpose. Pointing it at `cwd` was the first version, and it
+    turned matplotlib's ordinary `~/.matplotlib` cache into a reported defect in five tests --
+    a harness artefact that reads exactly like the bug under test. Writing to HOME is legitimate;
+    writing to the directory you were launched from is not, and only the second is measured here.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as home:
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=cwd,
+            env={
+                "PATH": "/usr/bin:/bin",
+                "PYTHONPATH": str(REPO),
+                "HOME": home,
+                "MPLCONFIGDIR": home,
+                "XDG_CACHE_HOME": home,
+            },
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    return {p.name for p in cwd.iterdir()}, proc
+
+
+@pytest.mark.parametrize("module", IMPORTS)
+def test_importing_writes_nothing_to_the_working_directory(module, tmp_path):
+    """The whole listing, not a denylist of the two names already known to be wrong."""
+    before = {p.name for p in tmp_path.iterdir()}
+    assert before == set(), "tmp_path was not empty; the measurement below would mean nothing"
+
+    after, proc = _listing_after(f"import {module}", tmp_path)
+    assert proc.returncode == 0, f"import {module} failed, so nothing was measured:\n{proc.stderr[-1500:]}"
+    assert after == set(), (
+        f"import {module} created {sorted(after)} in the caller's working directory. "
+        f"A library may not write where it was launched from; anchor to an explicit path or "
+        f"create the directory at the point of an actual write."
+    )
+
+
+def test_naming_a_workflow_writes_nothing():
+    """Constructing a `Workflow` used to `mkdir` and open a log file inside it, so the test
+    suite's own `Workflow(name="test")` calls were part of the 20,322."""
+    code = "from mfgarchon.workflow import Workflow\nw = Workflow(name='probe')\nassert w.name == 'probe'\n"
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        cwd = Path(d)
+        after, proc = _listing_after(code, cwd)
+    assert proc.returncode == 0, f"construction failed, so nothing was measured:\n{proc.stderr[-1500:]}"
+    assert after == set(), f"naming a workflow created {sorted(after)}"
+
+
+def test_the_probe_would_notice_a_write():
+    """Positive control. Every assertion above is that a set is empty, and an empty set is what a
+    broken probe returns too -- a subprocess that never ran, a cwd that is not the one inspected,
+    an exception swallowed into returncode 0. This writes on purpose and must be caught.
+    """
+    code = "import pathlib\npathlib.Path('sentinel_dir').mkdir()\n"
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        cwd = Path(d)
+        after, proc = _listing_after(code, cwd)
+    assert proc.returncode == 0, proc.stderr[-800:]
+    assert after == {"sentinel_dir"}, (
+        f"the probe reported {sorted(after)} for a program that certainly wrote one directory; "
+        f"it is not measuring the directory it claims to measure"
+    )
+
+
+def test_saving_a_result_does_create_the_directory():
+    """The other direction: deferring the write must not mean never writing.
+
+    A fix that simply stopped persisting would pass every assertion above, so assert that the
+    directory appears at the point it is supposed to -- when a workflow is actually saved.
+    """
+    code = (
+        "from pathlib import Path\n"
+        "from mfgarchon.workflow import WorkflowManager\n"
+        "m = WorkflowManager(workspace_path=Path('ws'))\n"
+        "assert not Path('ws').exists(), 'the manager created its workspace at construction'\n"
+        "w = m.create_workflow('real', 'persisted on purpose')\n"
+        "meta = Path('ws') / f'workflow_{w.id}' / 'metadata.json'\n"
+        "assert meta.exists(), f'create_workflow did not persist metadata: {sorted(Path().rglob(\"*\"))}'\n"
+    )
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        cwd = Path(d)
+        after, proc = _listing_after(code, cwd)
+    assert proc.returncode == 0, f"the persistence path is broken:\n{proc.stderr[-1500:]}"
+    assert after == {"ws"}, f"expected only the workspace the caller named, got {sorted(after)}"

--- a/tests/unit/test_workflow/test_workflow_manager.py
+++ b/tests/unit/test_workflow/test_workflow_manager.py
@@ -13,6 +13,7 @@ import pytest
 from mfgarchon.workflow.workflow_manager import (
     StepStatus,
     Workflow,
+    WorkflowManager,
     WorkflowStatus,
 )
 
@@ -47,14 +48,19 @@ def test_workflow_creation_with_description():
 @pytest.mark.unit
 @pytest.mark.fast
 def test_workflow_creation_with_workspace():
-    """Test workflow creation with custom workspace path."""
+    """Test workflow creation with custom workspace path.
+
+    ~~`assert wf.workflow_dir.exists()`~~ [CORRECTED 2026-08-14] — construction no longer
+    creates the directory (#1917). The path is computed; the directory appears when something
+    is persisted into it. See `test_the_directory_appears_when_something_is_saved` below.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         workspace = Path(tmpdir)
         wf = Workflow(name="test", workspace_path=workspace)
 
         assert wf.workspace_path == workspace
-        assert wf.workflow_dir.exists()
         assert wf.workflow_dir.parent == workspace
+        assert not wf.workflow_dir.exists(), "naming a workflow must not create its directory"
 
 
 @pytest.mark.unit
@@ -69,12 +75,37 @@ def test_workflow_generates_unique_ids():
 
 @pytest.mark.unit
 @pytest.mark.fast
-def test_workflow_creates_directory():
-    """Test workflow automatically creates its directory."""
-    wf = Workflow(name="test")
+def test_workflow_does_not_create_a_directory_when_merely_named():
+    """[SUPERSEDED 2026-08-14] Was `test_workflow_creates_directory`, asserting the opposite.
 
-    assert wf.workflow_dir.exists()
-    assert wf.workflow_dir.is_dir()
+    It pinned the defect, and it was also a producer of it: `Workflow(name="test")` passes no
+    workspace, so every run of this test wrote `.mfg_workflows/workflow_<uuid>/` into whatever
+    directory pytest was launched from. That is part of how 21,498 empty directories reached
+    this repository (#1917). A workspace is named here so the assertion cannot depend on where
+    the suite is run from.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wf = Workflow(name="test", workspace_path=Path(tmpdir) / "ws")
+
+        assert not wf.workflow_dir.exists()
+        assert not wf.workspace_path.exists(), "naming a workflow created the workspace itself"
+
+
+def test_the_directory_appears_when_something_is_saved():
+    """The other direction: deferring the write must not mean never writing.
+
+    A change that simply stopped persisting would satisfy every "creates nothing" assertion in
+    this file and in tests/unit/test_no_writes_at_import.py.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir) / "ws"
+        manager = WorkflowManager(workspace_path=workspace)
+        assert not workspace.exists(), "the manager created its workspace at construction"
+
+        wf = manager.create_workflow("real", "persisted on purpose")
+
+        assert wf.workflow_dir.exists(), "create_workflow did not materialise the workflow"
+        assert (wf.workflow_dir / "metadata.json").exists(), "metadata was not written"
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #1917. Closes #1674.

`import mfgarchon.workflow` ran an initialiser that built the global manager against `Path.cwd()`, created `.mfg_workflows/`, and persisted an example workflow — with a step — as a side effect of reading the module. `import mfgarchon` separately created `performance_data/`, from a module-level `global_performance_monitor = PerformanceMonitor()` whose constructor called `mkdir`.

Both constructors now compute their paths and stop. `_materialise()` creates the directory; every writing path calls it and no constructor does.

```
before:  .mfg_workflows/  performance_data/
after:   (nothing)
```

Independent review re-swept **all 375 modules** of the package from an empty tmp cwd: `deltas: {}`, `final_listing: []`, 0 import errors, with an in-sweep positive control. The same sweep against `origin/main` produces both directories. On `main` the import also **crashes** in a read-only cwd (`PermissionError` on `performance_data`); this branch does not.

## What produced 21,498 directories

**Not the example builder.** The example was written once — the single `metadata.json` in the whole tree, dated 2026-07-28. The producer is `_load_existing_workflows`: it constructs a `Workflow(...)` for every metadata-bearing directory it finds, that constructor mkdir'd a **fresh** uuid directory, and the next line reassigned `workflow_dir` and orphaned it.

Reproduced on `main`, and independently by review at two seed counts:

```
1 seeded workflow:   dirs = 2, 3, 4   metadata constant at 1
2 seeded workflows:  dirs = 4, 6, 8   metadata constant at 2
```

So the growth was **one orphan per already-persisted workflow per import**, not a flat one.

## #1674 is fixed here because #1917's acceptance test requires it

The test the issue asks for is *"import in a tmp cwd and assert the directory listing is unchanged"*, which `performance_data/` makes impossible. Same shape, same split: `_load_stored_data` only reads and guards on `.exists()`; `_save_data` creates the directory it writes into.

## The test

`tests/unit/test_no_writes_at_import.py` asserts the **whole directory listing** over five entry points — a denylist of the two known-bad names would pass over the next site. It carries a positive control (a program that certainly writes must be caught; every other assertion is that a set is empty, which is also what a broken probe returns) and the opposite direction (`create_workflow` must still persist).

#1674 had been open since before those 21,498 directories were created. A fix with no test is what that looks like from the outside.

## Two rounds of review, and what each corrected

**Round 1 — MERGE-BLOCKED.** The restructure had lifted `attach_log_file` out of `if not logger.handlers:`, reviving a path dead since #621 (2026-02-06): `get_logger` always attaches a StreamHandler first, so no `FileHandler` had been constructed for any caller. Switching it back on wrote `parameter_sweep.log` and `experiment.log` into the caller's cwd, and — because `mfg_workflow_manager`, `mfg_experiment_tracker` and `mfg_parameter_sweep` are **fixed** logger names — appended a handler per instance instead of replacing one. **298 KB written into this repository's root during the gate run that was verifying the branch.**

Fixed by **not reviving it**: `attach_log_file` deleted, the guard restored, `_materialise()` is mkdir-only. That is a separate decision needing the fixed-name loggers dealt with first → **#1929**.

Round 1 also corrected two claims this PR had asserted as fact:

| Claim | Truth |
|---|---|
| "`Workflow.__init__` opened `workflow.log`" | Only the `mkdir` happened. **The proof was in hand and pointed the other way: 21,498 directories, all empty.** Had construction opened a log file, every one would have contained one. |
| "`if not self.workflows` is always true, so every import wrote nothing" | Self-contradictory — there would be 21,498 `metadata.json` files, not one. See the `_load_existing_workflows` account above. |

`delay=True` prevented nothing either: no handler was being constructed. Removed.

**Round 2 — MERGE-BLOCKED on documentation.** The behaviour was confirmed resolved (216 tests, seven mutants, five `_setup_logging` methods diffed against main, full logger-state dumps identical modulo UUIDs), but the remedy commit had introduced three more false statements:

| Claim | Truth |
|---|---|
| "126 distinct output directories" | **37** in the window the sentence is about. 128 is the whole file's nine-month total and 91 of those predate #621, with zero overlap — attributing them to a 14-minute run overstated the mechanism 3.5×. |
| "three days earlier" (the 20,322 → 21,498 recount) | **≈4.5 hours** — filed 2026-08-13T12:54Z, recounted 17:19Z. The buried datum is the better one: **+1,176 directories in under six hours** of ordinary work. |
| Four docstrings on `_materialise` / `_setup_logging` describing a log file that is attached | Nothing is attached anywhere. The deletion orphaned every comment that described it. |

Round 2 also found the correction had been applied at **one of three sites**, and that this body previously asserted the false claims in its narrative while denying them in an appendix 66 lines below. This body is rewritten rather than appended to.

And one measured test gap: reviving file logging in `ExperimentTracker._setup_logging` alone bypasses the helper and **passed all 216 tests**. The probe now constructs an `ExperimentTracker` too, which kills it.

## Not in scope, filed instead

Five more constructor-time `Path.cwd()` mkdirs (`Experiment`, `ExperimentTracker`, `SweepConfiguration`, and four others), the `@cached` decorator that mkdirs **at decoration time**, and the six-months-dead file logging → **#1929**. This PR closes the import-time half, which is what its test covers.

## Cleanup and gates

21,497 empty directories and an empty `performance_data/` removed; the one directory with content kept. Review established the deletion was safe for a reason not originally given: since `workflow.log` was never written, the only writers into `workflow_<uuid>/` were `metadata.json`, `result.json` and `data/`, so an empty directory provably means nothing was ever persisted.

`fail_fast_baseline.json` moves `broad_except` 109 → 108 — the deleted initialiser's `except Exception`. Regenerated here as the script instructs.

`./scripts/local_ci.sh` → **GATE GREEN**, and **0 bytes** added to `.mfg_sweeps/parameter_sweep.log`, against 3,016 lines written by the run before the round-1 fix.
