### PR TITLE
perf(backends): import torch on demand, not on `import mfgarchon`

### DIFF
--- a/changelog.d/1930-lazy-optional-backends.changed.md
+++ b/changelog.d/1930-lazy-optional-backends.changed.md
@@ -2,13 +2,15 @@
 
 torch is optional — declared in the `[all]` extra, not in `dependencies` — but two eager sites
 imported it for anyone who touched the package: `backends/__init__.py` registered the torch and
-jax backends at import, and `utils/acceleration/__init__.py` re-exported `torch_utils`, whose
-first statement is `import torch`.
+jax backends at import, and `utils/acceleration/__init__.py` re-exported `torch_utils`, which
+imports torch (inside a `try/except ImportError`, so that module loads fine without it — but the
+import still runs when torch is installed).
 
 Both are now on demand. `create_backend("torch")` already carried the import-and-register path;
 eager registration was what made it unreachable. `mfgarchon.utils.acceleration` resolves its
-torch names through a module `__getattr__`, so `TORCH_UTILS_AVAILABLE` still answers correctly —
-it uses `importlib.util.find_spec`, which does not import anything.
+torch names through a module `__getattr__`, and `TORCH_UTILS_AVAILABLE` is resolved the same way
+— so it still answers the question it always answered ("did `import torch` succeed"), computed on
+first read rather than at import.
 
 Measured: `import mfgarchon` 4.12s → 3.27s, with torch absent from `sys.modules`. NumPy stays
 eager: it is a hard dependency and costs 0.07s.

--- a/changelog.d/1930-lazy-optional-backends.changed.md
+++ b/changelog.d/1930-lazy-optional-backends.changed.md
@@ -11,4 +11,8 @@ torch names through a module `__getattr__`, so `TORCH_UTILS_AVAILABLE` still ans
 it uses `importlib.util.find_spec`, which does not import anything.
 
 Measured: `import mfgarchon` 4.12s → 3.27s, with torch absent from `sys.modules`. NumPy stays
-eager: it is a hard dependency and costs 0.07s. (#1930)
+eager: it is a hard dependency and costs 0.07s.
+
+One observable consequence: `get_backend_info()["registered_backends"]` now reports
+`["numpy"]` at import rather than every installed backend. Asking for a backend still
+registers it, so the list grows as backends are used. (#1930)

--- a/changelog.d/1930-lazy-optional-backends.changed.md
+++ b/changelog.d/1930-lazy-optional-backends.changed.md
@@ -1,0 +1,14 @@
+`import mfgarchon` no longer imports PyTorch.
+
+torch is optional — declared in the `[all]` extra, not in `dependencies` — but two eager sites
+imported it for anyone who touched the package: `backends/__init__.py` registered the torch and
+jax backends at import, and `utils/acceleration/__init__.py` re-exported `torch_utils`, whose
+first statement is `import torch`.
+
+Both are now on demand. `create_backend("torch")` already carried the import-and-register path;
+eager registration was what made it unreachable. `mfgarchon.utils.acceleration` resolves its
+torch names through a module `__getattr__`, so `TORCH_UTILS_AVAILABLE` still answers correctly —
+it uses `importlib.util.find_spec`, which does not import anything.
+
+Measured: `import mfgarchon` 4.12s → 3.27s, with torch absent from `sys.modules`. NumPy stays
+eager: it is a hard dependency and costs 0.07s. (#1930)

--- a/mfgarchon/backends/__init__.py
+++ b/mfgarchon/backends/__init__.py
@@ -303,7 +303,9 @@ except ImportError:
 # consequence: "backends/__init__.py registers 'torch' into _BACKENDS whether or not torch exists.
 # The `if backend_name not in _BACKENDS` branch is therefore unreachable."
 #
-# `torch_backend.py:30` is a bare `import torch`, so registering it eagerly imported torch for
+# `torch_backend.py` imports torch (inside a `try/except ImportError`, so the module itself
+# loads fine without it -- but the import still runs when torch IS installed), so registering it
+# eagerly imported torch for
 # anyone who touched this package. Measured on 1aa71b98: deferring this together with the eager
 # `torch_utils` re-export in `utils/acceleration/__init__.py` takes `import mfgarchon` from 4.12s
 # to 3.30s and removes torch from `sys.modules`. Deferring either alone changes nothing -- three

--- a/mfgarchon/backends/__init__.py
+++ b/mfgarchon/backends/__init__.py
@@ -297,21 +297,20 @@ try:
 except ImportError:
     warnings.warn("NumPy backend not available")
 
-try:
-    from .torch_backend import TorchBackend
-
-    register_backend("torch", TorchBackend)
-except ImportError:
-    logger.debug("PyTorch backend not available (optional)")
-    # PyTorch is optional
-
-try:
-    from .jax_backend import JAXBackend
-
-    register_backend("jax", JAXBackend)
-except ImportError:
-    logger.debug("JAX backend not available (optional)")
-    # JAX is optional
+# torch and jax are NOT registered here. `create_backend` already carries the on-demand path --
+# `if backend_name not in _BACKENDS:` imports and registers whichever backend was asked for -- and
+# eager registration is what made that branch unreachable. `test_backend_factory.py` records the
+# consequence: "backends/__init__.py registers 'torch' into _BACKENDS whether or not torch exists.
+# The `if backend_name not in _BACKENDS` branch is therefore unreachable."
+#
+# `torch_backend.py:30` is a bare `import torch`, so registering it eagerly imported torch for
+# anyone who touched this package. Measured on 1aa71b98: deferring this together with the eager
+# `torch_utils` re-export in `utils/acceleration/__init__.py` takes `import mfgarchon` from 4.12s
+# to 3.30s and removes torch from `sys.modules`. Deferring either alone changes nothing -- three
+# independent routes reach torch and cutting one leaves the others. #1930.
+#
+# numpy stays eager: it is a hard dependency, costs 0.07s, and several callers assume it is
+# registered the moment the package is imported.
 
 
 # Ensure essential backends are always available for compatibility

--- a/mfgarchon/backends/__init__.py
+++ b/mfgarchon/backends/__init__.py
@@ -307,8 +307,13 @@ except ImportError:
 # loads fine without it -- but the import still runs when torch IS installed), so registering it
 # eagerly imported torch for
 # anyone who touched this package. Measured on 1aa71b98: deferring this together with the eager
-# `torch_utils` re-export in `utils/acceleration/__init__.py` takes `import mfgarchon` from 4.12s
-# to 3.30s and removes torch from `sys.modules`. Deferring either alone changes nothing -- three
+# `torch_utils` re-export in `utils/acceleration/__init__.py` cuts ~0.8s off `import mfgarchon`
+# and removes torch from `sys.modules`. No absolute pair is quoted here: five measurement rounds
+# put the absolutes between 4.01 and 4.30 (base) and 3.24 and 3.40 (head) on one machine, while
+# the DELTA held at 0.73-0.85. Restating a pair invites the reader to check it against a run that
+# will not reproduce it -- and two of the four restatements of it in this branch had already
+# drifted apart (3.27 vs 3.30). The changelog carries one measurement with its conditions.
+# Deferring either alone changes nothing -- three
 # independent routes reach torch and cutting one leaves the others. #1930.
 #
 # numpy stays eager: it is a hard dependency, costs 0.07s, and several callers assume it is

--- a/mfgarchon/utils/acceleration/__init__.py
+++ b/mfgarchon/utils/acceleration/__init__.py
@@ -16,8 +16,6 @@ This replaces the old mfgarchon/accelerated/ directory with better organization.
 
 from __future__ import annotations
 
-import importlib.util
-
 from mfgarchon.utils.mfg_logging import get_logger
 
 logger = get_logger(__name__)
@@ -72,14 +70,25 @@ except ImportError:
 # `adjoint_validation`, through `utils.geometry`, and through `backends` -- so torch was imported
 # unconditionally by anyone who touched the package, whichever route they arrived by. Measured on
 # 1aa71b98: deferring this and the eager registrations in `backends/__init__.py` together takes
-# `import mfgarchon` from 4.12s to 3.30s and removes torch from `sys.modules` entirely. Deferring
+# `import mfgarchon` from 4.12s to 3.27s and removes torch from `sys.modules` entirely. Deferring
 # either one alone changes nothing, because the other route still arrives. #1930.
 #
-# `TORCH_UTILS_AVAILABLE` stays eager and cheap: it answers "is torch installed", which
-# `importlib.util.find_spec` settles without importing anything.
-TORCH_UTILS_AVAILABLE = importlib.util.find_spec("torch") is not None
+# `TORCH_UTILS_AVAILABLE` is deferred too, for the same reason the names are.
+#
+# It must answer "did `import torch` succeed", which is what the old eager
+# `try: from .torch_utils import ...` measured. ~~`find_spec("torch") is not None`~~ [CORRECTED
+# 2026-08-14] answers "is torch on disk" instead: for an installed-but-broken torch the old form
+# gave False and that gives True, and `get_acceleration_info()` then reports the
+# self-contradictory `{"torch_utils_available": True, "torch_available": False}`. Found by review.
+#
+# Computing it eagerly and correctly is not available: the only authority is `torch_utils.HAS_TORCH`,
+# and importing that module imports torch whenever torch works -- which is the whole thing this
+# change removes. (An earlier attempt at this correction did exactly that and put torch back in
+# `sys.modules`; caught by the test below rather than by inspection.) So the flag joins the lazy
+# map: correct on first read, free until then.
 
 _LAZY_TORCH = {
+    "TORCH_UTILS_AVAILABLE": "torch_utils",
     "HAS_CUDA": "torch_utils",
     "HAS_MPS": "torch_utils",
     "HAS_TORCH": "torch_utils",
@@ -97,7 +106,17 @@ def __getattr__(name: str):
     if name in _LAZY_TORCH:
         from importlib import import_module
 
-        module = import_module(f".{_LAZY_TORCH[name]}", __name__)
+        try:
+            module = import_module(f".{_LAZY_TORCH[name]}", __name__)
+        except ImportError:
+            if name == "TORCH_UTILS_AVAILABLE":
+                globals()[name] = False
+                return False
+            raise
+        if name == "TORCH_UTILS_AVAILABLE":
+            value = bool(getattr(module, "HAS_TORCH", False))
+            globals()[name] = value
+            return value
         attr = "tridiagonal_solve" if name == "torch_tridiagonal_solve" else name
         value = getattr(module, attr)
         globals()[name] = value  # bind, so the next access does not re-enter here
@@ -106,14 +125,14 @@ def __getattr__(name: str):
 
 
 def __dir__():
-    return sorted([*globals(), *_LAZY_TORCH])
+    return sorted({*globals(), *_LAZY_TORCH})  # a set: a name bound by __getattr__ is in both
 
 
 def get_acceleration_info():
     """Get information about available acceleration utilities."""
     info = {
         "jax_utils_available": JAX_UTILS_AVAILABLE,
-        "torch_utils_available": TORCH_UTILS_AVAILABLE,
+        "torch_utils_available": __getattr__("TORCH_UTILS_AVAILABLE"),
     }
 
     if JAX_UTILS_AVAILABLE:
@@ -129,7 +148,10 @@ def get_acceleration_info():
         except ImportError as e:
             logger.debug(f"Could not retrieve JAX detailed info: {e}")
 
-    if TORCH_UTILS_AVAILABLE:
+    # `__getattr__(...)`, not the bare name: a module-level `__getattr__` is NOT consulted for
+    # a global lookup inside a function in the same module -- that goes straight to
+    # `module.__dict__` and raises NameError. ruff F821 caught this; the tests did not.
+    if __getattr__("TORCH_UTILS_AVAILABLE"):
         try:
             from .torch_utils import HAS_CUDA, HAS_MPS, HAS_TORCH
 

--- a/mfgarchon/utils/acceleration/__init__.py
+++ b/mfgarchon/utils/acceleration/__init__.py
@@ -16,6 +16,8 @@ This replaces the old mfgarchon/accelerated/ directory with better organization.
 
 from __future__ import annotations
 
+import importlib.util
+
 from mfgarchon.utils.mfg_logging import get_logger
 
 logger = get_logger(__name__)
@@ -63,26 +65,48 @@ try:
 except ImportError:
     JAX_UTILS_AVAILABLE = False
 
-# Re-export PyTorch utilities (explicit imports, Issue #756)
-try:
-    from .torch_utils import (
-        HAS_CUDA,
-        HAS_MPS,
-        HAS_TORCH,
-        GaussianKDE,
-        ensure_torch_available,
-        get_default_device,
-        to_numpy,
-        to_tensor,
-    )
-    from .torch_utils import (
-        tridiagonal_solve as torch_tridiagonal_solve,
-    )
+# PyTorch utilities, re-exported LAZILY (PEP 562).
+#
+# This block used to `from .torch_utils import (...)` eagerly, and `torch_utils.py:16` is a bare
+# `import torch`. Three independent routes reach this file during `import mfgarchon` -- through
+# `adjoint_validation`, through `utils.geometry`, and through `backends` -- so torch was imported
+# unconditionally by anyone who touched the package, whichever route they arrived by. Measured on
+# 1aa71b98: deferring this and the eager registrations in `backends/__init__.py` together takes
+# `import mfgarchon` from 4.12s to 3.30s and removes torch from `sys.modules` entirely. Deferring
+# either one alone changes nothing, because the other route still arrives. #1930.
+#
+# `TORCH_UTILS_AVAILABLE` stays eager and cheap: it answers "is torch installed", which
+# `importlib.util.find_spec` settles without importing anything.
+TORCH_UTILS_AVAILABLE = importlib.util.find_spec("torch") is not None
 
-    # Only mark as available if torch is actually installed
-    TORCH_UTILS_AVAILABLE = HAS_TORCH
-except ImportError:
-    TORCH_UTILS_AVAILABLE = False
+_LAZY_TORCH = {
+    "HAS_CUDA": "torch_utils",
+    "HAS_MPS": "torch_utils",
+    "HAS_TORCH": "torch_utils",
+    "GaussianKDE": "torch_utils",
+    "ensure_torch_available": "torch_utils",
+    "get_default_device": "torch_utils",
+    "to_numpy": "torch_utils",
+    "to_tensor": "torch_utils",
+    "torch_tridiagonal_solve": "torch_utils",
+}
+
+
+def __getattr__(name: str):
+    """Import `torch_utils` on first use of a name it owns, not at package import."""
+    if name in _LAZY_TORCH:
+        from importlib import import_module
+
+        module = import_module(f".{_LAZY_TORCH[name]}", __name__)
+        attr = "tridiagonal_solve" if name == "torch_tridiagonal_solve" else name
+        value = getattr(module, attr)
+        globals()[name] = value  # bind, so the next access does not re-enter here
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted([*globals(), *_LAZY_TORCH])
 
 
 def get_acceleration_info():

--- a/mfgarchon/utils/acceleration/__init__.py
+++ b/mfgarchon/utils/acceleration/__init__.py
@@ -17,6 +17,7 @@ This replaces the old mfgarchon/accelerated/ directory with better organization.
 from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
 
 from mfgarchon.utils.mfg_logging import get_logger
 
@@ -72,7 +73,8 @@ except ImportError:
 # `adjoint_validation`, through `utils.geometry`, and through `backends` -- so torch was imported
 # unconditionally by anyone who touched the package, whichever route they arrived by. Measured on
 # 1aa71b98: deferring this and the eager registrations in `backends/__init__.py` together takes
-# `import mfgarchon` from 4.12s to 3.27s and removes torch from `sys.modules` entirely. Deferring
+# ~0.8s off `import mfgarchon` and removes torch from `sys.modules` entirely (the changelog holds
+# the one measurement with its conditions; absolutes drift ~0.4s between rounds). Deferring
 # either one alone changes nothing, because the other route still arrives. #1930.
 #
 # `TORCH_UTILS_AVAILABLE` is deferred too, for the same reason the names are.
@@ -101,6 +103,44 @@ _LAZY_TORCH = {
     "to_tensor": "torch_utils",
     "torch_tridiagonal_solve": "torch_utils",
 }
+
+# A KNOWN COST OF THIS DEFERRAL, stated here because it is not recoverable and should not be
+# re-attempted. Defining a module-level `__getattr__` tells a type checker that ANY attribute of
+# this module may exist, so mypy stops reporting `attr-defined` for the whole module -- not only for
+# the ten deferred names. Measured with a probe asserting three nonexistent names, two through this
+# module and one through `mfgarchon.backends` as a control that must stay flagged in every state:
+#
+#     base 7ac9df18                        3 errors
+#     head, before the block below         1 error   (the control only)
+#     head, with the block below           1 error   <- the block does NOT restore it
+#     head, `__getattr__ -> object`        1 error
+#     head, `__getattr__ -> bool`          1 error
+#
+# ~~Re-declaring the names under TYPE_CHECKING restores the check~~ [CORRECTED 2026-08-15] -- that
+# was the fifth review's prescription and it is wrong on the mechanism, measured above: the
+# catch-all is the *presence* of `__getattr__`, and declaring ten names adds types for those ten
+# without removing it. Narrowing the return type does not help either. So a downstream user's
+# `acc.typo` type-checks clean, and that is the price of not importing torch.
+#
+# The block below is kept for what it does deliver: real types for the ten names under IDE hover
+# and `reveal_type`, at zero import cost, since it never runs. `ci.yml` scopes mypy to
+# `mfgarchon/config`, so no gate here would have surfaced any of this.
+if TYPE_CHECKING:
+    from .torch_utils import (
+        HAS_CUDA,
+        HAS_MPS,
+        HAS_TORCH,
+        GaussianKDE,
+        ensure_torch_available,
+        get_default_device,
+        to_numpy,
+        to_tensor,
+    )
+    from .torch_utils import (
+        tridiagonal_solve as torch_tridiagonal_solve,
+    )
+
+    TORCH_UTILS_AVAILABLE: bool
 
 
 def __getattr__(name: str):

--- a/mfgarchon/utils/acceleration/__init__.py
+++ b/mfgarchon/utils/acceleration/__init__.py
@@ -16,6 +16,8 @@ This replaces the old mfgarchon/accelerated/ directory with better organization.
 
 from __future__ import annotations
 
+import sys
+
 from mfgarchon.utils.mfg_logging import get_logger
 
 logger = get_logger(__name__)
@@ -132,7 +134,7 @@ def get_acceleration_info():
     """Get information about available acceleration utilities."""
     info = {
         "jax_utils_available": JAX_UTILS_AVAILABLE,
-        "torch_utils_available": __getattr__("TORCH_UTILS_AVAILABLE"),
+        "torch_utils_available": sys.modules[__name__].TORCH_UTILS_AVAILABLE,
     }
 
     if JAX_UTILS_AVAILABLE:
@@ -148,10 +150,14 @@ def get_acceleration_info():
         except ImportError as e:
             logger.debug(f"Could not retrieve JAX detailed info: {e}")
 
-    # `__getattr__(...)`, not the bare name: a module-level `__getattr__` is NOT consulted for
-    # a global lookup inside a function in the same module -- that goes straight to
-    # `module.__dict__` and raises NameError. ruff F821 caught this; the tests did not.
-    if __getattr__("TORCH_UTILS_AVAILABLE"):
+    # `sys.modules[__name__].NAME`, not the bare name and not `__getattr__(...)` directly.
+    # A bare global lookup inside a function does not consult the module `__getattr__` -- it goes to
+    # `module.__dict__` and raises NameError (ruff F821 caught that; the tests did not). Calling the
+    # dunder by hand fixes the NameError but skips `__dict__`, so it reads THROUGH an override:
+    # `m.TORCH_UTILS_AVAILABLE = False` then reported True here, and `monkeypatch.setattr` on this
+    # flag would have been silently ignored. A real attribute lookup checks `__dict__` first and
+    # falls through to `__getattr__` only when unbound. Found by review.
+    if sys.modules[__name__].TORCH_UTILS_AVAILABLE:
         try:
             from .torch_utils import HAS_CUDA, HAS_MPS, HAS_TORCH
 

--- a/tests/unit/test_backends/test_backend_factory.py
+++ b/tests/unit/test_backends/test_backend_factory.py
@@ -383,7 +383,7 @@ class TestBackendInitialization:
         """[SUPERSEDED 2026-08-14] Was `test_optional_backends_registered_if_available`, which
         asserted the opposite: that touching the package registers torch and jax when installed.
 
-        #1930 stopped that, because registering them imported them -- 0.82s of a 4.12s
+        #1930 stopped that, because registering them imported them -- ~0.8s of a ~4s
         `import mfgarchon` for anyone who never asked for a backend. `create_backend` already
         carried the on-demand path; eager registration was what made it unreachable.
 

--- a/tests/unit/test_backends/test_backend_factory.py
+++ b/tests/unit/test_backends/test_backend_factory.py
@@ -396,9 +396,24 @@ class TestBackendInitialization:
         a global; a fresh interpreter is the instrument.
         """
         import json
+        import os
         import subprocess
         import sys
 
+        repo = Path(__file__).resolve().parents[3]
+        # `cwd=repo` does not pin the tree. For `python -c`, `sys.path[0]` is the current directory
+        # and precedes PYTHONPATH -- so cwd wins, until `-P` / `PYTHONSAFEPATH=1` strips it, which
+        # is exactly what `scripts/local_ci.sh:311` sets and what `subprocess.run` inherits. Under
+        # the gate the cwd entry is gone, nothing replaces it, and this probe measures the EDITABLE
+        # INSTALL instead of the tree under test -- silently identical on the canonical checkout,
+        # wrong in the worktree this repo mandates for pre-merge review. So: put the tree back on
+        # the path, and report `mfgarchon.__file__` so the assertion below can check it rather than
+        # trust the plumbing. (This repo's own #1906 review: an import-origin check is only evidence
+        # if the wrong answer is reachable.)
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(x for x in (str(repo), os.environ.get("PYTHONPATH", "")) if x),
+        }
         proc = subprocess.run(
             [
                 sys.executable,
@@ -410,9 +425,10 @@ class TestBackendInitialization:
                 "if b.get_available_backends()['jax']:\n"
                 "    b.create_backend('jax')\n"
                 "    asked = sorted(b._BACKENDS)\n"
-                "print(json.dumps({'at_import': at_import, 'after_asking': asked}))\n",
+                "print(json.dumps({'at_import': at_import, 'after_asking': asked, 'tree': b.__file__}))\n",
             ],
-            cwd=Path(__file__).resolve().parents[3],
+            cwd=repo,
+            env=env,
             capture_output=True,
             text=True,
             timeout=300,
@@ -421,6 +437,13 @@ class TestBackendInitialization:
         line = [x for x in proc.stdout.splitlines() if x.startswith("{")]
         assert line, f"no verdict:\n{proc.stdout[-600:]}\n{proc.stderr[-600:]}"
         result = json.loads(line[-1])
+
+        # A path check, not a string prefix: on macOS TMPDIR is a symlink, so a worktree's logical
+        # and physical spellings differ and `startswith` compares False on the correct tree.
+        assert Path(result["tree"]).resolve().is_relative_to(repo.resolve()), (
+            f"the probe imported {result['tree']}, not the tree under test at {repo}. Its verdict "
+            f"says nothing about this checkout."
+        )
 
         assert result["at_import"] == ["numpy"], (
             f"at import the registry holds {result['at_import']}, expected only numpy. Registering "

--- a/tests/unit/test_backends/test_backend_factory.py
+++ b/tests/unit/test_backends/test_backend_factory.py
@@ -5,6 +5,7 @@ Tests backend registration, discovery, creation, and auto-selection logic.
 """
 
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -151,15 +152,21 @@ class TestCreateBackend:
         with pytest.raises(ValueError, match="Unknown backend"):
             create_backend("nonexistent_backend")
 
-    def test_create_backend_torch_when_unavailable(self, monkeypatch):
+    def test_create_backend_torch_when_unavailable(self, monkeypatch, clean_backend_registry):
         """A machine without PyTorch gets TorchBackend's own diagnostic.
 
         `torch_backend.py` imports fine without torch -- it degrades to `TORCH_AVAILABLE =
-        False` -- so `backends/__init__.py` registers "torch" into `_BACKENDS` whether or not
-        torch exists. The `if backend_name not in _BACKENDS` branch is therefore unreachable
-        for torch, and the error a real user sees comes from the constructor
-        (`torch_backend.py:109`). Clearing the flag is what reproduces that path; popping
-        `_BACKENDS` or blocking the import both exercise a branch no install can reach.
+        False` -- so the error a real user sees comes from the constructor
+        (`torch_backend.py:109`). Clearing the flag is what reproduces that path.
+
+        ~~`backends/__init__.py` registers "torch" into `_BACKENDS` whether or not torch
+        exists, so the `if backend_name not in _BACKENDS` branch is unreachable for torch~~
+        [CORRECTED 2026-08-14] -- it is reachable now: #1930 stopped registering torch and jax
+        eagerly, so `create_backend("torch")` imports and registers on demand. This test
+        therefore REGISTERS torch as a side effect, which is why it takes
+        `clean_backend_registry`. Without it, `test_optional_backends_registered_if_available`
+        reads the residue and passes for the wrong reason -- serially and under a lucky xdist
+        schedule -- while failing 3/3 on a directory-scoped `-n auto` run.
         """
         import mfgarchon.backends.torch_backend as torch_backend
 
@@ -168,11 +175,13 @@ class TestCreateBackend:
         with pytest.raises(ImportError, match="PyTorch is required for TorchBackend"):
             create_backend("torch")
 
-    def test_create_backend_jax_when_unavailable(self, monkeypatch):
+    def test_create_backend_jax_when_unavailable(self, monkeypatch, clean_backend_registry):
         """A machine without JAX gets JAXBackend's own diagnostic.
 
-        Same shape as the torch case: `jax_backend.py` imports without JAX, so "jax" is always
-        registered and the constructor raises (`jax_backend.py:66`).
+        Same shape as the torch case: `jax_backend.py` imports without JAX, so the constructor
+        raises (`jax_backend.py:66`). ~~so "jax" is always registered~~ [CORRECTED 2026-08-14]
+        -- jax is registered on demand since #1930, so this test registers it and needs the
+        cleanup fixture.
         """
         import mfgarchon.backends.jax_backend as jax_backend
 
@@ -182,15 +191,15 @@ class TestCreateBackend:
             create_backend("jax")
 
     def test_create_backend_numba_when_unavailable(self, monkeypatch):
-        """Numba is the one backend whose lazy-registration branch is live.
+        """Numba reaches the lazy-registration branch by a different route than torch and jax.
 
-        Unlike torch and jax, `numba_backend.py` raises `ImportError` at import time rather
-        than degrading to a flag, so it is never pre-registered and `create_backend` really
-        does take the `if backend_name not in _BACKENDS` path. Blocking the import is the
-        faithful simulation here.
+        ~~Numba is the one backend whose lazy-registration branch is live~~ [CORRECTED
+        2026-08-14] -- since #1930 all three are registered on demand. The difference that
+        remains is WHY: `numba_backend.py` raises `ImportError` at import time rather than
+        degrading to a flag, so blocking the import is the faithful simulation here, while
+        torch and jax degrade and their constructors raise instead.
 
-        This asymmetry is not by design as far as this test can tell -- it is recorded so the
-        next person does not "fix" the three to look alike (Issue #1663).
+        Recorded so the next person does not "fix" the three to look alike (Issue #1663).
         """
         import mfgarchon.backends as backends_module
 
@@ -370,19 +379,56 @@ class TestBackendInitialization:
 
         assert "numpy" in backends_module._BACKENDS
 
-    def test_optional_backends_registered_if_available(self):
-        """Test that optional backends are registered when available."""
-        import mfgarchon.backends as backends_module
+    def test_optional_backends_are_not_registered_until_asked_for(self):
+        """[SUPERSEDED 2026-08-14] Was `test_optional_backends_registered_if_available`, which
+        asserted the opposite: that touching the package registers torch and jax when installed.
 
-        available = get_available_backends()
+        #1930 stopped that, because registering them imported them -- 0.82s of a 4.12s
+        `import mfgarchon` for anyone who never asked for a backend. `create_backend` already
+        carried the on-demand path; eager registration was what made it unreachable.
 
-        # Torch should be registered if available
-        if available["torch"]:
-            assert "torch" in backends_module._BACKENDS
+        **In a subprocess, because `_BACKENDS` is a module global and this is an assertion about
+        its state at import.** Any test anywhere that asks for a backend registers one, so an
+        in-process check reads whatever the session happened to do first. The first attempt at
+        this test used `clean_backend_registry` and still failed in the full suite -- the fixture
+        restores the registry after the polluter, but not before this test, and under `-n auto`
+        the order is not fixed. Order-independence is not something a fixture can retrofit onto
+        a global; a fresh interpreter is the instrument.
+        """
+        import json
+        import subprocess
+        import sys
 
-        # JAX should be registered if available
-        if available["jax"]:
-            assert "jax" in backends_module._BACKENDS
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import json\n"
+                "import mfgarchon.backends as b\n"
+                "at_import = sorted(b._BACKENDS)\n"
+                "asked = None\n"
+                "if b.get_available_backends()['jax']:\n"
+                "    b.create_backend('jax')\n"
+                "    asked = sorted(b._BACKENDS)\n"
+                "print(json.dumps({'at_import': at_import, 'after_asking': asked}))\n",
+            ],
+            cwd=Path(__file__).resolve().parents[3],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        assert proc.returncode == 0, f"the probe never ran:\n{proc.stderr[-1500:]}"
+        line = [x for x in proc.stdout.splitlines() if x.startswith("{")]
+        assert line, f"no verdict:\n{proc.stdout[-600:]}\n{proc.stderr[-600:]}"
+        result = json.loads(line[-1])
+
+        assert result["at_import"] == ["numpy"], (
+            f"at import the registry holds {result['at_import']}, expected only numpy. Registering "
+            f"torch or jax imports it, which is what #1930 removed -- see "
+            f"tests/unit/test_optional_backends_are_not_imported_eagerly.py"
+        )
+        if result["after_asking"] is not None:
+            assert "jax" in result["after_asking"], "create_backend('jax') did not register it"
 
 
 class TestBackendCreationEdgeCases:

--- a/tests/unit/test_optional_backends_are_not_imported_eagerly.py
+++ b/tests/unit/test_optional_backends_are_not_imported_eagerly.py
@@ -28,6 +28,7 @@ such assertion; the sentence described a test that was never written.)
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -35,6 +36,22 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).resolve().parents[2]
+
+
+# `cwd=REPO` alone does NOT pin which tree a probe imports. For `python -c`, `sys.path[0]` is the
+# current directory and precedes PYTHONPATH -- so cwd wins, until `-P` / `PYTHONSAFEPATH=1` strips
+# it, and `scripts/local_ci.sh:311` sets exactly that (deliberately: xdist workers do not inherit
+# `-P`). `subprocess.run` inherits the environment, so under the gate the cwd entry is gone, nothing
+# replaces it, and the probe imports whatever the EDITABLE INSTALL points at. On the canonical
+# checkout the two trees coincide and the gate is honest; in a worktree -- which this repo MANDATES
+# for pre-merge review -- they differ, and the probe reports on a tree that was never under test.
+# Recorded from this repo's own #1906 review: an import-origin check is only evidence if the wrong
+# answer is reachable. Hence both halves: put the tree back on the path, and have each probe print
+# `mfgarchon.__file__` so the caller can assert it rather than trust the plumbing.
+_PROBE_ENV = {
+    **os.environ,
+    "PYTHONPATH": os.pathsep.join(x for x in (str(REPO), os.environ.get("PYTHONPATH", "")) if x),
+}
 
 _PROBE = (
     "import sys, json\n"
@@ -53,6 +70,7 @@ def _modules_after(code: str) -> dict[str, bool]:
     proc = subprocess.run(
         [sys.executable, "-c", code],
         cwd=REPO,
+        env=_PROBE_ENV,
         capture_output=True,
         text=True,
         timeout=300,
@@ -61,6 +79,40 @@ def _modules_after(code: str) -> dict[str, bool]:
     line = [x for x in proc.stdout.splitlines() if x.startswith("{")]
     assert line, f"the probe produced no verdict:\n{proc.stdout[-800:]}\n{proc.stderr[-800:]}"
     return json.loads(line[-1])
+
+
+def test_the_subprocess_probes_import_the_tree_under_test():
+    """Validate the instrument before trusting any number it produces.
+
+    Every probe in this file is a fresh interpreter, and which `mfgarchon` that interpreter finds
+    is decided by `sys.path`, not by which directory the test file lives in. `cwd=REPO` puts the
+    tree first only while `sys.path[0]` is the cwd; the gate runs under `PYTHONSAFEPATH=1`, which
+    removes that entry, and `subprocess.run` inherits it -- so without `_PROBE_ENV` the probes
+    report on the editable install. That is invisible on the canonical checkout, where the two
+    coincide, and wrong in a worktree, where they do not.
+
+    This does not stop the other probes from measuring the wrong tree; it makes the whole file go
+    red when they would, which is the point. A check that only confirms the good case is
+    decoration -- so the failure it names must be reachable, and in a worktree it is.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", "import json, mfgarchon; print(json.dumps({'tree': mfgarchon.__file__}))"],
+        cwd=REPO,
+        env=_PROBE_ENV,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"the instrument check never ran:\n{proc.stderr[-1500:]}"
+    line = [x for x in proc.stdout.splitlines() if x.startswith("{")]
+    assert line, f"no verdict:\n{proc.stdout[-600:]}\n{proc.stderr[-600:]}"
+    tree = json.loads(line[-1])["tree"]
+    # `resolve().is_relative_to`, not `startswith`: on macOS TMPDIR is a symlink, so a worktree's
+    # logical and physical spellings differ and a string prefix compares False on a correct tree.
+    assert Path(tree).resolve().is_relative_to(REPO.resolve()), (
+        f"the probes import {tree}, not the tree under test at {REPO}. Every subprocess result in "
+        f"this file is therefore about a different checkout. Check PYTHONSAFEPATH/PYTHONPATH."
+    )
 
 
 def test_importing_the_package_does_not_import_torch():
@@ -198,11 +250,13 @@ def test_dir_lists_each_deferred_name_once():
     """
     import mfgarchon.utils.acceleration as acceleration
 
-    # `to_tensor`, not `TORCH_UTILS_AVAILABLE`. Both are in `_LAZY_TORCH`, but the flag's
-    # membership is what THIS PR adds, so binding it would make this test's precondition depend on
-    # a decision the same PR is still revising -- review measured that: with the flag reverted to
-    # eager AND the `sorted([...])` defect restored, this test alone goes green again. `to_tensor`
-    # was lazy before this branch and stays lazy after it.
+    # `to_tensor`, not `TORCH_UTILS_AVAILABLE`. Not because one predates the branch -- neither
+    # does; `git show 7ac9df18:mfgarchon/utils/acceleration/__init__.py | grep -c _LAZY_TORCH` is 0
+    # and the whole map is new here. The distinction is that the flag's COMPUTATION was revised
+    # twice inside this PR while `to_tensor` was not, so binding the flag would rest this test's
+    # precondition on a decision the same PR is still moving. Measured: with the flag reverted to
+    # eager AND the `sorted([...])` defect restored, the old form of this test goes green when run
+    # alone; the `to_tensor` form reddens under the dir defect alone, torch-present and torch-free.
     acceleration.to_tensor  # noqa: B018 - bind one lazy name, which is the precondition
     listing = dir(acceleration)
     duplicated = sorted({n for n in listing if listing.count(n) > 1})
@@ -219,12 +273,16 @@ def test_the_introspection_helper_still_works():
     """
     import mfgarchon.utils.acceleration as acceleration
 
-    # The precondition here is UNBOUND, and it is the exact opposite of the one
-    # `test_dir_lists_each_deferred_name_once` establishes. They share one module global and run in
-    # declaration order, so while that test bound THIS name the bare lookup below found it in
-    # `__dict__`, no `NameError` could fire, and the defect survived the whole file (review
-    # measured 59 passed with both call sites reverted). `vars(...).pop`, not `del`: `del` raises
-    # `AttributeError` when this test runs first and nothing has bound the name yet.
+    # The precondition here is UNBOUND, and something else in the suite binds it. Not the dir test
+    # above -- that binds `to_tensor`. The binder is
+    # `tests/integration/test_cross_backend_consistency.py:16`, whose module-level
+    # `from mfgarchon.utils.acceleration import ... TORCH_UTILS_AVAILABLE` triggers the PEP 562
+    # `__getattr__`, which caches via `globals()[name] = value`. That runs at COLLECTION, so it has
+    # already happened in every xdist worker before any test body starts, and then the bare lookup
+    # inside `get_acceleration_info` finds the name in `__dict__` and no `NameError` can fire.
+    # Measured with all three files under `-n 4`, 3 repeats: both call sites reverted -> 1 failed
+    # with this pop, 61 passed without it. `vars(...).pop`, not `del`: `del` raises
+    # `AttributeError` when nothing has bound the name yet.
     vars(acceleration).pop("TORCH_UTILS_AVAILABLE", None)
 
     info = acceleration.get_acceleration_info()
@@ -233,17 +291,25 @@ def test_the_introspection_helper_still_works():
     assert "jax_utils_available" in info
 
     # Pin the lookup ORDER, not just the value. `__getattr__("TORCH_UTILS_AVAILABLE")` reaches the
-    # module `__getattr__` directly and so skips `__dict__`, which means it reads PAST an explicit
+    # module `__getattr__` directly and so skips `__dict__`, i.e. it reads PAST an explicit
     # override; `sys.modules[__name__].TORCH_UTILS_AVAILABLE` is normal attribute lookup and does
-    # not. Nothing else in the tree overrides this module, so reverting that form was caught by
-    # nothing until this assertion.
-    acceleration.TORCH_UTILS_AVAILABLE = False
-    try:
-        assert acceleration.get_acceleration_info()["torch_utils_available"] is False, (
-            "the helper read past an explicit override, so it is not going through attribute lookup"
-        )
-    finally:
-        vars(acceleration).pop("TORCH_UTILS_AVAILABLE", None)
+    # not.
+    #
+    # BOTH directions, and that is the whole point. Overriding only to `False` is vacuous wherever
+    # torch does not import: `__getattr__` returns `bool(torch_utils.HAS_TORCH)` = False there, so
+    # the reverted form satisfies the assertion and the pin is silent on exactly the machines CI
+    # runs on (review measured 17 passed torch-free with both call sites reverted). Hardcoding the
+    # dict entry to `False` survives torch-PRESENT for the mirror reason. Looping catches both,
+    # because no single constant can equal both members of the loop.
+    for override in (True, False):
+        acceleration.TORCH_UTILS_AVAILABLE = override
+        try:
+            assert acceleration.get_acceleration_info()["torch_utils_available"] is override, (
+                f"the helper reported {acceleration.get_acceleration_info()['torch_utils_available']!r} "
+                f"under an explicit override of {override!r}: it is not going through attribute lookup"
+            )
+        finally:
+            vars(acceleration).pop("TORCH_UTILS_AVAILABLE", None)
 
 
 def test_the_availability_flag_reports_whether_torch_IMPORTS_not_whether_it_exists():
@@ -291,6 +357,7 @@ def test_the_availability_flag_reports_whether_torch_IMPORTS_not_whether_it_exis
     proc = subprocess.run(
         [sys.executable, "-c", code],
         cwd=REPO,
+        env=_PROBE_ENV,
         capture_output=True,
         text=True,
         timeout=300,

--- a/tests/unit/test_optional_backends_are_not_imported_eagerly.py
+++ b/tests/unit/test_optional_backends_are_not_imported_eagerly.py
@@ -2,8 +2,8 @@
 
 Both are optional, both are declared in the `[all]` extra rather than in `dependencies`, and
 both were nonetheless imported by anything that touched the package. Measured on `1aa71b98`:
-`import mfgarchon` was 4.12s and put `torch` in `sys.modules`; deferring the two eager sites
-below takes it to 3.27s with `torch` absent — 0.82s, which is exactly torch's own cold import
+`import mfgarchon` put `torch` in `sys.modules`; deferring the two eager sites below removes it
+and cuts ~0.8s — the same order as torch's own cold import
 cost measured on its own.
 
 **Two sites, and cutting either alone changes nothing.** Three independent routes reach torch
@@ -14,7 +14,11 @@ during `import mfgarchon`:
     utils/__init__.py:92 -> utils/geometry.py:30 -> geometry -> ... -> (same leaf)
     base_hjb.py:11 -> backends/compat -> backends/__init__.py -> torch_backend.py:30
 
-The first two converge on `utils/acceleration`; the third does not touch it. Deferring only
+The first two converge on `utils/acceleration`; the third does not *import torch through* it —
+though it does load the module (`import mfgarchon.backends` leaves `utils.acceleration` in
+`sys.modules`, measured on the base tree). `acceleration/__init__.py` states the loading reading
+and this states the torch-route reading; the operative conclusion is the same either way.
+Deferring only
 `backends` leaves routes 1 and 2; deferring only `acceleration` leaves route 3. That is why this
 test asserts the outcome — torch is absent — rather than the shape of either file: an outcome
 assertion cannot be satisfied by fixing one site and calling it done.
@@ -56,7 +60,9 @@ _PROBE_ENV = {
 _PROBE = (
     "import sys, json\n"
     "import mfgarchon\n"
-    "print(json.dumps({p: p in sys.modules for p in ('torch', 'jax', 'numba', 'scipy')}))\n"
+    "d = {p: p in sys.modules for p in ('torch', 'jax', 'numba', 'scipy')}\n"
+    "d['__tree__'] = mfgarchon.__file__\n"
+    "print(json.dumps(d))\n"
 )
 
 
@@ -78,7 +84,31 @@ def _modules_after(code: str) -> dict[str, bool]:
     assert proc.returncode == 0, f"the probe never ran, so it measured nothing:\n{proc.stderr[-1500:]}"
     line = [x for x in proc.stdout.splitlines() if x.startswith("{")]
     assert line, f"the probe produced no verdict:\n{proc.stdout[-800:]}\n{proc.stderr[-800:]}"
-    return json.loads(line[-1])
+    payload = json.loads(line[-1])
+
+    # The tree identity travels WITH each probe's own payload. A separate test that builds its own
+    # `subprocess.run` can only validate its own invocation: review dropped `env=` from this
+    # function alone, pointed PYTHONPATH at an identical package outside the checkout, and got
+    # `18 passed` with the standalone instrument test green -- a clean bill of health while every
+    # probe here had imported a foreign tree. The probe invocation is restated at four sites, so a
+    # fifth copy checking itself proves nothing about the other four.
+    #
+    # The requirement is derived from the probe's own source, not left to the caller to remember:
+    # any probe that imports the package must say which one it imported. A probe that forgets would
+    # otherwise be silently exempt, which is how the hole above opened.
+    if "import mfgarchon" in code:
+        assert "__tree__" in payload, (
+            "this probe imports mfgarchon but does not report `__tree__`, so its result cannot be "
+            "attributed to any particular checkout. Add `d['__tree__'] = mfgarchon.__file__`."
+        )
+        # `resolve().is_relative_to`, not `startswith`: on macOS TMPDIR is a symlink, so logical and
+        # physical spellings differ and a string prefix compares False on a correct tree.
+        assert Path(payload["__tree__"]).resolve().is_relative_to(REPO.resolve()), (
+            f"the probe imported {payload['__tree__']}, not the tree under test at {REPO}. Every "
+            f"number it returned is about a different checkout. Check PYTHONSAFEPATH/PYTHONPATH."
+        )
+        payload.pop("__tree__")
+    return payload
 
 
 def test_the_subprocess_probes_import_the_tree_under_test():
@@ -91,9 +121,13 @@ def test_the_subprocess_probes_import_the_tree_under_test():
     report on the editable install. That is invisible on the canonical checkout, where the two
     coincide, and wrong in a worktree, where they do not.
 
-    This does not stop the other probes from measuring the wrong tree; it makes the whole file go
-    red when they would, which is the point. A check that only confirms the good case is
-    decoration -- so the failure it names must be reachable, and in a worktree it is.
+    ~~This does not stop the other probes from measuring the wrong tree; it makes the whole file go
+    red when they would~~ [CORRECTED 2026-08-15] -- false, and review measured it: this test builds
+    its OWN `subprocess.run`, so it validates its own invocation and fires only when the cause is
+    shared (`_PROBE_ENV`, or the ambient environment). Drop `env=` from `_modules_after` alone and
+    this test stays green while every probe there reads a foreign tree. Each probe now carries its
+    own tree identity in its payload and `_modules_after` asserts it; this test remains as the
+    cheapest check of the shared plumbing, which is all it ever was.
     """
     proc = subprocess.run(
         [sys.executable, "-c", "import json, mfgarchon; print(json.dumps({'tree': mfgarchon.__file__}))"],
@@ -119,7 +153,7 @@ def test_importing_the_package_does_not_import_torch():
     loaded = _modules_after(_PROBE)
     assert not loaded["torch"], (
         "`import mfgarchon` imported torch. It is optional, declared in the `[all]` extra, and "
-        "costs 0.82s. Three routes reach it and cutting one leaves the others -- check both "
+        "costs ~0.8s. Three routes reach it and cutting one leaves the others -- check both "
         "`backends/__init__.py` (eager `register_backend('torch', ...)`) and "
         "`utils/acceleration/__init__.py` (eager `from .torch_utils import ...`). #1930"
     )

--- a/tests/unit/test_optional_backends_are_not_imported_eagerly.py
+++ b/tests/unit/test_optional_backends_are_not_imported_eagerly.py
@@ -1,0 +1,105 @@
+"""Importing `mfgarchon` must not import torch or jax.
+
+Both are optional, both are declared in the `[all]` extra rather than in `dependencies`, and
+both were nonetheless imported by anything that touched the package. Measured on `1aa71b98`:
+`import mfgarchon` was 4.12s and put `torch` in `sys.modules`; deferring the two eager sites
+below takes it to 3.27s with `torch` absent — 0.82s, which is exactly torch's own cold import
+cost measured on its own.
+
+**Two sites, and cutting either alone changes nothing.** Three independent routes reach torch
+during `import mfgarchon`:
+
+    utils/__init__.py:30 -> adjoint_validation.py:55 -> alg -> ...
+        -> nonlinear_solvers.py:45 -> utils/acceleration/__init__.py -> torch_utils.py:16
+    utils/__init__.py:92 -> utils/geometry.py:30 -> geometry -> ... -> (same leaf)
+    base_hjb.py:11 -> backends/compat -> backends/__init__.py -> torch_backend.py:30
+
+The first two converge on `utils/acceleration`; the third does not touch it. Deferring only
+`backends` leaves routes 1 and 2; deferring only `acceleration` leaves route 3. That is why this
+test asserts the outcome — torch is absent — rather than the shape of either file: an outcome
+assertion cannot be satisfied by fixing one site and calling it done.
+
+jax is asserted separately and more weakly, because it still arrives through cvxpy, which is a
+third-party import chain this repository does not control (#1930).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+_PROBE = (
+    "import sys, json\n"
+    "import mfgarchon\n"
+    "print(json.dumps({p: p in sys.modules for p in ('torch', 'jax', 'numba', 'scipy')}))\n"
+)
+
+
+def _modules_after(code: str) -> dict[str, bool]:
+    """What is in `sys.modules` after `code` runs in a fresh interpreter.
+
+    A subprocess because by the time this file is collected the package is already imported and
+    every heavy module with it -- an in-process check would report the state of the test runner,
+    not of a fresh import.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"the probe never ran, so it measured nothing:\n{proc.stderr[-1500:]}"
+    line = [x for x in proc.stdout.splitlines() if x.startswith("{")]
+    assert line, f"the probe produced no verdict:\n{proc.stdout[-800:]}\n{proc.stderr[-800:]}"
+    return json.loads(line[-1])
+
+
+def test_importing_the_package_does_not_import_torch():
+    loaded = _modules_after(_PROBE)
+    assert not loaded["torch"], (
+        "`import mfgarchon` imported torch. It is optional, declared in the `[all]` extra, and "
+        "costs 0.82s. Three routes reach it and cutting one leaves the others -- check both "
+        "`backends/__init__.py` (eager `register_backend('torch', ...)`) and "
+        "`utils/acceleration/__init__.py` (eager `from .torch_utils import ...`). #1930"
+    )
+
+
+def test_the_probe_would_notice_an_import():
+    """Positive control. The assertion above is that a flag is False, which is also what a probe
+    that never imported anything returns."""
+    loaded = _modules_after("import sys, json, torch\nprint(json.dumps({'torch': 'torch' in sys.modules}))\n")
+    assert loaded["torch"], "the probe cannot see torch even when it is imported outright"
+
+
+def test_scipy_is_still_imported_so_the_absence_above_means_something():
+    """The other direction: a package that SHOULD arrive must arrive.
+
+    Without this, a change that broke `import mfgarchon` into importing almost nothing would
+    satisfy the torch assertion perfectly.
+    """
+    loaded = _modules_after(_PROBE)
+    assert loaded["scipy"], "`import mfgarchon` no longer reaches scipy; the package is not loading normally"
+
+
+def test_the_torch_backend_still_works_when_asked_for():
+    """Deferring must not mean never. `create_backend('torch')` takes the on-demand path in
+    `create_backend` -- the one that eager registration had made unreachable."""
+    torch = pytest.importorskip("torch", reason="torch is optional; this asserts the on-demand path when present")
+    assert torch is not None
+    loaded = _modules_after(
+        "import sys, json\n"
+        "from mfgarchon.backends import create_backend\n"
+        "before = 'torch' in sys.modules\n"
+        "b = create_backend('torch')\n"
+        "print(json.dumps({'before': before, 'after': 'torch' in sys.modules, 'name': type(b).__name__}))\n"
+    )
+    assert loaded["before"] is False, "torch was already imported before it was asked for"
+    assert loaded["after"] is True, "asking for the torch backend did not import torch"
+    assert loaded["name"] == "TorchBackend"

--- a/tests/unit/test_optional_backends_are_not_imported_eagerly.py
+++ b/tests/unit/test_optional_backends_are_not_imported_eagerly.py
@@ -198,7 +198,12 @@ def test_dir_lists_each_deferred_name_once():
     """
     import mfgarchon.utils.acceleration as acceleration
 
-    acceleration.TORCH_UTILS_AVAILABLE  # noqa: B018 - bind one lazy name, which is the precondition
+    # `to_tensor`, not `TORCH_UTILS_AVAILABLE`. Both are in `_LAZY_TORCH`, but the flag's
+    # membership is what THIS PR adds, so binding it would make this test's precondition depend on
+    # a decision the same PR is still revising -- review measured that: with the flag reverted to
+    # eager AND the `sorted([...])` defect restored, this test alone goes green again. `to_tensor`
+    # was lazy before this branch and stays lazy after it.
+    acceleration.to_tensor  # noqa: B018 - bind one lazy name, which is the precondition
     listing = dir(acceleration)
     duplicated = sorted({n for n in listing if listing.count(n) > 1})
     assert not duplicated, f"dir() lists these more than once: {duplicated}"
@@ -214,10 +219,31 @@ def test_the_introspection_helper_still_works():
     """
     import mfgarchon.utils.acceleration as acceleration
 
+    # The precondition here is UNBOUND, and it is the exact opposite of the one
+    # `test_dir_lists_each_deferred_name_once` establishes. They share one module global and run in
+    # declaration order, so while that test bound THIS name the bare lookup below found it in
+    # `__dict__`, no `NameError` could fire, and the defect survived the whole file (review
+    # measured 59 passed with both call sites reverted). `vars(...).pop`, not `del`: `del` raises
+    # `AttributeError` when this test runs first and nothing has bound the name yet.
+    vars(acceleration).pop("TORCH_UTILS_AVAILABLE", None)
+
     info = acceleration.get_acceleration_info()
     assert "torch_utils_available" in info
     assert isinstance(info["torch_utils_available"], bool)
     assert "jax_utils_available" in info
+
+    # Pin the lookup ORDER, not just the value. `__getattr__("TORCH_UTILS_AVAILABLE")` reaches the
+    # module `__getattr__` directly and so skips `__dict__`, which means it reads PAST an explicit
+    # override; `sys.modules[__name__].TORCH_UTILS_AVAILABLE` is normal attribute lookup and does
+    # not. Nothing else in the tree overrides this module, so reverting that form was caught by
+    # nothing until this assertion.
+    acceleration.TORCH_UTILS_AVAILABLE = False
+    try:
+        assert acceleration.get_acceleration_info()["torch_utils_available"] is False, (
+            "the helper read past an explicit override, so it is not going through attribute lookup"
+        )
+    finally:
+        vars(acceleration).pop("TORCH_UTILS_AVAILABLE", None)
 
 
 def test_the_availability_flag_reports_whether_torch_IMPORTS_not_whether_it_exists():

--- a/tests/unit/test_optional_backends_are_not_imported_eagerly.py
+++ b/tests/unit/test_optional_backends_are_not_imported_eagerly.py
@@ -19,8 +19,10 @@ The first two converge on `utils/acceleration`; the third does not touch it. Def
 test asserts the outcome — torch is absent — rather than the shape of either file: an outcome
 assertion cannot be satisfied by fixing one site and calling it done.
 
-jax is asserted separately and more weakly, because it still arrives through cvxpy, which is a
-third-party import chain this repository does not control (#1930).
+jax is NOT asserted here. It still arrives through cvxpy, a third-party chain this repository
+does not control, so there is no outcome to pin yet (#1930). The probe collects its presence for
+the record only. (~~asserted separately and more weakly~~ [CORRECTED 2026-08-14] -- there was no
+such assertion; the sentence described a test that was never written.)
 """
 
 from __future__ import annotations
@@ -72,8 +74,27 @@ def test_importing_the_package_does_not_import_torch():
 
 
 def test_the_probe_would_notice_an_import():
-    """Positive control. The assertion above is that a flag is False, which is also what a probe
-    that never imported anything returns."""
+    """Positive control, on a module that is always installed.
+
+    ~~`import torch`~~ [CORRECTED 2026-08-14] -- torch is optional, declared in `[all]`, and is
+    **not installed on any CI runner**: every workflow installs `-e .[dev]` or
+    `-e ".[dev,numerical]"`. This control therefore failed on nightly, on `python-compat` for
+    3.12/3.13/3.14, and on the release tier, while `test_importing_the_package_does_not_import_torch`
+    was VACUOUSLY satisfied there -- the guard discriminated only on a machine with `[all]`
+    installed. Found by review; the control now uses a module the runners have.
+    """
+    loaded = _modules_after(
+        "import sys, json, decimal\nprint(json.dumps({'decimal': 'decimal' in sys.modules}))\n"
+    )
+    assert loaded["decimal"], "the probe cannot see a module even when it is imported outright"
+
+
+@pytest.mark.optional_torch
+def test_the_probe_would_notice_torch_specifically():
+    """The same control for torch itself, where torch exists. Marked, so it is skipped rather
+    than failed on the runners -- `test_the_probe_would_notice_an_import` above keeps the probe
+    mechanism covered everywhere."""
+    pytest.importorskip("torch", reason="torch is optional and absent on CI runners")
     loaded = _modules_after("import sys, json, torch\nprint(json.dumps({'torch': 'torch' in sys.modules}))\n")
     assert loaded["torch"], "the probe cannot see torch even when it is imported outright"
 
@@ -88,6 +109,7 @@ def test_scipy_is_still_imported_so_the_absence_above_means_something():
     assert loaded["scipy"], "`import mfgarchon` no longer reaches scipy; the package is not loading normally"
 
 
+@pytest.mark.optional_torch
 def test_the_torch_backend_still_works_when_asked_for():
     """Deferring must not mean never. `create_backend('torch')` takes the on-demand path in
     `create_backend` -- the one that eager registration had made unreachable."""
@@ -103,3 +125,86 @@ def test_the_torch_backend_still_works_when_asked_for():
     assert loaded["before"] is False, "torch was already imported before it was asked for"
     assert loaded["after"] is True, "asking for the torch backend did not import torch"
     assert loaded["name"] == "TorchBackend"
+
+
+LAZY_TORCH_NAMES = (
+    "HAS_CUDA",
+    "HAS_MPS",
+    "HAS_TORCH",
+    "GaussianKDE",
+    "ensure_torch_available",
+    "get_default_device",
+    "to_numpy",
+    "to_tensor",
+    "torch_tridiagonal_solve",
+)
+
+
+@pytest.mark.optional_torch
+@pytest.mark.parametrize("name", LAZY_TORCH_NAMES)
+def test_each_deferred_name_still_resolves(name):
+    """The deferral must not be a removal, per name.
+
+    Review found the whole `__getattr__` could be replaced with `raise AttributeError` and the
+    full suite still returned 6006 passed: **no file in the repository references any of these
+    nine names through `mfgarchon.utils.acceleration`**, so nothing exercised the machinery this
+    change introduced. The two mutation tests above pin that torch is not imported EAGERLY; they
+    say nothing about whether it can be imported at all.
+    """
+    pytest.importorskip("torch", reason="torch is optional and absent on CI runners")
+    import mfgarchon.utils.acceleration as acceleration
+
+    resolved = getattr(acceleration, name)
+    assert resolved is not None, f"{name} resolved to None"
+    # Resolving twice must give the same object: `__getattr__` binds into `globals()` on first
+    # use, and a second call that re-imported would be a different object each time.
+    assert getattr(acceleration, name) is resolved
+
+
+@pytest.mark.optional_torch
+def test_the_renamed_export_points_at_the_right_function():
+    """`torch_tridiagonal_solve` is `torch_utils.tridiagonal_solve` under another name — the one
+    entry in the lazy map whose source attribute differs from its exported one, and the only
+    place a copy-paste error would be silent."""
+    pytest.importorskip("torch", reason="torch is optional and absent on CI runners")
+    import mfgarchon.utils.acceleration as acceleration
+    from mfgarchon.utils.acceleration import torch_utils
+
+    assert acceleration.torch_tridiagonal_solve is torch_utils.tridiagonal_solve
+
+
+def test_an_unknown_name_raises_attribute_error_not_import_error():
+    """`hasattr` depends on this. `__getattr__` must raise `AttributeError` for a name it does
+    not own; raising `ImportError` would make `hasattr` propagate instead of returning False."""
+    import mfgarchon.utils.acceleration as acceleration
+
+    with pytest.raises(AttributeError):
+        _ = acceleration.definitely_not_a_real_name
+
+    assert hasattr(acceleration, "get_acceleration_info"), "a real attribute stopped resolving"
+
+
+def test_dir_lists_each_deferred_name_once():
+    """`__dir__` merges `globals()` with the lazy map, and a name bound by an earlier
+    `__getattr__` call is in both. Review measured three names listed twice."""
+    import mfgarchon.utils.acceleration as acceleration
+
+    listing = dir(acceleration)
+    duplicated = sorted({n for n in listing if listing.count(n) > 1})
+    assert not duplicated, f"dir() lists these more than once: {duplicated}"
+
+
+def test_the_introspection_helper_still_works():
+    """`get_acceleration_info()` reads `TORCH_UTILS_AVAILABLE`, which is now lazy.
+
+    A module-level `__getattr__` is **not** consulted for a bare global lookup inside a function
+    in the same module — that goes straight to `module.__dict__` and raises `NameError`. Deferring
+    the flag therefore broke this function, and every test above still passed: they exercise
+    import behaviour, not the package's own callers. `ruff F821` is what caught it.
+    """
+    import mfgarchon.utils.acceleration as acceleration
+
+    info = acceleration.get_acceleration_info()
+    assert "torch_utils_available" in info
+    assert isinstance(info["torch_utils_available"], bool)
+    assert "jax_utils_available" in info

--- a/tests/unit/test_optional_backends_are_not_imported_eagerly.py
+++ b/tests/unit/test_optional_backends_are_not_imported_eagerly.py
@@ -83,9 +83,7 @@ def test_the_probe_would_notice_an_import():
     was VACUOUSLY satisfied there -- the guard discriminated only on a machine with `[all]`
     installed. Found by review; the control now uses a module the runners have.
     """
-    loaded = _modules_after(
-        "import sys, json, decimal\nprint(json.dumps({'decimal': 'decimal' in sys.modules}))\n"
-    )
+    loaded = _modules_after("import sys, json, decimal\nprint(json.dumps({'decimal': 'decimal' in sys.modules}))\n")
     assert loaded["decimal"], "the probe cannot see a module even when it is imported outright"
 
 
@@ -140,7 +138,6 @@ LAZY_TORCH_NAMES = (
 )
 
 
-@pytest.mark.optional_torch
 @pytest.mark.parametrize("name", LAZY_TORCH_NAMES)
 def test_each_deferred_name_still_resolves(name):
     """The deferral must not be a removal, per name.
@@ -151,7 +148,12 @@ def test_each_deferred_name_still_resolves(name):
     change introduced. The two mutation tests above pin that torch is not imported EAGERLY; they
     say nothing about whether it can be imported at all.
     """
-    pytest.importorskip("torch", reason="torch is optional and absent on CI runners")
+    # No `importorskip`: `torch_utils.py` wraps `import torch` in `try/except ImportError` and
+    # publishes `HAS_TORCH = False`, so it imports cleanly without torch and every name below
+    # resolves. Marking these `optional_torch` excluded them from every automated tier -- the gate,
+    # nightly and python-compat all deselect that marker -- so the machinery they exist to pin was
+    # covered by tests that never ran. Found by review, which also measured that they pass with
+    # torch genuinely absent. The torch-less user is what CI is; that is the case worth pinning.
     import mfgarchon.utils.acceleration as acceleration
 
     resolved = getattr(acceleration, name)
@@ -161,12 +163,10 @@ def test_each_deferred_name_still_resolves(name):
     assert getattr(acceleration, name) is resolved
 
 
-@pytest.mark.optional_torch
 def test_the_renamed_export_points_at_the_right_function():
     """`torch_tridiagonal_solve` is `torch_utils.tridiagonal_solve` under another name — the one
     entry in the lazy map whose source attribute differs from its exported one, and the only
     place a copy-paste error would be silent."""
-    pytest.importorskip("torch", reason="torch is optional and absent on CI runners")
     import mfgarchon.utils.acceleration as acceleration
     from mfgarchon.utils.acceleration import torch_utils
 
@@ -186,9 +186,19 @@ def test_an_unknown_name_raises_attribute_error_not_import_error():
 
 def test_dir_lists_each_deferred_name_once():
     """`__dir__` merges `globals()` with the lazy map, and a name bound by an earlier
-    `__getattr__` call is in both. Review measured three names listed twice."""
+    `__getattr__` call is in both.
+
+    **The binding happens inside this test.** Without it the two sets are disjoint and the buggy
+    `sorted([...])` form produces no duplicates -- so the test passed with the defect present when
+    run alone (1 passed) and under the gate's marker set (6 passed, 12 deselected), because the
+    `optional_torch` cases that would have bound the names are excluded there. Only an unfiltered
+    whole-file run caught it. That is the same failure mode as the registry test earlier in this
+    branch: an assertion about a module global satisfied by whatever ran first. Found by review;
+    order-independence is not something the surrounding suite can supply.
+    """
     import mfgarchon.utils.acceleration as acceleration
 
+    acceleration.TORCH_UTILS_AVAILABLE  # noqa: B018 - bind one lazy name, which is the precondition
     listing = dir(acceleration)
     duplicated = sorted({n for n in listing if listing.count(n) > 1})
     assert not duplicated, f"dir() lists these more than once: {duplicated}"
@@ -208,3 +218,66 @@ def test_the_introspection_helper_still_works():
     assert "torch_utils_available" in info
     assert isinstance(info["torch_utils_available"], bool)
     assert "jax_utils_available" in info
+
+
+def test_the_availability_flag_reports_whether_torch_IMPORTS_not_whether_it_exists():
+    """An installed-but-broken torch must give `False`.
+
+    The first version of this deferral used `importlib.util.find_spec("torch") is not None`, which
+    answers "is torch on disk". For a torch that is installed but raises on import, the eager form
+    it replaced gave `False` and that gives `True` — and `get_acceleration_info()` then reported the
+    self-contradictory `{"torch_utils_available": True, "torch_available": False}`.
+
+    The fix was unpinned: review reverted it and the whole suite stayed green, because nothing in
+    the tree simulates a broken torch. The guard that DID catch the other wrong fix — importing
+    `torch_utils` eagerly — only sees the eagerness failure, not the semantics.
+    """
+    import textwrap
+
+    code = textwrap.dedent(
+        """
+        import json, pathlib, sys, tempfile
+
+        tmp = tempfile.mkdtemp()
+        pkg = pathlib.Path(tmp) / "torch"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("raise ImportError('broken on purpose')\\n")
+        sys.path.insert(0, tmp)
+
+        import importlib.util
+        # control: the shadow must be BOTH findable and un-importable, or this proves nothing
+        assert importlib.util.find_spec("torch") is not None, "control: the shadow torch is not findable"
+        try:
+            import torch
+            print(json.dumps({"control": "FAILED - the shadow torch imported"}))
+            raise SystemExit(0)
+        except ImportError:
+            pass
+
+        import mfgarchon.utils.acceleration as acc
+        print(json.dumps({
+            "control": "ok",
+            "flag": bool(acc.TORCH_UTILS_AVAILABLE),
+            "info": bool(acc.get_acceleration_info()["torch_utils_available"]),
+        }))
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"the probe never ran:\n{proc.stderr[-1500:]}"
+    line = [x for x in proc.stdout.splitlines() if x.startswith("{")]
+    assert line, f"no verdict:\n{proc.stdout[-600:]}\n{proc.stderr[-600:]}"
+    import json as _json
+
+    got = _json.loads(line[-1])
+    assert got["control"] == "ok", got["control"]
+    assert got["flag"] is False, (
+        "TORCH_UTILS_AVAILABLE is True for a torch that does not import. The flag answers "
+        "'is torch on disk' rather than 'does importing it succeed'."
+    )
+    assert got["info"] is False, "get_acceleration_info() disagrees with the flag"


### PR DESCRIPTION
Step 2 of #1930 — and the first step in that issue that moves the number.

`import mfgarchon` imported PyTorch. It is optional, declared in the `[all]` extra rather than in `dependencies`, and it cost **0.82s of a 4.12s import** for anyone who touched the package whether or not they ever asked for a backend.

## Two sites, and cutting either alone does nothing

Three independent routes reach torch during `import mfgarchon`:

```
1.  utils/__init__.py:30 -> adjoint_validation.py:55 -> alg -> ...
        -> nonlinear_solvers.py:45 -> utils/acceleration/__init__.py -> torch_utils.py:16
2.  utils/__init__.py:92 -> utils/geometry.py:30 -> geometry -> ...  -> (same leaf)
3.  base_hjb.py:11 -> backends/compat -> backends/__init__.py -> torch_backend.py:30
```

Routes 1 and 2 converge on `utils/acceleration`; route 3 never touches it. Measured, median of 5:

| | time | heavy packages |
|---|---:|---|
| as shipped | 4.12s | torch, jax, numba, cvxpy, polars, scipy |
| `backends/__init__` deferred only | 4.07s | **torch still present** |
| **both deferred** | **3.27s** | torch **absent** |

0.85s, against torch's own cold import cost of 0.82s measured on its own.

## The machinery already existed

`backends/__init__.py` stops registering torch and jax at import. `create_backend` **already** carries the on-demand path — `if backend_name not in _BACKENDS:` imports and registers whichever backend was asked for — and eager registration is exactly what made that branch unreachable. `tests/unit/test_backends/test_backend_factory.py` had already recorded the consequence in a docstring:

> *"`backends/__init__.py` registers 'torch' into `_BACKENDS` whether or not torch exists. The `if backend_name not in _BACKENDS` branch is therefore unreachable."*

So the change is deleting the eager block, not writing new machinery.

`utils/acceleration/__init__.py` re-exports its nine torch names through a module `__getattr__` (PEP 562), binding into `globals()` on first use so the second access does not re-enter. ~~`TORCH_UTILS_AVAILABLE` stays eager and stays correct — it answers "is torch installed", which `importlib.util.find_spec` settles without importing anything.~~ **[SUPERSEDED 2026-08-14 — SUPERSEDED-BY: the D3/D5 corrections below.]** The flag joined the lazy map, and the question it answers is *"did `import torch` succeed"*, not *"is torch installed"* — an installed-but-broken torch has a spec and still raises. The code corrected this; this paragraph did not, and stood unmarked for two review rounds.

**numpy stays eager.** Hard dependency, 0.07s, and callers assume it is registered the moment the package is imported. Not every eager import is worth deferring.

## The test asserts the outcome, not the shape of either file

`torch not in sys.modules` after `import mfgarchon` cannot be satisfied by fixing one site and calling it done. Verified — each site restored independently reddens it:

```
backends registers torch eagerly again          -> 2 failed
acceleration imports torch_utils eagerly again  -> 2 failed
```

It carries a positive control (the probe must see torch when it is imported outright — every other assertion here is that a flag is False, which is also what a broken probe returns), the reverse direction (scipy must still arrive, or "torch absent" could just mean the package stopped loading), and the deferral's own converse (`create_backend("torch")` must still work, and must import torch when it does).

## Not fixed here

jax still arrives, through **cvxpy** — a third-party import chain this repository does not control. Recorded in #1930, along with the remaining steps: the `gfdm_strategies` back-edge, sinking `SchemeFamily`, and making `utils/__init__` lazy as a whole, all of which are blocked behind the import cycle. These two files are not on that cycle, which is why this step could be done now.

`./scripts/local_ci.sh` → **6006 passed, GATE GREEN**.

---

## Third independent review — MERGE-BLOCKED, one blocker, now fixed and measured

**The blocker was created by the fix for the previous round's blocker.** D1 bound `TORCH_UTILS_AVAILABLE` into `globals()` to give the `dir()` test its precondition; `test_the_introspection_helper_still_works` needs that same name **unbound**, because a module-level `__getattr__` is not consulted for a bare global lookup and finding the name in `__dict__` is exactly what stops the `NameError` from firing. Two tests, one module global, opposite preconditions, declaration order deciding which wins.

That is the third instance of one pattern on this branch, and the first one this branch inflicted on itself. The two before it were assertions satisfied by state an earlier test created; this one is an assertion satisfied by state an earlier test created **inside the fix for the previous instance**.

Mutation M-C — both call sites reverted to the bare global, i.e. the defect that actually shipped and that only `ruff F821` caught:

| run | before this commit | after |
|---|---|---|
| gate marker set | 57 passed | **1 failed**, 56 passed |
| gate marker set, `-n 4` | 57 passed | **1 failed**, 56 passed |

`vars(acceleration).pop(name, None)` rather than `del`: `del` raises `AttributeError` when that test runs first and nothing has bound the name yet.

**D7 — the dir() fix rested on a neighbouring decision.** It bound the one name whose laziness this PR *adds*, so it reverted to order-dependence the moment the flag stopped being lazy: compound mutation (dir defect + flag eager), dir test alone → **1 passed with the defect present**. Now binds `to_tensor`. ~~which was lazy before this branch and stays lazy after it~~ **[CORRECTED 2026-08-14]** — false, and review measured it: `git show 7ac9df18:mfgarchon/utils/acceleration/__init__.py | grep -c _LAZY_TORCH` is **0**, the whole map is new here. The real distinction is that the *flag's computation* was revised twice inside this PR while `to_tensor` was not. The choice stands; the stated reason did not. Same mutation → 1 failed.

**D8 — the D4 fix was unpinned.** Reverting `sys.modules[__name__].NAME` to `__getattr__("NAME")` — the form that reads *past* an explicit override — was caught by nothing (59 passed). The introspection test now sets the attribute and asserts the helper sees it → 1 failed.

**Review retracted results of its own.** Its round-2 harness re-applied each edit from the original text, so on any multi-edit mutation only the last survived and the mutant measured was not the mutant named. It re-ran M-D and M-D4 cumulatively; the conclusions held, the evidence did not. Every number above comes from a harness that applies edits cumulatively and asserts each replacement is present in the written file.

**Fourth independent timing round**, interleaved, 11 samples per tree, tree identity asserted per sample: base `7ac9df18` median **4.237s**, head **3.397s**, delta **0.840s**. Across four rounds the delta is 0.73–0.84s while the absolutes drift ~0.4s.

`./scripts/local_ci.sh` → **6019 passed, GATE GREEN**.



---

## Fourth independent review — MERGE-BLOCKED on three, all fixed and measured

It also **corrected two premises I had written into the code comments, the commit message and this PR body**. Both were about *why* the previous round's fix works, and a maintainer following either would have undone it.

**B1 — the override pin was one-sided, so it was silent exactly where CI runs.** `__getattr__("TORCH_UTILS_AVAILABLE")` returns `bool(torch_utils.HAS_TORCH)`, which is `False` wherever torch does not import — precisely what an override to `False` asserts. Looping over `(True, False)` closes it, because no constant equals both members. Measured under the gate's marker set, mutations applied **cumulatively** with each replacement asserted present on disk and the restore sha256-verified, torch-free simulated by a shadow `torch/__init__.py` that has a spec and raises on import (control: `find_spec` returns a spec, `import torch` raises):

| mutation | torch present | torch free |
|---|---|---|
| unmutated | 18 passed | 18 passed |
| M-C — both sites → bare global | 1 failed | 1 failed |
| M-D4 — both sites → `__getattr__("NAME")` | 1 failed | **1 failed** *(was 17 passed)* |
| M-FALSE — dict entry hardcoded `False` | **1 failed** *(was 17 passed)* | 1 failed |

**B2 — two comments this branch added were false at head.** The dir test and the introspection test do **not** share a module global: the first binds `to_tensor`, only the second touches the flag. The actual binder is `tests/integration/test_cross_backend_consistency.py:16`, whose module-level from-import triggers the PEP 562 `__getattr__` and its `globals()[name] = value` cache — at **collection**, so in every xdist worker before any test body. With all three files under `-n 4`: both call sites reverted gives **1 failed** with the `vars().pop`, **61 passed** without it. The pop is load-bearing for a reason its own comment did not name.

**B3 — the three subprocess probes did not pin which tree they measured.** For `python -c`, `sys.path[0]` is the cwd and precedes `PYTHONPATH`, so `cwd=REPO` works *until* `-P` / `PYTHONSAFEPATH=1` strips that entry — which `scripts/local_ci.sh:311` sets and `subprocess.run` inherits. Under the gate the probes import the **editable install**.

Reproduced both directions in a real worktree, gate's exact invocation, with the wrong answer made reachable by parking the canonical checkout on a ref that lacks this change:

| | result |
|---|---|
| canonical on `main`, worktree files without the fix | **2 failed** — `test_importing_the_package_does_not_import_torch`, `test_optional_backends_are_not_registered_until_asked_for` |
| canonical on `main`, worktree files with the fix | **58 passed** |

Both halves applied: `PYTHONPATH` prepended, **and** a new `test_the_subprocess_probes_import_the_tree_under_test` that resolves the probe's `mfgarchon.__file__` and asserts it is inside the tree under test — so the whole file reddens when the probes would be measuring elsewhere, rather than the guard depending on env plumbing staying correct. Same class as #1933's D1/D2, and already in this repo's record from the #1906 review: *an import-origin check is only evidence if the wrong answer is reachable.*

**Review also retracted a result of its own** from round 3, whose harness re-applied each edit from the original text so that only the last survived on any multi-edit mutation. Every number above comes from a cumulative harness that asserts each replacement landed.

Independent re-measurement of the headline, 6 runs each with the import root pinned and tree identity asserted per sample: base `7ac9df18` **4.012 s** with torch in `sys.modules`, head **3.239 s** with torch absent — delta **0.77 s** against the claimed 0.82 s.

`./scripts/local_ci.sh` → **6020 passed, 12 skipped, 21 xfailed, GATE GREEN**.
