### PR TITLE
chore: cut the import cycle's back-edge, unblocking the hub deferral

### DIFF
--- a/changelog.d/1930-cut-the-import-cycle.removed.md
+++ b/changelog.d/1930-cut-the-import-cycle.removed.md
@@ -1,0 +1,13 @@
+`mfgarchon.utils.numerical` no longer re-exports the GFDM strategy classes.
+
+`BoundaryHandler`, `DifferentialOperator`, `DirectCollocationHandler`, `GhostNodeHandler`,
+`LocalRBFOperator`, `TaylorOperator`, `UpwindOperator`, `create_bc_handler` and
+`create_operator` live in `mfgarchon.alg.numerical.gfdm_components.gfdm_strategies`; import
+them from there. No code in the repository used the `utils` spelling.
+
+The re-export was the back-edge of an import cycle — `mfgarchon.utils` sits below
+`mfgarchon.alg`, and importing upward reached `fp_network`, which needs a name from
+`utils.numerical` while that module is still executing. The cycle was invisible in normal use
+because an eager import elsewhere completed `utils.numerical` by another route first, and only
+surfaced when that eager import was made lazy. Removing it is what makes that deferral possible.
+(#1930)

--- a/mfgarchon/utils/numerical/__init__.py
+++ b/mfgarchon/utils/numerical/__init__.py
@@ -28,7 +28,9 @@ Submodules:
 # That error was invisible in normal use because `utils/__init__.py`'s eager
 # `from .adjoint_validation import (...)` completes `utils.numerical` by another route first --
 # so the cycle only surfaced when someone tried to make that import lazy, which is #1930 step 5.
-# Measured: with this block present, deferring it fails; with it gone, deferring it works.
+# Measured: with this block present, deferring that import fails; with it gone, it works.
+# No timing is claimed either way -- import totals on one machine drift 0.4s between rounds,
+# so a two-row before/after would read as a measurement of this change when it is noise.
 #
 # Zero files imported these nine names through `utils.numerical` -- verified by AST over
 # `mfgarchon/`, `tests/` and `examples/`, for both `from`-imports and attribute access. #1930
@@ -118,7 +120,6 @@ from mfgarchon.utils.numerical.particle.interpolation import (
 __all__ = [
     # GFDM operators (legacy; canonical: alg.numerical.gfdm_components.gfdm_strategies)
     "GFDMOperator",
-    # GFDM Strategy Pattern (scattered points)
     # Monotonicity tracking
     "MonotonicityStats",
     "verify_m_matrix_property",

--- a/mfgarchon/utils/numerical/__init__.py
+++ b/mfgarchon/utils/numerical/__init__.py
@@ -14,18 +14,24 @@ Submodules:
 
 # Flux diagnostics for mass conservation analysis
 # GFDMOperator: deprecated, moved to _compat. Import without triggering warning.
-# GFDM Strategy Pattern (canonical location: alg/numerical/gfdm_components/)
-from mfgarchon.alg.numerical.gfdm_components.gfdm_strategies import (
-    BoundaryHandler,
-    DifferentialOperator,
-    DirectCollocationHandler,
-    GhostNodeHandler,
-    LocalRBFOperator,
-    TaylorOperator,
-    UpwindOperator,
-    create_bc_handler,
-    create_operator,
-)
+# GFDM strategies are NOT re-exported here. They live in
+# `mfgarchon.alg.numerical.gfdm_components.gfdm_strategies`; import them from there.
+#
+# This block was the back-edge of an import cycle. `mfgarchon.utils` sits BELOW `mfgarchon.alg`,
+# so importing upward from here reached `alg/__init__` -> fp_solvers -> network_solvers ->
+# `fp_network.py:36`, which needs a name from `utils.numerical` while this file is still stopped
+# at this line:
+#
+#     ImportError: cannot import name 'clip_nonnegative_or_raise' from partially initialized
+#     module 'mfgarchon.utils.numerical' (most likely due to a circular import)
+#
+# That error was invisible in normal use because `utils/__init__.py`'s eager
+# `from .adjoint_validation import (...)` completes `utils.numerical` by another route first --
+# so the cycle only surfaced when someone tried to make that import lazy, which is #1930 step 5.
+# Measured: with this block present, deferring it fails; with it gone, deferring it works.
+#
+# Zero files imported these nine names through `utils.numerical` -- verified by AST over
+# `mfgarchon/`, `tests/` and `examples/`, for both `from`-imports and attribute access. #1930
 
 # SDF utilities (canonical location: geometry/implicit/)
 from mfgarchon.geometry.implicit.sdf_utils import (
@@ -113,15 +119,6 @@ __all__ = [
     # GFDM operators (legacy; canonical: alg.numerical.gfdm_components.gfdm_strategies)
     "GFDMOperator",
     # GFDM Strategy Pattern (scattered points)
-    "DifferentialOperator",
-    "BoundaryHandler",
-    "TaylorOperator",
-    "UpwindOperator",
-    "LocalRBFOperator",
-    "DirectCollocationHandler",
-    "GhostNodeHandler",
-    "create_operator",
-    "create_bc_handler",
     # Monotonicity tracking
     "MonotonicityStats",
     "verify_m_matrix_property",

--- a/tests/unit/test_utils_does_not_import_alg.py
+++ b/tests/unit/test_utils_does_not_import_alg.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import os
 import re
 from pathlib import Path
 
@@ -129,9 +130,12 @@ def _runs_at_import(node: ast.AST, tree: ast.Module) -> bool:
       failure message's own advice ("defer it into the function that uses it") can be misread
       into, so it is named here.
     - **`importlib.import_module(...)` / `__import__(...)`** are not `ast.Import` nodes and are
-      invisible to any version of this scanner. The two deleted paths are covered by
-      `test_a_lazy_shim_cannot_restore_a_deleted_import_path`, which resolves at runtime; a NEW
-      edge introduced that way would not be.
+      invisible to this SCANNER. They are not invisible to the file: review injected a
+      module-level `import_module("mfgarchon.alg...gfdm_strategies")` into
+      `utils/numerical/__init__.py` and `test_the_hub_can_be_deferred_without_a_circular_import`
+      caught it (`1 failed, 23 passed`) while the AST ratchet stayed green -- because such an edge
+      recreates the cycle, which that test measures directly. What remains uncovered is a dynamic
+      edge that does NOT recreate a cycle.
     """
     stack: list[ast.AST] = list(tree.body)
     while stack:
@@ -374,7 +378,9 @@ def test_the_hub_can_be_deferred_without_a_circular_import():
 
     hub = REPO / "mfgarchon" / "utils" / "__init__.py"
     source = hub.read_text()
-    match = re.search(r"^# Adjoint duality validation \(Issue #580\)\nfrom \.adjoint_validation import \(([^)]*)\)\n", source, re.M)
+    match = re.search(
+        r"^# Adjoint duality validation \(Issue #580\)\nfrom \.adjoint_validation import \(([^)]*)\)\n", source, re.M
+    )
     assert match, "the eager hub import moved; this test is pinning something that is no longer there"
     names = tuple(n.strip().rstrip(",") for n in match.group(1).split() if n.strip().rstrip(","))
     assert names, "parsed no re-exported names; the deferral below would prove nothing"
@@ -392,16 +398,34 @@ def test_the_hub_can_be_deferred_without_a_circular_import():
         tree = Path(tmp) / "tree"
         shutil.copytree(REPO / "mfgarchon", tree / "mfgarchon", ignore=shutil.ignore_patterns("__pycache__"))
         (tree / "mfgarchon" / "utils" / "__init__.py").write_text(source.replace(match.group(0), lazy, 1))
+        # `PYTHONPATH` and an explicit `sys.path` insert, not cwd: `local_ci.sh:311` runs pytest
+        # under `PYTHONSAFEPATH=1`, which drops cwd from `sys.path` -- and the subprocess then
+        # resolved `mfgarchon` from the EDITABLE INSTALL, which imports fine, so this test passed
+        # over a tree it never read. Measured: back-edge restored + PYTHONSAFEPATH=1 -> 1 passed,
+        # same mutation without it -> 1 failed. Found by review.
+        env = {**os.environ, "PYTHONPATH": str(tree), "PYTHONSAFEPATH": ""}
         proc = subprocess.run(
-            [sys.executable, "-c", "import mfgarchon; print('OK')"],
+            [
+                sys.executable,
+                "-c",
+                f"import sys; sys.path.insert(0, {str(tree)!r})\nimport mfgarchon; print('TREE:' + mfgarchon.__file__)",
+            ],
             cwd=tree,
             capture_output=True,
             text=True,
             timeout=300,
+            env=env,
         )
 
     assert proc.returncode == 0, (
         "deferring `utils/__init__.py`'s eager import of `adjoint_validation` fails, which means "
         "an upward `utils -> alg` import has reintroduced the cycle:\n" + proc.stderr[-2000:]
     )
-    assert "OK" in proc.stdout
+    # The token identifies the tree, not just success. "OK" would be printed just as happily by
+    # the installed package, which is the whole failure mode above.
+    reported = [line[len("TREE:") :] for line in proc.stdout.splitlines() if line.startswith("TREE:")]
+    assert reported, f"the probe printed no tree token:\n{proc.stdout[-600:]}"
+    assert reported[0].startswith(str(tree)), (
+        f"the subprocess imported {reported[0]}, not the patched copy at {tree}. The result says "
+        f"nothing about the patch."
+    )

--- a/tests/unit/test_utils_does_not_import_alg.py
+++ b/tests/unit/test_utils_does_not_import_alg.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
@@ -50,9 +51,13 @@ import pytest
 REPO = Path(__file__).resolve().parents[2]
 UTILS = REPO / "mfgarchon" / "utils"
 
-# The two that remain, each with what it would take to remove it:
-#   utils/numerical/__init__.py     re-exports `gfdm_strategies`, which lives in alg
+# The one that remains:
 #   utils/adjoint_validation.py     imports one enum, `SchemeFamily`, from alg.base_solver
+#
+# ~~utils/numerical/__init__.py re-exports `gfdm_strategies`~~ removed 2026-08-14 (#1930 step 3).
+# It was the cycle's back-edge and had zero consumers. Removing it is what makes deferring
+# `utils/__init__.py`'s eager import possible at all -- measured: with the re-export present that
+# deferral raises a circular ImportError, with it gone it succeeds.
 #
 # Pinned by EQUALITY, not by `<=`. That was the first form, and review named the reason it is
 # wrong: a bound cannot tell "an edge was removed" from "the scanner stopped seeing edges", and
@@ -60,7 +65,7 @@ UTILS = REPO / "mfgarchon" / "utils"
 # import -- both now fixed, both silently under a `<=`). It is also the house convention, for a
 # recorded reason: `scripts/check_single_source.py:47` records a change "which removes nothing"
 # dropping a count 6 -> 0 and printing SHRANK.
-EXPECTED_MODULE_LEVEL = 2
+EXPECTED_MODULE_LEVEL = 1
 
 
 def _absolute_target(node: ast.Import | ast.ImportFrom, path: Path) -> str:
@@ -341,3 +346,62 @@ def test_relative_imports_resolve_to_the_same_name_python_would_use(rel, level, 
     assert path.exists(), f"{rel} moved; this case is testing a file that is not there"
     node = ast.ImportFrom(module=module, names=[ast.alias(name="X")], level=level)
     assert _absolute_target(node, path) == expected
+
+
+def test_the_hub_can_be_deferred_without_a_circular_import():
+    """The cycle is broken, asserted as the thing that was blocked rather than as its cause.
+
+    `utils/__init__.py`'s eager `from .adjoint_validation import (...)` is what makes every heavy
+    package arrive on `import mfgarchon`, and #1930 step 5 is to defer it. Before the
+    `gfdm_strategies` re-export was removed from `utils/numerical/__init__.py`, that deferral
+    failed:
+
+        ImportError: cannot import name 'clip_nonnegative_or_raise' from partially initialized
+        module 'mfgarchon.utils.numerical' (most likely due to a circular import)
+
+    because `utils.numerical` imported `alg`, which reached `fp_network.py`, which needed a name
+    from `utils.numerical` while it was still executing that import. The eager hub import hid the
+    cycle by completing `utils.numerical` through another route first -- so the cycle was only
+    observable by attempting the very change it blocked.
+
+    This performs the attempt in a subprocess against a patched copy of the tree, so the property
+    is checked rather than remembered. If it ever fails again, an upward import has returned.
+    """
+    import shutil
+    import subprocess
+    import sys
+    import tempfile
+
+    hub = REPO / "mfgarchon" / "utils" / "__init__.py"
+    source = hub.read_text()
+    match = re.search(r"^# Adjoint duality validation \(Issue #580\)\nfrom \.adjoint_validation import \(([^)]*)\)\n", source, re.M)
+    assert match, "the eager hub import moved; this test is pinning something that is no longer there"
+    names = tuple(n.strip().rstrip(",") for n in match.group(1).split() if n.strip().rstrip(","))
+    assert names, "parsed no re-exported names; the deferral below would prove nothing"
+
+    lazy = (
+        f"_LAZY = {names!r}\n\n\n"
+        "def __getattr__(name):\n"
+        "    if name in _LAZY:\n"
+        "        from . import adjoint_validation as _m\n\n"
+        "        return getattr(_m, name)\n"
+        "    raise AttributeError(name)\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tree = Path(tmp) / "tree"
+        shutil.copytree(REPO / "mfgarchon", tree / "mfgarchon", ignore=shutil.ignore_patterns("__pycache__"))
+        (tree / "mfgarchon" / "utils" / "__init__.py").write_text(source.replace(match.group(0), lazy, 1))
+        proc = subprocess.run(
+            [sys.executable, "-c", "import mfgarchon; print('OK')"],
+            cwd=tree,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+    assert proc.returncode == 0, (
+        "deferring `utils/__init__.py`'s eager import of `adjoint_validation` fails, which means "
+        "an upward `utils -> alg` import has reintroduced the cycle:\n" + proc.stderr[-2000:]
+    )
+    assert "OK" in proc.stdout

--- a/tests/unit/test_utils_does_not_import_alg.py
+++ b/tests/unit/test_utils_does_not_import_alg.py
@@ -403,7 +403,14 @@ def test_the_hub_can_be_deferred_without_a_circular_import():
         # resolved `mfgarchon` from the EDITABLE INSTALL, which imports fine, so this test passed
         # over a tree it never read. Measured: back-edge restored + PYTHONSAFEPATH=1 -> 1 passed,
         # same mutation without it -> 1 failed. Found by review.
-        env = {**os.environ, "PYTHONPATH": str(tree), "PYTHONSAFEPATH": ""}
+        env = {**os.environ}
+        # Prepend, do not overwrite: the previous form dropped the parent's PYTHONPATH, which
+        # nothing here needs but a future runner might.
+        env["PYTHONPATH"] = os.pathsep.join(x for x in (str(tree), os.environ.get("PYTHONPATH", "")) if x)
+        # `pop`, not `= ""`. The empty string does clear the flag (CPython treats empty env vars
+        # as unset), but it stays visible to anything checking presence rather than truth, and
+        # "0" and " " both ENABLE it -- a value worth not having to remember.
+        env.pop("PYTHONSAFEPATH", None)
         proc = subprocess.run(
             [
                 sys.executable,
@@ -425,7 +432,15 @@ def test_the_hub_can_be_deferred_without_a_circular_import():
     # the installed package, which is the whole failure mode above.
     reported = [line[len("TREE:") :] for line in proc.stdout.splitlines() if line.startswith("TREE:")]
     assert reported, f"the probe printed no tree token:\n{proc.stdout[-600:]}"
-    assert reported[0].startswith(str(tree)), (
+    # `resolve().is_relative_to`, not `startswith`. On macOS TMPDIR is a symlink, so the logical
+    # spelling (`/var/folders/...`) and the physical one `os.getcwd()` returns
+    # (`/private/var/folders/...`) differ, and a string prefix compares False on the correct
+    # tree. It passed only because `sys.path.insert` fed the import machinery the same string
+    # this line compares against -- a guard whose correctness depended on a co-located
+    # mechanism, which is the hazard this whole assertion exists to remove. Review measured it:
+    # with the insert taken away the CLEAN tree reddens too, and a check red in both states is
+    # stuck rather than discriminating.
+    assert Path(reported[0]).resolve().is_relative_to(tree.resolve()), (
         f"the subprocess imported {reported[0]}, not the patched copy at {tree}. The result says "
         f"nothing about the patch."
     )


### PR DESCRIPTION
Step 3 of #1930.

`utils/numerical/__init__.py` re-exported nine GFDM strategy names from `mfgarchon.alg`. `mfgarchon.utils` sits **below** `mfgarchon.alg`, so that import reached `alg/__init__` → `fp_solvers` → `network_solvers` → `fp_network.py:36`, which needs a name from `utils.numerical` while that module is still stopped at the re-export line:

```
ImportError: cannot import name 'clip_nonnegative_or_raise' from partially
initialized module 'mfgarchon.utils.numerical' (most likely due to a circular import)
```

The cycle was **invisible in normal use**, because `utils/__init__.py`'s eager `from .adjoint_validation import (...)` completes `utils.numerical` by another route first. It surfaced only when someone attempted the very change it blocked — deferring that eager import, which is #1930 step 5.

## Zero consumers

Re-verified on this head rather than carried over from the earlier survey: AST scan across `mfgarchon/`, `tests/` and `examples/`, for both `from`-imports and attribute access, of all nine names through `utils.numerical` → **0 files**. The block's own comment already named `alg` as the canonical location.

All nine were in `__all__`, so those entries go too — a `from ... import *` would otherwise raise.

```
module-level utils -> alg imports:  2 -> 1
```

## This buys no import time, and is not meant to

No before/after timing table: the hub has 18 module-level imports, deferring one is below this machine's run-to-run spread, and two rows would present noise as a measurement of the change. Independent review measured the two trees and got base 4.18s / head 4.36s -- the direction reverses. What this buys is not a number but a **binary fact**:

| | deferring `utils/__init__.py`'s eager import |
|---|---|
| with the re-export present | circular `ImportError` |
| with it removed | imports fine |

`test_the_hub_can_be_deferred_without_a_circular_import` pins that directly — it copies the tree, replaces the eager hub import with a PEP 562 `__getattr__`, and imports in a subprocess. **Mutation-verified: restoring the back-edge reddens it.**

Without that test the fact would live only in a commit message, and the next upward import would reintroduce the cycle with nothing to say so. That is the same shape as the rest of this issue's work — the guard asserts the property that was blocked, not the edit that unblocked it.

`EXPECTED_MODULE_LEVEL` lowered 2 → 1 in the same commit, as its own failure message instructs, with the reason recorded beside it.

## Where this leaves #1930

| step | state |
|---|---|
| 1. delete the overdue shims | done, #1931 |
| 2. lazy backend `__init__`s | #1932 — the one that moved the number, 4.12s → 3.27s, torch gone |
| **3. cut the back-edge** | **this PR** |
| 4. sink `SchemeFamily` | next; the last `utils → alg` edge |
| 5. make `utils/__init__` lazy as a whole | see the correction below |

`./scripts/local_ci.sh` → **6003 passed, GATE GREEN**.


---

## Correction from independent review (MERGE-OK, four corrections)

**"Step 5 is now unblocked by this PR" was overstated.** Review built the full step-5 change — PEP 562 over all 18 hub imports, 106 names — and ran it on **both trees**. It works on base too, with a positive control confirming the cycle had its chance to fire (`mfgarchon.alg`, `utils.numerical` and `fp_network` all in `sys.modules` at the end).

With all 18 deferred, `utils.numerical` is entered from `fp_network` at a point where `mfgarchon.alg` is already imported, and the back-edge names a **submodule** rather than an attribute of a partially-initialised package.

So what this PR unblocks is deferring **that one** hub import — which is what the test pins, what the code comment says, and what the changelog fragment says. I had built step 5 only on a tree with the back-edge already cut, so I never gave the claim a chance to fail: I measured the side that supported it.

The deletion stands on its own merits regardless — an upward layering violation with zero consumers, verified against the base SHA so the deadness is not manufactured by the diff itself.

**The test could pass over a tree it never read.** `local_ci.sh:311` runs pytest under `PYTHONSAFEPATH=1`, which drops cwd from `sys.path`; the subprocess then resolved `mfgarchon` from the editable install, imported it fine, and printed `OK`. Measured with the back-edge restored: `PYTHONSAFEPATH=1` → **1 passed**, normal path → 1 failed. The probe now prints `TREE:<mfgarchon.__file__>` and the test asserts the temp path is a prefix; the same mutation now reddens under both.

**The timing table was noise presented as a measurement.** `4.03 → 4.01s` here; review measured base 4.18s and head 4.36s — the direction reverses. The conclusion is unaffected and correct, but a two-row before/after reads as a measurement *of the change*. Replaced with the binary fact the change establishes.

**A stated limit was too broad in this PR's favour.** The docstring said `importlib.import_module` edges are invisible to any version of the scanner; review injected one and the cycle test **caught it** (`1 failed, 23 passed`) while the AST ratchet stayed green — such an edge recreates the cycle, which that test measures directly.

Review also independently re-derived the zero-consumer claim with four detectors over 1120 tracked files including notebooks, **on the base tree as well as the head**, with a positive control proving the query form reaches `examples/`, `benchmarks/` and `docs/`. The one consumer question it could not close is the private MFG-Research repository, which imports MFGArchon and which no scan from here can see.

