### PR TITLE
fix(geometry): ImplicitApplicator reads the BC value from where it lives

### DIFF
--- a/changelog.d/1938-implicit-applicator-bc-value.fixed.md
+++ b/changelog.d/1938-implicit-applicator-bc-value.fixed.md
@@ -4,7 +4,8 @@ coefficients: it read `getattr(bc, "value", 0.0)` and `getattr(bc, "alpha"/"beta
 the owners on the parent `MeshfreeApplicator`; this subclass kept the pre-fix code.
 
 The defect was unreachable in practice for a second reason, now also fixed: `_detect_boundary_points`
-called `is_on_boundary(points, tolerance=...)`, but all seven `ImplicitDomain` subclasses the package
-ships name that parameter `tol`, so `apply()` raised `TypeError` for every real geometry. The call is
-now positional. The suite missed both because its fixture supplied a geometry written against the
+called `is_on_boundary(points, tolerance=...)`, while `ImplicitDomain` names that parameter `tol` and
+the whole implicit family inherits it, so `apply()` raised `TypeError` for every real geometry. The
+call is now positional. (Seven classes are affected; exactly one, `ImplicitDomain` itself, defines
+the method -- `Hyperrectangle`, `Hypersphere` and the CSG domains inherit it.) The suite missed both because its fixture supplied a geometry written against the
 applicator's call rather than against `GeometryProtocol`.

--- a/changelog.d/1938-implicit-applicator-bc-value.fixed.md
+++ b/changelog.d/1938-implicit-applicator-bc-value.fixed.md
@@ -6,6 +6,7 @@ the owners on the parent `MeshfreeApplicator`; this subclass kept the pre-fix co
 The defect was unreachable in practice for a second reason, now also fixed: `_detect_boundary_points`
 called `is_on_boundary(points, tolerance=...)`, while `ImplicitDomain` names that parameter `tol` and
 the whole implicit family inherits it, so `apply()` raised `TypeError` for every real geometry. The
-call is now positional. (Seven classes are affected; exactly one, `ImplicitDomain` itself, defines
-the method -- `Hyperrectangle`, `Hypersphere` and the CSG domains inherit it.) The suite missed both because its fixture supplied a geometry written against the
+call is now positional. (Two different sevens, worth keeping apart: seven classes *define* `is_on_boundary`, six of them
+naming the parameter `tolerance`; and seven classes *resolve* to `tol` -- `ImplicitDomain` plus the
+six that inherit from it. Only one definition needs renaming.) The suite missed both because its fixture supplied a geometry written against the
 applicator's call rather than against `GeometryProtocol`.

--- a/changelog.d/1938-implicit-applicator-bc-value.fixed.md
+++ b/changelog.d/1938-implicit-applicator-bc-value.fixed.md
@@ -1,0 +1,10 @@
+`ImplicitApplicator` applied every Dirichlet boundary condition as `0.0` and ignored all Robin
+coefficients: it read `getattr(bc, "value", 0.0)` and `getattr(bc, "alpha"/"beta", ...)` from
+`BoundaryConditions`, which carries none of them — the values live on `BCSegment`. #1558 established
+the owners on the parent `MeshfreeApplicator`; this subclass kept the pre-fix code.
+
+The defect was unreachable in practice for a second reason, now also fixed: `_detect_boundary_points`
+called `is_on_boundary(points, tolerance=...)`, but all seven `ImplicitDomain` subclasses the package
+ships name that parameter `tol`, so `apply()` raised `TypeError` for every real geometry. The call is
+now positional. The suite missed both because its fixture supplied a geometry written against the
+applicator's call rather than against `GeometryProtocol`.

--- a/mfgarchon/geometry/boundary/applicator_implicit.py
+++ b/mfgarchon/geometry/boundary/applicator_implicit.py
@@ -217,27 +217,45 @@ class ImplicitApplicator(MeshfreeApplicator):
         # `.value` attribute, so the default fired on every call and every Dirichlet BC was applied
         # as 0.0 regardless of what the caller asked for. The value lives on the segments.
         #
-        # Selected by TYPE, mirroring `_robin_alpha_beta`. ~~`next(s for s in bc.segments if
-        # s.value is not None)`~~ [CORRECTED 2026-08-15] was the first version and it was worse than
-        # what it replaced on one configuration: `BCSegment.value` defaults to `0.0`, not `None`, and
-        # nothing in the package passes `value=None`, so that filter never filtered and the
-        # expression was unconditionally `segments[0]`. Segments sort priority-descending, so the
-        # value came from whichever segment sorted first while `bc_type` came from
-        # `_resolve_default_bc` -- two segments feeding one condition. Measured on a Robin wall plus
-        # a higher-priority Dirichlet exit: alpha/beta = (2.0, 3.0) from the ROBIN segment and
-        # g = 7.0 from the DIRICHLET one, against a correct 1.0; and on no-flux walls plus a
-        # Dirichlet exit, where the pre-fix `0.0` had been RIGHT and this returned 7.0.
+        # A segment's value is read ONLY for a uniform BC, and only when its type is the one that
+        # was resolved. Otherwise `bc.default_value`.
         #
-        # NEUMANN and NO_FLUX are matched as one family because `apply()` dispatches them as one;
-        # without that, a NEUMANN segment under `default_bc=NO_FLUX` falls through to
-        # `bc.default_value`.
+        # `apply()` resolves ONE `bc_type` through `_resolve_default_bc` and applies it to every
+        # boundary point; this applicator has no spatial dispatch at all -- moving a segment's
+        # `normal_direction` from one arc to another, or deleting its region spec entirely, gives
+        # byte-identical output. So for a genuinely mixed BC, taking the value from *any* segment is
+        # meaningless: whichever it is, it gets imposed everywhere, including where that segment was
+        # never meant to act. `default_value` is the field that means "the value where no segment
+        # governs", which is the honest answer here. (That the applicator silently flattens a mixed
+        # BC at all is a separate, pre-existing defect, filed on its own.)
         #
-        # Not `bc.default_value` as the primary source: it is a plain float and the factory writes
-        # 0.0 into it whenever the value is callable (`conditions.py:929`), so routing through it
-        # would fix the scalar case and silently break the callable one this method exists to serve.
-        family = (BCType.NEUMANN, BCType.NO_FLUX) if bc_type in (BCType.NEUMANN, BCType.NO_FLUX) else (bc_type,)
-        segment = next((s for s in bc.segments if s.bc_type in family), None)
-        value = segment.value if segment is not None else bc.default_value
+        # Two earlier versions of this line, both measured wrong:
+        #
+        # ~~`next(s for s in bc.segments if s.value is not None)`~~ [CORRECTED 2026-08-15] --
+        # `BCSegment.value` defaults to `0.0`, not `None`, and nothing in the package passes
+        # `value=None`, so that filter never filtered and the expression was unconditionally
+        # `segments[0]`. Segments sort priority-descending, so the value came from whichever segment
+        # sorted first while `bc_type` came from `_resolve_default_bc` and alpha/beta from
+        # `_robin_alpha_beta`. Three sources, one condition.
+        #
+        # ~~a NEUMANN/NO_FLUX family clause~~ [CORRECTED 2026-08-15] -- it made a NO_FLUX resolution
+        # impose a non-zero flux: `[BCSegment(NEUMANN, value=2.5)]` under `default_bc=NO_FLUX` gave
+        # an implied `du/dn` of 2.5, where NO_FLUX means 0 by definition, and reordering the segments
+        # changed the answer. Its stated justification -- "without that, a NEUMANN segment under
+        # `default_bc=NO_FLUX` falls through to `bc.default_value`" -- described the CORRECT
+        # behaviour as the bug: `default_value` is 0.0 there, which is exactly what NO_FLUX requires.
+        # Review measured that the clause's only support was one case of the test written to justify
+        # it, in the same commit.
+        #
+        # Not `bc.default_value` as the primary source either: it is a plain float and the factory
+        # writes 0.0 into it whenever the value is callable (`conditions.py:929`), so routing
+        # everything through it would fix the scalar case and silently break the callable one this
+        # method exists to serve. Hence the uniform gate rather than a blanket substitution.
+        uniform_segment = bc.segments[0] if bc.is_uniform else None
+        if uniform_segment is not None and uniform_segment.bc_type == bc_type:
+            value = uniform_segment.value
+        else:
+            value = bc.default_value
 
         if callable(value):
             # Time-dependent or space-dependent BC

--- a/mfgarchon/geometry/boundary/applicator_implicit.py
+++ b/mfgarchon/geometry/boundary/applicator_implicit.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 
 from .applicator_base import GridType
-from .applicator_meshfree import MeshfreeApplicator
+from .applicator_meshfree import MeshfreeApplicator, _robin_alpha_beta
 from .types import BCType
 
 if TYPE_CHECKING:
@@ -144,8 +144,11 @@ class ImplicitApplicator(MeshfreeApplicator):
                 result, boundary_mask, normals, bc_value, points, spacing
             )
         elif bc_type == BCType.ROBIN:
-            alpha = getattr(boundary_conditions, "alpha", 1.0)
-            beta = getattr(boundary_conditions, "beta", 1.0)
+            # `_robin_alpha_beta`, not `getattr(boundary_conditions, ...)`. alpha/beta live on the
+            # BCSegment; `BoundaryConditions` has no such attribute, so the previous form always
+            # took its own defaults and made every Robin BC identical. #1558 established this owner
+            # on the parent class and this subclass kept the pre-fix code. #1938
+            alpha, beta = _robin_alpha_beta(boundary_conditions)
             result[boundary_mask] = self._apply_robin_along_normal(
                 result, boundary_mask, normals, alpha, beta, bc_value, points, spacing
             )
@@ -167,8 +170,17 @@ class ImplicitApplicator(MeshfreeApplicator):
         Returns:
             Boolean mask of boundary points
         """
-        # is_on_boundary is GeometryProtocol-guaranteed (protocol.py:208)
-        return self.geometry.is_on_boundary(points, tolerance=self._boundary_tolerance)
+        # Positional, not `tolerance=`. `GeometryProtocol.is_on_boundary` names the parameter
+        # `tolerance` and 18 classes follow it, but all seven `ImplicitDomain` subclasses --
+        # Hyperrectangle, Hypersphere, Union/Intersection/Complement/DifferenceDomain and the base
+        # -- name it `tol`. Since this applicator exists FOR implicit geometries, the keyword form
+        # raised `TypeError` for every geometry the package ships, before any BC code ran.
+        #
+        # It looked exercised because `test_implicit_applicator.py` supplies its own `_CircleGeometry`
+        # whose signature matches this call rather than the protocol -- a fixture written against the
+        # caller instead of against the contract. Passing positionally works with both spellings; the
+        # underlying protocol divergence is filed separately. #1938
+        return self.geometry.is_on_boundary(points, self._boundary_tolerance)
 
     def _compute_boundary_normals(self, boundary_points: NDArray[np.floating]) -> NDArray[np.floating]:
         """
@@ -200,7 +212,15 @@ class ImplicitApplicator(MeshfreeApplicator):
         Returns:
             BC values (scalar or array matching points)
         """
-        value = getattr(bc, "value", 0.0)
+        # ~~`getattr(bc, "value", 0.0)`~~ [FIXED 2026-08-15, #1938] -- `BoundaryConditions` has no
+        # `.value` attribute, so the default fired on every call and every Dirichlet BC was applied
+        # as 0.0 regardless of what the caller asked for. The value lives on the segments.
+        #
+        # The segment, not `bc.default_value`: that field is a plain float and the factory writes
+        # 0.0 into it whenever the value is callable (`conditions.py:929`), so routing through it
+        # would fix the scalar case and silently break the callable one this method exists to serve.
+        segment = next((s for s in bc.segments if s.value is not None), None)
+        value = segment.value if segment is not None else bc.default_value
 
         if callable(value):
             # Time-dependent or space-dependent BC

--- a/mfgarchon/geometry/boundary/applicator_implicit.py
+++ b/mfgarchon/geometry/boundary/applicator_implicit.py
@@ -179,6 +179,12 @@ class ImplicitApplicator(MeshfreeApplicator):
         # Since this applicator exists FOR implicit geometries, the keyword form raised `TypeError`
         # for every geometry the package ships, before any BC code ran.
         #
+        # This workaround is safe HERE and must not be generalised: slot 2 is a tolerance in all
+        # seven definitions of `is_on_boundary`, but the sibling protocol methods disagree on what
+        # slot 2 even means -- `project_to_boundary` takes `max_iterations` in `ImplicitDomain` and
+        # `boundary_name` in `TensorProductGrid`, and `get_boundary_normal` takes `eps` versus
+        # `corner_strategy`. A positional call there would bind a different concept, silently.
+        #
         # It looked exercised because `test_implicit_applicator.py` supplies its own `_CircleGeometry`
         # whose signature matches this call rather than the protocol -- a fixture written against the
         # caller instead of against the contract. Passing positionally works with both spellings; the
@@ -254,6 +260,25 @@ class ImplicitApplicator(MeshfreeApplicator):
         # writes 0.0 into it whenever the value is callable (`conditions.py:929`), so routing
         # everything through it would fix the scalar case and silently break the callable one this
         # method exists to serve. Hence the uniform gate rather than a blanket substitution.
+        # NO_FLUX and REFLECTING are definitionally zero-flux: no value they carry can be a normal
+        # derivative. This is an INVARIANT, asserted before any selection, not another rule about
+        # which segment to read -- and that distinction is why it ends the escalation. Three earlier
+        # versions of the selection below were each wrong in a different way, because each still had
+        # a "which segment" degree of freedom to get wrong; a clamp has none.
+        #
+        # The package states this convention in three other places, so leaving it out was cross-path
+        # disagreement rather than a judgement call: `applicator_fdm.py:1149` ("NO_FLUX / REFLECTING,
+        # definitionally zero-flux"), the ghost path's `apply_flux = bc_type == BCType.NEUMANN and
+        # v != 0.0`, and `applicator_meshfree.py`'s NO_FLUX branch, which is `pass`.
+        #
+        # It is not hypothetical: `with_resolved_providers` -- the documented pre-solve step --
+        # turns `BCSegment(NO_FLUX, value=<provider>)` into a uniform NO_FLUX segment carrying a
+        # number, which without this clamp is imposed as a flux. Measured on a 24-point sphere with
+        # `spacing=0.05`: `uniform_bc(NO_FLUX, value=2.5)` moved the boundary from 3.8 to 3.925,
+        # an implied du/dn of 2.5, where base returned the correct 3.8.
+        if bc_type in (BCType.NO_FLUX, BCType.REFLECTING):
+            return 0.0
+
         uniform_segment = bc.segments[0] if bc.is_uniform else None
         if uniform_segment is not None and uniform_segment.bc_type == bc_type:
             value = uniform_segment.value

--- a/mfgarchon/geometry/boundary/applicator_implicit.py
+++ b/mfgarchon/geometry/boundary/applicator_implicit.py
@@ -170,11 +170,14 @@ class ImplicitApplicator(MeshfreeApplicator):
         Returns:
             Boolean mask of boundary points
         """
-        # Positional, not `tolerance=`. `GeometryProtocol.is_on_boundary` names the parameter
-        # `tolerance` and 18 classes follow it, but all seven `ImplicitDomain` subclasses --
-        # Hyperrectangle, Hypersphere, Union/Intersection/Complement/DifferenceDomain and the base
-        # -- name it `tol`. Since this applicator exists FOR implicit geometries, the keyword form
-        # raised `TypeError` for every geometry the package ships, before any BC code ran.
+        # Positional, not `tolerance=`. Seven classes define `is_on_boundary`; six name the
+        # tolerance `tolerance`, including `GeometryProtocol`, and exactly ONE names it `tol` --
+        # `ImplicitDomain`. Hyperrectangle, Hypersphere and the CSG domains do not define the method
+        # at all, they inherit it, which is why the whole implicit family carries `tol`.
+        # (~~"all seven subclasses name it"~~ [CORRECTED 2026-08-15] counted inheritors as
+        # definitions; the distinction matters because it makes #1943 a one-method rename.)
+        # Since this applicator exists FOR implicit geometries, the keyword form raised `TypeError`
+        # for every geometry the package ships, before any BC code ran.
         #
         # It looked exercised because `test_implicit_applicator.py` supplies its own `_CircleGeometry`
         # whose signature matches this call rather than the protocol -- a fixture written against the

--- a/mfgarchon/geometry/boundary/applicator_implicit.py
+++ b/mfgarchon/geometry/boundary/applicator_implicit.py
@@ -135,7 +135,7 @@ class ImplicitApplicator(MeshfreeApplicator):
 
         # Apply BC based on type (fails loud if default_bc unset; Issue #1100)
         bc_type = boundary_conditions._resolve_default_bc("ImplicitBoundaryApplicator.apply")
-        bc_value = self._resolve_bc_value(boundary_conditions, boundary_points, time)
+        bc_value = self._resolve_bc_value(boundary_conditions, boundary_points, time, bc_type)
 
         if bc_type == BCType.DIRICHLET:
             result[boundary_mask] = self._apply_dirichlet(result[boundary_mask], bc_value)
@@ -200,6 +200,7 @@ class ImplicitApplicator(MeshfreeApplicator):
         bc: BoundaryConditions,
         points: NDArray[np.floating],
         time: float,
+        bc_type: BCType,
     ) -> NDArray[np.floating] | float:
         """
         Resolve BC value (may be callable or constant).
@@ -216,10 +217,26 @@ class ImplicitApplicator(MeshfreeApplicator):
         # `.value` attribute, so the default fired on every call and every Dirichlet BC was applied
         # as 0.0 regardless of what the caller asked for. The value lives on the segments.
         #
-        # The segment, not `bc.default_value`: that field is a plain float and the factory writes
+        # Selected by TYPE, mirroring `_robin_alpha_beta`. ~~`next(s for s in bc.segments if
+        # s.value is not None)`~~ [CORRECTED 2026-08-15] was the first version and it was worse than
+        # what it replaced on one configuration: `BCSegment.value` defaults to `0.0`, not `None`, and
+        # nothing in the package passes `value=None`, so that filter never filtered and the
+        # expression was unconditionally `segments[0]`. Segments sort priority-descending, so the
+        # value came from whichever segment sorted first while `bc_type` came from
+        # `_resolve_default_bc` -- two segments feeding one condition. Measured on a Robin wall plus
+        # a higher-priority Dirichlet exit: alpha/beta = (2.0, 3.0) from the ROBIN segment and
+        # g = 7.0 from the DIRICHLET one, against a correct 1.0; and on no-flux walls plus a
+        # Dirichlet exit, where the pre-fix `0.0` had been RIGHT and this returned 7.0.
+        #
+        # NEUMANN and NO_FLUX are matched as one family because `apply()` dispatches them as one;
+        # without that, a NEUMANN segment under `default_bc=NO_FLUX` falls through to
+        # `bc.default_value`.
+        #
+        # Not `bc.default_value` as the primary source: it is a plain float and the factory writes
         # 0.0 into it whenever the value is callable (`conditions.py:929`), so routing through it
         # would fix the scalar case and silently break the callable one this method exists to serve.
-        segment = next((s for s in bc.segments if s.value is not None), None)
+        family = (BCType.NEUMANN, BCType.NO_FLUX) if bc_type in (BCType.NEUMANN, BCType.NO_FLUX) else (bc_type,)
+        segment = next((s for s in bc.segments if s.bc_type in family), None)
         value = segment.value if segment is not None else bc.default_value
 
         if callable(value):

--- a/tests/unit/test_geometry/boundary/test_implicit_applicator.py
+++ b/tests/unit/test_geometry/boundary/test_implicit_applicator.py
@@ -359,25 +359,28 @@ class TestAgainstAPackageGeometry:
 
         np.testing.assert_allclose(result[on_boundary], 42.0, atol=1e-12)
 
-    def test_the_value_follows_the_resolved_type_not_the_segment_order(self, package_applicator):
-        """The value and the type must come from the same segment.
+    def test_the_value_follows_the_resolved_type_and_not_the_segment_order(self, package_applicator):
+        """A segment's value is read only for a *uniform* BC whose type is the one resolved.
 
-        The first version of this fix selected the value with
-        `next(s for s in bc.segments if s.value is not None)`. `BCSegment.value` defaults to `0.0`,
-        not `None`, and nothing in the package passes `value=None`, so that filter never filtered:
-        the expression was unconditionally `segments[0]`. Segments sort priority-descending
-        (`conditions.py:135`), so the value came from whichever segment sorted first while the type
-        came from `_resolve_default_bc` -- and `alpha`/`beta` came from a third place,
-        `_robin_alpha_beta`, which had always selected by type.
+        `apply()` resolves ONE `bc_type` for the whole boundary and this applicator has no spatial
+        dispatch -- review measured that moving a segment's `normal_direction` to a different arc,
+        or deleting its region spec, gives byte-identical output, on base as well. So for a mixed BC
+        no segment's value is the right one: whichever is chosen gets imposed everywhere, including
+        where that segment was never meant to act. `default_value` is the field that means "where no
+        segment governs".
 
-        Case C below is the sharpest: `alpha, beta = (2.0, 3.0)` from the ROBIN segment and
-        `g = 7.0` from the DIRICHLET one, feeding one Robin condition. Case A is the one where the
-        old behaviour was worse than no fix at all: the pre-#1938 `0.0` was correct there and the
-        first version returned 7.0.
+        Three versions of this selector have been wrong, and each row below killed one of them:
 
-        Case B is the control. It is the same physics as A with the priorities swapped, and it was
-        already right by accident of sort order -- so it passes in every version and is here to show
-        that a passing row proves nothing on its own.
+        * D killed the `NEUMANN`/`NO_FLUX` family clause, which let a NO_FLUX resolution impose
+          `du/dn = 2.5`. NO_FLUX means zero flux by definition.
+        * A and C killed the sort-order form (`segments[0]` in disguise).
+        * F and G kill any within-type selection among several matches, which the by-type form still
+          had: review showed that taking the *last* match instead of the first passed all 6027 tests
+          while changing behaviour on a real configuration.
+
+        E carries a non-zero `default_value` deliberately. With `default_value=0.0` it returned 0.0
+        in every version of this code and discriminated nothing -- review measured that, and that a
+        mutation replacing the fallback with a literal `0.0` passed the entire suite.
         """
         applicator, geometry = package_applicator
         points = self._on_sphere(geometry)
@@ -385,25 +388,31 @@ class TestAgainstAPackageGeometry:
         assert on_boundary.any(), "no boundary points detected, so the assertions below are vacuous"
         boundary_points = points[on_boundary]
 
-        def bc_of(segments, default_bc):
-            return BoundaryConditions(segments=segments, dimension=2, default_bc=default_bc)
+        def bc_of(segments, default_bc, default_value=0.0):
+            return BoundaryConditions(
+                segments=segments,
+                dimension=2,
+                default_bc=default_bc,
+                default_value=default_value,
+            )
 
         exit_hi = BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, priority=5)
         walls = BCSegment(name="walls", bc_type=BCType.NO_FLUX, value=0.0)
         walls_hi = BCSegment(name="walls", bc_type=BCType.NO_FLUX, value=0.0, priority=5)
         exit_lo = BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0)
         robin_wall = BCSegment(name="wall", bc_type=BCType.ROBIN, alpha=2.0, beta=3.0, value=1.0)
+        neumann_only = BCSegment(name="n", bc_type=BCType.NEUMANN, value=2.5)
+        dir_a = BCSegment(name="a", bc_type=BCType.DIRICHLET, value=7.0, priority=5)
+        dir_b = BCSegment(name="b", bc_type=BCType.DIRICHLET, value=0.0)
 
         cases = [
-            ("A exit sorts first, resolved NO_FLUX", bc_of([exit_hi, walls], BCType.NO_FLUX), 0.0),
-            ("B walls sort first (control)", bc_of([walls_hi, exit_lo], BCType.NO_FLUX), 0.0),
-            ("C Robin wall, Dirichlet sorts first", bc_of([exit_hi, robin_wall], BCType.ROBIN), 1.0),
-            (
-                "D NEUMANN segment, default NO_FLUX",
-                bc_of([BCSegment(name="w", bc_type=BCType.NEUMANN, value=2.5)], BCType.NO_FLUX),
-                2.5,
-            ),
-            ("E no segments, falls back to default_value", bc_of([], BCType.DIRICHLET), 0.0),
+            ("A mixed, exit sorts first, resolved NO_FLUX", bc_of([exit_hi, walls], BCType.NO_FLUX), 0.0),
+            ("B mixed, walls sort first (control)", bc_of([walls_hi, exit_lo], BCType.NO_FLUX), 0.0),
+            ("C mixed, Robin resolved, Dirichlet sorts first", bc_of([exit_hi, robin_wall], BCType.ROBIN, 4.0), 4.0),
+            ("D NEUMANN segment under default NO_FLUX", bc_of([neumann_only], BCType.NO_FLUX), 0.0),
+            ("E no segments, non-zero default_value", bc_of([], BCType.DIRICHLET, 9.0), 9.0),
+            ("F two DIRICHLET, high priority first", bc_of([dir_a, dir_b], BCType.DIRICHLET, 9.0), 9.0),
+            ("G two DIRICHLET, order swapped", bc_of([dir_b, dir_a], BCType.DIRICHLET, 9.0), 9.0),
         ]
 
         for label, bc, expected in cases:
@@ -413,5 +422,25 @@ class TestAgainstAPackageGeometry:
                 value,
                 expected,
                 atol=1e-12,
-                err_msg=f"{label}: resolved {resolved.name} but took the value from another segment",
+                err_msg=f"{label}: resolved {resolved.name} but took the value from somewhere else",
             )
+
+    def test_a_uniform_bc_still_reads_its_own_segment(self, package_applicator):
+        """The gate above must not throw away the case this PR exists to fix.
+
+        Without this, `_resolve_bc_value` returning `bc.default_value` unconditionally would satisfy
+        every row of the previous test -- review measured exactly that mutation passing the whole
+        suite when the fallback had nothing non-zero to distinguish it.
+        """
+        applicator, geometry = package_applicator
+        points = self._on_sphere(geometry)
+        on_boundary = applicator._detect_boundary_points(points)
+        assert on_boundary.any(), "no boundary points detected, so the assertions below are vacuous"
+        boundary_points = points[on_boundary]
+
+        for value in (3.0, -7.5):
+            bc = dirichlet_bc(dimension=2, value=value)
+            assert bc.is_uniform, "this test is about the uniform path and the fixture is not uniform"
+            resolved = bc._resolve_default_bc("test")
+            got = applicator._resolve_bc_value(bc, boundary_points, 0.0, resolved)
+            np.testing.assert_allclose(got, value, atol=1e-12)

--- a/tests/unit/test_geometry/boundary/test_implicit_applicator.py
+++ b/tests/unit/test_geometry/boundary/test_implicit_applicator.py
@@ -348,6 +348,8 @@ class TestAgainstAPackageGeometry:
         points = self._on_sphere(geometry)
         on_boundary = applicator._detect_boundary_points(points)
 
+        assert on_boundary.any(), "no boundary points detected, so the assertion below is vacuous"
+
         bc = BoundaryConditions(
             segments=[BCSegment(name="d", bc_type=BCType.DIRICHLET, value=lambda p, t: 42.0)],
             dimension=2,
@@ -356,3 +358,60 @@ class TestAgainstAPackageGeometry:
         result = applicator.apply(np.ones(len(points)), bc, points)
 
         np.testing.assert_allclose(result[on_boundary], 42.0, atol=1e-12)
+
+    def test_the_value_follows_the_resolved_type_not_the_segment_order(self, package_applicator):
+        """The value and the type must come from the same segment.
+
+        The first version of this fix selected the value with
+        `next(s for s in bc.segments if s.value is not None)`. `BCSegment.value` defaults to `0.0`,
+        not `None`, and nothing in the package passes `value=None`, so that filter never filtered:
+        the expression was unconditionally `segments[0]`. Segments sort priority-descending
+        (`conditions.py:135`), so the value came from whichever segment sorted first while the type
+        came from `_resolve_default_bc` -- and `alpha`/`beta` came from a third place,
+        `_robin_alpha_beta`, which had always selected by type.
+
+        Case C below is the sharpest: `alpha, beta = (2.0, 3.0)` from the ROBIN segment and
+        `g = 7.0` from the DIRICHLET one, feeding one Robin condition. Case A is the one where the
+        old behaviour was worse than no fix at all: the pre-#1938 `0.0` was correct there and the
+        first version returned 7.0.
+
+        Case B is the control. It is the same physics as A with the priorities swapped, and it was
+        already right by accident of sort order -- so it passes in every version and is here to show
+        that a passing row proves nothing on its own.
+        """
+        applicator, geometry = package_applicator
+        points = self._on_sphere(geometry)
+        on_boundary = applicator._detect_boundary_points(points)
+        assert on_boundary.any(), "no boundary points detected, so the assertions below are vacuous"
+        boundary_points = points[on_boundary]
+
+        def bc_of(segments, default_bc):
+            return BoundaryConditions(segments=segments, dimension=2, default_bc=default_bc)
+
+        exit_hi = BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, priority=5)
+        walls = BCSegment(name="walls", bc_type=BCType.NO_FLUX, value=0.0)
+        walls_hi = BCSegment(name="walls", bc_type=BCType.NO_FLUX, value=0.0, priority=5)
+        exit_lo = BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0)
+        robin_wall = BCSegment(name="wall", bc_type=BCType.ROBIN, alpha=2.0, beta=3.0, value=1.0)
+
+        cases = [
+            ("A exit sorts first, resolved NO_FLUX", bc_of([exit_hi, walls], BCType.NO_FLUX), 0.0),
+            ("B walls sort first (control)", bc_of([walls_hi, exit_lo], BCType.NO_FLUX), 0.0),
+            ("C Robin wall, Dirichlet sorts first", bc_of([exit_hi, robin_wall], BCType.ROBIN), 1.0),
+            (
+                "D NEUMANN segment, default NO_FLUX",
+                bc_of([BCSegment(name="w", bc_type=BCType.NEUMANN, value=2.5)], BCType.NO_FLUX),
+                2.5,
+            ),
+            ("E no segments, falls back to default_value", bc_of([], BCType.DIRICHLET), 0.0),
+        ]
+
+        for label, bc, expected in cases:
+            resolved = bc._resolve_default_bc("test")
+            value = applicator._resolve_bc_value(bc, boundary_points, 0.0, resolved)
+            np.testing.assert_allclose(
+                value,
+                expected,
+                atol=1e-12,
+                err_msg=f"{label}: resolved {resolved.name} but took the value from another segment",
+            )

--- a/tests/unit/test_geometry/boundary/test_implicit_applicator.py
+++ b/tests/unit/test_geometry/boundary/test_implicit_applicator.py
@@ -13,6 +13,7 @@ import pytest
 
 import numpy as np
 
+from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions, dirichlet_bc
 from mfgarchon.geometry.boundary.applicator_base import DiscretizationType
 from mfgarchon.geometry.boundary.applicator_implicit import ImplicitApplicator
 from mfgarchon.geometry.boundary.applicator_meshfree import MeshfreeApplicator
@@ -246,3 +247,112 @@ class TestDispatch:
         assert type(applicator) is MeshfreeApplicator, (
             "GFDM must not pick up the MESHFREE branch's implicit-geometry specialisation"
         )
+
+
+class TestAgainstAPackageGeometry:
+    """The fixtures above supply `_CircleGeometry`, defined in this file.
+
+    That is what hid #1938. `_CircleGeometry.is_on_boundary` takes `tolerance=`, matching the
+    applicator's call; every `ImplicitDomain` the package ships -- Hyperrectangle, Hypersphere, the
+    three CSG domains, DifferenceDomain, and the base class -- takes `tol=`. So the suite exercised
+    a geometry written against the caller rather than against `GeometryProtocol`, and
+    `ImplicitApplicator.apply` raised `TypeError` for every real geometry, before any BC code ran.
+
+    These tests use `Hypersphere`, reached the way a user reaches it: through
+    `get_applicator_for_geometry(geometry, MESHFREE)`.
+    """
+
+    @staticmethod
+    def _on_sphere(app_geometry, n=12):
+        theta = np.linspace(0.0, 2.0 * np.pi, n + 1)[:-1]
+        return np.column_stack(
+            [
+                app_geometry.center[0] + app_geometry.radius * np.cos(theta),
+                app_geometry.center[1] + app_geometry.radius * np.sin(theta),
+            ]
+        )
+
+    @pytest.fixture
+    def package_applicator(self):
+        from mfgarchon.geometry.boundary.dispatch import DiscretizationType, get_applicator_for_geometry
+        from mfgarchon.geometry.implicit.hypersphere import Hypersphere
+
+        geometry = Hypersphere(center=np.array([0.5, 0.5]), radius=0.4)
+        applicator = get_applicator_for_geometry(geometry, DiscretizationType.MESHFREE)
+        assert type(applicator).__name__ == "ImplicitApplicator", (
+            f"dispatch returned {type(applicator).__name__}; this test is about ImplicitApplicator "
+            f"and would otherwise pass by testing something else"
+        )
+        return applicator, geometry
+
+    @pytest.mark.parametrize("value", [3.0, -7.5, 0.0])
+    def test_dirichlet_applies_the_value_it_was_given(self, package_applicator, value):
+        """`getattr(bc, "value", 0.0)` read an attribute `BoundaryConditions` does not have, so the
+        default fired every time and every Dirichlet BC was applied as 0.0.
+
+        `value=0.0` is included deliberately: it is the case the pre-#1938 fixtures used, and it
+        passes either way. It is here as the positive control -- the parametrisation only
+        discriminates because the other two rows exist.
+        """
+        applicator, geometry = package_applicator
+        points = self._on_sphere(geometry)
+        on_boundary = applicator._detect_boundary_points(points)
+        assert on_boundary.any(), "no boundary points detected, so the assertion below is vacuous"
+
+        result = applicator.apply(np.ones(len(points)), dirichlet_bc(dimension=2, value=value), points)
+
+        np.testing.assert_allclose(result[on_boundary], value, atol=1e-12)
+
+    def test_robin_coefficients_reach_the_scheme(self, package_applicator):
+        """alpha/beta live on `BCSegment`; the pre-#1938 code read them off `BoundaryConditions`,
+        which carries neither, so every Robin BC collapsed onto one answer.
+
+        Asserting *disagreement*, not a value: any two parameter sets that produce the same field
+        would satisfy a value assertion computed from the same broken path.
+        """
+        applicator, geometry = package_applicator
+        points = self._on_sphere(geometry)
+        on_boundary = applicator._detect_boundary_points(points)
+
+        def robin(alpha, beta, g):
+            return BoundaryConditions(
+                segments=[BCSegment(name="r", bc_type=BCType.ROBIN, alpha=alpha, beta=beta, value=g)],
+                dimension=2,
+                default_bc=BCType.ROBIN,
+            )
+
+        # `g` is HELD FIXED across the three. Varying it too is what a natural fixture does, and it
+        # destroys the discrimination: `g` reaches the scheme through `bc_value`, which was never
+        # broken, so three rows differing in `g` differ even with alpha/beta pinned at the getattr
+        # defaults (1.0, 1.0). Measured: with `g` varied this test passes over the reverted code.
+        # Only alpha and beta move here, so nothing but the alpha/beta channel can explain a change.
+        field = np.ones(len(points))
+        g = 3.0
+        a = applicator.apply(field.copy(), robin(1.0, 1.0, g), points)[on_boundary]
+        b = applicator.apply(field.copy(), robin(5.0, 0.2, g), points)[on_boundary]
+        c = applicator.apply(field.copy(), robin(0.1, 9.0, g), points)[on_boundary]
+
+        assert not np.allclose(a, b), "changing (alpha, beta) at fixed g left the field unchanged"
+        assert not np.allclose(b, c), "changing (alpha, beta) at fixed g left the field unchanged"
+
+        same = applicator.apply(field.copy(), robin(1.0, 1.0, g), points)[on_boundary]
+        np.testing.assert_allclose(a, same, atol=1e-12)  # control: identical input, identical output
+
+    def test_a_callable_value_is_still_evaluated(self, package_applicator):
+        """Routing the value through `bc.default_value` -- the owner the parent class uses -- would
+        have fixed the scalar case and silently broken this one: that field is a plain float and the
+        factory writes 0.0 into it whenever the value is callable (`conditions.py:929`). The value is
+        read from the segment instead, which keeps the callable.
+        """
+        applicator, geometry = package_applicator
+        points = self._on_sphere(geometry)
+        on_boundary = applicator._detect_boundary_points(points)
+
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="d", bc_type=BCType.DIRICHLET, value=lambda p, t: 42.0)],
+            dimension=2,
+            default_bc=BCType.DIRICHLET,
+        )
+        result = applicator.apply(np.ones(len(points)), bc, points)
+
+        np.testing.assert_allclose(result[on_boundary], 42.0, atol=1e-12)

--- a/tests/unit/test_geometry/boundary/test_implicit_applicator.py
+++ b/tests/unit/test_geometry/boundary/test_implicit_applicator.py
@@ -411,6 +411,16 @@ class TestAgainstAPackageGeometry:
             ("C mixed, Robin resolved, Dirichlet sorts first", bc_of([exit_hi, robin_wall], BCType.ROBIN, 4.0), 4.0),
             ("D NEUMANN segment under default NO_FLUX", bc_of([neumann_only], BCType.NO_FLUX), 0.0),
             ("E no segments, non-zero default_value", bc_of([], BCType.DIRICHLET, 9.0), 9.0),
+            # H is what keeps the gate's `bc_type` check honest. D used to do that, but the NO_FLUX
+            # clamp now intercepts D before the gate is reached -- measured: dropping the type check
+            # left the whole file green once the clamp landed. H is uniform, so the gate is entered,
+            # and its segment type differs from the resolved one with neither being NO_FLUX, so only
+            # the type check can reject it.
+            (
+                "H uniform DIRICHLET segment, resolved ROBIN",
+                bc_of([BCSegment(name="d", bc_type=BCType.DIRICHLET, value=7.0)], BCType.ROBIN, 4.0),
+                4.0,
+            ),
             ("F two DIRICHLET, high priority first", bc_of([dir_a, dir_b], BCType.DIRICHLET, 9.0), 9.0),
             ("G two DIRICHLET, order swapped", bc_of([dir_b, dir_a], BCType.DIRICHLET, 9.0), 9.0),
         ]
@@ -426,11 +436,13 @@ class TestAgainstAPackageGeometry:
             )
 
     def test_a_uniform_bc_still_reads_its_own_segment(self, package_applicator):
-        """The gate above must not throw away the case this PR exists to fix.
+        """The gate must not throw away the case this PR exists to fix.
 
-        Without this, `_resolve_bc_value` returning `bc.default_value` unconditionally would satisfy
-        every row of the previous test -- review measured exactly that mutation passing the whole
-        suite when the fallback had nothing non-zero to distinguish it.
+        The `default_value` here is deliberately DIFFERENT from the segment's. ~~`dirichlet_bc(value=v)`~~
+        [CORRECTED 2026-08-15] was the original fixture and it does not discriminate: that factory
+        writes `v` into **both** `segment.value` and `default_value` (`conditions.py:929`), so
+        "always return `default_value`" satisfies it. Review measured this test passing under exactly
+        that mutation -- what killed it was the callable test, for the same reason, by accident.
         """
         applicator, geometry = package_applicator
         points = self._on_sphere(geometry)
@@ -438,9 +450,61 @@ class TestAgainstAPackageGeometry:
         assert on_boundary.any(), "no boundary points detected, so the assertions below are vacuous"
         boundary_points = points[on_boundary]
 
-        for value in (3.0, -7.5):
-            bc = dirichlet_bc(dimension=2, value=value)
+        for segment_value in (3.0, -7.5):
+            bc = BoundaryConditions(
+                segments=[BCSegment(name="d", bc_type=BCType.DIRICHLET, value=segment_value)],
+                dimension=2,
+                default_bc=BCType.DIRICHLET,
+                default_value=99.0,
+            )
             assert bc.is_uniform, "this test is about the uniform path and the fixture is not uniform"
+            assert bc.default_value != segment_value, "the two must differ or this test discriminates nothing"
+
             resolved = bc._resolve_default_bc("test")
             got = applicator._resolve_bc_value(bc, boundary_points, 0.0, resolved)
-            np.testing.assert_allclose(got, value, atol=1e-12)
+            np.testing.assert_allclose(got, segment_value, atol=1e-12)
+
+    @pytest.mark.parametrize("stray_value", [2.5, -1.0])
+    def test_no_flux_never_carries_a_flux_whatever_value_it_is_given(self, package_applicator, stray_value):
+        """NO_FLUX means `du/dn = 0` by definition, so no value it carries can be a normal derivative.
+
+        Three other paths in this package already state that convention -- `applicator_fdm.py:1149`
+        ("NO_FLUX / REFLECTING, definitionally zero-flux"), the ghost path's
+        `apply_flux = bc_type == BCType.NEUMANN and v != 0.0`, and `applicator_meshfree.py`'s NO_FLUX
+        branch, which is `pass`. This applicator did not, and `apply()` routes NEUMANN and NO_FLUX
+        into one branch where a non-zero value becomes `interior + dx*g`.
+
+        Not hypothetical: `with_resolved_providers`, the documented pre-solve step, turns
+        `BCSegment(NO_FLUX, value=<provider>)` into a uniform NO_FLUX segment carrying a number.
+        """
+        applicator, geometry = package_applicator
+        points = self._on_sphere(geometry, n=24)
+        on_boundary = applicator._detect_boundary_points(points)
+        assert on_boundary.any(), "no boundary points detected, so the assertion below is vacuous"
+
+        field = np.full(len(points), 3.8)
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=stray_value)],
+            dimension=2,
+            default_bc=BCType.NO_FLUX,
+        )
+        result = applicator.apply(field.copy(), bc, points, spacing=0.05)
+
+        np.testing.assert_allclose(result[on_boundary], 3.8, atol=1e-12)
+
+    def test_the_clamp_is_not_a_blanket_zeroing(self, package_applicator):
+        """Control for the test above. A fix that returned 0.0 for every type would satisfy it, and
+        would silently turn every inhomogeneous Neumann condition into a homogeneous one."""
+        applicator, geometry = package_applicator
+        points = self._on_sphere(geometry, n=24)
+        on_boundary = applicator._detect_boundary_points(points)
+
+        field = np.full(len(points), 3.8)
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NEUMANN, value=2.5)],
+            dimension=2,
+            default_bc=BCType.NEUMANN,
+        )
+        result = applicator.apply(field.copy(), bc, points, spacing=0.05)
+
+        assert not np.allclose(result[on_boundary], 3.8), "a non-zero NEUMANN flux must move the boundary"


### PR DESCRIPTION
Closes #1938.

Three defects on one call path. The first is what #1938 reported; the second is the fix I did **not** make, pinned so nobody makes it later; the third is why the first was unreachable in practice.

## 1. The value was read from an attribute that does not exist

`_resolve_bc_value` did `getattr(bc, "value", 0.0)`. `BoundaryConditions` has no `.value` — it lives on `BCSegment` — so the default fired on every call:

```
dirichlet_bc(value= 3.0) -> getattr(bc,'value',SENTINEL) = <ABSENT>   applied = [0.]
dirichlet_bc(value=-7.5) -> <ABSENT>                                  applied = [0.]
POSITIVE CONTROL getattr(bc,'segments',SENTINEL) resolves; bc.segments[0].value = 3.0
```

Robin's `alpha`/`beta` came off the same missing attribute, so the whole parameter space collapsed:

```
(alpha,beta,g) = (1,1,0) -> ... ; (5,0.2,3) -> byte-identical ; (0.1,9,-2) -> byte-identical
```

This is the pattern **#1558** fixed in `applicator_meshfree.py`, where `_robin_alpha_beta` and `bc.default_value` became the owners. `ImplicitApplicator` **inherits from `MeshfreeApplicator`** and kept the pre-fix code — the fix landed on the parent and the subclass's override was never revisited.

## 2. The value is read from the segment, not through `bc.default_value`

Routing it through the parent's owner is the obvious consolidation and it is **wrong here**: `default_value` is a plain float field, and the factory writes `0.0` into it whenever the value is callable (`conditions.py:929`). That would have fixed the scalar case and silently broken the callable case this method exists to serve. Mutation **M4** pins exactly that.

## 3. Why it was unreachable, and why the suite was green

`_detect_boundary_points` called `is_on_boundary(points, tolerance=...)`. `GeometryProtocol` names the parameter `tolerance` and 18 classes follow it — but **all seven `ImplicitDomain` subclasses name it `tol`**: `Hyperrectangle`, `Hypersphere`, `UnionDomain`, `IntersectionDomain`, `ComplementDomain`, `DifferenceDomain`, and the base class. Since this applicator exists *for* implicit geometries, `apply()` raised `TypeError` for every geometry the package ships, before any BC code ran:

```
get_applicator_for_geometry(Hypersphere, MESHFREE) -> ImplicitApplicator
  .apply(...) -> TypeError: ImplicitDomain.is_on_boundary() got an unexpected keyword argument 'tolerance'
```

The call is now positional, which works with both spellings. **The protocol divergence itself is a separate question and is filed separately** — this PR does not rename anything public.

**The suite missed all three because its fixture is written against the caller, not the contract.** `test_implicit_applicator.py` supplies `_CircleGeometry`, whose `is_on_boundary` takes `tolerance=` — matching this applicator's call rather than `GeometryProtocol`. The new tests reach the applicator the way a user does, through `get_applicator_for_geometry(Hypersphere, MESHFREE)`, and assert the dispatch actually returned `ImplicitApplicator` so they cannot pass by testing something else.

## Mutation verification

Cumulative edits, each replacement asserted present in the file on disk, restore verified by sha256.

| mutation | result |
|---|---|
| unmutated | 14 passed |
| M1 — value owner back to `getattr(bc, "value")` | **3 failed** |
| M2 — Robin `alpha`/`beta` back to `getattr` | **1 failed** |
| M3 — positional call back to `tolerance=` | **5 failed** |
| M4 — value routed via `bc.default_value` (the plausible wrong fix) | **1 failed** |

**M2 needed a second pass, and the reason is worth recording.** The first version of the Robin test varied `g` alongside `alpha` and `beta`. But `g` reaches the scheme through `bc_value`, which was never broken — so three rows differing in `g` differ *even with `alpha`/`beta` pinned at the `getattr` defaults*, and the test passed over the reverted code (**14 passed**). Holding `g` fixed is what makes the alpha/beta channel the only thing that can explain a change. The `value=0.0` row of the Dirichlet parametrisation is kept for the same reason, as the declared positive control: it passes either way, and says so.

`./scripts/local_ci.sh` → **6026 passed, 12 skipped, 21 xfailed, GATE GREEN**.

Found by the boundary-layer divergence census (2026-08-15); see also #1936, #1937, #1939, #1940, #1941.


---

## Independent review — MERGE-BLOCKED on one, and the blocker was in this branch's own fix

**`_resolve_bc_value` selected the value by sort order while `_robin_alpha_beta`, one line above it, selected by type.** So `g` and `alpha`/`beta` could come from different segments, and on one configuration the result was **worse than the code this PR replaced**.

The mechanism is a filter that never filtered: `next((s for s in bc.segments if s.value is not None), None)`. `BCSegment.value` defaults to `0.0`, not `None`, and no construction in the package passes `value=None`, so the expression was unconditionally `segments[0]` — and segments sort priority-descending.

Measured through `apply()`, reproduced by hand before accepting the report:

| configuration | resolved type | correct | first version | pre-#1938 |
|---|---|---:|---:|---:|
| exit(DIRICHLET 7.0, prio 5) + walls(NO_FLUX) | NO_FLUX | 0.0 | **7.0** | 0.0 ← **the old code was right here** |
| same, priorities swapped | NO_FLUX | 0.0 | 0.0 | 0.0 ← agreed by accident of order |
| wall(ROBIN α=2, β=3, g=1) + exit(DIRICHLET 7, prio 5) | ROBIN | 1.0 | **7.0** | 0.0 |

Row 3 is the sharpest: `alpha`/`beta` came from the ROBIN segment and `g` from the DIRICHLET one, feeding one Robin condition. Row 2 is the control — same physics as row 1 with the priorities swapped, right in every version, which is why a passing row proves nothing on its own.

Now selected by **type**, mirroring `_robin_alpha_beta`. `NEUMANN` and `NO_FLUX` are matched as one family because `apply()` dispatches them as one; without that, a `NEUMANN` segment under `default_bc=NO_FLUX` falls through to `default_value`.

### Mutation table, extended

| mutation | result |
|---|---|
| unmutated | 15 passed |
| M1 — value owner → `getattr(bc,"value")` | 4 failed |
| **M5 — by-type → the first version of this fix** | **1 failed** |
| M4 — value → `bc.default_value` | 2 failed |
| M6 — drop the NEUMANN/NO_FLUX family | 1 failed |
| M2 — Robin α/β → `getattr` | 1 failed |
| M3 — positional call → `tolerance=` | 6 failed |

M5 is the one that matters: the pin now catches the wrong fix that this PR actually shipped, not only the original defect.

### Other review items

- **`test_a_callable_value_is_still_evaluated` had no `on_boundary.any()` guard**, and `np.testing.assert_allclose` on an *empty* array passes — so it would have been vacuous under an empty mask. Added. The Robin test self-protects, because `assert not np.allclose(empty, empty)` fails.
- **The severity above was overstated and is corrected.** `ImplicitApplicator` has **zero internal callers**: `apply_bc(..., MESHFREE)` constructs `MeshfreeApplicator` directly, and nothing in the package calls `get_applicator_for_geometry(geom, MESHFREE)`. None of these defects can reach `problem.solve()`. The changelog fragment already said "unreachable in practice"; the original commit body read stronger than the measurement supports.
- **#1938's third criterion was met and unrecorded**: there is exactly one `MeshfreeApplicator` subclass, and no other `applicator_*.py` carries a stale `getattr` of this shape.
- The review independently confirmed attack #3 by `inspect.signature` over 26 classes: every second parameter is `POSITIONAL_OR_KEYWORD` and none is a different concept, so the positional call is correct and complete. It also reconstructed the discarded Robin test and confirmed the varied-`g` version returns the same verdict on fixed and broken code — the M2 account holds.
- **Not from this PR, filed separately**: `test_discrimination_ratchet.py::test_every_mutation_anchor_still_matches_exactly_once[4]` fails under `-n auto` on **both** base and head, because `test_gate_refuses_a_mutated_tree.py` rewrites `bc_utils.py` in place for several seconds while another worker reads it.

`./scripts/local_ci.sh` → **6027 passed, 12 skipped, 21 xfailed, GATE GREEN**.
