### PR TITLE
fix(geometry): the per-face ghost path drops the flux and invents a fallback

### DIFF
--- a/changelog.d/1937-per-face-bc-path.fixed.md
+++ b/changelog.d/1937-per-face-bc-path.fixed.md
@@ -1,0 +1,11 @@
+The per-face ghost path silently dropped a non-zero Neumann flux and handed unclaimed walls the
+first segment instead of `default_bc`.
+
+`PreallocatedGhostBuffer` dispatches on `bc.is_uniform`, so stating the same boundary condition as
+one unrestricted segment or as one segment per face selected different code. `_apply_ghost_for_face`
+mirrored the interior without adding `dx * value`, which `_apply_linear_reflection` has done since
+#1262 — a per-face `du/dn = 2` was applied as `du/dn = 0`. Its fallback for a face no segment claimed
+was `bc.segments[0]`, and segments sort priority-descending, so the highest-priority segment (usually
+the exit) governed every wall it had not claimed; `default_bc` was never consulted. Resolution now
+goes through `_resolve_default_bc`, which raises when no default is set (#1100) rather than supplying
+one by accident of sort order.

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -1513,10 +1513,25 @@ class PreallocatedGhostBuffer:
                 segment = self._find_segment_for_face(bc, target_face)
 
                 if segment is None:
-                    # No explicit segment - use default BC (first segment or Neumann)
-                    segment = bc.segments[0] if bc.segments else None
-                    if segment is None:
-                        continue  # No BC defined, skip
+                    # `default_bc`, not `bc.segments[0]`. Segments are sorted priority-DESCENDING
+                    # (`conditions.py:135`), so the old fallback handed every unclaimed wall the
+                    # highest-priority segment -- typically the exit. Measured on the mixed-BC idiom
+                    # from `BCSegment`'s own docstring (one DIRICHLET exit on x_min, default_bc
+                    # NO_FLUX): 4 of 4 walls received the Dirichlet ghost, and dropping the exit's
+                    # priority to -5 changed it to 1 of 4, which is the fingerprint of a sort-order
+                    # fallback rather than of any BC semantics. `default_bc` exists, is documented,
+                    # and `get_bc_type_at_boundary` already answers correctly on the same object.
+                    #
+                    # `_resolve_default_bc` raises when `default_bc` is unset (#1100) rather than
+                    # guessing -- that is deliberate and it is why this is not a silent change: a BC
+                    # whose segments do not cover every face and which names no default was
+                    # previously given one by accident of sort order.
+                    default_type = bc._resolve_default_bc("PreallocatedGhostBuffer._update_ghosts_mixed")
+                    segment = BCSegment(
+                        name="__default__",
+                        bc_type=default_type,
+                        value=bc.default_value,
+                    )
 
                 # Apply ghost cell formula for this face
                 self._apply_ghost_for_face(buf, axis, side, segment, time, g)
@@ -1632,9 +1647,22 @@ class PreallocatedGhostBuffer:
             buf[tuple(ghost_slices)] = 2 * v - buf[tuple(interior_slices)]
 
         elif bc_type in [BCType.NO_FLUX, BCType.NEUMANN, BCType.REFLECTING]:
-            # Zero-gradient Neumann: ghost = adjacent interior (simple reflection).
-            # For cell-centered grids: du/dn = (u_interior - u_ghost)/dx = 0
-            # => u_ghost = u_interior (adjacent)
+            # ghost = adjacent interior, PLUS dx*v for an inhomogeneous Neumann flux.
+            #
+            # The flux term was missing here while `_apply_linear_reflection` (the uniform-BC path,
+            # :1151) has carried it since #1262. Both paths are live and which one runs is decided
+            # by `bc.is_uniform` -- i.e. by whether the caller wrote one unrestricted segment or one
+            # per face, which the docs present as equivalent ways of saying the same thing. Measured
+            # on du/dn = 2, dx = 0.25: uniform gave an implied du/dn of +/-2.0, per-face gave 0.0,
+            # differing by exactly dx*v. A caller stating a per-face Neumann flux silently got
+            # zero-flux. #1937
+            #
+            # Same sign at both walls, matching the uniform path: at the low wall the outward normal
+            # is -x, so ghost = u_i + dx*v gives du/dx = -v and du/dn = +v; at the high wall
+            # du/dx = +v and du/dn = +v. That is the du/dn convention #1262 established, and the
+            # agreement between the two paths is what the pin asserts.
+            apply_flux = bc_type == BCType.NEUMANN and v != 0.0
+            dx = self._grid_spacing[axis] if self._grid_spacing is not None else 1.0
             for k in range(g):
                 single_ghost = [slice(None)] * d
                 single_interior = [slice(None)] * d
@@ -1645,6 +1673,8 @@ class PreallocatedGhostBuffer:
                     single_ghost[axis] = -(k + 1)  # Ghost cells from -1 down to -g
                     single_interior[axis] = -(g + k + 1)  # Adjacent interior cells
                 buf[tuple(single_ghost)] = buf[tuple(single_interior)]
+                if apply_flux:
+                    buf[tuple(single_ghost)] += dx * v
 
         elif bc_type == BCType.ROBIN:
             # Robin: alpha*u + beta*du/dn = g

--- a/tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py
+++ b/tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py
@@ -138,3 +138,83 @@ def test_an_uncovered_face_with_no_default_bc_raises_rather_than_guessing():
 
     with pytest.raises(ValueError, match="default_bc was not"):
         FDMApplicator(dimension=2).apply(np.ones((4, 11)), bc)
+
+
+@pytest.mark.parametrize(
+    ("default_bc", "default_value", "expected_hi_ghost"),
+    [
+        (BCType.NO_FLUX, 0.0, 13.0),  # mirror: u[-1]
+        (BCType.NEUMANN, 3.0, 13.75),  # u[-1] + dx*v = 13.0 + 0.25*3
+        (BCType.DIRICHLET, 5.0, -3.0),  # 2*g - u[-1] = 10 - 13
+        (BCType.PERIODIC, 0.0, 10.0),  # wraps to u[0]
+    ],
+)
+def test_the_default_branch_uses_both_default_bc_and_default_value(default_bc, default_value, expected_hi_ghost):
+    """The synthetic fallback segment must carry the declared type AND the declared value.
+
+    Independent review measured that the branch this file exercises is entered seven times across
+    the suite and that `default_bc` is *always* `NO_FLUX` with `default_value=0.0` -- a fixture
+    monoculture in which hardcoding `NO_FLUX`, dropping `default_value`, and corrupting the `dx`
+    fallback all pass. One value of one parameter cannot discriminate a two-parameter construction.
+
+    Each row here produces a different number by a different formula, so no single wrong constant
+    can satisfy more than one. The `x_min` wall is claimed by an explicit Dirichlet segment in every
+    row and its ghost is asserted unchanged at `2*7 - 10 = 4.0`, which is the control: it shows the
+    rows differ because the DEFAULT branch differs, not because the whole BC changed.
+    """
+    bc = BoundaryConditions(
+        segments=[BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, boundary="x_min")],
+        dimension=1,
+        default_bc=default_bc,
+        default_value=default_value,
+    )
+
+    padded = pad_array_with_ghosts(_RAMP, bc, spacing=_DX)
+
+    assert padded[-1] == pytest.approx(expected_hi_ghost, abs=1e-12)
+    assert padded[0] == pytest.approx(4.0, abs=1e-12), (
+        "the claimed wall moved, so the row is not isolating the default branch"
+    )
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+def test_the_flux_is_applied_at_every_ghost_layer(ghost_depth):
+    """The flux loop runs `for k in range(g)`. With `g=1` a fix that applied the flux only to the
+    outermost layer would be indistinguishable from a correct one, and every other test in this file
+    uses the default depth."""
+    uniform = pad_array_with_ghosts(_RAMP, neumann_bc(dimension=1, value=2.0), ghost_depth=ghost_depth, spacing=_DX)
+    per_face = pad_array_with_ghosts(_RAMP, _per_face_neumann(2.0), ghost_depth=ghost_depth, spacing=_DX)
+
+    np.testing.assert_allclose(per_face, uniform, atol=1e-12)
+
+
+def test_each_axis_uses_its_own_spacing():
+    """`dx` is indexed by `axis`. Every other test here is 1-D, where axis 0 *is* the axis, so a fix
+    that read `self._grid_spacing[0]` would be indistinguishable from a correct one -- measured: that
+    mutation passes the whole rest of this file.
+
+    Non-square on purpose, with three different spacings and a non-square shape, so a swapped axis
+    index cannot coincide with the right answer.
+    """
+    spacing = (0.25, 0.1)
+    flux = 2.0
+    field = np.zeros((4, 6))
+
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name=f"{ax}_{side}", bc_type=BCType.NEUMANN, value=flux, boundary=f"{ax}_{side}")
+            for ax in ("x", "y")
+            for side in ("min", "max")
+        ],
+        dimension=2,
+    )
+    padded = pad_array_with_ghosts(field, bc, spacing=spacing)
+
+    # Interior is all zeros, so each ghost is exactly its own axis's dx * flux.
+    for axis, dx in enumerate(spacing):
+        lo = padded[(0, slice(1, -1)) if axis == 0 else (slice(1, -1), 0)]
+        hi = padded[(-1, slice(1, -1)) if axis == 0 else (slice(1, -1), -1)]
+        np.testing.assert_allclose(lo, dx * flux, atol=1e-12, err_msg=f"axis {axis} low wall used the wrong dx")
+        np.testing.assert_allclose(hi, dx * flux, atol=1e-12, err_msg=f"axis {axis} high wall used the wrong dx")
+
+    assert spacing[0] != spacing[1], "the spacings must differ or this test cannot detect a swap"

--- a/tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py
+++ b/tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py
@@ -1,0 +1,140 @@
+"""The per-face ghost path must agree with the uniform one, and must not invent a fallback.
+
+`PreallocatedGhostBuffer.update_ghosts` dispatches on `bc.is_uniform`: one unrestricted segment
+routes to `_update_ghosts_uniform` -> `_apply_linear_reflection`, anything else to
+`_update_ghosts_mixed` -> `_apply_ghost_for_face`. Both are live, and the choice between them is the
+caller's phrasing of the same physical condition. #1937
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    dirichlet_bc,
+    neumann_bc,
+    no_flux_bc,
+    pad_array_with_ghosts,
+)
+from mfgarchon.geometry.boundary.applicator_fdm import FDMApplicator
+
+# u[0] != u[1] and the step is 0.75, deliberately not equal to any dx*g used below. A ramp whose
+# per-axis step happens to equal dx*g makes `u[0] + dx*g` and `u[1]` identical, which collapses the
+# two ghost conventions onto each other and makes the comparison below pass over the defect.
+_RAMP = np.array([10.0, 10.75, 11.5, 12.25, 13.0])
+_DX = 0.25
+
+
+def _per_face_neumann(value: float) -> BoundaryConditions:
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="lo", bc_type=BCType.NEUMANN, value=value, boundary="x_min"),
+            BCSegment(name="hi", bc_type=BCType.NEUMANN, value=value, boundary="x_max"),
+        ],
+        dimension=1,
+    )
+
+
+@pytest.mark.parametrize("flux", [2.0, -3.0, 0.0])
+def test_the_two_ghost_paths_agree_on_an_inhomogeneous_neumann_flux(flux):
+    """`_apply_ghost_for_face` mirrored the interior and never read the segment's value, so a
+    per-face Neumann BC was applied as zero-flux while the identical uniform BC was not.
+
+    `flux=0.0` is the declared positive control: the two paths agreed there before the fix, so it
+    passes either way and is here to show the comparison can produce agreement.
+    """
+    uniform = pad_array_with_ghosts(_RAMP, neumann_bc(dimension=1, value=flux), spacing=_DX)
+    per_face = pad_array_with_ghosts(_RAMP, _per_face_neumann(flux), spacing=_DX)
+
+    np.testing.assert_allclose(per_face, uniform, atol=1e-12)
+
+
+@pytest.mark.parametrize("flux", [2.0, -3.0])
+def test_the_per_face_path_imposes_the_flux_that_was_asked_for(flux):
+    """An oracle independent of both paths: recover `du/dn` from the ghost and compare it to the
+    requested value.
+
+    A path-A-vs-path-B comparison alone goes tautological the moment the two share an
+    implementation. This does not: it is the boundary condition's own definition, with the outward
+    normal pointing `-x` at the low wall and `+x` at the high wall.
+    """
+    padded = pad_array_with_ghosts(_RAMP, _per_face_neumann(flux), spacing=_DX)
+
+    du_dn_low = -(_RAMP[0] - padded[0]) / _DX
+    du_dn_high = (padded[-1] - _RAMP[-1]) / _DX
+
+    assert du_dn_low == pytest.approx(flux, abs=1e-12)
+    assert du_dn_high == pytest.approx(flux, abs=1e-12)
+
+
+def _mixed_exit_and_walls(exit_priority: int) -> BoundaryConditions:
+    """The idiom from `BCSegment`'s own docstring: one Dirichlet exit, the rest walls."""
+    return BoundaryConditions(
+        segments=[
+            BCSegment(
+                name="exit",
+                bc_type=BCType.DIRICHLET,
+                value=7.0,
+                boundary="x_min",
+                priority=exit_priority,
+            ),
+            BCSegment(name="walls", bc_type=BCType.NO_FLUX, value=0.0),
+        ],
+        dimension=2,
+        default_bc=BCType.NO_FLUX,
+        domain_bounds=np.array([[0.0, 10.0], [0.0, 3.0]]),
+    )
+
+
+def _walls_carrying_the_dirichlet_ghost(bc: BoundaryConditions) -> int:
+    """How many of the four walls came back with `2*7 - 1 = 13`, the Dirichlet ghost."""
+    field = np.ones((4, 11))
+    out = np.asarray(FDMApplicator(dimension=2).apply(field, bc))
+    walls = [out[0, 1:-1], out[-1, 1:-1], out[1:-1, 0], out[1:-1, -1]]
+    return sum(1 for w in walls if np.allclose(w, 13.0))
+
+
+@pytest.mark.parametrize("exit_priority", [1, -5])
+def test_an_unclaimed_wall_takes_default_bc_and_not_the_first_segment(exit_priority):
+    """`_update_ghosts_mixed` fell back to `bc.segments[0]`, and segments sort priority-descending,
+    so the highest-priority segment became the fallback for every wall it had not claimed.
+
+    Both priorities are asserted to give the same answer, and only one of them detects anything.
+    Measured against the reverted code: `exit_priority=1` gives 4 of 4 and fails; `exit_priority=-5`
+    gives 1 of 4 and **passes**, because at that priority the exit sorts last and `segments[0]` is
+    the walls segment, so the old fallback happens to coincide with the correct answer.
+
+    The `-5` row is therefore a control, not a detector, and it is kept for what it shows: a result
+    that moves with segment sort order is a fingerprint of the fallback rather than of any boundary
+    condition. Anyone tempted to drop the `1` row as redundant should note that it is the only row
+    that fails when the fallback returns.
+    """
+    assert _walls_carrying_the_dirichlet_ghost(_mixed_exit_and_walls(exit_priority)) == 1
+
+
+def test_the_wall_count_probe_can_produce_both_answers():
+    """Positive controls for the probe above, in both directions.
+
+    Without these, `== 1` could be satisfied by a probe that cannot count, or by a Dirichlet ghost
+    that never appears at all.
+    """
+    assert _walls_carrying_the_dirichlet_ghost(no_flux_bc(dimension=2)) == 0
+    assert _walls_carrying_the_dirichlet_ghost(dirichlet_bc(dimension=2, value=7.0)) == 4
+
+
+def test_an_uncovered_face_with_no_default_bc_raises_rather_than_guessing():
+    """#1100: resolution must not substitute a default. The old `segments[0]` fallback supplied one
+    by accident of sort order, which is exactly the silent guess that rule forbids."""
+    bc = BoundaryConditions(
+        segments=[BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, boundary="x_min")],
+        dimension=2,
+        domain_bounds=np.array([[0.0, 10.0], [0.0, 3.0]]),
+    )
+
+    with pytest.raises(ValueError, match="default_bc was not"):
+        FDMApplicator(dimension=2).apply(np.ones((4, 11)), bc)


### PR DESCRIPTION
Closes #1937.

`PreallocatedGhostBuffer.update_ghosts` dispatches on `bc.is_uniform`. One unrestricted segment goes to `_update_ghosts_uniform` → `_apply_linear_reflection`; anything else goes to `_update_ghosts_mixed` → `_apply_ghost_for_face`. Both are live, and the choice between them is only how the caller phrased the same physical condition — which the documentation presents as equivalent.

## A — the per-face path dropped a non-zero Neumann flux

`_apply_ghost_for_face` mirrored the interior and never read the segment's value. `_apply_linear_reflection` has added `dx * v` since #1262.

```
du/dn = 2, dx = 0.25, u = [10, 10.75, 11.5, 12.25, 13]
  uniform   lo=10.50  hi=13.50   implied du/dn = -2.000 / +2.000
  per-face  lo=10.00  hi=13.00   implied du/dn =  0.000 /  0.000   <- the flux was dropped
  difference                     lo=-0.50  hi=-0.50   ( = dx*v )
  POSITIVE CONTROL g=0: identical either way
```

The sign is the same at both walls, matching the uniform path: at the low wall the outward normal is `-x`, so `ghost = u_i + dx*v` gives `du/dx = -v` and `du/dn = +v`; at the high wall both are `+v`. That is the `du/dn` convention #1262 established.

## B — an unclaimed face took `bc.segments[0]`, never `default_bc`

Segments sort **priority-descending** (`conditions.py:135`), so the highest-priority segment — typically the exit — governed every wall it had not claimed. On the mixed-BC idiom from `BCSegment`'s own docstring, one Dirichlet exit declared on `x_min`, `default_bc=NO_FLUX`:

| | walls carrying the Dirichlet ghost |
|---|---|
| exit `priority=1`, before | **4 of 4** (declared: 1) |
| exit `priority=-5`, before | 1 of 4 |
| after, both priorities | **1 of 4** |

A result that moves with segment sort order is a fingerprint of the fallback rather than of any boundary condition. Resolution now goes through `_resolve_default_bc`, which **raises** when no default is set (#1100) instead of guessing. That is a behaviour change and it is the point: a `BoundaryConditions` whose segments do not cover every face and which names no default was previously handed one by accident. The full suite is green with it.

## Mutation verification

Run in an isolated worktree; each replacement asserted present in the file on disk, restore verified by sha256.

| mutation | result |
|---|---|
| unmutated | 9 passed |
| MA — revert the flux term | **4 failed** |
| MB — revert to the `segments[0]` fallback | **2 failed** |
| MC — flux sign flipped (`-=` for `+=`) | **4 failed** |

**MB reddens only the `exit_priority=1` row, and the test now says so.** At `-5` the exit sorts last, `segments[0]` *is* the walls segment, and the old fallback coincides with the correct answer — so that row is a control, not a detector. My first docstring implied both rows discriminated; it was corrected after the measurement rather than before.

## The oracles, and why the fixtures are what they are

The cross-path agreement test **goes tautological** the moment the two paths share an implementation, so the flux is pinned twice: once against the uniform path, and once against the boundary condition's own definition — recover `du/dn` from the ghost and compare it to the requested value. The second survives consolidation.

The ramp's step is `0.75`, deliberately not equal to any `dx * g` used. A field whose per-axis step equals `dx * g` makes `u[0] + dx*g` and `u[1]` identical, which collapses the two ghost conventions onto each other; the census hit exactly that and had to change faces to see the split. The `flux=0.0` row and the two wall-count controls (`no_flux` → 0 of 4, uniform `dirichlet` → 4 of 4) are declared as controls in their docstrings.

`./scripts/local_ci.sh` → **6030 passed, 12 skipped, 21 xfailed, GATE GREEN**, run with `PYTHONPATH` pinned to the worktree. That pin is not cosmetic: under `PYTHONSAFEPATH=1`, which `local_ci.sh:311` sets, a run inside a worktree resolves `mfgarchon` through the editable install — I verified the suite imported the worktree's tree and not the other one before reading the result. Same hazard as #1943's neighbourhood and as the fix in #1933.

Found by the boundary-layer divergence census (2026-08-15), independently by three of its four reviewers; see also #1936, #1938/#1942, #1939, #1940, #1941, #1943.


---

## Independent review — **MERGE-OK**, no blocker introduced, one measured gap in my own tests now closed

The review ran the attacks I asked for and found the fix correct: signs verified at all 4 walls in 2-D and all 6 in 3-D with per-axis `dx` genuinely discriminated (0.25 / 0.1 / 0.4 all giving 2.0, impossible if the wrong axis's spacing or the 1.0 fallback were used); corners compose 4/4 and 8/8 identically across paths, against a base control of 0/4 and 0/8; agreement also holds at ghost depths 2 and 3. The fail-loud change regresses no legitimate construction — the strongest static candidate passes, and instrumentation confirms its default branch is never entered, a null result from a probe that demonstrably fires 7× elsewhere.

### The gap, and what closed it

**The branch this PR adds is entered seven times across the suite and `default_bc` is *always* `NO_FLUX` with `default_value=0.0`.** One value of one parameter cannot discriminate a two-parameter construction, so review measured that hardcoding `NO_FLUX`, dropping `default_value`, and corrupting the `dx` fallback **all passed**. Two more mutations of my own then also turned out to survive.

Four rows now produce four numbers by four different formulas:

| `default_bc` | `default_value` | high ghost | formula |
|---|---:|---:|---|
| `NO_FLUX` | 0.0 | 13.00 | mirror `u[-1]` |
| `NEUMANN` | 3.0 | 13.75 | `u[-1] + dx*v` |
| `DIRICHLET` | 5.0 | −3.00 | `2*g - u[-1]` |
| `PERIODIC` | 0.0 | 10.00 | wraps to `u[0]` |

with the claimed `x_min` wall asserted unchanged at `4.0` in every row, so the rows differ because the *default branch* differs and not because the BC changed.

| mutation | before | after |
|---|---|---|
| R1 — hardcode the default type to `NO_FLUX` | passed | **3 failed** |
| R2 — drop `default_value` | passed | **2 failed** |
| R4 — apply the flux only at `k == 0` | passed | **2 failed** |
| R5 — `self._grid_spacing[0]` instead of `[axis]` | passed | **1 failed** |

R4 survived because every other test used `ghost_depth=1`, where the loop has one iteration and a partial fix is indistinguishable from a correct one — depths 1, 2, 3 now. R5 survived because every other test was 1-D, where axis 0 *is* the axis — there is now a 2-D case with spacings `(0.25, 0.1)` on a non-square field, plus an assertion that the two spacings differ, so the test cannot be silently de-fanged by making them equal.

### Recorded, not fixed here

- **`default_bc=ROBIN` imposes exactly Dirichlet**, because `BoundaryConditions` has no `default_alpha`/`default_beta` field at all. The existing `get_bc_at_point` returns the identical `alpha=1.0, beta=0.0`, so this branch matches the query path; the gap is the API's and it is pre-existing.
- **`EXTRAPOLATION_*` and degenerate ROBIN still diverge between the two paths**, and the uniform path writes *unset* memory for the extrapolation types. Byte-identical on base. Filed separately.
- **The `dx` fallback of 1.0 is reachable**, because `FDMApplicator.apply` documents `grid_spacing` as accepted and discarded. The uniform path already behaved this way on base, so this PR makes the two consistent rather than introducing it — deliberately not pinned here, since #1904 is where the threading gets fixed and pinning inherited behaviour would obstruct that.

### Correction to my earlier claim

The previous commit's "MB → 2 failed (only the `exit_priority=1` row)" conflated two *different tests*. The substance — that only that row detects anything among the parametrised rows — holds; the attribution did not.

`./scripts/local_ci.sh` → **6038 passed, 12 skipped, 21 xfailed, GATE GREEN**, with `PYTHONPATH` pinned to the worktree and the imported tree verified before the result was read.
