### PR TITLE
fix(geometry): one resolver for boundary names, and no guessing an unknown one

### DIFF
--- a/changelog.d/1939-boundary-name-aliases.fixed.md
+++ b/changelog.d/1939-boundary-name-aliases.fixed.md
@@ -1,0 +1,13 @@
+Boundary-name aliases resolved on the FDM ghost path and not on the query path, so one
+`BoundaryConditions` object answered differently depending on which route asked. A Dirichlet exit
+declared as `"left"` — the alias `BCSegment`'s own docstring lists first — was honoured by
+`pad_array_with_ghosts` and ignored by `get_bc_type_at_boundary`, `get_bc_value_at_boundary` and
+`BCSegment.matches_point`, which compared the raw strings with `==`. All three now route through
+`parse_boundary_face`, the owner, and compare faces.
+
+Two defects in that owner are fixed with them. It now parses `dim{N}_{side}`, which
+`applicator_particle._get_boundary_id` emits for `d >= 3` and which previously resolved to **axis 0** —
+so a condition declared on the fourth axis was applied to the first while its own axis took the
+default. And an unrecognised prefix such as `"inlet_min"` now returns `None` instead of
+`BoundaryFace(0, side)`: a naming mismatch falls through to the caller's declared default rather than
+silently governing a boundary nobody named.

--- a/changelog.d/1939-boundary-name-aliases.fixed.md
+++ b/changelog.d/1939-boundary-name-aliases.fixed.md
@@ -11,3 +11,9 @@ so a condition declared on the fourth axis was applied to the first while its ow
 default. And an unrecognised prefix such as `"inlet_min"` now returns `None` instead of
 `BoundaryFace(0, side)`: a naming mismatch falls through to the caller's declared default rather than
 silently governing a boundary nobody named.
+
+**Existing numbers can change.** `applicator_particle._get_boundary_id` emits `"left"`/`"right"` in
+1-D, so a 1-D particle setup that declared `boundary="x_min"` matched nothing before and now matches:
+measured, absorbed particles go from `[0, 0, 0]` to `[1, 0, 0]`, and mass leaves the domain where it
+previously reflected. That is the correct behaviour and it is the point of the fix, but it is a
+behaviour change for anyone whose configuration relied on the mismatch.

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -43,6 +43,7 @@ from .types import (
     BoundaryFace,
     PeriodicGridConvention,
     _compute_sdf_gradient,
+    parse_boundary_face,
     repeated_endpoint_count,
 )
 
@@ -389,6 +390,26 @@ class BoundaryConditions:
             priority=-1,
         )
 
+    def _segment_covers(self, segment: BCSegment, boundary: str) -> bool:
+        """Does `segment` govern the face named by `boundary`?
+
+        One resolver. `parse_boundary_face` already normalises aliases -- "left" and "x_min" are the
+        same face -- but these accessors compared the raw strings with `==`, while the FDM ghost path
+        went through the owner. The same `BoundaryConditions` object therefore answered differently
+        depending on which route asked, and an absorbing wall declared as "left" silently became
+        no-flux on the query path. #1939
+
+        Falls back to string equality only when a name resolves to no face at all, so an unrecognised
+        identifier still matches itself rather than matching nothing.
+        """
+        if segment.boundary is None:
+            return True
+        mine = parse_boundary_face(segment.boundary)
+        theirs = parse_boundary_face(boundary)
+        if mine is None or theirs is None:
+            return segment.boundary == boundary
+        return mine == theirs
+
     def get_bc_type_at_boundary(self, boundary: str) -> BCType:
         """
         Get the BC type at a specific boundary (safe accessor for mixed BCs).
@@ -422,10 +443,7 @@ class BoundaryConditions:
 
         # For mixed BCs, find the highest priority segment matching this boundary
         for segment in self.segments:  # Already sorted by priority
-            if segment.boundary is None:
-                # Default segment matches all boundaries
-                return segment.bc_type
-            if segment.boundary == boundary:
+            if self._segment_covers(segment, boundary):
                 return segment.bc_type
 
         # No match - return default BC type (fails loud if default_bc unset)
@@ -454,7 +472,7 @@ class BoundaryConditions:
 
         # For mixed BCs, find the highest priority segment
         for segment in self.segments:
-            if segment.boundary is None or segment.boundary == boundary:
+            if self._segment_covers(segment, boundary):
                 if callable(segment.value):
                     if point is not None:
                         return segment.value(point, time)

--- a/mfgarchon/geometry/boundary/types.py
+++ b/mfgarchon/geometry/boundary/types.py
@@ -342,20 +342,26 @@ def parse_boundary_face(boundary: str | int | BoundaryFace | None) -> BoundaryFa
         # Check alias table first
         if boundary in _BOUNDARY_STRING_TO_FACE:
             return _BOUNDARY_STRING_TO_FACE[boundary]
-        # Try "axis{N}_{side}" format
-        if boundary.startswith("axis") and "_" in boundary:
-            parts = boundary.split("_", 1)
-            try:
-                axis = int(parts[0][4:])  # "axis5" -> 5
-                side = parts[1]
+        # Numeric-axis formats. Both spellings exist in the tree and mean the same thing:
+        # `BoundaryEntity.to_string` emits "axis{N}_{side}" for axes past w, and
+        # `applicator_particle._get_boundary_id` emits "dim{N}_{side}" for d >= 3. Accepting only
+        # the first meant a segment declared on "dim3_min" resolved to axis 0 -- see below. Both are
+        # accepted here so there is one resolver; that two emitters exist is a separate problem.
+        for prefix in ("axis", "dim"):
+            if boundary.startswith(prefix) and "_" in boundary:
+                head, _, side = boundary.partition("_")
                 if side in ("min", "max"):
-                    return BoundaryFace(axis, side)
-            except (ValueError, IndexError):
-                pass
-        # Try "{letter}_{side}" for unknown letters
-        if len(boundary) > 2 and boundary[-4:] in ("_min", "_max"):
-            side = boundary[-3:]
-            return BoundaryFace(0, side)  # Default to axis 0 for unknown
+                    try:
+                        return BoundaryFace(int(head[len(prefix) :]), side)
+                    except ValueError:
+                        pass
+        # ~~"{letter}_{side}" for unknown letters -> BoundaryFace(0, side)~~ [REMOVED 2026-08-15]
+        # An unrecognised prefix now returns None rather than guessing axis 0. That branch turned a
+        # naming mismatch into a *dropped boundary condition*: "dim3_min" became axis 0, so a
+        # Dirichlet exit declared on the fourth axis was applied to the first, while the axis it was
+        # written for silently took the default. "inlet_min" resolved the same way. Returning None
+        # lets the caller fall through to its declared default, which is a wrong answer the caller
+        # asked for rather than one this function invented. #1939
     return None
 
 
@@ -598,8 +604,22 @@ class BCSegment:
                 )
 
         # Method 1: Check boundary identifier match (rectangular domains)
+        #
+        # Compared as FACES, not as strings. `parse_boundary_face` is the owner and it resolves
+        # aliases -- "left" and "x_min" are the same face -- but this site used `!=` on the raw
+        # strings, so the same `BoundaryConditions` object answered differently depending on which
+        # route asked. Measured end-to-end on a 1-D FP-FDM solve: with `boundary="x_min"` the
+        # absorbing wall gave `m[0] = 0.0`; with `boundary="left"`, the alias `BCSegment`'s own
+        # docstring lists first, it gave 3.9e-02 -- the wall had silently become no-flux. #1939
         if self.boundary is not None and self.boundary != "all":
-            if boundary_id is None or self.boundary != boundary_id:
+            if boundary_id is None:
+                return False
+            mine = parse_boundary_face(self.boundary)
+            theirs = parse_boundary_face(boundary_id)
+            if mine is None or theirs is None:
+                if self.boundary != boundary_id:
+                    return False
+            elif mine != theirs:
                 return False
 
         # Method 2: Check coordinate range constraints (rectangular domains)

--- a/mfgarchon/geometry/boundary/types.py
+++ b/mfgarchon/geometry/boundary/types.py
@@ -343,10 +343,18 @@ def parse_boundary_face(boundary: str | int | BoundaryFace | None) -> BoundaryFa
         if boundary in _BOUNDARY_STRING_TO_FACE:
             return _BOUNDARY_STRING_TO_FACE[boundary]
         # Numeric-axis formats. Both spellings exist in the tree and mean the same thing:
-        # `BoundaryEntity.to_string` emits "axis{N}_{side}" for axes past w, and
-        # `applicator_particle._get_boundary_id` emits "dim{N}_{side}" for d >= 3. Accepting only
-        # the first meant a segment declared on "dim3_min" resolved to axis 0 -- see below. Both are
-        # accepted here so there is one resolver; that two emitters exist is a separate problem.
+        # `BoundaryEntity.to_string` emits "axis{N}_{side}" for axes past w, and `dim{N}_{side}` is
+        # emitted by THREE sites -- `applicator_particle._get_boundary_id`,
+        # `_compat._get_boundary_name_nd:755`, and `flux_diagnostics.py:161`. (~~two emitters~~
+        # [CORRECTED 2026-08-15] undercounted; review enumerated them.) Accepting only the first
+        # spelling meant a segment declared on "dim3_min" resolved to axis 0 -- see below.
+        #
+        # Two further spellings exist and are deliberately NOT accepted: `geometry/base.py:739`
+        # emits "v_min" for axis 4, and `adjoint/operators.py::_get_axis_name` emits "x_1_min" for
+        # dim > 3. Both resolved to axis 0 before and to None now, and neither reaches this function
+        # -- they are dict keys. `tensor_grid.py:1889` is a fifth, independent regex resolver that
+        # `mark_region` uses instead of this one. So "one resolver" is true of the path this
+        # function serves and not of the tree; the rest is #1936's ground.
         for prefix in ("axis", "dim"):
             if boundary.startswith(prefix) and "_" in boundary:
                 head, _, side = boundary.partition("_")

--- a/tests/unit/test_geometry/boundary/test_boundary_name_aliases_1939.py
+++ b/tests/unit/test_geometry/boundary/test_boundary_name_aliases_1939.py
@@ -183,3 +183,53 @@ def test_matches_point_still_rejects_a_different_face():
     )
 
     assert bc.get_bc_at_point(np.array([1.0]), boundary_id="x_max").bc_type is BCType.NO_FLUX
+
+
+def test_a_faceless_segment_covers_every_face_and_is_not_the_default():
+    """The catch-all branch of `_segment_covers` -- `segment.boundary is None` -- must return True.
+
+    This is the consolidation's own new code: two inline copies became one method, and the rule for
+    that is a pin that outlives the fork. Mutating this branch to `return False` left **all 6215
+    tests green**, measured, because every other fixture here gives the catch-all `wall` segment the
+    same `NO_FLUX` that `default_bc` carries -- so the segment and the fall-through are
+    indistinguishable and either path produces the right answer.
+
+    Here the two differ on both axes: the wall is `NO_FLUX` with value 3.0, and the default is
+    `PERIODIC` with value 99.0. Only the segment can produce this answer.
+    """
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, boundary="x_max"),
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=3.0),
+        ],
+        dimension=1,
+        default_bc=BCType.PERIODIC,
+        default_value=99.0,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+    assert not bc.is_uniform, "a uniform BC would short-circuit before the branch under test"
+    assert bc.get_bc_type_at_boundary("x_min") is BCType.NO_FLUX
+    assert bc.get_bc_value_at_boundary("x_min") == pytest.approx(3.0)
+
+
+def test_matches_point_distinguishes_the_axis_and_not_only_the_side():
+    """`test_matches_point_still_rejects_a_different_face` varies only the SIDE -- `left` against
+    `x_max`, both axis 0 -- so it cannot separate "faces are equal" from "sides are equal".
+
+    Measured: mutating `matches_point`'s `mine != theirs` to `mine.side != theirs.side` survives that
+    test and all 1007 geometry tests; at full-suite scope exactly one pre-existing test in another
+    directory catches it. `y_min` is axis 1 and side "min", so only a comparison that looks at the
+    axis can reject it.
+    """
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, boundary="left"),
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0),
+        ],
+        dimension=2,
+        default_bc=BCType.NO_FLUX,
+        domain_bounds=np.array([[0.0, 1.0], [0.0, 1.0]]),
+    )
+
+    assert bc.get_bc_at_point(np.array([0.0, 0.0]), boundary_id="y_min").bc_type is BCType.NO_FLUX

--- a/tests/unit/test_geometry/boundary/test_boundary_name_aliases_1939.py
+++ b/tests/unit/test_geometry/boundary/test_boundary_name_aliases_1939.py
@@ -1,0 +1,185 @@
+"""One resolver for boundary names, and no guessing when a name is unknown.
+
+`parse_boundary_face` normalises aliases -- "left" and "x_min" are the same face. The FDM ghost path
+went through it; `get_bc_type_at_boundary`, `get_bc_value_at_boundary` and `BCSegment.matches_point`
+compared the raw strings with `==`. So one `BoundaryConditions` object answered differently depending
+on which route asked, and an absorbing wall declared with the alias `BCSegment`'s own docstring lists
+first silently became no-flux on the query path. #1939
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    pad_array_with_ghosts,
+)
+from mfgarchon.geometry.boundary.types import BoundaryFace, parse_boundary_face
+
+_U = np.array([1.0, 2.0, 4.0, 7.0, 11.0])
+_DX = 0.25
+
+
+def _exit_on(boundary: str) -> BoundaryConditions:
+    """A Dirichlet exit on one face, no-flux everywhere else.
+
+    `default_bc` is NO_FLUX and the exit is DIRICHLET **on purpose**. With the two equal, the query
+    path's fall-through returns the right answer for the wrong reason and the two routes agree
+    whether or not the alias resolved -- the census hit exactly that and had to rebuild the fixture.
+    """
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=0.0, boundary=boundary),
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0),
+        ],
+        dimension=1,
+        default_bc=BCType.NO_FLUX,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+
+def _bc_type_the_ghost_path_applied(bc: BoundaryConditions) -> str:
+    """Read back which condition the ghost path imposed at the low x wall.
+
+    Dirichlet(0) gives `2*0 - u[0] = -u[0]`; no-flux mirrors to `u[0]`. The two are distinguishable
+    only because `u[0] != 0`, which is why the field starts at 1.0 rather than 0.
+    """
+    ghost = pad_array_with_ghosts(_U, bc, spacing=_DX)[0]
+    if np.isclose(ghost, -_U[0]):
+        return "DIRICHLET"
+    if np.isclose(ghost, _U[0]):
+        return "NO_FLUX"
+    raise AssertionError(f"ghost {ghost} matches neither convention; the probe cannot classify it")
+
+
+@pytest.mark.parametrize(("spelling", "expected"), [("x_min", "DIRICHLET"), ("left", "DIRICHLET")])
+def test_an_alias_resolves_on_the_query_path_as_well_as_the_ghost_path(spelling, expected):
+    """`left` is an alias for `x_min` in `_BOUNDARY_STRING_TO_FACE`, and `BCSegment`'s docstring
+    names it first. Before this fix the ghost path honoured it and the query path did not."""
+    bc = _exit_on(spelling)
+
+    assert _bc_type_the_ghost_path_applied(bc) == expected
+    assert bc.get_bc_type_at_boundary("x_min").name == expected
+
+
+@pytest.mark.parametrize("spelling", ["bottom", "y_min"])
+def test_a_face_on_another_axis_is_not_matched(spelling):
+    """Control, in the other direction. `bottom` and `y_min` are axis 1, so at the x_min wall both
+    routes must say NO_FLUX. Without this, a resolver that matched everything would pass the test
+    above."""
+    bc = _exit_on(spelling)
+
+    assert _bc_type_the_ghost_path_applied(bc) == "NO_FLUX"
+    assert bc.get_bc_type_at_boundary("x_min").name == "NO_FLUX"
+
+
+def test_the_two_routes_agree_on_the_value_as_well_as_the_type():
+    """`get_bc_value_at_boundary` carried the same raw `==`."""
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, boundary="left"),
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0),
+        ],
+        dimension=1,
+        default_bc=BCType.NO_FLUX,
+        default_value=99.0,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+    assert bc.get_bc_value_at_boundary("x_min") == pytest.approx(7.0)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("x_min", BoundaryFace(0, "min")),
+        ("left", BoundaryFace(0, "min")),
+        ("bottom", BoundaryFace(1, "min")),
+        ("w_min", BoundaryFace(3, "min")),
+        ("axis3_min", BoundaryFace(3, "min")),
+        ("dim3_min", BoundaryFace(3, "min")),
+        ("axis7_max", BoundaryFace(7, "max")),
+        ("dim7_max", BoundaryFace(7, "max")),
+    ],
+)
+def test_every_spelling_in_the_tree_resolves_to_the_same_face(name, expected):
+    """Three emitters produce three spellings for the same face past `z`: `BoundaryEntity.to_string`
+    gives `w_min` for axis 3 and `axis{N}_{side}` beyond it, while
+    `applicator_particle._get_boundary_id` gives `dim{N}_{side}`. Only the first two parsed.
+
+    `dim3_min` previously resolved to **axis 0**, so a condition declared on the fourth axis was
+    applied to the first while the axis it was written for took the default. That the tree has three
+    emitters at all is a separate problem; this asserts there is one resolver.
+    """
+    assert parse_boundary_face(name) == expected
+
+
+@pytest.mark.parametrize("name", ["inlet_min", "outlet_max", "wall_min"])
+def test_an_unrecognised_prefix_resolves_to_nothing_rather_than_axis_zero(name):
+    """The old last branch mapped any string ending `_min`/`_max` to `BoundaryFace(0, side)`.
+
+    That turned a naming mismatch into a *misapplied* boundary condition rather than an unmatched
+    one: the caller's segment silently governed axis 0. Returning `None` lets the caller fall through
+    to the default it declared -- a wrong answer it asked for, rather than one the resolver invented.
+    """
+    assert parse_boundary_face(name) is None
+
+
+def test_an_unresolvable_name_still_matches_itself():
+    """The fall-back to string equality is deliberate: a name neither route can resolve should still
+    match the identical string, so this change does not silently drop a working custom identifier."""
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="inlet", bc_type=BCType.DIRICHLET, value=5.0, boundary="inlet_min"),
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0),
+        ],
+        dimension=1,
+        default_bc=BCType.NO_FLUX,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+    assert parse_boundary_face("inlet_min") is None, "the premise of this test is that it resolves to nothing"
+    assert bc.get_bc_type_at_boundary("inlet_min") is BCType.DIRICHLET
+    assert bc.get_bc_type_at_boundary("x_min") is BCType.NO_FLUX
+
+
+@pytest.mark.parametrize("queried_as", ["x_min", "left"])
+def test_matches_point_resolves_aliases_too(queried_as):
+    """`BCSegment.matches_point` carried the same raw `!=`, and it is the third route to the same
+    question -- `get_bc_at_point` goes through it.
+
+    The segment is declared as `left` and queried as both spellings; a raw comparison honours only
+    the identical one. Without this test, reverting `matches_point` alone passes the whole rest of
+    this file -- measured.
+    """
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, boundary="left"),
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0),
+        ],
+        dimension=1,
+        default_bc=BCType.NO_FLUX,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+    assert bc.get_bc_at_point(np.array([0.0]), boundary_id=queried_as).bc_type is BCType.DIRICHLET
+
+
+def test_matches_point_still_rejects_a_different_face():
+    """Control for the test above, so a resolver that matched everything would not pass it."""
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=7.0, boundary="left"),
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0),
+        ],
+        dimension=1,
+        default_bc=BCType.NO_FLUX,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+    assert bc.get_bc_at_point(np.array([1.0]), boundary_id="x_max").bc_type is BCType.NO_FLUX


### PR DESCRIPTION
Closes #1939.

`parse_boundary_face` is the owner of boundary-name resolution and it normalises aliases — `"left"` and `"x_min"` are the same face. The FDM ghost path went through it. `get_bc_type_at_boundary`, `get_bc_value_at_boundary` and `BCSegment.matches_point` compared the raw strings with `==`, so **one `BoundaryConditions` object answered differently depending on which route asked.**

The census measured the consequence end-to-end on a 1-D FP-FDM solve: with `boundary="x_min"` the absorbing wall gave `m[0] = 0.0` and mass `0.245622`; with `boundary="left"` — the alias `BCSegment`'s own docstring lists **first** — it gave `m[0] = 3.9e-02` and mass `0.248713`. The wall had silently become no-flux.

All three sites now route through the owner and compare faces:

| spelling on the segment | ghost path applied | query path says | agree |
|---|---|---|---|
| `x_min` | DIRICHLET | DIRICHLET | yes |
| `left` | DIRICHLET | DIRICHLET | yes |
| `bottom` | NO_FLUX | NO_FLUX | yes ← axis 1, the control |
| `y_min` | NO_FLUX | NO_FLUX | yes |

## Two defects in the owner, fixed with them

**It now parses `dim{N}_{side}`.** Three emitters produce three spellings for the same face past `z`: `BoundaryEntity.to_string` gives `w_min` for axis 3 and `axis{N}_{side}` beyond it, while `applicator_particle._get_boundary_id` gives `dim{N}_{side}`. Only the first two parsed, so `dim3_min` resolved to **axis 0** — a condition declared on the fourth axis was applied to the first, while its own axis silently took the default. That three emitters exist at all is a separate problem; this makes one resolver accept all of them.

**An unrecognised prefix returns `None`.** The old last branch mapped *any* string ending `_min`/`_max` to `BoundaryFace(0, side)`, which turns a naming mismatch into a **misapplied** condition rather than an unmatched one: `"inlet_min"` silently governed axis 0. `None` lets the caller fall through to the default it declared — a wrong answer it asked for, rather than one the resolver invented. The fall-back to string equality is kept so an unresolvable custom identifier still matches itself, and that is pinned.

## Mutation verification

Each replacement asserted present in the file on disk, restores verified byte-identical.

| mutation | result |
|---|---|
| unmutated | 20 passed |
| W1 — type accessor back to raw `==` | **1 failed** |
| W2 — value accessor back to raw `==` | **1 failed** |
| W3 — restore the axis-0 guess | **4 failed** |
| W4 — drop `dim{N}` parsing | **2 failed** |
| W5 — `matches_point` back to raw `!=` | **1 failed** |

**W5 survived the first version of the tests**: nothing exercised `matches_point`, the third route to this question, which `get_bc_at_point` uses. Two tests through that route were added, with a control (`x_max` must still be rejected) so a match-everything resolver would not pass them.

## Why the fixture is what it is

`default_bc=NO_FLUX` against a `DIRICHLET` exit, deliberately. **With the two equal, the query path's fall-through returns the right answer for the wrong reason and both routes agree whether or not the alias resolved** — the census hit exactly that and had to rebuild its probe. The field starts at `1.0` rather than `0` for the same reason: `Dirichlet(0)` gives `-u[0]` and no-flux gives `u[0]`, which are distinguishable only when `u[0] != 0`.

`./scripts/local_ci.sh` → **6068 passed, 12 skipped, 21 xfailed, GATE GREEN**.

Found by the boundary-layer divergence census (2026-08-15). Related: #1936 (the ghost value has no owner — the same absence one level down), #1948 (five applicators, no shared contract).
