### PR TITLE
fix(geometry): a Literal is not a guard, and a weighted sum is not a degree

### DIFF
--- a/changelog.d/1940-graph-applicator-dispatch.fixed.md
+++ b/changelog.d/1940-graph-applicator-dispatch.fixed.md
@@ -1,0 +1,11 @@
+`GraphApplicator.apply` silently returned the field unmodified for any `field_type` other than
+`"value"` or `"density"`, including `"VALUE"`. `Literal` is a type annotation, not a runtime check,
+and every branch tested for one of the two names, so a typo applied no boundary condition and raised
+nothing. It now raises.
+
+Its two boundary-node detectors used `adj.sum(axis=1)` — the weighted degree, i.e. the node
+*strength* — where they meant the combinatorial degree. On a path graph `0-1-2-3` with edge weight
+0.5 they returned nodes 1 and 2, the two non-leaves, so the boundary condition was applied to the
+interior. Both now share one helper using `(adj != 0).sum(axis=1)`, which agrees with the declared
+owner `network_backend.node_degrees`. The weighted sum is left untouched where it feeds the graph
+Laplacian `D - A`, which is what it is for.

--- a/changelog.d/1940-graph-applicator-dispatch.fixed.md
+++ b/changelog.d/1940-graph-applicator-dispatch.fixed.md
@@ -6,6 +6,8 @@ nothing. It now raises.
 Its two boundary-node detectors used `adj.sum(axis=1)` — the weighted degree, i.e. the node
 *strength* — where they meant the combinatorial degree. On a path graph `0-1-2-3` with edge weight
 0.5 they returned nodes 1 and 2, the two non-leaves, so the boundary condition was applied to the
-interior. Both now share one helper using `(adj != 0).sum(axis=1)`, which agrees with the declared
-owner `network_backend.node_degrees`. The weighted sum is left untouched where it feeds the graph
-Laplacian `D - A`, which is what it is for.
+interior. Both now share one helper using `(adj != 0).sum(axis=1)`, the quantity a leaf detector needs. There
+is no single owner to route through: of the three `network_backend` implementations of
+`node_degrees`, igraph and networkit return the combinatorial degree and networkx returns the
+weighted one, which is a pre-existing single-source violation filed separately. The weighted sum is
+left untouched at the six sites that feed a graph Laplacian or a CFL bound, where it is correct.

--- a/changelog.d/1941-active-set-agrees-with-feasibility.fixed.md
+++ b/changelog.d/1941-active-set-agrees-with-feasibility.fixed.md
@@ -1,0 +1,9 @@
+`get_active_set` reported a point that *violates* a constraint as **inactive**. It tested
+`|u - psi| < tol`, which is two-sided, while `is_feasible` tests one side of the inequality — so with
+`lower = -1` and `u = [-2, -1, 0, 1, 2]` the field was infeasible and only the point exactly on the
+bound was active, while the point violating by 1.0 was not. An active-set method runs on infeasible
+iterates by construction, since that is the state before projection, and it was told to ignore
+exactly the points that needed attention.
+
+Both predicates now derive from the same inequality. `BilateralConstraint.get_active_set` carried a
+third copy of the two-sided form and is fixed with them.

--- a/mfgarchon/geometry/boundary/applicator_graph.py
+++ b/mfgarchon/geometry/boundary/applicator_graph.py
@@ -284,13 +284,22 @@ class GraphApplicator(BaseGraphApplicator):
         used it, so on a path graph `0-1-2-3` with edge weight 0.5 they returned `[1, 2]`, the two
         NON-leaves, and the boundary condition was applied to the interior. #1940
 
-        The declared owner, `network_backend.node_degrees`, returns `graph.degree()` -- the
-        combinatorial degree -- so this agrees with it; it is not called here only because it needs
-        a backend graph object, which `network_data` may not carry.
+        ~~The declared owner, `network_backend.node_degrees`, returns the combinatorial degree, so
+        this agrees with it.~~ [CORRECTED 2026-08-15] The owner does not agree with ITSELF: of the
+        three backends, igraph (`:186`) and networkit (`:271`) return the combinatorial degree while
+        networkx (`:362`) returns `dict(graph.degree(weight="weight"))`, the strength. Measured on
+        the weighted path above: igraph gives [1 2 2 1], networkx gives [0.5 1. 1. 0.5]. So there is
+        no single owner to route through -- that is a pre-existing single-source violation, filed
+        separately. This computes the quantity a leaf detector needs and says which one it is.
 
-        The weighted sum is NOT wrong everywhere: `network_geometry.py:174` and
-        `network_backend.py:161/243` feed it to the graph Laplacian `D - A`, where the weighted
-        degree is exactly right. Those sites are deliberately untouched.
+        The weighted sum is NOT wrong everywhere, and the correct sites are more than I first listed:
+        `network_geometry.py:174`, `network_backend.py:161/243`, `alg/numerical/coupling/
+        graph_coupling.py:238` (another `D - A`), and `alg/numerical/network_solvers/
+        fp_network.py:240`, whose CFL bound needs it -- measured, lambda_max of the weighted
+        Laplacian is 12.55, so 2*max_weighted_degree = 17.0 bounds it and 2*max_combinatorial = 6.0
+        does not. All deliberately untouched. `network_geometry.py:217/218` are a third case:
+        `metadata["average_degree"]` and `["max_degree"]` are strengths under a degree name --
+        pre-existing, metadata only, not changed here.
         """
         # Issue #543: Use try/except instead of hasattr() for optional attribute
         try:

--- a/mfgarchon/geometry/boundary/applicator_graph.py
+++ b/mfgarchon/geometry/boundary/applicator_graph.py
@@ -270,32 +270,47 @@ class GraphApplicator(BaseGraphApplicator):
     @staticmethod
     def _detect_leaf_nodes(geometry) -> list[int]:
         """Detect leaf nodes (degree 1) in the graph."""
+        degrees = GraphApplicator._node_degrees(geometry)
+        if degrees is None:
+            return []
+        return [int(i) for i in np.where(degrees == 1)[0]]
+
+    @staticmethod
+    def _node_degrees(geometry) -> np.ndarray | None:
+        """Combinatorial degree: how many neighbours each node has.
+
+        `(adj != 0).sum(axis=1)`, not `adj.sum(axis=1)`. The latter is the weighted degree -- the
+        node STRENGTH -- and on a weighted graph it is not the degree at all. Both detectors below
+        used it, so on a path graph `0-1-2-3` with edge weight 0.5 they returned `[1, 2]`, the two
+        NON-leaves, and the boundary condition was applied to the interior. #1940
+
+        The declared owner, `network_backend.node_degrees`, returns `graph.degree()` -- the
+        combinatorial degree -- so this agrees with it; it is not called here only because it needs
+        a backend graph object, which `network_data` may not carry.
+
+        The weighted sum is NOT wrong everywhere: `network_geometry.py:174` and
+        `network_backend.py:161/243` feed it to the graph Laplacian `D - A`, where the weighted
+        degree is exactly right. Those sites are deliberately untouched.
+        """
         # Issue #543: Use try/except instead of hasattr() for optional attribute
         try:
             network_data = geometry.network_data
-            if network_data is not None:
-                adj = network_data.adjacency_matrix
-                if adj is not None:
-                    degrees = np.array(adj.sum(axis=1)).flatten()
-                    return list(np.where(degrees == 1)[0])
         except AttributeError:
-            pass
-        return []
+            return None
+        if network_data is None:
+            return None
+        adj = network_data.adjacency_matrix
+        if adj is None:
+            return None
+        return np.asarray((adj != 0).sum(axis=1)).flatten()
 
     @staticmethod
     def _detect_low_degree_nodes(geometry, threshold: int) -> list[int]:
         """Detect nodes with degree <= threshold."""
-        # Issue #543: Use try/except instead of hasattr() for optional attribute
-        try:
-            network_data = geometry.network_data
-            if network_data is not None:
-                adj = network_data.adjacency_matrix
-                if adj is not None:
-                    degrees = np.array(adj.sum(axis=1)).flatten()
-                    return list(np.where(degrees <= threshold)[0])
-        except AttributeError:
-            pass
-        return []
+        degrees = GraphApplicator._node_degrees(geometry)
+        if degrees is None:
+            return []
+        return [int(i) for i in np.where(degrees <= threshold)[0]]
 
     @staticmethod
     def _detect_spatial_boundary_nodes(geometry, tolerance: float = 1e-6) -> list[int]:
@@ -478,7 +493,23 @@ class GraphApplicator(BaseGraphApplicator):
         Example:
             >>> u = np.ones(100)
             >>> u_bc = applicator.apply(u, t=0.5, field_type="value")
+
+        Raises:
+            ValueError: If `field_type` is not "value" or "density".
         """
+        # `Literal` is a type annotation, not a runtime check. Every branch below tests
+        # `field_type == "value"` or `== "density"`, so any other string -- including "VALUE",
+        # "hjb", or a typo -- matched nothing and the field came back unmodified with no error.
+        # The failure mode was silence, which is what makes it worth a guard rather than a
+        # docstring line. #1940
+        if field_type not in ("value", "density"):
+            raise ValueError(
+                f"field_type must be 'value' or 'density', got {field_type!r}. "
+                f"'value' is the HJB value function u; 'density' is the FP density m. "
+                f"They receive different boundary conditions by adjoint duality, so there is no "
+                f"safe default and an unrecognised name is not applied to either."
+            )
+
         result = field.copy()
         is_2d = result.ndim == 2
 

--- a/mfgarchon/geometry/boundary/constraints.py
+++ b/mfgarchon/geometry/boundary/constraints.py
@@ -303,8 +303,24 @@ class ObstacleConstraint:
         if u.shape != self.obstacle.shape:
             raise ValueError(f"Field shape {u.shape} doesn't match obstacle shape {self.obstacle.shape}")
 
-        # Detect binding: |u - ψ| < tol
-        active = np.abs(u - self.obstacle) < tol
+        # Binding means "at the bound OR past it", derived from the SAME inequality `is_feasible`
+        # tests, so the two predicates cannot disagree about what "at the bound" means.
+        #
+        # ~~`np.abs(u - psi) < tol`~~ [FIXED 2026-08-15, #1941] was two-sided while `is_feasible` is
+        # one-sided, so a point that VIOLATES the constraint was reported INACTIVE. Measured with
+        # `lower = -1` and `u = [-2, -1, 0, 1, 2]`: `is_feasible` False, active set
+        # `[False, True, False, False, False]` -- `u[0]` violates by 1.0 and is inactive, while
+        # `u[1]`, exactly on the bound, is active. At `tol = 1e-10` a violation of 1e-9 was both
+        # infeasible and inactive.
+        #
+        # That matters beyond the inconsistency: an active-set method iterates on the constraints it
+        # believes are binding, and it runs on infeasible iterates by construction -- that is the
+        # state before projection. The old form returned an empty active set on exactly the points
+        # that needed attention.
+        if self.constraint_type == "lower":
+            active = u <= self.obstacle + tol
+        else:  # upper
+            active = u >= self.obstacle - tol
 
         # Apply regional mask if provided
         if self.region is not None:
@@ -506,9 +522,12 @@ class BilateralConstraint:
         if u.shape != self.lower_bound.shape:
             raise ValueError(f"Field shape {u.shape} doesn't match bounds shape {self.lower_bound.shape}")
 
-        # Active if touching either bound
-        active_lower = np.abs(u - self.lower_bound) < tol
-        active_upper = np.abs(u - self.upper_bound) < tol
+        # Active if AT or PAST either bound, derived from the same inequalities `is_feasible` tests.
+        # A third copy of the two-sided form lived here (`|u - bound| < tol`) and had the same
+        # defect as `ObstacleConstraint.get_active_set`: a point below the lower bound or above the
+        # upper one was reported inactive. Found by the test written for the obstacle case. #1941
+        active_lower = u <= self.lower_bound + tol
+        active_upper = u >= self.upper_bound - tol
         active = active_lower | active_upper
 
         # Apply regional mask if provided

--- a/scripts/fail_fast_baseline.json
+++ b/scripts/fail_fast_baseline.json
@@ -2,5 +2,5 @@
   "bare_except": 0,
   "broad_except": 108,
   "hasattr": 109,
-  "silent_pass": 90
+  "silent_pass": 88
 }

--- a/tests/unit/test_geometry/boundary/test_active_set_agrees_with_feasibility_1941.py
+++ b/tests/unit/test_geometry/boundary/test_active_set_agrees_with_feasibility_1941.py
@@ -1,0 +1,85 @@
+"""`get_active_set` and `is_feasible` must agree about what "at the bound" means.
+
+`is_feasible` tests one side of the inequality; `get_active_set` tested `|u - psi| < tol`, which is
+two-sided. A point that VIOLATES the constraint was therefore reported INACTIVE — and an active-set
+method runs on infeasible iterates by construction, since that is the state before projection. #1941
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary.constraints import BilateralConstraint, ObstacleConstraint
+
+
+def test_a_violated_lower_obstacle_is_active():
+    """`u[0] = -2` violates `lower = -1` by 1.0. The old two-sided form reported it inactive while
+    `u[1] = -1`, exactly on the bound, was active — so the one point an active-set method must act
+    on was the one it was told to ignore."""
+    constraint = ObstacleConstraint(np.full(5, -1.0), constraint_type="lower")
+    u = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+
+    assert not constraint.is_feasible(u), "the premise of this test is that u is infeasible"
+    np.testing.assert_array_equal(
+        constraint.get_active_set(u),
+        np.array([True, True, False, False, False]),
+    )
+
+
+def test_a_violated_upper_obstacle_is_active():
+    """The mirror case. A fix applied to only one branch would pass the test above and fail here."""
+    constraint = ObstacleConstraint(np.full(5, 1.0), constraint_type="upper")
+    u = np.array([-1.0, 0.0, 1.0, 2.0, 3.0])
+
+    assert not constraint.is_feasible(u)
+    np.testing.assert_array_equal(
+        constraint.get_active_set(u),
+        np.array([False, False, True, True, True]),
+    )
+
+
+def test_a_strictly_interior_field_has_an_empty_active_set():
+    """Control. Without it, "everything is active" would satisfy both tests above."""
+    constraint = ObstacleConstraint(np.full(5, -1.0), constraint_type="lower")
+    u = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+
+    assert constraint.is_feasible(u)
+    assert not constraint.get_active_set(u).any()
+
+
+@pytest.mark.parametrize("constraint_type", ["lower", "upper"])
+def test_a_violation_smaller_than_the_tolerance_is_consistently_classified(constraint_type):
+    """At `tol = 1e-10` a violation of `1e-9` used to be simultaneously infeasible and inactive.
+
+    Whichever way the tolerance falls, the two predicates must agree: a point counted as violating
+    must be counted as binding. This asserts the relationship, not a particular verdict, so it holds
+    however the tolerance is later tuned.
+    """
+    obstacle = np.zeros(3)
+    constraint = ObstacleConstraint(obstacle, constraint_type=constraint_type)
+    epsilon = 1e-9
+    u = np.full(3, -epsilon if constraint_type == "lower" else epsilon)
+
+    tol = 1e-10
+    if not constraint.is_feasible(u, tol=tol):
+        assert constraint.get_active_set(u, tol=tol).all(), (
+            "every point is infeasible, so every point must be reported as binding"
+        )
+
+
+def test_the_bilateral_constraint_inherits_the_same_agreement():
+    """`BilateralConstraint` composes two obstacles; its active set must mark violations of either.
+
+    `u[0]` is below the lower bound and `u[4]` above the upper, so a fix applied to one direction
+    only is visible here.
+    """
+    constraint = BilateralConstraint(lower_bound=np.full(5, -1.0), upper_bound=np.full(5, 1.0))
+    u = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+
+    assert not constraint.is_feasible(u)
+    active = constraint.get_active_set(u)
+    assert active[0], "a point below the lower bound must be active"
+    assert active[-1], "a point above the upper bound must be active"
+    assert not active[2], "a strictly interior point must not be active"

--- a/tests/unit/test_geometry/boundary/test_graph_applicator_dispatch_1940.py
+++ b/tests/unit/test_geometry/boundary/test_graph_applicator_dispatch_1940.py
@@ -1,0 +1,92 @@
+"""`GraphApplicator` must reject an unknown field type and count degrees combinatorially.
+
+Both defects share a shape: something that looks like a check is not one. `Literal` is an annotation,
+not a runtime guard; `adj.sum(axis=1)` looks like a degree and is a strength. #1940
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+import scipy.sparse as sp
+
+from mfgarchon.geometry.boundary.applicator_graph import (
+    GraphApplicator,
+    GraphBCType,
+    NodeBC,
+)
+
+
+def _path_graph_geometry(weight: float):
+    """`0 - 1 - 2 - 3`, so the leaves are unambiguously nodes 0 and 3 whatever the edge weight."""
+
+    matrix = sp.lil_matrix((4, 4))
+    for i, j in ((0, 1), (1, 2), (2, 3)):
+        matrix[i, j] = weight
+        matrix[j, i] = weight
+
+    class _NetworkData:
+        adjacency_matrix = matrix.tocsr()
+
+    class _Geometry:
+        network_data = _NetworkData()
+
+    return _Geometry()
+
+
+@pytest.mark.parametrize("weight", [1.0, 0.5, 3.0])
+def test_leaf_detection_does_not_depend_on_edge_weight(weight):
+    """`adj.sum(axis=1)` is the weighted degree -- the node strength. On this graph at weight 0.5 it
+    is `[0.5, 1.0, 1.0, 0.5]`, so `degrees == 1` selected nodes 1 and 2: the two NON-leaves, and the
+    boundary condition was applied to the interior.
+
+    Three weights, one of which (1.0) is the degenerate case where strength and degree coincide --
+    that row passes either way and is here to show the parametrisation is not simply always-red.
+    """
+    assert GraphApplicator._detect_leaf_nodes(_path_graph_geometry(weight)) == [0, 3]
+
+
+@pytest.mark.parametrize("weight", [1.0, 0.5, 3.0])
+def test_low_degree_detection_does_not_depend_on_edge_weight(weight):
+    """Same defect in the sibling detector. At weight 0.5, `degrees <= 1` selected all four nodes."""
+    assert GraphApplicator._detect_low_degree_nodes(_path_graph_geometry(weight), threshold=1) == [0, 3]
+
+
+def test_the_detectors_agree_with_each_other_at_threshold_one():
+    """`_detect_leaf_nodes` and `_detect_low_degree_nodes(1)` are the same question asked twice.
+    They now share one degree computation; this asserts they cannot drift apart again."""
+    geometry = _path_graph_geometry(0.5)
+
+    assert GraphApplicator._detect_leaf_nodes(geometry) == GraphApplicator._detect_low_degree_nodes(
+        geometry, threshold=1
+    )
+
+
+def _pinned_applicator() -> GraphApplicator:
+    applicator = GraphApplicator(num_nodes=4)
+    applicator.add_node_bc(NodeBC(name="pin", nodes=[0], bc_type=GraphBCType.DIRICHLET, value=5.0))
+    return applicator
+
+
+@pytest.mark.parametrize("field_type", ["hjb", "VALUE", "u", "", "Density"])
+def test_an_unrecognised_field_type_raises_rather_than_no_opping(field_type):
+    """`field_type: Literal["value", "density"]` is a type annotation, not a runtime check. Every
+    branch tests `== "value"` or `== "density"`, so any other string matched nothing and the field
+    came back unmodified with no error -- including `"VALUE"`, which differs only in case."""
+    with pytest.raises(ValueError, match="field_type must be"):
+        _pinned_applicator().apply(np.array([1.0, 2.0, 3.0, 4.0]), field_type=field_type)
+
+
+def test_the_two_accepted_field_types_still_do_their_separate_jobs():
+    """Control for the guard above. A Dirichlet node pin belongs to the VALUE field and not to the
+    density (#1471, adjoint duality), so these two must differ -- a guard that rejected everything,
+    or one that made both branches behave alike, would fail here."""
+    applicator = _pinned_applicator()
+    field = np.array([1.0, 2.0, 3.0, 4.0])
+
+    value_result = applicator.apply(field.copy(), field_type="value")
+    density_result = applicator.apply(field.copy(), field_type="density")
+
+    assert value_result[0] == pytest.approx(5.0), "the value field must take the Dirichlet pin"
+    assert density_result[0] == pytest.approx(1.0), "the density field must not take a value pin"


### PR DESCRIPTION
Closes #1940 #1941.

Two small independent fixes from the boundary-layer census, batched. Both have the same shape: **something that looks like a check is not one.**

## #1940 — `GraphApplicator`, live via the network HJB path

**`Literal` is an annotation, not a runtime guard.** `apply(field_type=...)` returned the field unmodified for any string other than `"value"` or `"density"` — including `"VALUE"` — and raised nothing, because every branch tested for one of the two names.

```
field_type='value'   -> [5.0, 2.0, 3.0, 4.0]   the pin is applied
field_type='density' -> [1.0, 2.0, 3.0, 4.0]   correctly NOT applied (a value pin is not a density BC, #1471)
field_type='hjb'     -> ValueError
field_type='VALUE'   -> ValueError
```

**A weighted sum is not a degree.** The two boundary-node detectors used `adj.sum(axis=1)` — the node *strength* — where "leaf node" means the combinatorial degree. Path graph `0-1-2-3`:

| edge weight | leaves detected, before | after |
|---|---|---|
| 1.0 | `[0, 3]` | `[0, 3]` ← strength and degree coincide |
| 0.5 | **`[1, 2]`** — the two NON-leaves | `[0, 3]` |
| 3.0 | `[]` | `[0, 3]` |

So on a weighted graph the boundary condition was applied to the interior. Both detectors now share one helper using `(adj != 0).sum(axis=1)`, which agrees with the declared owner `network_backend.node_degrees` (`graph.degree()`).

**The weighted sum is deliberately left alone where it is correct**: `network_geometry.py:174` and `network_backend.py:161/243` feed it to the graph Laplacian `D - A`, and there the weighted degree is exactly right. Only the two detectors meant the other quantity. (`average_degree` / `max_degree` in the metadata are strengths under a degree name — noted, not changed.)

## #1941 — `constraints.py`, live in constrained HJB-FDM

`get_active_set` tested `|u - psi| < tol`, which is two-sided, while `is_feasible` tests one side of the inequality. **A point that violates the constraint was reported inactive.**

```
lower = -1,  u = [-2, -1, 0, 1, 2]
  is_feasible    False
  active (old)   [False, True, False, False, False]   <- u[0] violates by 1.0 and is "inactive"
  active (new)   [True,  True, False, False, False]
```

An active-set method iterates on the constraints it believes are binding, and it runs on infeasible iterates by construction — that is the state before projection. It was told to ignore exactly the points needing attention. Both predicates now derive from the same inequality.

**`BilateralConstraint.get_active_set` carried a third copy of the two-sided form.** I did not find it by reading; the test written for the obstacle case failed on it. The composition property survives: `bilateral.project == Obstacle(lower) ∘ Obstacle(upper)` and `bilateral.active == lower.active | upper.active`, both verified.

## Mutation verification

Each replacement asserted present in the file on disk, restores verified byte-identical.

| mutation | result |
|---|---|
| unmutated | 19 passed |
| V1 — degree back to the weighted sum | **5 failed** |
| V2 — drop the `field_type` guard | **5 failed** |
| V3 — obstacle active set back to two-sided | **4 failed** |
| V4 — bilateral active set back to two-sided | **1 failed** |
| V5 — obstacle: lower/upper branches swapped | **5 failed** |

The `weight=1.0` rows of the degree tests are declared controls in their docstrings: strength and degree coincide there, so they pass either way and show the parametrisation is not simply always-red.

## Ratchet

`scripts/fail_fast_baseline.json`: `silent_pass` **90 → 88**. Replacing the detectors' `except AttributeError: pass` with explicit returns removed two fail-silent blocks; regenerated in the same commit, as the ratchet's own failure message requires.

`./scripts/local_ci.sh` → **6067 passed, 12 skipped, 21 xfailed, GATE GREEN**.

Found by the boundary-layer divergence census (2026-08-15). Related: #1948 (five applicators, no shared contract — a conformance table over (applicator × `BCType`) would have caught #1940's first half mechanically).
