### PR TITLE
fix(geometry): one owner for BCType → particle action

### DIFF
--- a/changelog.d/1956-one-particle-action-owner.fixed.md
+++ b/changelog.d/1956-one-particle-action-owner.fixed.md
@@ -1,0 +1,41 @@
+One owner for `BCType -> particle action`. The mapping was written out twice --
+`MeshfreeApplicator.apply_particles` and `ParticleApplicator.apply` -- and had drifted on
+**four of `BCType`'s eight members**. Measured on the same five particles and the same domain:
+
+| BCType | MeshfreeApplicator | ParticleApplicator |
+|---|---|---|
+| `REFLECTING` | **ValueError** | reflecting |
+| `ROBIN` (default `alpha=1, beta=0`) | **absorbing** | **reflecting** |
+| `EXTRAPOLATION_LINEAR` / `_QUADRATIC` | ValueError | **reflecting** |
+
+The `ROBIN` row is the defect that matters: the *same* `BoundaryConditions` object made one
+path build an absorbing wall and the other an impermeable one -- opposite physics, no error.
+
+`particle_action_for_bc_type` is now the single owner and both dispatches are deleted. Each
+divergence is resolved toward whichever path was right, so this is not either previous
+behaviour:
+
+- `REFLECTING` reflects. It is `BCType`'s own documented particle spelling of an impermeable
+  wall, and refusing it was the defect.
+- `ROBIN` dispatches on its coefficients. `beta = 0` makes the condition `alpha*u = g`, which
+  is Dirichlet, so the particle is absorbed; `alpha = 0` is a flux condition, so it reflects;
+  a genuinely mixed Robin reflects, conserving mass.
+- `EXTRAPOLATION_*` raises, naming the type. These describe how to continue a *field* past a
+  truncated domain and carry no boundary datum; the segment-aware path's `else` branch used to
+  reflect them silently.
+
+The coefficients now come off the **matched segment** on the segment-aware path, so a mixed BC
+with a different Robin coefficient per wall is read per wall. The uniform path's
+`_robin_alpha_beta` cannot do that -- it takes the first Robin segment in the whole
+specification whichever face is being processed -- and that remains open.
+
+**Behaviour changes**, all of them repairs: `MeshfreeApplicator` accepts `REFLECTING` instead
+of raising; `ParticleApplicator` absorbs at a `beta = 0` Robin wall instead of reflecting, and
+raises on `EXTRAPOLATION_*` instead of silently reflecting. Of 22 probed cells, **15 are
+byte-identical** across the change and 2 differ only in an exception message.
+
+The pin does not compare the two paths against each other -- once both route through the owner
+that is tautological and would pass over a broken owner. It pins the table against the physics
+and each repaired cell against the behaviour captured before the merge. Three mutations were
+measured to redden it: dropping `REFLECTING` from the impermeable arm (2 failures), restoring
+the always-reflect Robin (4), and restoring the silent `EXTRAPOLATION_*` fallback (4).

--- a/mfgarchon/geometry/boundary/applicator_meshfree.py
+++ b/mfgarchon/geometry/boundary/applicator_meshfree.py
@@ -38,6 +38,7 @@ from mfgarchon.geometry.protocol import GeometryProtocol
 
 # Import base class for inheritance
 from .applicator_base import BaseMeshfreeApplicator
+from .applicator_particle import particle_action_for_bc_type
 from .types import BCType
 
 
@@ -456,38 +457,16 @@ class MeshfreeApplicator(BaseMeshfreeApplicator):
         # Fails loud if default_bc unset (Issue #1100)
         bc_type = boundary_conditions._resolve_default_bc("MeshfreeBoundaryApplicator.apply_particles")
 
-        if bc_type == BCType.NEUMANN:
-            # Zero-flux Neumann → reflecting BC for particles
-            return self.apply_particle_bc(particles, "reflecting")
-
-        elif bc_type == BCType.NO_FLUX:
-            # Explicit no-flux → reflecting BC
-            return self.apply_particle_bc(particles, "reflecting")
-
-        elif bc_type == BCType.DIRICHLET:
-            # Dirichlet → absorbing BC (particles "exit" at boundary)
-            return self.apply_particle_bc(particles, "absorbing")
-
-        elif bc_type == BCType.PERIODIC:
-            # Periodic → wrap-around
-            return self.apply_particle_bc(particles, "periodic")
-
-        elif bc_type == BCType.ROBIN:
-            # Robin: behavior depends on α/β ratio
+        # One owner for BCType -> particle action, shared with ParticleApplicator. The two
+        # copies had drifted on four of BCType's eight members; REFLECTING raised here and
+        # reflected there, and a Robin BC left at its default coefficients absorbed here and
+        # reflected there -- the same object building an absorbing wall on one path and an
+        # impermeable one on the other.
+        alpha = beta = None
+        if bc_type == BCType.ROBIN:
             alpha, beta = _robin_alpha_beta(boundary_conditions)
 
-            if np.isclose(beta, 0.0):
-                # Pure Dirichlet-like → absorbing
-                return self.apply_particle_bc(particles, "absorbing")
-            elif np.isclose(alpha, 0.0):
-                # Pure Neumann-like → reflecting
-                return self.apply_particle_bc(particles, "reflecting")
-            else:
-                # Mixed Robin → default to reflecting (mass conservation)
-                return self.apply_particle_bc(particles, "reflecting")
-
-        else:
-            raise ValueError(f"Unsupported BC type for particles: {bc_type}")
+        return self.apply_particle_bc(particles, particle_action_for_bc_type(bc_type, alpha, beta))
 
 
 class SDFParticleBCHandler:

--- a/mfgarchon/geometry/boundary/applicator_particle.py
+++ b/mfgarchon/geometry/boundary/applicator_particle.py
@@ -6,15 +6,21 @@ BoundaryConditions segment matching. Unlike MeshfreeApplicator which uses
 geometry-based boundary detection, this applicator queries BCSegments to
 determine the appropriate action at each boundary point.
 
-BC Type Interpretation for Particles:
+BC Type Interpretation for Particles -- owned by `particle_action_for_bc_type` in this
+module, and shared with `MeshfreeApplicator.apply_particles`, which used to write it out
+again and had drifted from it on four of BCType's eight members (#1956):
+
 - DIRICHLET: Absorb particle (remove from simulation) - exits/sinks
 - NEUMANN: Reflect particle (elastic bounce)
 - REFLECTING / NO_FLUX: Reflect particle (elastic bounce)
 - PERIODIC: Wrap particle to opposite boundary
+- ROBIN: by coefficient -- `beta = 0` is Dirichlet, so absorb; otherwise reflect
+- EXTRAPOLATION_LINEAR / _QUADRATIC: refused, they are field-truncation rules
 
 Architecture:
     BoundaryConditions provides segment matching via get_bc_at_point()
-    ParticleApplicator interprets BCType for particle dynamics
+    particle_action_for_bc_type interprets BCType for particle dynamics
+    ParticleApplicator executes the action, per matched segment
 
 Created: 2025-01-03
 Part of: Unified Boundary Condition Architecture (Issue #536)
@@ -22,14 +28,95 @@ Part of: Unified Boundary Condition Architecture (Issue #536)
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
+
+from .types import BCType
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from .conditions import BoundaryConditions
+
+ParticleAction = Literal["reflecting", "absorbing", "periodic"]
+
+
+def particle_action_for_bc_type(
+    bc_type: BCType,
+    alpha: float | None = None,
+    beta: float | None = None,
+) -> ParticleAction:
+    """Map a ``BCType`` to what a particle does when it reaches the boundary.
+
+    One owner for a mapping that used to be written twice -- here and in
+    ``MeshfreeApplicator.apply_particles`` -- and had drifted on **four of BCType's
+    eight members**, measured on the same five particles and the same domain:
+
+    ===========================  ===================  ==================
+    BCType                       MeshfreeApplicator   ParticleApplicator
+    ===========================  ===================  ==================
+    ``DIRICHLET``                absorbing            absorbing
+    ``NEUMANN`` / ``NO_FLUX``    reflecting           reflecting
+    ``PERIODIC``                 periodic             periodic
+    ``REFLECTING``               **ValueError**       reflecting
+    ``ROBIN`` (alpha=1, beta=0)  **absorbing**        **reflecting**
+    ``EXTRAPOLATION_*``          ValueError           **reflecting**
+    ===========================  ===================  ==================
+
+    The `ROBIN` row is the one that mattered: the *same* specification made one path
+    build an impermeable wall and the other an absorbing one. Each divergence is
+    resolved toward whichever path was right, so this function is not either previous
+    behaviour:
+
+    - `REFLECTING` reflects. It is `BCType`'s own documented particle spelling of an
+      impermeable wall; refusing it was the defect.
+    - `ROBIN` dispatches on the coefficients. With `beta = 0` the condition reads
+      `alpha*u = g`, which is Dirichlet, so the particle is absorbed. With `alpha = 0`
+      it reads `beta*du/dn = g`, a flux condition, so the particle reflects. A genuinely
+      mixed Robin reflects, which conserves mass and is the conservative reading.
+    - `EXTRAPOLATION_LINEAR` / `EXTRAPOLATION_QUADRATIC` raise. They are not boundary
+      conditions on a particle at all -- they are a statement about how to continue a
+      *field* past a truncated domain, and carry no boundary datum. Silently reflecting
+      them, which is what the segment-aware path's ``else`` branch did, answers a
+      question that was never asked.
+
+    Args:
+        bc_type: The condition to interpret.
+        alpha: Robin coefficient on ``u``. Required when ``bc_type`` is ``ROBIN``.
+        beta: Robin coefficient on ``du/dn``. Required when ``bc_type`` is ``ROBIN``.
+
+    Returns:
+        The particle action, in the vocabulary ``MeshfreeApplicator.apply_particle_bc``
+        already accepted.
+
+    Raises:
+        ValueError: for a type with no particle interpretation, naming it.
+    """
+    if bc_type == BCType.DIRICHLET:
+        return "absorbing"
+
+    if bc_type in (BCType.NEUMANN, BCType.NO_FLUX, BCType.REFLECTING):
+        return "reflecting"
+
+    if bc_type == BCType.PERIODIC:
+        return "periodic"
+
+    if bc_type == BCType.ROBIN:
+        if alpha is None or beta is None:
+            raise ValueError(
+                "particle_action_for_bc_type: BCType.ROBIN needs alpha and beta; "
+                "they live on the BCSegment, not on BoundaryConditions."
+            )
+        if np.isclose(beta, 0.0):
+            return "absorbing"
+        return "reflecting"
+
+    raise ValueError(
+        f"particle_action_for_bc_type: {bc_type} has no particle interpretation. "
+        "EXTRAPOLATION_LINEAR and EXTRAPOLATION_QUADRATIC describe how to continue a "
+        "field past a truncated domain and say nothing about a particle that reaches it."
+    )
 
 
 class ParticleApplicator:
@@ -87,7 +174,6 @@ class ParticleApplicator:
             - absorbed_mask: Boolean mask of absorbed particles, shape (N,)
             - exit_positions: Positions where particles were absorbed, shape (K, d)
         """
-        from .types import BCType
 
         particles = np.atleast_2d(particles)
         n_particles = len(particles)
@@ -136,23 +222,19 @@ class ParticleApplicator:
                 result_particles[idx] = self._reflect_particle(particle, domain_min, domain_max, domain_size)
                 continue
 
-            # Apply BC based on type
-            if segment.bc_type == BCType.DIRICHLET:
-                # Absorbing BC - mark for removal
+            # alpha/beta come off the matched segment, so a mixed BC with a different
+            # Robin coefficient per wall is read per wall. The uniform path's
+            # `_robin_alpha_beta` cannot do that -- it takes the first Robin segment in
+            # the whole specification, whichever face is being processed.
+            action = particle_action_for_bc_type(segment.bc_type, segment.alpha, segment.beta)
+
+            if action == "absorbing":
                 absorbed_mask[idx] = True
                 exit_positions_list.append(particle.copy())
-
-            elif segment.bc_type in (BCType.REFLECTING, BCType.NO_FLUX, BCType.NEUMANN):
-                # Reflecting BC - bounce particle back
+            elif action == "reflecting":
                 result_particles[idx] = self._reflect_particle(particle, domain_min, domain_max, domain_size)
-
-            elif segment.bc_type == BCType.PERIODIC:
-                # Periodic BC - wrap to opposite boundary
-                result_particles[idx] = self._wrap_particle(particle, domain_min, domain_size)
-
             else:
-                # Unknown BC type - default to reflecting
-                result_particles[idx] = self._reflect_particle(particle, domain_min, domain_max, domain_size)
+                result_particles[idx] = self._wrap_particle(particle, domain_min, domain_size)
 
         # Build exit positions array
         if exit_positions_list:
@@ -192,7 +274,6 @@ class ParticleApplicator:
             - exit_positions: Positions where absorbed, shape (K, d)
             - absorbed_per_segment: Dict mapping segment name to absorbed count
         """
-        from .types import BCType
 
         particles = np.atleast_2d(particles)
         n_particles = len(particles)
@@ -234,7 +315,9 @@ class ParticleApplicator:
                 result_particles[idx] = self._reflect_particle(particle, domain_min, domain_max, domain_size)
                 continue
 
-            if segment.bc_type == BCType.DIRICHLET:
+            action = particle_action_for_bc_type(segment.bc_type, segment.alpha, segment.beta)
+
+            if action == "absorbing":
                 seg_name = segment.name
 
                 # Check flux capacity
@@ -255,14 +338,11 @@ class ParticleApplicator:
                     absorbed_mask[idx] = True
                     exit_positions_list.append(particle.copy())
 
-            elif segment.bc_type in (BCType.REFLECTING, BCType.NO_FLUX, BCType.NEUMANN):
+            elif action == "reflecting":
                 result_particles[idx] = self._reflect_particle(particle, domain_min, domain_max, domain_size)
-
-            elif segment.bc_type == BCType.PERIODIC:
-                result_particles[idx] = self._wrap_particle(particle, domain_min, domain_size)
 
             else:
-                result_particles[idx] = self._reflect_particle(particle, domain_min, domain_max, domain_size)
+                result_particles[idx] = self._wrap_particle(particle, domain_min, domain_size)
 
         if exit_positions_list:
             exit_positions = np.array(exit_positions_list)

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -383,9 +383,27 @@ class BoundaryConditions:
                 return segment
 
         # No match - return default BC as a segment (fails loud if default_bc unset)
+        default_type = self._resolve_default_bc("get_bc_at_point")
+
+        # A Robin default is inexpressible: this class carries `default_bc` and `default_value`
+        # and no default alpha/beta, so the segment below would take `BCSegment`'s dataclass
+        # defaults, alpha=1.0 and beta=0.0 -- which is the Dirichlet corner of the Robin family.
+        # Consumers that read those coefficients then act on a condition nobody wrote: a user's
+        # pure-flux wall (alpha=0, beta=1) becomes absorbing on an uncovered face, destroying
+        # mass with nothing raised. Measured on a 2-D BC whose Robin segments cover only the x
+        # faces: 3 particles in, 1 out.
+        if default_type == BCType.ROBIN:
+            raise ValueError(
+                "BoundaryConditions: default_bc is ROBIN, but a fall-through point cannot carry "
+                "Robin coefficients -- this class has default_bc and default_value and no "
+                "default alpha/beta, so alpha=1.0, beta=0.0 would be fabricated, which is a "
+                "Dirichlet wall. Give every face an explicit BCSegment carrying its own alpha "
+                "and beta, or choose a default_bc whose condition needs no coefficients."
+            )
+
         return BCSegment(
             name="default",
-            bc_type=self._resolve_default_bc("get_bc_at_point"),
+            bc_type=default_type,
             value=self.default_value,
             priority=-1,
         )

--- a/tests/unit/test_geometry/boundary/test_one_particle_action_owner_1956.py
+++ b/tests/unit/test_geometry/boundary/test_one_particle_action_owner_1956.py
@@ -187,3 +187,59 @@ def test_the_three_actions_are_distinguishable_on_this_probe():
 
     assert not np.allclose(reflected, wrapped), "reflect and wrap must differ on this fixture"
     assert len(absorbed) != len(reflected), "absorb must differ from reflect on this fixture"
+
+
+# =============================================================================
+# The fall-through cannot fabricate Robin coefficients
+# =============================================================================
+
+
+def test_a_robin_default_refuses_rather_than_fabricating_its_coefficients():
+    """`BoundaryConditions` has `default_bc` and `default_value` and no default alpha/beta, so a
+    fall-through segment took `BCSegment`'s dataclass defaults `alpha=1.0, beta=0.0` -- the
+    Dirichlet corner of the Robin family.
+
+    Found by independent review of this PR. The hole predates it and was inert: nothing read
+    those coefficients off the returned segment. Routing the particle path through
+    `particle_action_for_bc_type` makes them load-bearing, and a user's pure-flux wall
+    (`alpha=0, beta=1`) then became **absorbing** on any uncovered face -- measured, 3 particles
+    in and 1 out, mass destroyed with nothing raised.
+
+    `test_robin_without_coefficients_refuses_rather_than_assuming` above asserts the owner must
+    refuse rather than assume, and could not fire here: its guard tests `alpha is None`, while
+    `BCSegment` hands over `1.0` and `0.0`. The refusal therefore belongs at the point of
+    fabrication, not at the point of use.
+    """
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="flux", bc_type=BCType.ROBIN, value=0.0, alpha=0.0, beta=1.0, boundary="x_min"),
+            BCSegment(name="flux2", bc_type=BCType.ROBIN, value=0.0, alpha=0.0, beta=1.0, boundary="x_max"),
+        ],
+        dimension=2,
+        default_bc=BCType.ROBIN,
+        default_value=0.0,
+        domain_bounds=np.array(_BOUNDS),
+    )
+    particles = np.array([[0.5, 0.5], [0.5, 1.05], [0.5, -0.05]])  # two leave through uncovered y faces
+
+    with pytest.raises(ValueError, match="cannot carry"):
+        ParticleApplicator().apply(particles, bc, _BOUNDS)
+
+
+def test_a_fully_covered_robin_wall_still_reflects():
+    """Control. The refusal must be narrow: a Robin condition whose segments cover every face
+    carries its own coefficients and is unaffected. Without this, raising on every Robin BC would
+    pass the test above."""
+    bc = BoundaryConditions(
+        segments=[BCSegment(name="flux", bc_type=BCType.ROBIN, value=0.0, alpha=0.0, beta=1.0)],
+        dimension=2,
+        default_bc=BCType.NO_FLUX,
+        default_value=0.0,
+        domain_bounds=np.array(_BOUNDS),
+    )
+    particles = np.array([[0.5, 0.5], [0.5, 1.05], [0.5, -0.05]])
+
+    remaining, absorbed, _ = ParticleApplicator().apply(particles, bc, _BOUNDS)
+
+    assert len(remaining) == 3, "a pure-flux wall absorbs nothing"
+    assert not absorbed.any()

--- a/tests/unit/test_geometry/boundary/test_one_particle_action_owner_1956.py
+++ b/tests/unit/test_geometry/boundary/test_one_particle_action_owner_1956.py
@@ -1,0 +1,189 @@
+"""One owner for `BCType -> particle action`, and the four cells where the two copies disagreed.
+
+`MeshfreeApplicator.apply_particles` and `ParticleApplicator.apply` each wrote the mapping out.
+They agreed on DIRICHLET, NEUMANN, NO_FLUX and PERIODIC, and diverged on the other four members:
+
+    REFLECTING           meshfree raised          particle reflected
+    ROBIN(alpha=1,beta=0) meshfree absorbed       particle reflected
+    EXTRAPOLATION_LINEAR  meshfree raised         particle reflected
+    EXTRAPOLATION_QUAD    meshfree raised         particle reflected
+
+The ROBIN row is the one that mattered: the same `BoundaryConditions` object made one path build
+an absorbing wall and the other an impermeable one.
+
+**These tests do not compare the two paths against each other.** Once both route through
+`particle_action_for_bc_type`, agreement is tautological and would pass over a broken owner. They
+pin the owner's table against the physics, and each repaired cell against the behaviour recorded
+before the consolidation. #1956
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry import Hyperrectangle
+from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions
+from mfgarchon.geometry.boundary.applicator_meshfree import MeshfreeApplicator
+from mfgarchon.geometry.boundary.applicator_particle import (
+    ParticleApplicator,
+    particle_action_for_bc_type,
+)
+
+_BOUNDS = [(0.0, 1.0), (0.0, 1.0)]
+
+# One interior particle and four that have left, one through each wall. The interior one is what
+# makes "absorbing" distinguishable from "everything vanished"; the four are what make reflecting
+# distinguishable from wrapping, since a reflected 1.2 comes back to 0.8 and a wrapped one to 0.2.
+_PARTICLES = np.array([[0.5, 0.5], [1.2, 0.3], [-0.1, 0.4], [0.0, 0.7], [0.6, 1.05]])
+
+
+def _uniform(bc_type: BCType, alpha: float = 1.0, beta: float = 0.0) -> BoundaryConditions:
+    return BoundaryConditions(
+        segments=[BCSegment(name="wall", bc_type=bc_type, value=0.0, alpha=alpha, beta=beta)],
+        dimension=2,
+        default_bc=bc_type,
+        domain_bounds=np.array(_BOUNDS),
+    )
+
+
+def _meshfree(bc: BoundaryConditions) -> np.ndarray:
+    return MeshfreeApplicator(Hyperrectangle([[0.0, 1.0], [0.0, 1.0]])).apply_particles(_PARTICLES.copy(), bc)
+
+
+def _particle(bc: BoundaryConditions) -> np.ndarray:
+    return ParticleApplicator().apply(_PARTICLES.copy(), bc, _BOUNDS)[0]
+
+
+# =============================================================================
+# The owner's table, pinned against the physics rather than against a caller
+# =============================================================================
+
+_EXPECTED = {
+    BCType.DIRICHLET: "absorbing",
+    BCType.NEUMANN: "reflecting",
+    BCType.NO_FLUX: "reflecting",
+    BCType.REFLECTING: "reflecting",
+    BCType.PERIODIC: "periodic",
+    BCType.ROBIN: "absorbing",  # at the default coefficients alpha=1, beta=0
+}
+_NO_PARTICLE_MEANING = {BCType.EXTRAPOLATION_LINEAR, BCType.EXTRAPOLATION_QUADRATIC}
+
+
+def test_the_table_covers_every_bctype_member():
+    """Derived from the enum, not listed. Adding a `BCType` member fails this until someone
+    decides what a particle does when it reaches that kind of wall -- which is the property a
+    hand-maintained list cannot have, and the reason the two copies could drift unnoticed."""
+    assert set(_EXPECTED) | _NO_PARTICLE_MEANING == set(BCType), (
+        "a BCType member is neither given a particle action nor declared to have none"
+    )
+
+
+@pytest.mark.parametrize(("bc_type", "expected"), sorted(_EXPECTED.items(), key=lambda kv: kv[0].name))
+def test_each_bc_type_maps_to_its_particle_action(bc_type, expected):
+    assert particle_action_for_bc_type(bc_type, alpha=1.0, beta=0.0) == expected
+
+
+@pytest.mark.parametrize("bc_type", sorted(_NO_PARTICLE_MEANING, key=lambda t: t.name))
+def test_a_field_truncation_rule_is_refused_and_named(bc_type):
+    """`EXTRAPOLATION_*` says how to continue a field past a cut domain and carries no boundary
+    datum. The segment-aware path used to send it to a catch-all `else` and reflect, which answers
+    a question nobody asked. The message must name the type -- a bare raise leaves the caller
+    unable to tell which of its segments is the problem."""
+    with pytest.raises(ValueError, match=bc_type.name):
+        particle_action_for_bc_type(bc_type)
+
+
+# =============================================================================
+# Robin: the coefficients decide, and they are not optional
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("alpha", "beta", "expected"),
+    [
+        (1.0, 0.0, "absorbing"),  # alpha*u = g is Dirichlet
+        (0.0, 1.0, "reflecting"),  # beta*du/dn = g is a flux condition
+        (1.0, 1.0, "reflecting"),  # genuinely mixed: conserve mass
+        (3.0, 0.0, "absorbing"),  # the scale of alpha does not enter; only beta == 0 does
+    ],
+)
+def test_robin_dispatches_on_its_coefficients(alpha, beta, expected):
+    assert particle_action_for_bc_type(BCType.ROBIN, alpha, beta) == expected
+
+
+def test_robin_without_coefficients_refuses_rather_than_assuming():
+    """A default here would be the #1558 failure a third time. `alpha=1, beta=0` is Dirichlet, so
+    any implicit default silently turns an unspecified Robin wall into an absorbing one."""
+    with pytest.raises(ValueError, match="needs alpha and beta"):
+        particle_action_for_bc_type(BCType.ROBIN)
+
+
+# =============================================================================
+# The four repaired cells, each against the behaviour recorded before the merge
+# =============================================================================
+
+
+def test_meshfree_reflecting_no_longer_raises():
+    """Measured before this change: `ValueError: Unsupported BC type for particles:
+    BCType.REFLECTING` -- for the member `BCType`'s own docstring calls the particle spelling of
+    an impermeable wall."""
+    result = _meshfree(_uniform(BCType.REFLECTING))
+
+    assert len(result) == len(_PARTICLES), "an impermeable wall absorbs nothing"
+    assert np.all(Hyperrectangle([[0.0, 1.0], [0.0, 1.0]]).contains(result)), "every particle is back inside"
+
+
+def test_particle_robin_at_default_coefficients_absorbs():
+    """Measured before this change: reflected, because `ROBIN` was not in the dispatch and fell to
+    the catch-all. With `beta = 0` the condition is `alpha*u = g` -- Dirichlet -- so the wall is an
+    exit, and treating it as impermeable is the opposite physics."""
+    result = _particle(_uniform(BCType.ROBIN, alpha=1.0, beta=0.0))
+
+    assert len(result) == 1, "only the interior particle survives an absorbing wall"
+    np.testing.assert_allclose(result[0], [0.5, 0.5])
+
+
+def test_particle_robin_with_zero_alpha_still_reflects():
+    """Control for the test above. Without it, an owner that absorbed every Robin would pass."""
+    result = _particle(_uniform(BCType.ROBIN, alpha=0.0, beta=1.0))
+
+    assert len(result) == len(_PARTICLES), "a pure flux condition absorbs nothing"
+
+
+@pytest.mark.parametrize("bc_type", sorted(_NO_PARTICLE_MEANING, key=lambda t: t.name))
+def test_the_segment_aware_path_no_longer_silently_reflects_a_truncation_rule(bc_type):
+    """Measured before this change: reflected, silently, via the `else` branch. A wrong answer
+    that looks like a right one is the failure this whole consolidation is about."""
+    with pytest.raises(ValueError, match=bc_type.name):
+        _particle(_uniform(bc_type))
+
+
+# =============================================================================
+# The cells that must NOT have moved
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("bc_type", "surviving"),
+    [(BCType.DIRICHLET, 1), (BCType.NEUMANN, 5), (BCType.NO_FLUX, 5), (BCType.PERIODIC, 5)],
+)
+def test_the_four_cells_that_already_agreed_are_unchanged(bc_type, surviving):
+    """Fifteen of the twenty-two probed cells were byte-identical across the consolidation. These
+    are the four where both paths already agreed; a merge that "fixed" them would be a regression
+    wearing the same commit message."""
+    assert len(_meshfree(_uniform(bc_type))) == surviving
+    assert len(_particle(_uniform(bc_type))) == surviving
+
+
+def test_the_three_actions_are_distinguishable_on_this_probe():
+    """Negative control for every assertion above. If reflecting and wrapping produced the same
+    positions on `_PARTICLES`, the whole file would pass over an owner that confused them --
+    which is exactly the state the two copies were in for `REFLECTING`."""
+    reflected = _meshfree(_uniform(BCType.NO_FLUX))
+    wrapped = _meshfree(_uniform(BCType.PERIODIC))
+    absorbed = _meshfree(_uniform(BCType.DIRICHLET))
+
+    assert not np.allclose(reflected, wrapped), "reflect and wrap must differ on this fixture"
+    assert len(absorbed) != len(reflected), "absorb must differ from reflect on this fixture"


### PR DESCRIPTION
Stage 1 of the BC dispatch consolidation. Two copies of one mapping, drifted on **four of `BCType`'s eight members**.

## The defect

`MeshfreeApplicator.apply_particles` and `ParticleApplicator.apply` each wrote out `BCType → particle action`. Measured on the same five particles and the same domain, **before** this change:

| BCType | MeshfreeApplicator | ParticleApplicator |
|---|---|---|
| `DIRICHLET` | absorbing | absorbing |
| `NEUMANN` / `NO_FLUX` | reflecting | reflecting |
| `PERIODIC` | periodic | periodic |
| `REFLECTING` | **ValueError** | reflecting |
| `ROBIN` (default `α=1, β=0`) | **absorbing** | **reflecting** |
| `EXTRAPOLATION_LINEAR` / `_QUADRATIC` | ValueError | **reflecting** |

The `ROBIN` row is the one that matters: the *same* `BoundaryConditions` object made one path build an **absorbing** wall and the other an **impermeable** one. Opposite physics, no error, and nothing in the tree could have caught it — the two paths are never called together.

## The fix

`particle_action_for_bc_type` is the single owner; both dispatches are deleted. Each divergence resolves toward whichever path was right, so this is **not either previous behaviour**:

- **`REFLECTING` reflects.** It is `BCType`'s own documented particle spelling of an impermeable wall — refusing it was the defect.
- **`ROBIN` dispatches on its coefficients.** `β = 0` makes the condition `αu = g`, which is Dirichlet, so absorb; `α = 0` is a flux condition, so reflect; genuinely mixed reflects and conserves mass.
- **`EXTRAPOLATION_*` raises, naming the type.** These say how to continue a *field* past a truncated domain and carry no boundary datum. The segment-aware path's `else` branch reflected them silently.

The segment-aware path now reads `α`/`β` off the **matched segment**, so a mixed BC with a different Robin coefficient per wall is read per wall.

## What did not change

Of **22 probed cells, 15 are byte-identical** and 2 differ only in an exception message. The four cells where both paths already agreed are pinned as unchanged — a merge that "fixed" them would fail.

## The pin is not path-A-vs-path-B

Once both route through the owner that comparison is tautological and would pass over a broken owner. The test pins the table **against the physics**, and each repaired cell against the capture taken **before** the merge. Three mutations measured to redden it:

```
REFLECTING dropped from the impermeable arm    2 failed / 22 passed
Robin always reflects (pre-merge particle)     4 failed / 20 passed
EXTRAPOLATION_* silently reflects again        4 failed / 20 passed
```

Source restored byte-identical after each.

## Mechanical checks (`domains/cs` § single source of truth)

- implementations of the mapping: **2 → 1** ✅
- net source lines: **+53** — a growth, **not** a pass. Executable lines are **−24**; the 47-line docstring carries the divergence table and why each cell resolved as it did. Flagging rather than claiming compliance.

## Still open, deliberately not in scope

`_robin_alpha_beta` takes the *first* Robin segment in the whole specification whichever face is being processed, so the **uniform** path still cannot vary `α, β` per wall. Separate issue.

## Gate

`./scripts/local_ci.sh` → **6113 passed, 12 skipped, 21 xfailed, GATE GREEN**.
Also run locally: `check_internal_deprecation`, `check_docs_structure`, `check_critical_issues` — the three CI-only checks `local_ci.sh` does not cover (learned from #1955).