### PR TITLE
fix(geometry): Robin's outward normal (#1907), and the FP resolver resolves instead of renaming

### DIFF
--- a/changelog.d/1907-robin-outward-normal.fixed.md
+++ b/changelog.d/1907-robin-outward-normal.fixed.md
@@ -1,0 +1,37 @@
+**Robin's `du/dn` is the outward normal derivative at both walls.** The low wall applied the
+outward sign a second time, imposing `alpha*u + beta*du/dx = g` — the axis condition, a
+physically different wall. Measured on `main`, `alpha=1, beta=0.3, g=0.7`: the residual of the
+condition `BCSegment.beta` declares was **6.17 at the min wall** and 0 at the max.
+
+On a cell-centred grid the ghost lies outside at *both* walls, so the quotient toward it,
+`(u_g - u_i)/dx`, already is the outward normal derivative; no further factor is due.
+`ghost_cell_robin` owns that derivation and the three sites that restated it now call it:
+`PreallocatedGhostBuffer._apply_linear_reflection`, `._apply_ghost_for_face`, and
+`BaseStructuredApplicator._compute_ghost_robin`.
+
+**User-visible consequence.** `uniform_bc(ROBIN, alpha, beta, value)` reads as "the same
+condition on every wall" and was not: the two walls carried different physics whenever
+`beta != 0`. `robin_bc(g, alpha=0, beta=1)` and `neumann_bc(g)` are the same condition and
+disagreed at the low wall by exactly `2*dx*g`.
+
+**What changed and what did not.** Of thirteen probed cells, **nine are byte-identical** — every
+`BCType` other than `ROBIN`, plus `ROBIN` with `beta = 0`, where the derivative term vanishes and
+the two conventions coincide. The four that moved are all `ROBIN` with `beta != 0` at the low
+wall, and each now satisfies the declared condition to `3e-14` or better across six coefficient
+sets including negative `beta` and negative `g`.
+
+**Second behaviour change, from the deletion.** Two of the removed implementations silently
+mirrored the interior cell when `alpha/2 + beta/dx == 0`. A singular coefficient means the
+condition does not determine the ghost, so the surviving owner raises instead of inventing an
+answer.
+
+The pin is the **condition itself**, not a comparison between paths: once all sites route through
+one owner, path-A-vs-path-B is tautological and would pass over a broken owner. Two mutations
+were measured to redden it — restoring the axis convention in the owner (15 of 20 failures) and
+restoring the silent mirror (1).
+
+Two existing tests are re-pointed rather than deleted. `test_ghost_spacing_1904.py` had said so
+itself: *"the sign convention this asserts is the applicator's own … which #1907 reports is one
+factor too many there … it will need re-pointing when #1907 lands."* And
+`test_fp_particle_gradient_bc_1255.py` pinned **both** conventions, one per wall, because it
+recorded what the code did rather than what the condition says.

--- a/changelog.d/1957-resolved-bc-field-coefficients.changed.md
+++ b/changelog.d/1957-resolved-bc-field-coefficients.changed.md
@@ -1,0 +1,28 @@
+**`FPResolver` resolves the impermeable wall instead of renaming it.** `NO_FLUX` and
+`REFLECTING` now become `MathBCType.ROBIN` carrying the coefficients of the flux condition:
+`J.n = 0` with `J = v*m - D*grad(m)` is `v_n*m - D*d_n m = 0`, i.e. `alpha = v_n`, `beta = -D`,
+`g = 0`. Verified against the condition itself, not against the previous code path: over 16
+coefficient sets the resulting ghost leaves `|J.n| <= 3.6e-15`.
+
+They previously became `MathBCType.ZERO_FLUX`, whose own enum comment read *"needs
+drift+diffusion for calculator"* — the physical intent passed through under a second name, so
+Layer 3 had to dispatch on it again. That member is **removed**; the enum's docstring already
+said it "contains no physical intent types", and `ZERO_FLUX` was the exception to its own rule.
+`ZeroFluxCalculator` itself stays, still reached through
+`bc_to_topology_calculator(use_zero_flux=True)`.
+
+**`ResolvedBC` coefficients may now be fields.** `alpha`, `beta` and `value` were declared
+`float`, and that is what blocked the resolution above: the Robin coefficient of a reflecting FP
+wall is `D_pH(x, grad u) . n`, which varies along the boundary and is recomputed every Picard
+iterate. A float cannot hold it. `ghost_cell_robin` consumes field coefficients as well — its
+arithmetic was already elementwise and only the singularity guard assumed a scalar; it now
+reports how many boundary points are singular.
+
+**No default for a mathematical parameter.** Resolving an impermeable wall without `drift` or
+`diffusion` in `solver_state` raises, naming the missing key. A defaulted drift makes the wall
+pure Neumann, which conserves mass at a tangential wall and leaks at every other one — a wrong
+answer that still converges. An unrecognised `BCType` likewise raises rather than defaulting to
+a zero-flux wall, which was an impermeable boundary imposed on a condition nobody wrote.
+
+Three tests in `test_resolution.py` are re-pointed rather than deleted: they asserted the
+`ZERO_FLUX` passthrough, which was the behaviour under replacement.

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -92,7 +92,7 @@ from .applicator_base import (
 from .conditions import BoundaryConditions
 from .enforcement import enforce_dirichlet_value_nd, enforce_neumann_value_nd
 from .fdm_bc_1d import BoundaryConditions as BoundaryConditions1DFDM
-from .ghost_cells import GhostCellConfig
+from .ghost_cells import GhostCellConfig, ghost_cell_robin
 from .types import (
     BCSegment,
     BCType,
@@ -1172,29 +1172,22 @@ class PreallocatedGhostBuffer:
                         buf[tuple(hi_ghost)] += dx * v
 
         elif bc_type == BCType.ROBIN:
-            # Robin: alpha*u + beta*du/dn = g (cell-centered ghost formula).
-            # Issue #1255 (C), 2026-06-10 audit: use the same general formula as
-            # _apply_ghost_for_face (mixed-segment path, lines 1549-1582) instead of
-            # the prior hardcoded alpha=0/beta=1 (pure-Neumann special case).
+            # Robin: alpha*u + beta*du/dn = g, du/dn the OUTWARD normal derivative, which is
+            # what `BCSegment.beta` and `BCType.ROBIN` both declare.
             #
-            # Cell-centred derivation (boundary at x_b midway between ghost x_g and
-            # interior x_i; spacing dx between cell centres):
-            #   u_b   = (u_g + u_i)/2
-            #   du/dn = (u_g - u_i)/dx * outward_sign
-            # Robin BC: alpha*(u_g+u_i)/2 + beta*(u_g-u_i)/dx*sign = g
-            # => u_g * (alpha/2 + beta*sign/dx) = g - u_i*(alpha/2 - beta*sign/dx)
+            # This used to carry its own arithmetic with an `outward_sign` factor on beta,
+            # which is the axis convention alpha*u + beta*du/dx = g -- a physically different
+            # condition at the low wall. Measured before the fix, on alpha=1, beta=0.3, g=0.7:
+            # the declared condition's residual was 6.17 at the min wall and 0 at the max.
+            # The sibling NEUMANN branch above already carries the outward convention, fixed
+            # for exactly this reason in #1262; this branch kept the pre-fix sign.
+            #
+            # For a cell-centred grid the ghost sits outside at both walls, so the quotient
+            # toward the ghost IS the outward derivative and the formula is side-free. That
+            # derivation lives in `ghost_cell_robin`, which now owns it.
             for axis in range(d):
                 dx = self._grid_spacing[axis] if self._grid_spacing is not None else 1.0
 
-                # Precompute per-wall (min/max) coefficients.
-                # Low wall: outward_sign = -1
-                coeff_ghost_lo = alpha / 2.0 - beta / dx
-                coeff_int_lo = alpha / 2.0 + beta / dx
-                # High wall: outward_sign = +1
-                coeff_ghost_hi = alpha / 2.0 + beta / dx
-                coeff_int_hi = alpha / 2.0 - beta / dx
-
-                # Get adjacent interior values (first/last interior cell).
                 lo_int_sl = [slice(None)] * d
                 lo_int_sl[axis] = g
                 u_lo_interior = buf[tuple(lo_int_sl)]
@@ -1204,21 +1197,13 @@ class PreallocatedGhostBuffer:
                 u_hi_interior = buf[tuple(hi_int_sl)]
 
                 for k in range(g):
-                    # Low ghost (outward normal = -1)
                     lo_ghost = [slice(None)] * d
                     lo_ghost[axis] = g - 1 - k
-                    if abs(coeff_ghost_lo) < 1e-12:
-                        buf[tuple(lo_ghost)] = u_lo_interior  # Degenerate: mirror
-                    else:
-                        buf[tuple(lo_ghost)] = (v - u_lo_interior * coeff_int_lo) / coeff_ghost_lo
+                    buf[tuple(lo_ghost)] = ghost_cell_robin(u_lo_interior, v, alpha, beta, dx)
 
-                    # High ghost (outward normal = +1)
                     hi_ghost = [slice(None)] * d
                     hi_ghost[axis] = -(g - k)
-                    if abs(coeff_ghost_hi) < 1e-12:
-                        buf[tuple(hi_ghost)] = u_hi_interior  # Degenerate: mirror
-                    else:
-                        buf[tuple(hi_ghost)] = (v - u_hi_interior * coeff_int_hi) / coeff_ghost_hi
+                    buf[tuple(hi_ghost)] = ghost_cell_robin(u_hi_interior, v, alpha, beta, dx)
 
     def _apply_poly_extrapolation(
         self,
@@ -1688,47 +1673,27 @@ class PreallocatedGhostBuffer:
             else:
                 dx = 1.0  # Fallback (may give incorrect results without proper dx)
 
-            # Outward normal sign: +1 for max, -1 for min
-            outward_sign = 1.0 if side == "max" else -1.0
-
-            # Ghost cell formula (cell-centered):
-            # For cell-centered grids, ghost and interior cell centers are dx apart.
-            # Boundary value: u_b = (u_g + u_i)/2 (midpoint between ghost and interior)
-            # Normal derivative: du/dn = (u_g - u_i)/dx * sign (not 2*dx!)
-            # Robin BC: alpha * u_b + beta * du/dn = g
-            # => alpha * (u_g + u_i)/2 + beta * (u_g - u_i)/dx * sign = g
-            # Solving for u_g:
-            # u_g * (alpha/2 + beta*sign/dx) = g - u_i * (alpha/2 - beta*sign/dx)
-            coeff_ghost = alpha / 2.0 + beta * outward_sign / dx
-            coeff_interior = alpha / 2.0 - beta * outward_sign / dx
-
-            if abs(coeff_ghost) < 1e-12:
-                # Degenerate case: fall back to reflection
-                for k in range(g):
-                    single_ghost = [slice(None)] * d
-                    single_interior = [slice(None)] * d
-                    if side == "min":
-                        single_ghost[axis] = k
-                        single_interior[axis] = 2 * g - k
-                    else:
-                        single_ghost[axis] = -(k + 1)
-                        single_interior[axis] = -(2 * g + k + 1)
-                    buf[tuple(single_ghost)] = buf[tuple(single_interior)]
-            else:
-                # Apply proper Robin formula using adjacent interior cell
-                # For min boundary: ghost[k] uses interior[g] (first interior cell)
-                # For max boundary: ghost[-k-1] uses interior[-g-1] (last interior cell)
-                for k in range(g):
-                    single_ghost = [slice(None)] * d
-                    single_interior = [slice(None)] * d
-                    if side == "min":
-                        single_ghost[axis] = g - 1 - k  # Ghost cells from g-1 down to 0
-                        single_interior[axis] = g  # Adjacent interior at index g
-                    else:
-                        single_ghost[axis] = -(g - k)  # Ghost cells from -g up to -1
-                        single_interior[axis] = -g - 1  # Adjacent interior at index -g-1
-                    u_interior = buf[tuple(single_interior)]
-                    buf[tuple(single_ghost)] = (v - u_interior * coeff_interior) / coeff_ghost
+            # `du/dn` is the OUTWARD normal derivative, as `BCSegment.beta` declares. The
+            # arithmetic that stood here multiplied beta by an outward sign, which imposes
+            # alpha*u + beta*du/dx = g instead -- a different physical condition at the low
+            # wall. `ghost_cell_robin` owns the derivation, including why the cell-centred
+            # formula is side-free: the ghost is outside at both walls, so the quotient
+            # toward it is already the outward derivative.
+            #
+            # The degenerate branch went with it. A singular coefficient means the condition
+            # does not determine the ghost, and mirroring invents an answer the caller never
+            # asked for; the owner raises instead.
+            for k in range(g):
+                single_ghost = [slice(None)] * d
+                single_interior = [slice(None)] * d
+                if side == "min":
+                    single_ghost[axis] = g - 1 - k  # Ghost cells from g-1 down to 0
+                    single_interior[axis] = g  # Adjacent interior at index g
+                else:
+                    single_ghost[axis] = -(g - k)  # Ghost cells from -g up to -1
+                    single_interior[axis] = -g - 1  # Adjacent interior at index -g-1
+                u_interior = buf[tuple(single_interior)]
+                buf[tuple(single_ghost)] = ghost_cell_robin(u_interior, v, alpha, beta, dx)
 
         else:
             # Fallback for unknown BC types: use reflection

--- a/mfgarchon/geometry/boundary/ghost_cells.py
+++ b/mfgarchon/geometry/boundary/ghost_cells.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import numpy as np
+
 from .protocols import GridType
 
 
@@ -146,8 +148,21 @@ def ghost_cell_robin(
     coeff_ghost = alpha / 2.0 + beta / dx
     coeff_interior = alpha / 2.0 - beta / dx
 
-    if abs(coeff_ghost) < 1e-12:
-        raise ValueError("Robin BC coefficients lead to singular ghost cell formula")
+    # alpha, beta and rhs_value may be FIELDS -- one value per boundary point. The impermeable
+    # wall of a Fokker-Planck equation is this condition with alpha = the outward normal drift,
+    # which varies along the boundary and is recomputed each Picard iterate. The arithmetic
+    # above is already elementwise; only this guard needed to stop assuming a scalar.
+    singular = np.abs(coeff_ghost) < 1e-12
+    if np.any(singular):
+        where = (
+            ""
+            if np.isscalar(singular) or singular.ndim == 0
+            else f" at {int(np.count_nonzero(singular))} of {singular.size} boundary points"
+        )
+        raise ValueError(
+            f"Robin BC coefficients lead to singular ghost cell formula{where}: "
+            f"alpha/2 + beta/dx = 0, so the condition does not determine the ghost value."
+        )
 
     return (rhs_value - interior_value * coeff_interior) / coeff_ghost
 

--- a/mfgarchon/geometry/boundary/protocols.py
+++ b/mfgarchon/geometry/boundary/protocols.py
@@ -518,18 +518,18 @@ class BaseStructuredApplicator(BaseBCApplicator):
             This formula is shared across 1D/2D/3D/nD to eliminate duplication.
             Fix (commit 0ae5515a): Changed from /(2*dx) to /dx.
         """
+        from .ghost_cells import ghost_cell_robin
+
         # Evaluate callable BC values
         if callable(g):
             g_val = g(time)
         else:
             g_val = g
 
-        # Robin formula (valid for both left and right boundaries)
-        # Cell centers are dx apart, not 2*dx
-        coeff_ghost = alpha / 2.0 + beta / dx
-        coeff_interior = alpha / 2.0 - beta / dx
-
-        return (g_val - u_interior * coeff_interior) / coeff_ghost
+        # The arithmetic that stood here was correct and was the third copy of it. `side` is
+        # accepted and unused for the same reason `ghost_cell_robin` documents: on a
+        # cell-centred grid the ghost lies outside at both walls, so the formula is side-free.
+        return ghost_cell_robin(u_interior, g_val, alpha, beta, dx)
 
     # =========================================================================
     # Shared Validation and Utility Methods (Issue #598)

--- a/mfgarchon/geometry/boundary/resolution.py
+++ b/mfgarchon/geometry/boundary/resolution.py
@@ -31,9 +31,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from mfgarchon.utils.mfg_logging import get_logger
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
 
 from .conditions import (
     BoundaryConditions,
@@ -58,13 +62,19 @@ class MathBCType(Enum):
     Unlike ``BCType`` (Layer 1), this enum contains no physical intent types
     (NO_FLUX, REFLECTING) or ambiguous types. Those are resolved into one of
     these mathematical types by a ``BCResolver``.
+
+    ~~``ZERO_FLUX``~~ was a member and broke that rule [REMOVED 2026-08-16]: ``J.n = 0`` is a
+    physical intent, its own comment read "needs drift+diffusion for calculator", and Layer 3
+    therefore had to dispatch on it a second time. ``FPResolver`` now resolves the impermeable
+    wall to ``ROBIN`` with ``alpha = v_n``, ``beta = -D``, ``g = 0``, so nothing produces it.
+    ``ZeroFluxCalculator`` itself stays; it is still reached through
+    ``bc_to_topology_calculator(use_zero_flux=True)``.
     """
 
     DIRICHLET = "dirichlet"  # u = g
     NEUMANN = "neumann"  # du/dn = g
     ROBIN = "robin"  # alpha*u + beta*du/dn = g
     PERIODIC = "periodic"  # u(x_min) = u(x_max)
-    ZERO_FLUX = "zero_flux"  # J*n = 0, needs drift+diffusion for calculator
     EXTRAPOLATION_LINEAR = "extrapolation_linear"  # d^2u/dx^2 = 0 at boundary
     EXTRAPOLATION_QUADRATIC = "extrapolation_quadratic"  # d^3u/dx^3 = 0
 
@@ -82,12 +92,24 @@ class ResolvedBC:
     concrete coefficient values, and traceability to the original segment.
 
     Produced by a ``BCResolver`` from a ``BCSegment``.
+
+    **The coefficients may be fields, not only scalars.** The reflecting wall of a
+    Fokker-Planck equation is ``(sigma^2/2) d_n m + m (D_pH(x, grad u) . n) = 0`` -- a Robin
+    condition whose ``alpha`` is the outward normal drift, which varies along the boundary and
+    is recomputed every Picard iterate. Declaring these ``float`` is what stopped ``FPResolver``
+    from resolving ``NO_FLUX``: it had to pass the intent through as a ``ZERO_FLUX`` tag and let
+    Layer 3 dispatch on it again, which is the restatement this layer exists to remove.
+
+    ``alpha`` and ``beta`` carry the **outward normal** convention, the one ``BCSegment.beta``
+    declares and the one every ghost formula uses since #1907. A caller supplying a drift must
+    give its outward normal component, not its axis component; the two differ in sign at a low
+    wall and produce a physically different condition there.
     """
 
     math_type: MathBCType
-    value: float = 0.0
-    alpha: float = 1.0  # Robin: weight on u
-    beta: float = 0.0  # Robin: weight on du/dn
+    value: float | NDArray[np.floating] = 0.0
+    alpha: float | NDArray[np.floating] = 1.0  # Robin: weight on u
+    beta: float | NDArray[np.floating] = 0.0  # Robin: weight on du/dn (OUTWARD normal)
     segment_name: str = ""
     original_bc_type: BCType | None = None
 
@@ -230,16 +252,46 @@ class HJBResolver:
         )
 
 
+def _require_coefficient(solver_state: dict[str, Any], key: str, segment: BCSegment) -> float | NDArray[np.floating]:
+    """Read a PDE coefficient the resolution genuinely needs, or fail naming what is missing.
+
+    Separate from a ``.get(key, default)`` on purpose. The defaults that would be natural here
+    -- zero drift, unit diffusion -- are each a *different physical wall*, and both produce a
+    solve that runs to convergence.
+    """
+    if key not in solver_state or solver_state[key] is None:
+        raise ValueError(
+            f"FPResolver: segment '{segment.name}' is {segment.bc_type.name}, whose condition is "
+            f"J.n = 0 = v_n*m - D*d_n m, so it needs '{key}' in solver_state. "
+            f"Present keys: {sorted(solver_state)}. "
+            "'drift' is the OUTWARD normal velocity component at the wall (a scalar, or one "
+            "value per boundary point); 'diffusion' is D = sigma^2/2."
+        )
+    return solver_state[key]
+
+
 class FPResolver:
     """Resolves BC intent for Fokker-Planck equations.
 
     Resolution rules:
-        - NO_FLUX, REFLECTING -> ZERO_FLUX: mass-conserving impermeable wall.
-          The zero-flux condition J*n = 0 where J = v*m - D*grad(m) requires
-          the ``ZeroFluxCalculator`` with drift and diffusion coefficients.
-          Pure Neumann (dm/dn = 0) is incorrect when drift != 0 at boundary
-          and violates the Lopatinski-Shapiro condition in the
-          advection-dominated regime.
+        - NO_FLUX, REFLECTING -> **ROBIN** with the coefficients of the flux condition.
+          ``J . n = 0`` with ``J = v*m - D*grad(m)`` is ``v_n*m - D*d_n m = 0``, i.e.
+          ``alpha = v_n``, ``beta = -D``, ``g = 0`` in the Robin form
+          ``alpha*u + beta*d_n u = g``. Pure Neumann (``dm/dn = 0``) is the special case
+          ``v_n = 0``; imposing it when the drift is non-tangential at the wall leaks mass at
+          a rate proportional to ``m_wall * v_n`` and violates the Lopatinski-Shapiro
+          condition in the advection-dominated regime.
+
+          ``v_n`` is the **outward normal** component, matching the convention
+          ``BCSegment.beta`` declares and every ghost formula uses since #1907. It is read
+          from ``solver_state``; there is no default, because a defaulted drift silently turns
+          the wall into pure Neumann, which is exactly the failure this resolution exists to
+          prevent, and the wrong answer would still converge.
+
+          ~~-> ZERO_FLUX~~ [CORRECTED 2026-08-16] passed the physical intent through as a
+          second tag whose own comment read "needs drift+diffusion for calculator", so Layer 3
+          had to dispatch on it again. The blocker was that ``ResolvedBC`` declared its
+          coefficients ``float`` and ``v_n`` is a field.
         - All other types: passthrough.
 
     References:
@@ -252,32 +304,41 @@ class FPResolver:
         segment: BCSegment,
         solver_state: dict[str, Any],
     ) -> ResolvedBC:
-        """Resolve a BCSegment for Fokker-Planck equation."""
+        """Resolve a BCSegment for Fokker-Planck equation.
+
+        Args:
+            segment: Physical boundary specification.
+            solver_state: Must carry ``'drift'`` and ``'diffusion'`` when the segment is
+                ``NO_FLUX`` or ``REFLECTING``. ``'drift'`` is the **outward normal** component
+                of the velocity at the wall, scalar or one value per boundary point;
+                ``'diffusion'`` is ``D = sigma^2/2``.
+
+        Raises:
+            ValueError: if an impermeable wall is resolved without them. A defaulted drift
+                turns the condition into pure Neumann, which conserves mass at a tangential
+                wall and leaks at every other one -- the wrong answer still converges, so it
+                cannot be allowed to be the silent option.
+        """
         # Check passthrough types first
         result = _resolve_passthrough(segment)
         if result is not None:
             return result
 
-        # Equation-specific: NO_FLUX and REFLECTING
+        # Equation-specific: the impermeable wall is J.n = 0, which is Robin in m.
         if segment.bc_type in (BCType.NO_FLUX, BCType.REFLECTING):
             return ResolvedBC(
-                math_type=MathBCType.ZERO_FLUX,
-                value=0.0,
+                math_type=MathBCType.ROBIN,
+                value=0.0,  # the flux condition is homogeneous
+                alpha=_require_coefficient(solver_state, "drift", segment),
+                beta=-_require_coefficient(solver_state, "diffusion", segment),
                 segment_name=segment.name,
                 original_bc_type=segment.bc_type,
             )
 
-        # Unknown BCType: default to zero flux with warning
-        logger.warning(
-            "FPResolver: unrecognized BCType %s on segment '%s', defaulting to ZERO_FLUX",
-            segment.bc_type,
-            segment.name,
-        )
-        return ResolvedBC(
-            math_type=MathBCType.ZERO_FLUX,
-            value=0.0,
-            segment_name=segment.name,
-            original_bc_type=segment.bc_type,
+        raise ValueError(
+            f"FPResolver: unrecognized BCType {segment.bc_type} on segment '{segment.name}'. "
+            "It used to default to a zero-flux wall, which is an impermeable boundary imposed "
+            "on a condition nobody wrote -- mass-conserving, plausible, and not what was asked."
         )
 
 
@@ -333,8 +394,9 @@ def resolved_bc_to_calculator(
         resolved: A resolved BC from a BCResolver.
         shape: Grid shape (interior points).
         grid_type: Grid type for ghost cell formulas. Defaults to CELL_CENTERED.
-        drift_velocity: Normal drift component (for ZERO_FLUX calculator).
-        diffusion_coeff: Diffusion coefficient D = sigma^2/2 (for ZERO_FLUX).
+        drift_velocity: Unused since the impermeable wall resolves to ROBIN carrying its own
+            coefficients. Kept so existing call sites do not break; slated for removal.
+        diffusion_coeff: Unused, as above.
 
     Returns:
         Tuple of (Topology, Calculator | None). Calculator is None for periodic.
@@ -347,7 +409,6 @@ def resolved_bc_to_calculator(
         PeriodicTopology,
         QuadraticExtrapolationCalculator,
         RobinCalculator,
-        ZeroFluxCalculator,
     )
     from .protocols import GridType as GridTypeEnum
 
@@ -363,8 +424,6 @@ def resolved_bc_to_calculator(
             return BoundedTopology(dimension, shape), NeumannCalculator(resolved.value, gt)
         case MathBCType.ROBIN:
             return BoundedTopology(dimension, shape), RobinCalculator(resolved.alpha, resolved.beta, resolved.value, gt)
-        case MathBCType.ZERO_FLUX:
-            return BoundedTopology(dimension, shape), ZeroFluxCalculator(drift_velocity, diffusion_coeff, gt)
         case MathBCType.EXTRAPOLATION_LINEAR:
             return BoundedTopology(dimension, shape), LinearExtrapolationCalculator()
         case MathBCType.EXTRAPOLATION_QUADRATIC:
@@ -386,7 +445,6 @@ _MATH_TO_BC_TYPE: dict[MathBCType, BCType] = {
     MathBCType.NEUMANN: BCType.NEUMANN,
     MathBCType.ROBIN: BCType.ROBIN,
     MathBCType.PERIODIC: BCType.PERIODIC,
-    MathBCType.ZERO_FLUX: BCType.NO_FLUX,
     MathBCType.EXTRAPOLATION_LINEAR: BCType.EXTRAPOLATION_LINEAR,
     MathBCType.EXTRAPOLATION_QUADRATIC: BCType.EXTRAPOLATION_QUADRATIC,
 }
@@ -403,9 +461,10 @@ def to_boundary_conditions(
     mapping MathBCType back to BCType.
 
     Note:
-        ZERO_FLUX maps to BCType.NO_FLUX. The equation-awareness is lost in
-        the round-trip, so callers needing full fidelity should use
-        ``resolved_bc_to_calculator()`` instead.
+        The round-trip is lossy in the other direction now: an impermeable wall resolves to
+        ROBIN carrying the drift and diffusion of the flux condition, and ``BCType.ROBIN``
+        carries only the segment's own scalar alpha/beta. Callers needing full fidelity should
+        use ``resolved_bc_to_calculator()``.
 
     Args:
         resolved: List of ResolvedBC from a resolver.
@@ -476,12 +535,12 @@ if __name__ == "__main__":
     fp = FPResolver()
 
     print("\nFP Resolver:")
-    # NO_FLUX -> ZERO_FLUX
+    # NO_FLUX -> ROBIN carrying the flux condition's coefficients
     bc = no_flux_bc(dimension=1)
-    results = resolve_bc(bc, fp, state)
+    results = resolve_bc(bc, fp, {**state, "drift": 0.6, "diffusion": 0.35})
     for r in results:
-        print(f"  NO_FLUX -> {r.math_type.value}")
-    assert results[0].math_type == MathBCType.ZERO_FLUX
+        print(f"  NO_FLUX -> {r.math_type.value}(alpha={r.alpha}, beta={r.beta})")
+    assert results[0].math_type == MathBCType.ROBIN
 
     # DIRICHLET -> DIRICHLET (passthrough)
     bc = dirichlet_bc(0.0, dimension=1)
@@ -494,7 +553,7 @@ if __name__ == "__main__":
     print("\nLayer 2->3 bridge (resolved_bc_to_calculator):")
     for rbc in [
         ResolvedBC(MathBCType.NEUMANN, 0.0, segment_name="test_neum"),
-        ResolvedBC(MathBCType.ZERO_FLUX, 0.0, segment_name="test_flux"),
+        ResolvedBC(MathBCType.ROBIN, 0.0, alpha=0.6, beta=-0.35, segment_name="test_flux"),
         ResolvedBC(MathBCType.DIRICHLET, 1.0, segment_name="test_dir"),
     ]:
         topo, calc = resolved_bc_to_calculator(rbc, shape=(100,))

--- a/mfgarchon/geometry/boundary/resolution.py
+++ b/mfgarchon/geometry/boundary/resolution.py
@@ -450,6 +450,28 @@ _MATH_TO_BC_TYPE: dict[MathBCType, BCType] = {
 }
 
 
+def _refuse_field_coefficients(rbc: ResolvedBC) -> None:
+    """A ``BCSegment`` declares its coefficients ``float`` and this bridge builds segments.
+
+    ``ResolvedBC`` may carry fields; ``BCSegment`` may not. Copying an array through produced a
+    segment that looked well-formed and died two calls later inside the ghost formula with
+    ``operands could not be broadcast together with shapes (6,) (4,)`` -- an error naming the
+    padded array rather than the coefficient that caused it. Refuse here, where the fact is
+    still legible, and name the other bridge, which does support fields.
+    """
+    import numpy as _np
+
+    for name in ("alpha", "beta", "value"):
+        v = getattr(rbc, name)
+        if isinstance(v, _np.ndarray) and v.ndim > 0:
+            raise ValueError(
+                f"to_boundary_conditions: segment '{rbc.segment_name}' has a field-valued "
+                f"'{name}' of shape {v.shape}, and BCSegment.{name} is a float. This bridge "
+                "cannot carry it. Use resolved_bc_to_calculator(), which consumes the "
+                "coefficients directly and does support fields."
+            )
+
+
 def to_boundary_conditions(
     resolved: list[ResolvedBC],
     dimension: int | None = None,
@@ -461,10 +483,15 @@ def to_boundary_conditions(
     mapping MathBCType back to BCType.
 
     Note:
-        The round-trip is lossy in the other direction now: an impermeable wall resolves to
-        ROBIN carrying the drift and diffusion of the flux condition, and ``BCType.ROBIN``
-        carries only the segment's own scalar alpha/beta. Callers needing full fidelity should
-        use ``resolved_bc_to_calculator()``.
+        Lossless for scalar coefficients -- ``alpha`` and ``beta`` are copied verbatim -- and
+        **impossible** for field-valued ones, which this function now refuses by name rather
+        than letting them die in a broadcast error two calls downstream. An impermeable wall
+        resolved with a per-point drift is exactly that case. Use
+        ``resolved_bc_to_calculator()`` there; it consumes the coefficients directly.
+
+        ~~"BCType.ROBIN carries only the segment's own scalar alpha/beta"~~ was written here
+        and is false about the function twelve lines below it, which copies ``rbc.alpha`` and
+        ``rbc.beta`` straight through [CORRECTED 2026-08-16, found by independent review].
 
     Args:
         resolved: List of ResolvedBC from a resolver.
@@ -478,6 +505,7 @@ def to_boundary_conditions(
 
     segments = []
     for rbc in resolved:
+        _refuse_field_coefficients(rbc)
         bc_type = _MATH_TO_BC_TYPE.get(rbc.math_type, BCType.NEUMANN)
         seg = BCSegment(
             name=rbc.segment_name or f"resolved_{rbc.math_type.value}",

--- a/tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py
+++ b/tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py
@@ -286,10 +286,21 @@ class TestUniformRobinGhostAlphaBeta:
         """
         Low-wall ghost must use the general Robin formula, not pure Neumann.
         Buggy value: -4.0 (pure Neumann, alpha=0, beta=1).
-        Fixed value: (5 - 1*2.5)/(-1.5) = -2.5/-1.5 ≈ 1.6667.
+
+        RE-POINTED 2026-08-16 (#1907). This asserted `(5 - 1*2.5)/(-1.5)`, i.e. the low-wall
+        coefficients `alpha/2 -+ beta/dx`, which is the AXIS condition `alpha*u + beta*du/dx = g`.
+        `BCSegment.beta` declares `du/dn`, the outward normal derivative, and the sibling test
+        for the high wall two functions down already asserts the outward form -- so this file
+        pinned BOTH conventions, one per wall, because it recorded what the code did rather than
+        what the condition says. #1255 was fixing a different defect (a hardcoded pure-Neumann
+        special case) and carried the low-wall sign along untouched.
+
+        The outward condition is side-free on a cell-centred grid, so the expected value is now
+        the same expression as the high wall's, and the two walls agree because this fixture's
+        adjacent interior cell is 1.0 at both ends.
         """
         u_ghost_lo = ghost_buffer.padded[0]  # index 0 = low ghost
-        expected = (5.0 - 1.0 * 2.5) / (-1.5)  # ≈ 1.6667
+        expected = (5.0 - 1.0 * (-1.5)) / 2.5  # = 2.6, identical to the high wall
         assert abs(u_ghost_lo - expected) < 1e-9, (
             f"Low ghost: expected {expected:.4f} (general Robin), "
             f"got {u_ghost_lo:.4f}. "

--- a/tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py
+++ b/tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py
@@ -1,0 +1,165 @@
+"""Robin's `du/dn` is the outward normal derivative, at both walls. #1907
+
+The low wall applied the outward sign a second time. On a cell-centred grid the ghost lies
+outside at both walls, so the quotient toward it, `(u_g - u_i)/dx`, IS the outward normal
+derivative and no further factor is due. Multiplying by `outward_sign = -1` there imposes
+`alpha*u + beta*du/dx = g` -- the axis condition, a physically different wall.
+
+Measured on `main` before the fix, `alpha=1, beta=0.3, g=0.7`: the declared condition's residual
+was **6.17 at the min wall** and 0 at the max.
+
+**The oracle is the condition itself, not the other code path.** Four implementations wrote this
+formula; the fix routes all of them through `ghost_cell_robin`, after which comparing any two is
+tautological and would pass over a broken owner. So every assertion below evaluates
+`alpha*u_b + beta*du/dn - g` on the ghost the shipped API returned.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    neumann_bc,
+    pad_array_with_ghosts,
+    robin_bc,
+)
+
+_U = np.array([2.5, 3.1, 4.0, 5.2, 6.6])
+_DX = 0.25
+
+
+def _residual(ghost: float, interior: float, alpha: float, beta: float, g: float, dx: float) -> float:
+    """`alpha*u_b + beta*du/dn - g`, with `du/dn` the quotient toward the ghost.
+
+    Side-free by construction: at the low wall the outward normal is $-x$ and the ghost sits at
+    lower $x$, so $\\partial_n u = -\\partial_x u = (u_g - u_i)/dx$; at the high wall the outward
+    normal is $+x$ and the ghost sits at higher $x$, giving the same expression.
+    """
+    return alpha * (ghost + interior) / 2 + beta * (ghost - interior) / dx - g
+
+
+def _uniform_robin(alpha: float, beta: float, g: float) -> BoundaryConditions:
+    return BoundaryConditions(
+        segments=[BCSegment(name="wall", bc_type=BCType.ROBIN, value=g, alpha=alpha, beta=beta)],
+        dimension=1,
+        default_bc=BCType.ROBIN,
+        default_value=g,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("alpha", "beta", "g"),
+    [
+        (1.0, 0.3, 0.7),  # the case measured at residual 6.17 before the fix
+        (1.0, 0.3, 0.0),  # homogeneous: the conventions still differ, beta is what matters
+        (0.0, 1.0, 0.7),  # pure flux
+        (2.0, 0.5, 0.0),
+        (3.0, -0.4, 1.1),  # negative beta
+        (0.5, 2.0, -0.3),  # negative g
+    ],
+)
+@pytest.mark.parametrize("wall", ["min", "max"])
+def test_the_ghost_satisfies_the_declared_condition_at_both_walls(alpha, beta, g, wall):
+    """`BCSegment.beta` is documented "Weight on du/dn (Neumann term)" and `BCType.ROBIN` as
+    `alpha*u + beta*du/dn = g`. That is the contract; this asserts the shipped ghost meets it.
+
+    Both walls are parametrised on purpose. The max wall passed before the fix and passes now --
+    a one-wall test would have been green throughout and pinned nothing.
+    """
+    padded = pad_array_with_ghosts(_U, _uniform_robin(alpha, beta, g), spacing=_DX)
+    ghost, interior = (padded[0], _U[0]) if wall == "min" else (padded[-1], _U[-1])
+
+    assert _residual(ghost, interior, alpha, beta, g, _DX) == pytest.approx(0.0, abs=1e-12)
+
+
+@pytest.mark.parametrize("g", [0.0, 2.0, -1.5])
+def test_robin_with_alpha_zero_beta_one_is_the_neumann_condition(g):
+    """The headline of #1907: `robin_bc(g, alpha=0, beta=1)` and `neumann_bc(g)` are the same
+    condition, `du/dn = g`, and they disagreed at the low wall by exactly `2*dx*g`.
+
+    Measured before the fix at `g = 2.0`, spacing threaded: `neumann` gave 0.600000 and
+    `robin(0,1)` gave 0.400000 on a 21-point grid, difference `0.2 = 2*h*g`, shrinking with `h`
+    and identically zero at the high wall. `g = 0` is included as the degenerate row where the
+    two agreed even before the fix -- without it a test that simply returned the Neumann value
+    would pass, and with it alone the whole property would look already satisfied.
+    """
+    robin = pad_array_with_ghosts(_U, robin_bc(dimension=1, alpha=0.0, beta=1.0, value=g), spacing=_DX)
+    neumann = pad_array_with_ghosts(_U, neumann_bc(dimension=1, value=g), spacing=_DX)
+
+    assert robin[0] == pytest.approx(neumann[0], abs=1e-12), "low wall"
+    assert robin[-1] == pytest.approx(neumann[-1], abs=1e-12), "high wall"
+
+
+def test_a_uniform_robin_wall_is_the_same_physics_at_both_ends():
+    """The user-visible consequence, stated without reference to any formula.
+
+    `uniform Robin` reads as "the same condition on every wall". Under the axis convention it was
+    not: the low wall got `alpha*u + beta*du/dx = g` and the high wall `alpha*u + beta*du/dn = g`,
+    which are different physical walls. A field that is symmetric about the domain centre must
+    therefore produce symmetric ghosts.
+    """
+    symmetric = np.array([1.0, 2.0, 3.0, 2.0, 1.0])
+    padded = pad_array_with_ghosts(symmetric, _uniform_robin(1.0, 0.4, 0.9), spacing=_DX)
+
+    assert padded[0] == pytest.approx(padded[-1], abs=1e-12), (
+        "a symmetric field under a wall-symmetric condition must give symmetric ghosts"
+    )
+
+
+def test_the_fixture_would_expose_an_asymmetry():
+    """Control for the test above. The symmetric field makes the two walls comparable only
+    because the interior values at the two ends are equal; this asserts the probe can still tell
+    the walls apart when the condition genuinely differs between them, so the symmetry check is
+    not vacuous."""
+    symmetric = np.array([1.0, 2.0, 3.0, 2.0, 1.0])
+    mixed = BoundaryConditions(
+        segments=[
+            BCSegment(name="lo", bc_type=BCType.ROBIN, value=0.9, alpha=1.0, beta=0.4, boundary="x_min"),
+            BCSegment(name="hi", bc_type=BCType.DIRICHLET, value=0.9, boundary="x_max"),
+        ],
+        dimension=1,
+        default_bc=BCType.ROBIN,
+        default_value=0.9,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+    padded = pad_array_with_ghosts(symmetric, mixed, spacing=_DX)
+
+    assert padded[0] != pytest.approx(padded[-1], abs=1e-12)
+
+
+def test_a_singular_coefficient_raises_rather_than_mirroring():
+    """`alpha/2 + beta/dx == 0` leaves the ghost undetermined by the condition. Two of the four
+    deleted implementations silently mirrored the interior cell there, which answers a question
+    the caller did not ask; the surviving owner raises.
+
+    With `dx = 0.25`, `alpha = 2` and `beta = -0.25` give `1 + (-1) = 0` exactly.
+    """
+    with pytest.raises(ValueError, match="singular"):
+        pad_array_with_ghosts(_U, _uniform_robin(2.0, -0.25, 0.5), spacing=_DX)
+
+
+@pytest.mark.parametrize(
+    ("bc_factory", "label"),
+    [
+        (lambda: neumann_bc(dimension=1, value=0.0), "NEUMANN"),
+        (lambda: robin_bc(dimension=1, alpha=1.0, beta=0.0, value=0.7), "ROBIN with beta=0"),
+    ],
+)
+def test_the_cells_that_must_not_have_moved(bc_factory, label):
+    """Nine of the thirteen probed cells were byte-identical across this change; these are the
+    two that could plausibly have been disturbed. `beta = 0` removes the derivative term, so the
+    conventions coincide there -- a fix that changed it would be a regression."""
+    padded = pad_array_with_ghosts(_U, bc_factory(), spacing=_DX)
+
+    if label == "NEUMANN":
+        assert padded[0] == pytest.approx(_U[0])
+        assert padded[-1] == pytest.approx(_U[-1])
+    else:
+        assert padded[0] == pytest.approx(2 * 0.7 - _U[0])
+        assert padded[-1] == pytest.approx(2 * 0.7 - _U[-1])

--- a/tests/unit/test_geometry/test_ghost_spacing_1904.py
+++ b/tests/unit/test_geometry/test_ghost_spacing_1904.py
@@ -128,17 +128,24 @@ def test_robin_reads_the_same_spacing(dx: float):
     found by independent review of #1906]: two spacings give different ghosts under any
     denominator whatever, and it probed only index 0.
 
-    NOTE the sign convention this asserts is the applicator's own, `outward_sign = -1` at the
-    low wall, which #1907 reports is one factor too many there. This test pins the ghost against
-    the equation the code currently writes; it is deliberately NOT the oracle for that defect,
-    and it will need re-pointing when #1907 lands.
+    RE-POINTED 2026-08-16, when #1907 landed. This previously asserted the residual of the
+    equation the applicator then wrote, `... /dx*outward_sign = g` with `outward_sign = -1` at
+    the low wall, and said so in this note: "deliberately NOT the oracle for that defect, and it
+    will need re-pointing when #1907 lands". The applicator now writes the condition
+    `BCSegment.beta` declares -- `du/dn` the OUTWARD normal derivative -- and on a cell-centred
+    grid the ghost lies outside at both walls, so `(u_g - u_i)/dx` IS that derivative and no
+    further sign is due. The two `outward_sign` factors are therefore gone from the oracle, and
+    with them the last place in the suite that asserted the low wall's old convention.
+
+    The spacing property this test exists for is untouched: the residual is machine-zero when
+    the spacing is threaded and O(1/dx) when the buffer substitutes 1.0.
     """
     u = np.random.default_rng(7).normal(size=7)
     alpha, beta, g = 1.0, 1.0, 0.5
     bc = robin_bc(dimension=1, alpha=alpha, beta=beta, value=g)
     p = pad_array_with_ghosts(u, bc, ghost_depth=1, time=0.0, spacing=dx)
-    low = alpha * (p[0] + p[1]) / 2 + beta * (p[0] - p[1]) / dx * (-1.0) - g
-    high = alpha * (p[-1] + p[-2]) / 2 + beta * (p[-1] - p[-2]) / dx * (+1.0) - g
+    low = alpha * (p[0] + p[1]) / 2 + beta * (p[0] - p[1]) / dx - g
+    high = alpha * (p[-1] + p[-2]) / 2 + beta * (p[-1] - p[-2]) / dx - g
     assert low == pytest.approx(0.0, abs=1e-12), f"dx={dx}: Robin low wall residual {low:.3e}"
     assert high == pytest.approx(0.0, abs=1e-12), f"dx={dx}: Robin high wall residual {high:.3e}"
 

--- a/tests/unit/test_geometry/test_resolution.py
+++ b/tests/unit/test_geometry/test_resolution.py
@@ -146,18 +146,48 @@ class TestHJBResolver:
 
 
 class TestFPResolver:
-    def test_no_flux_resolves_to_zero_flux(self, fp_resolver, empty_state):
-        bc = no_flux_bc(dimension=1)
-        results = resolve_bc(bc, fp_resolver, empty_state)
-        for r in results:
-            assert r.math_type == MathBCType.ZERO_FLUX
-            assert r.original_bc_type == BCType.NO_FLUX
+    @pytest.mark.parametrize("bc_type", [BCType.NO_FLUX, BCType.REFLECTING])
+    def test_an_impermeable_wall_resolves_to_the_robin_coefficients_of_the_flux_condition(self, fp_resolver, bc_type):
+        """RE-POINTED 2026-08-16. This asserted ``MathBCType.ZERO_FLUX``, which was the intent
+        passed through under a second name -- its own enum comment read "needs drift+diffusion
+        for calculator", so Layer 3 had to dispatch on it again.
 
-    def test_reflecting_resolves_to_zero_flux(self, fp_resolver, empty_state):
-        seg = BCSegment(name="wall", bc_type=BCType.REFLECTING, value=0.0)
+        ``J.n = 0`` with ``J = v*m - D*grad(m)`` is ``v_n*m - D*d_n m = 0``, i.e. Robin with
+        ``alpha = v_n``, ``beta = -D``, ``g = 0``. The resolution is now that arithmetic.
+        """
+        seg = BCSegment(name="wall", bc_type=bc_type, value=0.0)
         bc = BoundaryConditions(segments=[seg], dimension=1)
-        results = resolve_bc(bc, fp_resolver, empty_state)
-        assert results[0].math_type == MathBCType.ZERO_FLUX
+
+        r = resolve_bc(bc, fp_resolver, {"drift": 0.6, "diffusion": 0.35})[0]
+
+        assert r.math_type == MathBCType.ROBIN
+        assert r.original_bc_type == bc_type
+        assert r.alpha == pytest.approx(0.6), "alpha is the outward normal drift"
+        assert r.beta == pytest.approx(-0.35), "beta is -D"
+        assert r.value == pytest.approx(0.0), "the flux condition is homogeneous"
+
+    def test_an_impermeable_wall_without_the_coefficients_refuses(self, fp_resolver, empty_state):
+        """A defaulted drift makes the wall pure Neumann, which conserves mass at a tangential
+        wall and leaks at every other one -- a wrong answer that still converges. The message
+        must name the missing key, since the caller has two to supply."""
+        seg = BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0)
+        bc = BoundaryConditions(segments=[seg], dimension=1)
+
+        with pytest.raises(ValueError, match="drift"):
+            resolve_bc(bc, fp_resolver, empty_state)
+        with pytest.raises(ValueError, match="diffusion"):
+            resolve_bc(bc, fp_resolver, {"drift": 0.6})
+
+    def test_the_drift_may_be_a_field(self, fp_resolver):
+        """The reason ``ResolvedBC`` stopped declaring its coefficients ``float``: the outward
+        normal drift varies along the wall and is recomputed each Picard iterate."""
+        seg = BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0)
+        bc = BoundaryConditions(segments=[seg], dimension=2)
+        drift = np.array([0.0, 0.6, -0.6, 2.5])
+
+        r = resolve_bc(bc, fp_resolver, {"drift": drift, "diffusion": 0.35})[0]
+
+        np.testing.assert_allclose(r.alpha, drift)
 
     def test_dirichlet_passthrough(self, fp_resolver, empty_state):
         bc = dirichlet_bc(0.0, dimension=1)
@@ -213,7 +243,7 @@ class TestResolveBC:
     def test_segment_names_preserved(self, fp_resolver, empty_state):
         seg = BCSegment(name="my_wall", bc_type=BCType.NO_FLUX, value=0.0)
         bc = BoundaryConditions(segments=[seg], dimension=1)
-        results = resolve_bc(bc, fp_resolver, empty_state)
+        results = resolve_bc(bc, fp_resolver, {"drift": 0.0, "diffusion": 1.0})
         assert results[0].segment_name == "my_wall"
 
 
@@ -245,11 +275,6 @@ class TestToBoundaryConditions:
         assert bc.segments[0].bc_type == BCType.NEUMANN
         assert bc.segments[1].bc_type == BCType.DIRICHLET
         assert bc.segments[1].value == 1.0
-
-    def test_zero_flux_maps_to_no_flux(self):
-        resolved = [ResolvedBC(MathBCType.ZERO_FLUX, 0.0, segment_name="wall")]
-        bc = to_boundary_conditions(resolved, dimension=1)
-        assert bc.segments[0].bc_type == BCType.NO_FLUX
 
     def test_empty_resolved_returns_default(self):
         bc = to_boundary_conditions([], dimension=1)

--- a/tests/unit/test_geometry/test_resolution.py
+++ b/tests/unit/test_geometry/test_resolution.py
@@ -300,3 +300,42 @@ class TestResolvedBC:
         assert rbc.beta == 0.0
         assert rbc.segment_name == ""
         assert rbc.original_bc_type is None
+
+
+class TestFieldCoefficientsAcrossTheTwoBridges:
+    """`ResolvedBC` may carry fields; `BCSegment` may not. The two Layer-2 -> Layer-3 bridges
+    therefore differ, and the difference has to be legible at the boundary rather than two calls
+    downstream. Found by independent review of this PR."""
+
+    @staticmethod
+    def _field_resolved():
+        seg = BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0)
+        bc = BoundaryConditions(segments=[seg], dimension=2)
+        return resolve_bc(bc, FPResolver(), {"drift": np.array([0.0, 0.6, -0.6, 2.5]), "diffusion": 0.35})
+
+    def test_the_segment_bridge_refuses_a_field_and_names_it(self):
+        """It used to copy the array into `BCSegment.alpha`, declared `float`, producing a
+        segment that looked well-formed and died inside the ghost formula with
+        `operands could not be broadcast together with shapes (6,) (4,)` -- an error naming the
+        padded array rather than the coefficient responsible."""
+        with pytest.raises(ValueError, match="field-valued 'alpha'"):
+            to_boundary_conditions(self._field_resolved(), dimension=2)
+
+    def test_the_calculator_bridge_carries_the_field(self):
+        """Control, and the reason the refusal above is not a capability loss: the other bridge
+        consumes the coefficients directly and never builds a segment."""
+        _topo, calc = resolved_bc_to_calculator(self._field_resolved()[0], shape=(4, 4))
+
+        np.testing.assert_allclose(calc._alpha, np.array([0.0, 0.6, -0.6, 2.5]))
+
+    def test_a_scalar_still_round_trips_through_the_segment_bridge(self):
+        """Scope control. The refusal must be narrow -- a scalar coefficient is unaffected, and a
+        fix that rejected every Robin would pass the test above."""
+        seg = BCSegment(name="wall", bc_type=BCType.NO_FLUX, value=0.0)
+        bc = BoundaryConditions(segments=[seg], dimension=1)
+        resolved = resolve_bc(bc, FPResolver(), {"drift": 0.6, "diffusion": 0.35})
+
+        out = to_boundary_conditions(resolved, dimension=1)
+
+        assert out.segments[0].alpha == pytest.approx(0.6)
+        assert out.segments[0].beta == pytest.approx(-0.35)


### PR DESCRIPTION
Two commits. The first is a live defect that blocked the second.

---

## 1 — `14361fe6` Robin's `du/dn` is the outward normal at both walls (#1907)

**The shipped FDM path violated the Robin condition the package declares, at the low wall only.** Measured on `main` through `pad_array_with_ghosts`, `alpha=1, beta=0.3, g=0.7`:

| wall | residual of `alpha*u_b + beta*du/dn - g` |
|---|---|
| min | **6.17** |
| max | −6.7e−16 |

The low wall applied the outward sign a second time, imposing `alpha*u + beta*du/dx = g` — the **axis** condition, a physically different wall. On a cell-centred grid the ghost lies outside at *both* walls, so `(u_g - u_i)/dx` already **is** the outward normal derivative.

**Four implementations, two conventions.** `ghost_cell_robin` and `BaseStructuredApplicator._compute_ghost_robin` were byte-for-byte the same correct side-free form; `PreallocatedGhostBuffer._apply_linear_reflection` and `._apply_ghost_for_face` each carried the extra sign. `ghost_cell_robin` is now the owner — implementations **4 → 2**, and the survivor in `_compat.py` is deleted by #1955.

**User-visible:** `uniform_bc(ROBIN, alpha, beta, value)` reads as "the same condition on every wall" and was not, whenever `beta != 0`. `robin_bc(g, alpha=0, beta=1)` and `neumann_bc(g)` are one condition and disagreed at the low wall by exactly `2*dx*g`.

**What did not change:** 9 of 13 probed cells byte-identical — every other `BCType`, and `ROBIN` with `beta = 0` where the derivative term vanishes. Those are pinned as unchanged.

**Second behaviour change, from the deletion:** two removed implementations silently mirrored when `alpha/2 + beta/dx == 0`. The owner raises — a singular coefficient means the condition doesn't determine the ghost.

**The pin is the condition, not a path comparison** — after routing every site through one owner, path-A-vs-path-B is tautological and passes over a broken owner. Mutations measured: axis convention restored → **15 of 20 failed**; silent mirror restored → **1 failed**.

Two existing tests are **re-pointed, not deleted**. `test_ghost_spacing_1904` predicted this in its own docstring: *"it will need re-pointing when #1907 lands."* `test_fp_particle_gradient_bc_1255` pinned **both** conventions, one per wall, because it recorded what the code did rather than what the condition says.

---

## 2 — `1deb7532` The FP resolver resolves instead of renaming

**Layer 2 has existed since #856 and is unreachable.** Traced, not inferred:

| symbol | library callers |
|---|---|
| `HJBResolver` / `FPResolver` / `BCResolver` in `alg/` | **0** |
| `resolved_bc_to_calculator` | **0** (module demo + 1 test) |
| `resolved_to_boundary_conditions` | **0** |

**Why it stalled is in its own source:**

```python
ZERO_FLUX = "zero_flux"   # J*n = 0, needs drift+diffusion for calculator
```

`FPResolver` "resolved" the impermeable wall by **renaming the intent**, so Layer 3 dispatched on it again. It could not do better: `ResolvedBC.alpha/beta` were `float`, and the Robin coefficient of a reflecting FP wall is `D_pH(x, ∇u)·n` — a **field**.

**The fix.** `ResolvedBC` coefficients accept fields; `FPResolver` emits `ROBIN` with `alpha = v_n`, `beta = -D`, `g = 0`. Verified against the condition:

```
16 scalar coefficient sets      worst |J.n| = 3.6e-15
field-valued drift over a wall  worst |J.n| = 2.2e-16, each point uses its own coefficient
scalar path                     bit-identical
```

`MathBCType.ZERO_FLUX` is **deleted** — the enum's docstring says it "contains no physical intent types" and this was the exception to its own rule. `ZeroFluxCalculator` stays, still reached via `bc_to_topology_calculator(use_zero_flux=True)`.

**No default for a mathematical parameter.** Resolving an impermeable wall without `drift`/`diffusion` raises, naming the missing key. A defaulted drift makes the wall pure Neumann — conserves mass at a tangential wall, leaks at every other one, and **the wrong answer still converges**.

---

## Context

This is step 1 of the plan in the Joplin note *"BC classification for MFG — settled from sources"* §10. The classification was settled from the literature this session: one physical wall imposes **two structurally different conditions**, `∂_n u = 0` on HJB and a **Robin** condition on FP whose coefficient depends on the solution (Carmona–Delarue I §4.7 (4.169)/(4.170); Cirant *JMPA* 103 (2015) system (MFG) *hjn*)/*kn*)). The field calls both "Neumann" — harmless in prose, fatal once a name drives a dispatch.

**Not in scope:** routing `alg/` callers through the resolver and deleting the 26 chains (step 2), and the `σ = 0` regime gate (step 3).

## Gate

`./scripts/local_ci.sh` → **6110 passed, 12 skipped, 21 xfailed, GATE GREEN**.
Also run: `check_internal_deprecation`, `check_docs_structure`, `check_critical_issues` — the CI-only checks the local gate does not cover.