### PR TITLE
fix(geometry): particle_action_for_bc_type drops the alpha it never read (#1960)

### DIFF
--- a/changelog.d/1960-particle-action-drops-alpha.changed.md
+++ b/changelog.d/1960-particle-action-drops-alpha.changed.md
@@ -1,0 +1,18 @@
+`particle_action_for_bc_type` no longer takes `alpha`. It required the coefficient and never
+read it: the Robin branch dispatches on `beta` alone, so `ROBIN(alpha=0, beta=1)` and
+`ROBIN(alpha=9, beta=1)` went through the same `return`.
+
+The docstring described three Robin cases as though they were three branches. There are two,
+and the vocabulary is why. A genuinely mixed Robin — both coefficients nonzero — is a
+**partially absorbing** wall: the particle counterpart of `alpha*m + beta*d_n m = g` is a
+diffusion that reflects with a probability set by `alpha/beta`, Feller's elastic boundary.
+`ParticleAction` has three members and none of them is that, so the function returns
+`"reflecting"`, which conserves mass and is the conservative reading of a wall it cannot
+express. That is now stated where it can be read.
+
+`test_robin_dispatches_on_its_coefficients` had four rows, two of which passed through the same
+`return` — it looked like it discriminated the pure-flux case from the mixed one and did not.
+Re-pointed to the two cases that exist.
+
+`alpha` comes back the day `ParticleAction` grows a partially-absorbing member, because that
+member's probability is exactly what `alpha/beta` sets.

--- a/mfgarchon/geometry/boundary/applicator_meshfree.py
+++ b/mfgarchon/geometry/boundary/applicator_meshfree.py
@@ -462,11 +462,13 @@ class MeshfreeApplicator(BaseMeshfreeApplicator):
         # reflected there, and a Robin BC left at its default coefficients absorbed here and
         # reflected there -- the same object building an absorbing wall on one path and an
         # impermeable one on the other.
-        alpha = beta = None
+        beta = None
         if bc_type == BCType.ROBIN:
-            alpha, beta = _robin_alpha_beta(boundary_conditions)
+            # alpha is read here only to keep `_robin_alpha_beta`'s single-owner contract; the
+            # particle mapping dispatches on beta alone (#1960).
+            _alpha, beta = _robin_alpha_beta(boundary_conditions)
 
-        return self.apply_particle_bc(particles, particle_action_for_bc_type(bc_type, alpha, beta))
+        return self.apply_particle_bc(particles, particle_action_for_bc_type(bc_type, beta))
 
 
 class SDFParticleBCHandler:

--- a/mfgarchon/geometry/boundary/applicator_particle.py
+++ b/mfgarchon/geometry/boundary/applicator_particle.py
@@ -44,7 +44,6 @@ ParticleAction = Literal["reflecting", "absorbing", "periodic"]
 
 def particle_action_for_bc_type(
     bc_type: BCType,
-    alpha: float | None = None,
     beta: float | None = None,
 ) -> ParticleAction:
     """Map a ``BCType`` to what a particle does when it reaches the boundary.
@@ -71,10 +70,24 @@ def particle_action_for_bc_type(
 
     - `REFLECTING` reflects. It is `BCType`'s own documented particle spelling of an
       impermeable wall; refusing it was the defect.
-    - `ROBIN` dispatches on the coefficients. With `beta = 0` the condition reads
-      `alpha*u = g`, which is Dirichlet, so the particle is absorbed. With `alpha = 0`
-      it reads `beta*du/dn = g`, a flux condition, so the particle reflects. A genuinely
-      mixed Robin reflects, which conserves mass and is the conservative reading.
+    - `ROBIN` dispatches on `beta`, and on `beta` alone. With `beta = 0` the condition
+      reads `alpha*u = g`, which is Dirichlet, so the particle is absorbed. Every other
+      `beta` reflects.
+
+      **This is two cases, not three, and the vocabulary is why.** A genuinely mixed
+      Robin -- `alpha` and `beta` both nonzero -- is a *partially absorbing* wall: the
+      particle counterpart of `alpha*m + beta*d_n m = g` is a diffusion that reflects with
+      a probability set by `alpha/beta` (Feller's elastic boundary). `ParticleAction` has
+      three members and none of them is that, so this function returns `"reflecting"`,
+      which conserves mass and is the conservative reading of a wall it cannot express.
+      ~~"With `alpha = 0` it reads `beta*du/dn = g` ... A genuinely mixed Robin reflects"~~
+      was written as though those were separate branches [CORRECTED 2026-08-16, #1960]:
+      they share one, so the `alpha = 0` case was undiscriminated and `test_robin_
+      dispatches_on_its_coefficients` had two rows passing through the same `return`.
+
+      `alpha` is therefore **not a parameter of this function**. It was required and never
+      read. It comes back the day `ParticleAction` grows a partially-absorbing member,
+      because that member's probability is exactly what `alpha/beta` sets.
     - `EXTRAPOLATION_LINEAR` / `EXTRAPOLATION_QUADRATIC` raise. They are not boundary
       conditions on a particle at all -- they are a statement about how to continue a
       *field* past a truncated domain, and carry no boundary datum. Silently reflecting
@@ -83,8 +96,8 @@ def particle_action_for_bc_type(
 
     Args:
         bc_type: The condition to interpret.
-        alpha: Robin coefficient on ``u``. Required when ``bc_type`` is ``ROBIN``.
-        beta: Robin coefficient on ``du/dn``. Required when ``bc_type`` is ``ROBIN``.
+        beta: Robin coefficient on ``du/dn``. Required when ``bc_type`` is ``ROBIN``, and
+            the only coefficient this mapping reads -- see the ROBIN note above.
 
     Returns:
         The particle action, in the vocabulary ``MeshfreeApplicator.apply_particle_bc``
@@ -103,10 +116,12 @@ def particle_action_for_bc_type(
         return "periodic"
 
     if bc_type == BCType.ROBIN:
-        if alpha is None or beta is None:
+        if beta is None:
             raise ValueError(
-                "particle_action_for_bc_type: BCType.ROBIN needs alpha and beta; "
-                "they live on the BCSegment, not on BoundaryConditions."
+                "particle_action_for_bc_type: BCType.ROBIN needs beta; it lives on the "
+                "BCSegment, not on BoundaryConditions. A default would be the #1558 failure "
+                "a third time -- beta=0 is Dirichlet, so an unspecified Robin wall would "
+                "silently become absorbing."
             )
         if np.isclose(beta, 0.0):
             return "absorbing"
@@ -226,7 +241,7 @@ class ParticleApplicator:
             # Robin coefficient per wall is read per wall. The uniform path's
             # `_robin_alpha_beta` cannot do that -- it takes the first Robin segment in
             # the whole specification, whichever face is being processed.
-            action = particle_action_for_bc_type(segment.bc_type, segment.alpha, segment.beta)
+            action = particle_action_for_bc_type(segment.bc_type, segment.beta)
 
             if action == "absorbing":
                 absorbed_mask[idx] = True
@@ -315,7 +330,7 @@ class ParticleApplicator:
                 result_particles[idx] = self._reflect_particle(particle, domain_min, domain_max, domain_size)
                 continue
 
-            action = particle_action_for_bc_type(segment.bc_type, segment.alpha, segment.beta)
+            action = particle_action_for_bc_type(segment.bc_type, segment.beta)
 
             if action == "absorbing":
                 seg_name = segment.name

--- a/tests/unit/test_geometry/boundary/test_one_particle_action_owner_1956.py
+++ b/tests/unit/test_geometry/boundary/test_one_particle_action_owner_1956.py
@@ -82,7 +82,7 @@ def test_the_table_covers_every_bctype_member():
 
 @pytest.mark.parametrize(("bc_type", "expected"), sorted(_EXPECTED.items(), key=lambda kv: kv[0].name))
 def test_each_bc_type_maps_to_its_particle_action(bc_type, expected):
-    assert particle_action_for_bc_type(bc_type, alpha=1.0, beta=0.0) == expected
+    assert particle_action_for_bc_type(bc_type, beta=0.0) == expected
 
 
 @pytest.mark.parametrize("bc_type", sorted(_NO_PARTICLE_MEANING, key=lambda t: t.name))
@@ -101,22 +101,29 @@ def test_a_field_truncation_rule_is_refused_and_named(bc_type):
 
 
 @pytest.mark.parametrize(
-    ("alpha", "beta", "expected"),
+    ("beta", "expected"),
     [
-        (1.0, 0.0, "absorbing"),  # alpha*u = g is Dirichlet
-        (0.0, 1.0, "reflecting"),  # beta*du/dn = g is a flux condition
-        (1.0, 1.0, "reflecting"),  # genuinely mixed: conserve mass
-        (3.0, 0.0, "absorbing"),  # the scale of alpha does not enter; only beta == 0 does
+        (0.0, "absorbing"),  # beta = 0 leaves alpha*u = g, which is Dirichlet
+        (1.0, "reflecting"),  # any flux term at all
+        (-2.5, "reflecting"),  # sign does not enter
     ],
 )
-def test_robin_dispatches_on_its_coefficients(alpha, beta, expected):
-    assert particle_action_for_bc_type(BCType.ROBIN, alpha, beta) == expected
+def test_robin_dispatches_on_beta(beta, expected):
+    """RE-POINTED 2026-08-16 (#1960). This passed `alpha` as well and parametrised four rows,
+    two of which -- `(0.0, 1.0)` and `(1.0, 1.0)` -- went through the same `return`. It looked
+    like it discriminated the pure-flux case from the genuinely mixed one and did not, because
+    `alpha` was required and never read.
+
+    Two cases is what the three-valued `ParticleAction` can express. A genuinely mixed Robin is a
+    *partially absorbing* wall -- reflection with a probability set by `alpha/beta`, Feller's
+    elastic boundary -- and none of the three members is that."""
+    assert particle_action_for_bc_type(BCType.ROBIN, beta) == expected
 
 
-def test_robin_without_coefficients_refuses_rather_than_assuming():
-    """A default here would be the #1558 failure a third time. `alpha=1, beta=0` is Dirichlet, so
-    any implicit default silently turns an unspecified Robin wall into an absorbing one."""
-    with pytest.raises(ValueError, match="needs alpha and beta"):
+def test_robin_without_beta_refuses_rather_than_assuming():
+    """A default here would be the #1558 failure a third time: `beta = 0` is Dirichlet, so an
+    unspecified Robin wall would silently become absorbing."""
+    with pytest.raises(ValueError, match="needs beta"):
         particle_action_for_bc_type(BCType.ROBIN)
 
 


### PR DESCRIPTION
Closes #1960. Found by independent review of #1956.

## The defect

The function required `alpha`, refused to proceed without it, and dispatched on `beta` alone:

```
ROBIN(alpha=0.0, beta=1.0) -> reflecting
ROBIN(alpha=9.0, beta=1.0) -> reflecting
```

The docstring claimed three Robin branches. There are two — and the vocabulary is the reason.

## Why there are only two, stated where it can be read

A genuinely mixed Robin — both coefficients nonzero — is a **partially absorbing** wall. The particle counterpart of `alpha*m + beta*d_n m = g` is a diffusion that reflects with a probability set by `alpha/beta` (Feller's elastic boundary). `ParticleAction` has three members and **none of them is that**.

So `"reflecting"` there is a conservative approximation of a wall this vocabulary cannot express, not a derived answer. That is now in the docstring rather than implied away by a three-case story the code does not implement.

## Considered and rejected: raising on a mixed Robin

It is reachable — `test_meshfree_robin_coeffs_1558` passes `alpha=1, beta=1`, and `FPParticleSolver` holds a `ParticleApplicator`. Refusing would break a working path over a defect that is, today, in the documentation rather than in the returned action.

## The guard survives the narrowing

`beta is None` still catches the caller who supplies nothing, and `beta = 0` is the Dirichlet corner — so it is precisely the coefficient whose absence would silently produce an absorbing wall. That was the #1558 failure mode twice over, and the reason a default is refused here.

## Test

Re-pointed, not deleted. Four rows became three, and the two that shared a `return` are now one row, so a mutation to either surviving branch is catchable. It previously looked like it discriminated the pure-flux case from the mixed one and did not.

`alpha` comes back the day `ParticleAction` grows a partially-absorbing member, because that member's probability is exactly what `alpha/beta` sets.

## Gate

`./scripts/local_ci.sh` → **6110 passed, 12 skipped, 21 xfailed, GATE GREEN**.