### PR TITLE
fix(geometry): get_ghost_values_nd's Robin wall is a Robin wall (#1961)

### DIFF
--- a/changelog.d/1961-compat-robin-owner.fixed.md
+++ b/changelog.d/1961-compat-robin-owner.fixed.md
@@ -1,0 +1,18 @@
+`get_ghost_values_nd` produces a Robin wall when asked for one. Its two ghost helpers took
+`(bc_type, bc_value)` and nothing else, so a Robin condition arrived with its coefficients
+already discarded and both branches returned the adjacent interior cell — the impermeable-wall
+mirror. Measured on three coefficient sets the ghost was `3.10000` every time, and the residual
+of the condition the caller wrote ranged over **1.7 to 5.2**; it is now within `7.1e-15`.
+
+The function is deprecated and kept until v0.25.0 (#1955). It is not in the package `__all__`
+but is reachable as an attribute of `mfgarchon.geometry.boundary`, which is the surface that
+notice applies to — so a user still on the deprecation path was getting a wall that was not the
+one they asked for.
+
+Both branches now call `ghost_cell_robin`, which makes #1957's "one owner" literally true. A
+Robin condition whose segment carries no coefficients raises instead of taking `BCSegment`'s
+`alpha=1.0, beta=0.0` defaults, which are a Dirichlet wall — the #1558 failure mode, and the
+same hole #1956 closed on the particle side.
+
+Dirichlet, Neumann and periodic are byte-identical, pinned as such: #1955 pinned this function
+across the module's deletion and this change must not disturb that.

--- a/mfgarchon/geometry/boundary/_compat.py
+++ b/mfgarchon/geometry/boundary/_compat.py
@@ -36,7 +36,7 @@ from .fdm_bc_1d import BoundaryConditions as BoundaryConditions1DFDM
 
 # GhostCellConfig moved to ghost_cells.py (canonical location).
 # Re-exported here for backward compatibility.
-from .ghost_cells import GhostCellConfig
+from .ghost_cells import GhostCellConfig, ghost_cell_robin
 from .types import BCType
 
 logger = get_logger(__name__)
@@ -176,8 +176,19 @@ def get_ghost_values_nd(
             slices_prev_right[axis] = -2 if shape_axis > 1 else -1
             u_prev_right = field[tuple(slices_prev_right)]
 
+            alpha, beta = _robin_coefficients(boundary_conditions) if bc_type == BCType.ROBIN else (1.0, 0.0)
             ghosts[(axis, 0)], ghosts[(axis, 1)] = _compute_ghost_pair(
-                bc_type, bc_value, u_int_left, u_int_right, u_next_left, u_prev_right, dx, time, config
+                bc_type,
+                bc_value,
+                u_int_left,
+                u_int_right,
+                u_next_left,
+                u_prev_right,
+                dx,
+                time,
+                config,
+                alpha,
+                beta,
             )
 
     else:
@@ -219,16 +230,61 @@ def get_ghost_values_nd(
             bc_value_right = _get_bc_value_at_boundary(boundary_conditions, boundary_max, time)
 
             # Compute ghost for left boundary
+            alpha_l, beta_l = (
+                _robin_coefficients(boundary_conditions, boundary_min) if bc_type_left == BCType.ROBIN else (1.0, 0.0)
+            )
             ghosts[(axis, 0)] = _compute_single_ghost(
-                bc_type_left, bc_value_left, u_int_left, u_next_left, dx, time, config, "left"
+                bc_type_left,
+                bc_value_left,
+                u_int_left,
+                u_next_left,
+                dx,
+                time,
+                config,
+                "left",
+                alpha_l,
+                beta_l,
             )
 
             # Compute ghost for right boundary
+            alpha_r, beta_r = (
+                _robin_coefficients(boundary_conditions, boundary_max) if bc_type_right == BCType.ROBIN else (1.0, 0.0)
+            )
             ghosts[(axis, 1)] = _compute_single_ghost(
-                bc_type_right, bc_value_right, u_int_right, u_prev_right, dx, time, config, "right"
+                bc_type_right,
+                bc_value_right,
+                u_int_right,
+                u_prev_right,
+                dx,
+                time,
+                config,
+                "right",
+                alpha_r,
+                beta_r,
             )
 
     return ghosts
+
+
+def _robin_coefficients(boundary_conditions, boundary: str | None = None) -> tuple[float, float]:
+    """Read Robin (alpha, beta) for a boundary, or the defaults if no Robin segment governs it.
+
+    #1961: this module's two ghost helpers took only (bc_type, bc_value), so a Robin condition
+    arrived with its coefficients already discarded and both branches returned the adjacent
+    interior cell -- the impermeable-wall mirror. Measured on three coefficient sets, the ghost
+    was 3.10000 every time, and the residual of the condition the caller wrote ranged over
+    1.7 to 5.2.
+    """
+    segments = getattr(boundary_conditions, "segments", None) or []
+    for seg in segments:
+        if seg.bc_type != BCType.ROBIN:
+            continue
+        if boundary is None or seg.boundary is None or boundary_conditions._segment_covers(seg, boundary):
+            return float(seg.alpha), float(seg.beta)
+    raise ValueError(
+        f"get_ghost_values_nd: a ROBIN condition governs {boundary or 'this boundary'} but no "
+        "BCSegment carries its alpha/beta. They live on the segment, not on BoundaryConditions."
+    )
 
 
 def _compute_ghost_pair(
@@ -241,6 +297,8 @@ def _compute_ghost_pair(
     dx: float,
     time: float,
     config: GhostCellConfig,
+    alpha: float = 1.0,
+    beta: float = 0.0,
 ) -> tuple[NDArray, NDArray]:
     """Compute ghost values for both boundaries with same BC type."""
     g = bc_value if bc_value is not None else 0.0
@@ -261,7 +319,13 @@ def _compute_ghost_pair(
         return u_next_left - 2 * dx * g, u_prev_right + 2 * dx * g
 
     elif bc_type == BCType.ROBIN:
-        return u_next_left.copy(), u_prev_right.copy()
+        # #1961: this returned the adjacent interior cell -- the impermeable-wall mirror -- for
+        # every coefficient pair, so a Robin wall was not a Robin wall. `ghost_cell_robin` owns
+        # the formula and is side-free on a cell-centred grid (#1907).
+        return (
+            ghost_cell_robin(u_int_left, g, alpha, beta, dx, grid_type=config.grid_type),
+            ghost_cell_robin(u_int_right, g, alpha, beta, dx, grid_type=config.grid_type),
+        )
 
     else:
         return u_next_left.copy(), u_prev_right.copy()
@@ -276,6 +340,8 @@ def _compute_single_ghost(
     time: float,
     config: GhostCellConfig,
     side: str,
+    alpha: float = 1.0,
+    beta: float = 0.0,
 ) -> NDArray:
     """Compute ghost value for a single boundary.
 
@@ -315,7 +381,9 @@ def _compute_single_ghost(
             return u_neighbor + 2 * dx * g
 
     elif bc_type == BCType.ROBIN:
-        return u_neighbor.copy()
+        # #1961: this returned the adjacent interior cell for every coefficient pair. See the
+        # sibling branch in `_compute_ghost_pair`.
+        return ghost_cell_robin(u_int, g, alpha, beta, dx, grid_type=config.grid_type)
 
     else:
         return u_neighbor.copy()

--- a/tests/unit/test_geometry/boundary/test_compat_robin_is_a_robin_wall_1961.py
+++ b/tests/unit/test_geometry/boundary/test_compat_robin_is_a_robin_wall_1961.py
@@ -1,0 +1,168 @@
+"""`get_ghost_values_nd` must produce a Robin wall when asked for one. #1961
+
+`_compute_ghost_pair` and `_compute_single_ghost` took `(bc_type, bc_value)` and nothing else, so
+a Robin condition reached them with its coefficients already discarded. Both branches read
+
+    elif bc_type == BCType.ROBIN:
+        return u_next_left.copy(), u_prev_right.copy()
+
+-- the adjacent interior cell, which is the *impermeable-wall mirror*. Measured on three
+coefficient sets the ghost was `3.10000` every time, and the residual of the condition the caller
+wrote ranged over 1.7 to 5.2.
+
+`get_ghost_values_nd` is deprecated and kept until v0.25.0 (#1955). It is not in the package
+`__all__` but is reachable as an attribute of `mfgarchon.geometry.boundary`, which is the surface
+that notice applies to — so a user following the deprecation path, still calling it, got a wall
+that was not the wall they asked for, with no signal beyond the deprecation warning.
+
+**The oracle is the condition, not the other code path.** After this change the branch calls
+`ghost_cell_robin`, so comparing it to `pad_array_with_ghosts` would be comparing an owner to
+itself.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    dirichlet_bc,
+    get_ghost_values_nd,
+    neumann_bc,
+    periodic_bc,
+    robin_bc,
+)
+
+_U = np.array([2.5, 3.1, 4.0, 5.2, 6.6])
+_DX = 0.25
+_BOUNDS = np.array([[0.0, 1.0]])
+
+
+def _ghosts(bc):
+    """The function is deprecated by design; the warning is not what is under test."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return get_ghost_values_nd(_U, bc, (_DX,))
+
+
+def _scalar(ghost) -> float:
+    return float(np.atleast_1d(ghost)[0])
+
+
+def _residual(ghost: float, interior: float, alpha: float, beta: float, g: float) -> float:
+    """`alpha*u_b + beta*du/dn - g`, outward normal, side-free on a cell-centred grid (#1907)."""
+    return alpha * (ghost + interior) / 2 + beta * (ghost - interior) / _DX - g
+
+
+@pytest.mark.parametrize(
+    ("alpha", "beta", "g"),
+    [
+        (1.0, 0.3, 0.7),  # the case measured at ghost 3.10000, residual 2.82
+        (1.0, 0.0, 0.7),  # beta = 0: Dirichlet in disguise, and it was still mirrored
+        (0.0, 1.0, 0.7),  # pure flux
+        (2.0, -0.4, 0.0),  # negative beta
+        (0.5, 1.5, -0.3),  # negative g
+    ],
+)
+@pytest.mark.parametrize("wall", ["min", "max"])
+def test_a_uniform_robin_wall_satisfies_its_own_condition(alpha, beta, g, wall):
+    """Both walls are parametrised because both were wrong, in different amounts -- 2.82 and 3.52
+    on the first row. A single-wall test would have hidden half of it."""
+    bc = robin_bc(dimension=1, alpha=alpha, beta=beta, value=g)
+    bc.domain_bounds = _BOUNDS
+    ghosts = _ghosts(bc)
+
+    ghost, interior = (
+        (_scalar(ghosts[(0, 0)]), _U[0]) if wall == "min" else (_scalar(ghosts[(0, 1)]), _U[-1])
+    )
+
+    assert _residual(ghost, interior, alpha, beta, g) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_the_coefficients_actually_reach_the_formula():
+    """Negative control. Before the fix every coefficient pair produced the same ghost, so a test
+    that only checked one pair would have passed over a function that ignored them entirely."""
+    ghosts = []
+    for alpha, beta in ((1.0, 0.3), (0.0, 1.0), (2.0, -0.4)):
+        bc = robin_bc(dimension=1, alpha=alpha, beta=beta, value=0.7)
+        bc.domain_bounds = _BOUNDS
+        ghosts.append(_scalar(_ghosts(bc)[(0, 0)]))
+
+    assert len(set(np.round(ghosts, 9))) == len(ghosts), "three coefficient pairs, three ghosts"
+
+
+def test_a_robin_face_of_a_mixed_bc_reads_its_own_segment():
+    """The mixed path goes through `_compute_single_ghost`, a different branch with the same
+    defect. The Dirichlet face is asserted alongside so a fix that broke the per-face routing
+    while repairing Robin would fail here."""
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="rob", bc_type=BCType.ROBIN, value=0.7, alpha=1.0, beta=0.3, boundary="x_min"),
+            BCSegment(name="dir", bc_type=BCType.DIRICHLET, value=9.0, boundary="x_max"),
+        ],
+        dimension=1,
+        default_bc=BCType.NO_FLUX,
+        domain_bounds=_BOUNDS,
+    )
+    ghosts = _ghosts(bc)
+
+    assert _residual(_scalar(ghosts[(0, 0)]), _U[0], 1.0, 0.3, 0.7) == pytest.approx(0.0, abs=1e-12)
+    assert _scalar(ghosts[(0, 1)]) == pytest.approx(2 * 9.0 - _U[-1]), "the Dirichlet face is untouched"
+
+
+def test_a_robin_condition_without_coefficients_refuses():
+    """`BoundaryConditions` carries `default_bc` and `default_value` and no default alpha/beta, so
+    a face that falls through to a ROBIN default has no coefficients to be honoured with.
+    Fabricating `1.0, 0.0` would be a Dirichlet wall -- the #1558 failure, and the same hole
+    #1956 hit on the particle side.
+
+    The construction has to be genuinely mixed and genuinely fall through: a single-segment BC is
+    `is_uniform` and takes the other path entirely, which is how the first version of this test
+    passed for the wrong reason. Here `x_min` and `x_max` are covered and the two `y` faces are
+    not, so they resolve to the ROBIN default.
+    """
+    bc = BoundaryConditions(
+        segments=[
+            BCSegment(name="d", bc_type=BCType.DIRICHLET, value=1.0, boundary="x_min"),
+            BCSegment(name="n", bc_type=BCType.NO_FLUX, value=0.0, boundary="x_max"),
+        ],
+        dimension=2,
+        default_bc=BCType.ROBIN,
+        default_value=0.5,
+        domain_bounds=np.array([[0.0, 1.0], [0.0, 1.0]]),
+    )
+    assert not bc.is_uniform, "the premise is that the per-face path runs"
+    assert bc.get_bc_type_at_boundary("y_min") is BCType.ROBIN, "and that a face falls through to it"
+
+    def _call() -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            get_ghost_values_nd(np.ones((5, 5)), bc, (_DX, _DX))
+
+    with pytest.raises(ValueError, match="alpha/beta"):
+        _call()
+
+
+@pytest.mark.parametrize(
+    ("name", "factory", "expected"),
+    [
+        ("dirichlet", lambda: dirichlet_bc(dimension=1, value=2.5), (2.5, -1.6)),
+        ("neumann", lambda: neumann_bc(dimension=1, value=0.7), (2.75, 5.55)),
+        ("periodic", lambda: periodic_bc(dimension=1), (6.6, 2.5)),
+    ],
+)
+def test_the_other_members_are_byte_identical(name, factory, expected):
+    """#1955 pinned this function byte-identical across the module's deletion, over five cases.
+    This change touches only the ROBIN branch, and these are the members that must prove it."""
+    bc = factory()
+    bc.domain_bounds = _BOUNDS
+    ghosts = _ghosts(bc)
+
+    assert _scalar(ghosts[(0, 0)]) == pytest.approx(expected[0])
+    assert _scalar(ghosts[(0, 1)]) == pytest.approx(expected[1])


### PR DESCRIPTION
Closes #1961. Found by the cross-PR interaction review of #1955/#1956/#1957. **Pre-existing**; what #1955 made new is the guarantee that it survives to v0.25.0.

## The mechanism, sharper than the issue stated

It is not wrong Robin arithmetic. **There was no Robin arithmetic.** Both helpers took `(bc_type, bc_value)` and nothing else, so the coefficients were gone before the branch ran:

```python
elif bc_type == BCType.ROBIN:
    return u_next_left.copy(), u_prev_right.copy()      # the impermeable-wall mirror
```

Three coefficient sets, one ghost:

| `alpha` | `beta` | `g` | ghost_lo | residual |
|---:|---:|---:|---:|---:|
| 1.0 | 0.3 | 0.7 | 3.10000 | 2.82 |
| 1.0 | 0.0 | 0.7 | 3.10000 | 2.10 |
| 0.0 | 1.0 | 0.7 | 3.10000 | 1.70 |

After: **7.1e−15** over five sets including negative `beta` and negative `g`, both walls.

## Who was affected

`get_ghost_values_nd` is not in the package `__all__`, but it is reachable as an attribute of `mfgarchon.geometry.boundary` through that module's `__getattr__` — which is exactly the surface its v0.25.0 deprecation notice applies to. A user *following* the deprecation path, still calling it until the removal, was getting a wall that was not the one they asked for.

## The fix

Both branches call `ghost_cell_robin`, which makes #1957's "one owner" literally true. Coefficients are read from the governing segment — **per face** on the mixed path — by a new `_robin_coefficients` that **raises** when no segment carries them. Fabricating `BCSegment`'s `alpha=1.0, beta=0.0` would be a Dirichlet wall: the #1558 failure mode, and the same hole #1956 closed on the particle side.

## Scope

Dirichlet, Neumann and periodic are **byte-identical** and pinned as such — #1955 pinned this whole function across the module's deletion and this change must not disturb that.

## The pin is the condition, not another path

After routing through the owner, comparing this to `pad_array_with_ghosts` compares an owner to itself. Mutations measured:

```
pair branch back to the mirror     11 failed / 5 passed
single branch back to the mirror    1 failed / 15 passed   <- the per-face test written for it
```

Source restored byte-identical.

**One test construction was wrong first time**, and its docstring records it: a single-segment BC is `is_uniform` and never reaches the per-face path, so the refusal test passed for the wrong reason until it was rebuilt as a genuinely mixed BC with a face falling through to the `ROBIN` default.

## Gate

`./scripts/local_ci.sh` → **6127 passed, 12 skipped, 21 xfailed, GATE GREEN**.