### PR TITLE
fix(geometry): pair the high wall's ghost layers nearest-first, and scale the flux offset with the layer (#1967)

### DIFF
--- a/changelog.d/1967-ghost-layer-order-and-flux.fixed.md
+++ b/changelog.d/1967-ghost-layer-order-and-flux.fixed.md
@@ -13,9 +13,17 @@ must scale with the layer. `dx · v` was applied to every layer — the `k = 1` 
 throughout, drifting by `(2k-2)·dx·v`.
 
 **Both are invisible at `ghost_depth = 1`**, where a single layer has no order to reverse and
-`(2·1−1)·dx = dx`. Every caller in the library passes 1 or omits it, which is why a suite of 6147
-was green with both present. The one production consumer at depth 3 is `hjb_weno.py:330`, whose
-`_SUPPORTED_BC_TYPES` is `{NEUMANN, NO_FLUX, PERIODIC}` — exactly the family the first defect hits.
+`(2·1−1)·dx = dx`. `hjb_weno.py:330` is the library's only production `ghost_depth >= 2`, so every
+other caller sits in that blind spot, which is why a suite of 6147 was green with both defects
+present.
+
+**Reachability, measured rather than inferred.** WENO's `_SUPPORTED_BC_TYPES` is
+`{NEUMANN, NO_FLUX, PERIODIC}` — the family these defects hit — but on every *uniform* BC it
+admits, it dispatches to `_apply_poly_extrapolation`, which neither defect touches and this change
+leaves byte-identical. The corrected lines are reached only through a *per-face* BC, and no
+in-repo code hands WENO one: the two per-face HJB constructors both emit `BCType.ROBIN`, which
+WENO refuses at construction. So this is a correctness fix on a path that is reachable but not
+currently reached — not, as an earlier draft of this fragment said, the live consumer's own path.
 
 Eighteen of twenty-four probed cells are unchanged, every `ghost_depth = 1` cell among them, and
 that is pinned: since every caller uses depth 1, a change there would be a regression in
@@ -24,3 +32,7 @@ everything that currently works.
 Found by four independent verification oracles — convergence order, invariance,
 cross-implementation and grid convention — run in parallel on #1966, which had certified this
 family as correct after measuring one wall.
+
+A **third** copy of the same reversal survives in `GhostBuffer._update_bounded`, at both walls and
+with identical magnitudes; it is unreachable today (`create_ghost_buffer_from_bc` has no library
+caller) and is filed separately. This change corrects two of three.

--- a/changelog.d/1967-ghost-layer-order-and-flux.fixed.md
+++ b/changelog.d/1967-ghost-layer-order-and-flux.fixed.md
@@ -1,0 +1,26 @@
+**The high wall paired its ghost layers backwards, and an inhomogeneous flux offset did not grow
+with the layer.** Two defects in the same loop, in both copies of it.
+
+The high ghosts occupy padded indices `-g .. -1` and `-g` is the one adjacent to the wall, so both
+the ghost walk and the interior walk must start there. The high-wall loop started its ghost walk
+at `-1`, the far end, while its interior walk started near — pairing the layers in reverse for
+`ghost_depth >= 2`. Measured on `cos(2πx)`, which is even about both walls so `NEUMANN(0)` is
+exact at both: the low wall was machine-zero at every depth while the high wall was **5.4e-01 at
+`g=2` and 1.3e+00 at `g=3`**, with `reversed(got) == want` — every value correct, every slot wrong.
+
+Separately, ghost layer `k` sits `(2k-1)·dx` from its mirror, so an inhomogeneous Neumann offset
+must scale with the layer. `dx · v` was applied to every layer — the `k = 1` value used
+throughout, drifting by `(2k-2)·dx·v`.
+
+**Both are invisible at `ghost_depth = 1`**, where a single layer has no order to reverse and
+`(2·1−1)·dx = dx`. Every caller in the library passes 1 or omits it, which is why a suite of 6147
+was green with both present. The one production consumer at depth 3 is `hjb_weno.py:330`, whose
+`_SUPPORTED_BC_TYPES` is `{NEUMANN, NO_FLUX, PERIODIC}` — exactly the family the first defect hits.
+
+Eighteen of twenty-four probed cells are unchanged, every `ghost_depth = 1` cell among them, and
+that is pinned: since every caller uses depth 1, a change there would be a regression in
+everything that currently works.
+
+Found by four independent verification oracles — convergence order, invariance,
+cross-implementation and grid convention — run in parallel on #1966, which had certified this
+family as correct after measuring one wall.

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -1164,17 +1164,38 @@ class PreallocatedGhostBuffer:
                     lo_interior[axis] = g + k  # Adjacent interior cells from g up
                     buf[tuple(lo_ghost)] = buf[tuple(lo_interior)]
                     if apply_flux:
-                        buf[tuple(lo_ghost)] += dx * v  # Issue #1262: was -= (du/dx sign), now += (du/dn sign)
+                        # #1967: the offset is the mirror SEPARATION times the flux, and that
+                        # separation grows with the layer. Ghost layer k and its mirror interior
+                        # are (2k-1)*dx apart on a cell-centred grid -- 1*dx for the pair adjacent
+                        # to the wall, 3*dx for the next, and so on. `dx * v` on every layer is the
+                        # k=1 value applied throughout, so g=1 was exact and g>=2 drifted by
+                        # (2k-2)*dx*v. Measured on f = -2x+1 with du/dn = 2: 0 at g=1, 5.0e-01 at
+                        # g=2, 1.0e+00 at g=3. v == 0 leaves the pure mirror, byte-identical.
+                        buf[tuple(lo_ghost)] += (2 * (k + 1) - 1) * dx * v
 
-                # High boundary: ghost mirrors adjacent interior
+                # High boundary: ghost mirrors adjacent interior.
+                #
+                # #1967: both indices must walk in the SAME direction, and they did not. The low
+                # loop above pairs `g-1-k` with `g+k` -- ghost nearest the wall with interior
+                # nearest the wall, k advancing outward on both sides. This loop paired `-(k+1)`,
+                # which also starts nearest the wall, with `-(g+k+1)`, which starts at the
+                # FARTHEST interior cell of the stencil and moves further in. At g=1 the two
+                # expressions coincide, which is why every caller in the library saw the right
+                # answer; at g>=2 the layers arrive reversed.
+                #
+                # Measured on u = cos(2*pi*x), even about both walls so Neumann(0) is exact at
+                # both: low wall machine-zero at g=1,2,3 while the high wall was 5.4e-01 at g=2
+                # and 1.3e+00 at g=3, with reversed(got) == want at every depth -- the values were
+                # right and the slots were wrong.
                 for k in range(g):
                     hi_ghost = [slice(None)] * d
-                    hi_ghost[axis] = -(k + 1)  # Ghost cells from -1 down to -g
+                    # The high ghosts occupy -g .. -1, and -g is the one ADJACENT to the wall.
+                    hi_ghost[axis] = -(g - k)  # -g, -(g-1), ... -1  : nearest the wall first
                     hi_interior = [slice(None)] * d
-                    hi_interior[axis] = -(g + k + 1)  # Adjacent interior cells
+                    hi_interior[axis] = -(g + 1) - k  # -(g+1), -(g+2), ... : nearest first too
                     buf[tuple(hi_ghost)] = buf[tuple(hi_interior)]
                     if apply_flux:
-                        buf[tuple(hi_ghost)] += dx * v
+                        buf[tuple(hi_ghost)] += (2 * (k + 1) - 1) * dx * v
 
         elif bc_type == BCType.ROBIN:
             # Robin: alpha*u + beta*du/dn = g, du/dn the OUTWARD normal derivative, which is
@@ -1691,18 +1712,24 @@ class PreallocatedGhostBuffer:
             # agreement between the two paths is what the pin asserts.
             apply_flux = bc_type == BCType.NEUMANN and v != 0.0
             dx = self._grid_spacing[axis] if self._grid_spacing is not None else 1.0
+            # #1967, both halves, the same two as the uniform path above -- this is the second
+            # copy of that arithmetic and it carried the same errors.
             for k in range(g):
                 single_ghost = [slice(None)] * d
                 single_interior = [slice(None)] * d
                 if side == "min":
-                    single_ghost[axis] = g - 1 - k  # Ghost cells from g-1 down to 0
-                    single_interior[axis] = g + k  # Adjacent interior cells from g up
+                    single_ghost[axis] = g - 1 - k  # g-1 .. 0    : nearest the wall first
+                    single_interior[axis] = g + k  # g, g+1, ...  : nearest first
                 else:
-                    single_ghost[axis] = -(k + 1)  # Ghost cells from -1 down to -g
-                    single_interior[axis] = -(g + k + 1)  # Adjacent interior cells
+                    # The high ghosts occupy -g .. -1, and -g is the one ADJACENT to the wall,
+                    # so both walks must start there. `-(k+1)` started at the far end while the
+                    # interior walk started near, which pairs the layers backwards for g >= 2.
+                    single_ghost[axis] = -(g - k)  # -g .. -1     : nearest the wall first
+                    single_interior[axis] = -(g + 1) - k  # -(g+1), -(g+2), ... : nearest first
                 buf[tuple(single_ghost)] = buf[tuple(single_interior)]
                 if apply_flux:
-                    buf[tuple(single_ghost)] += dx * v
+                    # Layer k sits (2k-1)*dx from its mirror, so the offset grows with the layer.
+                    buf[tuple(single_ghost)] += (2 * (k + 1) - 1) * dx * v
 
         elif bc_type == BCType.ROBIN:
             # Robin: alpha*u + beta*du/dn = g

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -265,7 +265,7 @@ MUTATIONS: list[Mutation] = [
         path="mfgarchon/geometry/boundary/applicator_fdm.py",
         old="                        buf[tuple(lo_ghost)] += (2 * (k + 1) - 1) * dx * v",
         new="                        buf[tuple(lo_ghost)] -= (2 * (k + 1) - 1) * dx * v  # MUTATED: low wall reads du/dx instead of du/dn",
-        owner='inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and ghost = interior + dx*v, the same expression as the high wall (#1262). The line\'s own comment states the convention it replaced: "Issue #1262: was -= (du/dx sign), now += (du/dn sign)".',
+        owner='inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and the offset is ADDED, the same sign as the high wall (#1262). Since #1967 the magnitude is (2k-1)*dx*v rather than dx*v -- ghost layer k sits that far from its mirror -- so the k=1 case is the historical dx*v and the deeper layers scale.',
         verify="pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 0.9",
     ),
     Mutation(

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -263,8 +263,8 @@ MUTATIONS: list[Mutation] = [
     Mutation(
         name="neumann_low_wall_flux_sign",
         path="mfgarchon/geometry/boundary/applicator_fdm.py",
-        old="                        buf[tuple(lo_ghost)] += dx * v  # Issue #1262: was -= (du/dx sign), now += (du/dn sign)",
-        new="                        buf[tuple(lo_ghost)] -= dx * v  # MUTATED: low wall reads du/dx instead of du/dn",
+        old="                        buf[tuple(lo_ghost)] += (2 * (k + 1) - 1) * dx * v",
+        new="                        buf[tuple(lo_ghost)] -= (2 * (k + 1) - 1) * dx * v  # MUTATED: low wall reads du/dx instead of du/dn",
         owner='inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and ghost = interior + dx*v, the same expression as the high wall (#1262). The line\'s own comment states the convention it replaced: "Issue #1262: was -= (du/dx sign), now += (du/dn sign)".',
         verify="pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 0.9",
     ),

--- a/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
@@ -120,32 +120,56 @@ def test_the_high_wall_is_no_longer_the_reverse_of_itself(ghost_depth):
 
 
 @pytest.mark.parametrize("ghost_depth", [1, 2, 3])
-def test_an_inhomogeneous_flux_is_exact_at_every_layer(ghost_depth):
-    """`f = -2x + 1` has `du/dx = -2`, so `du/dn = +2` at the low wall, and the linear
-    continuation is the exact ghost.
+@pytest.mark.parametrize("wall", ["low", "high"])
+def test_an_inhomogeneous_flux_is_exact_at_every_layer(wall, ghost_depth):
+    """`f = -2x + 1` has `du/dx = -2`, so `du/dn = +2` at the low wall and `-2` at the high one,
+    and the linear continuation is the exact ghost at both.
 
-    Measured before the fix: 0 at `g=1`, `5.0e-01` at `g=2`, `1.0e+00` at `g=3` — the drift is
-    `(2k-2)·dx·v`, zero for the first layer, which is the whole reason a depth-1 suite saw nothing.
+    Measured before the fix at the low wall: 0 at `g=1`, `5.0e-01` at `g=2`, `1.0e+00` at `g=3` —
+    the drift is `(2k-2)·dx·v`, zero for the first layer, which is the whole reason a depth-1
+    suite saw nothing.
+
+    **Both walls are parametrised, and the first version of this test was not.** Independent
+    review left the high wall's offset at the pre-fix `dx*v` in both copies and the entire suite
+    of 6187 stayed green — an O(1) error (`0.25` where `1.25` is required at `g=3`) that nothing
+    caught, because every flux assertion here read `padded[:ghost_depth]`. That is the same
+    failure this PR exists to fix, reproduced inside the fix: last time `du/dn = 0` only, this
+    time one wall only.
     """
     field = -2.0 * _XC + 1.0
-    padded = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=2.0), ghost_depth=ghost_depth, spacing=_H)
+    flux = 2.0 if wall == "low" else -2.0
+    padded = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=flux), ghost_depth=ghost_depth, spacing=_H)
 
-    np.testing.assert_allclose(padded[:ghost_depth], -2.0 * _low_centres(ghost_depth) + 1.0, atol=1e-12)
+    centres = _low_centres(ghost_depth) if wall == "low" else _high_centres(ghost_depth)
+    got = padded[:ghost_depth] if wall == "low" else padded[-ghost_depth:]
+
+    np.testing.assert_allclose(got, -2.0 * centres + 1.0, atol=1e-12)
 
 
-def test_the_flux_offset_actually_scales_with_the_layer():
+@pytest.mark.parametrize("wall", ["low", "high"])
+def test_the_flux_offset_actually_scales_with_the_layer(wall):
     """Directly, without an exact solution: the gap between a `v = 0` wall and a `v != 0` one must
     be `(2k-1)·dx·v` per layer. A fix that applied a constant offset would satisfy the exactness
-    test above only for the field that happens to make it exact; this holds for any field."""
+    test above only for the field that happens to make it exact; this holds for any field.
+
+    Parametrised over both walls for the reason recorded above — the high wall's copy of this
+    arithmetic is separately omissible and was separately unpinned."""
     field = np.array([3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0])
     v, g = 2.0, 3
 
     hot = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=v), ghost_depth=g, spacing=_H)
     cold = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=0.0), ghost_depth=g, spacing=_H)
 
-    # outermost-first in the array, so layer k = g, g-1, ... 1
-    expected = np.array([(2 * k - 1) * _H * v for k in range(g, 0, -1)])
-    np.testing.assert_allclose(hot[:g] - cold[:g], expected, atol=1e-12)
+    if wall == "low":
+        # outermost-first in the array, so layer k = g, g-1, ... 1
+        expected = np.array([(2 * k - 1) * _H * v for k in range(g, 0, -1)])
+        got = hot[:g] - cold[:g]
+    else:
+        # the high ghosts run nearest-first, so layer k = 1 .. g
+        expected = np.array([(2 * k - 1) * _H * v for k in range(1, g + 1)])
+        got = hot[-g:] - cold[-g:]
+
+    np.testing.assert_allclose(got, expected, atol=1e-12)
 
 
 # =============================================================================
@@ -200,5 +224,35 @@ def test_depth_one_is_byte_identical(bc_type, value):
         assert padded[-1] == pytest.approx(field[0])
     elif bc_type == "dirichlet":
         assert padded[0] == pytest.approx(2 * value - field[0])
+        assert padded[-1] == pytest.approx(2 * value - field[-1])
     else:
+        # BOTH walls: the high wall is the half that moved at g >= 2, so asserting only the low
+        # one would leave the invariance claim resting on the side that never changed.
         assert padded[0] == pytest.approx(field[0] + _H * value)
+        assert padded[-1] == pytest.approx(field[-1] + _H * value)
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+def test_the_fix_holds_in_two_dimensions_including_the_corner(ghost_depth):
+    """Both axis sweeps write the corner block, so a per-axis fix can be right on the edges and
+    wrong where they meet. `cos(2*pi*x)*cos(2*pi*y)` is even about all four walls, so `NEUMANN(0)`
+    is exact everywhere on the boundary.
+
+    Measured before the fix: edge `5.0e-01` and corner `7.1e-01` at `g=2`, both `1.21e+00` at
+    `g=3`. Nothing in the rest of this file is 2-D."""
+    n = 8
+    h = 1.0 / n
+    c = (np.arange(n) + 0.5) * h
+    xx, yy = np.meshgrid(c, c, indexing="ij")
+    field = np.cos(2 * np.pi * xx) * np.cos(2 * np.pi * yy)
+
+    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=2)
+    bc.domain_bounds = np.array([[0.0, 1.0], [0.0, 1.0]])
+    padded = pad_array_with_ghosts(field, bc, ghost_depth=ghost_depth, spacing=(h, h))
+
+    g = ghost_depth
+    gc = np.concatenate([np.array([-(k - 0.5) * h for k in range(1, g + 1)])[::-1], c,
+                         np.array([1.0 + (k - 0.5) * h for k in range(1, g + 1)])])
+    gx, gy = np.meshgrid(gc, gc, indexing="ij")
+
+    np.testing.assert_allclose(padded, np.cos(2 * np.pi * gx) * np.cos(2 * np.pi * gy), atol=1e-12)

--- a/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
@@ -1,0 +1,204 @@
+"""Ghost layers must be paired nearest-first at both walls, and an inhomogeneous flux grows with
+the layer. #1967
+
+Two defects in the same loop, in two copies of it:
+
+1. **Layer order.** The high ghosts occupy padded indices `-g .. -1` and `-g` is the one adjacent
+   to the wall, so both the ghost walk and the interior walk must start there. The high-wall loop
+   started its ghost walk at `-1`, the far end, while its interior walk started near — pairing the
+   layers backwards for `g >= 2`. The low wall was already correct.
+2. **Flux offset.** Ghost layer `k` sits `(2k-1)*dx` from its mirror on a cell-centred grid, so an
+   inhomogeneous Neumann offset must scale with the layer. `dx * v` was applied to every layer —
+   the `k = 1` value used throughout.
+
+**Both are invisible at `ghost_depth = 1`**, where a single layer has no order to reverse and
+`(2·1-1)·dx = dx`. Every caller in the library passes 1 or omits it, which is why a suite of 6147
+was green with both present. The one production consumer at depth 3 is `hjb_weno.py:330`, whose
+`_SUPPORTED_BC_TYPES` is `{NEUMANN, NO_FLUX, PERIODIC}` — exactly the family defect 1 hits.
+
+**The oracle is an exact continuation, not another code path.** `cos(2πx)` is even about both
+`x = 0` and `x = 1`, so `NEUMANN(0)` is satisfied exactly at both walls and the correct ghost is
+the field itself at the ghost centres. For the inhomogeneous case a linear field makes the
+prescribed flux exact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
+    neumann_bc,
+    pad_array_with_ghosts,
+    uniform_bc,
+)
+
+_N = 8
+_H = 1.0 / _N
+_XC = (np.arange(_N) + 0.5) * _H  # cell centres, the geometry this branch uses (#1968)
+
+_MIRROR_FAMILY = ["neumann", "no_flux", "reflecting"]
+
+
+def _low_centres(g: int) -> np.ndarray:
+    """Ghost layer k has centre at -(k - 1/2)h; returned outermost-first to match the buffer."""
+    return np.array([-(k - 0.5) * _H for k in range(1, g + 1)])[::-1]
+
+
+def _high_centres(g: int) -> np.ndarray:
+    return np.array([1.0 + (k - 0.5) * _H for k in range(1, g + 1)])
+
+
+def _uniform(bc_type: str, value: float = 0.0) -> BoundaryConditions:
+    bc = uniform_bc(bc_type=bc_type, value=value, dimension=1)
+    bc.domain_bounds = np.array([[0.0, 1.0]])
+    return bc
+
+
+def _per_face(bc_type: BCType, value: float = 0.0) -> BoundaryConditions:
+    """The other copy of the same loop. Two segments make `is_uniform` False, which is what
+    routes to `_apply_ghost_for_face` instead of `_apply_linear_reflection`."""
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="lo", bc_type=bc_type, value=value, boundary="x_min"),
+            BCSegment(name="hi", bc_type=bc_type, value=value, boundary="x_max"),
+        ],
+        dimension=1,
+        default_bc=bc_type,
+        default_value=value,
+        domain_bounds=np.array([[0.0, 1.0]]),
+    )
+
+
+# =============================================================================
+# Defect 1: layer order, against an exact continuation
+# =============================================================================
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+@pytest.mark.parametrize("wall", ["low", "high"])
+@pytest.mark.parametrize("bc_type", _MIRROR_FAMILY)
+def test_the_mirror_family_is_exact_at_both_walls_and_every_depth(bc_type, wall, ghost_depth):
+    """`cos(2πx)` is even about both walls, so a homogeneous Neumann condition is exact there and
+    the ghost is the field itself.
+
+    **Both walls are parametrised on purpose.** The low wall was machine-zero throughout while the
+    high wall was `5.4e-01` at `g=2` and `1.3e+00` at `g=3`. A one-wall test measured the correct
+    half of the loop and certified the whole thing — that is how #1966 came to clear this family.
+    """
+    field = np.cos(2 * np.pi * _XC)
+    padded = pad_array_with_ghosts(field, _uniform(bc_type), ghost_depth=ghost_depth, spacing=_H)
+
+    if wall == "low":
+        got, want = padded[:ghost_depth], np.cos(2 * np.pi * _low_centres(ghost_depth))
+    else:
+        got, want = padded[-ghost_depth:], np.cos(2 * np.pi * _high_centres(ghost_depth))
+
+    np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+@pytest.mark.parametrize("ghost_depth", [2, 3])
+def test_the_high_wall_is_no_longer_the_reverse_of_itself(ghost_depth):
+    """The signature of the defect was that `reversed(got) == want` held exactly — every value
+    correct, every slot wrong. Asserting the reverse does *not* match is a different statement
+    from asserting the values are right, and it is the one that fails if a future change
+    reintroduces the swap while keeping the arithmetic."""
+    field = np.cos(2 * np.pi * _XC)
+    padded = pad_array_with_ghosts(field, _uniform("neumann"), ghost_depth=ghost_depth, spacing=_H)
+    got = padded[-ghost_depth:]
+
+    assert not np.allclose(got[::-1], np.cos(2 * np.pi * _high_centres(ghost_depth)), atol=1e-12)
+
+
+# =============================================================================
+# Defect 2: the flux offset grows with the layer
+# =============================================================================
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+def test_an_inhomogeneous_flux_is_exact_at_every_layer(ghost_depth):
+    """`f = -2x + 1` has `du/dx = -2`, so `du/dn = +2` at the low wall, and the linear
+    continuation is the exact ghost.
+
+    Measured before the fix: 0 at `g=1`, `5.0e-01` at `g=2`, `1.0e+00` at `g=3` — the drift is
+    `(2k-2)·dx·v`, zero for the first layer, which is the whole reason a depth-1 suite saw nothing.
+    """
+    field = -2.0 * _XC + 1.0
+    padded = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=2.0), ghost_depth=ghost_depth, spacing=_H)
+
+    np.testing.assert_allclose(padded[:ghost_depth], -2.0 * _low_centres(ghost_depth) + 1.0, atol=1e-12)
+
+
+def test_the_flux_offset_actually_scales_with_the_layer():
+    """Directly, without an exact solution: the gap between a `v = 0` wall and a `v != 0` one must
+    be `(2k-1)·dx·v` per layer. A fix that applied a constant offset would satisfy the exactness
+    test above only for the field that happens to make it exact; this holds for any field."""
+    field = np.array([3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0])
+    v, g = 2.0, 3
+
+    hot = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=v), ghost_depth=g, spacing=_H)
+    cold = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=0.0), ghost_depth=g, spacing=_H)
+
+    # outermost-first in the array, so layer k = g, g-1, ... 1
+    expected = np.array([(2 * k - 1) * _H * v for k in range(g, 0, -1)])
+    np.testing.assert_allclose(hot[:g] - cold[:g], expected, atol=1e-12)
+
+
+# =============================================================================
+# The second copy of the same loop
+# =============================================================================
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+@pytest.mark.parametrize("bc_type", [BCType.NEUMANN, BCType.NO_FLUX, BCType.REFLECTING])
+def test_the_per_face_path_carries_the_same_repair(bc_type, ghost_depth):
+    """`_apply_ghost_for_face` is a second copy of this arithmetic and carried both defects. It is
+    reached whenever the BC names its faces rather than being uniform — measured, fixing only the
+    uniform path made the two paths disagree and reddened
+    `test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer`."""
+    field = np.cos(2 * np.pi * _XC)
+    padded = pad_array_with_ghosts(field, _per_face(bc_type), ghost_depth=ghost_depth, spacing=_H)
+
+    np.testing.assert_allclose(padded[:ghost_depth], np.cos(2 * np.pi * _low_centres(ghost_depth)), atol=1e-12)
+    np.testing.assert_allclose(padded[-ghost_depth:], np.cos(2 * np.pi * _high_centres(ghost_depth)), atol=1e-12)
+
+
+def test_the_two_paths_agree_on_an_inhomogeneous_flux_at_depth():
+    """The cross-path check that caught the incomplete fix. It is not the oracle — after both
+    copies are corrected, agreement is compatible with both being wrong — so it sits beside the
+    exactness tests above rather than replacing them."""
+    field = -2.0 * _XC + 1.0
+    uniform = pad_array_with_ghosts(field, neumann_bc(dimension=1, value=2.0), ghost_depth=3, spacing=_H)
+    per_face = pad_array_with_ghosts(field, _per_face(BCType.NEUMANN, 2.0), ghost_depth=3, spacing=_H)
+
+    np.testing.assert_allclose(per_face, uniform, atol=1e-12)
+
+
+# =============================================================================
+# Depth 1 is the blind spot, and must not move
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("bc_type", "value"),
+    [("neumann", 0.0), ("neumann", 2.0), ("no_flux", 0.0), ("reflecting", 0.0), ("dirichlet", 1.0), ("periodic", 0.0)],
+)
+def test_depth_one_is_byte_identical(bc_type, value):
+    """Eighteen of the twenty-four probed cells were unchanged by this fix; every `ghost_depth = 1`
+    cell is among them, because that is where the two expressions coincide. Since every caller in
+    the library uses depth 1, a change here would be a regression in everything that currently
+    works, and nothing else in this file would see it."""
+    field = np.cos(2 * np.pi * _XC)
+    padded = pad_array_with_ghosts(field, _uniform(bc_type, value), ghost_depth=1, spacing=_H)
+
+    if bc_type == "periodic":
+        assert padded[0] == pytest.approx(field[-1])
+        assert padded[-1] == pytest.approx(field[0])
+    elif bc_type == "dirichlet":
+        assert padded[0] == pytest.approx(2 * value - field[0])
+    else:
+        assert padded[0] == pytest.approx(field[0] + _H * value)

--- a/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
@@ -13,8 +13,26 @@ Two defects in the same loop, in two copies of it:
 
 **Both are invisible at `ghost_depth = 1`**, where a single layer has no order to reverse and
 `(2·1-1)·dx = dx`. Every caller in the library passes 1 or omits it, which is why a suite of 6147
-was green with both present. The one production consumer at depth 3 is `hjb_weno.py:330`, whose
-`_SUPPORTED_BC_TYPES` is `{NEUMANN, NO_FLUX, PERIODIC}` — exactly the family defect 1 hits.
+was green with both present.
+
+~~The one production consumer at depth 3 is `hjb_weno.py:330`, whose `_SUPPORTED_BC_TYPES` is
+`{NEUMANN, NO_FLUX, PERIODIC}` — exactly the family defect 1 hits.~~ [CORRECTED] The supported set
+is right and the depth is right, but the routing is not: at depth 3 a *uniform* BC does not enter
+the repaired loop at all. Instrumented call counts through a real `HJBWenoSolver`, depth 3,
+order 5:
+
+| BC handed to WENO             | poly | linear_reflect | per_face |
+|:------------------------------|-----:|---------------:|---------:|
+| uniform NEUMANN(0)/(2)/NO_FLUX|    1 |              0 |        0 |
+| uniform PERIODIC              |    1 |  1 (PERIODIC branch, untouched) | 0 |
+| per-face NEUMANN(0)/(2)/NO_FLUX|   0 |              0 |    2, at g=3 |
+| per-face ROBIN                |    — |              — | refused at construction |
+
+So the reached path is `_apply_poly_extrapolation`, which `self._order` selects and
+`_update_ghosts_mixed` ignores. The repaired loop is reachable only per-face, and both in-repo
+per-face HJB constructors — `geometry/boundary/bc_coupling.py:65` (deprecated) and
+`alg/numerical/adjoint/bc_coupling.py:178` — emit `ROBIN`, which WENO refuses. **Reachable but
+not currently reached**, which is a weaker claim than the struck sentence and is the true one.
 
 **The oracle is an exact continuation, not another code path.** `cos(2πx)` is even about both
 `x = 0` and `x = 1`, so `NEUMANN(0)` is satisfied exactly at both walls and the correct ghost is


### PR DESCRIPTION
Closes #1967.

Two defects in one loop, and the loop has two copies.

## Defect 1 — the high wall pairs its layers backwards

The high ghosts occupy padded indices `-g .. -1`, and **`-g` is the one adjacent to the wall**, so both the ghost walk and the interior walk must start there.

```python
lo_ghost = g - 1 - k        lo_interior = g + k          # nearest ↔ nearest      correct
hi_ghost = -(k + 1)         hi_interior = -(g + k + 1)   # nearest ↔ FARTHEST     reversed
```

At `g = 1` the two expressions coincide. At `g >= 2` the layers arrive in reverse order.

**Measured.** `cos(2πx)` is even about *both* `x = 0` and `x = 1`, so `NEUMANN(0)` is exact at both walls and the correct ghost is the field itself at the ghost centres:

| | low wall | high wall |
|---|---|---|
| `g=1` | 0 | 0 |
| `g=2` | 0 | **5.41e−01** |
| `g=3` | 0 | **1.31e+00** |

`reversed(got) == want` at every depth — **every value correct, every slot wrong**, which is what separates an indexing error from bad arithmetic. After the fix: `4.4e−16` at both walls, all depths.

## Defect 2 — the flux offset does not grow with the layer

Ghost layer `k` sits `(2k−1)·dx` from its mirror, so an inhomogeneous Neumann offset scales with the layer. `dx · v` was the `k = 1` value applied to every layer, drifting by `(2k−2)·dx·v`: **0 at `g=1`, 5.0e−01 at `g=2`, 1.0e+00 at `g=3`** on `f = −2x+1` with `du/dn = 2`.

This one was missed by the first pass, which tested only `du/dn = 0` — where the term vanishes. Non-discriminating input.

## Both copies

`_apply_ghost_for_face` (the per-face path) carried both. Fixing only the uniform copy made the two disagree and reddened `test_per_face_bc_path_1937::test_the_flux_is_applied_at_every_ghost_layer` — **that test doing its job**, and the reason it is not the oracle here: once both copies are corrected, agreement is compatible with both being wrong.

## Why a suite of 6147 was green

**Both defects are invisible at `ghost_depth = 1`** — one layer has no order to reverse, and `(2·1−1)·dx = dx`. Every caller in the library passes 1 or omits it.

The one production consumer at depth 3 is `hjb_weno.py:330`, and its `_SUPPORTED_BC_TYPES` is `{NEUMANN, NO_FLUX, PERIODIC}` — **exactly the family defect 1 hits**.

## Scope, pinned

Eighteen of twenty-four probed cells are unchanged, every `ghost_depth = 1` cell among them, and that is asserted: since every caller uses depth 1, a change there would be a regression in everything that currently works and nothing else in the file would catch it.

The discrimination ratchet's `neumann_low_wall_flux_sign` anchor is re-pointed to the new line — it failed because the source moved, which is what that check exists for.

## Mutations

One per defect per copy:

```
uniform  order reversed again      9 failed / 31 passed
uniform  flux offset constant      4 failed / 36 passed
per-face order reversed again      7 failed / 33 passed
per-face flux offset constant      1 failed / 39 passed
```

Source restored byte-identical after each.

## Provenance

Found by **four independent oracles run in parallel** on #1966 — convergence order, invariance, cross-implementation, grid convention. #1966 had certified this family as correct after measuring **one wall**; its correction is recorded there, along with three others (the count, the priority framing, and a `grep` false negative that hid the live consumer).

One method note: mirror invariance, nominated as the sharpest test of a layer-order defect, is **structurally blind** to a defect that reverses both walls symmetrically. Depth-consistency catches that one — and is itself blind to the Robin collapse, since a layer-independent value is trivially depth-consistent. No single oracle here saw everything.

## Gate

`./scripts/local_ci.sh` → **6187 passed, 12 skipped, 21 xfailed, GATE GREEN**.