### PR TITLE
fix: pair GhostBuffer's ghost and interior slices in the same direction (#1971)

### DIFF
--- a/changelog.d/1971-ghost-buffer-layer-pairing.fixed.md
+++ b/changelog.d/1971-ghost-buffer-layer-pairing.fixed.md
@@ -1,6 +1,9 @@
-`GhostBuffer` paired ghost and interior layers in opposite directions at `ghost_depth > 1`, on
-both walls — the third and last copy of the reversal corrected in #1967. The ghost slice `[0:g]`
-runs outermost-first while `[g:2g]` runs nearest-first, so the element-wise assignment gave ghost
-layer 1 the value computed for the farthest interior cell; the high side had the mirror problem.
-At `ghost_depth = 1` a one-element slice is its own reverse, which is why the only depth anything
-uses looked correct. (#1971)
+`GhostBuffer` paired ghost and interior layers in opposite directions at `ghost_depth > 1`, on both
+walls. The ghost slice `[0:g]` runs outermost-first while `[g:2g]` runs nearest-first, and the
+element-wise assignment gave ghost layer 1 the value computed for the farthest interior cell; the
+high side had the mirror problem. At `ghost_depth = 1` a one-element slice is its own reverse,
+which is why the only depth anything uses looked correct.
+
+This is the copy in `GhostBuffer._update_bounded` and it does **not** close the family: the same
+slice-pair construct is written out twice more in `PreallocatedGhostBuffer`, both reversed at both
+walls, tracked as #1966 Defect 2. (#1971)

--- a/changelog.d/1971-ghost-buffer-layer-pairing.fixed.md
+++ b/changelog.d/1971-ghost-buffer-layer-pairing.fixed.md
@@ -1,0 +1,6 @@
+`GhostBuffer` paired ghost and interior layers in opposite directions at `ghost_depth > 1`, on
+both walls — the third and last copy of the reversal corrected in #1967. The ghost slice `[0:g]`
+runs outermost-first while `[g:2g]` runs nearest-first, so the element-wise assignment gave ghost
+layer 1 the value computed for the farthest interior cell; the high side had the mirror problem.
+At `ghost_depth = 1` a one-element slice is its own reverse, which is why the only depth anything
+uses looked correct. (#1971)

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -760,12 +760,20 @@ class GhostBuffer:
             lo_ghost = [slice(None)] * d
             lo_ghost[axis] = slice(0, g)
             lo_interior = [slice(None)] * d
-            lo_interior[axis] = slice(g, 2 * g)
+            # #1971: the ghost slice [0:g] runs OUTERMOST-first (index g-1 is the one adjacent to
+            # the wall) while [g:2g] runs nearest-first, and the assignment pairs them
+            # element-wise -- so ghost layer 1 received the value computed for the FARTHEST
+            # interior cell. Stepping the interior slice backwards makes both run wall-outward,
+            # which is the pairing a mirror means. Reversing the calculator's OUTPUT instead
+            # would have to be done along `axis`, and the obvious `[::-1]` reverses axis 0.
+            lo_interior[axis] = slice(2 * g - 1, g - 1, -1)
 
             hi_ghost = [slice(None)] * d
             hi_ghost[axis] = slice(-g, None)
             hi_interior = [slice(None)] * d
-            hi_interior[axis] = slice(-2 * g, -g)
+            # Mirror problem on this side: the ghost slice runs nearest-first, the interior
+            # [-2g:-g] runs farthest-first.
+            hi_interior[axis] = slice(-g - 1, -2 * g - 1, -1)
 
             # Get interior arrays (views, not copies)
             interior_lo = buf[tuple(lo_interior)]
@@ -786,6 +794,10 @@ class GhostBuffer:
                 **kwargs,
             )
 
+            # At g=1 a one-element slice is its own reverse, which is why every caller saw the
+            # right answer. Measured at g=2 and g=3 on u = cos(2*pi*x), even about both walls so
+            # Neumann(0) is exact there: 5.4e-01 and 1.3e+00 at BOTH walls, with
+            # reversed(got) == want -- every value correct, every slot wrong. (#1971)
             buf[tuple(lo_ghost)] = ghost_lo
             buf[tuple(hi_ghost)] = ghost_hi
 

--- a/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
@@ -1,8 +1,9 @@
 """`GhostBuffer` paired its ghost and interior slices in opposite directions. #1971
 
-The third and last copy of the pairing corrected in #1967, and the only one that reverses **both**
-walls. It differs in kind from the other two: they were per-layer loops with a wrong index
-expression, this one is a vectorised slice assignment where the two slices run opposite ways.
+The copy of the #1967 pairing defect that lives in `GhostBuffer._update_bounded`, and the only one
+of the three *mirror* copies that reverses **both** walls. It differs in kind from the two fixed in
+#1969: those were per-layer loops with a wrong index expression, this one is a vectorised slice
+assignment where the two slices run opposite ways.
 
     lo_ghost    = [0:g]        index g-1 is adjacent to the wall, index 0 outermost
     lo_interior = [g:2g]       index g   is adjacent to the wall
@@ -14,10 +15,32 @@ The high side has the mirror problem: its ghost slice runs nearest-first and its
 **At `ghost_depth = 1` a one-element slice is its own reverse**, which is why the route looks
 correct at the only depth anything uses.
 
-The fix steps the *interior* slice backwards rather than reversing the calculator's output,
-because the output would have to be reversed along `axis` and the obvious `[::-1]` reverses axis
-0 — correct in 1-D and wrong for any other axis in n-D. That mistake was made and caught by the
-2-D check below before it shipped.
+**This does not close the family.** The same slice-pair construct is written out twice more in
+`PreallocatedGhostBuffer` -- `_apply_linear_reflection`'s DIRICHLET branch and the per-face
+`_apply_ghost_for_face` -- and both are reversed at both walls (`reversed(got) == want`, magnitudes
+1.1 to 3.4 at g = 2..4). Those are #1966 Defect 2 and are not fixed here. `_update_ghosts_legacy`
+carries the construct as well. The claim this file used to make -- "third and last copy" -- was
+wrong, and it was wrong in the same way #1969's "the loop has two copies" was.
+
+The fix steps the *interior* slice backwards rather than reversing the calculator's output. The
+output would have to be reversed along `axis`; the obvious `[::-1]` reverses axis 0, which is
+correct in 1-D and wrong for any other axis in n-D. (`np.flip(out, axis=axis)` would also be
+correct -- the interior-slice form is a preference, not the only option.) The `[::-1]` version was
+written first and passes **every** 1-D assertion below.
+
+## The oracle, and why the fixture is random
+
+A ghost rule for a mirror wall is a permutation fixed by the grid geometry alone: on a
+cell-centred grid, ghost layer `k` sits at `-(k-1/2)h` and its mirror is interior layer `k` at
+`+(k-1/2)h`. That is derived from the geometry, not from another code path, so it survives any
+later consolidation of these copies into one owner.
+
+The interior values are **unconstrained** by that -- evenness about a wall relates ghosts to
+interior samples and says nothing about the interior itself -- so the fixture may be anything.
+It must not be `cos(2*pi*x)` on a symmetric grid, which is what this file used to use: that field
+is palindromic on the interior, so a high-wall/low-end confusion is value-identical on it and
+passed 20 of 21 assertions here and 1180 of 1181 in `tests/unit/test_geometry/`. Seeded random
+data has no symmetry to hide behind.
 """
 
 from __future__ import annotations
@@ -29,22 +52,17 @@ import numpy as np
 from mfgarchon.geometry.boundary import uniform_bc
 from mfgarchon.geometry.boundary.applicator_fdm import create_ghost_buffer_from_bc
 
-_N = 8
-_H = 1.0 / _N
-_XC = (np.arange(_N) + 0.5) * _H
+_SEED = 19710816
 
 
-def _low_centres(g: int) -> np.ndarray:
-    return np.array([-(k - 0.5) * _H for k in range(1, g + 1)])[::-1]
+def _interior(shape) -> np.ndarray:
+    """Asymmetric, non-palindromic, no repeated values -- every slot is its own witness."""
+    return np.random.default_rng(_SEED).standard_normal(shape)
 
 
-def _high_centres(g: int) -> np.ndarray:
-    return np.array([1.0 + (k - 0.5) * _H for k in range(1, g + 1)])
-
-
-def _neumann_2d_bc():
-    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=2)
-    bc.domain_bounds = np.array([[0.0, 1.0], [0.0, 1.0]])
+def _bc(bc_type, dimension, bounds, value=0.0):
+    bc = uniform_bc(bc_type=bc_type, value=value, dimension=dimension)
+    bc.domain_bounds = np.asarray(bounds, dtype=float)
     return bc
 
 
@@ -55,59 +73,87 @@ def _filled(bc, shape, dx, ghost_depth, interior):
     return np.asarray(buffer.padded)
 
 
-# =============================================================================
-# 1-D, both walls, against an exact continuation
-# =============================================================================
+def _mirror_expectation(interior: np.ndarray, axis: int, g: int) -> tuple[np.ndarray, np.ndarray]:
+    """Ghost blocks a zero-gradient mirror must produce, from the geometry alone.
 
-
-@pytest.mark.parametrize("ghost_depth", [1, 2, 3, 4])
-@pytest.mark.parametrize("wall", ["low", "high"])
-def test_the_ghost_layers_are_exact_at_both_walls(wall, ghost_depth):
-    """`cos(2πx)` is even about both `x = 0` and `x = 1`, so `NEUMANN(0)` is exact at both and the
-    correct ghost is the field itself at the ghost centres.
-
-    Measured before the fix: `5.412e-01` at `g=2` and `1.307e+00` at `g=3`, **at both walls** —
-    unlike the two copies fixed in #1967, where only the high wall was affected. `g=4` is included
-    because the two other copies were each verified to depth 3 only.
+    Low: ghost element j is layer `g-j`, whose mirror is interior layer `g-j`, i.e. interior index
+    `g-j-1`. High: ghost element j is layer `j+1`, mirror interior index `-(j+1)`.
     """
-    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=1)
-    bc.domain_bounds = np.array([[0.0, 1.0]])
-    padded = _filled(bc, (_N,), _H, ghost_depth, np.cos(2 * np.pi * _XC))
-
-    if wall == "low":
-        got, centres = padded[:ghost_depth], _low_centres(ghost_depth)
-    else:
-        got, centres = padded[-ghost_depth:], _high_centres(ghost_depth)
-
-    np.testing.assert_allclose(got, np.cos(2 * np.pi * centres), atol=1e-12)
+    take = lambda idx: np.take(interior, idx, axis=axis)  # noqa: E731
+    lo = take([g - j - 1 for j in range(g)])
+    hi = take([-(j + 1) for j in range(g)])
+    return lo, hi
 
 
-@pytest.mark.parametrize("ghost_depth", [2, 3])
+def _ghost_blocks(padded: np.ndarray, axis: int, g: int) -> tuple[np.ndarray, np.ndarray]:
+    lo = [slice(None)] * padded.ndim
+    hi = [slice(None)] * padded.ndim
+    lo[axis], hi[axis] = slice(0, g), slice(-g, None)
+    return padded[tuple(lo)], padded[tuple(hi)]
+
+
+# =============================================================================
+# 1-D, both walls, against the geometric mirror
+# =============================================================================
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("bc_type", ["neumann", "no_flux", "reflecting"])
+def test_the_ghost_layers_mirror_the_interior_at_both_walls(bc_type, ghost_depth):
+    """Exact, not approximate: a mirror is a permutation of existing values, so the correct result
+    is bit-identical to the interior samples.
+
+    Measured before the fix on the old smooth fixture: 5.412e-01 at g=2 and 1.307e+00 at g=3, **at
+    both walls** -- unlike the two copies fixed in #1969, where only the high wall moved. Depths
+    5 and 6 are here because the slice algebra carries no depth constant and the claim that it
+    cannot break at larger g should be asserted, not argued.
+    """
+    n = 9
+    interior = _interior(n)
+    padded = _filled(_bc(bc_type, 1, [[0.0, 1.0]]), (n,), 1.0 / n, ghost_depth, interior)
+
+    got_lo, got_hi = _ghost_blocks(padded, 0, ghost_depth)
+    want_lo, want_hi = _mirror_expectation(interior, 0, ghost_depth)
+    np.testing.assert_array_equal(got_lo, want_lo)
+    np.testing.assert_array_equal(got_hi, want_hi)
+
+
+@pytest.mark.parametrize("ghost_depth", [2, 3, 4])
 @pytest.mark.parametrize("wall", ["low", "high"])
 def test_neither_wall_is_the_reverse_of_itself(wall, ghost_depth):
-    """The signature of this defect was `reversed(got) == want` holding exactly — every value
-    right, every slot wrong. Asserting the reverse does *not* match is a different statement from
+    """The signature of this defect was `reversed(got) == want` holding exactly -- every value
+    right, every slot wrong. Asserting the reverse does NOT match is a different statement from
     asserting the values are right, and it is the one that fails if the pairing is swapped back
     while the arithmetic stays correct."""
-    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=1)
-    bc.domain_bounds = np.array([[0.0, 1.0]])
-    padded = _filled(bc, (_N,), _H, ghost_depth, np.cos(2 * np.pi * _XC))
+    n = 9
+    interior = _interior(n)
+    padded = _filled(_bc("neumann", 1, [[0.0, 1.0]]), (n,), 1.0 / n, ghost_depth, interior)
 
-    if wall == "low":
-        got, centres = padded[:ghost_depth], _low_centres(ghost_depth)
-    else:
-        got, centres = padded[-ghost_depth:], _high_centres(ghost_depth)
+    got_lo, got_hi = _ghost_blocks(padded, 0, ghost_depth)
+    want_lo, want_hi = _mirror_expectation(interior, 0, ghost_depth)
+    got, want = (got_lo, want_lo) if wall == "low" else (got_hi, want_hi)
 
-    assert not np.allclose(got[::-1], np.cos(2 * np.pi * centres), atol=1e-12)
+    assert not np.array_equal(got[::-1], want)
+
+
+def test_the_two_walls_do_not_receive_the_same_block():
+    """A high-wall/low-end confusion is value-identical on a palindromic fixture, which is what
+    this file used to use. On random data the two ghost blocks share no value."""
+    n = 9
+    interior = _interior(n)
+    padded = _filled(_bc("neumann", 1, [[0.0, 1.0]]), (n,), 1.0 / n, 3, interior)
+    got_lo, got_hi = _ghost_blocks(padded, 0, 3)
+
+    assert not np.array_equal(got_lo, got_hi)
+    assert not np.array_equal(got_lo, got_hi[::-1])
 
 
 def test_the_interior_is_never_touched():
     """Control. A pairing fix that wrote into the interior would satisfy every ghost assertion
     above while corrupting the field."""
-    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=1)
-    bc.domain_bounds = np.array([[0.0, 1.0]])
-    interior = np.cos(2 * np.pi * _XC)
-    padded = _filled(bc, (_N,), _H, 3, interior)
+    n = 9
+    interior = _interior(n)
+    padded = _filled(_bc("neumann", 1, [[0.0, 1.0]]), (n,), 1.0 / n, 3, interior)
 
     np.testing.assert_array_equal(padded[3:-3], interior)
 
@@ -117,55 +163,66 @@ def test_the_interior_is_never_touched():
 # =============================================================================
 
 
-@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
-def test_the_pairing_is_correct_on_every_axis_and_in_the_corners(ghost_depth):
-    """`cos(2πx)·cos(2πy)` is even about all four walls, so the whole padded array has a known
-    exact value — edges, and the corner blocks both axis sweeps write.
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3, 4])
+def test_every_axis_and_every_corner_mirrors_correctly_in_2d(ghost_depth):
+    """The whole padded array, edges and the corner blocks both axis sweeps write.
 
     **This is the test that matters for the shape of the fix.** Reversing the calculator's output
-    with `[::-1]` reverses axis 0, which is correct in 1-D and wrong for axis 1 in 2-D; every 1-D
-    assertion above passes under that version. Stepping the interior *slice* backwards is indexed
-    by `axis` and cannot have that failure.
+    with `[::-1]` reverses axis 0 -- correct in 1-D, wrong for axis 1 in 2-D; every 1-D assertion
+    above passes under that version. Deliberately non-square with unequal spacings: a square shape
+    lets a swapped axis index coincide with the right answer.
     """
-    n = 6
-    h = 1.0 / n
-    c = (np.arange(n) + 0.5) * h
-    xx, yy = np.meshgrid(c, c, indexing="ij")
-    padded = _filled(_neumann_2d_bc(), (n, n), (h, h), ghost_depth, np.cos(2 * np.pi * xx) * np.cos(2 * np.pi * yy))
-
+    nx, ny, hx, hy = 5, 8, 0.2, 0.05
     g = ghost_depth
-    gc = np.concatenate(
-        [
-            np.array([-(k - 0.5) * h for k in range(1, g + 1)])[::-1],
-            c,
-            np.array([1.0 + (k - 0.5) * h for k in range(1, g + 1)]),
-        ]
-    )
-    gx, gy = np.meshgrid(gc, gc, indexing="ij")
+    interior = _interior((nx, ny))
+    padded = _filled(_bc("no_flux", 2, [[0, nx * hx], [0, ny * hy]]), (nx, ny), (hx, hy), g, interior)
 
-    np.testing.assert_allclose(padded, np.cos(2 * np.pi * gx) * np.cos(2 * np.pi * gy), atol=1e-12)
+    # Build the expected padded array by applying the same geometric mirror on each axis in turn,
+    # which is what makes the corner blocks predicted rather than merely asserted non-NaN.
+    want = np.empty_like(padded)
+    want[(slice(g, -g),) * 2] = interior
+    for axis in (0, 1):
+        core = [slice(g, -g)] * 2
+        core[axis] = slice(None)
+        block = want[tuple(core)]
+        lo, hi = _mirror_expectation(interior, axis, g)
+        sl_lo, sl_hi = [slice(None)] * 2, [slice(None)] * 2
+        sl_lo[axis], sl_hi[axis] = slice(0, g), slice(-g, None)
+        block[tuple(sl_lo)] = np.take(lo, range(lo.shape[1 - axis]), axis=1 - axis)
+        block[tuple(sl_hi)] = np.take(hi, range(hi.shape[1 - axis]), axis=1 - axis)
+
+    np.testing.assert_array_equal(padded[g:-g, g:-g], interior)
+    for axis in (0, 1):
+        core = [slice(g, -g)] * 2
+        core[axis] = slice(None)
+        got_lo, got_hi = _ghost_blocks(padded[tuple(core)], axis, g)
+        want_lo, want_hi = _mirror_expectation(interior, axis, g)
+        np.testing.assert_array_equal(got_lo, want_lo)
+        np.testing.assert_array_equal(got_hi, want_hi)
+
+    assert np.all(np.isfinite(padded)), "corner blocks were left unwritten"
 
 
-def test_a_non_square_grid_does_not_let_an_axis_swap_hide():
-    """Square shapes and equal spacings let a swapped axis index coincide with the right answer.
-    Different extents, different spacings, different point counts on the two axes."""
-    nx, ny = 5, 8
-    hx, hy = 0.2, 0.05
-    cx = (np.arange(nx) + 0.5) * hx
-    cy = (np.arange(ny) + 0.5) * hy
-    xx, yy = np.meshgrid(cx, cy, indexing="ij")
-    interior = np.cos(np.pi * xx / (nx * hx)) * np.cos(np.pi * yy / (ny * hy))
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("ghost_depth", [2, 3])
+def test_each_axis_is_mirrored_independently_in_3d(axis, ghost_depth):
+    """Three distinct extents, point counts and spacings, so no axis can stand in for another.
+    Parametrised on `axis` because the single unparametrised 2-D check was carrying the entire
+    axis-discrimination load of this file.
+    """
+    shape, spacing = (4, 5, 6), (0.25, 0.1, 1.0 / 30.0)
+    bounds = [[0.0, n * h] for n, h in zip(shape, spacing, strict=True)]
+    g = ghost_depth
+    interior = _interior(shape)
+    padded = _filled(_bc("no_flux", 3, bounds), shape, spacing, g, interior)
 
-    bc = uniform_bc(bc_type="no_flux", dimension=2)
-    bc.domain_bounds = np.array([[0.0, nx * hx], [0.0, ny * hy]])
-    padded = _filled(bc, (nx, ny), (hx, hy), 2, interior)
+    core = [slice(g, -g)] * 3
+    core[axis] = slice(None)
+    got_lo, got_hi = _ghost_blocks(padded[tuple(core)], axis, g)
+    want_lo, want_hi = _mirror_expectation(interior, axis, g)
 
-    # A no-flux wall mirrors, so the two ghost layers on each side must be the first two interior
-    # planes reversed -- checked per axis, which is what an axis swap breaks.
-    np.testing.assert_allclose(padded[:2, 2:-2], interior[1::-1, :], atol=1e-12)
-    np.testing.assert_allclose(padded[-2:, 2:-2], interior[:-3:-1, :], atol=1e-12)
-    np.testing.assert_allclose(padded[2:-2, :2], interior[:, 1::-1], atol=1e-12)
-    np.testing.assert_allclose(padded[2:-2, -2:], interior[:, :-3:-1], atol=1e-12)
+    np.testing.assert_array_equal(got_lo, want_lo)
+    np.testing.assert_array_equal(got_hi, want_hi)
 
 
 # =============================================================================
@@ -179,18 +236,26 @@ def test_a_non_square_grid_does_not_let_an_axis_swap_hide():
 )
 def test_depth_one_is_unchanged(bc_type, value):
     """A one-element slice is its own reverse, so every depth-1 result predates this change and
-    must survive it. Every caller of this route — of which there are none in the library today —
+    must survive it. Every caller of this route -- of which there are none in the library today --
     would be using depth 1.
 
     The flux types are pinned at `value = 0`, where the ghost is the interior whatever the
-    normal-derivative spacing convention is. At nonzero flux this route's coefficient disagrees
-    with the live one by a factor of 2 and, at the low wall, by a sign (#1972); that is a second
-    defect on the same dead route and it is not what this file pins.
+    normal-derivative convention is. At nonzero flux this route disagrees with the live one in
+    **three** independent ways and only two of them are #1972's: a factor of 2, a sign at the low
+    wall, and -- because `Calculator.compute(interior_value, dx, side)` carries no layer index --
+    an offset that stays constant across layers where it must scale as `2k-1`. Measured at
+    `neumann(2.0)`, h = 0.125, offset of ghost layer k from its mirror:
+
+        GhostBuffer              low  [-0.5, -0.5, -0.5, -0.5]   flat
+        PreallocatedGhostBuffer  low  [0.25, 0.75, 1.25, 1.75]   = 0.25 * [1, 3, 5, 7]
+        required ratio                [   1,    3,    5,    7]
+
+    No constant factor and no sign flip turns a flat sequence into 1:3:5:7. None of that is what
+    this file pins.
     """
-    bc = uniform_bc(bc_type=bc_type, value=value, dimension=1)
-    bc.domain_bounds = np.array([[0.0, 1.0]])
-    interior = np.cos(2 * np.pi * _XC)
-    padded = _filled(bc, (_N,), _H, 1, interior)
+    n = 9
+    interior = _interior(n)
+    padded = _filled(_bc(bc_type, 1, [[0.0, 1.0]], value=value), (n,), 1.0 / n, 1, interior)
 
     if bc_type == "dirichlet":
         assert padded[0] == pytest.approx(2 * value - interior[0])

--- a/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
@@ -196,8 +196,15 @@ def test_every_axis_and_every_corner_mirrors_correctly_in_2d(ghost_depth):
     interior = _interior((nx, ny))
     padded = _filled(_bc("no_flux", 2, [[0, nx * hx], [0, ny * hy]]), (nx, ny), (hx, hy), g, interior)
 
-    # The whole padded array at once, corners included. Separable, so no corner argument is
-    # needed: if either axis sweep skips or double-writes a corner block, this fails.
+    # The whole padded array at once, corners included. What this catches is a corner value that
+    # differs from the separable mirror -- measured against six corner mutations (filled with a
+    # constant, never written, swapped with the opposite corner, left as the raw interior block,
+    # reversed along axis 0, transposed): 6 of 6 caught here, 0 of 6 on the file this replaced.
+    #
+    # It does NOT catch every way a sweep could mishandle a corner, and two such ways are not
+    # defects: the axis-0 sweep skipping the corner is byte-identical to the correct output
+    # because the axis-1 sweep's full-span write repairs it, and the correct code double-writes
+    # the corner by design for the same reason.
     maps = [_mirror_index_map(n, g) for n, g in ((nx, g), (ny, g))]
     np.testing.assert_array_equal(padded, interior[np.ix_(*maps)])
 

--- a/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
@@ -1,0 +1,200 @@
+"""`GhostBuffer` paired its ghost and interior slices in opposite directions. #1971
+
+The third and last copy of the pairing corrected in #1967, and the only one that reverses **both**
+walls. It differs in kind from the other two: they were per-layer loops with a wrong index
+expression, this one is a vectorised slice assignment where the two slices run opposite ways.
+
+    lo_ghost    = [0:g]        index g-1 is adjacent to the wall, index 0 outermost
+    lo_interior = [g:2g]       index g   is adjacent to the wall
+    buf[lo_ghost] = calc(buf[lo_interior])      pairs outermost ghost with nearest interior
+
+The high side has the mirror problem: its ghost slice runs nearest-first and its interior slice
+`[-2g:-g]` runs farthest-first.
+
+**At `ghost_depth = 1` a one-element slice is its own reverse**, which is why the route looks
+correct at the only depth anything uses.
+
+The fix steps the *interior* slice backwards rather than reversing the calculator's output,
+because the output would have to be reversed along `axis` and the obvious `[::-1]` reverses axis
+0 — correct in 1-D and wrong for any other axis in n-D. That mistake was made and caught by the
+2-D check below before it shipped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import uniform_bc
+from mfgarchon.geometry.boundary.applicator_fdm import create_ghost_buffer_from_bc
+
+_N = 8
+_H = 1.0 / _N
+_XC = (np.arange(_N) + 0.5) * _H
+
+
+def _low_centres(g: int) -> np.ndarray:
+    return np.array([-(k - 0.5) * _H for k in range(1, g + 1)])[::-1]
+
+
+def _high_centres(g: int) -> np.ndarray:
+    return np.array([1.0 + (k - 0.5) * _H for k in range(1, g + 1)])
+
+
+def _neumann_2d_bc():
+    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=2)
+    bc.domain_bounds = np.array([[0.0, 1.0], [0.0, 1.0]])
+    return bc
+
+
+def _filled(bc, shape, dx, ghost_depth, interior):
+    buffer = create_ghost_buffer_from_bc(bc, shape=shape, dx=dx, ghost_depth=ghost_depth)
+    buffer.copy_to_interior(interior)
+    buffer.update()
+    return np.asarray(buffer.padded)
+
+
+# =============================================================================
+# 1-D, both walls, against an exact continuation
+# =============================================================================
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3, 4])
+@pytest.mark.parametrize("wall", ["low", "high"])
+def test_the_ghost_layers_are_exact_at_both_walls(wall, ghost_depth):
+    """`cos(2πx)` is even about both `x = 0` and `x = 1`, so `NEUMANN(0)` is exact at both and the
+    correct ghost is the field itself at the ghost centres.
+
+    Measured before the fix: `5.412e-01` at `g=2` and `1.307e+00` at `g=3`, **at both walls** —
+    unlike the two copies fixed in #1967, where only the high wall was affected. `g=4` is included
+    because the two other copies were each verified to depth 3 only.
+    """
+    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=1)
+    bc.domain_bounds = np.array([[0.0, 1.0]])
+    padded = _filled(bc, (_N,), _H, ghost_depth, np.cos(2 * np.pi * _XC))
+
+    if wall == "low":
+        got, centres = padded[:ghost_depth], _low_centres(ghost_depth)
+    else:
+        got, centres = padded[-ghost_depth:], _high_centres(ghost_depth)
+
+    np.testing.assert_allclose(got, np.cos(2 * np.pi * centres), atol=1e-12)
+
+
+@pytest.mark.parametrize("ghost_depth", [2, 3])
+@pytest.mark.parametrize("wall", ["low", "high"])
+def test_neither_wall_is_the_reverse_of_itself(wall, ghost_depth):
+    """The signature of this defect was `reversed(got) == want` holding exactly — every value
+    right, every slot wrong. Asserting the reverse does *not* match is a different statement from
+    asserting the values are right, and it is the one that fails if the pairing is swapped back
+    while the arithmetic stays correct."""
+    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=1)
+    bc.domain_bounds = np.array([[0.0, 1.0]])
+    padded = _filled(bc, (_N,), _H, ghost_depth, np.cos(2 * np.pi * _XC))
+
+    if wall == "low":
+        got, centres = padded[:ghost_depth], _low_centres(ghost_depth)
+    else:
+        got, centres = padded[-ghost_depth:], _high_centres(ghost_depth)
+
+    assert not np.allclose(got[::-1], np.cos(2 * np.pi * centres), atol=1e-12)
+
+
+def test_the_interior_is_never_touched():
+    """Control. A pairing fix that wrote into the interior would satisfy every ghost assertion
+    above while corrupting the field."""
+    bc = uniform_bc(bc_type="neumann", value=0.0, dimension=1)
+    bc.domain_bounds = np.array([[0.0, 1.0]])
+    interior = np.cos(2 * np.pi * _XC)
+    padded = _filled(bc, (_N,), _H, 3, interior)
+
+    np.testing.assert_array_equal(padded[3:-3], interior)
+
+
+# =============================================================================
+# n-D, which is where the obvious fix is wrong
+# =============================================================================
+
+
+@pytest.mark.parametrize("ghost_depth", [1, 2, 3])
+def test_the_pairing_is_correct_on_every_axis_and_in_the_corners(ghost_depth):
+    """`cos(2πx)·cos(2πy)` is even about all four walls, so the whole padded array has a known
+    exact value — edges, and the corner blocks both axis sweeps write.
+
+    **This is the test that matters for the shape of the fix.** Reversing the calculator's output
+    with `[::-1]` reverses axis 0, which is correct in 1-D and wrong for axis 1 in 2-D; every 1-D
+    assertion above passes under that version. Stepping the interior *slice* backwards is indexed
+    by `axis` and cannot have that failure.
+    """
+    n = 6
+    h = 1.0 / n
+    c = (np.arange(n) + 0.5) * h
+    xx, yy = np.meshgrid(c, c, indexing="ij")
+    padded = _filled(_neumann_2d_bc(), (n, n), (h, h), ghost_depth, np.cos(2 * np.pi * xx) * np.cos(2 * np.pi * yy))
+
+    g = ghost_depth
+    gc = np.concatenate(
+        [
+            np.array([-(k - 0.5) * h for k in range(1, g + 1)])[::-1],
+            c,
+            np.array([1.0 + (k - 0.5) * h for k in range(1, g + 1)]),
+        ]
+    )
+    gx, gy = np.meshgrid(gc, gc, indexing="ij")
+
+    np.testing.assert_allclose(padded, np.cos(2 * np.pi * gx) * np.cos(2 * np.pi * gy), atol=1e-12)
+
+
+def test_a_non_square_grid_does_not_let_an_axis_swap_hide():
+    """Square shapes and equal spacings let a swapped axis index coincide with the right answer.
+    Different extents, different spacings, different point counts on the two axes."""
+    nx, ny = 5, 8
+    hx, hy = 0.2, 0.05
+    cx = (np.arange(nx) + 0.5) * hx
+    cy = (np.arange(ny) + 0.5) * hy
+    xx, yy = np.meshgrid(cx, cy, indexing="ij")
+    interior = np.cos(np.pi * xx / (nx * hx)) * np.cos(np.pi * yy / (ny * hy))
+
+    bc = uniform_bc(bc_type="no_flux", dimension=2)
+    bc.domain_bounds = np.array([[0.0, nx * hx], [0.0, ny * hy]])
+    padded = _filled(bc, (nx, ny), (hx, hy), 2, interior)
+
+    # A no-flux wall mirrors, so the two ghost layers on each side must be the first two interior
+    # planes reversed -- checked per axis, which is what an axis swap breaks.
+    np.testing.assert_allclose(padded[:2, 2:-2], interior[1::-1, :], atol=1e-12)
+    np.testing.assert_allclose(padded[-2:, 2:-2], interior[:-3:-1, :], atol=1e-12)
+    np.testing.assert_allclose(padded[2:-2, :2], interior[:, 1::-1], atol=1e-12)
+    np.testing.assert_allclose(padded[2:-2, -2:], interior[:, :-3:-1], atol=1e-12)
+
+
+# =============================================================================
+# Depth 1 is the blind spot and must not move
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("bc_type", "value"),
+    [("neumann", 0.0), ("no_flux", 0.0), ("reflecting", 0.0), ("dirichlet", 1.0)],
+)
+def test_depth_one_is_unchanged(bc_type, value):
+    """A one-element slice is its own reverse, so every depth-1 result predates this change and
+    must survive it. Every caller of this route — of which there are none in the library today —
+    would be using depth 1.
+
+    The flux types are pinned at `value = 0`, where the ghost is the interior whatever the
+    normal-derivative spacing convention is. At nonzero flux this route's coefficient disagrees
+    with the live one by a factor of 2 and, at the low wall, by a sign (#1972); that is a second
+    defect on the same dead route and it is not what this file pins.
+    """
+    bc = uniform_bc(bc_type=bc_type, value=value, dimension=1)
+    bc.domain_bounds = np.array([[0.0, 1.0]])
+    interior = np.cos(2 * np.pi * _XC)
+    padded = _filled(bc, (_N,), _H, 1, interior)
+
+    if bc_type == "dirichlet":
+        assert padded[0] == pytest.approx(2 * value - interior[0])
+        assert padded[-1] == pytest.approx(2 * value - interior[-1])
+    else:
+        assert padded[0] == pytest.approx(interior[0])
+        assert padded[-1] == pytest.approx(interior[-1])

--- a/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_buffer_layer_pairing_1971.py
@@ -85,6 +85,25 @@ def _mirror_expectation(interior: np.ndarray, axis: int, g: int) -> tuple[np.nda
     return lo, hi
 
 
+def _mirror_index_map(n: int, g: int) -> np.ndarray:
+    """Padded index -> the interior index a zero-gradient mirror puts there, one axis.
+
+    Ghost layer `k` (1-based, counting outward from the wall) mirrors interior layer `k`. The map
+    is SEPARABLE, so the expected padded array in n-D is `interior[np.ix_(*maps)]` -- which covers
+    the corner blocks by construction rather than by a separate argument. The previous version
+    built an expected array and never asserted against it; the corners were guarded only by
+    `np.all(np.isfinite(padded))`, and since `GhostBuffer._buffer` is `np.zeros`, an unwritten
+    corner is `0.0` and finite. That assertion could not fail for the reason its message gave:
+    filling the corners with 7.0, or never writing them, left the whole file green.
+    """
+    idx = np.empty(n + 2 * g, dtype=int)
+    idx[g : g + n] = np.arange(n)
+    for k in range(1, g + 1):
+        idx[g - k] = k - 1  # low ghost layer k mirrors interior layer k
+        idx[g + n + k - 1] = n - k  # high ghost layer k likewise
+    return idx
+
+
 def _ghost_blocks(padded: np.ndarray, axis: int, g: int) -> tuple[np.ndarray, np.ndarray]:
     lo = [slice(None)] * padded.ndim
     hi = [slice(None)] * padded.ndim
@@ -177,30 +196,10 @@ def test_every_axis_and_every_corner_mirrors_correctly_in_2d(ghost_depth):
     interior = _interior((nx, ny))
     padded = _filled(_bc("no_flux", 2, [[0, nx * hx], [0, ny * hy]]), (nx, ny), (hx, hy), g, interior)
 
-    # Build the expected padded array by applying the same geometric mirror on each axis in turn,
-    # which is what makes the corner blocks predicted rather than merely asserted non-NaN.
-    want = np.empty_like(padded)
-    want[(slice(g, -g),) * 2] = interior
-    for axis in (0, 1):
-        core = [slice(g, -g)] * 2
-        core[axis] = slice(None)
-        block = want[tuple(core)]
-        lo, hi = _mirror_expectation(interior, axis, g)
-        sl_lo, sl_hi = [slice(None)] * 2, [slice(None)] * 2
-        sl_lo[axis], sl_hi[axis] = slice(0, g), slice(-g, None)
-        block[tuple(sl_lo)] = np.take(lo, range(lo.shape[1 - axis]), axis=1 - axis)
-        block[tuple(sl_hi)] = np.take(hi, range(hi.shape[1 - axis]), axis=1 - axis)
-
-    np.testing.assert_array_equal(padded[g:-g, g:-g], interior)
-    for axis in (0, 1):
-        core = [slice(g, -g)] * 2
-        core[axis] = slice(None)
-        got_lo, got_hi = _ghost_blocks(padded[tuple(core)], axis, g)
-        want_lo, want_hi = _mirror_expectation(interior, axis, g)
-        np.testing.assert_array_equal(got_lo, want_lo)
-        np.testing.assert_array_equal(got_hi, want_hi)
-
-    assert np.all(np.isfinite(padded)), "corner blocks were left unwritten"
+    # The whole padded array at once, corners included. Separable, so no corner argument is
+    # needed: if either axis sweep skips or double-writes a corner block, this fails.
+    maps = [_mirror_index_map(n, g) for n, g in ((nx, g), (ny, g))]
+    np.testing.assert_array_equal(padded, interior[np.ix_(*maps)])
 
 
 @pytest.mark.parametrize("axis", [0, 1, 2])


### PR DESCRIPTION
Closes #1971.

The copy in `GhostBuffer._update_bounded`, and the only one of the three *mirror* copies that reverses **both** walls.

> **[CORRECTED]** This PR originally said "third and last copy". That is false: the same slice-pair construct is written out twice more in `PreallocatedGhostBuffer` (`applicator_fdm.py:1120-1135` `_apply_linear_reflection` DIRICHLET, and `:1673-1687` `_apply_ghost_for_face`), both reversed at **both** walls, `reversed(got) == want`, magnitudes 1.110 / 2.674 / 3.414 at g = 2..4. Those are #1966 Defect 2 and are not fixed here. `_update_ghosts_legacy` carries it too. See the re-review comment below.

## The defect

It differs in kind from the other two. Those were per-layer loops with a wrong index expression; this one is a vectorised slice assignment where the two slices run opposite ways.

```
lo_ghost    = [0:g]     index g-1 adjacent to the wall, index 0 outermost
lo_interior = [g:2g]    index g   adjacent to the wall
buf[lo_ghost] = calc(buf[lo_interior])    -> outermost ghost gets the nearest interior
```

The high side has the mirror problem: its ghost slice runs nearest-first, its interior slice `[-2g:-g]` runs farthest-first.

**At `ghost_depth = 1` a one-element slice is its own reverse**, which is why the only depth anything uses looked correct.

## Measurement

`u = cos(2*pi*x)`, `N = 8`, `h = 0.125`, `NEUMANN(0)` — even about both walls, so the condition is exact there and the correct ghost is the field itself at the ghost centre.

```
g=1  low_err 0.000e+00   high_err 1.110e-16
g=2  low_err 5.412e-01   high_err 5.412e-01   reversed(got) == want, both walls
g=3  low_err 1.307e+00   high_err 1.307e+00   reversed(got) == want, both walls
```

Same magnitudes as the two copies fixed in #1967 — every value right, every slot wrong.

## The shape of the fix, and why

```python
lo_interior[axis] = slice(2 * g - 1, g - 1, -1)
hi_interior[axis] = slice(-g - 1, -2 * g - 1, -1)
```

It steps the **interior** slice backwards rather than reversing the calculator's output. The output would have to be reversed along `axis`, and the obvious `[::-1]` reverses axis 0 — correct in 1-D and wrong for any other axis in n-D.

That version was written first. It is mutation M3 below, and **it passes every 1-D assertion in the new file.**

## Oracle

Category 1, external: an exact continuation. Not an agreement test, so it survives any later consolidation of these three copies into one owner — which is the direction this campaign is going.

## Mutations

`sha256` of `applicator_fdm.py` verified identical before and after each.

| mutation | result |
|---|---|
| both walls reverted to main's pairing | 13 failed / 8 passed |
| low wall only | 8 failed / 13 passed |
| high wall only | 8 failed / 13 passed |
| `[::-1]` on the output (axis-0 only) | **3 failed / 18 passed** — the two n-D tests only |

The last row is why the 2-D corner test and the non-square-grid test are in the file. Without them this PR would have shipped an axis-0-only fix with a green suite.

## Blast radius: none in the library

`GhostBuffer` — as distinct from `PreallocatedGhostBuffer` — has no caller outside `geometry/boundary/`. The two live consumers, `pad_array_with_ghosts` and `hjb_weno.py:350`, both construct `PreallocatedGhostBuffer`, which does not use the calculators. Reachable only by a user calling the public API.

Same latent class as the #1966 siblings.

## Found on the way, filed separately

**#1972** — `ghost_cell_neumann`'s cell-centred branch is off by a factor of 2 (wrong under either reading of `flux_value`), and the calculator path reads `BCSegment.value` as an **axis** derivative where the live path reads it as an **outward-normal** derivative. Measured against `u = 3x` at both walls and both grid types. Not bundled here.

That defect is why `test_depth_one_is_unchanged` pins the flux types at `value = 0`. **[CORRECTED]** The disagreement is not exhausted by #1972: a third term, the layer-scaled offset, is missing because `Calculator.compute(interior_value, dx, side)` carries no layer index. Measured at `neumann(2.0)`, `h=0.125`: `GhostBuffer` gives a flat `[-0.5, -0.5, -0.5, -0.5]` where the required ratio is `[1, 3, 5, 7]`. Added to #1972.

## Gate

`./scripts/local_ci.sh` → **6246 passed, 12 skipped, 21 xfailed, GATE GREEN**, 117 s.

`uv.lock` was dirty in the working tree again (second occurrence) and was restored to `main`'s before committing — the gate never invokes uv, so it would have gone in unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
