### PR TITLE
test(geometry): pin the FP boundary coefficient gap (#1975)

### DIFF
--- a/changelog.d/1975-fp-boundary-coefficient-census.added.md
+++ b/changelog.d/1975-fp-boundary-coefficient-census.added.md
@@ -1,19 +1,35 @@
 A test file recording which solvers declare their BC support and that the FDM boundary assembly
 reads none of a ROBIN segment's coefficients (#1975, #1977, #1979).
 
-Assertions only. Four revisions put the reasoning, the history and the physics in the file as
-prose, and four independent reviews found a false statement in that prose each time -- five wrong
-numbers, one wrong sign, and a correction of a reviewer that was itself wrong. Nothing is now
-stated that the file does not compute; the narrative lives in #1975.
+Assertions only. Five revisions put the reasoning, the history and the physics in the file as
+prose, and five independent reviews found a false statement in that prose each time -- six wrong
+numbers, one wrong sign, a correction of a reviewer that was itself wrong, and an argument for
+keeping a filter that measurement showed did nothing. No NUMBER is now stated that the file does
+not compute; the traced source references it carries instead each name a file and a line.
 
 The population is discovered by `walk_packages` + `issubclass` + `inspect.isabstract`, keyed on
-class identity, with the root package imported explicitly and cross-module re-exports collapsed by
-the defining-module filter. Verified against injected escapes: a solver in `alg/__init__.py`, one
-named `Baseline*`, a factory-built class, an alias sorting alphabetically earlier, and the deletion
-of a dead alias.
+class identity, with the root package imported explicitly and the canonical name pinned to
+`cls.__name__` so an alphabetically earlier alias cannot displace it. There is no defining-module
+filter: it gained nothing (21 classes with it, 21 without) and hid one real cross-module alias,
+`HJBNetworkSolver` at `network_solvers/__init__.py:19`, from the very test written to catch that
+case. Verified against injected escapes: a solver in `alg/__init__.py`, one named `Baseline*`, an
+alias sorting alphabetically earlier, a cross-module alias, and the deletion of a dead alias.
+
+A factory-built class whose `__module__` points at another scanned module is NOT caught -- that
+escape is real as a mechanism and has no instance in this tree (measured: 0 classes defined in a
+scanned module and never bound there).
 
 The gate reads `supported_bc_types`; this file reads `_SUPPORTED_BC_TYPES`. Those coincide only
-while every property forwards, so that premise is now itself asserted: all 11 declaring solvers
-have a property whose body is exactly `return self._SUPPORTED_BC_TYPES`, and the 11 that declare
-nothing have no property at all. Widening the live gate through the property while leaving the
-private attribute alone previously left the file green.
+while every property forwards, and that premise is NOT asserted. A revision asserted it by
+comparing `inspect.getsource(...).splitlines()[-1]`; review measured that open in three shapes and
+falsely closed on a fourth, so it is deleted rather than repaired and the hole is stated in the
+file: a solver can widen its live support through the property alone and every assertion stays
+green. Of 21 concrete solvers, 11 declare and 10 do not.
+
+Two disclosed scope limits. The population predicate is `BaseNumericalSolver`, while
+`_validate_bc_support` and `honors_inhomogeneous_neumann` live on `BaseMFGSolver`: 4 concrete
+classes (`PrimalDualMFGSolver`, `SinkhornMFGSolver`, `VariationalMFGSolver`,
+`WassersteinMFGSolver`) are in the gate's reach and outside the census. None mentions a boundary
+condition anywhere, so none hides a live defect. And the behavioural oracle is 1D with
+`interface_velocity=None`, so the conservative wall's multi-axis branch and its interface-velocity
+branch are exercised by nothing here.

--- a/changelog.d/1975-fp-boundary-coefficient-census.added.md
+++ b/changelog.d/1975-fp-boundary-coefficient-census.added.md
@@ -1,0 +1,7 @@
+A census pin over every solver's `_SUPPORTED_BC_TYPES`, plus two assertions on the gap it
+records (#1975). The Fokker-Planck reflecting wall is Robin in `m`; no FP solver accepts
+`BCType.ROBIN`, the only solver that does is on the HJB side where the condition is Neumann, and
+`FPResolver` emits exactly the type every consumer refuses. Measured: a mixed `ROBIN(alpha=999)`
+wall assembles byte-identically to no-flux, so `(alpha, beta, g)` is read by nothing on the FP
+side and the gate refusing ROBIN is honest rather than an oversight. Both gap assertions pin
+neither side, so they go green when the gap closes from either end.

--- a/changelog.d/1975-fp-boundary-coefficient-census.added.md
+++ b/changelog.d/1975-fp-boundary-coefficient-census.added.md
@@ -1,7 +1,16 @@
-A census pin over every solver's `_SUPPORTED_BC_TYPES`, plus two assertions on the gap it
-records (#1975). The Fokker-Planck reflecting wall is Robin in `m`; no FP solver accepts
-`BCType.ROBIN`, the only solver that does is on the HJB side where the condition is Neumann, and
-`FPResolver` emits exactly the type every consumer refuses. Measured: a mixed `ROBIN(alpha=999)`
-wall assembles byte-identically to no-flux, so `(alpha, beta, g)` is read by nothing on the FP
-side and the gate refusing ROBIN is honest rather than an oversight. Both gap assertions pin
-neither side, so they go green when the gap closes from either end.
+A test file recording which wall each FP path actually imposes, and which solvers sit outside the
+BC capability gate (#1975, #1977, #1979).
+
+Its load-bearing test is an external oracle the area was missing: **mass conservation at a wall
+with wall-normal drift.** The conservative schemes -- `divergence_upwind`, the default, and
+`divergence_centered` -- impose `J.n = 0` structurally by zeroing the total face flux, conserving
+mass to machine precision with `d_n m` nonzero at the wall; the `gradient_*` family imposes
+`d_n m = 0` and loses 75-78% (non-conservative by design, #1075). Neither behaviour was asserted
+anywhere, and that absence is what let this file's own first version read the right answer as a
+defect.
+
+The census now discovers its population with `walk_packages` + `issubclass`, a predicate
+independent of the declaration it audits, and records the **ungated** solvers as a population
+rather than as an absence: 11 of 22 concrete solvers declare no `_SUPPORTED_BC_TYPES`, including
+`FPFEMSolver`, the one FP solver implementing a general Robin. Two further classes apply BCs
+without being solver subclasses at all and are named rather than discovered.

--- a/changelog.d/1975-fp-boundary-coefficient-census.added.md
+++ b/changelog.d/1975-fp-boundary-coefficient-census.added.md
@@ -1,16 +1,14 @@
-A test file recording which wall each FP path actually imposes, and which solvers sit outside the
-BC capability gate (#1975, #1977, #1979).
+A test file recording which solvers sit outside the BC capability gate, and that the FDM boundary
+assembly reads none of a ROBIN segment's coefficients (#1975, #1977, #1979).
 
-Its load-bearing test is an external oracle the area was missing: **mass conservation at a wall
-with wall-normal drift.** The conservative schemes -- `divergence_upwind`, the default, and
-`divergence_centered` -- impose `J.n = 0` structurally by zeroing the total face flux, conserving
-mass to machine precision with `d_n m` nonzero at the wall; the `gradient_*` family imposes
-`d_n m = 0` and loses 75-78% (non-conservative by design, #1075). Neither behaviour was asserted
-anywhere, and that absence is what let this file's own first version read the right answer as a
-defect.
+The population is discovered by `walk_packages` + `issubclass` + `inspect.isabstract`, keyed on
+class identity: a predicate independent of the declaration it audits. Two same-module alias pairs
+(`NetworkFPSolver = FPNetworkSolver`, `NetworkHJBSolver = HJBNetworkSolver`) are collapsed and
+pinned separately, the root package is imported explicitly because `walk_packages` never yields it,
+and the `startswith("Base")` name heuristic is gone -- it excluded any concrete solver whose name
+began with "Base" and bought nothing `isabstract` did not already cover. Verified against four
+injected escapes: a solver in `alg/__init__.py`, one named `Baseline*`, a factory-built class, and
+the deletion of a dead alias.
 
-The census now discovers its population with `walk_packages` + `issubclass`, a predicate
-independent of the declaration it audits, and records the **ungated** solvers as a population
-rather than as an absence: 11 of 22 concrete solvers declare no `_SUPPORTED_BC_TYPES`, including
-`FPFEMSolver`, the one FP solver implementing a general Robin. Two further classes apply BCs
-without being solver subclasses at all and are named rather than discovered.
+No count is restated in prose. Three independent attempts at this file produced three different
+counts, each written down as a fact; the frozen sets are the measurement.

--- a/changelog.d/1975-fp-boundary-coefficient-census.added.md
+++ b/changelog.d/1975-fp-boundary-coefficient-census.added.md
@@ -1,35 +1,32 @@
 A test file recording which solvers declare their BC support and that the FDM boundary assembly
 reads none of a ROBIN segment's coefficients (#1975, #1977, #1979).
 
-Assertions only. Five revisions put the reasoning, the history and the physics in the file as
-prose, and five independent reviews found a false statement in that prose each time -- six wrong
-numbers, one wrong sign, a correction of a reviewer that was itself wrong, and an argument for
-keeping a filter that measurement showed did nothing. No NUMBER is now stated that the file does
-not compute; the traced source references it carries instead each name a file and a line.
+Assertions, with the reasoning in #1975. Six revisions put the reasoning in the file as prose and
+six independent reviews found a false statement in it each time -- including in the sentences that
+announced the file's own discipline, which were false in the same commit that added them. Those
+sentences are gone; what the file can compute it asserts, and what it cannot it cites at a line.
 
 The population is discovered by `walk_packages` + `issubclass` + `inspect.isabstract`, keyed on
 class identity, with the root package imported explicitly and the canonical name pinned to
 `cls.__name__` so an alphabetically earlier alias cannot displace it. There is no defining-module
-filter: it gained nothing (21 classes with it, 21 without) and hid one real cross-module alias,
-`HJBNetworkSolver` at `network_solvers/__init__.py:19`, from the very test written to catch that
-case. Verified against injected escapes: a solver in `alg/__init__.py`, one named `Baseline*`, an
-alias sorting alphabetically earlier, a cross-module alias, and the deletion of a dead alias.
-
-A factory-built class whose `__module__` points at another scanned module is NOT caught -- that
-escape is real as a mechanism and has no instance in this tree (measured: 0 classes defined in a
-scanned module and never bound there).
+filter. Removing it gained no classes and admitted one name -- the cross-module alias
+`HJBNetworkSolver` at `network_solvers/__init__.py:19`, which the test written for that case could
+not see -- and it also closed the factory escape, since a `type()`-built class over an `ABCMeta`
+base gets `__module__ == 'abc'` and was rejected in every scanned module while the filter stood.
+Verified against injected escapes: a solver in `alg/__init__.py`, one named `Baseline*`, an alias
+sorting alphabetically earlier, a cross-module alias, a factory-built class with a retargeted
+`__module__`, and the deletion of a dead alias.
 
 The gate reads `supported_bc_types`; this file reads `_SUPPORTED_BC_TYPES`. Those coincide only
 while every property forwards, and that premise is NOT asserted. A revision asserted it by
 comparing `inspect.getsource(...).splitlines()[-1]`; review measured that open in three shapes and
 falsely closed on a fourth, so it is deleted rather than repaired and the hole is stated in the
 file: a solver can widen its live support through the property alone and every assertion stays
-green. Of 21 concrete solvers, 11 declare and 10 do not.
+green.
 
-Two disclosed scope limits. The population predicate is `BaseNumericalSolver`, while
-`_validate_bc_support` and `honors_inhomogeneous_neumann` live on `BaseMFGSolver`: 4 concrete
-classes (`PrimalDualMFGSolver`, `SinkhornMFGSolver`, `VariationalMFGSolver`,
-`WassersteinMFGSolver`) are in the gate's reach and outside the census. None mentions a boundary
-condition anywhere, so none hides a live defect. And the behavioural oracle is 1D with
-`interface_velocity=None`, so the conservative wall's multi-axis branch and its interface-velocity
-branch are exercised by nothing here.
+Two scope limits. The population predicate is `BaseNumericalSolver` while `_validate_bc_support`
+and `honors_inhomogeneous_neumann` live on `BaseMFGSolver`, so four concrete classes are in the
+gate's reach and outside the census; that gap is now computed by a test rather than described,
+because the prose version of it shipped a false negative claim about their contents. And the
+behavioural oracle is 1D with `interface_velocity=None`, so the conservative wall's multi-axis and
+interface-velocity branches are exercised by nothing here.

--- a/changelog.d/1975-fp-boundary-coefficient-census.added.md
+++ b/changelog.d/1975-fp-boundary-coefficient-census.added.md
@@ -1,14 +1,19 @@
-A test file recording which solvers sit outside the BC capability gate, and that the FDM boundary
-assembly reads none of a ROBIN segment's coefficients (#1975, #1977, #1979).
+A test file recording which solvers declare their BC support and that the FDM boundary assembly
+reads none of a ROBIN segment's coefficients (#1975, #1977, #1979).
+
+Assertions only. Four revisions put the reasoning, the history and the physics in the file as
+prose, and four independent reviews found a false statement in that prose each time -- five wrong
+numbers, one wrong sign, and a correction of a reviewer that was itself wrong. Nothing is now
+stated that the file does not compute; the narrative lives in #1975.
 
 The population is discovered by `walk_packages` + `issubclass` + `inspect.isabstract`, keyed on
-class identity: a predicate independent of the declaration it audits. Two same-module alias pairs
-(`NetworkFPSolver = FPNetworkSolver`, `NetworkHJBSolver = HJBNetworkSolver`) are collapsed and
-pinned separately, the root package is imported explicitly because `walk_packages` never yields it,
-and the `startswith("Base")` name heuristic is gone -- it excluded any concrete solver whose name
-began with "Base" and bought nothing `isabstract` did not already cover. Verified against four
-injected escapes: a solver in `alg/__init__.py`, one named `Baseline*`, a factory-built class, and
-the deletion of a dead alias.
+class identity, with the root package imported explicitly and cross-module re-exports collapsed by
+the defining-module filter. Verified against injected escapes: a solver in `alg/__init__.py`, one
+named `Baseline*`, a factory-built class, an alias sorting alphabetically earlier, and the deletion
+of a dead alias.
 
-No count is restated in prose. Three independent attempts at this file produced three different
-counts, each written down as a fact; the frozen sets are the measurement.
+The gate reads `supported_bc_types`; this file reads `_SUPPORTED_BC_TYPES`. Those coincide only
+while every property forwards, so that premise is now itself asserted: all 11 declaring solvers
+have a property whose body is exactly `return self._SUPPORTED_BC_TYPES`, and the 11 that declare
+nothing have no property at all. Widening the live gate through the property while leaving the
+private attribute alone previously left the file green.

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -145,6 +145,91 @@ def test_the_permissive_default_is_claimed_by_inheritance():
     assert all(getattr(cls, field) is True for cls, n in _population().items() if n[0] in inherited["BaseMFGSolver"])
 
 
+# The external oracle -- which wall is actually imposed
+# =============================================================================
+
+_SIGMA, _DRIFT, _NX, _STEPS = 0.3, 3.2, 81, 200
+
+
+def _run(scheme: str) -> tuple[float, float]:
+    """One drifted-wall run. Returns (mass drift in %, d_n m at the high wall).
+
+    `u = -drift*x` gives a constant wall-normal velocity, the case where `J.n = 0` and
+    `d_n m = 0` are DIFFERENT conditions. A scheme imposing `J.n = 0` conserves mass and has
+    `d_n m != 0`; one imposing `d_n m = 0` leaks.
+    """
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_NX], boundary_conditions=no_flux_bc(dimension=1))
+    h = grid.get_grid_spacing()[0]
+    x = np.linspace(0.0, 1.0, _NX)
+    m = np.exp(-50 * (x - 0.5) ** 2)
+    m /= m.sum() * h
+    m0 = m.sum() * h
+
+    for _ in range(_STEPS):
+        m = solve_timestep_full_nd(
+            M_current=m,
+            U_current=-_DRIFT * x,
+            problem=object(),
+            dt=1e-3,
+            sigma=_SIGMA,
+            coupling_coefficient=1.0,
+            spacing=(h,),
+            grid=grid,
+            ndim=1,
+            shape=(_NX,),
+            boundary_conditions=no_flux_bc(dimension=1),
+            advection_scheme=scheme,
+        )
+    return 100.0 * (m.sum() * h - m0) / m0, (m[-1] - m[-2]) / h
+
+
+@pytest.mark.parametrize("scheme", ["divergence_upwind", "divergence_centered"])
+def test_the_conservative_schemes_conserve_mass_at_a_drifted_wall(scheme):
+    """`J.n = 0`, imposed structurally by zeroing the total face flux -- no BC-type branch.
+
+    **This is the test whose absence let #1975 be filed on a false premise.** It is an external
+    oracle: mass conservation is a law of the equation, computed here without reference to any
+    scheme's internals, so it cannot go tautological the way a declaration census can.
+
+    `divergence_upwind` is the default. Measured: -0.0000% and -0.0000%.
+    """
+    drift_pct, dmdx = _run(scheme)
+    assert abs(drift_pct) < 1e-6, f"{scheme} leaked {drift_pct:.4f}% at a wall with normal drift"
+    assert abs(dmdx) > 1.0, (
+        f"{scheme} has d_n m = {dmdx:.4g} at the wall. J.n = 0 requires d_n m = (v/D)*m, which is "
+        "large here; a near-zero gradient means the wall became d_n m = 0."
+    )
+
+
+@pytest.mark.parametrize("scheme", ["gradient_upwind", "gradient_centered"])
+def test_the_gradient_schemes_impose_a_zero_gradient_wall_and_leak(scheme):
+    """The counterpart, pinned so the distinction cannot quietly collapse in either direction.
+
+    These impose `d_n m = 0`, which is the wrong condition when the drift is not tangential, and
+    they are documented non-conservative (#1075). Measured: -78.05% and -75.47%.
+    """
+    drift_pct, _ = _run(scheme)
+    assert drift_pct < -10.0, (
+        f"{scheme} conserved mass ({drift_pct:.4f}%) at a drifted wall. If it now imposes "
+        "J.n = 0 that is a fix worth recording -- see #1075 and #1975 before updating this."
+    )
+
+
+def test_the_two_families_disagree_by_a_large_margin():
+    """A control on the pair above: if the fixture stopped driving mass into the wall, both
+    families would conserve trivially and both tests would still pass in the wrong way."""
+    conservative, _ = _run("divergence_upwind")
+    gradient, _ = _run("gradient_upwind")
+    assert gradient - conservative < -50.0, (
+        "the two schemes no longer separate; the fixture may have stopped exercising the wall"
+    )
+
+
+# =============================================================================
+
+
 # --------------------------------------------------------------------------------------
 # What the FDM boundary assembly reads
 # --------------------------------------------------------------------------------------
@@ -240,34 +325,20 @@ def test_an_unsupported_bc_raises_at_construction():
         problem.solve(max_iterations=1)
 
 
-def test_the_gate_reads_what_this_file_reads():
-    """The gate reads `supported_bc_types`; every assertion here reads `_SUPPORTED_BC_TYPES`.
-
-    Those are the same thing only while every property just forwards. Measured: all 11 gated
-    solvers have a property whose body is exactly `return self._SUPPORTED_BC_TYPES`, and the 11
-    ungated ones have no property at all. If either stops being true, this file is measuring
-    something the gate does not use -- which is how a solver could widen its live support with
-    every assertion here still green.
-    """
-    import textwrap
-
-    for cls, names in _population().items():
-        prop = inspect.getattr_static(cls, "supported_bc_types", None)
-        fget = getattr(prop, "fget", None)
-        declares = getattr(cls, "_SUPPORTED_BC_TYPES", None) is not None
-        if not declares:
-            assert fget is None, f"{names[0]} declares nothing but defines the property"
-            continue
-        assert fget is not None, f"{names[0]} declares but has no supported_bc_types property"
-        body = textwrap.dedent(inspect.getsource(fget)).strip().splitlines()[-1].strip()
-        assert body == "return self._SUPPORTED_BC_TYPES", (
-            f"{names[0]}'s property no longer just forwards ({body!r}); the gate and this file "
-            "now read different things"
-        )
-
-
 def test_no_fp_solver_declares_robin_while_the_assembly_ignores_the_coefficient():
-    """Justified by the test above: the private attribute is what the gate ends up reading."""
+    """Reads `_SUPPORTED_BC_TYPES`; the #1456 gate reads `supported_bc_types`.
+
+    Today every declaring solver's property is exactly `return self._SUPPORTED_BC_TYPES`, so the
+    two coincide -- but that premise is NOT asserted here. A previous revision asserted it by
+    comparing `inspect.getsource(...).splitlines()[-1]`, and review measured that open in three
+    of five shapes (a multi-line body ending in the forward; a `functools.wraps`-decorated
+    property, since `getsource` unwraps; an ungated class gaining a non-`property` attribute,
+    which `assert fget is None` accepts while the gate goes live) and closed falsely on one
+    (a behaviour-preserving `frozenset(...)` copy). It is the instrument an earlier revision
+    deleted for being wrong in both directions, and it was wrong in both directions again, so it
+    is gone rather than repaired. **The hole is: a solver can widen its live support through the
+    property alone and every assertion here stays green.**
+    """
     declaring = {
         n[0]
         for c, n in _population().items()

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -1,26 +1,8 @@
-"""Which wall each FP path actually imposes, and which solvers are outside the capability gate.
+"""Which solvers declare their BC support, and what the FDM boundary assembly reads. #1975 #1977
 
-This file replaces one that got the physics backwards, so the reasoning is written down.
-
-**The reflecting wall is `J.n = 0`, not `d_n m = 0`.** They coincide only when the drift is
-tangential at the wall. The conservative schemes impose the first **structurally** -- by zeroing
-the total face flux, advective plus diffusive -- with no BC-type branch naming it; the
-`gradient_*` family imposes the second and leaks. `FPParticleSolver` gets `J.n = 0` from Skorokhod
-reflection of the path, also without naming it.
-
-That is why the first version of this file was wrong. It read "no BC-type dispatch at the
-boundary" as "imposes `d_n m = 0`", measured `ROBIN(alpha=3.2) == no_flux` byte-identically, and
-called that a defect. With `u = -3.2x`, coupling 1, sigma 0.3, `FPResolver` emits
-`ROBIN(alpha=+3.2, beta=-0.045)` -- **the same numbers** -- so that case *is* the physical wall the
-default scheme already imposes and byte-identity there is the correct answer. Only a wall that is
-genuinely different (`alpha != v_n`, or `g != 0`) shows a real gap.
-
-So the load-bearing test here is `test_the_conservative_schemes_conserve_mass_at_a_drifted_wall`:
-an external oracle, computed independently of any scheme, that says which condition is actually
-imposed. A census keyed on declarations cannot say that -- correctness here is structural, not
-declared -- and its absence is what let the wrong reading stand.
-
-Refs #1975, #1977, #1979.
+Assertions only. The reasoning, the history and the physics live in #1975; four revisions of this
+file put them here as prose and four independent reviews found a false statement in that prose
+each time. Nothing below is stated that is not computed in this file.
 """
 
 from __future__ import annotations
@@ -37,11 +19,32 @@ from mfgarchon.alg.base_solver import BaseNumericalSolver
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions, no_flux_bc
 
-# Measured 2026-08-17 by walking `mfgarchon.alg` with `walk_packages` and keeping concrete
-# `BaseNumericalSolver` subclasses, keyed on class identity -- a predicate independent of the
-# declaration audited. The sets below are the measurement; no count is restated in prose, because
-# three independent attempts at this file produced three different counts and each was written
-# down as a fact.
+# --------------------------------------------------------------------------------------
+# Population
+# --------------------------------------------------------------------------------------
+
+
+def _population() -> dict[type, list[str]]:
+    """Concrete `BaseNumericalSolver` subclasses -> the names they are bound under in their OWN
+    module. `walk_packages` never yields the root, so `mfgarchon.alg` is imported explicitly."""
+    import mfgarchon.alg as alg_pkg
+
+    found: dict[type, list[str]] = {}
+    for mod_name in ["mfgarchon.alg"] + [
+        m.name for m in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg.")
+    ]:
+        module = importlib.import_module(mod_name)
+        for name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__:
+                continue  # a re-export; the defining module owns the row
+            if not issubclass(cls, BaseNumericalSolver) or inspect.isabstract(cls):
+                continue
+            found.setdefault(cls, [])
+            if name not in found[cls]:
+                found[cls].append(name)
+    return found
+
+
 _GATED = {
     "FPFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
     "FPFVMSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
@@ -56,172 +59,95 @@ _GATED = {
     "HJBWENOSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
 }
 
-# Recorded as a POPULATION, not as an absence. Half the solvers declare nothing, so
-# `_validate_bc_support` no-ops on them (`base_solver.py:282`) -- including `FPFEMSolver`, the one
-# FP solver that implements a general Robin. #1977.
+#: Declares nothing, so `_validate_bc_support` no-ops on it (`base_solver.py:282`). #1977.
 _UNGATED = {
     "FPFEMSolver",
     "FPNetworkSolver",
     "HJBFEMSolver",
-    "HJBNetworkSolver",
     "MeshlessGalerkinFPSolver",
     "MeshlessGalerkinHJBSolver",
+    "NetworkHJBSolver",
     "NetworkPolicyIterationHJBSolver",
     "PenaltyHJBSolver",
     "WeakFormFPSolver",
     "WeakFormHJBSolver",
 }
 
-#: Same class bound under two names in its own module. Both pairs, because a name-keyed
-#: population reports each as two independent rows.
-_ALIASES = {
-    "FPNetworkSolver": ["NetworkFPSolver"],
-    "HJBNetworkSolver": ["NetworkHJBSolver"],
-}
+#: Same class bound twice in its own module.
+_ALIASES = {"FPNetworkSolver": ["NetworkFPSolver"]}
 
-# Outside even a subclass predicate: plain classes that read BC segments and write Dirichlet
-# values and Neumann normal-gradient rows. No population predicate over `BaseNumericalSolver`
-# reaches them, which is why they are named rather than discovered.
-_NOT_EVEN_SUBCLASSES = {
-    # Applies BC segments directly -- `is_dirichlet`, Neumann-by-extension rows (hjb_howard.py:363).
+#: Apply BC segments without being solver subclasses, so no predicate here reaches them. Named,
+#: not discovered -- and this list is known to be incomplete.
+_NOT_REACHED = {
     "HJBHowardSolver": "mfgarchon.alg.numerical.hjb_solvers.hjb_howard",
-    # Passes `bc` to the grid's Laplacian rather than writing rows itself; listed because no
-    # predicate here reaches it, not because it writes BC rows.
     "ImplicitHeatSolver": "mfgarchon.alg.numerical.pde_solvers.implicit_heat",
-    # Owns `build_neumann_bc_weights` / `create_ghost_neighbors` / `apply_ghost_nodes_to_...`.
     "BoundaryHandler": "mfgarchon.alg.numerical.gfdm_components.boundary_handler",
 }
 
 
-def _solver_population() -> dict[type, list[str]]:
-    """Every concrete `BaseNumericalSolver` subclass -> every name it is bound under.
-
-    Keyed on the CLASS, not the binding name: `NetworkFPSolver = FPNetworkSolver` and
-    `NetworkHJBSolver = HJBNetworkSolver` are same-module aliases, and `cls.__module__ !=
-    module.__name__` does not catch those, so a name-keyed population reports two rows per pair.
-
-    `inspect.isabstract` rather than `name.startswith("Base")`: the name heuristic bought nothing
-    (isabstract already covers the real bases) and silently excluded any concrete solver whose
-    name begins with "Base".
-
-    `walk_packages` yields SUBMODULES of `mfgarchon.alg`, never `mfgarchon.alg` itself, so the
-    root is imported explicitly. A class defined in `alg/__init__.py` was invisible without it.
-
-    Still not reached, and stated rather than implied: a class built by a factory (`type()` called
-    in another module), one produced by `__getattr__`, and anything outside `mfgarchon.alg`.
-    """
-    import mfgarchon.alg as alg_pkg
-
-    found: dict[type, list[str]] = {}
-    names = ["mfgarchon.alg"] + [m.name for m in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg.")]
-    for mod_name in names:
-        module = importlib.import_module(mod_name)
-        for name, cls in inspect.getmembers(module, inspect.isclass):
-            if not issubclass(cls, BaseNumericalSolver) or inspect.isabstract(cls):
-                continue
-            found.setdefault(cls, [])
-            if name not in found[cls]:
-                found[cls].append(name)
-    return found
+def test_the_population_is_exactly_the_two_sets():
+    got = {names[0] for names in _population().values()}
+    want = _GATED.keys() | _UNGATED
+    assert got == want, f"added {sorted(got - want)}, removed {sorted(want - got)}"
 
 
-def _declared(name: str) -> set[str]:
-    for mod in pkgutil.walk_packages(importlib.import_module("mfgarchon.alg").__path__, prefix="mfgarchon.alg."):
-        module = importlib.import_module(mod.name)
-        cls = getattr(module, name, None)
-        if cls is not None and inspect.isclass(cls) and cls.__module__ == module.__name__:
-            declared = getattr(cls, "_SUPPORTED_BC_TYPES", None)
-            if declared is not None:
-                return {t.name for t in declared}
-    raise AssertionError(f"{name} not found, or declares nothing")
+def test_the_alias_bindings_are_unchanged():
+    got = {names[0]: names[1:] for names in _population().values() if len(names) > 1}
+    assert got == _ALIASES, f"alias bindings changed: {got}"
 
 
-# =============================================================================
-# The external oracle -- which wall is actually imposed
-# =============================================================================
-
-_SIGMA, _DRIFT, _NX, _STEPS = 0.3, 3.2, 81, 200
-
-
-def _run(scheme: str) -> tuple[float, float]:
-    """One drifted-wall run. Returns (mass drift in %, d_n m at the high wall).
-
-    `u = -drift*x` gives a constant wall-normal velocity, the case where `J.n = 0` and
-    `d_n m = 0` are DIFFERENT conditions. A scheme imposing `J.n = 0` conserves mass and has
-    `d_n m != 0`; one imposing `d_n m = 0` leaks.
-    """
-    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
-
-    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_NX], boundary_conditions=no_flux_bc(dimension=1))
-    h = grid.get_grid_spacing()[0]
-    x = np.linspace(0.0, 1.0, _NX)
-    m = np.exp(-50 * (x - 0.5) ** 2)
-    m /= m.sum() * h
-    m0 = m.sum() * h
-
-    for _ in range(_STEPS):
-        m = solve_timestep_full_nd(
-            M_current=m,
-            U_current=-_DRIFT * x,
-            problem=object(),
-            dt=1e-3,
-            sigma=_SIGMA,
-            coupling_coefficient=1.0,
-            spacing=(h,),
-            grid=grid,
-            ndim=1,
-            shape=(_NX,),
-            boundary_conditions=no_flux_bc(dimension=1),
-            advection_scheme=scheme,
-        )
-    return 100.0 * (m.sum() * h - m0) / m0, (m[-1] - m[-2]) / h
+def test_no_solver_is_bound_under_a_name_the_census_does_not_know():
+    """`names[0]` is whichever binding `inspect.getmembers` yields first, so a new alias that
+    sorts earlier would silently replace a canonical name in every set above."""
+    known = _GATED.keys() | _UNGATED | {a for v in _ALIASES.values() for a in v}
+    unknown = {n for names in _population().values() for n in names} - known
+    assert not unknown, f"names not in any set: {sorted(unknown)}"
 
 
-@pytest.mark.parametrize("scheme", ["divergence_upwind", "divergence_centered"])
-def test_the_conservative_schemes_conserve_mass_at_a_drifted_wall(scheme):
-    """`J.n = 0`, imposed structurally by zeroing the total face flux -- no BC-type branch.
-
-    **This is the test whose absence let #1975 be filed on a false premise.** It is an external
-    oracle: mass conservation is a law of the equation, computed here without reference to any
-    scheme's internals, so it cannot go tautological the way a declaration census can.
-
-    `divergence_upwind` is the default. Measured: -0.0000% and -0.0000%.
-    """
-    drift_pct, dmdx = _run(scheme)
-    assert abs(drift_pct) < 1e-6, f"{scheme} leaked {drift_pct:.4f}% at a wall with normal drift"
-    assert abs(dmdx) > 1.0, (
-        f"{scheme} has d_n m = {dmdx:.4g} at the wall. J.n = 0 requires d_n m = (v/D)*m, which is "
-        "large here; a near-zero gradient means the wall became d_n m = 0."
-    )
+@pytest.mark.parametrize("solver", sorted(_GATED))
+def test_each_gated_solver_declares_exactly_this(solver):
+    cls = next(c for c, n in _population().items() if n[0] == solver)
+    got = {t.name for t in cls._SUPPORTED_BC_TYPES}
+    want = _GATED[solver]
+    assert got == want, f"gained {sorted(got - want)}, lost {sorted(want - got)}"
 
 
-@pytest.mark.parametrize("scheme", ["gradient_upwind", "gradient_centered"])
-def test_the_gradient_schemes_impose_a_zero_gradient_wall_and_leak(scheme):
-    """The counterpart, pinned so the distinction cannot quietly collapse in either direction.
-
-    These impose `d_n m = 0`, which is the wrong condition when the drift is not tangential, and
-    they are documented non-conservative (#1075). Measured: -78.05% and -75.47%.
-    """
-    drift_pct, _ = _run(scheme)
-    assert drift_pct < -10.0, (
-        f"{scheme} conserved mass ({drift_pct:.4f}%) at a drifted wall. If it now imposes "
-        "J.n = 0 that is a fix worth recording -- see #1075 and #1975 before updating this."
-    )
+def test_exactly_these_solvers_declare_nothing():
+    ungated = {n[0] for c, n in _population().items() if getattr(c, "_SUPPORTED_BC_TYPES", None) is None}
+    assert ungated == _UNGATED, f"newly silent {sorted(ungated - _UNGATED)}; now declaring {sorted(_UNGATED - ungated)}"
 
 
-def test_the_two_families_disagree_by_a_large_margin():
-    """A control on the pair above: if the fixture stopped driving mass into the wall, both
-    families would conserve trivially and both tests would still pass in the wrong way."""
-    conservative, _ = _run("divergence_upwind")
-    gradient, _ = _run("gradient_upwind")
-    assert gradient - conservative < -50.0, (
-        "the two schemes no longer separate; the fixture may have stopped exercising the wall"
-    )
+@pytest.mark.parametrize(("name", "module"), sorted(_NOT_REACHED.items()))
+def test_the_named_unreached_classes_are_still_unreached(name, module):
+    cls = getattr(importlib.import_module(module), name)
+    assert not issubclass(cls, BaseNumericalSolver), f"{name} is now a solver subclass"
 
 
-# =============================================================================
-# The real gap: a wall that is NOT the reflecting one
-# =============================================================================
+def test_the_permissive_default_is_claimed_by_inheritance():
+    """`honors_inhomogeneous_neumann` defaults to True on `BaseMFGSolver`, so a solver that never
+    mentions it claims to honour an inhomogeneous flux."""
+    field = "honors_inhomogeneous_neumann"
+    own, inherited = set(), {}
+    for cls, names in _population().items():
+        owner = next((k.__name__ for k in cls.__mro__ if field in k.__dict__), None)
+        if owner is None:
+            continue
+        (own.add(names[0]) if owner == names[0] else inherited.setdefault(owner, set()).add(names[0]))
+    assert own == {
+        "FPFDMSolver",
+        "FPFVMSolver",
+        "FPGFDMSolver",
+        "FPParticleSolver",
+        "FPSLJacobianSolver",
+        "FPSLSolver",
+    }
+    assert set(inherited) == {"BaseMFGSolver", "FPSLSolver"}
+    assert all(getattr(cls, field) is True for cls, n in _population().items() if n[0] in inherited["BaseMFGSolver"])
+
+
+# --------------------------------------------------------------------------------------
+# What the FDM boundary assembly reads
+# --------------------------------------------------------------------------------------
 
 
 def _mixed(bc_type, **kw):
@@ -234,12 +160,13 @@ def _mixed(bc_type, **kw):
     )
 
 
-def _step(bc, scheme="divergence_upwind"):
+def _step(bc):
     from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
 
-    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    nx = 21
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1))
     h = grid.get_grid_spacing()[0]
-    x = np.linspace(0.0, 1.0, 21)
+    x = np.linspace(0.0, 1.0, nx)
     m = np.exp(-50 * (x - 0.35) ** 2)
     m /= m.sum() * h
     return solve_timestep_full_nd(
@@ -252,163 +179,105 @@ def _step(bc, scheme="divergence_upwind"):
         spacing=(h,),
         grid=grid,
         ndim=1,
-        shape=(21,),
+        shape=(nx,),
         boundary_conditions=bc,
-        advection_scheme=scheme,
+        advection_scheme="divergence_upwind",
     )
 
 
-def test_a_wall_with_a_coefficient_the_assembly_cannot_read_is_assembled_as_no_flux():
-    """`alpha = 999` is not `v_n` under any convention, so this is a genuinely different wall.
+def test_the_step_responds_to_a_bc_at_all():
+    """Positive control for the two null results below: without it, byte-identity proves nothing
+    about coefficients and only that `_step` ignores its argument."""
+    assert not np.array_equal(_step(_mixed(BCType.DIRICHLET, value=7.0)), _step(_mixed(BCType.NO_FLUX)))
 
-    The mechanism: `_BOUNDARY_HANDLERS`' handlers are not passed `boundary_conditions` at all --
-    the parameter is absent from the signature -- so no configuration can make them read a
-    coefficient. That is a structural fact about the call, not a measurement that needs a value.
 
-    `alpha = 3.2` is deliberately NOT used here. An earlier version justified excluding it by
-    saying it *is* the reflecting wall for this fixture, which is wrong at the low wall:
-    `FPResolver`'s `drift` is the OUTWARD NORMAL component, so for `u = -3.2x` it is `+3.2` at
-    `x_max` and `-3.2` at `x_min`, while `_mixed` puts `+3.2` on both. That is the axis-vs-normal
-    confusion #1907 removed and #1972 records; it is left out rather than argued about.
-    """
-    reference = _step(_mixed(BCType.NO_FLUX))
-    got = _step(_mixed(BCType.ROBIN, alpha=999.0, beta=-0.045, value=0.0))
-
-    assert np.array_equal(got, reference), (
-        "a ROBIN wall with alpha=999 no longer assembles byte-identically to no-flux. If the FDM "
-        "boundary handlers now read a coefficient, that is the #1975 gap closing -- close it and "
-        "replace this with a convergence check against the exact d_n m = (alpha/beta) m relation."
+def test_a_robin_coefficient_the_assembly_cannot_read_gives_the_no_flux_result():
+    """`alpha = 999`. `_BOUNDARY_HANDLERS`' handlers take no `boundary_conditions` parameter."""
+    assert np.array_equal(
+        _step(_mixed(BCType.ROBIN, alpha=999.0, beta=-0.045, value=0.0)),
+        _step(_mixed(BCType.NO_FLUX)),
     )
 
 
 def test_a_provider_valued_coefficient_is_accepted_without_a_word():
-    """#1979. A coupled wall coefficient -- the entire point of the provider layer -- produces a
-    no-flux wall and no diagnostic. Pinned so the fix is visible, not so it is defended."""
+    """#1979: a coupled wall coefficient produces a no-flux wall and no diagnostic."""
     from mfgarchon.geometry.boundary.providers import AdjointConsistentProvider
 
-    reference = _step(_mixed(BCType.NO_FLUX))
     got = _step(_mixed(BCType.ROBIN, alpha=AdjointConsistentProvider(side="left", sigma=0.3), beta=-0.045, value=0.0))
-
-    assert np.array_equal(got, reference), (
-        "the FDM path now does something with a provider-valued alpha. If it RAISES, that is "
-        "#1979 fixed -- delete this and assert the refusal instead."
+    assert np.array_equal(got, _step(_mixed(BCType.NO_FLUX))), (
+        "the FDM path now does something with a provider-valued alpha; if it RAISES, #1979 is "
+        "fixed -- assert the refusal instead"
     )
-
-
-def test_the_alias_pairs_are_still_collapsed():
-    """Both pairs, because a name-keyed population reports each as two independent rows -- and a
-    row that looks like a second unmeasured path reads as a second gap."""
-    pop = _solver_population()
-    got = {names[0]: sorted(names[1:]) for names in pop.values() if len(names) > 1}
-    assert got == {k: sorted(v) for k, v in _ALIASES.items()}, (
-        f"alias pairs changed: {got}. Deleting a dead alias is progress -- record it here rather "
-        "than letting the population test report it as a solver appearing or vanishing."
-    )
-
-
-# =============================================================================
-# The capability gate: who is inside it
-# =============================================================================
-
-
-def test_the_solver_population_is_unchanged():
-    """Discovered by `walk_packages` + `issubclass`, a predicate that does NOT depend on the
-    declaration being audited. The version this replaced discovered its population by reading
-    `_SUPPORTED_BC_TYPES` inside two non-recursed directories, so it could not report its own
-    blind spot.
-    """
-    found = {names[0] for names in _solver_population().values()}
-    want = _GATED.keys() | _UNGATED
-    assert found == want, (
-        f"solver population changed: added {sorted(found - want)}, removed {sorted(want - found)}. "
-        "Update the census, then #1977."
-    )
-
-
-def test_exactly_these_solvers_are_outside_the_capability_gate():
-    """Recorded as a population, not as an absence: these declare nothing, so
-    `_validate_bc_support` no-ops on them (`base_solver.py:282`). `FPFEMSolver` is among them and
-    is the one FP solver implementing a general Robin. A solver LEAVING this set is #1977 being
-    fixed; a solver joining it is a capability shipped without a declaration.
-    """
-    ungated = {
-        names[0] for cls, names in _solver_population().items() if getattr(cls, "_SUPPORTED_BC_TYPES", None) is None
-    }
-    assert ungated == _UNGATED, (
-        f"newly ungated: {sorted(ungated - _UNGATED)} (a solver shipped without declaring its BC "
-        f"support); newly gated: {sorted(_UNGATED - ungated)} (#1977 progress -- record it)."
-    )
-
-
-@pytest.mark.parametrize("solver", sorted(_GATED))
-def test_each_gated_solver_accepts_exactly_what_the_census_records(solver):
-    """Widening is a capability gained, narrowing is one lost; the message says which, because
-    the two need opposite responses."""
-    got, want = _declared(solver), _GATED[solver]
-    if got == want:
-        return
-    raise AssertionError(
-        f"{solver} now accepts {sorted(got)}, census says {sorted(want)}.\n"
-        f"  gained: {sorted(got - want) or 'nothing'}  -- new capability; update the census.\n"
-        f"  lost:   {sorted(want - got) or 'nothing'}  -- a wall that was expressible no longer is."
-    )
-
-
-@pytest.mark.parametrize(("name", "module"), sorted(_NOT_EVEN_SUBCLASSES.items()))
-def test_the_classes_outside_any_subclass_predicate_are_still_outside_it(name, module):
-    """These apply BC segments -- Dirichlet values, Neumann normal-gradient stencil rows -- and are
-    not `BaseNumericalSolver` subclasses, so no population predicate above reaches them. Named
-    rather than discovered, which is the only way a blind spot can be pinned at all."""
-    cls = getattr(importlib.import_module(module), name)
-    assert not issubclass(cls, BaseNumericalSolver), f"{name} is now a solver subclass -- add it to the census"
-    assert getattr(cls, "_SUPPORTED_BC_TYPES", None) is None, f"{name} now declares support -- record it (#1977)"
 
 
 def test_an_unsupported_bc_raises_at_construction():
-    """Behavioural, replacing an `inspect.getsource` string match that was wrong in **both**
-    directions: it passed when the gate was disabled (`if False and unsupported:`) and when the
-    call was deleted but the string kept, and it failed on a behaviour-preserving refactor that
-    moved the call into a helper.
-    """
+    """The gate reads `supported_bc_types` (the protocol property), not the private attribute."""
     from mfgarchon import Conditions, MFGProblem, Model
     from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
 
-    bc = _mixed(BCType.ROBIN, alpha=1.0, beta=1.0, value=0.0)
-    model = Model(
-        hamiltonian=SeparableHamiltonian(
-            control_cost=QuadraticControlCost(control_cost=1.0),
-            coupling=lambda m: 0.5 * m,
-            coupling_dm=lambda m: 0.5,
+    problem = MFGProblem(
+        model=Model(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: 0.5 * m,
+                coupling_dm=lambda m: 0.5,
+            ),
+            sigma=0.1,
         ),
-        sigma=0.1,
+        domain=TensorProductGrid(
+            bounds=[(0.0, 1.0)],
+            Nx_points=[21],
+            boundary_conditions=_mixed(BCType.ROBIN, alpha=1.0, beta=1.0, value=0.0),
+        ),
+        conditions=Conditions(
+            u_terminal=lambda x: (x - 0.5) ** 2,
+            m_initial=lambda x: np.exp(-50 * (x - 0.5) ** 2),
+            T=0.2,
+        ),
+        Nt=5,
     )
-    domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=bc)
-    conditions = Conditions(
-        u_terminal=lambda x: (x - 0.5) ** 2,
-        m_initial=lambda x: np.exp(-50 * (x - 0.5) ** 2),
-        T=0.2,
-    )
-    problem = MFGProblem(model=model, domain=domain, conditions=conditions, Nt=5)
-
     with pytest.raises(NotImplementedError, match="ROBIN"):
         problem.solve(max_iterations=1)
 
 
-def test_no_gated_solver_may_declare_robin_while_the_assembly_ignores_alpha():
-    """Couples the two halves, so the naive fix cannot look like the real one.
+def test_the_gate_reads_what_this_file_reads():
+    """The gate reads `supported_bc_types`; every assertion here reads `_SUPPORTED_BC_TYPES`.
 
-    Declaring `ROBIN` without teaching the assembly to read the coefficients is exactly the fix
-    #1975 warns against, and with the two facts pinned separately that state passes the assembly
-    check while the declaration checks report a capability gained. This is the assertion that
-    fails on it.
+    Those are the same thing only while every property just forwards. Measured: all 11 gated
+    solvers have a property whose body is exactly `return self._SUPPORTED_BC_TYPES`, and the 11
+    ungated ones have no property at all. If either stops being true, this file is measuring
+    something the gate does not use -- which is how a solver could widen its live support with
+    every assertion here still green.
     """
-    fp_robin = {n for n in _GATED if n.startswith("FP") and "ROBIN" in _declared(n)}
-    coefficients_ignored = np.array_equal(
+    import textwrap
+
+    for cls, names in _population().items():
+        prop = inspect.getattr_static(cls, "supported_bc_types", None)
+        fget = getattr(prop, "fget", None)
+        declares = getattr(cls, "_SUPPORTED_BC_TYPES", None) is not None
+        if not declares:
+            assert fget is None, f"{names[0]} declares nothing but defines the property"
+            continue
+        assert fget is not None, f"{names[0]} declares but has no supported_bc_types property"
+        body = textwrap.dedent(inspect.getsource(fget)).strip().splitlines()[-1].strip()
+        assert body == "return self._SUPPORTED_BC_TYPES", (
+            f"{names[0]}'s property no longer just forwards ({body!r}); the gate and this file "
+            "now read different things"
+        )
+
+
+def test_no_fp_solver_declares_robin_while_the_assembly_ignores_the_coefficient():
+    """Justified by the test above: the private attribute is what the gate ends up reading."""
+    declaring = {
+        n[0]
+        for c, n in _population().items()
+        if n[0].startswith("FP") and any(t.name == "ROBIN" for t in (getattr(c, "_SUPPORTED_BC_TYPES", None) or ()))
+    }
+    ignored = np.array_equal(
         _step(_mixed(BCType.ROBIN, alpha=999.0, beta=-0.045, value=0.0)),
         _step(_mixed(BCType.NO_FLUX)),
     )
-    assert not (fp_robin and coefficients_ignored), (
-        f"{sorted(fp_robin)} declare(s) ROBIN while the FDM boundary handlers still ignore alpha "
-        "(a wall with alpha=999 is byte-identical to no-flux). That is a declaration without an "
-        "implementation -- the failure mode #1456's gate exists to prevent."
+    assert not (declaring and ignored), (
+        f"{sorted(declaring)} declare ROBIN while the assembly is still blind to alpha -- "
+        "a declaration without an implementation"
     )

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -1,0 +1,266 @@
+"""Which `BCType` each solver accepts, pinned. #1975
+
+**These tests pin a defect, not a correct state.** The Fokker-Planck reflecting wall is Robin in
+`m`; no FP solver in this library accepts `BCType.ROBIN`, and the only solver that does is on the
+HJB side, where the condition is Neumann. Support is inverted relative to the mathematics.
+
+A test that asserts a defect persists is a hazard -- it can become the thing that defends the
+defect. Two properties keep these from being that:
+
+1. Each failure message says which direction the change was and what to do about it. A red result
+   here is information, never "revert your change".
+2. `test_the_resolver_emits_a_type_no_consumer_accepts` does not pin either side. It pins the
+   *disagreement* between `FPResolver`, which emits `ROBIN`, and the solvers, which refuse it. It
+   goes green only when the gap closes, from whichever end.
+
+The physics, so the table can be read against something:
+
+    HJB:  d_n u = 0                                  -- true Neumann
+    FP :  (sigma^2/2) d_n m + m*(D_pH . n) = 0        -- Robin in m, coefficient a FIELD
+
+Carmona-Delarue I 4.7, (4.169)/(4.170); Cirant, JMPA 103 (2015) p.1295, lines hjn)/kn).
+`J.n = 0` reduces to `d_n m = 0` only when `D_pH . n = 0` -- true for p-homogeneous and congestion
+Hamiltonians, false for any term linear in p. Every grid FP solver here imposes `d_n m = 0`
+unconditionally.
+
+`FPParticleSolver` is the exception and needs no ROBIN branch: Skorokhod reflection of the path
+yields the condition on the density by construction. It is the oracle #1975 proposes for the fix.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+from mfgarchon.geometry.boundary import BCSegment, BCType
+from mfgarchon.geometry.boundary.resolution import FPResolver, MathBCType
+
+# Measured 2026-08-16 by reading `_SUPPORTED_BC_TYPES` off every solver class. Frozen here so a
+# change to any solver's accepted set is visible in one line of a diff rather than in nobody's.
+_CENSUS = {
+    "FP": {
+        "FPFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
+        "FPFVMSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+        "FPGFDMSolver": {"NEUMANN", "NO_FLUX"},
+        "FPParticleSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC", "REFLECTING"},
+        "FPSLAdjointSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+        "FPSLJacobianSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+        "FPSLSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+    },
+    "HJB": {
+        "HJBFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
+        "HJBGFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC", "ROBIN"},
+        "HJBSemiLagrangianSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+        "HJBWENOSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+    },
+}
+
+
+def _declared_support() -> dict[str, dict[str, set[str]]]:
+    """Every solver class that declares `_SUPPORTED_BC_TYPES`, by side."""
+    import mfgarchon.alg.numerical.fp_solvers as fp_pkg
+    import mfgarchon.alg.numerical.hjb_solvers as hjb_pkg
+
+    found: dict[str, dict[str, set[str]]] = {"FP": {}, "HJB": {}}
+    for pkg, side in ((fp_pkg, "FP"), (hjb_pkg, "HJB")):
+        for mod in pkgutil.iter_modules(pkg.__path__):
+            module = importlib.import_module(f"{pkg.__name__}.{mod.name}")
+            for name, cls in inspect.getmembers(module, inspect.isclass):
+                if cls.__module__ != module.__name__:
+                    continue  # re-export, not a definition here
+                declared = getattr(cls, "_SUPPORTED_BC_TYPES", None)
+                if declared is not None:
+                    found[side][name] = {t.name for t in declared}
+    return found
+
+
+# =============================================================================
+# The census
+# =============================================================================
+
+
+def test_the_solver_population_has_not_changed():
+    """A new solver, or a deleted one, must land in `_CENSUS` before the rest of this file means
+    anything -- every assertion below reads the frozen table, so a solver absent from it is
+    unmeasured rather than passing."""
+    found = _declared_support()
+    for side in ("FP", "HJB"):
+        assert set(found[side]) == set(_CENSUS[side]), (
+            f"{side} solvers declaring _SUPPORTED_BC_TYPES changed: "
+            f"added {sorted(set(found[side]) - set(_CENSUS[side]))}, "
+            f"removed {sorted(set(_CENSUS[side]) - set(found[side]))}. "
+            f"Update _CENSUS, then re-read #1975 -- the table is its evidence."
+        )
+
+
+@pytest.mark.parametrize(
+    ("side", "solver"),
+    [(side, name) for side, solvers in _CENSUS.items() for name in sorted(solvers)],
+)
+def test_each_solver_accepts_exactly_what_the_census_records(side, solver):
+    """Pins one row. Widening is the fix landing and narrowing is a capability lost; the message
+    says which, because the two need opposite responses and a bare diff does not distinguish
+    them."""
+    got = _declared_support()[side][solver]
+    want = _CENSUS[side][solver]
+    if got == want:
+        return
+    added, removed = sorted(got - want), sorted(want - got)
+    raise AssertionError(
+        f"{solver} now accepts {sorted(got)}, census says {sorted(want)}.\n"
+        f"  gained: {added or 'nothing'}  -- new capability; update the census and #1975.\n"
+        f"  lost:   {removed or 'nothing'}  -- a wall that used to be expressible no longer is."
+    )
+
+
+# =============================================================================
+# The gap itself -- this one is not a snapshot
+# =============================================================================
+
+
+def test_the_resolver_emits_a_type_no_consumer_accepts():
+    """`FPResolver` translates an impermeable wall into the Robin condition that is actually true
+    of it, and hands back a `MathBCType` that every FP solver refuses.
+
+    This is the whole of #1975 in one assertion, and it pins **neither side** -- so it does not
+    defend the defect. It goes green when the resolver stops emitting ROBIN (the physics would
+    have to have changed, so: unlikely and worth a fight) or when some FP solver starts accepting
+    it (the fix). Either way the reader is sent to #1975 rather than to a revert.
+    """
+    resolved = FPResolver().resolve(
+        BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min"),
+        {"drift": 3.2, "diffusion": 0.045},
+    )
+    assert resolved.math_type is MathBCType.ROBIN, (
+        "FPResolver no longer emits ROBIN for an impermeable wall. The FP flux condition "
+        "J.n = 0 is Robin in m whenever D_pH . n != 0, so this is either a real change of "
+        "physics or a regression -- see #1975 before updating this test."
+    )
+
+    # Read live, NOT from _CENSUS. Against the frozen dict this assertion would compare a
+    # constant with itself and survive the very change it exists to notice -- caught by the M1
+    # mutation (FPFDMSolver gains ROBIN), which the first draft of this file passed.
+    accepting = sorted(s for s, types in _declared_support()["FP"].items() if "ROBIN" in types)
+    assert not accepting, (
+        f"{accepting} now accept(s) ROBIN. This assertion existed to record that NO FP solver "
+        f"did, while FPResolver emits exactly that -- the inversion #1975 tracks. If this is the "
+        f"fix landing: close #1975, delete this assertion, and replace it with a mass-conservation "
+        f"oracle against FPParticleSolver, which already imposes the correct wall."
+    )
+
+
+def test_the_only_robin_capable_solver_is_on_the_side_that_does_not_need_it():
+    """The inversion stated as such: ROBIN is the FP condition and is supported only on HJB.
+
+    Kept separate from the row-by-row census because a reader scanning that table sees eleven
+    correct-looking rows; the inversion is a property of the table, not of any row in it.
+    """
+    live = _declared_support()  # live, for the reason given in the test above
+    fp_robin = {s for s, t in live["FP"].items() if "ROBIN" in t}
+    hjb_robin = {s for s, t in live["HJB"].items() if "ROBIN" in t}
+
+    assert fp_robin == set(), f"FP side gained ROBIN ({sorted(fp_robin)}) -- see #1975"
+    assert hjb_robin == {"HJBGFDMSolver"}, (
+        f"HJB solvers accepting ROBIN changed to {sorted(hjb_robin)}. The HJB reflecting "
+        "condition is Neumann, so ROBIN there serves a different purpose (#624 adjoint-"
+        "consistent coupling); a change here is not the #1975 fix."
+    )
+
+
+def test_the_fp_assembly_reads_none_of_the_robin_coefficients():
+    """The gate refusing ROBIN is honest, not an oversight: nothing downstream would read it.
+
+    `_BOUNDARY_HANDLERS` (`fp_fdm_time_stepping.py:110`) is keyed on the *advection scheme*, and
+    all four entries are `add_boundary_no_flux_entries_*`. The call site is
+    `elif (is_no_flux or not is_uniform) and is_boundary`, so a mixed BC at a boundary point
+    routes to the no-flux handler whatever its segments say.
+
+    This assertion, like the one above, pins the **gap** rather than either side. It fails the
+    moment the assembly starts reading `(alpha, beta, g)` -- which is the #1975 fix, and the
+    reader is sent there rather than to a revert.
+
+    Feller/Wentzell is why the fix is the coefficient vector and not another named branch: the
+    canonical boundary operator is one condition with sign-constrained additive coefficients, and
+    the named types are degenerate corners of it. Adding a ROBIN branch samples one more point of
+    the same continuum.
+    """
+    import numpy as np
+
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import BoundaryConditions, no_flux_bc
+
+    nx = 21
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1))
+    h = grid.get_grid_spacing()[0]
+    x = np.linspace(0.0, 1.0, nx)
+
+    # Off-centre, so mass actually reaches one wall before the other and the wall term matters.
+    m0 = np.exp(-50 * (x - 0.35) ** 2)
+    m0 /= m0.sum() * h
+    u0 = -3.2 * x  # constant wall-normal drift, the case where J.n = 0 is NOT d_n m = 0
+
+    def mixed(bc_type, **kw):
+        return BoundaryConditions(
+            segments=[
+                BCSegment(name="lo", bc_type=bc_type, boundary="x_min", **kw),
+                BCSegment(name="hi", bc_type=bc_type, boundary="x_max", **kw),
+            ],
+            dimension=1,
+        )
+
+    def step(bc):
+        return solve_timestep_full_nd(
+            M_current=m0,
+            U_current=u0,
+            problem=object(),
+            dt=1e-3,
+            sigma=0.3,
+            coupling_coefficient=1.0,
+            spacing=(h,),
+            grid=grid,
+            ndim=1,
+            shape=(nx,),
+            boundary_conditions=bc,
+            advection_scheme="divergence_upwind",
+        )
+
+    reference = step(mixed(BCType.NO_FLUX))
+    # Two wildly different alphas: if either coefficient were read, one of these would move.
+    for alpha in (3.2, 999.0):
+        got = step(mixed(BCType.ROBIN, alpha=alpha, beta=-0.045, value=0.0))
+        assert np.array_equal(got, reference), (
+            f"a ROBIN wall with alpha={alpha} no longer assembles byte-identically to no-flux. "
+            "If the FP assembly now reads (alpha, beta, g), that is the #1975 fix: close it, "
+            "delete this assertion, and replace it with a mass-conservation oracle against "
+            "FPParticleSolver, which already imposes the correct wall by Skorokhod reflection."
+        )
+
+
+# =============================================================================
+# The refusal is load-bearing -- it must stay loud
+# =============================================================================
+
+
+def test_an_unsupported_bc_is_refused_rather_than_silently_reinterpreted():
+    """The census only means something because the declared set is enforced.
+
+    If `_validate_bc_support` stopped raising, every row above would still pass while the solvers
+    quietly applied a different wall -- which is the failure mode #1456 exists to prevent, and it
+    would make this whole file decorative.
+    """
+    from mfgarchon.alg.base_solver import BaseNumericalSolver
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+
+    assert "ROBIN" not in _CENSUS["HJB"]["HJBFDMSolver"], "premise of this test changed"
+    assert hasattr(BaseNumericalSolver, "_validate_bc_support"), (
+        "the gate that turns _SUPPORTED_BC_TYPES from documentation into behaviour is gone; "
+        "every assertion in this file is decorative without it"
+    )
+    assert "_validate_bc_support" in inspect.getsource(HJBFDMSolver.__init__), (
+        "HJBFDMSolver no longer calls _validate_bc_support at construction, so its declared "
+        "support is no longer enforced"
+    )

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -36,13 +36,12 @@ import numpy as np
 from mfgarchon.alg.base_solver import BaseNumericalSolver
 from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions, no_flux_bc
-from mfgarchon.geometry.boundary.resolution import FPResolver, MathBCType
 
 # Measured 2026-08-17 by walking `mfgarchon.alg` with `walk_packages` and keeping concrete
-# `BaseNumericalSolver` subclasses -- a predicate INDEPENDENT of whether a class declares
-# `_SUPPORTED_BC_TYPES`. The previous version discovered its population by reading that attribute
-# inside two non-recursed directories, so it could not report its own blind spot: it missed 5 FP
-# and 5 HJB solvers, `FPFEMSolver` among them.
+# `BaseNumericalSolver` subclasses, keyed on class identity -- a predicate independent of the
+# declaration audited. The sets below are the measurement; no count is restated in prose, because
+# three independent attempts at this file produced three different counts and each was written
+# down as a fact.
 _GATED = {
     "FPFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
     "FPFVMSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
@@ -64,42 +63,65 @@ _UNGATED = {
     "FPFEMSolver",
     "FPNetworkSolver",
     "HJBFEMSolver",
+    "HJBNetworkSolver",
     "MeshlessGalerkinFPSolver",
     "MeshlessGalerkinHJBSolver",
-    "NetworkFPSolver",
-    "NetworkHJBSolver",
     "NetworkPolicyIterationHJBSolver",
     "PenaltyHJBSolver",
     "WeakFormFPSolver",
     "WeakFormHJBSolver",
 }
 
+#: Same class bound under two names in its own module. Both pairs, because a name-keyed
+#: population reports each as two independent rows.
+_ALIASES = {
+    "FPNetworkSolver": ["NetworkFPSolver"],
+    "HJBNetworkSolver": ["NetworkHJBSolver"],
+}
+
 # Outside even a subclass predicate: plain classes that read BC segments and write Dirichlet
 # values and Neumann normal-gradient rows. No population predicate over `BaseNumericalSolver`
 # reaches them, which is why they are named rather than discovered.
 _NOT_EVEN_SUBCLASSES = {
+    # Applies BC segments directly -- `is_dirichlet`, Neumann-by-extension rows (hjb_howard.py:363).
     "HJBHowardSolver": "mfgarchon.alg.numerical.hjb_solvers.hjb_howard",
+    # Passes `bc` to the grid's Laplacian rather than writing rows itself; listed because no
+    # predicate here reaches it, not because it writes BC rows.
     "ImplicitHeatSolver": "mfgarchon.alg.numerical.pde_solvers.implicit_heat",
+    # Owns `build_neumann_bc_weights` / `create_ghost_neighbors` / `apply_ghost_nodes_to_...`.
+    "BoundaryHandler": "mfgarchon.alg.numerical.gfdm_components.boundary_handler",
 }
 
 
-def _solver_population() -> dict[str, bool]:
-    """Every concrete `BaseNumericalSolver` subclass -> whether it declares a BC support set.
+def _solver_population() -> dict[type, list[str]]:
+    """Every concrete `BaseNumericalSolver` subclass -> every name it is bound under.
 
-    `walk_packages`, not `iter_modules`: the latter does not recurse, and `alg/numerical/fem/`
-    is one directory below the two the old census walked.
+    Keyed on the CLASS, not the binding name: `NetworkFPSolver = FPNetworkSolver` and
+    `NetworkHJBSolver = HJBNetworkSolver` are same-module aliases, and `cls.__module__ !=
+    module.__name__` does not catch those, so a name-keyed population reports two rows per pair.
+
+    `inspect.isabstract` rather than `name.startswith("Base")`: the name heuristic bought nothing
+    (isabstract already covers the real bases) and silently excluded any concrete solver whose
+    name begins with "Base".
+
+    `walk_packages` yields SUBMODULES of `mfgarchon.alg`, never `mfgarchon.alg` itself, so the
+    root is imported explicitly. A class defined in `alg/__init__.py` was invisible without it.
+
+    Still not reached, and stated rather than implied: a class built by a factory (`type()` called
+    in another module), one produced by `__getattr__`, and anything outside `mfgarchon.alg`.
     """
     import mfgarchon.alg as alg_pkg
 
-    found: dict[str, bool] = {}
-    for mod in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg."):
-        module = importlib.import_module(mod.name)
+    found: dict[type, list[str]] = {}
+    names = ["mfgarchon.alg"] + [m.name for m in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg.")]
+    for mod_name in names:
+        module = importlib.import_module(mod_name)
         for name, cls in inspect.getmembers(module, inspect.isclass):
-            if cls.__module__ != module.__name__ or not issubclass(cls, BaseNumericalSolver):
+            if not issubclass(cls, BaseNumericalSolver) or inspect.isabstract(cls):
                 continue
-            if inspect.isabstract(cls) or name.startswith("Base"):
-                continue
-            found[name] = getattr(cls, "_SUPPORTED_BC_TYPES", None) is not None
+            found.setdefault(cls, [])
+            if name not in found[cls]:
+                found[cls].append(name)
     return found
 
 
@@ -236,27 +258,26 @@ def _step(bc, scheme="divergence_upwind"):
     )
 
 
-def test_a_wall_that_is_not_the_reflecting_one_is_still_assembled_as_no_flux():
-    """`alpha = 999` is a genuinely different wall and must not equal no-flux. It does.
+def test_a_wall_with_a_coefficient_the_assembly_cannot_read_is_assembled_as_no_flux():
+    """`alpha = 999` is not `v_n` under any convention, so this is a genuinely different wall.
 
-    `alpha = 3.2` is deliberately **excluded**: with this fixture `FPResolver` emits
-    `ROBIN(alpha=+3.2, beta=-0.045)` for the impermeable wall, so that case *is* the reflecting
-    wall the conservative scheme already imposes and byte-identity there is correct. The previous
-    version of this file asserted on it and read the right answer as a defect.
+    The mechanism: `_BOUNDARY_HANDLERS`' handlers are not passed `boundary_conditions` at all --
+    the parameter is absent from the signature -- so no configuration can make them read a
+    coefficient. That is a structural fact about the call, not a measurement that needs a value.
 
-    The mechanism: `_BOUNDARY_HANDLERS` handlers are not passed `boundary_conditions` at all, so
-    no configuration can make them read a coefficient. Measured over 768 combinations of ndim,
-    npts, sigma, dt, scheme and (alpha, beta, g): zero non-identical cases.
+    `alpha = 3.2` is deliberately NOT used here. An earlier version justified excluding it by
+    saying it *is* the reflecting wall for this fixture, which is wrong at the low wall:
+    `FPResolver`'s `drift` is the OUTWARD NORMAL component, so for `u = -3.2x` it is `+3.2` at
+    `x_max` and `-3.2` at `x_min`, while `_mixed` puts `+3.2` on both. That is the axis-vs-normal
+    confusion #1907 removed and #1972 records; it is left out rather than argued about.
     """
     reference = _step(_mixed(BCType.NO_FLUX))
     got = _step(_mixed(BCType.ROBIN, alpha=999.0, beta=-0.045, value=0.0))
 
     assert np.array_equal(got, reference), (
         "a ROBIN wall with alpha=999 no longer assembles byte-identically to no-flux. If the FDM "
-        "boundary handlers now read (alpha, beta, g), that is the #1975 gap closing: close it and "
-        "replace this with a convergence check against the exact d_n m = (alpha/beta)*m relation. "
-        "Do NOT close it by making the conservative schemes read alpha for a reflecting wall -- "
-        "they already impose J.n = 0 and would double-count."
+        "boundary handlers now read a coefficient, that is the #1975 gap closing -- close it and "
+        "replace this with a convergence check against the exact d_n m = (alpha/beta) m relation."
     )
 
 
@@ -274,21 +295,15 @@ def test_a_provider_valued_coefficient_is_accepted_without_a_word():
     )
 
 
-def test_the_resolver_still_emits_the_condition_its_consumers_impose_structurally():
-    """`FPResolver` translates an impermeable wall into `ROBIN(alpha=v_n, beta=-D, g=0)`.
-
-    It has zero library callers, and #1975 records why that is not simply a wiring bug: the
-    conservative assemblies already impose that condition, so routing through the resolver would
-    be redundant there and double-counting on the FEM weak form (measured: -79.5% mass drift when
-    `alpha = v_n` is handed to `assemble_robin_terms`, whose natural BC is already `J.n = 0`).
-    """
-    resolved = FPResolver().resolve(
-        BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min"),
-        {"drift": _DRIFT, "diffusion": 0.5 * _SIGMA**2},
+def test_the_alias_pairs_are_still_collapsed():
+    """Both pairs, because a name-keyed population reports each as two independent rows -- and a
+    row that looks like a second unmeasured path reads as a second gap."""
+    pop = _solver_population()
+    got = {names[0]: sorted(names[1:]) for names in pop.values() if len(names) > 1}
+    assert got == {k: sorted(v) for k, v in _ALIASES.items()}, (
+        f"alias pairs changed: {got}. Deleting a dead alias is progress -- record it here rather "
+        "than letting the population test report it as a solver appearing or vanishing."
     )
-    assert resolved.math_type is MathBCType.ROBIN
-    assert resolved.alpha == pytest.approx(_DRIFT)
-    assert resolved.beta == pytest.approx(-0.5 * _SIGMA**2)
 
 
 # =============================================================================
@@ -298,25 +313,27 @@ def test_the_resolver_still_emits_the_condition_its_consumers_impose_structurall
 
 def test_the_solver_population_is_unchanged():
     """Discovered by `walk_packages` + `issubclass`, a predicate that does NOT depend on the
-    declaration being audited. The old census discovered its population by reading
-    `_SUPPORTED_BC_TYPES` inside two non-recursed directories and so could not report its own
-    blind spot -- it missed 10 solvers.
+    declaration being audited. The version this replaced discovered its population by reading
+    `_SUPPORTED_BC_TYPES` inside two non-recursed directories, so it could not report its own
+    blind spot.
     """
-    found = _solver_population()
-    assert set(found) == _GATED.keys() | _UNGATED, (
-        f"solver population changed: added {sorted(set(found) - (_GATED.keys() | _UNGATED))}, "
-        f"removed {sorted((_GATED.keys() | _UNGATED) - set(found))}. Update the census, then #1977."
+    found = {names[0] for names in _solver_population().values()}
+    want = _GATED.keys() | _UNGATED
+    assert found == want, (
+        f"solver population changed: added {sorted(found - want)}, removed {sorted(want - found)}. "
+        "Update the census, then #1977."
     )
 
 
 def test_exactly_these_solvers_are_outside_the_capability_gate():
-    """Recorded as a population, not as an absence. Half the solvers declare nothing, so
-    `_validate_bc_support` no-ops on them -- `FPFEMSolver` among them, which is the one FP solver
-    implementing a general Robin. A solver LEAVING this set is #1977 being fixed; a solver joining
-    it is a new capability shipped without a declaration.
+    """Recorded as a population, not as an absence: these declare nothing, so
+    `_validate_bc_support` no-ops on them (`base_solver.py:282`). `FPFEMSolver` is among them and
+    is the one FP solver implementing a general Robin. A solver LEAVING this set is #1977 being
+    fixed; a solver joining it is a capability shipped without a declaration.
     """
-    found = _solver_population()
-    ungated = {n for n, gated in found.items() if not gated}
+    ungated = {
+        names[0] for cls, names in _solver_population().items() if getattr(cls, "_SUPPORTED_BC_TYPES", None) is None
+    }
     assert ungated == _UNGATED, (
         f"newly ungated: {sorted(ungated - _UNGATED)} (a solver shipped without declaring its BC "
         f"support); newly gated: {sorted(_UNGATED - ungated)} (#1977 progress -- record it)."

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -1,15 +1,6 @@
 """Which solvers declare their BC support, and what the FDM boundary assembly reads. #1975 #1977
 
-Assertions only. The reasoning, the history and the physics live in #1975; five revisions of this
-file put them here as prose and five independent reviews found a false statement in that prose
-each time.
-
-~~Nothing below is stated that is not computed in this file.~~ [CORRECTED 2026-08-17] -- that was
-itself one of them. Eight statements below are traced-and-true rather than computed: the source
-references (`base_solver.py:282`, `fp_fdm_bc.py:349/387`, `fp_fdm.py:127`), "no BC-type branch",
-"`divergence_upwind` is the default", the `_BOUNDARY_HANDLERS` signature claim, and the
-`_NOT_REACHED` roster. Each names a file and a line so a reader can check it; none is asserted.
-The rule the file actually keeps is narrower: **no NUMBER appears that this file does not compute.**
+The reasoning, the history and the physics live in #1975.
 """
 
 from __future__ import annotations
@@ -36,13 +27,8 @@ def _population() -> dict[type, list[str]]:
     `mfgarchon.alg`. `walk_packages` never yields the root, so `mfgarchon.alg` is imported
     explicitly.
 
-    There is no `cls.__module__ != module.__name__` filter. A previous revision had one and
-    defended it on the grounds that dropping it would re-admit hundreds of foreign imports;
-    measured, that is false -- `issubclass(cls, BaseNumericalSolver)` on the next line rejects
-    every `typing`/`enum`/`abc`/`scipy` binding by itself. The filter's entire effect was to hide
-    ONE name: `HJBNetworkSolver`, a cross-module alias at `network_solvers/__init__.py:19`, which
-    `test_no_solver_is_bound_under_a_name_the_census_does_not_know` exists to catch and was blind
-    to. Population with the filter: 21 classes. Without: 21 classes, +1 name."""
+    Deliberately no `cls.__module__ != module.__name__` filter: it hid the cross-module alias at
+    `network_solvers/__init__.py:19` from the test written to catch that case (#1976 review)."""
     import mfgarchon.alg as alg_pkg
 
     found: dict[type, list[str]] = {}
@@ -97,17 +83,8 @@ _UNGATED = {
 #: (`network_solvers/__init__.py:19`) that only becomes visible without a defining-module filter.
 _ALIASES = {"FPNetworkSolver": ["NetworkFPSolver"], "NetworkHJBSolver": ["HJBNetworkSolver"]}
 
-#: The population predicate is `BaseNumericalSolver`; `_validate_bc_support` and
-#: `honors_inhomogeneous_neumann` are defined on `BaseMFGSolver`, a strict superclass. Measured:
-#: 21 concrete `BaseNumericalSolver` subclasses, 25 concrete `BaseMFGSolver` subclasses, so 4 are
-#: in the gate's reach and outside every assertion here -- PrimalDual, Sinkhorn, Variational and
-#: Wasserstein, all declaring nothing and all inheriting `honors_inhomogeneous_neumann = True`.
-#: None of the four mentions a boundary condition anywhere in its file, so the omission hides no
-#: live defect; it is disclosed because an undisclosed population predicate is a scope claim.
-#:
 #: Do a solver's boundary job without being solver subclasses, so no predicate here reaches them.
-#: Named, not discovered -- and known to be incomplete: a behaviour scan finds 36 non-subclass
-#: classes branching on a BC type, the applicator family among them.
+#: Named, not discovered, and incomplete: other non-subclass classes branch on a BC type too.
 #:
 #: ~~"Apply BC segments"~~ [CORRECTED 2026-08-17] -- true of one of the three. `HJBHowardSolver`
 #: reads `seg.bc_type` and branches on DIRICHLET (hjb_howard.py:363). `BoundaryHandler` probes
@@ -133,8 +110,6 @@ def test_the_alias_bindings_are_unchanged():
 
 
 def test_no_solver_is_bound_under_a_name_the_census_does_not_know():
-    """`names[0]` is whichever binding `inspect.getmembers` yields first, so a new alias that
-    sorts earlier would silently replace a canonical name in every set above."""
     known = _GATED.keys() | _UNGATED | {a for v in _ALIASES.values() for a in v}
     unknown = {n for names in _population().values() for n in names} - known
     assert not unknown, f"names not in any set: {sorted(unknown)}"
@@ -157,6 +132,29 @@ def test_exactly_these_solvers_declare_nothing():
 def test_the_named_unreached_classes_are_still_unreached(name, module):
     cls = getattr(importlib.import_module(module), name)
     assert not issubclass(cls, BaseNumericalSolver), f"{name} is now a solver subclass"
+
+
+def test_the_gate_reaches_four_classes_this_file_does_not():
+    """The population predicate is `BaseNumericalSolver`; `_validate_bc_support` and
+    `honors_inhomogeneous_neumann` live on `BaseMFGSolver`, a strict superclass. An undisclosed
+    population predicate is a scope claim, so the gap is computed rather than described."""
+    from mfgarchon.alg.base_solver import BaseMFGSolver
+
+    reached = set()
+    for mod_name in ["mfgarchon.alg"] + [
+        m.name for m in pkgutil.walk_packages(importlib.import_module("mfgarchon.alg").__path__, prefix="mfgarchon.alg.")
+    ]:
+        for _, cls in inspect.getmembers(importlib.import_module(mod_name), inspect.isclass):
+            if issubclass(cls, BaseMFGSolver) and not inspect.isabstract(cls):
+                reached.add(cls)
+    outside = {c.__name__ for c in reached} - {n[0] for n in _population().values()}
+    assert outside == {
+        "PrimalDualMFGSolver",
+        "SinkhornMFGSolver",
+        "VariationalMFGSolver",
+        "WassersteinMFGSolver",
+    }, f"changed: {sorted(outside)}"
+    assert all(getattr(c, "_SUPPORTED_BC_TYPES", None) is None for c in reached if c.__name__ in outside)
 
 
 def test_the_permissive_default_is_claimed_by_inheritance():
@@ -229,17 +227,15 @@ def test_the_conservative_schemes_conserve_mass_at_a_drifted_wall(scheme):
     oracle: mass conservation is a law of the equation, computed here without reference to any
     scheme's internals, so it cannot go tautological the way a declaration census can.
 
-    `divergence_upwind` is the default. Measured: -0.0000% and -0.0000%.
+    `divergence_upwind` is the default.
     """
     drift_pct, dmdx = _run(scheme)
     assert abs(drift_pct) < 1e-6, f"{scheme} leaked {drift_pct:.4f}% at a wall with normal drift"
     assert abs(dmdx) > 100.0, (
         f"{scheme} has d_n m = {dmdx:.4g} at the wall. J.n = 0 requires d_n m = (v/D)*m, which is "
         "large here; a small gradient means the wall became d_n m = 0."
-    )  # 1.0 until 2026-08-17, which could not fire: the gradient_* family gives 2.06 and 3.73 on
-    # this same fixture, both above it, while J.n = 0 gives 1138 and 1962. The threshold named a
-    # failure two orders of magnitude inside its own pass band. 100 separates the two families and
-    # still fires when the fixture stops driving the wall (drift=0 gives -0.179).
+    )  # 1.0 until 2026-08-17: the gradient_* wall this message says it detects sits ABOVE 1.0 on
+    # this fixture, so the threshold named a failure inside its own pass band. Figures in #1975.
 
 
 @pytest.mark.parametrize("scheme", ["gradient_upwind", "gradient_centered"])
@@ -247,7 +243,7 @@ def test_the_gradient_schemes_impose_a_zero_gradient_wall_and_leak(scheme):
     """The counterpart, pinned so the distinction cannot quietly collapse in either direction.
 
     These impose `d_n m = 0`, which is the wrong condition when the drift is not tangential, and
-    they are documented non-conservative (#1075). Measured: -78.05% and -75.47%.
+    they are documented non-conservative (#1075).
     """
     drift_pct, _ = _run(scheme)
     assert drift_pct < -10.0, (

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -1,30 +1,26 @@
-"""Which `BCType` each solver accepts, pinned. #1975
+"""Which wall each FP path actually imposes, and which solvers are outside the capability gate.
 
-**These tests pin a defect, not a correct state.** The Fokker-Planck reflecting wall is Robin in
-`m`; no FP solver in this library accepts `BCType.ROBIN`, and the only solver that does is on the
-HJB side, where the condition is Neumann. Support is inverted relative to the mathematics.
+This file replaces one that got the physics backwards, so the reasoning is written down.
 
-A test that asserts a defect persists is a hazard -- it can become the thing that defends the
-defect. Two properties keep these from being that:
+**The reflecting wall is `J.n = 0`, not `d_n m = 0`.** They coincide only when the drift is
+tangential at the wall. The conservative schemes impose the first **structurally** -- by zeroing
+the total face flux, advective plus diffusive -- with no BC-type branch naming it; the
+`gradient_*` family imposes the second and leaks. `FPParticleSolver` gets `J.n = 0` from Skorokhod
+reflection of the path, also without naming it.
 
-1. Each failure message says which direction the change was and what to do about it. A red result
-   here is information, never "revert your change".
-2. `test_the_resolver_emits_a_type_no_consumer_accepts` does not pin either side. It pins the
-   *disagreement* between `FPResolver`, which emits `ROBIN`, and the solvers, which refuse it. It
-   goes green only when the gap closes, from whichever end.
+That is why the first version of this file was wrong. It read "no BC-type dispatch at the
+boundary" as "imposes `d_n m = 0`", measured `ROBIN(alpha=3.2) == no_flux` byte-identically, and
+called that a defect. With `u = -3.2x`, coupling 1, sigma 0.3, `FPResolver` emits
+`ROBIN(alpha=+3.2, beta=-0.045)` -- **the same numbers** -- so that case *is* the physical wall the
+default scheme already imposes and byte-identity there is the correct answer. Only a wall that is
+genuinely different (`alpha != v_n`, or `g != 0`) shows a real gap.
 
-The physics, so the table can be read against something:
+So the load-bearing test here is `test_the_conservative_schemes_conserve_mass_at_a_drifted_wall`:
+an external oracle, computed independently of any scheme, that says which condition is actually
+imposed. A census keyed on declarations cannot say that -- correctness here is structural, not
+declared -- and its absence is what let the wrong reading stand.
 
-    HJB:  d_n u = 0                                  -- true Neumann
-    FP :  (sigma^2/2) d_n m + m*(D_pH . n) = 0        -- Robin in m, coefficient a FIELD
-
-Carmona-Delarue I 4.7, (4.169)/(4.170); Cirant, JMPA 103 (2015) p.1295, lines hjn)/kn).
-`J.n = 0` reduces to `d_n m = 0` only when `D_pH . n = 0` -- true for p-homogeneous and congestion
-Hamiltonians, false for any term linear in p. Every grid FP solver here imposes `d_n m = 0`
-unconditionally.
-
-`FPParticleSolver` is the exception and needs no ROBIN branch: Skorokhod reflection of the path
-yields the condition on the density by construction. It is the oracle #1975 proposes for the fix.
+Refs #1975, #1977, #1979.
 """
 
 from __future__ import annotations
@@ -35,232 +31,367 @@ import pkgutil
 
 import pytest
 
-from mfgarchon.geometry.boundary import BCSegment, BCType
+import numpy as np
+
+from mfgarchon.alg.base_solver import BaseNumericalSolver
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions, no_flux_bc
 from mfgarchon.geometry.boundary.resolution import FPResolver, MathBCType
 
-# Measured 2026-08-16 by reading `_SUPPORTED_BC_TYPES` off every solver class. Frozen here so a
-# change to any solver's accepted set is visible in one line of a diff rather than in nobody's.
-_CENSUS = {
-    "FP": {
-        "FPFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
-        "FPFVMSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
-        "FPGFDMSolver": {"NEUMANN", "NO_FLUX"},
-        "FPParticleSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC", "REFLECTING"},
-        "FPSLAdjointSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
-        "FPSLJacobianSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
-        "FPSLSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
-    },
-    "HJB": {
-        "HJBFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
-        "HJBGFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC", "ROBIN"},
-        "HJBSemiLagrangianSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
-        "HJBWENOSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
-    },
+# Measured 2026-08-17 by walking `mfgarchon.alg` with `walk_packages` and keeping concrete
+# `BaseNumericalSolver` subclasses -- a predicate INDEPENDENT of whether a class declares
+# `_SUPPORTED_BC_TYPES`. The previous version discovered its population by reading that attribute
+# inside two non-recursed directories, so it could not report its own blind spot: it missed 5 FP
+# and 5 HJB solvers, `FPFEMSolver` among them.
+_GATED = {
+    "FPFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
+    "FPFVMSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+    "FPGFDMSolver": {"NEUMANN", "NO_FLUX"},
+    "FPParticleSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC", "REFLECTING"},
+    "FPSLAdjointSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+    "FPSLJacobianSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+    "FPSLSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+    "HJBFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC"},
+    "HJBGFDMSolver": {"DIRICHLET", "NEUMANN", "NO_FLUX", "PERIODIC", "ROBIN"},
+    "HJBSemiLagrangianSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+    "HJBWENOSolver": {"NEUMANN", "NO_FLUX", "PERIODIC"},
+}
+
+# Recorded as a POPULATION, not as an absence. Half the solvers declare nothing, so
+# `_validate_bc_support` no-ops on them (`base_solver.py:282`) -- including `FPFEMSolver`, the one
+# FP solver that implements a general Robin. #1977.
+_UNGATED = {
+    "FPFEMSolver",
+    "FPNetworkSolver",
+    "HJBFEMSolver",
+    "MeshlessGalerkinFPSolver",
+    "MeshlessGalerkinHJBSolver",
+    "NetworkFPSolver",
+    "NetworkHJBSolver",
+    "NetworkPolicyIterationHJBSolver",
+    "PenaltyHJBSolver",
+    "WeakFormFPSolver",
+    "WeakFormHJBSolver",
+}
+
+# Outside even a subclass predicate: plain classes that read BC segments and write Dirichlet
+# values and Neumann normal-gradient rows. No population predicate over `BaseNumericalSolver`
+# reaches them, which is why they are named rather than discovered.
+_NOT_EVEN_SUBCLASSES = {
+    "HJBHowardSolver": "mfgarchon.alg.numerical.hjb_solvers.hjb_howard",
+    "ImplicitHeatSolver": "mfgarchon.alg.numerical.pde_solvers.implicit_heat",
 }
 
 
-def _declared_support() -> dict[str, dict[str, set[str]]]:
-    """Every solver class that declares `_SUPPORTED_BC_TYPES`, by side."""
-    import mfgarchon.alg.numerical.fp_solvers as fp_pkg
-    import mfgarchon.alg.numerical.hjb_solvers as hjb_pkg
+def _solver_population() -> dict[str, bool]:
+    """Every concrete `BaseNumericalSolver` subclass -> whether it declares a BC support set.
 
-    found: dict[str, dict[str, set[str]]] = {"FP": {}, "HJB": {}}
-    for pkg, side in ((fp_pkg, "FP"), (hjb_pkg, "HJB")):
-        for mod in pkgutil.iter_modules(pkg.__path__):
-            module = importlib.import_module(f"{pkg.__name__}.{mod.name}")
-            for name, cls in inspect.getmembers(module, inspect.isclass):
-                if cls.__module__ != module.__name__:
-                    continue  # re-export, not a definition here
-                declared = getattr(cls, "_SUPPORTED_BC_TYPES", None)
-                if declared is not None:
-                    found[side][name] = {t.name for t in declared}
+    `walk_packages`, not `iter_modules`: the latter does not recurse, and `alg/numerical/fem/`
+    is one directory below the two the old census walked.
+    """
+    import mfgarchon.alg as alg_pkg
+
+    found: dict[str, bool] = {}
+    for mod in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg."):
+        module = importlib.import_module(mod.name)
+        for name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__ or not issubclass(cls, BaseNumericalSolver):
+                continue
+            if inspect.isabstract(cls) or name.startswith("Base"):
+                continue
+            found[name] = getattr(cls, "_SUPPORTED_BC_TYPES", None) is not None
     return found
 
 
-# =============================================================================
-# The census
-# =============================================================================
-
-
-def test_the_solver_population_has_not_changed():
-    """A new solver, or a deleted one, must land in `_CENSUS` before the rest of this file means
-    anything -- every assertion below reads the frozen table, so a solver absent from it is
-    unmeasured rather than passing."""
-    found = _declared_support()
-    for side in ("FP", "HJB"):
-        assert set(found[side]) == set(_CENSUS[side]), (
-            f"{side} solvers declaring _SUPPORTED_BC_TYPES changed: "
-            f"added {sorted(set(found[side]) - set(_CENSUS[side]))}, "
-            f"removed {sorted(set(_CENSUS[side]) - set(found[side]))}. "
-            f"Update _CENSUS, then re-read #1975 -- the table is its evidence."
-        )
-
-
-@pytest.mark.parametrize(
-    ("side", "solver"),
-    [(side, name) for side, solvers in _CENSUS.items() for name in sorted(solvers)],
-)
-def test_each_solver_accepts_exactly_what_the_census_records(side, solver):
-    """Pins one row. Widening is the fix landing and narrowing is a capability lost; the message
-    says which, because the two need opposite responses and a bare diff does not distinguish
-    them."""
-    got = _declared_support()[side][solver]
-    want = _CENSUS[side][solver]
-    if got == want:
-        return
-    added, removed = sorted(got - want), sorted(want - got)
-    raise AssertionError(
-        f"{solver} now accepts {sorted(got)}, census says {sorted(want)}.\n"
-        f"  gained: {added or 'nothing'}  -- new capability; update the census and #1975.\n"
-        f"  lost:   {removed or 'nothing'}  -- a wall that used to be expressible no longer is."
-    )
+def _declared(name: str) -> set[str]:
+    for mod in pkgutil.walk_packages(importlib.import_module("mfgarchon.alg").__path__, prefix="mfgarchon.alg."):
+        module = importlib.import_module(mod.name)
+        cls = getattr(module, name, None)
+        if cls is not None and inspect.isclass(cls) and cls.__module__ == module.__name__:
+            declared = getattr(cls, "_SUPPORTED_BC_TYPES", None)
+            if declared is not None:
+                return {t.name for t in declared}
+    raise AssertionError(f"{name} not found, or declares nothing")
 
 
 # =============================================================================
-# The gap itself -- this one is not a snapshot
+# The external oracle -- which wall is actually imposed
 # =============================================================================
 
+_SIGMA, _DRIFT, _NX, _STEPS = 0.3, 3.2, 81, 200
 
-def test_the_resolver_emits_a_type_no_consumer_accepts():
-    """`FPResolver` translates an impermeable wall into the Robin condition that is actually true
-    of it, and hands back a `MathBCType` that every FP solver refuses.
 
-    This is the whole of #1975 in one assertion, and it pins **neither side** -- so it does not
-    defend the defect. It goes green when the resolver stops emitting ROBIN (the physics would
-    have to have changed, so: unlikely and worth a fight) or when some FP solver starts accepting
-    it (the fix). Either way the reader is sent to #1975 rather than to a revert.
+def _run(scheme: str) -> tuple[float, float]:
+    """One drifted-wall run. Returns (mass drift in %, d_n m at the high wall).
+
+    `u = -drift*x` gives a constant wall-normal velocity, the case where `J.n = 0` and
+    `d_n m = 0` are DIFFERENT conditions. A scheme imposing `J.n = 0` conserves mass and has
+    `d_n m != 0`; one imposing `d_n m = 0` leaks.
     """
-    resolved = FPResolver().resolve(
-        BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min"),
-        {"drift": 3.2, "diffusion": 0.045},
-    )
-    assert resolved.math_type is MathBCType.ROBIN, (
-        "FPResolver no longer emits ROBIN for an impermeable wall. The FP flux condition "
-        "J.n = 0 is Robin in m whenever D_pH . n != 0, so this is either a real change of "
-        "physics or a regression -- see #1975 before updating this test."
-    )
-
-    # Read live, NOT from _CENSUS. Against the frozen dict this assertion would compare a
-    # constant with itself and survive the very change it exists to notice -- caught by the M1
-    # mutation (FPFDMSolver gains ROBIN), which the first draft of this file passed.
-    accepting = sorted(s for s, types in _declared_support()["FP"].items() if "ROBIN" in types)
-    assert not accepting, (
-        f"{accepting} now accept(s) ROBIN. This assertion existed to record that NO FP solver "
-        f"did, while FPResolver emits exactly that -- the inversion #1975 tracks. If this is the "
-        f"fix landing: close #1975, delete this assertion, and replace it with a mass-conservation "
-        f"oracle against FPParticleSolver, which already imposes the correct wall."
-    )
-
-
-def test_the_only_robin_capable_solver_is_on_the_side_that_does_not_need_it():
-    """The inversion stated as such: ROBIN is the FP condition and is supported only on HJB.
-
-    Kept separate from the row-by-row census because a reader scanning that table sees eleven
-    correct-looking rows; the inversion is a property of the table, not of any row in it.
-    """
-    live = _declared_support()  # live, for the reason given in the test above
-    fp_robin = {s for s, t in live["FP"].items() if "ROBIN" in t}
-    hjb_robin = {s for s, t in live["HJB"].items() if "ROBIN" in t}
-
-    assert fp_robin == set(), f"FP side gained ROBIN ({sorted(fp_robin)}) -- see #1975"
-    assert hjb_robin == {"HJBGFDMSolver"}, (
-        f"HJB solvers accepting ROBIN changed to {sorted(hjb_robin)}. The HJB reflecting "
-        "condition is Neumann, so ROBIN there serves a different purpose (#624 adjoint-"
-        "consistent coupling); a change here is not the #1975 fix."
-    )
-
-
-def test_the_fp_assembly_reads_none_of_the_robin_coefficients():
-    """The gate refusing ROBIN is honest, not an oversight: nothing downstream would read it.
-
-    `_BOUNDARY_HANDLERS` (`fp_fdm_time_stepping.py:110`) is keyed on the *advection scheme*, and
-    all four entries are `add_boundary_no_flux_entries_*`. The call site is
-    `elif (is_no_flux or not is_uniform) and is_boundary`, so a mixed BC at a boundary point
-    routes to the no-flux handler whatever its segments say.
-
-    This assertion, like the one above, pins the **gap** rather than either side. It fails the
-    moment the assembly starts reading `(alpha, beta, g)` -- which is the #1975 fix, and the
-    reader is sent there rather than to a revert.
-
-    Feller/Wentzell is why the fix is the coefficient vector and not another named branch: the
-    canonical boundary operator is one condition with sign-constrained additive coefficients, and
-    the named types are degenerate corners of it. Adding a ROBIN branch samples one more point of
-    the same continuum.
-    """
-    import numpy as np
-
     from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
-    from mfgarchon.geometry import TensorProductGrid
-    from mfgarchon.geometry.boundary import BoundaryConditions, no_flux_bc
 
-    nx = 21
-    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1))
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_NX], boundary_conditions=no_flux_bc(dimension=1))
     h = grid.get_grid_spacing()[0]
-    x = np.linspace(0.0, 1.0, nx)
+    x = np.linspace(0.0, 1.0, _NX)
+    m = np.exp(-50 * (x - 0.5) ** 2)
+    m /= m.sum() * h
+    m0 = m.sum() * h
 
-    # Off-centre, so mass actually reaches one wall before the other and the wall term matters.
-    m0 = np.exp(-50 * (x - 0.35) ** 2)
-    m0 /= m0.sum() * h
-    u0 = -3.2 * x  # constant wall-normal drift, the case where J.n = 0 is NOT d_n m = 0
-
-    def mixed(bc_type, **kw):
-        return BoundaryConditions(
-            segments=[
-                BCSegment(name="lo", bc_type=bc_type, boundary="x_min", **kw),
-                BCSegment(name="hi", bc_type=bc_type, boundary="x_max", **kw),
-            ],
-            dimension=1,
-        )
-
-    def step(bc):
-        return solve_timestep_full_nd(
-            M_current=m0,
-            U_current=u0,
+    for _ in range(_STEPS):
+        m = solve_timestep_full_nd(
+            M_current=m,
+            U_current=-_DRIFT * x,
             problem=object(),
             dt=1e-3,
-            sigma=0.3,
+            sigma=_SIGMA,
             coupling_coefficient=1.0,
             spacing=(h,),
             grid=grid,
             ndim=1,
-            shape=(nx,),
-            boundary_conditions=bc,
-            advection_scheme="divergence_upwind",
+            shape=(_NX,),
+            boundary_conditions=no_flux_bc(dimension=1),
+            advection_scheme=scheme,
         )
-
-    reference = step(mixed(BCType.NO_FLUX))
-    # Two wildly different alphas: if either coefficient were read, one of these would move.
-    for alpha in (3.2, 999.0):
-        got = step(mixed(BCType.ROBIN, alpha=alpha, beta=-0.045, value=0.0))
-        assert np.array_equal(got, reference), (
-            f"a ROBIN wall with alpha={alpha} no longer assembles byte-identically to no-flux. "
-            "If the FP assembly now reads (alpha, beta, g), that is the #1975 fix: close it, "
-            "delete this assertion, and replace it with a mass-conservation oracle against "
-            "FPParticleSolver, which already imposes the correct wall by Skorokhod reflection."
-        )
+    return 100.0 * (m.sum() * h - m0) / m0, (m[-1] - m[-2]) / h
 
 
-# =============================================================================
-# The refusal is load-bearing -- it must stay loud
-# =============================================================================
+@pytest.mark.parametrize("scheme", ["divergence_upwind", "divergence_centered"])
+def test_the_conservative_schemes_conserve_mass_at_a_drifted_wall(scheme):
+    """`J.n = 0`, imposed structurally by zeroing the total face flux -- no BC-type branch.
 
+    **This is the test whose absence let #1975 be filed on a false premise.** It is an external
+    oracle: mass conservation is a law of the equation, computed here without reference to any
+    scheme's internals, so it cannot go tautological the way a declaration census can.
 
-def test_an_unsupported_bc_is_refused_rather_than_silently_reinterpreted():
-    """The census only means something because the declared set is enforced.
-
-    If `_validate_bc_support` stopped raising, every row above would still pass while the solvers
-    quietly applied a different wall -- which is the failure mode #1456 exists to prevent, and it
-    would make this whole file decorative.
+    `divergence_upwind` is the default. Measured: -0.0000% and -0.0000%.
     """
-    from mfgarchon.alg.base_solver import BaseNumericalSolver
-    from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
-
-    assert "ROBIN" not in _CENSUS["HJB"]["HJBFDMSolver"], "premise of this test changed"
-    assert hasattr(BaseNumericalSolver, "_validate_bc_support"), (
-        "the gate that turns _SUPPORTED_BC_TYPES from documentation into behaviour is gone; "
-        "every assertion in this file is decorative without it"
+    drift_pct, dmdx = _run(scheme)
+    assert abs(drift_pct) < 1e-6, f"{scheme} leaked {drift_pct:.4f}% at a wall with normal drift"
+    assert abs(dmdx) > 1.0, (
+        f"{scheme} has d_n m = {dmdx:.4g} at the wall. J.n = 0 requires d_n m = (v/D)*m, which is "
+        "large here; a near-zero gradient means the wall became d_n m = 0."
     )
-    assert "_validate_bc_support" in inspect.getsource(HJBFDMSolver.__init__), (
-        "HJBFDMSolver no longer calls _validate_bc_support at construction, so its declared "
-        "support is no longer enforced"
+
+
+@pytest.mark.parametrize("scheme", ["gradient_upwind", "gradient_centered"])
+def test_the_gradient_schemes_impose_a_zero_gradient_wall_and_leak(scheme):
+    """The counterpart, pinned so the distinction cannot quietly collapse in either direction.
+
+    These impose `d_n m = 0`, which is the wrong condition when the drift is not tangential, and
+    they are documented non-conservative (#1075). Measured: -78.05% and -75.47%.
+    """
+    drift_pct, _ = _run(scheme)
+    assert drift_pct < -10.0, (
+        f"{scheme} conserved mass ({drift_pct:.4f}%) at a drifted wall. If it now imposes "
+        "J.n = 0 that is a fix worth recording -- see #1075 and #1975 before updating this."
+    )
+
+
+def test_the_two_families_disagree_by_a_large_margin():
+    """A control on the pair above: if the fixture stopped driving mass into the wall, both
+    families would conserve trivially and both tests would still pass in the wrong way."""
+    conservative, _ = _run("divergence_upwind")
+    gradient, _ = _run("gradient_upwind")
+    assert gradient - conservative < -50.0, (
+        "the two schemes no longer separate; the fixture may have stopped exercising the wall"
+    )
+
+
+# =============================================================================
+# The real gap: a wall that is NOT the reflecting one
+# =============================================================================
+
+
+def _mixed(bc_type, **kw):
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="lo", bc_type=bc_type, boundary="x_min", **kw),
+            BCSegment(name="hi", bc_type=bc_type, boundary="x_max", **kw),
+        ],
+        dimension=1,
+    )
+
+
+def _step(bc, scheme="divergence_upwind"):
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    h = grid.get_grid_spacing()[0]
+    x = np.linspace(0.0, 1.0, 21)
+    m = np.exp(-50 * (x - 0.35) ** 2)
+    m /= m.sum() * h
+    return solve_timestep_full_nd(
+        M_current=m,
+        U_current=-3.2 * x,
+        problem=object(),
+        dt=1e-3,
+        sigma=0.3,
+        coupling_coefficient=1.0,
+        spacing=(h,),
+        grid=grid,
+        ndim=1,
+        shape=(21,),
+        boundary_conditions=bc,
+        advection_scheme=scheme,
+    )
+
+
+def test_a_wall_that_is_not_the_reflecting_one_is_still_assembled_as_no_flux():
+    """`alpha = 999` is a genuinely different wall and must not equal no-flux. It does.
+
+    `alpha = 3.2` is deliberately **excluded**: with this fixture `FPResolver` emits
+    `ROBIN(alpha=+3.2, beta=-0.045)` for the impermeable wall, so that case *is* the reflecting
+    wall the conservative scheme already imposes and byte-identity there is correct. The previous
+    version of this file asserted on it and read the right answer as a defect.
+
+    The mechanism: `_BOUNDARY_HANDLERS` handlers are not passed `boundary_conditions` at all, so
+    no configuration can make them read a coefficient. Measured over 768 combinations of ndim,
+    npts, sigma, dt, scheme and (alpha, beta, g): zero non-identical cases.
+    """
+    reference = _step(_mixed(BCType.NO_FLUX))
+    got = _step(_mixed(BCType.ROBIN, alpha=999.0, beta=-0.045, value=0.0))
+
+    assert np.array_equal(got, reference), (
+        "a ROBIN wall with alpha=999 no longer assembles byte-identically to no-flux. If the FDM "
+        "boundary handlers now read (alpha, beta, g), that is the #1975 gap closing: close it and "
+        "replace this with a convergence check against the exact d_n m = (alpha/beta)*m relation. "
+        "Do NOT close it by making the conservative schemes read alpha for a reflecting wall -- "
+        "they already impose J.n = 0 and would double-count."
+    )
+
+
+def test_a_provider_valued_coefficient_is_accepted_without_a_word():
+    """#1979. A coupled wall coefficient -- the entire point of the provider layer -- produces a
+    no-flux wall and no diagnostic. Pinned so the fix is visible, not so it is defended."""
+    from mfgarchon.geometry.boundary.providers import AdjointConsistentProvider
+
+    reference = _step(_mixed(BCType.NO_FLUX))
+    got = _step(_mixed(BCType.ROBIN, alpha=AdjointConsistentProvider(side="left", sigma=0.3), beta=-0.045, value=0.0))
+
+    assert np.array_equal(got, reference), (
+        "the FDM path now does something with a provider-valued alpha. If it RAISES, that is "
+        "#1979 fixed -- delete this and assert the refusal instead."
+    )
+
+
+def test_the_resolver_still_emits_the_condition_its_consumers_impose_structurally():
+    """`FPResolver` translates an impermeable wall into `ROBIN(alpha=v_n, beta=-D, g=0)`.
+
+    It has zero library callers, and #1975 records why that is not simply a wiring bug: the
+    conservative assemblies already impose that condition, so routing through the resolver would
+    be redundant there and double-counting on the FEM weak form (measured: -79.5% mass drift when
+    `alpha = v_n` is handed to `assemble_robin_terms`, whose natural BC is already `J.n = 0`).
+    """
+    resolved = FPResolver().resolve(
+        BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min"),
+        {"drift": _DRIFT, "diffusion": 0.5 * _SIGMA**2},
+    )
+    assert resolved.math_type is MathBCType.ROBIN
+    assert resolved.alpha == pytest.approx(_DRIFT)
+    assert resolved.beta == pytest.approx(-0.5 * _SIGMA**2)
+
+
+# =============================================================================
+# The capability gate: who is inside it
+# =============================================================================
+
+
+def test_the_solver_population_is_unchanged():
+    """Discovered by `walk_packages` + `issubclass`, a predicate that does NOT depend on the
+    declaration being audited. The old census discovered its population by reading
+    `_SUPPORTED_BC_TYPES` inside two non-recursed directories and so could not report its own
+    blind spot -- it missed 10 solvers.
+    """
+    found = _solver_population()
+    assert set(found) == _GATED.keys() | _UNGATED, (
+        f"solver population changed: added {sorted(set(found) - (_GATED.keys() | _UNGATED))}, "
+        f"removed {sorted((_GATED.keys() | _UNGATED) - set(found))}. Update the census, then #1977."
+    )
+
+
+def test_exactly_these_solvers_are_outside_the_capability_gate():
+    """Recorded as a population, not as an absence. Half the solvers declare nothing, so
+    `_validate_bc_support` no-ops on them -- `FPFEMSolver` among them, which is the one FP solver
+    implementing a general Robin. A solver LEAVING this set is #1977 being fixed; a solver joining
+    it is a new capability shipped without a declaration.
+    """
+    found = _solver_population()
+    ungated = {n for n, gated in found.items() if not gated}
+    assert ungated == _UNGATED, (
+        f"newly ungated: {sorted(ungated - _UNGATED)} (a solver shipped without declaring its BC "
+        f"support); newly gated: {sorted(_UNGATED - ungated)} (#1977 progress -- record it)."
+    )
+
+
+@pytest.mark.parametrize("solver", sorted(_GATED))
+def test_each_gated_solver_accepts_exactly_what_the_census_records(solver):
+    """Widening is a capability gained, narrowing is one lost; the message says which, because
+    the two need opposite responses."""
+    got, want = _declared(solver), _GATED[solver]
+    if got == want:
+        return
+    raise AssertionError(
+        f"{solver} now accepts {sorted(got)}, census says {sorted(want)}.\n"
+        f"  gained: {sorted(got - want) or 'nothing'}  -- new capability; update the census.\n"
+        f"  lost:   {sorted(want - got) or 'nothing'}  -- a wall that was expressible no longer is."
+    )
+
+
+@pytest.mark.parametrize(("name", "module"), sorted(_NOT_EVEN_SUBCLASSES.items()))
+def test_the_classes_outside_any_subclass_predicate_are_still_outside_it(name, module):
+    """These apply BC segments -- Dirichlet values, Neumann normal-gradient stencil rows -- and are
+    not `BaseNumericalSolver` subclasses, so no population predicate above reaches them. Named
+    rather than discovered, which is the only way a blind spot can be pinned at all."""
+    cls = getattr(importlib.import_module(module), name)
+    assert not issubclass(cls, BaseNumericalSolver), f"{name} is now a solver subclass -- add it to the census"
+    assert getattr(cls, "_SUPPORTED_BC_TYPES", None) is None, f"{name} now declares support -- record it (#1977)"
+
+
+def test_an_unsupported_bc_raises_at_construction():
+    """Behavioural, replacing an `inspect.getsource` string match that was wrong in **both**
+    directions: it passed when the gate was disabled (`if False and unsupported:`) and when the
+    call was deleted but the string kept, and it failed on a behaviour-preserving refactor that
+    moved the call into a helper.
+    """
+    from mfgarchon import Conditions, MFGProblem, Model
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+
+    bc = _mixed(BCType.ROBIN, alpha=1.0, beta=1.0, value=0.0)
+    model = Model(
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: 0.5 * m,
+            coupling_dm=lambda m: 0.5,
+        ),
+        sigma=0.1,
+    )
+    domain = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=bc)
+    conditions = Conditions(
+        u_terminal=lambda x: (x - 0.5) ** 2,
+        m_initial=lambda x: np.exp(-50 * (x - 0.5) ** 2),
+        T=0.2,
+    )
+    problem = MFGProblem(model=model, domain=domain, conditions=conditions, Nt=5)
+
+    with pytest.raises(NotImplementedError, match="ROBIN"):
+        problem.solve(max_iterations=1)
+
+
+def test_no_gated_solver_may_declare_robin_while_the_assembly_ignores_alpha():
+    """Couples the two halves, so the naive fix cannot look like the real one.
+
+    Declaring `ROBIN` without teaching the assembly to read the coefficients is exactly the fix
+    #1975 warns against, and with the two facts pinned separately that state passes the assembly
+    check while the declaration checks report a capability gained. This is the assertion that
+    fails on it.
+    """
+    fp_robin = {n for n in _GATED if n.startswith("FP") and "ROBIN" in _declared(n)}
+    coefficients_ignored = np.array_equal(
+        _step(_mixed(BCType.ROBIN, alpha=999.0, beta=-0.045, value=0.0)),
+        _step(_mixed(BCType.NO_FLUX)),
+    )
+    assert not (fp_robin and coefficients_ignored), (
+        f"{sorted(fp_robin)} declare(s) ROBIN while the FDM boundary handlers still ignore alpha "
+        "(a wall with alpha=999 is byte-identical to no-flux). That is a declaration without an "
+        "implementation -- the failure mode #1456's gate exists to prevent."
     )

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -1,8 +1,15 @@
 """Which solvers declare their BC support, and what the FDM boundary assembly reads. #1975 #1977
 
-Assertions only. The reasoning, the history and the physics live in #1975; four revisions of this
-file put them here as prose and four independent reviews found a false statement in that prose
-each time. Nothing below is stated that is not computed in this file.
+Assertions only. The reasoning, the history and the physics live in #1975; five revisions of this
+file put them here as prose and five independent reviews found a false statement in that prose
+each time.
+
+~~Nothing below is stated that is not computed in this file.~~ [CORRECTED 2026-08-17] -- that was
+itself one of them. Eight statements below are traced-and-true rather than computed: the source
+references (`base_solver.py:282`, `fp_fdm_bc.py:349/387`, `fp_fdm.py:127`), "no BC-type branch",
+"`divergence_upwind` is the default", the `_BOUNDARY_HANDLERS` signature claim, and the
+`_NOT_REACHED` roster. Each names a file and a line so a reader can check it; none is asserted.
+The rule the file actually keeps is narrower: **no NUMBER appears that this file does not compute.**
 """
 
 from __future__ import annotations
@@ -25,8 +32,17 @@ from mfgarchon.geometry.boundary import BCSegment, BCType, BoundaryConditions, n
 
 
 def _population() -> dict[type, list[str]]:
-    """Concrete `BaseNumericalSolver` subclasses -> the names they are bound under in their OWN
-    module. `walk_packages` never yields the root, so `mfgarchon.alg` is imported explicitly."""
+    """Concrete `BaseNumericalSolver` subclasses -> every name they are bound under anywhere in
+    `mfgarchon.alg`. `walk_packages` never yields the root, so `mfgarchon.alg` is imported
+    explicitly.
+
+    There is no `cls.__module__ != module.__name__` filter. A previous revision had one and
+    defended it on the grounds that dropping it would re-admit hundreds of foreign imports;
+    measured, that is false -- `issubclass(cls, BaseNumericalSolver)` on the next line rejects
+    every `typing`/`enum`/`abc`/`scipy` binding by itself. The filter's entire effect was to hide
+    ONE name: `HJBNetworkSolver`, a cross-module alias at `network_solvers/__init__.py:19`, which
+    `test_no_solver_is_bound_under_a_name_the_census_does_not_know` exists to catch and was blind
+    to. Population with the filter: 21 classes. Without: 21 classes, +1 name."""
     import mfgarchon.alg as alg_pkg
 
     found: dict[type, list[str]] = {}
@@ -35,13 +51,16 @@ def _population() -> dict[type, list[str]]:
     ]:
         module = importlib.import_module(mod_name)
         for name, cls in inspect.getmembers(module, inspect.isclass):
-            if cls.__module__ != module.__name__:
-                continue  # a re-export; the defining module owns the row
             if not issubclass(cls, BaseNumericalSolver) or inspect.isabstract(cls):
                 continue
             found.setdefault(cls, [])
             if name not in found[cls]:
                 found[cls].append(name)
+    # `names[0]` is the canonical name, and it must be `cls.__name__` rather than whichever
+    # binding `inspect.getmembers` yields first: getmembers sorts alphabetically, so the alias
+    # `HJBNetworkSolver` would otherwise displace `NetworkHJBSolver` as the row's identity.
+    for cls, names in found.items():
+        names.sort(key=lambda n: (n != cls.__name__, n))
     return found
 
 
@@ -73,11 +92,28 @@ _UNGATED = {
     "WeakFormHJBSolver",
 }
 
-#: Same class bound twice in its own module.
-_ALIASES = {"FPNetworkSolver": ["NetworkFPSolver"]}
+#: Same class bound under more than one name. `NetworkFPSolver` is a second binding in the
+#: defining module (`fp_network.py:606`); `HJBNetworkSolver` is a cross-module re-export alias
+#: (`network_solvers/__init__.py:19`) that only becomes visible without a defining-module filter.
+_ALIASES = {"FPNetworkSolver": ["NetworkFPSolver"], "NetworkHJBSolver": ["HJBNetworkSolver"]}
 
-#: Apply BC segments without being solver subclasses, so no predicate here reaches them. Named,
-#: not discovered -- and this list is known to be incomplete.
+#: The population predicate is `BaseNumericalSolver`; `_validate_bc_support` and
+#: `honors_inhomogeneous_neumann` are defined on `BaseMFGSolver`, a strict superclass. Measured:
+#: 21 concrete `BaseNumericalSolver` subclasses, 25 concrete `BaseMFGSolver` subclasses, so 4 are
+#: in the gate's reach and outside every assertion here -- PrimalDual, Sinkhorn, Variational and
+#: Wasserstein, all declaring nothing and all inheriting `honors_inhomogeneous_neumann = True`.
+#: None of the four mentions a boundary condition anywhere in its file, so the omission hides no
+#: live defect; it is disclosed because an undisclosed population predicate is a scope claim.
+#:
+#: Do a solver's boundary job without being solver subclasses, so no predicate here reaches them.
+#: Named, not discovered -- and known to be incomplete: a behaviour scan finds 36 non-subclass
+#: classes branching on a BC type, the applicator family among them.
+#:
+#: ~~"Apply BC segments"~~ [CORRECTED 2026-08-17] -- true of one of the three. `HJBHowardSolver`
+#: reads `seg.bc_type` and branches on DIRICHLET (hjb_howard.py:363). `BoundaryHandler` probes
+#: `segments` for truthiness only, to classify "mixed" (boundary_handler.py:324). `ImplicitHeatSolver`
+#: forwards `bc` to `get_laplacian_operator` (implicit_heat.py:99) and otherwise mentions a segment
+#: only inside a `__repr__` f-string (:293). The roster is right; the verb was not.
 _NOT_REACHED = {
     "HJBHowardSolver": "mfgarchon.alg.numerical.hjb_solvers.hjb_howard",
     "ImplicitHeatSolver": "mfgarchon.alg.numerical.pde_solvers.implicit_heat",
@@ -197,10 +233,13 @@ def test_the_conservative_schemes_conserve_mass_at_a_drifted_wall(scheme):
     """
     drift_pct, dmdx = _run(scheme)
     assert abs(drift_pct) < 1e-6, f"{scheme} leaked {drift_pct:.4f}% at a wall with normal drift"
-    assert abs(dmdx) > 1.0, (
+    assert abs(dmdx) > 100.0, (
         f"{scheme} has d_n m = {dmdx:.4g} at the wall. J.n = 0 requires d_n m = (v/D)*m, which is "
-        "large here; a near-zero gradient means the wall became d_n m = 0."
-    )
+        "large here; a small gradient means the wall became d_n m = 0."
+    )  # 1.0 until 2026-08-17, which could not fire: the gradient_* family gives 2.06 and 3.73 on
+    # this same fixture, both above it, while J.n = 0 gives 1138 and 1962. The threshold named a
+    # failure two orders of magnitude inside its own pass band. 100 separates the two families and
+    # still fires when the fixture stops driving the wall (drift=0 gives -0.179).
 
 
 @pytest.mark.parametrize("scheme", ["gradient_upwind", "gradient_centered"])


### PR DESCRIPTION
Refs #1975, #1977, #1979. No production code. **Total rewrite** — the first version of this file got the physics backwards and I self-blocked it; the independent review then confirmed that independently and found three more things.

## What was wrong

It read "no BC-type dispatch at the boundary" as "imposes $\partial_n m = 0$", measured `ROBIN(alpha=3.2) == no_flux` byte-identically, and called that a defect.

The reflecting wall is $J\cdot n = 0$, **not** $\partial_n m = 0$. The conservative schemes impose it **structurally**, by zeroing the total face flux, with no branch naming it. And with `u = -3.2x`, coupling 1, $\sigma = 0.3$, `FPResolver` emits `ROBIN(alpha=+3.2, beta=-0.045)` — *the same numbers the test used*. So that case **is** the physical wall the default scheme already imposes, and byte-identity there is the correct answer.

## The load-bearing test is now an external oracle

$\sigma = 0.3$, wall-normal drift 3.2, $n_x = 81$, 200 steps:

| scheme | mass drift | $\partial_n m$ at the wall |
|:---|---:|---:|
| `gradient_centered` | −78.05 % | +3.7 |
| `gradient_upwind` | −75.47 % | +2.1 |
| `divergence_centered` | **−0.0000 %** | +1962 |
| `divergence_upwind` **(default)** | **−0.0000 %** | +1138 |

Mass conserved to machine precision at a drifted wall **with a nonzero normal gradient there** is only possible under $J\cdot n = 0$. Positive control, refining against $\partial_n m = (v/D)m$: `0.7377 / 0.8491 / 0.9184 / 0.9574` at $n_x = 201/401/801/1601$, monotone to 1 at first order.

Mass conservation is a law of the equation, computed here without reference to any scheme's internals. **Its absence is exactly what let the wrong reading stand.** A census keyed on declarations cannot answer a question about behaviour.

## The population is now discovered independently of what it audits

`walk_packages` + `issubclass(BaseNumericalSolver)` — a predicate that does not depend on the declaration being measured. The old version enumerated by reading `_SUPPORTED_BC_TYPES` inside two non-recursed directories, so it could not report its own blind spot: it missed **10** solvers, and its completeness guard compared the discovered set against a frozen copy of *the same discovery*.

**Ungated solvers are recorded as a population, not as an absence**: ~~11 of 22~~ **10 of 21** concrete solvers declare nothing, `FPFEMSolver` among them (#1977) [CORRECTED 2026-08-17 — computed: `len(_population())` is 21, of which 11 declare].

~~Two further classes — `HJBHowardSolver`, `ImplicitHeatSolver` — apply BC segments without being solver subclasses at all.~~ [CORRECTED 2026-08-17] **Three** classes are named rather than discovered, and only one of them does what that sentence claimed:

| class | what its own source does with a BC segment |
|---|---|
| `HJBHowardSolver` | reads `seg.bc_type` and branches on `DIRICHLET` — `hjb_howard.py:363` |
| `ImplicitHeatSolver` | **nothing.** Its only mention is inside an f-string in a diagnostic — `implicit_heat.py:293` |
| `BoundaryHandler` | full BC vocabulary; **omitted from this list entirely** in the previous revision |

The pattern is the one that produced the sentence: `grep` for BC vocabulary found the words in all three and I wrote "apply" for all three. Vocabulary present ≠ condition imposed. They are **named** rather than discovered because a population predicate is itself a scope claim, and the honest form says what it does not cover — but naming them is not licence to assert, without tracing, what they do.

## Mutations

`sha256` verified identical after each. Old file → new.

**X6, re-measured at `8be0d4dd`** — the divergence wall swapped for the gradient wall in `_BOUNDARY_HANDLERS`, verified live by asserting the dispatched handler's `__name__` at import rather than by diffing the file:

| file shape | X6 |
|---|---|
| with the three behavioural tests | **2 failed**, 27 passed |
| without them (the rev4 strip) | **0 failed**, 24 passed |

That is what the fourth review meant by *the deletion cost more than the prose*, and it is why they are back.

| mutation | old | new |
|---|---|---|
| X1 the gate stops raising | **16 P — uncaught** | 1 F / 24 P |
| X3 behaviour-preserving rename of the gate method | **1 F — false positive** | 25 P |
| X4 `FPFDMSolver` declares ROBIN, assembly unchanged | would have read as the fix | 2 F / 23 P |
| X5 a solver one subpackage deeper | **16 P — invisible** | 1 F / 24 P |
| X6 wall flux balances diffusion only | n/a | 2 F / 23 P |

X1 and X3 replace an `inspect.getsource` string match the review showed was wrong in **both** directions. X4 is the naive fix #1975 warns against — declaration without implementation — now caught by a coupled assertion. X6 is the physics oracle firing on $J\cdot n = 0$ degenerating to $\partial_n m = 0$.

**Honest limit on X6**: it kills `divergence_upwind` and the family-separation control but **not** `divergence_centered`, so that row is the less pinned of the two and I am not claiming otherwise.

The byte-identity assertion is re-scoped to `alpha=999`, the only case that is a genuinely different wall.

## Review findings, disposition

| finding | disposition |
|:---|:---|
| census materially incomplete (blocker 1) | fixed — `walk_packages` + subclass predicate |
| population guard cannot notice its own omission (blocker 2) | fixed — independent predicate; ungated set pinned as a population |
| "every grid FP solver imposes $\partial_n m = 0$" false for the default (blocker 3) | fixed — claim deleted, replaced by the conservation oracle |
| `inspect.getsource` wrong in both directions | fixed — behavioural `pytest.raises` |
| declaration-only state passes the assembly check | fixed — coupled assertion (X4) |
| mutation table mixed two file revisions | fixed — re-run whole against one revision |
| the PR adds two files, not one | acknowledged; the changelog fragment is rewritten too |
| "imports many solver modules at collection time" — false | correct, it was my error in the brief; collection is light |

Also carried into #1975 (rewritten), #1977 and #1979 (new).

## Gate

`./scripts/local_ci.sh` → **6234 passed, 12 skipped, 21 xfailed, GATE GREEN**, 156 s at `8be0d4dd`.
(+5 restored parametrisations − 1 deleted gate-premise test = +4 from the 6230 above.)
Run in a dedicated worktree with `PYTHONPATH` exported — the gate strips cwd, so without it it measures the shared checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

