### PR TITLE
docs(fp): correct three declarations that said FP-FDM supports Robin (#1975)

### DIFF
--- a/changelog.d/1975-false-robin-declarations.fixed.md
+++ b/changelog.d/1975-false-robin-declarations.fixed.md
@@ -1,7 +1,7 @@
 Three shipped declarations said the FP-FDM path supports Robin. It does not: the boundary handlers
 are not passed `boundary_conditions` at all, so a ROBIN segment assembles byte-identically to
 no-flux (measured at alpha=3.2 and alpha=999 across 768 configurations). Corrected
-`solve_fp_system_1d`'s deprecation docstring, the legacy-BC diagnostic that recommended `robin_bc`
+`FPFDMSolver._solve_fp_1d`'s deprecation docstring, the legacy-BC diagnostic that recommended `robin_bc`
 on a path that cannot assemble it, and `robin_bc`'s own docstring.
 
 `robin_bc` now also says what none of the three said and what matters most in practice: **you do
@@ -9,5 +9,5 @@ not need a ROBIN segment for a reflecting wall.** The conservative schemes -- `d
 (the default) and `divergence_centered` -- impose `J.n = 0` structurally by zeroing the total face
 flux, conserving mass to machine precision at a wall with wall-normal drift; the `gradient_*`
 family imposes `d_n m = 0` instead and loses 75-78% (non-conservative by design, #1075). Handing
-the FEM path `alpha = v_n` explicitly double-counts the same term. Reach for `robin_bc` only for a
+adding a Robin segment on top of it destroys that wall: `A_robin` contributes a residual outflux `J.n = D*(alpha/beta)*m`, so the implied wall is `D d_n m = (v_n - D*alpha/beta) m`. Reach for `robin_bc` only for a
 wall that is not the reflecting one. (#1975)

--- a/changelog.d/1975-false-robin-declarations.fixed.md
+++ b/changelog.d/1975-false-robin-declarations.fixed.md
@@ -1,13 +1,22 @@
 Three shipped declarations said the FP-FDM path supports Robin. It does not: the boundary handlers
 are not passed `boundary_conditions` at all, so a ROBIN segment assembles byte-identically to
-no-flux (measured at alpha=3.2 and alpha=999 across 768 configurations). Corrected
-`FPFDMSolver._solve_fp_1d`'s deprecation docstring, the legacy-BC diagnostic that recommended `robin_bc`
-on a path that cannot assemble it, and `robin_bc`'s own docstring.
+no-flux. Corrected `FPFDMSolver._solve_fp_1d`'s deprecation docstring, the legacy-BC diagnostic
+that recommended `robin_bc` on a path that cannot assemble it, and `robin_bc`'s own docstring.
 
-`robin_bc` now also says what none of the three said and what matters most in practice: **you do
-not need a ROBIN segment for a reflecting wall.** The conservative schemes -- `divergence_upwind`
-(the default) and `divergence_centered` -- impose `J.n = 0` structurally by zeroing the total face
-flux, conserving mass to machine precision at a wall with wall-normal drift; the `gradient_*`
-family imposes `d_n m = 0` instead and loses 75-78% (non-conservative by design, #1075). Handing
-adding a Robin segment on top of it destroys that wall: `A_robin` contributes a residual outflux `J.n = D*(alpha/beta)*m`, so the implied wall is `D d_n m = (v_n - D*alpha/beta) m`. Reach for `robin_bc` only for a
-wall that is not the reflecting one. (#1975)
+That byte-identity is reachable only **below** the `_validate_bc_support` gate, which refuses every
+ROBIN segment at construction -- uniform and mixed alike -- so it is a property of the assembly
+rather than something a caller reaches through the API.
+
+`robin_bc` now says what none of the three said and what matters most in practice: **you do not
+need a ROBIN segment for a reflecting wall.** The conservative schemes -- `divergence_upwind` (the
+default) and `divergence_centered` -- impose `J.n = 0` structurally by zeroing the total face flux,
+conserving mass to machine precision at a wall with wall-normal drift. The `gradient_*` family
+imposes `d_n m = 0` exactly, at every T and Nx measured, and therefore loses essentially all the
+mass: -78.05% at T = 0.20, -98.98% at 0.30, -99.996% by 0.50 (sigma = 0.3, Nx = 81, drift 3.2).
+The percentage is a function of T and is now quoted with one; the mechanism behind it is not.
+
+Adding a Robin segment on top of the conservative wall **destroys** it rather than restating it:
+`A_robin` contributes a residual outflux `J.n = D*(alpha/beta)*m`, so the implied wall is
+`D d_n m = (v_n - D*alpha/beta) m`. The reflecting condition's own coefficients
+`(alpha, beta) = (v_n, D)` give `D*alpha/beta = v_n` and hence `d_n m = 0` -- the non-conservative
+wall -- so encoding the condition as a `robin_bc` lands on exactly what it warns against. (#1975)

--- a/changelog.d/1975-false-robin-declarations.fixed.md
+++ b/changelog.d/1975-false-robin-declarations.fixed.md
@@ -1,7 +1,13 @@
-Three shipped declarations said the FP-FDM path supports Robin. It does not: `_BOUNDARY_HANDLERS`
-is keyed on the advection scheme, all four entries are `add_boundary_no_flux_entries_*`, and a
-ROBIN segment assembles byte-identically to no-flux (measured at alpha=3.2 and alpha=999). Corrected
+Three shipped declarations said the FP-FDM path supports Robin. It does not: the boundary handlers
+are not passed `boundary_conditions` at all, so a ROBIN segment assembles byte-identically to
+no-flux (measured at alpha=3.2 and alpha=999 across 768 configurations). Corrected
 `solve_fp_system_1d`'s deprecation docstring, the legacy-BC diagnostic that recommended `robin_bc`
-on a path that cannot assemble it, and `robin_bc`'s own docstring — which now states which solvers
-do honour a Robin wall (`FPFEMSolver` / `HJBFEMSolver` in weak form, `HJBGFDMSolver` for the
-adjoint-consistent case) and which refuse it. (#1975)
+on a path that cannot assemble it, and `robin_bc`'s own docstring.
+
+`robin_bc` now also says what none of the three said and what matters most in practice: **you do
+not need a ROBIN segment for a reflecting wall.** The conservative schemes -- `divergence_upwind`
+(the default) and `divergence_centered` -- impose `J.n = 0` structurally by zeroing the total face
+flux, conserving mass to machine precision at a wall with wall-normal drift; the `gradient_*`
+family imposes `d_n m = 0` instead and loses 75-78% (non-conservative by design, #1075). Handing
+the FEM path `alpha = v_n` explicitly double-counts the same term. Reach for `robin_bc` only for a
+wall that is not the reflecting one. (#1975)

--- a/changelog.d/1975-false-robin-declarations.fixed.md
+++ b/changelog.d/1975-false-robin-declarations.fixed.md
@@ -1,0 +1,7 @@
+Three shipped declarations said the FP-FDM path supports Robin. It does not: `_BOUNDARY_HANDLERS`
+is keyed on the advection scheme, all four entries are `add_boundary_no_flux_entries_*`, and a
+ROBIN segment assembles byte-identically to no-flux (measured at alpha=3.2 and alpha=999). Corrected
+`solve_fp_system_1d`'s deprecation docstring, the legacy-BC diagnostic that recommended `robin_bc`
+on a path that cannot assemble it, and `robin_bc`'s own docstring — which now states which solvers
+do honour a Robin wall (`FPFEMSolver` / `HJBFEMSolver` in weak form, `HJBGFDMSolver` for the
+adjoint-consistent case) and which refuse it. (#1975)

--- a/changelog.d/1975-false-robin-declarations.fixed.md
+++ b/changelog.d/1975-false-robin-declarations.fixed.md
@@ -12,11 +12,16 @@ need a ROBIN segment for a reflecting wall.** The conservative schemes -- `diver
 default) and `divergence_centered` -- impose `J.n = 0` structurally by zeroing the total face flux,
 conserving mass to machine precision at a wall with wall-normal drift. The `gradient_*` family
 imposes `d_n m = 0` exactly, at every T and Nx measured, and therefore loses essentially all the
-mass: -78.05% at T = 0.20, -98.98% at 0.30, -99.996% by 0.50 (sigma = 0.3, Nx = 81, drift 3.2).
-The percentage is a function of T and is now quoted with one; the mechanism behind it is not.
+mass: about -78% at T = 0.20, -99% at 0.30, -99.99% by 0.50 (sigma = 0.3, 81 points on [0,1],
+dt = 1e-3, Gaussian initial density centred at 0.5, drift 3.2). The percentage is a function of T
+and of the initial condition, so it is quoted to the precision the stated configuration supports;
+the `d_n m = 0` mechanism behind it is not T-dependent.
 
 Adding a Robin segment on top of the conservative wall **destroys** it rather than restating it:
 `A_robin` contributes a residual outflux `J.n = D*(alpha/beta)*m`, so the implied wall is
-`D d_n m = (v_n - D*alpha/beta) m`. The reflecting condition's own coefficients
-`(alpha, beta) = (v_n, D)` give `D*alpha/beta = v_n` and hence `d_n m = 0` -- the non-conservative
-wall -- so encoding the condition as a `robin_bc` lands on exactly what it warns against. (#1975)
+`D d_n m = (v_n - D*alpha/beta) m`. The reflecting condition's own coefficients are
+`(alpha, beta) = (D_pH.n, D)`, and since this library's FP velocity is `v = -D_pH`, that is
+`alpha = -v_n` -- verified by residual on the structurally reflecting solution rather than by
+substitution. So `D*alpha/beta = -v_n`, the row that DOUBLES: encoding the reflecting condition as
+a Robin segment on a wall that already imposes it is unbounded (+1.7e31% measured), not merely
+leaky. (#1975)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -799,7 +799,15 @@ class FPFDMSolver(BaseFPSolver):
 
             The unified nD solver provides:
             - Consistent behavior across all dimensions
-            - Full BC support (no_flux, neumann, robin, periodic, dirichlet)
+            - ~~Full BC support (no_flux, neumann, robin, periodic, dirichlet)~~
+              [CORRECTED 2026-08-16, #1975] It assembles no-flux, homogeneous Neumann
+              (identical to no-flux for FP), Dirichlet and periodic. **Not Robin**, and not
+              an inhomogeneous Neumann (#1686). `_BOUNDARY_HANDLERS` is keyed on the
+              advection scheme and all four entries are `add_boundary_no_flux_entries_*`,
+              so a ROBIN segment assembles byte-identically to no-flux -- measured at
+              alpha=3.2 and alpha=999, max|difference| = 0. `_SUPPORTED_BC_TYPES` refuses
+              ROBIN for that reason and the refusal is load-bearing. A Robin wall needs
+              `FPFEMSolver`, which assembles it in weak form and does read the coefficients.
             - Cleaner codebase with less code path branching
         """
         # Use geometry-based interface (geometry is always available)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -805,7 +805,9 @@ class FPFDMSolver(BaseFPSolver):
               an inhomogeneous Neumann (#1686). `_BOUNDARY_HANDLERS` is keyed on the
               advection scheme and all four entries are `add_boundary_no_flux_entries_*`,
               so a ROBIN segment assembles byte-identically to no-flux -- measured at
-              alpha=3.2 and alpha=999, max|difference| = 0. `_SUPPORTED_BC_TYPES` refuses
+              alpha=3.2 and alpha=999, max|difference| = 0 -- reachable only BELOW the
+              `_validate_bc_support` gate, which refuses every ROBIN segment at construction.
+              `_SUPPORTED_BC_TYPES` refuses
               ROBIN for that reason and the refusal is load-bearing. A *general* Robin wall
               needs `FPFEMSolver`, which assembles it in weak form and reads the coefficients.
               The **reflecting** wall is a different matter and does not need a ROBIN segment

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -806,8 +806,14 @@ class FPFDMSolver(BaseFPSolver):
               advection scheme and all four entries are `add_boundary_no_flux_entries_*`,
               so a ROBIN segment assembles byte-identically to no-flux -- measured at
               alpha=3.2 and alpha=999, max|difference| = 0. `_SUPPORTED_BC_TYPES` refuses
-              ROBIN for that reason and the refusal is load-bearing. A Robin wall needs
-              `FPFEMSolver`, which assembles it in weak form and does read the coefficients.
+              ROBIN for that reason and the refusal is load-bearing. A *general* Robin wall
+              needs `FPFEMSolver`, which assembles it in weak form and reads the coefficients.
+              The **reflecting** wall is a different matter and does not need a ROBIN segment
+              at all: the conservative schemes (`divergence_upwind`, the default, and
+              `divergence_centered`) impose `J.n = 0` structurally by zeroing the total face
+              flux -- mass conserved to machine precision at a wall with wall-normal drift,
+              with `d_n m` nonzero there. The `gradient_*` family imposes `d_n m = 0` instead
+              and is non-conservative (#1075). See #1975.
             - Cleaner codebase with less code path branching
         """
         # Use geometry-based interface (geometry is always available)

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -1321,8 +1321,9 @@ def solve_timestep_full_nd(
                     f"mfgarchon.geometry.boundary (periodic_bc / dirichlet_bc / no_flux_bc) "
                     f"with the modern BoundaryConditions instead (Issue #1559). robin_bc is NOT in "
                     f"that list on purpose: this assembly reads none of a ROBIN segment's "
-                    f"coefficients, so it would be a no-flux wall wearing a label. A Robin wall "
-                    f"needs FPFEMSolver, which assembles it in weak form (Issue #1975)."
+                    f"coefficients, so it would be a no-flux wall wearing a label. For a "
+                    f"reflecting wall you want no_flux_bc on a conservative scheme, which imposes "
+                    f"J.n = 0 structurally; a GENERAL Robin needs FPFEMSolver (Issue #1975)."
                 ) from None
             is_no_flux = True
             is_uniform = False

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -1306,13 +1306,23 @@ def solve_timestep_full_nd(
             # NO wrap here -- it is byte-identical to legacy no_flux and differs from canonical
             # periodic_bc by O(1) once mass reaches the wall (verified with an off-center bump).
             # Canonical periodic_bc / dirichlet_bc DO assemble correctly; use those.
+            # ~~robin_bc was recommended here too~~ [CORRECTED 2026-08-16, #1975] -- switching to
+            # the canonical BC does not make a Robin wall work ON THIS PATH. The dispatch below
+            # routes any non-Dirichlet boundary point to the no-flux handler, so a ROBIN segment
+            # assembles byte-identically to no-flux (measured at alpha=3.2 and alpha=999).
+            # Recommending it here sent users from a loud failure to a silent one. It IS honoured
+            # by FPFEMSolver, which reads the coefficients in weak form -- hence the pointer below
+            # rather than a bare removal.
             if legacy_type not in ("neumann", "no_flux"):
                 raise NotImplementedError(
                     f"Legacy fdm_bc_1d BoundaryConditions(type={legacy_type!r}) is not honored by the "
                     f"FP-FDM time-stepping assembly (only neumann/no_flux are); it would be silently "
                     f"assembled as no-flux (a legacy 'periodic' does NOT wrap). Use "
-                    f"mfgarchon.geometry.boundary (periodic_bc / dirichlet_bc / robin_bc / no_flux_bc) "
-                    f"with the modern BoundaryConditions instead (Issue #1559)."
+                    f"mfgarchon.geometry.boundary (periodic_bc / dirichlet_bc / no_flux_bc) "
+                    f"with the modern BoundaryConditions instead (Issue #1559). robin_bc is NOT in "
+                    f"that list on purpose: this assembly reads none of a ROBIN segment's "
+                    f"coefficients, so it would be a no-flux wall wearing a label. A Robin wall "
+                    f"needs FPFEMSolver, which assembles it in weak form (Issue #1975)."
                 ) from None
             is_no_flux = True
             is_uniform = False

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -1308,7 +1308,7 @@ def solve_timestep_full_nd(
             # Canonical periodic_bc / dirichlet_bc DO assemble correctly; use those.
             # ~~robin_bc was recommended here too~~ [CORRECTED 2026-08-16, #1975] -- switching to
             # the canonical BC does not make a Robin wall work ON THIS PATH. The dispatch below
-            # routes any non-Dirichlet boundary point to the no-flux handler, so a ROBIN segment
+            # routes a boundary point of a MIXED bc to the no-flux handler, so a ROBIN segment
             # assembles byte-identically to no-flux (measured at alpha=3.2 and alpha=999).
             # Recommending it here sent users from a loud failure to a silent one. It IS honoured
             # by FPFEMSolver, which reads the coefficients in weak form -- hence the pointer below

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1133,100 +1133,54 @@ def robin_bc(
     """
     Create Robin boundary conditions (alpha*u + beta*du/dn = value).
 
-    Which solvers honour it (#1975):
+    **You probably do not want this for a reflecting FP wall.** ``J.n = 0`` is Robin in ``m``, but
+    the conservative schemes already impose it structurally -- by zeroing the total face flux,
+    with no BC-type branch naming it -- and ``FPParticleSolver`` gets the same wall from Skorokhod
+    reflection. Adding a Robin segment on top of such a wall destroys it rather than restating it.
 
-    - ``FPFEMSolver`` / ``HJBFEMSolver`` -- weak form, the coefficients are read
-      (``A_robin = D*(alpha/beta)*int_dOmega phi_i phi_j``, load ``D*(1/beta)*int_dOmega g phi_i``).
-      Only a **constant** ``g`` is implemented; ``beta == 0`` fails loud; a provider-valued
-      ``alpha`` currently raises a bare ``TypeError`` from ``float()``. These solvers declare no
-      ``_SUPPORTED_BC_TYPES``, so none of that is checked at construction (#1977).
-    - ``HJBGFDMSolver`` -- the adjoint-consistent ``Robin(0, 1)`` case; general-Robin sub-cases
-      fail loud in the row builder.
-    - **Every grid FP solver refuses it**, and the refusal is load-bearing rather than an
-      oversight: the FDM boundary handlers are not passed ``boundary_conditions`` at all, so they
-      read none of ``alpha``/``beta``/``value``. **Every ROBIN configuration is refused at
-      construction**: ``_validate_bc_support`` (#1456) iterates every segment, so uniform and
-      mixed alike raise from ``base_solver.py:324``; a uniform one is refused twice more (#1250,
-      #1071). The silent no-flux assembly is reachable only BELOW that gate -- calling
-      ``solve_timestep_full_nd`` directly, or mutating ``solver.boundary_conditions`` after
-      construction (the #1699 bypass class). There it is byte-identical to no-flux across
-      4 schemes x alpha in {3.2, 999, -7} x beta in {1, 2} x g in {0, 5}, and a provider-valued
-      coefficient is accepted without a word (#1979).
+    Which solvers read the coefficients (#1975):
 
-    **You probably do not need this for a reflecting wall.** The FP reflecting condition
-    ``J.n = 0`` is Robin in ``m`` with ``alpha = D_pH(x, grad u) . n``, but the conservative
-    schemes already impose it *structurally*, by zeroing the total face flux, without any
-    BC-type branch naming it. Measured, sigma=0.3 with a wall-normal drift of 3.2:
-    ``divergence_upwind`` (the default) and ``divergence_centered`` conserve mass to machine
-    precision with ``d_n m`` nonzero at the wall and converging to ``(v/D)*m`` at first order,
-    while the ``gradient_*`` family hard-codes the mirrored ghost
-    ``m_{N+1} = m_{N-1}`` (fp_fdm_alg_gradient_upwind.py:319), so its CENTERED wall derivative is
-    zero by construction rather than by convergence -- the one-sided estimate used for the
-    conservative row above is not zero there -- and therefore leaks badly. How badly is a
-    property of the configuration, not of the family: at sigma=0.3, 81 points on [0,1], dt=1e-3,
-    and a Gaussian initial density of width s0 at 0.5, through the potential channel
-    (``_INTERFACE_VELOCITY_SCHEMES`` is ``{"divergence_upwind"}``, so the other three never read a
-    caller-supplied face velocity; #1632. ~~"the only scheme that reads ``drift_field``"~~
-    [CORRECTED] -- that generalised the issue's ``interface_velocity`` to a different kwarg, and
-    a callable ``drift_field`` reaches all four through ``_DriftDispatcher``):
+    - ``FPFEMSolver`` / ``HJBFEMSolver`` -- weak form, coefficients read:
+      ``A_robin = D*(alpha/beta)*int_dOmega phi_i phi_j``, load ``D*(1/beta)*int_dOmega g phi_i``.
+      Constant ``g`` only; ``beta == 0`` fails loud; a provider-valued ``alpha`` raises a bare
+      ``TypeError`` from ``float()``. Neither declares ``_SUPPORTED_BC_TYPES``, so none of that is
+      checked at construction (#1977).
+    - ``HJBGFDMSolver`` -- the adjoint-consistent ``Robin(0, 1)`` case only.
+    - **Every grid FP solver refuses ROBIN at construction** (``_validate_bc_support``, #1456,
+      raising from ``base_solver.py:324``), uniform and mixed alike. The refusal is load-bearing:
+      the FDM boundary handlers are not passed ``boundary_conditions``, so they read none of
+      ``alpha``/``beta``/``value``. Below the gate -- calling ``solve_timestep_full_nd`` directly,
+      or mutating ``solver.boundary_conditions`` after construction (#1699) -- a ROBIN segment is
+      byte-identical to no-flux, and a provider-valued coefficient is accepted silently (#1979).
 
-        scheme               s0     T=0.20    T=0.30    T=0.50
-        gradient_centered    0.1     -78.1%    -99.0%    -100.0%
-        gradient_upwind      0.1     -75.5%    -97.9%    -100.0%
-        gradient_centered    0.3     -42.0%    -57.6%     -60.0%
-
-    So "loses essentially all the mass" is true at s0=0.1 and false at s0=0.3, and the two
-    schemes differ by 2.6 points. The ``d_n m = 0`` mechanism behind the leak is not
-    configuration-dependent (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
-    reflection. So ``no_flux_bc()`` on a conservative scheme is the reflecting wall, and adding a
-    Robin segment on top of it **destroys** that wall rather than restating it. The weak form's
-    natural BC is already ``J.n = 0``, so ``A_robin`` adds a residual outflux on top of it:
+    The perturbation a Robin segment adds to an already-reflecting wall:
 
         J.n = D*(alpha/beta)*m          i.e.   D d_n m = (v_n - D*alpha/beta) * m
 
-    ~~the implied wall becomes ``D d_n m = 2 v_n m``~~ [CORRECTED] -- that is one row of the law,
-    and not the row it was attributed to: at ``D*alpha/beta = v_n`` the law gives ``d_n m = 0``,
-    while the row that DOUBLES is ``D*alpha/beta = -v_n``, an influx.
-
-    ``A_robin``'s boundary column sums are exactly ``D*alpha/beta``. Measured at beta = 1:
-    0.1440 / 0.4000 / 1.6000 / 3.2000 for D = 0.045 / 0.125 / 0.5 / 1.0; and 0.0360 at
-    (D, alpha, beta) = (0.045, 3.2, 4), where ``D*alpha`` would be 0.1440. So the perturbation
-    scales with ``D`` and inversely with ``beta``, never with ``v_n``.
+    ``A_robin``'s boundary column sums are exactly ``D*alpha/beta``: measured 0.1440 / 0.4000 /
+    1.6000 / 3.2000 at beta=1 for D = 0.045 / 0.125 / 0.5 / 1.0, and 0.0360 at
+    (D, alpha, beta) = (0.045, 3.2, 4) where ``D*alpha`` would be 0.1440. **It scales with ``D``
+    and inversely with ``beta``, never with ``v_n``** -- so the invariant is the ratio, and any
+    test written on ``alpha`` alone passes a whole equivalence class of identical walls.
+    Measured: ``(-2*v_n, 2*D)`` is bit-identical to ``(-v_n, D)`` (``max|m - m_ref| = 0``), while
+    ``(-v_n, 2*D)`` differs by ``6.2e+46``.
 
     **The trap.** The reflecting condition's own coefficients are
-    ``(alpha, beta) = (D_pH(x, grad u).n, D)``, so ``alpha = -v_n``, NOT ``+v_n``, wherever the
-    FP transport velocity is ``v = -D_pH``.
+    ``(alpha, beta) = (D_pH(x, grad u).n, D)``, so ``alpha = -v_n``, NOT ``+v_n``, wherever the FP
+    transport velocity is ``v = -D_pH``. That also follows from the library's own
+    ``J = v*m - D grad m`` without mentioning ``D_pH``, which is the sense-free route to it.
 
-    That antecedent is a MINIMIZE fact, not a library-wide one, and it is decided in two places.
-    ``HamiltonianBase.optimal_control`` (core/hamiltonian.py:1284) returns ``-self._sign * dH_dp``
-    with ``_sign = -1`` under MAXIMIZE (:838). ``SeparableHamiltonian`` overrides it (:2524) and
-    delegates to ``control_cost.optimal_control(p)``, because in the separable case the control
-    enters only through the control cost -- so its sign comes from ``QuadraticControlCost.sign``
-    (:403), a second and independent sense field. **The two routes agree on every consistent
-    configuration**: measured, MINIMIZE/MINIMIZE gives ``-D_pH`` and MAXIMIZE/MAXIMIZE gives
-    ``+D_pH``, the same as the base class.
+    ``D*alpha/beta = -v_n`` is by the law above the row that DOUBLES -- an influx. So encoding the
+    reflecting condition as a Robin segment on a conservative assembly is unbounded, not merely
+    leaky. (Magnitudes are not quotable: over mesh 50-400, T 0.05-0.4, Nt 50-800 and IC width
+    0.05-0.3 the growth spans well over ninety orders of magnitude and flips sign at coarse
+    ``Nt``, where the positivity clip dominates -- ``weak_form_fp_solver.py:225-230`` reports its
+    cumulative injection at solve end.)
 
-    They can be set to disagree, and nothing checks. All four (cost sense, Hamiltonian sense)
-    pairs construct without complaint, and on the two mismatched ones the control cost decides
-    while ``_sign`` is never read. That is a silent-acceptance gap, not a counterexample to the
-    line above; it is filed separately.
-
-    Every path that forms the drift itself is gated to quadratic-MINIMIZE by
-    ``assert_quadratic_minimize_drift`` (utils/pde_coefficients.py:24) -- note it reads
-    ``control_cost.sign``, not the Hamiltonian's sense -- so the antecedent holds on all of them.
-    The caller-supplied-``alpha*`` velocity channel (``compute_fp_velocity_field``) is not gated.
-    No solver reachable through it declares ROBIN, and ``FPFEMSolver`` -- the only FP solver that
-    reads Robin coefficients -- rejects MAXIMIZE, so the conclusion below is safe by two gates
-    rather than by the antecedent being universal.
-
-    ``alpha = -v_n`` also follows from the library's own ``J = v*m - D grad m`` without
-    mentioning ``D_pH`` at all, which is the sense-free route to the same place.
-
-    The measured wall, at ``sigma=0.3``, ``v_n=+3.2``, ``D=0.045`` (so ``v_n/D = 71.111``),
-    ``FPFDMSolver`` / ``divergence_upwind`` on [0,1], Gaussian initial density of width 0.1 at
-    0.5, T=0.2, Nt=200, ``drift_field=+3.2``. Columns 3 and 4 are ``alpha*m + beta*d_n m``
-    evaluated on that profile and normalised by ``|alpha|*m`` -- they are column 2 rearranged,
-    not a second measurement:
+    Measured wall, ``sigma=0.3``, ``v_n=+3.2``, ``D=0.045`` (so ``v_n/D = 71.111``), ``FPFDMSolver``
+    / ``divergence_upwind`` on [0,1], Gaussian initial density of width 0.1 at 0.5, T=0.2, Nt=200,
+    ``drift_field=+3.2``. Columns 3 and 4 are ``alpha*m + beta*d_n m`` normalised by ``|alpha|*m``,
+    i.e. column 2 rearranged rather than a second measurement:
 
         Nx      d_n m / m     (+v_n, D)     (-v_n, D)
         161        56.41        1.7933       -0.2067
@@ -1234,37 +1188,34 @@ def robin_bc(
         641        67.10        1.9437       -0.0563
        1281        69.09        1.9716       -0.0284
 
-    Column 2 converges to 71.111 at first order. ``(-v_n, D)`` goes to zero; ``(+v_n, D)`` goes
-    to 2, i.e. off by ``2*alpha*m``.
+    Column 2 converges to 71.111 at first order; ``(-v_n, D)`` goes to zero and ``(+v_n, D)`` to 2.
 
-    So ``D*alpha/beta = -v_n``, which by the law above is the row that DOUBLES -- an influx, and
-    the wall that diverges. On ``FPFEMSolver``: no segment conserves to machine precision;
-    ``robin_bc(alpha=+v_n, beta=D)`` leaks; ``robin_bc(alpha=-v_n, beta=D)`` -- the correct
-    encoding of the reflecting condition -- grows without bound. ~~+0.0000% / -48% / +1.7e31%~~
-    [CORRECTED] -- that trio is not quotable: over mesh 50-400, T 0.05-0.4, Nt 50-800 and IC
-    width 0.05-0.3 the third column spans well over ninety orders of magnitude, and at coarse
-    ``Nt`` it comes out NEGATIVE, so even its sign is a property of the configuration.
+    The ``v = -D_pH`` antecedent is a MINIMIZE fact decided in two places.
+    ``HamiltonianBase.optimal_control`` (``core/hamiltonian.py:1284``) returns ``-self._sign *
+    dH_dp`` with ``_sign`` set at ``:838``. ``SeparableHamiltonian`` overrides it (``:2524``) and
+    delegates to ``control_cost.optimal_control(p)``, since in the separable case the control
+    enters only through the control cost -- its sign comes from ``QuadraticControlCost.sign``
+    (``:403``), an independent sense field. The two routes agree on every consistent
+    configuration: MINIMIZE/MINIMIZE gives ``-D_pH``, MAXIMIZE/MAXIMIZE gives ``+D_pH``. They can
+    be set to disagree and nothing checks; that gap is filed separately. Paths that form the drift
+    themselves are gated to quadratic-MINIMIZE by ``assert_quadratic_minimize_drift``
+    (``utils/pde_coefficients.py:24``, which reads ``control_cost.sign``); the caller-supplied
+    velocity channel is not, but no solver reachable through it declares ROBIN and ``FPFEMSolver``
+    rejects MAXIMIZE.
 
-    ~~The growth is influx, not a clip artifact (cumulative clip injection 0.0, min density
-    +2e-11).~~ [CORRECTED 2026-08-17] -- those two numbers are from the 200-element / Nt=200 run
-    and were placed against the coarse-``Nt`` sign flip, which they do not cover: review measured
-    the negative configurations to be clip-dominated. This path clips
-    (weak_form_fp_solver.py:225-230 reports a CUMULATIVE injection at solve end), so any figure
-    taken from it owes that warning's value alongside. No claim is made here about which regime a
-    given configuration is in. **Encoding the reflecting condition as a Robin segment
-    on top of a wall that already imposes it is unbounded, not merely leaky.**
+    For contrast, the ``gradient_*`` family imposes ``d_n m = 0`` by hard-coding the mirrored ghost
+    ``m_{N+1} = m_{N-1}`` (``fp_fdm_alg_gradient_upwind.py:318``,
+    ``fp_fdm_alg_gradient_centered.py:243``) and is non-conservative by design (#1075). How much it
+    leaks is a property of the configuration, not of the family -- at sigma=0.3, 81 points on
+    [0,1], dt=1e-3, Gaussian initial density of width s0 at 0.5, potential channel:
 
-    Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one:
-    ``D*alpha/beta != -v_n``, or an inhomogeneous ``g``.
+        scheme               s0     T=0.20    T=0.30    T=0.50
+        gradient_centered    0.1     -78.1%    -99.0%    -100.0%
+        gradient_upwind      0.1     -75.5%    -97.9%    -100.0%
+        gradient_centered    0.3     -42.0%    -57.6%     -60.0%
 
-    ~~``alpha != D_pH.n`` (i.e. ``alpha != -v_n``)~~ [CORRECTED] -- the law two paragraphs up
-    depends only on the RATIO, so that test passes a whole equivalence class of segments that
-    produce the identical diverging wall. Measured: ``(alpha, beta) = (-2*v_n, 2*D)`` satisfies
-    ``alpha != -v_n`` and is bit-identical to ``(-v_n, D)`` (``max|m - m_ref| = 0.000e+00``);
-    positive control ``(-v_n, 2*D)`` differs (``6.2e+46``). The wrong test also contradicted the
-    sentence above it, which already said the perturbation scales inversely with ``beta``.
-
-    See #1975.
+    **Reach for ``robin_bc`` when you want a wall that is not the reflecting one:
+    ``D*alpha/beta != -v_n``, or an inhomogeneous ``g``.** See #1975.
 
     Args:
         value: RHS value g in alpha*u + beta*du/dn = g

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1162,11 +1162,19 @@ def robin_bc(
     while the ``gradient_*`` family hard-codes the mirrored ghost
     ``m_{N+1} = m_{N-1}`` (fp_fdm_alg_gradient_upwind.py:319), so its CENTERED wall derivative is
     zero by construction rather than by convergence -- the one-sided estimate used for the
-    conservative row above is not zero there -- and therefore loses essentially all the mass: about -78% at T = 0.20, -99% at 0.30,
-    -99.99% by 0.50 (sigma=0.3, 81 points on [0,1], dt=1e-3, Gaussian initial density at 0.5).
-    Quoted to the precision that configuration supports -- the trio moves with the initial
-    condition and the step, which four significant figures would imply it does not. The percentage is a function of T and is quoted with one;
-    the ``d_n m = 0`` mechanism behind it is not (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
+    conservative row above is not zero there -- and therefore leaks badly. How badly is a
+    property of the configuration, not of the family: at sigma=0.3, 81 points on [0,1], dt=1e-3,
+    and a Gaussian initial density of width s0 at 0.5, through the potential channel
+    (``divergence_upwind`` is the only scheme that reads ``drift_field``, #1632):
+
+        scheme               s0     T=0.20    T=0.30    T=0.50
+        gradient_centered    0.1     -78.1%    -99.0%    -100.0%
+        gradient_upwind      0.1     -75.5%    -97.9%    -100.0%
+        gradient_centered    0.3     -42.0%    -57.6%     -60.0%
+
+    So "loses essentially all the mass" is true at s0=0.1 and false at s0=0.3, and the two
+    schemes differ by 2.6 points. The ``d_n m = 0`` mechanism behind the leak is not
+    configuration-dependent (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
     reflection. So ``no_flux_bc()`` on a conservative scheme is the reflecting wall, and adding a
     Robin segment on top of it **destroys** that wall rather than restating it. The weak form's
     natural BC is already ``J.n = 0``, so ``A_robin`` adds a residual outflux on top of it:
@@ -1183,11 +1191,27 @@ def robin_bc(
     scales with ``D`` and inversely with ``beta``, never with ``v_n``.
 
     **The trap.** The reflecting condition's own coefficients are
-    ``(alpha, beta) = (D_pH(x, grad u).n, D)``, and in this library the FP transport velocity is
-    ``v = -D_pH`` (``H.optimal_control`` returns ``-D_pH``; ``fp_fdm_advection`` transports with
-    it), so ``alpha = -v_n``, NOT ``+v_n``. Verified by residual rather than by substitution:
-    evaluating ``alpha*m + beta*d_n m`` on the structurally reflecting solution, normalised by
-    ``|alpha|*m`` at ``x_max``, ``sigma=0.3``, ``v_n=+3.2``, ``D=0.045``, 200 steps:
+    ``(alpha, beta) = (D_pH(x, grad u).n, D)``, so ``alpha = -v_n``, NOT ``+v_n``, wherever the
+    FP transport velocity is ``v = -D_pH``.
+
+    That antecedent is a MINIMIZE fact, not a library-wide one. ``H.optimal_control`` returns
+    ``-self._sign * dH_dp`` (core/hamiltonian.py:1315) with ``_sign = -1`` under MAXIMIZE
+    (:838), so it yields ``+D_pH`` there. Every path that forms the drift itself is gated to
+    quadratic-MINIMIZE by ``assert_quadratic_minimize_drift`` (utils/pde_coefficients.py:24), so
+    the antecedent holds on all of them; the caller-supplied-``alpha*`` velocity channel
+    (``compute_fp_velocity_field``) is not gated and reaches ``+D_pH`` under MAXIMIZE. That
+    channel is FDM, which refuses ROBIN at construction, and ``FPFEMSolver`` -- the only FP
+    solver that reads Robin coefficients -- rejects MAXIMIZE, so the conclusion below is safe
+    today. It is safe by two gates, not by the antecedent being universal.
+
+    ``alpha = -v_n`` also follows from the library's own ``J = v*m - D grad m`` without
+    mentioning ``D_pH`` at all, which is the sense-free route to the same place.
+
+    The measured wall, at ``sigma=0.3``, ``v_n=+3.2``, ``D=0.045`` (so ``v_n/D = 71.111``),
+    ``FPFDMSolver`` / ``divergence_upwind`` on [0,1], Gaussian initial density of width 0.1 at
+    0.5, T=0.2, Nt=200, ``drift_field=+3.2``. Columns 3 and 4 are ``alpha*m + beta*d_n m``
+    evaluated on that profile and normalised by ``|alpha|*m`` -- they are column 2 rearranged,
+    not a second measurement:
 
         Nx      d_n m / m     (+v_n, D)     (-v_n, D)
         161        56.41        1.7933       -0.2067
@@ -1195,17 +1219,31 @@ def robin_bc(
         641        67.10        1.9437       -0.0563
        1281        69.10        1.9716       -0.0284
 
-    ``(-v_n, D)`` goes to zero at first order; ``(+v_n, D)`` goes to 2, i.e. off by ``2*alpha*m``.
+    Column 2 converges to 71.111 at first order. ``(-v_n, D)`` goes to zero; ``(+v_n, D)`` goes
+    to 2, i.e. off by ``2*alpha*m``.
 
     So ``D*alpha/beta = -v_n``, which by the law above is the row that DOUBLES -- an influx, and
-    the wall that diverges. Measured on ``FPFEMSolver``: no segment conserves to +0.0000%;
-    ``robin_bc(alpha=+v_n, beta=D)`` loses 48%; ``robin_bc(alpha=-v_n, beta=D)`` -- the correct
-    encoding of the reflecting condition -- blows up to +1.7e31%. **Encoding the reflecting
-    condition as a Robin segment on top of a wall that already imposes it is unbounded, not
-    merely leaky.**
+    the wall that diverges. On ``FPFEMSolver``: no segment conserves to machine precision;
+    ``robin_bc(alpha=+v_n, beta=D)`` leaks; ``robin_bc(alpha=-v_n, beta=D)`` -- the correct
+    encoding of the reflecting condition -- grows without bound. ~~+0.0000% / -48% / +1.7e31%~~
+    [CORRECTED] -- that trio is not quotable: over mesh 50-400, T 0.05-0.4, Nt 50-800 and IC
+    width 0.05-0.3 the third column spans about 90 orders of magnitude and at (400 elements,
+    T=0.2, Nt=50) it comes out NEGATIVE, so even its sign is a property of the configuration.
+    The growth itself is real (cumulative positivity-clip injection 0.0, min density +2e-11 --
+    it is influx, not a clip artifact). **Encoding the reflecting condition as a Robin segment
+    on top of a wall that already imposes it is unbounded, not merely leaky.**
 
     Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one:
-    ``alpha != D_pH.n`` (i.e. ``alpha != -v_n``), or an inhomogeneous ``g``. See #1975.
+    ``D*alpha/beta != -v_n``, or an inhomogeneous ``g``.
+
+    ~~``alpha != D_pH.n`` (i.e. ``alpha != -v_n``)~~ [CORRECTED] -- the law two paragraphs up
+    depends only on the RATIO, so that test passes a whole equivalence class of segments that
+    produce the identical diverging wall. Measured: ``(alpha, beta) = (-2*v_n, 2*D)`` satisfies
+    ``alpha != -v_n`` and is bit-identical to ``(-v_n, D)`` (``max|m - m_ref| = 0.000e+00``);
+    positive control ``(-v_n, 2*D)`` differs (``6.2e+46``). The wrong test also contradicted the
+    sentence above it, which already said the perturbation scales inversely with ``beta``.
+
+    See #1975.
 
     Args:
         value: RHS value g in alpha*u + beta*du/dn = g

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1144,9 +1144,11 @@ def robin_bc(
       fail loud in the row builder.
     - **Every grid FP solver refuses it**, and the refusal is load-bearing rather than an
       oversight: the FDM boundary handlers are not passed ``boundary_conditions`` at all, so they
-      read none of ``alpha``/``beta``/``value`` and a ROBIN wall that got past the gate would be
-      a no-flux wall wearing a label (byte-identical at alpha=3.2 and alpha=999 across 768
-      configurations). A provider-valued coefficient is worse -- silently accepted (#1979).
+      read none of ``alpha``/``beta``/``value``. **A uniform ROBIN is refused loudly** -- twice,
+      by the #1250 assembly guard and by ``LaplacianOperator`` (#1071). The silent hole is a ROBIN
+      **segment inside a mixed BC**, which routes to the no-flux handler and is byte-identical to
+      it (alpha=3.2 and alpha=999, 768 configurations). A provider-valued coefficient there is
+      worse still -- silently accepted (#1979).
 
     **You probably do not need this for a reflecting wall.** The FP reflecting condition
     ``J.n = 0`` is Robin in ``m`` with ``alpha = D_pH(x, grad u) . n``, but the conservative
@@ -1156,9 +1158,17 @@ def robin_bc(
     precision with ``d_n m`` nonzero at the wall and converging to ``(v/D)*m`` at first order,
     while the ``gradient_*`` family imposes ``d_n m = 0`` and loses 75-78% of the mass
     (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
-    reflection. So ``no_flux_bc()`` on a conservative scheme is the reflecting wall, and handing
-    the FEM path ``alpha = v_n`` explicitly **double-counts** it -- the weak form's natural BC is
-    already ``J.n = 0``, so the implied wall becomes ``D d_n m = 2 v_n m`` and mass drifts -79.5%.
+    reflection. So ``no_flux_bc()`` on a conservative scheme is the reflecting wall, and adding a
+    Robin segment on top of it **destroys** that wall rather than restating it. The weak form's
+    natural BC is already ``J.n = 0``, so ``A_robin`` adds a residual outflux on top of it:
+
+        J.n = D*(alpha/beta)*m          i.e.   D d_n m = (v_n - D*alpha/beta) * m
+
+    ~~the implied wall becomes ``D d_n m = 2 v_n m``~~ [CORRECTED] -- that is one row of the law,
+    not the law. `A_robin`'s boundary column sums are exactly ``D*alpha`` (measured 0.144 / 1.6 /
+    3.2 at D = 0.045 / 0.125 / 1.0), so the perturbation scales with ``D``, not with ``v_n``. The
+    operational test: if the wall were ``2 v_n m`` then ``alpha = v_n/2`` would restore
+    ``J.n = 0``; it does not (-50.08% mass), and only dropping the segment does (+5e-11%).
 
     Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one: ``alpha != v_n``,
     or an inhomogeneous ``g``. See #1975.

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1143,14 +1143,25 @@ def robin_bc(
     - ``HJBGFDMSolver`` -- the adjoint-consistent ``Robin(0, 1)`` case; general-Robin sub-cases
       fail loud in the row builder.
     - **Every grid FP solver refuses it**, and the refusal is load-bearing rather than an
-      oversight: the FDM boundary assembly reads none of ``alpha``/``beta``/``value``, so a ROBIN
-      wall that got past the gate would be a no-flux wall wearing a label (measured byte-identical
-      at alpha=3.2 and alpha=999).
+      oversight: the FDM boundary handlers are not passed ``boundary_conditions`` at all, so they
+      read none of ``alpha``/``beta``/``value`` and a ROBIN wall that got past the gate would be
+      a no-flux wall wearing a label (byte-identical at alpha=3.2 and alpha=999 across 768
+      configurations). A provider-valued coefficient is worse -- silently accepted (#1979).
 
-    Why this matters for MFG: the FP reflecting wall *is* Robin in ``m``, with
-    ``alpha = D_pH(x, grad u) . n`` recomputed each Picard iterate, while the HJB side is true
-    Neumann. So a reflecting wall with wall-normal drift is expressible on the FEM path and not on
-    the grid paths.
+    **You probably do not need this for a reflecting wall.** The FP reflecting condition
+    ``J.n = 0`` is Robin in ``m`` with ``alpha = D_pH(x, grad u) . n``, but the conservative
+    schemes already impose it *structurally*, by zeroing the total face flux, without any
+    BC-type branch naming it. Measured, sigma=0.3 with a wall-normal drift of 3.2:
+    ``divergence_upwind`` (the default) and ``divergence_centered`` conserve mass to machine
+    precision with ``d_n m`` nonzero at the wall and converging to ``(v/D)*m`` at first order,
+    while the ``gradient_*`` family imposes ``d_n m = 0`` and loses 75-78% of the mass
+    (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
+    reflection. So ``no_flux_bc()`` on a conservative scheme is the reflecting wall, and handing
+    the FEM path ``alpha = v_n`` explicitly **double-counts** it -- the weak form's natural BC is
+    already ``J.n = 0``, so the implied wall becomes ``D d_n m = 2 v_n m`` and mass drifts -79.5%.
+
+    Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one: ``alpha != v_n``,
+    or an inhomogeneous ``g``. See #1975.
 
     Args:
         value: RHS value g in alpha*u + beta*du/dn = g

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1144,11 +1144,14 @@ def robin_bc(
       fail loud in the row builder.
     - **Every grid FP solver refuses it**, and the refusal is load-bearing rather than an
       oversight: the FDM boundary handlers are not passed ``boundary_conditions`` at all, so they
-      read none of ``alpha``/``beta``/``value``. **A uniform ROBIN is refused loudly** -- twice,
-      by the #1250 assembly guard and by ``LaplacianOperator`` (#1071). The silent hole is a ROBIN
-      **segment inside a mixed BC**, which routes to the no-flux handler and is byte-identical to
-      it (alpha=3.2 and alpha=999, 768 configurations). A provider-valued coefficient there is
-      worse still -- silently accepted (#1979).
+      read none of ``alpha``/``beta``/``value``. **Every ROBIN configuration is refused at
+      construction**: ``_validate_bc_support`` (#1456) iterates every segment, so uniform and
+      mixed alike raise from ``base_solver.py:324``; a uniform one is refused twice more (#1250,
+      #1071). The silent no-flux assembly is reachable only BELOW that gate -- calling
+      ``solve_timestep_full_nd`` directly, or mutating ``solver.boundary_conditions`` after
+      construction (the #1699 bypass class). There it is byte-identical to no-flux across
+      4 schemes x alpha in {3.2, 999, -7} x beta in {1, 2} x g in {0, 5}, and a provider-valued
+      coefficient is accepted without a word (#1979).
 
     **You probably do not need this for a reflecting wall.** The FP reflecting condition
     ``J.n = 0`` is Robin in ``m`` with ``alpha = D_pH(x, grad u) . n``, but the conservative
@@ -1156,8 +1159,10 @@ def robin_bc(
     BC-type branch naming it. Measured, sigma=0.3 with a wall-normal drift of 3.2:
     ``divergence_upwind`` (the default) and ``divergence_centered`` conserve mass to machine
     precision with ``d_n m`` nonzero at the wall and converging to ``(v/D)*m`` at first order,
-    while the ``gradient_*`` family imposes ``d_n m = 0`` and loses 75-78% of the mass
-    (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
+    while the ``gradient_*`` family imposes ``d_n m = 0`` -- exactly, at every T and every Nx
+    measured -- and therefore loses essentially all the mass: -78% at T = 0.20, -98.98% at 0.30,
+    -99.996% by 0.50 (sigma=0.3, Nx=81). The percentage is a function of T and is quoted with one;
+    the ``d_n m = 0`` mechanism behind it is not (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
     reflection. So ``no_flux_bc()`` on a conservative scheme is the reflecting wall, and adding a
     Robin segment on top of it **destroys** that wall rather than restating it. The weak form's
     natural BC is already ``J.n = 0``, so ``A_robin`` adds a residual outflux on top of it:
@@ -1165,10 +1170,18 @@ def robin_bc(
         J.n = D*(alpha/beta)*m          i.e.   D d_n m = (v_n - D*alpha/beta) * m
 
     ~~the implied wall becomes ``D d_n m = 2 v_n m``~~ [CORRECTED] -- that is one row of the law,
-    not the law. `A_robin`'s boundary column sums are exactly ``D*alpha`` (measured 0.144 / 1.6 /
-    3.2 at D = 0.045 / 0.125 / 1.0), so the perturbation scales with ``D``, not with ``v_n``. The
-    operational test: if the wall were ``2 v_n m`` then ``alpha = v_n/2`` would restore
-    ``J.n = 0``; it does not (-50.08% mass), and only dropping the segment does (+5e-11%).
+    and not the row it was attributed to: at ``D*alpha/beta = v_n`` the law gives ``d_n m = 0``,
+    while the row that DOUBLES is ``D*alpha/beta = -v_n``, an influx.
+
+    ``A_robin``'s boundary column sums are exactly ``D*alpha/beta``. Measured at beta = 1:
+    0.1440 / 0.4000 / 1.6000 / 3.2000 for D = 0.045 / 0.125 / 0.5 / 1.0; and 0.0360 at
+    (D, alpha, beta) = (0.045, 3.2, 4), where ``D*alpha`` would be 0.1440. So the perturbation
+    scales with ``D`` and inversely with ``beta``, never with ``v_n``.
+
+    **The trap.** The reflecting condition's own coefficients are ``(alpha, beta) = (v_n, D)``,
+    giving ``D*alpha/beta = v_n`` and therefore ``d_n m = 0`` -- the non-conservative wall.
+    Encoding the first sentence of this paragraph as a ``robin_bc`` lands on exactly the wall the
+    paragraph warns against.
 
     Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one: ``alpha != v_n``,
     or an inhomogeneous ``g``. See #1975.

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1133,6 +1133,25 @@ def robin_bc(
     """
     Create Robin boundary conditions (alpha*u + beta*du/dn = value).
 
+    Which solvers honour it (#1975):
+
+    - ``FPFEMSolver`` / ``HJBFEMSolver`` -- weak form, the coefficients are read
+      (``A_robin = D*(alpha/beta)*int_dOmega phi_i phi_j``, load ``D*(1/beta)*int_dOmega g phi_i``).
+      Only a **constant** ``g`` is implemented; ``beta == 0`` fails loud; a provider-valued
+      ``alpha`` currently raises a bare ``TypeError`` from ``float()``. These solvers declare no
+      ``_SUPPORTED_BC_TYPES``, so none of that is checked at construction (#1977).
+    - ``HJBGFDMSolver`` -- the adjoint-consistent ``Robin(0, 1)`` case; general-Robin sub-cases
+      fail loud in the row builder.
+    - **Every grid FP solver refuses it**, and the refusal is load-bearing rather than an
+      oversight: the FDM boundary assembly reads none of ``alpha``/``beta``/``value``, so a ROBIN
+      wall that got past the gate would be a no-flux wall wearing a label (measured byte-identical
+      at alpha=3.2 and alpha=999).
+
+    Why this matters for MFG: the FP reflecting wall *is* Robin in ``m``, with
+    ``alpha = D_pH(x, grad u) . n`` recomputed each Picard iterate, while the HJB side is true
+    Neumann. So a reflecting wall with wall-normal drift is expressible on the FEM path and not on
+    the grid paths.
+
     Args:
         value: RHS value g in alpha*u + beta*du/dn = g
         alpha: Coefficient of u

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1165,7 +1165,10 @@ def robin_bc(
     conservative row above is not zero there -- and therefore leaks badly. How badly is a
     property of the configuration, not of the family: at sigma=0.3, 81 points on [0,1], dt=1e-3,
     and a Gaussian initial density of width s0 at 0.5, through the potential channel
-    (``divergence_upwind`` is the only scheme that reads ``drift_field``, #1632):
+    (``_INTERFACE_VELOCITY_SCHEMES`` is ``{"divergence_upwind"}``, so the other three never read a
+    caller-supplied face velocity; #1632. ~~"the only scheme that reads ``drift_field``"~~
+    [CORRECTED] -- that generalised the issue's ``interface_velocity`` to a different kwarg, and
+    a callable ``drift_field`` reaches all four through ``_DriftDispatcher``):
 
         scheme               s0     T=0.20    T=0.30    T=0.50
         gradient_centered    0.1     -78.1%    -99.0%    -100.0%
@@ -1194,15 +1197,27 @@ def robin_bc(
     ``(alpha, beta) = (D_pH(x, grad u).n, D)``, so ``alpha = -v_n``, NOT ``+v_n``, wherever the
     FP transport velocity is ``v = -D_pH``.
 
-    That antecedent is a MINIMIZE fact, not a library-wide one. ``H.optimal_control`` returns
-    ``-self._sign * dH_dp`` (core/hamiltonian.py:1315) with ``_sign = -1`` under MAXIMIZE
-    (:838), so it yields ``+D_pH`` there. Every path that forms the drift itself is gated to
-    quadratic-MINIMIZE by ``assert_quadratic_minimize_drift`` (utils/pde_coefficients.py:24), so
-    the antecedent holds on all of them; the caller-supplied-``alpha*`` velocity channel
-    (``compute_fp_velocity_field``) is not gated and reaches ``+D_pH`` under MAXIMIZE. That
-    channel is FDM, which refuses ROBIN at construction, and ``FPFEMSolver`` -- the only FP
-    solver that reads Robin coefficients -- rejects MAXIMIZE, so the conclusion below is safe
-    today. It is safe by two gates, not by the antecedent being universal.
+    That antecedent is a MINIMIZE fact, not a library-wide one, and it is decided in two places.
+    ``HamiltonianBase.optimal_control`` (core/hamiltonian.py:1284) returns ``-self._sign * dH_dp``
+    with ``_sign = -1`` under MAXIMIZE (:838). ``SeparableHamiltonian`` overrides it (:2524) and
+    delegates to ``control_cost.optimal_control(p)``, because in the separable case the control
+    enters only through the control cost -- so its sign comes from ``QuadraticControlCost.sign``
+    (:403), a second and independent sense field. **The two routes agree on every consistent
+    configuration**: measured, MINIMIZE/MINIMIZE gives ``-D_pH`` and MAXIMIZE/MAXIMIZE gives
+    ``+D_pH``, the same as the base class.
+
+    They can be set to disagree, and nothing checks. All four (cost sense, Hamiltonian sense)
+    pairs construct without complaint, and on the two mismatched ones the control cost decides
+    while ``_sign`` is never read. That is a silent-acceptance gap, not a counterexample to the
+    line above; it is filed separately.
+
+    Every path that forms the drift itself is gated to quadratic-MINIMIZE by
+    ``assert_quadratic_minimize_drift`` (utils/pde_coefficients.py:24) -- note it reads
+    ``control_cost.sign``, not the Hamiltonian's sense -- so the antecedent holds on all of them.
+    The caller-supplied-``alpha*`` velocity channel (``compute_fp_velocity_field``) is not gated.
+    No solver reachable through it declares ROBIN, and ``FPFEMSolver`` -- the only FP solver that
+    reads Robin coefficients -- rejects MAXIMIZE, so the conclusion below is safe by two gates
+    rather than by the antecedent being universal.
 
     ``alpha = -v_n`` also follows from the library's own ``J = v*m - D grad m`` without
     mentioning ``D_pH`` at all, which is the sense-free route to the same place.
@@ -1217,7 +1232,7 @@ def robin_bc(
         161        56.41        1.7933       -0.2067
         321        63.27        1.8898       -0.1102
         641        67.10        1.9437       -0.0563
-       1281        69.10        1.9716       -0.0284
+       1281        69.09        1.9716       -0.0284
 
     Column 2 converges to 71.111 at first order. ``(-v_n, D)`` goes to zero; ``(+v_n, D)`` goes
     to 2, i.e. off by ``2*alpha*m``.
@@ -1227,10 +1242,16 @@ def robin_bc(
     ``robin_bc(alpha=+v_n, beta=D)`` leaks; ``robin_bc(alpha=-v_n, beta=D)`` -- the correct
     encoding of the reflecting condition -- grows without bound. ~~+0.0000% / -48% / +1.7e31%~~
     [CORRECTED] -- that trio is not quotable: over mesh 50-400, T 0.05-0.4, Nt 50-800 and IC
-    width 0.05-0.3 the third column spans about 90 orders of magnitude and at (400 elements,
-    T=0.2, Nt=50) it comes out NEGATIVE, so even its sign is a property of the configuration.
-    The growth itself is real (cumulative positivity-clip injection 0.0, min density +2e-11 --
-    it is influx, not a clip artifact). **Encoding the reflecting condition as a Robin segment
+    width 0.05-0.3 the third column spans well over ninety orders of magnitude, and at coarse
+    ``Nt`` it comes out NEGATIVE, so even its sign is a property of the configuration.
+
+    ~~The growth is influx, not a clip artifact (cumulative clip injection 0.0, min density
+    +2e-11).~~ [CORRECTED 2026-08-17] -- those two numbers are from the 200-element / Nt=200 run
+    and were placed against the coarse-``Nt`` sign flip, which they do not cover: review measured
+    the negative configurations to be clip-dominated. This path clips
+    (weak_form_fp_solver.py:225-230 reports a CUMULATIVE injection at solve end), so any figure
+    taken from it owes that warning's value alongside. No claim is made here about which regime a
+    given configuration is in. **Encoding the reflecting condition as a Robin segment
     on top of a wall that already imposes it is unbounded, not merely leaky.**
 
     Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one:

--- a/mfgarchon/geometry/boundary/conditions.py
+++ b/mfgarchon/geometry/boundary/conditions.py
@@ -1159,9 +1159,13 @@ def robin_bc(
     BC-type branch naming it. Measured, sigma=0.3 with a wall-normal drift of 3.2:
     ``divergence_upwind`` (the default) and ``divergence_centered`` conserve mass to machine
     precision with ``d_n m`` nonzero at the wall and converging to ``(v/D)*m`` at first order,
-    while the ``gradient_*`` family imposes ``d_n m = 0`` -- exactly, at every T and every Nx
-    measured -- and therefore loses essentially all the mass: -78% at T = 0.20, -98.98% at 0.30,
-    -99.996% by 0.50 (sigma=0.3, Nx=81). The percentage is a function of T and is quoted with one;
+    while the ``gradient_*`` family hard-codes the mirrored ghost
+    ``m_{N+1} = m_{N-1}`` (fp_fdm_alg_gradient_upwind.py:319), so its CENTERED wall derivative is
+    zero by construction rather than by convergence -- the one-sided estimate used for the
+    conservative row above is not zero there -- and therefore loses essentially all the mass: about -78% at T = 0.20, -99% at 0.30,
+    -99.99% by 0.50 (sigma=0.3, 81 points on [0,1], dt=1e-3, Gaussian initial density at 0.5).
+    Quoted to the precision that configuration supports -- the trio moves with the initial
+    condition and the step, which four significant figures would imply it does not. The percentage is a function of T and is quoted with one;
     the ``d_n m = 0`` mechanism behind it is not (non-conservative by design, #1075). ``FPParticleSolver`` gets the same wall from Skorokhod
     reflection. So ``no_flux_bc()`` on a conservative scheme is the reflecting wall, and adding a
     Robin segment on top of it **destroys** that wall rather than restating it. The weak form's
@@ -1178,13 +1182,30 @@ def robin_bc(
     (D, alpha, beta) = (0.045, 3.2, 4), where ``D*alpha`` would be 0.1440. So the perturbation
     scales with ``D`` and inversely with ``beta``, never with ``v_n``.
 
-    **The trap.** The reflecting condition's own coefficients are ``(alpha, beta) = (v_n, D)``,
-    giving ``D*alpha/beta = v_n`` and therefore ``d_n m = 0`` -- the non-conservative wall.
-    Encoding the first sentence of this paragraph as a ``robin_bc`` lands on exactly the wall the
-    paragraph warns against.
+    **The trap.** The reflecting condition's own coefficients are
+    ``(alpha, beta) = (D_pH(x, grad u).n, D)``, and in this library the FP transport velocity is
+    ``v = -D_pH`` (``H.optimal_control`` returns ``-D_pH``; ``fp_fdm_advection`` transports with
+    it), so ``alpha = -v_n``, NOT ``+v_n``. Verified by residual rather than by substitution:
+    evaluating ``alpha*m + beta*d_n m`` on the structurally reflecting solution, normalised by
+    ``|alpha|*m`` at ``x_max``, ``sigma=0.3``, ``v_n=+3.2``, ``D=0.045``, 200 steps:
 
-    Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one: ``alpha != v_n``,
-    or an inhomogeneous ``g``. See #1975.
+        Nx      d_n m / m     (+v_n, D)     (-v_n, D)
+        161        56.41        1.7933       -0.2067
+        321        63.27        1.8898       -0.1102
+        641        67.10        1.9437       -0.0563
+       1281        69.10        1.9716       -0.0284
+
+    ``(-v_n, D)`` goes to zero at first order; ``(+v_n, D)`` goes to 2, i.e. off by ``2*alpha*m``.
+
+    So ``D*alpha/beta = -v_n``, which by the law above is the row that DOUBLES -- an influx, and
+    the wall that diverges. Measured on ``FPFEMSolver``: no segment conserves to +0.0000%;
+    ``robin_bc(alpha=+v_n, beta=D)`` loses 48%; ``robin_bc(alpha=-v_n, beta=D)`` -- the correct
+    encoding of the reflecting condition -- blows up to +1.7e31%. **Encoding the reflecting
+    condition as a Robin segment on top of a wall that already imposes it is unbounded, not
+    merely leaky.**
+
+    Reach for ``robin_bc`` when you want a wall that is *not* the reflecting one:
+    ``alpha != D_pH.n`` (i.e. ``alpha != -v_n``), or an inhomogeneous ``g``. See #1975.
 
     Args:
         value: RHS value g in alpha*u + beta*du/dn = g


### PR DESCRIPTION
Refs #1975 item 4. Documentation and one diagnostic string. No behaviour change.

## The three

1. **`fp_fdm.py:802`** — the deprecation docstring for `solve_fp_system_1d` advertised the unified nD solver as *"Full BC support (no_flux, neumann, robin, periodic, dirichlet)"*.
2. **`fp_fdm_time_stepping.py:1314`** — the fail-loud diagnostic for a legacy BC told users to *"Use `mfgarchon.geometry.boundary` (periodic_bc / dirichlet_bc / **robin_bc** / no_flux_bc) with the modern BoundaryConditions instead"*. The same file cannot assemble what it recommends. This one is the worst of the three: it routed a user from a **loud** failure to a **silent** one.
3. **`robin_bc`'s own docstring** said nothing about which solvers honour it.

## The fact

`_BOUNDARY_HANDLERS` (`fp_fdm_time_stepping.py:110`) is keyed on the *advection scheme*, not on BC type, and all four entries are `add_boundary_no_flux_entries_*`. The call site is `elif (is_no_flux or not is_uniform) and is_boundary`, so a mixed BC at a boundary point takes the no-flux handler whatever its segments say. One assembled step:

```
mixed NO_FLUX               max|m - m_noflux| = 0.000e+00   IDENTICAL
mixed ROBIN(a=3.2,b=-.045)  max|m - m_noflux| = 0.000e+00   IDENTICAL
mixed ROBIN(a=999,b=-.045)  max|m - m_noflux| = 0.000e+00   IDENTICAL
```

## Why these are corrections, not removals

Robin **is** honoured elsewhere in the library — which I got wrong in #1975's first draft and corrected there:

- **`FPFEMSolver` / `HJBFEMSolver`** assemble it in weak form via `assemble_robin_terms` and read every coefficient. Measured: `sum|A|(alpha=999)/sum|A|(alpha=3.2) = 312.187500` against `999/3.2 = 312.187500`; `beta` exactly inverse; `g` into the load.
- **`HJBGFDMSolver`** takes the adjoint-consistent `Robin(0, 1)` case.

So `robin_bc`'s docstring now says which solvers honour it, which refuse it, **and** the limits: constant `g` only, `beta == 0` fails loud, and a provider-valued `alpha` raises a bare `TypeError` from `float()`. The FDM diagnostic now points at `FPFEMSolver` instead of just dropping `robin_bc` from the list.

Related: **#1977** — both FEM solvers declare no `_SUPPORTED_BC_TYPES`, so none of those limits is checked at construction.

## Documentation discipline

Struck rather than rewritten where the text shipped: `~~Full BC support (...)~~` followed by `[CORRECTED 2026-08-16, #1975]` and the measurement. A claim that shipped and was wrong is not silently replaced.

## Gate

`./scripts/local_ci.sh` → **6206 passed, 12 skipped, 21 xfailed, GATE GREEN**, 195 s.

Run inside a dedicated worktree with `PYTHONPATH` exported. Worth recording: the gate invokes `PYTHONSAFEPATH=1 "$PY" -P -m pytest`, and both flags strip cwd, so **running `local_ci.sh` from inside a worktree without exporting `PYTHONPATH` silently measures the shared checkout instead.** Measured:

```
cwd=WT, no PYTHONPATH, plain                     -> WT/mfgarchon        (cwd wins)
cwd=WT, no PYTHONPATH, -P + PYTHONSAFEPATH=1     -> shared checkout     (editable finder wins)
cwd=WT, PYTHONPATH=WT, -P + PYTHONSAFEPATH=1     -> WT/mfgarchon        (PYTHONPATH wins)
cwd=/tmp, PYTHONPATH=WT, -P + PYTHONSAFEPATH=1   -> WT/mfgarchon        (PYTHONPATH wins)
```

A plain `pytest` and the gate can therefore resolve to *different trees* in the same shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)