### PR TITLE
feat(scripts): a capability census — what classes declare, and what FP walls actually do

### DIFF
--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -1,23 +1,20 @@
-`scripts/capability_census.py` and its ratchet: what each class **declares**, and the wall-ratio
-**sequence** each FP path produces.
+`scripts/capability_census.py` and its ratchet: what each class **declares** about the boundary
+conditions it accepts.
 
-Lane 1 discovers its population with `walk_packages` + `issubclass` + `inspect.isabstract`, keyed
-on class identity -- a predicate independent of the declaration it audits -- so "declares nothing"
-is a recorded row rather than an absence, and own declarations are separated from inherited ones by
-walking the MRO.
+The 2026-08-13 design census had four lanes and every one looks for reality falling *short* of a
+claim; it found 77 over-claims. Nobody counted the other direction, and that is what made #1975
+wrong -- `FPFEMSolver` implements a general Robin wall and declares nothing, so a census keyed on
+`_SUPPORTED_BC_TYPES` reported the capability absent.
 
-**Lane 2 renders no verdict.** An earlier version classified each path from the ratio's trend
-across three resolutions; independent review showed the rule cannot do that. `FPFVMSolver` reads
-0.392 / 0.649 / 1.106 and keeps going to 12.699 at nx=1281, so a "within tolerance of 1" clause
-fires on a value the sequence merely transits, and `FPSLSolver` reads 0.998 at nx=201 then 1.926
-and 3.500. Three resolutions cannot separate approach from transit, and neither can six. The
-sequence is reported and the reading is left to a person.
+The population comes from `walk_packages` + `issubclass`, a predicate independent of the
+declaration audited, so "declares nothing" is a recorded row rather than an absence; own
+declarations are separated from inherited ones by walking the MRO. `honors_inhomogeneous_neumann`
+defaults to `True` on `BaseMFGSolver`, so 20 solvers claim to honour an inhomogeneous flux by a
+default nobody chose. Three classes apply BC segments without being subclasses of any root and are
+named rather than discovered; that list is stated to be incomplete.
 
-Mass drift is reported beside it as a **form property**: neither sufficient (streamline diffusion
-conserves to 1e-12 while the ratio collapses) nor necessary (`FPSLJacobianSolver` is the Lagrangian
-form, non-conservative by construction, deprecated for adjoint inconsistency rather than for mass).
-
-Also folded: the empty deprecated subclass `FPSLAdjointSolver(FPSLSolver)`, via its own
-`_deprecation_meta["alias_for"]` -- class-keying collapses `X = Y` but not `class X(Y): pass`, and
-two identical rows read as two independent confirmations. The clip exemption is keyed on the
-declared `kde_boundary_smoothing` flag rather than a substring of the class name. (#1975, #1977)
+A second lane measuring which wall each FP path imposes was removed. Its findings are recorded in
+#1975. It needed a discrimination rule for the LIMIT behaviour of a numerical scheme -- four
+attempts failed to state one, and 41% of a 32-mutation sweep survived the ratchet built over it,
+including the pins for three of the defects that ratchet claimed to have fixed. A ratchet over an
+unstated rule pins nothing.

--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -1,12 +1,10 @@
 `scripts/capability_census.py` and its ratchet `tests/unit/test_capability_census.py`: what each
-class **declares**, and what the FP paths actually **do** at a wall.
+class **declares**, and which wall each FP path actually **imposes**.
 
 Both lanes answer a question the 2026-08-13 design census could not. All four of its lanes look for
 reality falling *short* of a claim, and it found 77 over-claims; nobody counted the other
-direction. The other direction is what made #1975 wrong twice — `FPFEMSolver` implements a general
-Robin wall and declares nothing, and the default FDM scheme imposes `J.n = 0` structurally with no
-branch naming it. Over-claiming makes a user's code fail loudly; under-claiming makes a maintainer
-"fix" something that works.
+direction, and the other direction made #1975 wrong twice. Over-claiming makes a user's code fail
+loudly; under-claiming makes a maintainer "fix" something that works.
 
 Lane 1 discovers its population with `walk_packages` + `issubclass` — a predicate independent of
 every declaration it audits — so "declares nothing" is a recorded row rather than an absence. Own
@@ -14,10 +12,15 @@ declarations are separated from inherited ones by walking the MRO: `honors_inhom
 defaults to `True` on `BaseMFGSolver`, so 19 solvers claim to honour an inhomogeneous Neumann flux
 by a default nobody chose.
 
-Lane 2 is the oracle this area was missing: mass conservation at a wall with wall-normal drift,
-a law of the equation computed without reference to any scheme. Five FP paths conserve to machine
-precision — several imposing `J.n = 0` structurally, one by Skorokhod reflection. The zero-drift
-control fired immediately: `FPSLJacobianSolver` gains mass at `O(h)` with no drift at all
-(+0.1396 / +0.0689 / +0.0343 % at Nx = 41 / 81 / 161), so its drifted figure says nothing about its
-wall — the quantified reason its deprecation notes never gave. Six paths are `NOT_MEASURED`, which
-is recorded as a finding rather than a pass. (#1975, #1977)
+Lane 2's verdict is the wall ratio `d_n m / ((v_n/D) m_wall)` and its **trend under refinement**,
+not mass conservation. Mass conservation is neither sufficient (streamline diffusion conserves to
+1e-12 while the ratio collapses 0.967 -> 0.414) nor necessary (`FPSLJacobianSolver` is the
+Lagrangian form, non-conservative by construction, deprecated for adjoint inconsistency rather than
+for mass). Mass drift is reported as a form property beside the verdict, never as it.
+
+The instrument was rebuilt after eight defects, each of which produced a confident verdict rather
+than a failure — four found by independently measuring the paths it could not construct, four more
+only by re-running it against a path whose answer was already known. The sharpest: it passed a
+potential to the three solvers whose declared `_drift_convention` is `VELOCITY`, so the
+wall-normal drift vanished at the wall the mass reached and the discriminating property was absent
+while a verdict printed anyway. (#1975, #1977)

--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -1,0 +1,23 @@
+`scripts/capability_census.py` and its ratchet `tests/unit/test_capability_census.py`: what each
+class **declares**, and what the FP paths actually **do** at a wall.
+
+Both lanes answer a question the 2026-08-13 design census could not. All four of its lanes look for
+reality falling *short* of a claim, and it found 77 over-claims; nobody counted the other
+direction. The other direction is what made #1975 wrong twice — `FPFEMSolver` implements a general
+Robin wall and declares nothing, and the default FDM scheme imposes `J.n = 0` structurally with no
+branch naming it. Over-claiming makes a user's code fail loudly; under-claiming makes a maintainer
+"fix" something that works.
+
+Lane 1 discovers its population with `walk_packages` + `issubclass` — a predicate independent of
+every declaration it audits — so "declares nothing" is a recorded row rather than an absence. Own
+declarations are separated from inherited ones by walking the MRO: `honors_inhomogeneous_neumann`
+defaults to `True` on `BaseMFGSolver`, so 19 solvers claim to honour an inhomogeneous Neumann flux
+by a default nobody chose.
+
+Lane 2 is the oracle this area was missing: mass conservation at a wall with wall-normal drift,
+a law of the equation computed without reference to any scheme. Five FP paths conserve to machine
+precision — several imposing `J.n = 0` structurally, one by Skorokhod reflection. The zero-drift
+control fired immediately: `FPSLJacobianSolver` gains mass at `O(h)` with no drift at all
+(+0.1396 / +0.0689 / +0.0343 % at Nx = 41 / 81 / 161), so its drifted figure says nothing about its
+wall — the quantified reason its deprecation notes never gave. Six paths are `NOT_MEASURED`, which
+is recorded as a finding rather than a pass. (#1975, #1977)

--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -31,3 +31,10 @@ lane 1 because lane 2's code no longer exists to mutate, so the two percentages 
 and neither is auditable from this branch -- the harness for THESE 32 mutations is not
 committed. (`scripts/test_discrimination.py` is a committed mutation harness, for a different set.) What IS reproducible
 is stated per-mutation in the PR body, each with its liveness check.
+
+The script emits JSON only. An earlier revision also printed a prose report; nothing invoked it
+(zero references outside this changelog), it restated what the test file asserts with nothing
+keeping the restatement honest, and a review round went to correcting its labels -- it had called
+an inherited `False` and a `property` object "permissive defaults". 53 lines removed rather than
+relabelled: a mechanism with no invocations is fairly judged by that, and a second surface saying
+what the assertions already say is the failure this census exists to find, committed by the census.

--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -12,11 +12,21 @@ declarations are separated from inherited ones by walking the MRO, and a class b
 own module is one row. **18 solvers claim to honour an inhomogeneous Neumann flux by inheriting
 `BaseMFGSolver`'s `True`, a default nobody chose.** A nineteenth inherits the same field from a
 sibling and inherits `False` -- a deliberate refusal, the opposite case, and pinned separately.
-Three classes apply BC segments without subclassing any root; they are named rather than
-discovered and that list is stated to be incomplete.
+Three classes do a root's job without subclassing one; they are named rather than discovered and
+that list is stated to be incomplete. ~~"apply BC segments"~~ [CORRECTED] -- `HJBHowardSolver`
+reads `seg.bc_type` and `ParticleApplicator` interprets `BCType` throughout, but
+`ImplicitHeatSolver` only forwards `bc` to `get_laplacian_operator` and prints a segment in a
+`__repr__`. The script's own comment already had the accurate wording.
 
 A second lane measuring which wall each FP path imposes was removed. Its findings are in #1975. It
 needed a discrimination rule for the LIMIT behaviour of a numerical scheme -- four attempts failed
 to state one, and 41% of a 32-mutation sweep survived the ratchet built over it, including the pins
-for three of the defects that ratchet claimed to have fixed. After the removal the same sweep
-leaves 19% surviving, each with a working positive control.
+for three of the defects that ratchet claimed to have fixed.
+
+~~After the removal the same sweep leaves 19% surviving.~~ [CORRECTED 2026-08-17] -- it cannot be
+the same sweep. The surviving test set is a strict subset of the one that scored 41%, and deleting
+tests turns kills into survivals, never the reverse; 13 survivors cannot become 6 against a smaller
+suite over an identical mutation set. The second sweep is a different 32 mutations, retargeted at
+lane 1 because lane 2's code no longer exists to mutate, so the two percentages are not comparable
+and neither is auditable from this branch -- no mutation harness is committed. What IS reproducible
+is stated per-mutation in the PR body, each with its liveness check.

--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -8,13 +8,15 @@ wrong -- `FPFEMSolver` implements a general Robin wall and declares nothing, so 
 
 The population comes from `walk_packages` + `issubclass`, a predicate independent of the
 declaration audited, so "declares nothing" is a recorded row rather than an absence; own
-declarations are separated from inherited ones by walking the MRO. `honors_inhomogeneous_neumann`
-defaults to `True` on `BaseMFGSolver`, so 20 solvers claim to honour an inhomogeneous flux by a
-default nobody chose. Three classes apply BC segments without being subclasses of any root and are
-named rather than discovered; that list is stated to be incomplete.
+declarations are separated from inherited ones by walking the MRO, and a class bound twice in its
+own module is one row. **18 solvers claim to honour an inhomogeneous Neumann flux by inheriting
+`BaseMFGSolver`'s `True`, a default nobody chose.** A nineteenth inherits the same field from a
+sibling and inherits `False` -- a deliberate refusal, the opposite case, and pinned separately.
+Three classes apply BC segments without subclassing any root; they are named rather than
+discovered and that list is stated to be incomplete.
 
-A second lane measuring which wall each FP path imposes was removed. Its findings are recorded in
-#1975. It needed a discrimination rule for the LIMIT behaviour of a numerical scheme -- four
-attempts failed to state one, and 41% of a 32-mutation sweep survived the ratchet built over it,
-including the pins for three of the defects that ratchet claimed to have fixed. A ratchet over an
-unstated rule pins nothing.
+A second lane measuring which wall each FP path imposes was removed. Its findings are in #1975. It
+needed a discrimination rule for the LIMIT behaviour of a numerical scheme -- four attempts failed
+to state one, and 41% of a 32-mutation sweep survived the ratchet built over it, including the pins
+for three of the defects that ratchet claimed to have fixed. After the removal the same sweep
+leaves 19% surviving, each with a working positive control.

--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -1,26 +1,23 @@
-`scripts/capability_census.py` and its ratchet `tests/unit/test_capability_census.py`: what each
-class **declares**, and which wall each FP path actually **imposes**.
+`scripts/capability_census.py` and its ratchet: what each class **declares**, and the wall-ratio
+**sequence** each FP path produces.
 
-Both lanes answer a question the 2026-08-13 design census could not. All four of its lanes look for
-reality falling *short* of a claim, and it found 77 over-claims; nobody counted the other
-direction, and the other direction made #1975 wrong twice. Over-claiming makes a user's code fail
-loudly; under-claiming makes a maintainer "fix" something that works.
+Lane 1 discovers its population with `walk_packages` + `issubclass` + `inspect.isabstract`, keyed
+on class identity -- a predicate independent of the declaration it audits -- so "declares nothing"
+is a recorded row rather than an absence, and own declarations are separated from inherited ones by
+walking the MRO.
 
-Lane 1 discovers its population with `walk_packages` + `issubclass` — a predicate independent of
-every declaration it audits — so "declares nothing" is a recorded row rather than an absence. Own
-declarations are separated from inherited ones by walking the MRO: `honors_inhomogeneous_neumann`
-defaults to `True` on `BaseMFGSolver`, so 19 solvers claim to honour an inhomogeneous Neumann flux
-by a default nobody chose.
+**Lane 2 renders no verdict.** An earlier version classified each path from the ratio's trend
+across three resolutions; independent review showed the rule cannot do that. `FPFVMSolver` reads
+0.392 / 0.649 / 1.106 and keeps going to 12.699 at nx=1281, so a "within tolerance of 1" clause
+fires on a value the sequence merely transits, and `FPSLSolver` reads 0.998 at nx=201 then 1.926
+and 3.500. Three resolutions cannot separate approach from transit, and neither can six. The
+sequence is reported and the reading is left to a person.
 
-Lane 2's verdict is the wall ratio `d_n m / ((v_n/D) m_wall)` and its **trend under refinement**,
-not mass conservation. Mass conservation is neither sufficient (streamline diffusion conserves to
-1e-12 while the ratio collapses 0.967 -> 0.414) nor necessary (`FPSLJacobianSolver` is the
-Lagrangian form, non-conservative by construction, deprecated for adjoint inconsistency rather than
-for mass). Mass drift is reported as a form property beside the verdict, never as it.
+Mass drift is reported beside it as a **form property**: neither sufficient (streamline diffusion
+conserves to 1e-12 while the ratio collapses) nor necessary (`FPSLJacobianSolver` is the Lagrangian
+form, non-conservative by construction, deprecated for adjoint inconsistency rather than for mass).
 
-The instrument was rebuilt after eight defects, each of which produced a confident verdict rather
-than a failure — four found by independently measuring the paths it could not construct, four more
-only by re-running it against a path whose answer was already known. The sharpest: it passed a
-potential to the three solvers whose declared `_drift_convention` is `VELOCITY`, so the
-wall-normal drift vanished at the wall the mass reached and the discriminating property was absent
-while a verdict printed anyway. (#1975, #1977)
+Also folded: the empty deprecated subclass `FPSLAdjointSolver(FPSLSolver)`, via its own
+`_deprecation_meta["alias_for"]` -- class-keying collapses `X = Y` but not `class X(Y): pass`, and
+two identical rows read as two independent confirmations. The clip exemption is keyed on the
+declared `kde_boundary_smoothing` flag rather than a substring of the class name. (#1975, #1977)

--- a/changelog.d/1975-capability-census.added.md
+++ b/changelog.d/1975-capability-census.added.md
@@ -28,5 +28,6 @@ the same sweep. The surviving test set is a strict subset of the one that scored
 tests turns kills into survivals, never the reverse; 13 survivors cannot become 6 against a smaller
 suite over an identical mutation set. The second sweep is a different 32 mutations, retargeted at
 lane 1 because lane 2's code no longer exists to mutate, so the two percentages are not comparable
-and neither is auditable from this branch -- no mutation harness is committed. What IS reproducible
+and neither is auditable from this branch -- the harness for THESE 32 mutations is not
+committed. (`scripts/test_discrimination.py` is a committed mutation harness, for a different set.) What IS reproducible
 is stated per-mutation in the PR body, each with its liveness check.

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -167,75 +167,18 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
     }
 
 
-def _print_declarations(result: dict[str, Any]) -> None:
-    for label, path, err in result["roots_missing"]:
-        print(f"  ROOT UNAVAILABLE  {label}: {path} -> {err}")
-    if result["import_failures"]:
-        print(f"\n=== modules that would not import ({len(result['import_failures'])}) ===")
-        for name, err in result["import_failures"]:
-            print(f"  {name}: {err}")
-
-    rows = result["rows"]
-    print(f"\n=== population: {len(rows)} concrete classes ===")
-    print(f"{'role':11s} {'class':32s} {'own':>3s}  own declarations / [inherited]")
-    for r in rows:
-        own = ", ".join(r["own"]) or "-- DECLARES NOTHING --"
-        inh = ", ".join(f"{k}={v['value']}<-{v['from']}" for k, v in r["inherited"].items())
-        print(f"{','.join(r['roles']):11s} {r['name']:32s} {len(r['own']):3d}  {own}" + (f"   [{inh}]" if inh else ""))
-
-    print("\n=== declares nothing of its own ===")
-    for role in sorted({x for r in rows for x in r["roles"]}):
-        members = [r for r in rows if role in r["roles"]]
-        silent = [r for r in members if r["declares_nothing"]]
-        print(f"  {role:11s} {len(silent):3d} of {len(members):3d}  ({100 * len(silent) / len(members):.0f}%)")
-    print("  Not evidence of no capability -- it is the case where capability cannot be read off")
-    print("  the class at all, which is the blind spot #1975 fell into.")
-
-    print("\n=== declarations that arrive by inheritance, grouped by what is inherited ===")
-    for decl in DECLARATIONS:
-        inheritors = [r for r in rows if decl in r["inherited"]]
-        owners = [r["name"] for r in rows if decl in r["own"]]
-        if not (inheritors or owners):
-            continue
-        print(f"  {decl}: own {len(owners)}, inherited {len(inheritors)}")
-        groups: dict[tuple[str, str], list[str]] = {}
-        for r in inheritors:
-            e = r["inherited"][decl]
-            groups.setdefault((str(e["from"]), str(e["value"])), []).append(r["names"][0])
-        for (src, val), who in sorted(groups.items(), key=lambda kv: -len(kv[1])):
-            shown = val if not val.startswith("<property object") else "<property>"
-            print(f"      {len(who):3d}  <- {src:26s} = {shown[:46]}")
-    print("  A count alone cannot say whether an inherited declaration is permissive. Grouping")
-    print("  can: an inherited `True` on honors_inhomogeneous_neumann is a claim nobody made")
-    print("  deliberately; an inherited `False`, or a restrictive frozenset, or a `property`")
-    print("  object, is not -- and a bare count previously reported all four as the same thing.")
-
-    if result["excluded_by_name_prefix"]:
-        print(f"\n=== concrete, under a root, dropped by a NAME prefix: {len(result['excluded_by_name_prefix'])} ===")
-        for nm in result["excluded_by_name_prefix"]:
-            print(f"  {nm}")
-
-    print("\n=== outside every population predicate (named, not discovered) ===")
-    for name, reached in sorted(result["outside_every_predicate"].items()):
-        print(f"  {name:22s} reached by: {reached or 'NOTHING'}")
-
-
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    """Dump the matrix as JSON. There is no prose report: the previous one restated what
+    tests/unit/test_capability_census.py asserts, with nothing keeping the restatement honest,
+    and a review round went to correcting its labels on output nothing ran."""
+
+    ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--package", default="mfgarchon")
-    ap.add_argument("--json", metavar="FILE")
     args = ap.parse_args()
-
-    import mfgarchon
-
-    print(f"module root: {mfgarchon.__file__}\n")
     result = declaration_matrix(args.package)
-    _print_declarations(result)
-
-    if args.json:
-        with open(args.json, "w") as fh:
-            json.dump(result, fh, indent=2)
-        print(f"\nwrote {args.json}")
+    for row in result["rows"]:
+        row.pop("cls_id", None)
+    print(json.dumps(result, indent=2, sort_keys=True, default=str))
     return 0
 
 

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -102,10 +102,20 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
             missing.append((label, f"{module_path}.{name}", f"{type(exc).__name__}: {exc}"))
 
     classes, import_failures = _walk(package)
-    rows = []
+    rows: list[dict] = []
+    excluded_by_name: list[str] = []
     for name, cls in classes:
         labels = sorted(lbl for lbl, base in roots.items() if issubclass(cls, base))
-        if not labels or inspect.isabstract(cls) or name.startswith(("Base", "_")):
+        if not labels:
+            continue
+        if inspect.isabstract(cls):
+            continue
+        if name.startswith(("Base", "_")):
+            # A NAME deciding the population, in a script whose other lane was deleted for
+            # exactly that. Kept because these are intended-abstract bases, but recorded:
+            # `inspect.isabstract` is False for them (empty `__abstractmethods__`), and three
+            # of them OWN `discretization_type` and appear as the `<-` owner below.
+            excluded_by_name.append(name)
             continue
         # Same class bound twice in its own module (`NetworkFPSolver = FPNetworkSolver`,
         # fp_network.py:606) yields two rows unless collapsed. The removed conservation lane
@@ -118,7 +128,10 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
             owner = next((k.__name__ for k in cls.__mro__ if decl in k.__dict__), None)
             if owner is None:
                 continue
-            target = own if owner == name else inherited
+            # `owner == cls.__name__`, not `owner == name`: `name` is whichever binding
+            # `inspect.getmembers` yielded first (alphabetical), so an alias sorting earlier
+            # would report the class as inheriting its own declaration.
+            target = own if owner == cls.__name__ else inherited
             target[decl] = {"value": str(getattr(cls, decl)), "from": owner}
         rows.append(
             {
@@ -128,10 +141,12 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
                 "module": cls.__module__,
                 "roles": labels,
                 "own": sorted(own),
+                "own_values": {k: v["value"] for k, v in own.items()},
                 "inherited": inherited,
                 "declares_nothing": not own,
             }
         )
+
     rows.sort(key=lambda r: (r["roles"], len(r["own"]), r["name"]))
 
     outside = {}
@@ -147,6 +162,7 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
         "roots_missing": missing,
         "import_failures": import_failures,
         "outside_every_predicate": outside,
+        "excluded_by_name_prefix": sorted(set(excluded_by_name)),
     }
 
 
@@ -174,13 +190,29 @@ def _print_declarations(result: dict[str, Any]) -> None:
     print("  Not evidence of no capability -- it is the case where capability cannot be read off")
     print("  the class at all, which is the blind spot #1975 fell into.")
 
-    print("\n=== claimed only by inheriting a permissive default ===")
+    print("\n=== declarations that arrive by inheritance, grouped by what is inherited ===")
     for decl in DECLARATIONS:
-        inheritors = [r["name"] for r in rows if decl in r["inherited"]]
+        inheritors = [r for r in rows if decl in r["inherited"]]
         owners = [r["name"] for r in rows if decl in r["own"]]
-        if inheritors or owners:
-            print(f"  {decl}: own {len(owners)}, INHERITED {len(inheritors)}")
-    print("  An inherited permissive default is a claim nobody made deliberately.")
+        if not (inheritors or owners):
+            continue
+        print(f"  {decl}: own {len(owners)}, inherited {len(inheritors)}")
+        groups: dict[tuple[str, str], list[str]] = {}
+        for r in inheritors:
+            e = r["inherited"][decl]
+            groups.setdefault((str(e["from"]), str(e["value"])), []).append(r["names"][0])
+        for (src, val), who in sorted(groups.items(), key=lambda kv: -len(kv[1])):
+            shown = val if not val.startswith("<property object") else "<property>"
+            print(f"      {len(who):3d}  <- {src:26s} = {shown[:46]}")
+    print("  A count alone cannot say whether an inherited declaration is permissive. Grouping")
+    print("  can: an inherited `True` on honors_inhomogeneous_neumann is a claim nobody made")
+    print("  deliberately; an inherited `False`, or a restrictive frozenset, or a `property`")
+    print("  object, is not -- and a bare count previously reported all four as the same thing.")
+
+    if result["excluded_by_name_prefix"]:
+        print(f"\n=== concrete, under a root, dropped by a NAME prefix: {len(result['excluded_by_name_prefix'])} ===")
+        for nm in result["excluded_by_name_prefix"]:
+            print(f"  {nm}")
 
     print("\n=== outside every population predicate (named, not discovered) ===")
     for name, reached in sorted(result["outside_every_predicate"].items()):

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python
+"""What each class DECLARES, and what the FP paths actually DO at a wall.
+
+Two lanes, both answering a question the 2026-08-13 design census could not.
+
+That census had four lanes -- claim-vs-actual, dead surface, own-geometry-vocabulary, import
+structure -- and every one looks for reality falling **short** of a claim. It found 77 over-claims.
+Nobody counted the other direction, and the other direction is what made #1975 wrong twice:
+
+  - `FPFEMSolver` implements a general Robin wall and declares nothing, so a census keyed on
+    `_SUPPORTED_BC_TYPES` reported the capability absent.
+  - the default FDM scheme imposes `J.n = 0` structurally, by zeroing the total face flux, with no
+    branch naming it -- so a sweep over branch names reported the wrong wall.
+
+Over-claiming makes a USER's code fail loudly. Under-claiming makes a MAINTAINER delete or "fix"
+something that works: the fix #1975 prescribed would have taken two correct FP paths from
+-7.4e-15 to -79.5% mass drift.
+
+## Lane 1 -- `declarations`
+
+Population: every concrete class under a named root, discovered by `walk_packages` +
+`issubclass`. **The predicate must not be the property audited**, so no declaration takes part in
+choosing the population; each declaration is a column and "declares nothing" is a recorded row.
+
+`getattr` is not enough: it finds a base-class default and reports it as a declaration. The MRO is
+walked instead, and an inherited permissive default is reported separately -- it is a claim nobody
+made deliberately. `honors_inhomogeneous_neumann` defaults to `True` on `BaseMFGSolver`.
+
+## Lane 2 -- `conservation`
+
+Population: every concrete class implementing `solve_fp_system`. Again not a declaration.
+
+Oracle: mass conservation at a wall with wall-normal drift. `J.n = 0` is `m*v_n - D*d_n m = 0`;
+with a normal drift it is NOT `d_n m = 0`, and a conserved quantity separates them --
+
+    imposes J.n = 0    ->  mass conserved, `d_n m != 0` at the wall
+    imposes d_n m = 0  ->  mass leaks at a rate proportional to `m_wall * v_n`
+
+Two controls, because "conserves" is otherwise unfalsifiable:
+  1. **zero drift** -- every path must conserve. One that leaks here is broken for an unrelated
+     reason and its drifted number says nothing about its wall. This control fired on the first
+     run: `FPSLJacobianSolver` gains mass at `O(h)` with no drift at all.
+  2. **a known-good reference** -- `divergence_upwind` on the raw assembly. If the harness reports
+     that leaking, the harness is wrong and every row is void.
+
+## What neither lane can say
+
+  - A capability announced by a method, a registry entry or `__getattr__` is invisible to lane 1.
+  - Lane 2 measures each solver **at its default configuration**. Non-default advection schemes are
+    reachable and differ: `gradient_upwind` loses 75% where `divergence_upwind` loses nothing.
+  - A class outside every root's subclass tree is reached by nothing here; the known ones are
+    listed in `OUTSIDE_EVERY_PREDICATE` and are **named, not discovered**, because a population
+    predicate is itself a claim about scope.
+  - `NOT MEASURED` is not a pass. It is a path whose wall nobody in this repository can currently
+    observe -- the state that let #1975 be filed on a false premise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import pkgutil
+import sys
+from typing import Any
+
+import numpy as np
+
+# --------------------------------------------------------------------------------------
+# Lane 1 -- declarations
+# --------------------------------------------------------------------------------------
+
+#: Class-level attributes this repository uses to announce a capability or a constraint.
+DECLARATIONS = (
+    "_SUPPORTED_BC_TYPES",
+    "honors_inhomogeneous_neumann",
+    "discretization_type",
+)
+
+#: Roots whose concrete subclasses form each population.
+ROOTS = {
+    "solver": ("mfgarchon.alg.base_solver", "BaseMFGSolver"),
+    "applicator": ("mfgarchon.geometry.boundary.protocols", "BaseBCApplicator"),
+    "backend": ("mfgarchon.backends.base_backend", "BaseBackend"),
+    "geometry": ("mfgarchon.geometry.base", "Geometry"),
+}
+
+#: Classes doing a root's job without subclassing it, so no predicate above reaches them.
+#: Named rather than discovered -- that is the honest form of a scope claim.
+OUTSIDE_EVERY_PREDICATE = {
+    "ParticleApplicator": "mfgarchon.geometry.boundary.applicator_particle",
+    "HJBHowardSolver": "mfgarchon.alg.numerical.hjb_solvers.hjb_howard",
+    "ImplicitHeatSolver": "mfgarchon.alg.numerical.pde_solvers.implicit_heat",
+}
+
+
+def _walk(package: str) -> tuple[list[tuple[str, type]], list[tuple[str, str]]]:
+    pkg = importlib.import_module(package)
+    classes: list[tuple[str, type]] = []
+    failures: list[tuple[str, str]] = []
+    for mod in pkgutil.walk_packages(pkg.__path__, prefix=f"{package}."):
+        try:
+            module = importlib.import_module(mod.name)
+        except Exception as exc:
+            failures.append((mod.name, f"{type(exc).__name__}: {exc}"))
+            continue
+        classes.extend(
+            (name, cls)
+            for name, cls in inspect.getmembers(module, inspect.isclass)
+            if cls.__module__ == module.__name__
+        )
+    return classes, failures
+
+
+def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
+    """One row per concrete class under a root, with own vs inherited declarations separated."""
+    roots, missing = {}, []
+    for label, (module_path, name) in ROOTS.items():
+        try:
+            roots[label] = getattr(importlib.import_module(module_path), name)
+        except Exception as exc:
+            missing.append((label, f"{module_path}.{name}", f"{type(exc).__name__}: {exc}"))
+
+    classes, import_failures = _walk(package)
+    rows = []
+    for name, cls in classes:
+        labels = sorted(lbl for lbl, base in roots.items() if issubclass(cls, base))
+        if not labels or inspect.isabstract(cls) or name.startswith(("Base", "_")):
+            continue
+        own, inherited = {}, {}
+        for decl in DECLARATIONS:
+            owner = next((k.__name__ for k in cls.__mro__ if decl in k.__dict__), None)
+            if owner is None:
+                continue
+            target = own if owner == name else inherited
+            target[decl] = {"value": str(getattr(cls, decl)), "from": owner}
+        rows.append(
+            {
+                "name": name,
+                "module": cls.__module__,
+                "roles": labels,
+                "own": sorted(own),
+                "inherited": inherited,
+                "declares_nothing": not own,
+            }
+        )
+    rows.sort(key=lambda r: (r["roles"], len(r["own"]), r["name"]))
+
+    outside = {}
+    for name, path in OUTSIDE_EVERY_PREDICATE.items():
+        try:
+            cls = getattr(importlib.import_module(path), name)
+            outside[name] = sorted(lbl for lbl, base in roots.items() if issubclass(cls, base))
+        except Exception as exc:
+            outside[name] = [f"UNAVAILABLE: {type(exc).__name__}"]
+
+    return {
+        "rows": rows,
+        "roots_missing": missing,
+        "import_failures": import_failures,
+        "outside_every_predicate": outside,
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Lane 2 -- conservation at a drifted wall
+# --------------------------------------------------------------------------------------
+
+NX, STEPS, DT, SIGMA, DRIFT = 81, 200, 1e-3, 0.3, 3.2
+TOL = 1e-3  # percent; the conserving paths measure at 1e-4 % or better
+
+
+def fp_solver_population() -> list[tuple[str, type]]:
+    """Every concrete class implementing `solve_fp_system` -- the METHOD is the predicate."""
+    import mfgarchon.alg as alg_pkg
+
+    found: dict[str, type] = {}
+    for mod in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg."):
+        try:
+            module = importlib.import_module(mod.name)
+        except Exception:
+            continue
+        for name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__ or inspect.isabstract(cls):
+                continue
+            if name.startswith(("Base", "_")):
+                continue
+            fn = getattr(cls, "solve_fp_system", None)
+            if callable(fn) and not getattr(fn, "__isabstractmethod__", False):
+                found[name] = cls
+    return sorted(found.items())
+
+
+def _problem(drift: float):
+    from mfgarchon import Conditions, MFGProblem, Model
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    return MFGProblem(
+        model=Model(
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: 0.0 * m,
+                coupling_dm=lambda m: 0.0,
+            ),
+            sigma=SIGMA,
+        ),
+        domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=no_flux_bc(dimension=1)),
+        conditions=Conditions(
+            u_terminal=lambda x: -drift * x,
+            m_initial=lambda x: np.exp(-50 * (x - 0.5) ** 2),
+            T=STEPS * DT,
+        ),
+        Nt=STEPS,
+    )
+
+
+def _initial_density() -> tuple[np.ndarray, np.ndarray, float]:
+    x = np.linspace(0.0, 1.0, NX)
+    h = 1.0 / (NX - 1)
+    m0 = np.exp(-50 * (x - 0.5) ** 2)
+    return x, m0 / (m0.sum() * h), h
+
+
+def reference_drift_pct() -> float:
+    """Control 2: the raw assembly path, which #1975 measured at -0.0000%."""
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
+    from mfgarchon.geometry import TensorProductGrid
+    from mfgarchon.geometry.boundary import no_flux_bc
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=no_flux_bc(dimension=1))
+    x, m, h = _initial_density()
+    start = m.sum() * h
+    for _ in range(STEPS):
+        m = solve_timestep_full_nd(
+            M_current=m,
+            U_current=-DRIFT * x,
+            problem=object(),
+            dt=DT,
+            sigma=SIGMA,
+            coupling_coefficient=1.0,
+            spacing=(h,),
+            grid=grid,
+            ndim=1,
+            shape=(NX,),
+            boundary_conditions=no_flux_bc(dimension=1),
+            advection_scheme="divergence_upwind",
+        )
+    return 100.0 * (m.sum() * h - start) / start
+
+
+def _one_run(cls, drift: float) -> tuple[str, float | None, str]:
+    try:
+        problem = _problem(drift)
+    except Exception as exc:
+        return "harness_fail", None, f"{type(exc).__name__}: {exc}"
+    try:
+        solver = cls(problem)
+    except Exception as exc:
+        return "construct_fail", None, f"{type(exc).__name__}: {str(exc).splitlines()[0][:140]}"
+
+    x, m0, h = _initial_density()
+    u = np.tile(-drift * x, (STEPS + 1, 1))
+    try:
+        m = solver.solve_fp_system(m0, u)
+    except TypeError:
+        try:
+            m = solver.solve_fp_system(m0, potential_field=u)
+        except Exception as exc:
+            return "solve_fail", None, f"{type(exc).__name__}: {str(exc).splitlines()[0][:140]}"
+    except Exception as exc:
+        return "solve_fail", None, f"{type(exc).__name__}: {str(exc).splitlines()[0][:140]}"
+
+    m = np.asarray(m)
+    if m.ndim != 2 or not np.all(np.isfinite(m)):
+        return "solve_fail", None, f"shape {m.shape}, finite={bool(np.all(np.isfinite(m)))}"
+    start, end = m[0].sum() * h, m[-1].sum() * h
+    if start <= 0:
+        return "solve_fail", None, f"initial mass {start:.3e}"
+    return "ok", 100.0 * (end - start) / start, ""
+
+
+def conservation_verdicts() -> dict[str, Any]:
+    rows = []
+    for name, cls in fp_solver_population():
+        v0, d0, e0 = _one_run(cls, 0.0)
+        v1, d1, e1 = _one_run(cls, DRIFT)
+        if v0 != "ok" or v1 != "ok":
+            verdict = "NOT_MEASURED"
+            detail = e0 or e1
+        elif abs(d0) > TOL:
+            verdict = "CONTROL_FAILED"
+            detail = f"leaks {d0:+.4f}% with no drift; the drifted number says nothing about its wall"
+        elif abs(d1) < TOL:
+            verdict = "CONSERVES"
+            detail = "imposes J.n = 0"
+        else:
+            verdict = "LEAKS"
+            detail = f"{d1:+.4f}% at a drifted wall -- imposes d_n m = 0, not J.n = 0"
+        rows.append({"class": name, "no_drift_pct": d0, "drift_pct": d1, "verdict": verdict, "detail": detail})
+    return {"reference_drift_pct": reference_drift_pct(), "rows": rows}
+
+
+# --------------------------------------------------------------------------------------
+
+
+def _print_declarations(result: dict[str, Any]) -> None:
+    for label, path, err in result["roots_missing"]:
+        print(f"  ROOT UNAVAILABLE  {label}: {path} -> {err}")
+    if result["import_failures"]:
+        print(f"\n=== modules that would not import ({len(result['import_failures'])}) ===")
+        for name, err in result["import_failures"]:
+            print(f"  {name}: {err}")
+
+    rows = result["rows"]
+    print(f"\n=== population: {len(rows)} concrete classes ===")
+    print(f"{'role':11s} {'class':32s} {'own':>3s}  own declarations / [inherited]")
+    for r in rows:
+        own = ", ".join(r["own"]) or "-- DECLARES NOTHING --"
+        inh = ", ".join(f"{k}={v['value']}<-{v['from']}" for k, v in r["inherited"].items())
+        print(f"{','.join(r['roles']):11s} {r['name']:32s} {len(r['own']):3d}  {own}" + (f"   [{inh}]" if inh else ""))
+
+    print("\n=== declares nothing of its own ===")
+    for role in sorted({x for r in rows for x in r["roles"]}):
+        members = [r for r in rows if role in r["roles"]]
+        silent = [r for r in members if r["declares_nothing"]]
+        print(f"  {role:11s} {len(silent):3d} of {len(members):3d}  ({100 * len(silent) / len(members):.0f}%)")
+    print("  Not evidence of no capability -- it is the case where capability cannot be read off")
+    print("  the class at all, which is the blind spot #1975 fell into.")
+
+    print("\n=== claimed only by inheriting a permissive default ===")
+    for decl in DECLARATIONS:
+        inheritors = [r["name"] for r in rows if decl in r["inherited"]]
+        owners = [r["name"] for r in rows if decl in r["own"]]
+        if inheritors or owners:
+            print(f"  {decl}: own {len(owners)}, INHERITED {len(inheritors)}")
+    print("  An inherited permissive default is a claim nobody made deliberately.")
+
+    print("\n=== outside every population predicate (named, not discovered) ===")
+    for name, reached in sorted(result["outside_every_predicate"].items()):
+        print(f"  {name:22s} reached by: {reached or 'NOTHING'}")
+
+
+def _print_conservation(result: dict[str, Any]) -> int:
+    ref = result["reference_drift_pct"]
+    ok = abs(ref) < TOL
+    print(f"=== control 2: reference path drift {ref:+.4f}%  {'HARNESS OK' if ok else 'HARNESS SUSPECT'} ===")
+    if not ok:
+        print("  the reference is supposed to conserve exactly; every row below is void")
+
+    print(f"\n{'class':32s} {'no drift':>12s} {'drift':>12s}   verdict")
+    for r in result["rows"]:
+        cell = lambda v: f"{v:+11.4f}%" if v is not None else f"{'--':>12s}"  # noqa: E731
+        print(
+            f"{r['class']:32s} {cell(r['no_drift_pct']):>12s} {cell(r['drift_pct']):>12s}   {r['verdict']}: {r['detail']}"
+        )
+
+    counts: dict[str, int] = {}
+    for r in result["rows"]:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    print("\n=== " + ", ".join(f"{v} {k}" for k, v in sorted(counts.items())) + " ===")
+    print("NOT_MEASURED is not a pass. It is a path whose wall nobody here can currently observe.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("lane", choices=("declarations", "conservation", "both"), nargs="?", default="both")
+    ap.add_argument("--json", metavar="FILE")
+    args = ap.parse_args()
+
+    import mfgarchon
+
+    print(f"module root: {mfgarchon.__file__}\n")
+    out: dict[str, Any] = {}
+    if args.lane in ("declarations", "both"):
+        out["declarations"] = declaration_matrix()
+        _print_declarations(out["declarations"])
+    if args.lane in ("conservation", "both"):
+        if out:
+            print()
+        out["conservation"] = conservation_verdicts()
+        _print_conservation(out["conservation"])
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump(out, fh, indent=2)
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -107,6 +107,12 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
         labels = sorted(lbl for lbl, base in roots.items() if issubclass(cls, base))
         if not labels or inspect.isabstract(cls) or name.startswith(("Base", "_")):
             continue
+        # Same class bound twice in its own module (`NetworkFPSolver = FPNetworkSolver`,
+        # fp_network.py:606) yields two rows unless collapsed. The removed conservation lane
+        # carried that knowledge; lane 1 inherited the bug when it went.
+        if any(r["cls_id"] == id(cls) for r in rows):
+            next(r for r in rows if r["cls_id"] == id(cls))["names"].append(name)
+            continue
         own, inherited = {}, {}
         for decl in DECLARATIONS:
             owner = next((k.__name__ for k in cls.__mro__ if decl in k.__dict__), None)
@@ -117,6 +123,8 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
         rows.append(
             {
                 "name": name,
+                "names": [name],
+                "cls_id": id(cls),
                 "module": cls.__module__,
                 "roles": labels,
                 "own": sorted(own),

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -113,8 +113,9 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
         if name.startswith(("Base", "_")):
             # A NAME deciding the population, in a script whose other lane was deleted for
             # exactly that. Kept because these are intended-abstract bases, but recorded:
-            # `inspect.isabstract` is False for them (empty `__abstractmethods__`), and three
-            # of them OWN `discretization_type` and appear as the `<-` owner below.
+            # `inspect.isabstract` is False for them (empty `__abstractmethods__`), and all four
+            # OWN `discretization_type` (protocols.py:338/625/653/682); three appear as the `<-`
+            # owner below, the fourth having no surviving subclass in the population.
             excluded_by_name.append(name)
             continue
         # Same class bound twice in its own module (`NetworkFPSolver = FPNetworkSolver`,

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -1,22 +1,13 @@
-#!/usr/bin/env python
-"""What each class DECLARES, and what the FP paths actually DO at a wall.
+"""What each class DECLARES about the boundary conditions it accepts.
 
-Two lanes, both answering a question the 2026-08-13 design census could not.
-
-That census had four lanes -- claim-vs-actual, dead surface, own-geometry-vocabulary, import
-structure -- and every one looks for reality falling **short** of a claim. It found 77 over-claims.
-Nobody counted the other direction, and the other direction is what made #1975 wrong twice:
-
-  - `FPFEMSolver` implements a general Robin wall and declares nothing, so a census keyed on
-    `_SUPPORTED_BC_TYPES` reported the capability absent.
-  - the default FDM scheme imposes `J.n = 0` structurally, by zeroing the total face flux, with no
-    branch naming it -- so a sweep over branch names reported the wrong wall.
+The 2026-08-13 design census had four lanes -- claim-vs-actual, dead surface,
+own-geometry-vocabulary, import structure -- and every one looks for reality falling **short** of
+a claim. It found 77 over-claims. Nobody counted the other direction, and the other direction is
+what made #1975 wrong twice: `FPFEMSolver` implements a general Robin wall and declares nothing,
+so a census keyed on `_SUPPORTED_BC_TYPES` reported the capability absent.
 
 Over-claiming makes a USER's code fail loudly. Under-claiming makes a MAINTAINER delete or "fix"
-something that works: the fix #1975 prescribed would have taken two correct FP paths from
--7.4e-15 to -79.5% mass drift.
-
-## Lane 1 -- `declarations`
+something that works.
 
 Population: every concrete class under a named root, discovered by `walk_packages` +
 `issubclass`. **The predicate must not be the property audited**, so no declaration takes part in
@@ -26,33 +17,23 @@ choosing the population; each declaration is a column and "declares nothing" is 
 walked instead, and an inherited permissive default is reported separately -- it is a claim nobody
 made deliberately. `honors_inhomogeneous_neumann` defaults to `True` on `BaseMFGSolver`.
 
-## Lane 2 -- `conservation`
+`cls.__module__ != module.__name__` is deliberate: it collapses cross-module re-exports, so a
+class re-exported from a package `__init__` is one row rather than two.
 
-Population: every concrete class implementing `solve_fp_system`. Again not a declaration.
+## What this cannot say
 
-Oracle: mass conservation at a wall with wall-normal drift. `J.n = 0` is `m*v_n - D*d_n m = 0`;
-with a normal drift it is NOT `d_n m = 0`, and a conserved quantity separates them --
+  - A capability announced by a method, a registry entry or `__getattr__` is invisible here.
+  - A class outside every root's subclass tree is reached by nothing; the known ones are listed in
+    `OUTSIDE_EVERY_PREDICATE` and are **named, not discovered**, because a population predicate is
+    itself a claim about scope. That list is incomplete.
+  - "Declares nothing" is not "has no capability" -- it is the case where capability cannot be
+    read off the class at all, which is the blind spot #1975 fell into.
 
-    imposes J.n = 0    ->  mass conserved, `d_n m != 0` at the wall
-    imposes d_n m = 0  ->  mass leaks at a rate proportional to `m_wall * v_n`
-
-Two controls, because "conserves" is otherwise unfalsifiable:
-  1. **zero drift** -- every path must conserve. One that leaks here is broken for an unrelated
-     reason and its drifted number says nothing about its wall. This control fired on the first
-     run: `FPSLJacobianSolver` gains mass at `O(h)` with no drift at all.
-  2. **a known-good reference** -- `divergence_upwind` on the raw assembly. If the harness reports
-     that leaking, the harness is wrong and every row is void.
-
-## What neither lane can say
-
-  - A capability announced by a method, a registry entry or `__getattr__` is invisible to lane 1.
-  - Lane 2 measures each solver **at its default configuration**. Non-default advection schemes are
-    reachable and differ: `gradient_upwind` loses 75% where `divergence_upwind` loses nothing.
-  - A class outside every root's subclass tree is reached by nothing here; the known ones are
-    listed in `OUTSIDE_EVERY_PREDICATE` and are **named, not discovered**, because a population
-    predicate is itself a claim about scope.
-  - `NOT MEASURED` is not a pass. It is a path whose wall nobody in this repository can currently
-    observe -- the state that let #1975 be filed on a false premise.
+A second lane, measuring which wall each FP path imposes, was removed. Its findings are recorded
+in #1975. The measurement needed a discrimination rule for the LIMIT behaviour of a numerical
+scheme, four attempts failed to state one correctly, and 41% of a 32-mutation sweep survived the
+ratchet built over it -- including the pins for three of the defects it claimed to have fixed. A
+ratchet over an unstated rule pins nothing.
 """
 
 from __future__ import annotations
@@ -64,8 +45,6 @@ import json
 import pkgutil
 import sys
 from typing import Any
-
-import numpy as np
 
 # --------------------------------------------------------------------------------------
 # Lane 1 -- declarations
@@ -163,338 +142,6 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
     }
 
 
-# --------------------------------------------------------------------------------------
-# Lane 2 -- what wall each FP path actually imposes
-# --------------------------------------------------------------------------------------
-#
-# The first version of this lane had three defects, each found by an independent measurement
-# and each of a kind that produces a CONFIDENT WRONG ANSWER rather than a visible failure.
-#
-# 1. It assumed the mass functional. `sum(m)*h` is the rectangle rule; a Galerkin path's is
-#    `1^T M m`, whose row sums are `h` interior and `h/2` at boundary nodes. With mass piled
-#    against a wall they differ by `h/2 * m_wall` -- measured `+37.13%` where the truth was
-#    `-4.2e-13%`. Three paths would have been reported `CONTROL_FAILED`. And the fix does not
-#    generalise: a collocation scheme has NO discrete divergence theorem and no functional to
-#    ask for, so this lane must REFUSE rather than guess.
-#
-# 2. Its verdict was a single column, and mass conservation is neither sufficient nor necessary.
-#    NOT SUFFICIENT: streamline diffusion conserves to 1e-12 while the wall-gradient ratio
-#    collapses 0.967 -> 0.414 -- conserving, flux wrong. NOT NECESSARY: `FPSLJacobianSolver` is
-#    the Lagrangian form `m^{n+1}(x) = m^n(x - a*dt) * exp(-dt*div a)`, non-conservative BY
-#    CONSTRUCTION with an O(h) mass error that vanishes under refinement, and deprecated for
-#    ADJOINT INCONSISTENCY, not for mass. The first version labelled it `CONTROL_FAILED` --
-#    a legitimate scheme reported as broken.
-#
-# 3. It could not tell a stability failure from a wall. Above cell Peclet 2 the positivity clip
-#    at `weak_form_fp_solver.py:223` INJECTS mass (+4379% measured) and the old verdict printed
-#    "LEAKS ... imposes d_n m = 0". The zero-drift control cannot catch it -- it fires only WITH
-#    drift -- and a post-hoc negativity check cannot either, because the clip already zeroed the
-#    negatives. The tell is `min(m) == 0.0` exactly.
-#
-# So the verdict is now three independent columns plus a gate:
-#
-#   d_n m ratio -> 1     the BC itself, pointwise. Independent of the mass functional and of
-#                        whether the scheme is in conservative form. THIS is correctness.
-#   dmass vs flux        attribution: does the boundary flux the scheme itself imposes account
-#                        for the mass change? Separates wall / interior / spurious.
-#   dmass at fixed h     conservative form? A DESIGN PROPERTY, not right or wrong.
-#
-#   gate: min(m) == 0.0  the clip fired; every number in the row is void.
-
-NX, STEPS, DT, SIGMA, DRIFT = 81, 200, 1e-3, 0.3, 3.2
-D_COEF = 0.5 * SIGMA**2
-TOL = 1e-3  # percent
-RESOLUTIONS = (41, 81, 161)  # the wall ratio is only meaningful as a LIMIT, so sweep
-RATIO_TOL = 0.15  # closeness to 1 (or 0) required at the FINEST resolution
-
-
-def fp_solver_population() -> dict[type, list[str]]:
-    """Every concrete class implementing `solve_fp_system`, keyed on the CLASS.
-
-    The METHOD is the predicate, not any declaration. Keyed on the class object rather than the
-    binding name because `NetworkFPSolver = FPNetworkSolver` (`fp_network.py:606`) is a
-    module-level alias: name-keying reported 12 rows for 11 implementations and produced two
-    identical `NOT_MEASURED` entries that looked like two independent gaps.
-    """
-    import mfgarchon.alg as alg_pkg
-
-    found: dict[type, list[str]] = {}
-    for mod in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg."):
-        try:
-            module = importlib.import_module(mod.name)
-        except Exception:
-            continue
-        for name, cls in inspect.getmembers(module, inspect.isclass):
-            if cls.__module__ != module.__name__ or inspect.isabstract(cls):
-                continue
-            if name.startswith(("Base", "_")):
-                continue
-            fn = getattr(cls, "solve_fp_system", None)
-            if callable(fn) and not getattr(fn, "__isabstractmethod__", False):
-                found.setdefault(cls, [])
-                if name not in found[cls]:
-                    found[cls].append(name)
-
-    # Class-keying collapses `X = Y`. It does NOT collapse `class X(Y): pass`, and
-    # `FPSLAdjointSolver(FPSLSolver)` is exactly that -- an empty deprecated subclass that says so
-    # in machine-readable form. Left as its own row would give two identical rows that read as two
-    # independent confirmations.
-    for cls in list(found):
-        meta = getattr(cls, "_deprecation_meta", None)
-        target = meta.get("alias_for") if isinstance(meta, dict) else None
-        if not target:
-            continue
-        for other, names in found.items():
-            if other is not cls and target in names:
-                found[other].extend(n for n in found.pop(cls) if n not in found[other])
-                break
-    return found
-
-
-def _grid_problem(drift: float, nx: int = NX):
-    from mfgarchon import Conditions, MFGProblem, Model
-    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
-    from mfgarchon.geometry import TensorProductGrid
-    from mfgarchon.geometry.boundary import no_flux_bc
-
-    return MFGProblem(
-        model=Model(
-            hamiltonian=SeparableHamiltonian(
-                control_cost=QuadraticControlCost(control_cost=1.0),
-                coupling=lambda m: 0.0 * m,
-                coupling_dm=lambda m: 0.0,
-            ),
-            sigma=SIGMA,
-        ),
-        domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1)),
-        conditions=Conditions(
-            u_terminal=lambda x: -drift * x,
-            m_initial=lambda x: np.exp(-50 * (x - 0.5) ** 2),
-            T=STEPS * DT,
-        ),
-        Nt=STEPS,
-    )
-
-
-def _initial_density(x: np.ndarray, weights: np.ndarray) -> np.ndarray:
-    m = np.exp(-50 * (x - 0.5) ** 2)
-    return m / float(weights @ m)
-
-
-def reference_drift_pct() -> float:
-    """Control 2: the raw assembly path. If this does not conserve, every row is VOID, not wrong."""
-    from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
-    from mfgarchon.geometry import TensorProductGrid
-    from mfgarchon.geometry.boundary import no_flux_bc
-
-    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=no_flux_bc(dimension=1))
-    x = np.linspace(0.0, 1.0, NX)
-    h = grid.get_grid_spacing()[0]
-    m = _initial_density(x, np.full(NX, h))
-    start = float(m.sum() * h)
-    for _ in range(STEPS):
-        m = solve_timestep_full_nd(
-            M_current=m,
-            U_current=-DRIFT * x,
-            problem=object(),
-            dt=DT,
-            sigma=SIGMA,
-            coupling_coefficient=1.0,
-            spacing=(h,),
-            grid=grid,
-            ndim=1,
-            shape=(NX,),
-            boundary_conditions=no_flux_bc(dimension=1),
-            advection_scheme="divergence_upwind",
-        )
-    return 100.0 * (float(m.sum() * h) - start) / start
-
-
-# --- the mass functional, which must come from the discretisation ----------------------------
-
-
-def _mass_weights(solver, x: np.ndarray) -> tuple[np.ndarray | None, str]:
-    """The discretisation's own conserved functional, or `None` with the reason.
-
-    Returning `None` is a result. A collocation scheme has no discrete divergence theorem and
-    therefore no conserved functional to ask for; guessing one there produced a `+50.9%` error
-    against the exact steady state, which would have been read as a leak.
-    """
-    mass_matrix = getattr(solver, "_M", None)
-    if mass_matrix is not None:  # Galerkin: 1^T M, exact by partition of unity
-        return np.asarray(mass_matrix.sum(axis=1)).ravel(), "galerkin 1^T M"
-    if x.ndim == 1 and x.size > 1 and np.allclose(np.diff(x), x[1] - x[0]):
-        return np.full(x.size, float(x[1] - x[0])), "uniform rectangle"
-    return None, "no conserved functional on this discretisation"
-
-
-def _wall_ratio(m: np.ndarray, x: np.ndarray, drift: float) -> tuple[float | None, str]:
-    """`d_n m / ((v_n/D) * m_wall)` at the OUTFLOW wall. 1 => `J.n = 0`; 0 => `d_n m = 0`.
-
-    The sharpest of the three columns and the only one needing neither a mass functional nor a
-    conservative form, so it survives when the other two cannot be computed.
-
-    **Which wall is the outflow wall is measured, not assumed.** The first version of this
-    function hard-coded `x = 1` from the sign of `u_terminal = -drift*x`, and got `-0.897` for
-    `FPFDMSolver` -- a solver whose drift convention sends the mass to the other wall. Assuming a
-    convention is exactly the trap `FPGFDMSolver` sets (`_drift_convention = VELOCITY`, second
-    positional argument `drift_field` not a potential), where the same assumption produces a
-    plausible `+1.53%` that is off by a factor of 50 and points the wrong way. So: find the wall
-    the mass actually piled against, and report which one it was.
-    """
-    if drift == 0.0 or m.ndim != 2 or m.shape[1] < 3:
-        return None, ""
-    final = m[-1]
-    high = float(final[-1]) >= float(final[0])
-    m_wall = float(final[-1] if high else final[0])
-    if abs(m_wall) < 1e-30:
-        return None, ""
-    h = float(x[-1] - x[-2])
-    # outward normal is +x at the high wall and -x at the low one, so d_n m is the one-sided
-    # difference taken outward in both cases; v_n is +|drift| at whichever wall the flow reaches.
-    d_n_m = (float(final[-1]) - float(final[-2])) / h if high else (float(final[0]) - float(final[1])) / h
-    return d_n_m / ((abs(drift) / D_COEF) * m_wall), ("x_max" if high else "x_min")
-
-
-def _one_run(cls, drift: float, nx: int = NX) -> dict[str, Any]:
-    """One drifted-wall run, reporting every column and refusing rather than guessing."""
-    out: dict[str, Any] = {
-        "status": "ok",
-        "detail": "",
-        "drift_pct": None,
-        "ratio": None,
-        "functional": None,
-        "clipped": None,
-        "wall": "",
-        "convention": "",
-    }
-    try:
-        problem = _grid_problem(drift, nx)
-    except Exception as exc:
-        return {**out, "status": "harness_fail", "detail": f"{type(exc).__name__}: {exc}"}
-    try:
-        solver = cls(problem)
-    except Exception as exc:
-        return {**out, "status": "construct_fail", "detail": f"{type(exc).__name__}: {str(exc).splitlines()[0][:120]}"}
-
-    x = np.linspace(0.0, 1.0, nx)
-    weights, functional = _mass_weights(solver, x)
-    out["functional"] = functional
-    m0 = _initial_density(x, weights if weights is not None else np.full(nx, 1.0 / (nx - 1)))
-
-    # READ the declared convention; do not assume it. The second positional argument is named
-    # `drift_field` on three solvers and `potential_field` on the rest, and `_drift_convention`
-    # says which meaning is intended. The first version of this lane passed the potential
-    # `u = -drift*x` to every one of them, so on a VELOCITY solver it was consumed as the
-    # velocity field `a(x) = -drift*x` -- which vanishes at x=0, the very wall the mass then
-    # piled against. Those rows had NO wall-normal drift at the measured wall, i.e. the
-    # discriminating property was absent, and they still printed a verdict.
-    #
-    # Note `FPParticleSolver`: its parameter is named `drift_field` while its declared convention
-    # is VALUE_FUNCTION. Name and declaration disagree; the declaration is what is followed here.
-    convention = getattr(getattr(cls, "_drift_convention", None), "name", "VALUE_FUNCTION")
-    out["convention"] = convention
-    field = np.full(nx, drift) if convention == "VELOCITY" else -drift * x
-    u = np.tile(field, (STEPS + 1, 1))
-
-    try:
-        m = solver.solve_fp_system(m0, u)
-    except TypeError:
-        try:
-            m = solver.solve_fp_system(m0, potential_field=u)
-        except Exception as exc:
-            return {**out, "status": "solve_fail", "detail": f"{type(exc).__name__}: {str(exc).splitlines()[0][:120]}"}
-    except Exception as exc:
-        return {**out, "status": "solve_fail", "detail": f"{type(exc).__name__}: {str(exc).splitlines()[0][:120]}"}
-
-    m = np.asarray(m)
-    if m.ndim != 2 or not np.all(np.isfinite(m)):
-        return {**out, "status": "solve_fail", "detail": f"shape {m.shape}, finite={bool(np.all(np.isfinite(m)))}"}
-
-    # GATE. The positivity clip zeroes negatives in place, so the returned array has no negative
-    # entry to find; an exact 0.0 is the only tell that it fired, and it INJECTS mass (+4379%
-    # measured above cell Peclet 2). A clipped row is VOID, not a leak.
-    # The clip zeroes negatives in place, so an exact 0.0 is the only tell that it fired. But a
-    # particle method produces exact zeros in empty bins as a matter of course, so the tell is a
-    # FALSE POSITIVE there -- it fired on `FPParticleSolver` on this function's first run. Gate it
-    # on a grid scheme whose density is strictly positive by construction, and on mass having been
-    # INJECTED, which is what the clip does and what a leak never does.
-    # An exact 0.0 is the only tell the clip leaves, since it zeroes negatives in place. The
-    # exemption is a declared flag, not a substring of the class name -- a name carries no
-    # capability, which is this script's own lane-1 thesis.
-    smooths = bool(getattr(solver, "kde_boundary_smoothing", False))
-    out["clipped"] = bool(np.any(m == 0.0)) and not smooths
-    out["ratio"], out["wall"] = _wall_ratio(m, x, drift)
-
-    if weights is None:
-        return {**out, "status": "no_mass_functional", "detail": functional}
-    start, end = float(weights @ m[0]), float(weights @ m[-1])
-    if start <= 0:
-        return {**out, "status": "solve_fail", "detail": f"initial mass {start:.3e}"}
-    out["drift_pct"] = 100.0 * (end - start) / start
-    return out
-
-
-def conservation_report() -> dict[str, Any]:
-    """One row per implementation: the wall-ratio SEQUENCE, the mass drift, and the status.
-
-    **This function renders no verdict, and that is deliberate.** A previous version classified
-    each row as IMPOSES_J_DOT_N / IMPOSES_ZERO_GRADIENT / IMPOSES_NEITHER from the ratio's trend
-    across three resolutions. Independent review showed the rule cannot do that:
-
-        solver        41     81    161    321    641   1281
-        FPFDMSolver  0.346  0.519  0.685  0.814  0.898  0.946     converging
-        FPFVMSolver  0.392  0.649  1.106  2.203  5.216 12.699     DIVERGING
-        FPSLSolver  -0.007  0.041  0.465  ... 0.998 (201) ... 1.926, 3.500
-
-    The `abs(finest - 1) <= tol` clause fired for FVM on 1.106 -- a value the sequence merely
-    passes through on the way up -- and the `rising` clause is satisfied by unbounded growth. Three
-    points cannot separate approach from transit, and neither can six: FPSLSolver reads 0.998 at
-    nx = 201 and keeps doubling. So the sequence is reported and the reading is left to whoever
-    reads it.
-
-    What IS asserted here is only what this function computes: whether the solver constructs,
-    whether the clip fired, the mass drift under its own conserved functional, and the ratio at
-    each resolution. Every interpretive figure that used to live in this docstring came from
-    measurements taken elsewhere and is gone -- one of them, a calibration series quoted as this
-    harness's own, did not reproduce (0.4592/0.6438/0.7933 stated; 0.3464/0.5191/0.6855 measured).
-    """
-    rows = []
-    for cls, names in fp_solver_population().items():
-        zero = _one_run(cls, 0.0)
-        sweep = [(nx, _one_run(cls, DRIFT, nx)) for nx in RESOLUTIONS]
-        run = dict(sweep[-1][1])
-        ratios = [(nx, r["ratio"]) for nx, r in sweep if r["ratio"] is not None]
-
-        if zero["status"] != "ok" or run["status"] in {"harness_fail", "construct_fail", "solve_fail"}:
-            status, detail = "NOT_MEASURED", (zero["detail"] or run["detail"])
-        elif any(r["clipped"] for _, r in sweep):
-            status = "VOID_CLIPPED"
-            detail = "the positivity clip fired -- a stability failure, not a wall; no column is readable"
-        else:
-            status = "MEASURED"
-            detail = "ratio " + " -> ".join(f"{r:.3f}" for _, r in ratios) + f" at {run.get('wall')}"
-
-        rows.append(
-            {
-                "class": names[0],
-                "aliases": names[1:],
-                "convention": run.get("convention", ""),
-                "no_drift_pct": zero["drift_pct"],
-                "drift_pct": run["drift_pct"],
-                "ratios": ratios,
-                "clipped": any(r["clipped"] for _, r in sweep),
-                "status": status,
-                "detail": detail,
-            }
-        )
-    rows.sort(key=lambda r: (r["status"], r["class"]))
-    return {"reference_drift_pct": reference_drift_pct(), "rows": rows}
-
-
-# --------------------------------------------------------------------------------------
-
-
 def _print_declarations(result: dict[str, Any]) -> None:
     for label, path, err in result["roots_missing"]:
         print(f"  ROOT UNAVAILABLE  {label}: {path} -> {err}")
@@ -532,54 +179,21 @@ def _print_declarations(result: dict[str, Any]) -> None:
         print(f"  {name:22s} reached by: {reached or 'NOTHING'}")
 
 
-def _print_conservation(result: dict[str, Any]) -> int:
-    ref = result["reference_drift_pct"]
-    ok = abs(ref) < TOL
-    print(f"=== control 2: reference path drift {ref:+.4f}%  {'HARNESS OK' if ok else 'HARNESS SUSPECT'} ===")
-    if not ok:
-        print("  the reference is supposed to conserve exactly; every row below is VOID, not wrong")
-
-    print(f"\n{'class':30s} {'wall ratio':>11s} {'mass @h':>11s} {'convention':14s} status")
-    for r in result["rows"]:
-        ratio = f"{r['ratios'][-1][1]:11.3f}" if r.get("ratios") else f"{'--':>11s}"
-        mass = f"{r['drift_pct']:+10.4f}%" if r["drift_pct"] is not None else f"{'--':>11s}"
-        alias = f" (={', '.join(r['aliases'])})" if r["aliases"] else ""
-        print(f"{r['class'] + alias:30s} {ratio} {mass} {r['convention'] or '--'!s:14s} {r['status']}")
-        print(f"{'':30s} {r['detail']}")
-
-    counts: dict[str, int] = {}
-    for r in result["rows"]:
-        counts[r["status"]] = counts.get(r["status"], 0) + 1
-    print("\n=== " + ", ".join(f"{v} {k}" for k, v in sorted(counts.items())) + " ===")
-    print("No verdict is rendered. The ratio sequence is the observation; three resolutions cannot")
-    print("separate converging-to-1 from transiting-1 (FPFVMSolver reaches 12.7 at nx=1281), and")
-    print("mass drift is a FORM property -- a non-conservative form has an O(h) error by")
-    print("construction. NOT_MEASURED is not a pass: it is a path nobody here can observe.")
-    return 0
-
-
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("lane", choices=("declarations", "conservation", "both"), nargs="?", default="both")
+    ap.add_argument("--package", default="mfgarchon")
     ap.add_argument("--json", metavar="FILE")
     args = ap.parse_args()
 
     import mfgarchon
 
     print(f"module root: {mfgarchon.__file__}\n")
-    out: dict[str, Any] = {}
-    if args.lane in ("declarations", "both"):
-        out["declarations"] = declaration_matrix()
-        _print_declarations(out["declarations"])
-    if args.lane in ("conservation", "both"):
-        if out:
-            print()
-        out["conservation"] = conservation_report()
-        _print_conservation(out["conservation"])
+    result = declaration_matrix(args.package)
+    _print_declarations(result)
 
     if args.json:
         with open(args.json, "w") as fh:
-            json.dump(out, fh, indent=2)
+            json.dump(result, fh, indent=2)
         print(f"\nwrote {args.json}")
     return 0
 

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -164,18 +164,61 @@ def declaration_matrix(package: str = "mfgarchon") -> dict[str, Any]:
 
 
 # --------------------------------------------------------------------------------------
-# Lane 2 -- conservation at a drifted wall
+# Lane 2 -- what wall each FP path actually imposes
 # --------------------------------------------------------------------------------------
+#
+# The first version of this lane had three defects, each found by an independent measurement
+# and each of a kind that produces a CONFIDENT WRONG ANSWER rather than a visible failure.
+#
+# 1. It assumed the mass functional. `sum(m)*h` is the rectangle rule; a Galerkin path's is
+#    `1^T M m`, whose row sums are `h` interior and `h/2` at boundary nodes. With mass piled
+#    against a wall they differ by `h/2 * m_wall` -- measured `+37.13%` where the truth was
+#    `-4.2e-13%`. Three paths would have been reported `CONTROL_FAILED`. And the fix does not
+#    generalise: a collocation scheme has NO discrete divergence theorem and no functional to
+#    ask for, so this lane must REFUSE rather than guess.
+#
+# 2. Its verdict was a single column, and mass conservation is neither sufficient nor necessary.
+#    NOT SUFFICIENT: streamline diffusion conserves to 1e-12 while the wall-gradient ratio
+#    collapses 0.967 -> 0.414 -- conserving, flux wrong. NOT NECESSARY: `FPSLJacobianSolver` is
+#    the Lagrangian form `m^{n+1}(x) = m^n(x - a*dt) * exp(-dt*div a)`, non-conservative BY
+#    CONSTRUCTION with an O(h) mass error that vanishes under refinement, and deprecated for
+#    ADJOINT INCONSISTENCY, not for mass. The first version labelled it `CONTROL_FAILED` --
+#    a legitimate scheme reported as broken.
+#
+# 3. It could not tell a stability failure from a wall. Above cell Peclet 2 the positivity clip
+#    at `weak_form_fp_solver.py:223` INJECTS mass (+4379% measured) and the old verdict printed
+#    "LEAKS ... imposes d_n m = 0". The zero-drift control cannot catch it -- it fires only WITH
+#    drift -- and a post-hoc negativity check cannot either, because the clip already zeroed the
+#    negatives. The tell is `min(m) == 0.0` exactly.
+#
+# So the verdict is now three independent columns plus a gate:
+#
+#   d_n m ratio -> 1     the BC itself, pointwise. Independent of the mass functional and of
+#                        whether the scheme is in conservative form. THIS is correctness.
+#   dmass vs flux        attribution: does the boundary flux the scheme itself imposes account
+#                        for the mass change? Separates wall / interior / spurious.
+#   dmass at fixed h     conservative form? A DESIGN PROPERTY, not right or wrong.
+#
+#   gate: min(m) == 0.0  the clip fired; every number in the row is void.
 
 NX, STEPS, DT, SIGMA, DRIFT = 81, 200, 1e-3, 0.3, 3.2
-TOL = 1e-3  # percent; the conserving paths measure at 1e-4 % or better
+D_COEF = 0.5 * SIGMA**2
+TOL = 1e-3  # percent
+RESOLUTIONS = (41, 81, 161)  # the wall ratio is only meaningful as a LIMIT, so sweep
+RATIO_TOL = 0.15  # closeness to 1 (or 0) required at the FINEST resolution
 
 
-def fp_solver_population() -> list[tuple[str, type]]:
-    """Every concrete class implementing `solve_fp_system` -- the METHOD is the predicate."""
+def fp_solver_population() -> dict[type, list[str]]:
+    """Every concrete class implementing `solve_fp_system`, keyed on the CLASS.
+
+    The METHOD is the predicate, not any declaration. Keyed on the class object rather than the
+    binding name because `NetworkFPSolver = FPNetworkSolver` (`fp_network.py:606`) is a
+    module-level alias: name-keying reported 12 rows for 11 implementations and produced two
+    identical `NOT_MEASURED` entries that looked like two independent gaps.
+    """
     import mfgarchon.alg as alg_pkg
 
-    found: dict[str, type] = {}
+    found: dict[type, list[str]] = {}
     for mod in pkgutil.walk_packages(alg_pkg.__path__, prefix="mfgarchon.alg."):
         try:
             module = importlib.import_module(mod.name)
@@ -188,11 +231,13 @@ def fp_solver_population() -> list[tuple[str, type]]:
                 continue
             fn = getattr(cls, "solve_fp_system", None)
             if callable(fn) and not getattr(fn, "__isabstractmethod__", False):
-                found[name] = cls
-    return sorted(found.items())
+                found.setdefault(cls, [])
+                if name not in found[cls]:
+                    found[cls].append(name)
+    return found
 
 
-def _problem(drift: float):
+def _grid_problem(drift: float, nx: int = NX):
     from mfgarchon import Conditions, MFGProblem, Model
     from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
     from mfgarchon.geometry import TensorProductGrid
@@ -207,7 +252,7 @@ def _problem(drift: float):
             ),
             sigma=SIGMA,
         ),
-        domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=no_flux_bc(dimension=1)),
+        domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=no_flux_bc(dimension=1)),
         conditions=Conditions(
             u_terminal=lambda x: -drift * x,
             m_initial=lambda x: np.exp(-50 * (x - 0.5) ** 2),
@@ -217,22 +262,22 @@ def _problem(drift: float):
     )
 
 
-def _initial_density() -> tuple[np.ndarray, np.ndarray, float]:
-    x = np.linspace(0.0, 1.0, NX)
-    h = 1.0 / (NX - 1)
-    m0 = np.exp(-50 * (x - 0.5) ** 2)
-    return x, m0 / (m0.sum() * h), h
+def _initial_density(x: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    m = np.exp(-50 * (x - 0.5) ** 2)
+    return m / float(weights @ m)
 
 
 def reference_drift_pct() -> float:
-    """Control 2: the raw assembly path, which #1975 measured at -0.0000%."""
+    """Control 2: the raw assembly path. If this does not conserve, every row is VOID, not wrong."""
     from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import solve_timestep_full_nd
     from mfgarchon.geometry import TensorProductGrid
     from mfgarchon.geometry.boundary import no_flux_bc
 
     grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[NX], boundary_conditions=no_flux_bc(dimension=1))
-    x, m, h = _initial_density()
-    start = m.sum() * h
+    x = np.linspace(0.0, 1.0, NX)
+    h = grid.get_grid_spacing()[0]
+    m = _initial_density(x, np.full(NX, h))
+    start = float(m.sum() * h)
     for _ in range(STEPS):
         m = solve_timestep_full_nd(
             M_current=m,
@@ -248,58 +293,188 @@ def reference_drift_pct() -> float:
             boundary_conditions=no_flux_bc(dimension=1),
             advection_scheme="divergence_upwind",
         )
-    return 100.0 * (m.sum() * h - start) / start
+    return 100.0 * (float(m.sum() * h) - start) / start
 
 
-def _one_run(cls, drift: float) -> tuple[str, float | None, str]:
+# --- the mass functional, which must come from the discretisation ----------------------------
+
+
+def _mass_weights(solver, x: np.ndarray) -> tuple[np.ndarray | None, str]:
+    """The discretisation's own conserved functional, or `None` with the reason.
+
+    Returning `None` is a result. A collocation scheme has no discrete divergence theorem and
+    therefore no conserved functional to ask for; guessing one there produced a `+50.9%` error
+    against the exact steady state, which would have been read as a leak.
+    """
+    mass_matrix = getattr(solver, "_M", None)
+    if mass_matrix is not None:  # Galerkin: 1^T M, exact by partition of unity
+        return np.asarray(mass_matrix.sum(axis=1)).ravel(), "galerkin 1^T M"
+    if x.ndim == 1 and x.size > 1 and np.allclose(np.diff(x), x[1] - x[0]):
+        return np.full(x.size, float(x[1] - x[0])), "uniform rectangle"
+    return None, "no conserved functional on this discretisation"
+
+
+def _wall_ratio(m: np.ndarray, x: np.ndarray, drift: float) -> tuple[float | None, str]:
+    """`d_n m / ((v_n/D) * m_wall)` at the OUTFLOW wall. 1 => `J.n = 0`; 0 => `d_n m = 0`.
+
+    The sharpest of the three columns and the only one needing neither a mass functional nor a
+    conservative form, so it survives when the other two cannot be computed.
+
+    **Which wall is the outflow wall is measured, not assumed.** The first version of this
+    function hard-coded `x = 1` from the sign of `u_terminal = -drift*x`, and got `-0.897` for
+    `FPFDMSolver` -- a solver whose drift convention sends the mass to the other wall. Assuming a
+    convention is exactly the trap `FPGFDMSolver` sets (`_drift_convention = VELOCITY`, second
+    positional argument `drift_field` not a potential), where the same assumption produces a
+    plausible `+1.53%` that is off by a factor of 50 and points the wrong way. So: find the wall
+    the mass actually piled against, and report which one it was.
+    """
+    if drift == 0.0 or m.ndim != 2 or m.shape[1] < 3:
+        return None, ""
+    final = m[-1]
+    high = float(final[-1]) >= float(final[0])
+    m_wall = float(final[-1] if high else final[0])
+    if abs(m_wall) < 1e-30:
+        return None, ""
+    h = float(x[-1] - x[-2])
+    # outward normal is +x at the high wall and -x at the low one, so d_n m is the one-sided
+    # difference taken outward in both cases; v_n is +|drift| at whichever wall the flow reaches.
+    d_n_m = (float(final[-1]) - float(final[-2])) / h if high else (float(final[0]) - float(final[1])) / h
+    return d_n_m / ((abs(drift) / D_COEF) * m_wall), ("x_max" if high else "x_min")
+
+
+def _one_run(cls, drift: float, nx: int = NX) -> dict[str, Any]:
+    """One drifted-wall run, reporting every column and refusing rather than guessing."""
+    out: dict[str, Any] = {
+        "status": "ok",
+        "detail": "",
+        "drift_pct": None,
+        "ratio": None,
+        "functional": None,
+        "clipped": None,
+        "wall": "",
+        "convention": "",
+    }
     try:
-        problem = _problem(drift)
+        problem = _grid_problem(drift, nx)
     except Exception as exc:
-        return "harness_fail", None, f"{type(exc).__name__}: {exc}"
+        return {**out, "status": "harness_fail", "detail": f"{type(exc).__name__}: {exc}"}
     try:
         solver = cls(problem)
     except Exception as exc:
-        return "construct_fail", None, f"{type(exc).__name__}: {str(exc).splitlines()[0][:140]}"
+        return {**out, "status": "construct_fail", "detail": f"{type(exc).__name__}: {str(exc).splitlines()[0][:120]}"}
 
-    x, m0, h = _initial_density()
-    u = np.tile(-drift * x, (STEPS + 1, 1))
+    x = np.linspace(0.0, 1.0, nx)
+    weights, functional = _mass_weights(solver, x)
+    out["functional"] = functional
+    m0 = _initial_density(x, weights if weights is not None else np.full(nx, 1.0 / (nx - 1)))
+
+    # READ the declared convention; do not assume it. The second positional argument is named
+    # `drift_field` on three solvers and `potential_field` on the rest, and `_drift_convention`
+    # says which meaning is intended. The first version of this lane passed the potential
+    # `u = -drift*x` to every one of them, so on a VELOCITY solver it was consumed as the
+    # velocity field `a(x) = -drift*x` -- which vanishes at x=0, the very wall the mass then
+    # piled against. Those rows had NO wall-normal drift at the measured wall, i.e. the
+    # discriminating property was absent, and they still printed a verdict.
+    #
+    # Note `FPParticleSolver`: its parameter is named `drift_field` while its declared convention
+    # is VALUE_FUNCTION. Name and declaration disagree; the declaration is what is followed here.
+    convention = getattr(getattr(cls, "_drift_convention", None), "name", "VALUE_FUNCTION")
+    out["convention"] = convention
+    field = np.full(nx, drift) if convention == "VELOCITY" else -drift * x
+    u = np.tile(field, (STEPS + 1, 1))
+
     try:
         m = solver.solve_fp_system(m0, u)
     except TypeError:
         try:
             m = solver.solve_fp_system(m0, potential_field=u)
         except Exception as exc:
-            return "solve_fail", None, f"{type(exc).__name__}: {str(exc).splitlines()[0][:140]}"
+            return {**out, "status": "solve_fail", "detail": f"{type(exc).__name__}: {str(exc).splitlines()[0][:120]}"}
     except Exception as exc:
-        return "solve_fail", None, f"{type(exc).__name__}: {str(exc).splitlines()[0][:140]}"
+        return {**out, "status": "solve_fail", "detail": f"{type(exc).__name__}: {str(exc).splitlines()[0][:120]}"}
 
     m = np.asarray(m)
     if m.ndim != 2 or not np.all(np.isfinite(m)):
-        return "solve_fail", None, f"shape {m.shape}, finite={bool(np.all(np.isfinite(m)))}"
-    start, end = m[0].sum() * h, m[-1].sum() * h
+        return {**out, "status": "solve_fail", "detail": f"shape {m.shape}, finite={bool(np.all(np.isfinite(m)))}"}
+
+    # GATE. The positivity clip zeroes negatives in place, so the returned array has no negative
+    # entry to find; an exact 0.0 is the only tell that it fired, and it INJECTS mass (+4379%
+    # measured above cell Peclet 2). A clipped row is VOID, not a leak.
+    # The clip zeroes negatives in place, so an exact 0.0 is the only tell that it fired. But a
+    # particle method produces exact zeros in empty bins as a matter of course, so the tell is a
+    # FALSE POSITIVE there -- it fired on `FPParticleSolver` on this function's first run. Gate it
+    # on a grid scheme whose density is strictly positive by construction, and on mass having been
+    # INJECTED, which is what the clip does and what a leak never does.
+    out["clipped"] = bool(np.any(m == 0.0)) and "Particle" not in cls.__name__
+    out["ratio"], out["wall"] = _wall_ratio(m, x, drift)
+
+    if weights is None:
+        return {**out, "status": "no_mass_functional", "detail": functional}
+    start, end = float(weights @ m[0]), float(weights @ m[-1])
     if start <= 0:
-        return "solve_fail", None, f"initial mass {start:.3e}"
-    return "ok", 100.0 * (end - start) / start, ""
+        return {**out, "status": "solve_fail", "detail": f"initial mass {start:.3e}"}
+    out["drift_pct"] = 100.0 * (end - start) / start
+    return out
 
 
 def conservation_verdicts() -> dict[str, Any]:
+    """One row per implementation, verdict from the wall ratio's TREND across resolutions.
+
+    A single resolution cannot decide this. At NX=81 the boundary layer is D/v = 0.014 against
+    h = 0.0125, so a path that correctly imposes J.n = 0 reads a ratio near 0.6 -- and a
+    fixed threshold called that "imposes neither". Measured on a known-good path, the ratio
+    climbs 0.4592 / 0.6438 / 0.7933 / 0.8898 / 0.9437 at Nx = 41 / 81 / 161 / 321 / 641.
+    So: sweep, and read the trend.
+    """
     rows = []
-    for name, cls in fp_solver_population():
-        v0, d0, e0 = _one_run(cls, 0.0)
-        v1, d1, e1 = _one_run(cls, DRIFT)
-        if v0 != "ok" or v1 != "ok":
-            verdict = "NOT_MEASURED"
-            detail = e0 or e1
-        elif abs(d0) > TOL:
-            verdict = "CONTROL_FAILED"
-            detail = f"leaks {d0:+.4f}% with no drift; the drifted number says nothing about its wall"
-        elif abs(d1) < TOL:
-            verdict = "CONSERVES"
-            detail = "imposes J.n = 0"
+    for cls, names in fp_solver_population().items():
+        zero = _one_run(cls, 0.0)
+        sweep = [(nx, _one_run(cls, DRIFT, nx)) for nx in RESOLUTIONS]
+        run = dict(sweep[-1][1])
+        ratios = [(nx, r["ratio"]) for nx, r in sweep if r["ratio"] is not None]
+        row = {
+            "class": names[0],
+            "aliases": names[1:],
+            "convention": run.get("convention", ""),
+            "no_drift_pct": zero["drift_pct"],
+            "drift_pct": run["drift_pct"],
+            "ratios": ratios,
+            "clipped": any(r["clipped"] for _, r in sweep),
+        }
+        finest = ratios[-1][1] if ratios else None
+        rising = len(ratios) >= 2 and ratios[-1][1] > ratios[0][1] + 0.05
+
+        if zero["status"] != "ok" or run["status"] in {"harness_fail", "construct_fail", "solve_fail"}:
+            row["verdict"], row["detail"] = "NOT_MEASURED", zero["detail"] or run["detail"]
+        elif row["clipped"]:
+            row["verdict"] = "VOID_CLIPPED"
+            row["detail"] = "the positivity clip fired -- a stability failure, not a wall; no column is readable"
+        elif finest is None:
+            row["verdict"], row["detail"] = "NOT_MEASURED", run["detail"] or "no wall ratio"
+        elif abs(finest - 1.0) <= RATIO_TOL or rising:
+            row["verdict"] = "IMPOSES_J_DOT_N"
+            row["detail"] = (
+                "ratio "
+                + " -> ".join(f"{r:.3f}" for _, r in ratios)
+                + f" at {run.get('wall')}; converging to 1. Mass drift "
+                + f"{run['drift_pct']:+.4f}% is a FORM property, not a verdict"
+            )
+        elif abs(finest) <= RATIO_TOL:
+            row["verdict"] = "IMPOSES_ZERO_GRADIENT"
+            row["detail"] = (
+                "ratio "
+                + " -> ".join(f"{r:.3f}" for _, r in ratios)
+                + f" at {run.get('wall')}; flat near 0 -- d_n m = 0, the wrong wall"
+            )
         else:
-            verdict = "LEAKS"
-            detail = f"{d1:+.4f}% at a drifted wall -- imposes d_n m = 0, not J.n = 0"
-        rows.append({"class": name, "no_drift_pct": d0, "drift_pct": d1, "verdict": verdict, "detail": detail})
+            row["verdict"] = "IMPOSES_NEITHER"
+            row["detail"] = (
+                "ratio "
+                + " -> ".join(f"{r:.3f}" for _, r in ratios)
+                + f" at {run.get('wall')}; near neither 1 nor 0 and not rising"
+            )
+        rows.append(row)
+    rows.sort(key=lambda r: (r["verdict"], r["class"]))
     return {"reference_drift_pct": reference_drift_pct(), "rows": rows}
 
 
@@ -348,20 +523,23 @@ def _print_conservation(result: dict[str, Any]) -> int:
     ok = abs(ref) < TOL
     print(f"=== control 2: reference path drift {ref:+.4f}%  {'HARNESS OK' if ok else 'HARNESS SUSPECT'} ===")
     if not ok:
-        print("  the reference is supposed to conserve exactly; every row below is void")
+        print("  the reference is supposed to conserve exactly; every row below is VOID, not wrong")
 
-    print(f"\n{'class':32s} {'no drift':>12s} {'drift':>12s}   verdict")
+    print(f"\n{'class':30s} {'wall ratio':>11s} {'mass @h':>11s} {'convention':14s} verdict")
     for r in result["rows"]:
-        cell = lambda v: f"{v:+11.4f}%" if v is not None else f"{'--':>12s}"  # noqa: E731
-        print(
-            f"{r['class']:32s} {cell(r['no_drift_pct']):>12s} {cell(r['drift_pct']):>12s}   {r['verdict']}: {r['detail']}"
-        )
+        ratio = f"{r['ratios'][-1][1]:11.3f}" if r.get("ratios") else f"{'--':>11s}"
+        mass = f"{r['drift_pct']:+10.4f}%" if r["drift_pct"] is not None else f"{'--':>11s}"
+        alias = f" (={', '.join(r['aliases'])})" if r["aliases"] else ""
+        print(f"{r['class'] + alias:30s} {ratio} {mass} {r['convention'] or '--'!s:14s} {r['verdict']}")
+        print(f"{'':30s} {r['detail']}")
 
     counts: dict[str, int] = {}
     for r in result["rows"]:
         counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
     print("\n=== " + ", ".join(f"{v} {k}" for k, v in sorted(counts.items())) + " ===")
-    print("NOT_MEASURED is not a pass. It is a path whose wall nobody here can currently observe.")
+    print("The WALL RATIO column is the verdict. Mass drift is a form property: a non-conservative")
+    print("form has an O(h) error by construction and is not thereby wrong. NOT_MEASURED is not a")
+    print("pass -- it is a path whose wall nobody here can currently observe.")
     return 0
 
 

--- a/scripts/capability_census.py
+++ b/scripts/capability_census.py
@@ -234,6 +234,20 @@ def fp_solver_population() -> dict[type, list[str]]:
                 found.setdefault(cls, [])
                 if name not in found[cls]:
                     found[cls].append(name)
+
+    # Class-keying collapses `X = Y`. It does NOT collapse `class X(Y): pass`, and
+    # `FPSLAdjointSolver(FPSLSolver)` is exactly that -- an empty deprecated subclass that says so
+    # in machine-readable form. Left as its own row would give two identical rows that read as two
+    # independent confirmations.
+    for cls in list(found):
+        meta = getattr(cls, "_deprecation_meta", None)
+        target = meta.get("alias_for") if isinstance(meta, dict) else None
+        if not target:
+            continue
+        for other, names in found.items():
+            if other is not cls and target in names:
+                found[other].extend(n for n in found.pop(cls) if n not in found[other])
+                break
     return found
 
 
@@ -405,7 +419,11 @@ def _one_run(cls, drift: float, nx: int = NX) -> dict[str, Any]:
     # FALSE POSITIVE there -- it fired on `FPParticleSolver` on this function's first run. Gate it
     # on a grid scheme whose density is strictly positive by construction, and on mass having been
     # INJECTED, which is what the clip does and what a leak never does.
-    out["clipped"] = bool(np.any(m == 0.0)) and "Particle" not in cls.__name__
+    # An exact 0.0 is the only tell the clip leaves, since it zeroes negatives in place. The
+    # exemption is a declared flag, not a substring of the class name -- a name carries no
+    # capability, which is this script's own lane-1 thesis.
+    smooths = bool(getattr(solver, "kde_boundary_smoothing", False))
+    out["clipped"] = bool(np.any(m == 0.0)) and not smooths
     out["ratio"], out["wall"] = _wall_ratio(m, x, drift)
 
     if weights is None:
@@ -417,14 +435,29 @@ def _one_run(cls, drift: float, nx: int = NX) -> dict[str, Any]:
     return out
 
 
-def conservation_verdicts() -> dict[str, Any]:
-    """One row per implementation, verdict from the wall ratio's TREND across resolutions.
+def conservation_report() -> dict[str, Any]:
+    """One row per implementation: the wall-ratio SEQUENCE, the mass drift, and the status.
 
-    A single resolution cannot decide this. At NX=81 the boundary layer is D/v = 0.014 against
-    h = 0.0125, so a path that correctly imposes J.n = 0 reads a ratio near 0.6 -- and a
-    fixed threshold called that "imposes neither". Measured on a known-good path, the ratio
-    climbs 0.4592 / 0.6438 / 0.7933 / 0.8898 / 0.9437 at Nx = 41 / 81 / 161 / 321 / 641.
-    So: sweep, and read the trend.
+    **This function renders no verdict, and that is deliberate.** A previous version classified
+    each row as IMPOSES_J_DOT_N / IMPOSES_ZERO_GRADIENT / IMPOSES_NEITHER from the ratio's trend
+    across three resolutions. Independent review showed the rule cannot do that:
+
+        solver        41     81    161    321    641   1281
+        FPFDMSolver  0.346  0.519  0.685  0.814  0.898  0.946     converging
+        FPFVMSolver  0.392  0.649  1.106  2.203  5.216 12.699     DIVERGING
+        FPSLSolver  -0.007  0.041  0.465  ... 0.998 (201) ... 1.926, 3.500
+
+    The `abs(finest - 1) <= tol` clause fired for FVM on 1.106 -- a value the sequence merely
+    passes through on the way up -- and the `rising` clause is satisfied by unbounded growth. Three
+    points cannot separate approach from transit, and neither can six: FPSLSolver reads 0.998 at
+    nx = 201 and keeps doubling. So the sequence is reported and the reading is left to whoever
+    reads it.
+
+    What IS asserted here is only what this function computes: whether the solver constructs,
+    whether the clip fired, the mass drift under its own conserved functional, and the ratio at
+    each resolution. Every interpretive figure that used to live in this docstring came from
+    measurements taken elsewhere and is gone -- one of them, a calibration series quoted as this
+    harness's own, did not reproduce (0.4592/0.6438/0.7933 stated; 0.3464/0.5191/0.6855 measured).
     """
     rows = []
     for cls, names in fp_solver_population().items():
@@ -432,49 +465,30 @@ def conservation_verdicts() -> dict[str, Any]:
         sweep = [(nx, _one_run(cls, DRIFT, nx)) for nx in RESOLUTIONS]
         run = dict(sweep[-1][1])
         ratios = [(nx, r["ratio"]) for nx, r in sweep if r["ratio"] is not None]
-        row = {
-            "class": names[0],
-            "aliases": names[1:],
-            "convention": run.get("convention", ""),
-            "no_drift_pct": zero["drift_pct"],
-            "drift_pct": run["drift_pct"],
-            "ratios": ratios,
-            "clipped": any(r["clipped"] for _, r in sweep),
-        }
-        finest = ratios[-1][1] if ratios else None
-        rising = len(ratios) >= 2 and ratios[-1][1] > ratios[0][1] + 0.05
 
         if zero["status"] != "ok" or run["status"] in {"harness_fail", "construct_fail", "solve_fail"}:
-            row["verdict"], row["detail"] = "NOT_MEASURED", zero["detail"] or run["detail"]
-        elif row["clipped"]:
-            row["verdict"] = "VOID_CLIPPED"
-            row["detail"] = "the positivity clip fired -- a stability failure, not a wall; no column is readable"
-        elif finest is None:
-            row["verdict"], row["detail"] = "NOT_MEASURED", run["detail"] or "no wall ratio"
-        elif abs(finest - 1.0) <= RATIO_TOL or rising:
-            row["verdict"] = "IMPOSES_J_DOT_N"
-            row["detail"] = (
-                "ratio "
-                + " -> ".join(f"{r:.3f}" for _, r in ratios)
-                + f" at {run.get('wall')}; converging to 1. Mass drift "
-                + f"{run['drift_pct']:+.4f}% is a FORM property, not a verdict"
-            )
-        elif abs(finest) <= RATIO_TOL:
-            row["verdict"] = "IMPOSES_ZERO_GRADIENT"
-            row["detail"] = (
-                "ratio "
-                + " -> ".join(f"{r:.3f}" for _, r in ratios)
-                + f" at {run.get('wall')}; flat near 0 -- d_n m = 0, the wrong wall"
-            )
+            status, detail = "NOT_MEASURED", (zero["detail"] or run["detail"])
+        elif any(r["clipped"] for _, r in sweep):
+            status = "VOID_CLIPPED"
+            detail = "the positivity clip fired -- a stability failure, not a wall; no column is readable"
         else:
-            row["verdict"] = "IMPOSES_NEITHER"
-            row["detail"] = (
-                "ratio "
-                + " -> ".join(f"{r:.3f}" for _, r in ratios)
-                + f" at {run.get('wall')}; near neither 1 nor 0 and not rising"
-            )
-        rows.append(row)
-    rows.sort(key=lambda r: (r["verdict"], r["class"]))
+            status = "MEASURED"
+            detail = "ratio " + " -> ".join(f"{r:.3f}" for _, r in ratios) + f" at {run.get('wall')}"
+
+        rows.append(
+            {
+                "class": names[0],
+                "aliases": names[1:],
+                "convention": run.get("convention", ""),
+                "no_drift_pct": zero["drift_pct"],
+                "drift_pct": run["drift_pct"],
+                "ratios": ratios,
+                "clipped": any(r["clipped"] for _, r in sweep),
+                "status": status,
+                "detail": detail,
+            }
+        )
+    rows.sort(key=lambda r: (r["status"], r["class"]))
     return {"reference_drift_pct": reference_drift_pct(), "rows": rows}
 
 
@@ -525,21 +539,22 @@ def _print_conservation(result: dict[str, Any]) -> int:
     if not ok:
         print("  the reference is supposed to conserve exactly; every row below is VOID, not wrong")
 
-    print(f"\n{'class':30s} {'wall ratio':>11s} {'mass @h':>11s} {'convention':14s} verdict")
+    print(f"\n{'class':30s} {'wall ratio':>11s} {'mass @h':>11s} {'convention':14s} status")
     for r in result["rows"]:
         ratio = f"{r['ratios'][-1][1]:11.3f}" if r.get("ratios") else f"{'--':>11s}"
         mass = f"{r['drift_pct']:+10.4f}%" if r["drift_pct"] is not None else f"{'--':>11s}"
         alias = f" (={', '.join(r['aliases'])})" if r["aliases"] else ""
-        print(f"{r['class'] + alias:30s} {ratio} {mass} {r['convention'] or '--'!s:14s} {r['verdict']}")
+        print(f"{r['class'] + alias:30s} {ratio} {mass} {r['convention'] or '--'!s:14s} {r['status']}")
         print(f"{'':30s} {r['detail']}")
 
     counts: dict[str, int] = {}
     for r in result["rows"]:
-        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
     print("\n=== " + ", ".join(f"{v} {k}" for k, v in sorted(counts.items())) + " ===")
-    print("The WALL RATIO column is the verdict. Mass drift is a form property: a non-conservative")
-    print("form has an O(h) error by construction and is not thereby wrong. NOT_MEASURED is not a")
-    print("pass -- it is a path whose wall nobody here can currently observe.")
+    print("No verdict is rendered. The ratio sequence is the observation; three resolutions cannot")
+    print("separate converging-to-1 from transiting-1 (FPFVMSolver reaches 12.7 at nx=1281), and")
+    print("mass drift is a FORM property -- a non-conservative form has an O(h) error by")
+    print("construction. NOT_MEASURED is not a pass: it is a path nobody here can observe.")
     return 0
 
 
@@ -559,7 +574,7 @@ def main() -> int:
     if args.lane in ("conservation", "both"):
         if out:
             print()
-        out["conservation"] = conservation_verdicts()
+        out["conservation"] = conservation_report()
         _print_conservation(out["conservation"])
 
     if args.json:

--- a/tests/unit/test_capability_census.py
+++ b/tests/unit/test_capability_census.py
@@ -1,27 +1,17 @@
 """Ratchet over `scripts/capability_census.py`. Refs #1975, #1977.
 
-Two lanes, both answering a question the 2026-08-13 design census could not: all four of its lanes
-look for reality falling *short* of a claim, and it found 77 over-claims. Nobody counted the other
-direction — capability that exists undeclared, and a wall imposed with nothing naming it — and
-that direction made #1975 wrong twice.
+The census answers a question the 2026-08-13 design census could not: all four of its lanes look
+for reality falling *short* of a claim and it found 77 over-claims; nobody counted the other
+direction, and capability that exists undeclared is what made #1975 wrong.
 
-**Lane 2's instrument was rebuilt after eight defects, and every one produced a confident verdict
-rather than a failure.** Four were found by independent measurement of the paths it could not
-construct; four more only by re-running it against a path whose answer was already known:
+Everything is imported from the script rather than restated, so the two cannot drift. The frozen
+sets are the ratchet: leaving them is #1977 progress, joining them is a capability shipped without
+a declaration, and each failure message says which.
 
-1. it assumed the mass functional (`sum(m)*h` vs a Galerkin `1^T M`, `+37%` vs `-4e-13%`);
-2. its verdict was sign-blind (a `d_n m = 0` wall *loses* mass; the clip *gains* it);
-3. it could not tell a stability failure from a wall;
-4. it double-counted a module-level alias, reporting 12 rows for 11 implementations;
-5. it assumed which wall was the outflow wall;
-6. its clip gate false-positived on a particle method, where exact zeros are ordinary;
-7. **it assumed the drift convention** — `_drift_convention` is a declared class attribute reading
-   `VELOCITY` on three solvers, and passing them a potential made the wall-normal drift vanish at
-   the very wall the mass reached, so the discriminating property was absent and a verdict printed
-   anyway;
-8. it thresholded a quantity that is only meaningful as a limit.
-
-Everything here is imported from the script rather than restated, so the two cannot drift.
+A second lane over the FP wall condition was removed with the script's. Its findings are in #1975.
+The measurement needed a discrimination rule for the LIMIT behaviour of a numerical scheme; four
+attempts failed to state one, and 41% of a 32-mutation sweep survived the ratchet built over it --
+including the pins for three of the defects that ratchet claimed to have fixed.
 """
 
 from __future__ import annotations
@@ -47,11 +37,6 @@ def census():
 @pytest.fixture(scope="module")
 def declarations(census):
     return census.declaration_matrix()
-
-
-@pytest.fixture(scope="module")
-def conservation(census):
-    return census.conservation_report()
 
 
 # =============================================================================
@@ -101,7 +86,14 @@ _DECLARES_NOTHING = {
 
 @pytest.mark.parametrize("role", sorted(_DECLARES_NOTHING))
 def test_the_set_of_classes_declaring_nothing_is_unchanged(declarations, role):
-    """Leaving this set is #1977 progress; joining it is a capability shipped undeclared."""
+    """Leaving this set is #1977 progress; joining it is a capability shipped undeclared.
+
+    **This pins WHETHER a class declares, not WHAT it declares.** Measured: widening a gated
+    solver's `_SUPPORTED_BC_TYPES` to include `ROBIN` leaves this file green. The declared VALUES
+    are pinned per solver in `tests/unit/test_alg/test_solver_bc_support_census_1975.py`; keeping
+    a second copy of those sets here would give two frozen copies of one measurement, which is the
+    divergence this census exists to find.
+    """
     got = {r["name"] for r in declarations["rows"] if role in r["roles"] and r["declares_nothing"]}
     want = _DECLARES_NOTHING[role]
     if got == want:
@@ -162,116 +154,3 @@ def test_the_permissive_default_is_still_claimed_by_inheritance(declarations):
     assert len(from_base) == 19, f"solvers claiming True by the permissive default: {sorted(from_base)}"
     assert set(from_base.values()) == {"True"}
     assert from_sibling == {"FPSLAdjointSolver": ("FPSLSolver", "False")}
-
-
-# =============================================================================
-# Lane 2 -- the wall-ratio sequence, reported and pinned; no verdict
-# =============================================================================
-
-#: Rows the harness can construct and run. The ratio sequence is pinned loosely -- it is a
-#: measurement of a numerical scheme, not a constant -- and the ORDER of magnitude and sign are
-#: what a regression would move.
-_MEASURED = {
-    "FPFDMSolver": (0.35, 0.69),
-    "FPFVMSolver": (0.39, 1.11),
-    "FPParticleSolver": (-0.01, 0.01),
-    "FPSLJacobianSolver": (0.00, 0.05),
-    "FPSLSolver": (-0.01, 0.47),
-}
-
-#: Not a pass. Each needs a geometry or an argument this harness does not build.
-_NOT_MEASURED = {
-    "FPFEMSolver",
-    "FPGFDMSolver",
-    "FPNetworkSolver",
-    "MeshlessGalerkinFPSolver",
-    "WeakFormFPSolver",
-}
-
-#: Same class under two names, and one empty deprecated SUBCLASS. Class-keying collapses the
-#: first; `_deprecation_meta["alias_for"]` collapses the second. Two identical rows read as two
-#: independent confirmations, which is why both are folded rather than reported twice.
-_COLLAPSED = {"FPNetworkSolver": ["NetworkFPSolver"], "FPSLSolver": ["FPSLAdjointSolver"]}
-
-
-def _row(conservation, name):
-    matching = [r for r in conservation["rows"] if r["class"] == name]
-    assert matching, f"{name} is not in the population at all"
-    return matching[0]
-
-
-def test_the_harness_reference_path_conserves(conservation):
-    """Control. If the reference stops conserving, every row is VOID rather than wrong."""
-    ref = conservation["reference_drift_pct"]
-    assert abs(ref) < 1e-3, f"reference path drifted {ref:+.4f}% -- the harness is broken"
-
-
-def test_the_population_is_exactly_the_two_sets(conservation):
-    got = {r["class"] for r in conservation["rows"]}
-    want = set(_MEASURED) | _NOT_MEASURED
-    assert got == want, f"population changed: added {sorted(got - want)}, removed {sorted(want - got)}"
-
-
-def test_the_alias_and_the_deprecated_subclass_are_both_collapsed(conservation):
-    got = {r["class"]: r["aliases"] for r in conservation["rows"] if r["aliases"]}
-    assert got == _COLLAPSED, (
-        f"collapsing changed: {got}. Class-keying catches `X = Y`; `class X(Y): pass` needs the "
-        "`_deprecation_meta['alias_for']` fold, and without it two identical rows appear."
-    )
-
-
-@pytest.mark.parametrize("solver", sorted(_MEASURED))
-def test_the_wall_ratio_sequence_is_unchanged(solver, conservation):
-    """**No verdict.** The sequence is the observation.
-
-    A previous version classified each row from the trend across three resolutions. Independent
-    review showed the rule cannot do that: `FPFVMSolver` reads 0.392 / 0.649 / **1.106** and keeps
-    going to 12.699 at nx=1281, so a "within 0.15 of 1" clause fires on a value the sequence merely
-    transits; `FPSLSolver` reads 0.998 at nx=201 and then 1.926, 3.500. Three points cannot
-    separate approach from transit and neither can six.
-
-    So this pins the first and last of the sequence and leaves the reading to a person.
-    """
-    row = _row(conservation, solver)
-    assert row["status"] == "MEASURED", f"{solver} is now {row['status']}: {row['detail']}"
-    first, last = row["ratios"][0][1], row["ratios"][-1][1]
-    want_first, want_last = _MEASURED[solver]
-    assert first == pytest.approx(want_first, abs=0.05), f"{solver} first ratio moved: {row['ratios']}"
-    assert last == pytest.approx(want_last, abs=0.05), f"{solver} last ratio moved: {row['ratios']}"
-
-
-def test_mass_drift_is_reported_beside_the_ratio_and_not_as_a_verdict(conservation):
-    """Mass conservation is neither sufficient nor necessary, so it must never be the status.
-
-    NOT SUFFICIENT: streamline diffusion conserves to 1e-12 while the wall ratio collapses.
-    NOT NECESSARY: `FPSLJacobianSolver` is the Lagrangian form, non-conservative BY CONSTRUCTION
-    with an O(h) error, deprecated for adjoint inconsistency rather than for mass. It carries a
-    real drift and is still `MEASURED`; that is the separation this asserts.
-    """
-    jac = _row(conservation, "FPSLJacobianSolver")
-    assert jac["status"] == "MEASURED"
-    assert jac["drift_pct"] is not None
-    assert abs(jac["drift_pct"]) > 1.0, "the one row where the two axes visibly disagree lost its drift"
-
-
-@pytest.mark.parametrize("solver", sorted(_NOT_MEASURED))
-def test_these_paths_remain_unobservable_by_this_harness(solver, conservation):
-    """**NOT_MEASURED is not a pass.** `FPFEMSolver` is in this set and is the class that made
-    #1975 wrong the first time."""
-    row = _row(conservation, solver)
-    assert row["status"] == "NOT_MEASURED", f"{solver} is now measurable: {row['detail']}"
-
-
-def test_the_declared_drift_convention_is_read_and_not_assumed(census):
-    """`_drift_convention` reads VELOCITY on three solvers whose second positional argument is
-    `drift_field`. Passing them a potential made the wall-normal drift vanish at the wall the mass
-    reached -- the discriminating property absent while a verdict printed anyway."""
-    velocity = {
-        names[0]
-        for cls, names in census.fp_solver_population().items()
-        if getattr(getattr(cls, "_drift_convention", None), "name", None) == "VELOCITY"
-    }
-    assert velocity == {"FPFDMSolver", "FPFVMSolver", "FPGFDMSolver"}, (
-        f"the VELOCITY-convention set changed to {sorted(velocity)}; the harness feeds each solver "
-        "according to this declaration, so a change here changes what was measured."
-    )

--- a/tests/unit/test_capability_census.py
+++ b/tests/unit/test_capability_census.py
@@ -83,15 +83,47 @@ _DECLARES_NOTHING = {
 }
 
 
+#: Every solver that OWNS `honors_inhomogeneous_neumann` refuses an inhomogeneous flux. A `True`
+#: here is a live claim the #1686 gate stops enforcing, and nothing else in the tree pins it.
+_HONORS_INHOMOGENEOUS_NEUMANN_OWN = {
+    "FPFDMSolver": "False",
+    "FPFVMSolver": "False",
+    "FPGFDMSolver": "False",
+    "FPParticleSolver": "False",
+    "FPSLJacobianSolver": "False",
+    "FPSLSolver": "False",
+}
+
+
+def test_the_solvers_that_own_the_inhomogeneous_neumann_flag_all_refuse(declarations):
+    """A capability whose VALUE nothing else asserts. Joining or leaving this set is #1686 news."""
+    got = {
+        r["names"][0]: r["own_values"]["honors_inhomogeneous_neumann"]
+        for r in declarations["rows"]
+        if "honors_inhomogeneous_neumann" in r["own"]
+    }
+    assert got == _HONORS_INHOMOGENEOUS_NEUMANN_OWN, f"changed: {got}"
+
+
 @pytest.mark.parametrize("role", sorted(_DECLARES_NOTHING))
 def test_the_set_of_classes_declaring_nothing_is_unchanged(declarations, role):
     """Leaving this set is #1977 progress; joining it is a capability shipped undeclared.
 
     **This pins WHETHER a class declares, not WHAT it declares.** Measured: widening a gated
-    solver's `_SUPPORTED_BC_TYPES` to include `ROBIN` leaves this file green. The declared VALUES
-    will be pinned per solver by PR #1976, which is OPEN and not yet on `main`. Until it lands the
-    hole has no cover, so **#1976 must merge first**; a second frozen copy here would give two
-    copies of one measurement, the divergence this census exists to find.
+    solver's `_SUPPORTED_BC_TYPES` to include `ROBIN` leaves this file green.
+
+    ~~The declared VALUES will be pinned per solver by PR #1976.~~ [CORRECTED 2026-08-17] -- true
+    of ONE of the three declarations. #1976 pins `_SUPPORTED_BC_TYPES` per solver (verified: the
+    same ROBIN mutation fails 2 of its 29 tests), so that hole has a cover and **#1976 must merge
+    first**; a second frozen copy here would give two copies of one measurement, the divergence
+    this census exists to find.
+
+    `honors_inhomogeneous_neumann` had NO cover in either file -- flipping `FPFDMSolver`'s own
+    value `False -> True`, a solver silently claiming to honour a flux it does not honour, passed
+    8 of 8 here and 29 of 29 there. Since nothing else pins it, there is no duplication to create,
+    and the test below now does. `discretization_type`'s two owners declare it as a `property`
+    object whose `str()` carries a memory address, so its value is not pinnable this way and stays
+    uncovered.
 
     An unwritten sibling of the same hole: a declaration set on the INSTANCE
     (`self._SUPPORTED_BC_TYPES = ...` in `__init__`) is invisible here while the runtime gate
@@ -119,6 +151,10 @@ def test_no_module_in_the_package_fails_to_import(declarations):
 
 
 def test_the_roots_still_exist(declarations):
+    """The emptiness guard comes first: `roots_missing == []` is also true of a census with no
+    roots at all, and so is the outside-predicate test below. Measured with `ROOTS = {}`: 5 of the
+    8 tests went red and these two stayed green, each on a vacuous truth."""
+    assert len(declarations["rows"]) > 40, f"population collapsed to {len(declarations['rows'])} rows"
     assert declarations["roots_missing"] == [], f"unresolvable roots: {declarations['roots_missing']}"
 
 

--- a/tests/unit/test_capability_census.py
+++ b/tests/unit/test_capability_census.py
@@ -1,13 +1,27 @@
 """Ratchet over `scripts/capability_census.py`. Refs #1975, #1977.
 
-The census answers two questions the 2026-08-13 design census could not, because all four of its
-lanes look for reality falling *short* of a claim. These look the other way — at capability that
-exists and is not declared, and at a wall imposed with nothing naming it. Both directions of that
-blind spot produced a wrong issue (#1975, filed on a false premise and corrected twice).
+Two lanes, both answering a question the 2026-08-13 design census could not: all four of its lanes
+look for reality falling *short* of a claim, and it found 77 over-claims. Nobody counted the other
+direction — capability that exists undeclared, and a wall imposed with nothing naming it — and
+that direction made #1975 wrong twice.
 
-Everything here is imported from the script rather than restated, so the two cannot drift. The
-frozen sets below are the ratchet: a change is information, and each failure message says which
-direction it went and what that means.
+**Lane 2's instrument was rebuilt after eight defects, and every one produced a confident verdict
+rather than a failure.** Four were found by independent measurement of the paths it could not
+construct; four more only by re-running it against a path whose answer was already known:
+
+1. it assumed the mass functional (`sum(m)*h` vs a Galerkin `1^T M`, `+37%` vs `-4e-13%`);
+2. its verdict was sign-blind (a `d_n m = 0` wall *loses* mass; the clip *gains* it);
+3. it could not tell a stability failure from a wall;
+4. it double-counted a module-level alias, reporting 12 rows for 11 implementations;
+5. it assumed which wall was the outflow wall;
+6. its clip gate false-positived on a particle method, where exact zeros are ordinary;
+7. **it assumed the drift convention** — `_drift_convention` is a declared class attribute reading
+   `VELOCITY` on three solvers, and passing them a potential made the wall-normal drift vanish at
+   the very wall the mass reached, so the discriminating property was absent and a verdict printed
+   anyway;
+8. it thresholded a quantity that is only meaningful as a limit.
+
+Everything here is imported from the script rather than restated, so the two cannot drift.
 """
 
 from __future__ import annotations
@@ -25,7 +39,7 @@ _SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "capability_census.p
 def census():
     spec = importlib.util.spec_from_file_location("capability_census", _SCRIPT)
     module = importlib.util.module_from_spec(spec)
-    sys.modules["capability_census"] = module  # dataclass/typing lookups need it registered
+    sys.modules["capability_census"] = module
     spec.loader.exec_module(module)
     return module
 
@@ -44,9 +58,6 @@ def conservation(census):
 # Lane 1 -- who declares nothing
 # =============================================================================
 
-# Measured 2026-08-17. Recorded as a POPULATION, not as an absence: a class here is one whose
-# capability cannot be read off the class at all, which is the state that let #1975 report
-# FPFEMSolver's Robin implementation as absent.
 _DECLARES_NOTHING = {
     "solver": {
         "FPFEMSolver",
@@ -103,8 +114,8 @@ def test_the_set_of_classes_declaring_nothing_is_unchanged(declarations, role):
 
 
 def test_no_module_in_the_package_fails_to_import(declarations):
-    """The population is only as complete as the walk. A module that will not import is a hole in
-    it, and a silent one — `walk_packages` yields the name either way."""
+    """The population is only as complete as the walk, and `walk_packages` yields a name whether
+    or not the module imports."""
     assert declarations["import_failures"] == [], (
         f"modules that would not import: {declarations['import_failures']}. Every class they "
         "define is missing from every row of this census."
@@ -112,38 +123,26 @@ def test_no_module_in_the_package_fails_to_import(declarations):
 
 
 def test_the_roots_still_exist(declarations):
-    """A root that cannot be resolved silently empties its whole lane."""
     assert declarations["roots_missing"] == [], f"unresolvable roots: {declarations['roots_missing']}"
 
 
 def test_the_classes_outside_every_predicate_are_still_outside_it(declarations):
-    """These do a root's job without subclassing it, so no predicate reaches them. Named rather
-    than discovered — a population predicate is itself a claim about scope, and this is the part
-    no mechanism recovers."""
+    """Named rather than discovered — a population predicate is itself a claim about scope, and
+    this is the part no mechanism recovers."""
     assert declarations["outside_every_predicate"] == {
         "HJBHowardSolver": [],
         "ImplicitHeatSolver": [],
         "ParticleApplicator": [],
-    }, (
-        "a class outside every population predicate moved. If it is now a subclass, delete it from "
-        "OUTSIDE_EVERY_PREDICATE — the census reaches it on its own."
-    )
+    }
 
 
 def test_the_permissive_default_is_still_claimed_by_inheritance(declarations):
     """`honors_inhomogeneous_neumann` defaults to True on `BaseMFGSolver`, so a solver that never
-    mentions it claims to honour an inhomogeneous Neumann flux. That claim was made by a default,
-    not by anyone.
+    mentions it claims to honour an inhomogeneous Neumann flux — a claim made by a default, not by
+    anyone, and invisible at every call site.
 
-    Two inheritance chains, and they mean opposite things — a first draft of this test asserted
-    every inherited value was True and failed on the second:
-
-      - from `BaseMFGSolver`: the permissive default nobody chose;
-      - from a sibling solver (`FPSLAdjointSolver` <- `FPSLSolver`): a deliberate `False`, one
-        level up, which is a real declaration made by someone.
-
-    This does not assert the default is wrong. It asserts the counts do not drift unnoticed,
-    because an inherited claim is invisible at every call site.
+    Two inheritance chains meaning opposite things: from `BaseMFGSolver` it is that default; from
+    a sibling (`FPSLAdjointSolver` <- `FPSLSolver`) it is a deliberate `False`.
     """
     rows = declarations["rows"]
     field = "honors_inhomogeneous_neumann"
@@ -161,99 +160,160 @@ def test_the_permissive_default_is_still_claimed_by_inheritance(declarations):
 
     assert len(owners) == 6, f"solvers stating it themselves: {sorted(owners)}"
     assert len(from_base) == 19, f"solvers claiming True by the permissive default: {sorted(from_base)}"
-    assert set(from_base.values()) == {"True"}, (
-        f"the permissive default is no longer uniformly True: {from_base}. That changes what "
-        f"{len(from_base)} solvers claim, at no call site."
-    )
-    assert from_sibling == {"FPSLAdjointSolver": ("FPSLSolver", "False")}, (
-        f"inheritance from a sibling solver changed: {from_sibling}. Unlike the base default, "
-        "this one is a choice someone made -- treat a change here as a real declaration moving."
-    )
+    assert set(from_base.values()) == {"True"}
+    assert from_sibling == {"FPSLAdjointSolver": ("FPSLSolver", "False")}
 
 
 # =============================================================================
-# Lane 2 -- which FP paths impose J.n = 0
+# Lane 2 -- which wall each FP path imposes
 # =============================================================================
 
-_CONSERVES = {
-    "FPFDMSolver",
-    "FPFVMSolver",
-    "FPParticleSolver",
-    "FPSLAdjointSolver",
-    "FPSLSolver",
-}
-#: `FPSLJacobianSolver` gains mass at O(h) with NO drift at all (+0.1396 / +0.0689 / +0.0343 % at
-#: Nx = 41 / 81 / 161, ratio 2.01), so its drifted figure says nothing about its wall. Deprecated
-#: — this is the quantified reason the deprecation notes never gave.
-_CONTROL_FAILED = {"FPSLJacobianSolver"}
-#: Not a pass. Each needs a geometry this harness does not build: an unstructured mesh, collocation
-#: points, a network, or an explicit discretization.
+#: The wall ratio `d_n m / ((v_n/D) m_wall)` RISES toward 1 under refinement. Measured at
+#: Nx = 41 / 81 / 161. These paths impose `J.n = 0`; several do it structurally, with no branch
+#: naming the condition, which is what made a sweep over branch names read the wrong answer.
+_IMPOSES_J_DOT_N = {"FPFDMSolver", "FPFVMSolver", "FPSLSolver", "FPSLAdjointSolver"}
+
+#: The ratio FALLS toward 0: the wall converges to `d_n m = 0`, which is the wrong condition when
+#: the drift is not tangential. Its `O(h)` mass error is a SEPARATE and legitimate fact — the
+#: Lagrangian form is non-conservative by construction — and the previous instrument fused the two
+#: into one `CONTROL_FAILED`.
+_IMPOSES_ZERO_GRADIENT = {"FPSLJacobianSolver"}
+
+#: Measured, but the witness does not transfer. A particle method's density is a binned/KDE
+#: reconstruction, so a one-sided difference on it is not the `d_n m` the ratio is defined from,
+#: and the reflection lives in the paths rather than in the density. Recorded rather than given a
+#: verdict: a witness that does not apply is not evidence either way.
+_WITNESS_NOT_APPLICABLE = {"FPParticleSolver"}
+
+#: Not a pass. Each needs a geometry or an argument this harness does not build. Independent
+#: measurement (recipes in #1975) found `FPFEMSolver` and `MeshlessGalerkinFPSolver` impose
+#: `J.n = 0` as the NATURAL BC of the weak form, `FPNetworkSolver` conserves structurally with no
+#: boundary in this sense, `WeakFormFPSolver` is not independently constructible, and
+#: `FPGFDMSolver` imposes NEITHER condition -- its `_boundary_type` is resolved, gate-validated,
+#: stored at `fp_gfdm.py:209` and never read again.
 _NOT_MEASURED = {
     "FPFEMSolver",
     "FPGFDMSolver",
     "FPNetworkSolver",
     "MeshlessGalerkinFPSolver",
-    "NetworkFPSolver",
     "WeakFormFPSolver",
 }
 
 
+def _row(conservation, name):
+    return next(r for r in conservation["rows"] if r["class"] == name)
+
+
 def test_the_harness_reference_path_conserves(conservation):
-    """Control 2. `divergence_upwind` on the raw assembly must conserve exactly; if it does not,
-    every verdict below is void rather than merely wrong."""
+    """Control 2. If the reference stops conserving, every verdict is VOID rather than wrong."""
     ref = conservation["reference_drift_pct"]
     assert abs(ref) < 1e-3, f"reference path drifted {ref:+.4f}% -- the harness is broken, not the solvers"
 
 
-@pytest.mark.parametrize("solver", sorted(_CONSERVES))
-def test_these_paths_conserve_mass_at_a_wall_with_normal_drift(conservation, solver):
-    """The oracle #1975 was missing: mass conservation is a law of the equation, computed without
-    reference to any scheme's internals, so it answers a question about behaviour that no census
-    over declarations or branch names can answer.
+def test_the_population_is_exactly_the_four_sets(conservation):
+    """Keyed on the class, not the binding name: `NetworkFPSolver = FPNetworkSolver` is a
+    module-level alias (`fp_network.py:606`) and name-keying reported it as a second, independent
+    unmeasured path."""
+    got = {r["class"] for r in conservation["rows"]}
+    want = _IMPOSES_J_DOT_N | _IMPOSES_ZERO_GRADIENT | _WITNESS_NOT_APPLICABLE | _NOT_MEASURED
+    assert got == want, f"FP solver population changed: added {sorted(got - want)}, removed {sorted(want - got)}."
 
-    Conserving here means the path imposes `J.n = 0`. Several do it **structurally**, by zeroing
-    the total face flux or by reflecting particle paths, with no branch naming the condition —
-    which is exactly why reading the dispatch gave the wrong answer.
-    """
-    row = next(r for r in conservation["rows"] if r["class"] == solver)
-    assert row["verdict"] == "CONSERVES", (
-        f"{solver} was conserving and now reports {row['verdict']}: {row['detail']}. "
-        "It has stopped imposing J.n = 0 at a wall with wall-normal drift."
+
+def test_the_alias_is_still_reported_as_an_alias(conservation):
+    assert _row(conservation, "FPNetworkSolver")["aliases"] == ["NetworkFPSolver"], (
+        "the alias collapsed or moved; a name-keyed population would double-count it again"
     )
 
 
-@pytest.mark.parametrize("solver", sorted(_CONTROL_FAILED))
-def test_these_paths_fail_the_zero_drift_control(conservation, solver):
-    """Pinned so the control's own finding does not evaporate. A path that leaks with no drift is
-    not a wall problem, and reading its drifted number as one is the mistake the control exists to
-    stop."""
-    row = next(r for r in conservation["rows"] if r["class"] == solver)
-    assert row["verdict"] == "CONTROL_FAILED", (
-        f"{solver} now reports {row['verdict']}. If it conserves, that is a fix -- move it to _CONSERVES and say so."
+@pytest.mark.parametrize("solver", sorted(_IMPOSES_J_DOT_N))
+def test_these_paths_converge_to_the_flux_wall(conservation, solver):
+    """The verdict is the ratio's TREND, not its value. At Nx=81 the boundary layer is
+    `D/v = 0.014` against `h = 0.0125`, so a correct path reads ~0.5-0.7 there — a fixed threshold
+    called that "imposes neither", which is defect 8 above."""
+    row = _row(conservation, solver)
+    assert row["verdict"] == "IMPOSES_J_DOT_N", f"{solver} now reports {row['verdict']}: {row['detail']}"
+    ratios = [r for _, r in row["ratios"]]
+    assert ratios[-1] > ratios[0], f"{solver}'s wall ratio stopped rising under refinement: {ratios}"
+
+
+@pytest.mark.parametrize("solver", sorted(_IMPOSES_ZERO_GRADIENT))
+def test_these_paths_converge_to_the_zero_gradient_wall(conservation, solver):
+    """The wrong wall under a normal drift, and a finding independent of the mass column."""
+    row = _row(conservation, solver)
+    assert row["verdict"] == "IMPOSES_ZERO_GRADIENT", (
+        f"{solver} now reports {row['verdict']}: {row['detail']}. If its ratio now rises toward 1 "
+        "that is a fix -- move it to _IMPOSES_J_DOT_N and say so."
+    )
+
+
+def test_a_non_conservative_form_is_not_thereby_wrong(conservation):
+    """Mass conservation is neither sufficient nor necessary, so it must never be the verdict.
+
+    NOT SUFFICIENT: streamline diffusion conserves to 1e-12 while the wall ratio collapses
+    0.967 -> 0.414. NOT NECESSARY: `FPSLJacobianSolver` is the Lagrangian form
+    `m^{n+1}(x) = m^n(x - a dt) exp(-dt div a)`, non-conservative by construction with an O(h)
+    error that halves under refinement, and deprecated for ADJOINT INCONSISTENCY, not for mass.
+
+    This asserts the two axes stay separable: a path may carry a real mass drift and still be
+    judged on its wall.
+    """
+    row = _row(conservation, "FPSLJacobianSolver")
+    assert row["drift_pct"] is not None, "FPSLJacobianSolver's mass column went unmeasured"
+    assert abs(row["drift_pct"]) > 1.0, (
+        "FPSLJacobianSolver's mass drift vanished; it is the only path where the two axes visibly "
+        "disagree, and this test is what keeps them from being fused back into one verdict"
+    )
+    assert row["verdict"] == "IMPOSES_ZERO_GRADIENT", "the verdict must come from the wall, not the mass"
+
+
+@pytest.mark.parametrize("solver", sorted(_WITNESS_NOT_APPLICABLE))
+def test_the_wall_witness_does_not_transfer_to_a_particle_density(conservation, solver):
+    """Recorded, not judged. The ratio is defined from `d_n m` on a represented density; a binned
+    or KDE-reconstructed one is a different object, and the reflection lives in the paths. A
+    witness that does not apply is not evidence either way — treating its output as a verdict is
+    the same error as reading `NOT_MEASURED` as a pass."""
+    row = _row(conservation, solver)
+    assert row["ratios"], f"{solver} produced no ratio at all; the row's premise changed"
+    assert all(abs(r) < 1e-9 for _, r in row["ratios"]), (
+        f"{solver}'s ratio is no longer identically zero ({row['ratios']}). If the density is now "
+        "represented rather than binned, this witness may apply -- re-derive before judging."
     )
 
 
 @pytest.mark.parametrize("solver", sorted(_NOT_MEASURED))
 def test_these_paths_remain_unobservable_by_this_harness(conservation, solver):
-    """**A NOT_MEASURED row is not a pass.** It is a path whose wall nobody in this repository can
-    currently observe, and that state is what let #1975 be filed on a false premise: `FPFEMSolver`
-    is in this set and implements the very thing the issue said was absent.
-
-    A solver leaving this set is the harness gaining reach — record the verdict it now returns.
-    """
-    row = next(r for r in conservation["rows"] if r["class"] == solver)
+    """**NOT_MEASURED is not a pass.** It is a path whose wall this harness cannot observe.
+    `FPFEMSolver` is in this set and is the class that made #1975 wrong the first time."""
+    row = _row(conservation, solver)
     assert row["verdict"] == "NOT_MEASURED", (
         f"{solver} is now measurable and reports {row['verdict']}: {row['detail']}. Move it to the matching set."
     )
 
 
-def test_the_population_is_exactly_the_three_sets(conservation):
-    """No solver may be silently absent from all three. The population comes from the presence of
-    `solve_fp_system`, not from any declaration — so a new FP solver appears here whether or not it
-    announces anything."""
-    got = {r["class"] for r in conservation["rows"]}
-    want = _CONSERVES | _CONTROL_FAILED | _NOT_MEASURED
-    assert got == want, (
-        f"FP solver population changed: added {sorted(got - want)}, removed {sorted(want - got)}. "
-        "A new FP solver must be classified before this file means anything."
+def test_the_declared_drift_convention_is_read_and_not_assumed(conservation, census):
+    """Defect 7, pinned. `_drift_convention` reads `VELOCITY` on three solvers; passing them a
+    potential made the wall-normal drift vanish at the wall the mass reached, so the
+    discriminating property was absent while a verdict printed anyway."""
+    # Read from the CLASS, not from the measured row: the declaration exists whether or not the
+    # harness can construct the solver, and reading it off the measurement made FPGFDMSolver --
+    # which is NOT_MEASURED -- silently drop out of the set. Same shape as defect 7 itself.
+    velocity = {
+        names[0]
+        for cls, names in census.fp_solver_population().items()
+        if getattr(getattr(cls, "_drift_convention", None), "name", None) == "VELOCITY"
+    }
+    assert velocity == {"FPFDMSolver", "FPFVMSolver", "FPGFDMSolver"}, (
+        f"the set of VELOCITY-convention solvers changed to {sorted(velocity)}; the harness feeds "
+        "each solver according to this declaration, so a change here changes what was measured."
+    )
+    # Name and declaration disagree here, and the declaration is what the harness follows.
+    import inspect
+
+    from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
+
+    params = list(inspect.signature(FPParticleSolver.solve_fp_system).parameters)
+    assert params[2] == "drift_field", "the disagreement this pins has moved"
+    assert getattr(FPParticleSolver._drift_convention, "name", None) == "VALUE_FUNCTION", (
+        "FPParticleSolver's parameter is named `drift_field` while its declared convention is "
+        "VALUE_FUNCTION; if that is reconciled, record it -- it is a live trap for any harness."
     )

--- a/tests/unit/test_capability_census.py
+++ b/tests/unit/test_capability_census.py
@@ -51,7 +51,7 @@ def declarations(census):
 
 @pytest.fixture(scope="module")
 def conservation(census):
-    return census.conservation_verdicts()
+    return census.conservation_report()
 
 
 # =============================================================================
@@ -165,32 +165,21 @@ def test_the_permissive_default_is_still_claimed_by_inheritance(declarations):
 
 
 # =============================================================================
-# Lane 2 -- which wall each FP path imposes
+# Lane 2 -- the wall-ratio sequence, reported and pinned; no verdict
 # =============================================================================
 
-#: The wall ratio `d_n m / ((v_n/D) m_wall)` RISES toward 1 under refinement. Measured at
-#: Nx = 41 / 81 / 161. These paths impose `J.n = 0`; several do it structurally, with no branch
-#: naming the condition, which is what made a sweep over branch names read the wrong answer.
-_IMPOSES_J_DOT_N = {"FPFDMSolver", "FPFVMSolver", "FPSLSolver", "FPSLAdjointSolver"}
+#: Rows the harness can construct and run. The ratio sequence is pinned loosely -- it is a
+#: measurement of a numerical scheme, not a constant -- and the ORDER of magnitude and sign are
+#: what a regression would move.
+_MEASURED = {
+    "FPFDMSolver": (0.35, 0.69),
+    "FPFVMSolver": (0.39, 1.11),
+    "FPParticleSolver": (-0.01, 0.01),
+    "FPSLJacobianSolver": (0.00, 0.05),
+    "FPSLSolver": (-0.01, 0.47),
+}
 
-#: The ratio FALLS toward 0: the wall converges to `d_n m = 0`, which is the wrong condition when
-#: the drift is not tangential. Its `O(h)` mass error is a SEPARATE and legitimate fact — the
-#: Lagrangian form is non-conservative by construction — and the previous instrument fused the two
-#: into one `CONTROL_FAILED`.
-_IMPOSES_ZERO_GRADIENT = {"FPSLJacobianSolver"}
-
-#: Measured, but the witness does not transfer. A particle method's density is a binned/KDE
-#: reconstruction, so a one-sided difference on it is not the `d_n m` the ratio is defined from,
-#: and the reflection lives in the paths rather than in the density. Recorded rather than given a
-#: verdict: a witness that does not apply is not evidence either way.
-_WITNESS_NOT_APPLICABLE = {"FPParticleSolver"}
-
-#: Not a pass. Each needs a geometry or an argument this harness does not build. Independent
-#: measurement (recipes in #1975) found `FPFEMSolver` and `MeshlessGalerkinFPSolver` impose
-#: `J.n = 0` as the NATURAL BC of the weak form, `FPNetworkSolver` conserves structurally with no
-#: boundary in this sense, `WeakFormFPSolver` is not independently constructible, and
-#: `FPGFDMSolver` imposes NEITHER condition -- its `_boundary_type` is resolved, gate-validated,
-#: stored at `fp_gfdm.py:209` and never read again.
+#: Not a pass. Each needs a geometry or an argument this harness does not build.
 _NOT_MEASURED = {
     "FPFEMSolver",
     "FPGFDMSolver",
@@ -199,121 +188,90 @@ _NOT_MEASURED = {
     "WeakFormFPSolver",
 }
 
+#: Same class under two names, and one empty deprecated SUBCLASS. Class-keying collapses the
+#: first; `_deprecation_meta["alias_for"]` collapses the second. Two identical rows read as two
+#: independent confirmations, which is why both are folded rather than reported twice.
+_COLLAPSED = {"FPNetworkSolver": ["NetworkFPSolver"], "FPSLSolver": ["FPSLAdjointSolver"]}
+
 
 def _row(conservation, name):
-    return next(r for r in conservation["rows"] if r["class"] == name)
+    matching = [r for r in conservation["rows"] if r["class"] == name]
+    assert matching, f"{name} is not in the population at all"
+    return matching[0]
 
 
 def test_the_harness_reference_path_conserves(conservation):
-    """Control 2. If the reference stops conserving, every verdict is VOID rather than wrong."""
+    """Control. If the reference stops conserving, every row is VOID rather than wrong."""
     ref = conservation["reference_drift_pct"]
-    assert abs(ref) < 1e-3, f"reference path drifted {ref:+.4f}% -- the harness is broken, not the solvers"
+    assert abs(ref) < 1e-3, f"reference path drifted {ref:+.4f}% -- the harness is broken"
 
 
-def test_the_population_is_exactly_the_four_sets(conservation):
-    """Keyed on the class, not the binding name: `NetworkFPSolver = FPNetworkSolver` is a
-    module-level alias (`fp_network.py:606`) and name-keying reported it as a second, independent
-    unmeasured path."""
+def test_the_population_is_exactly_the_two_sets(conservation):
     got = {r["class"] for r in conservation["rows"]}
-    want = _IMPOSES_J_DOT_N | _IMPOSES_ZERO_GRADIENT | _WITNESS_NOT_APPLICABLE | _NOT_MEASURED
-    assert got == want, f"FP solver population changed: added {sorted(got - want)}, removed {sorted(want - got)}."
+    want = set(_MEASURED) | _NOT_MEASURED
+    assert got == want, f"population changed: added {sorted(got - want)}, removed {sorted(want - got)}"
 
 
-def test_the_alias_is_still_reported_as_an_alias(conservation):
-    assert _row(conservation, "FPNetworkSolver")["aliases"] == ["NetworkFPSolver"], (
-        "the alias collapsed or moved; a name-keyed population would double-count it again"
+def test_the_alias_and_the_deprecated_subclass_are_both_collapsed(conservation):
+    got = {r["class"]: r["aliases"] for r in conservation["rows"] if r["aliases"]}
+    assert got == _COLLAPSED, (
+        f"collapsing changed: {got}. Class-keying catches `X = Y`; `class X(Y): pass` needs the "
+        "`_deprecation_meta['alias_for']` fold, and without it two identical rows appear."
     )
 
 
-@pytest.mark.parametrize("solver", sorted(_IMPOSES_J_DOT_N))
-def test_these_paths_converge_to_the_flux_wall(conservation, solver):
-    """The verdict is the ratio's TREND, not its value. At Nx=81 the boundary layer is
-    `D/v = 0.014` against `h = 0.0125`, so a correct path reads ~0.5-0.7 there — a fixed threshold
-    called that "imposes neither", which is defect 8 above."""
-    row = _row(conservation, solver)
-    assert row["verdict"] == "IMPOSES_J_DOT_N", f"{solver} now reports {row['verdict']}: {row['detail']}"
-    ratios = [r for _, r in row["ratios"]]
-    assert ratios[-1] > ratios[0], f"{solver}'s wall ratio stopped rising under refinement: {ratios}"
+@pytest.mark.parametrize("solver", sorted(_MEASURED))
+def test_the_wall_ratio_sequence_is_unchanged(solver, conservation):
+    """**No verdict.** The sequence is the observation.
 
+    A previous version classified each row from the trend across three resolutions. Independent
+    review showed the rule cannot do that: `FPFVMSolver` reads 0.392 / 0.649 / **1.106** and keeps
+    going to 12.699 at nx=1281, so a "within 0.15 of 1" clause fires on a value the sequence merely
+    transits; `FPSLSolver` reads 0.998 at nx=201 and then 1.926, 3.500. Three points cannot
+    separate approach from transit and neither can six.
 
-@pytest.mark.parametrize("solver", sorted(_IMPOSES_ZERO_GRADIENT))
-def test_these_paths_converge_to_the_zero_gradient_wall(conservation, solver):
-    """The wrong wall under a normal drift, and a finding independent of the mass column."""
-    row = _row(conservation, solver)
-    assert row["verdict"] == "IMPOSES_ZERO_GRADIENT", (
-        f"{solver} now reports {row['verdict']}: {row['detail']}. If its ratio now rises toward 1 "
-        "that is a fix -- move it to _IMPOSES_J_DOT_N and say so."
-    )
-
-
-def test_a_non_conservative_form_is_not_thereby_wrong(conservation):
-    """Mass conservation is neither sufficient nor necessary, so it must never be the verdict.
-
-    NOT SUFFICIENT: streamline diffusion conserves to 1e-12 while the wall ratio collapses
-    0.967 -> 0.414. NOT NECESSARY: `FPSLJacobianSolver` is the Lagrangian form
-    `m^{n+1}(x) = m^n(x - a dt) exp(-dt div a)`, non-conservative by construction with an O(h)
-    error that halves under refinement, and deprecated for ADJOINT INCONSISTENCY, not for mass.
-
-    This asserts the two axes stay separable: a path may carry a real mass drift and still be
-    judged on its wall.
+    So this pins the first and last of the sequence and leaves the reading to a person.
     """
-    row = _row(conservation, "FPSLJacobianSolver")
-    assert row["drift_pct"] is not None, "FPSLJacobianSolver's mass column went unmeasured"
-    assert abs(row["drift_pct"]) > 1.0, (
-        "FPSLJacobianSolver's mass drift vanished; it is the only path where the two axes visibly "
-        "disagree, and this test is what keeps them from being fused back into one verdict"
-    )
-    assert row["verdict"] == "IMPOSES_ZERO_GRADIENT", "the verdict must come from the wall, not the mass"
-
-
-@pytest.mark.parametrize("solver", sorted(_WITNESS_NOT_APPLICABLE))
-def test_the_wall_witness_does_not_transfer_to_a_particle_density(conservation, solver):
-    """Recorded, not judged. The ratio is defined from `d_n m` on a represented density; a binned
-    or KDE-reconstructed one is a different object, and the reflection lives in the paths. A
-    witness that does not apply is not evidence either way — treating its output as a verdict is
-    the same error as reading `NOT_MEASURED` as a pass."""
     row = _row(conservation, solver)
-    assert row["ratios"], f"{solver} produced no ratio at all; the row's premise changed"
-    assert all(abs(r) < 1e-9 for _, r in row["ratios"]), (
-        f"{solver}'s ratio is no longer identically zero ({row['ratios']}). If the density is now "
-        "represented rather than binned, this witness may apply -- re-derive before judging."
-    )
+    assert row["status"] == "MEASURED", f"{solver} is now {row['status']}: {row['detail']}"
+    first, last = row["ratios"][0][1], row["ratios"][-1][1]
+    want_first, want_last = _MEASURED[solver]
+    assert first == pytest.approx(want_first, abs=0.05), f"{solver} first ratio moved: {row['ratios']}"
+    assert last == pytest.approx(want_last, abs=0.05), f"{solver} last ratio moved: {row['ratios']}"
+
+
+def test_mass_drift_is_reported_beside_the_ratio_and_not_as_a_verdict(conservation):
+    """Mass conservation is neither sufficient nor necessary, so it must never be the status.
+
+    NOT SUFFICIENT: streamline diffusion conserves to 1e-12 while the wall ratio collapses.
+    NOT NECESSARY: `FPSLJacobianSolver` is the Lagrangian form, non-conservative BY CONSTRUCTION
+    with an O(h) error, deprecated for adjoint inconsistency rather than for mass. It carries a
+    real drift and is still `MEASURED`; that is the separation this asserts.
+    """
+    jac = _row(conservation, "FPSLJacobianSolver")
+    assert jac["status"] == "MEASURED"
+    assert jac["drift_pct"] is not None
+    assert abs(jac["drift_pct"]) > 1.0, "the one row where the two axes visibly disagree lost its drift"
 
 
 @pytest.mark.parametrize("solver", sorted(_NOT_MEASURED))
-def test_these_paths_remain_unobservable_by_this_harness(conservation, solver):
-    """**NOT_MEASURED is not a pass.** It is a path whose wall this harness cannot observe.
-    `FPFEMSolver` is in this set and is the class that made #1975 wrong the first time."""
+def test_these_paths_remain_unobservable_by_this_harness(solver, conservation):
+    """**NOT_MEASURED is not a pass.** `FPFEMSolver` is in this set and is the class that made
+    #1975 wrong the first time."""
     row = _row(conservation, solver)
-    assert row["verdict"] == "NOT_MEASURED", (
-        f"{solver} is now measurable and reports {row['verdict']}: {row['detail']}. Move it to the matching set."
-    )
+    assert row["status"] == "NOT_MEASURED", f"{solver} is now measurable: {row['detail']}"
 
 
-def test_the_declared_drift_convention_is_read_and_not_assumed(conservation, census):
-    """Defect 7, pinned. `_drift_convention` reads `VELOCITY` on three solvers; passing them a
-    potential made the wall-normal drift vanish at the wall the mass reached, so the
-    discriminating property was absent while a verdict printed anyway."""
-    # Read from the CLASS, not from the measured row: the declaration exists whether or not the
-    # harness can construct the solver, and reading it off the measurement made FPGFDMSolver --
-    # which is NOT_MEASURED -- silently drop out of the set. Same shape as defect 7 itself.
+def test_the_declared_drift_convention_is_read_and_not_assumed(census):
+    """`_drift_convention` reads VELOCITY on three solvers whose second positional argument is
+    `drift_field`. Passing them a potential made the wall-normal drift vanish at the wall the mass
+    reached -- the discriminating property absent while a verdict printed anyway."""
     velocity = {
         names[0]
         for cls, names in census.fp_solver_population().items()
         if getattr(getattr(cls, "_drift_convention", None), "name", None) == "VELOCITY"
     }
     assert velocity == {"FPFDMSolver", "FPFVMSolver", "FPGFDMSolver"}, (
-        f"the set of VELOCITY-convention solvers changed to {sorted(velocity)}; the harness feeds "
-        "each solver according to this declaration, so a change here changes what was measured."
-    )
-    # Name and declaration disagree here, and the declaration is what the harness follows.
-    import inspect
-
-    from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
-
-    params = list(inspect.signature(FPParticleSolver.solve_fp_system).parameters)
-    assert params[2] == "drift_field", "the disagreement this pins has moved"
-    assert getattr(FPParticleSolver._drift_convention, "name", None) == "VALUE_FUNCTION", (
-        "FPParticleSolver's parameter is named `drift_field` while its declared convention is "
-        "VALUE_FUNCTION; if that is reconciled, record it -- it is a live trap for any harness."
+        f"the VELOCITY-convention set changed to {sorted(velocity)}; the harness feeds each solver "
+        "according to this declaration, so a change here changes what was measured."
     )

--- a/tests/unit/test_capability_census.py
+++ b/tests/unit/test_capability_census.py
@@ -51,7 +51,6 @@ _DECLARES_NOTHING = {
         "HJBFEMSolver",
         "MeshlessGalerkinFPSolver",
         "MeshlessGalerkinHJBSolver",
-        "NetworkFPSolver",
         "NetworkHJBSolver",
         "NetworkPolicyIterationHJBSolver",
         "PenaltyHJBSolver",
@@ -90,9 +89,14 @@ def test_the_set_of_classes_declaring_nothing_is_unchanged(declarations, role):
 
     **This pins WHETHER a class declares, not WHAT it declares.** Measured: widening a gated
     solver's `_SUPPORTED_BC_TYPES` to include `ROBIN` leaves this file green. The declared VALUES
-    are pinned per solver in `tests/unit/test_alg/test_solver_bc_support_census_1975.py`; keeping
-    a second copy of those sets here would give two frozen copies of one measurement, which is the
-    divergence this census exists to find.
+    will be pinned per solver by PR #1976, which is OPEN and not yet on `main`. Until it lands the
+    hole has no cover, so **#1976 must merge first**; a second frozen copy here would give two
+    copies of one measurement, the divergence this census exists to find.
+
+    An unwritten sibling of the same hole: a declaration set on the INSTANCE
+    (`self._SUPPORTED_BC_TYPES = ...` in `__init__`) is invisible here while the runtime gate
+    would honour it -- `_validate_bc_support` reads `getattr(self, "supported_bc_types")` and
+    `fp_fdm.py:121` returns `self._SUPPORTED_BC_TYPES`. No class does this today.
     """
     got = {r["name"] for r in declarations["rows"] if role in r["roles"] and r["declares_nothing"]}
     want = _DECLARES_NOTHING[role]
@@ -151,6 +155,6 @@ def test_the_permissive_default_is_still_claimed_by_inheritance(declarations):
     }
 
     assert len(owners) == 6, f"solvers stating it themselves: {sorted(owners)}"
-    assert len(from_base) == 19, f"solvers claiming True by the permissive default: {sorted(from_base)}"
+    assert len(from_base) == 18, f"solvers claiming True by the permissive default: {sorted(from_base)}"
     assert set(from_base.values()) == {"True"}
     assert from_sibling == {"FPSLAdjointSolver": ("FPSLSolver", "False")}

--- a/tests/unit/test_capability_census.py
+++ b/tests/unit/test_capability_census.py
@@ -1,0 +1,259 @@
+"""Ratchet over `scripts/capability_census.py`. Refs #1975, #1977.
+
+The census answers two questions the 2026-08-13 design census could not, because all four of its
+lanes look for reality falling *short* of a claim. These look the other way — at capability that
+exists and is not declared, and at a wall imposed with nothing naming it. Both directions of that
+blind spot produced a wrong issue (#1975, filed on a false premise and corrected twice).
+
+Everything here is imported from the script rather than restated, so the two cannot drift. The
+frozen sets below are the ratchet: a change is information, and each failure message says which
+direction it went and what that means.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "capability_census.py"
+
+
+@pytest.fixture(scope="module")
+def census():
+    spec = importlib.util.spec_from_file_location("capability_census", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["capability_census"] = module  # dataclass/typing lookups need it registered
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def declarations(census):
+    return census.declaration_matrix()
+
+
+@pytest.fixture(scope="module")
+def conservation(census):
+    return census.conservation_verdicts()
+
+
+# =============================================================================
+# Lane 1 -- who declares nothing
+# =============================================================================
+
+# Measured 2026-08-17. Recorded as a POPULATION, not as an absence: a class here is one whose
+# capability cannot be read off the class at all, which is the state that let #1975 report
+# FPFEMSolver's Robin implementation as absent.
+_DECLARES_NOTHING = {
+    "solver": {
+        "FPFEMSolver",
+        "FPNetworkSolver",
+        "FPSLAdjointSolver",
+        "HJBFEMSolver",
+        "MeshlessGalerkinFPSolver",
+        "MeshlessGalerkinHJBSolver",
+        "NetworkFPSolver",
+        "NetworkHJBSolver",
+        "NetworkPolicyIterationHJBSolver",
+        "PenaltyHJBSolver",
+        "PrimalDualMFGSolver",
+        "SinkhornMFGSolver",
+        "VariationalMFGSolver",
+        "WassersteinMFGSolver",
+        "WeakFormFPSolver",
+        "WeakFormHJBSolver",
+    },
+    "applicator": {"FDMApplicator", "GraphApplicator", "ImplicitApplicator", "MeshfreeApplicator"},
+    "backend": {"JAXBackend", "NumPyBackend", "NumbaBackend", "TorchBackend"},
+    "geometry": {
+        "ComplementDomain",
+        "CustomNetwork",
+        "DifferenceDomain",
+        "GridNetwork",
+        "Hyperrectangle",
+        "Hypersphere",
+        "IntersectionDomain",
+        "MazeGeometry",
+        "Mesh1D",
+        "Mesh2D",
+        "Mesh3D",
+        "RandomNetwork",
+        "ScaleFreeNetwork",
+        "TensorProductGrid",
+        "UnionDomain",
+    },
+}
+
+
+@pytest.mark.parametrize("role", sorted(_DECLARES_NOTHING))
+def test_the_set_of_classes_declaring_nothing_is_unchanged(declarations, role):
+    """Leaving this set is #1977 progress; joining it is a capability shipped undeclared."""
+    got = {r["name"] for r in declarations["rows"] if role in r["roles"] and r["declares_nothing"]}
+    want = _DECLARES_NOTHING[role]
+    if got == want:
+        return
+    raise AssertionError(
+        f"{role}: classes declaring nothing changed.\n"
+        f"  newly silent ({sorted(got - want)}) -- a capability shipped without a declaration.\n"
+        f"  now declaring ({sorted(want - got)}) -- #1977 progress; record it here."
+    )
+
+
+def test_no_module_in_the_package_fails_to_import(declarations):
+    """The population is only as complete as the walk. A module that will not import is a hole in
+    it, and a silent one — `walk_packages` yields the name either way."""
+    assert declarations["import_failures"] == [], (
+        f"modules that would not import: {declarations['import_failures']}. Every class they "
+        "define is missing from every row of this census."
+    )
+
+
+def test_the_roots_still_exist(declarations):
+    """A root that cannot be resolved silently empties its whole lane."""
+    assert declarations["roots_missing"] == [], f"unresolvable roots: {declarations['roots_missing']}"
+
+
+def test_the_classes_outside_every_predicate_are_still_outside_it(declarations):
+    """These do a root's job without subclassing it, so no predicate reaches them. Named rather
+    than discovered — a population predicate is itself a claim about scope, and this is the part
+    no mechanism recovers."""
+    assert declarations["outside_every_predicate"] == {
+        "HJBHowardSolver": [],
+        "ImplicitHeatSolver": [],
+        "ParticleApplicator": [],
+    }, (
+        "a class outside every population predicate moved. If it is now a subclass, delete it from "
+        "OUTSIDE_EVERY_PREDICATE — the census reaches it on its own."
+    )
+
+
+def test_the_permissive_default_is_still_claimed_by_inheritance(declarations):
+    """`honors_inhomogeneous_neumann` defaults to True on `BaseMFGSolver`, so a solver that never
+    mentions it claims to honour an inhomogeneous Neumann flux. That claim was made by a default,
+    not by anyone.
+
+    Two inheritance chains, and they mean opposite things — a first draft of this test asserted
+    every inherited value was True and failed on the second:
+
+      - from `BaseMFGSolver`: the permissive default nobody chose;
+      - from a sibling solver (`FPSLAdjointSolver` <- `FPSLSolver`): a deliberate `False`, one
+        level up, which is a real declaration made by someone.
+
+    This does not assert the default is wrong. It asserts the counts do not drift unnoticed,
+    because an inherited claim is invisible at every call site.
+    """
+    rows = declarations["rows"]
+    field = "honors_inhomogeneous_neumann"
+    owners = [r["name"] for r in rows if field in r["own"]]
+    from_base = {
+        r["name"]: r["inherited"][field]["value"]
+        for r in rows
+        if r["inherited"].get(field, {}).get("from") == "BaseMFGSolver"
+    }
+    from_sibling = {
+        r["name"]: (r["inherited"][field]["from"], r["inherited"][field]["value"])
+        for r in rows
+        if field in r["inherited"] and r["inherited"][field]["from"] != "BaseMFGSolver"
+    }
+
+    assert len(owners) == 6, f"solvers stating it themselves: {sorted(owners)}"
+    assert len(from_base) == 19, f"solvers claiming True by the permissive default: {sorted(from_base)}"
+    assert set(from_base.values()) == {"True"}, (
+        f"the permissive default is no longer uniformly True: {from_base}. That changes what "
+        f"{len(from_base)} solvers claim, at no call site."
+    )
+    assert from_sibling == {"FPSLAdjointSolver": ("FPSLSolver", "False")}, (
+        f"inheritance from a sibling solver changed: {from_sibling}. Unlike the base default, "
+        "this one is a choice someone made -- treat a change here as a real declaration moving."
+    )
+
+
+# =============================================================================
+# Lane 2 -- which FP paths impose J.n = 0
+# =============================================================================
+
+_CONSERVES = {
+    "FPFDMSolver",
+    "FPFVMSolver",
+    "FPParticleSolver",
+    "FPSLAdjointSolver",
+    "FPSLSolver",
+}
+#: `FPSLJacobianSolver` gains mass at O(h) with NO drift at all (+0.1396 / +0.0689 / +0.0343 % at
+#: Nx = 41 / 81 / 161, ratio 2.01), so its drifted figure says nothing about its wall. Deprecated
+#: — this is the quantified reason the deprecation notes never gave.
+_CONTROL_FAILED = {"FPSLJacobianSolver"}
+#: Not a pass. Each needs a geometry this harness does not build: an unstructured mesh, collocation
+#: points, a network, or an explicit discretization.
+_NOT_MEASURED = {
+    "FPFEMSolver",
+    "FPGFDMSolver",
+    "FPNetworkSolver",
+    "MeshlessGalerkinFPSolver",
+    "NetworkFPSolver",
+    "WeakFormFPSolver",
+}
+
+
+def test_the_harness_reference_path_conserves(conservation):
+    """Control 2. `divergence_upwind` on the raw assembly must conserve exactly; if it does not,
+    every verdict below is void rather than merely wrong."""
+    ref = conservation["reference_drift_pct"]
+    assert abs(ref) < 1e-3, f"reference path drifted {ref:+.4f}% -- the harness is broken, not the solvers"
+
+
+@pytest.mark.parametrize("solver", sorted(_CONSERVES))
+def test_these_paths_conserve_mass_at_a_wall_with_normal_drift(conservation, solver):
+    """The oracle #1975 was missing: mass conservation is a law of the equation, computed without
+    reference to any scheme's internals, so it answers a question about behaviour that no census
+    over declarations or branch names can answer.
+
+    Conserving here means the path imposes `J.n = 0`. Several do it **structurally**, by zeroing
+    the total face flux or by reflecting particle paths, with no branch naming the condition —
+    which is exactly why reading the dispatch gave the wrong answer.
+    """
+    row = next(r for r in conservation["rows"] if r["class"] == solver)
+    assert row["verdict"] == "CONSERVES", (
+        f"{solver} was conserving and now reports {row['verdict']}: {row['detail']}. "
+        "It has stopped imposing J.n = 0 at a wall with wall-normal drift."
+    )
+
+
+@pytest.mark.parametrize("solver", sorted(_CONTROL_FAILED))
+def test_these_paths_fail_the_zero_drift_control(conservation, solver):
+    """Pinned so the control's own finding does not evaporate. A path that leaks with no drift is
+    not a wall problem, and reading its drifted number as one is the mistake the control exists to
+    stop."""
+    row = next(r for r in conservation["rows"] if r["class"] == solver)
+    assert row["verdict"] == "CONTROL_FAILED", (
+        f"{solver} now reports {row['verdict']}. If it conserves, that is a fix -- move it to _CONSERVES and say so."
+    )
+
+
+@pytest.mark.parametrize("solver", sorted(_NOT_MEASURED))
+def test_these_paths_remain_unobservable_by_this_harness(conservation, solver):
+    """**A NOT_MEASURED row is not a pass.** It is a path whose wall nobody in this repository can
+    currently observe, and that state is what let #1975 be filed on a false premise: `FPFEMSolver`
+    is in this set and implements the very thing the issue said was absent.
+
+    A solver leaving this set is the harness gaining reach — record the verdict it now returns.
+    """
+    row = next(r for r in conservation["rows"] if r["class"] == solver)
+    assert row["verdict"] == "NOT_MEASURED", (
+        f"{solver} is now measurable and reports {row['verdict']}: {row['detail']}. Move it to the matching set."
+    )
+
+
+def test_the_population_is_exactly_the_three_sets(conservation):
+    """No solver may be silently absent from all three. The population comes from the presence of
+    `solve_fp_system`, not from any declaration — so a new FP solver appears here whether or not it
+    announces anything."""
+    got = {r["class"] for r in conservation["rows"]}
+    want = _CONSERVES | _CONTROL_FAILED | _NOT_MEASURED
+    assert got == want, (
+        f"FP solver population changed: added {sorted(got - want)}, removed {sorted(want - got)}. "
+        "A new FP solver must be classified before this file means anything."
+    )

--- a/tests/unit/test_capability_census.py
+++ b/tests/unit/test_capability_census.py
@@ -152,8 +152,9 @@ def test_no_module_in_the_package_fails_to_import(declarations):
 
 def test_the_roots_still_exist(declarations):
     """The emptiness guard comes first: `roots_missing == []` is also true of a census with no
-    roots at all, and so is the outside-predicate test below. Measured with `ROOTS = {}`: 5 of the
-    8 tests went red and these two stayed green, each on a vacuous truth."""
+    roots at all, and so is the outside-predicate test below. Measured with `ROOTS = {}` at this
+    commit: 6 of the 9 tests went red without the guard, and these two stayed green on a vacuous
+    truth."""
     assert len(declarations["rows"]) > 40, f"population collapsed to {len(declarations['rows'])} rows"
     assert declarations["roots_missing"] == [], f"unresolvable roots: {declarations['roots_missing']}"
 


### PR DESCRIPTION
Refs #1975, #1977. Adds `scripts/capability_census.py` and its ratchet `tests/unit/test_capability_census.py`. No changes to library code.

> **[REWRITTEN 2026-08-17]** — the previous body documented a second lane deleted two commits ago (`e3b3123c`) and carried five numbers measured against that vanished version: `16 of 26`, `19 solvers`, two `1 F / 21 P` mutation rows against a 22-test file, and a gate line of `6228 passed / 171 s`. Everything below is measured at `1728fb2b`.

## Why this exists

The 2026-08-13 design census had four lanes, and **every one looks for reality falling short of a claim.** Nobody counted the other direction, and the other direction is what made #1975 wrong twice: a solver that implements a capability and declares nothing is invisible to a sweep that reads declarations. `FPFEMSolver` implements a general Robin wall and says so nowhere a grep can find.

## What it measures

Population by `pkgutil.walk_packages` + `issubclass` against four named roots, then own-vs-inherited by walking the MRO. The predicate does not depend on the property being audited.

```
=== declares nothing of its own ===
  applicator    4 of   5  (80%)
  backend       4 of   4  (100%)
  geometry     15 of  15  (100%)
  solver       15 of  25  (60%)
```

Declarations that arrive by inheritance are now grouped by `(owner, value)` rather than counted:

```
  honors_inhomogeneous_neumann: own 6, inherited 19
       18  <- BaseMFGSolver            = True
        1  <- FPSLSolver               = False
  _SUPPORTED_BC_TYPES: own 10, inherited 1
        1  <- FPSLSolver               = frozenset({PERIODIC, NEUMANN, NO_FLUX})
  discretization_type: own 2, inherited 24
       20  <- BaseNumericalSolver      = FDM
        4  <- three applicator bases   = <property>
```

**18 solvers claim to honour an inhomogeneous Neumann flux by a default nobody chose.** The count alone said 19 and called all of them permissive; the 19th inherits `False` — a deliberate refusal, the opposite of the claim. Two of the three rows were not permissive defaults at all. That is why the section groups now.

## Mutations

Every mutant's identity asserted at import before reading the result; every file restored and `sha256`-verified after.

| mutation | result |
|---|---|
| M1 — `BaseMFGSolver.honors_inhomogeneous_neumann` `True → False` | **1 F / 8 P** |
| M3 — `FPFEMSolver` starts declaring `_SUPPORTED_BC_TYPES` | **1 F / 8 P** |
| MH — `FPFDMSolver`'s own `honors_inhomogeneous_neumann` `False → True` | **1 F / 8 P** (was 0 F before this round) |
| ML — a gated solver widens `_SUPPORTED_BC_TYPES` to include ROBIN | **0 F / 9 P** — uncovered here, see below |

## The one stated limit, and its cover

ML is not caught by this file and is not meant to be: pinning per-solver declared values here would duplicate #1976's frozen copy, which is the divergence this census exists to find. Verified that the cover is real — the same ROBIN mutation against #1976 at `8be0d4dd`: **2 failed, 27 passed**, one of them `test_each_gated_solver_declares_exactly_this[FPFDMSolver]`. **#1976 must merge before this PR.**

The previous revision claimed #1976 would pin "the declared VALUES". It pins one of the three: `_SUPPORTED_BC_TYPES`. `honors_inhomogeneous_neumann`'s own values were pinned by neither file — MH passed 8/8 here and 29/29 there — so this round pins them here, where there is nothing to duplicate. `discretization_type`'s two owners declare a `property` object whose `str()` carries a memory address; not pinnable this way, and stated as uncovered.

## What this cannot say

- **A name still decides part of the population.** `startswith(("Base", "_"))` drops 4 concrete classes under a root — `BaseGraphApplicator`, `BaseMeshfreeApplicator`, `BaseStructuredApplicator`, `BaseUnstructuredApplicator` — all with `inspect.isabstract` False, and all four *own* `discretization_type` (three appear as the `<-` owner in the output; the fourth has no surviving subclass). The script now prints them rather than dropping them silently. A name sweep deciding a population is the reason the second lane was deleted; this is the residue.
- **A namespace-style subpackage is invisible.** `iter_modules` never yields a directory without `__init__.py`. Current count of such directories: **0** (372 modules on disk, 372 walked).
- **Instance-level declarations are invisible.** `self._SUPPORTED_BC_TYPES = ...` in `__init__` would be honoured by the runtime gate and unseen here. No class does this today.
- **The JSON artifact is not reproducible** — `cls_id` and `<property object at 0x…>` differ between runs, and frozenset ordering moves with `PYTHONHASHSEED`. The fields the tests read are stable; the artifact is not.

## Gate

`./scripts/local_ci.sh` → **6215 passed, 12 skipped, 21 xfailed, GATE GREEN**, 164 s at `1728fb2b`.
Run in a dedicated worktree with `PYTHONPATH` exported — the gate strips cwd, so without it it measures the shared checkout.

