### PR TITLE
fix(fp_gfdm): drop the boundary type nothing reads, and pin the refusal that hid behind it

### DIFF
--- a/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_gfdm.py
@@ -164,7 +164,16 @@ class FPGFDMSolver(BaseFPSolver):
 
         # Resolve boundary conditions using unified infrastructure
         # Issue #527: Integrate with geometry.boundary infrastructure
-        resolved_bc_type = self._resolve_boundary_type(
+        # Called for its validation side effect only. `_resolve_default_bc` (#1100) raises on a
+        # segments-only BoundaryConditions carrying no default, and this is the ONLY call on this
+        # construction path that does -- `_validate_bc_support` below does not invoke it. Measured
+        # 2026-08-17: replacing this call with `None` leaves 755 gfdm/boundary tests green, so the
+        # refusal is now pinned by test_issue_1456_bc_capability_gate.py.
+        #
+        # The RETURN value is discarded. It used to be stored as `self._boundary_type`, which
+        # nothing in the package ever read (removed 2026-08-17); `TaylorOperator` takes no boundary
+        # argument at all, so the resolved string reached nothing.
+        self._resolve_boundary_type(
             boundary_conditions=boundary_conditions,
             boundary_type_str=boundary_type,
         )
@@ -206,7 +215,6 @@ class FPGFDMSolver(BaseFPSolver):
                 "FPGFDMSolver(domain_bounds=...) is accepted but never applied (Issue #1426): the "
                 "domain is taken from problem.geometry. Remove the argument."
             )
-        self._boundary_type = resolved_bc_type
 
         # Store upwind parameters
         self.upwind_scheme = upwind_scheme

--- a/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
+++ b/tests/unit/test_alg/test_issue_1456_bc_capability_gate.py
@@ -27,7 +27,16 @@ from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonia
 from mfgarchon.core.mfg_components import MFGComponents
 from mfgarchon.core.mfg_problem import MFGProblem
 from mfgarchon.geometry import TensorProductGrid
-from mfgarchon.geometry.boundary import dirichlet_bc, neumann_bc, no_flux_bc, periodic_bc, robin_bc, uniform_bc
+from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BoundaryConditions,
+    dirichlet_bc,
+    neumann_bc,
+    no_flux_bc,
+    periodic_bc,
+    robin_bc,
+    uniform_bc,
+)
 from mfgarchon.geometry.boundary.types import BCType
 
 pytestmark = pytest.mark.filterwarnings("ignore")
@@ -85,6 +94,27 @@ def test_fp_gfdm_fails_loud_on_periodic():
     """
     with pytest.raises(NotImplementedError, match="does not support"):
         FPGFDMSolver(_problem(periodic_bc(dimension=1)), collocation_points=_pts(), delta=0.25)
+
+
+def test_fp_gfdm_fails_loud_on_a_segments_only_bc_with_no_default():
+    """A construction-time refusal on the same path as the gate above, from a different mechanism.
+
+    `_resolve_default_bc` (#1100) raises when a `BoundaryConditions` carries segments but no
+    default and a point matches none of them. On this path it is reached only through
+    `FPGFDMSolver._resolve_boundary_type`, whose return value is discarded -- so the call looks
+    dead and is not. Measured 2026-08-17: stubbing it out left 755 gfdm/boundary tests green.
+
+    `_validate_bc_support` does NOT cover this: it never calls `_resolve_default_bc`.
+    """
+    segments_only = BoundaryConditions(
+        segments=[
+            BCSegment(name="lo", bc_type=BCType.NO_FLUX, boundary="x_min"),
+            BCSegment(name="hi", bc_type=BCType.NO_FLUX, boundary="x_max"),
+        ],
+        dimension=1,
+    )
+    with pytest.raises(ValueError, match="default_bc was not"):
+        FPGFDMSolver(_problem(segments_only), collocation_points=_pts(), delta=0.25)
 
 
 @pytest.mark.parametrize("bc_factory", [no_flux_bc, dirichlet_bc, periodic_bc, robin_bc])


### PR DESCRIPTION
First item of the unification plan (U1a): the divergences found during the #1975 sweep, taken in order of evidential dependency rather than severity.

## What was dead

`self._boundary_type = resolved_bc_type` at `fp_gfdm.py:209` — the only occurrence of that attribute anywhere in the package. Assigned once, read nowhere. `TaylorOperator` takes no boundary argument, so the resolved string reached nothing. `test_issue_1456_bc_capability_gate.py:79` already noted it in passing.

## What was not dead, and had no cover

The call producing that value carries the path's only fail-loud. Measured:

| probe | result |
|---|---|
| `BoundaryConditions(segments=[...])` with no `default_bc` → `_resolve_default_bc` | **ValueError** |
| does `_validate_bc_support` call `_resolve_default_bc`? | **no** |
| `FPGFDMSolver(...)` with that BC | **ValueError**, message names `_resolve_boundary_type` |
| stub the call out → gfdm/boundary subset | **755 passed** — nothing caught it |

Mutant asserted live at import (source inspection of `__init__`), not by diffing text.

So the deletion is paired with a pinning test in the same change. Without it the call now reads as 100% dead and the next person removes it — which is what this change was about to do before the measurement.

New test verified both directions: passes as written, **fails** when the call is stubbed.

## Gate

`./scripts/local_ci.sh` → **6247 passed, 12 skipped, 21 xfailed, GATE GREEN**, 134 s.
Run in a dedicated worktree with `PYTHONPATH` exported — the gate strips cwd, so without it it measures the shared checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)