### PR TITLE
fix: nine imports name mfgarchon modules that do not exist

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
     from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
     from mfgarchon.config import MFGSolverConfig
-    from mfgarchon.problem.base_mfg_problem import MFGProblem
+    from mfgarchon.core.mfg_problem import MFGProblem
 
 
 class FictitiousPlayIterator(BaseCouplingIterator):

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
     from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
     from mfgarchon.config import MFGSolverConfig
-    from mfgarchon.problem.base_mfg_problem import MFGProblem
+    from mfgarchon.core.mfg_problem import MFGProblem
 
 # Type alias for iteration callback (Issue #614)
 # Signature: callback(iteration, U, M, error_U, error_M) -> bool

--- a/mfgarchon/alg/numerical/density_estimation.py
+++ b/mfgarchon/alg/numerical/density_estimation.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 if TYPE_CHECKING:
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
 
 # Try importing scipy for fallback CPU KDE
 try:

--- a/mfgarchon/factory/problem_factories.py
+++ b/mfgarchon/factory/problem_factories.py
@@ -58,8 +58,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    from mfgarchon.geometry import BoundaryConditions
-    from mfgarchon.geometry.domain import Domain
+    from mfgarchon.geometry import BoundaryConditions, GeometryProtocol
 
 logger = get_logger(__name__)
 
@@ -135,7 +134,7 @@ def create_mfg_problem(
     problem_type: ProblemType,
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: Literal[True] = True,
@@ -148,7 +147,7 @@ def create_mfg_problem(
     problem_type: Literal["network"],
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: Literal[False],
@@ -161,7 +160,7 @@ def create_mfg_problem(
     problem_type: Literal["stochastic"],
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: Literal[False],
@@ -173,7 +172,7 @@ def create_mfg_problem(
     problem_type: ProblemType,
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: bool = True,
@@ -327,7 +326,7 @@ def create_standard_problem(
     hamiltonian: Any,  # HamiltonianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     potential: Callable | None = None,
     boundary_conditions: BoundaryConditions | None = None,
@@ -409,7 +408,7 @@ def create_network_problem(
     node_interaction: Callable,
     edge_cost: Callable,
     initial_density: Callable | NDArray,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     edge_interaction: Callable | None = None,
     terminal_cost: Callable | None = None,
@@ -470,7 +469,7 @@ def create_variational_problem(
     lagrangian: Any,  # LagrangianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     boundary_conditions: BoundaryConditions | None = None,
     time_horizon: float = 1.0,
@@ -571,7 +570,7 @@ def create_stochastic_problem(
     hamiltonian: Any,  # HamiltonianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     noise_intensity: float = 0.0,
     common_noise: Callable | None = None,
@@ -652,7 +651,7 @@ def create_highdim_problem(
     hamiltonian: Any,  # HamiltonianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     dimension: int,
     potential: Callable | None = None,
@@ -723,7 +722,7 @@ def create_highdim_problem(
 
 def create_lq_problem(
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     terminal_cost: Callable,
     initial_density: Callable,
     running_cost_control: float = 1.0,
@@ -799,7 +798,7 @@ def create_lq_problem(
 
 def create_crowd_problem(
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     target_location: NDArray | Callable,
     initial_density: Callable,
     running_cost_control: float = 1.0,

--- a/mfgarchon/operators/interpolation/projection.py
+++ b/mfgarchon/operators/interpolation/projection.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
     from mfgarchon.geometry.base import BaseGeometry
 
 

--- a/mfgarchon/utils/convergence/convergence_monitors.py
+++ b/mfgarchon/utils/convergence/convergence_monitors.py
@@ -34,7 +34,7 @@ from mfgarchon.utils.mfg_logging import get_logger
 from .convergence_metrics import DistributionComparator
 
 if TYPE_CHECKING:
-    from mfgarchon.alg.base_mfg_solver import MFGSolver  # type: ignore[import-not-found]
+    from mfgarchon.types.protocols import MFGSolver
 
 logger = get_logger(__name__)
 # =============================================================================

--- a/mfgarchon/utils/numerical/particle/boundary.py
+++ b/mfgarchon/utils/numerical/particle/boundary.py
@@ -34,7 +34,7 @@ import numpy as np
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
 
 
 def apply_boundary_conditions_gpu(

--- a/mfgarchon/utils/numerical/tensor_calculus.py
+++ b/mfgarchon/utils/numerical/tensor_calculus.py
@@ -57,7 +57,7 @@ else:
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from mfgarchon.backends.backend_manager import ArrayBackend
+    from mfgarchon.backends.base_backend import BaseBackend as ArrayBackend
     from mfgarchon.geometry.boundary.conditions import BoundaryConditions
 
 

--- a/mfgarchon/utils/particle_utils.py
+++ b/mfgarchon/utils/particle_utils.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
 
 
 def interpolate_1d_gpu(x_query, x_grid, y_grid, backend: "BaseBackend"):

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -142,7 +142,8 @@ def test_the_gate_reaches_four_classes_this_file_does_not():
 
     reached = set()
     for mod_name in ["mfgarchon.alg"] + [
-        m.name for m in pkgutil.walk_packages(importlib.import_module("mfgarchon.alg").__path__, prefix="mfgarchon.alg.")
+        m.name
+        for m in pkgutil.walk_packages(importlib.import_module("mfgarchon.alg").__path__, prefix="mfgarchon.alg.")
     ]:
         for _, cls in inspect.getmembers(importlib.import_module(mod_name), inspect.isclass):
             if issubclass(cls, BaseMFGSolver) and not inspect.isabstract(cls):

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -476,7 +476,9 @@ def test_without_a_matrix_the_comparison_itself_is_silent(td):
         c
         for c in calls
         if (len(c.args) >= 3 and not (isinstance(c.args[2], ast.Constant) and c.args[2].value is None))
-        or any(k.arg == "matrix" and not (isinstance(k.value, ast.Constant) and k.value.value is None) for k in c.keywords)
+        or any(
+            k.arg == "matrix" and not (isinstance(k.value, ast.Constant) and k.value.value is None) for k in c.keywords
+        )
     ]
     assert wired, (
         "main() loads the matrix but no longer hands it to the comparison: "

--- a/tests/unit/test_geometry/boundary/test_compat_robin_is_a_robin_wall_1961.py
+++ b/tests/unit/test_geometry/boundary/test_compat_robin_is_a_robin_wall_1961.py
@@ -78,9 +78,7 @@ def test_a_uniform_robin_wall_satisfies_its_own_condition(alpha, beta, g, wall):
     bc.domain_bounds = _BOUNDS
     ghosts = _ghosts(bc)
 
-    ghost, interior = (
-        (_scalar(ghosts[(0, 0)]), _U[0]) if wall == "min" else (_scalar(ghosts[(0, 1)]), _U[-1])
-    )
+    ghost, interior = (_scalar(ghosts[(0, 0)]), _U[0]) if wall == "min" else (_scalar(ghosts[(0, 1)]), _U[-1])
 
     assert _residual(ghost, interior, alpha, beta, g) == pytest.approx(0.0, abs=1e-12)
 

--- a/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
@@ -269,8 +269,13 @@ def test_the_fix_holds_in_two_dimensions_including_the_corner(ghost_depth):
     padded = pad_array_with_ghosts(field, bc, ghost_depth=ghost_depth, spacing=(h, h))
 
     g = ghost_depth
-    gc = np.concatenate([np.array([-(k - 0.5) * h for k in range(1, g + 1)])[::-1], c,
-                         np.array([1.0 + (k - 0.5) * h for k in range(1, g + 1)])])
+    gc = np.concatenate(
+        [
+            np.array([-(k - 0.5) * h for k in range(1, g + 1)])[::-1],
+            c,
+            np.array([1.0 + (k - 0.5) * h for k in range(1, g + 1)]),
+        ]
+    )
     gx, gy = np.meshgrid(gc, gc, indexing="ij")
 
     np.testing.assert_allclose(padded, np.cos(2 * np.pi * gx) * np.cos(2 * np.pi * gy), atol=1e-12)

--- a/tests/unit/test_internal_import_paths_resolve.py
+++ b/tests/unit/test_internal_import_paths_resolve.py
@@ -1,0 +1,42 @@
+"""Every `mfgarchon.*` module path named in an import must exist.
+
+Runtime cannot catch this class: all seven sites found on 2026-08-17 sat inside `if TYPE_CHECKING:`
+blocks, which Python never evaluates, so the imports were dead for months while every test passed.
+mypy does catch it -- but `scripts/local_ci.sh` does not run mypy, and turning it on wholesale means
+1318 errors of which this class is 3. This asserts only the unambiguous part.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2] / "mfgarchon"
+
+
+def _imported_internal_modules() -> dict[str, list[str]]:
+    """Module path -> the files naming it. Walks the whole AST, so TYPE_CHECKING is included."""
+    found: dict[str, list[str]] = {}
+    for py in sorted(_ROOT.rglob("*.py")):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            mods = []
+            if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                mods = [node.module]
+            elif isinstance(node, ast.Import):
+                mods = [a.name for a in node.names]
+            for m in mods:
+                if m == "mfgarchon" or m.startswith("mfgarchon."):
+                    found.setdefault(m, []).append(str(py.relative_to(_ROOT.parent)))
+    return found
+
+
+def test_every_internal_import_path_exists():
+    imported = _imported_internal_modules()
+    assert len(imported) > 100, f"the walk found only {len(imported)} internal imports; it broke"
+
+    missing = {mod: sorted(set(files)) for mod, files in imported.items() if importlib.util.find_spec(mod) is None}
+    assert not missing, "import paths that do not exist:\n" + "\n".join(
+        f"  {m}  <- {', '.join(f)}" for m, f in sorted(missing.items())
+    )


### PR DESCRIPTION
Stage 2e of the package sweep, which began on the backends and hit `mfgarchon.backends.backend_protocol` — not a module.

## Five dead paths, nine sites

| path | sites | correct target |
|---|---|---|
| `mfgarchon.backends.backend_protocol` | 4 | `mfgarchon.backends.base_backend` |
| `mfgarchon.problem.base_mfg_problem` | 2 | `mfgarchon.core.mfg_problem` |
| `mfgarchon.geometry.domain` | 1 | **`Domain` exists nowhere** — 11 annotations retargeted to `GeometryProtocol`, which `MFGProblem.geometry` already is |
| `mfgarchon.alg.base_mfg_solver` | 1 | `mfgarchon.types.protocols` |
| `mfgarchon.backends.backend_manager` | 1 | **`ArrayBackend` exists nowhere** — aliased to `BaseBackend`, which carries the `array_module` the annotated code uses |

Every one is inside `if TYPE_CHECKING:`, so Python never evaluates it and no test can fail on it. Two of the five name a type that does not exist at all, not merely a moved one.

## Why nothing saw them

- **mypy catches this class** — positive control fires, it names `backend_protocol` as missing. It is a pinned dependency with a `[tool.mypy]` section and `mypy_path = "stubs"` in `pyproject.toml`. **`scripts/local_ci.sh` references it zero times.** Wholesale is not an option: 1322 errors across 149 of 277 files, of which this class is 5.
- One site carried `# type: ignore[import-not-found]` — seen once, silenced rather than fixed. The only such suppression in the package.

## The ratchet

`tests/unit/test_internal_import_paths_resolve.py` AST-walks every `mfgarchon/**/*.py`, collects each `mfgarchon.*` module named in an import (TYPE_CHECKING included), and asserts `find_spec` resolves it. Mutation-verified in both directions, mutant liveness asserted before reading the result.

**Stricter than mypy here**: mypy reported 3 of the 5 paths; the AST walk found all 5. The extra two are in files mypy's reachability skipped.

## Gate

`./scripts/local_ci.sh` → **6286 passed, 12 skipped, 21 xfailed, GATE GREEN**, 122 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)