### PR TITLE
fix(core): sense_sign had two implementations on one object; give it one owner (#1986)

### DIFF
--- a/mfgarchon/alg/numerical/coupling/fictitious_play.py
+++ b/mfgarchon/alg/numerical/coupling/fictitious_play.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
     from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
     from mfgarchon.config import MFGSolverConfig
-    from mfgarchon.problem.base_mfg_problem import MFGProblem
+    from mfgarchon.core.mfg_problem import MFGProblem
 
 
 class FictitiousPlayIterator(BaseCouplingIterator):

--- a/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
+++ b/mfgarchon/alg/numerical/coupling/fixed_point_iterator.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
     from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
     from mfgarchon.config import MFGSolverConfig
-    from mfgarchon.problem.base_mfg_problem import MFGProblem
+    from mfgarchon.core.mfg_problem import MFGProblem
 
 # Type alias for iteration callback (Issue #614)
 # Signature: callback(iteration, U, M, error_U, error_M) -> bool

--- a/mfgarchon/alg/numerical/density_estimation.py
+++ b/mfgarchon/alg/numerical/density_estimation.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 if TYPE_CHECKING:
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
 
 # Try importing scipy for fallback CPU KDE
 try:

--- a/mfgarchon/core/hamiltonian.py
+++ b/mfgarchon/core/hamiltonian.py
@@ -838,6 +838,18 @@ class MFGOperatorBase(ABC):
         self._sign = 1 if sense == OptimizationSense.MINIMIZE else -1
 
     @property
+    def sense_sign(self) -> float:
+        """Orientation of the MINIMIZE<->MAXIMIZE mirror: ``+1`` for MINIMIZE (cost-to-go, agents
+        move DOWNHILL toward lower value), ``-1`` for MAXIMIZE (reward-to-go, agents move UPHILL).
+        Every sense-dependent piece is ``s * (MINIMIZE form)``.
+
+        This is the public reading of ``_sign``, set once above. `NetworkHamiltonian` computed the
+        same expression a second time from the same `self.sense` while inheriting `_sign` from here
+        (#1986); that copy is gone, and this is the one owner.
+        """
+        return float(self._sign)
+
+    @property
     @abstractmethod
     def is_hamiltonian(self) -> bool:
         """Return True if this is a Hamiltonian operator."""

--- a/mfgarchon/extensions/topology.py
+++ b/mfgarchon/extensions/topology.py
@@ -92,16 +92,6 @@ class NetworkHamiltonian(HamiltonianBase):
             self._num_nodes = self.network_data.num_nodes
         return self._num_nodes
 
-    @property
-    def sense_sign(self) -> float:
-        """Orientation sign of the finite-state control (Issue #1476): ``+1`` for MINIMIZE (cost-to-go,
-        agents move DOWNHILL toward lower value), ``-1`` for MAXIMIZE (reward-to-go, agents move UPHILL
-        toward higher value). Every sense-dependent piece — the control cost in ``_default_hamiltonian``,
-        ``optimal_control``, ``dp``, and the HJB integration sign in ``hjb_network`` — is ``s * (MINIMIZE
-        form)``, so this one property is the single source of the MINIMIZE<->MAXIMIZE mirror.
-        """
-        return 1.0 if self.sense == OptimizationSense.MINIMIZE else -1.0
-
     def _extract_own_density(self, m: np.ndarray) -> np.ndarray:
         """Extract this population's density from stacked m_all.
 

--- a/mfgarchon/factory/problem_factories.py
+++ b/mfgarchon/factory/problem_factories.py
@@ -58,8 +58,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    from mfgarchon.geometry import BoundaryConditions
-    from mfgarchon.geometry.domain import Domain
+    from mfgarchon.geometry import BoundaryConditions, GeometryProtocol
 
 logger = get_logger(__name__)
 
@@ -135,7 +134,7 @@ def create_mfg_problem(
     problem_type: ProblemType,
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: Literal[True] = True,
@@ -148,7 +147,7 @@ def create_mfg_problem(
     problem_type: Literal["network"],
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: Literal[False],
@@ -161,7 +160,7 @@ def create_mfg_problem(
     problem_type: Literal["stochastic"],
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: Literal[False],
@@ -173,7 +172,7 @@ def create_mfg_problem(
     problem_type: ProblemType,
     components: MFGComponents,
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     time_horizon: float = 1.0,
     num_timesteps: int = 100,
     use_unified: bool = True,
@@ -327,7 +326,7 @@ def create_standard_problem(
     hamiltonian: Any,  # HamiltonianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     potential: Callable | None = None,
     boundary_conditions: BoundaryConditions | None = None,
@@ -409,7 +408,7 @@ def create_network_problem(
     node_interaction: Callable,
     edge_cost: Callable,
     initial_density: Callable | NDArray,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     edge_interaction: Callable | None = None,
     terminal_cost: Callable | None = None,
@@ -470,7 +469,7 @@ def create_variational_problem(
     lagrangian: Any,  # LagrangianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     boundary_conditions: BoundaryConditions | None = None,
     time_horizon: float = 1.0,
@@ -571,7 +570,7 @@ def create_stochastic_problem(
     hamiltonian: Any,  # HamiltonianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     noise_intensity: float = 0.0,
     common_noise: Callable | None = None,
@@ -652,7 +651,7 @@ def create_highdim_problem(
     hamiltonian: Any,  # HamiltonianBase
     terminal_cost: Callable,
     initial_density: Callable,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     *,
     dimension: int,
     potential: Callable | None = None,
@@ -723,7 +722,7 @@ def create_highdim_problem(
 
 def create_lq_problem(
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     terminal_cost: Callable,
     initial_density: Callable,
     running_cost_control: float = 1.0,
@@ -799,7 +798,7 @@ def create_lq_problem(
 
 def create_crowd_problem(
     *,
-    geometry: Domain,
+    geometry: GeometryProtocol,
     target_location: NDArray | Callable,
     initial_density: Callable,
     running_cost_control: float = 1.0,

--- a/mfgarchon/operators/interpolation/projection.py
+++ b/mfgarchon/operators/interpolation/projection.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
     from mfgarchon.geometry.base import BaseGeometry
 
 

--- a/mfgarchon/utils/convergence/convergence_monitors.py
+++ b/mfgarchon/utils/convergence/convergence_monitors.py
@@ -34,7 +34,7 @@ from mfgarchon.utils.mfg_logging import get_logger
 from .convergence_metrics import DistributionComparator
 
 if TYPE_CHECKING:
-    from mfgarchon.alg.base_mfg_solver import MFGSolver  # type: ignore[import-not-found]
+    from mfgarchon.types.protocols import MFGSolver
 
 logger = get_logger(__name__)
 # =============================================================================

--- a/mfgarchon/utils/numerical/particle/boundary.py
+++ b/mfgarchon/utils/numerical/particle/boundary.py
@@ -34,7 +34,7 @@ import numpy as np
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
 
 
 def apply_boundary_conditions_gpu(

--- a/mfgarchon/utils/numerical/tensor_calculus.py
+++ b/mfgarchon/utils/numerical/tensor_calculus.py
@@ -57,7 +57,7 @@ else:
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from mfgarchon.backends.backend_manager import ArrayBackend
+    from mfgarchon.backends.base_backend import BaseBackend as ArrayBackend
     from mfgarchon.geometry.boundary.conditions import BoundaryConditions
 
 

--- a/mfgarchon/utils/particle_utils.py
+++ b/mfgarchon/utils/particle_utils.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from mfgarchon.backends.backend_protocol import BaseBackend
+    from mfgarchon.backends.base_backend import BaseBackend
 
 
 def interpolate_1d_gpu(x_query, x_grid, y_grid, backend: "BaseBackend"):

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -142,7 +142,8 @@ def test_the_gate_reaches_four_classes_this_file_does_not():
 
     reached = set()
     for mod_name in ["mfgarchon.alg"] + [
-        m.name for m in pkgutil.walk_packages(importlib.import_module("mfgarchon.alg").__path__, prefix="mfgarchon.alg.")
+        m.name
+        for m in pkgutil.walk_packages(importlib.import_module("mfgarchon.alg").__path__, prefix="mfgarchon.alg.")
     ]:
         for _, cls in inspect.getmembers(importlib.import_module(mod_name), inspect.isclass):
             if issubclass(cls, BaseMFGSolver) and not inspect.isabstract(cls):

--- a/tests/unit/test_core/test_sense_sign_single_owner_1986.py
+++ b/tests/unit/test_core/test_sense_sign_single_owner_1986.py
@@ -1,0 +1,62 @@
+"""`sense_sign` has one owner. #1986
+
+The pin is deliberately NOT `NetworkHamiltonian.sense_sign == MFGOperatorBase.sense_sign`. Once the
+rival implementation is deleted both readings route through the same expression, so that comparison
+is tautological and would pass over a broken owner. These are the values captured by running the
+PRE-consolidation code, at `cdab5349`, before `NetworkHamiltonian`'s copy was removed:
+
+    sense=MINIMIZE   sense_sign = 1.0   (float)
+    sense=MAXIMIZE   sense_sign = -1.0  (float)
+
+`float` is part of the capture: the deleted copy returned `1.0 / -1.0` while `_sign` holds `1 / -1`,
+and consumers multiply by it, so the owner returns `float(self._sign)` rather than `self._sign`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mfgarchon.core.hamiltonian import OptimizationSense
+from mfgarchon.extensions.topology import NetworkHamiltonian
+
+_CAPTURED_BEFORE_CONSOLIDATION = {
+    OptimizationSense.MINIMIZE: 1.0,
+    OptimizationSense.MAXIMIZE: -1.0,
+}
+
+
+class _StubNetwork:
+    num_nodes = 3
+    adjacency_matrix = None
+
+    def __getattr__(self, _name: str):
+        return None
+
+
+@pytest.mark.parametrize("sense", sorted(_CAPTURED_BEFORE_CONSOLIDATION, key=lambda s: s.value))
+def test_sense_sign_matches_the_pre_consolidation_capture(sense):
+    got = NetworkHamiltonian(_StubNetwork(), sense=sense).sense_sign
+    want = _CAPTURED_BEFORE_CONSOLIDATION[sense]
+    assert got == want, f"{sense.name}: {got} != {want} captured before the merge"
+    assert isinstance(got, float), f"{sense.name}: returned {type(got).__name__}, capture was float"
+
+
+def test_the_sense_to_sign_expression_has_one_owner_on_the_operator_side():
+    """The consolidation's own gate: the count of places computing it must not climb back.
+
+    Two remain, and they are on different objects rather than duplicates of each other:
+    `MFGOperatorBase` (Hamiltonians) and the control-cost base. Whether those two must agree is a
+    design question, open in #1986; this asserts only that no third appears and that the
+    Hamiltonian side has exactly one.
+    """
+    import inspect
+
+    from mfgarchon.core import hamiltonian
+    from mfgarchon.extensions import topology
+
+    src = inspect.getsource(hamiltonian)
+    n = src.count("if sense == OptimizationSense.MINIMIZE else -1")
+    assert n == 2, f"{n} sense->sign expressions in core.hamiltonian; 2 expected (control cost, operator base)"
+    assert "OptimizationSense.MINIMIZE else -1" not in inspect.getsource(topology), (
+        "NetworkHamiltonian recomputes the sign it inherits from MFGOperatorBase"
+    )

--- a/tests/unit/test_discrimination_ratchet.py
+++ b/tests/unit/test_discrimination_ratchet.py
@@ -476,7 +476,9 @@ def test_without_a_matrix_the_comparison_itself_is_silent(td):
         c
         for c in calls
         if (len(c.args) >= 3 and not (isinstance(c.args[2], ast.Constant) and c.args[2].value is None))
-        or any(k.arg == "matrix" and not (isinstance(k.value, ast.Constant) and k.value.value is None) for k in c.keywords)
+        or any(
+            k.arg == "matrix" and not (isinstance(k.value, ast.Constant) and k.value.value is None) for k in c.keywords
+        )
     ]
     assert wired, (
         "main() loads the matrix but no longer hands it to the comparison: "

--- a/tests/unit/test_geometry/boundary/test_compat_robin_is_a_robin_wall_1961.py
+++ b/tests/unit/test_geometry/boundary/test_compat_robin_is_a_robin_wall_1961.py
@@ -78,9 +78,7 @@ def test_a_uniform_robin_wall_satisfies_its_own_condition(alpha, beta, g, wall):
     bc.domain_bounds = _BOUNDS
     ghosts = _ghosts(bc)
 
-    ghost, interior = (
-        (_scalar(ghosts[(0, 0)]), _U[0]) if wall == "min" else (_scalar(ghosts[(0, 1)]), _U[-1])
-    )
+    ghost, interior = (_scalar(ghosts[(0, 0)]), _U[0]) if wall == "min" else (_scalar(ghosts[(0, 1)]), _U[-1])
 
     assert _residual(ghost, interior, alpha, beta, g) == pytest.approx(0.0, abs=1e-12)
 

--- a/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
+++ b/tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py
@@ -269,8 +269,13 @@ def test_the_fix_holds_in_two_dimensions_including_the_corner(ghost_depth):
     padded = pad_array_with_ghosts(field, bc, ghost_depth=ghost_depth, spacing=(h, h))
 
     g = ghost_depth
-    gc = np.concatenate([np.array([-(k - 0.5) * h for k in range(1, g + 1)])[::-1], c,
-                         np.array([1.0 + (k - 0.5) * h for k in range(1, g + 1)])])
+    gc = np.concatenate(
+        [
+            np.array([-(k - 0.5) * h for k in range(1, g + 1)])[::-1],
+            c,
+            np.array([1.0 + (k - 0.5) * h for k in range(1, g + 1)]),
+        ]
+    )
     gx, gy = np.meshgrid(gc, gc, indexing="ij")
 
     np.testing.assert_allclose(padded, np.cos(2 * np.pi * gx) * np.cos(2 * np.pi * gy), atol=1e-12)

--- a/tests/unit/test_internal_import_paths_resolve.py
+++ b/tests/unit/test_internal_import_paths_resolve.py
@@ -1,0 +1,42 @@
+"""Every `mfgarchon.*` module path named in an import must exist.
+
+Runtime cannot catch this class: all seven sites found on 2026-08-17 sat inside `if TYPE_CHECKING:`
+blocks, which Python never evaluates, so the imports were dead for months while every test passed.
+mypy does catch it -- but `scripts/local_ci.sh` does not run mypy, and turning it on wholesale means
+1318 errors of which this class is 3. This asserts only the unambiguous part.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2] / "mfgarchon"
+
+
+def _imported_internal_modules() -> dict[str, list[str]]:
+    """Module path -> the files naming it. Walks the whole AST, so TYPE_CHECKING is included."""
+    found: dict[str, list[str]] = {}
+    for py in sorted(_ROOT.rglob("*.py")):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            mods = []
+            if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                mods = [node.module]
+            elif isinstance(node, ast.Import):
+                mods = [a.name for a in node.names]
+            for m in mods:
+                if m == "mfgarchon" or m.startswith("mfgarchon."):
+                    found.setdefault(m, []).append(str(py.relative_to(_ROOT.parent)))
+    return found
+
+
+def test_every_internal_import_path_exists():
+    imported = _imported_internal_modules()
+    assert len(imported) > 100, f"the walk found only {len(imported)} internal imports; it broke"
+
+    missing = {mod: sorted(set(files)) for mod, files in imported.items() if importlib.util.find_spec(mod) is None}
+    assert not missing, "import paths that do not exist:\n" + "\n".join(
+        f"  {m}  <- {', '.join(f)}" for m, f in sorted(missing.items())
+    )


### PR DESCRIPTION
Refs #1986. First consolidation of the sweep, run against the `cs` domain's *Single source of truth — sharp form*.

## The duplication

`NetworkHamiltonian` subclasses `MFGOperatorBase`, which already sets `_sign`, and defined `sense_sign` recomputing the same expression from the same `self.sense`:

```
core/hamiltonian.py:838      self._sign = 1   if sense == OptimizationSense.MINIMIZE else -1
extensions/topology.py:103   return     1.0 if self.sense == OptimizationSense.MINIMIZE else -1.0
```

The copy's docstring called itself *"the single source of the MINIMIZE↔MAXIMIZE mirror"*.

## The gate: implementation count must drop

```
git grep -cE '(1(\.0)? if .*MINIMIZE.*else *-1)' -- mfgarchon
  before: 3      after: 2
```

Reported, not gated: total **+2**, executable **+1** on `mfgarchon/`.

## The pin is not copy-vs-owner

That comparison goes tautological the moment the copy is deleted, and would pass over a broken owner. It is frozen against output captured by **running the pre-consolidation code** at `cdab5349`:

| sense | `sense_sign` |
|---|---|
| MINIMIZE | `1.0` (float) |
| MAXIMIZE | `-1.0` (float) |

`float` is part of the capture — the copy returned `1.0/-1.0` while `_sign` holds `1/-1`, and consumers multiply by it, so the owner returns `float(self._sign)`.

## What is deliberately left

`ControlCostBase.sign` and `MFGOperatorBase._sign` are on **different objects**. Whether a control cost's sense must agree with its Hamiltonian's is a design question, not duplication — the protocol's counter-force clause. Measured: all four (cost sense, Hamiltonian sense) pairs construct without complaint, and on the two mismatched ones the control cost silently decides. Open in #1986.

## Gate

`./scripts/local_ci.sh` → **6289 passed, 12 skipped, 21 xfailed, GATE GREEN**, 135 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)