### PR TITLE
fix(geometry): one Neumann ghost formula, not three (#1972)

### DIFF
--- a/mfgarchon/geometry/boundary/calculators.py
+++ b/mfgarchon/geometry/boundary/calculators.py
@@ -207,9 +207,12 @@ class NeumannCalculator:
         **kwargs,
     ) -> T:
         """Compute ghost value for Neumann BC (vectorized)."""
-        # Outward normal sign: +1 for max boundary, -1 for min boundary
-        outward_sign = 1.0 if side == "max" else -1.0
-        return ghost_cell_neumann(interior_value, self._flux_value, dx, outward_sign, self._grid_type)
+        # No `side` and no centring: `_flux_value` is du/dn, which carries the direction, and the
+        # ghost-to-interior separation is `dx` for both centrings (#1972). This wrapper previously
+        # multiplied by an outward sign and reached the `2*dx` branch, so it disagreed with the live
+        # applicator path by a factor of 2 AND by a sign at the min wall -- 0.0 against 1.5 for
+        # u0=1, dx=0.25, value=2.
+        return ghost_cell_neumann(interior_value, self._flux_value, dx)
 
     def __repr__(self) -> str:
         return f"NeumannCalculator(flux_value={self._flux_value})"
@@ -590,9 +593,11 @@ def calculator_to_constraint(
     # Tier 2: Gradient constraints (Neumann/ZeroGradient)
     if isinstance(calculator, (NeumannCalculator, ZeroGradientCalculator)):
         flux_value = calculator._flux_value if isinstance(calculator, NeumannCalculator) else 0.0
-        # For cell-centered: u_ghost = u_inner +/- dx * g (sign depends on side)
-        sign = 1.0 if side == "max" else -1.0
-        return LinearConstraint(weights={0: 1.0}, bias=sign * dx * flux_value)
+        # u_ghost = u_inner + dx*g, both walls: `g` is du/dn and carries the direction. The
+        # `sign * dx * flux_value` form here was the third implementation of this one quantity and
+        # the second convention (#1972); it agreed with the live path at the max wall and inverted
+        # at the min.
+        return LinearConstraint(weights={0: 1.0}, bias=dx * flux_value)
 
     # Tier 3: Flux constraints (Robin/ZeroFlux)
     if isinstance(calculator, (RobinCalculator, ZeroFluxCalculator)):

--- a/mfgarchon/geometry/boundary/ghost_cells.py
+++ b/mfgarchon/geometry/boundary/ghost_cells.py
@@ -81,11 +81,9 @@ def ghost_cell_neumann(
     interior_value: float,
     flux_value: float,
     dx: float,
-    outward_normal_sign: float = 1.0,
-    grid_type: GridType = GridType.CELL_CENTERED,
 ) -> float:
     """
-    Compute ghost cell value for Neumann BC.
+    Compute ghost cell value for Neumann BC. `flux_value` is du/dn.
 
     For cell-centered grids:
         du/dn = (u_ghost - u_interior) / (2*dx) * sign = g
@@ -95,13 +93,22 @@ def ghost_cell_neumann(
         interior_value: Value at interior point
         flux_value: Prescribed flux (du/dn)
         dx: Grid spacing
-        outward_normal_sign: +1 for max boundary, -1 for min boundary
-        grid_type: Grid type
     """
-    if grid_type == GridType.VERTEX_CENTERED:
-        return interior_value + dx * flux_value * outward_normal_sign
-    else:
-        return interior_value + 2.0 * dx * flux_value * outward_normal_sign
+    # One formula, both centrings, both walls. The ghost-to-interior separation is `dx` either way
+    # -- cell-centred puts them at -dx/2 and +dx/2, vertex-centred at -dx and 0 -- so there is no
+    # geometric reason to branch, and `flux_value` is du/dn, which already carries the direction.
+    #
+    # ~~cell-centred: interior + 2*dx*g*sign~~ [CORRECTED 2026-08-18, #1972]. That branch stated
+    # `du/dn = (u_ghost - u_interior)/(2*dx)*sign` and satisfied it to machine zero at every
+    # resolution -- self-consistent with a wrong definition, which is why nothing caught it. On
+    # `u = sin(2*pi*x)` the residual against the correct spacing was frozen at exactly `2*pi = k`,
+    # i.e. the discrete flux was exactly 2g, not approximately. `outward_normal_sign` went with it:
+    # it converted du/dn to du/dx so the formula could convert back, and the round trip is where
+    # the sign errors lived.
+    #
+    # Verified exact on 12 combinations (2 centrings x 2 walls x slopes 3, -1.7, 0) against
+    # `u = a*x`, which any first-order ghost rule reproduces exactly; O(h^2) on `u = x^2`.
+    return interior_value + dx * flux_value
 
 
 def ghost_cell_robin(

--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -361,22 +361,46 @@ class TestCalculatorClasses:
         # Zero flux: ghost = interior
         assert np.isclose(ghost, 3.0)
 
-    def test_neumann_calculator_nonzero_flux(self):
-        """Test NeumannCalculator with non-zero flux."""
+    def test_neumann_calculator_reproduces_a_linear_field(self):
+        """An external oracle, not the formula restated. #1972
+
+        The version here asserted `expected_min = 5.0 - 2*dx*g` with the comment
+        `# For min side (outward_sign = -1): ghost = interior - 2*dx*g` -- `expected` copied from
+        the implementation, so it could only check that the code equals itself. It protected two
+        defects at once: a factor of 2 (the ghost-to-interior separation is `dx`, not `2*dx`, on
+        both centrings) and a sign (`flux_value` is du/dn, which already carries the direction, so
+        the wrapper's `outward_sign` inverted the min wall). Measured before the fix, u0=1, dx=0.25,
+        value=2: this calculator gave 0.0/2.0 where the live applicator path gave 1.5/1.5.
+
+        `u = a*x` is reproduced exactly by any consistent first-order ghost rule, so it decides the
+        question without reference to any implementation.
+        """
         from mfgarchon.geometry.boundary import NeumannCalculator
 
-        calc = NeumannCalculator(flux_value=1.0)
-        dx = 0.1
+        dx, slope = 0.1, 3.0
 
-        # For min side (outward_sign = -1): ghost = interior - 2*dx*g
-        ghost_min = calc.compute(interior_value=5.0, dx=dx, side="min")
-        expected_min = 5.0 - 2 * dx * 1.0  # = 4.8
-        assert np.isclose(ghost_min, expected_min)
+        for side, x_interior, x_ghost in (("min", dx / 2, -dx / 2), ("max", 1.0 - dx / 2, 1.0 + dx / 2)):
+            g = -slope if side == "min" else +slope  # du/dn: the outward normal flips at the min wall
+            got = NeumannCalculator(flux_value=g).compute(interior_value=slope * x_interior, dx=dx, side=side)
+            assert np.isclose(got, slope * x_ghost), f"{side}: {got} != {slope * x_ghost} for u = {slope}x"
 
-        # For max side (outward_sign = +1): ghost = interior + 2*dx*g
-        ghost_max = calc.compute(interior_value=5.0, dx=dx, side="max")
-        expected_max = 5.0 + 2 * dx * 1.0  # = 5.2
-        assert np.isclose(ghost_max, expected_max)
+    def test_neumann_calculator_agrees_with_the_live_applicator_path(self):
+        """The two implementations of this ghost disagreed by a factor of 2 and a sign until #1972.
+
+        Not a tautology: they are still separate call paths -- `pad_array_with_ghosts` reaches
+        `ghost_cell_neumann` through the applicator, this reaches it through the calculator -- and
+        nothing but this test compares them.
+        """
+        from mfgarchon.geometry.boundary import NeumannCalculator, neumann_bc
+        from mfgarchon.geometry.boundary.applicator_fdm import pad_array_with_ghosts
+
+        u = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        for g in (0.0, 2.0, -7.0):
+            for dx in (0.05, 0.25):
+                padded = pad_array_with_ghosts(u, neumann_bc(g, dimension=1), ghost_depth=1, spacing=dx)
+                calc = NeumannCalculator(flux_value=g)
+                assert np.isclose(padded[0], calc.compute(interior_value=u[0], dx=dx, side="min"))
+                assert np.isclose(padded[-1], calc.compute(interior_value=u[-1], dx=dx, side="max"))
 
     def test_robin_calculator(self):
         """Test RobinCalculator for mixed boundary conditions."""


### PR DESCRIPTION
Closes #1972.

## Three implementations, three answers

Same input — `u0 = 1.0`, `dx = 0.25`, `du/dn = 2.0`:

| implementation | min wall | max wall | |
|---|---:|---:|---|
| live applicator path | **1.50000** | **1.50000** | correct |
| `NeumannCalculator` | 0.00000 | 2.00000 | factor 2 **and** inverted min wall |
| constraint path (`LinearConstraint`) | 0.50000 | 1.50000 | inverted min wall |

Each is internally consistent. They only disagree side by side, which is why nothing caught it.

## The function satisfied its own definition exactly

`ghost_cell_neumann`'s docstring stated `du/dn = (u_ghost - u_interior)/(2*dx)*sign = g`, and it met that identity **to machine zero at every resolution**. On `u = sin(2πx)` the residual against the geometrically correct spacing is frozen at exactly `2π = k` — the discrete flux is *exactly* 2g. Not a discretisation error, and invisible to any oracle taken from the function itself.

## The branch is the defect, not the constant

Ghost-to-interior separation is `dx` for **both** centrings — cell-centred at −dx/2 and +dx/2, vertex-centred at −dx and 0. A Neumann rule has no geometric reason to branch on `grid_type`, and the `2*dx` is what the spurious branch existed to hold. `outward_normal_sign` goes with it: it converted du/dn to du/dx so the formula could convert back, and the round trip is where the sign errors lived.

```python
u_ghost = u_interior + dx * flux_value      # flux_value is du/dn
```

Exact on 12 combinations (2 centrings × 2 walls × slopes 3, −1.7, 0) against `u = a·x`; O(h²) on `u = x²`.

**Implementations: 3 → 1.** The live path is byte-unchanged against output captured before the change at (g, dx) ∈ {0, 2, −7} × {0.05, 0.25}.

## The test that held both defects in place

```python
# For min side (outward_sign = -1): ghost = interior - 2*dx*g
expected_min = 5.0 - 2 * dx * 1.0  # = 4.8
```

`expected` copied from the implementation — it could only check that the code equals itself. Replaced by an external oracle (`u = a·x`, reproduced exactly by any consistent first-order rule) and a cross-path comparison against `pad_array_with_ghosts`, which is still a separate call route.

Mutations, liveness asserted at import: restoring the factor 2 → **2 failed**; restoring the sign → **2 failed**. The old test caught neither.

## Not touched

`ghost_cell_robin`, `ghost_cell_fp_no_flux`, `high_order_ghost_neumann` still take `outward_normal_sign`. Measured under #1936: every call site of a sign-dependent function passes it, so the default is never taken where it would matter.

## Gate

`./scripts/local_ci.sh` → **6250 passed, 12 skipped, 23 xfailed, GATE GREEN**, 141 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)