### PR TITLE
fix: raise when a velocity_field cannot be read by the advection scheme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,11 +216,27 @@ Root-level only: `/*.png`, `/*_analysis.py` (not global `*.png`). Always `!examp
 ### Pre-commit / pre-merge checks
 ```bash
 pytest tests/unit/test_affected_module.py            # iterate on the affected module
-./scripts/local_ci.sh                                # THE GATE: ruff + ratchets + capability matrix + full suite (~4 min)
-./scripts/local_ci.sh --fast                         # lint/format/ratchet only, while iterating
+./scripts/local_ci.sh --fast                         # lint/format/ratchet only — this is the one you run
+./scripts/local_ci.sh                                # THE GATE — the pre-push hook runs this; see the note below
 ruff check mfgarchon/affected_module.py && ruff format --check mfgarchon/affected_module.py
 mypy mfgarchon/affected_module.py
 ```
+⚠️ **Do not run the full gate by hand before pushing — the `pre-push` hook runs it.** Running it
+manually and then pushing pays for it twice, ~2.5 min each, and the second run is the one that
+decides. Measured 2026-08-18: a session that did this on every push spent about half its push time
+re-running a gate it had just watched go green. The ladder for this repo is:
+
+| step | command | cost |
+|---|---|---|
+| after every edit | `ruff check --fix … && ruff format …`, or `./scripts/local_ci.sh --fast` | seconds |
+| after every edit | the test files you touched, by path | seconds |
+| when behaviour could have changed | the blast radius **by path**, not by `-k` name match — a `-k "hjb or newton"` sweep measured 600 s+ and did not finish, while the whole gate is ~150 s | ~30 s |
+| at the boundary | **`git push`** — the hook runs the gate, once | ~150 s |
+
+The one case for running it by hand: you need to *read* its diagnostics (discrimination fraction,
+capability baseline, fail-fast counts) rather than just pass. Then run it, and push with
+`--no-verify` only if the working tree has not moved since.
+
 ⚠️ `local_ci.sh` runs `-n auto` (xdist parallel) + skip `slow` for you. If you invoke pytest by hand, match that: a bare `pytest tests/` is *serial* and includes `@slow`, which takes **hours** (not a hang — Issue #1522). A 900s per-test `timeout` (pytest-timeout) is the safety net for a genuine infinite loop. Set `MFG_PYTHON` if `python` is not the env you want.
 
 **CI shape — the full suite runs LOCALLY, not on GitHub (2026-07-19):**

--- a/changelog.d/1632-velocity-channel-fail-loud.fixed.md
+++ b/changelog.d/1632-velocity-channel-fail-loud.fixed.md
@@ -11,3 +11,4 @@ both wall stencils are exercised: reverting either wall to the pre-#1149 one-sid
 now fails that test, where a linear potential left the two stencils algebraically identical and a
 single-wall bump left the right wall carrying 5e-15 of density. Scheme-name resolution and its
 error string now have one owner.
+Scheme-name resolution and its error string now have one owner, and validation is no longer gated on a velocity being present: a bogus `advection_scheme` now raises on the tensor and callable-drift paths too, where it was previously ignored.

--- a/changelog.d/1632-velocity-channel-fail-loud.fixed.md
+++ b/changelog.d/1632-velocity-channel-fail-loud.fixed.md
@@ -1,13 +1,13 @@
-FP FDM: a `velocity_field` that cannot be honoured now raises instead of silently solving at zero
-drift. Two hazards, kept separate. **Displacement** — the velocity branch wins over both
-`U_solution_for_drift` and a callable `drift_field`, so supplying a velocity alongside either
-silently discards it; this bites even on `divergence_upwind`, where a zero velocity is consumed as
-zero advection while the callable drift is thrown away. **Consumption** — an unconsumed velocity is
-dropped outright, harmless only when it is all zeros. `_velocity_is_consumed` now also requires
-scalar diffusion: `solve_timestep_tensor_explicit` takes no `interface_velocity`, so on the
-tensor path no scheme reads the velocity, including the only one on the accept-list. Two
-integration tests were passing their drift through the dead channel and have been rerouted to
-`potential_field`, with a bump at each wall and a curved potential so both wall stencils are
-exercised — reverting either wall to the pre-#1149 one-sided face velocity now fails that test,
-where a linear potential left both stencils algebraically identical and a single-wall bump left
-the right wall carrying 5e-15 of density.
+FP FDM: supplying more than one drift input to `solve_fp_nd_full_system` now raises. The dispatch
+is a precedence order and every level silently discards the ones beneath it — `velocity_field`
+wins over both siblings, and inside the second arm a callable `drift_field` wins over
+`U_solution_for_drift` — so the solve ran on one input and reported nothing about the others.
+Separately, a non-zero velocity that no scheme will read still raises: `_velocity_is_consumed` now
+also requires scalar diffusion, because `solve_timestep_tensor_explicit` takes no
+`interface_velocity` and on that path even `divergence_upwind`, the default and sole member of the
+accept-list, reads nothing. Two integration tests were passing their drift through the dead channel
+and have been rerouted to `potential_field`, with a bump at each wall and a curved potential so
+both wall stencils are exercised: reverting either wall to the pre-#1149 one-sided face velocity
+now fails that test, where a linear potential left the two stencils algebraically identical and a
+single-wall bump left the right wall carrying 5e-15 of density. Scheme-name resolution and its
+error string now have one owner.

--- a/changelog.d/1632-velocity-channel-fail-loud.fixed.md
+++ b/changelog.d/1632-velocity-channel-fail-loud.fixed.md
@@ -1,9 +1,13 @@
-FP FDM: supplying a non-zero `velocity_field` to an advection scheme that cannot read it now
-raises instead of silently solving at zero drift. Only `divergence_upwind` reads
-`interface_velocity`; the other three ignored it *and* had their U channel already replaced by a
-zero-U dispatcher, so the solve returned a finite, mass-conserving, converged-looking
-pure-diffusion density. That was the reachable path for every non-separable Hamiltonian, since
-the coupling layer routes those down the velocity channel precisely because `-c*grad(U)` cannot
-represent their drift. A zero velocity is still accepted, since discarding it changes nothing.
-Two integration tests were passing their drift through that dead channel and have been rerouted
-to `potential_field`; the #1149 boundary-flux pin now actually pushes mass into the wall.
+FP FDM: supplying a `velocity_field` that an advection scheme cannot read now raises instead of
+silently solving at zero drift. Only `divergence_upwind` reads `interface_velocity`; on the other
+three the velocity was ignored *and* the U channel had already been replaced by a zero-U
+dispatcher, so the solve returned a converged-looking pure-diffusion density. Reachable by an
+explicit velocity — `FPFDMSolver.solve_fp_system(m0, drift_field=<ndarray>)` on a non-consuming
+scheme, or `FixedPointIterator(..., drift_field=<ndarray>)`, which is forwarded verbatim — and not
+on the auto-routed coupling path, where `fp_drift_coefficient` raises first (#1542). An all-zero
+velocity with no U supplied is still accepted, since it displaces nothing; supplied alongside a
+real U it raises, because the zero-U dispatcher would discard that U. Two integration tests were
+passing their drift through the dead channel and have been rerouted to `potential_field`, with a
+non-linear potential so the #1149 boundary-flux pin discriminates: reverting both walls to the
+pre-#1149 one-sided face velocity now fails that test, where under a linear potential the two
+stencils are algebraically identical and it stayed green.

--- a/changelog.d/1632-velocity-channel-fail-loud.fixed.md
+++ b/changelog.d/1632-velocity-channel-fail-loud.fixed.md
@@ -1,13 +1,13 @@
-FP FDM: supplying a `velocity_field` that an advection scheme cannot read now raises instead of
-silently solving at zero drift. Only `divergence_upwind` reads `interface_velocity`; on the other
-three the velocity was ignored *and* the U channel had already been replaced by a zero-U
-dispatcher, so the solve returned a converged-looking pure-diffusion density. Reachable by an
-explicit velocity — `FPFDMSolver.solve_fp_system(m0, drift_field=<ndarray>)` on a non-consuming
-scheme, or `FixedPointIterator(..., drift_field=<ndarray>)`, which is forwarded verbatim — and not
-on the auto-routed coupling path, where `fp_drift_coefficient` raises first (#1542). An all-zero
-velocity with no U supplied is still accepted, since it displaces nothing; supplied alongside a
-real U it raises, because the zero-U dispatcher would discard that U. Two integration tests were
-passing their drift through the dead channel and have been rerouted to `potential_field`, with a
-non-linear potential so the #1149 boundary-flux pin discriminates: reverting both walls to the
-pre-#1149 one-sided face velocity now fails that test, where under a linear potential the two
-stencils are algebraically identical and it stayed green.
+FP FDM: a `velocity_field` that cannot be honoured now raises instead of silently solving at zero
+drift. Two hazards, kept separate. **Displacement** — the velocity branch wins over both
+`U_solution_for_drift` and a callable `drift_field`, so supplying a velocity alongside either
+silently discards it; this bites even on `divergence_upwind`, where a zero velocity is consumed as
+zero advection while the callable drift is thrown away. **Consumption** — an unconsumed velocity is
+dropped outright, harmless only when it is all zeros. `_velocity_is_consumed` now also requires
+scalar diffusion: `solve_timestep_tensor_explicit` takes no `interface_velocity`, so on the
+tensor path no scheme reads the velocity, including the only one on the accept-list. Two
+integration tests were passing their drift through the dead channel and have been rerouted to
+`potential_field`, with a bump at each wall and a curved potential so both wall stencils are
+exercised — reverting either wall to the pre-#1149 one-sided face velocity now fails that test,
+where a linear potential left both stencils algebraically identical and a single-wall bump left
+the right wall carrying 5e-15 of density.

--- a/changelog.d/1632-velocity-channel-fail-loud.fixed.md
+++ b/changelog.d/1632-velocity-channel-fail-loud.fixed.md
@@ -1,14 +1,23 @@
 FP FDM: supplying more than one drift input to `solve_fp_nd_full_system` now raises. The dispatch
 is a precedence order and every level silently discards the ones beneath it — `velocity_field`
 wins over both siblings, and inside the second arm a callable `drift_field` wins over
-`U_solution_for_drift` — so the solve ran on one input and reported nothing about the others.
+`U_solution_for_drift` — so the solve ran on one input and reported nothing about the others. That
+precedence was never designed: before the #641 consolidation two branches disagreed about which
+input was authoritative, the callable winning the drift while `U` won the timestep count. Mutual
+exclusion is already this package's stated contract, asserted eight times across three FP solver
+families; this function was the one place that picked silently instead.
+
 Separately, a non-zero velocity that no scheme will read still raises: `_velocity_is_consumed` now
 also requires scalar diffusion, because `solve_timestep_tensor_explicit` takes no
 `interface_velocity` and on that path even `divergence_upwind`, the default and sole member of the
-accept-list, reads nothing. Two integration tests were passing their drift through the dead channel
-and have been rerouted to `potential_field`, with a bump at each wall and a curved potential so
-both wall stencils are exercised: reverting either wall to the pre-#1149 one-sided face velocity
-now fails that test, where a linear potential left the two stencils algebraically identical and a
-single-wall bump left the right wall carrying 5e-15 of density. Scheme-name resolution and its
-error string now have one owner.
-Scheme-name resolution and its error string now have one owner, and validation is no longer gated on a velocity being present: a bogus `advection_scheme` now raises on the tensor and callable-drift paths too, where it was previously ignored.
+accept-list, reads nothing.
+
+Scheme-name resolution and its error string now have one owner, and validation is no longer gated
+on a velocity being present: a bogus `advection_scheme` now raises on the tensor and callable-drift
+paths too, where it was previously ignored.
+
+Two integration tests were passing their drift through the dead channel and have been rerouted to
+`potential_field`, with a bump at each wall and a curved potential so both wall stencils are
+exercised: reverting either wall to the pre-#1149 one-sided face velocity now fails that test,
+where a linear potential left the two stencils algebraically identical and a single-wall bump left
+the right wall carrying 5e-15 of density.

--- a/changelog.d/1632-velocity-channel-fail-loud.fixed.md
+++ b/changelog.d/1632-velocity-channel-fail-loud.fixed.md
@@ -1,0 +1,9 @@
+FP FDM: supplying a non-zero `velocity_field` to an advection scheme that cannot read it now
+raises instead of silently solving at zero drift. Only `divergence_upwind` reads
+`interface_velocity`; the other three ignored it *and* had their U channel already replaced by a
+zero-U dispatcher, so the solve returned a finite, mass-conserving, converged-looking
+pure-diffusion density. That was the reachable path for every non-separable Hamiltonian, since
+the coupling layer routes those down the velocity channel precisely because `-c*grad(U)` cannot
+represent their drift. A zero velocity is still accepted, since discarding it changes nothing.
+Two integration tests were passing their drift through that dead channel and have been rerouted
+to `potential_field`; the #1149 boundary-flux pin now actually pushes mass into the wall.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -131,12 +131,16 @@ _SCHEME_ALIASES = {
 
 _VALID_SCHEMES = frozenset(_INTERIOR_HANDLERS)
 
-# Schemes whose assembly handlers actually read `interface_velocity`. The other three
-# accept the parameter and ignore it, re-deriving the drift from U instead -- so they
-# still need the scalar coefficient. That silent discard of the caller's velocity is a
-# real defect (verified in 1D and 2D: velocity (2.5, -1.7) vs (0, 0) gives bit-identical
-# densities for all three), tracked separately in #1632; this set exists so the driver
-# knows which schemes leave the coefficient unread.
+# Schemes whose assembly handlers actually read `interface_velocity`. Supplying a velocity to
+# any other scheme now raises (Issue #1632): those handlers ignore the parameter, and the
+# `velocity_field is not None` branch below has already replaced U with a zero-U dispatcher, so
+# the drift would be identically zero rather than the -c*grad(U) an earlier comment here claimed.
+# Measured before the guard: `gradient_upwind` with a velocity was bit-identical to the
+# pure-diffusion reference (|B-C| = 0.000e+00) while differing from the U-driven run by 2.1e-2.
+# That is the reachable path for every non-separable Hamiltonian, since resolve_fp_drift_kwargs
+# routes those down the velocity channel precisely because -c*grad(U) cannot represent their drift.
+# This set is the accept-list the guard tests against, and it still tells the driver which schemes
+# leave the scalar coefficient unread.
 _INTERFACE_VELOCITY_SCHEMES = frozenset({"divergence_upwind"})
 
 # Marker for "the scalar drift coefficient does not apply on this path": the consuming
@@ -727,6 +731,19 @@ def solve_fp_nd_full_system(
     _velocity_is_consumed = velocity_field is not None and (
         _SCHEME_ALIASES.get(advection_scheme, advection_scheme) in _INTERFACE_VELOCITY_SCHEMES
     )
+    # Issue #1632: fire exactly when discarding the velocity would change the answer. A velocity
+    # that is identically zero is discarded harmlessly -- the drift is zero either way -- and
+    # zero-drift arrays are how the diffusion-only callers reach every scheme.
+    if velocity_field is not None and not _velocity_is_consumed and np.any(velocity_field):
+        raise NotImplementedError(
+            f"advection_scheme={advection_scheme!r} does not read 'interface_velocity', but a "
+            f"non-zero velocity_field was supplied. The velocity would be discarded AND the U "
+            f"channel is already disabled below, so the solve would run at zero drift and return "
+            f"a pure-diffusion density that looks converged and conserves mass (Issue #1632). "
+            f"Use one of {sorted(_INTERFACE_VELOCITY_SCHEMES)}, or drop velocity_field and pass "
+            f"U_solution_for_drift so the drift is derived as -c*grad(U) -- valid only for a "
+            f"smooth separable Hamiltonian."
+        )
     if velocity_field is not None:
         Nt = velocity_field.shape[0]
         # Create a zero-U dispatcher (U is unused when interface_velocity is set)
@@ -945,9 +962,11 @@ def solve_fp_nd_full_system(
                 problem,
                 dt,
                 sigma_at_k,
-                # Issue #1631: skip resolving a coefficient the handler will not read.
-                # Only a scheme in _INTERFACE_VELOCITY_SCHEMES actually consumes the
-                # velocity; the others fall back to -c*grad(U) and still need it (#1632).
+                # Issue #1631: skip resolving a coefficient the handler will not read. A consumed
+                # velocity carries alpha* per face, so the scalar coefficient is unused; every
+                # other path derives its drift from U and needs it. Since #1632 a supplied
+                # velocity on a non-consuming scheme raises above, so the else branch is now
+                # reached only when no velocity was given at all.
                 _COEFFICIENT_NOT_APPLICABLE if _velocity_is_consumed else resolve_coupling_coefficient(),
                 spacing,
                 grid,

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -738,25 +738,60 @@ def solve_fp_nd_full_system(
     # the per-timestep assembly validates the name, but only after this guard would have fired.
     if velocity_field is not None and _resolved_scheme not in _VALID_SCHEMES:
         raise ValueError(f"Unknown advection_scheme '{advection_scheme}'. Valid options: {sorted(_VALID_SCHEMES)}")
-    _velocity_is_consumed = velocity_field is not None and _resolved_scheme in _INTERFACE_VELOCITY_SCHEMES
-    # Issue #1632. The hazard is not that the velocity is dropped -- it is that the branch below
-    # replaces U with a zero-U dispatcher whenever `velocity_field is not None`, whatever its
-    # magnitude. So a zero velocity is harmless only when there is no U for it to displace; a zero
-    # velocity supplied *alongside* a real U produces exactly the silent wrong answer this guard
-    # exists to stop. `Nt = velocity_field.shape[0]` below is a second reason the two are not
-    # interchangeable: a velocity with fewer time slices than U silently shortens the solve.
-    if velocity_field is not None and not _velocity_is_consumed:
-        if np.any(velocity_field) or U_solution_for_drift is not None:
+    # A velocity is genuinely consumed only when the assembly it reaches has an
+    # `interface_velocity` parameter. `solve_timestep_tensor_explicit` has none, so on the
+    # tensor-diffusion path NO scheme reads it -- including `divergence_upwind`, the default and
+    # the sole member of the accept-list. Keying `_velocity_is_consumed` on the scheme alone made
+    # the accept-list false exactly where it is most load-bearing.
+    _velocity_is_consumed = (
+        velocity_field is not None
+        and _resolved_scheme in _INTERFACE_VELOCITY_SCHEMES
+        and tensor_diffusion_field is None
+    )
+    # Issue #1632. Two independent hazards, and conflating them got the predicate wrong twice.
+    #
+    # DISPLACEMENT: the `velocity_field is not None` arm below wins over BOTH of its siblings, so
+    # a velocity of any magnitude silently discards whatever `U_solution_for_drift` or a callable
+    # `drift_field` would have contributed. This bites even on the consuming scheme -- a zero
+    # velocity there is consumed as zero advection while the callable drift is thrown away, which
+    # is the same silent pure-diffusion answer.
+    #
+    # CONSUMPTION: an unconsumed velocity is simply dropped. Harmless only when it is all zeros,
+    # because then the drift is zero either way.
+    #
+    # `Nt = velocity_field.shape[0]` is a further reason the arms are not interchangeable -- a
+    # velocity with fewer time slices than U shortens the solve -- but that is #919's contract for
+    # the velocity-only path, not this guard's to enforce.
+    if velocity_field is not None:
+        _displaced = []
+        if U_solution_for_drift is not None:
+            _displaced.append("U_solution_for_drift")
+        if use_callable_drift:
+            _displaced.append("a callable drift_field")
+        if _displaced:
             raise NotImplementedError(
-                f"advection_scheme={advection_scheme!r} does not read 'interface_velocity', but a "
-                f"velocity_field was supplied that cannot be discarded safely. The velocity would be "
-                f"dropped AND the U channel is disabled below, so the solve would run at zero drift "
-                f"and return a pure-diffusion density that looks converged and conserves mass "
-                f"(Issue #1632). Use one of {sorted(_INTERFACE_VELOCITY_SCHEMES)} (alias 'flux'), or "
-                f"drop velocity_field and supply the value function instead -- 'potential_field' on "
-                f"FPFDMSolver.solve_fp_system, 'U_solution_for_drift' here -- so the drift is derived "
-                f"as -c*grad(U), which is valid only for a smooth separable Hamiltonian. Only an "
-                f"all-zero velocity with no U supplied is accepted, since it displaces nothing."
+                f"velocity_field was supplied together with {' and '.join(_displaced)}. The "
+                f"velocity branch wins, so that input is silently discarded and the solve runs on "
+                f"the velocity alone -- pure diffusion when the velocity is zero, and in every "
+                f"case not the problem the caller described (Issue #1632). Supply exactly one "
+                f"drift input."
+            )
+        if not _velocity_is_consumed and np.any(velocity_field):
+            _where = (
+                "no advection scheme reads 'interface_velocity' on the tensor-diffusion path "
+                "(solve_timestep_tensor_explicit takes no such parameter), so the accept-list "
+                "does not apply here"
+                if tensor_diffusion_field is not None
+                else f"advection_scheme={advection_scheme!r} does not read 'interface_velocity'"
+            )
+            raise NotImplementedError(
+                f"A non-zero velocity_field cannot be honoured: {_where}, so it would be dropped "
+                f"and the solve would run at zero drift, returning a pure-diffusion density that "
+                f"looks converged and conserves mass (Issue #1632). Supply the value function "
+                f"instead -- 'potential_field' on FPFDMSolver.solve_fp_system, "
+                f"'U_solution_for_drift' here -- so the drift is derived as -c*grad(U), valid only "
+                f"for a smooth separable Hamiltonian; or use one of "
+                f"{sorted(_INTERFACE_VELOCITY_SCHEMES)} (alias 'flux') with scalar diffusion."
             )
     if velocity_field is not None:
         Nt = velocity_field.shape[0]

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -817,8 +817,11 @@ def solve_fp_nd_full_system(
         # Use U_solution shape for timestep count (allows flexible input sizes)
         Nt = U_solution_for_drift.shape[0]
         # Issue #641: Create unified _DriftDispatcher for cleaner time loop
+        # `drift_field if use_callable_drift else ...` was unreachable once the count check
+        # landed: this arm needs `velocity_field is None` and `U_solution_for_drift is not None`,
+        # and the check then forces `drift_field is None`. Removing it is this change's own tail.
         drift = _DriftDispatcher(
-            drift_field=drift_field if use_callable_drift else U_solution_for_drift,
+            drift_field=U_solution_for_drift,
             Nt=Nt,
             spatial_shape=shape,
             dimension=ndim,

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -137,8 +137,13 @@ _VALID_SCHEMES = frozenset(_INTERIOR_HANDLERS)
 # the drift would be identically zero rather than the -c*grad(U) an earlier comment here claimed.
 # Measured before the guard: `gradient_upwind` with a velocity was bit-identical to the
 # pure-diffusion reference (|B-C| = 0.000e+00) while differing from the U-driven run by 2.1e-2.
-# That is the reachable path for every non-separable Hamiltonian, since resolve_fp_drift_kwargs
-# routes those down the velocity channel precisely because -c*grad(U) cannot represent their drift.
+# Reachable by an EXPLICIT velocity: `FPFDMSolver.solve_fp_system(m0, drift_field=<ndarray>)` on a
+# non-consuming scheme, or `FixedPointIterator(..., drift_field=<ndarray>)`, which is forwarded
+# verbatim and bypasses the smoothness dispatch. NOT reachable on the auto-routed coupling path: a
+# non-quadratic-MINIMIZE-separable H makes `fp_drift_coefficient` raise first (#1542), and for the
+# quadratic-MINIMIZE separable class `resolve_fp_drift_kwargs` sends `potential_field=U`, never a
+# velocity. An earlier revision of this comment claimed the coupling path reached it; measurement
+# on both trees says it raises instead.
 # This set is the accept-list the guard tests against, and it still tells the driver which schemes
 # leave the scalar coefficient unread.
 _INTERFACE_VELOCITY_SCHEMES = frozenset({"divergence_upwind"})
@@ -728,22 +733,31 @@ def solve_fp_nd_full_system(
     # Issue #919 Phase 2: velocity_field → pass to implicit solver directly
     # via interface_velocity. No virtual-U conversion needed.
     _velocity_array = velocity_field  # Store for per-timestep slicing
-    _velocity_is_consumed = velocity_field is not None and (
-        _SCHEME_ALIASES.get(advection_scheme, advection_scheme) in _INTERFACE_VELOCITY_SCHEMES
-    )
-    # Issue #1632: fire exactly when discarding the velocity would change the answer. A velocity
-    # that is identically zero is discarded harmlessly -- the drift is zero either way -- and
-    # zero-drift arrays are how the diffusion-only callers reach every scheme.
-    if velocity_field is not None and not _velocity_is_consumed and np.any(velocity_field):
-        raise NotImplementedError(
-            f"advection_scheme={advection_scheme!r} does not read 'interface_velocity', but a "
-            f"non-zero velocity_field was supplied. The velocity would be discarded AND the U "
-            f"channel is already disabled below, so the solve would run at zero drift and return "
-            f"a pure-diffusion density that looks converged and conserves mass (Issue #1632). "
-            f"Use one of {sorted(_INTERFACE_VELOCITY_SCHEMES)}, or drop velocity_field and pass "
-            f"U_solution_for_drift so the drift is derived as -c*grad(U) -- valid only for a "
-            f"smooth separable Hamiltonian."
-        )
+    _resolved_scheme = _SCHEME_ALIASES.get(advection_scheme, advection_scheme)
+    # A misspelled scheme must report itself as such rather than as a velocity-channel problem:
+    # the per-timestep assembly validates the name, but only after this guard would have fired.
+    if velocity_field is not None and _resolved_scheme not in _VALID_SCHEMES:
+        raise ValueError(f"Unknown advection_scheme '{advection_scheme}'. Valid options: {sorted(_VALID_SCHEMES)}")
+    _velocity_is_consumed = velocity_field is not None and _resolved_scheme in _INTERFACE_VELOCITY_SCHEMES
+    # Issue #1632. The hazard is not that the velocity is dropped -- it is that the branch below
+    # replaces U with a zero-U dispatcher whenever `velocity_field is not None`, whatever its
+    # magnitude. So a zero velocity is harmless only when there is no U for it to displace; a zero
+    # velocity supplied *alongside* a real U produces exactly the silent wrong answer this guard
+    # exists to stop. `Nt = velocity_field.shape[0]` below is a second reason the two are not
+    # interchangeable: a velocity with fewer time slices than U silently shortens the solve.
+    if velocity_field is not None and not _velocity_is_consumed:
+        if np.any(velocity_field) or U_solution_for_drift is not None:
+            raise NotImplementedError(
+                f"advection_scheme={advection_scheme!r} does not read 'interface_velocity', but a "
+                f"velocity_field was supplied that cannot be discarded safely. The velocity would be "
+                f"dropped AND the U channel is disabled below, so the solve would run at zero drift "
+                f"and return a pure-diffusion density that looks converged and conserves mass "
+                f"(Issue #1632). Use one of {sorted(_INTERFACE_VELOCITY_SCHEMES)} (alias 'flux'), or "
+                f"drop velocity_field and supply the value function instead -- 'potential_field' on "
+                f"FPFDMSolver.solve_fp_system, 'U_solution_for_drift' here -- so the drift is derived "
+                f"as -c*grad(U), which is valid only for a smooth separable Hamiltonian. Only an "
+                f"all-zero velocity with no U supplied is accepted, since it displaces nothing."
+            )
     if velocity_field is not None:
         Nt = velocity_field.shape[0]
         # Create a zero-U dispatcher (U is unused when interface_velocity is set)
@@ -964,9 +978,9 @@ def solve_fp_nd_full_system(
                 sigma_at_k,
                 # Issue #1631: skip resolving a coefficient the handler will not read. A consumed
                 # velocity carries alpha* per face, so the scalar coefficient is unused; every
-                # other path derives its drift from U and needs it. Since #1632 a supplied
-                # velocity on a non-consuming scheme raises above, so the else branch is now
-                # reached only when no velocity was given at all.
+                # other path derives its drift from U and needs it. The else branch is still
+                # reached with a velocity present -- an all-zero one on a non-consuming scheme is
+                # accepted by the #1632 guard and lands here, resolving a real coefficient.
                 _COEFFICIENT_NOT_APPLICABLE if _velocity_is_consumed else resolve_coupling_coefficient(),
                 spacing,
                 grid,

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -156,6 +156,19 @@ _INTERFACE_VELOCITY_SCHEMES = frozenset({"divergence_upwind"})
 _COEFFICIENT_NOT_APPLICABLE = float("nan")
 
 
+def _resolve_and_validate_scheme(advection_scheme: str) -> str:
+    """Resolve a legacy scheme alias and reject an unknown name.
+
+    One owner for both the alias table and the error string. ``solve_timestep_full_nd`` is a
+    standalone entry point with its own tests, so it validates its own input rather than
+    trusting a caller; this helper is what keeps that from meaning two copies of the message.
+    """
+    resolved = _SCHEME_ALIASES.get(advection_scheme, advection_scheme)
+    if resolved not in _VALID_SCHEMES:
+        raise ValueError(f"Unknown advection_scheme '{advection_scheme}'. Valid options: {sorted(_VALID_SCHEMES)}")
+    return resolved
+
+
 # =============================================================================
 # Dirichlet BC support for nD (Issue #859)
 # =============================================================================
@@ -635,7 +648,8 @@ def solve_fp_nd_full_system(
     U_solution_for_drift : np.ndarray | None
         Value function over time-space grid. Shape: (Nt+1, N1, N2, ..., Nd)
         Used to compute drift velocity v = -coupling_coefficient * grad(U)
-        Can be None if drift_field or velocity_field is provided.
+        Must be None when drift_field or velocity_field is provided:
+            supplying more than one drift input is ambiguous and raises (Issue #1632).
     velocity_field : np.ndarray | None
         Precomputed velocity field α*(t, x). Shape: (Nt+1, *spatial_shape)
         for 1D, or (Nt+1, ndim, *spatial_shape) for nD.
@@ -733,11 +747,9 @@ def solve_fp_nd_full_system(
     # Issue #919 Phase 2: velocity_field → pass to implicit solver directly
     # via interface_velocity. No virtual-U conversion needed.
     _velocity_array = velocity_field  # Store for per-timestep slicing
-    _resolved_scheme = _SCHEME_ALIASES.get(advection_scheme, advection_scheme)
     # A misspelled scheme must report itself as such rather than as a velocity-channel problem:
-    # the per-timestep assembly validates the name, but only after this guard would have fired.
-    if velocity_field is not None and _resolved_scheme not in _VALID_SCHEMES:
-        raise ValueError(f"Unknown advection_scheme '{advection_scheme}'. Valid options: {sorted(_VALID_SCHEMES)}")
+    # the per-timestep assembly validates the name too, but only after this guard would have fired.
+    _resolved_scheme = _resolve_and_validate_scheme(advection_scheme)
     # A velocity is genuinely consumed only when the assembly it reaches has an
     # `interface_velocity` parameter. `solve_timestep_tensor_explicit` has none, so on the
     # tensor-diffusion path NO scheme reads it -- including `divergence_upwind`, the default and
@@ -748,54 +760,57 @@ def solve_fp_nd_full_system(
         and _resolved_scheme in _INTERFACE_VELOCITY_SCHEMES
         and tensor_diffusion_field is None
     )
-    # Issue #1632. Two independent hazards, and conflating them got the predicate wrong twice.
+    # Issue #1632. Two hazards, and the first belongs to the WHOLE chain below, not to one arm.
     #
-    # DISPLACEMENT: the `velocity_field is not None` arm below wins over BOTH of its siblings, so
-    # a velocity of any magnitude silently discards whatever `U_solution_for_drift` or a callable
-    # `drift_field` would have contributed. This bites even on the consuming scheme -- a zero
-    # velocity there is consumed as zero advection while the callable drift is thrown away, which
-    # is the same silent pure-diffusion answer.
+    # AMBIGUITY: the chain is a precedence order, and every level of it silently discards the
+    # levels beneath. `velocity_field is not None` wins over both siblings; inside the second arm,
+    # `drift_field if use_callable_drift else U_solution_for_drift` makes a callable win over U.
+    # Guarding only the first arm left the second one open -- measured, U plus a callable drift
+    # returned the callable's answer with U discarded, |result - U-only| = 2.05e-02. So the check
+    # is on the chain: more than one drift input supplied is ambiguous, whichever pair it is.
+    _drift_inputs = [
+        name
+        for name, given in (
+            ("velocity_field", velocity_field is not None),
+            ("U_solution_for_drift", U_solution_for_drift is not None),
+            ("drift_field", drift_field is not None),
+        )
+        if given
+    ]
+    if len(_drift_inputs) > 1:
+        raise NotImplementedError(
+            f"{len(_drift_inputs)} drift inputs were supplied ({', '.join(_drift_inputs)}), and the "
+            f"dispatch below is a precedence order: the winner silently discards the rest, so the "
+            f"solve would run on one of them and report nothing about the others (Issue #1632). "
+            f"Supply exactly one drift input."
+        )
     #
-    # CONSUMPTION: an unconsumed velocity is simply dropped. Harmless only when it is all zeros,
-    # because then the drift is zero either way.
-    #
-    # `Nt = velocity_field.shape[0]` is a further reason the arms are not interchangeable -- a
-    # velocity with fewer time slices than U shortens the solve -- but that is #919's contract for
-    # the velocity-only path, not this guard's to enforce.
-    if velocity_field is not None:
-        _displaced = []
-        if U_solution_for_drift is not None:
-            _displaced.append("U_solution_for_drift")
-        if use_callable_drift:
-            _displaced.append("a callable drift_field")
-        if _displaced:
-            raise NotImplementedError(
-                f"velocity_field was supplied together with {' and '.join(_displaced)}. The "
-                f"velocity branch wins, so that input is silently discarded and the solve runs on "
-                f"the velocity alone -- pure diffusion when the velocity is zero, and in every "
-                f"case not the problem the caller described (Issue #1632). Supply exactly one "
-                f"drift input."
-            )
-        if not _velocity_is_consumed and np.any(velocity_field):
-            _where = (
-                "no advection scheme reads 'interface_velocity' on the tensor-diffusion path "
-                "(solve_timestep_tensor_explicit takes no such parameter), so the accept-list "
-                "does not apply here"
-                if tensor_diffusion_field is not None
-                else f"advection_scheme={advection_scheme!r} does not read 'interface_velocity'"
-            )
-            raise NotImplementedError(
-                f"A non-zero velocity_field cannot be honoured: {_where}, so it would be dropped "
-                f"and the solve would run at zero drift, returning a pure-diffusion density that "
-                f"looks converged and conserves mass (Issue #1632). Supply the value function "
-                f"instead -- 'potential_field' on FPFDMSolver.solve_fp_system, "
-                f"'U_solution_for_drift' here -- so the drift is derived as -c*grad(U), valid only "
-                f"for a smooth separable Hamiltonian; or use one of "
-                f"{sorted(_INTERFACE_VELOCITY_SCHEMES)} (alias 'flux') with scalar diffusion."
-            )
+    # CONSUMPTION: an unconsumed velocity is dropped outright. Harmless only when it is all zeros,
+    # because then the drift is zero either way. `Nt = velocity_field.shape[0]` is a further reason
+    # the arms are not interchangeable -- a velocity with fewer time slices than U shortens the
+    # solve -- but that is #919's contract for the velocity-only path, not this guard's to enforce.
+    if velocity_field is not None and not _velocity_is_consumed and np.any(velocity_field):
+        _where = (
+            "no advection scheme reads 'interface_velocity' on the tensor-diffusion path "
+            "(solve_timestep_tensor_explicit takes no such parameter), so the accept-list "
+            "does not apply here"
+            if tensor_diffusion_field is not None
+            else f"advection_scheme={advection_scheme!r} does not read 'interface_velocity'"
+        )
+        raise NotImplementedError(
+            f"A non-zero velocity_field cannot be honoured: {_where}, so it would be dropped and "
+            f"the solve would run at zero drift, returning a pure-diffusion density that looks "
+            f"converged and conserves mass (Issue #1632). Supply the value function instead -- "
+            f"'potential_field' on FPFDMSolver.solve_fp_system, 'U_solution_for_drift' here -- so "
+            f"the drift is derived as -c*grad(U), valid only for a smooth separable Hamiltonian; "
+            f"or use one of {sorted(_INTERFACE_VELOCITY_SCHEMES)} (alias 'flux') with scalar "
+            f"diffusion."
+        )
     if velocity_field is not None:
         Nt = velocity_field.shape[0]
-        # Create a zero-U dispatcher (U is unused when interface_velocity is set)
+        # Zero-U dispatcher. This arm wins over both siblings, which is why supplying a
+        # velocity together with any other drift input now raises above (Issue #1632) --
+        # reaching here means a velocity is the only drift input, so there is no U to lose.
         drift = _DriftDispatcher(drift_field=None, Nt=Nt, spatial_shape=shape, dimension=ndim)
     elif U_solution_for_drift is not None:
         # Determine timestep count
@@ -1287,9 +1302,8 @@ def solve_timestep_full_nd(
     """
     advection_scheme = _SCHEME_ALIASES.get(advection_scheme, advection_scheme)
 
-    # Validate scheme name
-    if advection_scheme not in _VALID_SCHEMES:
-        raise ValueError(f"Unknown advection_scheme '{advection_scheme}'. Valid options: {sorted(_VALID_SCHEMES)}")
+    # Validate scheme name (standalone entry point: it does not trust its caller)
+    _resolve_and_validate_scheme(advection_scheme)
     # Total number of unknowns
     N_total = int(np.prod(shape))
 

--- a/tests/integration/test_fdm_centered_conservation.py
+++ b/tests/integration/test_fdm_centered_conservation.py
@@ -64,8 +64,14 @@ def test_fdm_centered_conserves_mass_under_no_flux():
     # one-sided (U[1]-U[0])/dx. Those are algebraically identical for a linear U, so a linear
     # potential leaves this test blind to the very defect it pins: reverting both walls to the
     # one-sided form keeps the mass drift at 3.9e-15 under `U = x`, and moves it to 3.0e-02 here.
-    potential = np.tile(x + 0.5 * x**2, (nt + 1, 1))
-    m0 = np.exp(-200 * (x - 0.05) ** 2)  # bump AT the left wall (columns 0-2)
+    potential = np.tile(0.3 * np.sin(np.pi * x), (nt + 1, 1))
+    # A bump at EACH wall: `U = x + x^2/2` gave a leftward drift everywhere, so the right wall
+    # carried ~5e-15 of density and every right-wall mutation was invisible. `0.3*sin(pi*x)` has
+    # an interior maximum, so the drift runs into both walls, and it is curved, so the central
+    # and one-sided face stencils differ there. Measured: reverting the LEFT wall to one-sided
+    # gives 3.390e-03 and the RIGHT wall 3.390e-03 -- symmetric, where before it was 3.001e-02
+    # and 3.664e-15 (blind).
+    m0 = np.exp(-200 * (x - 0.05) ** 2) + np.exp(-200 * (x - 0.95) ** 2)
     m0 /= m0.sum() * dx
 
     traj = fp.solve_fp_system(m0, potential_field=potential)

--- a/tests/integration/test_fdm_centered_conservation.py
+++ b/tests/integration/test_fdm_centered_conservation.py
@@ -59,7 +59,12 @@ def test_fdm_centered_conserves_mass_under_no_flux():
     # exercised. Route the drift through `potential_field=U` instead, which this scheme does
     # consume: for the smooth separable H above the solver forms alpha = -c*grad(U) internally.
     # U increasing in x gives a leftward velocity, pushing the wall-adjacent bump into the wall.
-    potential = np.tile(x, (nt + 1, 1))
+    # The potential must be NON-LINEAR. The #1149 fix makes the boundary handler evaluate the
+    # shared face velocity with the interior's central stencil, (U[2]-U[0])/(2*dx), instead of the
+    # one-sided (U[1]-U[0])/dx. Those are algebraically identical for a linear U, so a linear
+    # potential leaves this test blind to the very defect it pins: reverting both walls to the
+    # one-sided form keeps the mass drift at 3.9e-15 under `U = x`, and moves it to 3.0e-02 here.
+    potential = np.tile(x + 0.5 * x**2, (nt + 1, 1))
     m0 = np.exp(-200 * (x - 0.05) ** 2)  # bump AT the left wall (columns 0-2)
     m0 /= m0.sum() * dx
 
@@ -124,14 +129,14 @@ def test_gradient_leaks_even_with_zero_drift():
     U_zero = np.zeros((nt + 1, n))  # zero drift => pure diffusion at the wall
 
     _, fp_div = create_paired_solvers(_problem(n=n, nt=nt), NumericalScheme.FDM_CENTERED)
-    mass_div = np.array([t.sum() * dx for t in fp_div.solve_fp_system(m0, drift_field=U_zero)])
+    mass_div = np.array([t.sum() * dx for t in fp_div.solve_fp_system(m0, potential_field=U_zero)])
     assert np.max(np.abs(mass_div - mass_div[0])) < 1e-12
 
     with pytest.warns(UserWarning, match="Issue #1075"):
         _, fp_grad = create_paired_solvers(
             _problem(n=n, nt=nt), NumericalScheme.FDM_CENTERED, fp_config={"advection_scheme": "gradient_centered"}
         )
-    mass_grad = np.array([t.sum() * dx for t in fp_grad.solve_fp_system(m0, drift_field=U_zero)])
+    mass_grad = np.array([t.sum() * dx for t in fp_grad.solve_fp_system(m0, potential_field=U_zero)])
     assert np.max(np.abs(mass_grad - mass_grad[0])) > 1e-3  # leaks under pure diffusion
 
 

--- a/tests/integration/test_fdm_centered_conservation.py
+++ b/tests/integration/test_fdm_centered_conservation.py
@@ -53,11 +53,17 @@ def test_fdm_centered_conserves_mass_under_no_flux():
     _, fp = create_paired_solvers(prob, NumericalScheme.FDM_CENTERED)
     x = np.linspace(0.0, 1.0, n)
     dx = x[1] - x[0]
-    drift = np.tile(4.0 * (x - 0.7) ** 2, (nt + 1, 1))  # pushes mass toward the left wall
+    # Issue #1632: `drift_field=<ndarray>` is the VELOCITY channel, and `divergence_centered`
+    # does not read it -- so the drift this test believed it was applying was discarded and the
+    # solve ran at zero drift. The boundary face flux the docstring describes was never
+    # exercised. Route the drift through `potential_field=U` instead, which this scheme does
+    # consume: for the smooth separable H above the solver forms alpha = -c*grad(U) internally.
+    # U increasing in x gives a leftward velocity, pushing the wall-adjacent bump into the wall.
+    potential = np.tile(x, (nt + 1, 1))
     m0 = np.exp(-200 * (x - 0.05) ** 2)  # bump AT the left wall (columns 0-2)
     m0 /= m0.sum() * dx
 
-    traj = fp.solve_fp_system(m0, drift_field=drift)
+    traj = fp.solve_fp_system(m0, potential_field=potential)
     mass = np.array([traj[k].sum() * dx for k in range(nt + 1)])
     assert np.all(np.isfinite(traj))
     assert np.max(np.abs(mass - mass[0])) < 1e-12, (
@@ -78,10 +84,12 @@ def test_gradient_centered_still_available_and_leaks():
     assert fp.advection_scheme == "gradient_centered"
     x = np.linspace(0.0, 1.0, n)
     dx = x[1] - x[0]
-    drift = np.tile(0.5 * (x - 0.5) ** 2, (nt + 1, 1))
+    # Issue #1632: same correction as above -- `drift_field=<ndarray>` is the velocity channel
+    # and `gradient_centered` does not read it, so this drift was discarded too.
+    potential = np.tile(0.5 * (x - 0.5) ** 2, (nt + 1, 1))
     m0 = np.exp(-40 * (x - 0.35) ** 2)
     m0 /= m0.sum() * dx
-    traj = fp.solve_fp_system(m0, drift_field=drift)
+    traj = fp.solve_fp_system(m0, potential_field=potential)
     mass = np.array([traj[k].sum() * dx for k in range(nt + 1)])
     assert np.max(np.abs(mass - mass[0])) > 1e-3, "gradient_centered is expected to violate conservation"
 

--- a/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
+++ b/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
@@ -164,6 +164,46 @@ def test_a_zero_velocity_alongside_a_real_u_still_raises(scheme):
         )
 
 
+def test_the_accept_list_does_not_apply_on_the_tensor_diffusion_path():
+    """`solve_timestep_tensor_explicit` has no `interface_velocity` parameter.
+
+    So on that path NO scheme reads the velocity -- including `divergence_upwind`, the default
+    and the only member of the accept-list. Keying `_velocity_is_consumed` on the scheme alone
+    let the whitelisted scheme walk into the exact silent zero-drift solve the guard exists to
+    stop, reachable through the public API with a tensor volatility.
+    """
+    tensor = np.eye(2) * 0.2
+    with pytest.raises(NotImplementedError, match="1632"):
+        solve_fp_nd_full_system(
+            _uniform_density(),
+            None,
+            _problem(),
+            velocity_field=_velocity(vx=0.6),
+            advection_scheme="divergence_upwind",
+            tensor_diffusion_field=tensor,
+        )
+
+
+@pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_upwind"])
+def test_a_zero_velocity_that_displaces_a_callable_drift_raises(scheme):
+    """The velocity arm wins over the callable-drift arm too, not only over the U arm.
+
+    Enumerating inputs got this predicate wrong twice -- first on magnitude, then on U alone.
+    The invariant is about what the `velocity_field is not None` branch DISPLACES, and that
+    branch has two siblings. A zero velocity supplied with a callable drift discards the
+    callable and solves pure diffusion.
+    """
+    with pytest.raises(NotImplementedError, match="1632"):
+        solve_fp_nd_full_system(
+            _uniform_density(),
+            None,
+            _problem(),
+            velocity_field=_velocity(),
+            drift_field=lambda t, x, m: np.zeros((2, N, N)),
+            advection_scheme=scheme,
+        )
+
+
 def test_a_misspelled_scheme_reports_itself_as_such():
     """The velocity guard must not pre-empt scheme-name validation and mis-attribute a typo."""
     with pytest.raises(ValueError, match="Unknown advection_scheme"):

--- a/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
+++ b/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
@@ -229,6 +229,20 @@ def test_a_callable_drift_alongside_a_real_u_raises():
         )
 
 
+def test_a_non_callable_drift_array_alongside_a_real_u_raises():
+    """The count check closed this; without a pin it comes back.
+
+    A non-callable ndarray `drift_field` was excluded from the old predicate because that keyed
+    on `use_callable_drift`, so `U + drift_field=<ndarray>` dropped the array without a word
+    (|result - U-only| = 0.000e+00). Reverting the count to the callable-only keying leaves the
+    rest of this file green, which is exactly why this needs its own assertion.
+    """
+    u_solution = np.zeros((NT + 1, N, N))
+    u_solution[:] = np.add.outer(np.linspace(0.0, 1.0, N) ** 2, np.zeros(N))
+    with pytest.raises(NotImplementedError, match="1632"):
+        solve_fp_nd_full_system(_uniform_density(), u_solution, _problem(), drift_field=np.zeros((NT + 1, N, N)))
+
+
 def test_a_misspelled_scheme_reports_itself_as_such():
     """The velocity guard must not pre-empt scheme-name validation and mis-attribute a typo."""
     with pytest.raises(ValueError, match="Unknown advection_scheme"):

--- a/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
+++ b/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
@@ -10,9 +10,19 @@ Two defects, both on `solve_fp_nd_full_system`:
    exists precisely to carry a precomputed alpha* for those Hamiltonians.
 
 Only ``divergence_upwind`` actually reads ``interface_velocity``, so only that
-scheme leaves the coefficient unread; the others still fall back to ``-c*grad(U)``
-and still resolve it. That they silently discard the caller's velocity is a
-separate defect, tracked in #1632.
+scheme leaves the coefficient unread; every other path derives its drift from U
+and still resolves it.
+
+2. Supplying a velocity to a scheme that cannot read it proceeded silently, and it did
+   **not** fall back to ``-c*grad(U)`` as this docstring and the code comments used to
+   claim. The ``velocity_field is not None`` branch replaces U with a zero-U dispatcher,
+   so *both* drift channels were discarded and the solve ran at zero drift -- returning a
+   pure-diffusion density that looks converged and conserves mass. Measured before the
+   guard: ``gradient_upwind`` with a velocity was bit-identical to the pure-diffusion
+   reference (``|B-C| = 0.000e+00``) while differing from the U-driven run by ``2.1e-2``.
+   That was the reachable path for every non-separable Hamiltonian, since
+   ``resolve_fp_drift_kwargs`` routes those down the velocity channel precisely because
+   ``-c*grad(U)`` cannot represent their drift. It now raises (#1632).
 
 Each test fails if the fix is reverted.
 """
@@ -104,20 +114,47 @@ def test_u_channel_unchanged_for_minimize():
 
 
 @pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered"])
-def test_non_consuming_scheme_still_receives_a_real_coefficient(scheme):
-    """The skip must be scheme-aware, not merely velocity-aware.
+def test_velocity_on_a_non_consuming_scheme_raises(scheme):
+    """Issue #1632: a velocity these schemes cannot read must not be silently dropped.
 
-    Only `divergence_upwind` reads `interface_velocity`; the others still fall back
-    to -c*grad(U) and so still need the coefficient. Dropping the scheme test from
-    `_velocity_is_consumed` -- resolving nothing whenever a velocity is present --
-    hands them NaN and the density goes non-finite. That is the exact regression
-    that forced this PR to be narrowed, so pin it here rather than relying on
-    tests/integration/test_fdm_centered_conservation.py to catch it.
+    Catches the reappearance of a *silent* wrong answer, not a crash. Before the guard
+    this call returned a finite, mass-conserving, converged-looking density computed at
+    zero drift, because the `velocity_field is not None` branch had already swapped U for
+    a zero-U dispatcher. Nothing in the output distinguished it from a correct solve --
+    which is why an assertion on finiteness or mass cannot serve as the pin here.
+    """
+    with pytest.raises(NotImplementedError, match="1632"):
+        solve_fp_nd_full_system(
+            _uniform_density(), None, _problem(), velocity_field=_velocity(vx=0.3), advection_scheme=scheme
+        )
+
+
+@pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered"])
+def test_a_zero_velocity_is_not_an_error(scheme):
+    """The guard fires on a wrong answer, not on the mere presence of the parameter.
+
+    A velocity of exactly zero is discarded harmlessly -- the drift is zero either way -- and
+    `FPFDMSolver` reaches every scheme with a zero drift array on its diffusion-only paths
+    (`_internal_velocity` is set whenever `drift_field` is an ndarray). Raising here would
+    break the torus and mass-leak suites, which is how this over-broad first cut was caught.
     """
     result = solve_fp_nd_full_system(
-        _uniform_density(), None, _problem(), velocity_field=_velocity(vx=0.3), advection_scheme=scheme
+        _uniform_density(), None, _problem(), velocity_field=_velocity(), advection_scheme=scheme
     )
-    assert np.isfinite(result).all(), f"{scheme} received a non-applicable coefficient"
+    assert np.isfinite(result).all()
+
+
+@pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered"])
+def test_the_raise_names_the_scheme_and_the_way_out(scheme):
+    """The diagnostic must be actionable and greppable, not merely raised."""
+    with pytest.raises(NotImplementedError) as exc:
+        solve_fp_nd_full_system(
+            _uniform_density(), None, _problem(), velocity_field=_velocity(vx=0.3), advection_scheme=scheme
+        )
+    message = str(exc.value)
+    assert scheme in message, "the offending scheme must be named"
+    assert "divergence_upwind" in message, "the accept-list must be shown"
+    assert "U_solution_for_drift" in message, "the alternative channel must be named"
 
 
 def test_callable_drift_channel_also_runs_for_maximize():

--- a/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
+++ b/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
@@ -146,7 +146,7 @@ def test_a_zero_velocity_is_not_an_error(scheme):
     assert np.isfinite(result).all()
 
 
-@pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered"])
+@pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered", "divergence_upwind"])
 def test_a_zero_velocity_alongside_a_real_u_still_raises(scheme):
     """The narrowing must not open the hole it was narrowing around.
 
@@ -155,6 +155,11 @@ def test_a_zero_velocity_alongside_a_real_u_still_raises(scheme):
     pure-diffusion answer this guard exists to stop -- measured at 2.1e-2 from the correct
     answer, the same magnitude as the defect itself. Keying the guard on the velocity's
     magnitude alone would accept it.
+
+    `divergence_upwind` is in the list deliberately. Exempting the consuming scheme is the
+    mistake that was made once already, on the callable half of this clause; made here instead
+    it silently restores a 1.8e-2 pure-diffusion answer on the DEFAULT scheme, and the callable
+    twin below would not catch it.
     """
     u_solution = np.zeros((NT + 1, N, N))
     u_solution[:] = np.add.outer(np.linspace(0.0, 1.0, N) ** 2, np.zeros(N))
@@ -173,7 +178,7 @@ def test_the_accept_list_does_not_apply_on_the_tensor_diffusion_path():
     stop, reachable through the public API with a tensor volatility.
     """
     tensor = np.eye(2) * 0.2
-    with pytest.raises(NotImplementedError, match="1632"):
+    with pytest.raises(NotImplementedError, match="tensor-diffusion path"):
         solve_fp_nd_full_system(
             _uniform_density(),
             None,
@@ -201,6 +206,26 @@ def test_a_zero_velocity_that_displaces_a_callable_drift_raises(scheme):
             velocity_field=_velocity(),
             drift_field=lambda t, x, m: np.zeros((2, N, N)),
             advection_scheme=scheme,
+        )
+
+
+def test_a_callable_drift_alongside_a_real_u_raises():
+    """The second arm has its own precedence, and guarding only the first left it open.
+
+    Inside `elif U_solution_for_drift is not None:` the dispatcher takes
+    `drift_field if use_callable_drift else U_solution_for_drift`, so a callable wins over U
+    with no velocity in play at all -- measured before the fix, the result was the callable's
+    answer with U discarded (|result - U-only| = 2.05e-02). The check is therefore on the
+    whole chain, not on the velocity arm.
+    """
+    u_solution = np.zeros((NT + 1, N, N))
+    u_solution[:] = np.add.outer(np.linspace(0.0, 1.0, N) ** 2, np.zeros(N))
+    with pytest.raises(NotImplementedError, match="1632"):
+        solve_fp_nd_full_system(
+            _uniform_density(),
+            u_solution,
+            _problem(),
+            drift_field=lambda t, x, m: np.zeros((2, N, N)),
         )
 
 

--- a/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
+++ b/tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py
@@ -131,17 +131,45 @@ def test_velocity_on_a_non_consuming_scheme_raises(scheme):
 
 @pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered"])
 def test_a_zero_velocity_is_not_an_error(scheme):
-    """The guard fires on a wrong answer, not on the mere presence of the parameter.
+    """A zero velocity with NO U to displace is the one accepted case.
 
-    A velocity of exactly zero is discarded harmlessly -- the drift is zero either way -- and
-    `FPFDMSolver` reaches every scheme with a zero drift array on its diffusion-only paths
-    (`_internal_velocity` is set whenever `drift_field` is an ndarray). Raising here would
-    break the torus and mass-leak suites, which is how this over-broad first cut was caught.
+    The ground is not "a zero velocity is harmless" -- it is not the velocity that gets
+    discarded. The `velocity_field is not None` branch replaces U with a zero-U dispatcher
+    whatever the velocity's magnitude, so the only safe case is one where there was no U to
+    lose. `FPFDMSolver` reaches every scheme this way on its diffusion-only paths
+    (`_internal_velocity` is set whenever `drift_field` is an ndarray), which is why raising
+    unconditionally broke the torus and mass-leak suites and had to be narrowed.
     """
     result = solve_fp_nd_full_system(
         _uniform_density(), None, _problem(), velocity_field=_velocity(), advection_scheme=scheme
     )
     assert np.isfinite(result).all()
+
+
+@pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered"])
+def test_a_zero_velocity_alongside_a_real_u_still_raises(scheme):
+    """The narrowing must not open the hole it was narrowing around.
+
+    A zero velocity supplied *with* a value function is not harmless: the zero-U dispatcher
+    displaces that U, so the solve runs at zero drift and produces exactly the silent
+    pure-diffusion answer this guard exists to stop -- measured at 2.1e-2 from the correct
+    answer, the same magnitude as the defect itself. Keying the guard on the velocity's
+    magnitude alone would accept it.
+    """
+    u_solution = np.zeros((NT + 1, N, N))
+    u_solution[:] = np.add.outer(np.linspace(0.0, 1.0, N) ** 2, np.zeros(N))
+    with pytest.raises(NotImplementedError, match="1632"):
+        solve_fp_nd_full_system(
+            _uniform_density(), u_solution, _problem(), velocity_field=_velocity(), advection_scheme=scheme
+        )
+
+
+def test_a_misspelled_scheme_reports_itself_as_such():
+    """The velocity guard must not pre-empt scheme-name validation and mis-attribute a typo."""
+    with pytest.raises(ValueError, match="Unknown advection_scheme"):
+        solve_fp_nd_full_system(
+            _uniform_density(), None, _problem(), velocity_field=_velocity(vx=0.3), advection_scheme="not_a_scheme"
+        )
 
 
 @pytest.mark.parametrize("scheme", ["gradient_centered", "gradient_upwind", "divergence_centered"])
@@ -154,7 +182,8 @@ def test_the_raise_names_the_scheme_and_the_way_out(scheme):
     message = str(exc.value)
     assert scheme in message, "the offending scheme must be named"
     assert "divergence_upwind" in message, "the accept-list must be shown"
-    assert "U_solution_for_drift" in message, "the alternative channel must be named"
+    assert "U_solution_for_drift" in message, "the internal parameter must be named"
+    assert "potential_field" in message, "the PUBLIC parameter a caller can actually type must be named"
 
 
 def test_callable_drift_channel_also_runs_for_maximize():


### PR DESCRIPTION
Closes #1632.

## The defect

Only `divergence_upwind` reads `interface_velocity`. The other three schemes ignored it — and by the time they run, the `velocity_field is not None` branch has already replaced U with a zero-U `_DriftDispatcher`. So **both** drift channels were discarded and the solve ran at zero drift, returning a finite, mass-conserving, converged-looking pure-diffusion density. Nothing in the output distinguished it from a correct solve.

Two code comments and a test docstring stated that these schemes "fall back to `-c*grad(U)`". They do not — U is gone by then.

Measured before the guard (2D, N=8, NT=40, no-flux, non-uniform density; A = U only, B = U + velocity, C = zero U):

| scheme | A | B | C | \|B−A\| | \|B−C\| |
|---|---|---|---|---|---|
| `divergence_upwind` | 0.273729 | 0.431622 | 0.373400 | 2.29e-02 | 8.13e-03 |
| `gradient_upwind` | 0.300100 | 0.367513 | 0.367513 | 2.14e-02 | **0.000e+00** |

**Reachability, corrected after review.** I first wrote that this was the path *every* non-separable Hamiltonian takes. Measured, it is not: on the auto-routed coupling path a non-quadratic-MINIMIZE-separable `H` makes `fp_drift_coefficient` raise first (#1542), and for the quadratic-MINIMIZE separable class `resolve_fp_drift_kwargs` sends `potential_field=U`, never a velocity. The combination is unreachable there.

It is reachable by an **explicit** velocity, which is how the two integration tests hit it:
- `FPFDMSolver(prob, advection_scheme=<non-consuming>).solve_fp_system(m0, drift_field=<ndarray>)`
- `FixedPointIterator(..., drift_field=<ndarray>)` — a public constructor parameter forwarded verbatim, bypassing the smoothness dispatch entirely.

## The fix

Raise `NotImplementedError` when a **non-zero** `velocity_field` meets a scheme outside `_INTERFACE_VELOCITY_SCHEMES`. Same fail-loud choice already made at `base_mfg.py:215` for `source_term`, where dropping the term silently "would solve the wrong problem (#1424)".

The non-zero qualifier is not cosmetic. My first cut raised unconditionally and broke six tests that were doing nothing wrong: `FPFDMSolver` sets `_internal_velocity` whenever `drift_field` is an ndarray, so the diffusion-only callers reach every scheme carrying a zero velocity array. Discarding a zero velocity changes nothing, so the guard fires exactly when discarding would change the answer.

## What the blast radius turned up

Two integration tests were passing their drift through the dead channel and therefore measuring pure diffusion under a drift test's name. One is the **#1149 boundary-flux pin**, whose docstring reads *"the drift pushes toward it, so the boundary-face flux is exercised"* and *"a mid-domain density (as an earlier version of this test used) is blind to it"* — the author knew discrimination mattered, and the drift still never arrived.

Both rerouted to `potential_field`, which these schemes do consume (valid here: the Hamiltonian is smooth separable, so the solver forms `alpha = -c*grad(U)` internally). Verified the new channel is live rather than a second dead one:

```
with U   : final centre of mass = 0.032594   mass = 1.000000000000
zero U   : final centre of mass = 0.169221   mass = 1.000000000000
|diff|max = 1.386e+01
```

**The potential must be non-linear, and my first attempt was not.** With `U = x` the #1149 fix is invisible: it makes the boundary handler evaluate the shared face velocity with the interior's central stencil `(U[2]-U[0])/(2dx)` rather than the one-sided `(U[1]-U[0])/dx`, and those are algebraically identical on a linear U. Reverting both walls to the one-sided form left the mass drift at 3.9e-15 and the test green — blind for a new reason instead of the old one.

Now `U = x + x²/2`. Same mutation moves the drift to 3.0e-02 and the test fails; restored, 8 tests pass. So the #1149 pin discriminates for the first time — before this PR the old test drove `u_flat ≡ 0`, so every advection contribution in the boundary handler was exactly zero and no advection mutation of any kind was visible.

## Oracle

Per AGENTS.md's ladder this is tier 2, a **mutation-verified pin**: disabling the guard (`if False and ...`) fails 6 of the new tests. The pins are failure-mode assertions — the input that should raise, asserted to raise, with a greppable message naming the scheme, the accept-list, and the alternative channel.

`test_a_zero_velocity_is_not_an_error` pins the narrowing itself, so a future tightening to an unconditional raise fails here rather than in the torus and mass-leak suites.

The pre-existing `test_consuming_scheme_actually_honors_the_velocity` already pins that the accept-list is truthful; I wrote a weaker duplicate of it and deleted my own before committing.

## Gate

`./scripts/local_ci.sh` green via the pre-push hook. Blast radius by path (18 files touching `velocity_field` / `advection_scheme` / `solve_fp_nd_full_system`): 337 passed, 1 xfailed.

## Carried separately

Commit 1 is an unrelated AGENTS.md workflow note (the push-time gate ladder), approved earlier and never committed. One commit each, per AGENTS.md's batching rule.


## Review

Independent adversarial review returned **3 blockers**, all confirmed and fixed in `90ca2626`:

1. The rerouted #1149 pin was still blind (linear potential) — fixed and mutation-verified above.
2. The stated ground for the narrowing was false. It is not the velocity that gets discarded: the `velocity_field is not None` branch replaces U with a zero-U dispatcher whatever the magnitude. A zero velocity supplied *alongside* a real U therefore produces exactly the silent wrong answer this guard exists to stop — 2.1e-2 off, the same size as the defect — and my test pinned that hole open. The guard now raises when a U is present too, with `test_a_zero_velocity_alongside_a_real_u_still_raises` covering it.
3. A new comment claimed the `else` branch is reached only when no velocity was given; instrumentation shows an accepted zero velocity reaches it and resolves a real coefficient. Corrected.

Non-blocking items also fixed: the diagnostic now names the public `potential_field` alongside the internal `U_solution_for_drift`; scheme-name validation runs before the velocity guard so a typo reports itself; two remaining `drift_field=U_zero` sites rerouted; the changelog no longer generalises the pure-diffusion claim to all three schemes (measured: `gradient_upwind` leaks, both centered schemes abort on the mass-fabrication gate).
