### PR TITLE
feat: thread source_term through the WENO 1D path so MMS can reach it

### DIFF
--- a/changelog.d/1991-weno-source-term.added.md
+++ b/changelog.d/1991-weno-source-term.added.md
@@ -1,7 +1,11 @@
 `HJBWENOSolver.solve_hjb_system` accepts `source_term`, so a manufactured solution can reach it.
-MMS forcing enters through that slot and 8 of 11 HJB solvers did not accept it, which made WENO's
-order unmeasurable rather than merely unverified. The forcing enters each SSP-RK3 stage at that
-stage's own time; added once after the step it is explicit Euler for the source and caps the whole
-scheme at first order. Measured with the 1D reduction of the GFDM paper's manufactured pair: EOC
-2.00 at sigma=1 (the central second-difference diffusion sets the rate) and 5.70/5.43 at sigma=0.05
-(HJ-WENO5 sets it). Multi-D refuses the argument rather than applying it once per axis sweep.
+MMS forcing enters through that slot and most HJB solvers do not accept it, which made WENO's order
+unmeasurable rather than merely unverified. The forcing enters each SSP-RK3 stage at that stage's
+own time (backward stage times t, t-dt, t-dt/2); added once after the step it is explicit Euler for
+the source and caps the whole scheme at first order. `x` follows the documented `(N, d)` contract
+from the abstract base, so one manufactured source runs against FDM and WENO alike. Multi-D refuses
+the argument rather than applying it once per axis sweep. Measured with the 1D reduction of the GFDM
+paper's manufactured pair: HJ-WENO5 delivers fifth order (EOC 5.41, 5.04, 5.01 at sigma=0.0005),
+while the scheme's overall order is capped at 2 by the central second-difference diffusion (EOC 2.00
+at sigma=1). The two error terms have opposite signs and cancel at intermediate sigma, which is why
+an intermediate sweep shows an inflated 5.43 followed by 0.86 rather than a clean crossover.

--- a/changelog.d/1991-weno-source-term.added.md
+++ b/changelog.d/1991-weno-source-term.added.md
@@ -1,0 +1,7 @@
+`HJBWENOSolver.solve_hjb_system` accepts `source_term`, so a manufactured solution can reach it.
+MMS forcing enters through that slot and 8 of 11 HJB solvers did not accept it, which made WENO's
+order unmeasurable rather than merely unverified. The forcing enters each SSP-RK3 stage at that
+stage's own time; added once after the step it is explicit Euler for the source and caps the whole
+scheme at first order. Measured with the 1D reduction of the GFDM paper's manufactured pair: EOC
+2.00 at sigma=1 (the central second-difference diffusion sets the rate) and 5.70/5.43 at sigma=0.05
+(HJ-WENO5 sets it). Multi-D refuses the argument rather than applying it once per axis sweep.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -648,23 +648,27 @@ class HJBWENOSolver(BaseHJBSolver):
         # (1.445e-3 -> 9.16e-5 over 16x refinement, EOC 1.00), hiding the spatial order the study
         # exists to measure. Backward marching mirrors the forward SSP-RK3 stage times
         # t, t + dt, t + dt/2 into t, t - dt, t - dt/2.
-        def src(stage_t):
+        # Offsets rather than absolute stage times, so `t_now` is never arithmetic'd when there
+        # is no source. The previous form guarded each call site with `None if t_now is None`,
+        # which was dead on every reachable path and, had it fired, would only have handed `None`
+        # to the caller's source_fn.
+        def src(dt_offset):
             if source_fn is None:
                 return 0.0
-            return np.asarray(source_fn(stage_t), dtype=float).reshape(u.shape)
+            return np.asarray(source_fn(t_now + dt_offset), dtype=float).reshape(u.shape)
 
         if self.time_integration == "tvd_rk3":
             # Stage 1
-            k1 = self._compute_hjb_rhs_axis(u, m, axis) + src(t_now)
+            k1 = self._compute_hjb_rhs_axis(u, m, axis) + src(0.0)
             u1 = u + dt * k1
             # Stage 2
-            k2 = self._compute_hjb_rhs_axis(u1, m, axis) + src(t_now if t_now is None else t_now - dt)
+            k2 = self._compute_hjb_rhs_axis(u1, m, axis) + src(-dt)
             u2 = (3 / 4) * u + (1 / 4) * u1 + (1 / 4) * dt * k2
             # Stage 3
-            k3 = self._compute_hjb_rhs_axis(u2, m, axis) + src(t_now if t_now is None else t_now - 0.5 * dt)
+            k3 = self._compute_hjb_rhs_axis(u2, m, axis) + src(-0.5 * dt)
             return (1 / 3) * u + (2 / 3) * u2 + (2 / 3) * dt * k3
         elif self.time_integration == "explicit_euler":
-            return u + dt * (self._compute_hjb_rhs_axis(u, m, axis) + src(t_now))
+            return u + dt * (self._compute_hjb_rhs_axis(u, m, axis) + src(0.0))
         else:
             raise ValueError(f"Unknown time integration: {self.time_integration}")
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -51,6 +51,9 @@ from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 from .base_hjb import BaseHJBSolver
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+if TYPE_CHECKING:
     from mfgarchon.core.mfg_problem import MFGProblem
 
 WenoVariant = Literal["weno5", "weno-z", "weno-m", "weno-js"]
@@ -622,7 +625,15 @@ class HJBWENOSolver(BaseHJBSolver):
         """
         return self._solve_hjb_step_axis(u_current, m_current, dt, axis=0)
 
-    def _solve_hjb_step_axis(self, u: np.ndarray, m: np.ndarray, dt: float, axis: int) -> np.ndarray:
+    def _solve_hjb_step_axis(
+        self,
+        u: np.ndarray,
+        m: np.ndarray,
+        dt: float,
+        axis: int,
+        source_fn: Callable | None = None,
+        t_now: float | None = None,
+    ) -> np.ndarray:
         """One backward time step of the 1D HJB operator along ``axis``.
 
         The spatial discretisation (HJ-WENO5 derivatives + Lax-Friedrichs
@@ -631,18 +642,30 @@ class HJBWENOSolver(BaseHJBSolver):
         the 1D solve (axis 0) and for every direction of the multi-D
         dimensional split.
         """
+
+        # Issue #1991: the MMS forcing must enter each SSP-RK3 stage at that stage's own time,
+        # not be added once after the step. Added afterwards it is explicit Euler for the source
+        # and caps the whole scheme at O(dt) -- measured: the error halved with dt at fixed dx
+        # (1.445e-3 -> 9.16e-5 over 16x refinement, EOC 1.00), hiding the spatial order the study
+        # exists to measure. Backward marching mirrors the forward SSP-RK3 stage times
+        # t, t + dt, t + dt/2 into t, t - dt, t - dt/2.
+        def src(stage_t):
+            if source_fn is None:
+                return 0.0
+            return np.asarray(source_fn(stage_t), dtype=float).reshape(u.shape)
+
         if self.time_integration == "tvd_rk3":
             # Stage 1
-            k1 = self._compute_hjb_rhs_axis(u, m, axis)
+            k1 = self._compute_hjb_rhs_axis(u, m, axis) + src(t_now)
             u1 = u + dt * k1
             # Stage 2
-            k2 = self._compute_hjb_rhs_axis(u1, m, axis)
+            k2 = self._compute_hjb_rhs_axis(u1, m, axis) + src(None if t_now is None else t_now - dt)
             u2 = (3 / 4) * u + (1 / 4) * u1 + (1 / 4) * dt * k2
             # Stage 3
-            k3 = self._compute_hjb_rhs_axis(u2, m, axis)
+            k3 = self._compute_hjb_rhs_axis(u2, m, axis) + src(None if t_now is None else t_now - 0.5 * dt)
             return (1 / 3) * u + (2 / 3) * u2 + (2 / 3) * dt * k3
         elif self.time_integration == "explicit_euler":
-            return u + dt * self._compute_hjb_rhs_axis(u, m, axis)
+            return u + dt * (self._compute_hjb_rhs_axis(u, m, axis) + src(t_now))
         else:
             raise ValueError(f"Unknown time integration: {self.time_integration}")
 
@@ -878,6 +901,7 @@ class HJBWENOSolver(BaseHJBSolver):
         U_terminal: np.ndarray | None = None,
         U_coupling_prev: np.ndarray | None = None,
         volatility_field: float | np.ndarray | None = None,
+        source_term: Callable | None = None,
     ) -> np.ndarray:
         """
         Solve the complete HJB system using WENO spatial discretization.
@@ -923,8 +947,16 @@ class HJBWENOSolver(BaseHJBSolver):
             raise ValueError("U_coupling_prev is required")
 
         # Dispatch to dimensional solvers (using internal variable names)
+        if source_term is not None and self.dimension != 1:
+            raise NotImplementedError(
+                f"HJBWENOSolver: source_term is threaded through the 1D path only; this problem is "
+                f"{self.dimension}D. The multi-D path is a dimensional split, so a source added in "
+                f"each axis sweep would be applied {self.dimension} times per step. Accepting it "
+                f"here would silently solve the wrong problem, which is the failure Issue #1424 "
+                f"names. Tracked in Issue #1991."
+            )
         if self.dimension == 1:
-            return self._solve_hjb_system_1d(M_density, U_terminal, U_coupling_prev)
+            return self._solve_hjb_system_1d(M_density, U_terminal, U_coupling_prev, source_term)
         elif self.dimension == 2:
             return self._solve_hjb_system_2d(M_density, U_terminal, U_coupling_prev)
         elif self.dimension == 3:
@@ -998,8 +1030,16 @@ class HJBWENOSolver(BaseHJBSolver):
         M_density_evolution_from_FP: np.ndarray,
         U_final_condition_at_T: np.ndarray,
         U_from_prev_picard: np.ndarray,
+        source_term: Callable | None = None,
     ) -> np.ndarray:
-        """Solve 1D HJB system (original implementation)."""
+        """Solve 1D HJB system (original implementation).
+
+        ``source_term(t, x) -> array`` is the MMS forcing ``r_u`` of
+        ``-u_t - (sigma^2/2) u_xx + H(x, u_x, m) = r_u``. It is added once per CFL sub-step at
+        that sub-step's own physical time, not once per interval: ``_advance_full_interval``
+        may take many sub-steps per ``dt``, and forcing the whole interval at each of them
+        would scale the source by the sub-step count.
+        """
         # Extract dimensions from input
         # M_density has shape (n_time_points, Nx) where n_time_points = problem.Nt + 1
         n_time_points = M_density_evolution_from_FP.shape[0]
@@ -1011,6 +1051,10 @@ class HJBWENOSolver(BaseHJBSolver):
 
         # Set final condition (last time index)
         U_solved[-1, :] = U_final_condition_at_T
+        if source_term is not None:
+            bounds_1d = self._get_domain_bounds()[0]
+            x_grid = np.linspace(bounds_1d[0], bounds_1d[1], Nx)
+            forcing = lambda tt: source_term(tt, x_grid)  # noqa: E731
 
         # Backward time integration
         for t_idx in range(n_time_points - 2, -1, -1):
@@ -1021,8 +1065,22 @@ class HJBWENOSolver(BaseHJBSolver):
             u_current = U_solved[t_idx + 1, :].copy()
 
             # Sub-step over the full interval dt under the CFL/diffusion limit (Issue #1180)
+            if source_term is None:
+                step_fn = self.solve_hjb_step
+            else:
+                # `_advance_full_interval` marches backward from the later endpoint of this
+                # interval, so the clock starts at (t_idx + 1) * dt and decreases by each
+                # accepted sub-step. `solve_hjb_step` returns u + dt_sub * k with k = -u_t,
+                # so the forcing enters with the same sign as k.
+                clock = [(t_idx + 1) * dt]
+
+                def step_fn(u, m, dt_sub, _clock=clock):
+                    u_next = self._solve_hjb_step_axis(u, m, dt_sub, 0, source_fn=forcing, t_now=_clock[0])
+                    _clock[0] -= dt_sub
+                    return u_next
+
             U_solved[t_idx, :] = self._advance_full_interval(
-                u_current, m_current, dt, self._compute_dt_stable_1d, self.solve_hjb_step
+                u_current, m_current, dt, self._compute_dt_stable_1d, step_fn
             )
 
         return U_solved

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -53,7 +53,6 @@ from .base_hjb import BaseHJBSolver
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-if TYPE_CHECKING:
     from mfgarchon.core.mfg_problem import MFGProblem
 
 WenoVariant = Literal["weno5", "weno-z", "weno-m", "weno-js"]
@@ -659,10 +658,10 @@ class HJBWENOSolver(BaseHJBSolver):
             k1 = self._compute_hjb_rhs_axis(u, m, axis) + src(t_now)
             u1 = u + dt * k1
             # Stage 2
-            k2 = self._compute_hjb_rhs_axis(u1, m, axis) + src(None if t_now is None else t_now - dt)
+            k2 = self._compute_hjb_rhs_axis(u1, m, axis) + src(t_now if t_now is None else t_now - dt)
             u2 = (3 / 4) * u + (1 / 4) * u1 + (1 / 4) * dt * k2
             # Stage 3
-            k3 = self._compute_hjb_rhs_axis(u2, m, axis) + src(None if t_now is None else t_now - 0.5 * dt)
+            k3 = self._compute_hjb_rhs_axis(u2, m, axis) + src(t_now if t_now is None else t_now - 0.5 * dt)
             return (1 / 3) * u + (2 / 3) * u2 + (2 / 3) * dt * k3
         elif self.time_integration == "explicit_euler":
             return u + dt * (self._compute_hjb_rhs_axis(u, m, axis) + src(t_now))
@@ -1035,10 +1034,10 @@ class HJBWENOSolver(BaseHJBSolver):
         """Solve 1D HJB system (original implementation).
 
         ``source_term(t, x) -> array`` is the MMS forcing ``r_u`` of
-        ``-u_t - (sigma^2/2) u_xx + H(x, u_x, m) = r_u``. It is added once per CFL sub-step at
-        that sub-step's own physical time, not once per interval: ``_advance_full_interval``
-        may take many sub-steps per ``dt``, and forcing the whole interval at each of them
-        would scale the source by the sub-step count.
+        ``-u_t - (sigma^2/2) u_xx + H(x, u_x, m) = r_u``, with ``x`` of shape ``(N, d)`` per the
+        contract in :mod:`base_hjb`. It enters as a *rate* in each RK stage and is multiplied by
+        the sub-step there, evaluated at that sub-step's own physical time, so the clock has to
+        advance with the sub-steps rather than per interval.
         """
         # Extract dimensions from input
         # M_density has shape (n_time_points, Nx) where n_time_points = problem.Nt + 1
@@ -1052,8 +1051,11 @@ class HJBWENOSolver(BaseHJBSolver):
         # Set final condition (last time index)
         U_solved[-1, :] = U_final_condition_at_T
         if source_term is not None:
-            bounds_1d = self._get_domain_bounds()[0]
-            x_grid = np.linspace(bounds_1d[0], bounds_1d[1], Nx)
+            # base_hjb.py documents the contract as `source_term(t, x)` with x of shape (N, d),
+            # and both existing implementations get it from the geometry. Building a bare (N,)
+            # linspace here would make one manufactured source unrunnable across two solvers,
+            # which defeats the point of a shared MMS channel.
+            x_grid = self.problem.geometry.get_spatial_grid()
             forcing = lambda tt: source_term(tt, x_grid)  # noqa: E731
 
         # Backward time integration

--- a/tests/unit/test_alg/test_weno_mms_order_1991.py
+++ b/tests/unit/test_alg/test_weno_mms_order_1991.py
@@ -23,20 +23,41 @@ made exact for  -u_t - (sigma^2/2) u_xx + (1/2) u_x^2 = r_u.
 compatible with the no-flux boundary the solver imposes -- the boundary is not a separate
 error source here.
 
-What the measurement showed, and why both rates are correct:
+What the measurement shows:
 
-    sigma = 1.00   EOC 2.02, 1.98, 2.00      diffusion-dominated
-    sigma = 0.05   EOC 5.70, 5.43            advection-dominated
+    sigma = 1.0000   EOC 2.02, 1.98, 2.00           diffusion-dominated
+    sigma = 0.0005   EOC 5.41, 5.04, 5.01           advection-dominated, clean
+    sigma = 0.0500   EOC 5.70, 5.43, 0.86           advection-dominated, CONTAMINATED
 
-The total error is C5*h^5 from the HJ-WENO5 reconstruction plus C2*h^2 from the central
-second-difference diffusion, with C2 proportional to sigma^2. At sigma = 1 the second-order
-term dominates everywhere. At sigma = 0.05 the fifth-order term dominates until h^5 falls
-below it, after which the rate crosses back to 2 -- measured at Nx = 161 -> 321, EOC 1.91,
-and confirmed spatial rather than temporal because the error is bit-identical across
-Nt = 40, 80, 160, 320.
+The error has two terms of OPPOSITE sign: the HJ-WENO5 reconstruction at O(h^5) and the
+central second-difference diffusion at O(h^2), the latter scaling with sigma^2. They cancel,
+and an earlier version of this docstring asserted the same model with both terms positive --
+which confines the EOC to [2, 5] and so forbids the 0.86 sitting in its own table. Signed
+error at x = 0, sigma = 0.05:
 
-So WENO5 does deliver its advertised order; the scheme's overall order is capped by the
-diffusion discretisation, which is a design property and not a defect.
+    Nx= 21  -2.982166e-04
+    Nx= 41  -5.751384e-06
+    Nx= 81  +1.248895e-07     <- sign change: the two terms cross here
+    Nx=161  +7.366815e-08
+    Nx=321  +1.964453e-08
+
+So at sigma = 0.05 the 5.43 is inflated by the approaching cancellation and the 0.86 is its
+far side -- neither is a clean rate, and neither is "the order crossing back to 2". Pushing
+the diffusion out of range at sigma = 0.0005 removes the cancellation and gives 5.41, 5.04,
+5.01: HJ-WENO5 delivers its advertised fifth order, and the scheme's overall order is capped
+by the second-order diffusion discretisation, which is a design property, not a defect.
+
+WHAT THIS STUDY CANNOT SEE. `a1` is linear in `t`, so the exact trajectory is a straight line
+and SSP-RK3 integrates it exactly: the L-infinity error is 5.7514e-06 at Nx=41 for EVERY Nt
+from 10 to 320, EOC 0.00 throughout. That is deliberate -- it isolates the spatial operator --
+but it means no number here establishes third-order-in-time. It cuts the useful way for the
+stage-time tests: because the correct assignment drives the temporal error to zero rather than
+merely small, a wrong stage time is not buried under it but stands out as a flat O(dt) floor.
+
+The Nt-independence at Nx=161 is 7.3668145e-08 vs 7.3668131e-08 across Nt = 40 to 320 --
+identical to seven significant figures, not bit-identical as previously claimed; the sub-step
+sequence does change with Nt. The conclusion that the floor is spatial survives; the word did
+not.
 """
 
 import pytest
@@ -142,14 +163,19 @@ def test_diffusion_dominated_order_is_two():
 
 
 def test_advection_dominated_order_reaches_weno5():
-    """sigma small: HJ-WENO5 sets the rate and must clear fourth order.
+    """sigma tiny: HJ-WENO5 sets the rate, uncontaminated, and must clear fourth order.
 
-    Bounded below at 4 rather than pinned near 5 because the C2*h^2 diffusion term is present
-    at every level and pulls the fitted slope down as h shrinks; the crossover is real and
-    documented in the module docstring, so a tight two-sided band here would be pinning the
-    crossover location rather than the reconstruction order.
+    sigma = 0.0005 rather than 0.05, and Nx 41->81 rather than 21->41, both deliberately. At
+    sigma = 0.05 the O(h^2) diffusion term and the O(h^5) reconstruction have opposite signs and
+    cancel near h ~ 0.3, which inflates the 41->81 slope to 5.43 and collapses the next one to
+    0.86; and the 21->41 pair is pre-asymptotic, its EOC of 5.70 sitting ABOVE the design order,
+    which is the diagnostic that it is not yet asymptotic. Neither is a sound certificate even
+    though both clear the threshold. Here the measured ladder is 5.41, 5.04, 5.01.
+
+    Bounded below rather than pinned two-sided: the assertion should fail when the reconstruction
+    degrades, not when the crossover moves.
     """
-    order = _eoc(21, 41, nt=20, sigma=0.05)
+    order = _eoc(41, 81, nt=20, sigma=0.0005)
     assert order > 4.0, f"HJ-WENO5 should clear 4th order in the advection-dominated regime, got {order:.2f}"
 
 

--- a/tests/unit/test_alg/test_weno_mms_order_1991.py
+++ b/tests/unit/test_alg/test_weno_mms_order_1991.py
@@ -1,9 +1,15 @@
 """MMS order verification for HJBWENOSolver (Issue #1991).
 
-`source_term` is the slot MMS forcing enters through, and 8 of 11 HJB solvers did not
-accept it -- so no manufactured solution could reach WENO at all, and its order was not
-merely unverified but unmeasurable. This threads it through the 1D path and pins what the
+`source_term` is the slot MMS forcing enters through, and most HJB solvers do not accept it
+-- so no manufactured solution could reach WENO at all, and its order was not merely
+unverified but unmeasurable. This threads it through the 1D path and pins what the
 resulting measurement shows.
+
+(A census by parameter name gave 8 of 11 lacking it. That over-counts: `HJBGFDMSolver` has
+the same channel under the name `running_cost`, with a different convention -- `f(n) ->
+(n_points,)` rather than `f(t, x)`. The capability gate keys on the name `source_term`, so
+it rejects GFDM for lacking a capability GFDM has. Tracked on #1991; a divergent mechanism
+rather than a missing one, and not this PR's to fix.)
 
 The oracle is external in AGENTS.md's sense: an exact solution constructed independently of
 the scheme, not a second code path. The manufactured pair is the 1D reduction of the coupled

--- a/tests/unit/test_alg/test_weno_mms_order_1991.py
+++ b/tests/unit/test_alg/test_weno_mms_order_1991.py
@@ -1,0 +1,160 @@
+"""MMS order verification for HJBWENOSolver (Issue #1991).
+
+`source_term` is the slot MMS forcing enters through, and 8 of 11 HJB solvers did not
+accept it -- so no manufactured solution could reach WENO at all, and its order was not
+merely unverified but unmeasurable. This threads it through the 1D path and pins what the
+resulting measurement shows.
+
+The oracle is external in AGENTS.md's sense: an exact solution constructed independently of
+the scheme, not a second code path. The manufactured pair is the 1D reduction of the coupled
+MMS in the GFDM paper (`chapters/appendix.tex`, eq:mms_reference / eq:mms_system):
+
+    ubar(t,x) = a1(t) cos(c x),   a1(t) = 1 + (T - t)/(2T),   c = 2 pi / L
+
+made exact for  -u_t - (sigma^2/2) u_xx + (1/2) u_x^2 = r_u.
+
+`ubar_x = -a1 c sin(c x)` vanishes at both walls, so the manufactured solution is exactly
+compatible with the no-flux boundary the solver imposes -- the boundary is not a separate
+error source here.
+
+What the measurement showed, and why both rates are correct:
+
+    sigma = 1.00   EOC 2.02, 1.98, 2.00      diffusion-dominated
+    sigma = 0.05   EOC 5.70, 5.43            advection-dominated
+
+The total error is C5*h^5 from the HJ-WENO5 reconstruction plus C2*h^2 from the central
+second-difference diffusion, with C2 proportional to sigma^2. At sigma = 1 the second-order
+term dominates everywhere. At sigma = 0.05 the fifth-order term dominates until h^5 falls
+below it, after which the rate crosses back to 2 -- measured at Nx = 161 -> 321, EOC 1.91,
+and confirmed spatial rather than temporal because the error is bit-identical across
+Nt = 40, 80, 160, 320.
+
+So WENO5 does deliver its advertised order; the scheme's overall order is capped by the
+diffusion discretisation, which is a design property and not a defect.
+"""
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import HJBWENOSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+L = 20.0
+T = 4.0
+C = 2.0 * np.pi / L
+
+
+def _a1(t):
+    return 1.0 + (T - t) / (2.0 * T)
+
+
+def _u_exact(t, x):
+    return _a1(t) * np.cos(C * x)
+
+
+def _source(t, x, sigma):
+    x = np.asarray(x, dtype=float)
+    u_t = (-1.0 / (2.0 * T)) * np.cos(C * x)
+    u_xx = -_a1(t) * C**2 * np.cos(C * x)
+    u_x = -_a1(t) * C * np.sin(C * x)
+    return -u_t - 0.5 * sigma**2 * u_xx + 0.5 * u_x**2
+
+
+def _problem(nx, nt, sigma, dimension=1):
+    bounds = [(0.0, L)] * dimension
+    grid = TensorProductGrid(
+        bounds=bounds, Nx_points=[nx] * dimension, boundary_conditions=no_flux_bc(dimension=dimension)
+    )
+    if dimension == 1:
+        m_initial = lambda x: np.ones_like(np.asarray(x, dtype=float)) / L  # noqa: E731
+        u_terminal = lambda x: _u_exact(T, x)  # noqa: E731
+    else:
+        m_initial = lambda x, y: np.ones_like(np.asarray(x, dtype=float)) / (L * L)  # noqa: E731
+        u_terminal = lambda x, y: np.zeros_like(np.asarray(x, dtype=float))  # noqa: E731
+    comps = MFGComponents(
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+        m_initial=m_initial,
+        u_terminal=u_terminal,
+    )
+    return MFGProblem(geometry=grid, components=comps, T=T, Nt=nt, sigma=sigma)
+
+
+def _linf_error(nx, nt, sigma):
+    problem = _problem(nx, nt, sigma)
+    solver = HJBWENOSolver(problem)
+    x = np.linspace(0.0, L, nx)
+    m = np.tile(np.ones(nx) / L, (nt + 1, 1))
+    u_T = _u_exact(T, x)
+    U = solver.solve_hjb_system(
+        M_density=m,
+        U_terminal=u_T,
+        U_coupling_prev=np.tile(u_T, (nt + 1, 1)),
+        source_term=lambda t, xx: _source(t, xx, sigma),
+    )
+    return np.abs(U[0] - _u_exact(0.0, x)).max()
+
+
+def _eoc(nx_coarse, nx_fine, nt, sigma):
+    e_c = _linf_error(nx_coarse, nt, sigma)
+    e_f = _linf_error(nx_fine, nt, sigma)
+    h_c = L / (nx_coarse - 1)
+    h_f = L / (nx_fine - 1)
+    return np.log(e_c / e_f) / np.log(h_c / h_f)
+
+
+def test_weno_accepts_a_source_term_at_all():
+    """The precondition: without this slot no manufactured solution can reach WENO."""
+    nx, nt, sigma = 41, 20, 1.0
+    problem = _problem(nx, nt, sigma)
+    solver = HJBWENOSolver(problem)
+    x = np.linspace(0.0, L, nx)
+    m = np.tile(np.ones(nx) / L, (nt + 1, 1))
+    u_T = _u_exact(T, x)
+
+    forced = solver.solve_hjb_system(
+        M_density=m,
+        U_terminal=u_T,
+        U_coupling_prev=np.tile(u_T, (nt + 1, 1)),
+        source_term=lambda t, xx: _source(t, xx, sigma),
+    )
+    unforced = solver.solve_hjb_system(M_density=m, U_terminal=u_T, U_coupling_prev=np.tile(u_T, (nt + 1, 1)))
+    assert np.isfinite(forced).all()
+    # Discrimination: the source must actually change the answer, or every order figure
+    # below would be measuring an unforced solve that happens to sit near the exact solution.
+    assert np.abs(forced - unforced).max() > 1e-6, "source_term reached the solver but changed nothing"
+
+
+def test_diffusion_dominated_order_is_two():
+    """sigma = 1: the central second-difference diffusion sets the rate, not WENO5."""
+    order = _eoc(41, 81, nt=20, sigma=1.0)
+    assert 1.7 < order < 2.3, f"expected ~2 (diffusion-limited), measured {order:.2f}"
+
+
+def test_advection_dominated_order_reaches_weno5():
+    """sigma small: HJ-WENO5 sets the rate and must clear fourth order.
+
+    Bounded below at 4 rather than pinned near 5 because the C2*h^2 diffusion term is present
+    at every level and pulls the fitted slope down as h shrinks; the crossover is real and
+    documented in the module docstring, so a tight two-sided band here would be pinning the
+    crossover location rather than the reconstruction order.
+    """
+    order = _eoc(21, 41, nt=20, sigma=0.05)
+    assert order > 4.0, f"HJ-WENO5 should clear 4th order in the advection-dominated regime, got {order:.2f}"
+
+
+def test_source_term_is_refused_rather_than_dropped_in_multi_d():
+    """The multi-D path is a dimensional split, so a source added per axis sweep would be
+    applied `dimension` times per step. Refusing beats silently solving the wrong problem."""
+    problem = _problem(nx=11, nt=5, sigma=1.0, dimension=2)
+    solver = HJBWENOSolver(problem)
+    m = np.ones((6, 11, 11)) / (L * L)
+    u_T = np.zeros((11, 11))
+    with pytest.raises(NotImplementedError, match="1991"):
+        solver.solve_hjb_system(
+            M_density=m, U_terminal=u_T, U_coupling_prev=np.tile(u_T, (6, 1, 1)), source_term=lambda t, x: 0.0
+        )

--- a/tests/unit/test_alg/test_weno_mms_order_1991.py
+++ b/tests/unit/test_alg/test_weno_mms_order_1991.py
@@ -9,10 +9,16 @@ resulting measurement shows.
 the same channel under the name `running_cost`, with a different convention -- `f(n) ->
 (n_points,)` rather than `f(t, x)`. The capability gate keys on the name `source_term`, so
 it rejects GFDM for lacking a capability GFDM has. Tracked on #1991; a divergent mechanism
-rather than a missing one, and not this PR's to fix. The match is established on name and
-signature only -- `hjb_gfdm.py:3354` negates the user running cost before it enters Howard's
-slot, so the SIGN relationship to `source_term` is still open, and a port that carries an FDM
-source into GFDM unchanged would converge on the wrong solution.)
+rather than a missing one, and not this PR's to fix.
+
+The relationship is a plain negation, `running_cost = -source_term`, fixed by two documented
+primitives: `h_eval.py:83` returns the residual `-u_t + H(+running_cost) - D*lap_u`, while the
+source contract at `base_hjb.py:435` is `F(u) = (u-u_next)/dt + H - S = 0`; setting both to
+zero gives the sign. `hjb_gfdm.py:3079` states it directly -- "Added to Hamiltonian:
+H_total = H(x,p,m) + L(t,x)". Measured by running this same manufactured pair through GFDM at
+sigma=1: `-r_u` gives 3.1621e-03 -> 7.9413e-04, EOC 2.0; `+r_u` sits flat at 1.4233 -> 1.4241
+and never converges. So a port carrying an FDM source into GFDM unchanged would converge on the
+wrong solution, and the unified channel #1991 wants can be built on a settled premise.)
 
 The oracle is external in AGENTS.md's sense: an exact solution constructed independently of
 the scheme, not a second code path. The manufactured pair is the 1D reduction of the coupled

--- a/tests/unit/test_alg/test_weno_mms_order_1991.py
+++ b/tests/unit/test_alg/test_weno_mms_order_1991.py
@@ -9,7 +9,10 @@ resulting measurement shows.
 the same channel under the name `running_cost`, with a different convention -- `f(n) ->
 (n_points,)` rather than `f(t, x)`. The capability gate keys on the name `source_term`, so
 it rejects GFDM for lacking a capability GFDM has. Tracked on #1991; a divergent mechanism
-rather than a missing one, and not this PR's to fix.)
+rather than a missing one, and not this PR's to fix. The match is established on name and
+signature only -- `hjb_gfdm.py:3354` negates the user running cost before it enters Howard's
+slot, so the SIGN relationship to `source_term` is still open, and a port that carries an FDM
+source into GFDM unchanged would converge on the wrong solution.)
 
 The oracle is external in AGENTS.md's sense: an exact solution constructed independently of
 the scheme, not a second code path. The manufactured pair is the 1D reduction of the coupled
@@ -33,7 +36,8 @@ The error has two terms of OPPOSITE sign: the HJ-WENO5 reconstruction at O(h^5) 
 central second-difference diffusion at O(h^2), the latter scaling with sigma^2. They cancel,
 and an earlier version of this docstring asserted the same model with both terms positive --
 which confines the EOC to [2, 5] and so forbids the 0.86 sitting in its own table. Signed
-error at x = 0, sigma = 0.05:
+error at x = 0, sigma = 0.05, Nt = 40 (the EOC ladders above are Nt = 20; the sign change
+reproduces at either, but these magnitudes are the Nt = 40 ones):
 
     Nx= 21  -2.982166e-04
     Nx= 41  -5.751384e-06
@@ -48,8 +52,8 @@ the diffusion out of range at sigma = 0.0005 removes the cancellation and gives 
 by the second-order diffusion discretisation, which is a design property, not a defect.
 
 WHAT THIS STUDY CANNOT SEE. `a1` is linear in `t`, so the exact trajectory is a straight line
-and SSP-RK3 integrates it exactly: the L-infinity error is 5.7514e-06 at Nx=41 for EVERY Nt
-from 10 to 320, EOC 0.00 throughout. That is deliberate -- it isolates the spatial operator --
+and SSP-RK3 integrates it exactly: the L-infinity error is 5.7514e-06 at Nx=41, sigma=0.05,
+for EVERY Nt from 10 to 320, EOC 0.00 throughout. That is deliberate -- it isolates the spatial operator --
 but it means no number here establishes third-order-in-time. It cuts the useful way for the
 stage-time tests: because the correct assignment drives the temporal error to zero rather than
 merely small, a wrong stage time is not buried under it but stands out as a flat O(dt) floor.
@@ -188,5 +192,10 @@ def test_source_term_is_refused_rather_than_dropped_in_multi_d():
     u_T = np.zeros((11, 11))
     with pytest.raises(NotImplementedError, match="1991"):
         solver.solve_hjb_system(
-            M_density=m, U_terminal=u_T, U_coupling_prev=np.tile(u_T, (6, 1, 1)), source_term=lambda t, x: 0.0
+            M_density=m,
+            U_terminal=u_T,
+            U_coupling_prev=np.tile(u_T, (6, 1, 1)),
+            # Shape-correct even though it is never called: a scalar return is not a valid
+            # source under the base contract, and the test should not model an unsupported call.
+            source_term=lambda t, x: np.zeros(np.asarray(x).shape[0]),
         )


### PR DESCRIPTION
Refs #1991. Threads `source_term` through `HJBWENOSolver`'s 1D path, and uses it to settle a standing question.

## Why this is the precondition, not one improvement among several

MMS is the only **external** oracle in this library — every other check compares one code path against another. Its forcing enters through `source_term`, and 8 of 11 HJB solvers do not accept that argument (measured by parsing every `solve_hjb_system` with `ast`; posted on #1991). `HJBWENOSolver` is one of them. So WENO's order was not merely unverified: it was **unmeasurable**, which is why the doubt about this implementation had no way to be resolved.

## The subtle part

The forcing enters **each SSP-RK3 stage at that stage's own time** (backward stage times `t`, `t-dt`, `t-dt/2`).

My first cut added it once after the step. That is explicit Euler for the source and caps the whole scheme at first order. Measured, at fixed `dx = 0.25`, `sigma = 0.05`:

| Nt | 40 | 80 | 160 | 320 | 640 |
|---|---|---|---|---|---|
| L∞ | 1.445e-3 | 7.283e-4 | 3.656e-4 | 1.831e-4 | 9.163e-5 |

EOC 1.00 in time — the source injection, not the scheme, and it completely hid the spatial order the study exists to measure.

Multi-D **refuses** the argument rather than accepting it: that path is a dimensional split, so a source added in each axis sweep would be applied `dimension` times per step. Silently solving the wrong problem is the failure #1424 names.

## What it measures

Manufactured pair is the 1D reduction of the coupled MMS in the GFDM paper (`chapters/appendix.tex`, `eq:mms_reference` / `eq:mms_system`):

```
ubar(t,x) = a1(t) cos(c x),   a1(t) = 1 + (T-t)/(2T),   c = 2*pi/L,   L = 20, T = 4
```

exact for `-u_t - (sigma^2/2) u_xx + (1/2) u_x^2 = r_u`. `ubar_x` vanishes at both walls, so it is exactly compatible with the no-flux boundary the solver imposes — the boundary is not a separate error source.

```
sigma = 1.00                          sigma = 0.05
  Nx      h      Linf     EOC           Nx      h      Linf     EOC
  21  1.0000  1.898e-03    --           21  1.0000  2.982e-04    --
  41  0.5000  4.665e-04   2.02          41  0.5000  5.751e-06   5.70
  81  0.2500  1.181e-04   1.98          81  0.2500  1.338e-07   5.43
 161  0.1250  2.958e-05   2.00         161  0.1250  7.367e-08   0.86
```

**HJ-WENO5 delivers its advertised fifth order** — but the `sigma = 0.05` column above is *not* the evidence for it, and my first error model was wrong.

I asserted `error = C5*h^5 + C2*h^2` with both terms positive. Two same-signed terms confine the EOC to `[2, 5]`, so that model forbids the **0.86** sitting in its own table. The terms have **opposite** signs and cancel. Signed error at `x = 0`, `sigma = 0.05`:

```
Nx= 21  -2.982166e-04
Nx= 41  -5.751384e-06
Nx= 81  +1.248895e-07     <- sign change: the two terms cross here
Nx=161  +7.366815e-08
Nx=321  +1.964453e-08
```

So the 5.43 is inflated by the approaching cancellation and the 0.86 is its far side. Neither is a clean rate, and it is not "the order crossing back to 2".

Pushing diffusion out of range removes the cancellation:

```
sigma = 0.0005      Nx  21 -> 41 -> 81 -> 161      EOC  5.41, 5.04, 5.01
```

That is the clean certificate, and it is now what the test asserts (`Nx 41 -> 81`). The previous certifying pair was contaminated twice over: it sat on the cancellation, and `Nx 21 -> 41` is pre-asymptotic — its EOC of **5.70 above the design order** is itself the diagnostic that it is not asymptotic.

`sigma = 1` remains a clean 2.00: the second-order diffusion term dominates at every level. So the scheme's overall order is capped by the diffusion discretisation, a design property rather than a defect.

**What this study cannot see, stated because it is load-bearing.** `a1` is linear in `t`, so the exact trajectory is a straight line and SSP-RK3 integrates it *exactly*: `Linf = 5.7514e-06` at `Nx=41` for **every** `Nt` from 10 to 320, EOC 0.00 throughout. That isolates the spatial operator deliberately, but no number here establishes third-order-in-time. It cuts the useful way for the stage-time tests — a wrong stage time is not buried under a small temporal error, it stands out as a flat `O(dt)` floor.

Correction to a claim in the first version of this body: the Nt-independence is `7.3668145e-08` vs `7.3668131e-08`, identical to **seven significant figures**, not bit-identical. The sub-step sequence does change with Nt. The conclusion that the floor is spatial survives; the word did not.

## Oracle

Tier 1 on AGENTS.md's ladder — an **external oracle**, an exact solution constructed independently of the scheme. It cannot go tautological the way a path-A-vs-path-B agreement test does.

`test_weno_accepts_a_source_term_at_all` carries the discrimination check: the forced and unforced solves must differ, or every order figure would be measuring an unforced solve that happens to sit near the exact solution.

The advection-dominated test is bounded below at 4 rather than pinned near 5, deliberately: the `C2*h^2` term is present at every level and pulls the fitted slope down as `h` shrinks, so a tight two-sided band would be pinning the crossover location rather than the reconstruction order.

## Scope

1D only. The other 7 locked-out solvers, and WENO's multi-D path, stay open on #1991 — the multi-D case needs the source applied once per split step rather than once per axis sweep, which is a larger change than threading an argument.

## Gate

`./scripts/local_ci.sh` green via the pre-push hook. WENO blast radius by path (23 files): 478 passed, 1 skipped, 11 xfailed.


## Review

Independent adversarial review confirmed the headline with two measurements this PR did not have — a truncation decomposition (non-diffusion component EOC 5.43, 5.16, 5.04, 5.01, 5.05 across Nx 21→641) and a `sigma = 0.0005` sweep — and verified the manufactured source symbolically, the sign convention, the stage times against the Shu–Osher tableau, bit-identity of the unforced path, and a 9-variant mutation matrix in which no mutation survives.

It returned **1 blocker**, fixed in `b0f0df50`:

**`source_term` received the wrong `x` shape.** `base_hjb.py` documents the contract as `source_term(t, x)` with `x` of shape `(N, d)`, and both existing implementations take it from `geometry.get_spatial_grid()`. I built a bare `(N,)` linspace. A source written to the documented contract runs through `HJBFDMSolver` and raises `IndexError` through `HJBWENOSolver` — which defeats this PR's own thesis, since the point of `source_term` is that *one* manufactured source reaches every solver. It also propagated into `PenaltyHJBSolver.penalized_source`, which forwards this `x` to `obstacle_fn`. Now uses the geometry; the resulting `U` is bit-identical.

Non-blocking items also fixed: the error model and the certifying pair (above); the undisclosed temporal blindness (above); "bit-identical" (above); a duplicate `if TYPE_CHECKING:` block; dead `None` guards whose only reachable effect would be handing `None` to the caller's `source_fn`; and a docstring sentence describing a sub-step scaling mechanism that is not there.
