### PR TITLE
docs: the hamiltonian example is not congestion

### DIFF
--- a/changelog.d/1992-congestion-docstring.fixed.md
+++ b/changelog.d/1992-congestion-docstring.fixed.md
@@ -1,0 +1,7 @@
+`BaseMFGProblem.hamiltonian`'s docstring no longer calls `0.5*|p|^2 + 0.1*m` a congestion
+Hamiltonian. It is a separable Hamiltonian with a local coupling: congestion means the density
+scales the momentum term, `H = (m^alpha/gamma)(|p|/m^alpha)^gamma` (Gomes-Pimentel-Voskanyan
+p. 116), whereas there `m` sits in a term with no `p` in it. The example now points to
+`CongestionHamiltonian` for the real form, flips the sign to `-0.1*m` so the default is
+Lasry-Lions monotone rather than crowd-attracting, and states that `m` is the scalar density at
+`x` and not the measure, so a nonlocal coupling has to go through `source_term_hjb`.

--- a/changelog.d/1992-congestion-docstring.fixed.md
+++ b/changelog.d/1992-congestion-docstring.fixed.md
@@ -1,5 +1,5 @@
-`BaseMFGProblem.hamiltonian`'s docstring no longer calls `0.5*|p|^2 + 0.1*m` a congestion
-Hamiltonian. It is a separable Hamiltonian with a local coupling: congestion means the density
+`MFGProblemProtocol.hamiltonian`'s docstring no longer calls `0.5*|p|^2 + 0.1*m` a
+congestion Hamiltonian. It is a separable Hamiltonian with a local coupling: congestion means the density
 scales the momentum term, `H = (m^alpha/gamma)(|p|/m^alpha)^gamma` (Gomes-Pimentel-Voskanyan
 p. 116), whereas there `m` sits in a term with no `p` in it. The example now points to
 `CongestionHamiltonian` for the real form, flips the sign to `-0.1*m` so the default is

--- a/mfgarchon/core/base_problem.py
+++ b/mfgarchon/core/base_problem.py
@@ -120,10 +120,21 @@ class MFGProblemProtocol(Protocol):
             Hamiltonian value H(x, m, p, t)
 
         Note:
-            ``m`` is the density AT ``x``, a scalar -- not the measure. A coupling that needs the
-            whole density, such as a convolution ``(k * m)(x)``, cannot be written here; use
-            ``source_term_hjb(x, m_t, v_t, t)``, which receives the full array but is additive and
-            therefore sits outside the optimal-control minimisation.
+            On the grid and mesh interface ``m`` is the density AT ``x``, a scalar -- not the
+            measure. (``NetworkMFGProblem.hamiltonian`` takes a different, 5-argument form and
+            does receive the full nodal array.) A coupling needing the whole density, such as a
+            convolution ``(k * m)(x)``, cannot be written here; route it through
+            ``source_term_hjb(x, m_t, v_t, t)``, which receives the full spatial array at the
+            time slice. Two caveats worth knowing before you do:
+
+            - Only the FDM HJB solvers accept a ``source_term``. Setting ``source_term_hjb``
+              with any of the others raises rather than dropping it silently.
+            - The source is bound to the PREVIOUS Picard iterate and the FP drift is derived
+              from the Hamiltonian alone, never consulting it. A coupling with no ``p`` in it --
+              the usual nonlocal case ``F(x, m)`` -- is fine there and is the canonical
+              Lasry-Lions system. A ``p``-DEPENDENT coupling routed through the source is not:
+              it changes the effective Hamiltonian's minimiser while the FP equation keeps
+              advecting with the original ``-D_p H``, silently breaking the HJB/FP adjoint pair.
 
         Example:
             >>> # Separable Hamiltonian with a LOCAL coupling: H_0(p) plus a term in m alone.
@@ -133,11 +144,17 @@ class MFGProblemProtocol(Protocol):
 
             This is NOT congestion, which this example previously claimed to be. Congestion means
             moving is costlier where the crowd is dense, so the density scales the MOMENTUM term:
-            ``H(x, p, m) = (m**alpha / gamma) * (|p| / m**alpha)**gamma``, i.e. ``0.5*|p|**2 /
-            m**alpha`` at ``gamma = 2`` (Gomes, Pimentel & Voskanyan, *Regularity Theory for
-            Mean-Field Game Systems*, p. 116). Above, ``m`` appears in a term with no ``p`` in it
-            at all. For congestion use :class:`~mfgarchon.core.hamiltonian.CongestionHamiltonian`,
-            which implements that form together with its analytic ``dH/dm``.
+            ``H(x, p, m) = (m**alpha / gamma) * (|p| / m**alpha)**gamma``, for ``1 <= gamma < 2``
+            and ``0 < alpha < 1`` (Gomes, Pimentel & Voskanyan, *Regularity Theory for Mean-Field
+            Game Systems*, p. 116). The quadratic specialisation ``0.5*|p|**2 / m**alpha`` is the
+            shape this library implements; note it sits at ``gamma = 2``, outside the hypotheses of
+            the section cited. Above, ``m`` appears in a term with no ``p`` in it at all.
+
+            For congestion see :class:`~mfgarchon.core.hamiltonian.CongestionHamiltonian`, which is
+            the FAMILY containing that form -- ``H = |p|**2 / (2*lam*c(m)) + V + f(m)`` with a
+            user-supplied ``c(m)``. Pass ``congestion_factor=lambda m: m**alpha`` to obtain the
+            form above, and ``congestion_factor_dm`` if you want ``dH/dm`` analytic rather than by
+            finite difference.
 
             The sign is ``-0.1 * m`` rather than ``+0.1 * m`` so the example is Lasry--Lions
             monotone under the convention pairing ``H`` with ``-u_t + H = 0``. With ``+``, the

--- a/mfgarchon/core/base_problem.py
+++ b/mfgarchon/core/base_problem.py
@@ -119,11 +119,31 @@ class MFGProblemProtocol(Protocol):
         Returns:
             Hamiltonian value H(x, m, p, t)
 
+        Note:
+            ``m`` is the density AT ``x``, a scalar -- not the measure. A coupling that needs the
+            whole density, such as a convolution ``(k * m)(x)``, cannot be written here; use
+            ``source_term_hjb(x, m_t, v_t, t)``, which receives the full array but is additive and
+            therefore sits outside the optimal-control minimisation.
+
         Example:
-            >>> # Quadratic Hamiltonian with congestion
+            >>> # Separable Hamiltonian with a LOCAL coupling: H_0(p) plus a term in m alone.
             >>> def hamiltonian(self, x, m, p, t):
             ...     p_arr = np.array(p) if hasattr(p, '__iter__') else p
-            ...     return 0.5 * np.sum(p_arr**2) + 0.1 * m
+            ...     return 0.5 * np.sum(p_arr**2) - 0.1 * m
+
+            This is NOT congestion, which this example previously claimed to be. Congestion means
+            moving is costlier where the crowd is dense, so the density scales the MOMENTUM term:
+            ``H(x, p, m) = (m**alpha / gamma) * (|p| / m**alpha)**gamma``, i.e. ``0.5*|p|**2 /
+            m**alpha`` at ``gamma = 2`` (Gomes, Pimentel & Voskanyan, *Regularity Theory for
+            Mean-Field Game Systems*, p. 116). Above, ``m`` appears in a term with no ``p`` in it
+            at all. For congestion use :class:`~mfgarchon.core.hamiltonian.CongestionHamiltonian`,
+            which implements that form together with its analytic ``dH/dm``.
+
+            The sign is ``-0.1 * m`` rather than ``+0.1 * m`` so the example is Lasry--Lions
+            monotone under the convention pairing ``H`` with ``-u_t + H = 0``. With ``+``, the
+            coupling is crowd-ATTRACTING and lands in the known non-uniqueness regime -- fine for a
+            manufactured verification instance, where the computed solution is compared against an
+            imposed exact one, but a poor default for an example a reader copies.
         """
         ...
 

--- a/mfgarchon/core/base_problem.py
+++ b/mfgarchon/core/base_problem.py
@@ -129,8 +129,8 @@ class MFGProblemProtocol(Protocol):
 
             - Only the FDM HJB solvers accept a ``source_term``. Setting ``source_term_hjb``
               with any of the others raises rather than dropping it silently.
-            - The source is bound to the PREVIOUS Picard iterate and the FP drift is derived
-              from the Hamiltonian alone, never consulting it. A coupling with no ``p`` in it --
+            - The FP drift is derived from the Hamiltonian alone and never consults the source.
+              A coupling with no ``p`` in it --
               the usual nonlocal case ``F(x, m)`` -- is fine there and is the canonical
               Lasry-Lions system. A ``p``-DEPENDENT coupling routed through the source is not:
               it changes the effective Hamiltonian's minimiser while the FP equation keeps


### PR DESCRIPTION
Refs #1992. One docstring, three wrong things in it — and it is the example a reader copies.

## It is not congestion

`BaseMFGProblem.hamiltonian` labelled this "Quadratic Hamiltonian with congestion":

```python
return 0.5 * np.sum(p_arr**2) + 0.1 * m
```

Congestion means moving is costlier where the crowd is dense, so the density scales the **momentum** term:

$$H(x,p,m)=\frac{m^{\alpha}}{\gamma}\left(\frac{|p|}{m^{\alpha}}\right)^{\gamma},\qquad \text{i.e. } \frac{|p|^2}{2m^{\alpha}} \text{ at } \gamma=2$$

— Gomes, Pimentel & Voskanyan, *Regularity Theory for Mean-Field Game Systems*, p. 116, with the stated motivation *"agents face difficulties in moving at high speed in high-density areas"*. Every congestion model in that corpus is pointwise in `m` and puts it in the momentum term.

In the example `m` sits in a term with no `p` in it at all. Decomposed against Gomes (1.18), it is `H_0(x,p) - F(x,m)` — a **separable Hamiltonian with a local coupling**, the simplest form in the taxonomy.

The library already implements the real thing in `CongestionHamiltonian`, with an analytic `dH/dm`. The docstring now points there.

## The sign was the non-uniqueness one

Under the convention pairing `H` with `-u_t + H = 0` (Gomes (1.18), Cardaliaguet (4.13), CDLL (1.7), Bardi–Cirant (1.1) all use it), `F(x,m) = -0.1m` gives

$$\int\big(F(x,m_1)-F(x,m_2)\big)(m_1-m_2)\,dx = -0.1\int(m_1-m_2)^2 < 0$$

— crowd-**attracting**, violating Lasry–Lions monotonicity, in the regime where the known counterexamples to uniqueness live. Now `-0.1 * m`.

Worth saying what this is *not*: a non-monotone sign is perfectly legitimate in a manufactured verification instance, and the GFDM paper's own MMS takes it deliberately (`chapters/appendix.tex`: *"its congestion enters with the sign opposite… so it is not Lasry–Lions monotone… Neither affects the measured order, which compares a computed solution against an imposed exact one"*). The objection is to it being the **default example**, not to the sign as such.

## `m` is a scalar, and the docstring never said so

Added: `m` is the density **at** `x`, not the measure. A coupling needing the whole density — a convolution `(k*m)(x)`, the standard nonlocal form and the one the mainline MFG literature actually uses — cannot be written in this slot at all. It has to go through `source_term_hjb(x, m_t, v_t, t)`, which receives the full array but is additive and therefore sits **outside** the optimal-control minimisation.

That last distinction is the one that decides which MFG forms this interface can express, so it belongs where a reader implementing a Hamiltonian will see it.

## Gate

Docstring only, no behaviour change. `tests/unit/test_core`: 698 passed, 3 xfailed. Full gate green via the pre-push hook.

## One qualification on this PR's own framing

Review measured that `MFGProblem` — the library's main concrete problem class — does not implement `hamiltonian` at all (`hasattr(MFGProblem, "hamiltonian")` is `False`; it uses `H(x_idx, m_at_x, derivs, t_idx)` plus `hamiltonian_class`). `MFGProblemProtocol` is a `typing.Protocol` with a `...` body, `@runtime_checkable`, which checks attribute presence only — so nothing enforces it, and the protocol's own class docstring asserting `isinstance(problem, MFGProblemProtocol)` is false.

So "the example a reader copies" is softer than written. Real implementers of the 4-argument form exist — `examples/advanced/capacity_constrained_mfg/problem.py:149` and four test files — but the library's flagship class is not one of them. That does not weaken the correctness argument: a false statement in the norm is worth fixing whether or not traffic reaches it, and fixing the instances first would have meant correcting them against a specification that was itself wrong. It does mean the priority claim was overstated. Tracked on #1996, which also carries the same congestion mislabel in that example.
