### PR TITLE
refactor: one owner for the alpha-independent running cost

### DIFF
--- a/changelog.d/1991-gfdm-source-term.added.md
+++ b/changelog.d/1991-gfdm-source-term.added.md
@@ -1,9 +1,10 @@
 `HJBGFDMSolver.solve_hjb_system` accepts `source_term`, so a manufactured solution reaches GFDM
 through **both** inner solvers. The capability gate keys on that parameter name and had been
-rejecting GFDM for lacking a channel it already had under the name `running_cost`. The two are
-deliberately not unified: their signs are opposite (`running_cost = -source_term`, since `h_eval`
-assembles `-u_t + H(+running_cost) - D*lap_u` while the source contract subtracts), so the solver
-holds them as separate attributes and adds them at the call site. Measured with the 1D reduction of
+rejecting GFDM for lacking a channel it already had under the name `running_cost`. Their signs are opposite
+(`additive_source = -source_term`, since `h_eval` assembles `-u_t + H(+additive_source) - D*lap_u`
+while the source contract subtracts), and the solver converted between them at the call site.
+[SUPERSEDED by #1999, in this same release: the `running_cost` channel is gone, so only
+`source_term` remains and there is nothing left to hold separately.] Measured with the 1D reduction of
 the GFDM paper's manufactured pair: EOC 2.00/1.99 on the Newton path and 1.98/1.99 on the Howard
 path, with the sign flipped staying flat at 1.42 on both — which is what the tests assert. The rate
 is the SPATIAL order at fixed `nt`; the manufactured `a1(t)` is linear so backward Euler is exact in

--- a/changelog.d/1999-running-cost-one-owner.removed.md
+++ b/changelog.d/1999-running-cost-one-owner.removed.md
@@ -3,7 +3,10 @@ the Lagrangian — the potential `V(x,t)` and the coupling `f(m)` — is owned b
 already reaches the residual through it, so a second channel could only carry the same quantity a
 second time: supplied alongside a Hamiltonian that already held a potential it double-counted
 silently (#2001). The package's only caller of that channel used it as an MMS source and has moved
-to `source_term`, which #1991 added for exactly that. `h_eval.assemble_hjb_residual`'s parameter is
+to `source_term`, which #1991 added for exactly that. **Migrating callers must negate:
+`source_term = -running_cost`.** `h_eval` assembles `-u_t + H(+additive_source) - D*lap_u` while
+the package-wide source contract is `F(u) = (u-u_next)/dt + H - S = 0`, so the two slots carry
+opposite signs. Passing the old callable unchanged solves a different problem and nothing raises. `h_eval.assemble_hjb_residual`'s parameter is
 renamed `additive_source` to match what it now carries, and the orphaned `_normalize_running_cost`
 machinery is deleted. `HJBHowardSolver`'s `running_cost=` is unchanged. It is public — the class is exported and
 its `__init__` still takes the argument — but it is not a rival owner at that layer, because

--- a/changelog.d/1999-running-cost-one-owner.removed.md
+++ b/changelog.d/1999-running-cost-one-owner.removed.md
@@ -5,5 +5,7 @@ second time: supplied alongside a Hamiltonian that already held a potential it d
 silently (#2001). The package's only caller of that channel used it as an MMS source and has moved
 to `source_term`, which #1991 added for exactly that. `h_eval.assemble_hjb_residual`'s parameter is
 renamed `additive_source` to match what it now carries, and the orphaned `_normalize_running_cost`
-machinery is deleted. `HJBHowardSolver`'s `running_cost=` is unchanged: it is internal wiring fed by
-GFDM from the Hamiltonian's own decomposition, not a channel a caller can reach.
+machinery is deleted. `HJBHowardSolver`'s `running_cost=` is unchanged. It is public — the class is exported and
+its `__init__` still takes the argument — but it is not a rival owner at that layer, because
+Howard has no Hamiltonian of its own and GFDM feeds it the decomposition. So the count this
+removal moves is one parameter on one solver, not every `running_cost=` in the package.

--- a/changelog.d/1999-running-cost-one-owner.removed.md
+++ b/changelog.d/1999-running-cost-one-owner.removed.md
@@ -7,7 +7,9 @@ the Hamiltonian route does not deliver today, and both are open: an alpha-free `
 `SeparableHamiltonian` cannot express because its `coupling` takes only `m` (#2010); and anything at
 all on the Howard path, whose closure keys on `SeparableHamiltonian` private attributes and drops a
 general `HamiltonianBase` subclass bitwise (#2011). Neither is a reason to keep a double-counting
-channel, and `source_term` is not a substitute for either — its contract forbids depending on `m`.
+channel. `source_term` does reach Howard's closure — that is what #1991 added — so #2011 costs
+nothing for `m`-free forcing; what it costs is model data, because `source_term`'s contract forbids
+depending on `m`, and that is also why it cannot stand in for #2010.
 The owner of an alpha-free `F(x, m)` is the Lagrangian, which is where the literature puts it. The package's only caller of that channel used it as an MMS source and has moved
 to `source_term`, which #1991 added for exactly that. **Migrating callers must negate:
 `source_term = -running_cost`.** `h_eval` assembles `-u_t + H(+additive_source) - D*lap_u` while

--- a/changelog.d/1999-running-cost-one-owner.removed.md
+++ b/changelog.d/1999-running-cost-one-owner.removed.md
@@ -1,0 +1,9 @@
+`HJBGFDMSolver.solve_hjb_system` no longer accepts `running_cost`. The alpha-independent part of
+the Lagrangian — the potential `V(x,t)` and the coupling `f(m)` — is owned by the Hamiltonian and
+already reaches the residual through it, so a second channel could only carry the same quantity a
+second time: supplied alongside a Hamiltonian that already held a potential it double-counted
+silently (#2001). The package's only caller of that channel used it as an MMS source and has moved
+to `source_term`, which #1991 added for exactly that. `h_eval.assemble_hjb_residual`'s parameter is
+renamed `additive_source` to match what it now carries, and the orphaned `_normalize_running_cost`
+machinery is deleted. `HJBHowardSolver`'s `running_cost=` is unchanged: it is internal wiring fed by
+GFDM from the Hamiltonian's own decomposition, not a channel a caller can reach.

--- a/changelog.d/1999-running-cost-one-owner.removed.md
+++ b/changelog.d/1999-running-cost-one-owner.removed.md
@@ -1,8 +1,14 @@
-`HJBGFDMSolver.solve_hjb_system` no longer accepts `running_cost`. The alpha-independent part of
-the Lagrangian — the potential `V(x,t)` and the coupling `f(m)` — is owned by the Hamiltonian and
-already reaches the residual through it, so a second channel could only carry the same quantity a
-second time: supplied alongside a Hamiltonian that already held a potential it double-counted
-silently (#2001). The package's only caller of that channel used it as an MMS source and has moved
+`HJBGFDMSolver.solve_hjb_system` no longer accepts `running_cost`. Supplied alongside a Hamiltonian
+that already held a potential, it double-counted silently (#2001), and that is what the removal
+fixes.
+
+Not that a second channel could *only* have carried the same quantity — it could carry two things
+the Hamiltonian route does not deliver today, and both are open: an alpha-free `F(x, m)`, which
+`SeparableHamiltonian` cannot express because its `coupling` takes only `m` (#2010); and anything at
+all on the Howard path, whose closure keys on `SeparableHamiltonian` private attributes and drops a
+general `HamiltonianBase` subclass bitwise (#2011). Neither is a reason to keep a double-counting
+channel, and `source_term` is not a substitute for either — its contract forbids depending on `m`.
+The owner of an alpha-free `F(x, m)` is the Lagrangian, which is where the literature puts it. The package's only caller of that channel used it as an MMS source and has moved
 to `source_term`, which #1991 added for exactly that. **Migrating callers must negate:
 `source_term = -running_cost`.** `h_eval` assembles `-u_t + H(+additive_source) - D*lap_u` while
 the package-wide source contract is `F(u) = (u-u_next)/dt + H - S = 0`, so the two slots carry

--- a/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
@@ -81,7 +81,11 @@ def assemble_hjb_residual(
 ) -> NDArray:
     r"""Assemble the implicit-backward-Euler HJB residual (Layer B of #1071).
 
-    Returns ``-u_t + H(+additive_source) - D·lap_u`` with ``D = σ²/2``, so the diffusion-term
+    Returns ``-u_t + H(+additive_source) - D·lap_u``. **The sign is opposite to the
+    package-wide** ``source_term`` **contract**, which `base_hjb` states as
+    ``F(u) = (u-u_next)/dt + H - S``: a caller holding an MMS source ``S`` must pass
+    ``-S`` here. GFDM does that conversion once, in ``_source_at``. The name says
+    *additive*, not *source*, for exactly that reason with ``D = σ²/2``, so the diffusion-term
     convention (Issue #1073/#811) lives in one place. The caller supplies its own discrete
     operators (gradient ``p``, Laplacian ``lap_u``) and the time-derivative
     ``u_t = (u^{n+1}-u^n)/dt``; it owns its own framing -- this is the implicit residual

--- a/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
@@ -77,11 +77,11 @@ def assemble_hjb_residual(
     sigma: float | NDArray,
     t: float,
     u_t: NDArray,
-    running_cost: NDArray | None = None,
+    additive_source: NDArray | None = None,
 ) -> NDArray:
     r"""Assemble the implicit-backward-Euler HJB residual (Layer B of #1071).
 
-    Returns ``-u_t + H(+running_cost) - D·lap_u`` with ``D = σ²/2``, so the diffusion-term
+    Returns ``-u_t + H(+additive_source) - D·lap_u`` with ``D = σ²/2``, so the diffusion-term
     convention (Issue #1073/#811) lives in one place. The caller supplies its own discrete
     operators (gradient ``p``, Laplacian ``lap_u``) and the time-derivative
     ``u_t = (u^{n+1}-u^n)/dt``; it owns its own framing -- this is the implicit residual
@@ -93,8 +93,8 @@ def assemble_hjb_residual(
     inline ``diffusion_from_volatility(sigma_eff, kind="field") * lap_u`` LLF expression it replaces.
     """
     H = eval_H_batch(H_class, x, m, p, t)
-    if running_cost is not None:
-        H = H + running_cost
+    if additive_source is not None:
+        H = H + additive_source
     return -u_t + H - _diffusion_coeff(sigma) * lap_u
 
 

--- a/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/h_eval.py
@@ -85,8 +85,8 @@ def assemble_hjb_residual(
     package-wide** ``source_term`` **contract**, which `base_hjb` states as
     ``F(u) = (u-u_next)/dt + H - S``: a caller holding an MMS source ``S`` must pass
     ``-S`` here. GFDM does that conversion once, in ``_source_at``. The name says
-    *additive*, not *source*, for exactly that reason with ``D = σ²/2``, so the diffusion-term
-    convention (Issue #1073/#811) lives in one place. The caller supplies its own discrete
+    *additive*, not *source*, for exactly that reason. ``D = σ²/2`` throughout, so the
+    diffusion-term convention (Issue #1073/#811) lives in one place. The caller supplies its own discrete
     operators (gradient ``p``, Laplacian ``lap_u``) and the time-derivative
     ``u_t = (u^{n+1}-u^n)/dt``; it owns its own framing -- this is the implicit residual
     ``-u_t + H - D·lap``, NOT the WENO explicit-RHS framing ``-H + D·Δu``.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -2284,7 +2284,7 @@ class HJBGFDMSolver(BaseHJBSolver):
 
             H = self.problem.H(i, m_n_plus_1[i], derivs=p_derivs, x_position=x_pos)
 
-            # Running cost L(x) at this timestep (passed explicitly from backward loop)
+            # Additive source at this timestep (passed explicitly from the backward loop)
             if additive_source is not None:
                 H = H + additive_source[i]
 
@@ -3036,8 +3036,10 @@ class HJBGFDMSolver(BaseHJBSolver):
                 source cannot be confused with a running cost: there is no longer a second slot
                 to confuse it with (Issue #1999). Internally the two still meet with OPPOSITE
                 signs, since ``h_eval`` assembles ``-u_t + H(+additive_source) - D*lap_u`` while
-                the source contract subtracts; the conversion happens once, in ``_source_at``.
-                Added to Hamiltonian: H_total = H(x,p,m) + L(t,x).
+                the source contract subtracts; the conversion happens once, in ``_source_at``,
+                which returns ``-S``. So the effective Hamiltonian is ``H_total = H - S``, NOT
+                ``H + S``: migrating a callable from the retired ``running_cost=`` channel
+                requires FLIPPING ITS SIGN, since ``running_cost = -source_term``.
             volatility_field: Optional SDE-volatility override. Accepts a scalar,
                 an inspectable one-argument space-only callable ``sigma(x)`` evaluated
                 at each collocation point, or a
@@ -3091,8 +3093,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Store original spatial shape for reshaping output
         self._output_spatial_shape = M_density.shape[1:]
 
-        # Normalize running cost to callable f(n) -> (n_points,)
-        # Accepts: None, 1D array, 2D array, or callable
         # Issue #1999: there is no user running-cost channel. The alpha-independent part of the
         # Lagrangian -- V(x,t) + f(m) -- is owned by the Hamiltonian and already enters through
         # `eval_H_batch` on the Newton path and `howard_running_cost` on the Howard path. A second
@@ -3116,7 +3116,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                 # Shape-check rather than reshape. A 2D source handed back in the wrong point
                 # order has the right SIZE and silently yields a different value function --
                 # measured, an F-ordered (nx, ny) array is accepted and changes Linf from
-                # 6.6433e+00 to 4.6862e+00 with no diagnostic. the retired running-cost channel already
+                # 6.6433e+00 to 4.6862e+00 with no diagnostic, and nothing downstream
                 # validates its callable's output; this is the same contract.
                 if s_n.shape != (self.n_points,):
                     # An (N,1) or (1,N) vector has an unambiguous ordering, and `base_hjb`
@@ -3390,7 +3390,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                 if mms_src is not None:
                     # `_mms_source_fn` already returns -S in the Newton slot's convention, and the
                     # `-rc` below applies Howard's own flip, so it enters here un-negated exactly
-                    # like `user_rc`.
+                    # in the slot the retired user running cost used.
                     rc = rc + np.asarray(mms_src(t_idx), dtype=float).ravel()
                 return -rc  # rc_t = -(V + f(m) + S_mms); see SIGN note above.
 

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -1166,51 +1166,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         self._D_grad: list | None = None  # Gradient differentiation matrices
         self._D_lap: Any | None = None  # Laplacian differentiation matrix
         self._cached_derivative_weights: dict | None = None  # Pre-computed GFDM weights
-        self._running_cost_fn: Callable[[int], np.ndarray] | None = None  # Running cost f(n) -> (n_points,)
         self._f_potential_warned: bool = False  # One-time warning for unused f_potential (Issue #766)
-
-    def _normalize_running_cost(
-        self,
-        running_cost: np.ndarray | Callable[[int], np.ndarray] | None,
-        n_time_points: int,
-    ) -> Callable[[int], np.ndarray] | None:
-        """Normalize running cost input to a callable f(n) -> (n_points,).
-
-        Accepts three input forms:
-            - None: no running cost
-            - 1D array (n_points,): static cost, same at every timestep
-            - 2D array (n_time_points, n_points): time-dependent cost
-            - Callable: f(time_index) -> (n_points,) array, used directly
-        """
-        if running_cost is None:
-            return None
-
-        # Callable path: validate output shape and return directly
-        if callable(running_cost):
-            test_output = np.asarray(running_cost(0))
-            if test_output.shape != (self.n_points,):
-                raise ValueError(f"running_cost callable must return shape ({self.n_points},), got {test_output.shape}")
-            return running_cost
-
-        # Array path: normalize to callable
-        running_cost = np.asarray(running_cost)
-        if running_cost.ndim == 1:
-            if running_cost.shape[0] != self.n_points:
-                raise ValueError(
-                    f"running_cost must have shape ({self.n_points},) or "
-                    f"({n_time_points}, {self.n_points}), got {running_cost.shape}"
-                )
-            rc_static = running_cost.copy()
-            return lambda _n: rc_static
-        elif running_cost.ndim == 2:
-            if running_cost.shape != (n_time_points, self.n_points):
-                raise ValueError(
-                    f"running_cost must have shape ({n_time_points}, {self.n_points}), got {running_cost.shape}"
-                )
-            rc_full = running_cost.copy()
-            return lambda n: rc_full[n]
-        else:
-            raise ValueError(f"running_cost must be 1D or 2D array, got {running_cost.ndim}D")
 
     def _compute_n_spatial_grid_points(self) -> int:
         """Compute total number of spatial grid points from geometry."""
@@ -2213,7 +2169,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         lap_u: np.ndarray,
         H_class: Any,
         current_time: float,
-        running_cost: np.ndarray | None = None,
+        additive_source: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Compute HJB residual using batch Hamiltonian class (Issue #775).
@@ -2249,7 +2205,7 @@ class HJBGFDMSolver(BaseHJBSolver):
             sigma=sigma,
             t=current_time,
             u_t=u_t,
-            running_cost=running_cost,
+            additive_source=additive_source,
         )
 
     def _compute_hjb_jacobian_hamiltonian(
@@ -2303,7 +2259,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         m_n_plus_1: np.ndarray,
         time_idx: int,
         cached_derivs: dict[int, dict[tuple[int, ...], float]],
-        running_cost: np.ndarray | None = None,
+        additive_source: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Compute HJB residual using pre-computed derivatives (per-point path).
@@ -2329,8 +2285,8 @@ class HJBGFDMSolver(BaseHJBSolver):
             H = self.problem.H(i, m_n_plus_1[i], derivs=p_derivs, x_position=x_pos)
 
             # Running cost L(x) at this timestep (passed explicitly from backward loop)
-            if running_cost is not None:
-                H = H + running_cost[i]
+            if additive_source is not None:
+                H = H + additive_source[i]
 
             sigma_val = self._get_sigma_value(i)
             diffusion_term = diffusion_from_volatility(sigma_val) * laplacian
@@ -3062,7 +3018,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         U_coupling_prev: np.ndarray | None = None,
         show_progress: bool | None = None,
         volatility_field: float | np.ndarray | Callable | None = None,
-        running_cost: np.ndarray | Callable[[int], np.ndarray] | None = None,
         source_term: Callable | None = None,
     ) -> np.ndarray:
         """
@@ -3073,21 +3028,15 @@ class HJBGFDMSolver(BaseHJBSolver):
             U_terminal: (*spatial_shape,) terminal condition u(T,x)
             U_coupling_prev: (Nt, *spatial_shape) previous coupling iteration estimate
             show_progress: Whether to display progress bar for timesteps
-            running_cost: Running cost L(x) or L(t,x) at collocation points.
-                Static array: shape (n_points,) -- same cost at every backward step.
-                Time-dependent array: shape (n_time_points, n_points) -- L(t_n, x) per step.
-                Callable: f(time_index) -> (n_points,) array, evaluated per step.
             source_term: MMS forcing ``r_u`` of ``-u_t - (sigma^2/2) lap u + H = r_u``, with the
                 package-wide contract ``source_term(t, x) -> array``, ``x`` of shape ``(N, d)``
-                (:mod:`base_hjb`). Distinct from ``running_cost``: a running cost is model data
-                and may depend on ``m``, a source is an artificial forcing for verification and
-                may not. They share an arithmetic slot with OPPOSITE sign -- ``h_eval`` assembles
-                ``-u_t + H(+running_cost) - D*lap_u`` while the source contract subtracts, so
-                ``running_cost = -source_term`` -- and this argument exists so one manufactured
-                solution runs against every solver rather than being rewritten per convention.
-                Supplying both adds them, since they are different quantities. (The
-                "Added to Hamiltonian: H_total = H + L(t,x)" line below belongs to
-                ``running_cost``, not to this argument, whose relation is the negation above.)
+                (:mod:`base_hjb`). This is the ONLY additive channel a caller can reach. The
+                alpha-independent part of the Lagrangian -- the potential ``V(x,t)`` and the
+                coupling ``f(m)`` -- belongs to the Hamiltonian and arrives through it, so a
+                source cannot be confused with a running cost: there is no longer a second slot
+                to confuse it with (Issue #1999). Internally the two still meet with OPPOSITE
+                signs, since ``h_eval`` assembles ``-u_t + H(+additive_source) - D*lap_u`` while
+                the source contract subtracts; the conversion happens once, in ``_source_at``.
                 Added to Hamiltonian: H_total = H(x,p,m) + L(t,x).
             volatility_field: Optional SDE-volatility override. Accepts a scalar,
                 an inspectable one-argument space-only callable ``sigma(x)`` evaluated
@@ -3144,13 +3093,15 @@ class HJBGFDMSolver(BaseHJBSolver):
 
         # Normalize running cost to callable f(n) -> (n_points,)
         # Accepts: None, 1D array, 2D array, or callable
-        self._running_cost_fn = self._normalize_running_cost(running_cost, n_time_points)
-        # Kept SEPARATE from `_running_cost_fn` rather than folded into it. They occupy one
-        # arithmetic slot but are different quantities: a running cost is model data and may
-        # depend on `m` (Howard documents this slot as "the non-quadratic-in-alpha part of the
-        # Lagrangian -- potential V(x), congestion g(x, m)"), while an MMS source is artificial
-        # forcing that must not. Folding them would leave one opaque callable in which a
-        # congestion term and a verification forcing are indistinguishable after the fact.
+        # Issue #1999: there is no user running-cost channel. The alpha-independent part of the
+        # Lagrangian -- V(x,t) + f(m) -- is owned by the Hamiltonian and already enters through
+        # `eval_H_batch` on the Newton path and `howard_running_cost` on the Howard path. A second
+        # channel could only carry the same quantity, and adding it on top of a Hamiltonian that
+        # already holds a potential double-counted it silently (#2001).
+        # The MMS source is the ONLY additive channel a caller can reach (#1999). The
+        # alpha-independent part of the Lagrangian -- V(x,t) + f(m) -- belongs to the
+        # Hamiltonian and arrives through it, so a source and a running cost can no longer
+        # be confused: there is only one of them.
         self._mms_source_fn: Callable[[int], np.ndarray] | None = None
         if source_term is not None:
             _dt = self.problem.T / self.problem.Nt
@@ -3165,7 +3116,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                 # Shape-check rather than reshape. A 2D source handed back in the wrong point
                 # order has the right SIZE and silently yields a different value function --
                 # measured, an F-ordered (nx, ny) array is accepted and changes Linf from
-                # 6.6433e+00 to 4.6862e+00 with no diagnostic. `_normalize_running_cost` already
+                # 6.6433e+00 to 4.6862e+00 with no diagnostic. the retired running-cost channel already
                 # validates its callable's output; this is the same contract.
                 if s_n.shape != (self.n_points,):
                     # An (N,1) or (1,N) vector has an unambiguous ordering, and `base_hjb`
@@ -3243,16 +3194,13 @@ class HJBGFDMSolver(BaseHJBSolver):
             )
 
             for n in timestep_range:
-                rc_n = self._running_cost_fn(n) if self._running_cost_fn is not None else None
-                if self._mms_source_fn is not None:
-                    s_n = self._mms_source_fn(n)
-                    rc_n = s_n if rc_n is None else np.asarray(rc_n, dtype=float).reshape(-1) + s_n
+                rc_n = self._mms_source_fn(n) if self._mms_source_fn is not None else None
 
                 U_solution_collocation[n, :] = self._solve_timestep(
                     U_solution_collocation[n + 1, :],
                     M_collocation[n, :],  # FIXED: Use m^n, not m^{n+1} (same-time coupling)
                     n,
-                    running_cost=rc_n,
+                    additive_source=rc_n,
                 )
 
                 # Update progress bar with QP statistics if available (Issue #587 Protocol - no hasattr needed)
@@ -3412,7 +3360,6 @@ class HJBGFDMSolver(BaseHJBSolver):
         #   #1247 Defect 2 sign flip (it previously entered Howard's slot un-negated).
         potential = getattr(H_class, "_potential", None)
         coupling = getattr(H_class, "_coupling", None)
-        user_rc = self._running_cost_fn
         # Issue #1991: the Howard branch must consume the MMS source too. It was read only in the
         # Newton branch, so `solve_hjb_system(source_term=...)` on this path discarded it BITWISE
         # -- measured, |U(source) - U(no source)| = 0.000e+00 at two resolutions, with the Newton
@@ -3423,7 +3370,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         has_H_extra = potential is not None or coupling is not None
 
         howard_running_cost = None
-        if has_H_extra or user_rc is not None or mms_src is not None:
+        if has_H_extra or mms_src is not None:
             colloc_pts = self.collocation_points
             p_zero = np.zeros((self.n_points, self.dimension))
 
@@ -3440,14 +3387,12 @@ class HJBGFDMSolver(BaseHJBSolver):
                             dtype=float,
                         ).ravel()
                     )
-                if user_rc is not None:
-                    rc = rc + np.asarray(user_rc(t_idx), dtype=float).ravel()
                 if mms_src is not None:
                     # `_mms_source_fn` already returns -S in the Newton slot's convention, and the
                     # `-rc` below applies Howard's own flip, so it enters here un-negated exactly
                     # like `user_rc`.
                     rc = rc + np.asarray(mms_src(t_idx), dtype=float).ravel()
-                return -rc  # rc_t = -(V + f(m) + L_user + S_mms); see SIGN note above.
+                return -rc  # rc_t = -(V + f(m) + S_mms); see SIGN note above.
 
         # Issue #1071: the control-cost Lagrangian L(alpha) for the policy-evaluation RHS comes
         # from the single source (control_cost.lagrangian), not a hardcoded (1/2)|alpha|^2. The
@@ -3470,7 +3415,7 @@ class HJBGFDMSolver(BaseHJBSolver):
         u_n_plus_1: np.ndarray,
         m_n_plus_1: np.ndarray,
         time_idx: int,
-        running_cost: np.ndarray | None = None,
+        additive_source: np.ndarray | None = None,
     ) -> np.ndarray:
         """Solve HJB at one time step using Newton iteration with backtracking line search.
 
@@ -3536,7 +3481,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                     l_u,
                     H_class,
                     current_time,
-                    running_cost=running_cost,
+                    additive_source=additive_source,
                 )
             else:
                 derivs = self._approximate_all_derivatives_cached(u_trial)
@@ -3546,7 +3491,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                     m_n_plus_1,
                     time_idx,
                     derivs,
-                    running_cost=running_cost,
+                    additive_source=additive_source,
                 )
             return float(np.linalg.norm(r))
 
@@ -3568,7 +3513,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                     lap_u,
                     H_class,
                     current_time,
-                    running_cost=running_cost,
+                    additive_source=additive_source,
                 )
 
                 if np.linalg.norm(residual) < self.newton_tolerance:
@@ -3590,7 +3535,7 @@ class HJBGFDMSolver(BaseHJBSolver):
                     m_n_plus_1,
                     time_idx,
                     all_derivs,
-                    running_cost=running_cost,
+                    additive_source=additive_source,
                 )
 
                 if np.linalg.norm(residual) < self.newton_tolerance:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -3097,10 +3097,8 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Lagrangian -- V(x,t) + f(m) -- is owned by the Hamiltonian and already enters through
         # `eval_H_batch` on the Newton path and `howard_running_cost` on the Howard path. A second
         # channel could only carry the same quantity, and adding it on top of a Hamiltonian that
-        # already holds a potential double-counted it silently (#2001).
-        # The MMS source is the ONLY additive channel a caller can reach (#1999). The
-        # alpha-independent part of the Lagrangian -- V(x,t) + f(m) -- belongs to the
-        # Hamiltonian and arrives through it, so a source and a running cost can no longer
+        # already holds a potential double-counted it silently (#2001). The MMS source is now the
+        # only additive channel a caller can reach, so a source and a running cost can no longer
         # be confused: there is only one of them.
         self._mms_source_fn: Callable[[int], np.ndarray] | None = None
         if source_term is not None:
@@ -3108,8 +3106,8 @@ class HJBGFDMSolver(BaseHJBSolver):
             _x = self.collocation_points
 
             def _source_at(n: int, _dt: float = _dt, _x: np.ndarray = _x) -> np.ndarray:
-                # `running_cost = -source_term`: h_eval assembles `-u_t + H(+running_cost) -
-                # D*lap_u` while the source contract is `F(u) = (u-u_next)/dt + H - S = 0`.
+                # `additive_source = -source_term`: h_eval assembles `-u_t + H(+additive_source)
+                # - D*lap_u` while the source contract is `F(u) = (u-u_next)/dt + H - S = 0`.
                 # Getting this backwards is not subtle -- measured on the manufactured pair,
                 # `-r_u` converges at EOC 2.00/1.99 while `+r_u` sits flat at 1.42.
                 s_n = np.asarray(source_term(n * _dt, _x), dtype=float)
@@ -3247,8 +3245,8 @@ class HJBGFDMSolver(BaseHJBSolver):
         # Howard derives alpha* = -dH/dp and now consumes the control-cost Lagrangian
         # L(alpha) = lambda/2 |alpha|^2 from the single source (control_cost.lagrangian, wired
         # below), so any QUADRATIC control cost (unit or lambda != 1) MINIMIZE is faithful. The
-        # potential V(x, t), the density coupling f(m), and any caller running cost are wired
-        # (Issue #1247, below). What remains unmodelled — NON-quadratic control cost and the
+        # potential V(x, t), the density coupling f(m), and the MMS source are wired
+        # (Issue #1247, below); the user running-cost channel is gone (#1999). What remains unmodelled — NON-quadratic control cost and the
         # MAXIMIZE sense — is failed loud below (validated by
         # tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_rejects_*).
         control_cost = getattr(H_class, "control_cost", None)
@@ -3341,17 +3339,19 @@ class HJBGFDMSolver(BaseHJBSolver):
             return -eval_dH_dp_batch(H_class, x_pts, m, p, t_idx * dt)
 
         # Issue #1247 (#1118 PR2): route the Hamiltonian's non-quadratic-in-alpha source terms
-        # — potential V(x, t), density coupling f(m^n) — and any caller running cost L_user
-        # into Howard's running_cost slot, so Howard solves the full non-LQ HJB.
+        # — potential V(x, t), density coupling f(m^n) — and the MMS source into Howard's
+        # running_cost slot, so Howard solves the full non-LQ HJB. There is no user running
+        # cost to route: #1999 removed that channel.
         #
         #   SIGN of rc_t (load-bearing). Howard's converged policy-evaluation equation is
         #       (u^n - u^{n+1})/dt + (1/2)|grad u^n|^2 - (sigma^2/2) Lap u^n - rc_t = 0
         #   (substitute alpha* = -grad u^n into b = u^{n+1}/dt + (1/2)|alpha|^2 + rc_t and the
         #   advection operator A_adv u = alpha . grad u; see hjb_howard.py:_howard_step). The
-        #   Newton ground truth (h_eval.assemble_hjb_residual, -u_t + H + L_user - D Lap u = 0
-        #   with H = (1/2)|grad u|^2 + V + f(m)) is
-        #       (u^n - u^{n+1})/dt + (1/2)|grad u^n|^2 + V + f(m) + L_user - (sigma^2/2) Lap u^n = 0.
-        #   Matching the two forces rc_t = -(V + f(m) + L_user): Howard's slot is the Legendre
+        #   Newton ground truth (h_eval.assemble_hjb_residual, -u_t + H + S_slot - D Lap u = 0
+        #   with H = (1/2)|grad u|^2 + V + f(m), and S_slot = -S the MMS source already converted
+        #   into h_eval's additive_source convention by _source_at) is
+        #       (u^n - u^{n+1})/dt + (1/2)|grad u^n|^2 + V + f(m) + S_slot - (sigma^2/2) Lap u^n = 0.
+        #   Matching the two forces rc_t = -(V + f(m) + S_slot): Howard's slot is the Legendre
         #   dual side, which carries the H-additive terms with a FLIPPED sign. Resolved
         #   EMPIRICALLY (not by reasoning alone) by the Howard-vs-Newton agreement gate
         #   test_integrated_howard_matches_newton_nonlq: with Newton as ground truth, s=-1 gives

--- a/scripts/single_source_baseline.json
+++ b/scripts/single_source_baseline.json
@@ -68,6 +68,20 @@
       "count": 12,
       "note": "Hardcodes the exclusive convention (wrap at (0, Nx-1)) at every site. ENDPOINT_INCLUSIVE, which TensorProductGrid uses, puts the wrap at (0, Nx-2) instead -- so these sites and the grid disagree about which nodes are the same physical point. #1895 hit this three times in a row while extracting the Jacobian's BC bands. This entry has no owner yet, so its anchor is _calculate_derivatives(), the densest concentration of sites rather than an owner: _calculate_derivatives() holds 6 of these 12 sites, so the anchor trips on PARTIAL consolidation, not only full: fixing just those six exits 2 on unambiguous half-progress. That is a fact about this anchor, not an argument for it -- when it fires, move sentinel_symbol to a surviving site (the fp_fdm.py block, or base_hjb.py:966/1000) rather than retire the entry. Retirement is right only when the quantity really is fully single-sourced, because an entry left sitting at 0 reads clean forever. Uncounted by design: `np.roll` periodic wraps (9 code sites, of which base_hjb.py:1042-1043 and hjb_fdm.py:1322-1323 are genuine Jacobian wraps and the rest are Voronoi polygon shifts) -- too noisy to ratchet, so this entry does not cover them.",
       "sentinel_symbol": "_calculate_derivatives"
+    },
+    {
+      "name": "wall_drift_from_scalar_coupling",
+      "quantity": "the advective velocity at a cell face or wall, v = -c * grad(U)",
+      "owner": "ResolvedBC.alpha, produced by FPResolver (geometry/boundary/resolution.py)",
+      "pattern": "-\\s*coupling_coefficient\\s*\\*",
+      "include": [
+        "mfgarchon/**/*.py"
+      ],
+      "exclude": [],
+      "count": 50,
+      "sentinel_file": "mfgarchon/alg/numerical/fp_solvers/fp_fdm_alg_divergence_upwind.py",
+      "sentinel_symbol": "add_interior_entries_divergence_upwind",
+      "note": "Every FP assembly site re-derives the face velocity from a SCALAR coupling coefficient, v = -c*grad(U). That is D_pH for the separable-quadratic Hamiltonian only: for congestion D_pH = p/m^alpha depends on m, and at a wall the impermeable condition is J.n = 0, i.e. Robin in m with alpha = v_n, not dm/dn = 0. FPResolver already computes exactly this and declares it correctly (alpha = v_n, beta = -D), and ResolvedBC's coefficients were widened to fields on 2026-08-16 so they can carry v_n(x). Nothing consumes it: ResolvedBC is produced, exported and never read outside its own module (#2005). This entry ratchets the re-derivation so it cannot grow while that consolidation is pending. THE COUNT IS WHAT THIS PATTERN MATCHES, not a census of sites computing a face velocity -- some matches are inside strings and docstrings (fp_fdm.py:478 is an error message quoting the formula), and no regex separates those. The sentinel is chosen for that reason: add_interior_entries_divergence_upwind's body carries two matches in real code, not prose, and it survives the consolidation this entry pushes for -- it will still assemble upwind interior rows, it will just read the velocity instead of deriving it. Related: #1632 fixed the same quantity failing to arrive in the interior; #1970 built the provider for the wall; #2005 is the consolidation. COUNT PROVENANCE: this checker's own walker reports 50; a direct `re` scan of every mfgarchon/**/*.py reports 68, and `git grep -E` reports 2 because that engine does not implement `\\s` -- the same class of failure this file's docstring records for `\\b`. The three numbers measure three different things and only the checker's own is meaningful to the ratchet. Recorded so the gap is not rediscovered as a regression."
     }
   ]
 }

--- a/tests/integration/test_diffusion_magnitude_gate.py
+++ b/tests/integration/test_diffusion_magnitude_gate.py
@@ -34,7 +34,7 @@ per-point diffusion paths, the weak-form (FEM Galerkin) FP path via ``FPFEMSolve
 (the clean eigenmode invariant).
 
 The HJB-GFDM case isolates pure diffusion past the Hamiltonian advection with an
-MMS source ``L^n[i] = -H(grad u*^n)`` evaluated on the analytic backward-decaying
+MMS source ``S^n[i] = +H(grad u*^n)`` evaluated on the analytic backward-decaying
 eigenmode, so the ``H`` term cancels in the residual and the recovered field reads
 the diffusion coefficient directly (the #1073 chain: ``problem.diffusion`` already
 equals ``sigma^2/2``, so a path that re-squared it produced ``(sigma^2/2)^2``).
@@ -218,7 +218,7 @@ def _gfdm_diffusion_field_relerr(
     ``u*`` and the relerr is small; a mismatched ``D_reference`` detunes the decay and
     the relerr blows up -- which is how this gate would catch a wrong solver magnitude.
     The Hamiltonian ``H = |p|^2/(2 lam)`` advection is cancelled by the MMS source
-    ``L^n[i] = -H(grad u*^n)``; ``amp`` is kept small so the residual cancellation is
+    ``S^n[i] = +H(grad u*^n)``; ``amp`` is kept small so the residual cancellation is
     clean (diffusion O(amp) dominates the O(amp^2) Hamiltonian remnant).
     """
     grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n_x], boundary_conditions=no_flux_bc(dimension=1))

--- a/tests/integration/test_diffusion_magnitude_gate.py
+++ b/tests/integration/test_diffusion_magnitude_gate.py
@@ -237,16 +237,20 @@ def _gfdm_diffusion_field_relerr(
     solver = HJBGFDMSolver(
         prob, x.reshape(-1, 1), delta=delta, monotonicity_scheme="joint_socp", monotonicity_application="precompute"
     )
-    tspace = np.linspace(0.0, T, nt + 1)
 
-    def running_cost_fn(n):  # L^n[i] = -H(grad u*^n) on the analytic field
-        grad_u_star = -amp * np.exp(-D_reference * _PI**2 * (T - tspace[n])) * _PI * np.sin(_PI * x)
-        return -(grad_u_star**2) / (2.0 * lam)
+    # Issue #1999: this was `running_cost=`, which was the only caller of that channel in the
+    # package and used it as an MMS source -- cancelling H so the solve reduces to the backward
+    # heat equation with an analytic solution. It now uses `source_term`, the channel that exists
+    # for exactly this. The sign flips because `running_cost = -source_term`.
+    def source_fn(t, pts):  # S = +H(grad u*) on the analytic field
+        xx = np.asarray(pts, dtype=float).reshape(-1)
+        grad_u_star = -amp * np.exp(-D_reference * _PI**2 * (T - t)) * _PI * np.sin(_PI * xx)
+        return (grad_u_star**2) / (2.0 * lam)
 
     U = solver.solve_hjb_system(
         M_density=np.ones((nt + 1, n_x)),
         U_terminal=amp * np.cos(_PI * x),
-        running_cost=running_cost_fn,
+        source_term=source_fn,
         show_progress=False,
     )
     u0_star = amp * np.exp(-D_reference * _PI**2 * T) * np.cos(_PI * x)

--- a/tests/unit/test_alg/test_gfdm_mms_source_1991.py
+++ b/tests/unit/test_alg/test_gfdm_mms_source_1991.py
@@ -6,7 +6,11 @@ that argument, so the capability gate at `coupling/base_mfg.py:215` rejected it 
 HJB solver", while GFDM in fact had the channel all along under the name `running_cost`. The gate
 keys on a parameter NAME, so it was measuring a proxy for the capability it was asked about.
 
-`source_term` and `running_cost` are NOT the same quantity and are deliberately not unified:
+`source_term` and `running_cost` were never the same quantity. #1999 then removed the
+`running_cost=` parameter from this solver entirely -- not because they are the same, but
+because that channel could only carry what `source_term` already carries, at the opposite
+sign. The distinction below is why a *rename* would have been wrong; the removal rests on
+`source_term`'s own contract being general enough, which was verified bitwise:
 
 - `running_cost` is model data. `HJBHowardSolver` documents this slot as "the non-quadratic-in-alpha
   part of the Lagrangian (potential V(x), congestion g(x, m), etc.)", so it MAY depend on `m`; the
@@ -15,9 +19,9 @@ keys on a parameter NAME, so it was measuring a proxy for the capability it was 
 - `source_term` is artificial forcing for verification and must not depend on `m`.
 
 They share one arithmetic slot with opposite signs -- `h_eval.assemble_hjb_residual` returns
-`-u_t + H(+running_cost) - D*lap_u` while the source contract in `base_hjb` is
-`F(u) = (u-u_next)/dt + H - S = 0`, hence `running_cost = -source_term` -- so the solver keeps them
-as separate attributes and adds them only at the call site.
+`-u_t + H(+additive_source) - D*lap_u` while the source contract in `base_hjb` is
+`F(u) = (u-u_next)/dt + H - S = 0`, hence `running_cost = -source_term`. That sign is why a
+migration is not a rename, and it is what `test_the_source_sign_is_not_free` pins.
 
 Manufactured pair is the 1D reduction of the coupled MMS in the GFDM paper
 (`chapters/appendix.tex`, eq:mms_reference / eq:mms_system):
@@ -205,7 +209,7 @@ def test_the_per_point_residual_path_also_honours_the_source():
     """A THIRD arithmetic site, with its own sign, and nothing else reaches it.
 
     `qp_optimization_level != "none"` switches off the batch residual and uses the per-point
-    loop, where the source enters at `hjb_gfdm.py:2332` as `H = H + running_cost[i]` -- separate
+    loop, where the source enters at `hjb_gfdm.py` as `H = H + additive_source[i]` -- separate
     from `h_eval.assemble_hjb_residual` (Newton batch) and from `howard_running_cost`'s `-rc`.
     Three sites, three conventions to keep straight. Flipping the sign at that one line leaves
     every other test in this module green while the path sits at the flat-1.42 non-convergence

--- a/tests/unit/test_alg/test_gfdm_mms_source_1991.py
+++ b/tests/unit/test_alg/test_gfdm_mms_source_1991.py
@@ -99,7 +99,13 @@ def test_gfdm_accepts_the_package_wide_source_argument():
 
     params = set(inspect.signature(HJBGFDMSolver.solve_hjb_system).parameters)
     assert "source_term" in params, "the capability gate at base_mfg.py:215 tests for this name"
-    assert "running_cost" in params, "the modelling concept must survive; it is not the same quantity"
+    # Issue #1999: and there is no second additive channel beside it. The alpha-independent part
+    # of the Lagrangian -- V(x,t) + f(m) -- is the Hamiltonian's, and a `running_cost=` parameter
+    # could only carry the same quantity a second time: supplied alongside a Hamiltonian that
+    # already held a potential, it double-counted silently (#2001).
+    assert "running_cost" not in params, (
+        "a caller must not be able to inject an alpha-free cost that bypasses the Hamiltonian"
+    )
 
 
 def test_mms_reaches_gfdm_and_it_converges():

--- a/tests/unit/test_alg/test_gfdm_mms_source_1991.py
+++ b/tests/unit/test_alg/test_gfdm_mms_source_1991.py
@@ -8,15 +8,23 @@ keys on a parameter NAME, so it was measuring a proxy for the capability it was 
 
 `source_term` and `running_cost` were never the same quantity. #1999 then removed the
 `running_cost=` parameter from this solver entirely -- not because they are the same, but
-because that channel could only carry what `source_term` already carries, at the opposite
-sign. The distinction below is why a *rename* would have been wrong; the removal rests on
-`source_term`'s own contract being general enough, which was verified bitwise:
+because it double-counted against the Hamiltonian's own potential (#2001). The distinction below
+is why a *rename* would have been wrong, and it also bounds what the removal may be justified by:
 
-- `running_cost` is model data. `HJBHowardSolver` documents this slot as "the non-quadratic-in-alpha
-  part of the Lagrangian (potential V(x), congestion g(x, m), etc.)", so it MAY depend on `m`; the
-  alpha-dependent half of the Lagrangian is `control_lagrangian`, which sits inside the Legendre
+- `running_cost` was model data, and `HJBHowardSolver` documents that slot as "the
+  non-quadratic-in-alpha part of the Lagrangian (potential V(x), congestion g(x, m), etc.)", so it
+  MAY depend on `m`. The alpha-dependent half is `control_lagrangian`, inside the Legendre
   transform rather than beside it.
 - `source_term` is artificial forcing for verification and must not depend on `m`.
+
+So `source_term` is NOT a general replacement, and the removal must not be justified by claiming it
+is. What makes the removal right is that model data has a different owner: an alpha-free `F(x, m)`
+belongs in the Lagrangian, which is where both Cardaliaguet (lecture notes 2020, p.45 --
+"local coupling functions, i.e., when F = F(x, m(t,x))") and this project's own paper
+(`chapters/chap_01.tex`, running cost `L(x, m, alpha)`) put it. A `HamiltonianBase` subclass
+expresses it and GFDM honours it -- measured, `H = |p|^2/2 + g*x*m` moves `u(0,.)` by 2.24e-01 at
+g=1. What cannot express it is `SeparableHamiltonian`, whose `coupling` takes only `m`; that gap is
+real, it is what `running_cost` was masking, and it is #2010, not this channel's to carry.
 
 They share one arithmetic slot with opposite signs -- `h_eval.assemble_hjb_residual` returns
 `-u_t + H(+additive_source) - D*lap_u` while the source contract in `base_hjb` is
@@ -207,6 +215,13 @@ def test_the_source_reaches_gfdm_in_2d():
 @pytest.mark.slow
 def test_the_per_point_residual_path_also_honours_the_source():
     """A THIRD arithmetic site, with its own sign, and nothing else reaches it.
+
+    NOT IN THE AUTHORITATIVE GATE. `scripts/local_ci.sh` filters on `scripts/ci_markers.txt`,
+    which starts `not slow`, and this test measures 42.8 s -- 28% of the whole gate -- so the
+    marker is justified and removing it is not the fix. State the consequence rather than leave
+    it inferable: the batch path's sign control (`test_the_source_sign_is_not_free`) and Howard's
+    do run in the gate; this one does not, and the migrated caller in
+    `tests/integration/test_diffusion_magnitude_gate.py` runs on THIS path.
 
     `qp_optimization_level != "none"` switches off the batch residual and uses the per-point
     loop, where the source enters at `hjb_gfdm.py` as `H = H + additive_source[i]` -- separate

--- a/tests/unit/test_alg/test_gfdm_mms_source_1991.py
+++ b/tests/unit/test_alg/test_gfdm_mms_source_1991.py
@@ -22,9 +22,15 @@ is. What makes the removal right is that model data has a different owner: an al
 belongs in the Lagrangian, which is where both Cardaliaguet (lecture notes 2020, p.45 --
 "local coupling functions, i.e., when F = F(x, m(t,x))") and this project's own paper
 (`chapters/chap_01.tex`, running cost `L(x, m, alpha)`) put it. A `HamiltonianBase` subclass
-expresses it and GFDM honours it -- measured, `H = |p|^2/2 + g*x*m` moves `u(0,.)` by 2.24e-01 at
-g=1. What cannot express it is `SeparableHamiltonian`, whose `coupling` takes only `m`; that gap is
-real, it is what `running_cost` was masking, and it is #2010, not this channel's to carry.
+expresses it, and GFDM honours it **on the Newton paths** -- measured, `H = |p|^2/2 + g*x*m` moves
+`u(0,.)` by 2.24e-01 at g=1. State the path, because it does not generalize: `_solve_backward_howard`
+builds its running-cost closure from `getattr(H_class, "_potential")` / `"_coupling"`, which are
+`SeparableHamiltonian` internals, so the same subclass is dropped **bitwise** there -- 0.000e+00,
+against 2.000e-01 for a `SeparableHamiltonian` potential as a positive control on the same path.
+That hole is pre-existing and is #2011; `running_cost=` was the only route reaching it, so closing
+#2011 is what makes this removal costless on Howard. The other gap -- `SeparableHamiltonian`'s
+`coupling` taking only `m` -- is #2010. Neither is this channel's to carry, and neither is a reason
+to keep a channel that double-counts.
 
 They share one arithmetic slot with opposite signs -- `h_eval.assemble_hjb_residual` returns
 `-u_t + H(+additive_source) - D*lap_u` while the source contract in `base_hjb` is

--- a/tests/unit/test_alg/test_gfdm_mms_source_1991.py
+++ b/tests/unit/test_alg/test_gfdm_mms_source_1991.py
@@ -19,16 +19,23 @@ is why a *rename* would have been wrong, and it also bounds what the removal may
 
 So `source_term` is NOT a general replacement, and the removal must not be justified by claiming it
 is. What makes the removal right is that model data has a different owner: an alpha-free `F(x, m)`
-belongs in the Lagrangian, which is where both Cardaliaguet (lecture notes 2020, p.45 --
-"local coupling functions, i.e., when F = F(x, m(t,x))") and this project's own paper
+belongs in the Lagrangian, which is where both Cardaliaguet (lecture notes, section
+"Comments" of the second-order MFG chapter -- "local coupling functions, i.e., when
+F = F(x, m(t,x))"; cited by statement because two printings on this machine disagree on
+pagination, see #2010) and this project's own paper
 (`chapters/chap_01.tex`, running cost `L(x, m, alpha)`) put it. A `HamiltonianBase` subclass
 expresses it, and GFDM honours it **on the Newton paths** -- measured, `H = |p|^2/2 + g*x*m` moves
-`u(0,.)` by 2.24e-01 at g=1. State the path, because it does not generalize: `_solve_backward_howard`
+`u(0,.)` by 2.24e-01 at g=1 (21-point cloud on [0,1], `Nt=10`, `T=0.2`, `sigma=0.5`, default
+`delta`, `M` a normalized `exp(-(x-0.3)^2/0.02)` held fixed -- the figure moves with all of those,
+so it is evidence only with them). State the path, because it does not generalize: `_solve_backward_howard`
 builds its running-cost closure from `getattr(H_class, "_potential")` / `"_coupling"`, which are
 `SeparableHamiltonian` internals, so the same subclass is dropped **bitwise** there -- 0.000e+00,
 against 2.000e-01 for a `SeparableHamiltonian` potential as a positive control on the same path.
-That hole is pre-existing and is #2011; `running_cost=` was the only route reaching it, so closing
-#2011 is what makes this removal costless on Howard. The other gap -- `SeparableHamiltonian`'s
+That hole is pre-existing and is #2011. `source_term` reaches the SAME closure -- `hjb_gfdm.py:3373`
+is `if has_H_extra or mms_src is not None`, which is what #1991 added -- so Howard is not without an
+additive channel; `running_cost=` was the only route for MODEL DATA, since `source_term`'s contract
+bars depending on `m`. Closing #2011 is what makes this removal costless on Howard for the
+`m`-dependent case. The other gap -- `SeparableHamiltonian`'s
 `coupling` taking only `m` -- is #2010. Neither is this channel's to carry, and neither is a reason
 to keep a channel that double-counts.
 

--- a/tests/unit/test_alg/test_h_eval.py
+++ b/tests/unit/test_alg/test_h_eval.py
@@ -67,7 +67,7 @@ def test_assemble_hjb_residual_byte_identical():
     u_t = np.linspace(0.0, 0.5, n)
     rc = np.full(n, 0.05)
     sigma, t = 0.3, 0.1
-    out = assemble_hjb_residual(H_class=H, x=x, m=m, p=p, lap_u=lap_u, sigma=sigma, t=t, u_t=u_t, running_cost=rc)
+    out = assemble_hjb_residual(H_class=H, x=x, m=m, p=p, lap_u=lap_u, sigma=sigma, t=t, u_t=u_t, additive_source=rc)
     ref = -u_t + (np.asarray(H(x, m, p, t=t), dtype=float) + rc) - diffusion_from_volatility(sigma) * lap_u
     assert np.array_equal(out, ref)
 

--- a/tests/unit/test_alg/test_h_eval.py
+++ b/tests/unit/test_alg/test_h_eval.py
@@ -56,7 +56,7 @@ def test_eval_batch_passes_through_non_lq_coupling():
 
 
 def test_assemble_hjb_residual_byte_identical():
-    """Layer B: assemble_hjb_residual == -u_t + H(+running_cost) - D*lap_u (D = sigma^2/2)."""
+    """Layer B: assemble_hjb_residual == -u_t + H(+additive_source) - D*lap_u (D = sigma^2/2)."""
     from mfgarchon.alg.numerical.hjb_solvers.h_eval import assemble_hjb_residual
     from mfgarchon.utils.pde_coefficients import diffusion_from_volatility
 

--- a/tests/unit/test_alg/test_weno_mms_order_1991.py
+++ b/tests/unit/test_alg/test_weno_mms_order_1991.py
@@ -5,16 +5,17 @@
 unverified but unmeasurable. This threads it through the 1D path and pins what the
 resulting measurement shows.
 
-(A census by parameter name gave 8 of 11 lacking it. That over-counts: `HJBGFDMSolver` has
-the same channel under the name `running_cost`, with a different convention -- `f(n) ->
-(n_points,)` rather than `f(t, x)`. The capability gate keys on the name `source_term`, so
-it rejects GFDM for lacking a capability GFDM has. Tracked on #1991; a divergent mechanism
-rather than a missing one, and not this PR's to fix.
+(A census by parameter name gave 8 of 11 lacking it. At the time that over-counted:
+`HJBGFDMSolver` carried the same arithmetic slot under the name `running_cost`, at the opposite
+sign and with a different convention -- `f(n) -> (n_points,)` rather than `f(t, x)`. #1999 has
+since removed that channel, so GFDM now reaches the slot through `source_term` alone and the
+census is no longer an over-count on that solver.
 
-The relationship is a plain negation, `running_cost = -source_term`, fixed by two documented
-primitives: `h_eval.py:83` returns the residual `-u_t + H(+running_cost) - D*lap_u`, while the
-source contract at `base_hjb.py:435` is `F(u) = (u-u_next)/dt + H - S = 0`; setting both to
-zero gives the sign. `hjb_gfdm.py:3079` states it directly -- "Added to Hamiltonian:
+The sign relationship the two slots had is a plain negation, `additive_source = -source_term`,
+fixed by two documented primitives: `h_eval.py` returns the residual
+`-u_t + H(+additive_source) - D*lap_u`, while the source contract at `base_hjb.py:435` is
+`F(u) = (u-u_next)/dt + H - S = 0`; setting both to zero gives the sign. Note the historical
+hazard: the line that once "stated it directly" stated it with the WRONG sign -- "Added to
 H_total = H(x,p,m) + L(t,x)". Measured by running this same manufactured pair through GFDM at
 sigma=1: `-r_u` gives 3.1621e-03 -> 7.9413e-04, EOC 2.0; `+r_u` sits flat at 1.4233 -> 1.4241
 and never converges. So a port carrying an FDM source into GFDM unchanged would converge on the

--- a/tests/unit/test_alg/test_weno_mms_order_1991.py
+++ b/tests/unit/test_alg/test_weno_mms_order_1991.py
@@ -15,8 +15,12 @@ The sign relationship the two slots had is a plain negation, `additive_source = 
 fixed by two documented primitives: `h_eval.py` returns the residual
 `-u_t + H(+additive_source) - D*lap_u`, while the source contract at `base_hjb.py:435` is
 `F(u) = (u-u_next)/dt + H - S = 0`; setting both to zero gives the sign. Note the historical
-hazard: the line that once "stated it directly" stated it with the WRONG sign -- "Added to
-H_total = H(x,p,m) + L(t,x)". Measured by running this same manufactured pair through GFDM at
+hazard, and note what KIND it was: GFDM's docstring read "Added to Hamiltonian: H_total =
+H(x,p,m) + L(t,x)", which is exactly what `h_eval` computes and was correct **for the
+`running_cost` slot it documented**. The defect was placement -- a later edit deleted the
+disclaimer scoping it to that slot and left the line standing under `source_term`, whose sign is
+opposite. A correct relation under the wrong heading reads as a sign error and is worse than one,
+because the relation checks out. Measured by running this same manufactured pair through GFDM at
 sigma=1: `-r_u` gives 3.1621e-03 -> 7.9413e-04, EOC 2.0; `+r_u` sits flat at 1.4233 -> 1.4241
 and never converges. So a port carrying an FDM source into GFDM unchanged would converge on the
 wrong solution, and the unified channel #1991 wants can be built on a settled premise.)


### PR DESCRIPTION
Closes #2001, refs #1999.

## Why the removal is safe — corrected after review

My original argument was that the parameter's signature — `f(time_index) -> (n_points,)`, no `u`, no `p`, no `alpha` — proved it could carry nothing the Hamiltonian did not already own. **That argument is unsound, and review broke it in one line:** a closure carries arbitrary state, and the caller has `M_density` and `U_coupling_prev` in scope. Three legitimate things the old channel could carry that `SeparableHamiltonian` cannot express:

- an α-free cost depending jointly on `x` and `m`, e.g. `g(x)·m(x)`. `potential` takes `(x, t)`; `coupling` takes `m`; no combination yields it.
- a **lagged** zeroth-order term, `rho * u^{k-1}` read from `U_coupling_prev`. "No `u` ⇒ not zeroth-order" is the weak link, and it fails for a lagged term.
- a nonlocal `J[v]`, or a regime-switching cross-term.

What actually makes the removal safe is not the Hamiltonian — it is that **`source_term` is a general α-free additive channel whose own contract already names those uses.** `base_hjb.py:413-418` lists *"Non-local operators: J[v]"*, *"Regime-switching cross-terms"*, *"Penalty for variational inequalities"*, *"Common Noise Lions derivative correction"*. Nothing is lost; the capability moves to the channel designed for it.

And the substitution is exact — verified **bitwise** by review on all three GFDM solve paths: `running_cost=-S` produces an array identical to `source_term=+S` (`np.array_equal == True`, maxabs `0.000e+00`) for Newton batch, Newton per-point, and Howard, including with a `V + f(m)` Hamiltonian.

## The double-count this closes

```python
V = 0.7
H = SeparableHamiltonian(..., potential=lambda x, t=0: V)

assemble_hjb_residual(H_class=H, ..., running_cost=None)        -> 0.7000
assemble_hjb_residual(H_class=H, ..., running_cost=full(n, V))  -> 1.4000
```

Nothing raised, mass conserved, iteration converged. Different problem.

**Gate: the channel count drops 1 → 0** on `HJBGFDMSolver.solve_hjb_system`, by signature inspection. Stated precisely after review: `HJBHowardSolver` still takes `running_cost=` and is exported, so this moves one parameter on one solver, not every `running_cost=` in the package. Howard is not a rival *owner* — it has no Hamiltonian, and GFDM feeds it the decomposition — but "not a channel a caller can reach" was wrong.

## Scope, measured

- `HJBHowardSolver` is constructed in production only by GFDM; `assemble_hjb_residual` has exactly one production caller, also GFDM. Their `running_cost=` is internal wiring from the Hamiltonian's own decomposition.
- No indirect route: every `**kwargs` forward is built by `_build_hjb_kwargs`, which emits only `volatility_field` and `source_term`. No `HJBGFDMSolver` subclass in-tree. No notebook mentions it.

## The one caller was using it as an MMS source

`test_diffusion_magnitude_gate.py` returned `-H(∇u*)` on an analytic field to cancel the Hamiltonian. That is manufactured forcing, not model data. It moves to `source_term`, with the sign flipped.

## Deletions — this change's own tail

`_normalize_running_cost` (42 lines, removed by AST span) and `self._running_cost_fn` are unreachable once the parameter is gone. Proved with a control: the identical grep returns 7 hits on the merge base and **0** on this branch. `h_eval`'s parameter is renamed `additive_source`, since it now carries only the MMS source.

## Not swept in

`variational_problem`, `wasserstein_solver` and `mathematical_dsl` also say `running_cost`, and there it may mean the genuine control-theory running cost — the whole Lagrangian. `validate_running_cost` validates `components.potential_func` and never sees a solver kwarg. Both are #1999's naming half.

## Review

Two blockers, fixed in `e8a1b760`.

**B1 — the surviving channel documented the wrong sign.** The `source_term` docstring ended with `Added to Hamiltonian: H_total = H + L(t,x)`. At the merge base that line was explicitly disowned by a sentence saying it belonged to `running_cost`; this PR **deleted the disclaimer and kept the line**. `_source_at` returns `-S`, so the truth is `H_total = H - S`. The one public additive channel left standing was telling a migrating caller not to flip — in a PR whose migration *is* a sign flip. #2001's failure class, installed by the change that closes #2001.

**B2 — the gate never ran the migrated call site, and that site cannot detect the migration's failure mode.** `test_hjb_gfdm_diffusion_magnitude` carries `@pytest.mark.slow` and `scripts/ci_markers.txt` deselects it, so "6276 passed" structurally excludes it. Mutating that call: as written `relerr = 0.0120332`; `source_term` deleted entirely `0.0120335`; **sign flipped `0.0120368`** — all against a `0.05` threshold. Its own docstring explains why: `amp = 1e-3` makes the O(amp²) Hamiltonian remnant negligible against O(amp) diffusion, which is exactly what the channel cancels.

So correctness rests on the bitwise equivalence above, not on that test. The sign *is* gated — by `test_gfdm_mms_source_1991.py`'s flipped-sign controls, 112× separation on the per-point path — just not by the test that moved.

Non-blocking, also fixed: eight stale references to the deleted capability in the rewritten file, including a comment reading "Normalize running cost to callable" above code that normalises nothing and a dangling `# like user_rc`; `h_eval`'s opposite-sign convention now stated; the test module docstring, which asserted the two are "deliberately not unified" ninety lines above the assertion this PR changed; and the changelog's reachability claim.

## Gate

`./scripts/local_ci.sh` green: 6276 passed, 12 skipped, 23 xfailed.
