### PR TITLE
test(fp): MMS order study at a no-flux wall carrying drift (#1728)

### DIFF
--- a/changelog.d/1728-fp-mms-wall-order.added.md
+++ b/changelog.d/1728-fp-mms-wall-order.added.md
@@ -13,9 +13,15 @@ Two instances, and the pair is what separates the two defects `gradient_upwind` 
 `phi = -A.x` the drift is a constant vector, so the divergence and gradient interior forms coincide
 and only the wall closure is under test; repointing `gradient_upwind`'s wall at the conservative
 routine repairs it there completely (6.69e-1 -> 2.23e-2, EOC 0.937). With the GFDM paper's published
-source-free instance `phi = A(cos K x1 + cos K x2)` the drift is not constant, `m div(alpha)` is
-non-zero, and the same repointing leaves the scheme non-convergent (5.81e-1 -> 8.02e-1, EOC 0.108).
-So the gradient form is not the FP operator with a bad wall; it is a different operator. Both
+source-free instance `phi = A(cos K x1 + cos K x2)` the drift is not constant and `m div(alpha)` is
+non-zero. There the failure is provably not the wall's, by two wall-free checks: the instance is
+exactly periodic-compatible, and under `periodic_bc` -- where no wall handler runs -- `gradient_upwind`
+returns the same errors as under no-flux to seven figures (5.811380e-01 / 5.839517e-01, EOC -0.007
+both ways) while `divergence_upwind` does move (5.503e-2 -> 5.257e-2); and the omitted term is
+analytic, `div(alpha m) - alpha.grad(m) = -m Lap(phi)`, max 31.76 here and identically zero on the
+linear instance. So the gradient form is not the FP operator with a bad wall; it is a different
+operator. (Repointing the wall and re-measuring would give a flux-form boundary on a gradient
+interior, a hybrid that is neither scheme, so its number is not cited.) Both
 defects are pinned, each with its own retirement condition, verified to trip on its own fix and not
 on the other's.
 

--- a/changelog.d/1728-fp-mms-wall-order.added.md
+++ b/changelog.d/1728-fp-mms-wall-order.added.md
@@ -1,0 +1,40 @@
+An MMS order study for the FP-FDM advection schemes at a no-flux wall that carries drift (#1728).
+
+The test cited as covering `divergence_upwind`'s spatial order solves at zero drift, so substituting
+any other advection scheme leaves its output bit-identical and the stated order has never been under
+test. This file measures it with the advection term active.
+
+The construction is the zero-flux (Gibbs) pair: for any smooth potential `phi`, the drift
+`b* = -grad(phi)` and density `m* = Z^-1 exp(-phi/D)` make the flux `J = b* m - D grad(m)` vanish
+everywhere, so the source term is identically zero and the exact solution is stationary. No
+`source_term` channel is needed, which matters because only two FP solvers accept one.
+
+Two instances, and the pair is what separates the two defects `gradient_upwind` carries. With
+`phi = -A.x` the drift is a constant vector, so the divergence and gradient interior forms coincide
+and only the wall closure is under test; repointing `gradient_upwind`'s wall at the conservative
+routine repairs it there completely (6.69e-1 -> 2.23e-2, EOC 0.937). With the GFDM paper's published
+source-free instance `phi = A(cos K x1 + cos K x2)` the drift is not constant, `m div(alpha)` is
+non-zero, and the same repointing leaves the scheme non-convergent (5.81e-1 -> 8.02e-1, EOC 0.108).
+So the gradient form is not the FP operator with a bad wall; it is a different operator. Both
+defects are pinned, each with its own retirement condition, verified to trip on its own fix and not
+on the other's.
+
+Measured, relative L-inf at T over Nx = 21/41/81 in d = 1: `divergence_centered` 1.99e-4 / 5.09e-5 /
+1.29e-5 (EOC 1.97, 1.98); `divergence_upwind` 1.63e-2 / 8.53e-3 / 4.36e-3 (0.93, 0.97);
+`gradient_upwind` flat at 5.10e-1 with mass drift -1.4e-1. d = 2 agrees.
+
+The order tests assert an error LEVEL beside the order, because the order alone is a min over the
+wall closure and the interior stencil: a centered interior still reads EOC 0.89/0.94 and a centered
+wall 0.89/0.95, so neither is isolated along the axis the ratios are attributed to -- the same
+misattribution #1728 was filed about, one layer in. The level separates them (library 1.63e-2 at
+Nx = 21, centered-interior mutant 2.98e-2). The drift vector carries a negative component and the
+study is parametrized over its sign, because with one sign only one branch of each upwind selection
+is taken: a mutant that always upwinds from the left reproduces the library bitwise at A > 0 and
+separates at A < 0, while the library's own numbers are unchanged by the flip (the problem is
+mirror-symmetric).
+
+Existing coverage this does not duplicate: `test_solver_bc_support_census_1975.py` already pins the
+mass-drift half of the `gradient_*` wall on the same drive. New here are the accuracy form -- the
+scheme does not converge at all -- the separation of the wall defect from the interior-form one,
+and the magnitude: the constructor warning's "leaks O(1e-2)" is the zero-drift figure, an order of
+magnitude below the 1.4e-1 measured at wall-normal drift 0.7.

--- a/tests/unit/test_alg/test_fp_mms_wall_order_1728.py
+++ b/tests/unit/test_alg/test_fp_mms_wall_order_1728.py
@@ -1,35 +1,67 @@
-"""MMS order study for the FP-FDM advection schemes at a non-tangential no-flux wall.
+"""MMS order study for the FP-FDM advection schemes at a no-flux wall carrying drift.
 
 Closes the gap named in #1728: the MMS test previously cited as covering `divergence_upwind`'s
 spatial order runs at zero drift, so substituting any other advection scheme leaves its output
 bit-identical and the stated order has never been under test.
 
-Manufactured solution
----------------------
-An impermeable wall is J·n = 0 with J = αm − D∇m, D = σ²/2. For a **constant** drift vector A the
-density that makes the flux vanish everywhere — not merely on the wall — is
+The construction
+----------------
+An impermeable wall is J·n = 0 with J = αm − D∇m, D = σ²/2. The general zero-flux (Gibbs) pair is
 
-    m̄(x) = C exp(A·x / D),
+    phi any smooth potential,   b* = −∇phi,   m*(x) = Z⁻¹ exp(−phi(x)/D),
 
-since ∇m̄ = (A/D) m̄ gives J = A m̄ − D (A/D) m̄ ≡ 0. Hence the source term is identically zero:
-the manufactured solution is stationary, and the measurement is whether a scheme preserves it.
-No `source_term` channel is needed, so this oracle is available to every FP solver.
+for which ∇m* = −(∇phi/D) m* gives J = b* m* − D(−∇phi/D)m* ≡ 0 **everywhere**, not merely on the
+wall. Hence the source term is identically zero: the exact solution is stationary and source-free,
+and no `source_term` channel is needed -- which matters, because only `FPFDMSolver` and
+`FPFVMSolver` accept one.
 
-Why constant A: in the interior ∇·(αm) = α·∇m + m ∇·α reduces to α·∇m when α is constant, so the
-divergence and gradient forms coincide away from the wall. The probe therefore isolates the
-**wall treatment**, which is what distinguishes the two boundary architectures (#2005).
+Two instances of that family are measured, and they are independent of each other:
 
-Why the study runs over dimension: on the wall x_k = 0 the outward normal is −e_k, so A has normal
-component −A_k and tangential components A_j (j ≠ k). In d = 1 there is no tangential direction at
-all, so a scheme mishandling the tangential part cannot be discriminated there.
+- **linear** `phi = −A·x`, so b* = A is a constant vector and m* = Z⁻¹exp(A·x/D). Dimension-agnostic
+  for any d and any A. Its normal drift b*·n is non-zero *at the wall node itself*.
+- **Gibbs** `phi = A(cos Kx₁ + cos Kx₂)` with K = 4π, D = 1/8, A = D ln5/4, T = 1 on (0,1)²: the
+  published source-free exact reflected MFG of the GFDM paper (app:source_free_benchmark,
+  def:source_free_benchmark), whose m* has contrast max/min = 5. Here ∂_ν phi = 0 on ∂Ω, so b*·n
+  vanishes **at the wall node** -- but not on the boundary cell's interior face, where
+  |∂₁phi| = A K sin(K dx) = 0.195 at dx = 1/40. A published oracle reaching the same verdicts as
+  the linear one is worth more than either alone.
 
-Drive: α = −c∇U with U(x) = −A·x reproduces A exactly for QuadraticControlCost(1.0). The potential
-channel is used rather than the velocity channel because only the interface-velocity schemes read
-the latter (#1632).
+Why the study runs over dimension and over sign
+-----------------------------------------------
+On the wall x_k = 0 the outward normal is −e_k, so A has normal component −A_k and tangential
+components A_j (j ≠ k). In d = 1 there is no tangential direction at all: all three tangential
+mutants tried against this file (drop the tangential advection at wall rows, flip its sign, read the
+potential along the wrong axis) are **exact no-ops in 1D**, max error difference 0.000e+00, and two
+of the three separate in 2D.
 
-Cell Péclet is |A| dx / D = 0.07 at the coarsest level, so `divergence_centered` is nowhere near
-its stability limit: the tests below discriminate on order, not on stability (#1728's fourth
-acceptance condition).
+The sign is parametrized because A > 0 alone never exercises the upwind *selection*: every face
+velocity has one sign, so only one branch of each `if alpha >= 0 / else` is taken, and a mutant that
+always upwinds from the left reproduces the library's output to bitwise equality. The library's own
+numbers are unchanged by the flip -- the problem is mirror-symmetric under x -> L − x -- while such
+a mutant is not, so the coverage is free.
+
+WHAT THIS STUDY CANNOT SEE
+--------------------------
+- **It cannot attribute the order to the wall alone.** The measured order is a *min* over the wall
+  closure and the interior stencil: substituting a centered interior for `divergence_upwind` still
+  gives EOC 0.89/0.94, and substituting a centered *wall* still gives 0.89/0.95 in 1D. That is why
+  the first-order tests assert an error **level** as well as an order -- the level separates them
+  (library 1.63e-2, centered-interior mutant 2.98e-2 at Nx = 21, d = 1).
+- **The linear instance alone cannot distinguish the two interior advection forms** -- but the
+  pair can, which is why both are here. With constant A, ∇·(αm) = α·∇m + m∇·α reduces to α·∇m, so
+  `gradient_upwind`'s interior collapses to `divergence_upwind`'s flux difference, and repointing
+  the former's *wall* at the conservative routine makes the two agree to 2.5e-14 there. The Gibbs
+  instance is the complement: its potential is non-linear, so m∇·α ≠ 0, and the SAME wall
+  repointing leaves `gradient_upwind` non-convergent (5.81e-1 -> 8.02e-1, EOC −0.007 -> 0.108)
+  while it fully repairs the linear instance (6.69e-1 -> 2.23e-2, EOC 0.937). So the wall defect
+  and the interior-form defect are separated here without any source term: a non-constant
+  SOURCE-FREE potential suffices, and a sourced MMS is not needed for this question.
+- **It cannot see a dt error floor**, because the exact solution is stationary. `NT` is held fixed
+  while Nx refines for that reason -- not because the schemes are implicit, which buys unconditional
+  stability and nothing about accuracy. Measured: errors move < 2% from NT = 10 to NT = 640, and the
+  orders are unchanged under NT ~ Nx and NT ~ Nx². For a *non-stationary* manufactured solution the
+  same fixed-NT refinement would be confounded, and the explicit FP solvers are confounded by it
+  here (`fvm:upwind` reads EOC −1.34 at fixed NT and +0.81 once dt refines with dx).
 """
 
 from __future__ import annotations
@@ -48,93 +80,137 @@ from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc
 
 L = 1.0
-T = 0.5
-SIGMA = 1.0
-D = 0.5 * SIGMA**2
 NT = 40
 
-# Distinct components, so a reshape that transposed the field would break the flux control below.
-A_FULL = np.array([0.7, 0.4, 0.2])
+# Linear instance. Distinct components, one negative: distinctness breaks a transposed reshape,
+# the negative exercises the other branch of the upwind selection.
+LIN_T, LIN_SIGMA = 0.5, 1.0
+LIN_D = 0.5 * LIN_SIGMA**2
+A_FULL = np.array([0.7, -0.4, 0.2])
+
+# Gibbs instance -- the GFDM paper's published constants, reproduced exactly.
+GIBBS_T, GIBBS_D = 1.0, 1.0 / 8.0
+GIBBS_SIGMA = float(np.sqrt(2.0 * GIBBS_D))
+GIBBS_K = 4.0 * np.pi
+GIBBS_A = GIBBS_D * np.log(5.0) / 4.0
+
+LEVELS = {1: (21, 41, 81), 2: (21, 41)}
+
+# Error level at the coarsest level, above which the scheme is not the library's upwind one.
+# Set from measurement, midway between the library and the centered-interior mutant:
+#   d = 1  library 1.6305e-2  mutant 2.9791e-2
+#   d = 2  library 2.2303e-2  mutant 3.6212e-2
+UPWIND_LEVEL_BOUND = {1: 2.3e-2, 2: 2.9e-2}
+# Same construction for the Gibbs instance: library 5.5032e-2, centered-interior mutant 1.6857e-1.
+GIBBS_LEVEL_BOUND = 1.1e-1
 
 
-def _build(nx: int, d: int) -> tuple[TensorProductGrid, MFGProblem]:
+def _build(nx: int, d: int, sigma: float, horizon: float) -> tuple[TensorProductGrid, MFGProblem]:
     grid = TensorProductGrid(bounds=[(0.0, L)] * d, Nx_points=[nx] * d, boundary_conditions=no_flux_bc(dimension=d))
     components = MFGComponents(
         hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
         m_initial=lambda x: 1.0 / L**d,
         u_terminal=lambda x: 0.0,
     )
-    return grid, MFGProblem(geometry=grid, components=components, T=T, Nt=NT, sigma=SIGMA)
+    return grid, MFGProblem(geometry=grid, components=components, T=horizon, Nt=NT, sigma=sigma)
 
 
-def _manufactured(grid: TensorProductGrid, A: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Return (m̄, U) on the grid's own layout. Both exact, both time-independent."""
-    points = grid.get_spatial_grid()  # (N, d)
+def _zero_flux_pair(grid: TensorProductGrid, phi: np.ndarray, diffusion: float):
+    """Return (m*, U) for the zero-flux pair of a potential phi given on the flat point list.
+
+    m* = Z^-1 exp(-phi/D) and U = phi, since the solver forms alpha = -c grad(U) with c = 1 for
+    QuadraticControlCost(1.0) and the pair needs b* = -grad(phi). The potential channel is used
+    rather than the velocity channel because only the interface-velocity schemes read the latter
+    (#1632).
+    """
     shape = tuple(grid.Nx_points)
-    w = points @ A  # A·x
-    m = np.exp(w / D).reshape(shape)
     dx = L / (shape[0] - 1)
+    m = np.exp(-phi / diffusion).reshape(shape)
     m /= m.sum() * dx ** len(shape)
-    return m, (-w).reshape(shape)
+    return m, phi.reshape(shape)
 
 
-def _solve_error(scheme: str, nx: int, d: int) -> float:
+def _linear_phi(grid: TensorProductGrid, A: np.ndarray) -> np.ndarray:
+    return -(grid.get_spatial_grid() @ A)
+
+
+def _gibbs_phi(grid: TensorProductGrid) -> np.ndarray:
+    points = grid.get_spatial_grid()
+    return GIBBS_A * np.cos(GIBBS_K * points).sum(axis=1)
+
+
+def _solve_error(scheme: str, nx: int, instance: str, sign: int = 1, d: int = 2) -> float:
     """Relative L-inf distance between m(T) and the stationary exact solution."""
-    grid, problem = _build(nx, d)
-    m0, u = _manufactured(grid, A_FULL[:d])
+    if instance == "linear":
+        sigma, horizon, diffusion = LIN_SIGMA, LIN_T, LIN_D
+    else:
+        sigma, horizon, diffusion, d = GIBBS_SIGMA, GIBBS_T, GIBBS_D, 2
+    grid, problem = _build(nx, d, sigma, horizon)
+    phi = _linear_phi(grid, sign * A_FULL[:d]) if instance == "linear" else _gibbs_phi(grid)
+    m0, u = _zero_flux_pair(grid, phi, diffusion)
     U = np.broadcast_to(u, (NT + 1, *u.shape)).copy()
     solver = FPFDMSolver(problem, advection_scheme=scheme)
     M = np.asarray(solver.solve_fp_system(M_initial=m0, potential_field=U))
     return float(np.abs(M[-1] - m0).max() / m0.max())
 
 
-def _observed_orders(scheme: str, d: int, levels: tuple[int, ...]) -> list[float]:
-    errors = [_solve_error(scheme, nx, d) for nx in levels]
+def _errors(scheme: str, instance: str, sign: int, d: int) -> list[float]:
+    return [_solve_error(scheme, nx, instance, sign, d) for nx in LEVELS[d]]
+
+
+def _orders(errors: list[float]) -> list[float]:
     return [float(np.log(a / b) / np.log(2.0)) for a, b in pairwise(errors)]
-
-
-LEVELS = {1: (21, 41, 81), 2: (21, 41)}
 
 
 @pytest.mark.parametrize("d", [1, 2])
 def test_manufactured_pair_carries_zero_flux(d: int) -> None:
     """Positive control on the oracle itself, before any solver is measured against it.
 
-    The construction claims J ≡ 0. If it is wrong -- or if the flat (N, d) point list is reshaped
-    in the wrong order -- every order below is measured against a wrong reference. The finite
-    difference used here is second order, so the residual must fall by ~4 per refinement; a
-    scrambled field would not converge at all.
+    The construction claims J ≡ 0. If it is wrong -- or if the flat (N, d) point list is reshaped in
+    the wrong order -- every order below is measured against a wrong reference. The finite difference
+    used here is second order, so the residual must fall by ~4 per refinement; a scrambled field does
+    not converge at all (measured on an F-order reshape: order 0.001).
     """
     A = A_FULL[:d]
     residuals = []
     for nx in (21, 41):
-        grid, _ = _build(nx, d)
-        m, _ = _manufactured(grid, A)
+        grid, _ = _build(nx, d, LIN_SIGMA, LIN_T)
+        m, _ = _zero_flux_pair(grid, _linear_phi(grid, A), LIN_D)
         dx = L / (nx - 1)
         residuals.append(
             max(
-                float(np.abs(A[k] * m - D * np.gradient(m, dx, axis=k, edge_order=2)).max() / m.max()) for k in range(d)
+                float(np.abs(A[k] * m - LIN_D * np.gradient(m, dx, axis=k, edge_order=2)).max() / m.max())
+                for k in range(d)
             )
         )
     order = np.log(residuals[0] / residuals[1]) / np.log(2.0)
     assert order > 1.8, f"flux control is not converging at 2nd order: residuals={residuals}"
 
 
+@pytest.mark.parametrize("sign", [1, -1])
 @pytest.mark.parametrize("d", [1, 2])
-def test_divergence_upwind_is_first_order_at_a_drifting_wall(d: int) -> None:
+def test_divergence_upwind_is_first_order_at_a_drifting_wall(d: int, sign: int) -> None:
     """#1728: the scheme's advertised first order, measured with the advection term active.
 
-    The upper bound is what makes this mutation-red. `divergence_centered` scores ~1.97 on the same
-    manufactured solution, so substituting it fails here -- which is precisely the discrimination
-    the zero-drift MMS test cited in #1728 does not have.
+    Two assertions, and the second is not decoration. The ORDER is a min over the wall closure and
+    the interior stencil, so it alone cannot say which produced the O(h) -- a centered interior still
+    reads 0.89/0.94. The LEVEL separates them. Together they are mutation-red against a centered
+    interior, a centered wall, and a deleted upwind selection; the order bound alone catches none of
+    the three, and the upper bound is what rejects `divergence_centered` (~1.97).
     """
-    orders = _observed_orders("divergence_upwind", d, LEVELS[d])
+    errors = _errors("divergence_upwind", "linear", sign, d)
+    orders = _orders(errors)
     assert all(0.8 <= o <= 1.4 for o in orders), f"expected first order, observed {orders}"
+    assert errors[0] < UPWIND_LEVEL_BOUND[d], (
+        f"error level {errors[0]:.4e} exceeds {UPWIND_LEVEL_BOUND[d]:.1e}: the order is still ~1 but "
+        f"the constant moved, which is what a centered interior or a centered wall looks like here."
+    )
 
 
+@pytest.mark.parametrize("sign", [1, -1])
 @pytest.mark.parametrize("d", [1, 2])
-def test_divergence_centered_is_second_order_at_a_drifting_wall(d: int) -> None:
-    orders = _observed_orders("divergence_centered", d, LEVELS[d])
+def test_divergence_centered_is_second_order_at_a_drifting_wall(d: int, sign: int) -> None:
+    orders = _orders(_errors("divergence_centered", "linear", sign, d))
     assert all(o > 1.8 for o in orders), f"expected second order, observed {orders}"
 
 
@@ -142,21 +218,59 @@ def test_divergence_centered_is_second_order_at_a_drifting_wall(d: int) -> None:
 def test_gradient_upwind_does_not_converge_at_a_drifting_wall(d: int) -> None:
     """RECORDED DEFECT, not a contract. Fixing it trips this test, and that is intended.
 
-    `gradient_upwind` imposes ∂_n m = 0 at the wall (see the comment "No-flux: dm/dx = 0" in
-    add_boundary_no_flux_entries_gradient_upwind) rather than J·n = 0. With A·n ≠ 0 those differ,
-    and the gradient-form equation under ∂_n m = 0 has a UNIFORM steady state, so the scheme
-    converges to its own wrong limit: the exact profile spans a factor exp(A·L/D) = 4.06 across
-    the domain and the computed one spans 1.10.
+    `gradient_upwind` imposes ∂_n m = 0 (the comment "No-flux: dm/dx = 0" in
+    add_boundary_no_flux_entries_gradient_upwind) rather than J·n = 0, and drops the wall-normal
+    advective flux. Each wall row's steady state is therefore m_0 = m_1, and A·∇m = D∆m under
+    ∂_n m = 0 admits only constants -- so the scheme converges to a UNIFORM limit while the exact
+    solution spans exp(A·L/D) = 4.06. At T = 0.5 the computed span is 1.10, a partially relaxed
+    field; extended to T = 4.0 it reaches 1.0000, the limit itself.
 
-    #1075 records the mass-conservation half of this and is closed; the constructor emits a
-    UserWarning citing it. Neither states that the solution is also wrong in shape -- the warning
-    is about mass only, and its "leaks O(1e-2)" is the zero-drift figure, an order of magnitude
-    below the 1.4e-1 measured here at A = 0.7.
+    #1075 names the wrong condition in its title and is closed; the constructor warns about it; and
+    `test_solver_bc_support_census_1975.py::test_the_gradient_schemes_impose_a_zero_gradient_wall_and_leak`
+    already pins the mass-drift half on the same drive. What is new here is the accuracy form -- the
+    scheme does not converge at all -- and the magnitude: the warning's "leaks O(1e-2)" is the
+    zero-drift figure, an order of magnitude below the 1.4e-1 measured at A = 0.7.
 
     When the wall is rewritten to J·n = 0, this test fails and its message says what to do with it.
     """
-    orders = _observed_orders("gradient_upwind", d, LEVELS[d])
+    orders = _orders(_errors("gradient_upwind", "linear", 1, d))
     assert all(abs(o) < 0.2 for o in orders), (
-        f"gradient_upwind now converges (orders={orders}) -- the ∂_n m = 0 wall appears to be "
-        f"fixed. Delete this defect pin and give the scheme a real order assertion."
+        f"gradient_upwind now converges (orders={orders}) -- the ∂_n m = 0 wall appears to be fixed. "
+        f"Delete this defect pin and give the scheme a real order assertion."
+    )
+
+
+def test_divergence_upwind_is_first_order_on_the_published_gibbs_instance() -> None:
+    """The GFDM paper's source-free exact reflected MFG, as an independent published oracle.
+
+    Its drift is tangential AT the wall node (∂_ν phi = 0), which the linear instance's is not, and
+    its potential is non-linear, which exercises a part of the drift reconstruction the linear one
+    cannot. The order verdict must nevertheless agree, since it does not depend on the choice of phi.
+    """
+    errors = [_solve_error("divergence_upwind", nx, "gibbs") for nx in LEVELS[2]]
+    orders = _orders(errors)
+    assert all(0.8 <= o <= 1.4 for o in orders), f"expected first order, observed {orders}"
+    assert errors[0] < GIBBS_LEVEL_BOUND, (
+        f"error level {errors[0]:.4e} exceeds {GIBBS_LEVEL_BOUND:.1e} on the published instance"
+    )
+
+
+def test_gradient_upwind_is_wrong_on_a_non_linear_potential_for_a_second_reason() -> None:
+    """RECORDED DEFECT, not a contract -- and a DIFFERENT defect from the wall pinned above.
+
+    The linear instance has constant α, so ∇·(αm) = α·∇m there and the two interior forms coincide;
+    fixing the wall repairs `gradient_upwind` completely on it (6.69e-1 -> 2.23e-2, EOC 0.937,
+    matching `divergence_upwind`). On this instance α is not constant, m∇·α ≠ 0, and the gradient
+    form is therefore discretizing a different operator. The same wall repointing does NOT repair it
+    (5.81e-1 -> 8.02e-1, EOC −0.007 -> 0.108) -- which is the evidence that `gradient_upwind` is not
+    the FP operator with a bad wall, but a different operator.
+
+    Retirement condition, and it is NOT the wall fix: this pin retires when the interior form is
+    corrected to carry m∇·α, or when the scheme is removed. A wall-only change leaves it passing,
+    correctly.
+    """
+    errors = [_solve_error("gradient_upwind", nx, "gibbs") for nx in LEVELS[2]]
+    assert all(e > 0.5 for e in errors), (
+        f"gradient_upwind is no longer grossly wrong on a non-linear potential (errors={errors}). "
+        f"If the interior form now carries m*div(alpha), delete this pin and assert a real order."
     )

--- a/tests/unit/test_alg/test_fp_mms_wall_order_1728.py
+++ b/tests/unit/test_alg/test_fp_mms_wall_order_1728.py
@@ -22,8 +22,8 @@ Two instances of that family are measured, and they are independent of each othe
 - **Gibbs** `phi = A(cos Kx₁ + cos Kx₂)` with K = 4π, D = 1/8, A = D ln5/4, T = 1 on (0,1)²: the
   published source-free exact reflected MFG of the GFDM paper (app:source_free_benchmark,
   def:source_free_benchmark), whose m* has contrast max/min = 5. Here ∂_ν phi = 0 on ∂Ω, so b*·n
-  vanishes **at the wall node** -- but not on the boundary cell's interior face, where
-  |∂₁phi| = A K sin(K dx) = 0.195 at dx = 1/40. A published oracle reaching the same verdicts as
+  vanishes **at the wall node** -- but not on the boundary cell's interior face, where the
+  velocity the scheme forms, −(phi(dx) − phi(0))/dx, is 0.0985 at dx = 1/40. A published oracle reaching the same verdicts as
   the linear one is worth more than either alone.
 
 Why the study runs over dimension and over sign
@@ -37,11 +37,15 @@ of the three separate in 2D.
 The sign is parametrized because A > 0 alone never exercises the upwind *selection*: every face
 velocity has one sign, so only one branch of each `if alpha >= 0 / else` is taken, and a mutant that
 always upwinds from the left reproduces the library's output to bitwise equality. The library's own
-numbers are unchanged by the flip -- the problem is mirror-symmetric under x -> L − x -- while such
-a mutant is not, so the coverage is free.
+numbers are unchanged by the flip to 9.3e-14 -- the problem is mirror-symmetric under x -> L − x
+-- while such a mutant is not, so the coverage is free.
 
 WHAT THIS STUDY CANNOT SEE
 --------------------------
+- **The two `gradient_upwind` pins assert that it is broken, so they cannot protect what still
+  works in it.** Deleting its advection term outright leaves all tests here green. That is
+  inherent to pinning non-convergence, and it is the honest answer to "what change trips
+  neither pin while breaking the scheme": read them as recording two defects, not as coverage.
 - **It cannot attribute the order to the wall alone.** The measured order is a *min* over the wall
   closure and the interior stencil: substituting a centered interior for `divergence_upwind` still
   gives EOC 0.89/0.94, and substituting a centered *wall* still gives 0.89/0.95 in 1D. That is why
@@ -51,17 +55,28 @@ WHAT THIS STUDY CANNOT SEE
   pair can, which is why both are here. With constant A, ∇·(αm) = α·∇m + m∇·α reduces to α·∇m, so
   `gradient_upwind`'s interior collapses to `divergence_upwind`'s flux difference, and repointing
   the former's *wall* at the conservative routine makes the two agree to 2.5e-14 there. The Gibbs
-  instance is the complement: its potential is non-linear, so m∇·α ≠ 0, and the SAME wall
-  repointing leaves `gradient_upwind` non-convergent (5.81e-1 -> 8.02e-1, EOC −0.007 -> 0.108)
-  while it fully repairs the linear instance (6.69e-1 -> 2.23e-2, EOC 0.937). So the wall defect
-  and the interior-form defect are separated here without any source term: a non-constant
-  SOURCE-FREE potential suffices, and a sourced MMS is not needed for this question.
+  instance is the complement: its potential is non-linear, so m∇·α ≠ 0, and there the failure is
+  provably not the wall's. Two wall-free checks, because repointing the wall and re-measuring
+  gives a flux-form boundary on a gradient interior -- a hybrid that is neither scheme, so its
+  number measures nothing:
+
+    * The Gibbs instance is exactly periodic-compatible (phi(0) = phi(1), ∇phi = 0 at both ends),
+      and under `periodic_bc` no wall handler is called at all. `gradient_upwind` returns
+      **5.811380e-01 / 5.839517e-01 under both** boundary conditions, identical to seven figures,
+      EOC −0.007 either way. `divergence_upwind` does move (5.503e-2 -> 5.257e-2), which is the
+      control showing the boundary swap is a change this measurement can see.
+    * The omitted term is analytic: ∇·(αm) − α·∇m = m∇·α = −m Δphi, whose max is **31.76** on this
+      instance and identically **zero** on the linear one.
+
+  So the wall defect and the interior-form defect are separated here without any source term: a
+  non-constant SOURCE-FREE potential suffices, and a sourced MMS is not needed for this question.
 - **It cannot see a dt error floor**, because the exact solution is stationary. `NT` is held fixed
   while Nx refines for that reason -- not because the schemes are implicit, which buys unconditional
   stability and nothing about accuracy. Measured: errors move < 2% from NT = 10 to NT = 640, and the
   orders are unchanged under NT ~ Nx and NT ~ Nx². For a *non-stationary* manufactured solution the
   same fixed-NT refinement would be confounded, and the explicit FP solvers are confounded by it
-  here (`fvm:upwind` reads EOC −1.34 at fixed NT and +0.81 once dt refines with dx).
+  here: `fvm:upwind` reads EOC −1.34 at fixed NT, still −0.26 at dt ∝ dx, and only +0.91 at
+  dt ∝ dx², which is the rule the diffusive number D dt/dx² actually fixes.
 """
 
 from __future__ import annotations
@@ -103,6 +118,9 @@ LEVELS = {1: (21, 41, 81), 2: (21, 41)}
 UPWIND_LEVEL_BOUND = {1: 2.3e-2, 2: 2.9e-2}
 # Same construction for the Gibbs instance: library 5.5032e-2, centered-interior mutant 1.6857e-1.
 GIBBS_LEVEL_BOUND = 1.1e-1
+# Those constants are levels, not ratios, so they are meaningless at a different coarsest grid:
+# at Nx = 41 the B1 mutant slips under the d=1 bound and at Nx = 11 the library itself exceeds it.
+assert all(v[0] == 21 for v in LEVELS.values()), "level bounds were measured at Nx = 21"
 
 
 def _build(nx: int, d: int, sigma: float, horizon: float) -> tuple[TensorProductGrid, MFGProblem]:
@@ -162,24 +180,41 @@ def _orders(errors: list[float]) -> list[float]:
     return [float(np.log(a / b) / np.log(2.0)) for a, b in pairwise(errors)]
 
 
+def _analytic_drift(grid: TensorProductGrid, instance: str, A: np.ndarray) -> list[np.ndarray]:
+    """b* = -grad(phi), per component, on the grid layout."""
+    shape = tuple(grid.Nx_points)
+    if instance == "linear":
+        return [np.full(shape, A[k]) for k in range(len(shape))]
+    points = grid.get_spatial_grid()
+    return [(GIBBS_A * GIBBS_K * np.sin(GIBBS_K * points[:, k])).reshape(shape) for k in range(len(shape))]
+
+
+@pytest.mark.parametrize("instance", ["linear", "gibbs"])
 @pytest.mark.parametrize("d", [1, 2])
-def test_manufactured_pair_carries_zero_flux(d: int) -> None:
+def test_manufactured_pair_carries_zero_flux(d: int, instance: str) -> None:
     """Positive control on the oracle itself, before any solver is measured against it.
 
     The construction claims J ≡ 0. If it is wrong -- or if the flat (N, d) point list is reshaped in
     the wrong order -- every order below is measured against a wrong reference. The finite difference
     used here is second order, so the residual must fall by ~4 per refinement; a scrambled field does
     not converge at all (measured on an F-order reshape: order 0.001).
+
+    The Gibbs field is EXACTLY transpose-symmetric, so it can never detect an axis swap; the linear
+    pair, whose components are distinct, is what carries that half for both instances.
     """
     A = A_FULL[:d]
+    diffusion = LIN_D if instance == "linear" else GIBBS_D
+    sigma, horizon = (LIN_SIGMA, LIN_T) if instance == "linear" else (GIBBS_SIGMA, GIBBS_T)
     residuals = []
     for nx in (21, 41):
-        grid, _ = _build(nx, d, LIN_SIGMA, LIN_T)
-        m, _ = _zero_flux_pair(grid, _linear_phi(grid, A), LIN_D)
+        grid, _ = _build(nx, d, sigma, horizon)
+        phi = _linear_phi(grid, A) if instance == "linear" else _gibbs_phi(grid)
+        m, _ = _zero_flux_pair(grid, phi, diffusion)
+        b = _analytic_drift(grid, instance, A)
         dx = L / (nx - 1)
         residuals.append(
             max(
-                float(np.abs(A[k] * m - LIN_D * np.gradient(m, dx, axis=k, edge_order=2)).max() / m.max())
+                float(np.abs(b[k] * m - diffusion * np.gradient(m, dx, axis=k, edge_order=2)).max() / m.max())
                 for k in range(d)
             )
         )
@@ -261,16 +296,24 @@ def test_gradient_upwind_is_wrong_on_a_non_linear_potential_for_a_second_reason(
     The linear instance has constant α, so ∇·(αm) = α·∇m there and the two interior forms coincide;
     fixing the wall repairs `gradient_upwind` completely on it (6.69e-1 -> 2.23e-2, EOC 0.937,
     matching `divergence_upwind`). On this instance α is not constant, m∇·α ≠ 0, and the gradient
-    form is therefore discretizing a different operator. The same wall repointing does NOT repair it
-    (5.81e-1 -> 8.02e-1, EOC −0.007 -> 0.108) -- which is the evidence that `gradient_upwind` is not
-    the FP operator with a bad wall, but a different operator.
+    form is therefore discretizing a different operator. The evidence is wall-free, because
+    repointing the wall and re-measuring would give a flux-form boundary on a gradient interior --
+    a hybrid that is neither scheme. Instead: this instance is exactly periodic-compatible, and
+    under `periodic_bc`, where no wall handler runs at all, `gradient_upwind` returns the SAME
+    errors as under no-flux to seven figures (5.811380e-01 / 5.839517e-01, EOC −0.007 both ways)
+    while `divergence_upwind` does move (5.503e-2 -> 5.257e-2). The omitted term is analytic:
+    ∇·(αm) − α·∇m = −m Δphi, max 31.76 here and identically zero on the linear instance.
 
     Retirement condition, and it is NOT the wall fix: this pin retires when the interior form is
     corrected to carry m∇·α, or when the scheme is removed. A wall-only change leaves it passing,
     correctly.
+
+    The assertion is on the ORDER rather than the error level, because the level does not separate
+    the states it must: library 0.5811, interior-fixed 0.5150, advection-deleted 0.5185, all within
+    13% of each other. The order does: −0.007, +1.340, −0.004.
     """
-    errors = [_solve_error("gradient_upwind", nx, "gibbs") for nx in LEVELS[2]]
-    assert all(e > 0.5 for e in errors), (
-        f"gradient_upwind is no longer grossly wrong on a non-linear potential (errors={errors}). "
-        f"If the interior form now carries m*div(alpha), delete this pin and assert a real order."
+    orders = _orders([_solve_error("gradient_upwind", nx, "gibbs") for nx in LEVELS[2]])
+    assert all(abs(o) < 0.2 for o in orders), (
+        f"gradient_upwind now converges on a non-linear potential (orders={orders}). If the interior "
+        f"form carries m*div(alpha), delete this pin and assert a real order."
     )

--- a/tests/unit/test_alg/test_fp_mms_wall_order_1728.py
+++ b/tests/unit/test_alg/test_fp_mms_wall_order_1728.py
@@ -1,0 +1,162 @@
+"""MMS order study for the FP-FDM advection schemes at a non-tangential no-flux wall.
+
+Closes the gap named in #1728: the MMS test previously cited as covering `divergence_upwind`'s
+spatial order runs at zero drift, so substituting any other advection scheme leaves its output
+bit-identical and the stated order has never been under test.
+
+Manufactured solution
+---------------------
+An impermeable wall is J·n = 0 with J = αm − D∇m, D = σ²/2. For a **constant** drift vector A the
+density that makes the flux vanish everywhere — not merely on the wall — is
+
+    m̄(x) = C exp(A·x / D),
+
+since ∇m̄ = (A/D) m̄ gives J = A m̄ − D (A/D) m̄ ≡ 0. Hence the source term is identically zero:
+the manufactured solution is stationary, and the measurement is whether a scheme preserves it.
+No `source_term` channel is needed, so this oracle is available to every FP solver.
+
+Why constant A: in the interior ∇·(αm) = α·∇m + m ∇·α reduces to α·∇m when α is constant, so the
+divergence and gradient forms coincide away from the wall. The probe therefore isolates the
+**wall treatment**, which is what distinguishes the two boundary architectures (#2005).
+
+Why the study runs over dimension: on the wall x_k = 0 the outward normal is −e_k, so A has normal
+component −A_k and tangential components A_j (j ≠ k). In d = 1 there is no tangential direction at
+all, so a scheme mishandling the tangential part cannot be discriminated there.
+
+Drive: α = −c∇U with U(x) = −A·x reproduces A exactly for QuadraticControlCost(1.0). The potential
+channel is used rather than the velocity channel because only the interface-velocity schemes read
+the latter (#1632).
+
+Cell Péclet is |A| dx / D = 0.07 at the coarsest level, so `divergence_centered` is nowhere near
+its stability limit: the tests below discriminate on order, not on stability (#1728's fourth
+acceptance condition).
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+L = 1.0
+T = 0.5
+SIGMA = 1.0
+D = 0.5 * SIGMA**2
+NT = 40
+
+# Distinct components, so a reshape that transposed the field would break the flux control below.
+A_FULL = np.array([0.7, 0.4, 0.2])
+
+
+def _build(nx: int, d: int) -> tuple[TensorProductGrid, MFGProblem]:
+    grid = TensorProductGrid(bounds=[(0.0, L)] * d, Nx_points=[nx] * d, boundary_conditions=no_flux_bc(dimension=d))
+    components = MFGComponents(
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+        m_initial=lambda x: 1.0 / L**d,
+        u_terminal=lambda x: 0.0,
+    )
+    return grid, MFGProblem(geometry=grid, components=components, T=T, Nt=NT, sigma=SIGMA)
+
+
+def _manufactured(grid: TensorProductGrid, A: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return (m̄, U) on the grid's own layout. Both exact, both time-independent."""
+    points = grid.get_spatial_grid()  # (N, d)
+    shape = tuple(grid.Nx_points)
+    w = points @ A  # A·x
+    m = np.exp(w / D).reshape(shape)
+    dx = L / (shape[0] - 1)
+    m /= m.sum() * dx ** len(shape)
+    return m, (-w).reshape(shape)
+
+
+def _solve_error(scheme: str, nx: int, d: int) -> float:
+    """Relative L-inf distance between m(T) and the stationary exact solution."""
+    grid, problem = _build(nx, d)
+    m0, u = _manufactured(grid, A_FULL[:d])
+    U = np.broadcast_to(u, (NT + 1, *u.shape)).copy()
+    solver = FPFDMSolver(problem, advection_scheme=scheme)
+    M = np.asarray(solver.solve_fp_system(M_initial=m0, potential_field=U))
+    return float(np.abs(M[-1] - m0).max() / m0.max())
+
+
+def _observed_orders(scheme: str, d: int, levels: tuple[int, ...]) -> list[float]:
+    errors = [_solve_error(scheme, nx, d) for nx in levels]
+    return [float(np.log(a / b) / np.log(2.0)) for a, b in pairwise(errors)]
+
+
+LEVELS = {1: (21, 41, 81), 2: (21, 41)}
+
+
+@pytest.mark.parametrize("d", [1, 2])
+def test_manufactured_pair_carries_zero_flux(d: int) -> None:
+    """Positive control on the oracle itself, before any solver is measured against it.
+
+    The construction claims J ≡ 0. If it is wrong -- or if the flat (N, d) point list is reshaped
+    in the wrong order -- every order below is measured against a wrong reference. The finite
+    difference used here is second order, so the residual must fall by ~4 per refinement; a
+    scrambled field would not converge at all.
+    """
+    A = A_FULL[:d]
+    residuals = []
+    for nx in (21, 41):
+        grid, _ = _build(nx, d)
+        m, _ = _manufactured(grid, A)
+        dx = L / (nx - 1)
+        residuals.append(
+            max(
+                float(np.abs(A[k] * m - D * np.gradient(m, dx, axis=k, edge_order=2)).max() / m.max()) for k in range(d)
+            )
+        )
+    order = np.log(residuals[0] / residuals[1]) / np.log(2.0)
+    assert order > 1.8, f"flux control is not converging at 2nd order: residuals={residuals}"
+
+
+@pytest.mark.parametrize("d", [1, 2])
+def test_divergence_upwind_is_first_order_at_a_drifting_wall(d: int) -> None:
+    """#1728: the scheme's advertised first order, measured with the advection term active.
+
+    The upper bound is what makes this mutation-red. `divergence_centered` scores ~1.97 on the same
+    manufactured solution, so substituting it fails here -- which is precisely the discrimination
+    the zero-drift MMS test cited in #1728 does not have.
+    """
+    orders = _observed_orders("divergence_upwind", d, LEVELS[d])
+    assert all(0.8 <= o <= 1.4 for o in orders), f"expected first order, observed {orders}"
+
+
+@pytest.mark.parametrize("d", [1, 2])
+def test_divergence_centered_is_second_order_at_a_drifting_wall(d: int) -> None:
+    orders = _observed_orders("divergence_centered", d, LEVELS[d])
+    assert all(o > 1.8 for o in orders), f"expected second order, observed {orders}"
+
+
+@pytest.mark.parametrize("d", [1, 2])
+def test_gradient_upwind_does_not_converge_at_a_drifting_wall(d: int) -> None:
+    """RECORDED DEFECT, not a contract. Fixing it trips this test, and that is intended.
+
+    `gradient_upwind` imposes ∂_n m = 0 at the wall (see the comment "No-flux: dm/dx = 0" in
+    add_boundary_no_flux_entries_gradient_upwind) rather than J·n = 0. With A·n ≠ 0 those differ,
+    and the gradient-form equation under ∂_n m = 0 has a UNIFORM steady state, so the scheme
+    converges to its own wrong limit: the exact profile spans a factor exp(A·L/D) = 4.06 across
+    the domain and the computed one spans 1.10.
+
+    #1075 records the mass-conservation half of this and is closed; the constructor emits a
+    UserWarning citing it. Neither states that the solution is also wrong in shape -- the warning
+    is about mass only, and its "leaks O(1e-2)" is the zero-drift figure, an order of magnitude
+    below the 1.4e-1 measured here at A = 0.7.
+
+    When the wall is rewritten to J·n = 0, this test fails and its message says what to do with it.
+    """
+    orders = _observed_orders("gradient_upwind", d, LEVELS[d])
+    assert all(abs(o) < 0.2 for o in orders), (
+        f"gradient_upwind now converges (orders={orders}) -- the ∂_n m = 0 wall appears to be "
+        f"fixed. Delete this defect pin and give the scheme a real order assertion."
+    )


### PR DESCRIPTION
## What this closes

#1728: "No test in this repository can fail if `divergence_upwind` stops being first-order in
space." The MMS test cited as covering it solves at `potential_field=U_zero`, so substituting any
other advection scheme leaves its output bit-identical.

## The construction

An impermeable wall is $J\cdot n = 0$ with $J = \alpha m - D\nabla m$, $D = \sigma^2/2$. The general
zero-flux (Gibbs) pair is

$$b^* = -\nabla\phi,\qquad m^*(x) = Z^{-1}\exp(-\phi(x)/D),$$

for which $\nabla m^* = -(\nabla\phi/D)m^*$ gives $J \equiv 0$ **everywhere**, not merely on the
wall. So $r_m \equiv 0$: the exact solution is stationary and **source-free**, and no `source_term`
channel is needed — which matters, since only `FPFDMSolver` and `FPFVMSolver` accept one.

**Two instances, and the pair is the point.**

| | $\phi$ | drift | what it isolates |
|---|---|---|---|
| linear | $-A\cdot x$ | constant $A$, $b^*\!\cdot n \neq 0$ at the wall node | the **wall**: interior forms coincide |
| Gibbs | $A(\cos Kx_1 + \cos Kx_2)$ | non-constant, $b^*\!\cdot n = 0$ at the node | the **interior form**: $m\nabla\!\cdot\!\alpha \neq 0$ |

The Gibbs instance is the GFDM paper's published source-free exact reflected MFG
(`app:source_free_benchmark`), $K = 4\pi$, $D = 1/8$, $A = D\ln 5/4$ on $(0,1)^2$, contrast 5.

## Measured

Relative $L^\infty$ at $T$, $N_x = 21/41/81$, $d=1$:

| scheme | errors | EOC | mass drift |
|---|---|---|---|
| `divergence_centered` | 1.99e-4, 5.09e-5, 1.29e-5 | 1.97, 1.98 | 2e-14 |
| `divergence_upwind` | 1.63e-2, 8.53e-3, 4.36e-3 | 0.93, 0.97 | 9e-14 |
| `gradient_upwind` | 5.10e-1, 5.10e-1, 5.10e-1 | 0.00, 0.00 | **−1.4e-1** |

$d=2$ agrees: 1.97 / 0.94 / −0.00.

## The two instances separate two distinct defects

On the **linear** instance, repointing `gradient_upwind`'s wall at the conservative routine repairs
it completely: `6.69e-1 → 2.23e-2`, EOC `−0.000 → 0.937`, agreeing with `divergence_upwind` to
2.5e-14. On the **Gibbs** instance the failure is not the wall's at all, and the evidence is
wall-free — repointing and re-measuring there would give a flux-form boundary on a gradient interior,
a hybrid that is neither scheme, so that number is not cited:

- **Periodic BC.** The Gibbs instance is exactly periodic-compatible ($\phi(0)=\phi(1)$,
  $\nabla\phi=0$ at both ends), and under `periodic_bc` no wall handler runs. `gradient_upwind`
  returns **5.811380e-01 / 5.839517e-01 under both** boundary conditions — identical to seven
  figures, EOC −0.007 either way — while `divergence_upwind` does move (5.503e-2 → 5.257e-2), which
  is the control showing the swap is a change this measurement can see.
- **The omitted term is analytic.** $\nabla\!\cdot\!(\alpha m) - \alpha\!\cdot\!\nabla m
  = -m\,\Delta\phi$, whose max is **31.76** here and identically **zero** on the linear instance.

So `gradient_upwind` is not the FP operator with a bad wall; the gradient form drops
$m\nabla\!\cdot\!\alpha$. **It is a different operator.** That bears
on #2005: the two BC architectures are not two encodings of one wall with a seam to close. Filed as
#2007.

Each defect is pinned separately, and each pin is verified to trip on **its own** fix and not the
other's: wall fix → wall pin red, interior pin green (correctly); interior fix → interior pin red.

## Mutation-red — measured, not asserted

| mutation | before review | now |
|---|---|---|
| centered interior for `divergence_upwind` | 0 of 8 fail | **4 fail** |
| upwind selection deleted (always-left) | bitwise equal, undetectable | **2 fail** (the negative-sign cases) |
| `divergence_centered` in the first-order test | fails | fails |
| `gradient_upwind` wall repointed | pin fails | pin fails |
| `gradient_upwind` interior → divergence form | — | **interior pin fails** |

The order alone cannot attribute the $O(h)$ to the wall — a centered interior reads 0.89/0.94 and a
centered wall 0.89/0.95 — so the order tests assert an error **level** beside the order, with bounds
set from measurement (d=1 library 1.6305e-2 vs mutant 2.9791e-2; d=2 2.2303e-2 vs 3.6212e-2; Gibbs
5.5032e-2 vs 1.6857e-1). The drift carries a negative component and the study runs both signs,
because one sign takes only one branch of each upwind selection; the library's numbers are unchanged
by the flip (mirror symmetry) while the mutant's are not.

Cell Péclet is 0.07 at the coarsest level, so `divergence_centered` is far from its stability limit:
the tests discriminate on order, not stability (#1728's fourth condition).

## Corrections to this PR's earlier claims

- ~~"bit-identical"~~ → the repointed schemes agree to **2.5e-14**; `np.array_equal` is False.
- ~~"whether the repointing is a correct fix needs a non-constant-drift MMS, which does need
  `source_term`"~~ → **false**. A non-constant *source-free* potential settles it, and the Gibbs
  instance does.
- ~~"the probe isolates the wall treatment"~~ → true only along the divergence-vs-gradient axis;
  along upwind-vs-centered neither half is isolated, which is why the level assertions exist.
- The fixed-`NT` justification was implicitness. Implicitness buys unconditional stability, not
  accuracy; the operative reason is that the exact solution is **stationary**.
- The uniform-limit span 1.10 is a partially relaxed field at $T = 0.5$; the limit is **1.0000** at
  $T = 4.0$.

## Existing coverage this does not duplicate

`test_solver_bc_support_census_1975.py::test_the_gradient_schemes_impose_a_zero_gradient_wall_and_leak`
already pins the mass-drift half on the same drive, and is now cited in the file. New here: the
accuracy form (the scheme does not converge at all), the separation of the two defects, and the
magnitude — the constructor warning's "leaks O(1e-2)" is the **zero-drift** figure, an order of
magnitude below the 1.4e-1 at wall-normal drift.

## Filed from the review

- **#2007** — the two `gradient_*` defects; the warning string understates the leak by 10×.
- **#2008** — `examples/basic/three_mode_api_demo.py:103` loses **98.17%** of its mass while the
  Picard loop reports `err_M=9.27e-07`, and `examples/` is outside `testpaths`. Pre-existing.

## Known, deferred

The file uses the legacy `MFGProblem(geometry=, components=, ...)` API (19 DeprecationWarnings).
~~No test in the repository uses the v1.0 form~~ **9 do** — `grep "MFGProblem(model="` returns 0
because ruff wraps the call across lines; `rg -U` returns 9 against a control of **163** legacy call
sites. The defensible reason is the ratio, not an absence: the legacy form is this suite's
convention, so migrating one file alone would be the inconsistent move.

## Gate

`./scripts/local_ci.sh` via the pre-push hook: **Passed**, both pushes. 14 tests, 9.8 s.

Closes #1728

