### PR TITLE
test: delete a "h-convergence" test that compares two unconverged Picard residuals (#1998)

### DIFF
--- a/changelog.d/1998-nightly-residual-not-a-rate.removed.md
+++ b/changelog.d/1998-nightly-residual-not-a-rate.removed.md
@@ -38,12 +38,20 @@ entirely the **U** increment (at `Nx=40`, iteration 29: `err_U` 4.238e-04 agains
 while `test_fdm_upwind_stable`'s mass-conservation and `M.min() > 0` assertions constrain M's
 physics. The two sets are incomparable, not ordered, and that test stops at iteration 20.
 
-The rest is smaller than first stated. The `Nx=40` leg duplicates `test_fdm_upwind_stable` on every
-listed parameter, differing only in `max_iterations` (30 vs 20) and tolerance. And the coarse leg is
-not uncovered in kind: `tests/integration/test_fvm_hjb_coupling.py`'s `fdm_1d` fixture runs a coupled
-1D no-flux `FDM_UPWIND` solve at `Nx=25, Nt=12, sigma=0.4` asserting convergence, a 10× error drop,
-mass and positivity — strictly stronger, at comparable coarseness. What has no counterpart is the
-**low-σ / high-Péclet** coarse regime.
+The rest is smaller than first stated: the `Nx=40` leg duplicates `test_fdm_upwind_stable` on every
+listed parameter, differing only in `max_iterations` (30 vs 20) and tolerance.
+
+**The coarse leg has no counterpart anywhere, and an earlier version of this fragment said
+otherwise.** It claimed `tests/integration/test_fvm_hjb_coupling.py`'s `fdm_1d` fixture asserts
+"convergence, a 10× error drop, mass and positivity — strictly stronger". Those four assertions are
+made on the **`fvm_1d`** fixture, which runs `FVM_MUSCL`. `fdm_1d` runs `FDM_UPWIND` and has exactly
+one consumer, `test_1d_fvm_fdm_agreement`, which asserts cross-scheme agreement (`rel_m < 0.07`) and
+nothing about convergence, mass or positivity. Verified: `grep -n "fdm_1d\|fvm_1d"` over that file
+returns 9 lines, 3 of them the `fvm_1d`-only tests, 1 the shared agreement test.
+
+So a raise or a NaN from the coarse `FDM_UPWIND` solve is now caught by nothing — which is what this
+fragment originally said before the false citation replaced it. The **low-σ / high-Péclet** coarse
+regime is uncovered, and so is the coarse regime generally.
 
 **The case for repairing instead** is stronger than "fix the two-grid rate test", and worth weighing:
 `test_fdm_upwind_stable` already runs the identical `Nx=41, Nt=20, sigma=0.1, FDM_UPWIND` solve and

--- a/changelog.d/1998-nightly-residual-not-a-rate.removed.md
+++ b/changelog.d/1998-nightly-residual-not-a-rate.removed.md
@@ -1,0 +1,31 @@
+`TestDualityConvergence::test_mesh_refinement_improves_accuracy` is removed rather than repaired
+(#1998). It is the whole of "Nightly full test suite is failing": the validation shard reports
+`1 failed, 27 passed`, that one test, and every other shard is green.
+
+It recorded `result.max_error` — the final **Picard residual** — and compared two of them across
+`Nx = 20 / 40` under the name "h-convergence". Measured, with the test's own `tolerance=1e-8` and
+`max_iterations=30`, **both legs run to the cap**: `converged=False, iterations=30/30` on either
+grid. So the two numbers are residuals of unconverged iterations and their ratio is a fact about how
+far each got in thirty steps, not about mesh resolution. #1728 names this exact defect in a
+different test — "it compared `result.max_error`, the final Picard residual — so removing it lost
+nothing" — and a sibling in this same file, `test_centered_fdm_higher_order`, was removed on
+2026-07-25 for the same reason, with the account left in place above where this one sat.
+
+That also explains why bisecting the green-to-red window found nothing. Same code, same nightly
+invocation (`-n auto`, the nightly marker set, which does not exclude `slow`):
+
+| platform | `Nx=20` | `Nx=40` | assertion |
+|---|---|---|---|
+| darwin/arm64 | 5.935364e-04 | 4.237936e-04 | holds |
+| linux (CI) | 8.814973e-05 | 9.901234e-04 | fails, 11x |
+
+Both deterministic on their platform — CI produced identical digits on two different commits — so
+it is one BLAS path through a non-converged iteration against another, not a regression from any
+commit in the window.
+
+Nothing is lost. The `Nx=40` leg's configuration is identical to
+`TestNumericalStability::test_fdm_upwind_stable` in the same file — `Nx_points=[41]`, `Nt=20`,
+`T=1.0`, `sigma=0.1`, the same components, `FDM_UPWIND` — and that test asserts `U` and `M` finite
+and the density positive, strictly stronger than this one's `e < 1000` on a residual. Real
+h-convergence has a home as of #2006: `tests/unit/test_alg/test_fp_mms_wall_order_1728.py` measures
+observed order against a source-free exact solution, with error-level bounds verified mutation-red.

--- a/changelog.d/1998-nightly-residual-not-a-rate.removed.md
+++ b/changelog.d/1998-nightly-residual-not-a-rate.removed.md
@@ -6,8 +6,9 @@ the issue covers.
 It recorded `result.max_error` — the final **Picard residual** — and compared two of them across
 `Nx = 20 / 40` under the name "h-convergence". Measured, with the test's own `tolerance=1e-8` and
 `max_iterations=30`, **both legs run to the cap**: `converged=False, iterations=30/30`. Raising the
-cap does not help — at 300 the residual **limit-cycles** between `5.9e-05` and `1.7e-03` and ends
-worse than its own best. `max_error` here is a sample from a cycle, so no assertion over two samples
+cap does not help — at 300 neither converges: the residual peaks at **1.26e+03 around iteration 4**,
+then settles onto a `1e-4`…`2e-3` floor it never leaves, ending far from its own best
+(`1.78e-06` at iteration 194). `max_error` here is a sample from a cycle, so no assertion over two samples
 can measure a rate. The precedent is `TestConvergenceRate::test_upwind_first_order_convergence`,
 removed for this exact reason and named by #1728; the other removal in this file,
 `test_centered_fdm_higher_order`, is a different defect (one grid, tautological assertion).
@@ -27,13 +28,24 @@ what a limit-cycling residual does and is stronger grounds for deletion than a c
 No platform conditional exists in the window and CI pins the BLAS thread counts to 1. Anyone tracing
 an FDM_UPWIND no-flux discrepancy to this window should start at #1902 and #1904.
 
-**What the deletion costs.** The `Nx=40` leg duplicates `TestNumericalStability::test_fdm_upwind_stable`
-on every listed parameter — `Nx_points=[41]`, `Nt=20`, `T=1.0`, `sigma=0.1`, same components,
-`FDM_UPWIND` — differing only in `max_iterations` (30 vs 20) and tolerance, so iterations 21–30 there
-are now unexercised. That test's mass-conservation and `M.min() > 0` assertions dominate this one's
-`e < 1000`; its `isfinite` checks do not, since a finite oscillating iterate can carry a residual
-above 1000. The **coarse** leg — `Nx_points=[21]`, `Nt=10`, `sigma=0.1`, coupled — has no counterpart
-in the suite, so a raise or a NaN from that specific solve is now caught by nothing. Thin, and real.
+**What the deletion costs, and the first version of this understated it.** `e < 1000` was **not**
+vacuous: the residual crosses it by 26% in this very solve. So it was a crude but **live** guard on
+the transient decay rate — anything costing ~eight Picard iterations of convergence speed pushes
+iteration 30 back over 1000 and fires it. No domination claim survives either: `max_error` here is
+entirely the **U** increment (at `Nx=40`, iteration 29: `err_U` 4.238e-04 against `err_M` 4.807e-08),
+while `test_fdm_upwind_stable`'s mass-conservation and `M.min() > 0` assertions constrain M's
+physics. The two sets are incomparable, not ordered, and that test stops at iteration 20.
+
+The rest is smaller than first stated. The `Nx=40` leg duplicates `test_fdm_upwind_stable` on every
+listed parameter, differing only in `max_iterations` (30 vs 20) and tolerance. And the coarse leg is
+not uncovered in kind: `tests/integration/test_fvm_hjb_coupling.py`'s `fdm_1d` fixture runs a coupled
+1D no-flux `FDM_UPWIND` solve at `Nx=25, Nt=12, sigma=0.4` asserting convergence, a 10× error drop,
+mass and positivity — strictly stronger, at comparable coarseness. What has no counterpart is the
+**low-σ / high-Péclet** coarse regime, and the transient guard.
+
+Deleting is still right — a threshold on an unconverged residual is a poor instrument even when live,
+and the *rate* assertion beside it is indefensible at any threshold. But the transient goes unguarded
+and that is recorded, not claimed away.
 
 Coupled EOC through the production `FixedPointIterator` already exists in
 `tests/integration/test_coupled_mfg_mms.py`. What remains uncovered is coupled EOC **at a no-flux

--- a/changelog.d/1998-nightly-residual-not-a-rate.removed.md
+++ b/changelog.d/1998-nightly-residual-not-a-rate.removed.md
@@ -1,31 +1,41 @@
 `TestDualityConvergence::test_mesh_refinement_improves_accuracy` is removed rather than repaired
 (#1998). It is the whole of "Nightly full test suite is failing": the validation shard reports
-`1 failed, 27 passed`, that one test, and every other shard is green.
+`1 failed, 27 passed, 4 xfailed` — that one test — and every other shard is green, on both red runs
+the issue covers.
 
 It recorded `result.max_error` — the final **Picard residual** — and compared two of them across
 `Nx = 20 / 40` under the name "h-convergence". Measured, with the test's own `tolerance=1e-8` and
-`max_iterations=30`, **both legs run to the cap**: `converged=False, iterations=30/30` on either
-grid. So the two numbers are residuals of unconverged iterations and their ratio is a fact about how
-far each got in thirty steps, not about mesh resolution. #1728 names this exact defect in a
-different test — "it compared `result.max_error`, the final Picard residual — so removing it lost
-nothing" — and a sibling in this same file, `test_centered_fdm_higher_order`, was removed on
-2026-07-25 for the same reason, with the account left in place above where this one sat.
+`max_iterations=30`, **both legs run to the cap**: `converged=False, iterations=30/30`. Raising the
+cap does not help — at 300 the residual **limit-cycles** between `5.9e-05` and `1.7e-03` and ends
+worse than its own best. `max_error` here is a sample from a cycle, so no assertion over two samples
+can measure a rate. The precedent is `TestConvergenceRate::test_upwind_first_order_convergence`,
+removed for this exact reason and named by #1728; the other removal in this file,
+`test_centered_fdm_higher_order`, is a different defect (one grid, tautological assertion).
 
-That also explains why bisecting the green-to-red window found nothing. Same code, same nightly
-invocation (`-n auto`, the nightly marker set, which does not exclude `slow`):
+**The window is not clean, and saying so was wrong.** A real numerical change landed inside it:
+`c98a9c5f` (#1902) deletes the hand-rolled `u[0] = u[1] - g*dx` no-flux enforcement — the boundary
+treatment this test runs through — and moves these numbers ~5× on darwin:
 
-| platform | `Nx=20` | `Nx=40` | assertion |
+| ref | `Nx=20` | `Nx=40` | verdict |
 |---|---|---|---|
-| darwin/arm64 | 5.935364e-04 | 4.237936e-04 | holds |
-| linux (CI) | 8.814973e-05 | 9.901234e-04 | fails, 11x |
+| `179e55a7`, head of the last green nightly | 1.185395e-04 | 5.550650e-04 | **fails** on darwin |
+| `c98a9c5f` and after | 5.935364e-04 | 4.237936e-04 | passes on darwin |
+| linux (CI), `4a50e27b` and after | 8.814973e-05 | 9.901234e-04 | **fails**, 11× |
 
-Both deterministic on their platform — CI produced identical digits on two different commits — so
-it is one BLAS path through a non-converged iteration against another, not a regression from any
-commit in the window.
+The verdict flipped in *opposite directions* on the two platforms across the same change, which is
+what a limit-cycling residual does and is stronger grounds for deletion than a clean-window story.
+No platform conditional exists in the window and CI pins the BLAS thread counts to 1. Anyone tracing
+an FDM_UPWIND no-flux discrepancy to this window should start at #1902 and #1904.
 
-Nothing is lost. The `Nx=40` leg's configuration is identical to
-`TestNumericalStability::test_fdm_upwind_stable` in the same file — `Nx_points=[41]`, `Nt=20`,
-`T=1.0`, `sigma=0.1`, the same components, `FDM_UPWIND` — and that test asserts `U` and `M` finite
-and the density positive, strictly stronger than this one's `e < 1000` on a residual. Real
-h-convergence has a home as of #2006: `tests/unit/test_alg/test_fp_mms_wall_order_1728.py` measures
-observed order against a source-free exact solution, with error-level bounds verified mutation-red.
+**What the deletion costs.** The `Nx=40` leg duplicates `TestNumericalStability::test_fdm_upwind_stable`
+on every listed parameter — `Nx_points=[41]`, `Nt=20`, `T=1.0`, `sigma=0.1`, same components,
+`FDM_UPWIND` — differing only in `max_iterations` (30 vs 20) and tolerance, so iterations 21–30 there
+are now unexercised. That test's mass-conservation and `M.min() > 0` assertions dominate this one's
+`e < 1000`; its `isfinite` checks do not, since a finite oscillating iterate can carry a residual
+above 1000. The **coarse** leg — `Nx_points=[21]`, `Nt=10`, `sigma=0.1`, coupled — has no counterpart
+in the suite, so a raise or a NaN from that specific solve is now caught by nothing. Thin, and real.
+
+Coupled EOC through the production `FixedPointIterator` already exists in
+`tests/integration/test_coupled_mfg_mms.py`. What remains uncovered is coupled EOC **at a no-flux
+wall** — that suite is periodic — which the deleted test never measured either. #2006's standalone FP
+order study covers the wall but not the coupling.

--- a/changelog.d/1998-nightly-residual-not-a-rate.removed.md
+++ b/changelog.d/1998-nightly-residual-not-a-rate.removed.md
@@ -43,7 +43,7 @@ listed parameter, differing only in `max_iterations` (30 vs 20) and tolerance. A
 not uncovered in kind: `tests/integration/test_fvm_hjb_coupling.py`'s `fdm_1d` fixture runs a coupled
 1D no-flux `FDM_UPWIND` solve at `Nx=25, Nt=12, sigma=0.4` asserting convergence, a 10× error drop,
 mass and positivity — strictly stronger, at comparable coarseness. What has no counterpart is the
-**low-σ / high-Péclet** coarse regime, and the transient guard.
+**low-σ / high-Péclet** coarse regime.
 
 **The case for repairing instead** is stronger than "fix the two-grid rate test", and worth weighing:
 `test_fdm_upwind_stable` already runs the identical `Nx=41, Nt=20, sigma=0.1, FDM_UPWIND` solve and

--- a/changelog.d/1998-nightly-residual-not-a-rate.removed.md
+++ b/changelog.d/1998-nightly-residual-not-a-rate.removed.md
@@ -7,8 +7,8 @@ It recorded `result.max_error` — the final **Picard residual** — and compare
 `Nx = 20 / 40` under the name "h-convergence". Measured, with the test's own `tolerance=1e-8` and
 `max_iterations=30`, **both legs run to the cap**: `converged=False, iterations=30/30`. Raising the
 cap does not help — at 300 neither converges: the residual peaks at **1.26e+03 around iteration 4**,
-then settles onto a `1e-4`…`2e-3` floor it never leaves, ending far from its own best
-(`1.78e-06` at iteration 194). `max_error` here is a sample from a cycle, so no assertion over two samples
+then settles onto a noise floor — over iterations 26–300 it ranges `1.78e-06`…`3.44e-03` (`Nx=20`)
+and `7.12e-06`…`3.40e-03` (`Nx=40`) — ending far from its own best. `max_error` here is a sample from a cycle, so no assertion over two samples
 can measure a rate. The precedent is `TestConvergenceRate::test_upwind_first_order_convergence`,
 removed for this exact reason and named by #1728; the other removal in this file,
 `test_centered_fdm_higher_order`, is a different defect (one grid, tautological assertion).
@@ -29,9 +29,11 @@ No platform conditional exists in the window and CI pins the BLAS thread counts 
 an FDM_UPWIND no-flux discrepancy to this window should start at #1902 and #1904.
 
 **What the deletion costs, and the first version of this understated it.** `e < 1000` was **not**
-vacuous: the residual crosses it by 26% in this very solve. So it was a crude but **live** guard on
-the transient decay rate — anything costing ~eight Picard iterations of convergence speed pushes
-iteration 30 back over 1000 and fires it. No domination claim survives either: `max_error` here is
+vacuous: the residual crosses it by 26% in this very solve, so it was a **live** guard on the
+transient decay rate — but a very coarse one. Measured: the assertion samples the *final* residual,
+so tripping it needs the whole decay curve delayed by **24–26 of the 30 iterations**, or the
+per-iteration decay factor to fall from its actual **~1.85 to ≤ 1.01**. A solve that merely slowed
+down stays green; only one that has stopped converging fires it. No domination claim survives either: `max_error` here is
 entirely the **U** increment (at `Nx=40`, iteration 29: `err_U` 4.238e-04 against `err_M` 4.807e-08),
 while `test_fdm_upwind_stable`'s mass-conservation and `M.min() > 0` assertions constrain M's
 physics. The two sets are incomparable, not ordered, and that test stops at iteration 20.
@@ -43,9 +45,19 @@ not uncovered in kind: `tests/integration/test_fvm_hjb_coupling.py`'s `fdm_1d` f
 mass and positivity — strictly stronger, at comparable coarseness. What has no counterpart is the
 **low-σ / high-Péclet** coarse regime, and the transient guard.
 
-Deleting is still right — a threshold on an unconverged residual is a poor instrument even when live,
-and the *rate* assertion beside it is indefensible at any threshold. But the transient goes unguarded
-and that is recorded, not claimed away.
+**The case for repairing instead** is stronger than "fix the two-grid rate test", and worth weighing:
+`test_fdm_upwind_stable` already runs the identical `Nx=41, Nt=20, sigma=0.1, FDM_UPWIND` solve and
+already holds `result`, so a transient bound there is one line at zero marginal runtime — measured
+margin for `final < 1e-2 * peak` at its own 20-iteration budget: **73.5×** at `Nx=20`, **31.9×** at
+`Nx=40`.
+
+Deleting is still right, and not because the guard was worthless. Whatever the guard becomes belongs
+on the **surviving** test, so this one goes either way and the two questions are independent. It also
+wants a **decay** bound rather than a magnitude one — a residual threshold is scale- and
+configuration-dependent, while `final < 1e-2 * peak` is scale-free and fires exactly on the collapse
+above. Writing that assertion here, under an open nightly, is how `e < 1000` got into the file. It is
+#2014, with those margins as its measurement. The exposure between this deletion and that issue is
+stated rather than claimed away: nothing catches a Picard convergence collapse at `sigma=0.1`.
 
 Coupled EOC through the production `FixedPointIterator` already exists in
 `tests/integration/test_coupled_mfg_mms.py`. What remains uncovered is coupled EOC **at a no-flux

--- a/changelog.d/1998-nightly-residual-not-a-rate.removed.md
+++ b/changelog.d/1998-nightly-residual-not-a-rate.removed.md
@@ -51,13 +51,23 @@ already holds `result`, so a transient bound there is one line at zero marginal 
 margin for `final < 1e-2 * peak` at its own 20-iteration budget: **73.5×** at `Nx=20`, **31.9×** at
 `Nx=40`.
 
+**And the transient is not left unguarded** — an earlier draft of this fragment said it was.
+Measured on `test_dual_fdm_pair_converges`' own configuration (`Nx_points=[41]`, `Nt=20`,
+`sigma=0.1`, `FDM_UPWIND`, `max_iterations=50`), its `:94` assertion `final_error <= initial_max*2.0`
+reads threshold `1.003133e+03` against final `1.823556e+02` — a **5.50× margin** — and it is *more*
+sensitive than the deleted one: `:94` fires at a uniform post-peak decay factor below **1.0440**,
+`e < 1000` at below **1.0088**, so `:94`'s firing region strictly contains it, 20 iterations sooner.
+What the deletion actually costs is the `sigma=0.1` **coarse** leg (`Nx_points=[21]`), which has no
+such neighbour.
+
 Deleting is still right, and not because the guard was worthless. Whatever the guard becomes belongs
-on the **surviving** test, so this one goes either way and the two questions are independent. It also
-wants a **decay** bound rather than a magnitude one — a residual threshold is scale- and
-configuration-dependent, while `final < 1e-2 * peak` is scale-free and fires exactly on the collapse
-above. Writing that assertion here, under an open nightly, is how `e < 1000` got into the file. It is
-#2014, with those margins as its measurement. The exposure between this deletion and that issue is
-stated rather than claimed away: nothing catches a Picard convergence collapse at `sigma=0.1`.
+on the **surviving** test, so this one goes either way. It also wants a **decay** bound rather than a
+magnitude one — `final < 1e-2 * peak` is scale-free, margin **31.9×** at `test_fdm_upwind_stable`'s
+own budget. Writing a threshold here to fit what was observed is how this file got its numbers:
+`c1a3696b`, the day the file was created, is *"Relax convergence test to allow oscillatory behavior
+… final error ≤ 2× initial max error"* — and that is `:94`, the assertion now doing the real work.
+(`e < 1000` arrived with the file at `fc07ae31`, 2026-01-17; `nightly.yml` did not exist until
+`8fa80818`, 2026-04-02, so no nightly pressure was involved.) Tracked as #2014.
 
 Coupled EOC through the production `FixedPointIterator` already exists in
 `tests/integration/test_coupled_mfg_mms.py`. What remains uncovered is coupled EOC **at a no-flux

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -171,7 +171,9 @@ class TestDualityConvergence:
     # threshold 1.003133e+03 against final 1.823556e+02, a 5.50x margin -- and it is MORE sensitive
     # than the deleted one, not less: `:94` fires at a uniform post-peak decay factor below 1.0440,
     # `e < 1000` at below 1.0088, so `:94`'s firing region strictly contains it. Nearly model-free,
-    # too: the residual is non-increasing after the peak, so err_U[9] >= err_U[29] and any
+    # too: from the peak through iteration 29 AT THIS CONFIGURATION the residual is non-increasing
+    # -- strictly decreasing across 4->29 at Nx=41, though NOT monotone at Nx=21 nor on the noise
+    # floor generally, as the band two paragraphs up says -- so err_U[9] >= err_U[29] and any
     # perturbation leaving the later sample above 1000 leaves the earlier one above it as well,
     # 20 iterations sooner. So at THIS configuration the deletion costs nothing on the transient.
     #
@@ -188,7 +190,7 @@ class TestDualityConvergence:
     # tests/integration/test_fvm_hjb_coupling.py's `fdm_1d` fixture runs a coupled 1D no-flux
     # FDM_UPWIND solve at Nx=25, Nt=12, sigma=0.4 and asserts convergence, a 10x error drop, mass
     # and positivity -- strictly stronger, at comparable coarseness. What has no counterpart is the
-    # LOW-SIGMA / high-Peclet coarse regime, and the transient guard above.
+    # LOW-SIGMA / high-Peclet coarse regime.
     #
     # THE CASE FOR REPAIRING INSTEAD, which is stronger than "fix the two-grid rate test" and is
     # what a reader should weigh: test_fdm_upwind_stable below already runs the identical Nx=41,
@@ -202,11 +204,13 @@ class TestDualityConvergence:
     # either way, and the two questions are independent. It also wants a DECAY bound rather than a
     # magnitude one: a threshold on a residual is scale- and configuration-dependent, while
     # `final < 1e-2 * peak` is scale-free and fires exactly on the collapse described above.
-    # Writing a threshold here to fit what was observed is how this file got its numbers: c1a3696b,
-    # the same day the file was created, is titled "Relax convergence test to allow oscillatory
+    # Writing a threshold here to fit what was observed is how this file got `:94`: c1a3696b, the
+    # same day the file was created, reads "Relax convergence test to allow oscillatory
     # behavior -- Changed test from checking monotonic decrease to checking overall progress (final
-    # error <= 2x initial max error)", and that is `:94`, the assertion above that turned out to be
-    # doing the real work. (`e < 1000` came in with the file at fc07ae31, 2026-01-17; nightly.yml
+    # error <= 2x initial max error)", and its diff replaces `assert decreasing >= len(errors)//2`
+    # with exactly the `<= initial_max * 2.0` above -- the assertion that turned out to be doing
+    # the real work. (Nothing is known about why `e < 1000` got its value; it arrived with the
+    # file, under no such pressure.) (`e < 1000` came in with the file at fc07ae31, 2026-01-17; nightly.yml
     # did not exist until 8fa80818, 2026-04-02, so no nightly pressure was involved.) It is #2014,
     # with the margin above as its measurement.
     #

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -123,9 +123,12 @@ class TestDualityConvergence:
     #     Nx=20  peak 1.264638e+03 @iter4   best 1.778986e-06 @iter194   @iter29 5.935364e-04
     #     Nx=40  peak 1.243941e+03 @iter4   best 7.116063e-06 @iter166   @iter29 4.237936e-04
     #
-    # A transient peaking above 1.2e+03 around iteration 4, then a settled 1e-4..2e-3 noise floor
-    # it never leaves -- final value far from its own best. So `max_error` at iteration 30 is a
-    # sample off that floor, and no assertion over two samples can measure a rate.
+    # A transient peaking above 1.2e+03 around iteration 4, then a noise floor -- over iterations
+    # 26..300 the residual ranges 1.78e-06..3.44e-03 (Nx=20) and 7.12e-06..3.40e-03 (Nx=40), and
+    # ends far from its own best. So `max_error` at iteration 30 is a sample off that floor, and no
+    # assertion over two samples can measure a rate. (Note also that `max_error = max(err_U, err_M)`
+    # is the U increment at iteration 29 but NOT early: err_M dominates at index 0, 1.9832 against
+    # 0.9445 at Nx=20.)
     #
     # The precedent is TestConvergenceRate::test_upwind_first_order_convergence, removed for this
     # exact reason with its account at the bottom of this file -- "It measured the wrong quantity
@@ -155,13 +158,18 @@ class TestDualityConvergence:
     # start at #1902 and #1904, not conclude the window is computationally quiet.
     #
     # What the deletion costs. `e < 1000` was NOT a vacuous bound -- the residual crosses it, in
-    # this very solve, by 26%: the peak above is 1.26e+03. So that assertion was a crude but LIVE
-    # guard on the TRANSIENT DECAY RATE. Anything costing roughly eight Picard iterations of
-    # convergence speed pushes iteration 30 back over 1000 and fires it. Nothing else in the suite
-    # bounds that, and no claim of domination survives: `max_error = max(err_U, err_M)` is here
-    # entirely the U increment (at Nx=40, iteration 29: err_U 4.238e-04 against err_M 4.807e-08),
-    # while test_fdm_upwind_stable's mass-conservation and `M.min() > 0` assertions constrain M's
-    # physics. The two sets are incomparable, not ordered. That test also stops at iteration 20.
+    # this very solve, by 26%: the peak above is 1.26e+03. So that assertion was a LIVE guard on
+    # the transient decay rate -- but a very coarse one, and the first draft of this note overstated
+    # how coarse. MEASURED: the assertion samples the FINAL residual, so to push iteration 30 back
+    # over 1000 the whole decay curve has to be delayed by 24-26 of the 30 iterations, or
+    # equivalently the per-iteration decay factor has to fall from its actual ~1.85 to <= 1.01. A
+    # solve that merely slowed down stays green; only one that has stopped converging trips it.
+    #
+    # Still real, and nothing else in the suite bounds it. No claim of domination survives either:
+    # `max_error` is the U increment at iteration 29 (Nx=40: err_U 4.238e-04 against err_M
+    # 4.807e-08), while test_fdm_upwind_stable's mass-conservation and `M.min() > 0` assertions
+    # constrain M's physics. The two sets are incomparable, not ordered -- and that test stops at
+    # iteration 20.
     #
     # The rest of the cost is smaller than it first looked. The Nx=40 leg duplicates
     # test_fdm_upwind_stable on every listed parameter -- Nx_points=[41], Nt=20, T=1.0, sigma=0.1,
@@ -172,9 +180,22 @@ class TestDualityConvergence:
     # and positivity -- strictly stronger, at comparable coarseness. What has no counterpart is the
     # LOW-SIGMA / high-Peclet coarse regime, and the transient guard above.
     #
-    # Deleting is still right: a threshold on an unconverged residual is a poor instrument even
-    # when live, and the RATE assertion beside it is indefensible at any threshold. But the
-    # transient goes unguarded, and that is recorded rather than claimed away.
+    # THE CASE FOR REPAIRING INSTEAD, which is stronger than "fix the two-grid rate test" and is
+    # what a reader should weigh: test_fdm_upwind_stable below already runs the identical Nx=41,
+    # Nt=20, sigma=0.1, FDM_UPWIND solve and already holds `result`. A transient bound there is one
+    # line at zero marginal runtime -- measured margin for `final < 1e-2 * peak` at its own
+    # 20-iteration budget: 73.5x at Nx=20, 31.9x at Nx=40.
+    #
+    # Deleting is still right, and the reason is not that the guard was worthless. It is that
+    # whatever the guard becomes belongs on the SURVIVING test, not on this one -- so this test goes
+    # either way, and the two questions are independent. It also wants a DECAY bound rather than a
+    # magnitude one: a threshold on a residual is scale- and configuration-dependent, while
+    # `final < 1e-2 * peak` is scale-free and fires exactly on the collapse described above.
+    # Writing that assertion here, under an open nightly, is how `e < 1000` got into this file in
+    # the first place. It is #2014, with the margins above as its measurement.
+    #
+    # The exposure is stated rather than claimed away: between this deletion and that issue, nothing
+    # catches a Picard convergence collapse at sigma=0.1.
     #
     # Coupled EOC through the production FixedPointIterator already exists:
     # tests/integration/test_coupled_mfg_mms.py::TestCoupledMMSConvergence. What remains uncovered

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -110,36 +110,54 @@ class TestDualityConvergence:
     # numbers. Genuine centered-scheme order verification belongs with the MMS convergence
     # suite, not as a single-grid smoke test named after a rate.
 
-    # test_mesh_refinement_improves_accuracy was removed 2026-08-19 rather than repaired. Same
-    # family as the removal above, and it is what #1998 -- "Nightly full test suite is failing" --
-    # actually was.
+    # test_mesh_refinement_improves_accuracy was removed 2026-08-19 rather than repaired. It is
+    # what #1998 -- "Nightly full test suite is failing" -- actually was: the validation shard
+    # reports `1 failed, 27 passed, 4 xfailed`, that one test, every other shard green.
     #
     # It recorded `result.max_error`, which is the final PICARD RESIDUAL, not a discretization
-    # error against a known solution, and then compared two of them across Nx = 20 / 40 under the
-    # name "h-convergence". Measured: with tolerance=1e-8 and max_iterations=30 BOTH legs run to
-    # the cap -- `converged=False, iterations=30/30` on either grid -- so the two numbers are
-    # residuals of unconverged iterations, and their ratio is a fact about how far each got in
-    # thirty steps, not about mesh resolution. This is the defect #1728 names in a different test
-    # ("it compared `result.max_error`, the final Picard residual -- so removing it lost nothing").
+    # error against a known solution, and compared two of them across Nx = 20 / 40 under the name
+    # "h-convergence". Measured: with tolerance=1e-8 and max_iterations=30 BOTH legs run to the cap
+    # -- `converged=False, iterations=30/30` on either grid. Worse, at max_iterations=300 neither
+    # converges either: the residual LIMIT-CYCLES between 5.9e-05 and 1.7e-03, and its final value
+    # is worse than its own best. So `max_error` here is a sample from a cycle, and no assertion
+    # over two samples can measure a rate.
     #
-    # That is also why it was platform-dependent and not a regression. Same code, same nightly
-    # invocation (`-n auto`, the nightly marker set, which does NOT exclude `slow`):
+    # The precedent is TestConvergenceRate::test_upwind_first_order_convergence, removed for this
+    # exact reason with its account at the bottom of this file -- "It measured the wrong quantity
+    # ... it compared `result.max_error` ... the final PICARD RESIDUAL". #1728 names that test. (The
+    # removal noted ABOVE, test_centered_fdm_higher_order, is a different defect: one grid and a
+    # tautological assertion. Same file, same cleanup, not the same reason.)
     #
-    #     darwin/arm64  Nx=20 5.935364e-04   Nx=40 4.237936e-04   assertion holds
-    #     linux (CI)    Nx=20 8.814973e-05   Nx=40 9.901234e-04   assertion fails, 11x
+    # WHAT THIS IS NOT: a clean window. A real numerical change landed inside it. c98a9c5f
+    # ("stop overwriting the root the inner Newton just found", #1902) deletes the hand-rolled
+    # `u[0] = u[1] - g*dx` no-flux enforcement -- the exact boundary treatment this test's
+    # `no_flux_bc(dimension=1)` runs through -- and it moves these numbers ~5x on darwin:
     #
-    # Both are deterministic on their platform -- CI produced identical digits on two different
-    # commits -- so bisecting the window was never going to find a culprit. It is one BLAS path
-    # through a non-converged iteration versus another.
+    #     179e55a7 (head of the last GREEN nightly)  Nx=20 1.185395e-04  Nx=40 5.550650e-04  FAILS
+    #     c98a9c5f and after                         Nx=20 5.935364e-04  Nx=40 4.237936e-04  passes
+    #     linux (CI), 4a50e27b and after             Nx=20 8.814973e-05  Nx=40 9.901234e-04  FAILS
     #
-    # Nothing is lost by the deletion. The Nx=40 leg's configuration is identical to
-    # TestNumericalStability::test_fdm_upwind_stable below -- Nx_points=[41], Nt=20, T=1.0,
-    # sigma=0.1, the same components, FDM_UPWIND -- and that test asserts U and M finite and the
-    # density positive, which is strictly stronger than this one's `e < 1000` on a residual.
+    # So the verdict flipped in OPPOSITE directions on the two platforms across the same change,
+    # which is what a limit-cycling residual does and is stronger grounds for deletion than a
+    # clean-window story would have been. No platform conditional is involved, and CI pins the BLAS
+    # thread counts to 1. Anyone tracing an FDM_UPWIND no-flux discrepancy to this window should
+    # start at #1902 and #1904, not conclude the window is computationally quiet.
     #
-    # Real h-convergence now has a home: tests/unit/test_alg/test_fp_mms_wall_order_1728.py
-    # measures observed order against a source-free exact solution with mutation-red level bounds
-    # (#1728, #2006). That is where a refinement claim belongs.
+    # What the deletion costs, stated rather than waved away. The Nx=40 leg duplicates
+    # TestNumericalStability::test_fdm_upwind_stable below on every listed parameter -- Nx_points=
+    # [41], Nt=20, T=1.0, sigma=0.1, same components, FDM_UPWIND -- differing only in
+    # max_iterations (30 vs 20) and tolerance, so iterations 21-30 there are now unexercised. That
+    # test's mass-conservation and `M.min() > 0` assertions dominate this one's `e < 1000`; its
+    # isfinite checks do not, since a finite oscillating iterate can carry a residual above 1000.
+    # The COARSE leg -- Nx_points=[21], Nt=10, sigma=0.1, coupled -- has no counterpart anywhere in
+    # the suite, so a raise or a NaN from that specific solve is now caught by nothing. Thin, and
+    # real.
+    #
+    # Coupled EOC through the production FixedPointIterator already exists:
+    # tests/integration/test_coupled_mfg_mms.py::TestCoupledMMSConvergence. What remains uncovered
+    # is coupled EOC AT A NO-FLUX WALL -- that suite is periodic -- and the deleted test never
+    # measured it either. The standalone FP order study added by #2006
+    # (tests/unit/test_alg/test_fp_mms_wall_order_1728.py) covers the wall but not the coupling.
 
     def test_safe_mode_guarantees_duality(self):
         """Test that Safe Mode automatically creates dual pairs."""

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -110,43 +110,36 @@ class TestDualityConvergence:
     # numbers. Genuine centered-scheme order verification belongs with the MMS convergence
     # suite, not as a single-grid smoke test named after a rate.
 
-    @pytest.mark.slow
-    def test_mesh_refinement_improves_accuracy(self):
-        """Test that finer meshes reduce errors (h-convergence)."""
-        mesh_sizes = [20, 40]
-        final_errors = []
-
-        for Nx in mesh_sizes:
-            problem = MFGProblem(
-                geometry=TensorProductGrid(
-                    bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
-                ),
-                Nt=Nx // 2,
-                T=1.0,
-                sigma=0.1,
-                components=_default_components(),
-            )
-
-            result = problem.solve(
-                scheme=NumericalScheme.FDM_UPWIND,
-                max_iterations=30,
-                tolerance=1e-8,
-                verbose=False,
-            )
-
-            # Record final error (max of U and M errors)
-            final_errors.append(result.max_error)
-
-        # Finer mesh should have smaller error
-        # We can't guarantee strict convergence in all cases (problem-dependent),
-        # but we can check that errors are reasonable
-        assert all(e < 1000 for e in final_errors), "Errors should be bounded"
-
-        # If both converged well, expect refinement to help
-        if all(e < 1.0 for e in final_errors):
-            # Coarse mesh error should be larger (or comparable)
-            # Allow some tolerance for numerical noise
-            assert final_errors[0] >= final_errors[1] * 0.5, "Refinement should improve or maintain accuracy"
+    # test_mesh_refinement_improves_accuracy was removed 2026-08-19 rather than repaired. Same
+    # family as the removal above, and it is what #1998 -- "Nightly full test suite is failing" --
+    # actually was.
+    #
+    # It recorded `result.max_error`, which is the final PICARD RESIDUAL, not a discretization
+    # error against a known solution, and then compared two of them across Nx = 20 / 40 under the
+    # name "h-convergence". Measured: with tolerance=1e-8 and max_iterations=30 BOTH legs run to
+    # the cap -- `converged=False, iterations=30/30` on either grid -- so the two numbers are
+    # residuals of unconverged iterations, and their ratio is a fact about how far each got in
+    # thirty steps, not about mesh resolution. This is the defect #1728 names in a different test
+    # ("it compared `result.max_error`, the final Picard residual -- so removing it lost nothing").
+    #
+    # That is also why it was platform-dependent and not a regression. Same code, same nightly
+    # invocation (`-n auto`, the nightly marker set, which does NOT exclude `slow`):
+    #
+    #     darwin/arm64  Nx=20 5.935364e-04   Nx=40 4.237936e-04   assertion holds
+    #     linux (CI)    Nx=20 8.814973e-05   Nx=40 9.901234e-04   assertion fails, 11x
+    #
+    # Both are deterministic on their platform -- CI produced identical digits on two different
+    # commits -- so bisecting the window was never going to find a culprit. It is one BLAS path
+    # through a non-converged iteration versus another.
+    #
+    # Nothing is lost by the deletion. The Nx=40 leg's configuration is identical to
+    # TestNumericalStability::test_fdm_upwind_stable below -- Nx_points=[41], Nt=20, T=1.0,
+    # sigma=0.1, the same components, FDM_UPWIND -- and that test asserts U and M finite and the
+    # density positive, which is strictly stronger than this one's `e < 1000` on a residual.
+    #
+    # Real h-convergence now has a home: tests/unit/test_alg/test_fp_mms_wall_order_1728.py
+    # measures observed order against a source-free exact solution with mutation-red level bounds
+    # (#1728, #2006). That is where a refinement claim belongs.
 
     def test_safe_mode_guarantees_duality(self):
         """Test that Safe Mode automatically creates dual pairs."""

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -128,7 +128,7 @@ class TestDualityConvergence:
     # ends far from its own best. So `max_error` at iteration 30 is a sample off that floor, and no
     # assertion over two samples can measure a rate. (Note also that `max_error = max(err_U, err_M)`
     # is the U increment at iteration 29 but NOT early: err_M dominates at index 0, 1.9832 against
-    # 0.9445 at Nx=20.)
+    # 9.4455e-01 at Nx=20.)
     #
     # The precedent is TestConvergenceRate::test_upwind_first_order_convergence, removed for this
     # exact reason with its account at the bottom of this file -- "It measured the wrong quantity
@@ -165,7 +165,17 @@ class TestDualityConvergence:
     # equivalently the per-iteration decay factor has to fall from its actual ~1.85 to <= 1.01. A
     # solve that merely slowed down stays green; only one that has stopped converging trips it.
     #
-    # Still real, and nothing else in the suite bounds it. No claim of domination survives either:
+    # And the transient is NOT unguarded -- an earlier draft of this note said it was. Measured on
+    # test_dual_fdm_pair_converges' own configuration (Nx_points=[41], Nt=20, sigma=0.1,
+    # FDM_UPWIND, max_iterations=50), its `:94` assertion `final_error <= initial_max * 2.0` reads
+    # threshold 1.003133e+03 against final 1.823556e+02, a 5.50x margin -- and it is MORE sensitive
+    # than the deleted one, not less: `:94` fires at a uniform post-peak decay factor below 1.0440,
+    # `e < 1000` at below 1.0088, so `:94`'s firing region strictly contains it. Nearly model-free,
+    # too: the residual is non-increasing after the peak, so err_U[9] >= err_U[29] and any
+    # perturbation leaving the later sample above 1000 leaves the earlier one above it as well,
+    # 20 iterations sooner. So at THIS configuration the deletion costs nothing on the transient.
+    #
+    # No claim of domination survives either:
     # `max_error` is the U increment at iteration 29 (Nx=40: err_U 4.238e-04 against err_M
     # 4.807e-08), while test_fdm_upwind_stable's mass-conservation and `M.min() > 0` assertions
     # constrain M's physics. The two sets are incomparable, not ordered -- and that test stops at
@@ -184,18 +194,24 @@ class TestDualityConvergence:
     # what a reader should weigh: test_fdm_upwind_stable below already runs the identical Nx=41,
     # Nt=20, sigma=0.1, FDM_UPWIND solve and already holds `result`. A transient bound there is one
     # line at zero marginal runtime -- measured margin for `final < 1e-2 * peak` at its own
-    # 20-iteration budget: 73.5x at Nx=20, 31.9x at Nx=40.
+    # 20-iteration budget: 31.9x. (That test runs Nx=41 only; the 73.5x figure is the Nx=21 leg,
+    # which it does not run, so 31.9x is the binding one.)
     #
     # Deleting is still right, and the reason is not that the guard was worthless. It is that
     # whatever the guard becomes belongs on the SURVIVING test, not on this one -- so this test goes
     # either way, and the two questions are independent. It also wants a DECAY bound rather than a
     # magnitude one: a threshold on a residual is scale- and configuration-dependent, while
     # `final < 1e-2 * peak` is scale-free and fires exactly on the collapse described above.
-    # Writing that assertion here, under an open nightly, is how `e < 1000` got into this file in
-    # the first place. It is #2014, with the margins above as its measurement.
+    # Writing a threshold here to fit what was observed is how this file got its numbers: c1a3696b,
+    # the same day the file was created, is titled "Relax convergence test to allow oscillatory
+    # behavior -- Changed test from checking monotonic decrease to checking overall progress (final
+    # error <= 2x initial max error)", and that is `:94`, the assertion above that turned out to be
+    # doing the real work. (`e < 1000` came in with the file at fc07ae31, 2026-01-17; nightly.yml
+    # did not exist until 8fa80818, 2026-04-02, so no nightly pressure was involved.) It is #2014,
+    # with the margin above as its measurement.
     #
-    # The exposure is stated rather than claimed away: between this deletion and that issue, nothing
-    # catches a Picard convergence collapse at sigma=0.1.
+    # What the deletion actually costs, stated rather than claimed away: the sigma=0.1 COARSE leg,
+    # Nx_points=[21], which has no `:94`-bearing neighbour. The Nx=41 leg is covered.
     #
     # Coupled EOC through the production FixedPointIterator already exists:
     # tests/integration/test_coupled_mfg_mms.py::TestCoupledMMSConvergence. What remains uncovered

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -186,11 +186,16 @@ class TestDualityConvergence:
     # The rest of the cost is smaller than it first looked. The Nx=40 leg duplicates
     # test_fdm_upwind_stable on every listed parameter -- Nx_points=[41], Nt=20, T=1.0, sigma=0.1,
     # same components, FDM_UPWIND -- differing only in max_iterations (30 vs 20) and tolerance, so
-    # iterations 21-30 there are unexercised. And the COARSE leg is not uncovered in kind:
-    # tests/integration/test_fvm_hjb_coupling.py's `fdm_1d` fixture runs a coupled 1D no-flux
-    # FDM_UPWIND solve at Nx=25, Nt=12, sigma=0.4 and asserts convergence, a 10x error drop, mass
-    # and positivity -- strictly stronger, at comparable coarseness. What has no counterpart is the
-    # LOW-SIGMA / high-Peclet coarse regime.
+    # iterations 21-30 there are unexercised.
+    #
+    # THE COARSE LEG HAS NO COUNTERPART ANYWHERE, and an earlier version of this comment said
+    # otherwise. It cited tests/integration/test_fvm_hjb_coupling.py's `fdm_1d` fixture as asserting
+    # "convergence, a 10x error drop, mass and positivity -- strictly stronger". Those four
+    # assertions are on the `fvm_1d` fixture, which runs FVM_MUSCL. `fdm_1d` runs FDM_UPWIND and has
+    # exactly ONE consumer -- test_1d_fvm_fdm_agreement -- which asserts cross-scheme agreement
+    # (rel_m < 0.07) and says nothing about convergence, mass or positivity. So a raise or a NaN
+    # from the coarse FDM_UPWIND solve is now caught by nothing. The LOW-SIGMA / high-Peclet coarse
+    # regime is uncovered, and so is the coarse regime generally.
     #
     # THE CASE FOR REPAIRING INSTEAD, which is stronger than "fix the two-grid rate test" and is
     # what a reader should weigh: test_fdm_upwind_stable below already runs the identical Nx=41,

--- a/tests/validation/test_duality_convergence.py
+++ b/tests/validation/test_duality_convergence.py
@@ -117,10 +117,15 @@ class TestDualityConvergence:
     # It recorded `result.max_error`, which is the final PICARD RESIDUAL, not a discretization
     # error against a known solution, and compared two of them across Nx = 20 / 40 under the name
     # "h-convergence". Measured: with tolerance=1e-8 and max_iterations=30 BOTH legs run to the cap
-    # -- `converged=False, iterations=30/30` on either grid. Worse, at max_iterations=300 neither
-    # converges either: the residual LIMIT-CYCLES between 5.9e-05 and 1.7e-03, and its final value
-    # is worse than its own best. So `max_error` here is a sample from a cycle, and no assertion
-    # over two samples can measure a rate.
+    # -- `converged=False, iterations=30/30` on either grid. At max_iterations=300 neither converges
+    # either. The full history, both legs:
+    #
+    #     Nx=20  peak 1.264638e+03 @iter4   best 1.778986e-06 @iter194   @iter29 5.935364e-04
+    #     Nx=40  peak 1.243941e+03 @iter4   best 7.116063e-06 @iter166   @iter29 4.237936e-04
+    #
+    # A transient peaking above 1.2e+03 around iteration 4, then a settled 1e-4..2e-3 noise floor
+    # it never leaves -- final value far from its own best. So `max_error` at iteration 30 is a
+    # sample off that floor, and no assertion over two samples can measure a rate.
     #
     # The precedent is TestConvergenceRate::test_upwind_first_order_convergence, removed for this
     # exact reason with its account at the bottom of this file -- "It measured the wrong quantity
@@ -131,27 +136,45 @@ class TestDualityConvergence:
     # WHAT THIS IS NOT: a clean window. A real numerical change landed inside it. c98a9c5f
     # ("stop overwriting the root the inner Newton just found", #1902) deletes the hand-rolled
     # `u[0] = u[1] - g*dx` no-flux enforcement -- the exact boundary treatment this test's
-    # `no_flux_bc(dimension=1)` runs through -- and it moves these numbers ~5x on darwin:
+    # `no_flux_bc(dimension=1)` runs through. It moves these numbers on darwin -- ~5x on the coarse
+    # leg, 1.31x DOWNWARD on the fine one -- so the quantity that moves as a single number is the
+    # ratio the assertion tests: coarse/fine goes 0.2136 -> 1.4005, a factor 6.56:
     #
     #     179e55a7 (head of the last GREEN nightly)  Nx=20 1.185395e-04  Nx=40 5.550650e-04  FAILS
     #     c98a9c5f and after                         Nx=20 5.935364e-04  Nx=40 4.237936e-04  passes
     #     linux (CI), 4a50e27b and after             Nx=20 8.814973e-05  Nx=40 9.901234e-04  FAILS
     #
-    # So the verdict flipped in OPPOSITE directions on the two platforms across the same change,
+    # On darwin the flip bisects to c98a9c5f. On linux only the ENDPOINTS are known -- green at
+    # 179e55a7, red at 4a50e27b, sixteen commits between -- but c98a9c5f is the only commit in the
+    # window that moves this quantity on the platform we can measure, and the obvious rival
+    # (2e7a909a, the Neumann ghost consolidation) is bracketed by two bit-identical commits.
+    # So the verdict flipped in OPPOSITE directions on the two platforms,
     # which is what a limit-cycling residual does and is stronger grounds for deletion than a
     # clean-window story would have been. No platform conditional is involved, and CI pins the BLAS
     # thread counts to 1. Anyone tracing an FDM_UPWIND no-flux discrepancy to this window should
     # start at #1902 and #1904, not conclude the window is computationally quiet.
     #
-    # What the deletion costs, stated rather than waved away. The Nx=40 leg duplicates
-    # TestNumericalStability::test_fdm_upwind_stable below on every listed parameter -- Nx_points=
-    # [41], Nt=20, T=1.0, sigma=0.1, same components, FDM_UPWIND -- differing only in
-    # max_iterations (30 vs 20) and tolerance, so iterations 21-30 there are now unexercised. That
-    # test's mass-conservation and `M.min() > 0` assertions dominate this one's `e < 1000`; its
-    # isfinite checks do not, since a finite oscillating iterate can carry a residual above 1000.
-    # The COARSE leg -- Nx_points=[21], Nt=10, sigma=0.1, coupled -- has no counterpart anywhere in
-    # the suite, so a raise or a NaN from that specific solve is now caught by nothing. Thin, and
-    # real.
+    # What the deletion costs. `e < 1000` was NOT a vacuous bound -- the residual crosses it, in
+    # this very solve, by 26%: the peak above is 1.26e+03. So that assertion was a crude but LIVE
+    # guard on the TRANSIENT DECAY RATE. Anything costing roughly eight Picard iterations of
+    # convergence speed pushes iteration 30 back over 1000 and fires it. Nothing else in the suite
+    # bounds that, and no claim of domination survives: `max_error = max(err_U, err_M)` is here
+    # entirely the U increment (at Nx=40, iteration 29: err_U 4.238e-04 against err_M 4.807e-08),
+    # while test_fdm_upwind_stable's mass-conservation and `M.min() > 0` assertions constrain M's
+    # physics. The two sets are incomparable, not ordered. That test also stops at iteration 20.
+    #
+    # The rest of the cost is smaller than it first looked. The Nx=40 leg duplicates
+    # test_fdm_upwind_stable on every listed parameter -- Nx_points=[41], Nt=20, T=1.0, sigma=0.1,
+    # same components, FDM_UPWIND -- differing only in max_iterations (30 vs 20) and tolerance, so
+    # iterations 21-30 there are unexercised. And the COARSE leg is not uncovered in kind:
+    # tests/integration/test_fvm_hjb_coupling.py's `fdm_1d` fixture runs a coupled 1D no-flux
+    # FDM_UPWIND solve at Nx=25, Nt=12, sigma=0.4 and asserts convergence, a 10x error drop, mass
+    # and positivity -- strictly stronger, at comparable coarseness. What has no counterpart is the
+    # LOW-SIGMA / high-Peclet coarse regime, and the transient guard above.
+    #
+    # Deleting is still right: a threshold on an unconverged residual is a poor instrument even
+    # when live, and the RATE assertion beside it is indefensible at any threshold. But the
+    # transient goes unguarded, and that is recorded rather than claimed away.
     #
     # Coupled EOC through the production FixedPointIterator already exists:
     # tests/integration/test_coupled_mfg_mms.py::TestCoupledMMSConvergence. What remains uncovered


### PR DESCRIPTION
> **This body was rewritten at `6f63c22e`+.** The original text was the v1 account, and five review
> rounds falsified four of its claims. It is replaced rather than annotated because leaving both
> would license opposite conclusions with nothing marking which is current — the failure the last
> commit on this branch was written to fix, in the one place I had not checked. What v1 said, and
> why each part is wrong, is in *Corrections* at the bottom.

## What this does

Deletes `test_mesh_refinement_improves_accuracy` from `tests/validation/test_duality_convergence.py`
and replaces it with an account of why it measured nothing. The code diff is one deletion; **the
recorded account is the deliverable.**

## Why the test measured nothing

It compared the final Picard residual of an `Nx=20` solve against an `Nx=40` solve and called the
ratio a convergence rate. Neither solve converges. Measured over the full residual history at
`max_iterations=300`:

```
Nx=20   peak 1.264638e+03 @iter4   best 1.778986e-06 @iter194   @iter29 5.935364e-04
Nx=40   peak 1.243941e+03 @iter4   best 7.116063e-06 @iter166   @iter29 4.237936e-04
```

Both legs run to the iteration cap with `converged=False`. The quantity being compared is *how far
each iteration got in 30 steps*, which depends on the residual's oscillation phase, not on `h`. That
is why the verdict is platform-dependent and why it flipped in opposite directions on darwin and
linux across one commit.

## The provenance

The green-to-red window is `179e55a7..4a50e27b`, and `c98a9c5f` (#1902) is in it — the commit that
deletes the hand-rolled `u[0] = u[1] - g*dx` no-flux enforcement, which is the exact boundary
treatment this test runs through. It moves the coarse leg ~5× on darwin, moves the fine leg *down*
1.31×, and moves the ratio the assertion actually tests from 0.2136 to 1.4005 — a factor 6.56 —
flipping the darwin verdict.

Scope, stated because it was once overstated: **bisected on darwin, inferred on linux.** Only the
endpoints are known on linux. The inference is strong because `c98a9c5f` is the only commit in the
window that touches this computation, but it is an inference.

## What the deletion costs, and what it does not

**The `e < 1000` assertion was a live guard, not a vacuous one.** The residual crosses 1000 by 26%
in the same solve, at iteration 4. It bounded the transient decay rate.

**It was a coarse one.** Tripping it needs the whole decay curve delayed by 24–26 of the 30
iterations, or the per-iteration decay factor to fall from ~1.85 to ≤ 1.0088:

```
Nx=20   delays d with e[29-d] > 1000:  [25]
Nx=40   delays d with e[29-d] > 1000:  [24, 25, 26]
decay factor leaving e[29] exactly 1000:  1.0094 / 1.0088
actual median post-peak decay factor:     1.841 / 1.857
```

A solve that merely slowed down stays green; only one that has stopped converging fires it.

**The transient is not left unguarded at `Nx=41`.** `test_dual_fdm_pair_converges`'s `:94`
assertion (`final_error <= initial_max * 2.0`) reads threshold `1.003133e+03` against final
`1.823556e+02`, a 5.50× margin — and it is **more sensitive**: `:94` fires at a decay factor below
1.0440, `e < 1000` at below 1.0088, so `:94`'s firing region strictly contains it, twenty iterations
sooner.

**What is actually lost is the coarse leg**, `Nx_points=[21]` at `sigma=0.1`, which has no
`:94`-bearing neighbour. As of today's review that cost is *larger* than this PR previously stated —
see Corrections C5.

## Corrections — five rounds, and what each falsified

| v1 claim | status |
|---|---|
| "No commit in the green-to-red window changed the computation … not a regression" | **False.** The two commits I compared for identical digits are both *after* the window. `c98a9c5f` is inside it and moves the numbers. My three earlier bisections probed commits strictly after it and compared pass counts rather than values, so they could not have seen it. |
| Precedent is `test_centered_fdm_higher_order` | **Wrong sibling.** That was removed for a different reason (one grid, a `converged or iterations >= 30` tautology). The precedent for *this* reason is `test_upwind_first_order_convergence`. |
| "`e < 1000` is vacuous" | **False**, peak `1.26e+03`. Then over-corrected: "roughly eight iterations of convergence speed" was wrong by 3× — it is 24–26. |
| "Nothing is lost / strictly stronger than `e < 1000`" | **False.** `max_error` at iteration 29 is entirely the U increment (`err_U 4.238e-04` vs `err_M 4.807e-08`) while `test_fdm_upwind_stable` constrains M. The two assertion sets are **incomparable, not ordered.** |
| "The transient is unguarded" | **False**, `:94` bounds it more sensitively. Corrected in two of three places and left standing in the third — the fix for that is on this branch. |
| C5 (today) "the coarse leg is not uncovered in kind: `fdm_1d` asserts convergence, a 10× drop, mass and positivity" | **False, and it replaced a true statement.** Those four assertions are on the **`fvm_1d`** fixture, which runs `FVM_MUSCL`. `fdm_1d` runs `FDM_UPWIND` and has exactly one consumer, `test_1d_fvm_fdm_agreement`, asserting cross-scheme agreement (`rel_m < 0.07`) and nothing else. So the coarse leg has **no counterpart anywhere** — which is what the account said before this citation overwrote it. |

The habit that found the last one is worth keeping: after changing a claim, grep the diff's own
vocabulary across the file, the changelog fragment **and** the linked issue's title. It found three
instances after I had already "fixed" the claim once.

Refs #1998 #2014 #1902 #1728
