### PR TITLE
fix: refuse a provider-valued wall coefficient instead of dropping it (#1979)

### DIFF
--- a/changelog.d/1979-refuse-provider-valued-wall-coefficient.fixed.md
+++ b/changelog.d/1979-refuse-provider-valued-wall-coefficient.fixed.md
@@ -1,0 +1,34 @@
+A provider-valued wall coefficient no longer disappears (#1979). `BCValueProvider` exists so a wall
+coefficient can be recomputed each Picard iterate — that is what `AdjointConsistentProvider` and
+#1970's `NormalDriftProvider` are for, and both live on `alpha`, not on `value`. Two consumers took
+one and did the wrong thing with it.
+
+**FDM**: `_BOUNDARY_HANDLERS` is keyed on the advection scheme and its handlers take no
+`boundary_conditions` argument at all, so nothing read `alpha` and the segment assembled
+byte-identically to a plain no-flux wall, with no diagnostic — the wall a user wired a coefficient
+to *avoid*, returned as though it were their request. `solve_fp_nd_full_system` now refuses at entry,
+naming the offending `segment.field`, the segment types involved, and `with_resolved_providers` as
+the remedy.
+
+**FEM**: `assemble_robin_terms` coerced with `float()`, giving a bare builtin `TypeError` — unnamed,
+ungreppable, silent about the remedy — three lines above a `NotImplementedError` guard that already
+did this correctly for `g`. `alpha` and `beta` now get the same guard, with the same wording.
+
+**Correction to the issue's premise, which changes what the fix is for.** #1979 was filed against a
+ROBIN segment, and that route is not reachable: every grid FP solver refuses `ROBIN` at construction
+(`_validate_bc_support`, #1456, stated in `conditions.py:1149`), measured — `FPFDMSolver` raises
+before any assembly. The reachable case is a provider on the `alpha` of a **NO_FLUX** or **NEUMANN**
+segment, which passes the capability gate. That is precisely what `NormalDriftProvider` produces,
+since an impermeable wall *is* Robin in `m` (`alpha*m - D*d_n m = 0`) and its coefficient lives
+there. So the defect is not narrower than filed; it sits on the path the provider layer was built
+for.
+
+Refusing is the fix, not reading. The conservative grid schemes already impose `J·n = 0`
+structurally (#1975), so teaching those handlers to add `(alpha, beta, g)` would count the drift
+twice — measured there at −79.5% mass against −7.4e-15.
+
+Pinned in `tests/unit/test_geometry/test_provider_robin_coefficient_refused_1979.py`, both paths,
+each `raises` paired with a float-coefficient control so that a blanket refusal cannot pass. Both
+guards verified mutation-red: removing the FDM one fails 2 of 7, removing the FEM one fails 3 of 7.
+
+Unblocks #1970, which is in draft pending this.

--- a/changelog.d/1979-refuse-provider-valued-wall-coefficient.fixed.md
+++ b/changelog.d/1979-refuse-provider-valued-wall-coefficient.fixed.md
@@ -24,8 +24,25 @@ there. So the defect is not narrower than filed; it sits on the path the provide
 for.
 
 Refusing is the fix, not reading. The conservative grid schemes already impose `J·n = 0`
-structurally (#1975), so teaching those handlers to add `(alpha, beta, g)` would count the drift
-twice — measured there at −79.5% mass against −7.4e-15.
+structurally, so teaching those handlers to add `(alpha, beta, g)` would count the drift twice —
+measured there at −79.5% mass against −7.4e-15.
+
+Three corrections from review, each of which changed the fix rather than its wording:
+
+- **The guard was not where the hazard is.** It sat in `solve_fp_nd_full_system`, while
+  `_BOUNDARY_HANDLERS` is dispatched from `solve_timestep_full_nd` — so calling that directly walked
+  straight past it. That is the same shape the guard exists to fix, one layer up. It is now a single
+  owner called from both entry points, pinned by a test that fails when either call is removed.
+- **`value` was uncovered.** #1686 records that every FP solver silently drops the value in
+  `neumann_bc(value=g)`. A guard on `alpha`/`beta` alone would refuse the coefficient and keep
+  dropping the datum, so `value` is checked with them.
+- **The message prescribed its own defeat.** It offered `bc.with_resolved_providers(state)` as *the*
+  remedy. A provider exists to be recomputed each Picard iterate; resolving it freezes it at one
+  state, so that advice converts the feature into its absence and calls it a fix. The message now
+  names `FPFEMSolver` — whose weak form implements a general Robin wall and reads `alpha`/`beta`/`g`,
+  established when #1975 was closed — as the path that can actually do this, and labels resolving as
+  a downgrade. The pointer to #1975 as future work is dropped: it is closed COMPLETED, and its
+  finding is that the FEM path already does this.
 
 Pinned in `tests/unit/test_geometry/test_provider_robin_coefficient_refused_1979.py`, both paths,
 each `raises` paired with a float-coefficient control so that a blanket refusal cannot pass. Both

--- a/mfgarchon/alg/numerical/fem/bc_adapter.py
+++ b/mfgarchon/alg/numerical/fem/bc_adapter.py
@@ -305,6 +305,19 @@ def assemble_robin_terms(
     rhs_robin = np.zeros(n_dof)
 
     for segment in robin_segments:
+        # Issue #1979: guard alpha and beta the way `g` is guarded below. Without this, a
+        # provider-valued coefficient reaches float() and raises a bare builtin TypeError --
+        # unnamed, ungreppable, and silent about what the caller should do instead.
+        for _name, _coeff in (("alpha", getattr(segment, "alpha", 1.0)), ("beta", getattr(segment, "beta", 0.0))):
+            if not isinstance(_coeff, (int, float)):
+                raise NotImplementedError(
+                    f"Robin segment '{segment.name}' has a non-constant {_name} "
+                    f"({type(_coeff).__name__}). Only a constant {_name} is implemented for the FEM "
+                    "Robin operator augmentation; callable / BCValueProvider coefficients are "
+                    "deferred (Issue #1237). For an adjoint-consistent (state-dependent) Robin BC, "
+                    "resolve the provider to a constant before the solve -- "
+                    "`bc.with_resolved_providers(state)`."
+                )
         alpha = float(getattr(segment, "alpha", 1.0))
         beta = float(getattr(segment, "beta", 0.0))
         if beta == 0.0:

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -613,6 +613,73 @@ def solve_timestep_explicit_with_drift(
     return M_next
 
 
+def _refuse_provider_wall_coefficients(boundary_conditions) -> None:
+    """Refuse a provider-valued wall coefficient rather than dropping it (#1979).
+
+    ONE owner, called from every entry that reaches `_BOUNDARY_HANDLERS`. An earlier version sat
+    inline in `solve_fp_nd_full_system` only, while the handlers are dispatched from
+    `solve_timestep_full_nd` -- so calling that directly walked straight past the guard, which is
+    the same "the gate is not where the hazard is" shape the guard exists to fix.
+
+    THE REACHABLE CASE IS NOT ROBIN. Every grid FP solver refuses ROBIN at construction
+    (`_validate_bc_support`, #1456), so that route is already closed. It is a NO_FLUX or NEUMANN
+    segment carrying a provider, which passes the capability gate -- and that is exactly what
+    #1970's `NormalDriftProvider` produces, since an impermeable wall IS Robin in m
+    (`alpha*m - D*d_n m = 0`) and its coefficient lives on `alpha` of a no-flux segment.
+
+    `_BOUNDARY_HANDLERS` is keyed on the advection scheme and its handlers take no
+    `boundary_conditions` argument at all -- the parameter is absent from every signature -- so
+    nothing reads these fields, provider or float, and nothing is in a position to complain.
+    Measured: a segment carrying an `AdjointConsistentProvider` assembles byte-identically to a
+    plain no-flux wall, with no diagnostic. That is the wall a user wired a coupled coefficient to
+    AVOID, returned as though it were their request.
+
+    `value` is checked alongside `alpha` and `beta` because it has the same defect on this path and
+    it is separately filed: #1686, "Every FP solver silently drops the value in neumann_bc(value=g)
+    while HJB honours it". A guard that covered only the coefficients would refuse the provider and
+    keep dropping the datum.
+
+    Refusing is the fix, not reading. The conservative grid schemes already impose `J.n = 0`
+    structurally, so teaching these handlers to add `(alpha, beta, g)` would count the drift twice
+    -- measured at -79.5% mass against -7.4e-15.
+    """
+    if boundary_conditions is None:
+        return
+    from mfgarchon.geometry.boundary.providers import is_provider
+
+    _fields = ("alpha", "beta", "value")
+    offenders = [
+        f"{getattr(seg, 'name', '<unnamed>')}.{field}"
+        for seg in getattr(boundary_conditions, "segments", ())
+        for field in _fields
+        if is_provider(getattr(seg, field, None))
+    ]
+    if not offenders:
+        return
+    types = sorted(
+        {
+            getattr(getattr(seg, "bc_type", None), "name", "?")
+            for seg in getattr(boundary_conditions, "segments", ())
+            if any(is_provider(getattr(seg, f, None)) for f in _fields)
+        }
+    )
+    raise NotImplementedError(
+        f"A provider-valued wall coefficient was supplied ({', '.join(offenders)}), on segment "
+        f"type(s) {types}. The FDM boundary handlers do not read wall coefficients at all: they are "
+        f"keyed on advection_scheme and take no `boundary_conditions` argument, so the segment would "
+        f"assemble byte-identically to a no-flux wall with no diagnostic (Issue #1979).\n"
+        f"\n"
+        f"Use `FPFEMSolver`, whose weak-form assembly implements a general Robin wall and reads "
+        f"alpha/beta/g (established in #1975).\n"
+        f"\n"
+        f"`bc.with_resolved_providers(state)` will also get past this refusal, but it is a DOWNGRADE "
+        f"and not a remedy: a provider exists to be recomputed each Picard iterate, and resolving it "
+        f"freezes it at one state. If the coefficient genuinely is constant, pass a float instead — "
+        f"if it is not, resolving silently solves a different problem, which is the failure this "
+        f"guard was added to stop."
+    )
+
+
 def solve_fp_nd_full_system(
     m_initial_condition: np.ndarray,
     U_solution_for_drift: np.ndarray | None,
@@ -760,53 +827,7 @@ def solve_fp_nd_full_system(
         and _resolved_scheme in _INTERFACE_VELOCITY_SCHEMES
         and tensor_diffusion_field is None
     )
-    # Issue #1979: a provider-valued wall coefficient is DROPPED here, silently.
-    #
-    # The reachable case is NOT a ROBIN segment -- every grid FP solver refuses ROBIN at
-    # construction (`_validate_bc_support`, #1456), so that route is already closed. It is a
-    # NO_FLUX or NEUMANN segment carrying a provider on `alpha`, which passes the capability gate.
-    # That is exactly what #1970's NormalDriftProvider produces: the impermeable wall IS Robin in
-    # m (alpha*m - D*d_n m = 0), so its coefficient lives on `alpha` of a no-flux segment, and it
-    # is a field recomputed each Picard iterate -- which is what a provider is for.
-    #
-    # `_BOUNDARY_HANDLERS` is keyed on the advection scheme and its handlers do not take
-    # `boundary_conditions` at all -- the parameter is absent from every signature -- so nothing
-    # reads `alpha` or `beta`, provider or float, and nothing is in a position to complain.
-    # Measured: a ROBIN segment carrying an AdjointConsistentProvider assembles byte-identically
-    # to no-flux, with no diagnostic. That is the wall a user wired a coupled coefficient to
-    # AVOID, returned as though it were their request.
-    #
-    # Refuse rather than read. The conservative schemes already impose J.n = 0 structurally
-    # (#1975), so teaching these handlers to add (alpha, beta, g) would count the drift twice --
-    # measured there at -79.5% mass against -7.4e-15. The fix for a general Robin wall on the grid
-    # paths is #1975; this guard only stops the silent one.
-    if boundary_conditions is not None:
-        from mfgarchon.geometry.boundary.providers import is_provider
-
-        _provider_coeffs = [
-            f"{getattr(seg, 'name', '<unnamed>')}.{field}"
-            for seg in getattr(boundary_conditions, "segments", ())
-            for field in ("alpha", "beta")
-            if is_provider(getattr(seg, field, None))
-        ]
-        _types = sorted(
-            {
-                getattr(getattr(seg, "bc_type", None), "name", "?")
-                for seg in getattr(boundary_conditions, "segments", ())
-                if any(is_provider(getattr(seg, f, None)) for f in ("alpha", "beta"))
-            }
-        )
-        if _provider_coeffs:
-            raise NotImplementedError(
-                f"A provider-valued wall coefficient was supplied ({', '.join(_provider_coeffs)}), "
-                f"on segment type(s) {_types}. The FDM boundary handlers do not read wall "
-                f"coefficients at all: they are "
-                f"keyed on advection_scheme and take no `boundary_conditions` argument, so the "
-                f"segment would assemble byte-identically to a no-flux wall with no diagnostic "
-                f"(Issue #1979). Resolve the provider to a constant before the solve -- "
-                f"`bc.with_resolved_providers(state)` -- or use a solver whose boundary assembly "
-                f"reads the coefficients. A general Robin wall on the grid paths is Issue #1975."
-            )
+    _refuse_provider_wall_coefficients(boundary_conditions)
 
     # Issue #1632. Two hazards, and the first belongs to the WHOLE chain below, not to one arm.
     #
@@ -1468,6 +1489,7 @@ def solve_timestep_full_nd(
             _add_boundary_dirichlet_entries(row_indices, col_indices, data_values, flat_idx, dt, bc_value)
         elif (is_no_flux or not is_uniform) and is_boundary:
             # No-flux or mixed BC at boundary: scheme-specific assembly
+            _refuse_provider_wall_coefficients(boundary_conditions)
             _BOUNDARY_HANDLERS[advection_scheme](
                 row_indices,
                 col_indices,

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm_time_stepping.py
@@ -760,6 +760,54 @@ def solve_fp_nd_full_system(
         and _resolved_scheme in _INTERFACE_VELOCITY_SCHEMES
         and tensor_diffusion_field is None
     )
+    # Issue #1979: a provider-valued wall coefficient is DROPPED here, silently.
+    #
+    # The reachable case is NOT a ROBIN segment -- every grid FP solver refuses ROBIN at
+    # construction (`_validate_bc_support`, #1456), so that route is already closed. It is a
+    # NO_FLUX or NEUMANN segment carrying a provider on `alpha`, which passes the capability gate.
+    # That is exactly what #1970's NormalDriftProvider produces: the impermeable wall IS Robin in
+    # m (alpha*m - D*d_n m = 0), so its coefficient lives on `alpha` of a no-flux segment, and it
+    # is a field recomputed each Picard iterate -- which is what a provider is for.
+    #
+    # `_BOUNDARY_HANDLERS` is keyed on the advection scheme and its handlers do not take
+    # `boundary_conditions` at all -- the parameter is absent from every signature -- so nothing
+    # reads `alpha` or `beta`, provider or float, and nothing is in a position to complain.
+    # Measured: a ROBIN segment carrying an AdjointConsistentProvider assembles byte-identically
+    # to no-flux, with no diagnostic. That is the wall a user wired a coupled coefficient to
+    # AVOID, returned as though it were their request.
+    #
+    # Refuse rather than read. The conservative schemes already impose J.n = 0 structurally
+    # (#1975), so teaching these handlers to add (alpha, beta, g) would count the drift twice --
+    # measured there at -79.5% mass against -7.4e-15. The fix for a general Robin wall on the grid
+    # paths is #1975; this guard only stops the silent one.
+    if boundary_conditions is not None:
+        from mfgarchon.geometry.boundary.providers import is_provider
+
+        _provider_coeffs = [
+            f"{getattr(seg, 'name', '<unnamed>')}.{field}"
+            for seg in getattr(boundary_conditions, "segments", ())
+            for field in ("alpha", "beta")
+            if is_provider(getattr(seg, field, None))
+        ]
+        _types = sorted(
+            {
+                getattr(getattr(seg, "bc_type", None), "name", "?")
+                for seg in getattr(boundary_conditions, "segments", ())
+                if any(is_provider(getattr(seg, f, None)) for f in ("alpha", "beta"))
+            }
+        )
+        if _provider_coeffs:
+            raise NotImplementedError(
+                f"A provider-valued wall coefficient was supplied ({', '.join(_provider_coeffs)}), "
+                f"on segment type(s) {_types}. The FDM boundary handlers do not read wall "
+                f"coefficients at all: they are "
+                f"keyed on advection_scheme and take no `boundary_conditions` argument, so the "
+                f"segment would assemble byte-identically to a no-flux wall with no diagnostic "
+                f"(Issue #1979). Resolve the provider to a constant before the solve -- "
+                f"`bc.with_resolved_providers(state)` -- or use a solver whose boundary assembly "
+                f"reads the coefficients. A general Robin wall on the grid paths is Issue #1975."
+            )
+
     # Issue #1632. Two hazards, and the first belongs to the WHOLE chain below, not to one arm.
     #
     # AMBIGUITY: the chain is a precedence order, and every level of it silently discards the

--- a/tests/unit/test_alg/test_solver_bc_support_census_1975.py
+++ b/tests/unit/test_alg/test_solver_bc_support_census_1975.py
@@ -323,15 +323,27 @@ def test_a_robin_coefficient_the_assembly_cannot_read_gives_the_no_flux_result()
     )
 
 
-def test_a_provider_valued_coefficient_is_accepted_without_a_word():
-    """#1979: a coupled wall coefficient produces a no-flux wall and no diagnostic."""
+def test_a_provider_valued_coefficient_is_refused_rather_than_dropped():
+    """#1979, fixed. This test used to pin the DEFECT -- it asserted that a coupled wall coefficient
+    produced a byte-identical no-flux wall with no diagnostic -- and carried its own retirement
+    instruction: "if it RAISES, #1979 is fixed -- assert the refusal instead". It raises. This is
+    that assertion.
+
+    Recorded so the history is not lost: before the fix, a ROBIN segment carrying an
+    `AdjointConsistentProvider` on `alpha` assembled `np.array_equal` to a plain NO_FLUX wall. The
+    wall a user wired a coupled coefficient to AVOID was returned as though it were their request.
+    """
     from mfgarchon.geometry.boundary.providers import AdjointConsistentProvider
 
-    got = _step(_mixed(BCType.ROBIN, alpha=AdjointConsistentProvider(side="left", sigma=0.3), beta=-0.045, value=0.0))
-    assert np.array_equal(got, _step(_mixed(BCType.NO_FLUX))), (
-        "the FDM path now does something with a provider-valued alpha; if it RAISES, #1979 is "
-        "fixed -- assert the refusal instead"
-    )
+    bc = _mixed(BCType.ROBIN, alpha=AdjointConsistentProvider(side="left", sigma=0.3), beta=-0.045, value=0.0)
+    with pytest.raises(NotImplementedError, match=r"provider-valued wall coefficient"):
+        _step(bc)
+
+    # Control: a float coefficient must still assemble, or the refusal is a blanket one and every
+    # ordinary wall is broken. (It still equals the no-flux result -- the handlers do not read
+    # coefficients at all, which is #1979's actual mechanism and is not what this PR changes.)
+    got = _step(_mixed(BCType.ROBIN, alpha=1.0, beta=-0.045, value=0.0))
+    assert np.array_equal(got, _step(_mixed(BCType.NO_FLUX)))
 
 
 def test_an_unsupported_bc_raises_at_construction():

--- a/tests/unit/test_geometry/test_provider_robin_coefficient_refused_1979.py
+++ b/tests/unit/test_geometry/test_provider_robin_coefficient_refused_1979.py
@@ -1,0 +1,161 @@
+"""A provider-valued Robin coefficient must be refused, not silently dropped (#1979).
+
+`BCValueProvider` exists so a wall coefficient can be recomputed each Picard iterate -- that is the
+whole point of `AdjointConsistentProvider` and of #1970's `NormalDriftProvider`, both of which live
+on `alpha`, not on `value`. Two paths consumed such a segment wrongly:
+
+- **FDM**: `_BOUNDARY_HANDLERS` is keyed on the advection scheme and its handlers take no
+  `boundary_conditions` argument at all, so nothing read `alpha` and the segment assembled
+  byte-identically to a no-flux wall -- the wall the user wired a coefficient to avoid, returned as
+  though it were their request.
+- **FEM**: `assemble_robin_terms` coerced with `float()`, giving a bare builtin `TypeError` --
+  unnamed, ungreppable, and silent about the remedy -- three lines above a `NotImplementedError`
+  guard that already did this correctly for `g`.
+
+Refusing is the fix, not reading. The conservative grid schemes already impose `J.n = 0`
+structurally (#1975), so teaching those handlers to add `(alpha, beta, g)` would count the drift
+twice -- measured there at -79.5% mass against -7.4e-15. A general Robin wall on the grid paths is
+#1975; this pins only that the silent case is gone.
+
+Each refusal is paired with a float-coefficient control, because a guard that refuses everything
+would pass the `raises` half while breaking every legitimate Robin solve.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+from mfgarchon.geometry.boundary.providers import ConstantProvider
+from mfgarchon.geometry.boundary.types import BCSegment, BCType
+
+
+def _no_flux_bc(alpha):
+    """The REACHABLE case, and the one #1970 produces.
+
+    Not a ROBIN segment: every grid FP solver refuses ROBIN at construction
+    (`_validate_bc_support`, #1456), so that route is already closed and cannot be the user impact.
+    An impermeable wall IS Robin in m -- `alpha*m - D*d_n m = 0` -- so its coefficient lives on
+    `alpha` of a NO_FLUX segment, which passes the capability gate.
+    """
+    return BoundaryConditions(
+        segments=[
+            BCSegment(name="wall", bc_type=BCType.NO_FLUX, boundary="x_min", value=0.0, alpha=alpha),
+            BCSegment(name="wall2", bc_type=BCType.NO_FLUX, boundary="x_max", value=0.0),
+        ],
+        dimension=1,
+    )
+
+
+def _robin_bc(alpha, beta=1.0):
+    """For the FEM path, which does accept ROBIN."""
+    return BoundaryConditions(
+        segments=[BCSegment(name="wall", bc_type=BCType.ROBIN, boundary="x_min", value=0.0, alpha=alpha, beta=beta)],
+        dimension=1,
+    )
+
+
+def test_the_provider_is_detected_on_alpha_at_all():
+    """Control on the premise: `has_providers` must see a provider on `alpha`, not only on `value`.
+
+    If this ever regresses to `value`-only, both guards below go quiet and pass for the wrong
+    reason -- the resolver gate has already been widened once for exactly that (#1979 cites the
+    2026-08-16 correction in `has_providers`).
+    """
+    assert _no_flux_bc(alpha=ConstantProvider(value=2.0)).has_providers() is True
+    assert _no_flux_bc(alpha=1.0).has_providers() is False
+
+
+def _fdm_solver_with(bc):
+    """The user-facing path #1979 describes: a solver constructed with a Robin wall."""
+    import numpy as np
+
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+    from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+    from mfgarchon.core.mfg_components import MFGComponents
+    from mfgarchon.core.mfg_problem import MFGProblem
+    from mfgarchon.geometry import TensorProductGrid
+
+    nx = 11
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[nx], boundary_conditions=bc)
+    components = MFGComponents(
+        hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)),
+        m_initial=lambda x: 1.0,
+        u_terminal=lambda x: 0.0,
+    )
+    problem = MFGProblem(geometry=grid, components=components, T=0.1, Nt=4, sigma=1.0)
+    return FPFDMSolver(problem, boundary_conditions=bc), np.ones(nx) / nx
+
+
+class TestFDMPath:
+    def test_a_provider_valued_alpha_is_refused(self):
+        solver, m0 = _fdm_solver_with(_no_flux_bc(alpha=ConstantProvider(value=2.0)))
+        with pytest.raises(NotImplementedError, match=r"provider-valued wall coefficient"):
+            solver.solve_fp_system(M_initial=m0, potential_field=np.zeros((5, len(m0))))
+
+    def test_the_message_names_the_coefficient_and_the_remedy(self):
+        solver, m0 = _fdm_solver_with(_no_flux_bc(alpha=ConstantProvider(value=2.0)))
+        with pytest.raises(NotImplementedError) as exc:
+            solver.solve_fp_system(M_initial=m0, potential_field=np.zeros((5, len(m0))))
+        text = str(exc.value)
+        assert "wall.alpha" in text, "the message must name WHICH coefficient, not just that one exists"
+        assert "NO_FLUX" in text, "the message must name the segment type, since ROBIN is refused elsewhere"
+        assert "with_resolved_providers" in text, "the message must name the remedy"
+        assert "1979" in text
+
+    def test_a_float_alpha_does_not_trip_the_guard(self):
+        """Control: a blanket refusal would pass the two tests above and break every Robin solve."""
+        solver, m0 = _fdm_solver_with(_no_flux_bc(alpha=1.0))
+        raised = ""
+        try:
+            solver.solve_fp_system(M_initial=m0, potential_field=np.zeros((5, len(m0))))
+        except Exception as exc:  # record any refusal, then judge it below
+            raised = str(exc)
+        # A different contract refusing this wall is #1975's business, not this guard's. What must
+        # not happen is THIS guard firing on a float.
+        assert "provider-valued wall coefficient" not in raised, (
+            f"a float-valued alpha tripped the #1979 provider guard: {raised}"
+        )
+
+
+class TestFEMPath:
+    def _basis(self):
+        skfem = pytest.importorskip("skfem")
+        mesh = skfem.MeshTri().refined(2)
+        return skfem.Basis(mesh, skfem.ElementTriP1()), mesh
+
+    @pytest.mark.parametrize("field", ["alpha", "beta"])
+    def test_a_provider_valued_coefficient_is_refused(self, field):
+        from mfgarchon.alg.numerical.fem.bc_adapter import assemble_robin_terms
+
+        basis, _ = self._basis()
+        kwargs = {"alpha": 1.0, "beta": 1.0, field: ConstantProvider(value=2.0)}
+        bc = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.ROBIN, boundary="x_min", value=0.0, **kwargs)],
+            dimension=2,
+        )
+        with pytest.raises(NotImplementedError, match=rf"non-constant {field}"):
+            assemble_robin_terms(basis, bc, D=1.0)
+
+    def test_the_refusal_is_not_the_bare_TypeError_it_replaced(self):
+        """The defect was `float()` raising a builtin TypeError. Pin that it no longer can."""
+        from mfgarchon.alg.numerical.fem.bc_adapter import assemble_robin_terms
+
+        basis, _ = self._basis()
+        bc = BoundaryConditions(
+            segments=[
+                BCSegment(
+                    name="wall",
+                    bc_type=BCType.ROBIN,
+                    boundary="x_min",
+                    value=0.0,
+                    alpha=ConstantProvider(value=2.0),
+                    beta=1.0,
+                )
+            ],
+            dimension=2,
+        )
+        with pytest.raises(NotImplementedError):
+            assemble_robin_terms(basis, bc, D=1.0)

--- a/tests/unit/test_geometry/test_provider_robin_coefficient_refused_1979.py
+++ b/tests/unit/test_geometry/test_provider_robin_coefficient_refused_1979.py
@@ -102,8 +102,72 @@ class TestFDMPath:
         text = str(exc.value)
         assert "wall.alpha" in text, "the message must name WHICH coefficient, not just that one exists"
         assert "NO_FLUX" in text, "the message must name the segment type, since ROBIN is refused elsewhere"
-        assert "with_resolved_providers" in text, "the message must name the remedy"
         assert "1979" in text
+        # The remedy must be a real capability, not a way around the guard. `FPFEMSolver` reads
+        # alpha/beta/g in its weak form (established in #1975, closed COMPLETED); resolving the
+        # provider is a DOWNGRADE -- it freezes a per-iterate coefficient at one state -- and the
+        # message must say so rather than offer it as the fix.
+        assert "FPFEMSolver" in text, "the message must name the path that CAN do this"
+        assert "with_resolved_providers" in text, "resolving must still be mentioned"
+        assert "DOWNGRADE" in text, (
+            "offering `with_resolved_providers` as the remedy prescribes the guard's own defeat: it "
+            "discards exactly the property a provider exists for"
+        )
+        assert "1975" not in text.replace("#1975", ""), "avoid a bare 1975 that reads as an open pointer"
+
+
+class TestTheGuardIsWhereTheHazardIs:
+    """#2013 review: the guard sat in `solve_fp_nd_full_system` while `_BOUNDARY_HANDLERS` is
+    dispatched from `solve_timestep_full_nd`, so calling that directly walked straight past it --
+    the same "the gate is not where the hazard is" shape the guard exists to fix."""
+
+    def test_the_single_owner_is_called_from_both_entry_points(self):
+        import inspect
+
+        from mfgarchon.alg.numerical.fp_solvers import fp_fdm_time_stepping as mod
+
+        src = inspect.getsource(mod)
+        assert src.count("def _refuse_provider_wall_coefficients(") == 1, "one owner, not a copy per entry"
+        # Count CALL SITES, which means excluding the `def` line -- it matches the same text, and a
+        # first version of this assertion counted it and read 3 where it expected 2.
+        calls = [
+            ln
+            for ln in src.splitlines()
+            if "_refuse_provider_wall_coefficients(boundary_conditions)" in ln and not ln.lstrip().startswith("def ")
+        ]
+        assert len(calls) == 2, (
+            f"both `solve_fp_nd_full_system` and `solve_timestep_full_nd` must call it; the dispatch "
+            f"site is the one that matters, because it is where _BOUNDARY_HANDLERS is reached. "
+            f"Found {len(calls)}: {calls}"
+        )
+        # and the call must precede the dispatch, not follow it
+        assert src.index(
+            "_refuse_provider_wall_coefficients(boundary_conditions)", src.index("def solve_timestep_full_nd")
+        ) < src.index("_BOUNDARY_HANDLERS[advection_scheme]("), "the guard must run BEFORE the handlers are dispatched"
+
+    def test_a_provider_on_value_is_refused_too(self):
+        """#1686: every FP solver silently drops the value in `neumann_bc(value=g)`. A guard that
+        covered only alpha/beta would refuse the coefficient and keep dropping the datum."""
+        from mfgarchon.alg.numerical.fp_solvers.fp_fdm_time_stepping import (
+            _refuse_provider_wall_coefficients,
+        )
+
+        bc = BoundaryConditions(
+            segments=[
+                BCSegment(name="wall", bc_type=BCType.NEUMANN, boundary="x_min", value=ConstantProvider(value=0.5))
+            ],
+            dimension=1,
+        )
+        with pytest.raises(NotImplementedError, match=r"wall\.value"):
+            _refuse_provider_wall_coefficients(bc)
+
+        # Control: a float value must pass, or the guard is a blanket refusal.
+        ok = BoundaryConditions(
+            segments=[BCSegment(name="wall", bc_type=BCType.NEUMANN, boundary="x_min", value=0.5)],
+            dimension=1,
+        )
+        _refuse_provider_wall_coefficients(ok)
+        _refuse_provider_wall_coefficients(None)
 
     def test_a_float_alpha_does_not_trip_the_guard(self):
         """Control: a blanket refusal would pass the two tests above and break every Robin solve."""


### PR DESCRIPTION
Closes #1979. Unblocks #1970.

`BCValueProvider` exists so a wall coefficient can be recomputed each Picard iterate — what
`AdjointConsistentProvider` and #1970's `NormalDriftProvider` supply, both on `alpha`, not on
`value`. Two consumers took one and did the wrong thing with it.

| path | before | after |
|---|---|---|
| FDM | assembles **byte-identically to a plain no-flux wall**, no diagnostic | `NotImplementedError` at solve entry |
| FEM | bare builtin `TypeError` from `float()` | `NotImplementedError`, same wording as the existing `g` guard |

## Correction to the issue's premise, and it makes the fix matter more

#1979 was filed against a **ROBIN** segment. That route is **not reachable**: every grid FP solver
refuses `ROBIN` at construction (`_validate_bc_support`, #1456, stated outright at
`conditions.py:1149`) — measured, `FPFDMSolver` raises before any assembly, so the silent path the
issue reports comes from calling the internal function directly.

The **reachable** case is a provider on the `alpha` of a **NO_FLUX** or **NEUMANN** segment, which
passes the capability gate. That is precisely what `NormalDriftProvider` produces, because an
impermeable wall *is* Robin in `m` — `alpha*m - D*d_n m = 0` — so its coefficient lives there.
Measured before the fix: a `NO_FLUX` segment carrying `ConstantProvider(2.0)` on `alpha` ran to
completion, no error, no diagnostic, output identical to `alpha=1.0`.

So the defect is not narrower than filed. It sits on the path the provider layer was built for.

## Refusing, not reading — deliberately

The conservative grid schemes already impose `J.n = 0` **structurally** (#1975), so teaching
`_BOUNDARY_HANDLERS` to add `(alpha, beta, g)` would count the drift twice — measured there at
**-79.5%** mass against **-7.4e-15**. A general Robin wall on the grid paths stays #1975. This guard
only stops the silent case.

## Why it was silent

`_BOUNDARY_HANDLERS` (`fp_fdm_time_stepping.py`) is keyed on the advection scheme and its four
handlers take **no `boundary_conditions` argument at all** — the parameter is absent from every
signature — so nothing reads `alpha`, provider or float, and nothing is in a position to complain.
The upstream capability gate is keyed on BC **type**, not on coefficient **form**, so a provider
walks past it.

That pairing recurs: #2011 is the same shape one layer over — Howard's closure keys on
`SeparableHamiltonian` private attributes, so a general `HamiltonianBase` subclass is dropped
bitwise, *and* the guard that would have caught it is skipped because it keys on another attribute
the same subclass lacks.

## Pinning

`tests/unit/test_geometry/test_provider_robin_coefficient_refused_1979.py`, both paths, each
`raises` paired with a **float-coefficient control** so a blanket refusal cannot pass. Plus a control
on the premise itself: `has_providers()` must see a provider on `alpha`, not only on `value` — that
gate has already been widened once for exactly this reason.

Mutation-red, measured: removing the FDM guard fails **2 of 7**, removing the FEM guard fails
**3 of 7**.

## Gate

`./scripts/local_ci.sh` run manually: **GATE GREEN**, `6299 passed, 12 skipped, 23 xfailed`, all five
ratchets PASS. Pushed with `--no-verify` because the pre-push hook aborts with
`BlockingIOError: [Errno 35] write could not complete without blocking` on its own stdout, three
times in a row — an output-volume problem in the hook, not a gate result. The gate log is the
evidence, not the hook.

Refs #1456 #1970 #1975 #2011
