### PR TITLE
test: coupled 2D MMS on a no-flux box, through the production iterator

### DIFF
--- a/changelog.d/coupled-2d-mms-no-flux.added.md
+++ b/changelog.d/coupled-2d-mms-no-flux.added.md
@@ -4,25 +4,50 @@ A coupled 2D MMS on a no-flux box, run through the production `FixedPointIterato
 its own note, to avoid the no-flux boundary handling so the measured error is the interior scheme.
 So coupled convergence had never been measured in 2D, nor with a wall present at all.
 
-The manufactured pair is the GFDM paper's `eq:mms_reference` / `eq:mms_system` verbatim, on
-`Ω = (0,20)²`, `T = 4`, `σ = 1`, `ζ = 1/2`. Sources derived symbolically and cross-checked against a
-hand-written vectorised form to `1.1e-16` / `3.3e-19` over 200 random `(t,x)`. Two properties the
-paper states are reproduced as independent confirmation of the transcription: `∫_Ω r_m dx = 0`
-exactly, and `∂u/∂x_k = ∂m/∂x_k = 0` on every wall — the second is what makes `α·n = 0`, hence
-`J·n = 0`, so the pair is exactly compatible with the no-flux wall.
+The manufactured pair is the GFDM paper's `eq:mms_reference` / `eq:mms_system` with **two deliberate
+changes**, on `Ω = (0,20)²`, `T = 4`, `σ = 1`, `ζ = 1/2`. It is not the paper's pair verbatim, and
+both changes exist because the verbatim one cannot express the defects this test is for:
 
-Measured over `Nx = 11/21/31` with `Nt ∝ Nx`: EOC `u` 0.95 → 1.01, `m` 0.99 → 1.00, Picard
-converging in 4 outer iterations at every level. 48.9 s, marked `slow` and `integration`.
+- `c = π/L` instead of `2π/L`. Still Neumann-compatible (`sin(cL) = 0` either way) but no longer
+  L-periodic, so the mirror ghost and the periodic ghost stop coinciding. With the paper's `c`,
+  swapping the entire boundary-condition family to `periodic_bc` left every assertion green; with
+  this one it moves `eu` from `3.0125e-01` to `1.2939e+01` and collapses EOC `u` to `−0.118 / 0.067`.
+- `β = 0.6` breaking the symmetry between the axes, plus a `2c/4c` mix in `m`. The paper's pair is
+  exactly transpose-symmetric, so `eu` from `U[0]` and from `U[0].T` is bit-identical and a
+  wrong-axis read is unexpressible; here the transposed read is 45.7× / 81.8× / 119.5× off.
 
-The test asserts an error **level** beside the order, because an order alone is a min over the HJB
-scheme, the FP scheme and the wall closure. Bounds from measurement: baseline `eu` at the finest
-level is `5.959e-01`; a solver whose `D` is off by 1.21× gives `1.326e+00` with EOC `u` collapsing
-1.01 → 0.38, and by 2× gives `4.465e+00` with EOC → 0.06. Verified mutation-red against the 1.21×
-case.
+Sources re-derived for **this** pair with sympy and cross-checked against the hand-written
+vectorised forms to `5.6e-17` / `1.1e-19` over 400 random `(t,x)`, against residual scales `2.3e-01`
+/ `4.5e-04`, with a positive control (a `1e-7` relative perturbation registers at `4.5e-11`).
 
-Two limits are stated in the file rather than left to be discovered. The wall is **tangential**
-(`∂_ν u = 0`), so this exercises compatibility and not the treatment of a normal drift — that is
-#2006, FP-only. And it does not measure the **coupling direction**: `ζm` is ~2.5% of the HJB residual
-(RMS `1.28e-03` against `1.24e-01`), which the paper says of its own instance too. A model-side
-perturbation of `ζ` is swamped by the ~30% relative discretization error at these resolutions; a
-solver-side error is not, which is what the discrimination above measures.
+Two properties the paper states also hold for this pair — `∫_Ω r_m dx = 0` exactly, and
+`∂u/∂x_k = ∂m/∂x_k = 0` on all four walls. **Neither is a check on the transcription**: the first is
+one scalar per time and is blind to anything that integrates away, the second never touches the
+sources. The second matters for a different reason — it makes `α·n = 0`, hence `J·n = 0`, so the pair
+is exactly compatible with the no-flux wall, which is what lets it run on this box.
+
+Measured over `Nx = 11/21/31` with `Nt ∝ Nx`: `eu` `3.0125e-01 → 1.5759e-01 → 1.0534e-01`, EOC `u`
+0.935 → 0.993; `em` `9.876e-03 → 5.036e-03 → 3.383e-03`, EOC `m` 0.972 → 0.982. Picard converges in
+4 outer iterations at every level, and at every `σ` tried (1.0, 0.5, 0.3, 0.1). 47.5 s, marked
+`slow` and `integration`.
+
+Three limits are stated in the file rather than left to be discovered.
+
+**It cannot resolve a coefficient error below ~10%.** Measured across two solver-side defect
+families: a 5% error in the diffusion coefficient or in the drift scale passes every assertion. The
+error-level assertion is kept as a regression guard on the constant — EOC is a ratio and is blind to
+a uniform scaling — but it is *not* a discriminator: over ten measured mutants it never fails
+without the EOC assertion failing first.
+
+**The wall is tangential** (`∂_ν u = 0`), so this exercises compatibility and not the treatment of a
+normal drift — that is #2006, FP-only.
+
+**It does not measure the coupling direction**, which the paper says of its own instance too. `ζm`
+has RMS `1.26e-03` — 8.1% of the `|∇u|²/2` term and 1.1% of the whole HJB residual, which is
+dominated by `−∂_t u`. The discretization error at the finest level is 0.41% relative in `u` and
+6.6% in `m`, so a model-side perturbation of `ζ` is not resolvable here.
+
+Separately, the study established which solvers can run an MMS at all on this box: **2 of 8 solver
+pairings**. `FDM × FDM` and `GFDM × FDM` converge; the rest never enter the solve because
+`solve_*_system` does not take a `source_term` (#1991, #2020) or crash on the source argument
+convention (#2019).

--- a/changelog.d/coupled-2d-mms-no-flux.added.md
+++ b/changelog.d/coupled-2d-mms-no-flux.added.md
@@ -1,0 +1,28 @@
+A coupled 2D MMS on a no-flux box, run through the production `FixedPointIterator`.
+
+`test_coupled_mfg_mms.py` measures coupled EOC in **1D** under **periodic** BC — deliberately, per
+its own note, to avoid the no-flux boundary handling so the measured error is the interior scheme.
+So coupled convergence had never been measured in 2D, nor with a wall present at all.
+
+The manufactured pair is the GFDM paper's `eq:mms_reference` / `eq:mms_system` verbatim, on
+`Ω = (0,20)²`, `T = 4`, `σ = 1`, `ζ = 1/2`. Sources derived symbolically and cross-checked against a
+hand-written vectorised form to `1.1e-16` / `3.3e-19` over 200 random `(t,x)`. Two properties the
+paper states are reproduced as independent confirmation of the transcription: `∫_Ω r_m dx = 0`
+exactly, and `∂u/∂x_k = ∂m/∂x_k = 0` on every wall — the second is what makes `α·n = 0`, hence
+`J·n = 0`, so the pair is exactly compatible with the no-flux wall.
+
+Measured over `Nx = 11/21/31` with `Nt ∝ Nx`: EOC `u` 0.95 → 1.01, `m` 0.99 → 1.00, Picard
+converging in 4 outer iterations at every level. 48.9 s, marked `slow` and `integration`.
+
+The test asserts an error **level** beside the order, because an order alone is a min over the HJB
+scheme, the FP scheme and the wall closure. Bounds from measurement: baseline `eu` at the finest
+level is `5.959e-01`; a solver whose `D` is off by 1.21× gives `1.326e+00` with EOC `u` collapsing
+1.01 → 0.38, and by 2× gives `4.465e+00` with EOC → 0.06. Verified mutation-red against the 1.21×
+case.
+
+Two limits are stated in the file rather than left to be discovered. The wall is **tangential**
+(`∂_ν u = 0`), so this exercises compatibility and not the treatment of a normal drift — that is
+#2006, FP-only. And it does not measure the **coupling direction**: `ζm` is ~2.5% of the HJB residual
+(RMS `1.28e-03` against `1.24e-01`), which the paper says of its own instance too. A model-side
+perturbation of `ζ` is swamped by the ~30% relative discretization error at these resolutions; a
+solver-side error is not, which is what the discrimination above measures.

--- a/tests/integration/test_coupled_mms_2d_no_flux.py
+++ b/tests/integration/test_coupled_mms_2d_no_flux.py
@@ -157,10 +157,15 @@ def _solve(nx: int, nt: int):
 
 
 def _eoc(errors, levels):
-    return [
-        float(np.log(errors[i] / errors[i + 1]) / np.log(levels[i + 1][0] / levels[i][0]))
-        for i in range(len(errors) - 1)
-    ]
+    """Order against the MESH ratio h_i/h_{i+1}, not the point-count ratio.
+
+    `dx = L/(nx-1)`, so refining 11 -> 21 -> 31 halves h and then takes 2/3 of it: ratios 2.0 and
+    1.5, not 21/11 = 1.909 and 31/21 = 1.476. A first draft divided by the point counts and inflated
+    every order by 7.2% and 4.1% -- while `_solve` twelve lines up computed `dx` with `nx - 1`
+    correctly, so the file disagreed with itself.
+    """
+    h = [L / (nx - 1) for nx, _ in levels]
+    return [float(np.log(errors[i] / errors[i + 1]) / np.log(h[i] / h[i + 1])) for i in range(len(errors) - 1)]
 
 
 @pytest.mark.integration

--- a/tests/integration/test_coupled_mms_2d_no_flux.py
+++ b/tests/integration/test_coupled_mms_2d_no_flux.py
@@ -63,7 +63,22 @@ WHAT THIS STUDY CANNOT SEE
   perturbation of ζ is comparable to or smaller than the error already present, and this study
   cannot resolve it. That is a statement about resolution, not about the fixture: a *solver-side*
   error breaks it decisively, which is what the discrimination measurement below shows.
-- Only `FDM_UPWIND`. The pair is method-agnostic; other schemes are separate parametrisations.
+- Only `FDM_UPWIND`. The pair is method-agnostic, but the LIBRARY mostly is not: measured at
+  Nx=21 on this exact fixture, 2 of 8 solver pairings run at all.
+
+      HJB x FP                 outcome
+      FDM  x FDM               converged, 4 iter, eu = 1.5759e-01
+      GFDM x FDM               converged, 4 iter, eu = 1.9699e-02
+      WENO x FDM               NotImplementedError: source_term is 1D-path only, this is 2D
+      SemiLagrangian x FDM     NotImplementedError: solve_hjb_system takes no source_term
+      FDM  x GFDM/Particle/SL  NotImplementedError: solve_fp_system takes no source_term
+      FDM  x FVM               ValueError: cannot broadcast (21,21) against (882,)
+
+  The NotImplementedErrors are fail-loud guards, not bugs -- but they mean an MMS cannot reach
+  those solvers at all (#1991 for the HJB side). GFDM's source WAS verified to reach it: zeroing
+  s_hjb moves eu from 1.9699e-02 to 9.7640e+00, a factor of 496. The FVM crash is specific to the
+  2D-and-source cell -- 1D+source, 2D-no-source and both FDM cells all run -- so it is neither a
+  general 2D defect nor a general source defect.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_coupled_mms_2d_no_flux.py
+++ b/tests/integration/test_coupled_mms_2d_no_flux.py
@@ -16,22 +16,39 @@ Verbatim from the GFDM paper, `eq:mms_reference` / `eq:mms_system`, on Ω = (0,L
     -d_t u - (σ²/2)Δu + (1/2)|∇u|² + ζm = r_u
      d_t m - div(m ∇u) - (σ²/2)Δm       = r_m
 
-The sources were derived symbolically (sympy) and cross-checked against a hand-written vectorised
-form to 1.1e-16 / 3.3e-19 over 200 random (t,x). Two properties the paper states are reproduced as
-independent confirmation of the transcription:
+The pair actually used here is NOT the paper's verbatim one -- see C and BETA below for why and for
+what each change buys. The sources were re-derived for THIS pair symbolically (sympy, from the
+definitions of u and m) and cross-checked against the hand-written vectorised forms in this file to
+5.6e-17 / 1.1e-19 over 400 random (t,x), against residual scales 2.3e-01 / 4.5e-04. That comparison
+can fail: perturbing s_fp by 1e-7 relative registers as 4.5e-11.
+
+Two properties the paper states also hold for this pair, verified symbolically on it:
 
 - ∫_Ω r_m dx = 0 exactly (the paper: "the manufactured forward equation is mass-consistent")
-- ∂u/∂x_k = ∂m/∂x_k = 0 on every wall
+- ∂u/∂x_k = ∂m/∂x_k = 0 on each of the four walls
 
-The second matters here: α = -∇u, so α·n = 0 and hence J·n = αm - D∇m = 0. **The pair is exactly
-compatible with the no-flux wall**, which is what lets it run on this box at all.
+**Neither is a check on the transcription**, and an earlier version of this docstring called them
+"independent confirmation" of it. The first is one scalar per time and is blind to any error that
+integrates away: an r_m carrying a spurious (1/7)cos(2c x1)cos(4c x2) integrates to exactly 0 as
+well. The second is a property of u and m alone and never touches the sources. Only the sympy
+cross-check above bears on the transcription.
+
+The second property earns its place for a different reason: α = -∇u, so α·n = 0 and hence
+J·n = αm - D∇m = 0. **The pair is exactly compatible with the no-flux wall**, which is what lets
+it run on this box at all.
 
 SIGN CONVENTIONS (read off the working tree, not memory; same as test_coupled_mfg_mms.py)
 ------------------------------------------------------------------------------------------
 S_HJB = -d_t u + H(x, m, ∇u) - (σ²/2)Δu   with H = |p|²/(2λ) + f(m), λ = 1, f(m) = ζm
      => identical to the paper's r_u.
-S_FP  =  d_t m + div(α m) - (σ²/2)Δm      with α = -coupling_coefficient·∇U, coefficient = 1
+S_FP  =  d_t m + div(α m) - (σ²/2)Δm      with α = -c·∇U, c = 1
      => identical to the paper's r_m.
+
+c is NOT `problem.coupling_coefficient`. It comes from `fp_drift_coefficient`
+(`utils/pde_coefficients.py:118`), which for a quadratic-MINIMIZE SeparableHamiltonian returns
+1/control_cost.lambda_ and never reaches the `coupling_coefficient` fallback (#1420 / G-017). Here
+λ = 1, so c = 1. An earlier version of this file credited the value to the `coupling_coefficient=1.0`
+argument below -- wrong source, right number, which is exactly why the misattribution left no trace.
 
 WHAT THIS STUDY CANNOT SEE
 --------------------------
@@ -39,11 +56,13 @@ WHAT THIS STUDY CANNOT SEE
   and not its treatment of a normal drift. The non-tangential wall is
   `tests/unit/test_alg/test_fp_mms_wall_order_1728.py` (#2006), FP-only.
 - **It does not measure the coupling direction**, and the paper says so of its own instance: "this
-  leg measures discretization order and not the coupling direction analyzed above". Measured here,
-  ζm is ~2.5% of the HJB residual (RMS 1.28e-03 against 1.24e-01 for |∇u|²/2), so a *model-side*
-  perturbation of ζ is swamped by the discretization error, which is ~30% relative at these
-  resolutions. That is a statement about resolution, not about the fixture: a *solver-side* error
-  breaks it decisively, which is what the discrimination measurement below shows.
+  leg measures discretization order and not the coupling direction analyzed above". Measured on THIS
+  pair over the space-time box: ζm has RMS 1.26e-03 — 8.1% of the |∇u|²/2 term (1.55e-02) and 1.1%
+  of the whole HJB residual (1.17e-01, dominated by -∂_t u at 1.03e-01). Against that, the
+  discretization error at the finest level is 0.41% relative in u and 6.6% in m. So a *model-side*
+  perturbation of ζ is comparable to or smaller than the error already present, and this study
+  cannot resolve it. That is a statement about resolution, not about the fixture: a *solver-side*
+  error breaks it decisively, which is what the discrimination measurement below shows.
 - Only `FDM_UPWIND`. The pair is method-agnostic; other schemes are separate parametrisations.
 """
 
@@ -63,7 +82,19 @@ from mfgarchon.geometry import TensorProductGrid
 from mfgarchon.geometry.boundary import no_flux_bc
 
 L, T, SIGMA, ZETA = 20.0, 4.0, 1.0, 0.5
-C = 2.0 * np.pi / L
+# HALF a period, not the paper's full one. sin(cL) = 0 either way, so the pair stays Neumann
+# compatible -- but cos(pi x/L) is NOT L-periodic, so the mirror ghost and the periodic ghost no
+# longer coincide and the wall closure is actually exercised. Measured: with the paper's
+# c = 2 pi / L, swapping the entire boundary-condition family for `periodic_bc` left every
+# assertion green; with c = pi / L it moves eu from 3.0125e-01 to 1.2939e+01 at Nx=11 (42x) and
+# collapses EOC u to -0.118 / 0.067. That difference IS the wall closure.
+C = np.pi / L
+# Asymmetry between the axes, deliberately. With the paper's pair, u, m and BOTH sources are exactly
+# transpose-symmetric, so `eu` computed from U[0] and from U[0].T is bit-identical and the fixture
+# cannot express "read the potential along the wrong axis" -- one of the three mutants #2017 cites as
+# the reason to work in 2D. BETA breaks it in u; the 2c/4c pair breaks it in m. Measured: eu from
+# U[0].T is now 45.7x / 81.8x / 119.5x the eu from U[0] across the three levels.
+BETA = 0.6
 LEVELS = ((11, 8), (21, 16), (31, 24))
 
 
@@ -84,31 +115,31 @@ def _a2p(t):
 
 
 def u_star(t, x1, x2):
-    return _a1(t) * (np.cos(C * x1) + np.cos(C * x2))
+    return _a1(t) * (np.cos(C * x1) + BETA * np.cos(C * x2))
 
 
 def m_star(t, x1, x2):
-    return (1.0 + _a2(t) * np.cos(2 * C * x1) * np.cos(2 * C * x2)) / L**2
+    return (1.0 + _a2(t) * np.cos(2 * C * x1) * np.cos(4 * C * x2)) / L**2
 
 
 def s_hjb(t, x1, x2):
     """S_HJB = -d_t u + (1/2)|grad u|^2 + zeta*m - (sigma^2/2) Lap u."""
-    du_dt = _a1p(t) * (np.cos(C * x1) + np.cos(C * x2))
-    grad_sq = (_a1(t) * C) ** 2 * (np.sin(C * x1) ** 2 + np.sin(C * x2) ** 2)
-    lap_u = -_a1(t) * C**2 * (np.cos(C * x1) + np.cos(C * x2))
+    du_dt = _a1p(t) * (np.cos(C * x1) + BETA * np.cos(C * x2))
+    grad_sq = (_a1(t) * C) ** 2 * (np.sin(C * x1) ** 2 + BETA**2 * np.sin(C * x2) ** 2)
+    lap_u = -_a1(t) * C**2 * (np.cos(C * x1) + BETA * np.cos(C * x2))
     return -du_dt + 0.5 * grad_sq + ZETA * m_star(t, x1, x2) - 0.5 * SIGMA**2 * lap_u
 
 
 def s_fp(t, x1, x2):
     """S_FP = d_t m - div(m grad u) - (sigma^2/2) Lap m."""
-    dm_dt = _a2p(t) * np.cos(2 * C * x1) * np.cos(2 * C * x2) / L**2
+    dm_dt = _a2p(t) * np.cos(2 * C * x1) * np.cos(4 * C * x2) / L**2
     m = m_star(t, x1, x2)
-    gm1 = -2 * C * _a2(t) * np.sin(2 * C * x1) * np.cos(2 * C * x2) / L**2
-    gm2 = -2 * C * _a2(t) * np.cos(2 * C * x1) * np.sin(2 * C * x2) / L**2
+    gm1 = -2 * C * _a2(t) * np.sin(2 * C * x1) * np.cos(4 * C * x2) / L**2
+    gm2 = -4 * C * _a2(t) * np.cos(2 * C * x1) * np.sin(4 * C * x2) / L**2
     gu1 = -_a1(t) * C * np.sin(C * x1)
-    gu2 = -_a1(t) * C * np.sin(C * x2)
-    lap_u = -_a1(t) * C**2 * (np.cos(C * x1) + np.cos(C * x2))
-    lap_m = -8 * C**2 * _a2(t) * np.cos(2 * C * x1) * np.cos(2 * C * x2) / L**2
+    gu2 = -BETA * _a1(t) * C * np.sin(C * x2)
+    lap_u = -_a1(t) * C**2 * (np.cos(C * x1) + BETA * np.cos(C * x2))
+    lap_m = -20 * C**2 * _a2(t) * np.cos(2 * C * x1) * np.cos(4 * C * x2) / L**2
     return dm_dt - (gm1 * gu1 + gm2 * gu2 + m * lap_u) - 0.5 * SIGMA**2 * lap_m
 
 
@@ -174,10 +205,30 @@ def test_coupled_2d_no_flux_converges_at_first_order():
     """First order in both fields, with an error LEVEL beside the order.
 
     The level is not decoration. An order alone is a min over the HJB scheme, the FP scheme and the
-    wall closure, so it cannot say which produced the O(h); the level separates them. Bounds are set
-    from measurement, not chosen: baseline `eu` at the finest level is 5.959e-01, and a solver whose
-    D is off by 1.21x gives 1.326e+00 (EOC u collapsing 1.01 -> 0.38), by 2x gives 4.465e+00
-    (EOC u -> 0.06). 9e-01 separates them with margin on both sides.
+    wall closure, so it cannot say which produced the O(h); the level separates them.
+
+    Bounds are set from measurement. Baseline against two solver-side diffusion errors -- sigma is
+    wrong at problem CONSTRUCTION while s_hjb/s_fp stay closed over the true SIGMA, so the
+    manufactured pair is untouched and only the PDE the scheme discretizes is wrong:
+
+        D factor   eu(Nx=11)   eu(Nx=21)   eu(Nx=31)   EOC u
+        1.00       3.0125e-01  1.5759e-01  1.0534e-01   0.935,  0.993
+        1.21       3.5252e-01  2.4572e-01  2.2015e-01   0.521,  0.271
+        2.00       9.6882e-01  9.5405e-01  9.5607e-01   0.022, -0.005
+
+    So 1.5e-01 sits 1.42x above the baseline and 1.47x below the 1.21x mutant. The previous bound
+    of 9e-01 came from a different fixture and would have PASSED the 1.21x mutant outright.
+
+    `em` is not the discriminating field for this defect and no level bound is asserted on it: at
+    1.21x it moves only 3.383e-03 -> 3.487e-03 and its EOC stays inside the band at 0.956 / 0.945.
+    Only at 2x does it leave, at 0.886 / 0.777.
+
+    Do NOT reproduce these by mutating `problem.sigma` after construction -- that is inert and
+    silently so. `get_diffusion_coefficient_field` (mfg_problem.py:1416) resolves
+    override -> volatility_field -> self.sigma, and `volatility_field` is snapshotted at
+    construction (:560), so the solve comes back byte-identical while `problem.diffusion` reports
+    the mutated value. Measured: 1.21x and 2.0x that way both reproduce the baseline to every
+    printed digit.
     """
     errors = [_solve(nx, nt) for nx, nt in LEVELS]
     eu = [e[0] for e in errors]
@@ -186,7 +237,7 @@ def test_coupled_2d_no_flux_converges_at_first_order():
 
     assert all(0.8 <= o <= 1.3 for o in order_u), f"u is not first order: {order_u} (errors {eu})"
     assert all(0.8 <= o <= 1.3 for o in order_m), f"m is not first order: {order_m} (errors {em})"
-    assert eu[-1] < 9e-01, (
-        f"u error level {eu[-1]:.4e} at the finest grid exceeds 9e-01. The order can stay near 1 "
+    assert eu[-1] < 1.5e-01, (
+        f"u error level {eu[-1]:.4e} at the finest grid exceeds 1.5e-01. The order can stay near 1 "
         f"while the constant moves, which is what a wrong diffusion coefficient looks like here."
     )

--- a/tests/integration/test_coupled_mms_2d_no_flux.py
+++ b/tests/integration/test_coupled_mms_2d_no_flux.py
@@ -1,0 +1,187 @@
+"""Coupled 2D MMS on a no-flux box: the GFDM paper's manufactured pair, run through production.
+
+The gap this fills. `test_coupled_mfg_mms.py` measures coupled EOC, but in **1D** and under
+**periodic** BC (deliberately — its own note says periodic "avoids the no-flux conservative-Laplacian
+boundary handling (#1075) so the measured error" is the interior scheme). So nothing measured coupled
+convergence in 2D, and nothing measured it with a wall present at all.
+
+THE MANUFACTURED PAIR
+---------------------
+Verbatim from the GFDM paper, `eq:mms_reference` / `eq:mms_system`, on Ω = (0,L)² with L = 20, T = 4,
+σ = 1, c = 2π/L, ζ = 1/2:
+
+    u(t,x) = a1(t)(cos(c x1) + cos(c x2)),          a1 = 1 + (T-t)/(2T)
+    m(t,x) = L^-2 (1 + a2(t) cos(2c x1) cos(2c x2)), a2 = (2/5) cos(π t / (2T))
+
+    -d_t u - (σ²/2)Δu + (1/2)|∇u|² + ζm = r_u
+     d_t m - div(m ∇u) - (σ²/2)Δm       = r_m
+
+The sources were derived symbolically (sympy) and cross-checked against a hand-written vectorised
+form to 1.1e-16 / 3.3e-19 over 200 random (t,x). Two properties the paper states are reproduced as
+independent confirmation of the transcription:
+
+- ∫_Ω r_m dx = 0 exactly (the paper: "the manufactured forward equation is mass-consistent")
+- ∂u/∂x_k = ∂m/∂x_k = 0 on every wall
+
+The second matters here: α = -∇u, so α·n = 0 and hence J·n = αm - D∇m = 0. **The pair is exactly
+compatible with the no-flux wall**, which is what lets it run on this box at all.
+
+SIGN CONVENTIONS (read off the working tree, not memory; same as test_coupled_mfg_mms.py)
+------------------------------------------------------------------------------------------
+S_HJB = -d_t u + H(x, m, ∇u) - (σ²/2)Δu   with H = |p|²/(2λ) + f(m), λ = 1, f(m) = ζm
+     => identical to the paper's r_u.
+S_FP  =  d_t m + div(α m) - (σ²/2)Δm      with α = -coupling_coefficient·∇U, coefficient = 1
+     => identical to the paper's r_m.
+
+WHAT THIS STUDY CANNOT SEE
+--------------------------
+- **The wall is TANGENTIAL.** ∂_ν u = 0 makes α·n = 0, so this exercises the wall's *compatibility*
+  and not its treatment of a normal drift. The non-tangential wall is
+  `tests/unit/test_alg/test_fp_mms_wall_order_1728.py` (#2006), FP-only.
+- **It does not measure the coupling direction**, and the paper says so of its own instance: "this
+  leg measures discretization order and not the coupling direction analyzed above". Measured here,
+  ζm is ~2.5% of the HJB residual (RMS 1.28e-03 against 1.24e-01 for |∇u|²/2), so a *model-side*
+  perturbation of ζ is swamped by the discretization error, which is ~30% relative at these
+  resolutions. That is a statement about resolution, not about the fixture: a *solver-side* error
+  breaks it decisively, which is what the discrimination measurement below shows.
+- Only `FDM_UPWIND`. The pair is method-agnostic; other schemes are separate parametrisations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling import FixedPointIterator
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+L, T, SIGMA, ZETA = 20.0, 4.0, 1.0, 0.5
+C = 2.0 * np.pi / L
+LEVELS = ((11, 8), (21, 16), (31, 24))
+
+
+def _a1(t):
+    return 1.0 + 0.5 * (T - t) / T
+
+
+def _a1p(_t):
+    return -0.5 / T
+
+
+def _a2(t):
+    return 0.4 * np.cos(np.pi * t / (2.0 * T))
+
+
+def _a2p(t):
+    return -0.4 * (np.pi / (2.0 * T)) * np.sin(np.pi * t / (2.0 * T))
+
+
+def u_star(t, x1, x2):
+    return _a1(t) * (np.cos(C * x1) + np.cos(C * x2))
+
+
+def m_star(t, x1, x2):
+    return (1.0 + _a2(t) * np.cos(2 * C * x1) * np.cos(2 * C * x2)) / L**2
+
+
+def s_hjb(t, x1, x2):
+    """S_HJB = -d_t u + (1/2)|grad u|^2 + zeta*m - (sigma^2/2) Lap u."""
+    du_dt = _a1p(t) * (np.cos(C * x1) + np.cos(C * x2))
+    grad_sq = (_a1(t) * C) ** 2 * (np.sin(C * x1) ** 2 + np.sin(C * x2) ** 2)
+    lap_u = -_a1(t) * C**2 * (np.cos(C * x1) + np.cos(C * x2))
+    return -du_dt + 0.5 * grad_sq + ZETA * m_star(t, x1, x2) - 0.5 * SIGMA**2 * lap_u
+
+
+def s_fp(t, x1, x2):
+    """S_FP = d_t m - div(m grad u) - (sigma^2/2) Lap m."""
+    dm_dt = _a2p(t) * np.cos(2 * C * x1) * np.cos(2 * C * x2) / L**2
+    m = m_star(t, x1, x2)
+    gm1 = -2 * C * _a2(t) * np.sin(2 * C * x1) * np.cos(2 * C * x2) / L**2
+    gm2 = -2 * C * _a2(t) * np.cos(2 * C * x1) * np.sin(2 * C * x2) / L**2
+    gu1 = -_a1(t) * C * np.sin(C * x1)
+    gu2 = -_a1(t) * C * np.sin(C * x2)
+    lap_u = -_a1(t) * C**2 * (np.cos(C * x1) + np.cos(C * x2))
+    lap_m = -8 * C**2 * _a2(t) * np.cos(2 * C * x1) * np.cos(2 * C * x2) / L**2
+    return dm_dt - (gm1 * gu1 + gm2 * gu2 + m * lap_u) - 0.5 * SIGMA**2 * lap_m
+
+
+def _split(x):
+    a = np.asarray(x, dtype=float)
+    return (a[..., 0], a[..., 1]) if a.ndim >= 2 and a.shape[-1] == 2 else (a.ravel(), a.ravel())
+
+
+def _solve(nx: int, nt: int):
+    grid = TensorProductGrid(bounds=[(0.0, L)] * 2, Nx_points=[nx] * 2, boundary_conditions=no_flux_bc(dimension=2))
+    components = MFGComponents(
+        m_initial=lambda p: float(m_star(0.0, np.asarray(p).ravel()[0], np.asarray(p).ravel()[1])),
+        u_terminal=lambda p: float(u_star(T, np.asarray(p).ravel()[0], np.asarray(p).ravel()[1])),
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: ZETA * m,
+            coupling_dm=lambda _m: ZETA,
+        ),
+    )
+    problem = MFGProblem(
+        geometry=grid,
+        T=T,
+        Nt=nt,
+        sigma=SIGMA,
+        coupling_coefficient=1.0,  # alpha = -grad U, matching the paper's div(m grad u)
+        components=components,
+        source_term_hjb=lambda x, m, v, t: s_hjb(t, *_split(x)).ravel(),
+        source_term_fp=lambda x, m, v, t: s_fp(t, *_split(x)).ravel(),
+    )
+    result = FixedPointIterator(
+        problem, hjb_solver=HJBFDMSolver(problem), fp_solver=FPFDMSolver(problem), relaxation=1.0
+    ).solve(max_iterations=200, tolerance=1e-6, verbose=False)
+    # BEFORE any error metric: an EOC read off an unconverged outer iteration measures how far the
+    # iteration got in N steps, not a discretization order (#1998/#1728).
+    assert result.converged, (
+        f"Picard did not converge at Nx={nx} (iters={result.iterations}); an EOC measured on an "
+        "unconverged solve is a statistic about the iteration, not about the scheme."
+    )
+    points = problem.geometry.get_spatial_grid()
+    shape = tuple(problem.geometry.Nx_points)
+    dx = L / (nx - 1)
+    x1, x2 = points[:, 0].reshape(shape), points[:, 1].reshape(shape)
+    u_err = np.asarray(result.U)[0] - u_star(0.0, x1, x2)
+    m_err = np.asarray(result.M)[-1] - m_star(T, x1, x2)
+    return float(np.sqrt((u_err**2).sum()) * dx), float(np.sqrt((m_err**2).sum()) * dx)
+
+
+def _eoc(errors, levels):
+    return [
+        float(np.log(errors[i] / errors[i + 1]) / np.log(levels[i + 1][0] / levels[i][0]))
+        for i in range(len(errors) - 1)
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_coupled_2d_no_flux_converges_at_first_order():
+    """First order in both fields, with an error LEVEL beside the order.
+
+    The level is not decoration. An order alone is a min over the HJB scheme, the FP scheme and the
+    wall closure, so it cannot say which produced the O(h); the level separates them. Bounds are set
+    from measurement, not chosen: baseline `eu` at the finest level is 5.959e-01, and a solver whose
+    D is off by 1.21x gives 1.326e+00 (EOC u collapsing 1.01 -> 0.38), by 2x gives 4.465e+00
+    (EOC u -> 0.06). 9e-01 separates them with margin on both sides.
+    """
+    errors = [_solve(nx, nt) for nx, nt in LEVELS]
+    eu = [e[0] for e in errors]
+    em = [e[1] for e in errors]
+    order_u, order_m = _eoc(eu, LEVELS), _eoc(em, LEVELS)
+
+    assert all(0.8 <= o <= 1.3 for o in order_u), f"u is not first order: {order_u} (errors {eu})"
+    assert all(0.8 <= o <= 1.3 for o in order_m), f"m is not first order: {order_m} (errors {em})"
+    assert eu[-1] < 9e-01, (
+        f"u error level {eu[-1]:.4e} at the finest grid exceeds 9e-01. The order can stay near 1 "
+        f"while the constant moves, which is what a wrong diffusion coefficient looks like here."
+    )

--- a/tests/integration/test_coupled_mms_2d_no_flux.py
+++ b/tests/integration/test_coupled_mms_2d_no_flux.py
@@ -63,6 +63,9 @@ WHAT THIS STUDY CANNOT SEE
   perturbation of ζ is comparable to or smaller than the error already present, and this study
   cannot resolve it. That is a statement about resolution, not about the fixture: a *solver-side*
   error breaks it decisively, which is what the discrimination measurement below shows.
+- **It cannot resolve a coefficient error below ~10%.** Measured: a 5% error in the diffusion
+  coefficient (k = 1.05) or in the drift scale (lambda = 1.05) passes every assertion in this file.
+  Any order reported here is an order at that sensitivity, not a certificate below it.
 - Only `FDM_UPWIND`. The pair is method-agnostic, but the LIBRARY mostly is not: measured at
   Nx=21 on this exact fixture, 2 of 8 solver pairings run at all.
 
@@ -159,8 +162,29 @@ def s_fp(t, x1, x2):
 
 
 def _split(x):
+    """Split the solver's point array into (x1, x2). Raises rather than guessing.
+
+    The previous version fell back to ``(a.ravel(), a.ravel())`` for any other shape, which aliases
+    x2 := x1 and evaluates BOTH manufactured sources on the degenerate diagonal x1 == x2 -- a
+    plausible, wrong source field, silently. In an oracle that is the one failure that cannot be
+    afforded: the test would keep passing while measuring the scheme against the wrong exact
+    solution. Instrumented over a full converged solve, that branch was taken 0 times out of 64, so
+    it bought nothing and risked everything. The repo's own rule is at
+    `utils/pde_coefficients.py:114` -- "the prior silent fallback masked a malformed problem".
+
+    Note this convention is not universal in the library: `FPFVMSolver` passes
+    `geometry.meshgrid()`, a (d, *shape) tuple, where FDM and the whole HJB side pass (N, d)
+    points (#2019). Raising here is what makes that difference visible instead of silently
+    diagonal.
+    """
     a = np.asarray(x, dtype=float)
-    return (a[..., 0], a[..., 1]) if a.ndim >= 2 and a.shape[-1] == 2 else (a.ravel(), a.ravel())
+    if a.ndim >= 2 and a.shape[-1] == 2:
+        return a[..., 0], a[..., 1]
+    raise TypeError(
+        f"_split expected an (N, 2) point array from the solver, got shape {a.shape}. "
+        "Aliasing x2 := x1 would evaluate the manufactured sources on the diagonal and the test "
+        "would pass while measuring the wrong exact solution (see #2019 for the FVM convention)."
+    )
 
 
 def _solve(nx: int, nt: int):
@@ -179,7 +203,12 @@ def _solve(nx: int, nt: int):
         T=T,
         Nt=nt,
         sigma=SIGMA,
-        coupling_coefficient=1.0,  # alpha = -grad U, matching the paper's div(m grad u)
+        # INERT here, and kept only because MFGProblem's own default (0.5) would be equally
+        # inert and more confusing. The drift scale comes from `fp_drift_coefficient` = 1/lambda,
+        # never from this argument (see SIGN CONVENTIONS above). Measured: solves at
+        # coupling_coefficient = 0.5 / 1.0 / 7.0 are bit-identical, max|dU| = max|dM| = 0.000e+00,
+        # against a control where sigma=1.1 moves the same solve by 1.672e-02.
+        coupling_coefficient=1.0,
         components=components,
         source_term_hjb=lambda x, m, v, t: s_hjb(t, *_split(x)).ravel(),
         source_term_fp=lambda x, m, v, t: s_fp(t, *_split(x)).ravel(),
@@ -222,28 +251,56 @@ def test_coupled_2d_no_flux_converges_at_first_order():
     The level is not decoration. An order alone is a min over the HJB scheme, the FP scheme and the
     wall closure, so it cannot say which produced the O(h); the level separates them.
 
-    Bounds are set from measurement. Baseline against two solver-side diffusion errors -- sigma is
-    wrong at problem CONSTRUCTION while s_hjb/s_fp stay closed over the true SIGMA, so the
-    manufactured pair is untouched and only the PDE the scheme discretizes is wrong:
+    WHAT EACH ASSERTION ACTUALLY CATCHES, measured over two independent solver-side defect
+    families. In both, the manufactured pair is untouched -- the wrong coefficient is supplied at
+    problem CONSTRUCTION while s_hjb/s_fp stay closed over the true constants -- so only the PDE
+    the scheme discretizes is wrong.
 
-        D factor   eu(Nx=11)   eu(Nx=21)   eu(Nx=31)   EOC u
-        1.00       3.0125e-01  1.5759e-01  1.0534e-01   0.935,  0.993
-        1.21       3.5252e-01  2.4572e-01  2.2015e-01   0.521,  0.271
-        2.00       9.6882e-01  9.5405e-01  9.5607e-01   0.022, -0.005
+    Family 1, wrong diffusion (sigma at construction, so D = k*sigma^2/2):
 
-    So 1.5e-01 sits 1.42x above the baseline and 1.47x below the 1.21x mutant. The previous bound
-    of 9e-01 came from a different fixture and would have PASSED the 1.21x mutant outright.
+        k       eu(11)      eu(21)      eu(31)      EOC u           EOC-assert  level-assert
+        1.00    3.0125e-01  1.5759e-01  1.0534e-01   0.935,  0.993  pass        pass
+        1.05    3.0241e-01  1.6042e-01  1.1106e-01   0.915,  0.907  pass        pass
+        1.10    3.1101e-01  1.7715e-01  1.3559e-01   0.812,  0.659  FAIL        pass
+        1.15    3.2640e-01  2.0434e-01  1.7092e-01   0.676,  0.440  FAIL        FAIL
+        1.21    3.5252e-01  2.4572e-01  2.2015e-01   0.521,  0.271  FAIL        FAIL
+        2.00    9.6882e-01  9.5405e-01  9.5607e-01   0.022, -0.005  FAIL        FAIL
 
-    `em` is not the discriminating field for this defect and no level bound is asserted on it: at
-    1.21x it moves only 3.383e-03 -> 3.487e-03 and its EOC stays inside the band at 0.956 / 0.945.
-    Only at 2x does it leave, at 0.886 / 0.777.
+    Family 2, wrong drift scale (control_cost lambda, so alpha = -grad U / lambda):
 
-    Do NOT reproduce these by mutating `problem.sigma` after construction -- that is inert and
-    silently so. `get_diffusion_coefficient_field` (mfg_problem.py:1416) resolves
+        lambda  eu(11)      eu(21)      eu(31)      EOC u           EOC-assert  level-assert
+        1.00    3.0125e-01  1.5759e-01  1.0534e-01   0.935,  0.993  pass        pass
+        1.05    3.1276e-01  1.7232e-01  1.2388e-01   0.860,  0.814  pass        pass
+        1.20    3.8375e-01  2.6818e-01  2.3543e-01   0.517,  0.321  FAIL        FAIL
+        1.50    5.4156e-01  4.5111e-01  4.2713e-01   0.264,  0.135  FAIL        FAIL
+
+    Two things follow, and the first corrects an earlier version of this docstring.
+
+    **The level bound is not a discriminator for coefficient errors, and claiming it was is what
+    an earlier version of this file did.** Across 10 mutants in two families it never fails alone:
+    every row where it fails, the EOC assertion has already failed, and at k = 1.10 the EOC fails
+    while the level passes. The retracted claim -- "the previous bound of 9e-01 would have PASSED
+    the 1.21x mutant" -- is false for the same reason: EOC rejects that mutant on 0.521 / 0.271
+    whatever the level bound is.
+
+    It is kept, relabelled, as a **regression guard on the constant**: EOC is a ratio and is blind
+    to an error scaled uniformly across levels, so a future change that preserves first order while
+    multiplying the constant would pass the EOC assertion. No mutant here exhibits that, so this is
+    an unexercised guard and is labelled as one rather than sold as discrimination.
+
+    **The measured detection floor is between 5% and 10%.** A 5% error in either coefficient passes
+    the ENTIRE test (k = 1.05 and lambda = 1.05 both pass both assertions). That is a fact about
+    these resolutions, not about the fixture, and it belongs beside any order this test reports.
+
+    `em` is weaker still: at k = 1.21 it moves only 3.383e-03 -> 3.487e-03 with EOC 0.956 / 0.945,
+    inside the band. No level bound is asserted on it.
+
+    Do NOT reproduce any of this by mutating `problem.sigma` after construction -- that is inert
+    and silently so. `get_diffusion_coefficient_field` (mfg_problem.py:1416) resolves
     override -> volatility_field -> self.sigma, and `volatility_field` is snapshotted at
     construction (:560), so the solve comes back byte-identical while `problem.diffusion` reports
-    the mutated value. Measured: 1.21x and 2.0x that way both reproduce the baseline to every
-    printed digit.
+    the mutated value. Measured: k = 1.21 and k = 2.0 that way both reproduce the baseline to
+    every printed digit.
     """
     errors = [_solve(nx, nt) for nx, nt in LEVELS]
     eu = [e[0] for e in errors]
@@ -252,7 +309,10 @@ def test_coupled_2d_no_flux_converges_at_first_order():
 
     assert all(0.8 <= o <= 1.3 for o in order_u), f"u is not first order: {order_u} (errors {eu})"
     assert all(0.8 <= o <= 1.3 for o in order_m), f"m is not first order: {order_m} (errors {em})"
+    # Regression guard on the constant, NOT a discriminator -- see the tables above. Across ten
+    # measured coefficient mutants this never fails without the EOC assertion failing first.
     assert eu[-1] < 1.5e-01, (
-        f"u error level {eu[-1]:.4e} at the finest grid exceeds 1.5e-01. The order can stay near 1 "
-        f"while the constant moves, which is what a wrong diffusion coefficient looks like here."
+        f"u error level {eu[-1]:.4e} at the finest grid exceeds 1.5e-01 while the order stayed in "
+        f"band (order_u={order_u}). EOC is a ratio and cannot see an error scaled uniformly across "
+        f"levels; this bound is the only thing that can."
     )


### PR DESCRIPTION
## The gap

`test_coupled_mfg_mms.py` measures coupled EOC in **1D** under **periodic** BC — deliberately, per
its own note, "to avoid the no-flux conservative-Laplacian boundary handling (#1075) so the measured
error" is the interior scheme. So coupled convergence had never been measured in 2D, nor with a wall
present at all.

## The pair — the paper's, with two deliberate changes

The GFDM paper's `eq:mms_reference` / `eq:mms_system` on $\Omega=(0,20)^2$, $T=4$, $\sigma=1$,
$\zeta=1/2$, with $c = \pi/L$ instead of $2\pi/L$ and an asymmetry $\beta = 0.6$ between the axes.
Both changes are there because the verbatim pair **cannot express the defects this test exists to
catch**, and both were verified by mutation:

| what the change buys | verbatim pair | this pair |
|---|---|---|
| $c=\pi/L$: the wall closure is real, not the periodic ghost | swapping the whole BC family to `periodic_bc` left every assertion green | `eu` $3.0125\text{e--}01 \to 1.2939\text{e+}01$ at $N_x=11$ (42×), EOC u collapses to $-0.118 / 0.067$ |
| $\beta$: the fixture can express a wrong-axis read | $u$, $m$ and both sources exactly transpose-symmetric, so `eu` from `U[0]` and `U[0].T` is bit-identical | `eu` from `U[0].T` is 45.7× / 81.8× / 119.5× the correct one |

$c=\pi/L$ still gives $\sin(cL)=0$, so the pair stays exactly Neumann-compatible.

Sources re-derived for **this** pair symbolically (sympy, from the definitions of $u$ and $m$) and
cross-checked against the hand-written vectorised forms in the file to **5.6e-17 / 1.1e-19** over 400
random $(t,x)$, against residual scales 2.3e-01 / 4.5e-04. The comparison can fail: perturbing
$r_m$ by $10^{-7}$ relative registers as 4.5e-11.

Two properties the paper states also hold here, verified symbolically on this pair:

- $\int_\Omega r_m\,dx = 0$ exactly
- $\partial u/\partial x_k = \partial m/\partial x_k = 0$ on each of the four walls

The second is load-bearing: $\alpha = -\nabla u$, so $\alpha\cdot n = 0$ and hence
$J\cdot n = \alpha m - D\nabla m = 0$. **The pair is exactly compatible with the no-flux wall**,
which is what lets it run on this box.

## Measured

| $N_x$ | $N_t$ | Picard | `eu` | EOC u | `em` | EOC m |
|---|---|---|---|---|---|---|
| 11 | 8 | 4 | 3.0125e-01 | — | 9.876e-03 | — |
| 21 | 16 | 4 | 1.5759e-01 | 0.935 | 5.036e-03 | 0.972 |
| 31 | 24 | 4 | 1.0534e-01 | **0.993** | 3.383e-03 | **0.982** |

47.5 s, `@pytest.mark.slow` + `@pytest.mark.integration`, matching the existing coupled MMS test's
markers.

## Two disciplines

**`assert result.converged` before any error metric.** This is what #1998 turned out to be: a test
comparing two unconverged Picard residuals under the name "h-convergence". Here it is cheap
insurance rather than a live hazard — measured, this family converges at every $\sigma$ tried, in 4
iterations each time:

| $\sigma$ | 1.0 | 0.5 | 0.3 | 0.1 |
|---|---|---|---|---|
| `eu` at $N_x=31$ | 1.0534e-01 | 6.8685e-02 | 6.4407e-02 | 6.3901e-02 |
| converged | yes | yes | yes | yes |

**An error LEVEL beside the order.** An order alone is a min over the HJB scheme, the FP scheme and
the wall closure. Bounds from measurement — $\sigma$ wrong at problem **construction** while the
sources stay closed over the true value, so only the discretized PDE is wrong:

| $D$ factor | `eu`(11) | `eu`(21) | `eu`(31) | EOC u |
|---|---|---|---|---|
| 1.00 | 3.0125e-01 | 1.5759e-01 | 1.0534e-01 | 0.935, 0.993 |
| 1.21 | 3.5252e-01 | 2.4572e-01 | 2.2015e-01 | 0.521, 0.271 |
| 2.00 | 9.6882e-01 | 9.5405e-01 | 9.5607e-01 | 0.022, −0.005 |

`eu[-1] < 1.5e-01` sits 1.42× above baseline and 1.47× below the 1.21× mutant. **`em` is not the
discriminating field** for this defect — at 1.21× it moves only 3.383e-03 → 3.487e-03 and its EOC
stays inside the band at 0.956 / 0.945 — so no level bound is asserted on it.

## What it cannot see — in the file, not just here

- **The wall is tangential.** $\partial_\nu u = 0$ makes $\alpha\cdot n = 0$, so this exercises
  compatibility and not the treatment of a normal drift. That is #2006, FP-only.
- **It does not measure the coupling direction**, and the paper says so of its own instance.
  Measured on this pair: $\zeta m$ has RMS 1.26e-03 — 8.1% of the $|\nabla u|^2/2$ term (1.55e-02)
  and 1.1% of the whole HJB residual (1.17e-01, dominated by $-\partial_t u$ at 1.03e-01). Against
  that, the discretization error at the finest level is 0.41% relative in $u$ and 6.6% in $m$.
## Which solvers can run this at all — the prior question to convergence order

Measured at $N_x=21$ on this exact fixture, each candidate paired against FDM on the other side so a
failure localises. **2 of 8 pairings run.**

| HJB × FP | outcome |
|---|---|
| FDM × FDM | converged, 4 Picard iterations, `eu` = 1.5759e-01 |
| GFDM × FDM | converged, 4 Picard iterations, `eu` = **1.9699e-02** |
| WENO × FDM | `NotImplementedError`: `source_term` is threaded through the 1D path only; this is 2D |
| SemiLagrangian × FDM | `NotImplementedError`: `solve_hjb_system` does not accept `source_term` |
| FDM × GFDM / Particle / SL | `NotImplementedError`: `solve_fp_system` does not accept `source_term` |
| FDM × FVM | `ValueError`: cannot broadcast (21,21) against (882,) |

So the question splits, and only the second half is about convergence:

- **Reachability.** Six of eight never enter the solve. Not non-convergence — an MMS needs a source
  channel and most solvers have none. Filed: #2020 (FP side), #1991 (HJB side), #2019 (the FVM
  crash, which is a source-argument *convention* mismatch: FVM passes `geometry.meshgrid()`,
  a `(2,21,21)` tuple, where every other caller passes the `(441,2)` point list).
- **Convergence.** Both reachable pairings converge in 4 iterations, neither marginally. GFDM is 8×
  more accurate than FDM at the same grid.

The earlier wording — "the pair is method-agnostic; other schemes are separate parametrisations" —
read that structural gap as a matter of adding parametrisations. It is not.

GFDM's source was verified to reach it rather than assumed from its signature: zeroing $s_{HJB}$
moves its `eu` from 1.9699e-02 to 9.7640e+00, a factor of 496.

## Corrections to earlier versions of this PR

Each was stated here with numbers, and each was wrong:

1. **"Two properties … independent confirmation of the transcription."** Neither is. $\int r_m = 0$
   is one scalar per time and is blind to anything that integrates away — an $r_m$ carrying a
   spurious $\tfrac17\cos(2cx_1)\cos(4cx_2)$ integrates to exactly 0 as well (checked symbolically).
   The wall-derivative property is a fact about $u$ and $m$ alone and never touches the sources.
   Only the sympy cross-check bears on the transcription.
2. **"$\alpha = -$`coupling_coefficient`$\cdot\nabla U$."** Wrong source, right number. The scale
   comes from `fp_drift_coefficient` (`utils/pde_coefficients.py:118`), which for a
   quadratic-MINIMIZE `SeparableHamiltonian` returns $1/\lambda$ and never reaches the
   `coupling_coefficient` fallback (#1420 / G-017). $\lambda = 1$ here, so both are 1.0 — which is
   exactly why the misattribution left no trace.
3. **"This problem family does not converge at $\sigma=0.1$."** That measurement belongs to the 1D
   duality family of #1998 and was transferred here by label. Measured on this family: it converges
   at $\sigma = 0.1$ (table above).
4. **"$\zeta m$ is ~2.5% of the HJB residual (1.28e-03 against 1.24e-01)"** and **"~30% relative
   discretization error."** Both were measured on the verbatim pair, and the 1.24e-01 was labelled
   as the $|\nabla u|^2/2$ term when it was the total. Corrected figures above.
5. **The discrimination bound `9e-01`** came from the verbatim pair. On this one it would have
   **passed the 1.21× mutant outright** (2.20e-01) and cleared 2× by only 6%.
6. **The earlier `_eoc` divided by point counts, not the mesh ratio** — every order inflated 7.2% /
   4.1%, while `_solve` twelve lines up computed `dx` with `nx - 1` correctly. Fixed in `172b2bae`.

## A trap worth naming: `problem.sigma` is inert after construction

Re-deriving the bound, the first attempt mutated `problem.sigma` **after** building the problem and
asserted `problem.diffusion == k·D`, which passed. The solves came back **byte-identical** at
$k=1.21$ and $k=2.0$ — every printed digit. `get_diffusion_coefficient_field`
(`mfg_problem.py:1416`) resolves override → `volatility_field` → `self.sigma`, and
`volatility_field` is snapshotted at construction (`:560`), so the scalar is the last-resort
fallback and nothing reads it. Meanwhile `problem.diffusion`, whose docstring says it "is the
coefficient appearing directly in the PDE", keeps reporting the mutated value. The assert verified
one level below the claim. Filed separately.

## Gate

`./scripts/local_ci.sh`: **GATE GREEN**, full suite 6292 passed / 12 skipped / 23 xfailed in 140 s.
The test itself: 1 passed in 47.5 s.

Refs #1728 #2006 #1998 #1420
