### PR TITLE
docs: the dimension must be able to express the property under test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,38 @@ Cross-project testing discipline governs **what** a test must cover (edge/stress
 | Visualization | Sometimes | Yes | Smoke |
 | Utility function | No | Internal | Unit or smoke |
 
+### The dimension must be able to express the property under test ⚠️
+
+Not "prefer 2D" and not "1D is cheaper". The rule is that **a test in a dimension that cannot
+express the property is not a weak test — it cannot fail at all**, and it reads exactly like a
+passing one.
+
+- **Needs d ≥ 2**: anything involving a normal/tangential decomposition, an axis pairing, a corner,
+  a transpose, or anisotropy. A 1D wall's normal is always the coordinate axis and there is no
+  tangential component, so a scheme that mishandles the tangential part passes 1D by construction.
+- **Fully expressed in d = 1**: sign conventions, time-stepping order, convergence criteria, scalar
+  contracts, source-term plumbing. Here 2D buys runtime and nothing else — measured, the same FP
+  MMS study runs 0.1 s at d = 1 and 1.5 s at d = 2.
+
+**The discriminator is measurable, so do not argue it.** Write a mutation that breaks the property,
+run it in 1D, and read the difference:
+
+```
+drop the tangential advection at wall rows   1D: max|diff| = 0.000e+00   2D: separates
+flip its sign                                1D: max|diff| = 0.000e+00   2D: separates
+read the potential along the wrong axis      1D: max|diff| = 0.000e+00   2D: separates
+```
+
+Three mutants, three exact zeros (#1728/#2006). **`max|diff| = 0` in 1D means the test must go up a
+dimension**; a non-zero difference means 1D expresses it and the extra dimension is cost without
+coverage.
+
+The burden runs both ways: a 2D test whose 1D reduction separates the same mutants owes its runtime
+an explanation, and a 1D test of a directional property owes a mutant showing it can fail.
+
+This is the cross-project "non-discriminating test data" rule applied to dimension — the same shape
+as a uniform density that cannot separate a gradient-form bug from a correct scheme.
+
 ### Closing out a fix ⚠️ — name the oracle, or say there isn't one
 
 "Add a test" is **not** the default close-out for a fix here. Measured on this repo: the six load-bearing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,25 +140,43 @@ passing one.
 - **Needs d ≥ 2**: anything involving a normal/tangential decomposition, an axis pairing, a corner,
   a transpose, or anisotropy. A 1D wall's normal is always the coordinate axis and there is no
   tangential component, so a scheme that mishandles the tangential part passes 1D by construction.
+  Note the scope: d ≥ 2 is **necessary** for these, not sufficient — see the symmetry measurement
+  below.
 - **Fully expressed in d = 1**: sign conventions, time-stepping order, convergence criteria, scalar
   contracts, source-term plumbing. Here 2D buys runtime and nothing else — measured, the same FP
   MMS study runs 0.1 s at d = 1 and 1.5 s at d = 2.
 
 **The discriminator is measurable, so do not argue it.** Write a mutation that breaks the property,
-run it in 1D, and read the difference:
+run it in 1D, and read the difference. Measured against `test_fp_mms_wall_order_1728.py` (#1728/#2006):
 
 ```
-drop the tangential advection at wall rows   1D: max|diff| = 0.000e+00   2D: separates
-flip its sign                                1D: max|diff| = 0.000e+00   2D: separates
-read the potential along the wrong axis      1D: max|diff| = 0.000e+00   2D: separates
+drop the tangential advection at wall rows   1D: max|diff| = 0.000e+00
+flip its sign                                1D: max|diff| = 0.000e+00
+read the potential along the wrong axis      1D: max|diff| = 0.000e+00
 ```
 
-Three mutants, three exact zeros (#1728/#2006). **`max|diff| = 0` in 1D means the test must go up a
-dimension**; a non-zero difference means 1D expresses it and the extra dimension is cost without
-coverage.
+Three mutants, three exact zeros — **and only two of the three separate in 2D.** That last figure is
+the more useful one, and it is the second half of the rule.
+
+**`max|diff| = 0` in 1D means the test must go up a dimension. It does not mean going up is
+sufficient.** A 2D fixture that is symmetric in the relevant variable cannot express a defect in
+that variable either, and it looks exactly as healthy as one that can. Measured on
+`test_coupled_mms_2d_no_flux.py` (#2016), where the paper's verbatim manufactured pair is
+transpose-symmetric and periodic on the box:
+
+| mutant | verbatim 2D pair | after breaking the symmetry |
+|---|---|---|
+| swap the whole BC family, `no_flux` → `periodic` | byte-identical | `eu` 3.0125e-01 → 1.2939e+01 (42×), EOC → −0.118 |
+| read the potential along the wrong axis (`U[0].T`) | bit-identical | 45.7× / 81.8× / 119.5× |
+
+Two changes bought those: a half-period wavenumber, so the mirror ghost and the periodic ghost stop
+coinciding; and an asymmetry between the axes, so transposing the field is detectable. Neither is
+about dimension. **The question is never "is this 2D" — it is "can this fixture express the defect",
+and dimension is only the first thing that can make the answer no.**
 
 The burden runs both ways: a 2D test whose 1D reduction separates the same mutants owes its runtime
-an explanation, and a 1D test of a directional property owes a mutant showing it can fail.
+an explanation, and a test of a directional property — in any dimension — owes a mutant showing it
+can fail.
 
 This is the cross-project "non-discriminating test data" rule applied to dimension — the same shape
 as a uniform density that cannot separate a gradient-form bug from a correct scheme.

--- a/changelog.d/dimension-must-express-the-property.added.md
+++ b/changelog.d/dimension-must-express-the-property.added.md
@@ -1,0 +1,16 @@
+`AGENTS.md` gains a testing rule: **the dimension must be able to express the property under test.**
+
+Not "prefer 2D". The point is that a test in a dimension that cannot express the property is not a
+weak test — it cannot fail at all, and it reads exactly like a passing one. A 1D wall's normal is
+always the coordinate axis and there is no tangential component, so a scheme that mishandles the
+tangential part passes 1D by construction.
+
+The discriminator is measurable rather than arguable: write a mutation that breaks the property and
+run it in 1D. Measured on the FP wall study (#1728/#2006), three tangential mutants — dropping the
+tangential advection at wall rows, flipping its sign, reading the potential along the wrong axis —
+all give `max|diff| = 0.000e+00` in 1D and two of three separate in 2D. `max|diff| = 0` means the
+test must go up a dimension.
+
+The burden runs both ways: 2D costs real time (the same FP MMS study is 0.1 s at `d=1` against 1.5 s
+at `d=2`), so a 2D test whose 1D reduction separates the same mutants owes its runtime an
+explanation, and a 1D test of a directional property owes a mutant showing it can fail.


### PR DESCRIPTION
Adds one rule to `AGENTS.md` § Testing.

## The rule

Not "prefer 2D" and not "1D is cheaper":

> **A test in a dimension that cannot express the property is not a weak test — it cannot fail at
> all**, and it reads exactly like a passing one.

- **Needs d ≥ 2**: a normal/tangential decomposition, an axis pairing, a corner, a transpose,
  anisotropy. A 1D wall's normal is always the coordinate axis and there is no tangential component.
- **Fully expressed in d = 1**: sign conventions, time-stepping order, convergence criteria, scalar
  contracts, source-term plumbing.

## The discriminator is measurable, so it need not be argued

Write a mutation that breaks the property and run it in 1D:

```
drop the tangential advection at wall rows   1D: max|diff| = 0.000e+00   2D: separates
flip its sign                                1D: max|diff| = 0.000e+00   2D: separates
read the potential along the wrong axis      1D: max|diff| = 0.000e+00   2D: separates
```

Three mutants, three exact zeros, measured on #2006's FP wall study. `max|diff| = 0` in 1D means the
test must go up a dimension.

## The burden runs both ways

2D costs real time — the same FP MMS study is **0.1 s at d=1 against 1.5 s at d=2**. So a 2D test
whose 1D reduction separates the same mutants owes its runtime an explanation, and a 1D test of a
directional property owes a mutant showing it can fail.

This is the cross-project "non-discriminating test data" rule applied to dimension — the same shape
as a uniform density that cannot separate a gradient-form bug from a correct scheme.

## Why a rule rather than a preference

A preference ("2D unless you must") puts the burden on justifying 1D, which is an argument. This puts
the burden on a measurement that either party can run in a minute, and it cuts both ways.

`CLAUDE.md` is a symlink to `AGENTS.md`, so it is covered.

Gate: `./scripts/local_ci.sh --fast` **GREEN**.

Refs #1728 #2006
