### PR TITLE
fix: the weak-form HJB Picard branch negated the Hamiltonian (#2023)

### DIFF
--- a/changelog.d/2023-weak-form-hjb-picard-sign.fixed.md
+++ b/changelog.d/2023-weak-form-hjb-picard-sign.fixed.md
@@ -1,0 +1,47 @@
+The weak-form HJB solver's Picard branch — **the default** — applied the Hamiltonian with the wrong
+sign, so `HJBFEMSolver` and `MeshlessGalerkinHJBSolver` solved `-u_t - H - D·Lap(u) = 0` on the path
+a caller gets without asking.
+
+The canonical equation (`mfg_problem.py:197`) is `-u_t + H - (sigma²/2)·Lap(u) = S`, so backward
+Euler gives `(M/dt + D·K)·U[n] = (M/dt)·U[n+1] - M·H`. The line read `+=`.
+
+Measured on `H = c` constant with `u_T = 0` and no-flux, where the solution is spatially constant and
+`u(0) = -c·T` is exact:
+
+| c | analytic | Picard before | Picard after | Newton | FDM |
+|---|---|---|---|---|---|
+| 1.0 | −0.200000 | **+0.200000** | −0.200000 | −0.200000 | −0.200000 |
+| 2.0 | −0.400000 | **+0.400000** | −0.400000 | −0.400000 | −0.400000 |
+| −3.0 | +0.600000 | **−0.600000** | +0.600000 | +0.600000 | +0.600000 |
+
+Exactly `−1×` at every value. Independently confirmed against an external analytic oracle: with the
+control cost switched off the PDE is linear with a closed-form solution, and the corrected tree
+converges to it at second order (2.844e-03 → 1.383e-03 → 6.817e-04 → 3.384e-04, ratios 2.06 / 2.03 /
+2.02) while the old one plateaus at 3.30e-01 with ratios 0.996 / 0.998 / 0.999.
+
+**Provenance.** The line entered at `d9f66701` (#773), the file's first version — which stated the
+correct algebra in a comment three lines above the code, `M/dt·u^n = M/dt·u^{n+1} - D·K·u^n - H_rhs`,
+and then "rearranged" it to `+ source` on the very next line. `675e0049` (#1131) only relocated it.
+The file shipped with its own derivation contradicting its code, on adjacent lines.
+
+**Why five months of green.** Nothing ran the two branches on the same problem and compared. The one
+test that checks the weak-form family against an independent discretization
+(`test_meshless_stabilization.py`) passed `use_newton=True`, so the suite's only cross-implementation
+oracle was pointed at the branch that is not the default. It is now parametrized over both.
+
+Three tests changed, none by weakening a bound:
+
+- `test_fem_robin_bc.py::test_hjb_linear_loop_fixed_point` built its reference by `spsolve`-ing the
+  solver's own matrices against the same source the Hamiltonian carries (measured
+  `max|H(x,m,p=0) − _source| = 0.0`) — it was the buggy right-hand side written down twice. The
+  Hamiltonian potential is negated; the manufactured solution, the Robin data and the oracle line are
+  untouched, and `max|U[0] − u_steady|` is now 1.010e-14 against the unchanged 1e-9 bound.
+- The two coupled-FEM mass tests specified `coupling = lambda m: m`, which under this repo's
+  reward-signed convention (`mfg_problem.py:191-195`) is crowd-**seeking**: an aggregating,
+  anti-monotone MFG whose fixed point diverges. They passed only because the negated assembly turned
+  an aggregating specification into a dispersing computation. Both now specify congestion
+  (`-m`) and conserve mass to 2.2e-16. Verified pre-existing: their fixture through **main's own
+  Newton branch, no fix applied**, diverges to a mass drift of 7.36e+26.
+
+Also corrected: a recorded number in `test_meshless_galerkin_mfg.py`'s docstring (6.27e-02 →
+6.0468e-02; the assertion is unaffected).

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -344,13 +344,17 @@ class WeakFormHJBSolver(BaseHJBSolver):
                     H_values = np.asarray(
                         H_class(self._disc.dof_coordinates, M_density[n], p_prev, t=n * dt), dtype=float
                     ).ravel()
-                    # MINUS. The equation is -u_t + H - D*Lap(u) = 0, so backward Euler gives
-                    # (M/dt + D*K) U[n] = (M/dt) U[n+1] - M @ H -- H moves to the RHS with a sign
-                    # flip. This read `+=` from #1131 (675e0049) until #2023, which inverted the
-                    # whole Hamiltonian on the DEFAULT path (use_newton=False) while the Newton
-                    # branch twenty lines up had it right. Measured on H = c constant with u_T = 0,
-                    # where the analytic answer u(0) = -c*T is exact: picard returned +c*T for
-                    # c = 1, 2 and -3, against FDM and the Newton branch both returning -c*T.
+                    # MINUS. The canonical equation (mfg_problem.py:197) is
+                    # -u_t + H - (sigma^2/2) Lap(u) = S, so backward Euler gives
+                    # (M/dt + D*K) U[n] = (M/dt) U[n+1] - M @ H: H moves to the RHS with a sign
+                    # flip. This read `+=` from the file's FIRST version (d9f66701, #773) until
+                    # #2023 -- and that version stated the correct algebra in a comment three lines
+                    # above the code, `M/dt*u^n = M/dt*u^{n+1} - D*K*u^n - H_rhs`, then "rearranged"
+                    # it to `+ source` on the very next line. #1131 (675e0049) only relocated it
+                    # here. The DEFAULT path (use_newton=False) was affected; the Newton branch
+                    # forty lines up always had it right, so one method solved two equations.
+                    # Measured on H = c constant with u_T = 0, where u(0) = -c*T is exact: picard
+                    # returned +c*T at c = 1, 2 and -3, against FDM and Newton both giving -c*T.
                     rhs -= self._M @ H_values
                 if rhs_robin is not None:
                     rhs = rhs + rhs_robin

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -344,7 +344,14 @@ class WeakFormHJBSolver(BaseHJBSolver):
                     H_values = np.asarray(
                         H_class(self._disc.dof_coordinates, M_density[n], p_prev, t=n * dt), dtype=float
                     ).ravel()
-                    rhs += self._M @ H_values
+                    # MINUS. The equation is -u_t + H - D*Lap(u) = 0, so backward Euler gives
+                    # (M/dt + D*K) U[n] = (M/dt) U[n+1] - M @ H -- H moves to the RHS with a sign
+                    # flip. This read `+=` from #1131 (675e0049) until #2023, which inverted the
+                    # whole Hamiltonian on the DEFAULT path (use_newton=False) while the Newton
+                    # branch twenty lines up had it right. Measured on H = c constant with u_T = 0,
+                    # where the analytic answer u(0) = -c*T is exact: picard returned +c*T for
+                    # c = 1, 2 and -3, against FDM and the Newton branch both returning -c*T.
+                    rhs -= self._M @ H_values
                 if rhs_robin is not None:
                     rhs = rhs + rhs_robin
 

--- a/tests/integration/test_coupling_mesh_geometry.py
+++ b/tests/integration/test_coupling_mesh_geometry.py
@@ -31,7 +31,12 @@ def _fem_problem(refine: int = 2):
         m_initial=lambda x: float(np.exp(-10 * ((np.atleast_1d(x)[0] - 0.5) ** 2))),
         u_terminal=lambda x: 0.0,
         hamiltonian=SeparableHamiltonian(
-            control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: m, coupling_dm=lambda m: 1.0
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            # -m for #2023: `+m` is crowd-seeking (aggregating, anti-monotone) under the
+            # reward-signed convention and its coupled fixed point diverges; it passed only
+            # because the Picard assembly negated H. This test wants congestion.
+            coupling=lambda m: -m,
+            coupling_dm=lambda m: -1.0,
         ),
     )
     return MFGProblem(geometry=geom, T=0.2, Nt=5, sigma=0.3, components=components, coupling_coefficient=0.5)

--- a/tests/integration/test_fem_robin_bc.py
+++ b/tests/integration/test_fem_robin_bc.py
@@ -191,7 +191,13 @@ class TestRobinSolveLoopWiring:
         ne = 48
         ham = SeparableHamiltonian(
             control_cost=QuadraticControlCost(lambda_=1.0),
-            potential=lambda x, t: 4.0 * D * np.sin(2.0 * x[:, 0]),
+            # NEGATED for #2023. `u_steady` below is built from `+_source`, which is the RHS the
+            # PLUS assembly produced -- the reference was the buggy right-hand side written
+            # twice (measured max|H(x,m,p=0) - _source| = 0.0). With H entering the corrected
+            # equation as -M@H, the potential that makes `u_steady` the true fixed point is the
+            # negative one. The manufactured solution, the Robin data and the oracle line are
+            # unchanged; measured max|U[0] - u_steady| = 1.010e-14 against the 1e-9 bound.
+            potential=lambda x, t: -4.0 * D * np.sin(2.0 * x[:, 0]),
             coupling=lambda m: 0.0,
         )
         problem = _robin_problem_1d(ne, sigma, g_left, g_right, hamiltonian=ham)

--- a/tests/integration/test_fem_solver_path.py
+++ b/tests/integration/test_fem_solver_path.py
@@ -45,8 +45,12 @@ def _fem_problem(refine: int = 2):
         u_terminal=lambda x: 0.0,
         hamiltonian=SeparableHamiltonian(
             control_cost=QuadraticControlCost(control_cost=1.0),
-            coupling=lambda m: m,
-            coupling_dm=lambda m: 1.0,
+            coupling=lambda m: -m,  # -m for #2023: `+m` is crowd-SEEKING under this repo's reward-signed
+            # convention (mfg_problem.py:191-195), i.e. an aggregating, anti-monotone MFG whose
+            # coupled fixed point diverges. It passed only because the negated Picard assembly
+            # turned an aggregating specification into a dispersing computation. This test wants
+            # a congestion (monotone) MFG.
+            coupling_dm=lambda m: -1.0,
         ),
     )
     problem = MFGProblem(

--- a/tests/integration/test_meshless_galerkin_mfg.py
+++ b/tests/integration/test_meshless_galerkin_mfg.py
@@ -92,7 +92,8 @@ class TestMeshlessGalerkinMFG:
         # max|U[-1] - U_terminal| = 0.0 exactly.
         np.testing.assert_allclose(U[-1], 0.5 * (x - 0.5) ** 2, atol=1e-12)
         # ...and the backward sweep must actually transport it. Measured
-        # max|U[0] - U[-1]| = 6.27e-02, so a solver returning the terminal datum at every
+        # max|U[0] - U[-1]| = 6.0468e-02 (6.27e-02 before #2023 corrected the Picard sign), so a
+        # solver returning the terminal datum at every
         # level -- which the shape and finiteness checks accept -- fails here.
         assert np.max(np.abs(U[0] - U[-1])) > 1e-2
 

--- a/tests/unit/test_alg/test_meshless_stabilization.py
+++ b/tests/unit/test_alg/test_meshless_stabilization.py
@@ -177,9 +177,24 @@ def test_base_stabilization_hook_is_noop():
 
 # --- end-to-end: the recipe converges and matches a conservative reference -----
 @pytest.mark.integration
-def test_recipe_coupled_matches_fdm_on_wellposed_problem():
+@pytest.mark.parametrize(("use_newton", "sd_scale"), [(True, 1.0), (False, 0.0)], ids=["newton_sd", "picard"])
+def test_recipe_coupled_matches_fdm_on_wellposed_problem(use_newton, sd_scale):
     """On a decoupled (unique) LQ problem all schemes must agree. The meshless recipe
-    (Newton + SD) must converge and track FDM-upwind (the mass-conserving reference)."""
+    (Newton or Picard, + SD) must converge and track FDM-upwind (the mass-conserving reference).
+
+    BOTH inner solvers, since #2023. This is the only test that compares the weak-form family
+    against an independent discretization, and it ran `use_newton=True` only -- while
+    `meshless_galerkin/hjb_solver.py:51` and `WeakFormHJBSolver.solve_hjb_system` both DEFAULT to
+    Picard. The one cross-implementation oracle in the suite was pointed at the branch that is not
+    shipped, and the shipped branch carried an inverted Hamiltonian from #773 until #2023.
+
+    `sd_scale` is tied to the branch rather than parametrized independently: the solver fail-louds
+    on `streamline_diffusion_scale > 0` with Picard, because SD enters only the Newton Jacobian and
+    the Type-A duality A_FP = A_HJB^T would be lost. So the Picard cell runs SD off, which is the
+    shipped default pair. Measured against the FDM reference (mean 0.352026, std 0.214427):
+    newton+SD gives dmean 4.28e-03 / dstd 4.84e-04, picard gives 3.52e-03 / 6.10e-04, and
+    newton with SD off reproduces the picard numbers to 1e-6 -- i.e. after #2023 the two branches
+    agree with each other and with an independent discretization."""
     import numpy as _np
 
     from mfgarchon import MFGProblem
@@ -225,8 +240,8 @@ def test_recipe_coupled_matches_fdm_on_wellposed_problem():
         hjb_config={
             "collocation_points": cloud,
             "delta": 3.5 / 20,
-            "use_newton": True,
-            "streamline_diffusion_scale": 1.0,
+            "use_newton": use_newton,
+            "streamline_diffusion_scale": sd_scale,
         },
     )
     res = prob.solve(
@@ -234,7 +249,8 @@ def test_recipe_coupled_matches_fdm_on_wellposed_problem():
     )
     M = _np.asarray(res.M)
     assert _np.all(_np.isfinite(M)), "recipe blew up"
-    assert M[-1].min() > -1e-9, "density positive (SD suppresses undershoots)"
+    assert M[-1].min() > -1e-9, "density positive"
     mean, std = mean_std(M[-1])
-    assert abs(mean - ref_mean) < 2e-2, f"mean {mean:.4f} vs FDM {ref_mean:.4f}"
-    assert abs(std - ref_std) < 2e-2, f"std {std:.4f} vs FDM {ref_std:.4f}"
+    inner = "newton" if use_newton else "picard"
+    assert abs(mean - ref_mean) < 2e-2, f"[{inner}] mean {mean:.4f} vs FDM {ref_mean:.4f}"
+    assert abs(std - ref_std) < 2e-2, f"[{inner}] std {std:.4f} vs FDM {ref_std:.4f}"

--- a/tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py
+++ b/tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py
@@ -1,0 +1,168 @@
+"""Issue #2023: the weak-form HJB Picard branch applied the Hamiltonian with the wrong sign.
+
+`WeakFormHJBSolver.solve_hjb_system` has two branches. The Newton one assembles a residual; the
+Picard one -- **the default**, `use_newton=False` -- moves `H` to the right-hand side, and moving it
+flips its sign. It read `rhs += self._M @ H_values` from #1131 (675e0049, 2026-05-29) until this
+change, so `HJBFEMSolver` and `MeshlessGalerkinHJBSolver` solved `-u_t - H - D Lap(u) = 0` on the
+path a caller gets by default.
+
+WHY IT SURVIVED
+---------------
+Nothing ran both branches on the same problem and compared. Of the thirteen test files naming these
+solvers only three mention `use_newton` at all, and none against an oracle. Two branches of one
+method silently solving different equations is invisible to any test that exercises one branch.
+
+THE FIXTURE
+-----------
+`H = c` constant: a quadratic control cost whose coupling returns a constant, with `m == 1`. With
+`u_T = 0` and no-flux walls the solution stays spatially constant, so `p == 0` (killing the kinetic
+half, leaving `H == c` exactly) and `Lap u == 0`. The equation collapses to `u'(t) = c`, giving
+
+    u(t) = c (t - T),   u(0) = -c T
+
+with NO discretization error in the measured quantity -- the exact solution is in the FE space. That
+is what makes a sign inversion readable as `-1x` rather than as a convergence question.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import Mesh1D, TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+_T, _NT, _SIGMA, _NE = 0.2, 20, 0.3, 40
+_CONSTANTS = (1.0, 2.0, -3.0)
+
+
+def _hamiltonian(c: float):
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        coupling=lambda m, _c=c: np.full_like(np.asarray(m, dtype=float), _c),
+        coupling_dm=lambda m: np.zeros_like(np.asarray(m, dtype=float)),
+    )
+
+
+def _components(c: float):
+    return MFGComponents(
+        m_initial=lambda x: np.ones_like(np.asarray(x, dtype=float)),
+        u_terminal=lambda x: np.asarray(x, dtype=float) * 0.0,
+        hamiltonian=_hamiltonian(c),
+    )
+
+
+def _mesh_problem(c: float):
+    mesh = Mesh1D(bounds=(0.0, 1.0), num_elements=_NE)
+    mesh.generate_mesh()
+    mesh.boundary_conditions = no_flux_bc(dimension=1)
+    return MFGProblem(geometry=mesh, T=_T, Nt=_NT, sigma=_SIGMA, coupling_coefficient=0.0, components=_components(c))
+
+
+def _grid_problem(c: float):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_NE + 1], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=_T, Nt=_NT, sigma=_SIGMA, coupling_coefficient=0.0, components=_components(c))
+
+
+@pytest.mark.parametrize("c", _CONSTANTS)
+def test_the_picard_branch_agrees_with_the_analytic_constant_hamiltonian(c):
+    """u(0) = -c*T, and the wrong sign returns +c*T. Exactly -1x, so the assertion can be tight."""
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM solvers")
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+
+    solver = HJBFEMSolver(_mesh_problem(c), order=1)
+    n = len(solver._disc.dof_coordinates)
+    u = solver.solve_hjb_system(
+        M_density=np.ones((_NT + 1, n)),
+        U_terminal=np.zeros(n),
+        U_coupling_prev=np.zeros((_NT + 1, n)),
+        use_newton=False,
+    )
+    u0 = np.asarray(u)[0]
+
+    # The fixture only means what it claims if the solution really is spatially constant: p == 0 is
+    # what makes H == c rather than c + |grad u|^2/2.
+    assert float(np.ptp(u0)) < 1e-12, f"u(0) is not spatially constant (spread {float(np.ptp(u0)):.3e})"
+    assert float(np.mean(u0)) == pytest.approx(-c * _T, abs=1e-10), (
+        f"picard u(0) = {float(np.mean(u0)):+.6f}, analytic {-c * _T:+.6f}. A value of {c * _T:+.6f} "
+        f"is the #2023 sign inversion: `rhs += self._M @ H_values` where the equation "
+        f"-u_t + H - D*Lap(u) = 0 requires `-=`."
+    )
+
+
+@pytest.mark.parametrize("c", _CONSTANTS)
+def test_the_two_branches_of_one_method_solve_the_same_equation(c):
+    """Newton vs Picard on identical input. This is the comparison that was never made.
+
+    Asserting each against the analytic value separately would also catch #2023, but this pins the
+    stronger property: whatever the convention is, one method must not have two of them.
+    """
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM solvers")
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+
+    solver = HJBFEMSolver(_mesh_problem(c), order=1)
+    n = len(solver._disc.dof_coordinates)
+    kw = {
+        "M_density": np.ones((_NT + 1, n)),
+        "U_terminal": np.zeros(n),
+        "U_coupling_prev": np.zeros((_NT + 1, n)),
+    }
+    picard = np.asarray(solver.solve_hjb_system(**kw, use_newton=False))[0]
+    newton = np.asarray(solver.solve_hjb_system(**kw, use_newton=True))[0]
+    gap = float(np.abs(picard - newton).max())
+    assert gap < 1e-10, (
+        f"the Picard and Newton branches disagree by {gap:.3e} on a problem whose exact solution "
+        f"lies in the FE space. They are two discretizations of one equation and must agree here."
+    )
+
+
+@pytest.mark.parametrize("c", _CONSTANTS)
+def test_the_weak_form_family_agrees_with_the_reference_fdm_solver(c):
+    """Cross-implementation, because a shared convention error inside one family would pass the
+    two tests above. `HJBFDMSolver` is the suite's reference HJB discretization and does not share
+    this assembly code."""
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM solvers")
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+    from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
+
+    n = _NE + 1
+    fdm = np.asarray(
+        HJBFDMSolver(_grid_problem(c)).solve_hjb_system(
+            M_density=np.ones((_NT + 1, n)), U_terminal=np.zeros(n), U_coupling_prev=np.zeros((_NT + 1, n))
+        )
+    )[0]
+
+    fem_solver = HJBFEMSolver(_mesh_problem(c), order=1)
+    n_fem = len(fem_solver._disc.dof_coordinates)
+    fem = np.asarray(
+        fem_solver.solve_hjb_system(
+            M_density=np.ones((_NT + 1, n_fem)),
+            U_terminal=np.zeros(n_fem),
+            U_coupling_prev=np.zeros((_NT + 1, n_fem)),
+            use_newton=False,
+        )
+    )[0]
+
+    meshless_solver = MeshlessGalerkinHJBSolver(
+        _grid_problem(c), np.linspace(0.0, 1.0, n).reshape(-1, 1), delta=2.6 / np.sqrt(n)
+    )
+    meshless = np.asarray(meshless_solver.solve_hjb_system(np.ones((_NT + 1, n)), np.zeros(n), np.zeros((_NT + 1, n))))[
+        0
+    ]
+
+    # All three are spatially constant here, so comparing means is comparing the fields.
+    #
+    # 1e-6 is set from the reference's own accuracy, not tuned until green: FDM lands 1.48e-07 off
+    # the analytic value at c = 1 (its no-flux treatment is not exact even on a spatially constant
+    # field), while the weak-form solvers are exact to ~3e-16. The defect this discriminates is a
+    # factor of -1, i.e. 0.4 in absolute terms at c = 1 -- six orders of magnitude above the bound.
+    for label, field in (("weak-form FEM", fem), ("meshless Galerkin", meshless)):
+        assert float(np.mean(field)) == pytest.approx(float(np.mean(fdm)), abs=1e-6), (
+            f"{label} u(0) = {float(np.mean(field)):+.9f} against reference FDM "
+            f"{float(np.mean(fdm)):+.9f} (analytic {-c * _T:+.9f})"
+        )


### PR DESCRIPTION
`WeakFormHJBSolver.solve_hjb_system`'s Picard branch — **the default**, `use_newton=False` — added
`H` to the right-hand side where the canonical equation requires subtracting it. `HJBFEMSolver` and
`MeshlessGalerkinHJBSolver` therefore solved $-u_t - H - D\Delta u = 0$ on the path a caller gets
without asking, from #773 (2026-03-27) until now.

`mfg_problem.py:197` states the convention: $-u_t + H - (\sigma^2/2)\Delta u = S$. Backward Euler in
weak form gives $(M/\Delta t + DK)U^n = (M/\Delta t)U^{n+1} - MH$. One character.

## Measured

`H = c` constant, `u_T = 0`, no-flux. The solution stays spatially constant (spread ~1e-16), so
`p ≡ 0` and `Δu ≡ 0`, and `u(0) = -c·T` is **exact** — no discretization error to hide a sign in.

| c | analytic | picard before | picard after | newton | FDM |
|---|---|---|---|---|---|
| 1.0 | −0.200000 | **+0.200000** | −0.200000 | −0.200000 | −0.200000 |
| 2.0 | −0.400000 | **+0.400000** | −0.400000 | −0.400000 | −0.400000 |
| −3.0 | +0.600000 | **−0.600000** | +0.600000 | +0.600000 | +0.600000 |

Exactly $-1\times$ at every value. Independently reproduced against an external analytic oracle by a
reviewer who built their own fixture rather than reusing this one: with the control cost switched off
the PDE is linear with a closed form, and the corrected tree converges to it at second order
(2.844e-03 → 1.383e-03 → 6.817e-04 → 3.384e-04, ratios 2.06 / 2.03 / 2.02) while the old one plateaus
at 3.30e-01 with ratios 0.996 / 0.998 / 0.999.

## Provenance — the file shipped with its own algebra contradicting its code

`git log -S` puts the line at **`d9f66701` (#773)**, the file's first version. That version carried
the derivation in a comment three lines above the code:

```
# For implicit Euler backward: M/dt * u^n = M/dt * u^{n+1} - D*K*u^n - H_rhs      <- minus
# Rearranged: (M/dt + D*K) u^n = M/dt * u^{n+1} + source                          <- plus
```

The sign flips between two adjacent comment lines and the code follows the second. `675e0049`
(#1131) only relocated it — an earlier draft of this PR blamed #1131 and was wrong.

## Why five months of green

Nothing ran both branches on one problem and compared. `test_meshless_stabilization.py` is the only
test that checks the weak-form family against an independent discretization, and it passed
`use_newton=True` — so the suite's one cross-implementation oracle was pointed at the branch that is
not the default, while `meshless_galerkin/hjb_solver.py:51` and `WeakFormHJBSolver` both default to
Picard.

It is now parametrized over both, with streamline diffusion tied to the branch because the solver
fail-louds on SD + Picard (SD enters only the Newton Jacobian). After the fix the two branches agree
with each other to 1e-6 and both track FDM: Δmean 4.28e-03 (newton+SD) and 3.52e-03 (picard) against
a 2e-2 bound.

## Three tests changed, none by weakening a bound

**`test_fem_robin_bc.py::test_hjb_linear_loop_fixed_point`** built its reference by `spsolve`-ing the
solver's own matrices against the same source the Hamiltonian carries — measured
`max|H(x,m,p=0) − _source| = 0.0`, i.e. the buggy right-hand side written down twice. The two
candidate references differ by 3.648, so this was not cosmetic. The Hamiltonian potential is negated;
the manufactured solution `u* = sin(2x)`, the analytic Robin data and the oracle line are untouched.
`max|U[0] − u_steady|` = **1.010e-14** against the unchanged 1e-9 bound.

**The two coupled-FEM mass tests** specified `coupling = lambda m: m`, which under this repo's
reward-signed convention (`mfg_problem.py:191-195`) is crowd-**seeking**: an aggregating,
anti-monotone MFG whose fixed point diverges. They passed only because the negated assembly turned an
aggregating specification into a dispersing computation. Both now specify congestion and conserve
mass to 2.2e-16.

That these are pre-existing and not caused by this change is measured, not argued: their fixture run
through **`main`'s own Newton branch with no fix applied** diverges identically —

| iter | main picard (`+=`, shipped) | main newton (untouched) |
|---|---|---|
| 3 | drift 0.0 | 4.52e+05 |
| 7 | drift 2.2e-16 | **7.36e+26** |

The reported "mass drift" is also misnamed: the FP solver logs the mechanism during the blow-up —
`the Galerkin advection is not an M-matrix; enable streamline diffusion` (#1145 / #1489) — so it is
clip injection under a concentrating drift, not a `-Cᵀ` conservativeness failure.

## Verification

Three independent agents. One was assigned to **refute** the fix and default to `+=`; all four of its
attack lines failed and two reversed into evidence for the fix. A third mapped what else depends on
the sign. Cost 599k tokens, 224 tool calls.

They also established something neither table above shows: **the two mass tests cannot pin this sign
in either direction.** Crossed with the repo's recorded `optimal_control_sign` mutation they give a
perfect anti-diagonal with bit-identical numbers, because for a control cost even in `p` with
`U_T = 0`, flipping the `H` sign maps `U → −U` and flipping `α*` restores an identical drift. They
constrain only the *product* of the two signs.

## Known follow-up, not in this PR

`scripts/discrimination_killmatrix.json` records both mass tests as killers of `optimal_control_sign`
(40 killers) and `test_hjb_linear_loop_fixed_point` as a killer of `diffusion_scalar_2x` (145). The
first two rows invert under this change. Neither mutation is left without a killer, so nothing goes
uncovered, but the counts are stale and want a re-run of `scripts/test_discrimination.py` — which
refuses to start on a red baseline, so it had to wait for this to be green.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.

Closes #2023. Refs #773 #1131 #1145 #1489