### PR TITLE
feat: thread `source_term` through the weak-form family, and gate the signature (#2020)

### DIFF
--- a/changelog.d/2020-weak-form-source-term.added.md
+++ b/changelog.d/2020-weak-form-source-term.added.md
@@ -1,0 +1,42 @@
+`source_term` now reaches the weak-form solver family, and a class-definition-time gate stops a
+future solver from swallowing it.
+
+Six solvers accepted `source_term` through `**kwargs` and discarded it — no exception, no warning,
+bitwise-identical output. They reduce to two definers, so two changes cover all six:
+`WeakFormFPSolver.solve_fp_system` (used by `FPFEMSolver`, `MeshlessGalerkinFPSolver`) and
+`WeakFormHJBSolver.solve_hjb_system` (used by `HJBFEMSolver`, and by
+`MeshlessGalerkinHJBSolver`, which forwards to it).
+
+The HJB side needed no new machinery: `_solve_timestep_newton` already had a `rhs_coupling`
+parameter that its residual **subtracts**, and the documented contract is
+`F(u) = (u - u_next)/dt + H - S`, so that is the source slot.
+
+**Verified by order, not by liveness.** "Passing a source changes the answer" is a liveness check.
+Measured against manufactured solutions on `[0, 1]` with no-flux walls, with the spatial and
+temporal studies deliberately separated so neither caps the other:
+
+| study | HJB picard | HJB newton | FP |
+|---|---|---|---|
+| space, P1, steady `u*` | 1.883 / 1.945 / 1.974 | 1.818 / 1.805 / 1.895 | 2.021 / 2.014 / 2.008 |
+| time, backward Euler | 0.999 / 1.000 / 1.000 | 1.039 / 1.018 / 1.009 | 0.948 / 0.973 / 0.987 |
+
+$O(h^2)$ in space for P1 and $O(\Delta t)$ in time for backward Euler, on both HJB branches.
+
+The test file also pins the trap that produced those numbers on the second attempt: the first
+temporal fixture was linear in `t`, and backward Euler's truncation error is $(\Delta t/2)u_{tt}$,
+identically zero there. It reported order 0.02 from a correct implementation, because it was
+measuring the spatial floor. `test_the_time_fixture_is_not_degenerate` asserts $u_{tt} \neq 0$.
+
+**The gate.** An abstract method's signature is a declaration and Python does not enforce it — a
+subclass may override with `(*args, **kwargs)` and nothing checks, which is the structural reason
+this could exist unnoticed. `BaseHJBSolver` and `BaseFPSolver` now validate overrides at class
+definition: an override that accepts `**kwargs` must NAME `source_term` and `volatility_field`.
+Scoped to those two because they have the incident history (#1424, #2020; #1316, #1783); a blanket
+"name every declared parameter" rule is not satisfiable, since the base declares
+`m_initial_condition` while implementations use `m_initial` or `M_initial` — that is a rename, not a
+gate. Solvers without `**kwargs` are untouched: an unnamed parameter there already raises
+`TypeError`, which is loud.
+
+A solver that cannot support a parameter still names it and raises inside. That is what
+`HJBWENOSolver` does for multi-D `source_term`, and it is the honest shape: refusal is a behaviour,
+an absent signature is not.

--- a/mfgarchon/alg/numerical/fp_solvers/base_fp.py
+++ b/mfgarchon/alg/numerical/fp_solvers/base_fp.py
@@ -71,6 +71,46 @@ class BaseFPSolver(BaseNumericalSolver):
         - Enable state-dependent coefficients for nonlinear PDEs
     """
 
+    # --- Signature gate (#2020) ------------------------------------------------------------
+    # An abstract method's signature is a DECLARATION, and Python does not enforce it: a subclass
+    # may override with `(*args, **kwargs)` and nothing checks. That is the structural reason six
+    # solvers silently discarded `source_term` for months -- `**kwargs` converts the loud TypeError
+    # a narrower signature would have raised into silence, and a signature-keyed census then reads
+    # the swallower as accepting the parameter.
+    #
+    # Scoped to the two parameters with an incident history rather than to every declared name:
+    # `source_term` (#1424, #2020) and `volatility_field` (#1316, #1783). A blanket "must name every
+    # declared parameter" rule is NOT satisfiable here -- the base declares `m_initial_condition` while
+    # implementations use other names for it, so it would fail almost every solver in the tree and
+    # would be a rename, not a gate.
+    #
+    # Fires at class-definition time, so an offending solver cannot be imported rather than failing
+    # at some caller far away. A solver that cannot support a parameter still NAMES it and raises
+    # inside -- that is what HJBWENOSolver does for multi-D `source_term`, and it is the honest
+    # shape: refusal is a behaviour, not an absent signature.
+    _GUARDED_PARAMETERS = ("source_term", "volatility_field")
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        import inspect as _inspect
+
+        own = cls.__dict__.get("solve_fp_system")
+        if own is None:
+            return
+        params = _inspect.signature(own).parameters
+        if not any(p.kind is _inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            # No **kwargs: an unnamed parameter raises TypeError at the call site, which is loud.
+            return
+        missing = [p for p in cls._GUARDED_PARAMETERS if p not in params]
+        if missing:
+            raise TypeError(
+                f"{cls.__name__}.solve_fp_system accepts **kwargs but does not name {missing}. "
+                f"**kwargs would swallow {'them' if len(missing) > 1 else 'it'} silently -- no "
+                f"error, no warning, and a solve that quietly ignores what the caller asked for "
+                f"(#2020). Name the parameter and either honour it or raise NotImplementedError "
+                f"inside; refusing is a behaviour, an absent signature is not."
+            )
+
     # Scheme family trait for duality validation (Issue #580)
     _scheme_family = SchemeFamily.GENERIC
 

--- a/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/base_hjb.py
@@ -205,6 +205,46 @@ class BaseHJBSolver(BaseNumericalSolver):
     # Scheme family trait for duality validation (Issue #580)
     _scheme_family = SchemeFamily.GENERIC
 
+    # --- Signature gate (#2020) ------------------------------------------------------------
+    # An abstract method's signature is a DECLARATION, and Python does not enforce it: a subclass
+    # may override with `(*args, **kwargs)` and nothing checks. That is the structural reason six
+    # solvers silently discarded `source_term` for months -- `**kwargs` converts the loud TypeError
+    # a narrower signature would have raised into silence, and a signature-keyed census then reads
+    # the swallower as accepting the parameter.
+    #
+    # Scoped to the two parameters with an incident history rather than to every declared name:
+    # `source_term` (#1424, #2020) and `volatility_field` (#1316, #1783). A blanket "must name every
+    # declared parameter" rule is NOT satisfiable here -- the base declares `M_density` while
+    # implementations use other names for it, so it would fail almost every solver in the tree and
+    # would be a rename, not a gate.
+    #
+    # Fires at class-definition time, so an offending solver cannot be imported rather than failing
+    # at some caller far away. A solver that cannot support a parameter still NAMES it and raises
+    # inside -- that is what HJBWENOSolver does for multi-D `source_term`, and it is the honest
+    # shape: refusal is a behaviour, not an absent signature.
+    _GUARDED_PARAMETERS = ("source_term", "volatility_field")
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        import inspect as _inspect
+
+        own = cls.__dict__.get("solve_hjb_system")
+        if own is None:
+            return
+        params = _inspect.signature(own).parameters
+        if not any(p.kind is _inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            # No **kwargs: an unnamed parameter raises TypeError at the call site, which is loud.
+            return
+        missing = [p for p in cls._GUARDED_PARAMETERS if p not in params]
+        if missing:
+            raise TypeError(
+                f"{cls.__name__}.solve_hjb_system accepts **kwargs but does not name {missing}. "
+                f"**kwargs would swallow {'them' if len(missing) > 1 else 'it'} silently -- no "
+                f"error, no warning, and a solve that quietly ignores what the caller asked for "
+                f"(#2020). Name the parameter and either honour it or raise NotImplementedError "
+                f"inside; refusing is a behaviour, an absent signature is not."
+            )
+
     def __init__(self, problem: MFGProblem, config: BaseConfig | None = None) -> None:
         # Maintain backward compatibility - if no config provided, create a minimal one
         if config is None:

--- a/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/hjb_solver.py
@@ -79,14 +79,30 @@ class MeshlessGalerkinHJBSolver(WeakFormHJBSolver):
                 "omits S and the Type-A duality A_FP = A_HJB^T is lost."
             )
 
-    def solve_hjb_system(self, *args, use_newton: bool | None = None, **kwargs):
+    def solve_hjb_system(
+        self,
+        *args,
+        use_newton: bool | None = None,
+        volatility_field=None,
+        source_term=None,
+        **kwargs,
+    ):
         """Default the inner solver to the constructor's ``use_newton`` (default False =
         Picard, honouring the documented stiff-LQ finding); pass ``use_newton`` explicitly
         to force a path. Newton iteration limits/tolerance pass through unchanged. Delegates
         to ``WeakFormHJBSolver.solve_hjb_system``."""
         if use_newton is None:
             use_newton = self._use_newton_default
-        return super().solve_hjb_system(*args, use_newton=use_newton, **kwargs)
+        # `volatility_field` and `source_term` are named rather than left to **kwargs so that the
+        # signature states what this solver consumes. A bare `**kwargs` made both invisible to every
+        # signature-keyed gate while silently forwarding one and swallowing the other (#2020).
+        return super().solve_hjb_system(
+            *args,
+            use_newton=use_newton,
+            volatility_field=volatility_field,
+            source_term=source_term,
+            **kwargs,
+        )
 
     def _stabilization_terms(self, u: NDArray, D: float):
         """Streamline-diffusion block ``S`` for the HJB Newton path (added to residual and

--- a/mfgarchon/alg/numerical/weak_form_fp_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_fp_solver.py
@@ -28,6 +28,8 @@ from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import scalar_diffusion_from_volatility
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from numpy.typing import NDArray
     from scipy import sparse
 
@@ -117,6 +119,7 @@ class WeakFormFPSolver(BaseFPSolver):
         potential_field: NDArray | None = None,
         volatility_field: float | NDArray | None = None,
         drift_field: NDArray | None = None,  # DEPRECATED alias for potential_field (Issue #1043)
+        source_term: Callable | None = None,
         **kwargs,
     ) -> NDArray:
         """Solve the FP equation forward in time on the weak-form operators.
@@ -175,6 +178,18 @@ class WeakFormFPSolver(BaseFPSolver):
         m0_mass = float((self._M @ M[0]).sum())
         for n in range(Nt):
             rhs = (self._M / dt) @ M[n]
+            if source_term is not None:
+                # S of `d_t m + div(alpha m) - D Lap(m) = S`, evaluated implicitly at t_{n+1} to
+                # match FPFDMSolver, on the solver's own (N, d) dof coordinates (#2020).
+                s_vals = np.asarray(source_term((n + 1) * dt, self._disc.dof_coordinates), dtype=float).ravel()
+                if s_vals.shape != (N,):
+                    raise ValueError(
+                        f"source_term returned shape {s_vals.shape}; this solver needs ({N},), one "
+                        f"value per dof, evaluated on self._disc.dof_coordinates (shape "
+                        f"{self._disc.dof_coordinates.shape}). A grid-shaped return is the "
+                        f"FPFVMSolver convention, not this one (#2019)."
+                    )
+                rhs = rhs + self._M @ s_vals
             if rhs_robin is not None:
                 rhs = rhs + rhs_robin
 

--- a/mfgarchon/alg/numerical/weak_form_hjb_solver.py
+++ b/mfgarchon/alg/numerical/weak_form_hjb_solver.py
@@ -28,6 +28,8 @@ from mfgarchon.utils.mfg_logging import get_logger
 from mfgarchon.utils.pde_coefficients import scalar_diffusion_from_volatility
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from numpy.typing import NDArray
 
     from mfgarchon.alg.numerical.weak_form_discretization import WeakFormDiscretization
@@ -265,6 +267,7 @@ class WeakFormHJBSolver(BaseHJBSolver):
         U_terminal: NDArray | None = None,
         U_coupling_prev: NDArray | None = None,
         volatility_field: float | NDArray | None = None,
+        source_term: Callable | None = None,
         use_newton: bool = False,
         max_newton_iterations: int = 30,
         newton_tolerance: float = 1e-6,
@@ -275,7 +278,16 @@ class WeakFormHJBSolver(BaseHJBSolver):
         cross_density=None,
         **kwargs,
     ) -> NDArray:
-        """Solve the HJB system backward in time on the weak-form operators."""
+        """Solve the HJB system backward in time on the weak-form operators.
+
+        ``source_term(t, x) -> (N,)`` is the MMS forcing S of ``-u_t + H - D*Lap(u) = S``, with x the
+        solver's own ``(N, d)`` dof coordinates -- the same convention BaseHJBSolver documents and
+        HJBFDMSolver uses, evaluated at the time level being solved (#2020). It is SUBTRACTED, per
+        that contract: ``F(u) = (u - u_next)/dt + H - S``.
+
+        Before #2020 this parameter was swallowed by ``**kwargs``: passing it raised nothing, changed
+        nothing, and a convergence order measured through here was an order for the sourceless PDE.
+        """
         # Issue #1071: named explicitly (not swallowed by **kwargs) so a multi-population
         # cross-density trajectory fails loud rather than silently decoupling. Covers the
         # meshless-Galerkin solver, which forwards **kwargs here.
@@ -294,6 +306,20 @@ class WeakFormHJBSolver(BaseHJBSolver):
         Nt = self.problem.Nt
         dt = self.problem.dt
         N = self._n_dof
+
+        def _source_at(t: float) -> NDArray:
+            """M @ S(t, dofs). Zero vector when no source, so both branches stay one code path."""
+            if source_term is None:
+                return np.zeros(N)
+            s_vals = np.asarray(source_term(t, self._disc.dof_coordinates), dtype=float).ravel()
+            if s_vals.shape != (N,):
+                raise ValueError(
+                    f"source_term returned shape {s_vals.shape}; this solver needs ({N},), one value "
+                    f"per dof, evaluated on self._disc.dof_coordinates (shape "
+                    f"{self._disc.dof_coordinates.shape}). Returning a grid-shaped array is the "
+                    f"FPFVMSolver convention, not this one (#2019)."
+                )
+            return self._M @ s_vals
 
         if U_terminal is None:
             U_terminal = np.zeros(N)
@@ -333,7 +359,9 @@ class WeakFormHJBSolver(BaseHJBSolver):
                     D=D,
                     dt=dt,
                     t=n * dt,
-                    rhs_coupling=np.zeros(N),
+                    # The residual SUBTRACTS rhs_coupling, and the contract subtracts S, so this is
+                    # the source slot -- no change needed inside _solve_timestep_newton.
+                    rhs_coupling=_source_at(n * dt),
                     max_iterations=max_newton_iterations,
                     tolerance=newton_tolerance,
                 )
@@ -356,6 +384,7 @@ class WeakFormHJBSolver(BaseHJBSolver):
                     # Measured on H = c constant with u_T = 0, where u(0) = -c*T is exact: picard
                     # returned +c*T at c = 1, 2 and -3, against FDM and Newton both giving -c*T.
                     rhs -= self._M @ H_values
+                rhs = rhs + _source_at(n * dt)
                 if rhs_robin is not None:
                     rhs = rhs + rhs_robin
 

--- a/tests/integration/test_weak_form_source_mms_2020.py
+++ b/tests/integration/test_weak_form_source_mms_2020.py
@@ -1,0 +1,207 @@
+"""MMS for the `source_term` channel of the weak-form family (#2020).
+
+The channel was added because six solvers silently discarded `source_term`, so an MMS could not
+reach them. "The answer moves when a source is passed" is a liveness check, not a correctness one;
+what a source channel owes is an ORDER against an exact solution.
+
+TWO STUDIES, DELIBERATELY SEPARATED
+-----------------------------------
+Measured together the smaller order caps the larger and neither is visible.
+
+- SPACE: a STEADY manufactured solution. ``d_t u* == 0``, so backward Euler is exact on the time
+  term and the residual is purely spatial. P1 elements should give O(h^2).
+- TIME: a time-dependent solution on a mesh fine enough that the spatial error sits below the
+  temporal one. Backward Euler should give O(dt).
+
+THE FIXTURE TRAP THIS FILE ENCODES
+----------------------------------
+The first version of the time study used ``a(t) = 1 + (T - t)``, LINEAR in t. Backward Euler's local
+truncation error is ``(dt/2) * u_tt``, which is identically zero for a linear-in-t solution, so the
+study measured the spatial floor and reported order 0.02 -- an apparently catastrophic result from a
+correct implementation. ``test_the_time_fixture_is_not_degenerate`` pins that the fixture has
+``u_tt != 0``, because a fixture that cannot express the error is indistinguishable from a scheme
+that has none.
+
+u*(t,x) = a(t) cos(pi x) on [0,1]: ``d_x u* = -a pi sin(pi x)`` vanishes at both walls, so the pair
+is exactly no-flux compatible and the wall contributes no error of its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import Mesh1D
+from mfgarchon.geometry.boundary import no_flux_bc
+
+_T, _SIGMA, _LAM = 0.5, 0.4, 1.0
+_D = 0.5 * _SIGMA**2
+_PI = np.pi
+
+
+def _a(t, steady):
+    return 1.0 if steady else float(np.exp(-2.0 * t))
+
+
+def _ap(t, steady):
+    return 0.0 if steady else float(-2.0 * np.exp(-2.0 * t))
+
+
+def _u_star(t, x, steady):
+    return _a(t, steady) * np.cos(_PI * x)
+
+
+def _s_hjb(t, x, steady):
+    """S of -u_t + |u_x|^2/(2 lam) - D u_xx = S."""
+    ux = -_a(t, steady) * _PI * np.sin(_PI * x)
+    uxx = -_a(t, steady) * _PI**2 * np.cos(_PI * x)
+    return -_ap(t, steady) * np.cos(_PI * x) + ux**2 / (2.0 * _LAM) - _D * uxx
+
+
+def _b(t, steady):
+    return 0.3 if steady else float(0.3 * np.exp(-2.0 * t))
+
+
+def _bp(t, steady):
+    return 0.0 if steady else float(-0.6 * np.exp(-2.0 * t))
+
+
+def _m_star(t, x, steady):
+    return 1.0 + _b(t, steady) * np.cos(2 * _PI * x)
+
+
+def _s_fp(t, x, steady):
+    """S of m_t - D m_xx = S, with no potential so the drift is absent."""
+    return _bp(t, steady) * np.cos(2 * _PI * x) + _D * _b(t, steady) * (2 * _PI) ** 2 * np.cos(2 * _PI * x)
+
+
+def _problem(ne, nt):
+    mesh = Mesh1D(bounds=(0.0, 1.0), num_elements=ne)
+    mesh.generate_mesh()
+    mesh.boundary_conditions = no_flux_bc(dimension=1)
+    return MFGProblem(
+        geometry=mesh,
+        T=_T,
+        Nt=nt,
+        sigma=_SIGMA,
+        coupling_coefficient=0.0,
+        components=MFGComponents(
+            m_initial=lambda x: np.ones_like(np.asarray(x, dtype=float)),
+            u_terminal=lambda x: np.asarray(x, dtype=float) * 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=_LAM),
+                coupling=lambda m: np.asarray(m) * 0.0,
+                coupling_dm=lambda m: np.asarray(m) * 0.0,
+            ),
+        ),
+    )
+
+
+def _hjb_error(ne, nt, steady, use_newton):
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM solvers")
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+
+    problem = _problem(ne, nt)
+    solver = HJBFEMSolver(problem, order=1)
+    x = solver._disc.dof_coordinates[:, 0]
+    n = len(x)
+    # The Picard branch linearises H at the previous iterate; handing it the EXACT one makes the
+    # only remaining error the discretisation, which is what an order study must isolate.
+    u_prev = np.array([_u_star(k * problem.dt, x, steady) for k in range(nt + 1)])
+    u = np.asarray(
+        solver.solve_hjb_system(
+            M_density=np.ones((nt + 1, n)),
+            U_terminal=_u_star(_T, x, steady),
+            U_coupling_prev=u_prev,
+            source_term=lambda t, pts: _s_hjb(t, np.asarray(pts)[:, 0], steady),
+            use_newton=use_newton,
+        )
+    )
+    return float(np.sqrt(((u[0] - _u_star(0.0, x, steady)) ** 2).sum() / n))
+
+
+def _fp_error(ne, nt, steady):
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM solvers")
+    from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+
+    problem = _problem(ne, nt)
+    solver = FPFEMSolver(problem, order=1)
+    x = solver._disc.dof_coordinates[:, 0]
+    n = len(x)
+    m = np.asarray(
+        solver.solve_fp_system(
+            _m_star(0.0, x, steady),
+            potential_field=None,
+            volatility_field=_SIGMA,
+            source_term=lambda t, pts: _s_fp(t, np.asarray(pts)[:, 0], steady),
+        )
+    )
+    return float(np.sqrt(((m[-1] - _m_star(_T, x, steady)) ** 2).sum() / n))
+
+
+def _order(errors, ratios):
+    return [float(np.log(errors[i] / errors[i + 1]) / np.log(ratios[i])) for i in range(len(errors) - 1)]
+
+
+def test_the_time_fixture_is_not_degenerate():
+    """A linear-in-t manufactured solution has u_tt == 0, killing backward Euler's whole truncation
+    error. The first draft of the time study did exactly that and reported order 0.02 from a correct
+    implementation. Pin that the fixture can express what the study claims to measure."""
+    h = 1e-4
+    for f, label in ((lambda t: _a(t, False), "a"), (lambda t: _b(t, False), "b")):
+        second = (f(0.2 + h) - 2 * f(0.2) + f(0.2 - h)) / h**2
+        assert abs(second) > 1e-2, (
+            f"{label}''(t) = {second:.3e} is ~0, so backward Euler has no truncation error on this "
+            f"fixture and the temporal study below would measure the spatial floor instead."
+        )
+    # And the steady fixture must genuinely be steady, or the space study is capped by O(dt).
+    assert _a(0.0, True) == _a(_T, True), "the steady u* fixture is not steady"
+    assert _b(0.0, True) == _b(_T, True), "the steady m* fixture is not steady"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("use_newton", [False, True], ids=["picard", "newton"])
+def test_the_hjb_source_is_second_order_in_space(use_newton):
+    """P1 elements on a steady manufactured solution. Measured 1.883 / 1.945 / 1.974 (picard) and
+    1.818 / 1.805 / 1.895 (newton) over ne = 10..80 at Nt = 400."""
+    levels = (10, 20, 40)
+    errs = [_hjb_error(ne, 200, True, use_newton) for ne in levels]
+    orders = _order(errs, [levels[i + 1] / levels[i] for i in range(len(levels) - 1)])
+    assert all(o > 1.6 for o in orders), f"HJB spatial order {orders} (errors {errs}), expected ~2"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("use_newton", [False, True], ids=["picard", "newton"])
+def test_the_hjb_source_is_first_order_in_time(use_newton):
+    """Backward Euler. Measured 0.999 / 1.000 / 1.000 (picard) and 1.039 / 1.018 / 1.009 (newton)
+    over Nt = 5..40 at ne = 640."""
+    levels = (5, 10, 20)
+    errs = [_hjb_error(320, nt, False, use_newton) for nt in levels]
+    orders = _order(errs, [levels[i + 1] / levels[i] for i in range(len(levels) - 1)])
+    assert all(0.8 < o < 1.3 for o in orders), f"HJB temporal order {orders} (errors {errs}), expected ~1"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_the_fp_source_is_second_order_in_space():
+    """Measured 2.021 / 2.014 / 2.008 over ne = 10..80 at Nt = 400."""
+    levels = (10, 20, 40)
+    errs = [_fp_error(ne, 200, True) for ne in levels]
+    orders = _order(errs, [levels[i + 1] / levels[i] for i in range(len(levels) - 1)])
+    assert all(o > 1.6 for o in orders), f"FP spatial order {orders} (errors {errs}), expected ~2"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_the_fp_source_is_first_order_in_time():
+    """Measured 0.948 / 0.973 / 0.987 over Nt = 5..40 at ne = 640."""
+    levels = (5, 10, 20)
+    errs = [_fp_error(320, nt, False) for nt in levels]
+    orders = _order(errs, [levels[i + 1] / levels[i] for i in range(len(levels) - 1)])
+    assert all(0.8 < o < 1.3 for o in orders), f"FP temporal order {orders} (errors {errs}), expected ~1"

--- a/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
+++ b/tests/unit/test_alg/test_kwarg_gate_var_keyword_1783.py
@@ -16,6 +16,7 @@ Three lines below, the same function already raised for exactly this situation w
 
 from __future__ import annotations
 
+import functools
 import inspect
 import pathlib
 from dataclasses import dataclass
@@ -176,17 +177,58 @@ def test_the_meshless_pair_is_refused_end_to_end():
         )
 
     hjb, _fp = pair()
-    assert "volatility_field" not in inspect.signature(hjb.solve_hjb_system).parameters, (
-        "this solver must be the **kwargs shape, or the test does not exercise the hole"
-    )
+    # #2020: MeshlessGalerkinHJBSolver now NAMES volatility_field, so it is no longer an example of
+    # the hole -- and it never was an example of a solver that cannot consume the field. Measured:
+    # passing 0.9 against problem.sigma = 0.3 moves the solve by 4.369684e-01, a (0.5..0.9) array by
+    # 2.846775e-01, and passing 0.3 itself by exactly 0.0. So the gate should now FORWARD to this
+    # pair, not refuse it, and the refusal below is exercised against a stub instead. Pinning the
+    # gate to a stub is also what stops this test being invalidated again the next time a production
+    # solver widens its signature.
+    assert "volatility_field" in inspect.signature(hjb.solve_hjb_system).parameters
 
-    # Without the field, nothing changes -- the refusal must not break ordinary use.
+    # Without the field, nothing changes.
     FixedPointIterator(problem, *pair()).solve(max_iterations=2, verbose=False)
 
+    # And WITH the field the pair now runs rather than refusing, with both sides receiving it.
+    seen: dict[str, object] = {}
+    hjb2, fp2 = pair()
+    for solver, name in ((hjb2, "solve_hjb_system"), (fp2, "solve_fp_system")):
+        inner = getattr(solver, name)
+
+        # functools.wraps is load-bearing, not tidiness: the gate reads `inspect.signature` of what
+        # it is about to call, so a bare wrapper presents (*args, **kwargs) and gets REFUSED -- the
+        # instrument would then be measuring itself. wraps sets __wrapped__ and signature follows it.
+        def spy(*args, _inner=inner, _name=name, **kwargs):
+            seen[_name] = kwargs.get("volatility_field")
+            return _inner(*args, **kwargs)
+
+        spy = functools.wraps(inner)(spy)
+        setattr(solver, name, spy)
+    field = np.linspace(0.5, 0.9, n)
+    FixedPointIterator(problem, hjb2, fp2, volatility_field=field).solve(max_iterations=2, verbose=False)
+    for name in ("solve_hjb_system", "solve_fp_system"):
+        assert seen.get(name) is not None, f"{name} did not receive volatility_field"
+        assert np.array_equal(seen[name], field), f"{name} received a different field"
+
+    # The refusal itself, against a solver that really does have the **kwargs shape. Deliberately
+    # NOT a BaseHJBSolver subclass: BaseHJBSolver.__init_subclass__ refuses that shape at class
+    # definition (#2020), and the coupling layer duck-types, so a plain object is the right fixture.
+    class _SwallowingHJB:
+        hjb_method_name = "SwallowingHJB"
+
+        def __init__(self, problem):
+            self.problem = problem
+
+        def solve_hjb_system(self, *args, **kwargs):  # names neither parameter
+            raise AssertionError("the gate must refuse before the solver is reached")
+
+    swallow = _SwallowingHJB(problem)
+    assert "volatility_field" not in inspect.signature(swallow.solve_hjb_system).parameters, (
+        "the stub must have the **kwargs shape, or this half tests nothing"
+    )
+    _hjb_unused, fp3 = pair()
     with pytest.raises(NotImplementedError, match="does not accept 'volatility_field'"):
-        FixedPointIterator(problem, *pair(), volatility_field=np.linspace(0.5, 0.9, n)).solve(
-            max_iterations=2, verbose=False
-        )
+        FixedPointIterator(problem, swallow, fp3, volatility_field=field).solve(max_iterations=2, verbose=False)
 
 
 def test_the_newton_path_refuses_the_same_pair_the_picard_path_does():
@@ -231,9 +273,11 @@ def test_the_newton_path_refuses_the_same_pair_the_picard_path_does():
     delta = 2.6 / np.sqrt(n)
     hjb = MeshlessGalerkinHJBSolver(problem, points, delta=delta)
     fp = MeshlessGalerkinFPSolver(problem, points, delta=delta)
-    assert "volatility_field" not in inspect.signature(hjb.solve_hjb_system).parameters, (
-        "this solver must be the **kwargs shape, or the test does not exercise the hole"
-    )
+    # #2020: this solver now names the parameter, so the Newton path must FORWARD to it rather than
+    # refuse. The refusal half of the Newton gate is covered by the stub in the Picard test above;
+    # what this one still pins uniquely is that mfg_residual's two call sites route through the
+    # single owner rather than carrying inline copies.
+    assert "volatility_field" in inspect.signature(hjb.solve_hjb_system).parameters
 
     shape = (problem.Nt + 1, n)
     M0 = np.tile(np.ones(n) / n, (problem.Nt + 1, 1))
@@ -242,8 +286,22 @@ def test_the_newton_path_refuses_the_same_pair_the_picard_path_does():
     # A field the two sides would disagree about: mean 0.7 against problem.sigma = 0.3.
     hazard = np.linspace(0.5, 0.9, n)
     residual = MFGResidual(problem, hjb, fp, volatility_field=hazard)
-    with pytest.raises(NotImplementedError, match="does not accept 'volatility_field'"):
+    seen_hjb: dict[str, object] = {}
+    inner_hjb = hjb.solve_hjb_system
+
+    @functools.wraps(inner_hjb)
+    def spy_hjb(*args, **kwargs):
+        seen_hjb.update(kwargs)
+        return inner_hjb(*args, **kwargs)
+
+    hjb.solve_hjb_system = spy_hjb
+    try:
         residual.compute_hjb_output(M0, U0)
+    finally:
+        hjb.solve_hjb_system = inner_hjb
+    assert np.array_equal(seen_hjb.get("volatility_field"), hazard), (
+        "the Newton path must forward the field to an HJB solver that names it"
+    )
 
     # And the FP side, which DOES name the parameter, must actually RECEIVE it. Asserting only
     # that the call returns a well-shaped array leaves the site pinned by nothing: replacing the

--- a/tests/unit/test_alg/test_source_term_channel_2020.py
+++ b/tests/unit/test_alg/test_source_term_channel_2020.py
@@ -1,0 +1,261 @@
+"""Issue #2020: `source_term` must be honoured or refused, never silently discarded.
+
+WHY THIS IS NOT A SIGNATURE AUDIT
+---------------------------------
+`inspect.signature` answers "does this callable name the parameter", which is a coarser question
+than "does a source reach the discretisation". Two ways it diverges, both live in this repo:
+
+- `HJBWENOSolver` NAMES `source_term` and still refuses it in multi-D (`hjb_weno.py`), because the
+  multi-D path is a dimensional split and a source added per axis sweep would be applied `d` times.
+  A signature census counts it as reachable.
+- Four solvers declare `**kwargs` and swallow the parameter whole. A census keyed on "does not
+  raise TypeError" counts THOSE as reachable too.
+
+So the population predicate has to be behavioural: pass a source, and see whether the answer moves.
+That is the shape `test_weno_mms_order_1991.py` already uses for the solvers that do thread it.
+
+WHAT IS AND IS NOT AT RISK
+--------------------------
+The coupling layer is NOT the hazard. `resolve_volatility_kwarg` in `coupling/base_mfg.py` treats
+`**kwargs` as *not* accepting a parameter and raises; the `source_term` branch beside it has done the
+same since #1424, and `test_kwarg_gate_var_keyword_1783.py` pins that end-to-end on both the Picard
+and the Newton path. Anything going through `FixedPointIterator` or `MFGResidual` gets a loud
+refusal.
+
+The hazard is the DIRECT call, which bypasses that gate. Surveyed at the time of writing, no test in
+the suite drives a manufactured solution through a swallowing solver -- the six direct
+`source_term=` call sites are all on `HJBFDMSolver`, `FPFDMSolver`, `HJBGFDMSolver`,
+`HJBWENOSolver` and `PenaltyHJBSolver`. This file exists so that stays true by failure rather than
+by nobody having tried.
+
+STATUS AFTER #2020: every solver here now HONOURS a source. The four rows that were a recorded
+defect pin are ordinary rows, and `_SWALLOWERS` is empty. What the file still does that the
+class-definition gate cannot is check BEHAVIOUR: the gate reads a signature, and this repository has
+twice now had a solver whose signature and behaviour disagreed -- `HJBWENOSolver` names
+`source_term` and refuses it in multi-D, and six solvers named nothing and swallowed it. A signature
+gate cannot tell those apart; passing a real source and watching the answer can.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pkgutil
+from importlib import import_module
+
+import pytest
+
+import numpy as np
+
+import mfgarchon.alg as _alg
+from mfgarchon.alg.numerical.fp_solvers.base_fp import BaseFPSolver
+from mfgarchon.alg.numerical.hjb_solvers.base_hjb import BaseHJBSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import Mesh1D, TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+_N = 21
+
+# Classes whose resolved solve_*_system accepts **kwargs and discards `source_term`. RECORDED
+# DEFECT, not a contract: when one of these starts honouring or refusing the parameter, the
+# behavioural test below fails on that row and the failure message says to move it.
+# Empty, and the point is that it stays empty. `BaseHJBSolver.__init_subclass__` /
+# `BaseFPSolver.__init_subclass__` now refuse a `**kwargs` override that does not NAME
+# `source_term`, so a new swallower cannot be defined at all -- this set is the behavioural witness
+# that the structural gate is doing what it claims, which a class-definition gate cannot check about
+# itself. It held these six until #2020: HJBFEMSolver, MeshlessGalerkinHJBSolver, WeakFormHJBSolver,
+# FPFEMSolver, MeshlessGalerkinFPSolver, WeakFormFPSolver.
+_SWALLOWERS: set[str] = set()
+
+
+def _components():
+    return MFGComponents(
+        m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2),
+        u_terminal=lambda x: np.asarray(x) * 0.0,
+        hamiltonian=SeparableHamiltonian(
+            control_cost=QuadraticControlCost(control_cost=1.0),
+            coupling=lambda m: np.asarray(m) * 0.0,
+            coupling_dm=lambda m: np.asarray(m) * 0.0,
+        ),
+    )
+
+
+def _grid_problem():
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_N], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=0.2, Nt=5, sigma=0.3, components=_components(), coupling_coefficient=0.0)
+
+
+def _mesh_problem():
+    mesh = Mesh1D(bounds=(0.0, 1.0), num_elements=_N - 1)
+    mesh.generate_mesh()
+    mesh.boundary_conditions = no_flux_bc(dimension=1)
+    return MFGProblem(geometry=mesh, T=0.2, Nt=5, sigma=0.3, components=_components(), coupling_coefficient=0.0)
+
+
+class _Source:
+    """A source that records whether it was ever called. A constant 5.0 is deliberate: it is large
+    against every field in this fixture, so a solver that reaches it cannot produce a zero delta."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, _t, x):
+        self.calls += 1
+        a = np.asarray(x, dtype=float)
+        return np.full(a.shape[0] if a.ndim == 2 else a.size, 5.0)
+
+
+def _hjb_fdm():
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+
+    p = _grid_problem()
+    m = np.tile(np.ones(_N) / _N, (p.Nt + 1, 1))
+    u = np.zeros((p.Nt + 1, _N))
+    s = HJBFDMSolver(p)
+    return lambda f: s.solve_hjb_system(
+        M_density=m, U_terminal=np.zeros(_N), U_coupling_prev=u, **({"source_term": f} if f else {})
+    )
+
+
+def _fp_fdm():
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+
+    p = _grid_problem()
+    u = np.zeros((p.Nt + 1, _N))
+    s = FPFDMSolver(p)
+    return lambda f: s.solve_fp_system(np.ones(_N) / _N, potential_field=u, **({"source_term": f} if f else {}))
+
+
+def _meshless_hjb():
+    from mfgarchon.alg.numerical.meshless_galerkin.hjb_solver import MeshlessGalerkinHJBSolver
+
+    p = _grid_problem()
+    pts = np.linspace(0.0, 1.0, _N).reshape(-1, 1)
+    m = np.tile(np.ones(_N) / _N, (p.Nt + 1, 1))
+    u = np.zeros((p.Nt + 1, _N))
+    s = MeshlessGalerkinHJBSolver(p, pts, delta=2.6 / np.sqrt(_N))
+    return lambda f: s.solve_hjb_system(m, np.zeros(_N), u, **({"source_term": f} if f else {}))
+
+
+def _meshless_fp():
+    from mfgarchon.alg.numerical.meshless_galerkin.fp_solver import MeshlessGalerkinFPSolver
+
+    p = _grid_problem()
+    pts = np.linspace(0.0, 1.0, _N).reshape(-1, 1)
+    u = np.zeros((p.Nt + 1, _N))
+    s = MeshlessGalerkinFPSolver(p, pts, delta=2.6 / np.sqrt(_N))
+    return lambda f: s.solve_fp_system(np.ones(_N) / _N, potential_field=u, **({"source_term": f} if f else {}))
+
+
+def _hjb_fem():
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM solvers")
+    from mfgarchon.alg.numerical.fem.hjb_fem_solver import HJBFEMSolver
+
+    s = HJBFEMSolver(_mesh_problem(), order=1)
+    return lambda f: s.solve_hjb_system(
+        M_density=None, U_terminal=None, U_coupling_prev=None, **({"source_term": f} if f else {})
+    )
+
+
+def _fp_fem():
+    pytest.importorskip("skfem", reason="scikit-fem required for the weak-form FEM solvers")
+    from mfgarchon.alg.numerical.fem.fp_fem_solver import FPFEMSolver
+
+    s = FPFEMSolver(_mesh_problem(), order=1)
+    x = s._disc.dof_coordinates[:, 0]
+    m0 = np.ones_like(x) / len(x)
+    return lambda f: s.solve_fp_system(
+        m0.copy(), potential_field=None, volatility_field=0.3, **({"source_term": f} if f else {})
+    )
+
+
+# (label, factory, expected). "honours" rows are the positive control WITHOUT which the
+# "swallows" rows prove nothing -- a harness that never delivers a source would report every
+# solver as swallowing it.
+_CASES = [
+    ("HJBFDMSolver", _hjb_fdm, "honours"),
+    ("FPFDMSolver", _fp_fdm, "honours"),
+    ("MeshlessGalerkinHJBSolver", _meshless_hjb, "honours"),
+    ("MeshlessGalerkinFPSolver", _meshless_fp, "honours"),
+    ("HJBFEMSolver", _hjb_fem, "honours"),
+    ("FPFEMSolver", _fp_fem, "honours"),
+]
+
+
+@pytest.mark.parametrize(("label", "factory", "expected"), _CASES, ids=[c[0] for c in _CASES])
+def test_a_source_term_is_honoured_or_refused_never_discarded(label, factory, expected):
+    """Pass a source; the answer must move, or the call must raise. Silence is the defect."""
+    call = factory()
+    baseline = np.asarray(call(None), dtype=float)
+
+    src = _Source()
+    try:
+        forced = np.asarray(call(src), dtype=float)
+    except (TypeError, NotImplementedError):
+        # A refusal is a correct outcome for either class -- it is the third option the contract
+        # allows, and it is what the coupling layer produces for every solver here.
+        assert expected == "swallows", f"{label} refuses source_term but is listed as honouring it"
+        return
+
+    delta = float(np.abs(forced - baseline).max())
+
+    if expected == "honours":
+        assert src.calls > 0, f"{label} accepted source_term without ever calling it (delta {delta:.3e})"
+        assert delta > 1e-9, (
+            f"{label} called the source {src.calls} times and the answer did not move "
+            f"(max|diff| = {delta:.3e}). The channel is wired but inert."
+        )
+        return
+
+    # RECORDED DEFECT, not a contract. `source_term` is swallowed by a `**kwargs` signature and
+    # never reaches the discretisation. Fixing it -- by honouring the source or by refusing it --
+    # trips one of these two lines, and that failure is the instruction.
+    raise AssertionError(  # pragma: no cover - unreachable while _CASES has no "swallows" rows
+        f"{label} is listed as swallowing source_term, but every solver in _CASES now honours or "
+        f"refuses it (#2020). Remove the row or the classification."
+    )
+
+
+def test_the_swallowing_set_has_not_grown():
+    """A new solver inheriting a `**kwargs` solve method joins the defect silently otherwise.
+
+    Classification is by MRO-resolved signature, not by each class's own ``__dict__``: three of the
+    six define nothing themselves and resolve to a CONCRETE intermediate that already dropped the
+    parameter (``FPFEMSolver`` -> ``WeakFormFPSolver``, ``MeshlessGalerkinFPSolver`` ->
+    ``WeakFormFPSolver``, ``HJBFEMSolver`` -> ``WeakFormHJBSolver``). A ``__dict__``-only census
+    reads "not overridden" as "inherits the base, therefore accepts", which is how #1991's table
+    came to carry a row that was wrong when written.
+    """
+    found: dict[str, type] = {}
+    failed = []
+    for mod in pkgutil.walk_packages(_alg.__path__, _alg.__name__ + "."):
+        try:
+            module = import_module(mod.name)
+        except Exception:  # a module that cannot import cannot contribute a solver
+            failed.append(mod.name)
+            continue
+        for obj in vars(module).values():
+            if not inspect.isclass(obj):
+                continue
+            for base, method in ((BaseHJBSolver, "solve_hjb_system"), (BaseFPSolver, "solve_fp_system")):
+                if issubclass(obj, base) and obj is not base:
+                    found[obj.__name__] = getattr(obj, method)
+
+    assert not failed, f"modules failed to import, so the population is short: {failed}"
+    assert "HJBFDMSolver" in found, "the walk did not find a solver known to exist -- the query is wrong"
+    assert len(found) >= 15, f"expected the full solver population, found {len(found)}"
+
+    swallow = {
+        name
+        for name, fn in found.items()
+        if "source_term" not in inspect.signature(fn).parameters
+        and any(p.kind is inspect.Parameter.VAR_KEYWORD for p in inspect.signature(fn).parameters.values())
+    }
+    assert swallow == _SWALLOWERS, (
+        f"the set of solvers that swallow `source_term` through **kwargs changed.\n"
+        f"  added:   {sorted(swallow - _SWALLOWERS)}\n"
+        f"  removed: {sorted(_SWALLOWERS - swallow)}\n"
+        f"Added means a new solver joined the #2020 defect. Removed means one was fixed -- update "
+        f"_SWALLOWERS and the 'swallows' rows in _CASES."
+    )


### PR DESCRIPTION
**Stacked on #2024** (the Picard sign fix), because the source's sign is fixed relative to $H$'s —
placing $S$ against an inverted $H$ would have baked the inversion in. Review #2024 first.

Closes the gap #2020 names: six solvers accepted `source_term` through `**kwargs` and discarded it —
no exception, no warning, bitwise-identical output.

## Two changes cover all six

| definer | reached by |
|---|---|
| `WeakFormFPSolver.solve_fp_system` | `FPFEMSolver`, `MeshlessGalerkinFPSolver` |
| `WeakFormHJBSolver.solve_hjb_system` | `HJBFEMSolver`, and `MeshlessGalerkinHJBSolver` (forwards) |

The HJB side needed no new machinery. `_solve_timestep_newton` already had an `rhs_coupling`
parameter its residual **subtracts**, and the documented contract is
`F(u) = (u - u_next)/dt + H - S` — so that is the source slot.

## Verified by order, not by liveness

"Passing a source changes the answer" is a liveness check; what a source channel owes is an **order**
against an exact solution. Manufactured solutions on $[0,1]$ with no-flux walls, with the spatial and
temporal studies **deliberately separated** — measured together the smaller order caps the larger and
neither is visible:

| study | HJB picard | HJB newton | FP |
|---|---|---|---|
| space, P1, steady $u^\*$ | 1.883 / 1.945 / **1.974** | 1.818 / 1.805 / **1.895** | 2.021 / 2.014 / **2.008** |
| time, backward Euler | 0.999 / 1.000 / **1.000** | 1.039 / 1.018 / **1.009** | 0.948 / 0.973 / **0.987** |

$O(h^2)$ in space for P1 and $O(\Delta t)$ in time for backward Euler, on both HJB branches.

The steady/time split is not cosmetic: with a steady $u^\*$ the time term vanishes identically, so
backward Euler is exact and the residual is purely spatial.

**A trap the test file now pins.** The first temporal fixture was `a(t) = 1 + (T - t)` — linear in
$t$. Backward Euler's truncation error is $(\Delta t/2)\,u_{tt}$, identically zero there, so the
study measured the spatial floor and reported **order 0.02 from a correct implementation**.
`test_the_time_fixture_is_not_degenerate` asserts $u_{tt} \neq 0$, because a fixture that cannot
express the error is indistinguishable from a scheme that has none.

Mutation-checked: flipping the manufactured source's sign, making the time fixture linear again, and
zeroing the solver's source application each fail the expected test.

## The gate

An abstract method's signature is a **declaration** and Python does not enforce it — a subclass may
override with `(*args, **kwargs)` and nothing checks. That is the structural reason this could exist
unnoticed, and it is not fixed by threading the parameter.

`BaseHJBSolver` and `BaseFPSolver` now validate overrides at class-definition time: **an override
that accepts `**kwargs` must NAME `source_term` and `volatility_field`.**

Scoped to those two because they have the incident history (#1424, #2020; #1316, #1783). A blanket
"name every declared parameter" rule is **not satisfiable** — the base declares
`m_initial_condition` while seven implementations use `M_initial` and three use `m_initial`, so it
would be a rename, not a gate. Solvers without `**kwargs` are untouched: an unnamed parameter there
already raises `TypeError`, which is loud.

A solver that cannot support a parameter still names it and raises inside — which is what
`HJBWENOSolver` does for multi-D `source_term`. Refusal is a behaviour; an absent signature is not.

## Two #1783 tests repaired, with more coverage than before

They asserted the meshless pair is **refused** a `volatility_field`, guarded by *"this solver must be
the `**kwargs` shape, or the test does not exercise the hole"* — i.e. they depended on a production
solver keeping a hole, and the author flagged it.

Naming the parameter closes that hole, and the solver was never unable to consume the field:

| `volatility_field` | movement vs the `sigma=0.3` default |
|---|---|
| `0.3` | **0.000000e+00** — correct no-op |
| `0.9` | 4.369684e-01 |
| array 0.5→0.9 | 2.846775e-01 |

So the gate should now **forward** to this pair, and does — pinned by spying on both sides. The
refusal half moved to a **stub** that really has the `**kwargs` shape, deliberately not a
`BaseHJBSolver` subclass (the new gate refuses that shape at class definition, and the coupling layer
duck-types). That also stops this test being invalidated again by the next solver that widens its
signature.

One detail worth flagging for review: the spies use `functools.wraps`, and it is **load-bearing**.
The gate reads `inspect.signature` of what it is about to call, so a bare wrapper presents
`(*args, **kwargs)` and is itself refused — the instrument measuring itself. That cost one red gate
run to find.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.

Refs #2020 #2023 #1424 #1783 #1316