### PR TITLE
fix: the classifier's population excluded where the branches were

### DIFF
--- a/changelog.d/classifier-population-and-squash-claim.fixed.md
+++ b/changelog.d/classifier-population-and-squash-claim.fixed.md
@@ -1,0 +1,21 @@
+Two corrections to the branch classifier, both found by pointing it at the tree it was written for.
+
+**Its population excluded where the branches were.** It enumerated `refs/heads/` only, so on
+2026-08-21 it reported "0 branch(es) show evidence of having landed" on a repository carrying
+**sixteen** remote branches whose PRs were merged. They had never been local. That is the same shape
+as the defects this repository has been chasing — a check that is not where the thing it checks lives
+— and it is invisible in the way that matters: the output is a clean report, not an error. Both
+scopes are now pooled, and the remedy line names `git push origin --delete` alongside
+`git branch -D`, since the local command does not touch origin.
+
+**The squash-merge claim was overstated.** The comment said absorption by `merge-tree --write-tree`
+"holds under a squash merge". It holds only while `main` has not since modified the same regions;
+after that the three-way merge sees both sides changing one region and conflicts, so the branch reads
+unmerged again. Measured: of the sixteen merged branches above, **eight** classify as unmerged this
+way — `fix/1986-sense-sign-one-owner` (#1987) conflicts in `problem_factories.py`, which main has
+touched twice since that branch point.
+
+The error remains a **false negative** — a landed branch kept, never an unlanded one offered for
+deletion — which is why the merged-PR name signal runs first and is the primary evidence, with this
+predicate corroborating. The limitation is pinned by a test carrying its own retirement condition, so
+the flat claim cannot be re-asserted without a failure saying otherwise.

--- a/scripts/prune_local_branches.sh
+++ b/scripts/prune_local_branches.sh
@@ -42,9 +42,19 @@ TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 #
 # `merge-tree --write-tree` answers it directly: merge the branch into origin/main and compare the
 # resulting tree with origin/main's own. Equal means the branch contributes NOTHING to main, which
-# is exactly "absorbed" -- and it holds under a squash merge, where no commit of the branch is an
-# ancestor of main and every commit-graph predicate (`rev-list --count`, `branch --merged`) says
-# unmerged. A conflict exits non-zero and is, by construction, not absorbed.
+# is exactly "absorbed". A conflict exits non-zero and is, by construction, not absorbed.
+#
+# THE SQUASH-MERGE CLAIM IS CONDITIONAL, and an earlier version of this comment stated it flatly.
+# The predicate does recognise a squash-merged branch -- where no commit is an ancestor of main and
+# every commit-graph predicate says unmerged -- but ONLY while main has not since modified the same
+# regions. Once it has, the three-way merge sees both sides changing one region and conflicts, so
+# the branch reads unmerged again. Measured 2026-08-21: of sixteen remote branches whose PRs are
+# MERGED, eight classify as unmerged by this predicate; `fix/1986-sense-sign-one-owner` (#1987)
+# conflicts in `problem_factories.py`, which main has touched twice since that branch point.
+#
+# The error stays a FALSE NEGATIVE -- a landed branch kept, never an unlanded one offered for
+# deletion -- which is why the merged-PR name signal below runs FIRST and is the primary evidence
+# for a branch that has landed. This predicate is the corroborating one, not the load-bearing one.
 #
 # Requires git >= 2.38 for `--write-tree`; checked once at startup rather than per branch, because a
 # missing subcommand would otherwise return 1 for every branch and read as "nothing is absorbed".
@@ -117,11 +127,22 @@ while read -r b; do
     CLOSED) printf '%-46s %s\n' "$b" "name contains $n, CLOSED -- closed does not mean merged" ;;
     *)      printf '%-46s %s\n' "$b" "unmerged, no reference found" ;;
   esac
-done < <(git for-each-ref refs/heads/ --format='%(refname:lstrip=2)' | grep -vx main)
+done < <(
+  # POPULATION IS BOTH SCOPES. It was `refs/heads/` alone, which is how a tree carrying sixteen
+  # remote branches whose PRs are MERGED reported "0 branch(es) show evidence of having landed" on
+  # 2026-08-21: they had never been local. A classifier whose population excludes where the branches
+  # actually are reports clean and is read as "nothing to prune".
+  { git for-each-ref refs/heads/ --format='%(refname:lstrip=2)'
+    git for-each-ref refs/remotes/origin/ --format='%(refname:lstrip=3)'
+  } | grep -vxE 'main|HEAD' | sort -u
+)
 
 echo
 echo "$(wc -l < "$TMP/disposable.txt" | tr -d ' ') branch(es) show evidence of having landed."
 echo "Read the branch before acting. Two of the three signals above are weak by construction:"
 echo "  - the merged-pr signal compares NAMES; names are reused after a merge."
 echo "  - a 3-4 digit run in a branch name may be a grid size, not an issue number."
-echo "Then: git branch -D <name>   (record the sha first -- -D discards the branch's reflog)."
+echo "A name may exist locally, on origin, or both -- the scopes are pooled above because a branch"
+echo "invisible in one of them is exactly what this script existed to miss. Delete accordingly:"
+echo "  local : git branch -D <name>            (record the sha first -- -D discards the reflog)"
+echo "  remote: git push origin --delete <name> (record the sha first -- there is no reflog there)"

--- a/tests/unit/test_prune_local_branches.py
+++ b/tests/unit/test_prune_local_branches.py
@@ -192,3 +192,89 @@ def test_the_predicate_survives_an_unrelated_nearby_edit_in_main(repo):
         "the branch's content is entirely in main -- merging it produces main's own tree -- so it "
         "is absorbed. Reporting otherwise is the reverse-apply predicate's context sensitivity."
     )
+
+
+class TestThePopulationCoversBothScopes:
+    """2026-08-21: the classifier reported "0 branch(es) show evidence of having landed" on a tree
+    carrying SIXTEEN remote branches whose PRs were merged. They had never been local, and the
+    population was `refs/heads/` alone.
+
+    That is the same shape as the defects this repo has been chasing all week -- a check that is not
+    where the thing it checks lives -- and it is invisible in exactly the way that matters: the
+    output is a clean report, not an error.
+    """
+
+    def test_a_remote_only_branch_is_in_the_population(self, repo):
+        """The load-bearing one. Nothing local; the branch exists only on origin."""
+        _git(repo, "checkout", "-qb", "remote-only")
+        (repo / "r.txt").write_text("r\n")
+        _git(repo, "add", "r.txt")
+        _git(repo, "commit", "-qm", "r")
+        _git(repo, "push", "-q", "origin", "remote-only")
+        _git(repo, "checkout", "-q", "main")
+        _git(repo, "branch", "-qD", "remote-only")
+
+        listed = subprocess.run(
+            [
+                "bash",
+                "-c",
+                '{ git for-each-ref refs/heads/ --format="%(refname:lstrip=2)"; '
+                '  git for-each-ref refs/remotes/origin/ --format="%(refname:lstrip=3)"; '
+                "} | grep -vxE 'main|HEAD' | sort -u",
+            ],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+        assert "remote-only" in listed, f"a remote-only branch must be enumerated; got {listed}"
+
+    def test_the_population_expression_in_the_script_reads_both_refs(self):
+        """Pinned against the script text, because the expression above is a copy: if the shipped
+        one narrows back to `refs/heads/` the copy keeps passing."""
+        src = _SCRIPT.read_text()
+        assert "refs/remotes/origin/" in src, "the shipped population must enumerate remote refs"
+        assert src.count("git for-each-ref refs/heads/") == 1
+        assert src.count("git for-each-ref refs/remotes/origin/") == 1
+
+    def test_the_remedy_names_the_remote_command_too(self):
+        """`git branch -D` does not touch origin. A report that pools both scopes and then offers
+        only the local command sends the reader to a no-op."""
+        src = _SCRIPT.read_text()
+        assert "git push origin --delete" in src, "the remote remedy must be stated"
+        assert "git branch -D" in src, "the local one must still be stated"
+
+
+def test_a_squash_merged_branch_stops_being_recognised_once_main_moves_on(repo):
+    """The claim this predicate CANNOT make, pinned so it is not re-asserted.
+
+    An earlier comment said absorption "holds under a squash merge". It holds only while main has
+    not since modified the same regions -- after that the three-way merge conflicts and the branch
+    reads unmerged again. Measured on the real repository: of sixteen remote branches whose PRs are
+    merged, eight classify as unmerged this way.
+
+    The error is a FALSE NEGATIVE, which is why the merged-PR name signal is the primary evidence
+    and this predicate is corroborating. This test exists so the limitation is stated by a failing
+    assertion if anyone strengthens the claim.
+    """
+    _git(repo, "checkout", "-qb", "feature")
+    (repo / "a.txt").write_text("base\nfrom-feature\n")
+    _git(repo, "commit", "-qam", "feature edit")
+
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--squash", "feature")
+    _git(repo, "commit", "-qm", "squashed")
+    # main moves on, touching the same region
+    (repo / "a.txt").write_text("base\nfrom-feature\nand-then-main\n")
+    _git(repo, "commit", "-qam", "main moves on")
+    _git(repo, "push", "-q", "origin", "main")
+    _git(repo, "fetch", "-q", "origin")
+
+    # RECORDED LIMITATION, not a contract. 1 = not absorbed, which is WRONG about this branch --
+    # its content is in main. It is kept because the error is a false negative and because stating
+    # it here is what stops the flat claim being re-asserted in `absorbed()`.
+    assert _absorbed(repo, "feature") == 1, (
+        "the predicate now recognises a squash-merged branch under a moving main. That is an "
+        "improvement, not a failure: update the conditional wording in `absorbed()` and delete this "
+        "test -- but verify against the real repository first, where eight branches with MERGED PRs "
+        "classified as unmerged on 2026-08-21"
+    )


### PR DESCRIPTION
Two corrections to #1997, both found by pointing the tool at the tree it was written for — one of
them to a claim I made in it one day earlier.

## Its population excluded where the branches were

It enumerated `refs/heads/` only. On 2026-08-21 it reported **"0 branch(es) show evidence of having
landed"** on a repository carrying **sixteen** remote branches whose PRs were merged. They had never
been local.

That is the same shape as the defects this repository has been chasing all week — a check that is not
where the thing it checks lives — and it fails in the way that matters: the output is a **clean
report**, not an error. Both scopes are pooled now, and the remedy line names
`git push origin --delete` alongside `git branch -D`, since the local command does not touch origin.

Verified after the fix: the classifier reports 16 landed, matching a manual cross-reference of
tree-absorption against PR state, branch by branch.

## The squash-merge claim was overstated

#1997's comment said absorption by `merge-tree --write-tree` *"holds under a squash merge, where no
commit of the branch is an ancestor of main"*. **It holds only while `main` has not since modified
the same regions.** After that the three-way merge sees both sides changing one region and conflicts,
so the branch reads unmerged again.

Measured: of those sixteen merged branches, **eight** classify as unmerged this way.
`fix/1986-sense-sign-one-owner` (#1987) conflicts in `problem_factories.py`, which main has touched
twice since that branch point.

The error stays a **false negative** — a landed branch kept, never an unlanded one offered for
deletion — which is why the merged-PR name signal runs first and is the primary evidence, with this
predicate corroborating rather than load-bearing. #1997's changelog already framed the direction
correctly; it was the flat "holds under squash merge" that was wrong.

The limitation is now pinned by a test carrying its **own retirement condition**, so the flat claim
cannot return without a failure saying otherwise:

```
assert _absorbed(repo, "feature") == 1, (
    "the predicate now recognises a squash-merged branch under a moving main. That is an "
    "improvement, not a failure: update the wording in `absorbed()` and delete this test -- "
    "but verify against the real repository first ..."
)
```

Four new tests: a remote-only branch is enumerated; the shipped population expression reads both
refs (pinned against the script text, because the test's own copy would keep passing if the shipped
one narrowed); the remedy names both commands; and the squash limitation above.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.

Refs #1997