### PR TITLE
fix: one `source_term` convention across the FP solvers (#2019)

### DIFF
--- a/changelog.d/2019-one-source-term-convention.fixed.md
+++ b/changelog.d/2019-one-source-term-convention.fixed.md
@@ -1,0 +1,31 @@
+`source_term` now has one calling convention across the FP solvers (#2019).
+
+`FPFVMSolver` passed `geometry.meshgrid()` — a `(d, *shape)` tuple — and accepted only a grid-shaped
+return. `FPFDMSolver` and the whole HJB side pass `geometry.get_spatial_grid()`, an `(N, d)` point
+array, and ravel/reshape what comes back. So one callback could not serve both: a source written
+against the convention `BaseHJBSolver.solve_hjb_system` documents ("x has shape (N, d)") returned an
+`(N,)` array to FVM and hit
+
+```
+ValueError: operands could not be broadcast together with shapes (21,21) (882,)
+```
+
+where 882 = 2 × 441 is the two coordinate planes flattened together. FVM is moved onto the documented
+convention on both sides — argument and return — with a fail-loud size check rather than a broadcast.
+
+**Why it survived, and why the new tests are 2-D.** In 1-D the two conventions coincide:
+`meshgrid()` gives one `(21,)` array and `get_spatial_grid()` gives `(21, 1)`, so a raveling callback
+accepts both. The fork is expressible only in `d ≥ 2` — the rule `AGENTS.md` states as "the dimension
+must be able to express the property under test", and a test records that no 1-D test could have
+caught it.
+
+**A second divergence found and deliberately left alone.** FVM evaluates the source at `k*dt` where
+FDM uses `(k+1)*dt` and calls it implicit. Measured by MMS on a pure-diffusion manufactured solution,
+the two are indistinguishable at achievable resolutions: the first refinement gives order 0.910 at
+`k*dt` against 0.847 at `t_{k+1}`, and both then degrade — as does an FDM control, to 0.343 — because
+this scheme is first order in **space** (measured 1.026 / 1.004 / 0.978) and the spatial floor
+dominates before the temporal order is visible. Changing it would be a behaviour change with no
+evidence behind it, so the measurement is recorded at the line instead.
+
+Mutation-checked: reverting to `meshgrid()` fails both FVM cases; dropping the `reshape` fails the
+one that checks the source actually moves the answer.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fvm.py
@@ -518,7 +518,18 @@ class FPFVMSolver(BaseFPSolver):
         m_solution[0] = m0
         m = m0.copy()
 
-        source_grid = self.problem.geometry.meshgrid() if source_term is not None else None
+        # (N, d) POINTS, not a (d, *shape) meshgrid. This solver was the only caller passing
+        # `geometry.meshgrid()`, while FPFDMSolver and the whole HJB side pass
+        # `get_spatial_grid()` -- the convention `BaseHJBSolver.solve_hjb_system` documents
+        # ("x has shape (N, d)"). One callback therefore could not serve both: a source written
+        # against the documented convention returned an (N,) array here and hit
+        # `ValueError: operands could not be broadcast together with shapes (21,21) (882,)`,
+        # where 882 = 2 x 441 is the two coordinate planes flattened together (#2019).
+        #
+        # In 1D the two coincide, which is why this survived: `meshgrid()` gives one (21,) array
+        # and `get_spatial_grid()` gives (21, 1), and a callback that ravels its input accepts
+        # both. The fork was only ever visible in 2D.
+        source_grid = self.problem.geometry.get_spatial_grid() if source_term is not None else None
 
         for k in range(n_steps):
             idx = min(k, field.shape[0] - 1) if field is not None else 0
@@ -535,7 +546,26 @@ class FPFVMSolver(BaseFPSolver):
             m = self._strang_step(m, alpha_faces, alpha_wrap, dt, spacing, lu)
 
             if source_term is not None:
-                m = m + dt * np.asarray(source_term(k * dt, source_grid), dtype=float)
+                # `.reshape(shape)` for the same reason: FDM ravels the return and reshapes it
+                # (`fp_fdm_time_stepping.py:611`), so a callback returning one value per point is
+                # accepted there. Without this, FVM accepted ONLY a grid-shaped return, so even a
+                # caller obeying the argument convention above still failed here (#2019).
+                # `k*dt`, where FPFDMSolver uses `(k+1)*dt` and says "implicit". That divergence
+                # is real and is deliberately NOT changed here: measured by MMS on a pure-diffusion
+                # manufactured solution, the two are indistinguishable at achievable resolutions.
+                # First refinement (Nt 5 -> 10) gives order 0.910 at k*dt against 0.847 at t_{k+1},
+                # and both then degrade -- as does an FDM control, to 0.343 -- because this scheme
+                # is first order in SPACE (measured 1.026 / 1.004 / 0.978) and the spatial floor
+                # dominates before the temporal order is visible. Changing it would be a behaviour
+                # change with no evidence behind it.
+                s_vals = np.asarray(source_term(k * dt, source_grid), dtype=float).ravel()
+                if s_vals.size != m.size:
+                    raise ValueError(
+                        f"source_term returned {s_vals.size} values for {m.size} cells. It is "
+                        f"called with an (N, d) point array from geometry.get_spatial_grid() and "
+                        f"must return one value per point (#2019)."
+                    )
+                m = m + dt * s_vals.reshape(shape)
 
             if not np.all(np.isfinite(m)):
                 n_bad = int(np.sum(~np.isfinite(m)))

--- a/tests/unit/test_alg/test_source_term_convention_2019.py
+++ b/tests/unit/test_alg/test_source_term_convention_2019.py
@@ -1,0 +1,122 @@
+"""Issue #2019: `source_term` had two incompatible calling conventions across the FP solvers.
+
+`FPFVMSolver` passed `geometry.meshgrid()` — a `(d, *shape)` tuple — and accepted only a
+grid-shaped return. `FPFDMSolver` and the whole HJB side pass `geometry.get_spatial_grid()`, an
+`(N, d)` point array, and ravel/reshape the return. So one callback could not serve both: a source
+written against the convention `BaseHJBSolver.solve_hjb_system` documents ("x has shape (N, d)")
+returned an `(N,)` array to FVM and hit
+
+    ValueError: operands could not be broadcast together with shapes (21,21) (882,)
+
+where 882 = 2 x 441 is the two coordinate planes flattened together.
+
+WHY IT SURVIVED, AND WHY THE TESTS BELOW ARE 2-D
+------------------------------------------------
+In 1-D the two conventions coincide: `meshgrid()` gives one `(21,)` array and `get_spatial_grid()`
+gives `(21, 1)`, so a callback that ravels its input accepts both and the fork is invisible. It is
+expressible only in `d >= 2` — the rule `AGENTS.md` states as "the dimension must be able to express
+the property under test".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+_L, _T, _SIGMA = 1.0, 0.2, 0.4
+_D = 0.5 * _SIGMA**2
+
+
+def _problem(dim, n, nt):
+    grid = TensorProductGrid(
+        bounds=[(0.0, _L)] * dim, Nx_points=[n] * dim, boundary_conditions=no_flux_bc(dimension=dim)
+    )
+    return MFGProblem(
+        geometry=grid,
+        T=_T,
+        Nt=nt,
+        sigma=_SIGMA,
+        coupling_coefficient=0.0,
+        components=MFGComponents(
+            # Per-point callables returning a float: what the 2-D validator accepts.
+            m_initial=lambda p: 1.0,
+            u_terminal=lambda p: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: np.asarray(m) * 0.0,
+                coupling_dm=lambda m: np.asarray(m) * 0.0,
+            ),
+        ),
+    )
+
+
+def _solvers():
+    from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+    from mfgarchon.alg.numerical.fp_solvers.fp_fvm import FPFVMSolver
+
+    return (("FPFDMSolver", FPFDMSolver), ("FPFVMSolver", FPFVMSolver))
+
+
+@pytest.mark.parametrize(("name", "cls"), _solvers(), ids=[n for n, _ in _solvers()])
+def test_the_documented_point_array_convention_works_in_2d(name, cls):
+    """One callback, both solvers, `d = 2`. This is the assertion #2019 is about."""
+    n = 11
+    problem = _problem(2, n, 4)
+    solver = cls(problem)
+    seen: dict[str, tuple] = {}
+
+    def source(_t, x):
+        a = np.asarray(x, dtype=float)
+        seen["shape"] = a.shape
+        # The documented convention: (N, d) in, one value per point out.
+        return np.full(a.shape[0], 1.0)
+
+    m0 = np.ones(n * n) / (n * n)
+    out = np.asarray(solver.solve_fp_system(m0.reshape(n, n), potential_field=None, source_term=source))
+    assert seen.get("shape") == (n * n, 2), (
+        f"{name} called the source with shape {seen.get('shape')}, not the documented (N, d). "
+        f"A (d, *shape) meshgrid is the #2019 fork."
+    )
+    assert np.all(np.isfinite(out))
+
+
+@pytest.mark.parametrize(("name", "cls"), _solvers(), ids=[n for n, _ in _solvers()])
+def test_the_source_actually_moves_the_answer(name, cls):
+    """Accepting the convention is not the same as using what it delivers. Constant source S over
+    time T adds S*T to the total, which is checkable in closed form."""
+    n, nt = 11, 8
+    problem = _problem(2, n, nt)
+    solver = cls(problem)
+    m0 = (np.ones(n * n) / (n * n)).reshape(n, n)
+
+    base = np.asarray(solver.solve_fp_system(m0.copy(), potential_field=None))
+    forced = np.asarray(
+        solver.solve_fp_system(
+            m0.copy(), potential_field=None, source_term=lambda _t, x: np.full(np.asarray(x).shape[0], 2.0)
+        )
+    )
+    delta = float(np.abs(forced[-1] - base[-1]).max())
+    assert delta == pytest.approx(2.0 * _T, rel=0.25), (
+        f"{name}: a constant source of 2.0 over T={_T} should raise the density by ~{2.0 * _T}; measured {delta:.4e}"
+    )
+
+
+def test_the_fork_is_invisible_in_1d_which_is_why_it_survived():
+    """Recorded rather than asserted about the library: in 1-D both conventions produce an input a
+    raveling callback accepts, so no 1-D test could have caught this."""
+    grid1 = TensorProductGrid(bounds=[(0.0, _L)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    grid2 = TensorProductGrid(bounds=[(0.0, _L)] * 2, Nx_points=[21] * 2, boundary_conditions=no_flux_bc(dimension=2))
+    assert np.asarray(grid1.get_spatial_grid()).ravel().size == np.asarray(grid1.meshgrid()).ravel().size
+    assert np.asarray(grid2.get_spatial_grid()).ravel().size == np.asarray(grid2.meshgrid()).ravel().size
+    # Same total size in both dimensions -- so size alone never discriminates. The SHAPE does, and
+    # only in 2-D does a raveling callback produce a length the other convention rejects.
+    assert np.asarray(grid1.get_spatial_grid()).shape[0] == 21
+    assert np.asarray(grid2.get_spatial_grid()).shape[0] == 441
+    assert np.asarray(grid2.meshgrid()).shape == (2, 21, 21)


### PR DESCRIPTION
Closes #2019.

`FPFVMSolver` passed `geometry.meshgrid()` — a `(d, *shape)` tuple — and accepted only a grid-shaped
return. `FPFDMSolver` and the whole HJB side pass `get_spatial_grid()`, an `(N, d)` point array, and
ravel/reshape the return. **One callback could not serve both**: a source written against the
convention `BaseHJBSolver.solve_hjb_system` documents returned an `(N,)` array to FVM and hit

```
ValueError: operands could not be broadcast together with shapes (21,21) (882,)
```

882 = 2 × 441, the two coordinate planes flattened together. FVM moves onto the documented
convention on both sides, with a fail-loud size check rather than a broadcast.

Before / after, the 2×2 that isolates it:

| | 1D no-src | 1D +src | 2D no-src | 2D +src |
|---|---|---|---|---|
| FVM before | OK | OK | OK | **ValueError** |
| FVM after | OK | OK | OK | **OK** |
| FDM (control) | OK | OK | OK | OK |

## Why it survived, and why the tests are 2-D

In 1-D the conventions coincide — `meshgrid()` gives one `(21,)` array, `get_spatial_grid()` gives
`(21, 1)` — so a raveling callback accepts both and the fork is invisible. It is expressible only in
`d ≥ 2`. A test records that explicitly, so nobody adds a 1-D regression test believing it covers
this.

## A second divergence, found and deliberately left alone

FVM evaluates the source at `k*dt` where FDM uses `(k+1)*dt` and calls it implicit. Measured by MMS
on a pure-diffusion manufactured solution:

| | first refinement | then |
|---|---|---|
| FVM, source at `k*dt` (shipped) | 0.910 | 0.848 → 0.728 |
| FVM, source at `t_{k+1}` (FDM's) | 0.847 | 0.778 → 0.636 |
| **FDM control** | **0.695** | 0.531 → **0.343** |

The FDM control degrading to 0.343 is the tell: all three are measuring the **spatial** floor, not a
temporal order — this scheme is first order in space (1.026 / 1.004 / 0.978) and `n=400` already puts
the spatial error at the same magnitude. So the two time levels are **indistinguishable at achievable
resolutions**, and changing it would be a behaviour change with no evidence behind it. The
measurement is recorded at the line so the divergence is not re-litigated from scratch.

## Discrimination

Reverting to `meshgrid()` fails both FVM cases; dropping the `reshape` fails the one that checks the
source actually moves the answer (a constant source `S` over `T` must raise the density by `S·T`).

Gate: `./scripts/local_ci.sh` **GATE GREEN**.