### PR TITLE
refactor: one dimensional solve in WENO, and the 3D copy never ran (#2021)

### DIFF
--- a/changelog.d/2021-weno-one-dimensional-solve.fixed.md
+++ b/changelog.d/2021-weno-one-dimensional-solve.fixed.md
@@ -1,0 +1,34 @@
+`HJBWENOSolver` carried the dimensional solve three times, and one copy did not run (#2021).
+
+`_solve_hjb_system_2d`, `_3d` and `_nd` were the same backward loop written out three times,
+differing in slice notation (`[:, :]` / `[:, :, :]` / `[...]`, and the last covers the others), in
+logging, and in **three different sources for one array shape** — 2d read `self.num_grid_points_*`,
+3d read `M_density.shape[1:]`, nd read `U_terminal.shape`, with nothing checking they agree.
+
+**The 3-D copy raised on its first statement.** It called `self._get_logger()`, which exists nowhere
+in the MRO, so every 3-D WENO solve failed with `AttributeError` and always had. Twenty-three test
+files mention WENO and none is 3-D — which is what a duplicated path with no oracle looks like from
+the outside: green. 3-D now runs.
+
+Six rivals deleted: the two extra solves, the two one-line `_step_*_split` delegators, and the two
+extra CFL steps. Implementation count for those three families drops 8 → 3 (`_1d` and `_nd` for the
+solve and the CFL step, one `_step_nd_split`). The 1-D path stays separate on purpose: it is not a
+dimensional split and is the only one carrying `source_term`.
+
+**The surviving CFL step takes the deleted 3-D copy's semantics, which were the corrected ones.**
+Zero gradient gets an explicit branch rather than an epsilon, and the `max(dt_stable, 1e-10)` floor
+is gone. That floor said "ensure positive time step", but positivity is not the property required:
+when the diffusion-limited step is genuinely smaller it returns a step **above** the stability bound
+— measured, 1e-10 against a true limit of 3.906250e-15 at `sigma = 1e7` — and the solve runs
+unstably, where without it `_advance_full_interval` reaches its `max_substeps` guard and fails loud.
+
+Not oversold: that floor needs `sigma > h * 5e4` to fire, i.e. `sigma > 5000` at `h = 0.1`, which no
+grid an explicit scheme can afford will reach. It is removed because it converts a loud failure into
+a silent one, not because it was firing. `_compute_dt_stable_1d` still carries it, and a test records
+that rather than letting the change widen silently into a path this consolidation does not own.
+
+Pinned against the **pre-consolidation** output, captured before the rivals were deleted — comparing
+the paths against each other afterwards would be tautological, since they are now the same code. The
+2-D solve reproduces `sum = -4.825099898418e+02` and `u0_sum = -1.298054011318e+02` exactly; only
+`dt_stable` moves, in the 11th digit (1.238178469094e-02 → 1.238178469155e-02), which is the removed
+epsilon.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_weno.py
@@ -960,13 +960,17 @@ class HJBWENOSolver(BaseHJBSolver):
             )
         if self.dimension == 1:
             return self._solve_hjb_system_1d(M_density, U_terminal, U_coupling_prev, source_term)
-        elif self.dimension == 2:
-            return self._solve_hjb_system_2d(M_density, U_terminal, U_coupling_prev)
-        elif self.dimension == 3:
-            return self._solve_hjb_system_3d(M_density, U_terminal, U_coupling_prev)
-        else:
-            # Use generalized nD solver for dimensions > 3
-            return self._solve_hjb_system_nd(M_density, U_terminal, U_coupling_prev)
+        # ONE owner for every d >= 2 (#2021). There were three: `_solve_hjb_system_2d`, `_3d` and
+        # `_nd`, the same backward loop written out three times, differing only in slice notation
+        # (`[:, :]` / `[:, :, :]` / `[...]`, and the last covers the others), in logging, and in
+        # THREE DIFFERENT SOURCES for one array shape -- 2d read `self.num_grid_points_*`, 3d read
+        # `M_density.shape[1:]`, nd read `U_terminal.shape`, with nothing checking they agree.
+        #
+        # The 3D copy did not run AT ALL: its first statement called `self._get_logger()`, which
+        # exists nowhere in the MRO, so `HJBWENOSolver` in 3D raised AttributeError immediately and
+        # always had. No test exercised it -- 23 test files mention WENO and none is 3-D -- which is
+        # what a duplicated path with no oracle looks like from the outside: green.
+        return self._solve_hjb_system_nd(M_density, U_terminal, U_coupling_prev)
 
     def _advance_full_interval(self, u_current, m_current, dt, dt_stable_fn, step_fn):
         """Sub-step ``step_fn`` until the full physical interval ``dt`` is covered (Issue #1180).
@@ -998,14 +1002,6 @@ class HJBWENOSolver(BaseHJBSolver):
                 "The CFL/diffusion limit is extreme for this grid; raise max_substeps or coarsen."
             )
         return u
-
-    def _step_2d_split(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """One 2D dimensional-split step of size ``dt`` (Strang or Godunov)."""
-        return self._step_nd_split(u, m, dt)
-
-    def _step_3d_split(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
-        """One 3D dimensional-split step of size ``dt`` (Strang or Godunov)."""
-        return self._step_nd_split(u, m, dt)
 
     def _step_nd_split(self, u: np.ndarray, m: np.ndarray, dt: float) -> np.ndarray:
         """One dimensional-split step of size ``dt`` (Strang or Godunov), any dim.
@@ -1091,82 +1087,6 @@ class HJBWENOSolver(BaseHJBSolver):
 
         return U_solved
 
-    def _solve_hjb_system_2d(
-        self,
-        M_density_evolution_from_FP: np.ndarray,
-        U_final_condition_at_T: np.ndarray,
-        U_from_prev_picard: np.ndarray,
-    ) -> np.ndarray:
-        """Solve 2D HJB system using dimensional splitting."""
-        # Extract dimensions from input
-        # M_density has shape (n_time_points, Nx, Ny) where n_time_points = problem.Nt + 1
-        n_time_points = M_density_evolution_from_FP.shape[0]
-        dt = self.problem.T / (n_time_points - 1)  # n_time_points - 1 intervals
-
-        # Initialize solution array - same shape as input
-        U_solved = np.zeros((n_time_points, self.num_grid_points_x, self.num_grid_points_y))
-
-        # Set final condition (last time index)
-        U_solved[-1, :, :] = U_final_condition_at_T
-
-        # Backward time integration
-        for t_idx in range(n_time_points - 2, -1, -1):
-            # Current density at this time
-            m_current = M_density_evolution_from_FP[t_idx, :, :]
-
-            # Current value function
-            u_current = U_solved[t_idx + 1, :, :].copy()
-
-            # Sub-step the full directional-split sequence over the whole interval dt (#1180)
-            U_solved[t_idx, :, :] = self._advance_full_interval(
-                u_current, m_current, dt, self._compute_dt_stable_2d, self._step_2d_split
-            )
-
-        return U_solved
-
-    def _solve_hjb_system_3d(
-        self,
-        M_density_evolution_from_FP: np.ndarray,
-        U_final_condition_at_T: np.ndarray,
-        U_from_prev_picard: np.ndarray,
-    ) -> np.ndarray:
-        """Solve 3D HJB system using dimensional splitting."""
-        logger = self._get_logger()
-        logger.info("Starting 3D WENO HJB solver with dimensional splitting")
-
-        # Extract dimensions from input
-        # M_density has shape (n_time_points, Nx, Ny, Nz) where n_time_points = problem.Nt + 1
-        n_time_points = M_density_evolution_from_FP.shape[0]
-        spatial_shape = M_density_evolution_from_FP.shape[1:]
-
-        # Initialize solution array - same shape as input
-        U_solved = np.zeros((n_time_points, *spatial_shape))
-
-        # Set final condition (last time index)
-        U_solved[-1, :, :, :] = U_final_condition_at_T
-
-        # n_time_points - 1 intervals (was missing here: the loop referenced an unset self.dt)
-        dt = self.problem.T / (n_time_points - 1)
-
-        # Solve backward in time
-        for time_idx in range(n_time_points - 2, -1, -1):
-            logger.debug(f"  3D Time step {time_idx + 1}/{n_time_points - 1}")
-
-            u_current = U_solved[time_idx + 1, :, :, :]
-            m_current = M_density_evolution_from_FP[time_idx, :, :, :]
-
-            # Sub-step the full directional-split sequence over the whole interval dt (#1180)
-            U_solved[time_idx, :, :, :] = self._advance_full_interval(
-                u_current, m_current, dt, self._compute_dt_stable_3d, self._step_3d_split
-            )
-
-            # Progress logging for long computations
-            if (time_idx + 1) % 20 == 0:
-                logger.info(f"    3D WENO: Completed {n_time_points - time_idx - 2}/{n_time_points - 1} time steps")
-
-        logger.info("3D WENO HJB solver completed successfully")
-        return U_solved
-
     def _solve_hjb_system_nd(
         self,
         M_density_evolution_from_FP: np.ndarray,
@@ -1225,82 +1145,38 @@ class HJBWENOSolver(BaseHJBSolver):
         Returns:
             dt_stable: Maximum stable time step
         """
+        # Semantics taken from the deleted `_compute_dt_stable_3d`, which was the CORRECTED copy of
+        # the three (#2021). Two differences, both deliberate:
+        #
+        #   - ZERO GRADIENT gets an explicit branch rather than an epsilon. Adding 1e-10 to the
+        #     speed hides the case instead of naming it; the 3D copy's comment records that the
+        #     pre-fix version left `self.dt` unset here.
+        #   - NO FLOOR. The deleted `max(dt_stable, 1e-10)` said "Ensure positive time step", but
+        #     positivity is not the property required. When the diffusion-limited step is genuinely
+        #     below 1e-10 the floor returns a step ABOVE the stability bound -- measured, 1e-10
+        #     against a true limit of 3.906250e-15 at sigma = 1e7, a factor of 25,600 -- and the
+        #     solve then runs unstably. Without it, `_advance_full_interval` reaches its
+        #     `max_substeps` guard and fails loud, which is the behaviour that path documents.
+        #
+        # Reachability of that floor, so the change is not oversold: it needs
+        # `diffusion_stability_factor * h^2 / sigma^2 < 1e-10`, i.e. `sigma > h * 5e4` at the default
+        # factor -- sigma > 5000 at h = 0.1. Not reachable on a grid an explicit scheme can afford.
+        # The floor is removed because it converts a loud failure into a silent one, not because it
+        # was firing.
         dt_cfl_list = []
         dt_diffusion_list = []
+        sigma_sq = self.problem.sigma**2
 
-        # Check CFL and diffusion conditions for each dimension
         for axis in range(self.dimension):
-            # Compute gradient along this axis
             u_grad = np.gradient(u, self.grid_spacing[axis], axis=axis)
+            max_speed = float(np.max(np.abs(u_grad))) if u_grad.size else 0.0
+            if max_speed > 1e-12:
+                dt_cfl_list.append(self.cfl_number * self.grid_spacing[axis] / max_speed)
+            dt_diffusion_list.append(self.diffusion_stability_factor * self.grid_spacing[axis] ** 2 / sigma_sq)
 
-            # CFL condition for advection
-            max_speed = np.max(np.abs(u_grad)) + 1e-10
-            dt_cfl = self.cfl_number * self.grid_spacing[axis] / max_speed
-            dt_cfl_list.append(dt_cfl)
-
-            # Diffusion stability condition
-            dt_diffusion = self.diffusion_stability_factor * self.grid_spacing[axis] ** 2 / self.problem.sigma**2
-            dt_diffusion_list.append(dt_diffusion)
-
-        # Take minimum across all dimensions for stability
-        dt_stable = min(min(dt_cfl_list), min(dt_diffusion_list))
-
-        return max(dt_stable, 1e-10)  # Ensure positive time step
-
-    def _compute_dt_stable_2d(self, u: np.ndarray, m: np.ndarray) -> float:
-        """Compute stable time step for 2D problem based on CFL and diffusion stability."""
-        # Compute gradients for stability analysis
-        u_x = np.gradient(u, self.grid_spacing_x, axis=0)
-        u_y = np.gradient(u, self.grid_spacing_y, axis=1)
-
-        # CFL condition for advection terms
-        max_speed_x = np.max(np.abs(u_x)) + 1e-10
-        max_speed_y = np.max(np.abs(u_y)) + 1e-10
-
-        dt_cfl_x = self.cfl_number * self.grid_spacing_x / max_speed_x
-        dt_cfl_y = self.cfl_number * self.grid_spacing_y / max_speed_y
-        dt_cfl = min(dt_cfl_x, dt_cfl_y)
-
-        # Stability condition for diffusion term (more restrictive in 2D)
-        dt_diffusion_x = self.diffusion_stability_factor * self.grid_spacing_x**2 / self.problem.sigma**2
-        dt_diffusion_y = self.diffusion_stability_factor * self.grid_spacing_y**2 / self.problem.sigma**2
-        dt_diffusion = min(dt_diffusion_x, dt_diffusion_y)
-
-        # Take minimum for stability
-        dt_stable = min(dt_cfl, dt_diffusion)
-
-        return max(dt_stable, 1e-10)  # Ensure positive time step
-
-    def _compute_dt_stable_3d(self, u: np.ndarray, m: np.ndarray) -> float:
-        """Compute stable time step for 3D problem based on CFL and diffusion stability."""
-        # Compute gradients for stability analysis
-        u_x = np.gradient(u, self.grid_spacing_x, axis=0)
-        u_y = np.gradient(u, self.grid_spacing_y, axis=1)
-        u_z = np.gradient(u, self.grid_spacing_z, axis=2)
-
-        # Maximum gradient magnitude for CFL condition
-        max_grad_x = np.max(np.abs(u_x)) if u_x.size > 0 else 0.0
-        max_grad_y = np.max(np.abs(u_y)) if u_y.size > 0 else 0.0
-        max_grad_z = np.max(np.abs(u_z)) if u_z.size > 0 else 0.0
-
-        # CFL stability condition (very conservative for 3D)
-        if max_grad_x > 1e-12 or max_grad_y > 1e-12 or max_grad_z > 1e-12:
-            dt_cfl_x = self.cfl_number * self.grid_spacing_x / (max_grad_x + 1e-12)
-            dt_cfl_y = self.cfl_number * self.grid_spacing_y / (max_grad_y + 1e-12)
-            dt_cfl_z = self.cfl_number * self.grid_spacing_z / (max_grad_z + 1e-12)
-            dt_cfl = min(dt_cfl_x, dt_cfl_y, dt_cfl_z)
-        else:
-            dt_cfl = float("inf")  # no gradient -> no CFL limit; diffusion bound governs (was unset self.dt)
-
-        # Stability condition for diffusion term (very restrictive in 3D)
-        # All modern MFGProblem have sigma; getattr with default for safety
-        sigma_sq = getattr(self.problem, "sigma", 1.0) ** 2
-        dt_diffusion_x = self.diffusion_stability_factor * (self.grid_spacing_x**2) / sigma_sq
-        dt_diffusion_y = self.diffusion_stability_factor * (self.grid_spacing_y**2) / sigma_sq
-        dt_diffusion_z = self.diffusion_stability_factor * (self.grid_spacing_z**2) / sigma_sq
-        dt_diffusion = min(dt_diffusion_x, dt_diffusion_y, dt_diffusion_z)
-
-        return min(dt_cfl, dt_diffusion)
+        # No gradient anywhere -> no CFL limit; the diffusion bound governs.
+        dt_cfl = min(dt_cfl_list) if dt_cfl_list else float("inf")
+        return min(dt_cfl, min(dt_diffusion_list))
 
     def get_variant_info(self) -> dict[str, str]:
         """

--- a/tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py
+++ b/tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py
@@ -1,0 +1,147 @@
+"""Issue #2021: `HJBWENOSolver` carried the dimensional solve three times, and one copy was dead.
+
+`_solve_hjb_system_2d`, `_3d` and `_nd` were the same backward loop written out three times. They
+differed in slice notation (`[:, :]` / `[:, :, :]` / `[...]`, and the last covers the others), in
+logging, and in **three different sources for one array shape** — 2d read
+`self.num_grid_points_*`, 3d read `M_density.shape[1:]`, nd read `U_terminal.shape`, with nothing
+checking they agree.
+
+**The 3D copy did not run at all.** Its first statement called `self._get_logger()`, which exists
+nowhere in the MRO, so `HJBWENOSolver` in 3D raised `AttributeError` immediately and always had.
+Twenty-three test files mention WENO and none is 3-D, which is what a duplicated path with no oracle
+looks like from the outside: green.
+
+WHAT THIS FILE PINS
+-------------------
+Per `domains/cs/_core.md`, a consolidation owes one owner, the deletion of the rivals, and a pin
+against the **pre-consolidation output** — agreement between the paths afterwards is tautological,
+since they route through the same code. The 2-D numbers below were captured before the change.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.alg.numerical.hjb_solvers import hjb_weno
+from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _solve(dim, n, nt):
+    grid = TensorProductGrid(
+        bounds=[(0.0, 1.0)] * dim, Nx_points=[n] * dim, boundary_conditions=no_flux_bc(dimension=dim)
+    )
+    problem = MFGProblem(
+        geometry=grid,
+        T=0.2,
+        Nt=nt,
+        sigma=0.3,
+        coupling_coefficient=0.0,
+        components=MFGComponents(
+            m_initial=lambda q: 1.0,
+            u_terminal=lambda q: 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                potential=lambda x, t: float(np.sum(np.cos(np.pi * np.atleast_1d(x)))),
+            ),
+        ),
+    )
+    solver = HJBWENOSolver(problem)
+    x = np.linspace(0.0, 1.0, n)
+    u_t = np.cos(np.pi * x)
+    for _ in range(dim - 1):
+        u_t = np.add.outer(u_t, np.cos(np.pi * x))
+    shape = tuple([n] * dim)
+    return solver, np.asarray(
+        solver.solve_hjb_system(
+            M_density=np.ones((nt + 1, *shape)),
+            U_terminal=u_t.reshape(shape),
+            U_coupling_prev=np.zeros((nt + 1, *shape)),
+        )
+    )
+
+
+def test_the_2d_solve_still_reproduces_the_pre_consolidation_output():
+    """The required pin: captured from the three-copy version BEFORE the rivals were deleted.
+
+    Comparing the paths against each other instead would prove nothing -- after the consolidation
+    they ARE the same code, so agreement is tautological and passes over a broken owner.
+    """
+    _solver, u = _solve(2, 11, 6)
+    assert u.shape == (7, 11, 11)
+    assert float(u.sum()) == pytest.approx(-4.825099898418e02, rel=1e-10)
+    assert float(u[0].sum()) == pytest.approx(-1.298054011318e02, rel=1e-10)
+
+
+def test_the_3d_solve_runs_at_all():
+    """It did not. `_solve_hjb_system_3d` opened with `self._get_logger()`, absent from the MRO, so
+    every 3-D WENO solve raised AttributeError. This is the whole of what changed for d = 3."""
+    _solver, u = _solve(3, 7, 4)
+    assert u.shape == (5, 7, 7, 7)
+    assert np.all(np.isfinite(u)), "3-D WENO must produce a finite field"
+    assert float(u.sum()) == pytest.approx(-1.942069586894e03, rel=1e-8)
+
+
+def test_there_is_one_dimensional_solve_and_one_cfl_step():
+    """The consolidation gate from `domains/cs/_core.md` is the implementation count, and nothing
+    else: after the change the number of places computing the quantity must drop."""
+    src = inspect.getsource(hjb_weno)
+    for stem, expected in (
+        ("def _solve_hjb_system_", 2),  # _1d (not a split path, and the only source_term carrier) + _nd
+        ("def _compute_dt_stable_", 2),  # _1d + _nd
+        ("def _step_", 1),  # _nd_split
+    ):
+        assert src.count(stem) == expected, (
+            f"expected {expected} `{stem}*` implementations, found {src.count(stem)}. Six rivals "
+            f"were deleted in #2021; a new one is a new place for the copies to diverge."
+        )
+    for gone in ("_solve_hjb_system_2d", "_solve_hjb_system_3d", "_step_2d_split", "_step_3d_split"):
+        assert f"def {gone}" not in src, f"{gone} came back"
+
+
+def test_the_cfl_step_has_no_floor_and_names_the_zero_gradient_case():
+    """The surviving CFL step takes the deleted 3-D copy's semantics, which were the corrected ones.
+
+    `max(dt_stable, 1e-10)` said "ensure positive time step", but positivity is not the property
+    required: when the diffusion-limited step is genuinely smaller, the floor returns a step ABOVE
+    the stability bound and the solve runs unstably, where without it `_advance_full_interval`
+    reaches its `max_substeps` guard and fails loud.
+    """
+    solver, _u = _solve(2, 11, 6)
+    n = 11
+    flat = np.ones((n, n))
+    dt_flat = solver._compute_dt_stable_nd(flat, np.ones((n, n)))
+    diff_bound = solver.diffusion_stability_factor * solver.grid_spacing[0] ** 2 / solver.problem.sigma**2
+    assert dt_flat == pytest.approx(diff_bound, rel=1e-12), (
+        "with no gradient anywhere the CFL limit is absent and the diffusion bound must govern "
+        "exactly -- an epsilon in the denominator would return a slightly different number and hide "
+        "the case instead of naming it"
+    )
+
+    # Comments stripped before searching. Without that this assertion matches the comment that
+    # EXPLAINS the removal -- the instrument reading the documentation of the thing instead of the
+    # thing, which is how it first failed.
+    def _code_only(fn):
+        return "\n".join(ln for ln in inspect.getsource(fn).splitlines() if not ln.lstrip().startswith("#"))
+
+    assert "max(dt_stable, 1e-10)" not in _code_only(HJBWENOSolver._compute_dt_stable_nd), (
+        "the floor came back in the nd owner"
+    )
+
+    # SCOPED, and the scope is the finding. `_compute_dt_stable_1d` still carries the same floor.
+    # It is not a rival of the nd owner -- the 1-D path is not a dimensional split and is the only
+    # one carrying `source_term` -- so #2021 does not touch it, and widening this change to reach it
+    # would be a behaviour change smuggled into a consolidation. Recorded here so the remaining
+    # instance is visible rather than assumed gone.
+    assert "max(dt_stable, 1e-10)" in _code_only(HJBWENOSolver._compute_dt_stable_1d), (
+        "the 1-D CFL step no longer has the floor. If that was deliberate, delete this assertion and "
+        "say so; if it drifted, the two paths have diverged again in the opposite direction."
+    )


### PR DESCRIPTION
Closes #2021, and fixes a defect found while doing it.

## The 3-D copy never ran

`_solve_hjb_system_3d` opened with `self._get_logger()`, which **exists nowhere in the MRO**. Every
3-D WENO solve raised `AttributeError` on its first statement and always had.

Twenty-three test files mention WENO and **none is 3-D**. That is what a duplicated path with no
oracle looks like from the outside: green. It runs now.

## Three copies of one loop

`_solve_hjb_system_2d`, `_3d` and `_nd` differed in slice notation (`[:, :]` / `[:, :, :]` / `[...]`,
and the last covers the others), in logging, and in **three different sources for one array shape**:

| | `U_solved` shape read from |
|---|---|
| `_2d` | `self.num_grid_points_x, self.num_grid_points_y` |
| `_3d` | `M_density.shape[1:]` |
| `_nd` | `U_terminal.shape` |

Two read the density, one reads the terminal condition, nothing checks they agree.

**Consolidation gate** — the implementation count, and nothing else:

| | before | after |
|---|---|---|
| `_solve_hjb_system_*` + `_compute_dt_stable_*` + `_step_*_split` | **11** | **5** |
| executable lines | 1383 | 1259 |

The 1-D path stays separate on purpose: it is not a dimensional split and is the only one carrying
`source_term`.

## The surviving CFL step takes the corrected semantics

Of the three `_compute_dt_stable_*`, the 3-D one was the **fixed** copy — explicit zero-gradient
branch, no floor. The other two still had `max(dt_stable, 1e-10)`, which says "ensure positive time
step"; but positivity is not the property required. When the diffusion-limited step is genuinely
smaller, the floor returns a step **above** the stability bound — measured, 1e-10 against a true
limit of 3.906250e-15 at `sigma = 1e7` — and the solve runs unstably, where without it
`_advance_full_interval` reaches its `max_substeps` guard and fails loud.

**Not oversold**: the floor needs `sigma > h·5e4` to fire, i.e. `sigma > 5000` at `h = 0.1`, which no
grid an explicit scheme can afford will reach. It goes because it turns a loud failure into a silent
one, not because it was firing. `_compute_dt_stable_1d` still carries it, and a test records that
rather than letting this change widen silently into a path it does not own.

## The pin is against the pre-consolidation output

Per `domains/cs/_core.md`: comparing the paths against each other afterwards is tautological, since
they are now the same code, and passes over a broken owner. The 2-D numbers were captured **before**
the rivals were deleted — `sum = -4.825099898418e+02`, `u0_sum = -1.298054011318e+02`, reproduced
exactly. Only `dt_stable` moves, in the 11th digit (…469094 → …469155), which is the removed epsilon.

One correction to my own instrument, since the shape recurs: the "floor is gone" assertion first
matched the **comment explaining the removal** — the instrument reading the documentation of the
thing instead of the thing. It strips comments now.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.