### PR TITLE
fix: one owner for `jax_enable_x64`, and the conflict is now visible (#1923)

### DIFF
--- a/changelog.d/1923-one-x64-owner.fixed.md
+++ b/changelog.d/1923-one-x64-owner.fixed.md
@@ -1,0 +1,32 @@
+`jax_enable_x64` has one owner (#1923).
+
+It is a **process-global** switch, and three sites wrote it without agreeing:
+
+| site | write |
+|---|---|
+| `backends/jax_backend.py` | `False` when `precision='float32'`, `True` otherwise — a **policy** |
+| `utils/acceleration/jax_utils.py` | unconditional `True`, at **module import** |
+| `alg/.../meshless_galerkin/mls_basis.py` | unconditional `True`, **per call** |
+
+Last writer won, and which was last depended on import and call order. Nothing failed when they
+disagreed: the result is a precision, not an exception. Measured on
+`jax.experimental.sparse.linalg.spsolve` against scipy on a tridiagonal system with a known answer,
+the error was `2.4e-07` — float32 — where scipy gave `4.4e-16`.
+
+**The asymmetry that decides the design.** Two of those writes are *requirements* ("this computation
+needs float64") and one is a *policy* ("the user asked for float32"). A requirement that silently
+overwrites a policy is the defect — one MLS call turned a float32 process into a float64 one for
+everything that followed — and a policy that silently starves a requirement is no better. Ordering
+cannot settle it, because both are legitimate.
+
+So the owner does not pick a winner: `set_x64_policy(enabled, source)` is the only write that may
+turn x64 **off**, and `require_x64(reason)` **raises** when a policy forbids it, naming the policy,
+its source, and the two ways out (construct the backend with `precision='float64'`, or run in a
+separate process). It does not flip the switch on its way to raising.
+
+Writers outside the owner: 3 → 0, pinned by a test that scans the package rather than a fixed list,
+so a fourth joins loudly. Mutation-checked: reintroducing a direct write fails the SSOT gate, and
+making `require_x64` override the policy fails the fail-loud test.
+
+The tests mutate process-global state, which is the thing under test, so each restores both the flag
+and the recorded policy — a test that leaked its own precision would be an instance of the bug.

--- a/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
+++ b/mfgarchon/alg/numerical/meshless_galerkin/mls_basis.py
@@ -160,7 +160,11 @@ def shape_functions_and_grads_jax(
     except ImportError:
         raise ImportError("backend='jax' requires jax. Install jax, or use backend='numpy'.") from None
 
-    jax.config.update("jax_enable_x64", True)
+    # Through the single owner (#1923). This was an unconditional write PER CALL, so one MLS call
+    # silently turned a user's float32 process into a float64 one for everything that followed.
+    from mfgarchon.utils.acceleration.jax_precision import require_x64
+
+    require_x64("the meshless MLS basis (its normal equations are ill-conditioned in float32)")
     nodes_j = jnp.asarray(nodes, dtype=jnp.float64)
     exps_j = jnp.asarray(exponents)
 

--- a/mfgarchon/backends/jax_backend.py
+++ b/mfgarchon/backends/jax_backend.py
@@ -79,13 +79,18 @@ class JAXBackend(BaseBackend):
         import jax
 
         # Set precision
+        # Through the single owner (#1923). This is the only write that may turn x64 OFF, because
+        # it is the only one representing something the USER asked for; the library's internal
+        # float64 requirements go through `require_x64` and fail loud against it rather than
+        # silently overwriting it.
+        from mfgarchon.utils.acceleration.jax_precision import set_x64_policy
+
         if self.precision == "float32":
             self.dtype = jnp.float32
-            # Enable float32 mode in JAX
-            jax.config.update("jax_enable_x64", False)
+            set_x64_policy(False, source="JAXBackend(precision='float32')")
         else:
             self.dtype = jnp.float64
-            jax.config.update("jax_enable_x64", True)
+            set_x64_policy(True, source="JAXBackend(precision='float64')")
 
         # Device selection
         if self.device == "auto":

--- a/mfgarchon/utils/acceleration/jax_precision.py
+++ b/mfgarchon/utils/acceleration/jax_precision.py
@@ -1,0 +1,70 @@
+"""One owner for `jax_enable_x64` (#1923).
+
+`jax.config.update("jax_enable_x64", ...)` is a **process-global** switch. Three sites wrote it and
+they did not agree:
+
+    backends/jax_backend.py             False when precision='float32', True otherwise  (a policy)
+    utils/acceleration/jax_utils.py     unconditional True, at MODULE IMPORT
+    alg/.../meshless_galerkin/mls_basis.py  unconditional True, PER CALL
+
+Last writer wins, and which is last depends on import and call order. Nothing failed when they
+disagreed: the result is a precision, not an exception. Measured on
+`jax.experimental.sparse.linalg.spsolve` against scipy on a tridiagonal system with a known answer,
+the error was 2.4e-07 -- float32 -- where scipy gave 4.4e-16; setting the flag explicitly took it to
+bit-identical agreement at every size.
+
+THE ASYMMETRY THAT DECIDES THE DESIGN. Two of those writes are requirements ("this computation needs
+float64") and one is a policy ("the user asked for float32"). A requirement that silently overwrites
+a policy is the defect; so is a policy that silently starves a requirement. Neither can be resolved
+by ordering, because both are legitimate -- so the owner makes the conflict *visible* instead of
+picking a winner by import order.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["require_x64", "set_x64_policy", "x64_state"]
+
+_POLICY: bool | None = None  # what a backend last declared, None if none has
+_POLICY_SOURCE: str | None = None
+
+
+def _jax() -> Any:
+    import jax
+
+    return jax
+
+
+def x64_state() -> tuple[bool, bool | None, str | None]:
+    """`(effective, declared_policy, policy_source)` — for diagnostics and tests."""
+    return bool(_jax().config.jax_enable_x64), _POLICY, _POLICY_SOURCE
+
+
+def set_x64_policy(enabled: bool, source: str) -> None:
+    """Declare the process precision policy. Called by a backend that a user configured.
+
+    This is the only write that may turn x64 OFF, because it is the only one that represents
+    something the user asked for.
+    """
+    global _POLICY, _POLICY_SOURCE
+    _POLICY, _POLICY_SOURCE = bool(enabled), source
+    _jax().config.update("jax_enable_x64", bool(enabled))
+
+
+def require_x64(reason: str) -> None:
+    """Declare that the caller needs float64, and fail loud if a policy forbids it.
+
+    Silently flipping the switch is what this replaces: a per-call `update(..., True)` inside a
+    library routine turned a user's float32 backend into a float64 one for the rest of the process,
+    with no diagnostic and no way to notice except by measuring a precision.
+    """
+    if _POLICY is False:
+        raise RuntimeError(
+            f"{reason} requires float64, but jax_enable_x64 was explicitly disabled by "
+            f"{_POLICY_SOURCE or 'an unknown caller'}. `jax_enable_x64` is PROCESS-GLOBAL, so this "
+            f"cannot be resolved locally: either construct that backend with precision='float64', "
+            f"or run this computation in a separate process. Silently enabling it here would change "
+            f"the precision of everything else already running (Issue #1923)."
+        )
+    _jax().config.update("jax_enable_x64", True)

--- a/mfgarchon/utils/acceleration/jax_utils.py
+++ b/mfgarchon/utils/acceleration/jax_utils.py
@@ -26,9 +26,11 @@ if HAS_JAX:
     from jax import device_put, grad, jacfwd, jacrev, jit, vmap
     from jax.lax import cond, scan
 
-    # Enable float64 for numerical precision (JAX defaults to float32)
-    # This is critical for Newton's method convergence with tight tolerances
-    jax.config.update("jax_enable_x64", True)
+    # Through the single owner (#1923). This was an unconditional write AT MODULE IMPORT, so
+    # whether a user's float32 backend survived depended on import order.
+    from mfgarchon.utils.acceleration.jax_precision import require_x64
+
+    require_x64("jax_utils (Newton's method needs float64 for tight tolerances)")
 
     # Optax is optional for optimization schedules
     try:

--- a/tests/unit/test_jax_x64_one_owner_1923.py
+++ b/tests/unit/test_jax_x64_one_owner_1923.py
@@ -1,0 +1,96 @@
+"""Issue #1923: `jax_enable_x64` is process-global and had three disagreeing writers.
+
+    backends/jax_backend.py               False when precision='float32', True otherwise  (a POLICY)
+    utils/acceleration/jax_utils.py       unconditional True, at MODULE IMPORT
+    alg/.../meshless_galerkin/mls_basis.py   unconditional True, PER CALL
+
+Last writer won, and which was last depended on import and call order. Nothing failed when they
+disagreed — the result is a precision, not an exception. Measured on
+`jax.experimental.sparse.linalg.spsolve` against scipy on a tridiagonal system with a known answer:
+error 2.4e-07 (float32) where scipy gave 4.4e-16.
+
+THE ASYMMETRY. Two writes are *requirements* ("this needs float64") and one is a *policy* ("the user
+asked for float32"). A requirement silently overwriting a policy is the defect; a policy silently
+starving a requirement is equally bad. Neither can be settled by ordering, so the owner makes the
+conflict visible rather than picking a winner.
+
+THESE TESTS MUTATE PROCESS-GLOBAL STATE, which is the thing under test, so each restores what it
+found. A test that leaked its own precision setting would be an instance of the bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+jax = pytest.importorskip("jax", reason="jax not installed")
+
+from mfgarchon.utils.acceleration import jax_precision  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_precision():
+    """Restore both the flag and the recorded policy. Without this the suite's precision would
+    depend on test order -- the defect, reproduced inside its own regression test."""
+    before = bool(jax.config.jax_enable_x64)
+    policy, source = jax_precision._POLICY, jax_precision._POLICY_SOURCE
+    yield
+    jax_precision._POLICY, jax_precision._POLICY_SOURCE = policy, source
+    jax.config.update("jax_enable_x64", before)
+
+
+def test_a_requirement_is_honoured_when_no_policy_forbids_it():
+    jax_precision._POLICY, jax_precision._POLICY_SOURCE = None, None
+    jax.config.update("jax_enable_x64", False)
+    jax_precision.require_x64("a test")
+    assert jax.config.jax_enable_x64 is True
+
+
+def test_a_requirement_fails_loud_against_an_explicit_float32_policy():
+    """The behavioural point of #1923. Before, `mls_basis` flipped the switch and the user's float32
+    process silently became float64 for everything that followed."""
+    jax_precision.set_x64_policy(False, source="JAXBackend(precision='float32')")
+    with pytest.raises(RuntimeError) as exc:
+        jax_precision.require_x64("the meshless MLS basis")
+    text = str(exc.value)
+    assert "PROCESS-GLOBAL" in text, "the message must say why this cannot be resolved locally"
+    assert "float32" in text, "it must name the policy that forbids it"
+    assert "separate process" in text or "precision='float64'" in text, "it must offer a way out"
+    # And it must NOT have flipped the switch on its way to raising.
+    assert jax.config.jax_enable_x64 is False, "the refusal must leave the policy in force"
+
+
+def test_a_float64_policy_does_not_block_a_requirement():
+    """Control. Without it, a blanket refusal would pass the test above and break every float64 run."""
+    jax_precision.set_x64_policy(True, source="JAXBackend(precision='float64')")
+    jax_precision.require_x64("a test")
+    assert jax.config.jax_enable_x64 is True
+
+
+def test_the_state_accessor_reports_the_policy_and_its_source():
+    jax_precision.set_x64_policy(False, source="unit-test")
+    effective, policy, source = jax_precision.x64_state()
+    assert (effective, policy, source) == (False, False, "unit-test")
+
+
+def test_there_is_exactly_one_writer_in_the_package():
+    """The SSOT gate: the count of places writing a process-global switch, and nothing else.
+
+    Scanned over the package rather than a fixed list, so a fourth writer added later is caught
+    rather than joining the three silently.
+    """
+    import pathlib
+
+    import mfgarchon
+
+    root = pathlib.Path(mfgarchon.__file__).parent
+    owner = root / "utils" / "acceleration" / "jax_precision.py"
+    writers = sorted(
+        p.relative_to(root).as_posix()
+        for p in root.rglob("*.py")
+        if p != owner and 'config.update("jax_enable_x64"' in p.read_text(encoding="utf-8")
+    )
+    assert writers == [], (
+        f"jax_enable_x64 is PROCESS-GLOBAL and must have one owner "
+        f"(utils/acceleration/jax_precision.py). New writers: {writers}. Use `require_x64(reason)` "
+        f"to declare a need, or `set_x64_policy(...)` from a backend the user configured."
+    )


### PR DESCRIPTION
Closes #1923.

`jax_enable_x64` is **process-global** and three sites wrote it without agreeing:

| site | write |
|---|---|
| `backends/jax_backend.py` | `False` when `precision='float32'`, `True` otherwise — a **policy** |
| `utils/acceleration/jax_utils.py` | unconditional `True`, at **module import** |
| `alg/.../meshless_galerkin/mls_basis.py` | unconditional `True`, **per call** |

Last writer won, and which was last depended on import and call order. **Nothing failed when they
disagreed** — the result is a precision, not an exception.

## The asymmetry that decides the design

Two of those writes are **requirements** ("this computation needs float64") and one is a **policy**
("the user asked for float32").

- A requirement silently overwriting a policy is the defect: one MLS call turned a float32 process
  into a float64 one for everything that followed.
- A policy silently starving a requirement is no better.

Ordering cannot settle it, because **both are legitimate**. So the owner does not pick a winner:

- `set_x64_policy(enabled, source)` — the only write that may turn x64 **off**, because it is the
  only one representing something the user asked for.
- `require_x64(reason)` — **raises** when a policy forbids it, naming the policy, its source, and the
  two ways out (`precision='float64'`, or a separate process). It does **not** flip the switch on its
  way to raising, so the refusal leaves the policy in force.

## Gate

Writers outside the owner: **3 → 0**, pinned by a test that scans the package rather than a fixed
list, so a fourth writer joins loudly instead of silently.

Mutation-checked, both directions:

| mutant | result |
|---|---|
| reintroduce a direct `config.update` in `mls_basis` | `FAILED test_there_is_exactly_one_writer_in_the_package` |
| make `require_x64` override the policy | `FAILED test_a_requirement_fails_loud_against_an_explicit_float32_policy` |

A control test keeps the guard from degenerating into a blanket refusal: a float64 policy must
**not** block a requirement.

## One note on the tests

They mutate process-global state, which is the thing under test, so each restores both the flag and
the recorded policy. A test that leaked its own precision setting would be an instance of the very
bug — and the suite's precision would then depend on test order.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.