### PR TITLE
fix: the upwind advection matrix is not the operator, so refuse to extract it (#1981)

### DIFF
--- a/changelog.d/1981-advection-matrix-refuses-upwind.fixed.md
+++ b/changelog.d/1981-advection-matrix-refuses-upwind.fixed.md
@@ -1,0 +1,35 @@
+`AdvectionOperator.as_scipy_sparse()` refuses `scheme="upwind"` instead of returning a matrix that
+is not the operator (#1981).
+
+#1981 reported that `form=` is inert under upwind, so the public `conservative=` flag "silently does
+nothing". Measured, that is the symptom rather than the defect — narrower in one direction and much
+wider in another:
+
+- **The operator honours `form=`.** `__call__` / `@` separate `divergence` from `gradient` by 48.97
+  on a linear velocity, and the public flag reaches it: 9.13 through
+  `grid.get_advection_operator(...) @ m`.
+- **The matrix does not represent the operator at all**, not merely form-insensitively. Against
+  `__call__` on a smooth field it is off by **27.31 for a CONSTANT velocity**, where the two forms
+  coincide and there is no form to lose.
+
+| velocity | scheme | form | max&#124;A @ m − op(m)&#124; |
+|---|---|---|---|
+| constant 1 | centered | either | 0.000000 |
+| constant 1 | **upwind** | either | **27.313708** |
+| linear 1+2x | centered | either | 0.000000 |
+| linear 1+2x | **upwind** | divergence | **80.000000** |
+| linear 1+2x | **upwind** | gradient | **47.798990** |
+
+Upwinding chooses its difference direction from the local sign of the field, so the operator is
+**nonlinear and has no matrix**; probing it with unit vectors linearises it around impulses.
+`centered` is exact, so the extraction machinery is sound — the refusal is scoped to the scheme, not
+to the method.
+
+The method's docstring already said "❌ Do NOT use for implicit solver Jacobians". **A recommendation
+the code does not enforce** is the shape this repository keeps finding, so it raises now, and the
+message says why there is no matrix and what to use instead (`centered`, or a velocity-sign upwind
+construction, which is linear).
+
+Safe because nothing takes that path: every `as_scipy_sparse()` call site in the package is on
+`LaplacianOperator`. Pinned by a census, so adding an advection one becomes a decision rather than an
+accident — with a positive control confirming the census fires when a caller is introduced.

--- a/mfgarchon/operators/differential/advection.py
+++ b/mfgarchon/operators/differential/advection.py
@@ -400,25 +400,31 @@ class AdvectionOperator(LinearOperator):
         """
         Convert operator to scipy sparse matrix (CSR format).
 
-        **⚠️ IMPORTANT - Godunov Paradox Limitation**:
+        **REFUSES for scheme="upwind" (#1981).** The docstring used to carry this as a
+        recommendation -- "❌ Do NOT use for implicit solver Jacobians" -- and the code did not
+        enforce it, so the caller got a matrix instead of an error.
 
-        This method works by probing the operator with unit vectors (e_j).
-        For operators using Godunov upwinding (scheme="upwind" in tensor_calculus),
-        this can produce incorrect matrices due to state-dependent flux limiting.
+        There is no matrix to extract. Upwinding chooses its difference direction from the local
+        sign of the field, so the operator is NONLINEAR, and probing it with unit vectors
+        linearises it around impulses. Measured on a 9-point grid against the operator's own
+        ``__call__`` with a smooth field ``m = sin(2 pi x) + 2``:
 
-        **Why this matters**: Godunov upwind selects flux direction based on
-        sign(∇m), which changes between localized (unit vector) and distributed
-        (actual density) fields. The extracted matrix represents the operator
-        on impulses, not general smooth fields.
+            velocity      scheme     form         max|A @ m - op(m)|
+            constant 1    centered   either                0.000000
+            constant 1    upwind     either               27.313708
+            linear 1+2x   centered   either                0.000000
+            linear 1+2x   upwind     divergence           80.000000
+            linear 1+2x   upwind     gradient             47.798990
 
-        **Recommendation**:
-        - ✅ Use this method for periodic BC or exploratory analysis
-        - ❌ Do NOT use for implicit solver Jacobians
-        - ✅ For implicit solvers, use velocity-based upwind sparse construction
-          (see fp_fdm_alg_*.py modules)
+        `centered` is exact, so the extraction machinery is sound; the upwind matrix simply is not
+        the operator -- and not only for a varying velocity. #1981 reported the narrower symptom,
+        that `form="divergence"` and `form="gradient"` extract BYTE-IDENTICAL matrices under upwind
+        while `__call__` separates them by 48.97: the form is honoured by the operator and lost by
+        the extraction. That is one consequence of a matrix that does not represent the operator in
+        any case.
 
-        **See**: Godunov paradox and defect correction analysis for full
-        mathematical explanation and the Defect Correction solution strategy.
+        For an implicit solver, build the advection matrix from the VELOCITY sign rather than the
+        field's (see the `fp_fdm_alg_*` modules), which is linear and does have a matrix.
 
         Args:
             max_grid_size: Maximum allowed grid size (default 100,000).
@@ -430,6 +436,7 @@ class AdvectionOperator(LinearOperator):
 
         Raises:
             ValueError: If grid too large (N > max_grid_size)
+            NotImplementedError: If ``scheme="upwind"`` -- see above.
 
         Example:
             >>> # Exploratory use (understand stencil structure)
@@ -447,6 +454,21 @@ class AdvectionOperator(LinearOperator):
             - Suitable for analysis, not for production implicit solvers
         """
         import scipy.sparse as sparse
+
+        if self.scheme == "upwind":
+            raise NotImplementedError(
+                "AdvectionOperator.as_scipy_sparse() is not available for scheme='upwind' "
+                "(Issue #1981). Upwinding picks its difference direction from the local sign of "
+                "the field, so the operator is NONLINEAR and has no matrix; probing it with unit "
+                "vectors linearises it around impulses. Measured against this operator's own "
+                "__call__ on a smooth field, the extracted matrix is off by 27.3 even for a "
+                "CONSTANT velocity, and it loses `form=` entirely -- 'divergence' and 'gradient' "
+                "extract byte-identical matrices where __call__ separates them by 48.97.\n"
+                "\n"
+                "Use scheme='centered', which is exact here (0.000000 against __call__), or build "
+                "the advection matrix from the VELOCITY sign rather than the field's -- that is "
+                "linear and does have a matrix (see the `fp_fdm_alg_*` modules)."
+            )
 
         N = int(np.prod(self.field_shape))
 

--- a/tests/unit/test_operators/test_advection_matrix_refuses_upwind_1981.py
+++ b/tests/unit/test_operators/test_advection_matrix_refuses_upwind_1981.py
@@ -1,0 +1,114 @@
+"""Issue #1981, and a correction to what it reported.
+
+#1981 said `form=` is inert under `scheme="upwind"`, so the public `conservative=` flag "silently
+does nothing". Measured, that is the symptom rather than the defect, and it is narrower than the
+defect in one direction and wider in another:
+
+- The OPERATOR honours `form=` under upwind. `__call__` / `@` separate `divergence` from `gradient`
+  by 48.97 on a linear velocity, and the public `conservative=` flag reaches it: 9.13 through
+  `grid.get_advection_operator(...) @ m`.
+- The MATRIX does not represent the operator at all under upwind -- not merely form-insensitively.
+  Against `__call__` on a smooth field it is off by **27.31 even for a CONSTANT velocity**, where
+  the two forms coincide and there is no form to lose.
+
+The cause is that upwinding chooses its difference direction from the local sign of the field, so
+the operator is **nonlinear** and has no matrix; `as_scipy_sparse` probes it with unit vectors and
+linearises it around impulses. `centered` is exact (0.000000), so the extraction machinery is sound.
+
+The method's docstring already said "❌ Do NOT use for implicit solver Jacobians". A recommendation
+the code does not enforce is what this repo keeps finding; it raises now.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.operators.differential.advection import AdvectionOperator
+
+_N = 9
+_H = 1.0 / (_N - 1)
+_X = np.linspace(0.0, 1.0, _N)
+_M = np.sin(2 * np.pi * _X) + 2.0
+
+
+def _op(velocity, scheme, form):
+    return AdvectionOperator(
+        velocity_field=np.asarray(velocity)[None, :], spacings=[_H], field_shape=(_N,), scheme=scheme, form=form
+    )
+
+
+@pytest.mark.parametrize("form", ["divergence", "gradient"])
+@pytest.mark.parametrize("velocity", [np.ones(_N), 1 + 2 * _X], ids=["constant", "linear"])
+def test_the_upwind_matrix_is_refused(form, velocity):
+    with pytest.raises(NotImplementedError) as exc:
+        _op(velocity, "upwind", form).as_scipy_sparse()
+    text = str(exc.value)
+    assert "NONLINEAR" in text, "the message must say WHY there is no matrix, not just that there isn't"
+    assert "centered" in text, "it must name the scheme that does work"
+    assert "1981" in text
+
+
+@pytest.mark.parametrize("form", ["divergence", "gradient"])
+@pytest.mark.parametrize("velocity", [np.ones(_N), 1 + 2 * _X], ids=["constant", "linear"])
+def test_the_centered_matrix_is_exact_against_the_operator(form, velocity):
+    """Control, and the reason the refusal is scoped to upwind rather than to the method."""
+    op = _op(velocity, "centered", form)
+    a = op.as_scipy_sparse().toarray()
+    assert np.abs(a @ _M - np.asarray(op(_M.ravel()))).max() == pytest.approx(0.0, abs=1e-12)
+
+
+def test_the_operator_honours_the_form_under_upwind():
+    """The correction to #1981's headline. `form=` is not inert -- the extraction lost it."""
+    div = np.asarray(_op(1 + 2 * _X, "upwind", "divergence")(_M.ravel()))
+    grad = np.asarray(_op(1 + 2 * _X, "upwind", "gradient")(_M.ravel()))
+    assert np.abs(div - grad).max() > 1.0, (
+        "the two forms must differ under upwind; if they no longer do, the operator has acquired "
+        "the defect the matrix had"
+    )
+
+
+def test_the_public_conservative_flag_reaches_the_operator():
+    """`conservative=` maps to `form=` and is honoured through `@`, which uses `_matvec`, not the
+    matrix. #1981 reported it as silently doing nothing; measured, it does 9.13 worth."""
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_N], boundary_conditions=no_flux_bc(dimension=1))
+    v = (1 + 2 * _X)[None, :]
+    a = np.asarray(grid.get_advection_operator(v, scheme="upwind", conservative=True) @ _M.ravel())
+    b = np.asarray(grid.get_advection_operator(v, scheme="upwind", conservative=False) @ _M.ravel())
+    assert np.abs(a - b).max() > 1.0
+
+
+def test_no_production_caller_takes_the_refused_path():
+    """The refusal is safe because nothing in the package extracts an advection matrix: every
+    `as_scipy_sparse` call site in `mfgarchon/` is on `LaplacianOperator`. Pinned, so adding an
+    advection one is a decision rather than an accident."""
+    import pathlib
+
+    import mfgarchon
+
+    root = pathlib.Path(mfgarchon.__file__).parent
+    # The defining module is excluded, and that exclusion is the instrument being fixed rather than
+    # widened: a first version looked back six lines for "AdvectionOperator" and flagged the
+    # refusal's own error message, inside advection.py -- matching the DESCRIPTION of the thing
+    # instead of a call to it. Only a `.as_scipy_sparse()` whose receiver was constructed nearby as
+    # an AdvectionOperator counts.
+    defining = root / "operators" / "differential" / "advection.py"
+    offenders = []
+    for path in root.rglob("*.py"):
+        if path == defining:
+            continue
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            code = line.split("#", 1)[0]
+            if "as_scipy_sparse()" not in code or ">>>" in line:
+                continue
+            window = "\n".join(lines[max(0, i - 6) : i + 1])
+            if "AdvectionOperator(" in window:
+                offenders.append(f"{path.relative_to(root)}:{i + 1}")
+    assert offenders == [], (
+        f"a production caller now extracts an advection matrix: {offenders}. Under scheme='upwind' "
+        f"that path raises (#1981); under 'centered' it is exact. Confirm which scheme it uses."
+    )


### PR DESCRIPTION
Closes #1981 — and corrects what it reported, in both directions.

## The operator honours `form=`; the matrix loses it

#1981 said `form=` is inert under `scheme="upwind"` and the public `conservative=` flag "silently
does nothing". Measured, both halves are too strong:

| | measured |
|---|---|
| `__call__` / `@`, divergence vs gradient, linear velocity, upwind | **48.97** |
| `grid.get_advection_operator(..., conservative=True/False) @ m` | **9.13** |

The flag reaches the operator and the operator honours it.

## But the matrix does not represent the operator at all

Against `__call__` on a smooth field `m = sin(2πx) + 2`:

| velocity | scheme | form | max&#124;A @ m − op(m)&#124; |
|---|---|---|---|
| constant 1 | centered | either | 0.000000 |
| constant 1 | **upwind** | either | **27.313708** |
| linear 1+2x | centered | either | 0.000000 |
| linear 1+2x | **upwind** | divergence | **80.000000** |
| linear 1+2x | **upwind** | gradient | **47.798990** |

**27.31 for a constant velocity** — where the two forms coincide and there is no form to lose. So
form-insensitivity is one consequence of a matrix that is wrong in every case, not the defect itself.

Upwinding chooses its difference direction from the local sign of the field, so the operator is
**nonlinear and has no matrix**; `as_scipy_sparse` probes it with unit vectors and linearises it
around impulses. `centered` is exact, so the extraction machinery is sound and the refusal is scoped
to the scheme rather than to the method.

## The docstring already knew

> **Recommendation**: ❌ Do NOT use for implicit solver Jacobians

**A recommendation the code does not enforce** is the shape this repository keeps finding. It raises
now, and the message says why there is no matrix and what to use instead — `centered`, or a
velocity-sign upwind construction, which is linear and does have one.

## Safe, and pinned

Every `as_scipy_sparse()` call site in the package is on `LaplacianOperator`; nothing extracts an
advection matrix. A census pins that, so adding one becomes a decision rather than an accident — with
a **positive control** confirming the census fires when a caller is introduced.

One correction to that census, since the shape recurs: it first looked back six lines for
`AdvectionOperator` and flagged **the refusal's own error message**, inside `advection.py` — the
instrument matching the description of the thing instead of a call to it.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.