### PR TITLE
fix: the torch backend no longer narrows float64 behind the caller's back (#1921)

### DIFF
--- a/changelog.d/1921-torch-keeps-float64.fixed.md
+++ b/changelog.d/1921-torch-keeps-float64.fixed.md
@@ -1,0 +1,30 @@
+The torch backend no longer narrows `float64` to `float32` behind the caller's back (#1921).
+
+`TorchBackend(precision="float64")` — the default — returned float32, because `device="auto"`
+selected MPS and MPS has no float64 at all. It warned and narrowed:
+
+```
+warnings.warn("MPS does not support float64, using float32 instead. ...")
+```
+
+A `UserWarning` is not enough for that. This library's convergence tolerances are 1e-10 and 1e-12
+throughout, so a float32 backend does not make them *hard to hit* — it makes them **unreachable in
+principle**. Measured: `np.array([1.0 + 1e-10, 1.0])` came back with both entries equal.
+
+**The asymmetry, the same one behind #1923.** The precision was something the **user** asked for; the
+device was something the **library** chose for them under `auto`. A choice made for the user must not
+spend one the user made. So:
+
+- `auto` now prefers CPU whenever `float64` is requested. That costs nothing here — measured on this
+  machine over mean/max/trapezoid, torch is 9.2× slower than numpy at n = 1e6 and 361× at n = 1e4 —
+  and it is precision-scoped, so `float32` still reaches MPS.
+- An **explicit** `device='mps'` with `precision='float64'` raises. There the caller named both, they
+  genuinely conflict, and the message offers both ways out rather than choosing: `device='cpu'` to
+  keep float64, `precision='float32'` to keep MPS.
+
+The other half of #1921 — `create_backend(None)` auto-selecting torch — was already corrected on
+2026-08-17 and now returns numpy unconditionally.
+
+Mutation-checked: letting `auto` pick MPS under float64 again fails both the round-trip test and the
+device test. A control keeps the skip from becoming a blanket refusal of MPS, and the
+warn-and-narrow path is pinned gone against the source.

--- a/mfgarchon/backends/torch_backend.py
+++ b/mfgarchon/backends/torch_backend.py
@@ -133,13 +133,21 @@ class TorchBackend(BaseBackend):
         else:
             raise ValueError(f"Unsupported precision: {self.precision}")
 
-        # Handle MPS float64 limitation
+        # MPS cannot do float64. Reaching here means the user named BOTH explicitly, since `auto`
+        # no longer selects MPS under float64 (#1921) -- so this is a genuine conflict between two
+        # things the caller asked for, and silently resolving it is what this replaces.
+        #
+        # It used to warn and narrow to float32. A UserWarning is not enough for a precision
+        # downgrade in a library whose tolerances are 1e-10 and 1e-12: it makes them unreachable in
+        # principle rather than hard to hit.
         if self.device_type == "mps" and self.precision == "float64":
-            warnings.warn(
-                "MPS does not support float64, using float32 instead. Set precision='float32' to suppress this warning."
+            raise ValueError(
+                "device='mps' cannot provide precision='float64' -- MPS has no float64 at all. "
+                "This used to narrow silently to float32, which puts this library's 1e-10 and 1e-12 "
+                "convergence tolerances out of reach in principle (Issue #1921). Choose one: "
+                "device='cpu' to keep float64, or precision='float32' to keep MPS. "
+                "device='auto' picks CPU over MPS whenever float64 is requested."
             )
-            self.torch_dtype = torch.float32
-            self.precision = "float32"
 
         # Memory management
         if self.memory_efficient:
@@ -168,10 +176,22 @@ class TorchBackend(BaseBackend):
             ValueError: If specified device is unavailable
         """
         if device_spec == "auto":
-            # Automatic selection with priority: CUDA > MPS > CPU
+            # Automatic selection with priority: CUDA > MPS > CPU.
+            #
+            # MPS IS SKIPPED WHEN float64 WAS ASKED FOR (#1921). MPS cannot do float64, and the
+            # backend used to accept the device and silently narrow the precision instead -- a
+            # choice the LIBRARY made overriding one the USER made. In a library whose convergence
+            # tolerances are 1e-10 and 1e-12 throughout, that does not make them hard to reach, it
+            # makes them unreachable in principle: `1 + 1e-10 != 1` does not survive the round trip.
+            #
+            # CPU keeps the precision and is also faster here -- measured over mean/max/trapezoid,
+            # torch is 9.2x slower than numpy at n = 1e6 and 361x at n = 1e4 -- so nothing is traded
+            # away by preferring it. An EXPLICIT device='mps' with precision='float64' is a
+            # different case: the user asked for both, they conflict, and `_setup_backend` raises
+            # rather than choosing for them.
             if CUDA_AVAILABLE:
                 device = torch_device("cuda")
-            elif MPS_AVAILABLE and MPS_FUNCTIONAL:
+            elif MPS_AVAILABLE and MPS_FUNCTIONAL and self.precision != "float64":
                 device = torch_device("mps")
             else:
                 device = torch_device("cpu")

--- a/tests/unit/test_alg/test_fp_particle_seed_1838.py
+++ b/tests/unit/test_alg/test_fp_particle_seed_1838.py
@@ -219,7 +219,11 @@ def test_the_torch_sampler_repeats_and_leaves_the_global_torch_stream_alone(devi
     from mfgarchon.backends.torch_backend import TorchBackend
     from mfgarchon.utils.particle_utils import sample_from_density_gpu
 
-    backend = TorchBackend(device=device)
+    # float32 on MPS, which has no float64 at all -- since #1921 that combination raises rather
+    # than narrowing silently. This test's subject is the RNG stream, not precision, so the narrower
+    # dtype costs it nothing; asking for float64 here would be asking for a configuration that does
+    # not exist.
+    backend = TorchBackend(device=device, precision="float32" if device == "mps" else "float64")
     grid = backend.from_numpy(np.linspace(0.0, 1.0, 64))
     density = backend.from_numpy(np.exp(-10 * (np.linspace(0.0, 1.0, 64) - 0.5) ** 2))
 

--- a/tests/unit/test_backends/test_torch_keeps_float64_1921.py
+++ b/tests/unit/test_backends/test_torch_keeps_float64_1921.py
@@ -1,0 +1,104 @@
+"""Issue #1921: the torch backend silently narrowed float64 to float32.
+
+`TorchBackend(precision="float64")` -- the default -- returned float32, because `device="auto"`
+selected MPS and MPS has no float64 at all. The backend warned and narrowed:
+
+    warnings.warn("MPS does not support float64, using float32 instead. ...")
+
+A `UserWarning` is not enough for that. This library's convergence tolerances are 1e-10 and 1e-12
+throughout -- `hjb_residual_norm` against `DEFAULT_NEWTON_TOLERANCE`, the mass-conservation pins at
+`abs=1e-12` -- so a float32 backend does not make them hard to hit, it makes them **unreachable in
+principle**. Measured: `np.array([1.0 + 1e-10, 1.0])` came back with both entries equal.
+
+THE ASYMMETRY, the same one as #1923. The precision was something the USER asked for; the device was
+something the LIBRARY chose for them under `auto`. A choice made for the user must not override one
+the user made. So `auto` now prefers CPU whenever float64 is requested -- which costs nothing here,
+since torch is 9.2x-361x slower than numpy on this machine anyway -- and an EXPLICIT `device='mps'`
+with `precision='float64'` raises, because there the caller asked for both and they genuinely
+conflict.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+torch = pytest.importorskip("torch", reason="torch not installed")
+
+from mfgarchon.backends import create_backend  # noqa: E402
+
+# A difference float32 cannot hold.
+_X = np.array([1.0 + 1e-10, 1.0], dtype=np.float64)
+
+
+def test_the_default_torch_backend_keeps_float64():
+    """The headline. Before, this came back float32 with both entries equal."""
+    b = create_backend("torch")
+    out = b.to_numpy(b.from_numpy(_X))
+    assert out.dtype == np.float64, f"round trip narrowed to {out.dtype}"
+    assert out[0] != out[1], (
+        "1 + 1e-10 == 1 after the round trip: the backend is float32, and this library's 1e-10 / "
+        "1e-12 tolerances are then unreachable in principle"
+    )
+
+
+def test_numpy_is_the_control():
+    """Without it, a backend that returned constants would pass the test above."""
+    b = create_backend("numpy")
+    out = b.to_numpy(b.from_numpy(_X))
+    assert out.dtype == np.float64
+    assert out[0] != out[1]
+
+
+def test_auto_does_not_select_mps_when_float64_is_asked_for():
+    """The mechanism, not the symptom. `auto` is a choice made FOR the user; it must not spend the
+    precision they asked for."""
+    b = create_backend("torch", precision="float64")
+    assert getattr(b, "device_type", None) != "mps", (
+        "auto selected MPS under precision='float64'; MPS has no float64, so the precision would be narrowed silently"
+    )
+    assert b.precision == "float64", "the requested precision must survive device selection"
+
+
+def test_auto_may_still_select_mps_for_float32():
+    """Control: the skip is conditional on the precision, not a blanket refusal of MPS. Asserted
+    only where MPS exists, so it does not become a platform assumption."""
+    from mfgarchon.backends.torch_backend import MPS_AVAILABLE, MPS_FUNCTIONAL
+
+    if not (MPS_AVAILABLE and MPS_FUNCTIONAL) or torch.cuda.is_available():
+        pytest.skip("no MPS on this machine, or CUDA outranks it")
+    b = create_backend("torch", precision="float32")
+    assert b.device_type == "mps", "float32 must still reach MPS; the #1921 skip is precision-scoped"
+
+
+def test_an_explicit_mps_float64_request_raises():
+    """Both named by the caller, and they conflict. Silently resolving it is what this replaces."""
+    from mfgarchon.backends.torch_backend import MPS_AVAILABLE, MPS_FUNCTIONAL
+
+    if not (MPS_AVAILABLE and MPS_FUNCTIONAL):
+        pytest.skip("no MPS on this machine")
+    with pytest.raises(ValueError) as exc:
+        create_backend("torch", device="mps", precision="float64")
+    text = str(exc.value)
+    assert "1921" in text
+    # Both ways out, because which one is right depends on what the caller actually needs.
+    assert "device='cpu'" in text, "the message must offer keeping float64"
+    assert "precision='float32'" in text, "and it must offer keeping MPS"
+
+
+def test_the_silent_narrowing_path_is_gone():
+    """Pinned against the source: a warn-and-narrow is what made this survivable for so long."""
+    import inspect
+
+    from mfgarchon.backends import torch_backend
+
+    src = "\n".join(
+        ln
+        for ln in inspect.getsource(torch_backend.TorchBackend._setup_backend).splitlines()
+        if not ln.lstrip().startswith("#")
+    )
+    assert 'self.precision = "float32"' not in src, (
+        "the backend reassigns its own precision again; a downgrade the caller did not ask for "
+        "must raise, not be recorded after the fact (#1921)"
+    )


### PR DESCRIPTION
Closes #1921.

`TorchBackend(precision="float64")` — **the default** — returned float32, because `device="auto"`
selected MPS and MPS has no float64 at all. It warned and narrowed:

```python
warnings.warn("MPS does not support float64, using float32 instead. ...")
```

A `UserWarning` is not enough for that. This library's convergence tolerances are 1e-10 and 1e-12
throughout, so a float32 backend does not make them *hard to hit* — it makes them **unreachable in
principle**. Measured, `np.array([1.0 + 1e-10, 1.0])` came back with both entries equal.

## The asymmetry, the same one behind #1923

The precision was something the **user** asked for. The device was something the **library** chose
for them under `auto`. A choice made for the user must not spend one the user made.

- **`auto` prefers CPU whenever `float64` is requested.** That costs nothing here — measured on this
  machine over mean/max/trapezoid, torch is 9.2× slower than numpy at n = 1e6 and 361× at n = 1e4 —
  and it is precision-scoped, so `float32` still reaches MPS.
- **An explicit `device='mps'` with `precision='float64'` raises.** There the caller named both, they
  genuinely conflict, and the message offers both ways out rather than picking: `device='cpu'` to
  keep float64, `precision='float32'` to keep MPS.

| | before | after |
|---|---|---|
| `create_backend("torch")` round trip | float64 → **float32** | float64 → float64 |
| `1 + 1e-10 != 1` survives | **no** | **yes** |
| explicit `mps` + `float64` | warned, narrowed | **raises** |

The other half of #1921 — `create_backend(None)` auto-selecting torch — was already corrected on
2026-08-17 and now returns numpy unconditionally.

## One existing test changed, and not by weakening it

The #1838 seed test parametrises over devices and asked MPS for the default float64, which is now a
configuration that does not exist. Its subject is the RNG stream, not precision, so it asks for
`float32` on MPS — the narrower dtype costs that test nothing.

## Discrimination

Letting `auto` pick MPS under float64 again fails both the round-trip test and the device test. A
control keeps the skip from degenerating into a blanket refusal of MPS (`float32` must still reach
it), and the warn-and-narrow path is pinned gone against the source, since a downgrade recorded
after the fact is what made this survivable.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.