### PR TITLE
fix: one spelling for `is_on_boundary`'s tolerance across every geometry (#1943)

### DIFF
--- a/changelog.d/1943-is-on-boundary-one-spelling.fixed.md
+++ b/changelog.d/1943-is-on-boundary-one-spelling.fixed.md
@@ -1,0 +1,25 @@
+`is_on_boundary` accepts one spelling of its tolerance argument across every geometry (#1943).
+
+`GeometryProtocol` declares `tolerance=`, and eighteen implementers use it. The `ImplicitDomain`
+family used `tol=`. Positional calls worked either way, so **any keyword call broke on one side of
+the split** — and which side was decided only by which geometry the caller happened to be handed:
+
+```
+Hyperrectangle.is_on_boundary(pts, tol=0.03)        -> [True, False]
+Hyperrectangle.is_on_boundary(pts, tolerance=0.03)  -> TypeError
+```
+
+`ImplicitApplicator._detect_boundary_points` used the keyword form — an applicator that exists *for*
+this family, calling it in the spelling this family did not accept.
+
+The issue counts seven diverging classes; measured, six of them **inherit** the method, so there was
+one definition to change. `tol=` remains as a deprecated alias, and passing both raises rather than
+picking a winner — accepting both would introduce the class of defect this removes.
+
+The census is **behavioural rather than a name count**: it asserts every implementer *accepts*
+`tolerance`, walking `mfgarchon.geometry` so a new geometry joins by existing, and it skips classes
+whose signature is `**kwargs` (a separate concern, #2020). A subclass re-overriding with `tol=` is
+caught, which a census keyed on the base class would miss.
+
+Mutation-checked: reverting the rename fails both the protocol test and the census. A control keeps
+the positional call pinned, since a rename that broke it would be invisible to the keyword tests.

--- a/mfgarchon/geometry/implicit/implicit_domain.py
+++ b/mfgarchon/geometry/implicit/implicit_domain.py
@@ -17,6 +17,7 @@ References:
 - TECHNICAL_REFERENCE_HIGH_DIMENSIONAL_MFG.md Section 4
 """
 
+import warnings
 from abc import abstractmethod
 from collections.abc import Callable
 from typing import Literal
@@ -504,15 +505,35 @@ class ImplicitDomain(
 
         return x_proj[0] if is_single else x_proj
 
-    def is_on_boundary(self, x: NDArray[np.float64], tol: float = SDF_BOUNDARY_TOL) -> bool | NDArray[np.bool_]:
+    def is_on_boundary(
+        self,
+        x: NDArray[np.float64],
+        tolerance: float | None = None,
+        tol: float | None = None,
+    ) -> bool | NDArray[np.bool_]:
         """
         Check if point(s) are on the domain boundary using SDF.
 
-        A point is on the boundary if |φ(x)| < tol where φ is the SDF.
+        A point is on the boundary if |φ(x)| < tolerance where φ is the SDF.
+
+        `tolerance`, matching `GeometryProtocol.is_on_boundary` and the eighteen other
+        implementers (#1943). This family spelled it `tol`, so positional calls worked either way
+        and **any keyword call broke on one side of the split**, with which side decided only by
+        which geometry the caller happened to be handed. Measured before the fix:
+
+            Hyperrectangle.is_on_boundary(pts, tol=0.03)        -> [True, False]
+            Hyperrectangle.is_on_boundary(pts, tolerance=0.03)  -> TypeError
+
+        and `ImplicitApplicator._detect_boundary_points` used the keyword form -- an applicator that
+        exists *for* this family, calling it in the spelling this family did not accept.
+
+        `tol=` is still accepted and deprecated. Six subclasses inherit this method rather than
+        overriding it, so this is the one definition the whole family reads.
 
         Args:
             x: Point(s) to check - shape (d,) or (N, d)
-            tol: Tolerance for boundary detection
+            tolerance: Tolerance for boundary detection
+            tol: Deprecated alias for `tolerance`
 
         Returns:
             Boolean or array of booleans indicating if points are on boundary
@@ -524,8 +545,24 @@ class ImplicitDomain(
             >>> sphere.is_on_boundary(np.array([0.5, 0.0]))
             False
         """
+        if tol is not None:
+            if tolerance is not None:
+                raise TypeError(
+                    "is_on_boundary() received both `tolerance` and `tol`; they are the same "
+                    "argument. Use `tolerance`, which is what GeometryProtocol declares (#1943)."
+                )
+            warnings.warn(
+                "is_on_boundary(tol=...) is deprecated; use `tolerance=`, which is the spelling "
+                "GeometryProtocol and the other eighteen implementers use (#1943).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            tolerance = tol
+        if tolerance is None:
+            tolerance = SDF_BOUNDARY_TOL
+
         sd = self.signed_distance(x)
-        return np.abs(sd) < tol
+        return np.abs(sd) < tolerance
 
     # =========================================================================
     # Trait Protocol Implementations (Issue #590 Phase 1.2)

--- a/tests/unit/test_geometry/test_is_on_boundary_one_spelling_1943.py
+++ b/tests/unit/test_geometry/test_is_on_boundary_one_spelling_1943.py
@@ -1,0 +1,104 @@
+"""Issue #1943: `is_on_boundary`'s tolerance argument had two spellings.
+
+`GeometryProtocol` declares `tolerance=`, and eighteen implementers use it. The `ImplicitDomain`
+family used `tol=`. Positional calls worked either way, so **any keyword call broke on one side of
+the split**, with which side decided only by which geometry the caller happened to be handed:
+
+    Hyperrectangle.is_on_boundary(pts, tol=0.03)        -> [True, False]
+    Hyperrectangle.is_on_boundary(pts, tolerance=0.03)  -> TypeError
+
+And `ImplicitApplicator._detect_boundary_points` used the keyword form — an applicator that exists
+*for* this family, calling it in the spelling this family did not accept.
+
+The issue counts seven diverging classes; measured, six of them **inherit** the method, so there was
+one definition to change. The census below asserts against the resolved signature rather than the
+count, since a subclass could override it back.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pkgutil
+import warnings
+from importlib import import_module
+
+import pytest
+
+import numpy as np
+
+import mfgarchon.geometry as _geometry
+from mfgarchon.geometry.implicit.hyperrectangle import Hyperrectangle
+
+_PTS = np.array([[0.0, 0.5], [0.5, 0.5]])
+
+
+def _box():
+    return Hyperrectangle(bounds=np.array([[0.0, 1.0], [0.0, 1.0]]))
+
+
+def test_the_protocol_spelling_now_works_on_the_implicit_family():
+    """The assertion #1943 is about."""
+    assert np.array_equal(_box().is_on_boundary(_PTS, tolerance=0.03), np.array([True, False]))
+
+
+def test_the_old_spelling_still_works_and_warns():
+    """Deprecated, not removed: `tol=` is a released spelling and the two must not disagree while
+    both exist."""
+    box = _box()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        old = box.is_on_boundary(_PTS, tol=0.03)
+    assert [w.category for w in caught] == [DeprecationWarning]
+    assert np.array_equal(old, box.is_on_boundary(_PTS, tolerance=0.03)), (
+        "the alias must be the same argument, not a second one that drifts"
+    )
+
+
+def test_passing_both_is_refused():
+    """They are one argument. Accepting both would silently pick a winner, which is the class of
+    defect this fix removes rather than one to introduce."""
+    with pytest.raises(TypeError, match="same"):
+        _box().is_on_boundary(_PTS, tolerance=0.03, tol=0.03)
+
+
+def test_the_positional_call_is_unchanged():
+    """Control: positional calls worked on both sides before, so a rename that broke them would be
+    a regression the keyword tests could not see."""
+    assert np.array_equal(_box().is_on_boundary(_PTS, 0.03), np.array([True, False]))
+
+
+def test_every_implementer_accepts_the_protocol_spelling():
+    """The gate, and it is behavioural rather than a name count: a subclass could re-override with
+    `tol=` and a signature-name census keyed on the base would miss it.
+
+    Walks `mfgarchon.geometry`, so a new geometry joins the census by existing.
+    """
+    offenders = []
+    seen = set()
+    for module in pkgutil.walk_packages(_geometry.__path__, _geometry.__name__ + "."):
+        try:
+            mod = import_module(module.name)
+        except Exception:  # a module that cannot import contributes no implementer
+            continue
+        for obj in vars(mod).values():
+            if not inspect.isclass(obj) or obj.__name__ in seen:
+                continue
+            fn = getattr(obj, "is_on_boundary", None)
+            if fn is None or not callable(fn):
+                continue
+            seen.add(obj.__name__)
+            try:
+                params = inspect.signature(fn).parameters
+            except (TypeError, ValueError):
+                continue
+            if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+                continue  # **kwargs accepts anything; a separate concern (#2020)
+            if "tolerance" not in params:
+                offenders.append(f"{obj.__name__}{inspect.signature(fn)}")
+
+    assert "TensorProductGrid" in seen, "the walk found no known implementer -- the query is wrong"
+    assert len(seen) >= 10, f"expected the geometry population, found {len(seen)}"
+    assert offenders == [], (
+        f"GeometryProtocol declares `tolerance=`; these do not accept it: {offenders}. A caller "
+        f"cannot then write one keyword call that works for every geometry (#1943)."
+    )


### PR DESCRIPTION
Closes #1943.

`GeometryProtocol` declares `tolerance=` and eighteen implementers use it; the `ImplicitDomain`
family used `tol=`. Positional calls worked either way, so **any keyword call broke on one side of
the split** — and which side was decided only by which geometry the caller happened to be handed:

```
Hyperrectangle.is_on_boundary(pts, tol=0.03)        -> [True, False]
Hyperrectangle.is_on_boundary(pts, tolerance=0.03)  -> TypeError
```

`ImplicitApplicator._detect_boundary_points` used the keyword form — an applicator that exists *for*
this family, calling it in the spelling this family did not accept.

## One correction to the issue

It counts seven diverging classes. Measured, **six of them inherit** the method from
`ImplicitDomain`, so there was one definition to change rather than seven.

`tol=` stays as a deprecated alias, and passing **both** raises rather than picking a winner —
accepting both would introduce the class of defect this removes.

## The census is behavioural, not a name count

It asserts every implementer *accepts* `tolerance`, walking `mfgarchon.geometry` so a new geometry
joins by existing, and skipping `**kwargs` signatures (a separate concern, #2020). A subclass
re-overriding with `tol=` is caught — which a census keyed on the base class would miss, and the
inheritance correction above is exactly why that distinction matters here.

## Discrimination

| mutant | result |
|---|---|
| revert the rename | 4 of 5 fail, including the census |

A control pins the **positional** call, since it worked on both sides before and a rename that broke
it would be invisible to the keyword tests.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.