### PR TITLE
fix: the `gradient_*` warning states the drift dependence instead of understating it 10x (#2007)

### DIFF
--- a/changelog.d/2007-gradient-warning-states-the-drift.fixed.md
+++ b/changelog.d/2007-gradient-warning-states-the-drift.fixed.md
@@ -1,0 +1,28 @@
+The `gradient_*` non-conservation warning states the drift dependence instead of understating the
+leak by an order of magnitude (#2007).
+
+It read *"leaks O(1e-2), even with zero drift"*. Measured:
+
+| configuration | leak |
+|---|---|
+| genuinely zero drift, stationary initial density | **−1.7e-14** (none at all) |
+| wall-normal drift A = 0.7, D = 1/8, d = 1 | **−1.4e-1** |
+| wall-normal drift A = 0.7, D = 1/8, d = 2 | **−8.9e-1** |
+
+So the `1.5e-2` figure was a **transient** density, which the string did not say, and a reader
+budgeting against `O(1e-2)` was off by 10× exactly where the scheme is used.
+
+The message also now names the **second** defect, because a reader who hears only "does not conserve
+mass" will reach for a conservative wall and that would not fix it: `div(αm) = α·∇m + m ∇·α`, and the
+gradient form drops the second term, so it does not discretize the FP operator even away from the
+wall. Measured on a source-free instance, repointing the wall moves the error from 5.81e-1 to
+8.02e-1 — EOC −0.007 → 0.108.
+
+**What this change deliberately does not do.** #2007 recommends removing these schemes, and that
+recommendation stands. It is not settled here: `test_gradient_centered_still_available_and_leaks`
+records a standing decision to keep them explicitly selectable, and a warning is not the place to
+overturn a recorded decision. A first attempt at this change refused the scheme under `no_flux` and
+turned that test red — which is how the standing decision was found.
+
+The corrected figures are pinned, including that `O(1e-2)` may appear only as a retraction and not as
+a live claim, with a control confirming the `divergence_*` schemes do not warn.

--- a/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
+++ b/mfgarchon/alg/numerical/fp_solvers/fp_fdm.py
@@ -261,10 +261,28 @@ class FPFDMSolver(BaseFPSolver):
         # silently assembling a default (no-flux) wall.
         self._validate_bc_support(self.boundary_conditions)
 
-        # Issue #1075: the non-conservative gradient (point-value) advection schemes do
-        # NOT conserve mass at no-flux walls -- even for pure diffusion -- because the
-        # boundary node uses the point-value Neumann Laplacian (sigma^2/dx^2) rather than
-        # the finite-volume half-cell closure. Measured leak ~1.5e-2 (zero drift, n=81).
+        # Issue #1075 / #2007: the non-conservative gradient (point-value) advection schemes do
+        # NOT conserve mass at no-flux walls, because the boundary node uses the point-value
+        # Neumann Laplacian (sigma^2/dx^2) rather than the finite-volume half-cell closure.
+        #
+        # THE LEAK IS DRIFT-DEPENDENT, and the previous string understated it by an order of
+        # magnitude (#2007). It said "leaks O(1e-2), even with zero drift". Measured:
+        #
+        #   genuinely zero drift, stationary initial density   -1.7e-14   (no leak at all)
+        #   wall-normal drift A = 0.7, D = 1/8, d = 1          -1.4e-1
+        #   wall-normal drift A = 0.7, D = 1/8, d = 2          -8.9e-1
+        #
+        # So the 1.5e-2 figure was a TRANSIENT density, which the string did not say, and a reader
+        # budgeting against O(1e-2) was off by 10x exactly where the scheme is used.
+        #
+        # There is a second defect this warning does not cover, and it is not a wall problem:
+        # div(alpha m) = alpha.grad(m) + m div(alpha), and the gradient form drops the second term,
+        # so even repointing the wall leaves a scheme that discretizes a different equation
+        # (measured on a source-free instance, 5.81e-1 -> 8.02e-1, EOC -0.007 -> 0.108). #2007
+        # recommends removing these schemes for that reason; this warning is not a substitute for
+        # that decision, and `test_gradient_centered_still_available_and_leaks` records the
+        # standing one to keep them explicitly selectable.
+        #
         # The conservative path is a 'divergence_*' scheme. Warn once at construction.
         if self.advection_scheme.startswith("gradient") and (
             getattr(self.boundary_conditions, "is_uniform", False)
@@ -272,10 +290,15 @@ class FPFDMSolver(BaseFPSolver):
         ):
             warnings.warn(
                 f"advection_scheme='{self.advection_scheme}' uses the non-conservative "
-                "gradient (point-value) form and does NOT conserve mass at no-flux walls "
-                "(leaks O(1e-2), even with zero drift; see Issue #1075). Use a "
+                "gradient (point-value) form and does NOT conserve mass at no-flux walls. "
+                "The leak scales with the WALL-NORMAL DRIFT: measured -1.4e-1 in 1D and -8.9e-1 "
+                "in 2D at A = 0.7, D = 1/8, against -1.7e-14 at genuinely zero drift with a "
+                "stationary initial density. (This warning previously said 'O(1e-2), even with "
+                "zero drift', which was a transient and understates a driven solve by 10x -- "
+                "Issue #2007.) The same form also drops the m*div(alpha) term of div(alpha m), so "
+                "it does not discretize the FP operator even away from the wall. Use a "
                 "'divergence_*' scheme (default 'divergence_upwind') for mass-conservative "
-                "no-flux solves.",
+                "no-flux solves. See Issue #1075 and Issue #2007.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/tests/unit/test_alg/test_gradient_scheme_warning_states_the_drift_2007.py
+++ b/tests/unit/test_alg/test_gradient_scheme_warning_states_the_drift_2007.py
@@ -1,0 +1,110 @@
+"""Issue #2007: the `gradient_*` non-conservation warning understated the leak by 10x.
+
+It read "leaks O(1e-2), even with zero drift". Measured:
+
+    genuinely zero drift, stationary initial density   -1.7e-14   (no leak at all)
+    wall-normal drift A = 0.7, D = 1/8, d = 1          -1.4e-1
+    wall-normal drift A = 0.7, D = 1/8, d = 2          -8.9e-1
+
+So the 1.5e-2 figure was a **transient** density, which the string did not say, and a reader
+budgeting against O(1e-2) was off by an order of magnitude exactly where the scheme is used.
+
+WHAT THIS FILE DOES NOT DO. #2007 recommends removing these schemes, on the grounds that the
+gradient form also drops the `m div(alpha)` term of `div(alpha m)` and so does not discretize the FP
+operator even away from the wall -- repointing the wall moves a source-free instance from 5.81e-1 to
+8.02e-1. That is a live recommendation, not something settled here:
+`test_gradient_centered_still_available_and_leaks` records a standing decision to keep them
+explicitly selectable, and overriding a recorded decision is not a warning's job.
+
+So this is the uncontested half: the numbers a caller reads are the numbers that were measured.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+from mfgarchon.alg.numerical.fp_solvers.fp_fdm import FPFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.core.mfg_components import MFGComponents
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry import TensorProductGrid
+from mfgarchon.geometry.boundary import no_flux_bc
+
+
+def _warning_text(scheme="gradient_upwind", n=21):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[n], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(
+        geometry=grid,
+        T=0.2,
+        Nt=5,
+        sigma=0.5,
+        coupling_coefficient=0.0,
+        components=MFGComponents(
+            m_initial=lambda z: np.ones_like(np.asarray(z, dtype=float)),
+            u_terminal=lambda z: np.asarray(z, dtype=float) * 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: np.asarray(m) * 0.0,
+                coupling_dm=lambda m: np.asarray(m) * 0.0,
+            ),
+        ),
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        FPFDMSolver(problem, advection_scheme=scheme)
+    texts = [str(w.message) for w in caught if "conserve mass" in str(w.message)]
+    assert texts, f"no non-conservation warning was emitted for {scheme}"
+    return texts[0]
+
+
+def test_the_warning_states_the_drift_dependence():
+    text = _warning_text()
+    assert "WALL-NORMAL DRIFT" in text, "the leak scales with drift; a flat magnitude misleads"
+    assert "-1.4e-1" in text, "the 1D driven figure must be quotable"
+    assert "-8.9e-1" in text, "and the 2D one, which is another order up"
+    assert "-1.7e-14" in text, "and the zero-drift figure, which is what makes the old one a transient"
+
+
+def test_the_understated_phrase_is_gone_from_the_live_claim():
+    """`O(1e-2), even with zero drift` is the sentence that cost the order of magnitude. It may
+    appear as a RETRACTION -- the message says what it used to say -- but not as a live figure."""
+    text = _warning_text()
+    live = text.split("previously said")[0]
+    assert "O(1e-2)" not in live, (
+        "the understated magnitude is back in the part of the message a reader takes as current"
+    )
+
+
+def test_the_second_defect_is_mentioned_because_a_conservative_wall_would_not_fix_it():
+    """A reader who only hears 'does not conserve mass' will reach for a conservative wall. The
+    gradient form also drops `m div(alpha)`, so that would not make it the FP operator."""
+    text = _warning_text()
+    assert "div(alpha)" in text, "the interior defect must be named, not only the wall one"
+    assert "2007" in text
+
+
+def test_the_divergence_schemes_do_not_warn():
+    """Control. Without it, a warning emitted unconditionally would pass every test above."""
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1))
+    problem = MFGProblem(
+        geometry=grid,
+        T=0.2,
+        Nt=5,
+        sigma=0.5,
+        coupling_coefficient=0.0,
+        components=MFGComponents(
+            m_initial=lambda z: np.ones_like(np.asarray(z, dtype=float)),
+            u_terminal=lambda z: np.asarray(z, dtype=float) * 0.0,
+            hamiltonian=SeparableHamiltonian(
+                control_cost=QuadraticControlCost(control_cost=1.0),
+                coupling=lambda m: np.asarray(m) * 0.0,
+                coupling_dm=lambda m: np.asarray(m) * 0.0,
+            ),
+        ),
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        FPFDMSolver(problem, advection_scheme="divergence_upwind")
+    assert not [w for w in caught if "conserve mass" in str(w.message)]


### PR DESCRIPTION
Addresses the uncontested half of #2007. **Does not close it** — see below.

The warning read *"leaks O(1e-2), even with zero drift"*. Measured:

| configuration | leak |
|---|---|
| genuinely zero drift, stationary initial density | **−1.7e-14** (none at all) |
| wall-normal drift A = 0.7, D = 1/8, d = 1 | **−1.4e-1** |
| wall-normal drift A = 0.7, D = 1/8, d = 2 | **−8.9e-1** |

The `1.5e-2` figure was a **transient** density, which the string did not say. A reader budgeting
against `O(1e-2)` was off by an order of magnitude exactly where the scheme is used.

The message now also names the **second** defect, because a reader who hears only "does not conserve
mass" will reach for a conservative wall and that would not fix it:

$$\nabla\cdot(\alpha m) = \alpha\cdot\nabla m + m\,\nabla\cdot\alpha$$

and the gradient form drops the second term, so it does not discretize the FP operator even away
from the wall. Repointing the wall moves a source-free instance from 5.81e-1 to 8.02e-1, EOC
−0.007 → 0.108.

## What this deliberately does not do, and how I found out

#2007 recommends **removing** these schemes, and that recommendation stands. My first attempt at this
PR implemented its Option 3 in full — refusing `gradient_*` under `no_flux` — and turned seven tests
red. Six were defect pins. The seventh was not:

```python
def test_gradient_centered_still_available_and_leaks():
    """The non-conservative form is still selectable explicitly, and demonstrably does NOT
    conserve mass -- documenting why it is no longer the centered default."""
```

That is a **standing decision**, recorded deliberately, and a warning is not the place to overturn
one. So this PR carries only the half that contradicts nothing: the numbers a caller reads are the
numbers that were measured. Whether to remove the schemes is left where #2007 put it — as a decision,
with the evidence now in the warning a user actually sees.

## Pinned

The corrected figures, including that `O(1e-2)` may appear only as a **retraction** ("previously
said…") and never as a live claim — a test splits the message at that phrase and checks only the part
a reader takes as current. Plus a control: the `divergence_*` schemes must not warn, or a warning
emitted unconditionally would pass everything above.

Gate: `./scripts/local_ci.sh` **GATE GREEN**.

Refs #2007 #1075