### PR TITLE
fix(coupling): withdraw the false claims about `obstacle`, pin what the term actually does (#2002)

### DIFF
--- a/changelog.d/obstacle-penalty-is-u-free.fixed.md
+++ b/changelog.d/obstacle-penalty-is-u-free.fixed.md
@@ -1,0 +1,13 @@
+Corrected four false claims about the `obstacle` field and pinned the defect they concealed
+(#2002). `mfg_problem.py` declares `obstacle` as the variational inequality `v >= Psi(x)`, but
+both paths acting on it compute `max(0, Psi)` — no `v` — so the term is identical at a node
+satisfying the constraint and one violating it: it penalises position, not violation. The two
+also disagree by 1e10 (`(1/eps) * max(0, psi)` with `eps = 1e6` against
+`penalty_parameter * max(0, psi)` with `1e4`), while `source_composition`'s docstring asserted
+they "match rather than silently diverge" and pointed to `PenaltyHJBSolver` as "proper handling"
+— that wrapper carries the same stub, and its own docstring described the intended
+`(1/eps) * max(0, Psi - v)` rather than the implemented term. All four sentences are withdrawn
+at their sites. The constraint itself is implemented correctly and reachably elsewhere —
+`ObstacleConstraint.project` (#591), applied by `HJBFDMSolver(constraint=...)` — so this is a
+single-source-of-truth defect, not a missing capability. Behaviour is unchanged; which owner
+survives is #2002's open question.

--- a/changelog.d/obstacle-penalty-is-u-free.fixed.md
+++ b/changelog.d/obstacle-penalty-is-u-free.fixed.md
@@ -1,13 +1,14 @@
-Corrected four false claims about the `obstacle` field and pinned the defect they concealed
-(#2002). `mfg_problem.py` declares `obstacle` as the variational inequality `v >= Psi(x)`, but
-both paths acting on it compute `max(0, Psi)` — no `v` — so the term is identical at a node
-satisfying the constraint and one violating it: it penalises position, not violation. The two
-also disagree by 1e10 (`(1/eps) * max(0, psi)` with `eps = 1e6` against
-`penalty_parameter * max(0, psi)` with `1e4`), while `source_composition`'s docstring asserted
-they "match rather than silently diverge" and pointed to `PenaltyHJBSolver` as "proper handling"
-— that wrapper carries the same stub, and its own docstring described the intended
-`(1/eps) * max(0, Psi - v)` rather than the implemented term. All four sentences are withdrawn
-at their sites. The constraint itself is implemented correctly and reachably elsewhere —
-`ObstacleConstraint.project` (#591), applied by `HJBFDMSolver(constraint=...)` — so this is a
-single-source-of-truth defect, not a missing capability. Behaviour is unchanged; which owner
-survives is #2002's open question.
+Corrected false claims about the `obstacle` field and pinned the defect they concealed (#2002).
+`mfg_problem.py` declares `obstacle` as the variational inequality `v >= Psi(x)`, but both paths
+acting on it compute `max(0, Psi)` — no `v` — so the term is identical at a node satisfying the
+constraint and one violating it: it penalises position, not violation. The two also disagree by
+1e10 (`(1/eps) * max(0, psi)` with `eps = 1e6` against `penalty_parameter * max(0, psi)` with
+`1e4`), and they are additive rather than alternative — `PenaltyHJBSolver` adds its term on top of
+whatever `source_term` it receives, which for a problem with `obstacle` set is the other one.
+Withdrawn at their sites: the `PenaltyHJBSolver` pointer as "proper handling" (that wrapper carries
+the same stub), in both copies of that claim; and `hjb_penalty`'s docstring, which described the
+intended `(1/eps) * max(0, Psi - v)` rather than the term it computes. Behaviour is unchanged;
+which owner survives is #2002's open question. Two adjacent defects found while establishing the
+above are filed separately: #2036 (the `constraint=` path clips post-hoc in 1D and returns an
+infeasible terminal slice in nD) and #2037 (`PenaltyHJBSolver` has never run compatibility
+validation).

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -70,10 +70,22 @@ class MFGResidual:
         ``M = M_new``, so the residual root coincides with the Picard fixed point
         including the source/nonlocal/obstacle terms.
 
-        Obstacle handling matches the Picard path exactly: the approximate
-        ``v = 0`` penalty ``(1/eps) * max(0, psi)`` (see ``compose_hjb_source``).
-        Proper handling is the ``PenaltyHJBSolver`` wrapper (#924); both coupling
-        paths use the same approximation so they do not silently diverge.
+        Obstacle handling matches the Picard path exactly: the same
+        ``(1/eps) * max(0, psi)`` from the one ``compose_hjb_source``. Both coupling
+        paths therefore do not silently diverge -- that part holds and is the point
+        of #1361.
+
+        Two corrections to what this paragraph used to say (#2002):
+
+        - *"Proper handling is the ``PenaltyHJBSolver`` wrapper (#924)"* is withdrawn.
+          That wrapper carries the same stub, and scales it by ``penalty_parameter``
+          (``1e4``) where this path divides by ``eps`` (``1e6``) -- 1e10 apart.
+        - ``v = 0`` understates it. ``max(0, psi)`` contains no ``v``, so it is identical
+          at a node satisfying ``v >= Psi`` and one violating it: a position penalty, not
+          a weakened constraint. It cannot enforce the inequality at any ``eps``.
+
+        Corrected here as well as in ``compose_hjb_source`` because this is a second
+        copy of the same claim -- the fork this module exists to close.
 
     Attributes:
         problem: MFG problem definition

--- a/mfgarchon/alg/numerical/coupling/source_composition.py
+++ b/mfgarchon/alg/numerical/coupling/source_composition.py
@@ -27,27 +27,32 @@ Conventions (mirrored verbatim from the prior ``FixedPointIterator`` copy):
   time-``t`` slice of the value function (Issue #1259), matching
   ``graph_mfg_solver``'s sign convention.
 - **Obstacle** computes ``(1/eps) * max(0, psi)`` (``eps = problem._penalty_eps`` if set, else
-  ``1e6``). Two sentences that used to follow this were false and are withdrawn (#2002):
+  ``1e6``), and **both coupling paths -- Picard (``FixedPointIterator``) and coupled-Newton
+  (``MFGResidual``) -- use this one copy, so they do match rather than silently diverge.** That
+  is this module's whole purpose per the opening paragraph, and it holds: both call
+  ``compose_hjb_source``. The referent is spelled out here because a reader (this one) took
+  "both coupling paths" for the two *obstacle* spellings and wrongly withdrew the sentence.
 
-  - *"Proper handling is the ``PenaltyHJBSolver`` wrapper (#924)"* — that wrapper carries the same
-    stub and says so in its own comment, *"For now, we apply a static obstacle penalty"*. The
-    pointer sent a reader to a second copy.
-  - *"both coupling paths use this same approximation so they* **match** *rather than silently
-    diverge"* — same formula SHAPE, scalings **1e10 apart**. Measured at ``psi = 0.5``:
-    ``source_composition`` gives 5.000000e-07 (``1/eps``, ``eps = 1e6``) and ``hjb_penalty`` gives
-    5.000000e+03 (``penalty_param``, ``1e4``). One divides by its knob, the other multiplies. The
-    sentence asserting they agree is what would stop someone checking.
+  One sentence that used to follow IS false and is withdrawn (#2002): *"Proper handling is the
+  ``PenaltyHJBSolver`` wrapper (#924)"*. That wrapper carries the same stub and says so in its
+  own comment, *"For now, we apply a static obstacle penalty"*; its docstring separately
+  described the intended ``(1/eps) * max(0, Psi - v)`` rather than the term it computes, and
+  scales by ``penalty_parameter`` (``1e4``) where this path divides by ``eps`` -- 1e10 apart at
+  the defaults. The pointer sent a reader to a second, differently-scaled copy.
 
-  Neither expression can enforce what ``mfg_problem.py`` declares. Penalising ``v >= Psi`` needs
-  ``max(0, Psi - v)``, positive exactly when the constraint is broken; ``max(0, Psi)`` contains no
-  ``v`` at all and is positive wherever ``Psi > 0`` regardless. **It penalises position, not
-  violation** — verified, the value is unchanged at ``v = -10, 0, +10``.
+  **What the ``v = 0`` label understates.** ``max(0, psi)`` contains no ``v`` at all, so it is
+  positive wherever ``Psi > 0`` whether or not ``v >= Psi`` holds: it penalises position, not
+  violation, and is identical at a node satisfying the constraint and one violating it. Not an
+  approximation that degrades with distance from ``v = 0`` -- a different term. Verified through
+  this function: ``u`` nine units below the obstacle and nine above return byte-identical arrays.
 
-  The ``v`` is available here: ``_problem_hjb_source_terms`` is called with ``u_current`` three
-  lines above, and the ``nonlocal`` branch in the same closure uses ``nonlocal_operator @ v_t``.
-  What a fix owes, and why the decision is not this docstring's to make, is in #2002 — it turns on
-  whether the intent is a constraint or a state penalty ``V(x)``, and if the latter the term is
-  ``u``-free and belongs in the Hamiltonian's potential instead.
+  The ``v`` is available here: ``u_current`` is bound above and the ``nonlocal`` branch in the
+  same closure uses ``nonlocal_operator @ v_t``. What a fix owes is in #2002; it turns on whether
+  the intent is a constraint or a state penalty ``V(x)``, and if the latter the term is ``u``-free
+  and belongs in the Hamiltonian's potential instead. A constraint-shaped alternative already
+  exists under a different entry point -- ``ObstacleConstraint`` with
+  ``HJBFDMSolver(constraint=...)`` (#591) -- though it has defects of its own; see #2036.
+
 - The HJB source passes the **value-function slice** ``v_t`` to
   ``source_term_hjb(x, m, v, t)`` (Issue #1382), matching the documented
   ``Callable(x, m, v, t)`` contract (``mfg_problem.py``: "source_term_hjb/fp"),

--- a/mfgarchon/alg/numerical/coupling/source_composition.py
+++ b/mfgarchon/alg/numerical/coupling/source_composition.py
@@ -26,10 +26,28 @@ Conventions (mirrored verbatim from the prior ``FixedPointIterator`` copy):
 - **Nonlocal term** applied as ``s += nonlocal_operator @ v_t`` with ``v_t`` the
   time-``t`` slice of the value function (Issue #1259), matching
   ``graph_mfg_solver``'s sign convention.
-- **Obstacle** uses the approximate ``v = 0`` penalty ``(1/eps) * max(0, psi)``
-  (``eps = problem._penalty_eps`` if set, else ``1e6``). Proper handling is the
-  ``PenaltyHJBSolver`` wrapper (#924); both coupling paths use this same
-  approximation so they **match** rather than silently diverge.
+- **Obstacle** computes ``(1/eps) * max(0, psi)`` (``eps = problem._penalty_eps`` if set, else
+  ``1e6``). Two sentences that used to follow this were false and are withdrawn (#2002):
+
+  - *"Proper handling is the ``PenaltyHJBSolver`` wrapper (#924)"* — that wrapper carries the same
+    stub and says so in its own comment, *"For now, we apply a static obstacle penalty"*. The
+    pointer sent a reader to a second copy.
+  - *"both coupling paths use this same approximation so they* **match** *rather than silently
+    diverge"* — same formula SHAPE, scalings **1e10 apart**. Measured at ``psi = 0.5``:
+    ``source_composition`` gives 5.000000e-07 (``1/eps``, ``eps = 1e6``) and ``hjb_penalty`` gives
+    5.000000e+03 (``penalty_param``, ``1e4``). One divides by its knob, the other multiplies. The
+    sentence asserting they agree is what would stop someone checking.
+
+  Neither expression can enforce what ``mfg_problem.py`` declares. Penalising ``v >= Psi`` needs
+  ``max(0, Psi - v)``, positive exactly when the constraint is broken; ``max(0, Psi)`` contains no
+  ``v`` at all and is positive wherever ``Psi > 0`` regardless. **It penalises position, not
+  violation** — verified, the value is unchanged at ``v = -10, 0, +10``.
+
+  The ``v`` is available here: ``_problem_hjb_source_terms`` is called with ``u_current`` three
+  lines above, and the ``nonlocal`` branch in the same closure uses ``nonlocal_operator @ v_t``.
+  What a fix owes, and why the decision is not this docstring's to make, is in #2002 — it turns on
+  whether the intent is a constraint or a state penalty ``V(x)``, and if the latter the term is
+  ``u``-free and belongs in the Hamiltonian's potential instead.
 - The HJB source passes the **value-function slice** ``v_t`` to
   ``source_term_hjb(x, m, v, t)`` (Issue #1382), matching the documented
   ``Callable(x, m, v, t)`` contract (``mfg_problem.py``: "source_term_hjb/fp"),

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
@@ -125,10 +125,16 @@ class PenaltyHJBSolver(BaseHJBSolver):
            so it cannot push ``v`` anywhere in particular. See the comment at the
            expression itself.
 
-           The constraint IS implemented correctly elsewhere --
+           A constraint-shaped alternative exists elsewhere --
            :meth:`~mfgarchon.geometry.boundary.ObstacleConstraint.project` (#591), which
-           ``HJBFDMSolver`` applies when constructed with ``constraint=``. Prefer that path
-           until #2002 resolves which owner survives.
+           ``HJBFDMSolver`` applies when constructed with ``constraint=``. It does read ``u``
+           and does enforce ``u >= psi`` on what it returns, which is more than this term can
+           say. **It is not, however, an obstacle-problem solver, and "correct" overstates it**
+           (#2036): in 1D the projection runs after the backward sweep finishes, so the result
+           is exactly ``max(U_free, psi)`` -- the unconstrained solution clipped, with no free
+           boundary resolved; in nD it runs inside the time loop and does feed back, but the
+           terminal slice never passes through it and can violate the constraint. Prefer it
+           over this term while #2002 is open, knowing both limits.
         """
         penalty_param = self._penalty
         obstacle_fn = self._obstacle

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
@@ -111,11 +111,24 @@ class PenaltyHJBSolver(BaseHJBSolver):
     ) -> NDArray:
         """Solve HJB with obstacle constraint via penalty method.
 
-        Composes the penalty term (1/eps) * max(0, Psi - v) with any
-        existing source_term, then delegates to the inner solver.
+        .. warning::
 
-        The penalty pushes v upward when it falls below Psi, enforcing
-        the variational inequality v >= Psi in the limit eps -> 0.
+           **This docstring described the intended term, not the implemented one (#2002).**
+           It said the method "composes the penalty term ``(1/eps) * max(0, Psi - v)``" and
+           that "the penalty pushes v upward when it falls below Psi, enforcing the
+           variational inequality ``v >= Psi`` in the limit ``eps -> 0``". The code below
+           computes ``penalty_parameter * max(0, Psi)`` -- no ``v``, and the knob is the
+           reciprocal spelling. Both sentences are withdrawn.
+
+           What is actually applied is a **position** penalty: positive wherever
+           ``Psi > 0``, identical at a node satisfying the constraint and one violating it,
+           so it cannot push ``v`` anywhere in particular. See the comment at the
+           expression itself.
+
+           The constraint IS implemented correctly elsewhere --
+           :meth:`~mfgarchon.geometry.boundary.ObstacleConstraint.project` (#591), which
+           ``HJBFDMSolver`` applies when constructed with ``constraint=``. Prefer that path
+           until #2002 resolves which owner survives.
         """
         penalty_param = self._penalty
         obstacle_fn = self._obstacle
@@ -141,6 +154,16 @@ class PenaltyHJBSolver(BaseHJBSolver):
             # not (t, x, v) -> array. The v-dependent penalty must be
             # handled at the time-stepping level inside the solver.
             # For now, we apply a static obstacle penalty.
+            #
+            # #2002: `max(0, psi)` PENALISES POSITION, NOT VIOLATION. It contains no `v`, so it is
+            # positive wherever psi > 0 whether or not `v >= Psi` holds -- verified, unchanged at
+            # v = -10, 0, +10. This is not a weaker form of the constraint; it is a different term.
+            #
+            # And this is NOT the "proper handling" that `source_composition`'s docstring pointed
+            # here for. It is the same stub with the reciprocal knob: multiplying by
+            # `penalty_parameter` (1e4) where that path divides by `eps` (1e6). At psi = 0.5 the two
+            # give 5.000000e+03 and 5.000000e-07 -- 1e10 apart, while a comment there claimed they
+            # matched. That claim is withdrawn; this comment is the other half of the correction.
             psi = np.asarray(obstacle_fn(x)).ravel()
             return base + penalty_param * np.maximum(0.0, psi)
 

--- a/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
+++ b/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
@@ -138,7 +138,7 @@ def test_newton_solver_solves_with_obstacle():
     obstacle entirely, which is the #1285 defect.
 
     Threshold. The obstacle enters as ``(1/eps)*max(0, psi(x))`` with ``eps = 1e6``
-    (source_composition.py:130-133), so it is a small perturbation and the tolerance has to sit
+    (the obstacle branch of ``compose_hjb_source``), so it is a small perturbation and the tolerance has to sit
     below it or it certifies nothing. Measured on this fixture:
 
     - Newton-vs-Picard relative gap with the obstacle wired to both: 2.4e-10 (U), 7.6e-11 (M).

--- a/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
+++ b/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
@@ -1,34 +1,53 @@
-"""#2002 -- ``problem.obstacle`` is a second, broken spelling of a concept the library
-already implements correctly.
+"""#2002 -- the ``obstacle`` field is documented as a variational inequality and implemented
+as a position penalty, in two places that differ by 1e10.
 
-``mfg_problem.py`` declares ``obstacle`` as the variational inequality ``v >= Psi(x)``.
-Two code paths act on it and **neither reads ``v``**:
+``mfg_problem.py`` declares ``obstacle`` as ``v >= Psi(x)``. Two code paths act on it and
+**neither reads ``v``**:
 
 ===========================================  =============================  ==============
 path                                         expression                     ``psi = 0.5``
 ===========================================  =============================  ==============
-``source_composition.py``                    ``(1 / eps) * max(0, psi)``    ``5.0e-07``
+``coupling/source_composition.py``           ``(1 / eps) * max(0, psi)``    ``5.0e-07``
 ``hjb_solvers/hjb_penalty.py``               ``penalty * max(0, psi)``      ``5.0e+03``
 ===========================================  =============================  ==============
 
-The headline number is that those are 1e10 apart, but the disqualifying property is
-cheaper to state: **the term is identical at a node that satisfies the constraint and a
-node that violates it**, because ``max(0, psi)`` contains no ``v``. It penalises position,
-not violation. A docstring in ``source_composition`` asserted the two paths "match rather
-than silently diverge"; that sentence is withdrawn (see the module docstring there).
+The headline number is that those are 1e10 apart, but the disqualifying property is cheaper to
+state and independent of both constants: **the term is identical at a node that satisfies the
+constraint and one that violates it**, because ``max(0, psi)`` contains no ``v``. It penalises
+position, not violation.
 
-What makes this a single-source-of-truth defect rather than a missing feature: the
-constraint IS implemented, correctly and reachably, under a different entry point --
-``ObstacleConstraint.project`` (#591), which ``HJBFDMSolver`` calls at ``hjb_fdm.py:499``
-and ``:762`` when constructed with ``constraint=``. So the repo holds two spellings of one
-concept, and the reachable-from-``problem.obstacle`` one is the broken one.
+**The two are not alternatives.** ``FixedPointIterator`` passes ``compose_hjb_source``'s closure
+as ``source_term=`` to whatever HJB solver it holds, and ``PenaltyHJBSolver.penalized_source``
+starts from ``base = source_term(t, x)`` and *adds* its own term. A problem with ``obstacle`` set
+and wrapped in ``PenaltyHJBSolver`` applies both, summed. The 1e10 ratio is therefore a statement
+about two spellings of one knob, not a discrepancy between rival implementations to reconcile.
 
-These tests pin the defect so that reading the (now corrected) comments cannot restore the
-belief that the paths agree. **Retirement condition:** when #2002 routes ``problem.obstacle``
-to the constraint machinery or makes it fail loud, ``test_obstacle_term_cannot_tell_satisfied_from_violated``
-and ``test_the_two_obstacle_scalings_are_1e10_apart`` must be DELETED, not adjusted -- they
-assert current-wrong behaviour on purpose. ``test_the_correct_owner_exists_and_is_u_dependent``
-survives; it describes the target.
+Why the defect survived. It is NOT that no test exercises ``problem.obstacle`` --
+``test_issue1285_newton_fail_loud.py`` builds a problem with ``obstacle=`` and asserts
+``u_gap < 1e-8``. But that test compares **Picard against coupled-Newton**, and both consume the
+one ``compose_hjb_source``, so no amount of ``v``-freedom in the shared term could make it fail.
+The field has end-to-end coverage of *path agreement* and none of *what the term computes*.
+
+A constraint-shaped alternative exists under a different entry point --
+``ObstacleConstraint.project`` (#591), applied by ``HJBFDMSolver(constraint=...)``. It reads ``u``
+and enforces ``u >= psi`` on what it returns, which is more than these terms can say. Calling it
+*correct* overstates it: that path clips post-hoc in 1D and returns an infeasible terminal slice
+in nD (#2036).
+
+**Retirement condition.** When #2002 makes either term read ``v``:
+
+- ``test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u`` and
+  ``test_penalty_source_is_byte_identical_for_violated_and_satisfied_v`` assert current-wrong
+  behaviour on purpose and must be **DELETED, not adjusted**.
+- ``test_the_two_obstacle_spellings_are_1e10_apart`` reddens under a ``v``-dependence fix too,
+  because the fix moves the measured values -- **update its expected values, do not delete it**.
+  It is the only guard on the two constructor defaults, and it fires on its own when the knobs
+  are unified without any ``v`` change (measured).
+- ``test_the_constraint_owner_exists_and_is_u_dependent`` survives; it describes the target.
+- Expect a fourth failure outside this file:
+  ``test_issue1361_source_composition.py::test_hjb_composition_matches_reference_and_delegate``
+  reimplements the production obstacle formula as its oracle (lines 58-71) and reddens under any
+  compose-side fix. That is the oracle needing the same edit, not a regression.
 """
 
 import numpy as np
@@ -37,24 +56,34 @@ from mfgarchon.alg.numerical.coupling.source_composition import compose_hjb_sour
 from mfgarchon.alg.numerical.hjb_solvers.hjb_penalty import PenaltyHJBSolver
 from mfgarchon.geometry.boundary import ObstacleConstraint
 
-# The two literal defaults, read off the call sites named in the module docstring.
 EPS_DEFAULT = 1e6  # source_composition.py: getattr(problem, "_penalty_eps", 1e6)
-PENALTY_DEFAULT = 1e4  # hjb_penalty.py: penalty_parameter
+PENALTY_DEFAULT = 1e4  # hjb_penalty.py: penalty_parameter -- NOT passed below, so the real
+# constructor default is what gets exercised.
 
 PSI = 0.5
 NX = 5
-# Two value functions on opposite sides of the obstacle. A term that enforced `v >= Psi`
-# would vanish on SATISFIED and be strictly positive on VIOLATED.
-U_VIOLATED = np.full((3, NX), -9.0)
-U_SATISFIED = np.full((3, NX), +9.0)
+NT = 3
+# Two value functions on opposite sides of the obstacle. A term enforcing `v >= Psi` vanishes on
+# SATISFIED and is strictly positive on VIOLATED. Neither may be all-zero: `max(0, psi - 0)` is
+# `max(0, psi)`, so a zero `v` cannot distinguish the fix from the defect.
+U_VIOLATED = np.full((NT, NX), -9.0)
+U_SATISFIED = np.full((NT, NX), +9.0)
 
 
 def _flat_obstacle(x):
     return np.full(np.asarray(x).shape[0], PSI)
 
 
+def _x():
+    return np.linspace(0.0, 1.0, NX).reshape(-1, 1)
+
+
 class _ProblemStub:
-    """Minimal duck type carrying only the fields the obstacle branch reads."""
+    """Minimal duck type carrying only the fields the obstacle branch reads.
+
+    Verified byte-equal against a real ``MFGProblem(obstacle=...)``; it omits ``_penalty_eps`` on
+    purpose so the ``getattr`` default is the thing under test.
+    """
 
     obstacle = staticmethod(_flat_obstacle)
     nonlocal_operator = None
@@ -62,11 +91,36 @@ class _ProblemStub:
     dt = 0.1
 
 
-def test_the_correct_owner_exists_and_is_u_dependent():
+class _SpyInner:
+    """Captures the ``source_term`` the wrapper hands down, per call."""
+
+    problem = _ProblemStub()
+    config = None
+
+    def __init__(self):
+        self.captured = []
+
+    def solve_hjb_system(self, M, U_T, U_prev, volatility_field=None, source_term=None):
+        self.captured.append(source_term)
+        return np.zeros_like(U_T)
+
+
+def _penalty_source_for(u_prev):
+    """Drive the real ``PenaltyHJBSolver`` with a given ``U_coupling_prev`` and return the
+    ``source_term`` closure it produced, evaluated on the grid."""
+    inner = _SpyInner()
+    solver = PenaltyHJBSolver(inner_solver=inner, obstacle=_flat_obstacle)
+    solver.solve_hjb_system(np.zeros((NT, NX)), np.zeros(NX), u_prev)
+    assert inner.captured, "sanity: the wrapper must pass a source_term down"
+    return inner.captured[-1](0.0, _x())
+
+
+def test_the_constraint_owner_exists_and_is_u_dependent():
     """``ObstacleConstraint.project`` enforces ``u >= psi`` and reads ``u``.
 
-    This is the test that SURVIVES the fix: it establishes that #2002 is a routing
-    defect, not a missing capability. Without it the other two read as "this is hard".
+    SURVIVES the fix. Establishes that #2002 is about a term that cannot express the constraint,
+    not about the constraint being hard to express. It says nothing about whether the solver path
+    around ``project`` solves an obstacle problem -- it does not; see #2036.
     """
     psi = np.full(NX, PSI)
     u = np.array([1.0, 0.2, 0.5, -3.0, 0.9])  # entries 1 and 3 violate u >= psi
@@ -75,7 +129,7 @@ def test_the_correct_owner_exists_and_is_u_dependent():
     projected = constraint.project(u)
 
     assert np.all(projected >= psi - 1e-14), f"project did not enforce u >= psi: {projected}"
-    # Feasible entries must be left alone -- a projection, not a clamp-everything.
+    # Feasible entries untouched -- a projection, not a clamp-everything.
     assert projected[0] == u[0]
     assert projected[4] == u[4]
     # Violated entries land ON the obstacle.
@@ -88,13 +142,11 @@ def test_the_correct_owner_exists_and_is_u_dependent():
 def test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u():
     """DEFECT (#2002). Delete on fix -- do not adjust.
 
-    Drives the REAL ``compose_hjb_source``, which receives ``u_current`` and therefore
-    could distinguish the two regimes. It does not: the obstacle branch computes
-    ``max(0, psi)``, so feeding it a ``u`` nine units BELOW the obstacle and one nine units
-    ABOVE returns the same array. Any fix that makes the term read ``v`` breaks this.
+    Drives the real ``compose_hjb_source``, which receives ``u_current`` and could therefore
+    distinguish the two regimes. It does not.
     """
-    x = np.linspace(0.0, 1.0, NX).reshape(-1, 1)
-    m = np.zeros((3, NX))
+    x = _x()
+    m = np.zeros((NT, NX))
 
     f_violated = compose_hjb_source(_ProblemStub(), m, U_VIOLATED)
     f_satisfied = compose_hjb_source(_ProblemStub(), m, U_SATISFIED)
@@ -104,52 +156,47 @@ def test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u():
     out_violated = f_violated(0.0, x)
     out_satisfied = f_satisfied(0.0, x)
 
-    # The defect, stated as the property that disqualifies the term.
+    assert out_satisfied.shape == (NX,), f"degenerate grid would vacuously pass: {out_satisfied.shape}"
     assert np.array_equal(out_violated, out_satisfied), (
-        "the obstacle source distinguished the two regimes -- if #2002 is fixed, DELETE "
-        "this test rather than loosening it"
+        "the obstacle source distinguished the two regimes -- if #2002 is fixed, DELETE this test"
     )
-    # And it is not merely small-but-different: it is positive where it should vanish.
-    assert np.all(out_satisfied > 0.0), (
-        "u is 9 above the obstacle everywhere, so a constraint penalty must be exactly 0"
-    )
+    # Not merely small-but-different: positive where a constraint penalty must vanish.
+    assert np.all(out_satisfied > 0.0), "u is 9 above the obstacle everywhere; a penalty must be 0"
     assert np.allclose(out_satisfied, (1.0 / EPS_DEFAULT) * PSI)
 
 
-def test_penalty_solver_source_is_u_free_and_1e10_from_the_other_path():
+def test_penalty_source_is_byte_identical_for_violated_and_satisfied_v():
     """DEFECT (#2002). Delete on fix -- do not adjust.
 
-    Drives the REAL ``PenaltyHJBSolver``, capturing the ``source_term`` it hands to its
-    inner solver, and evaluates it. Pins both halves: no ``v`` dependence, and a scaling
-    1e10 from ``compose_hjb_source`` -- one divides by ``eps`` (defaulted LARGE, so the
-    coefficient is 1e-6), the other multiplies by ``penalty_parameter`` (1e4).
+    ``PenaltyHJBSolver.solve_hjb_system`` receives ``U_coupling_prev``, so the ``v`` its own
+    withdrawn docstring promised to use is already in hand. Drive it twice with ``v`` on opposite
+    sides of the obstacle and compare the closures it produced.
+
+    The comparison must use a NON-ZERO ``v``: with ``v = 0`` the fix ``max(0, psi - v)`` collapses
+    to ``max(0, psi)`` and this test would pass on a fixed implementation.
     """
-    x = np.linspace(0.0, 1.0, NX).reshape(-1, 1)
-    captured = {}
+    out_violated = _penalty_source_for(U_VIOLATED)
+    out_satisfied = _penalty_source_for(U_SATISFIED)
 
-    class _SpyInner:
-        problem = _ProblemStub()
-        config = None
-
-        def solve_hjb_system(self, M, U_T, U_prev, volatility_field=None, source_term=None):
-            captured["source_term"] = source_term
-            return np.zeros_like(U_T)
-
-    solver = PenaltyHJBSolver(
-        inner_solver=_SpyInner(),
-        obstacle=_flat_obstacle,
-        penalty_parameter=PENALTY_DEFAULT,
+    assert out_satisfied.shape == (NX,), f"degenerate grid would vacuously pass: {out_satisfied.shape}"
+    assert np.array_equal(out_violated, out_satisfied), (
+        "the penalty source distinguished v = -9 from v = +9 -- if #2002 is fixed, DELETE this test"
     )
-    solver.solve_hjb_system(np.zeros((3, NX)), np.zeros(NX), np.zeros((3, NX)))
+    assert np.all(out_satisfied > 0.0), "v is 9 above the obstacle everywhere; a penalty must be 0"
 
-    penalized = captured["source_term"]
-    assert penalized is not None, "sanity: the wrapper must pass a source_term down"
 
-    # The closure takes (t, x) only -- there is nowhere for v to enter.
-    value = penalized(0.0, x)
-    assert np.allclose(value, PENALTY_DEFAULT * PSI), f"hjb_penalty term moved: {value}"
+def test_the_two_obstacle_spellings_are_1e10_apart():
+    """Pins BOTH constructor defaults. Reddens under a ``v``-dependence fix as well -- update its
+    numbers rather than deleting it -- and fires alone when the knobs are unified.
 
-    # The other path, measured through its own real code, on the same obstacle.
-    other = compose_hjb_source(_ProblemStub(), np.zeros((3, NX)), U_VIOLATED)(0.0, x)
-    assert np.allclose(other, (1.0 / EPS_DEFAULT) * PSI)
-    assert np.allclose(value / other, 1.0e10), f"the gap between the two paths moved: {value / other}"
+    Neither default is passed in by the caller here: ``_ProblemStub`` omits ``_penalty_eps`` so
+    ``source_composition``'s ``getattr`` default fires, and ``_penalty_source_for`` omits
+    ``penalty_parameter`` so the constructor default fires. Changing either silently moves the
+    gap and reddens this test.
+    """
+    compose_out = compose_hjb_source(_ProblemStub(), np.zeros((NT, NX)), U_VIOLATED)(0.0, _x())
+    penalty_out = _penalty_source_for(U_VIOLATED)
+
+    assert np.allclose(compose_out, (1.0 / EPS_DEFAULT) * PSI), f"eps default moved: {compose_out}"
+    assert np.allclose(penalty_out, PENALTY_DEFAULT * PSI), f"penalty default moved: {penalty_out}"
+    assert np.allclose(penalty_out / compose_out, 1.0e10), f"the gap moved: {penalty_out / compose_out}"

--- a/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
+++ b/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
@@ -1,0 +1,155 @@
+"""#2002 -- ``problem.obstacle`` is a second, broken spelling of a concept the library
+already implements correctly.
+
+``mfg_problem.py`` declares ``obstacle`` as the variational inequality ``v >= Psi(x)``.
+Two code paths act on it and **neither reads ``v``**:
+
+===========================================  =============================  ==============
+path                                         expression                     ``psi = 0.5``
+===========================================  =============================  ==============
+``source_composition.py``                    ``(1 / eps) * max(0, psi)``    ``5.0e-07``
+``hjb_solvers/hjb_penalty.py``               ``penalty * max(0, psi)``      ``5.0e+03``
+===========================================  =============================  ==============
+
+The headline number is that those are 1e10 apart, but the disqualifying property is
+cheaper to state: **the term is identical at a node that satisfies the constraint and a
+node that violates it**, because ``max(0, psi)`` contains no ``v``. It penalises position,
+not violation. A docstring in ``source_composition`` asserted the two paths "match rather
+than silently diverge"; that sentence is withdrawn (see the module docstring there).
+
+What makes this a single-source-of-truth defect rather than a missing feature: the
+constraint IS implemented, correctly and reachably, under a different entry point --
+``ObstacleConstraint.project`` (#591), which ``HJBFDMSolver`` calls at ``hjb_fdm.py:499``
+and ``:762`` when constructed with ``constraint=``. So the repo holds two spellings of one
+concept, and the reachable-from-``problem.obstacle`` one is the broken one.
+
+These tests pin the defect so that reading the (now corrected) comments cannot restore the
+belief that the paths agree. **Retirement condition:** when #2002 routes ``problem.obstacle``
+to the constraint machinery or makes it fail loud, ``test_obstacle_term_cannot_tell_satisfied_from_violated``
+and ``test_the_two_obstacle_scalings_are_1e10_apart`` must be DELETED, not adjusted -- they
+assert current-wrong behaviour on purpose. ``test_the_correct_owner_exists_and_is_u_dependent``
+survives; it describes the target.
+"""
+
+import numpy as np
+
+from mfgarchon.alg.numerical.coupling.source_composition import compose_hjb_source
+from mfgarchon.alg.numerical.hjb_solvers.hjb_penalty import PenaltyHJBSolver
+from mfgarchon.geometry.boundary import ObstacleConstraint
+
+# The two literal defaults, read off the call sites named in the module docstring.
+EPS_DEFAULT = 1e6  # source_composition.py: getattr(problem, "_penalty_eps", 1e6)
+PENALTY_DEFAULT = 1e4  # hjb_penalty.py: penalty_parameter
+
+PSI = 0.5
+NX = 5
+# Two value functions on opposite sides of the obstacle. A term that enforced `v >= Psi`
+# would vanish on SATISFIED and be strictly positive on VIOLATED.
+U_VIOLATED = np.full((3, NX), -9.0)
+U_SATISFIED = np.full((3, NX), +9.0)
+
+
+def _flat_obstacle(x):
+    return np.full(np.asarray(x).shape[0], PSI)
+
+
+class _ProblemStub:
+    """Minimal duck type carrying only the fields the obstacle branch reads."""
+
+    obstacle = staticmethod(_flat_obstacle)
+    nonlocal_operator = None
+    source_term_hjb = None
+    dt = 0.1
+
+
+def test_the_correct_owner_exists_and_is_u_dependent():
+    """``ObstacleConstraint.project`` enforces ``u >= psi`` and reads ``u``.
+
+    This is the test that SURVIVES the fix: it establishes that #2002 is a routing
+    defect, not a missing capability. Without it the other two read as "this is hard".
+    """
+    psi = np.full(NX, PSI)
+    u = np.array([1.0, 0.2, 0.5, -3.0, 0.9])  # entries 1 and 3 violate u >= psi
+
+    constraint = ObstacleConstraint(psi, constraint_type="lower")
+    projected = constraint.project(u)
+
+    assert np.all(projected >= psi - 1e-14), f"project did not enforce u >= psi: {projected}"
+    # Feasible entries must be left alone -- a projection, not a clamp-everything.
+    assert projected[0] == u[0]
+    assert projected[4] == u[4]
+    # Violated entries land ON the obstacle.
+    assert projected[1] == psi[1]
+    assert projected[3] == psi[3]
+    # And the output genuinely depends on u.
+    assert not np.allclose(projected, constraint.project(u + 5.0))
+
+
+def test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u():
+    """DEFECT (#2002). Delete on fix -- do not adjust.
+
+    Drives the REAL ``compose_hjb_source``, which receives ``u_current`` and therefore
+    could distinguish the two regimes. It does not: the obstacle branch computes
+    ``max(0, psi)``, so feeding it a ``u`` nine units BELOW the obstacle and one nine units
+    ABOVE returns the same array. Any fix that makes the term read ``v`` breaks this.
+    """
+    x = np.linspace(0.0, 1.0, NX).reshape(-1, 1)
+    m = np.zeros((3, NX))
+
+    f_violated = compose_hjb_source(_ProblemStub(), m, U_VIOLATED)
+    f_satisfied = compose_hjb_source(_ProblemStub(), m, U_SATISFIED)
+    assert f_violated is not None, "sanity: an obstacle field must produce a closure"
+    assert f_satisfied is not None
+
+    out_violated = f_violated(0.0, x)
+    out_satisfied = f_satisfied(0.0, x)
+
+    # The defect, stated as the property that disqualifies the term.
+    assert np.array_equal(out_violated, out_satisfied), (
+        "the obstacle source distinguished the two regimes -- if #2002 is fixed, DELETE "
+        "this test rather than loosening it"
+    )
+    # And it is not merely small-but-different: it is positive where it should vanish.
+    assert np.all(out_satisfied > 0.0), (
+        "u is 9 above the obstacle everywhere, so a constraint penalty must be exactly 0"
+    )
+    assert np.allclose(out_satisfied, (1.0 / EPS_DEFAULT) * PSI)
+
+
+def test_penalty_solver_source_is_u_free_and_1e10_from_the_other_path():
+    """DEFECT (#2002). Delete on fix -- do not adjust.
+
+    Drives the REAL ``PenaltyHJBSolver``, capturing the ``source_term`` it hands to its
+    inner solver, and evaluates it. Pins both halves: no ``v`` dependence, and a scaling
+    1e10 from ``compose_hjb_source`` -- one divides by ``eps`` (defaulted LARGE, so the
+    coefficient is 1e-6), the other multiplies by ``penalty_parameter`` (1e4).
+    """
+    x = np.linspace(0.0, 1.0, NX).reshape(-1, 1)
+    captured = {}
+
+    class _SpyInner:
+        problem = _ProblemStub()
+        config = None
+
+        def solve_hjb_system(self, M, U_T, U_prev, volatility_field=None, source_term=None):
+            captured["source_term"] = source_term
+            return np.zeros_like(U_T)
+
+    solver = PenaltyHJBSolver(
+        inner_solver=_SpyInner(),
+        obstacle=_flat_obstacle,
+        penalty_parameter=PENALTY_DEFAULT,
+    )
+    solver.solve_hjb_system(np.zeros((3, NX)), np.zeros(NX), np.zeros((3, NX)))
+
+    penalized = captured["source_term"]
+    assert penalized is not None, "sanity: the wrapper must pass a source_term down"
+
+    # The closure takes (t, x) only -- there is nowhere for v to enter.
+    value = penalized(0.0, x)
+    assert np.allclose(value, PENALTY_DEFAULT * PSI), f"hjb_penalty term moved: {value}"
+
+    # The other path, measured through its own real code, on the same obstacle.
+    other = compose_hjb_source(_ProblemStub(), np.zeros((3, NX)), U_VIOLATED)(0.0, x)
+    assert np.allclose(other, (1.0 / EPS_DEFAULT) * PSI)
+    assert np.allclose(value / other, 1.0e10), f"the gap between the two paths moved: {value / other}"


### PR DESCRIPTION
## What this is

The **uncontested half** of #2002. The issue states that item 4 — soft wall or obstacle problem? — **gates the rest**, so this decides nothing about semantics. It corrects claims that are false whichever way item 4 goes, and pins the defect so those claims cannot re-form.

Two reviewers adjudicated the first commit and found real errors in it. `5dc4db13` fixes them; this description is the corrected version, and the errors are listed at the bottom rather than quietly dropped.

## The defect

The headline in #2002 is that the two paths are 1e10 apart. The disqualifying property is cheaper and does not depend on either constant: **the term cannot tell a satisfied node from a violated one.** `max(0, Psi)` contains no `v`, so it is positive wherever `Psi > 0` regardless of where `v` sits.

Measured through the real `compose_hjb_source`, same obstacle, `u` nine units either side:

| `u_current` | constraint | obstacle source |
|---|---|---|
| `-9` everywhere | violated | `5.000000e-07` |
| `+9` everywhere | satisfied | `5.000000e-07` |

Byte-identical. A correct `max(0, Psi - v)` would be `0` on the second row. The same holds for `PenaltyHJBSolver`, driven through its own real code with `U_coupling_prev` at ±9.

**The two paths are additive, not alternatives.** `FixedPointIterator` passes `compose_hjb_source`'s closure as `source_term=`, and `PenaltyHJBSolver.penalized_source` starts from `base = source_term(t, x)` and adds its own. A problem with `obstacle` set *and* wrapped applies both, summed. The 1e10 ratio is two spellings of one knob, not rival implementations to reconcile.

## Claims withdrawn at their sites

| site | claim | fact |
|---|---|---|
| `source_composition` | "proper handling is the `PenaltyHJBSolver` wrapper (#924)" | same stub; its own comment says *"For now, we apply a static obstacle penalty"* |
| `mfg_residual` | the same `#924` sentence, **second copy** | missed in the first commit — a change arguing single-source had left the fork open |
| `hjb_penalty` docstring | "composes the penalty term `(1/eps) * max(0, Psi - v)`" | that is the intended term, not the implemented one |
| `hjb_penalty` docstring | the penalty "pushes v upward when it falls below Psi" | there is no `v` in it |

Each path has one half of the scaling right: `source_composition` uses the penalty method's `1/eps` spelling but defaults `eps` *large* (coefficient `1e-6`); `hjb_penalty` has the right magnitude under the reciprocal spelling.

## Tests

Four, driving real code. Mutation-verified against three distinct fixes:

| mutant | fires |
|---|---|
| compose reads `v` | compose pin + the 1e10 pin |
| penalty reads `v` | penalty pin + the 1e10 pin |
| knobs unified, no `v` change | the 1e10 pin alone |

Reverted → all four green. Retirement condition is stated per-test, including the one that must be **updated rather than deleted** and a fourth failure expected outside this file.

## Errors in the first commit, corrected in the second

1. **A broken pin.** `test_penalty_solver_...` fed all-zero arrays; `max(0, psi - 0) == max(0, psi)`, so the fix it existed to detect left it green. The mutation check I reported had only perturbed that path's *scaling*, so it confirmed nothing about the property the test was named for.
2. **The headline was a misreading.** *"both coupling paths … match rather than silently diverge"* means **Picard vs coupled-Newton**, not the two obstacle spellings — fixed by this module's own opening paragraph (#1361), `mfg_residual.py`, and `fixed_point_iterator.py:667`. They do match; both call `compose_hjb_source`. That withdrawal is withdrawn, and the referent is now written into the docstring.
3. **"Correct" overstated the alternative.** `ObstacleConstraint.project` reads `u` and returns a feasible array in 1D — but the projection runs *after* the backward sweep, so the output is exactly `max(U_free, psi)` (measured byte-identical, constraint binding at `-0.255`); in nD the terminal slice is `U_terminal` passed straight through, violating by `-0.245`. Filed as **#2036**.
4. **A retracted claim.** "No test asserts a numerical outcome from `problem.obstacle`" is false — `test_newton_solver_solves_with_obstacle` sets `obstacle=` and asserts `u_gap < 1e-8`. My predicate was the string `.obstacle`, blind to the constructor keyword. The narrower true statement is now in the docstring: that test compares two paths sharing `compose_hjb_source`, so `v`-freedom in the shared term cannot make it fail.
5. Retirement condition named two tests that a rename had removed, and omitted a third that reddens outside this file; `penalty_parameter` was passed explicitly so its default was never pinned; and the first commit's added lines broke a cross-reference in `test_issue1285_newton_fail_loud.py`.

Behaviour is unchanged. 40 passed, 1 xfailed across the obstacle/penalty/source-composition/wiring surface; full gate green.

Also filed from this review: **#2037** — `PenaltyHJBSolver.__init__` reads `self._inner` one line before assigning it, so compatibility validation has never run for any caller.

Closes nothing — #2002 stays open on item 4.