### PR TITLE
fix(discrimination): a verify probe went blind; make verify two-sided; re-measure the matrix (#2038)

### DIFF
--- a/changelog.d/discrimination-rebaselined.changed.md
+++ b/changelog.d/discrimination-rebaselined.changed.md
@@ -1,0 +1,7 @@
+Re-measured the discrimination kill matrix and baseline, stale since `f961db90` (6138 collected;
+the suite is now 6384). Every one of the 24 conventions held or improved — no row lost killers.
+Tests that notice at least one convention: 449 → 581; (mutation, test) pairs: 582 → 778. Also
+fixed `bc_uniform_dispatch_reads_as_mixed`, whose `verify` probe had gone blind: the uniform and
+per-face ghost paths now agree on Neumann bit-for-bit, so the probe could not see the mutation take
+effect and the row scored INEFFECTIVE — which looks identical to "nothing catches this". Re-pointed
+at Robin, where the paths still diverge widely, the row reads 43 (#2038).

--- a/scripts/discrimination_baseline.json
+++ b/scripts/discrimination_baseline.json
@@ -1,14 +1,13 @@
 {
   "_comment": "Kill counts per mutated convention. --check-baseline fails when a count DROPS (discrimination lost) and when one RISES (record the gain in the same change). Counts, not test names: this population cannot be selected by name -- the agreement-shaped patterns give 51, 114 or 156 depending on the regex.",
   "_measured_at": {
-    "collected": 6138,
-    "commit": "f961db90",
+    "collected": 6384,
+    "commit": "03e41944",
     "excluded": "tests/unit/test_discrimination_ratchet.py",
     "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment and not manual",
     "paths": [
       "tests"
-    ],
-    "_note": "markers gained `not manual` in #1909; the population is UNCHANGED -- measured 6002 collected and 388 deselected under both sets, because every `manual` test also carries `slow` -- so the kill counts recorded here remain valid without a re-sweep"
+    ]
   },
   "mutations": {
     "bc_default_reads_as_reflect": {
@@ -17,32 +16,32 @@
       "status": "ok"
     },
     "bc_noflux_reads_as_clamp": {
-      "kill_count": 9,
+      "kill_count": 10,
       "owner": "no_flux/neumann/robin -> reflect (#1698)",
       "status": "ok"
     },
     "bc_uniform_dispatch_reads_as_mixed": {
-      "kill_count": 31,
+      "kill_count": 43,
       "owner": "PreallocatedGhostBuffer.update_ghosts routes a uniform BC to the single-segment path and a mixed BC to the per-face path (#577 Phase 3 for the mixed rewrite, #1255 (C) for the alpha/beta forwarding the uniform branch carries). The two paths are NOT equivalent: the uniform branch applies the inhomoge",
       "status": "ok"
     },
     "diffusion_field_2x": {
-      "kill_count": 6,
+      "kill_count": 7,
       "owner": "D = sigma^2/2 elementwise for a volatility field (#811)",
       "status": "ok"
     },
     "diffusion_scalar_2x": {
-      "kill_count": 145,
+      "kill_count": 162,
       "owner": "D = sigma^2/2 for scalar sigma (#811)",
       "status": "ok"
     },
     "drift_coefficient_2x": {
-      "kill_count": 20,
+      "kill_count": 29,
       "owner": "FP drift c = 1/control_cost (#1420 / G-017)",
       "status": "ok"
     },
     "fp_initial_condition_written_at_final_index": {
-      "kill_count": 90,
+      "kill_count": 128,
       "owner": "The FP marches FORWARD from t=0 with m_0 written at time row 0 -- the initial-condition half of the HJB/FP boundary-data pair. Single site in the live FDM FP time loop, fp_fdm_time_stepping.py:797, whose own docstring states the convention at :681: \"- Forward time evolution: k=0 -> Nt-1\". No issue n",
       "status": "ok"
     },
@@ -52,32 +51,32 @@
       "status": "ok"
     },
     "ghost_spacing_ignored": {
-      "kill_count": 22,
+      "kill_count": 58,
       "owner": "the ghost buffer uses the caller's spacing, not dx = 1.0 (#1904)",
       "status": "ok"
     },
     "godunov_branch_swap": {
-      "kill_count": 19,
+      "kill_count": 29,
       "owner": "Godunov upwind takes the BACKWARD difference where the central gradient is >= 0 -- the library's one statement of the upwind selection rule, consumed by the HJB residual, the HJB Jacobian, GradientOperator and AdvectionOperator (#1896 items 3-4 turn on it)",
       "status": "ok"
     },
     "grid_interval_count_reads_as_points": {
-      "kill_count": 28,
+      "kill_count": 35,
       "owner": "`Nx` names the INTERVAL count, so node count = Nx + 1 -- the #1889 interval-vs-node ambiguity at the grid's own entry point. Stated in the constructor docstring at tensor_grid.py:181-182: \"- Nx (intervals): Nx_points = Nx + 1\" / \"- Nx_points (points): Nx = Nx_points - 1\". Line 220-221 normalises a s",
       "status": "ok"
     },
     "grid_spacing_uses_point_count": {
-      "kill_count": 44,
+      "kill_count": 57,
       "owner": "uniform grid spacing is L/(node count - 1), not L/(node count) -- the L/n vs L/(n-1) convention. `self.spacing` is the single owner: get_grid_spacing() returns it verbatim (tensor_grid.py:823 `return self.spacing`), get_spacing() indexes it (:607), legacy_1d_attrs[\"Dx\"] reads it (:484), cell volume ",
       "status": "ok"
     },
     "hjb_marches_forward_in_time": {
-      "kill_count": 13,
+      "kill_count": 22,
       "owner": "The HJB marches BACKWARD in time, from the terminal row down to t=0, while the FP marches forward -- the adjoint pairing. Single site: base_hjb.py:1780, the only time loop in solve_hjb_system_backward. The M-indexing that rides on it is documented in the same loop body at base_hjb.py:1790: \"# BUG #7",
       "status": "ok"
     },
     "m_initial_1d_counting_measure": {
-      "kill_count": 8,
+      "kill_count": 18,
       "owner": "m(0,.) integrates to 1 under the geometry's own volume element, not under the counting measure -- the 1-D branch of the four-way normalisation dispatch at mfg_problem.py:1996-2042. Owner established by #1888 (`tests/unit/test_core/test_initial_density_mass_1888.py`), whose module docstring records t",
       "status": "ok"
     },
@@ -87,8 +86,8 @@
       "status": "ok"
     },
     "neumann_low_wall_flux_sign": {
-      "kill_count": 23,
-      "owner": "inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and ghost = interior + dx*v, the same expression as the high wall (#1262). The line's own comment states the convention it replaced: \"Issue #1262: was -= (du/dx sign), now += (du/dn sign)\".",
+      "kill_count": 37,
+      "owner": "inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and the offset is ADDED, the same sign as the high wall (#1262). Since #1967 the magnitude is (2k-1)*dx*v rather than dx*v -- ghost layer k sits that far from its mirror -- so the k=1 case is the historical dx*v and the deeper layers scale.",
       "status": "ok"
     },
     "newton_residual_grid_scaling_dropped": {
@@ -97,22 +96,22 @@
       "status": "ok"
     },
     "optimal_control_sign": {
-      "kill_count": 40,
+      "kill_count": 41,
       "owner": "QuadraticControlCost alpha* = -sign*p/lambda (#1649)",
       "status": "ok"
     },
     "particle_mass_counting_measure": {
-      "kill_count": 3,
+      "kill_count": 6,
       "owner": "The particle FP step measures total mass as `sum(density) * dV` with dV the grid volume element, and the KDE normalisation divides by it so the density on the grid integrates to 1 (`FPParticleSolver._compute_total_mass`, the scalar-spacing branch; consumed by `_normalize_density` at :823 and by the ",
       "status": "ok"
     },
     "periodic_endpoint_convention_inverted": {
-      "kill_count": 19,
+      "kill_count": 21,
       "owner": "where the last node sits, MEASURED from the coordinates the grid built (#1822). `_axis_convention` is the single owner: `periodic_convention` calls it (tensor_grid.py:415) and `_first_axis_with_convention` calls it (:385). The property docstring states why it is derived rather than asserted: \"Derive",
       "status": "ok"
     },
     "periodic_wrap_endpoint_inverted": {
-      "kill_count": 36,
+      "kill_count": 45,
       "owner": "how many trailing nodes of a periodic axis repeat a node the array already holds -- the ONE number both the ghost skip and the modular span derive from (#1822). types.py:126-130 states the ownership verbatim: \"Every periodic wrap in the package is one of two expressions of this single number, which ",
       "status": "ok"
     },
@@ -122,7 +121,7 @@
       "status": "ok"
     },
     "terminal_condition_pinned_at_initial_index": {
-      "kill_count": 4,
+      "kill_count": 8,
       "owner": "u is boundary-data at the TERMINAL time and m at the INITIAL one: preserve_terminal_condition re-imposes u(T)=g on the LAST time row after damping/Anderson. Single owner, three caller families -- fixed_point_iterator.py:644 and :724 (Picard), fictitious_play.py:432, block_iterators.py:583. No issue ",
       "status": "ok"
     },

--- a/scripts/discrimination_killmatrix.json
+++ b/scripts/discrimination_killmatrix.json
@@ -1,18 +1,44 @@
 {
   "_measured_at": {
-    "collected": 6138,
-    "commit": "f961db90",
+    "collected": 6384,
+    "commit": "03e41944",
     "excluded": "tests/unit/test_discrimination_ratchet.py",
     "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment and not manual",
     "paths": [
       "tests"
-    ],
-    "_note": "markers gained `not manual` in #1909; the population is UNCHANGED -- measured 6002 collected and 388 deselected under both sets, because every `manual` test also carries `slow` -- so the kill counts recorded here remain valid without a re-sweep"
+    ]
   },
   "_selection_regex_for_agreement_shaped": "::[^:]*?(_agree|_agrees|_matches|_equals|_single_source|_identical|_consistent)",
-  "baseline_seconds": 150.2,
+  "baseline_seconds": 131.2,
   "killed_by": {
+    "tests/integration/test_1043_coupler_fp_drift_convention.py::TestBlockIteratorFPDriftConvention::test_block_gauss_seidel_runs_and_produces_finite_M": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_1043_coupler_fp_drift_convention.py::TestFictitiousPlayFPDriftConvention::test_fictitious_play_density_is_non_negative": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/integration/test_1043_coupler_fp_drift_convention.py::TestFictitiousPlayFPDriftConvention::test_pre_fix_drift_field_produces_wrong_M": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_block_iterators.py::TestBlockIteratorBasic::test_gauss_seidel_executes": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_block_iterators.py::TestBlockIteratorBasic::test_jacobi_executes": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_block_iterators.py::TestBlockIteratorParameters::test_density_nonnegative": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_block_iterators.py::TestBlockIteratorParameters::test_no_damping": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_coupled_hjb_fp_2d.py::TestCoupledHJBFP2DBasic::test_2d_output_shapes": [
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/integration/test_coupling_mesh_geometry.py::TestFixedPointIteratorMeshGeometry::test_fem_couples_through_fixed_point_iterator": [
@@ -56,6 +82,14 @@
     "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_mass_conservation": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_periodic_bc_solution": [
+      "godunov_branch_swap",
+      "hjb_marches_forward_in_time",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_solution_non_negativity": [
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversNumericalProperties::test_initial_condition_satisfaction": [
       "fp_initial_condition_written_at_final_index"
     ],
@@ -68,10 +102,20 @@
     "tests/integration/test_hjb_fdm_2d_validation.py::TestHJBFDM2DSolving::test_2d_solve_fixed_point": [
       "godunov_branch_swap"
     ],
+    "tests/integration/test_hjb_with_obstacle.py::TestObstacleConvergenceProperties::test_tolerance_scaling": [
+      "godunov_branch_swap"
+    ],
     "tests/integration/test_mass_conservation_1d.py::TestExplicitDriftNoFluxDiffusionConservation::test_pure_diffusion_no_flux_conserves_mass": [
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/integration/test_mass_conservation_1d.py::TestMassConservation1D::test_coupled_fdm_mass_conservation_fast_tier": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_callable_diffusion_with_array": [
+      "diffusion_scalar_2x",
+      "diffusion_field_2x",
+      "m_initial_1d_counting_measure",
+      "hjb_marches_forward_in_time",
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_with_callable_diffusion": [
@@ -122,6 +166,11 @@
     "tests/integration/test_multi_population_cross_coupling.py::test_k1_matches_single_population_fp_convention": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/integration/test_newton_mfg_solver.py::TestMFGResidualComputation::test_residual_computation": [
+      "godunov_branch_swap",
+      "terminal_condition_pinned_at_initial_index",
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/integration/test_newton_mfg_solver.py::test_one_newton_step_reduces_the_mfg_residual": [
       "fp_initial_condition_written_at_final_index"
     ],
@@ -135,6 +184,12 @@
     ],
     "tests/integration/test_particle_collocation_mfg.py::TestFPGFDMSolver::test_fp_gfdm_mass_conservation": [
       "diffusion_scalar_2x"
+    ],
+    "tests/integration/test_particle_collocation_mfg.py::TestHJBGFDMWithParticleFP::test_fp_particle_outputs_to_grid": [
+      "particle_mass_counting_measure"
+    ],
+    "tests/integration/test_particle_collocation_mfg.py::TestHJBGFDMWithParticleFP::test_mass_conservation_particle_fp": [
+      "particle_mass_counting_measure"
     ],
     "tests/integration/test_three_mode_api.py::TestAutoMode::test_auto_mode_default_behavior": [
       "fp_initial_condition_written_at_final_index"
@@ -157,6 +212,13 @@
     "tests/integration/test_three_mode_api.py::TestSafeMode::test_safe_mode_string_scheme": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/integration/test_warm_start_nameerror_1285.py::TestWarmStartNameError1285::test_fictitious_play_iterator_warm_start": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/integration/test_warm_start_nameerror_1285.py::TestWarmStartNameError1285::test_fixed_point_iterator_warm_start": [
+      "m_initial_1d_counting_measure"
+    ],
     "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline": [
       "diffusion_scalar_2x",
       "drift_coefficient_2x",
@@ -175,6 +237,13 @@
     ],
     "tests/unit/test_alg/test_advection_coupled_conservation.py::TestCoupledAdvectionConservation::test_conservative_branch_accepts_explicit_periodic_bc": [
       "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_alg/test_callback_abort_is_not_convergence_1684.py::test_the_aborted_error_really_is_worse_than_the_run_that_reports_failure": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_coupling_metric_is_the_map_residual_1684.py::test_heavier_damping_does_not_buy_a_smaller_reported_error": [
+      "drift_coefficient_2x",
+      "terminal_condition_pinned_at_initial_index"
     ],
     "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[0.5]": [
       "drift_coefficient_2x",
@@ -248,7 +317,17 @@
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBasicSolution::test_solve_fp_system_initial_condition_preserved": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBasicSolution::test_solve_fp_system_shape": [
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBoundaryConditions::test_no_flux_boundary_conditions": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBoundaryConditions::test_periodic_boundary_conditions": [
+      "periodic_endpoint_convention_inverted",
+      "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDiffusion::test_callable_with_drift": [
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDiffusion::test_density_dependent_diffusion": [
@@ -257,10 +336,19 @@
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDiffusion::test_porous_medium_equation": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_callable_drift_2d": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_callable_drift_with_callable_diffusion": [
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_constant_drift_callable": [
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_state_dependent_drift": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_time_dependent_drift": [
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverMassConservation::test_mass_conservation_no_flux": [
@@ -269,7 +357,13 @@
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverMassConservation::test_mass_evolution_periodic": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverNonNegativity::test_initial_condition_non_negativity": [
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverProblemVolatility::test_problem_array_sigma_reaches_solver": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_callable_tensor": [
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_diagonal_tensor_2d": [
@@ -349,6 +443,13 @@
     "tests/unit/test_alg/test_fp_matrix_conservation.py::TestConservativeAdvection::test_tensor_explicit_path_conserves_at_wall": [
       "fv_upwind_donor_cell_swapped"
     ],
+    "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_density_stays_positive": [
+      "diffusion_scalar_2x",
+      "grid_spacing_uses_point_count",
+      "periodic_endpoint_convention_inverted",
+      "periodic_wrap_endpoint_inverted",
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_mass_conserved_no_flux_zero_drift": [
       "fp_initial_condition_written_at_final_index"
     ],
@@ -360,8 +461,59 @@
     "tests/unit/test_alg/test_fp_matrix_conservation.py::TestNeumannBCImplicitFP::test_mass_conserved_neumann_zero_value_zero_drift": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1--1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1-1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2--1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2-1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1--1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1-1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2--1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2-1]": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_on_the_published_gibbs_instance": [
+      "diffusion_scalar_2x",
+      "drift_coefficient_2x",
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/unit/test_alg/test_fp_network_solver.py::TestFPNetworkSolverSolveFPSystem::test_volatility_field_is_sigma_not_diffusion": [
       "diffusion_scalar_2x"
+    ],
+    "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_backward_compatibility_quadratic": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_custom_drift_callable_like": [
+      "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_equivalence_quadratic_explicit": [
       "drift_coefficient_2x"
@@ -375,10 +527,25 @@
     "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_quartic_control_drift": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/unit/test_alg/test_fp_particle.py::TestFPParticleSolverBasic::test_non_negative_density": [
+      "particle_mass_counting_measure"
+    ],
     "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestGradientBCOverrideThreaded::test_gradient_uses_periodic_override_not_noflux_geometry": [
       "grid_spacing_uses_point_count",
       "periodic_endpoint_convention_inverted",
       "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_high_wall_ghost_uses_general_robin_not_neumann": [
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_low_wall_ghost_uses_general_robin_not_neumann": [
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_uniform_matches_mixed_segment_path": [
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverHelperMethods::test_compute_gradient": [
+      "grid_spacing_uses_point_count"
     ],
     "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverHelperMethods::test_normalize_density_all": [
       "particle_mass_counting_measure"
@@ -388,6 +555,9 @@
     ],
     "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverSolveFPSystem::test_solve_fp_system_initial_condition": [
       "particle_mass_counting_measure"
+    ],
+    "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverSolveFPSystem::test_solve_with_non_zero_drift": [
+      "optimal_control_sign"
     ],
     "tests/unit/test_alg/test_fp_particle_time_level_1792.py::test_the_density_follows_the_well_forward_in_time[1-41-20000-2.0]": [
       "optimal_control_sign"
@@ -419,6 +589,17 @@
     "tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py::test_dmp_guard_uses_each_nodes_resolved_diffusion": [
       "diffusion_field_2x"
     ],
+    "tests/unit/test_alg/test_gfdm_mms_source_1991.py::test_mms_reaches_gfdm_and_it_converges": [
+      "diffusion_scalar_2x"
+    ],
+    "tests/unit/test_alg/test_hjb_analytic_jacobian_1607.py::test_analytic_jacobian_matches_fd_solution": [
+      "godunov_branch_swap",
+      "terminal_condition_pinned_at_initial_index",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_hjb_bc_enforcement_1900.py::test_the_surviving_enforcement_uses_the_grids_own_spacing": [
+      "grid_spacing_uses_point_count"
+    ],
     "tests/unit/test_alg/test_hjb_fdm_1d_nd_cross_path_agreement.py::TestHJBFDMCouplingIndexCrossPath::test_1d_and_nd_couple_un_to_mn[5]": [
       "hjb_marches_forward_in_time"
     ],
@@ -433,6 +614,34 @@
     ],
     "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverGhostValueBC::test_hjb_solver_time_varying_bc": [
       "godunov_branch_swap"
+    ],
+    "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverIntegration::test_solver_with_gaussian_density": [
+      "godunov_branch_swap"
+    ],
+    "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverIntegration::test_solver_with_uniform_density": [
+      "godunov_branch_swap"
+    ],
+    "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverNumericalProperties::test_solution_finiteness": [
+      "godunov_branch_swap",
+      "hjb_marches_forward_in_time"
+    ],
+    "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverParameterSensitivity::test_different_newton_iterations": [
+      "hjb_marches_forward_in_time"
+    ],
+    "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverParameterSensitivity::test_different_tolerances": [
+      "hjb_marches_forward_in_time"
+    ],
+    "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverSolveHJBSystem::test_solve_hjb_system_shape": [
+      "hjb_marches_forward_in_time"
+    ],
+    "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFAugmentationPinning::test_llf_at_least_one_node_augmented": [
+      "diffusion_scalar_2x"
+    ],
+    "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFAugmentationPinning::test_llf_sigma_eff_stored": [
+      "diffusion_scalar_2x"
+    ],
+    "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_cone_constant_effect": [
+      "diffusion_scalar_2x"
     ],
     "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_sigma_eff_formula_per_node_l_H": [
       "diffusion_scalar_2x"
@@ -462,11 +671,14 @@
       "ghost_spacing_ignored",
       "godunov_branch_swap",
       "upwind_jacobian_tiebreak_inverted",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
+    "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[False]": [
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
     "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[True]": [
-      "godunov_branch_swap"
+      "godunov_branch_swap",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_every_row_linearises_the_residual[piecewise_linear-True-dirichlet]": [
       "godunov_branch_swap",
@@ -487,9 +699,21 @@
     "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_legacy_no_bc_path_linearises_its_own_residual_too[True]": [
       "godunov_branch_swap"
     ],
+    "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_one_sided_stencils_are_algebra_on_the_two_operators_that_have_owners[linear-robin_sign_flipped]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_one_sided_stencils_are_algebra_on_the_two_operators_that_have_owners[random-robin_sign_flipped]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_one_sided_stencils_are_algebra_on_the_two_operators_that_have_owners[smooth-robin_sign_flipped]": [
+      "ghost_spacing_ignored"
+    ],
     "tests/unit/test_alg/test_hjb_jacobian_matches_residual_1894.py::test_periodic_wrap_with_a_volatility_field_does_not_collapse_the_jacobian": [
       "diffusion_field_2x",
       "grid_spacing_uses_point_count"
+    ],
+    "tests/unit/test_alg/test_hjb_newton_reports_returned_iterate.py::test_the_configuration_still_exercises_the_non_converged_path": [
+      "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestADIDiffusionMagnitude::test_adi_2d_diffusion_matches_analytic": [
       "diffusion_scalar_2x"
@@ -515,6 +739,10 @@
     "tests/unit/test_alg/test_implicit_heat.py::TestImplicitHeatSolver1D::test_periodic_bc": [
       "periodic_endpoint_convention_inverted",
       "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_obstacle": [
+      "terminal_condition_pinned_at_initial_index",
+      "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_diffusion_from_volatility_torch_numpy_parity": [
       "diffusion_scalar_2x"
@@ -706,7 +934,10 @@
       "m_initial_1d_counting_measure",
       "fp_initial_condition_written_at_final_index"
     ],
-    "tests/unit/test_alg/test_meshless_stabilization.py::test_recipe_coupled_matches_fdm_on_wellposed_problem": [
+    "tests/unit/test_alg/test_meshless_stabilization.py::test_recipe_coupled_matches_fdm_on_wellposed_problem[newton_sd]": [
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_meshless_stabilization.py::test_recipe_coupled_matches_fdm_on_wellposed_problem[picard]": [
       "fp_initial_condition_written_at_final_index"
     ],
     "tests/unit/test_alg/test_meshless_stabilization.py::test_sd_block_identical_in_fp_and_hjb": [
@@ -727,9 +958,11 @@
     "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[FPParticleSolver-PERIODIC]": [
       "optimal_control_sign"
     ],
-    "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[FPSLJacobianSolver-PERIODIC]": [
-      "diffusion_scalar_2x",
-      "drift_coefficient_2x"
+    "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-NEUMANN]": [
+      "godunov_branch_swap"
+    ],
+    "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-NO_FLUX]": [
+      "godunov_branch_swap"
     ],
     "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-PERIODIC]": [
       "godunov_branch_swap"
@@ -829,6 +1062,13 @@
     "tests/unit/test_alg/test_regime_switching_iterator.py::TestDiagonalOutflowIsNotALaggedSource::test_regime_masses_track_the_markov_chain_closed_form": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeSwitchingSolve::test_solutions_are_finite": [
+      "m_initial_1d_counting_measure",
+      "fp_initial_condition_written_at_final_index"
+    ],
+    "tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeSwitchingUpdateSchemes::test_jacobi_scheme": [
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/unit/test_alg/test_s1_drift_convention_routing.py::test_u_as_drift_field_solves_a_different_problem_than_u_as_potential_field": [
       "fp_initial_condition_written_at_final_index"
     ],
@@ -875,6 +1115,15 @@
       "grid_spacing_uses_point_count",
       "godunov_branch_swap"
     ],
+    "tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py::test_the_weak_form_family_agrees_with_the_reference_fdm_solver[-3.0]": [
+      "hjb_marches_forward_in_time"
+    ],
+    "tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py::test_the_weak_form_family_agrees_with_the_reference_fdm_solver[1.0]": [
+      "hjb_marches_forward_in_time"
+    ],
+    "tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py::test_the_weak_form_family_agrees_with_the_reference_fdm_solver[2.0]": [
+      "hjb_marches_forward_in_time"
+    ],
     "tests/unit/test_alg/test_weak_form_volatility.py::test_diffusion_coefficient_converts_sigma_to_D": [
       "diffusion_scalar_2x"
     ],
@@ -907,6 +1156,25 @@
       "grid_spacing_uses_point_count"
     ],
     "tests/unit/test_alg/test_weno_ghost_order.py::test_weno_ghost_cells_work": [
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_alg/test_weno_mms_order_1991.py::test_advection_dominated_order_reaches_weno5": [
+      "grid_spacing_uses_point_count",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_alg/test_weno_mms_order_1991.py::test_diffusion_dominated_order_is_two": [
+      "diffusion_scalar_2x",
+      "grid_spacing_uses_point_count",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_2d_solve_still_reproduces_the_pre_consolidation_output": [
+      "diffusion_scalar_2x",
+      "grid_spacing_uses_point_count",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_3d_solve_runs_at_all": [
+      "diffusion_scalar_2x",
+      "grid_spacing_uses_point_count",
       "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_check_single_source.py::test_repo_baseline_is_current": [
@@ -1104,6 +1372,180 @@
     "tests/unit/test_fp_fvm.py::test_gate4_fvm_fdm_agreement_shrinks": [
       "fp_initial_condition_written_at_final_index"
     ],
+    "tests/unit/test_gate_refuses_a_mutated_tree.py::test_the_guard_actually_refuses": [
+      "bc_noflux_reads_as_clamp"
+    ],
+    "tests/unit/test_geometry/boundary/test_extrapolation_reaches_the_buffer_1958.py::test_every_other_member_is_untouched[mixed-PERIODIC]": [
+      "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_geometry/boundary/test_extrapolation_reaches_the_buffer_1958.py::test_every_other_member_is_untouched[uniform-PERIODIC]": [
+      "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[high-1]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[high-2]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[high-3]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-1]": [
+      "ghost_spacing_ignored",
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-2]": [
+      "ghost_spacing_ignored",
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-3]": [
+      "ghost_spacing_ignored",
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_depth_one_is_byte_identical[neumann-2.0]": [
+      "ghost_spacing_ignored",
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_depth_one_is_byte_identical[periodic-0.0]": [
+      "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_flux_offset_actually_scales_with_the_layer[high]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_flux_offset_actually_scales_with_the_layer[low]": [
+      "ghost_spacing_ignored",
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_two_paths_agree_on_an_inhomogeneous_flux_at_depth": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_constructor_coefficient_wins_over_the_state": [
+      "grid_spacing_uses_point_count",
+      "grid_interval_count_reads_as_points"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_drift_is_projected_onto_the_outward_normal[falling--3.0]": [
+      "grid_spacing_uses_point_count",
+      "grid_interval_count_reads_as_points"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_drift_is_projected_onto_the_outward_normal[rising-2.0]": [
+      "grid_spacing_uses_point_count",
+      "grid_interval_count_reads_as_points"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[high-linear-falling-<lambda>]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[high-linear-rising-<lambda>]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[high-parabolic-<lambda>]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[low-linear-falling-<lambda>]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[low-linear-rising-<lambda>]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[low-parabolic-<lambda>]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_each_axis_uses_its_own_spacing": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_default_branch_uses_both_default_bc_and_default_value[BCType.NEUMANN-3.0-13.75]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_default_branch_uses_both_default_bc_and_default_value[BCType.PERIODIC-0.0-10.0]": [
+      "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[1]": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[2]": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[3]": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_per_face_path_imposes_the_flux_that_was_asked_for[-3.0]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_per_face_path_imposes_the_flux_that_was_asked_for[2.0]": [
+      "ghost_spacing_ignored"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_two_ghost_paths_agree_on_an_inhomogeneous_neumann_flux[-3.0]": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_two_ghost_paths_agree_on_an_inhomogeneous_neumann_flux[2.0]": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_providers_resolve_coefficients_1965.py::test_the_shipped_adjoint_consistent_config_is_unchanged": [
+      "grid_spacing_uses_point_count",
+      "grid_interval_count_reads_as_points"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_a_singular_coefficient_raises_rather_than_mirroring": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[-1.5]": [
+      "bc_uniform_dispatch_reads_as_mixed",
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[0.0]": [
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[2.0]": [
+      "bc_uniform_dispatch_reads_as_mixed",
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.0-1.0-0.7]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.5-2.0--0.3]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.0]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.7]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-2.0-0.5-0.0]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-3.0--0.4-1.1]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.0-1.0-0.7]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.5-2.0--0.3]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.0]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.7]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-2.0-0.5-0.0]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
+    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-3.0--0.4-1.1]": [
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
+    ],
     "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestBoundaryRegionMarking::test_3d_boundary_naming": [
       "grid_interval_count_reads_as_points"
     ],
@@ -1134,7 +1576,13 @@
     "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionMarkingUseCases::test_mixed_boundary_conditions_setup": [
       "grid_interval_count_reads_as_points"
     ],
+    "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionMarkingUseCases::test_obstacle_region_marking": [
+      "grid_interval_count_reads_as_points"
+    ],
     "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionOperations::test_union_regions_two_regions": [
+      "grid_interval_count_reads_as_points"
+    ],
+    "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionRetrieval::test_get_region_mask_retrieves_correct_mask": [
       "grid_interval_count_reads_as_points"
     ],
     "tests/unit/test_geometry/level_set/test_level_set_core.py::TestLevelSetFunction::test_1d_creation": [
@@ -1146,11 +1594,21 @@
     "tests/unit/test_geometry/level_set/test_level_set_core.py::TestLevelSetFunction::test_normal_field_1d": [
       "grid_interval_count_reads_as_points"
     ],
+    "tests/unit/test_geometry/level_set/test_reinitialization.py::TestReinitializationEdgeCases::test_handles_sign_zero": [
+      "grid_spacing_uses_point_count",
+      "grid_interval_count_reads_as_points"
+    ],
+    "tests/unit/test_geometry/level_set/test_reinitialization.py::TestReinitializationGlobal::test_convergence_tolerance": [
+      "grid_spacing_uses_point_count"
+    ],
     "tests/unit/test_geometry/level_set/test_subcell_interface.py::TestSubcellInterface1D::test_accuracy_vs_argmin": [
       "grid_interval_count_reads_as_points"
     ],
+    "tests/unit/test_geometry/test_bc_applicator.py::TestCalculatorClasses::test_neumann_calculator_agrees_with_the_live_applicator_path": [
+      "ghost_spacing_ignored",
+      "neumann_low_wall_flux_sign"
+    ],
     "tests/unit/test_geometry/test_bc_applicator.py::TestLinearReflectionNeumannFlux::test_nonzero_neumann_flux_recovered": [
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py::test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmless": [
@@ -1197,101 +1655,86 @@
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[161]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[21]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[41]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[81]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.01]": [
-      "ghost_spacing_ignored"
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.05]": [
-      "ghost_spacing_ignored"
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.5]": [
-      "ghost_spacing_ignored"
+      "ghost_spacing_ignored",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_spacing_accepts_a_scalar_or_one_value_per_axis[0.05]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_spacing_accepts_a_scalar_or_one_value_per_axis[scalar_or_sequence1]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_spacing_accepts_a_scalar_or_one_value_per_axis[scalar_or_sequence2]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_fallback_would_diverge_which_is_why_the_spacing_is_threaded": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[-1.5-0.01]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[-1.5-0.05]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[-1.5-0.5]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[3.0-0.01]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[3.0-0.05]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[3.0-0.5]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[-3.0-21]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[-3.0-81]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[2.0-21]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[2.0-81]": [
       "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_a_duck_typed_bc_is_checked_not_waved_through": [
@@ -1301,18 +1744,16 @@
       "bc_noflux_reads_as_clamp"
     ],
     "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_negative_v_low_ghost": [
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_and_order4_low_ghost_agree": [
       "neumann_low_wall_flux_sign"
     ],
-    "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_high_ghost_plus_dx_v": [
-      "bc_uniform_dispatch_reads_as_mixed"
-    ],
     "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_low_ghost_plus_dx_v": [
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_a_constant_field_is_unchanged_by_the_periodic_fill[uniform-path]": [
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[mixed-path-1]": [
       "periodic_wrap_endpoint_inverted"
@@ -1324,22 +1765,28 @@
       "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-1]": [
-      "periodic_wrap_endpoint_inverted"
+      "periodic_wrap_endpoint_inverted",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-2]": [
-      "periodic_wrap_endpoint_inverted"
+      "periodic_wrap_endpoint_inverted",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-3]": [
-      "periodic_wrap_endpoint_inverted"
+      "periodic_wrap_endpoint_inverted",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[1]": [
-      "periodic_wrap_endpoint_inverted"
+      "periodic_wrap_endpoint_inverted",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[2]": [
-      "periodic_wrap_endpoint_inverted"
+      "periodic_wrap_endpoint_inverted",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[3]": [
-      "periodic_wrap_endpoint_inverted"
+      "periodic_wrap_endpoint_inverted",
+      "bc_uniform_dispatch_reads_as_mixed"
     ],
     "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_3_dirichlet_1d": [
       "bc_uniform_dispatch_reads_as_mixed"
@@ -1401,6 +1848,12 @@
     "tests/unit/test_geometry/test_tensor_grid_docstring_examples.py::test_constructor_docstring_example_runs[L1826-]": [
       "grid_interval_count_reads_as_points"
     ],
+    "tests/unit/test_geometry/test_tensor_operators.py::TestDiagonalTensorEqualsScalar::test_diagonal_diffusion_matches_component_wise_laplacian": [
+      "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_geometry/test_tensor_operators.py::TestNDDispatcher::test_1d_fallback": [
+      "periodic_wrap_endpoint_inverted"
+    ],
     "tests/unit/test_geometry/test_tensor_product_grid.py::TestEdgeCases::test_asymmetric_2d_grid": [
       "grid_spacing_uses_point_count"
     ],
@@ -1456,6 +1909,12 @@
     "tests/unit/test_operators/test_laplacian.py::TestLaplacianBC::test_periodic_bc_sin": [
       "periodic_wrap_endpoint_inverted"
     ],
+    "tests/unit/test_operators/test_laplacian.py::TestLaplacianBCFailLoud1071::test_bc_none_still_periodic": [
+      "periodic_wrap_endpoint_inverted"
+    ],
+    "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_result_shape": [
+      "godunov_branch_swap"
+    ],
     "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_selection_rule_is_the_godunov_one_not_merely_accurate": [
       "godunov_branch_swap"
     ],
@@ -1493,7 +1952,7 @@
       "grid_interval_count_reads_as_points"
     ]
   },
-  "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment",
+  "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment and not manual",
   "mutations": {
     "bc_default_reads_as_reflect": {
       "kill_count": 2,
@@ -1502,14 +1961,15 @@
         "tests/unit/test_geometry/test_bc_utils_geometric_operation.py::TestGeometricOperationMapping::test_absent_bc_defaults_to_clamp_not_reflect"
       ],
       "owner": "absent BC defaults to clamp/absorbing (#1698)",
-      "seconds": 147.6,
+      "seconds": 133.6,
       "status": "ok",
       "verify": "bc_type_to_geometric_operation(None) == 'reflect'"
     },
     "bc_noflux_reads_as_clamp": {
-      "kill_count": 9,
+      "kill_count": 10,
       "killed": [
         "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestStochasticSLUnificationPinning::test_1d_step_byte_identical_to_legacy[cubic]",
+        "tests/unit/test_gate_refuses_a_mutated_tree.py::test_the_guard_actually_refuses",
         "tests/unit/test_geometry/test_bc_utils_geometric_operation.py::TestBCTypeStringFromConditions::test_the_two_halves_compose[<lambda>-reflect]",
         "tests/unit/test_geometry/test_bc_utils_geometric_operation.py::TestGeometricOperationMapping::test_each_declared_type_maps_to_its_operation[neumann-reflect]",
         "tests/unit/test_geometry/test_bc_utils_geometric_operation.py::TestGeometricOperationMapping::test_each_declared_type_maps_to_its_operation[no_flux-reflect]",
@@ -1520,53 +1980,66 @@
         "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_default_bc_is_a_second_lever_with_no_permutation_available"
       ],
       "owner": "no_flux/neumann/robin -> reflect (#1698)",
-      "seconds": 146.0,
+      "seconds": 130.8,
       "status": "ok",
       "verify": "bc_type_to_geometric_operation('no_flux') == 'clamp'"
     },
     "bc_uniform_dispatch_reads_as_mixed": {
-      "kill_count": 31,
+      "kill_count": 43,
       "killed": [
-        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_tied_wall_row_that_is_not_a_switching_node_still_gets_the_right_branch",
+        "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_high_wall_ghost_uses_general_robin_not_neumann",
+        "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_low_wall_ghost_uses_general_robin_not_neumann",
+        "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_uniform_matches_mixed_segment_path",
+        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[False]",
+        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[True]",
         "tests/unit/test_alg/test_weno_family.py::TestWenoHJDerivativeCorrectness::test_gradient_accurate_at_boundary_nodes",
         "tests/unit/test_alg/test_weno_ghost_order.py::test_weno_ghost_cells_work",
-        "tests/unit/test_geometry/test_bc_applicator.py::TestLinearReflectionNeumannFlux::test_nonzero_neumann_flux_recovered",
+        "tests/unit/test_alg/test_weno_mms_order_1991.py::test_advection_dominated_order_reaches_weno5",
+        "tests/unit/test_alg/test_weno_mms_order_1991.py::test_diffusion_dominated_order_is_two",
+        "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_2d_solve_still_reproduces_the_pre_consolidation_output",
+        "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_3d_solve_runs_at_all",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_a_singular_coefficient_raises_rather_than_mirroring",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[-1.5]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[2.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.0-1.0-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.5-2.0--0.3]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-2.0-0.5-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-3.0--0.4-1.1]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.0-1.0-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.5-2.0--0.3]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-2.0-0.5-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-3.0--0.4-1.1]",
         "tests/unit/test_geometry/test_ghost_buffer_order.py::test_order_3_works",
         "tests/unit/test_geometry/test_ghost_buffer_order.py::test_order_5_works",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[161]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[21]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[41]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[81]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_spacing_accepts_a_scalar_or_one_value_per_axis[0.05]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_spacing_accepts_a_scalar_or_one_value_per_axis[scalar_or_sequence1]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_spacing_accepts_a_scalar_or_one_value_per_axis[scalar_or_sequence2]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_fallback_would_diverge_which_is_why_the_spacing_is_threaded",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[-1.5-0.01]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[-1.5-0.05]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[-1.5-0.5]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[3.0-0.01]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[3.0-0.05]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_laplacian_path_threads_its_own_spacings_parameter[3.0-0.5]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[-3.0-21]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[-3.0-81]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[2.0-21]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[2.0-81]",
-        "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_negative_v_low_ghost",
-        "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_high_ghost_plus_dx_v",
-        "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_low_ghost_plus_dx_v",
+        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.01]",
+        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.05]",
+        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.5]",
+        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_a_constant_field_is_unchanged_by_the_periodic_fill[uniform-path]",
+        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-1]",
+        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-2]",
+        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-3]",
+        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[1]",
+        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[2]",
+        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[3]",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_3_dirichlet_1d",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_3_neumann_1d",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_5_neumann_both_boundaries_accurate",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_5_nonzero_neumann_flux"
       ],
       "owner": "PreallocatedGhostBuffer.update_ghosts routes a uniform BC to the single-segment path and a mixed BC to the per-face path (#577 Phase 3 for the mixed rewrite, #1255 (C) for the alpha/beta forwarding the uniform branch carries). The two paths are NOT equivalent: the uniform branch applies the inhomoge",
-      "seconds": 158.9,
+      "seconds": 144.3,
       "status": "ok",
-      "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 1.0"
+      "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), robin_bc(dimension=1, alpha=1.0, beta=1.0, value=3.0), ghost_depth=1, spacing=0.05)[0] == 5.0"
     },
     "diffusion_field_2x": {
-      "kill_count": 6,
+      "kill_count": 7,
       "killed": [
+        "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_callable_diffusion_with_array",
         "tests/unit/test_alg/test_gfdm_batch_spatial_volatility_1725.py::test_dmp_guard_uses_each_nodes_resolved_diffusion",
         "tests/unit/test_alg/test_hjb_jacobian_matches_residual_1894.py::test_periodic_wrap_with_a_volatility_field_does_not_collapse_the_jacobian",
         "tests/unit/test_alg/test_sigma_tensor_convention_rfc_1596.py::TestDiffusionOperatorShapeConsistency::test_from_volatility_vector_matches_diag_half_sigma_sq",
@@ -1575,12 +2048,12 @@
         "tests/unit/test_utils/test_diffusion_from_volatility.py::TestField::test_2d_field_is_elementwise"
       ],
       "owner": "D = sigma^2/2 elementwise for a volatility field (#811)",
-      "seconds": 144.8,
+      "seconds": 133.0,
       "status": "ok",
       "verify": "float(diffusion_from_volatility(np.array([2.0]), kind='field')[0]) == 4.0"
     },
     "diffusion_scalar_2x": {
-      "kill_count": 145,
+      "kill_count": 162,
       "killed": [
         "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[1]",
         "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[2]",
@@ -1589,6 +2062,7 @@
         "tests/integration/test_diffusion_magnitude_gate.py::test_fp_fdm_diffusion_magnitude[implicit]",
         "tests/integration/test_diffusion_magnitude_gate.py::test_weak_form_fem_fp_diffusion_magnitude",
         "tests/integration/test_fem_robin_bc.py::TestRobinSolveLoopWiring::test_hjb_linear_loop_fixed_point",
+        "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_callable_diffusion_with_array",
         "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[dirichlet]",
         "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[no_flux]",
         "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[periodic]",
@@ -1606,7 +2080,21 @@
         "tests/unit/test_alg/test_fp_gfdm_mass_gate.py::test_a_configuration_with_no_negatives_at_all_still_runs",
         "tests/unit/test_alg/test_fp_gfdm_mass_gate.py::test_the_drift_is_reported_at_warning_level",
         "tests/unit/test_alg/test_fp_gfdm_mass_gate.py::test_the_scheme_does_not_conserve_mass_and_now_says_so",
+        "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_density_stays_positive",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_on_the_published_gibbs_instance",
         "tests/unit/test_alg/test_fp_network_solver.py::TestFPNetworkSolverSolveFPSystem::test_volatility_field_is_sigma_not_diffusion",
+        "tests/unit/test_alg/test_gfdm_mms_source_1991.py::test_mms_reaches_gfdm_and_it_converges",
+        "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFAugmentationPinning::test_llf_at_least_one_node_augmented",
+        "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFAugmentationPinning::test_llf_sigma_eff_stored",
+        "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_cone_constant_effect",
         "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_sigma_eff_formula_per_node_l_H",
         "tests/unit/test_alg/test_hjb_gfdm_llf_augmentation.py::TestLLFNumerics::test_sigma_eff_formula_scalar_l_H",
         "tests/unit/test_alg/test_hjb_howard_solver.py::test_integrated_howard_matches_newton_nonlq[None-<lambda>-1.0-f(m)-only]",
@@ -1678,7 +2166,6 @@
         "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-0.5]",
         "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-1.0]",
         "tests/unit/test_alg/test_issue_1189_fp_sigma_migration.py::test_sigma_sq_over_dxsq_equals_negative_2D_boundary[0.5-2.0]",
-        "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[FPSLJacobianSolver-PERIODIC]",
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_a_periodic_solve_reproduces_the_heat_kernel[FPFDMSolver]",
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_a_periodic_solve_reproduces_the_heat_kernel[FPFVMSolver]",
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_every_channel_that_supplies_a_bc_gets_the_same_torus[FPFDMSolver]",
@@ -1693,6 +2180,9 @@
         "tests/unit/test_alg/test_sl_periodic_diffusion_1820.py::test_the_periodic_step_matches_the_analytic_heat_kernel",
         "tests/unit/test_alg/test_sl_periodic_diffusion_1820.py::test_the_spatial_order_is_second_not_first",
         "tests/unit/test_alg/test_weak_form_volatility.py::test_diffusion_coefficient_converts_sigma_to_D",
+        "tests/unit/test_alg/test_weno_mms_order_1991.py::test_diffusion_dominated_order_is_two",
+        "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_2d_solve_still_reproduces_the_pre_consolidation_output",
+        "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_3d_solve_runs_at_all",
         "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[0.1]",
         "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[0.7]",
         "tests/unit/test_convention_agreement.py::TestSigmaToDiffusionAgreement::test_backend_literal_equals_single_source[1.0]",
@@ -1729,19 +2219,29 @@
         "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_needs_no_kind"
       ],
       "owner": "D = sigma^2/2 for scalar sigma (#811)",
-      "seconds": 118.6,
+      "seconds": 133.8,
       "status": "ok",
       "verify": "diffusion_from_volatility(2.0) == 4.0"
     },
     "drift_coefficient_2x": {
-      "kill_count": 20,
+      "kill_count": 29,
       "killed": [
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
+        "tests/unit/test_alg/test_coupling_metric_is_the_map_residual_1684.py::test_heavier_damping_does_not_buy_a_smaller_reported_error",
         "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[0.5]",
         "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[1.0]",
         "tests/unit/test_alg/test_drift_contract.py::test_fp_scalar_drift_matches_hamiltonian_optimal_control[2.5]",
         "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_byte_identical_when_consistent",
         "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_uses_control_cost_not_coupling",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_on_the_published_gibbs_instance",
         "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_equivalence_quadratic_explicit",
         "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-0.5]",
         "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLJacobianSolver-_compute_velocity-1.0]",
@@ -1750,7 +2250,6 @@
         "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-1.0]",
         "tests/unit/test_alg/test_fp_sl_drift_control_cost_s003.py::test_sl_velocity_uses_control_cost[FPSLSolver-_compute_velocity_1d-2.0]",
         "tests/unit/test_alg/test_meshless_stabilization.py::test_sd_block_identical_in_fp_and_hjb",
-        "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[FPSLJacobianSolver-PERIODIC]",
         "tests/unit/test_alg/test_weakform_fp_drift_single_source.py::test_fp_drift_coefficient_sources_from_control_cost_not_coupling",
         "tests/unit/test_check_single_source.py::test_repo_baseline_is_current",
         "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[0.5]",
@@ -1758,14 +2257,21 @@
         "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[2.0]"
       ],
       "owner": "FP drift c = 1/control_cost (#1420 / G-017)",
-      "seconds": 149.8,
+      "seconds": 136.8,
       "status": "ok",
       "verify": "fp_drift_coefficient(_stub_problem(control_cost=2.0)) == 1.0"
     },
     "fp_initial_condition_written_at_final_index": {
-      "kill_count": 90,
+      "kill_count": 128,
       "killed": [
+        "tests/integration/test_1043_coupler_fp_drift_convention.py::TestBlockIteratorFPDriftConvention::test_block_gauss_seidel_runs_and_produces_finite_M",
+        "tests/integration/test_1043_coupler_fp_drift_convention.py::TestFictitiousPlayFPDriftConvention::test_fictitious_play_density_is_non_negative",
         "tests/integration/test_1043_coupler_fp_drift_convention.py::TestFictitiousPlayFPDriftConvention::test_pre_fix_drift_field_produces_wrong_M",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorBasic::test_gauss_seidel_executes",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorBasic::test_jacobi_executes",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorParameters::test_density_nonnegative",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorParameters::test_no_damping",
+        "tests/integration/test_coupled_hjb_fp_2d.py::TestCoupledHJBFP2DBasic::test_2d_output_shapes",
         "tests/integration/test_diffusion_magnitude_gate.py::test_fp_fdm_diffusion_magnitude[explicit]",
         "tests/integration/test_diffusion_magnitude_gate.py::test_fp_fdm_diffusion_magnitude[implicit]",
         "tests/integration/test_fdm_centered_conservation.py::test_callable_drift_explicit_path_respects_no_flux_no_periodic_wrap",
@@ -1773,9 +2279,12 @@
         "tests/integration/test_fdm_centered_conservation.py::test_gradient_centered_still_available_and_leaks",
         "tests/integration/test_fdm_centered_conservation.py::test_gradient_leaks_even_with_zero_drift",
         "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_mass_conservation",
+        "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_periodic_bc_solution",
+        "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_solution_non_negativity",
         "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversNumericalProperties::test_initial_condition_satisfaction",
         "tests/integration/test_mass_conservation_1d.py::TestExplicitDriftNoFluxDiffusionConservation::test_pure_diffusion_no_flux_conserves_mass",
         "tests/integration/test_mass_conservation_1d.py::TestMassConservation1D::test_coupled_fdm_mass_conservation_fast_tier",
+        "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_callable_diffusion_with_array",
         "tests/integration/test_mms_validation.py::TestCoupledHJBFPValidation::test_coupled_mass_conservation",
         "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[dirichlet]",
         "tests/integration/test_mms_validation.py::TestMMSConvergenceRates::test_fp_convergence_rate[no_flux]",
@@ -1787,6 +2296,7 @@
         "tests/integration/test_mms_validation.py::TestMassConservationStress::test_conservation_with_weak_drift",
         "tests/integration/test_mms_validation.py::TestMassConservationStress::test_long_time_conservation",
         "tests/integration/test_multi_population_cross_coupling.py::test_k1_matches_single_population_fp_convention",
+        "tests/integration/test_newton_mfg_solver.py::TestMFGResidualComputation::test_residual_computation",
         "tests/integration/test_newton_mfg_solver.py::test_one_newton_step_reduces_the_mfg_residual",
         "tests/integration/test_newton_picard_agreement.py::test_newton_matches_picard_small",
         "tests/integration/test_newton_picard_agreement.py::test_residual_consistent_with_picard_fixed_point",
@@ -1797,7 +2307,9 @@
         "tests/integration/test_three_mode_api.py::TestExpertMode::test_expert_mode_matching_fdm_solvers",
         "tests/integration/test_three_mode_api.py::TestSafeMode::test_safe_mode_fdm_upwind",
         "tests/integration/test_three_mode_api.py::TestSafeMode::test_safe_mode_string_scheme",
+        "tests/integration/test_warm_start_nameerror_1285.py::TestWarmStartNameError1285::test_fictitious_play_iterator_warm_start",
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
+        "tests/unit/test_alg/test_callback_abort_is_not_convergence_1684.py::test_the_aborted_error_really_is_worse_than_the_run_that_reports_failure",
         "tests/unit/test_alg/test_fp_fdm_mixed_bc_dirichlet.py::TestMixedBCDirichletNotFrozen::test_dirichlet_wall_reaches_prescribed_value",
         "tests/unit/test_alg/test_fp_fdm_mixed_bc_dirichlet.py::TestMixedBCDirichletNotFrozen::test_no_flux_wall_uses_no_flux_assembly",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverArrayDiffusion::test_array_diffusion_mass_conservation",
@@ -1805,14 +2317,21 @@
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverArrayDiffusion::test_spatially_varying_diffusion_1d",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverArrayDiffusion::test_spatiotemporal_diffusion_1d",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBasicSolution::test_solve_fp_system_initial_condition_preserved",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBasicSolution::test_solve_fp_system_shape",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBoundaryConditions::test_no_flux_boundary_conditions",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDiffusion::test_callable_with_drift",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDiffusion::test_density_dependent_diffusion",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDiffusion::test_porous_medium_equation",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_callable_drift_2d",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_callable_drift_with_callable_diffusion",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_constant_drift_callable",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_state_dependent_drift",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverCallableDrift::test_time_dependent_drift",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverMassConservation::test_mass_conservation_no_flux",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverMassConservation::test_mass_evolution_periodic",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverNonNegativity::test_initial_condition_non_negativity",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverProblemVolatility::test_problem_array_sigma_reaches_solver",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_callable_tensor",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_diagonal_tensor_2d",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_full_tensor_with_cross_diffusion",
         "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverTensorDiffusion::test_isotropic_tensor_matches_scalar_diffusion",
@@ -1830,15 +2349,31 @@
         "tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py::test_velocity_channel_runs_for_both_senses[divergence_upwind-OptimizationSense.MINIMIZE]",
         "tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py::test_velocity_channel_runs_for_both_senses[flux-OptimizationSense.MAXIMIZE]",
         "tests/unit/test_alg/test_fp_fdm_velocity_channel_1528.py::test_velocity_channel_runs_for_both_senses[flux-OptimizationSense.MINIMIZE]",
+        "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_density_stays_positive",
         "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_mass_conserved_no_flux_zero_drift",
         "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_mass_conserved_periodic_zero_drift",
         "tests/unit/test_alg/test_fp_matrix_conservation.py::TestNeumannBCImplicitFP::test_mass_conserved_neumann_zero_value_zero_drift",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[1-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_centered_is_second_order_at_a_drifting_wall[2-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[1-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2--1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_at_a_drifting_wall[2-1]",
+        "tests/unit/test_alg/test_fp_mms_wall_order_1728.py::test_divergence_upwind_is_first_order_on_the_published_gibbs_instance",
+        "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_backward_compatibility_quadratic",
+        "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_custom_drift_callable_like",
         "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_l1_control_drift",
         "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_mass_conservation_with_drift_field",
         "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_quartic_control_drift",
+        "tests/unit/test_alg/test_hjb_analytic_jacobian_1607.py::test_analytic_jacobian_matches_fd_solution",
+        "tests/unit/test_alg/test_hjb_newton_reports_returned_iterate.py::test_the_configuration_still_exercises_the_non_converged_path",
+        "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_obstacle",
         "tests/unit/test_alg/test_issue_1248_volatility_forwarding.py::TestD1SolveMustForwardVolatilityField::test_array_sigma_solve_differs_from_mean_sigma_solve",
         "tests/unit/test_alg/test_issue_1248_volatility_forwarding.py::TestD1SolveMustForwardVolatilityField::test_scalar_sigma_solve_is_unchanged",
-        "tests/unit/test_alg/test_meshless_stabilization.py::test_recipe_coupled_matches_fdm_on_wellposed_problem",
+        "tests/unit/test_alg/test_meshless_stabilization.py::test_recipe_coupled_matches_fdm_on_wellposed_problem[newton_sd]",
+        "tests/unit/test_alg/test_meshless_stabilization.py::test_recipe_coupled_matches_fdm_on_wellposed_problem[picard]",
         "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[FPFDMSolver-NEUMANN]",
         "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[FPFDMSolver-NO_FLUX]",
         "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_periodic_fp_solve_conserves_mass_in_the_limit[FPFDMSolver]",
@@ -1852,12 +2387,14 @@
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_fdm_and_fvm_converge_to_the_same_field_under_a_varying_periodic_drift",
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_zero_diffusion_and_zero_drift_do_not_move_the_density[FPFDMSolver]",
         "tests/unit/test_alg/test_regime_switching_iterator.py::TestDiagonalOutflowIsNotALaggedSource::test_regime_masses_track_the_markov_chain_closed_form",
+        "tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeSwitchingSolve::test_solutions_are_finite",
+        "tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeSwitchingUpdateSchemes::test_jacobi_scheme",
         "tests/unit/test_alg/test_s1_drift_convention_routing.py::test_u_as_drift_field_solves_a_different_problem_than_u_as_potential_field",
         "tests/unit/test_fp_fvm.py::test_gate4_fvm_fdm_agreement_shrinks",
         "tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py::test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmless"
       ],
       "owner": "The FP marches FORWARD from t=0 with m_0 written at time row 0 -- the initial-condition half of the HJB/FP boundary-data pair. Single site in the live FDM FP time loop, fp_fdm_time_stepping.py:797, whose own docstring states the convention at :681: \"- Forward time evolution: k=0 -> Nt-1\". No issue n",
-      "seconds": 130.3,
+      "seconds": 236.6,
       "status": "ok",
       "verify": "float(np.sum(solve_fp_nd_full_system(np.ones(6), np.zeros((3, 6)), MFGProblem(model=Model(hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: 0.0 * m, coupling_dm=lambda m: 0.0), sigma=0.3), domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[6], boundary_conditions=no_flux_bc(dimension=1)), conditions=Conditions(u_terminal=lambda x: 3.0 + 0.0 * x, m_initial=lambda x: 1.0 + 0.0 * x, T=0.1), Nt=2))[0])) == 0.0"
     },
@@ -1872,14 +2409,50 @@
         "tests/unit/test_operators/test_divergence.py::TestAdvectionPeriodicGridConvention::test_the_wrap_face_velocity_comes_from_the_last_real_cell_not_the_repeat"
       ],
       "owner": "the conservative FV upwind flux takes the UPSTREAM cell: F_{i+1/2} = v_{i+1/2} m_i when v_{i+1/2} >= 0, else v_{i+1/2} m_{i+1} (#1184 / #1428)",
-      "seconds": 160.3,
+      "seconds": 131.6,
       "status": "ok",
       "verify": "float(AdvectionOperator(velocity_field=np.ones((1, 3)), spacings=[1.0], field_shape=(3,), scheme='upwind', form='divergence', bc=no_flux_bc(dimension=1), mass_conservative=True)(np.array([1.0, 2.0, 3.0]))[0]) == 2.0"
     },
     "ghost_spacing_ignored": {
-      "kill_count": 22,
+      "kill_count": 58,
       "killed": [
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_tied_wall_row_that_is_not_a_switching_node_still_gets_the_right_branch",
+        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_one_sided_stencils_are_algebra_on_the_two_operators_that_have_owners[linear-robin_sign_flipped]",
+        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_one_sided_stencils_are_algebra_on_the_two_operators_that_have_owners[random-robin_sign_flipped]",
+        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_one_sided_stencils_are_algebra_on_the_two_operators_that_have_owners[smooth-robin_sign_flipped]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[high-1]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[high-2]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[high-3]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-1]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-2]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-3]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_depth_one_is_byte_identical[neumann-2.0]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_flux_offset_actually_scales_with_the_layer[high]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_flux_offset_actually_scales_with_the_layer[low]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[high-linear-falling-<lambda>]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[high-linear-rising-<lambda>]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[high-parabolic-<lambda>]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[low-linear-falling-<lambda>]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[low-linear-rising-<lambda>]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_wall_flux_is_zero[low-parabolic-<lambda>]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_each_axis_uses_its_own_spacing",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_default_branch_uses_both_default_bc_and_default_value[BCType.NEUMANN-3.0-13.75]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_per_face_path_imposes_the_flux_that_was_asked_for[-3.0]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_per_face_path_imposes_the_flux_that_was_asked_for[2.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_a_singular_coefficient_raises_rather_than_mirroring",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.0-1.0-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.5-2.0--0.3]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-2.0-0.5-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-3.0--0.4-1.1]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.0-1.0-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.5-2.0--0.3]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.7]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-2.0-0.5-0.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-3.0--0.4-1.1]",
+        "tests/unit/test_geometry/test_bc_applicator.py::TestCalculatorClasses::test_neumann_calculator_agrees_with_the_live_applicator_path",
         "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[161]",
         "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[21]",
         "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[41]",
@@ -1903,20 +2476,27 @@
         "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[2.0-81]"
       ],
       "owner": "the ghost buffer uses the caller's spacing, not dx = 1.0 (#1904)",
-      "seconds": 137.9,
+      "seconds": 132.5,
       "status": "ok",
       "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 3.0"
     },
     "godunov_branch_swap": {
-      "kill_count": 19,
+      "kill_count": 29,
       "killed": [
+        "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_periodic_bc_solution",
         "tests/integration/test_hjb_fdm_2d_validation.py::TestHJBFDM2DSolving::test_2d_solve_fixed_point",
+        "tests/integration/test_hjb_with_obstacle.py::TestObstacleConvergenceProperties::test_tolerance_scaling",
         "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_with_callable_diffusion",
         "tests/integration/test_mms_validation.py::TestMMSHJB1D::test_backward_heat_periodic_convergence",
+        "tests/integration/test_newton_mfg_solver.py::TestMFGResidualComputation::test_residual_computation",
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
         "tests/unit/test_alg/test_fp_matrix_conservation.py::TestConservativeAdvection::test_default_path_byte_identical_golden",
+        "tests/unit/test_alg/test_hjb_analytic_jacobian_1607.py::test_analytic_jacobian_matches_fd_solution",
         "tests/unit/test_alg/test_hjb_fdm_solver.py::TestBoundaryGradientBCAware1384::test_dirichlet_steep_terminal_converges",
         "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverGhostValueBC::test_hjb_solver_time_varying_bc",
+        "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverIntegration::test_solver_with_gaussian_density",
+        "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverIntegration::test_solver_with_uniform_density",
+        "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverNumericalProperties::test_solution_finiteness",
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_cancelled_wrap_entry_is_dropped_rather_than_kept_at_rounding_scale",
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_tied_wall_row_that_is_not_a_switching_node_still_gets_the_right_branch",
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[True]",
@@ -1925,20 +2505,27 @@
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_every_row_linearises_the_residual[piecewise_linear-True-periodic]",
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_every_row_linearises_the_residual[piecewise_linear-True-robin_alpha_eq_beta]",
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_the_legacy_no_bc_path_linearises_its_own_residual_too[True]",
+        "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-NEUMANN]",
+        "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-NO_FLUX]",
         "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-PERIODIC]",
         "tests/unit/test_alg/test_true_adjoint.py::TestJacobianTransposeEqualsAdvection::test_jacobian_coefficients_match_analytical_dh_dp",
+        "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_result_shape",
         "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_selection_rule_is_the_godunov_one_not_merely_accurate",
         "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_the_selection_predicate_is_pinned_not_only_the_branch_bodies"
       ],
       "owner": "Godunov upwind takes the BACKWARD difference where the central gradient is >= 0 -- the library's one statement of the upwind selection rule, consumed by the HJB residual, the HJB Jacobian, GradientOperator and AdvectionOperator (#1896 items 3-4 turn on it)",
-      "seconds": 155.5,
+      "seconds": 128.1,
       "status": "ok",
       "verify": "float(gradient_upwind(np.array([0.0, 1.0, 3.0]), axis=0, h=1.0)[1]) == 2.0"
     },
     "grid_interval_count_reads_as_points": {
-      "kill_count": 28,
+      "kill_count": 35,
       "killed": [
         "tests/unit/test_alg/test_implicit_heat.py::TestImplicitHeatSolver1D::test_multiple_steps",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_constructor_coefficient_wins_over_the_state",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_drift_is_projected_onto_the_outward_normal[falling--3.0]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_drift_is_projected_onto_the_outward_normal[rising-2.0]",
+        "tests/unit/test_geometry/boundary/test_providers_resolve_coefficients_1965.py::test_the_shipped_adjoint_consistent_config_is_unchanged",
         "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestBoundaryRegionMarking::test_3d_boundary_naming",
         "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestBoundaryRegionMarking::test_high_dimensional_boundary_naming",
         "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestBoundaryRegionMarking::test_standard_boundary_names[x_max-11-0-1.0]",
@@ -1949,10 +2536,13 @@
         "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestMarkRegionBasicFunctionality::test_mark_region_with_predicate",
         "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionMarkingUseCases::test_1d_domain_region_marking",
         "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionMarkingUseCases::test_mixed_boundary_conditions_setup",
+        "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionMarkingUseCases::test_obstacle_region_marking",
         "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionOperations::test_union_regions_two_regions",
+        "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestRegionRetrieval::test_get_region_mask_retrieves_correct_mask",
         "tests/unit/test_geometry/level_set/test_level_set_core.py::TestLevelSetFunction::test_1d_creation",
         "tests/unit/test_geometry/level_set/test_level_set_core.py::TestLevelSetFunction::test_2d_creation",
         "tests/unit/test_geometry/level_set/test_level_set_core.py::TestLevelSetFunction::test_normal_field_1d",
+        "tests/unit/test_geometry/level_set/test_reinitialization.py::TestReinitializationEdgeCases::test_handles_sign_zero",
         "tests/unit/test_geometry/level_set/test_subcell_interface.py::TestSubcellInterface1D::test_accuracy_vs_argmin",
         "tests/unit/test_geometry/test_tensor_grid_docstring_examples.py::test_annotated_example_values_are_truthful[104-grid.Nx-[100, 50]]",
         "tests/unit/test_geometry/test_tensor_grid_docstring_examples.py::test_annotated_example_values_are_truthful[104-grid.Nx_points-[101, 51]]",
@@ -1968,17 +2558,20 @@
         "tests/validation/test_stefan_analytical.py::TestStefanEnergyConservation::test_total_energy_preservation"
       ],
       "owner": "`Nx` names the INTERVAL count, so node count = Nx + 1 -- the #1889 interval-vs-node ambiguity at the grid's own entry point. Stated in the constructor docstring at tensor_grid.py:181-182: \"- Nx (intervals): Nx_points = Nx + 1\" / \"- Nx_points (points): Nx = Nx_points - 1\". Line 220-221 normalises a s",
-      "seconds": 138.7,
+      "seconds": 132.3,
       "status": "ok",
       "verify": "TensorProductGrid(bounds=[(0.0, 1.0)], Nx=[10], boundary_conditions=no_flux_bc(dimension=1)).Nx_points == [10]"
     },
     "grid_spacing_uses_point_count": {
-      "kill_count": 44,
+      "kill_count": 57,
       "killed": [
         "tests/integration/test_fdm_centered_conservation.py::test_fdm_centered_coupled_solve_conserves_mass",
         "tests/integration/test_mms_validation.py::TestMMSHJB1D::test_backward_heat_periodic_convergence",
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
+        "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_density_stays_positive",
         "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestGradientBCOverrideThreaded::test_gradient_uses_periodic_override_not_noflux_geometry",
+        "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverHelperMethods::test_compute_gradient",
+        "tests/unit/test_alg/test_hjb_bc_enforcement_1900.py::test_the_surviving_enforcement_uses_the_grids_own_spacing",
         "tests/unit/test_alg/test_hjb_jacobian_matches_residual_1894.py::test_periodic_wrap_with_a_volatility_field_does_not_collapse_the_jacobian",
         "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_periodic_fp_solve_conserves_mass_in_the_limit[FPParticleSolver]",
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_a_periodic_solve_reproduces_the_heat_kernel[FPFDMSolver]",
@@ -1998,8 +2591,18 @@
         "tests/unit/test_alg/test_weno_family.py::TestWenoHJDerivativeCorrectness::test_gradient_sign_and_magnitude",
         "tests/unit/test_alg/test_weno_family.py::TestWenoHJDerivativeCorrectness::test_high_order_convergence",
         "tests/unit/test_alg/test_weno_family.py::TestWenoHJDerivativeCorrectness::test_polynomial_exactness",
+        "tests/unit/test_alg/test_weno_mms_order_1991.py::test_advection_dominated_order_reaches_weno5",
+        "tests/unit/test_alg/test_weno_mms_order_1991.py::test_diffusion_dominated_order_is_two",
+        "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_2d_solve_still_reproduces_the_pre_consolidation_output",
+        "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_3d_solve_runs_at_all",
         "tests/unit/test_core/test_mfg_problem.py::test_mfg_problem_custom_domain",
         "tests/unit/test_fp_fvm.py::test_gate3_convergence_muscl_second_order",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_constructor_coefficient_wins_over_the_state",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_drift_is_projected_onto_the_outward_normal[falling--3.0]",
+        "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_drift_is_projected_onto_the_outward_normal[rising-2.0]",
+        "tests/unit/test_geometry/boundary/test_providers_resolve_coefficients_1965.py::test_the_shipped_adjoint_consistent_config_is_unchanged",
+        "tests/unit/test_geometry/level_set/test_reinitialization.py::TestReinitializationEdgeCases::test_handles_sign_zero",
+        "tests/unit/test_geometry/level_set/test_reinitialization.py::TestReinitializationGlobal::test_convergence_tolerance",
         "tests/unit/test_geometry/test_consolidated_base.py::TestCartesianGridUtilities::test_get_grid_spacing",
         "tests/unit/test_geometry/test_consolidated_base.py::TestSolverOperations::test_laplacian_on_quadratic_function_2d",
         "tests/unit/test_geometry/test_sparse_operations.py::TestIntegrationWithGrid::test_grid_refinement_convergence",
@@ -2021,17 +2624,23 @@
         "tests/validation/test_stefan_analytical.py::TestNeumannSolution::test_convergence_with_grid_refinement"
       ],
       "owner": "uniform grid spacing is L/(node count - 1), not L/(node count) -- the L/n vs L/(n-1) convention. `self.spacing` is the single owner: get_grid_spacing() returns it verbatim (tensor_grid.py:823 `return self.spacing`), get_spacing() indexes it (:607), legacy_1d_attrs[\"Dx\"] reads it (:484), cell volume ",
-      "seconds": 145.3,
+      "seconds": 133.5,
       "status": "ok",
       "verify": "TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1)).get_grid_spacing()[0] == 1.0 / 11"
     },
     "hjb_marches_forward_in_time": {
-      "kill_count": 13,
+      "kill_count": 22,
       "killed": [
+        "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_periodic_bc_solution",
+        "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_callable_diffusion_with_array",
         "tests/integration/test_mms_validation.py::TestMMSHJB1D::test_backward_heat_periodic_convergence",
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
         "tests/unit/test_alg/test_hjb_fdm_1d_nd_cross_path_agreement.py::TestHJBFDMCouplingIndexCrossPath::test_1d_and_nd_couple_un_to_mn[5]",
         "tests/unit/test_alg/test_hjb_fdm_1d_nd_cross_path_agreement.py::TestHJBFDMCouplingIndexCrossPath::test_1d_and_nd_couple_un_to_mn[7]",
+        "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverNumericalProperties::test_solution_finiteness",
+        "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverParameterSensitivity::test_different_newton_iterations",
+        "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverParameterSensitivity::test_different_tolerances",
+        "tests/unit/test_alg/test_hjb_fdm_solver.py::TestHJBFDMSolverSolveHJBSystem::test_solve_hjb_system_shape",
         "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestSLHJBConsistency::test_matches_fdm_with_potential[1.0]",
         "tests/unit/test_alg/test_hjb_semi_lagrangian.py::TestSLHJBConsistency::test_matches_fdm_with_potential[2.0]",
         "tests/unit/test_alg/test_sl_dpp_potential_sign_1645.py::test_dpp_error_converges_under_refinement",
@@ -2040,19 +2649,32 @@
         "tests/unit/test_alg/test_sl_dpp_potential_sign_1645.py::test_dpp_error_does_not_grow_with_the_potential[2.0]",
         "tests/unit/test_alg/test_sl_dpp_potential_sign_1645.py::test_dpp_error_does_not_grow_with_the_potential[5.0]",
         "tests/unit/test_alg/test_sl_foot_velocity_single_source_1547.py::test_congestion_error_actually_decreases_under_refinement",
-        "tests/unit/test_alg/test_sl_foot_velocity_single_source_1547.py::test_congestion_solve_tracks_an_independent_fdm_reference"
+        "tests/unit/test_alg/test_sl_foot_velocity_single_source_1547.py::test_congestion_solve_tracks_an_independent_fdm_reference",
+        "tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py::test_the_weak_form_family_agrees_with_the_reference_fdm_solver[-3.0]",
+        "tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py::test_the_weak_form_family_agrees_with_the_reference_fdm_solver[1.0]",
+        "tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py::test_the_weak_form_family_agrees_with_the_reference_fdm_solver[2.0]"
       ],
       "owner": "The HJB marches BACKWARD in time, from the terminal row down to t=0, while the FP marches forward -- the adjoint pairing. Single site: base_hjb.py:1780, the only time loop in solve_hjb_system_backward. The M-indexing that rides on it is documented in the same loop body at base_hjb.py:1790: \"# BUG #7",
-      "seconds": 118.3,
+      "seconds": 113.6,
       "status": "ok",
       "verify": "float(solve_hjb_system_backward(np.ones((3, 6)), np.full(6, 3.0), np.zeros((3, 6)), MFGProblem(model=Model(hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: 0.0 * m, coupling_dm=lambda m: 0.0), sigma=0.3), domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[6], boundary_conditions=no_flux_bc(dimension=1)), conditions=Conditions(u_terminal=lambda x: 3.0 + 0.0 * x, m_initial=lambda x: 1.0 + 0.0 * x, T=0.1), Nt=2))[0, 0]) < 1.0"
     },
     "m_initial_1d_counting_measure": {
-      "kill_count": 8,
+      "kill_count": 18,
       "killed": [
+        "tests/integration/test_1043_coupler_fp_drift_convention.py::TestBlockIteratorFPDriftConvention::test_block_gauss_seidel_runs_and_produces_finite_M",
+        "tests/integration/test_1043_coupler_fp_drift_convention.py::TestFictitiousPlayFPDriftConvention::test_fictitious_play_density_is_non_negative",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorBasic::test_gauss_seidel_executes",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorBasic::test_jacobi_executes",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorParameters::test_density_nonnegative",
+        "tests/integration/test_block_iterators.py::TestBlockIteratorParameters::test_no_damping",
         "tests/integration/test_fdm_centered_conservation.py::test_fdm_centered_coupled_solve_conserves_mass",
+        "tests/integration/test_mfg_callable_coefficients.py::TestMFGCallableCoefficients::test_mfg_callable_diffusion_with_array",
+        "tests/integration/test_warm_start_nameerror_1285.py::TestWarmStartNameError1285::test_fictitious_play_iterator_warm_start",
+        "tests/integration/test_warm_start_nameerror_1285.py::TestWarmStartNameError1285::test_fixed_point_iterator_warm_start",
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
         "tests/unit/test_alg/test_issue_1248_volatility_forwarding.py::TestD1SolveMustForwardVolatilityField::test_scalar_sigma_solve_is_unchanged",
+        "tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeSwitchingSolve::test_solutions_are_finite",
         "tests/unit/test_core/test_callable_adapter.py::test_mfg_problem_array_m_initial_1d",
         "tests/unit/test_core/test_callable_adapter.py::test_mfg_problem_scalar_m_initial",
         "tests/unit/test_core/test_initial_density_mass_1888.py::test_the_initial_density_integrates_to_one[1-11]",
@@ -2060,7 +2682,7 @@
         "tests/unit/test_core/test_mfg_problem.py::test_mfg_problem_with_custom_initial_density"
       ],
       "owner": "m(0,.) integrates to 1 under the geometry's own volume element, not under the counting measure -- the 1-D branch of the four-way normalisation dispatch at mfg_problem.py:1996-2042. Owner established by #1888 (`tests/unit/test_core/test_initial_density_mass_1888.py`), whose module docstring records t",
-      "seconds": 144.8,
+      "seconds": 125.8,
       "status": "ok",
       "verify": "abs(float(np.sum(MFGProblem(geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)), Nt=4, T=0.2, sigma=1.0, components=MFGComponents(m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2).squeeze(), u_terminal=lambda x: 0.0, hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)))).m_initial)) - 1.0) < 1e-9"
     },
@@ -2071,14 +2693,28 @@
         "tests/unit/test_utils/test_mass_conservation_error_1672.py::test_the_coupled_solve_reports_the_quantity_it_documents[fdm_upwind]"
       ],
       "owner": "`SolverResult.mass_conservation_error` is DRIFT from the initial mass, `max|mass(t)/mass(0) - 1|`, not deviation from a 1.0 target (#1672). Documented at `mfgarchon/utils/solver_result.py:41` -- \"mass_conservation_error: max|mass(t)/mass(0) - 1| over time steps -- the drift from the\" -- and argued a",
-      "seconds": 145.4,
+      "seconds": 134.5,
       "status": "ok",
       "verify": "MFGProblem(geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)), Nt=4, T=0.2, sigma=1.0, components=MFGComponents(m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2).squeeze(), u_terminal=lambda x: 0.0, hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)))).solve(scheme=NumericalScheme.FDM_UPWIND, max_iterations=2, verbose=False).mass_conservation_error > 0.5"
     },
     "neumann_low_wall_flux_sign": {
-      "kill_count": 23,
+      "kill_count": 37,
       "killed": [
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_tied_wall_row_that_is_not_a_switching_node_still_gets_the_right_branch",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-1]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-2]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-3]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_depth_one_is_byte_identical[neumann-2.0]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_flux_offset_actually_scales_with_the_layer[low]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_two_paths_agree_on_an_inhomogeneous_flux_at_depth",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[1]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[2]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[3]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_two_ghost_paths_agree_on_an_inhomogeneous_neumann_flux[-3.0]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_two_ghost_paths_agree_on_an_inhomogeneous_neumann_flux[2.0]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[-1.5]",
+        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[2.0]",
+        "tests/unit/test_geometry/test_bc_applicator.py::TestCalculatorClasses::test_neumann_calculator_agrees_with_the_live_applicator_path",
         "tests/unit/test_geometry/test_bc_applicator.py::TestLinearReflectionNeumannFlux::test_nonzero_neumann_flux_recovered",
         "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[161]",
         "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_inhomogeneous_neumann_recovers_the_requested_flux_at_every_resolution[21]",
@@ -2102,8 +2738,8 @@
         "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_and_order4_low_ghost_agree",
         "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_low_ghost_plus_dx_v"
       ],
-      "owner": "inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and ghost = interior + dx*v, the same expression as the high wall (#1262). The line's own comment states the convention it replaced: \"Issue #1262: was -= (du/dx sign), now += (du/dn sign)\".",
-      "seconds": 166.4,
+      "owner": "inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and the offset is ADDED, the same sign as the high wall (#1262). Since #1967 the magnitude is (2k-1)*dx*v rather than dx*v -- ghost layer k sits that far from its mirror -- so the k=1 case is the historical dx*v and the deeper layers scale.",
+      "seconds": 133.2,
       "status": "ok",
       "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 0.9"
     },
@@ -2117,12 +2753,12 @@
         "tests/unit/test_convention_agreement.py::TestHJBResidualNormGridScaling::test_the_scaling_is_what_makes_two_resolutions_comparable"
       ],
       "owner": "The HJB Newton residual is the grid-scaled discrete L2 norm ||F||_2 * sqrt(dx). Owner: hjb_residual_norm, base_hjb.py:1362, whose docstring says verbatim 'The one owner of \"how large is this HJB residual\".' and 'It is a function rather than an inline expression because the ``sqrt(dx)`` is load-beari",
-      "seconds": 170.4,
+      "seconds": 138.0,
       "status": "ok",
       "verify": "hjb_residual_norm(np.array([1.0, 0.0]), 0.25) == 1.0"
     },
     "optimal_control_sign": {
-      "kill_count": 40,
+      "kill_count": 41,
       "killed": [
         "tests/integration/test_coupling_mesh_geometry.py::TestFixedPointIteratorMeshGeometry::test_fem_couples_through_fixed_point_iterator",
         "tests/integration/test_fem_solver_path.py::TestFEMBoundaryConditionResolution::test_coupled_fem_no_flux_runs_and_conserves_mass",
@@ -2141,6 +2777,7 @@
         "tests/unit/test_alg/test_fp_drift_owner_optimal_control.py::test_owner_within_one_ulp_of_divide_form_nondyadic[2.5]",
         "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_byte_identical_when_consistent",
         "tests/unit/test_alg/test_fp_fdm_potential_field_g017.py::TestFPFDMPotentialFieldDriftSource::test_potential_path_uses_control_cost_not_coupling",
+        "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverSolveFPSystem::test_solve_with_non_zero_drift",
         "tests/unit/test_alg/test_fp_particle_time_level_1792.py::test_the_density_follows_the_well_forward_in_time[1-41-20000-2.0]",
         "tests/unit/test_alg/test_fp_particle_time_level_1792.py::test_the_density_follows_the_well_forward_in_time[1-41-20000-5.0]",
         "tests/unit/test_alg/test_fp_particle_time_level_1792.py::test_the_density_follows_the_well_forward_in_time[2-21-20000-5.0]",
@@ -2166,25 +2803,30 @@
         "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p2-OptimizationSense.MINIMIZE]"
       ],
       "owner": "QuadraticControlCost alpha* = -sign*p/lambda (#1649)",
-      "seconds": 145.3,
+      "seconds": 132.9,
       "status": "ok",
       "verify": "float(QuadraticControlCost(control_cost=1.0).optimal_control(np.array([1.0]))[0]) > 0"
     },
     "particle_mass_counting_measure": {
-      "kill_count": 3,
+      "kill_count": 6,
       "killed": [
+        "tests/integration/test_particle_collocation_mfg.py::TestHJBGFDMWithParticleFP::test_fp_particle_outputs_to_grid",
+        "tests/integration/test_particle_collocation_mfg.py::TestHJBGFDMWithParticleFP::test_mass_conservation_particle_fp",
+        "tests/unit/test_alg/test_fp_particle.py::TestFPParticleSolverBasic::test_non_negative_density",
         "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverHelperMethods::test_normalize_density_all",
         "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverHelperMethods::test_normalize_density_initial_only",
         "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverSolveFPSystem::test_solve_fp_system_initial_condition"
       ],
       "owner": "The particle FP step measures total mass as `sum(density) * dV` with dV the grid volume element, and the KDE normalisation divides by it so the density on the grid integrates to 1 (`FPParticleSolver._compute_total_mass`, the scalar-spacing branch; consumed by `_normalize_density` at :823 and by the ",
-      "seconds": 150.6,
+      "seconds": 132.6,
       "status": "ok",
       "verify": "FPParticleSolver(MFGProblem(geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)), Nt=4, T=0.2, sigma=1.0, components=MFGComponents(m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2).squeeze(), u_terminal=lambda x: 0.0, hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)))), num_particles=10)._compute_total_mass(np.ones(4), 0.25) == 4.0"
     },
     "periodic_endpoint_convention_inverted": {
-      "kill_count": 19,
+      "kill_count": 21,
       "killed": [
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBoundaryConditions::test_periodic_boundary_conditions",
+        "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_density_stays_positive",
         "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_mass_conserved_periodic_zero_drift",
         "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestGradientBCOverrideThreaded::test_gradient_uses_periodic_override_not_noflux_geometry",
         "tests/unit/test_alg/test_implicit_heat.py::TestImplicitHeatSolver1D::test_periodic_bc",
@@ -2206,14 +2848,16 @@
         "tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py::test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmless"
       ],
       "owner": "where the last node sits, MEASURED from the coordinates the grid built (#1822). `_axis_convention` is the single owner: `periodic_convention` calls it (tensor_grid.py:415) and `_first_axis_with_convention` calls it (:385). The property docstring states why it is derived rather than asserted: \"Derive",
-      "seconds": 135.8,
+      "seconds": 130.9,
       "status": "ok",
       "verify": "TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1)).periodic_convention is PeriodicGridConvention.ENDPOINT_EXCLUSIVE"
     },
     "periodic_wrap_endpoint_inverted": {
-      "kill_count": 36,
+      "kill_count": 45,
       "killed": [
         "tests/unit/test_alg/test_advection_coupled_conservation.py::TestCoupledAdvectionConservation::test_conservative_branch_accepts_explicit_periodic_bc",
+        "tests/unit/test_alg/test_fp_fdm_solver.py::TestFPFDMSolverBoundaryConditions::test_periodic_boundary_conditions",
+        "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_density_stays_positive",
         "tests/unit/test_alg/test_fp_matrix_conservation.py::TestFPProductionConservation::test_mass_conserved_periodic_zero_drift",
         "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestGradientBCOverrideThreaded::test_gradient_uses_periodic_override_not_noflux_geometry",
         "tests/unit/test_alg/test_hjb_fdm_solver.py::TestBoundaryGradientBCAware1384::test_periodic_gradient_matches_the_analytic_derivative_at_the_seam",
@@ -2233,6 +2877,10 @@
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_fdm_and_fvm_converge_to_the_same_field_under_a_varying_periodic_drift",
         "tests/unit/test_alg/test_periodic_torus_oracle_1822.py::test_the_fvm_wrap_face_velocity_is_the_face_between_the_last_cell_and_the_first",
         "tests/unit/test_fp_fvm.py::test_gate1_mass_conservation_periodic",
+        "tests/unit/test_geometry/boundary/test_extrapolation_reaches_the_buffer_1958.py::test_every_other_member_is_untouched[mixed-PERIODIC]",
+        "tests/unit/test_geometry/boundary/test_extrapolation_reaches_the_buffer_1958.py::test_every_other_member_is_untouched[uniform-PERIODIC]",
+        "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_depth_one_is_byte_identical[periodic-0.0]",
+        "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_default_branch_uses_both_default_bc_and_default_value[BCType.PERIODIC-0.0-10.0]",
         "tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py::test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmless",
         "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[mixed-path-1]",
         "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[mixed-path-2]",
@@ -2243,15 +2891,18 @@
         "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[1]",
         "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[2]",
         "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[3]",
+        "tests/unit/test_geometry/test_tensor_operators.py::TestDiagonalTensorEqualsScalar::test_diagonal_diffusion_matches_component_wise_laplacian",
+        "tests/unit/test_geometry/test_tensor_operators.py::TestNDDispatcher::test_1d_fallback",
         "tests/unit/test_operators/test_diffusion.py::TestIsotropicDiffusion::test_periodic_sin",
         "tests/unit/test_operators/test_divergence.py::TestAdvectionPeriodicGridConvention::test_bc_none_still_means_the_exclusive_layout",
         "tests/unit/test_operators/test_divergence.py::TestAdvectionPeriodicGridConvention::test_inclusive_periodic_conserves_mass_over_the_distinct_cells",
         "tests/unit/test_operators/test_divergence.py::TestAdvectionPeriodicGridConvention::test_the_repeated_cell_carries_the_first_cells_divergence",
         "tests/unit/test_operators/test_divergence.py::TestAdvectionPeriodicGridConvention::test_the_wrap_face_velocity_comes_from_the_last_real_cell_not_the_repeat",
-        "tests/unit/test_operators/test_laplacian.py::TestLaplacianBC::test_periodic_bc_sin"
+        "tests/unit/test_operators/test_laplacian.py::TestLaplacianBC::test_periodic_bc_sin",
+        "tests/unit/test_operators/test_laplacian.py::TestLaplacianBCFailLoud1071::test_bc_none_still_periodic"
       ],
       "owner": "how many trailing nodes of a periodic axis repeat a node the array already holds -- the ONE number both the ghost skip and the modular span derive from (#1822). types.py:126-130 states the ownership verbatim: \"Every periodic wrap in the package is one of two expressions of this single number, which ",
-      "seconds": 155.0,
+      "seconds": 129.5,
       "status": "ok",
       "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), periodic_bc(dimension=1), ghost_depth=1)[0] == 2.0"
     },
@@ -2262,20 +2913,24 @@
         "tests/unit/test_convention_agreement.py::TestPicardCriterionIsAConjunction::test_a_small_relative_error_alone_is_not_convergence"
       ],
       "owner": "Picard convergence requires BOTH the relative AND the absolute L2 error below tolerance. Owner: check_convergence_criteria, fixed_point_utils.py:192-229, whose docstring states 'Convergence criteria (both must be satisfied)'. Single-sourced by three call sites routing to it: fixed_point_iterator.py:",
-      "seconds": 179.2,
+      "seconds": 131.8,
       "status": "ok",
       "verify": "check_convergence_criteria(1e-9, 1e-9, 1.0, 1.0, 1e-6)[0]"
     },
     "terminal_condition_pinned_at_initial_index": {
-      "kill_count": 4,
+      "kill_count": 8,
       "killed": [
+        "tests/integration/test_newton_mfg_solver.py::TestMFGResidualComputation::test_residual_computation",
         "tests/integration/test_newton_picard_agreement.py::test_newton_matches_picard_small",
         "tests/integration/test_newton_picard_agreement.py::test_residual_consistent_with_picard_fixed_point",
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
+        "tests/unit/test_alg/test_coupling_metric_is_the_map_residual_1684.py::test_heavier_damping_does_not_buy_a_smaller_reported_error",
+        "tests/unit/test_alg/test_hjb_analytic_jacobian_1607.py::test_analytic_jacobian_matches_fd_solution",
+        "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_obstacle",
         "tests/unit/test_utils/test_runtime_validation.py::test_terminal_condition_survives_an_hjb_divergence"
       ],
       "owner": "u is boundary-data at the TERMINAL time and m at the INITIAL one: preserve_terminal_condition re-imposes u(T)=g on the LAST time row after damping/Anderson. Single owner, three caller families -- fixed_point_iterator.py:644 and :724 (Picard), fictitious_play.py:432, block_iterators.py:583. No issue ",
-      "seconds": 159.2,
+      "seconds": 252.5,
       "status": "ok",
       "verify": "preserve_terminal_condition(np.zeros((3, 4)), np.full(4, 7.0))[0, 0] == 7.0"
     },
@@ -2289,7 +2944,7 @@
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_every_row_linearises_the_residual[piecewise_linear-True-robin_alpha_eq_beta]"
       ],
       "owner": "on rows where forward and backward agree in VALUE, the upwind Jacobian's row is decided by sign(central), matching the residual's own selector -- the one place #1896 left the rule restated rather than measured (#1896 item 3)",
-      "seconds": 158.7,
+      "seconds": 131.4,
       "status": "ok",
       "verify": "float(_advection_bands(np.zeros(5), 0.25, None, 0.0, True, _bc_laplacian_bands(5, 0.25, None, 0.0))[1][2]) == -4.0"
     }

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -258,7 +258,13 @@ MUTATIONS: list[Mutation] = [
         old="        if bc.is_uniform:",
         new="        if False:  # MUTATED: uniform BC reads as mixed -- every BC takes the per-face path",
         owner="PreallocatedGhostBuffer.update_ghosts routes a uniform BC to the single-segment path and a mixed BC to the per-face path (#577 Phase 3 for the mixed rewrite, #1255 (C) for the alpha/beta forwarding the uniform branch carries). The two paths are NOT equivalent: the uniform branch applies the inhomoge",
-        verify="pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 1.0",
+        # Re-pointed 2026-08-21. The Neumann probe went blind: the uniform and per-face paths now
+        # agree on Neumann to the last bit, so forcing the per-face path changed nothing the probe
+        # could see and the mutation was scored INEFFECTIVE -- a dead instrument reported as a dead
+        # convention. Measured, same input under both: [1.1 1. 2. 3. 3.1] either way. Robin still
+        # separates them (clean [0] = 1.097561, mutant [0] = 5.0), so the divergence this mutation
+        # models is alive and only the Neumann witness died.
+        verify="pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), robin_bc(dimension=1, alpha=1.0, beta=1.0, value=3.0), ghost_depth=1, spacing=0.05)[0] == 5.0",
     ),
     Mutation(
         name="neumann_low_wall_flux_sign",
@@ -443,7 +449,7 @@ import numpy as np
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
 from mfgarchon.geometry.boundary.bc_utils import bc_type_to_geometric_operation
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
-from mfgarchon.geometry.boundary import neumann_bc
+from mfgarchon.geometry.boundary import neumann_bc, robin_bc
 from mfgarchon.geometry.boundary.applicator_fdm import pad_array_with_ghosts
 from mfgarchon import Conditions, MFGProblem, Model
 from mfgarchon import MFGProblem

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -258,20 +258,35 @@ MUTATIONS: list[Mutation] = [
         old="        if bc.is_uniform:",
         new="        if False:  # MUTATED: uniform BC reads as mixed -- every BC takes the per-face path",
         owner="PreallocatedGhostBuffer.update_ghosts routes a uniform BC to the single-segment path and a mixed BC to the per-face path (#577 Phase 3 for the mixed rewrite, #1255 (C) for the alpha/beta forwarding the uniform branch carries). The two paths are NOT equivalent: the uniform branch applies the inhomoge",
-        # Re-pointed 2026-08-21. The Neumann probe went blind: the uniform and per-face paths now
-        # agree on Neumann to the last bit, so forcing the per-face path changed nothing the probe
-        # could see and the mutation was scored INEFFECTIVE -- a dead instrument reported as a dead
-        # convention. Measured, same input under both: [1.1 1. 2. 3. 3.1] either way. Robin still
-        # separates them (clean [0] = 1.097561, mutant [0] = 5.0), so the divergence this mutation
-        # models is alive and only the Neumann witness died.
-        verify="pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), robin_bc(dimension=1, alpha=1.0, beta=1.0, value=3.0), ghost_depth=1, spacing=0.05)[0] == 5.0",
+        # Re-pointed twice on 2026-08-21. The original probe used a STATIC SCALAR Neumann value
+        # and went blind -- [1.1 1. 2. 3. 3.1] under mutant and clean alike -- so the row scored
+        # INEFFECTIVE, and a dead instrument reads exactly like a dead convention.
+        #
+        # The cause is NOT that "the Neumann paths converged". `_update_ghosts_mixed` finds no
+        # segment for a uniform BC, so it synthesizes `__default__` from `bc_type` and
+        # `bc.default_value` ONLY, dropping alpha, beta and callable values. Static scalar Neumann
+        # is invisible to that because its ghost formula reads none of them. Two order-2 witnesses
+        # to the drop do survive: a CALLABLE Neumann value (clean 1.1, mutant 1.0 -- the original
+        # probe was one lambda from working) and Robin (clean 1.097561, mutant 5.0, which is
+        # bit-identical to a clean Dirichlet(3.0), the beta=0 degenerate case, not Robin
+        # arithmetic).
+        #
+        # Neither is used, because both die the moment the drop is fixed: measured against a
+        # `__default__` that forwards alpha/beta/value, Robin returns to 1.097561 with the mutation
+        # STILL APPLIED. A probe whose witness is a latent defect is one bugfix from blind.
+        #
+        # order > 2 is the durable witness. `_update_ghosts_uniform` dispatches to
+        # `_apply_poly_extrapolation`; the per-face path has no order dispatch at all, so the
+        # separation is structural rather than a consequence of the drop. Measured at order 3:
+        # clean 3.490909, mutant 1.1, and mutant-plus-that-fix still 1.1.
+        verify="abs(_ghost0(neumann_bc(dimension=1, value=2.0), 3) - 1.1) < 1e-12",
     ),
     Mutation(
         name="neumann_low_wall_flux_sign",
         path="mfgarchon/geometry/boundary/applicator_fdm.py",
         old="                        buf[tuple(lo_ghost)] += (2 * (k + 1) - 1) * dx * v",
         new="                        buf[tuple(lo_ghost)] -= (2 * (k + 1) - 1) * dx * v  # MUTATED: low wall reads du/dx instead of du/dn",
-        owner='inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and the offset is ADDED, the same sign as the high wall (#1262). Since #1967 the magnitude is (2k-1)*dx*v rather than dx*v -- ghost layer k sits that far from its mirror -- so the k=1 case is the historical dx*v and the deeper layers scale.',
+        owner="inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and the offset is ADDED, the same sign as the high wall (#1262). Since #1967 the magnitude is (2k-1)*dx*v rather than dx*v -- ghost layer k sits that far from its mirror -- so the k=1 case is the historical dx*v and the deeper layers scale.",
         verify="pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 0.9",
     ),
     Mutation(
@@ -449,8 +464,21 @@ import numpy as np
 from mfgarchon.utils.pde_coefficients import diffusion_from_volatility, fp_drift_coefficient
 from mfgarchon.geometry.boundary.bc_utils import bc_type_to_geometric_operation
 from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
-from mfgarchon.geometry.boundary import neumann_bc, robin_bc
+from mfgarchon.geometry.boundary import neumann_bc
 from mfgarchon.geometry.boundary.applicator_fdm import pad_array_with_ghosts
+from mfgarchon.geometry.boundary.applicator_fdm import PreallocatedGhostBuffer
+
+
+def _ghost0(bc, order):
+    # Low-wall ghost value of [1,2,3] at a given reconstruction order.
+    # pad_array_with_ghosts does not expose `order`, and order is the one thing the
+    # per-face ghost path has no dispatch for -- which is what makes it a durable witness.
+    b = PreallocatedGhostBuffer(
+        interior_shape=(3,), boundary_conditions=bc, ghost_depth=1, order=order, spacing=0.05
+    )
+    b.interior[:] = np.array([1.0, 2.0, 3.0])
+    b.update_ghosts(time=0.0)
+    return float(b.padded.copy()[0])
 from mfgarchon import Conditions, MFGProblem, Model
 from mfgarchon import MFGProblem
 from mfgarchon.alg.numerical.coupling.fixed_point_utils import check_convergence_criteria
@@ -479,13 +507,8 @@ def _stub_problem(control_cost):
 """
 
 
-def _mutation_is_live(mut: Mutation) -> bool:
-    """Is the perturbation observable from outside? The control, on the thing in doubt.
-
-    Evaluated against the mutated tree in a fresh interpreter. Only when this is true
-    does a kill count of zero mean "no test covers this convention" rather than "the
-    mutation never ran".
-    """
+def _eval_verify(mut: Mutation) -> tuple[bool, str]:
+    """Evaluate `mut.verify` against whatever tree is on disk, in a fresh interpreter."""
     proc = subprocess.run(
         [sys.executable, "-B", "-c", f"{_VERIFY_PRELUDE}\nassert ({mut.verify}), {mut.verify!r}"],
         cwd=REPO,
@@ -493,10 +516,53 @@ def _mutation_is_live(mut: Mutation) -> bool:
         text=True,
         env=_env(),
     )
-    if proc.returncode != 0:
-        tail = (proc.stderr.strip().splitlines() or ["(no stderr)"])[-1]
-        print(f"  verify FAILED: {mut.verify}\n    {tail}", flush=True)
-    return proc.returncode == 0
+    tail = (proc.stderr.strip().splitlines() or ["(no stderr)"])[-1]
+    return proc.returncode == 0, tail
+
+
+def _mutation_is_live(mut: Mutation) -> bool:
+    """Is the perturbation observable from outside? The control, on the thing in doubt.
+
+    Only when this is true does a kill count of zero mean "no test covers this
+    convention" rather than "the mutation never ran".
+
+    **Two-sided since #2038.** It was evaluated against the MUTATED tree alone, which
+    proves the expression is true there and nothing else -- an expression true under
+    both trees would pass this and prove nothing, and one true under NEITHER is the
+    failure that actually happened: `bc_uniform_dispatch_reads_as_mixed`'s probe used a
+    static scalar Neumann value, the per-face path returns the same array for that input,
+    and the row scored INEFFECTIVE with the mutation applying perfectly. That direction
+    was caught only because a false-under-both probe fails the one-sided check by luck of
+    direction; a true-under-both probe would have sailed through.
+
+    So the clean side is asserted too: `verify` must be FALSE before the mutation and
+    TRUE after. A probe that cannot tell the two trees apart is not a control.
+
+    Call ONLY with the mutation applied. The clean evaluation temporarily restores the
+    file and re-applies afterwards, so the caller's `backups` stay authoritative.
+    """
+    live, tail = _eval_verify(mut)
+    if not live:
+        print(f"  verify FAILED on the mutated tree: {mut.verify}\n    {tail}", flush=True)
+        return False
+
+    target = REPO / mut.path
+    mutated_text = target.read_text()
+    target.write_text(mutated_text.replace(mut.new, mut.old))
+    try:
+        held_on_clean, _ = _eval_verify(mut)
+    finally:
+        target.write_text(mutated_text)
+
+    if held_on_clean:
+        print(
+            f"  verify is TRUE ON CLEAN CODE too, so it is not a control: {mut.verify}\n"
+            f"    it must be false before the mutation and true after; as written it "
+            f"cannot distinguish the two trees",
+            flush=True,
+        )
+        return False
+    return True
 
 
 def apply_mutation(mut: Mutation, backups: dict[str, str]) -> None:


### PR DESCRIPTION
Three commits. The kill matrix was stamped at `f961db90` / 6138 collected; the suite is now 6384 and the gate had been printing its fraction with a `STALE` marker.

## The alarming row that was not a fact about the suite

A first sweep returned `bc_uniform_dispatch_reads_as_mixed` at **31 killers → 0**, the only survivor, while 18 of 24 rows moved the other way. A kill count is a claim about the *suite*, so read literally that row said a convention 31 tests used to notice had become unguarded.

Its `status` was `INEFFECTIVE` and its `seconds` `0.0` — the suite never ran, because the probe could no longer see the mutation take effect. Re-pointed, the row measures **43**.

## What review corrected in the first diagnosis

I claimed *"the uniform and per-face ghost paths now agree bit-for-bit on Neumann"*. **False**, and confirmed false by measurement:

| input | clean | mutant |
|---|---|---|
| Neumann, **static scalar** `2.0` | `[1.1 1. 2. 3. 3.1]` | same |
| Neumann, **callable** `lambda t: 2.0` | `[1.1 …]` | `[1. …]` |
| Robin `α=1, β=1, g=3` | `[1.097561 …]` | `[5. …]` |
| Neumann, **order 3** | `3.490909` | `1.1` |

The dead probe asserted `== 1.0`, which is exactly what the mutant returns for a **callable** value — it was one `lambda` from working.

**The mechanism was wrong too.** Nothing converged on Neumann. `_update_ghosts_mixed` finds no segment for a uniform BC and synthesizes `__default__` from `bc_type` and `bc.default_value` **only**, dropping `alpha`, `beta` and callable values. Static scalar Neumann is invisible to that because its ghost formula reads none of them. The Robin witness is the same drop from the other side: the mutant's `5.0` is bit-identical to a clean `dirichlet_bc(value=3.0)` — the `β=0` degenerate case, not Robin arithmetic, and independent of the α and β the probe passes.

## So Robin was a bad replacement, and is not used

A probe whose witness is a latent defect is one bugfix from blind. Measured against a `__default__` that forwards `alpha`/`beta`/`value`, **Robin returns to `1.097561` with the mutation still fully applied** — dead exactly as before.

`order > 2` is structural: `_update_ghosts_uniform` dispatches to `_apply_poly_extrapolation`, and the per-face path has **no order dispatch at all**. At order 3 it separates clean from mutant *and from mutant-plus-that-fix*. `PreallocatedGhostBuffer` and a `_ghost0` helper were added to the prelude, since `pad_array_with_ghosts` does not expose `order`. The duplicate `robin_bc` import the first commit added is reverted — it was already imported three lines below.

## The harness gap that allowed all of this

`_mutation_is_live` evaluated `verify` against the **mutated tree alone**. That proves the expression is true there and nothing else: a probe true under *both* trees passes and proves nothing, and the failure that actually happened — true under *neither* — was caught only by luck of direction.

`verify` is now **two-sided**: false before the mutation, true after, with the file restored and re-applied around the clean evaluation so the caller's backups stay authoritative. Positive control, all three directions:

```
real probe (false clean, true mutant)  -> True
tautology '1 == 1' (true under both)   -> False   <- the case the old check would pass
impossible '1 == 2' (true under neither)-> False   <- the case that happened
```

## Re-measurement

```
tests noticing >= 1 convention   449 -> 581
(mutation, test) pairs           582 -> 778
collected                       6138 -> 6384
rows that LOST killers               0
INEFFECTIVE rows                     0
survivors (0 killers)                0
```

Largest gains: `fp_initial_condition_written_at_final_index` 90 → 128, `ghost_spacing_ignored` 22 → 58, `diffusion_scalar_2x` 145 → 162, `neumann_low_wall_flux_sign` 23 → 37, `bc_uniform` 31 → 43.

Regenerated in **one** sweep as the script instructs; the first sweep is discarded rather than merged, since a matrix assembled from two runs is not a measurement. `test_discrimination_ratchet.py`: 59 passed.

## Known and not fixed here

The `__default__` synthesis dropping `alpha`/`beta`/callable values is a real defect, deliberately left standing — fixing it is a separate change, and the probe is now chosen so that fixing it will **not** blind the row. Left open in #2038: whether `verify` should carry several probes rather than one, and whether the other 23 probes should be audited the same way (the two-sided check now does this automatically for every one of them on the next sweep).