### PR TITLE
test(alg): the source_term channel census covered 6 of 21 solvers (#2020)

### DIFF
--- a/changelog.d/2020-source-term-channel-coverage.changed.md
+++ b/changelog.d/2020-source-term-channel-coverage.changed.md
@@ -1,0 +1,8 @@
+`test_source_term_channel_2020.py` now covers **14 of the 21** concrete solvers instead of 6, and
+holds its parametrisation against discovery so the gap cannot reopen silently (#2020). The eight
+added rows are `HJBGFDMSolver`, `HJBWENOSolver` and `FPFVMSolver` (honour a source) and
+`HJBSemiLagrangianSolver`, `FPGFDMSolver`, `FPParticleSolver`, `FPSLSolver`, `FPSLJacobianSolver`
+(refuse it — a correct outcome, recorded per row so that one which starts honouring it fails and
+gets its row updated deliberately). The remaining seven are named in `_UNCOVERED` with the reason,
+rather than being absent. The file's status line said "every solver here now honours a source",
+which was true of its six rows and not of the channel: five of the eight added solvers refuse.

--- a/tests/unit/test_alg/test_source_term_channel_2020.py
+++ b/tests/unit/test_alg/test_source_term_channel_2020.py
@@ -28,10 +28,20 @@ the suite drives a manufactured solution through a swallowing solver -- the six 
 `HJBWENOSolver` and `PenaltyHJBSolver`. This file exists so that stays true by failure rather than
 by nobody having tried.
 
-STATUS AFTER #2020: every solver here now HONOURS a source. The four rows that were a recorded
-defect pin are ordinary rows, and `_SWALLOWERS` is empty. What the file still does that the
-class-definition gate cannot is check BEHAVIOUR: the gate reads a signature, and this repository has
-twice now had a solver whose signature and behaviour disagreed -- `HJBWENOSolver` names
+STATUS: `_SWALLOWERS` is empty -- nothing silently discards a source any more, which is what #2020
+was about. ~~every solver here now HONOURS a source~~ [CORRECTED 2026-08-21] that was true of the
+six rows this file had; it covered 6 of 21 concrete solvers. Eight more are now rows, and five of
+them REFUSE -- `HJBSemiLagrangianSolver`, `FPGFDMSolver`, `FPParticleSolver`, `FPSLSolver`,
+`FPSLJacobianSolver`. Refusing is a correct outcome and not a defect, but "every solver honours a
+source" and "every solver in my list honours a source" are different claims, and the list was the
+smaller half of the population.
+
+`test_every_concrete_solver_is_covered_or_named` now holds the parametrisation against discovery,
+so the gap between the two cannot reopen quietly. Seven solvers still have no row and are named in
+`_UNCOVERED` with the reason.
+
+What the file does that the class-definition gate cannot is check BEHAVIOUR: the gate reads a
+signature, and this repository has twice now had a solver whose signature and behaviour disagreed -- `HJBWENOSolver` names
 `source_term` and refuses it in multi-D, and six solvers named nothing and swallowed it. A signature
 gate cannot tell those apart; passing a real source and watching the answer can.
 """
@@ -170,6 +180,84 @@ def _fp_fem():
     )
 
 
+def _hjb_gfdm():
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_gfdm import HJBGFDMSolver
+
+    p = _grid_problem()
+    m = np.tile(np.ones(_N) / _N, (p.Nt + 1, 1))
+    u = np.zeros((p.Nt + 1, _N))
+    s = HJBGFDMSolver(p, collocation_points=np.linspace(0.0, 1.0, _N).reshape(-1, 1))
+    return lambda f: s.solve_hjb_system(m, np.zeros(_N), u, **({"source_term": f} if f else {}))
+
+
+def _hjb_weno():
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_weno import HJBWENOSolver
+
+    p = _grid_problem()
+    m = np.tile(np.ones(_N) / _N, (p.Nt + 1, 1))
+    u = np.zeros((p.Nt + 1, _N))
+    s = HJBWENOSolver(p)
+    # 1-D ONLY. `hjb_weno.py` refuses `source_term` for every d >= 2, deliberately: the multi-D
+    # path is a dimensional split, so a source added per axis sweep would be applied d times.
+    # This row therefore says nothing about WENO in 2-D, where the correct verdict is "refuses".
+    return lambda f: s.solve_hjb_system(m, np.zeros(_N), u, **({"source_term": f} if f else {}))
+
+
+def _fp_fvm():
+    from mfgarchon.alg.numerical.fp_solvers.fp_fvm import FPFVMSolver
+
+    p = _grid_problem()
+    u = np.zeros((p.Nt + 1, _N))
+    s = FPFVMSolver(p)
+    return lambda f: s.solve_fp_system(np.ones(_N) / _N, potential_field=u, **({"source_term": f} if f else {}))
+
+
+def _hjb_semi_lagrangian():
+    from mfgarchon.alg.numerical.hjb_solvers.hjb_semi_lagrangian import HJBSemiLagrangianSolver
+
+    p = _grid_problem()
+    m = np.tile(np.ones(_N) / _N, (p.Nt + 1, 1))
+    u = np.zeros((p.Nt + 1, _N))
+    s = HJBSemiLagrangianSolver(p)
+    return lambda f: s.solve_hjb_system(m, np.zeros(_N), u, **({"source_term": f} if f else {}))
+
+
+def _fp_gfdm():
+    from mfgarchon.alg.numerical.fp_solvers.fp_gfdm import FPGFDMSolver
+
+    p = _grid_problem()
+    u = np.zeros((p.Nt + 1, _N))
+    s = FPGFDMSolver(p, collocation_points=np.linspace(0.0, 1.0, _N).reshape(-1, 1))
+    return lambda f: s.solve_fp_system(np.ones(_N) / _N, drift_field=u, **({"source_term": f} if f else {}))
+
+
+def _fp_particle():
+    from mfgarchon.alg.numerical.fp_solvers.fp_particle import FPParticleSolver
+
+    p = _grid_problem()
+    u = np.zeros((p.Nt + 1, _N))
+    s = FPParticleSolver(p)
+    return lambda f: s.solve_fp_system(np.ones(_N) / _N, potential_field=u, **({"source_term": f} if f else {}))
+
+
+def _fp_sl():
+    from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian_adjoint import FPSLSolver
+
+    p = _grid_problem()
+    u = np.zeros((p.Nt + 1, _N))
+    s = FPSLSolver(p)
+    return lambda f: s.solve_fp_system(np.ones(_N) / _N, potential_field=u, **({"source_term": f} if f else {}))
+
+
+def _fp_sl_jacobian():
+    from mfgarchon.alg.numerical.fp_solvers.fp_semi_lagrangian import FPSLJacobianSolver
+
+    p = _grid_problem()
+    u = np.zeros((p.Nt + 1, _N))
+    s = FPSLJacobianSolver(p)
+    return lambda f: s.solve_fp_system(np.ones(_N) / _N, potential_field=u, **({"source_term": f} if f else {}))
+
+
 # (label, factory, expected). "honours" rows are the positive control WITHOUT which the
 # "swallows" rows prove nothing -- a harness that never delivers a source would report every
 # solver as swallowing it.
@@ -180,7 +268,89 @@ _CASES = [
     ("MeshlessGalerkinFPSolver", _meshless_fp, "honours"),
     ("HJBFEMSolver", _hjb_fem, "honours"),
     ("FPFEMSolver", _fp_fem, "honours"),
+    # Added 2026-08-21. These eight were in the population and outside _CASES, so the file's
+    # headline covered 6 of 21 concrete solvers while reading as though it covered the channel.
+    ("HJBGFDMSolver", _hjb_gfdm, "honours"),
+    ("HJBWENOSolver", _hjb_weno, "honours"),  # 1-D only -- see the factory
+    ("FPFVMSolver", _fp_fvm, "honours"),
+    ("HJBSemiLagrangianSolver", _hjb_semi_lagrangian, "refuses"),
+    ("FPGFDMSolver", _fp_gfdm, "refuses"),
+    ("FPParticleSolver", _fp_particle, "refuses"),
+    ("FPSLSolver", _fp_sl, "refuses"),
+    ("FPSLJacobianSolver", _fp_sl_jacobian, "refuses"),
 ]
+
+
+#: Concrete solvers with no row above, and why. NAMED rather than inferred: a curated
+#: parametrisation is a claim about scope, and the claim is only auditable if its gaps are written
+#: down. `test_every_concrete_solver_is_covered_or_named` compares this against discovery, so a
+#: solver added to the package cannot slip past the list in silence.
+_UNCOVERED: dict[str, str] = {
+    "FPSLAdjointSolver": "alias -- overrides only __init__ and shares FPSLSolver.solve_fp_system, "
+    "so a row here would measure the same method object twice",
+    "NetworkHJBSolver": "needs a network problem; raises NotImplementedError about node BCs on a grid",
+    "NetworkPolicyIterationHJBSolver": "needs a network problem; reads problem.num_nodes unguarded "
+    "and raises AttributeError on a grid",
+    "FPNetworkSolver": "needs a network problem",
+    "WeakFormHJBSolver": "intended-abstract base -- constructs given a discretization, then its BC "
+    "hooks raise NotImplementedError; the concrete subclasses are the FEM rows above",
+    "WeakFormFPSolver": "intended-abstract base -- same",
+    "PenaltyHJBSolver": "wrapper -- delegates solve_hjb_system to an inner solver, so it measures "
+    "whichever row that inner solver already has",
+}
+
+
+def _concrete_solvers() -> set[str]:
+    """Every concrete BaseHJBSolver / BaseFPSolver subclass under `mfgarchon.alg.numerical`.
+
+    Discovery must not be keyed on the property under audit, so no signature and no membership of
+    `_CASES` takes part in choosing the population.
+    """
+    import importlib
+    import pkgutil
+
+    import mfgarchon.alg.numerical as _numerical
+
+    found: set[str] = set()
+    for info in pkgutil.walk_packages(_numerical.__path__, _numerical.__name__ + "."):
+        try:
+            module = importlib.import_module(info.name)
+        except Exception:
+            continue
+        for obj in vars(module).values():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, (BaseHJBSolver, BaseFPSolver))
+                and obj not in (BaseHJBSolver, BaseFPSolver)
+            ):
+                found.add(obj.__name__)
+    return found
+
+
+def test_every_concrete_solver_is_covered_or_named():
+    """The parametrisation must account for the whole population, row by row or by name.
+
+    Without this the file reads as "the source_term channel is tested" while covering whichever
+    solvers someone thought of. It covered 6 of 21 until 2026-08-21 -- every FDM, FEM and meshless
+    path, and none of GFDM, WENO, FVM, semi-Lagrangian or particle -- and nothing said so.
+    """
+    population = _concrete_solvers()
+    assert len(population) == 21, sorted(population)
+
+    covered = {c[0] for c in _CASES}
+    assert covered - population == set(), f"rows for classes that are not in the population: {covered - population}"
+
+    unaccounted = population - covered - set(_UNCOVERED)
+    assert unaccounted == set(), (
+        f"concrete solvers with neither a row nor an entry in _UNCOVERED: {sorted(unaccounted)}. "
+        f"Add a row if the fixture can drive it, or name the reason it cannot."
+    )
+
+    stale = set(_UNCOVERED) - population
+    assert stale == set(), f"_UNCOVERED names classes that no longer exist: {sorted(stale)}"
+
+    overlap = set(_UNCOVERED) & covered
+    assert overlap == set(), f"listed as both covered and uncovered: {sorted(overlap)}"
 
 
 @pytest.mark.parametrize(("label", "factory", "expected"), _CASES, ids=[c[0] for c in _CASES])
@@ -193,12 +363,22 @@ def test_a_source_term_is_honoured_or_refused_never_discarded(label, factory, ex
     try:
         forced = np.asarray(call(src), dtype=float)
     except (TypeError, NotImplementedError):
-        # A refusal is a correct outcome for either class -- it is the third option the contract
-        # allows, and it is what the coupling layer produces for every solver here.
-        assert expected == "swallows", f"{label} refuses source_term but is listed as honouring it"
+        # A refusal is a correct outcome -- the third option the contract allows, and what the
+        # coupling layer produces for every solver here. It is recorded per row rather than
+        # accepted anywhere, so that a solver which STARTS honouring the parameter fails this
+        # test and gets its row updated deliberately (that is #2020 progress, not a regression).
+        assert expected in ("swallows", "refuses"), f"{label} refuses source_term but is listed as {expected!r}"
         return
 
     delta = float(np.abs(forced - baseline).max())
+
+    if expected == "refuses":
+        raise AssertionError(
+            f"{label} is listed as refusing source_term but accepted it "
+            f"(called {src.calls} times, max|diff| = {float(np.abs(forced - baseline).max()):.3e}). "
+            f"If it now honours the parameter that is #2020 progress -- change the row to "
+            f"'honours' and say so."
+        )
 
     if expected == "honours":
         assert src.calls > 0, f"{label} accepted source_term without ever calling it (delta {delta:.3e})"

--- a/tests/unit/test_alg/test_source_term_channel_2020.py
+++ b/tests/unit/test_alg/test_source_term_channel_2020.py
@@ -186,6 +186,11 @@ def _hjb_gfdm():
     p = _grid_problem()
     m = np.tile(np.ones(_N) / _N, (p.Nt + 1, 1))
     u = np.zeros((p.Nt + 1, _N))
+    # `inner_solver` defaults to 'newton'. The 'howard' branch is a SEPARATE source path and it
+    # discarded the source bitwise until #1991 -- `hjb_gfdm.py` records
+    # "|U(source) - U(no source)| = 0.000e+00 at two resolutions". Both honour it today (measured
+    # 2026-08-21, max|delta| = 1 on each), so this row's scope is the default branch and the other
+    # is unpinned here. Driving it needs `inner_solver='howard'` plus a monotonicity scheme.
     s = HJBGFDMSolver(p, collocation_points=np.linspace(0.0, 1.0, _N).reshape(-1, 1))
     return lambda f: s.solve_hjb_system(m, np.zeros(_N), u, **({"source_term": f} if f else {}))
 
@@ -285,6 +290,13 @@ _CASES = [
 #: parametrisation is a claim about scope, and the claim is only auditable if its gaps are written
 #: down. `test_every_concrete_solver_is_covered_or_named` compares this against discovery, so a
 #: solver added to the package cannot slip past the list in silence.
+#:
+#: KNOWN UNASSERTED SURFACE: only the KEYS are checked. The reason strings are prose that no
+#: assertion reads, so one can rot while its row stays green -- measured, a reason rewritten to
+#: "runs fine on a grid and honours a source" passes. They are kept because a named gap with a
+#: possibly-stale reason beats an unnamed gap, and checking them would mean re-implementing the
+#: construct-and-drive machinery for exactly the solvers this fixture cannot construct or drive.
+#: Re-verify a reason before relying on it; each was measured on 2026-08-21.
 _UNCOVERED: dict[str, str] = {
     "FPSLAdjointSolver": "alias -- overrides only __init__ and shares FPSLSolver.solve_fp_system, "
     "so a row here would measure the same method object twice",
@@ -312,10 +324,16 @@ def _concrete_solvers() -> set[str]:
     import mfgarchon.alg.numerical as _numerical
 
     found: set[str] = set()
+    failed: list[str] = []
     for info in pkgutil.walk_packages(_numerical.__path__, _numerical.__name__ + "."):
         try:
             module = importlib.import_module(info.name)
-        except Exception:
+        except Exception as exc:
+            # Recorded, not swallowed: a solver hidden behind an ImportError would otherwise
+            # surface only as a baffling `assert 20 == 21`, blaming the count for a module that
+            # never loaded. `test_the_swallowing_set_has_not_grown` already guards its walk this
+            # way; this one did not.
+            failed.append(f"{info.name}: {type(exc).__name__}")
             continue
         for obj in vars(module).values():
             if (
@@ -324,6 +342,7 @@ def _concrete_solvers() -> set[str]:
                 and obj not in (BaseHJBSolver, BaseFPSolver)
             ):
                 found.add(obj.__name__)
+    assert not failed, f"modules that would hide a solver from this census: {failed}"
     return found
 
 
@@ -335,16 +354,18 @@ def test_every_concrete_solver_is_covered_or_named():
     path, and none of GFDM, WENO, FVM, semi-Lagrangian or particle -- and nothing said so.
     """
     population = _concrete_solvers()
-    assert len(population) == 21, sorted(population)
-
     covered = {c[0] for c in _CASES}
-    assert covered - population == set(), f"rows for classes that are not in the population: {covered - population}"
 
+    # The informative assertion FIRST. `len(population) == 21` fires on the commonest real event --
+    # someone adds a solver -- and its message is a bare count, which blames the wrong thing.
     unaccounted = population - covered - set(_UNCOVERED)
     assert unaccounted == set(), (
         f"concrete solvers with neither a row nor an entry in _UNCOVERED: {sorted(unaccounted)}. "
         f"Add a row if the fixture can drive it, or name the reason it cannot."
     )
+
+    assert len(population) == 21, sorted(population)
+    assert covered - population == set(), f"rows for classes that are not in the population: {covered - population}"
 
     stale = set(_UNCOVERED) - population
     assert stale == set(), f"_UNCOVERED names classes that no longer exist: {sorted(stale)}"
@@ -360,14 +381,26 @@ def test_a_source_term_is_honoured_or_refused_never_discarded(label, factory, ex
     baseline = np.asarray(call(None), dtype=float)
 
     src = _Source()
+    refusal: str | None = None
     try:
         forced = np.asarray(call(src), dtype=float)
-    except (TypeError, NotImplementedError):
+    except (TypeError, NotImplementedError) as exc:
+        refusal = f"{type(exc).__name__}: {exc}"
+
+    if refusal is not None:
         # A refusal is a correct outcome -- the third option the contract allows, and what the
         # coupling layer produces for every solver here. It is recorded per row rather than
         # accepted anywhere, so that a solver which STARTS honouring the parameter fails this
         # test and gets its row updated deliberately (that is #2020 progress, not a regression).
         assert expected in ("swallows", "refuses"), f"{label} refuses source_term but is listed as {expected!r}"
+        # ... and it must refuse THE SOURCE, not some other argument. Without this, a row raising
+        # about `potential_field` whenever a source is passed scores as an honest refusal --
+        # measured: that mutant passes green without this line. Every current row is an
+        # argument-binding TypeError naming the parameter, so it costs nothing and pins the shape.
+        assert "source_term" in refusal, (
+            f"{label} raised something that never mentions source_term, so it is not evidence the "
+            f"SOURCE was refused: {refusal[:160]}"
+        )
         return
 
     delta = float(np.abs(forced - baseline).max())


### PR DESCRIPTION
`tests/unit/test_alg/test_source_term_channel_2020.py` is the owner of the behavioural `source_term` question and its argument is right. Its **parametrisation** was the smaller half of the population.

It covered every FDM, FEM and meshless path — and none of GFDM, WENO, FVM, semi-Lagrangian or particle. **6 of 21 concrete solvers.** Nothing in the file said so, and its status line read as a statement about the channel when it was a statement about six rows:

> STATUS AFTER #2020: every solver here now HONOURS a source.

True of its rows. Not true of the channel: **five of the eight solvers added here refuse it.**

## Eight rows added, measured on the file's own fixture

| verdict | solvers |
|---|---|
| honours | `HJBGFDMSolver`, `HJBWENOSolver`, `FPFVMSolver` |
| refuses | `HJBSemiLagrangianSolver`, `FPGFDMSolver`, `FPParticleSolver`, `FPSLSolver`, `FPSLJacobianSolver` |

`refuses` is a new classification. It is a **correct outcome, not a defect** — but it is recorded per row rather than accepted anywhere, so a solver that *starts* honouring the parameter fails its row and gets reclassified deliberately. That is #2020 progress and should not land silently.

## The gap is now held against discovery

`test_every_concrete_solver_is_covered_or_named` compares `_CASES` to `walk_packages` + `issubclass` over `mfgarchon.alg.numerical`: **21 concrete solvers, 14 rows, 7 named in `_UNCOVERED` with a reason.** Discovery is not keyed on the property under audit — no signature and no membership of `_CASES` takes part in choosing the population.

Mutation-verified:

| mutant | fires |
|---|---|
| a row deleted from `_CASES` without being named in `_UNCOVERED` | the coverage test |
| the population count no longer matching | the coverage test |
| a `refuses` row that starts honouring | that row |
| reverted | 16 passed |

## Two `_UNCOVERED` reasons are corrections, not restatements

- `NetworkPolicyIterationHJBSolver` does not so much "require a network problem" as read `problem.num_nodes` **unguarded** and raise `AttributeError` on a grid. Its sibling `NetworkHJBSolver` raises a deliberate `NotImplementedError` about node BCs — the two fail differently and only one of them fails on purpose.
- `FPSLAdjointSolver` overrides only `__init__`; a row for it would measure `FPSLSolver.solve_fp_system` a second time. The SL family is 3 classes over 2 code paths.

## The WENO row carries its dimension

`hjb_weno.py` refuses `source_term` for every `d >= 2` **on purpose** — the multi-D path is a dimensional split, so a source added per axis sweep would be applied `d` times. The row is a 1-D fact and says so at the factory rather than implying a general capability.

## Provenance

This supersedes a duplicate census I wrote and closed unmerged (#2043). I built it without checking whether one already existed; `find tests -name "*2020*"` returns this file in one command. What that PR genuinely added — the population reconciliation — is the one piece folded in here, onto the existing owner rather than beside it.

16 passed.