### PR TITLE
refactor(hjb)!: retire PenaltyHJBSolver — its channel cannot carry the constraint (#2002)

### DIFF
--- a/changelog.d/2002-retire-penalty-hjb-solver.removed.md
+++ b/changelog.d/2002-retire-penalty-hjb-solver.removed.md
@@ -1,0 +1,12 @@
+**BREAKING.** `PenaltyHJBSolver` is retired and its constructor now raises `NotImplementedError`
+(#2002). It was written to add the variational inequality `v >= Psi(x)` to any HJB solver by
+injecting a penalty into that solver's `source_term`, but a penalty for that constraint is
+`max(0, Psi - v)` and `source_term` is `(t, x) -> array` — there is nowhere for the value function
+to enter. What it applied was `penalty_parameter * max(0, Psi(x))`, byte-identical at a node
+satisfying the constraint and one violating it, and no value of `penalty_parameter` changes that.
+The name still resolves and the error explains the situation and names `HJBFDMSolver(constraint=...)`
+(#591) as the reachable alternative, with its own limits in #2036. Retiring it removes a capability
+that was never there: it was the only mechanism claiming to give obstacle support to solvers other
+than `HJBFDMSolver`, and #2046 tracks doing that properly by threading the constraint through the
+shared timestep solve. Two further copies of the withdrawn "proper handling is the PenaltyHJBSolver
+wrapper (#924)" claim, in `newton_mfg_solver` and `graph_mfg_solver`, are struck as well.

--- a/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/graph_mfg_solver.py
@@ -320,8 +320,13 @@ class GraphMFGSolver(BaseCouplingIterator):
         so that all Layer 1 feature dimensions (Levy, custom sources, graph)
         compose at each node, matching Binding Constraint #1 of the Plan.
 
-        Obstacle / penalty VI composition is handled by wrapping each node's
-        HJB solver in PenaltyHJBSolver, not here.
+        ~~Obstacle / penalty VI composition is handled by wrapping each node's
+        HJB solver in PenaltyHJBSolver, not here.~~
+        [CORRECTED 2026-08-21, #2002] ``PenaltyHJBSolver`` is RETIRED and raises on construction;
+        it injected a ``v``-free term through ``source_term``, which cannot carry the value
+        function, so it never composed a variational inequality. There is currently NO obstacle
+        route for a per-node HJB solver here -- ``constraint=`` exists only on ``HJBFDMSolver``
+        (#591), and #2046 tracks threading it through the shared timestep solve.
         """
         p = self._problems[k]
         has_problem_source = p.source_term_hjb is not None

--- a/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
+++ b/mfgarchon/alg/numerical/coupling/newton_mfg_solver.py
@@ -70,8 +70,14 @@ class NewtonMFGSolver(BaseCouplingIterator):
         ``source_composition`` helpers shared with the Picard
         ``FixedPointIterator``. The FD Jacobian differentiates through the source
         dependence (option A; see ``MFGResidual``), so Newton converges to the
-        same equilibrium as Picard. Obstacle uses the Picard-matching approximate
-        penalty; ``PenaltyHJBSolver`` (#924) is the proper-handling route.
+        same equilibrium as Picard. Obstacle uses the same ``(1/eps) * max(0, psi)``
+        the Picard path uses -- the two agree, which is #1361's point.
+        ~~``PenaltyHJBSolver`` (#924) is the proper-handling route.~~
+        [CORRECTED 2026-08-21, #2002] It never was, and it is now RETIRED: it injected the same
+        ``v``-free term through ``source_term``, which is ``(t, x) -> array`` and cannot carry the
+        value function a constraint penalty needs. The term both paths apply penalises POSITION,
+        not violation, and cannot enforce ``v >= Psi`` at any ``eps``. The reachable alternative is
+        ``HJBFDMSolver(constraint=...)`` (#591), with its own limits in #2036.
 
     Performance / solver selection:
         NewtonMFGSolver is research-grade for d>=2 / Nx>~50 — it is ~135x slower

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_penalty.py
@@ -85,7 +85,31 @@ class PenaltyHJBSolver(BaseHJBSolver):
         obstacle: Callable[[NDArray], NDArray],
         penalty_parameter: float = 1e4,
     ):
-        # Initialize with same problem and config as inner solver
+        raise NotImplementedError(
+            "PenaltyHJBSolver is RETIRED (#2002). It cannot do what it was written to do, and "
+            "the reason is structural rather than a bug in its arithmetic.\n\n"
+            "Its design is to add the variational inequality `v >= Psi(x)` to ANY inner solver by "
+            "injecting a penalty into that solver's `source_term`. A penalty for that constraint "
+            "is `max(0, Psi - v)`, which needs the value function. `source_term` has signature "
+            "`(t, x) -> array`. There is nowhere for `v` to enter, so what it actually applied "
+            "was `penalty_parameter * max(0, Psi(x))` -- positive wherever `Psi > 0` whether or "
+            "not the constraint holds, and byte-identical at a node satisfying it and one "
+            "violating it. It penalised POSITION, not VIOLATION, and no value of "
+            "`penalty_parameter` changes that.\n\n"
+            "What to use instead, and its limits:\n"
+            "  HJBFDMSolver(problem, constraint=ObstacleConstraint(psi, 'lower'))  -- #591.\n"
+            "`ObstacleConstraint.project` does read `u` and does enforce `u >= psi` on the "
+            "returned array. It is not yet an obstacle-problem SOLVER: in 1-D the projection runs "
+            "after the backward sweep, so the result is the unconstrained solution clipped, and "
+            "in n-D the terminal slice is never projected (#2036). It is also the only solver "
+            "carrying a `constraint` attribute, so this is an FDM-family capability, not a "
+            "general one -- #2046 tracks threading the constraint through the shared timestep "
+            "solve, which is where a projection can actually participate in the iteration.\n\n"
+            "If your obstacle is a state penalty V(x) rather than a constraint -- alpha-free and "
+            "u-free -- it belongs in the Hamiltonian's potential (#1999, #2001), not here."
+        )
+        # Unreachable. Left in place so the retirement is a one-line revert if #2002 decides the
+        # wrapper should return with a `(t, x, v)` channel behind it.
         super().__init__(inner_solver.problem, getattr(inner_solver, "config", None))
         self._inner = inner_solver
         self._obstacle = obstacle

--- a/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
+++ b/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
@@ -34,15 +34,20 @@ and enforces ``u >= psi`` on what it returns, which is more than these terms can
 *correct* overstates it: that path clips post-hoc in 1D and returns an infeasible terminal slice
 in nD (#2036).
 
-**Retirement condition.** When #2002 makes either term read ``v``:
+**Two of the four tests here have been RETIRED, by their own condition (2026-08-21).**
+``PenaltyHJBSolver`` was retired in #2002: its constructor now raises, because the penalty it
+injected could never read ``v`` -- ``source_term`` is ``(t, x) -> array`` and there is nowhere for
+the value function to enter. So ``test_penalty_source_is_byte_identical_for_violated_and_satisfied_v``
+is gone, per its own "delete on fix, do not adjust", and
+``test_the_two_obstacle_spellings_are_1e10_apart`` is gone as well -- it compared two spellings of
+one knob and there is now only one spelling. That second deletion goes beyond what its condition
+said ("update its numbers rather than deleting it"), because that instruction assumed the second
+side would still exist.
 
-- ``test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u`` and
-  ``test_penalty_source_is_byte_identical_for_violated_and_satisfied_v`` assert current-wrong
-  behaviour on purpose and must be **DELETED, not adjusted**.
-- ``test_the_two_obstacle_spellings_are_1e10_apart`` reddens under a ``v``-dependence fix too,
-  because the fix moves the measured values -- **update its expected values, do not delete it**.
-  It is the only guard on the two constructor defaults, and it fires on its own when the knobs
-  are unified without any ``v`` change (measured).
+**Remaining retirement condition.** When #2002 makes the compose-side term read ``v``:
+
+- ``test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u`` asserts
+  current-wrong behaviour on purpose and must be **DELETED, not adjusted**.
 - ``test_the_constraint_owner_exists_and_is_u_dependent`` survives; it describes the target.
 - Expect a fourth failure outside this file:
   ``test_issue1361_source_composition.py::test_hjb_composition_matches_reference_and_delegate``
@@ -53,12 +58,9 @@ in nD (#2036).
 import numpy as np
 
 from mfgarchon.alg.numerical.coupling.source_composition import compose_hjb_source
-from mfgarchon.alg.numerical.hjb_solvers.hjb_penalty import PenaltyHJBSolver
 from mfgarchon.geometry.boundary import ObstacleConstraint
 
 EPS_DEFAULT = 1e6  # source_composition.py: getattr(problem, "_penalty_eps", 1e6)
-PENALTY_DEFAULT = 1e4  # hjb_penalty.py: penalty_parameter -- NOT passed below, so the real
-# constructor default is what gets exercised.
 
 PSI = 0.5
 NX = 5
@@ -89,30 +91,6 @@ class _ProblemStub:
     nonlocal_operator = None
     source_term_hjb = None
     dt = 0.1
-
-
-class _SpyInner:
-    """Captures the ``source_term`` the wrapper hands down, per call."""
-
-    problem = _ProblemStub()
-    config = None
-
-    def __init__(self):
-        self.captured = []
-
-    def solve_hjb_system(self, M, U_T, U_prev, volatility_field=None, source_term=None):
-        self.captured.append(source_term)
-        return np.zeros_like(U_T)
-
-
-def _penalty_source_for(u_prev):
-    """Drive the real ``PenaltyHJBSolver`` with a given ``U_coupling_prev`` and return the
-    ``source_term`` closure it produced, evaluated on the grid."""
-    inner = _SpyInner()
-    solver = PenaltyHJBSolver(inner_solver=inner, obstacle=_flat_obstacle)
-    solver.solve_hjb_system(np.zeros((NT, NX)), np.zeros(NX), u_prev)
-    assert inner.captured, "sanity: the wrapper must pass a source_term down"
-    return inner.captured[-1](0.0, _x())
 
 
 def test_the_constraint_owner_exists_and_is_u_dependent():
@@ -163,40 +141,3 @@ def test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u():
     # Not merely small-but-different: positive where a constraint penalty must vanish.
     assert np.all(out_satisfied > 0.0), "u is 9 above the obstacle everywhere; a penalty must be 0"
     assert np.allclose(out_satisfied, (1.0 / EPS_DEFAULT) * PSI)
-
-
-def test_penalty_source_is_byte_identical_for_violated_and_satisfied_v():
-    """DEFECT (#2002). Delete on fix -- do not adjust.
-
-    ``PenaltyHJBSolver.solve_hjb_system`` receives ``U_coupling_prev``, so the ``v`` its own
-    withdrawn docstring promised to use is already in hand. Drive it twice with ``v`` on opposite
-    sides of the obstacle and compare the closures it produced.
-
-    The comparison must use a NON-ZERO ``v``: with ``v = 0`` the fix ``max(0, psi - v)`` collapses
-    to ``max(0, psi)`` and this test would pass on a fixed implementation.
-    """
-    out_violated = _penalty_source_for(U_VIOLATED)
-    out_satisfied = _penalty_source_for(U_SATISFIED)
-
-    assert out_satisfied.shape == (NX,), f"degenerate grid would vacuously pass: {out_satisfied.shape}"
-    assert np.array_equal(out_violated, out_satisfied), (
-        "the penalty source distinguished v = -9 from v = +9 -- if #2002 is fixed, DELETE this test"
-    )
-    assert np.all(out_satisfied > 0.0), "v is 9 above the obstacle everywhere; a penalty must be 0"
-
-
-def test_the_two_obstacle_spellings_are_1e10_apart():
-    """Pins BOTH constructor defaults. Reddens under a ``v``-dependence fix as well -- update its
-    numbers rather than deleting it -- and fires alone when the knobs are unified.
-
-    Neither default is passed in by the caller here: ``_ProblemStub`` omits ``_penalty_eps`` so
-    ``source_composition``'s ``getattr`` default fires, and ``_penalty_source_for`` omits
-    ``penalty_parameter`` so the constructor default fires. Changing either silently moves the
-    gap and reddens this test.
-    """
-    compose_out = compose_hjb_source(_ProblemStub(), np.zeros((NT, NX)), U_VIOLATED)(0.0, _x())
-    penalty_out = _penalty_source_for(U_VIOLATED)
-
-    assert np.allclose(compose_out, (1.0 / EPS_DEFAULT) * PSI), f"eps default moved: {compose_out}"
-    assert np.allclose(penalty_out, PENALTY_DEFAULT * PSI), f"penalty default moved: {penalty_out}"
-    assert np.allclose(penalty_out / compose_out, 1.0e10), f"the gap moved: {penalty_out / compose_out}"

--- a/tests/unit/test_alg/test_penalty_hjb_solver.py
+++ b/tests/unit/test_alg/test_penalty_hjb_solver.py
@@ -1,171 +1,81 @@
-"""
-Unit tests for PenaltyHJBSolver.
+"""`PenaltyHJBSolver` is retired and must refuse construction (#2002).
 
-Tests the variational inequality wrapper that adds obstacle constraints
-to any BaseHJBSolver via penalty method injection (#971).
+WHAT THIS FILE USED TO CONTAIN, AND WHY IT WAS DELETED RATHER THAN ADAPTED
+--------------------------------------------------------------------------
+Eight tests asserting the wrapper worked: that the penalty changed the answer, that a larger
+`penalty_parameter` changed it more, that a zero obstacle was a pass-through, that an existing
+`source_term` was composed with it. Every one of them passed, and every one of them was true.
+
+They measured the wrong quantity. The wrapper applied
+``penalty_parameter * max(0, Psi(x))`` -- no ``v`` -- so "the penalty changes the answer" and
+"a bigger penalty changes it more" are statements about a POSITION penalty, and hold exactly as
+well when the constraint ``v >= Psi`` is satisfied everywhere as when it is violated everywhere.
+A test suite can be fully green over a term that cannot express the thing its module is named
+after. Adapting them would have kept that shape; they are gone.
+
+WHY THE CLASS IS RETIRED
+------------------------
+Not an arithmetic bug. Its design is to add ``v >= Psi(x)`` to ANY inner solver by injecting a
+penalty into that solver's ``source_term``. The penalty for that constraint is
+``max(0, Psi - v)``, which needs the value function; ``source_term`` is ``(t, x) -> array``.
+**There is nowhere for ``v`` to enter.** The channel it chose cannot carry the quantity its
+purpose requires, so the wrapper was unimplementable in the shape it was written, and the
+``(1/eps) * max(0, Psi - v)`` in its own docstring was a description of the intent.
+
+The wrapper was also the only mechanism claiming to give obstacle support to solvers other than
+``HJBFDMSolver``, so retiring it removes a capability that was never there. What replaces it is
+``constraint=`` on that one solver today, and #2046 for the general case.
 """
+
+from __future__ import annotations
+
+import pytest
 
 import numpy as np
 
-from mfgarchon.alg.numerical.hjb_solvers import HJBFDMSolver
 from mfgarchon.alg.numerical.hjb_solvers.hjb_penalty import PenaltyHJBSolver
-from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
-from mfgarchon.core.mfg_components import MFGComponents
-from mfgarchon.core.mfg_problem import MFGProblem
-from mfgarchon.geometry import TensorProductGrid
-from mfgarchon.geometry.boundary import no_flux_bc
 
 
-def _make_problem(Nx: int = 51, Nt: int = 20, sigma: float = 0.3) -> MFGProblem:
-    """Create a simple 1D MFG problem for testing."""
-    H = SeparableHamiltonian(
-        control_cost=QuadraticControlCost(control_cost=1.0),
-        coupling=lambda m: m,
-        coupling_dm=lambda m: 1.0,
-    )
-    components = MFGComponents(
-        hamiltonian=H,
-        u_terminal=lambda x: 0.0,
-        m_initial=lambda x: 1.0,
-    )
-    return MFGProblem(
-        geometry=TensorProductGrid(
-            bounds=[(0.0, 1.0)], Nx_points=[Nx + 1], boundary_conditions=no_flux_bc(dimension=1)
-        ),
-        T=1.0,
-        Nt=Nt,
-        sigma=sigma,
-        components=components,
-    )
+class _StubInner:
+    """Enough of a solver to reach the constructor. It must never be used."""
+
+    problem = None
+    config = None
+
+    def solve_hjb_system(self, M, U_T, U_prev, volatility_field=None, source_term=None):  # pragma: no cover
+        raise AssertionError("the retired wrapper must not reach its inner solver")
 
 
-def _make_solver_inputs(problem: MFGProblem):
-    """Create standard solve_hjb_system inputs."""
-    Nt = problem.Nt
-    Nx = problem.geometry.get_grid_shape()[0]
-    M = np.ones((Nt + 1, Nx)) / Nx
-    U_T = problem.get_final_u()
-    U_prev = np.zeros((Nt + 1, Nx))
-    return M, U_T, U_prev
+def test_construction_refuses():
+    with pytest.raises(NotImplementedError) as excinfo:
+        PenaltyHJBSolver(inner_solver=_StubInner(), obstacle=lambda x: np.zeros(np.asarray(x).shape[0]))
+
+    message = str(excinfo.value)
+    # The refusal has to say WHY, or the next reader reimplements it the same way.
+    assert "RETIRED" in message
+    assert "source_term" in message, "must name the channel that cannot carry v"
+    assert "constraint=" in message, "must name the replacement"
+    assert "#2036" in message, "must name the replacement's own limits"
 
 
-class TestPenaltyHJBSolverInstantiation:
-    """Test PenaltyHJBSolver construction."""
-
-    def test_wraps_fdm_solver(self):
-        problem = _make_problem()
-        inner = HJBFDMSolver(problem)
-        solver = PenaltyHJBSolver(inner, obstacle=lambda x: np.zeros_like(x))
-        assert solver._inner is inner
-        assert solver._penalty == 1e4  # default
-
-    def test_custom_penalty_parameter(self):
-        problem = _make_problem()
-        inner = HJBFDMSolver(problem)
-        solver = PenaltyHJBSolver(inner, obstacle=lambda x: np.zeros_like(x), penalty_parameter=1e6)
-        assert solver._penalty == 1e6
-
-    def test_inherits_scheme_family(self):
-        problem = _make_problem()
-        inner = HJBFDMSolver(problem)
-        solver = PenaltyHJBSolver(inner, obstacle=lambda x: np.zeros_like(x))
-        assert solver._scheme_family == inner._scheme_family
+def test_the_refusal_survives_a_penalty_parameter():
+    """No value of the knob makes the term depend on `v`, so none of them re-enable the class."""
+    for penalty in (1e-6, 1.0, 1e4, 1e12):
+        with pytest.raises(NotImplementedError):
+            PenaltyHJBSolver(
+                inner_solver=_StubInner(),
+                obstacle=lambda x: np.zeros(np.asarray(x).shape[0]),
+                penalty_parameter=penalty,
+            )
 
 
-class TestPenaltyHJBSolverSolve:
-    """Test solve_hjb_system behavior."""
+def test_it_is_still_exported():
+    """Retired, not deleted: the public name must resolve and explain itself.
 
-    def test_terminal_condition_preserved(self):
-        """Terminal condition U(T) should match the problem's terminal condition."""
-        problem = _make_problem()
-        inner = HJBFDMSolver(problem)
-        solver = PenaltyHJBSolver(inner, obstacle=lambda x: np.zeros_like(x))
-        M, U_T, U_prev = _make_solver_inputs(problem)
-        U = solver.solve_hjb_system(M, U_T, U_prev)
-        np.testing.assert_allclose(U[-1], U_T, atol=1e-10)
+    Removing it from `hjb_solvers.__init__` would turn an explanation into an ImportError, which
+    tells a caller nothing about why their obstacle was never enforced.
+    """
+    from mfgarchon.alg.numerical import hjb_solvers
 
-
-class TestPenaltyEffect:
-    """Test that the penalty parameter affects the solution."""
-
-    def test_penalty_differs_from_unpanelized(self):
-        """Solution with obstacle should differ from solution without."""
-        problem = _make_problem()
-        inner_plain = HJBFDMSolver(problem)
-        inner_penalty = HJBFDMSolver(problem)
-
-        def obstacle(x):
-            return 0.3 * np.sin(np.pi * np.atleast_1d(x).ravel())
-
-        solver_penalty = PenaltyHJBSolver(inner_penalty, obstacle=obstacle, penalty_parameter=1e4)
-
-        M, U_T, U_prev = _make_solver_inputs(problem)
-        U_plain = inner_plain.solve_hjb_system(M, U_T, U_prev)
-        U_penalized = solver_penalty.solve_hjb_system(M, U_T, U_prev)
-
-        # Solutions should differ due to obstacle enforcement
-        assert not np.allclose(U_plain, U_penalized, atol=1e-6)
-
-    def test_higher_penalty_stronger_effect(self):
-        """Higher penalty parameter should push solution closer to obstacle."""
-        problem = _make_problem()
-
-        def obstacle(x):
-            return 0.5 * np.ones_like(np.atleast_1d(x).ravel())
-
-        M, U_T, U_prev = _make_solver_inputs(problem)
-
-        solver_weak = PenaltyHJBSolver(HJBFDMSolver(problem), obstacle=obstacle, penalty_parameter=1e2)
-        solver_strong = PenaltyHJBSolver(HJBFDMSolver(problem), obstacle=obstacle, penalty_parameter=1e5)
-
-        U_weak = solver_weak.solve_hjb_system(M, U_T, U_prev)
-        U_strong = solver_strong.solve_hjb_system(M, U_T, U_prev)
-
-        # Stronger penalty should produce larger (or equal) values at interior times
-        # since it pushes harder against the obstacle from below
-        assert U_strong[0].mean() >= U_weak[0].mean() - 1e-6
-
-    def test_zero_obstacle_is_passthrough(self):
-        """Zero obstacle with zero penalty should match plain solver."""
-        problem = _make_problem()
-        inner1 = HJBFDMSolver(problem)
-        inner2 = HJBFDMSolver(problem)
-
-        # penalty_parameter=0 effectively disables the penalty
-        solver = PenaltyHJBSolver(inner2, obstacle=lambda x: np.zeros_like(x), penalty_parameter=0.0)
-
-        M, U_T, U_prev = _make_solver_inputs(problem)
-        U_plain = inner1.solve_hjb_system(M, U_T, U_prev)
-        U_penalty = solver.solve_hjb_system(M, U_T, U_prev)
-
-        np.testing.assert_allclose(U_plain, U_penalty, atol=1e-10)
-
-    def test_existing_source_term_composed(self):
-        """Penalty should compose with an existing source_term."""
-        problem = _make_problem()
-        inner = HJBFDMSolver(problem)
-
-        def obstacle(x):
-            return np.zeros_like(np.atleast_1d(x).ravel())
-
-        solver = PenaltyHJBSolver(inner, obstacle=obstacle, penalty_parameter=1e3)
-
-        def base_source(t, x):
-            return 0.1 * np.ones(x.shape[0])
-
-        M, U_T, U_prev = _make_solver_inputs(problem)
-
-        # Should not raise — penalty composes with base source
-        U = solver.solve_hjb_system(M, U_T, U_prev, source_term=base_source)
-        assert np.all(np.isfinite(U))
-
-        # The obstacle is identically zero, so penalty * max(0, psi) == 0 and the wrapper must
-        # reduce exactly to the wrapped solver *carrying the base source through*.  Dropping
-        # `base` from penalized_source is the defect this catches; measured difference 0.0.
-        U_ref = HJBFDMSolver(problem).solve_hjb_system(M, U_T, U_prev, source_term=base_source)
-        np.testing.assert_array_equal(U, U_ref)
-
-        # Anti-vacuity: the identity above must not be satisfied by both sides ignoring the
-        # source entirely.  The constant 0.1 source moves the solution by 0.1 (measured).
-        U_no_source = solver.solve_hjb_system(M, U_T, U_prev)
-        assert np.max(np.abs(U - U_no_source)) > 1e-3
+    assert "PenaltyHJBSolver" in hjb_solvers.__all__
+    assert hjb_solvers.PenaltyHJBSolver is PenaltyHJBSolver


### PR DESCRIPTION
## What it was for

Add the variational inequality `v ≥ Ψ(x)` to **any** inner HJB solver, by injecting a penalty into that solver's `source_term`. Obstacle support written once instead of per solver — a good idea.

## Why it cannot work in that shape

A penalty for that constraint is `max(0, Ψ − v)`. `source_term` is `(t, x) -> array`. **There is nowhere for `v` to enter.** The file's own comment says so: *"the v-dependent penalty must be handled at the time-stepping level inside the solver."*

So what it applied was `penalty_parameter * max(0, Ψ(x))` — positive wherever `Ψ > 0` whether or not the constraint holds, byte-identical at `v = −9` and `v = +9`, and unchanged in kind by any value of the knob. It penalised **position**, not **violation**. Not an arithmetic bug: the channel it chose cannot carry the quantity its purpose requires.

Construction now raises with the whole account. The class is retired rather than deleted because the public name resolving to an explanation is worth more than an `ImportError` to someone whose obstacle was silently never enforced.

## The eight tests are deleted, not adapted

They asserted the penalty changed the answer, that a bigger penalty changed it more, that a zero obstacle was a pass-through, that an existing `source_term` composed. All true. All green. All about a **position** penalty — they hold exactly as well when the constraint is satisfied everywhere as when it is violated everywhere. A suite can be fully green over a term that cannot express the thing its module is named after; adapting them would have preserved that shape.

Replaced by three tests over the refusal contract, including that the message names the channel, the replacement, and the replacement's own limits.

Two pins from #2035 retire by their own stated condition — one of them going further than its condition allowed, and saying so: `test_the_two_obstacle_spellings_are_1e10_apart` compared two spellings of one knob, and there is now one spelling.

## Two more copies of the withdrawn #924 claim

Found by sweeping the **class name** rather than the sentence:

- `newton_mfg_solver.py` — *"`PenaltyHJBSolver` (#924) is the proper-handling route"*
- `graph_mfg_solver.py` — *"handled by wrapping each node's HJB solver in PenaltyHJBSolver, not here"*

That is the third and fourth copy of one false sentence. #2035 struck two, and I searched by wording both times.

## What this does not do

**It does not give the capability back.** `constraint=` exists on `HJBFDMSolver` alone — `grep -rl "self.constraint"` over both solver packages returns one file — and there it is applied *outside* the solve, so it clips rather than solving the VI (#2036).

**#2046** carries the architecture. `ConstraintProtocol` already has `project`, `is_feasible` and `get_active_set`, which is what a projected Newton or PSOR consumes. The missing part is wiring: neither `solve_hjb_system_backward` nor `solve_hjb_timestep_newton` accepts a constraint, so it cannot reach the iterate where `u` is in hand. That is where the wrapper's goal — obstacle support for every solver at once — is actually reachable, from the inside rather than the outside.

23 passed, 1 xfailed across the obstacle, penalty, coupling and composition surface.

**BREAKING**: `PenaltyHJBSolver(...)` now raises. Callers were getting a position penalty, not a constraint.