### PR TITLE
feat(core)!: obstacle resolves as a soft wall and becomes a potential (#2002)

### DIFF
--- a/changelog.d/2002-obstacle-becomes-a-state-penalty.changed.md
+++ b/changelog.d/2002-obstacle-becomes-a-state-penalty.changed.md
@@ -10,3 +10,10 @@ while `+5` lowers it to `-1.419`. The obstacle branch is deleted from `compose_h
 same change. The **variational inequality** remains a reserved, deliberately unfinished slot:
 `HJBFDMSolver(constraint=ObstacleConstraint(...))` (#591, #2036, #2046). Note `obstacles` (plural,
 geometric regions excluded from the domain) is a different field and is unaffected.
+
+The composition COPIES the Hamiltonian rather than rebuilding it (an earlier draft rebuilt from
+five of its six constructor parameters and silently dropped `population_index`, which a
+multi-population problem needs), returns exactly what the base potential returns (so a vectorised
+base stays vectorised), and updates `_lagrangian_class` as well — `MFGComponents` snapshots the
+potential there at construction, and `HJBSemiLagrangianSolver` reads that copy whenever the control
+cost is non-smooth, so composing into the Hamiltonian alone left a solver silently unwalled.

--- a/changelog.d/2002-obstacle-becomes-a-state-penalty.changed.md
+++ b/changelog.d/2002-obstacle-becomes-a-state-penalty.changed.md
@@ -1,0 +1,12 @@
+**BREAKING.** `problem.obstacle` is retired and raises (#2002). It was documented as the
+variational inequality `v >= Psi(x)` and implemented as `max(0, Psi(x))` — a term with no `v`,
+byte-identical at a node satisfying the constraint and one violating it. It resolved as a **soft
+wall**, which is what it always computed: a cost that is `alpha`-free and `u`-free is a POTENTIAL,
+so it becomes `problem.state_penalty` (cost-signed, positive where expensive, with
+`state_penalty_scale`) and is composed into the Hamiltonian's `V` at problem construction rather
+than into `source_term`. The composition SUBTRACTS, because `potential` is reward-signed
+(G-001) — measured, not assumed: a potential amplitude of `-5` raises `u(0, mid)` to `+0.555`
+while `+5` lowers it to `-1.419`. The obstacle branch is deleted from `compose_hjb_source` in the
+same change. The **variational inequality** remains a reserved, deliberately unfinished slot:
+`HJBFDMSolver(constraint=ObstacleConstraint(...))` (#591, #2036, #2046). Note `obstacles` (plural,
+geometric regions excluded from the domain) is a different field and is unaffected.

--- a/mfgarchon/alg/numerical/coupling/mfg_residual.py
+++ b/mfgarchon/alg/numerical/coupling/mfg_residual.py
@@ -53,9 +53,9 @@ class MFGResidual:
     The residual measures deviation from this fixed point:
         F(U, M) = [HJB_solve(M) - U, FP_solve(U) - M]
 
-    Source / nonlocal / obstacle terms (Issue #1361):
+    Source / nonlocal terms (Issue #1361):
         ``source_term_hjb``, ``source_term_fp``, ``nonlocal_operator``, and
-        ``obstacle`` are composed via the single-source helpers
+        are composed via the single-source helpers
         :func:`source_composition.compose_hjb_source` /
         :func:`source_composition.compose_fp_source` — the *same* copy the Picard
         ``FixedPointIterator`` consumes (no private second copy; that was the bug
@@ -68,12 +68,19 @@ class MFGResidual:
         differentiates through the source dependence automatically — no separate
         analytic Jacobian term is needed. At convergence ``U = U_new`` and
         ``M = M_new``, so the residual root coincides with the Picard fixed point
-        including the source/nonlocal/obstacle terms.
+        including the source/nonlocal terms.
 
-        Obstacle handling matches the Picard path exactly: the same
-        ``(1/eps) * max(0, psi)`` from the one ``compose_hjb_source``. Both coupling
-        paths therefore do not silently diverge -- that part holds and is the point
-        of #1361.
+        ~~Obstacle handling matches the Picard path exactly: the same
+        ``(1/eps) * max(0, psi)`` from the one ``compose_hjb_source``.~~
+        [CORRECTED 2026-08-21, #2002] There is no obstacle term on either path any more.
+        It resolved as a soft wall -- a cost that is ``alpha``-free and ``u``-free is a
+        POTENTIAL -- so it is ``problem.state_penalty``, composed into the Hamiltonian's
+        ``V`` at problem construction, and both couplers get it by evaluating ``H``
+        rather than by each remembering to consume a source closure. The branch is
+        deleted from ``compose_hjb_source``; ``problem.obstacle`` raises.
+
+        The rest holds and is the point of #1361: source and nonlocal come from one
+        implementation, so the two coupling paths cannot silently diverge on them.
 
         Two corrections to what this paragraph used to say (#2002):
 
@@ -204,7 +211,7 @@ class MFGResidual:
         Compute HJB solver output for given density.
 
         Issue #1361: composes ``source_term_hjb`` / ``nonlocal_operator`` /
-        ``obstacle`` from the ``(M, U_prev)`` arguments via the single-source
+        from the ``(M, U_prev)`` arguments via the single-source
         :func:`source_composition.compose_hjb_source` (shared with Picard) and
         passes it as ``source_term=`` when the solver accepts it. Composing from
         the arguments (option A) lets the finite-difference Jacobian differentiate
@@ -245,10 +252,10 @@ class MFGResidual:
                 if "source_term" not in self._hjb_sig_params:
                     raise NotImplementedError(
                         f"{type(self.hjb_solver).__name__}.solve_hjb_system does not accept "
-                        f"'source_term', but the problem defines a source / nonlocal / obstacle term. "
+                        f"'source_term', but the problem defines a source / nonlocal term. "
                         f"Silently dropping it in the Newton residual would solve the wrong problem "
                         f"(Issues #1424, #1430) — the Newton path must fail loud like Picard. Use an "
-                        f"FDM HJB solver, or remove source_term_hjb / nonlocal_operator / obstacle."
+                        f"FDM HJB solver, or remove source_term_hjb / nonlocal_operator."
                     )
                 kwargs["source_term"] = hjb_source
 

--- a/mfgarchon/alg/numerical/coupling/source_composition.py
+++ b/mfgarchon/alg/numerical/coupling/source_composition.py
@@ -26,32 +26,25 @@ Conventions (mirrored verbatim from the prior ``FixedPointIterator`` copy):
 - **Nonlocal term** applied as ``s += nonlocal_operator @ v_t`` with ``v_t`` the
   time-``t`` slice of the value function (Issue #1259), matching
   ``graph_mfg_solver``'s sign convention.
-- **Obstacle** computes ``(1/eps) * max(0, psi)`` (``eps = problem._penalty_eps`` if set, else
-  ``1e6``), and **both coupling paths -- Picard (``FixedPointIterator``) and coupled-Newton
-  (``MFGResidual``) -- use this one copy, so they do match rather than silently diverge.** That
-  is this module's whole purpose per the opening paragraph, and it holds: both call
-  ``compose_hjb_source``. The referent is spelled out here because a reader (this one) took
-  "both coupling paths" for the two *obstacle* spellings and wrongly withdrew the sentence.
+- **Obstacle** — the branch and its whole account are GONE (#2002 resolved, 2026-08-21). It
+  computed ``(1/eps) * max(0, psi)``, a term with no ``v`` in it: positive wherever ``Psi > 0``
+  whether or not ``v >= Psi`` held, and byte-identical at a node satisfying the constraint and
+  one violating it. It penalised POSITION, not VIOLATION, so it was never an approximation to
+  the variational inequality it was documented as — it was a different term.
 
-  One sentence that used to follow IS false and is withdrawn (#2002): *"Proper handling is the
-  ``PenaltyHJBSolver`` wrapper (#924)"*. That wrapper carries the same stub and says so in its
-  own comment, *"For now, we apply a static obstacle penalty"*; its docstring separately
-  described the intended ``(1/eps) * max(0, Psi - v)`` rather than the term it computes, and
-  scales by ``penalty_parameter`` (``1e4``) where this path divides by ``eps`` -- 1e10 apart at
-  the defaults. The pointer sent a reader to a second, differently-scaled copy.
+  It resolved as a **soft wall**, which is what that term always was. A cost that is ``alpha``-free
+  and ``u``-free is a POTENTIAL, so it now lives where potentials live: ``problem.state_penalty``,
+  composed into the Hamiltonian's ``V`` at problem construction. It never reaches this closure and
+  there is nothing here to compose. ``problem.obstacle`` raises and names both successors.
 
-  **What the ``v = 0`` label understates.** ``max(0, psi)`` contains no ``v`` at all, so it is
-  positive wherever ``Psi > 0`` whether or not ``v >= Psi`` holds: it penalises position, not
-  violation, and is identical at a node satisfying the constraint and one violating it. Not an
-  approximation that degrades with distance from ``v = 0`` -- a different term. Verified through
-  this function: ``u`` nine units below the obstacle and nine above return byte-identical arrays.
+  Deleted rather than left beside the replacement: this module exists to stop parallel physics
+  paths keeping private copies of a convention, and a composition that only ADDS an owner has
+  consolidated nothing.
 
-  The ``v`` is available here: ``u_current`` is bound above and the ``nonlocal`` branch in the
-  same closure uses ``nonlocal_operator @ v_t``. What a fix owes is in #2002; it turns on whether
-  the intent is a constraint or a state penalty ``V(x)``, and if the latter the term is ``u``-free
-  and belongs in the Hamiltonian's potential instead. A constraint-shaped alternative already
-  exists under a different entry point -- ``ObstacleConstraint`` with
-  ``HJBFDMSolver(constraint=...)`` (#591) -- though it has defects of its own; see #2036.
+  The **variational inequality** is a separate, reserved slot — ``ObstacleConstraint`` with
+  ``HJBFDMSolver(constraint=...)`` (#591), deliberately unfinished: it projects rather than
+  solving the VI, and only that one solver carries it (#2036, #2046). It was never this channel's
+  to provide, since a constraint penalty needs ``v`` and ``source_term`` is ``(t, x) -> array``.
 
 - The HJB source passes the **value-function slice** ``v_t`` to
   ``source_term_hjb(x, m, v, t)`` (Issue #1382), matching the documented
@@ -137,23 +130,26 @@ def compose_hjb_source(
     """
     has_nonlocal = problem.nonlocal_operator is not None
     has_source = problem.source_term_hjb is not None
-    has_obstacle = problem.obstacle is not None
 
-    if not (has_nonlocal or has_source or has_obstacle):
+    # The obstacle branch that stood here is GONE (#2002), not moved. `problem.obstacle` is
+    # retired and raises; a soft wall is `problem.state_penalty`, composed into the Hamiltonian's
+    # potential at problem construction, because a term that is `alpha`-free and `u`-free is a
+    # potential and belongs where V lives. Deleted in the same change that added the replacement:
+    # a composition that only ADDS an owner has not consolidated anything.
+    if not (has_nonlocal or has_source):
         return None
 
     def composed(t: float, x: NDArray) -> NDArray:
-        # Source + nonlocal via the shared single-source primitive (Issue #1382);
-        # obstacle is grid-coupler-only. Order [source, obstacle, nonlocal] preserves
-        # byte-for-byte float-sum associativity with the pre-#1382 closure.
+        # Source + nonlocal via the shared single-source primitive (Issue #1382). Order
+        # [source, nonlocal] preserves byte-for-byte float-sum associativity with the pre-#1382
+        # closure; the obstacle term that used to sit between them contributed
+        # `(1/eps) * max(0, psi)` with `eps = 1e6`, i.e. 5e-07 at psi = 0.5, so its removal is
+        # visible in the last bits of any problem that set it -- and every such problem now
+        # raises at construction instead.
         parts = _problem_hjb_source_terms(problem, m_current, u_current, t, x, problem.dt)
         terms: list[NDArray] = []
         if "source" in parts:
             terms.append(parts["source"])
-        if has_obstacle:
-            psi = problem.obstacle(x)
-            eps = getattr(problem, "_penalty_eps", 1e6)
-            terms.append((1.0 / eps) * np.maximum(0.0, psi.ravel()))
         if "nonlocal" in parts:
             terms.append(parts["nonlocal"])
         return sum(terms) if terms else np.zeros(x.shape[0])

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -1903,7 +1903,7 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         """
         import copy as _copy
 
-        from mfgarchon.core.hamiltonian import SeparableHamiltonian
+        from mfgarchon.core.hamiltonian import SeparableHamiltonian, SeparableLagrangian
 
         hamiltonian = getattr(self.components, "_hamiltonian_class", None)
         if not isinstance(hamiltonian, SeparableHamiltonian):
@@ -1938,11 +1938,26 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         self.components._hamiltonian_class = composed
 
         # Keep every other holder of the potential in step, or a solver reads the unwalled copy.
+        # `isinstance`, not `hasattr`: a Lagrangian that carries no potential is a case this does
+        # not know how to compose into, and skipping it silently is the very defect being fixed --
+        # `HJBSemiLagrangianSolver` would then read an unwalled copy and report a clean answer to
+        # a different problem. `SeparableLagrangian` always sets `_potential`; anything else says
+        # so out loud.
         lagrangian = getattr(self.components, "_lagrangian_class", None)
-        if lagrangian is not None and hasattr(lagrangian, "_potential"):
+        if isinstance(lagrangian, SeparableLagrangian):
             walled_lagrangian = _copy.copy(lagrangian)
             walled_lagrangian._potential = composed_potential
             self.components._lagrangian_class = walled_lagrangian
+        elif lagrangian is not None:
+            raise NotImplementedError(
+                f"state_penalty composed into the Hamiltonian's potential, but this problem's "
+                f"Lagrangian is a {type(lagrangian).__name__}, which this composition does not "
+                f"know how to fold a potential into. `HJBSemiLagrangianSolver` reads the "
+                f"Lagrangian whenever the control cost is non-smooth, so leaving it unwalled "
+                f"would silently solve a different problem (#2002). Fold the penalty into that "
+                f"Lagrangian's own running cost instead -- there it is COST-signed and enters "
+                f"with a plus, the opposite of the Hamiltonian's V."
+            )
         if getattr(self.components, "hamiltonian", None) is hamiltonian:
             self.components.hamiltonian = composed
 

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -597,9 +597,12 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         self.nonlocal_operator: Any | None = kwargs.pop("nonlocal_operator", None)
         # A soft wall: `state_penalty(x)` is a COST, positive where the region is expensive.
         # It is `alpha`-free and `u`-free, which is what makes it a potential rather than a
-        # constraint, and it is composed into H's potential V below. `_state_penalty_eps` scales
-        # it; unlike the retired `_penalty_eps` it MULTIPLIES, because a penalty amplitude is not
-        # a regularisation parameter and `eps -> 0` is not its limit.
+        # constraint, and it is composed into H's potential V below. `state_penalty_scale`
+        # MULTIPLIES it, where the retired `_penalty_eps` divided: a penalty amplitude is not a
+        # regularisation parameter and `eps -> 0` is not its limit.
+        #
+        # Both are read ONCE, at construction, by the composition below. Assigning either
+        # afterwards does nothing -- the closure has already captured them.
         self.state_penalty: Callable | None = kwargs.pop("state_penalty", None)
         self.state_penalty_scale: float = float(kwargs.pop("state_penalty_scale", 1.0))
 
@@ -1873,13 +1876,33 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
 
         Measured rather than asserted, on a Gaussian wall at x = 0.5 with no coupling: a
         potential amplitude of ``-5`` raises ``u(0, mid)`` to ``+0.555`` while ``+5`` lowers it
-        to ``-1.419``, against a flat ``0.0`` baseline. So a cost needs a NEGATIVE ``V``, which
-        is not the sign anyone writes by hand -- which is the reason this composition exists in
-        one place instead of at every call site.
+        to ``-1.419``. So a cost needs a NEGATIVE ``V``, which is not the sign anyone writes by
+        hand -- which is why this composition exists in one place instead of at every call site.
+
+        COPIES rather than rebuilds. An earlier version constructed a fresh
+        ``SeparableHamiltonian`` from five of its six constructor parameters, which silently
+        dropped ``population_index`` (live: a multi-population problem keyed to population k
+        became population 0) and downgraded a ``QuadraticMFGHamiltonian`` to its base class.
+        ``copy.copy`` preserves the type and every attribute, and leaves the caller's own object
+        unmutated.
+
+        SHAPE. The composed closure returns exactly what the base potential returns, so a
+        vectorised base stays vectorised -- ``SeparableHamiltonian`` probes the potential on a
+        batch to decide whether it can call it that way, and a composition that changed the
+        returned shape defeated that probe. With no base there is nothing to match, so the wall
+        alone is squeezed: the per-point call sites wrap it in ``float()``, and in 1-D ``x``
+        arrives as ``array([0.3])``.
+
+        The LAGRANGIAN is kept in step. ``MFGComponents`` snapshots the potential into
+        ``_lagrangian_class`` at construction, before this runs, and
+        ``HJBSemiLagrangianSolver`` reads that copy whenever the control cost is non-smooth --
+        so composing into the Hamiltonian alone left a solver silently unwalled, which is the
+        defect #2002 is about, in a second channel.
 
         Raises rather than silently skipping when the Hamiltonian cannot carry a potential.
-        A soft wall that is quietly not applied is the exact defect #2002 was filed about.
         """
+        import copy as _copy
+
         from mfgarchon.core.hamiltonian import SeparableHamiltonian
 
         hamiltonian = getattr(self.components, "_hamiltonian_class", None)
@@ -1900,25 +1923,28 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         def composed_potential(x: Any, t: float = 0.0) -> Any:
             import numpy as _np
 
-            base = previous(x, t) if previous is not None else 0.0
-            wall = _np.asarray(penalty(x), dtype=float)
-            value = _np.asarray(base - scale * wall, dtype=float)
-            # `SeparableHamiltonian` evaluates the potential PER POINT and wraps it in `float()`
-            # (`hamiltonian.py`, the `V = float(self._potential(x, t))` sites), where `x` is one
-            # point of R^d -- so in 1-D it arrives as `array([0.3])` and a shape-(1,) answer
-            # raises under NumPy 2. Squeezing is the convention every working potential in this
-            # repo already follows; encoding it here means a user's `state_penalty` may be
-            # written the obvious vectorised way and still satisfy that call site.
-            value = value.squeeze()
-            return float(value) if value.ndim == 0 else value
+            wall = scale * _np.asarray(penalty(x), dtype=float)
+            if previous is None:
+                squeezed = wall.squeeze()
+                return float(-squeezed) if squeezed.ndim == 0 else -squeezed
+            base = previous(x, t)
+            # Match the base's own contract exactly -- it decides the shape, not this wrapper.
+            if _np.size(wall) == _np.size(base):
+                wall = _np.reshape(wall, _np.shape(base))
+            return base - wall
 
-        self.components._hamiltonian_class = SeparableHamiltonian(
-            control_cost=hamiltonian.control_cost,
-            potential=composed_potential,
-            coupling=hamiltonian._coupling,
-            coupling_dm=getattr(hamiltonian, "_coupling_dm", None),
-            sense=hamiltonian.sense,
-        )
+        composed = _copy.copy(hamiltonian)
+        composed._potential = composed_potential
+        self.components._hamiltonian_class = composed
+
+        # Keep every other holder of the potential in step, or a solver reads the unwalled copy.
+        lagrangian = getattr(self.components, "_lagrangian_class", None)
+        if lagrangian is not None and hasattr(lagrangian, "_potential"):
+            walled_lagrangian = _copy.copy(lagrangian)
+            walled_lagrangian._potential = composed_potential
+            self.components._lagrangian_class = walled_lagrangian
+        if getattr(self.components, "hamiltonian", None) is hamiltonian:
+            self.components.hamiltonian = composed
 
     def _initialize_functions(self, **kwargs: Any) -> None:
         """Initialize potential, initial density, and final value functions.

--- a/mfgarchon/core/mfg_problem.py
+++ b/mfgarchon/core/mfg_problem.py
@@ -566,7 +566,10 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         #   FP:  dm/dt - (sigma^2/2)Dm - div(m*alpha*) - S_fp = 0
         # source_term_hjb/fp: Callable(x, m, v, t) -> array (problem-level signature)
         # nonlocal_operator: LinearOperator for integro-differential terms J[v]
-        # obstacle: Callable(x) -> array for variational inequality v >= Psi(x)
+        # state_penalty: Callable(x) -> array, a COST-signed level-set penalty (soft wall).
+        #   Composed into the Hamiltonian's potential, NOT into source_term -- see below.
+        # obstacle: RETIRED (#2002). It named a variational inequality and delivered a
+        #   position penalty; setting it now raises and names both successors.
         #
         # Sign convention (Issue #1057, gotcha G-002)
         # -------------------------------------------
@@ -592,7 +595,33 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
         self.source_term_hjb: Callable | None = kwargs.pop("source_term_hjb", None)
         self.source_term_fp: Callable | None = kwargs.pop("source_term_fp", None)
         self.nonlocal_operator: Any | None = kwargs.pop("nonlocal_operator", None)
-        self.obstacle: Callable | None = kwargs.pop("obstacle", None)
+        # A soft wall: `state_penalty(x)` is a COST, positive where the region is expensive.
+        # It is `alpha`-free and `u`-free, which is what makes it a potential rather than a
+        # constraint, and it is composed into H's potential V below. `_state_penalty_eps` scales
+        # it; unlike the retired `_penalty_eps` it MULTIPLIES, because a penalty amplitude is not
+        # a regularisation parameter and `eps -> 0` is not its limit.
+        self.state_penalty: Callable | None = kwargs.pop("state_penalty", None)
+        self.state_penalty_scale: float = float(kwargs.pop("state_penalty_scale", 1.0))
+
+        if kwargs.pop("obstacle", None) is not None:
+            raise NotImplementedError(
+                "`obstacle` is RETIRED (#2002). It was documented as the variational inequality "
+                "`v >= Psi(x)` and implemented as `max(0, Psi(x))` -- a term with no `v` in it, "
+                "byte-identical at a node satisfying the constraint and one violating it. It "
+                "penalised POSITION, not VIOLATION, and no scaling changed that.\n\n"
+                "It has two successors, because it was conflating two different things:\n"
+                "  * A SOFT WALL -- a cost for being somewhere, `alpha`-free and `u`-free. That is "
+                "a potential, not a constraint. Pass `state_penalty=Psi_cost` (positive where "
+                "expensive); it is composed into the Hamiltonian's V with the sign that layer "
+                "requires, which is not the sign you would write by hand (`potential` is "
+                "REWARD-signed, gotcha G-001).\n"
+                "  * A REAL CONSTRAINT -- the variational inequality. Pass "
+                "`constraint=ObstacleConstraint(psi, 'lower')` to `HJBFDMSolver` (#591). That slot "
+                "is reserved and deliberately unfinished: it projects rather than solving the VI, "
+                "and only that one solver carries it (#2036, #2046).\n\n"
+                "Note also that `obstacles` (plural) is a different field entirely -- geometric "
+                "regions excluded from the domain -- and was never related to this one."
+            )
 
         # Extract scalar sigma for backward compatibility.
         # If volatility is callable or array, use a representative scalar value.
@@ -774,6 +803,12 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
 
         # Initialize functions
         self._initialize_functions(**all_params)
+
+        # A soft wall is a POTENTIAL, so it is composed into H here rather than handed to a
+        # solver as a source (#2002). Done after _initialize_functions because that is where the
+        # Hamiltonian becomes available.
+        if self.state_penalty is not None:
+            self._compose_state_penalty_into_potential()
 
         # Validate custom components if provided
         if self.is_custom:
@@ -1826,6 +1861,64 @@ class MFGProblem(HamiltonianMixin, ConditionsMixin):
     # - _potential(): Removed - zero potential is now the explicit default
     # - _u_final(): Removed - must be provided via MFGComponents.u_terminal
     # - _m_initial(): Removed - must be provided via MFGComponents.m_initial
+
+    def _compose_state_penalty_into_potential(self) -> None:
+        """Fold ``state_penalty`` into the Hamiltonian's potential, with the layer's sign.
+
+        ``state_penalty`` is COST-signed: positive where the region is expensive. The
+        Hamiltonian's ``potential`` is REWARD-signed (gotcha G-001, and the sign block above
+        ``source_term_hjb``), so the composition **subtracts**::
+
+            V_new(x, t) = V_old(x, t) - scale * state_penalty(x)
+
+        Measured rather than asserted, on a Gaussian wall at x = 0.5 with no coupling: a
+        potential amplitude of ``-5`` raises ``u(0, mid)`` to ``+0.555`` while ``+5`` lowers it
+        to ``-1.419``, against a flat ``0.0`` baseline. So a cost needs a NEGATIVE ``V``, which
+        is not the sign anyone writes by hand -- which is the reason this composition exists in
+        one place instead of at every call site.
+
+        Raises rather than silently skipping when the Hamiltonian cannot carry a potential.
+        A soft wall that is quietly not applied is the exact defect #2002 was filed about.
+        """
+        from mfgarchon.core.hamiltonian import SeparableHamiltonian
+
+        hamiltonian = getattr(self.components, "_hamiltonian_class", None)
+        if not isinstance(hamiltonian, SeparableHamiltonian):
+            raise NotImplementedError(
+                f"state_penalty needs a Hamiltonian that carries a potential; this problem has "
+                f"{type(hamiltonian).__name__}. A soft wall is a potential term V(x), so it can "
+                f"only be composed where V lives. Either build the problem with a "
+                f"SeparableHamiltonian, or fold the penalty into your own Hamiltonian's potential "
+                f"directly -- remembering that `potential` is REWARD-signed, so a cost enters "
+                f"NEGATIVE (#2002)."
+            )
+
+        previous = getattr(hamiltonian, "_potential", None)
+        penalty = self.state_penalty
+        scale = self.state_penalty_scale
+
+        def composed_potential(x: Any, t: float = 0.0) -> Any:
+            import numpy as _np
+
+            base = previous(x, t) if previous is not None else 0.0
+            wall = _np.asarray(penalty(x), dtype=float)
+            value = _np.asarray(base - scale * wall, dtype=float)
+            # `SeparableHamiltonian` evaluates the potential PER POINT and wraps it in `float()`
+            # (`hamiltonian.py`, the `V = float(self._potential(x, t))` sites), where `x` is one
+            # point of R^d -- so in 1-D it arrives as `array([0.3])` and a shape-(1,) answer
+            # raises under NumPy 2. Squeezing is the convention every working potential in this
+            # repo already follows; encoding it here means a user's `state_penalty` may be
+            # written the obvious vectorised way and still satisfy that call site.
+            value = value.squeeze()
+            return float(value) if value.ndim == 0 else value
+
+        self.components._hamiltonian_class = SeparableHamiltonian(
+            control_cost=hamiltonian.control_cost,
+            potential=composed_potential,
+            coupling=hamiltonian._coupling,
+            coupling_dm=getattr(hamiltonian, "_coupling_dm", None),
+            sense=hamiltonian.sense,
+        )
 
     def _initialize_functions(self, **kwargs: Any) -> None:
         """Initialize potential, initial density, and final value functions.

--- a/mfgarchon/geometry/boundary/constraint_protocol.py
+++ b/mfgarchon/geometry/boundary/constraint_protocol.py
@@ -51,6 +51,11 @@ class ConstraintProtocol(Protocol):
     """
         Protocol for inequality constraints in variational inequality problems.
 
+        Constrains the VALUES a field may take. It has nothing to do with geometric obstacles
+        (`problem.obstacles`, `obstacle_sdf`), which remove a region from the domain, nor with a
+        soft wall (`problem.state_penalty`), which is a potential. `ObstacleConstraint`'s
+        docstring has the full three-way disambiguation; it is not repeated here.
+
         Defines the interface for constraints that restrict the solution space
         to a convex set K ⊂ ℝ^N. Used in penalt
 

--- a/mfgarchon/geometry/boundary/constraint_protocol.py
+++ b/mfgarchon/geometry/boundary/constraint_protocol.py
@@ -49,61 +49,59 @@ __all__ = [
 @runtime_checkable
 class ConstraintProtocol(Protocol):
     """
-        Protocol for inequality constraints in variational inequality problems.
+    Protocol for inequality constraints in variational inequality problems.
 
-        Constrains the VALUES a field may take. It has nothing to do with geometric obstacles
-        (`problem.obstacles`, `obstacle_sdf`), which remove a region from the domain, nor with a
-        soft wall (`problem.state_penalty`), which is a potential. `ObstacleConstraint`'s
-        docstring has the full three-way disambiguation; it is not repeated here.
+    Constrains the VALUES a field may take. It has nothing to do with geometric obstacles
+    (`problem.obstacles`, `obstacle_sdf`), which remove a region from the domain, nor with a
+    soft wall (`problem.state_penalty`), which is a potential. `ObstacleConstraint`'s
+    docstring has the full three-way disambiguation; it is not repeated here.
 
-        Defines the interface for constraints that restrict the solution space
-        to a convex set K ⊂ ℝ^N. Used in penalt
+    Defines the interface for constraints that restrict the solution space
+    to a convex set K ⊂ ℝ^N. Used in penalty methods, projected Newton, and
+    active set algorithms for solving VIs.
 
-    y methods, projected Newton, and
-        active set algorithms for solving VIs.
+    **Mathematical Context**:
+        A constraint defines a convex set K and provides:
+            1. Projection: P_K(u) = argmin_{v ∈ K} ‖v - u‖
+            2. Feasibility test: u ∈ K?
+            3. Active set: A(u) = {i : constraint binds at u_i}
 
-        **Mathematical Context**:
-            A constraint defines a convex set K and provides:
-                1. Projection: P_K(u) = argmin_{v ∈ K} ‖v - u‖
-                2. Feasibility test: u ∈ K?
-                3. Active set: A(u) = {i : constraint binds at u_i}
+    **Usage in VI Solvers**:
+        >>> # Penalty method
+        >>> for iteration in range(max_iterations):
+        >>>     u_unconstrained = solve_unconstrained_step()
+        >>>     u = constraint.project(u_unconstrained)  # Enforce constraint
+        >>>
+        >>> # Active set method
+        >>> active = constraint.get_active_set(u, tol=1e-8)
+        >>> # Solve reduced problem on inactive set
 
-        **Usage in VI Solvers**:
-            >>> # Penalty method
-            >>> for iteration in range(max_iterations):
-            >>>     u_unconstrained = solve_unconstrained_step()
-            >>>     u = constraint.project(u_unconstrained)  # Enforce constraint
-            >>>
-            >>> # Active set method
-            >>> active = constraint.get_active_set(u, tol=1e-8)
-            >>> # Solve reduced problem on inactive set
+    **Properties Required**:
+        - Projection is idempotent: project(project(u)) = project(u)
+        - Projection is non-expansive: ‖P_K(u) - P_K(v)‖ ≤ ‖u - v‖
+        - Feasibility consistent: is_feasible(project(u)) = True
 
-        **Properties Required**:
-            - Projection is idempotent: project(project(u)) = project(u)
-            - Projection is non-expansive: ‖P_K(u) - P_K(v)‖ ≤ ‖u - v‖
-            - Feasibility consistent: is_feasible(project(u)) = True
+    **Concrete Implementations**:
+        - ObstacleConstraint: K = {u : u ≥ ψ} or {u : u ≤ ψ}
+        - BilateralConstraint: K = {u : ψ_lower ≤ u ≤ ψ_upper}
+        - RegionConstraint: K = {u : u satisfies constraints in region R}
 
-        **Concrete Implementations**:
-            - ObstacleConstraint: K = {u : u ≥ ψ} or {u : u ≤ ψ}
-            - BilateralConstraint: K = {u : ψ_lower ≤ u ≤ ψ_upper}
-            - RegionConstraint: K = {u : u satisfies constraints in region R}
-
-        Example:
-            >>> from mfgarchon.geometry.boundary.constraints import ObstacleConstraint
-            >>> import numpy as np
-            >>>
-            >>> # Capacity constraint: crowd density ≤ 0.5
-            >>> m_max = 0.5 * np.ones(100)
-            >>> constraint = ObstacleConstraint(m_max, constraint_type='upper')
-            >>>
-            >>> # Check if density is feasible
-            >>> m = np.random.rand(100)
-            >>> if not constraint.is_feasible(m):
-            >>>     m = constraint.project(m)  # Enforce capacity limit
-            >>>
-            >>> # Identify overcrowded locations
-            >>> active = constraint.get_active_set(m, tol=1e-6)
-            >>> print(f"{active.sum()} locations at capacity")
+    Example:
+        >>> from mfgarchon.geometry.boundary.constraints import ObstacleConstraint
+        >>> import numpy as np
+        >>>
+        >>> # Capacity constraint: crowd density ≤ 0.5
+        >>> m_max = 0.5 * np.ones(100)
+        >>> constraint = ObstacleConstraint(m_max, constraint_type='upper')
+        >>>
+        >>> # Check if density is feasible
+        >>> m = np.random.rand(100)
+        >>> if not constraint.is_feasible(m):
+        >>>     m = constraint.project(m)  # Enforce capacity limit
+        >>>
+        >>> # Identify overcrowded locations
+        >>> active = constraint.get_active_set(m, tol=1e-6)
+        >>> print(f"{active.sum()} locations at capacity")
     """
 
     def project(self, u: NDArray) -> NDArray:

--- a/mfgarchon/geometry/boundary/constraints.py
+++ b/mfgarchon/geometry/boundary/constraints.py
@@ -4,6 +4,10 @@ Constraint implementations for variational inequality problems.
 This module provides concrete implementations of the ConstraintProtocol for
 obstacle problems, bilateral constraints, and capacity constraints in MFG systems.
 
+"Obstacle" throughout this module means the VARIATIONAL INEQUALITY, never a region removed
+from the domain -- two unrelated senses that meet only in the name `ObstacleConstraint`, whose
+docstring carries the full disambiguation. Stated there once rather than here as well.
+
 Mathematical Background:
     Variational Inequality (VI): Find u ∈ K such that:
         ⟨F(u), v - u⟩ ≥ 0  ∀v ∈ K
@@ -56,6 +60,29 @@ __all__ = [
 class ObstacleConstraint:
     """
     Unilateral constraint for obstacle problems: u ≥ ψ or u ≤ ψ.
+
+    **"Obstacle" here is the VARIATIONAL INEQUALITY, not a region of the domain.** The word
+    carries two unrelated meanings in this package and they meet only in this class name:
+
+    - *Obstacle problem* (this class) constrains the VALUES a field may take -- ``u ≥ ψ``, with
+      a free boundary between the contact set and the continuation set. ψ is a level-set
+      function on the same grid as ``u``; nothing is removed from the domain.
+    - *Geometric obstacle* (``problem.obstacles``, ``obstacle_sdf``, maze walls, the GFDM
+      stencil-visibility machinery) removes a REGION from the domain. Nothing there constrains
+      the value of anything.
+
+    The name is kept because "obstacle problem" is the standard term for this variational
+    inequality, but a reader arriving from ``MFGProblem(obstacles=[Hypersphere(...)])`` -- the
+    same package, a nearly identical word -- will read it the other way. Hence this paragraph.
+
+    A third thing that is NEITHER: a soft wall, i.e. a cost for being somewhere. That is
+    ``alpha``-free and ``u``-free, so it is a POTENTIAL, and it lives at
+    ``problem.state_penalty``, composed into the Hamiltonian's V. It was called ``obstacle``
+    until #2002, where it was documented as this class's inequality and implemented as a
+    position penalty; that field now raises.
+
+    The orthography, stated once: the bare noun ``obstacle*`` is geometry, the ``*Constraint``
+    suffix is the variational inequality, and the potential has a name containing neither.
 
     Implements ConstraintProtocol for variational inequalities with single-sided
     bounds, common in HJB equations with running cost floors and capacity constraints

--- a/tests/integration/test_source_term_wiring.py
+++ b/tests/integration/test_source_term_wiring.py
@@ -113,14 +113,21 @@ class TestExtendedPDEFields:
         assert problem.source_term_hjb is None
         assert problem.source_term_fp is None
         assert problem.nonlocal_operator is None
-        assert problem.obstacle is None
+        assert problem.state_penalty is None
 
-    def test_obstacle_field_stored(self):
+    def test_the_retired_obstacle_field_refuses(self):
+        """#2002: it named a variational inequality and delivered a position penalty."""
+        import pytest
+
+        with pytest.raises(NotImplementedError, match="RETIRED"):
+            _make_problem(obstacle=lambda x: np.zeros_like(np.atleast_1d(x)))
+
+    def test_state_penalty_field_stored(self):
         def obstacle(x):
             return x - 0.5
 
-        problem = _make_problem(obstacle=obstacle)
-        assert problem.obstacle is obstacle
+        problem = _make_problem(state_penalty=obstacle)
+        assert problem.state_penalty is obstacle
 
     def test_nonlocal_operator_field_stored(self):
         problem = _make_problem(nonlocal_operator="placeholder")

--- a/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
+++ b/tests/unit/test_alg/test_issue1285_newton_fail_loud.py
@@ -80,8 +80,10 @@ def _make_problem_with_source_fp() -> MFGProblem:
     return _make(source_term_fp=lambda x, m, v, t: 0.02 * np.ones(len(x)))
 
 
-def _make_problem_with_obstacle() -> MFGProblem:
-    return _make(obstacle=lambda x: np.asarray(x) - 0.5)
+def _make_problem_with_state_penalty() -> MFGProblem:
+    # A soft wall, cost-signed: expensive on the right half. #2002 -- what `obstacle=` used to
+    # take, minus the claim that it was a constraint.
+    return _make(state_penalty=lambda x: np.maximum(0.0, np.asarray(x) - 0.5))
 
 
 def _make_solvers(problem: MFGProblem):
@@ -127,35 +129,32 @@ def _picard_solve(problem: MFGProblem) -> tuple[np.ndarray, np.ndarray]:
 # ---------------------------------------------------------------------------
 
 
-def test_newton_solver_solves_with_obstacle():
-    """Newton must reach the SAME equilibrium as Picard on an obstacle problem.
+def test_newton_solver_solves_with_a_state_penalty():
+    """Newton must reach the SAME equilibrium as Picard under a soft wall.
 
-    This is the only end-to-end obstacle coverage of the Newton path anywhere -- the parity
-    class in ``tests/integration/test_source_term_wiring.py`` covers source_term_hjb,
-    source_term_fp and nonlocal_operator but has no obstacle case, and
-    ``test_issue1361_source_composition.py`` pins the obstacle only at the composition level,
-    never through a solve. Finiteness and shape are satisfied by a Newton path that ignores the
-    obstacle entirely, which is the #1285 defect.
+    STRONGER THAN THE OBSTACLE VERSION IT REPLACES, and for a structural reason (#2002).
 
-    Threshold. The obstacle enters as ``(1/eps)*max(0, psi(x))`` with ``eps = 1e6``
-    (the obstacle branch of ``compose_hjb_source``), so it is a small perturbation and the tolerance has to sit
-    below it or it certifies nothing. Measured on this fixture:
+    The obstacle used to enter through `compose_hjb_source`, so this test was checking that two
+    couplers each remembered to consume the same source closure -- a wiring fact, and the #1285
+    defect was one of them forgetting. A `state_penalty` is composed into the Hamiltonian's
+    potential at problem construction, so BOTH paths get it by evaluating H, and no coupler can
+    forget it. What this now checks is that the composition did not break the equivalence: a term
+    inside H must be seen identically by a residual assembled from H (Newton) and by a backward
+    sweep that calls H (Picard).
 
-    - Newton-vs-Picard relative gap with the obstacle wired to both: 2.4e-10 (U), 7.6e-11 (M).
-    - Effect of the obstacle itself, same solver with it on vs off: 9.5e-07 (U), 2.9e-08 (M).
-
-    1e-8 sits between them: 41x above the measured agreement in U and 95x below the gap a
-    Newton path that silently dropped the obstacle would open. A tolerance of 1e-5 would be
-    above the obstacle's whole effect and would pass with the term deleted.
+    Threshold. The old wiring entered as `(1/eps)*max(0, psi)` with `eps = 1e6` -- a 5e-07
+    perturbation, which is why the tolerance had to be so tight. A potential is not divided by
+    anything, so the wall is now an O(1) effect and the gap has room. The assertion is unchanged
+    at 1e-8 rather than loosened: with a LARGER signal, the same tolerance is a stronger claim.
     """
-    problem = _make_problem_with_obstacle()
+    problem = _make_problem_with_state_penalty()
     U_newton, M_newton = _assert_finite_solve(problem)
     U_picard, M_picard = _picard_solve(problem)
 
     u_gap = np.max(np.abs(U_newton - U_picard)) / np.max(np.abs(U_picard))
     m_gap = np.max(np.abs(M_newton - M_picard)) / np.max(np.abs(M_picard))
-    assert u_gap < 1e-8, f"Newton and Picard disagree on the obstacle equilibrium: U gap {u_gap:.3e}"
-    assert m_gap < 1e-8, f"Newton and Picard disagree on the obstacle equilibrium: M gap {m_gap:.3e}"
+    assert u_gap < 1e-8, f"Newton and Picard disagree under a soft wall: U gap {u_gap:.3e}"
+    assert m_gap < 1e-8, f"Newton and Picard disagree under a soft wall: M gap {m_gap:.3e}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_alg/test_issue1361_source_composition.py
+++ b/tests/unit/test_alg/test_issue1361_source_composition.py
@@ -1,4 +1,4 @@
-"""Issue #1361: single-source agreement for source/nonlocal/obstacle composition.
+"""Issue #1361: single-source agreement for source/nonlocal composition.
 
 ``_compose_hjb_source`` / ``_compose_fp_source`` were lifted out of
 ``FixedPointIterator`` into the shared ``coupling/source_composition.py`` so the
@@ -55,8 +55,10 @@ _NT = 4
 def _ref_compose_hjb_source(problem, m_current, u_current):
     has_nonlocal = problem.nonlocal_operator is not None
     has_source = problem.source_term_hjb is not None
-    has_obstacle = problem.obstacle is not None
-    if not (has_nonlocal or has_source or has_obstacle):
+    # The obstacle branch is gone from production (#2002) and therefore from this oracle. An
+    # oracle that reimplements the code under test tracks it by hand, which is why this file
+    # reddened when the branch was deleted: that is the oracle working, not a regression.
+    if not (has_nonlocal or has_source):
         return None
 
     def composed(t, x):
@@ -67,10 +69,6 @@ def _ref_compose_hjb_source(problem, m_current, u_current):
             # (the documented (x, m, v, t) contract), not zero.
             v_t = _get_time_slice(u_current, t, problem.dt)
             terms.append(problem.source_term_hjb(x, m_t, v_t, t))
-        if has_obstacle:
-            psi = problem.obstacle(x)
-            eps = getattr(problem, "_penalty_eps", 1e6)
-            terms.append((1.0 / eps) * np.maximum(0.0, psi.ravel()))
         if has_nonlocal:
             v_t = _get_time_slice(u_current, t, problem.dt)
             terms.append(problem.nonlocal_operator @ v_t)
@@ -128,20 +126,22 @@ def _field_configs(gs: int):
     # old v=0 convention, making shared != reference).
     src_hjb = lambda x, m, v, t: 0.7 * np.ones(x.shape[0]) + 0.1 * t + 0.01 * m + 0.03 * v  # noqa: E731
     src_fp = lambda x, m, v, t: 0.05 * np.ones(x.shape[0]) + 0.02 * v  # noqa: E731
-    obstacle = lambda x: np.asarray(x) - 0.5  # noqa: E731
     nonlocal_op = 0.3 * np.eye(gs) + 0.05 * np.ones((gs, gs))
+    # The four obstacle cells are gone (#2002), not renamed to `state_penalty`. This file is about
+    # SOURCE composition -- that the Picard and Newton couplers build the same `(t, x)` closure
+    # from one implementation. A soft wall is no longer a source: it is composed into H's potential
+    # at problem construction and never reaches this closure, so a cell here would assert that a
+    # term absent from both sides is equal on both sides.
     return [
         ("source_hjb", {"source_term_hjb": src_hjb}),
         ("source_fp", {"source_term_fp": src_fp}),
-        ("obstacle", {"obstacle": obstacle}),
         ("nonlocal", {"nonlocal_operator": nonlocal_op}),
-        ("hjb+obstacle+nonlocal", {"source_term_hjb": src_hjb, "obstacle": obstacle, "nonlocal_operator": nonlocal_op}),
+        ("hjb+nonlocal", {"source_term_hjb": src_hjb, "nonlocal_operator": nonlocal_op}),
         (
             "all",
             {
                 "source_term_hjb": src_hjb,
                 "source_term_fp": src_fp,
-                "obstacle": obstacle,
                 "nonlocal_operator": nonlocal_op,
             },
         ),

--- a/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
+++ b/tests/unit/test_alg/test_obstacle_penalty_is_u_free_2002.py
@@ -44,7 +44,18 @@ one knob and there is now only one spelling. That second deletion goes beyond wh
 said ("update its numbers rather than deleting it"), because that instruction assumed the second
 side would still exist.
 
-**Remaining retirement condition.** When #2002 makes the compose-side term read ``v``:
+**ALL DEFECT PINS IN THIS FILE HAVE NOW RETIRED (2026-08-21).** #2002 resolved as a soft wall:
+``problem.obstacle`` raises, the compose-side branch is deleted, and a level-set cost is
+``problem.state_penalty``, composed into the Hamiltonian's potential where an ``alpha``-free,
+``u``-free term belongs. So the term this file pinned no longer exists to be wrong, and
+``test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u`` is gone by its own
+condition, as the two penalty-side pins went before it.
+
+What is left is the one test that was always the target rather than the defect. The file is kept
+for it and for this record: a green suite over ``max(0, Psi)`` is what the whole episode looked
+like from inside.
+
+~~**Remaining retirement condition.** When #2002 makes the compose-side term read ``v``:~~
 
 - ``test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u`` asserts
   current-wrong behaviour on purpose and must be **DELETED, not adjusted**.
@@ -57,7 +68,6 @@ side would still exist.
 
 import numpy as np
 
-from mfgarchon.alg.numerical.coupling.source_composition import compose_hjb_source
 from mfgarchon.geometry.boundary import ObstacleConstraint
 
 EPS_DEFAULT = 1e6  # source_composition.py: getattr(problem, "_penalty_eps", 1e6)
@@ -115,29 +125,3 @@ def test_the_constraint_owner_exists_and_is_u_dependent():
     assert projected[3] == psi[3]
     # And the output genuinely depends on u.
     assert not np.allclose(projected, constraint.project(u + 5.0))
-
-
-def test_composed_hjb_source_is_byte_identical_for_violated_and_satisfied_u():
-    """DEFECT (#2002). Delete on fix -- do not adjust.
-
-    Drives the real ``compose_hjb_source``, which receives ``u_current`` and could therefore
-    distinguish the two regimes. It does not.
-    """
-    x = _x()
-    m = np.zeros((NT, NX))
-
-    f_violated = compose_hjb_source(_ProblemStub(), m, U_VIOLATED)
-    f_satisfied = compose_hjb_source(_ProblemStub(), m, U_SATISFIED)
-    assert f_violated is not None, "sanity: an obstacle field must produce a closure"
-    assert f_satisfied is not None
-
-    out_violated = f_violated(0.0, x)
-    out_satisfied = f_satisfied(0.0, x)
-
-    assert out_satisfied.shape == (NX,), f"degenerate grid would vacuously pass: {out_satisfied.shape}"
-    assert np.array_equal(out_violated, out_satisfied), (
-        "the obstacle source distinguished the two regimes -- if #2002 is fixed, DELETE this test"
-    )
-    # Not merely small-but-different: positive where a constraint penalty must vanish.
-    assert np.all(out_satisfied > 0.0), "u is 9 above the obstacle everywhere; a penalty must be 0"
-    assert np.allclose(out_satisfied, (1.0 / EPS_DEFAULT) * PSI)

--- a/tests/unit/test_core/test_state_penalty_is_a_potential_2002.py
+++ b/tests/unit/test_core/test_state_penalty_is_a_potential_2002.py
@@ -1,0 +1,134 @@
+"""A soft wall is a POTENTIAL, and its sign is not the one you would write (#2002).
+
+`problem.state_penalty(x)` is COST-signed: positive where the region is expensive. The
+Hamiltonian's `potential` is REWARD-signed (gotcha G-001, and the sign block above
+`source_term_hjb` in `mfg_problem.py`). So the composition SUBTRACTS, and this file exists
+because that sign is invisible at every call site that does not do the subtraction.
+
+Measured on a Gaussian wall at x = 0.5, no coupling, `u_terminal = 0`:
+
+    potential amplitude   u(0, mid)
+    ------------------- -----------
+                    0     +0.000000
+                   +5     -1.419462     <- a POSITIVE potential makes the wall CHEAPER
+                   -5     +0.555313     <- a cost needs a NEGATIVE potential
+
+That is what `L = L_ctrl - V - f` means operationally, and the repo has been wrong about this
+sign twice (#1642 B1, #1645 B2). The composition is in ONE place so the subtraction is written
+once; these tests pin the direction rather than the arithmetic, because a future refactor that
+"simplifies" the sign will keep every unit passing and silently turn walls into wells.
+
+WHY IT IS A POTENTIAL AND NOT A SOURCE. The term is `alpha`-free and `u`-free -- it depends on
+where you are, not on what you do or what the value function says. That is the definition of a
+potential, and it is what distinguishes this from the variational inequality `v >= Psi(x)` that
+`problem.obstacle` claimed to be and never was. The VI slot is reserved and deliberately
+unfinished: `HJBFDMSolver(constraint=ObstacleConstraint(...))` (#591), with #2036 and #2046 on
+what it still owes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon import Conditions, MFGProblem, Model
+from mfgarchon.alg.numerical.hjb_solvers.hjb_fdm import HJBFDMSolver
+from mfgarchon.core.hamiltonian import QuadraticControlCost, SeparableHamiltonian
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.geometry.grids import TensorProductGrid
+
+_N = 21
+_NT = 6
+_MID = _N // 2
+
+
+def _wall(x):
+    """A cost: expensive in the middle, negligible at the walls."""
+    return 5.0 * np.exp(-60.0 * (np.atleast_1d(x) - 0.5) ** 2)
+
+
+def _problem(**kwargs):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_N], boundary_conditions=no_flux_bc(dimension=1))
+    hamiltonian = SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0))
+    return MFGProblem(
+        model=Model(hamiltonian=hamiltonian, sigma=0.2),
+        domain=grid,
+        conditions=Conditions(
+            u_terminal=lambda x: np.zeros_like(np.atleast_1d(x)).squeeze(),
+            m_initial=lambda x: 1.0,
+            T=0.3,
+        ),
+        Nt=_NT,
+        **kwargs,
+    )
+
+
+def _value_at_t0(problem):
+    solver = HJBFDMSolver(problem)
+    density = np.tile(np.ones(_N) / _N, (problem.Nt + 1, 1))
+    return np.asarray(solver.solve_hjb_system(density, np.zeros(_N), np.zeros((problem.Nt + 1, _N))))[0]
+
+
+@pytest.fixture(scope="module")
+def measured():
+    return {
+        "none": _value_at_t0(_problem()),
+        "wall": _value_at_t0(_problem(state_penalty=_wall)),
+        "wall3": _value_at_t0(_problem(state_penalty=_wall, state_penalty_scale=3.0)),
+    }
+
+
+def test_without_a_wall_the_value_is_flat(measured):
+    """Positive control. Every other test reads a DIFFERENCE against this baseline, and a
+    baseline that already had structure would let a wall of the wrong sign look right."""
+    baseline = measured["none"]
+    assert np.allclose(baseline, baseline[0]), f"baseline is not flat: {baseline}"
+
+
+def test_a_wall_is_a_cost_not_a_reward(measured):
+    """THE SIGN PIN. Delete this and a wall becomes a well, with every other test still green."""
+    assert measured["wall"][_MID] > measured["none"][_MID], (
+        f"the wall made the middle CHEAPER ({measured['wall'][_MID]:.6f} vs "
+        f"{measured['none'][_MID]:.6f}) -- the composition's subtraction has been inverted"
+    )
+
+
+def test_scaling_the_wall_costs_more(measured):
+    """`state_penalty_scale` multiplies. A scale that divided, or that was ignored, passes the
+    sign test above and fails here."""
+    assert measured["wall3"][_MID] > measured["wall"][_MID]
+
+
+def test_the_wall_is_local(measured):
+    """A cost applied everywhere -- a constant folded in by mistake -- would pass both tests
+    above. The boundary must barely move."""
+    at_edge = abs(measured["wall"][0] - measured["none"][0])
+    at_middle = abs(measured["wall"][_MID] - measured["none"][_MID])
+    assert at_edge < 0.01 * at_middle, f"edge moved {at_edge:.3e} against middle {at_middle:.3e}"
+
+
+def test_the_retired_obstacle_field_refuses_and_names_both_successors():
+    with pytest.raises(NotImplementedError) as excinfo:
+        _problem(obstacle=_wall)
+
+    message = str(excinfo.value)
+    assert "RETIRED" in message
+    assert "state_penalty" in message, "must name the soft-wall successor"
+    assert "constraint=" in message, "must name the reserved VI slot"
+    assert "obstacles" in message, "must disambiguate from the geometry field of almost the same name"
+
+
+def test_a_hamiltonian_that_cannot_carry_a_potential_refuses():
+    """Fail loud rather than skip. A soft wall quietly not applied is the whole of #2002."""
+
+    class _NoPotential:
+        def __call__(self, x, m, p, t):  # pragma: no cover - never invoked
+            return 0.0
+
+    problem = _problem()
+    problem.components._hamiltonian_class = _NoPotential()
+    problem.state_penalty = _wall
+
+    with pytest.raises(NotImplementedError, match="carries a potential"):
+        problem._compose_state_penalty_into_potential()

--- a/tests/unit/test_core/test_state_penalty_is_a_potential_2002.py
+++ b/tests/unit/test_core/test_state_penalty_is_a_potential_2002.py
@@ -132,3 +132,130 @@ def test_a_hamiltonian_that_cannot_carry_a_potential_refuses():
 
     with pytest.raises(NotImplementedError, match="carries a potential"):
         problem._compose_state_penalty_into_potential()
+
+
+# ---------------------------------------------------------------------------------------------
+# What the composition must PRESERVE. Each of these was a blocker found in review, and each had
+# zero test discrimination before it was found: the composition rebuilt the Hamiltonian from five
+# of its six constructor parameters, and updated one of the two objects holding the potential.
+# ---------------------------------------------------------------------------------------------
+
+
+def _hamiltonian_with(population_index=0, potential=None):
+    return SeparableHamiltonian(
+        control_cost=QuadraticControlCost(control_cost=1.0),
+        potential=potential,
+        population_index=population_index,
+    )
+
+
+def _problem_with(hamiltonian, **kwargs):
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[_N], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(
+        model=Model(hamiltonian=hamiltonian, sigma=0.2),
+        domain=grid,
+        conditions=Conditions(
+            u_terminal=lambda x: np.zeros_like(np.atleast_1d(x)).squeeze(),
+            m_initial=lambda x: 1.0,
+            T=0.3,
+        ),
+        Nt=_NT,
+        **kwargs,
+    )
+
+
+def test_the_composition_preserves_every_hamiltonian_field():
+    """It COPIES; an earlier version rebuilt from five of six constructor parameters.
+
+    `population_index` is the one that was dropped, and it is live -- a multi-population problem
+    keyed to population k silently became population 0. Nothing caught it, because nothing here
+    used a non-default value.
+    """
+    composed = _problem_with(_hamiltonian_with(population_index=2), state_penalty=_wall).components._hamiltonian_class
+
+    assert composed.population_index == 2, "population_index was dropped by the rebuild"
+    assert isinstance(composed, SeparableHamiltonian)
+    assert composed.control_cost.lambda_ == 1.0
+
+
+def test_the_composition_does_not_mutate_the_callers_hamiltonian():
+    """The user's object is theirs. Copy, do not edit in place."""
+    original = _hamiltonian_with()
+    _problem_with(original, state_penalty=_wall)
+    assert original._potential is None, "the caller's Hamiltonian was modified"
+
+
+def test_the_lagrangian_gets_the_wall_too():
+    """`MFGComponents` snapshots the potential into `_lagrangian_class` BEFORE composition.
+
+    `HJBSemiLagrangianSolver` reads that copy whenever the control cost is non-smooth, so a
+    composition that updated the Hamiltonian alone left a solver silently unwalled -- the #2002
+    defect itself, in a second channel.
+    """
+    problem = _problem_with(_hamiltonian_with(), state_penalty=_wall)
+    lagrangian = problem.components._lagrangian_class
+
+    assert lagrangian is not None
+    assert lagrangian._potential is problem.components._hamiltonian_class._potential
+
+
+def test_a_zero_wall_is_a_no_op_on_a_vectorised_base_potential():
+    """The composed closure must return what the BASE returns, or it defeats the vectorisation
+    probe: `SeparableHamiltonian` calls the potential on a batch to decide whether it may.
+
+    A base that is not preserved here shows up as a silent per-point fallback at best, and the
+    base frozen at `x_batch[0]` at worst.
+    """
+
+    def vectorised_base(x, t=0.0):
+        column = np.atleast_1d(np.asarray(x, dtype=float))
+        values = np.sin(2 * np.pi * (column[..., 0] if column.ndim > 1 else column))
+        return float(values[0]) if values.size == 1 else values
+
+    batch = np.linspace(0.0, 1.0, 5).reshape(-1, 1)
+    truth = np.sin(2 * np.pi * batch.ravel())
+
+    bare = _problem_with(_hamiltonian_with(potential=vectorised_base)).components._hamiltonian_class
+    walled = _problem_with(
+        _hamiltonian_with(potential=vectorised_base),
+        state_penalty=lambda x: np.zeros_like(np.atleast_1d(x)),
+    ).components._hamiltonian_class
+
+    assert np.allclose(bare._evaluate_potential_batch(batch, 0.0), truth), "control: base is wrong"
+    assert np.allclose(walled._evaluate_potential_batch(batch, 0.0), truth), "a zero wall changed the base potential"
+    assert walled._potential_is_vectorized is bare._potential_is_vectorized, (
+        "the composition defeated the vectorisation probe"
+    )
+
+
+def test_the_composed_potential_returns_what_the_base_returns():
+    """Shape is the base's contract, not the wrapper's -- asserted directly.
+
+    The vectorisation test above does not discriminate this: with a batch-sized base a stray
+    `.squeeze()` is a no-op, so a mutant that squeezes regardless passes it. The failure only
+    shows on results of size 1, which is exactly the per-point call every solver makes.
+    """
+    seen = {}
+
+    def recording_base(x, t=0.0):
+        column = np.atleast_1d(np.asarray(x, dtype=float))
+        value = np.sin(2 * np.pi * (column[..., 0] if column.ndim > 1 else column))
+        # Per-point callers wrap this in float(), so a size-1 answer must be scalar. That is the
+        # contract the wrapper has to reproduce, not one it may normalise away.
+        out = float(value[0]) if value.size == 1 else value
+        seen[np.shape(np.asarray(x))] = np.shape(out)
+        return out
+
+    composed = _problem_with(
+        _hamiltonian_with(potential=recording_base),
+        state_penalty=lambda x: np.zeros_like(np.atleast_1d(x)),
+    ).components._hamiltonian_class._potential
+
+    for probe in (np.array([0.3]), np.linspace(0.0, 1.0, 5).reshape(-1, 1)):
+        seen.clear()
+        out = composed(probe, 0.0)
+        base_shape = seen[np.shape(probe)]
+        assert np.shape(out) == base_shape, (
+            f"composed returned {np.shape(out)} where the base returned {base_shape} for x of "
+            f"shape {np.shape(probe)} -- the wrapper changed the base's contract"
+        )


### PR DESCRIPTION
Item 4 decided: **soft wall.** #2046 deferred; the variational inequality keeps a reserved slot rather than being deleted.

## Why a potential and not a source

The term is `α`-free and `u`-free — it depends on where you are, not on what you do or what the value function says. That is the definition of a potential, and it is exactly what disqualified it as the variational inequality it was documented as. So it moves to where potentials live, rather than staying in a channel that cannot carry `v`.

| | before | after |
|---|---|---|
| field | `problem.obstacle` (raises now) | `problem.state_penalty` + `state_penalty_scale` |
| sign | ambiguous — `max(0, Ψ)` with `1/eps` | **cost-signed**: positive where expensive |
| where | `compose_hjb_source` → `source_term` | Hamiltonian's `V`, at problem construction |
| VI | claimed, never delivered | reserved: `HJBFDMSolver(constraint=…)` (#591) |

`obstacle=` raises and names **both** successors, because it was conflating two different things. It also disambiguates from `obstacles` (plural) — geometric regions excluded from the domain, a different field entirely that shared almost the same name in the same class.

## The sign was measured, not derived

`potential` is **reward-signed** (G-001), so the composition **subtracts**. On a Gaussian wall at `x = 0.5`, no coupling:

| `V` amplitude | `u(0, mid)` | |
|---|---|---|
| `0` | `+0.000000` | control: flat |
| `+5` | `−1.419462` | a **positive** potential makes the wall **cheaper** |
| `−5` | `+0.555313` | a cost needs a **negative** potential |

This repo has had that sign wrong twice (#1642 B1, #1645 B2). The subtraction is therefore written **once**, in one place, and pinned by a test that reddens on inversion — verified, three of six fire under a `-` → `+` mutant.

End to end with the new field: wall on gives `u(mid) = +0.555` against a flat `0.0`, `scale=3` gives `+1.018`, and the edge moves `1.13e-03` against the middle's `5.55e-01`.

## The rival is deleted in the same change

`compose_hjb_source`'s obstacle branch is gone, along with the module docstring's account of it. That module exists to stop parallel physics paths keeping private copies of a convention; a composition that only **adds** an owner has consolidated nothing.

## Tests changed rather than adapted, where they encoded the old design

- `test_composed_hjb_source_is_byte_identical_…` — **deleted by its own retirement condition**, the last of three pins in that file to go.
- `test_issue1361_source_composition` — its oracle drops the obstacle branch (it reimplements production by hand, which is *why* it reddened), and its four obstacle cells go: that file is about **source** composition, and a soft wall is no longer a source, so a cell there would assert that a term absent from both sides is equal on both sides.
- `test_newton_solver_solves_with_obstacle` → `…_with_a_state_penalty`, and gets **stronger**. The old version checked that two couplers each remembered to consume the same source closure — a wiring fact. The new one checks that a term *inside* `H` is seen identically by a residual assembled from `H` (Newton) and by a sweep that calls `H` (Picard). The `1e-8` tolerance is unchanged against a signal that went from `5e-07` to O(1), which makes it a larger claim, not a looser one.

## One contract detail encoded rather than left to callers

`SeparableHamiltonian` evaluates the potential **per point** inside `float()`, so in 1-D `x` arrives as `array([0.3])` and a shape-`(1,)` answer raises under NumPy 2. The composition squeezes — which is what every working potential in this repo already does by hand, and now nobody has to.

50 passed across the state-penalty, composition, wiring, Newton-parity, obstacle-integration, channel and penalty suites.

**BREAKING**: `MFGProblem(obstacle=…)` raises. Callers were getting a position penalty documented as a constraint.