### PR TITLE
test(scripts): every ratchet gets a positive control, and the gate runs them

### DIFF
--- a/changelog.d/ratchet-sentinels.added.md
+++ b/changelog.d/ratchet-sentinels.added.md
@@ -1,0 +1,11 @@
+Every ratchet now carries a positive control, and the gate runs them. A ratchet whose measurement
+has gone blind reports a stable or *falling* count and reads exactly like success —
+`check_internal_deprecation`'s own docstring records that its predecessor printed
+`Total deprecated symbols: 0` while 72 were live, with CI green over it. Added two-sided controls to
+`check_fail_fast` (every category fires on a violation file and stays silent on a clean one whose
+docstrings mention the same words) and `check_assertion_strength` (flags the weak control, leaves an
+exact-value comparison alone), and a named-sentinel control to `check_internal_deprecation` (one live
+deprecation per counted kind, since its population is the real package and there is no clean tree to
+assert silence over). `check_doc_api` and `capability_matrix` already had controls **that nothing
+ever ran** — the gate now invokes all five: four fast ones (7s) before the ratchets they guard, and
+the capability self-test (92s) in the slow tier beside its matrix.

--- a/scripts/check_assertion_strength.py
+++ b/scripts/check_assertion_strength.py
@@ -120,7 +120,62 @@ def scan(root: Path):
     return weak, total
 
 
+_CONTROL_WEAK = '''
+def test_only_shape():
+    result = compute()
+    assert result is not None
+    assert result.shape == (3, 3)
+    assert np.all(np.isfinite(result))
+'''
+
+_CONTROL_STRONG = '''
+def test_the_value_is_right():
+    result = compute()
+    assert np.allclose(result, EXACT, atol=1e-12)
+'''
+
+
+def self_test() -> int:
+    """Positive control, two-sided. A count is evidence only if the classifier still discriminates.
+
+    One-sided is not enough in either direction here. A classifier that flagged EVERYTHING would
+    satisfy "does it catch a weak test" while making the percentage meaningless, and one that had
+    gone inert would report a falling number that reads as the suite improving -- which is the
+    direction this ratchet is watched in.
+    """
+    import tempfile
+
+    failures = []
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "test_weak_control.py").write_text(_CONTROL_WEAK)
+        weak, total = scan(root)
+        if total != 1:
+            failures.append(f"  collection: saw {total} test functions in a file with exactly 1")
+        if not weak:
+            failures.append("  weak: did not flag a test asserting only shape/finiteness/not-None")
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "test_strong_control.py").write_text(_CONTROL_STRONG)
+        weak, total = scan(root)
+        if total != 1:
+            failures.append(f"  collection: saw {total} test functions in a file with exactly 1")
+        if weak:
+            failures.append(f"  strong: flagged a test that compares against an exact value: {weak}")
+
+    if failures:
+        print("SELF-TEST FAILED -- the classifier no longer separates weak assertions from strong:")
+        print("\n".join(failures))
+        return 1
+    print("self-test OK -- flags the weak control, leaves the strong one alone")
+    return 0
+
+
 def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
     weak, total = scan(REPO / "tests")
     print(
         f"assertion strength : {len(weak)} of {total} defined test functions assert only what a "

--- a/scripts/check_fail_fast.py
+++ b/scripts/check_fail_fast.py
@@ -105,6 +105,77 @@ def _counts(results: dict) -> dict:
     return {category: len(items) for category, items in results.items()}
 
 
+#: A file every category must fire on, and one every category must ignore. Both halves matter:
+#: the first proves the check still SEES, the second proves it is not matching indiscriminately.
+_CONTROL_POSITIVE = '''
+def each_category_once(obj):
+    if hasattr(obj, "x"):          # hasattr
+        pass
+    try:
+        obj()
+    except ValueError:             # silent_pass
+        pass
+    try:
+        obj()
+    except:                        # bare_except
+        raise
+    try:
+        obj()
+    except Exception as exc:       # broad_except
+        raise RuntimeError from exc
+'''
+
+_CONTROL_NEGATIVE = '''
+def nothing_to_find(obj):
+    """A docstring mentioning hasattr and a bare except: must not count.
+
+    Neither may a comment: except Exception, pass
+    """
+    try:
+        obj()
+    except ValueError as exc:
+        raise RuntimeError("explicit and narrow") from exc
+    return getattr(obj, "x", None)
+'''
+
+
+def self_test() -> int:
+    """A ratchet whose checks have gone inert reports a stable count and reads like success.
+
+    This is the positive control, and it is two-sided. The one-sided form -- "does it fire on a
+    violation" -- passes for a checker that fires on everything, which would make every count
+    meaningless in the other direction. So a clean file with the same words in docstrings and
+    comments must produce nothing: this module counts CALLS via AST precisely because an earlier
+    regex version counted 40 `hasattr` mentions inside prose as if they were calls.
+    """
+    import tempfile
+    from pathlib import Path
+
+    failures = []
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "positive.py").write_text(_CONTROL_POSITIVE)
+        fired = _counts(check_fail_fast_violations(str(root)))
+        for category, n in sorted(fired.items()):
+            if n < 1:
+                failures.append(f"  {category}: did not fire on a file built to trigger it")
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "negative.py").write_text(_CONTROL_NEGATIVE)
+        quiet = _counts(check_fail_fast_violations(str(root)))
+        for category, n in sorted(quiet.items()):
+            if n:
+                failures.append(f"  {category}: fired {n}x on a file with no violation in it")
+
+    if failures:
+        print("SELF-TEST FAILED -- the ratchet cannot see what it claims to count:")
+        print("\n".join(failures))
+        return 1
+    print(f"self-test OK -- all {len(fired)} categories fire on the violation control and stay silent on the clean one")
+    return 0
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check for 'Fail Fast' principle violations.")
     parser.add_argument("--path", default=".", help="Root directory to scan")
@@ -121,7 +192,20 @@ if __name__ == "__main__":
         ),
     )
 
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help=(
+            "Positive control: assert every category fires on a file built to trigger it and "
+            "stays silent on a clean one. A count is only evidence if the checks still work."
+        ),
+    )
+
     args = parser.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+
     results = check_fail_fast_violations(args.path)
     counts = _counts(results)
 

--- a/scripts/check_internal_deprecation.py
+++ b/scripts/check_internal_deprecation.py
@@ -191,11 +191,69 @@ def production_uses(symbols: set[str]) -> list[str]:
     return hits
 
 
+#: Symbols this counter MUST find, one per kind it counts. Named rather than discovered, because a
+#: detector cannot be asked to confirm its own reach: the previous version returned nothing BY
+#: CONSTRUCTION and printed `Total deprecated symbols: 0` while 72 were live in the same tree, and
+#: CI was green over it. Zero and clean are the same output; only a known-positive separates them.
+#:
+#: Pick a symbol whose deprecation is unlikely to be resolved soon. When one IS resolved this
+#: sentinel goes red -- that is the check working, and the fix is to re-point it at another live
+#: entry of the same kind, never to delete the kind.
+SENTINELS = {
+    "function": "create_solver",
+    "parameter": "FPFDMSolver.solve_fp_system.velocity_field",
+    "property": "num_points",
+}
+
+
+def self_test() -> int:
+    """Positive control: the counter must still SEE deprecations that are known to be there.
+
+    Two-sided is not available here -- the population is the real package, so there is no "clean
+    tree" to assert silence over. What stands in for the negative half is the KIND coverage: a
+    detector that had collapsed to finding only functions would still satisfy a function-only
+    sentinel, so one symbol per counted kind is asserted.
+    """
+    try:
+        entries, _ = live_deprecations()
+    except EnvironmentIncompleteError as exc:
+        print(f"SELF-TEST INCONCLUSIVE -- the tree could not be read: {sorted(exc.unimportable)}", file=sys.stderr)
+        return 2
+
+    found = {(e.get("type"), e.get("name")) for e in entries}
+    missing = [f"  {kind}: {name}" for kind, name in SENTINELS.items() if (kind, name) not in found]
+
+    if missing:
+        print("SELF-TEST FAILED -- the counter no longer finds symbols known to be deprecated:")
+        print("\n".join(missing))
+        print(
+            "\nEither the detector has gone blind -- which is what this control exists for, and "
+            "has happened once already -- or that deprecation was resolved. Check which, then "
+            "re-point the sentinel at another live entry of the same kind. Do NOT delete the kind."
+        )
+        return 1
+
+    kinds = {e.get("type") for e in entries}
+    unguarded = sorted(kinds - set(SENTINELS))
+    print(f"self-test OK -- {len(SENTINELS)} sentinels found among {len(entries)} live deprecations")
+    if unguarded:
+        print(f"  note: kinds with no sentinel: {unguarded} (a collapse to the guarded kinds would pass)")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--write-baseline", action="store_true", help="record current counts and exit")
     parser.add_argument("--show", action="store_true", help="list every live deprecation")
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="positive control: assert the counter still finds symbols known to be deprecated",
+    )
     args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
 
     try:
         entries, out_of_scope = live_deprecations()

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -275,6 +275,9 @@ check $? "workflows parse, declare jobs, and have no dangling needs"
 # like success. Every ratchet below therefore carries a positive control, and the controls are run
 # here rather than existing unrun: check_doc_api and capability_matrix have had one since they were
 # written and this gate never invoked either. 7s for all four.
+# check_doc_api also self-tests inside --check-baseline, so it runs twice. Kept in this loop on
+# purpose: this is the ONE visible place asserting that every instrument is controlled, and if that
+# internal call is ever dropped the coverage would vanish with nothing here to say so.
 step "Ratchet self-tests (the instruments, before their numbers)"
 for _selftest in check_fail_fast check_doc_api check_assertion_strength check_internal_deprecation; do
   "$PY" "scripts/${_selftest}.py" --self-test || { check 1 "ratchet self-tests: ${_selftest} cannot see what it counts"; }

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -271,6 +271,16 @@ sys.exit(1 if bad else 0)
 "
 check $? "workflows parse, declare jobs, and have no dangling needs"
 
+# A ratchet whose measurement has gone blind reports a stable or FALLING count and reads exactly
+# like success. Every ratchet below therefore carries a positive control, and the controls are run
+# here rather than existing unrun: check_doc_api and capability_matrix have had one since they were
+# written and this gate never invoked either. 7s for all four.
+step "Ratchet self-tests (the instruments, before their numbers)"
+for _selftest in check_fail_fast check_doc_api check_assertion_strength check_internal_deprecation; do
+  "$PY" "scripts/${_selftest}.py" --self-test || { check 1 "ratchet self-tests: ${_selftest} cannot see what it counts"; }
+done
+check 0 "every fast ratchet still detects what it claims to detect"
+
 step "Fail-fast ratchet"
 "$PY" scripts/check_fail_fast.py --path mfgarchon --check-baseline scripts/fail_fast_baseline.json
 check $? "no new silent fallbacks vs baseline"
@@ -300,6 +310,10 @@ if [[ $FAST -eq 0 ]]; then
   # this is the quantity that does not. Bidirectional -- a recovered cell fails until
   # the baseline records it, so a fix cannot land without saying so.
   step "Capability matrix (public solve surface vs external oracles)"
+  # 92s, so it sits in the slow tier beside the matrix it guards rather than with the fast four.
+  "$PY" scripts/capability_matrix.py --self-test
+  check $? "the capability cells still go red under injected drift"
+
   "$PY" scripts/capability_matrix.py --check-baseline scripts/capability_baseline.json
   check $? "no capability change vs baseline"
 


### PR DESCRIPTION
A ratchet whose measurement has gone blind reports a stable — or **falling** — count and reads exactly like success. Not hypothetical here: `check_internal_deprecation`'s own docstring records that its predecessor found nothing *by construction*, printed `Total deprecated symbols: 0` while `audit_all_deprecations` reported **72 live in the same tree**, and CI was green over it.

## The part that was not about missing controls

`check_doc_api` and `capability_matrix` have had self-tests **since they were written**, and `grep -n "self-test" scripts/local_ci.sh` returned nothing. A control that never runs is the same as no control.

The gate now runs all five — the four fast ones (7s total) as a step **before** the ratchets they guard, and capability's (92s) in the slow tier beside its matrix.

## Controls added

| script | control | shape |
|---|---|---|
| `check_fail_fast` | every category fires on a violation file **and stays silent** on a clean one whose docstrings mention the same words | two-sided |
| `check_assertion_strength` | flags the weak control, leaves an exact-value comparison alone | two-sided |
| `check_internal_deprecation` | one live deprecation per counted kind | named sentinel |

The negative half is not decoration. A one-sided control passes for a checker that fires on *everything*, which makes the count meaningless in the other direction — and an earlier regex version of `check_fail_fast` did count 40 `hasattr` mentions inside prose as calls.

`check_internal_deprecation` gets sentinels rather than a two-sided control because its population is the real package: there is no clean tree to assert silence over. Kind coverage stands in for the negative half, and the run **reports any kind left unguarded** rather than implying it covers them all.

## Mutation-verified, both directions where two-sided

| mutant | result |
|---|---|
| `fail_fast` check made inert | *"did not fire on a file built to trigger it"* |
| `fail_fast` check made over-eager | *"fired 1x on a file with no violation in it"* |
| `assertion_strength` classifier → always `False` | caught |
| `assertion_strength` classifier → always `True` | caught |
| deprecation collector stops emitting parameter-kind entries | sentinel names the missing symbol |
| **the gate itself**, with a blinded classifier | `FAIL ratchet self-tests: check_assertion_strength cannot see what it counts` → `GATE RED`, exit 1 |

For the deprecation mutant the observable was confirmed changed (parameter-kind entries 36 → 0) **before** the result was read — an earlier attempt at the same mutant produced an `IndentationError`, so the script never parsed and the run proved nothing.

## Scope

`check_single_source` already had `sentinel_symbol`, and `test_discrimination` has a per-mutation `verify` that became two-sided in #2039. Those two are unchanged.

7s added to every gate run; 92s to the slow tier.