### PR TITLE
fix: two guards where the answer was right for the wrong reason (#2041, #2045)

### DIFF
--- a/changelog.d/2041-2045-two-guards.fixed.md
+++ b/changelog.d/2041-2045-two-guards.fixed.md
@@ -1,0 +1,15 @@
+Two guards, each closing a case where the answer was right for the wrong reason.
+
+`_solved` in `scripts/capability_matrix.py` keyed its trigger on a hardcoded pair, so
+`fvm_picard_converged` could **veto** a verdict but never cause one to be evaluated: an artifact
+whose only convergence evidence said the solve did *not* converge fell through to the
+"absent means not applicable" branch and gated **green** (#2041). Every `*picard_converged` key now
+both triggers and contributes, so a future prefix is covered by construction.
+
+`NetworkPolicyIterationHJBSolver` sets `_honors_node_bc` and therefore skips its base class's
+deliberate node-BC refusal, falling through to an unguarded `problem.num_nodes` — an
+`AttributeError` from inside construction, indistinguishable from a defect in the solver, where its
+sibling raises `NotImplementedError` naming the reason (#2045). Both now refuse loudly. The guard is
+a `try/except AttributeError` around all three network reads rather than `hasattr` on one: the
+fail-fast policy names try-except as the replacement (a `hasattr` moved that ratchet 107 → 108), and
+a single-attribute guard would wave through a problem carrying `num_nodes` but no adjacency accessor.

--- a/mfgarchon/alg/numerical/network_solvers/hjb_network.py
+++ b/mfgarchon/alg/numerical/network_solvers/hjb_network.py
@@ -126,13 +126,29 @@ class NetworkHJBSolver(BaseHJBSolver):
                 f"NetworkPolicyIterationHJBSolver, which applies node-BC, or remove the geometry's BC."
             )
 
+        # Issue #2045: refuse a non-network problem in the same shape the node-BC check above
+        # uses, rather than letting the first network-only attribute read raise AttributeError.
+        # `NetworkPolicyIterationHJBSolver` sets `_honors_node_bc`, so it SKIPS that check and
+        # used to fall through to here -- an unguarded read that told the caller nothing about
+        # why the solver was inapplicable, and was indistinguishable from a defect in the solver.
         self.scheme = scheme
         self.tolerance = tolerance
 
-        # Network properties
-        self.num_nodes = problem.num_nodes
-        self.adjacency_matrix = problem.get_adjacency_matrix()
-        self.laplacian_matrix = problem.get_laplacian_matrix()
+        # Network properties. Read inside try/except rather than guarded by `hasattr`: the
+        # fail-fast policy names try-except as the replacement for `hasattr`, and it covers the
+        # wider case -- a problem carrying `num_nodes` but no adjacency accessor fails here too,
+        # where a single-attribute guard would have waved it through to the next line.
+        try:
+            self.num_nodes = problem.num_nodes
+            self.adjacency_matrix = problem.get_adjacency_matrix()
+            self.laplacian_matrix = problem.get_laplacian_matrix()
+        except AttributeError as exc:
+            raise NotImplementedError(
+                f"{type(self).__name__} requires a network problem -- one carrying `num_nodes`, an "
+                f"adjacency matrix and a graph Laplacian. This problem's geometry is "
+                f"{type(problem.geometry).__name__} and it is missing {exc}. The network solvers "
+                f"discretize on nodes and edges and have no continuous-domain path (Issue #2045)."
+            ) from exc
 
         # Time discretization
         self.dt = problem.T / problem.Nt

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -281,10 +281,19 @@ def _solved(art: dict) -> bool:
     Absent means not applicable rather than not converged: cells that run no coupled iteration
     (construction checks) carry no such field and are unaffected.
     """
-    for field in ("picard_converged", "fdm_picard_converged"):
-        if field in art:
-            return bool(art[field]) and bool(art.get("fvm_picard_converged", True))
-    return True
+    # Every `*picard_converged` key both TRIGGERS and CONTRIBUTES. The hardcoded pair it replaced
+    # (#2041) had `fvm_picard_converged` in the `and` clause only, so it could veto a verdict but
+    # never cause one to be evaluated: an artifact whose ONLY convergence evidence said the solve
+    # did not converge fell through to `return True` -- the "absent means not applicable" branch,
+    # which is meant for construction cells that run no coupled iteration at all.
+    #
+    # Unreachable then, because the one prefixed caller writes both keys in a single expression.
+    # But `_picard_verdict(result, prefix=...)` takes an arbitrary prefix and nothing pairs them,
+    # so an FVM-only cell was one addition away. A field that can only ever WEAKEN a verdict must
+    # not be the field that triggers one; the trigger set and the veto set were written as if they
+    # were the same thing.
+    flags = [value for key, value in art.items() if key.endswith("picard_converged")]
+    return all(bool(value) for value in flags) if flags else True
 
 
 def _picard_verdict(result, prefix: str = "") -> dict:

--- a/tests/unit/test_alg/test_network_solvers_refuse_a_grid_problem_2045.py
+++ b/tests/unit/test_alg/test_network_solvers_refuse_a_grid_problem_2045.py
@@ -1,0 +1,100 @@
+"""Both network HJB solvers must REFUSE a continuous-domain problem, and say why (#2045).
+
+They used to fail differently, and only one of them on purpose:
+
+    NetworkHJBSolver                 NotImplementedError, naming node BCs
+    NetworkPolicyIterationHJBSolver  AttributeError: 'MFGProblem' object has no attribute 'num_nodes'
+
+The asymmetry is subtle rather than accidental. `NetworkPolicyIterationHJBSolver` sets
+`_honors_node_bc`, so it SKIPS the deliberate node-BC refusal its base class raises and fell
+through to the first network-only attribute read. An `AttributeError` from inside construction
+tells a caller nothing about why the solver is inapplicable, and is indistinguishable from a
+defect in the solver itself -- so a capability sweep classifying solvers by how they fail has to
+special-case it, and `AttributeError` is the bucket such sweeps tend to read as "harness problem"
+rather than "solver refused".
+
+The guard is a try/except around the three network reads rather than `hasattr` on one of them.
+Two reasons, and the second is the load-bearing one: the fail-fast policy names try-except as the
+replacement for `hasattr` (a `hasattr` here moved the ratchet 107 -> 108), and a single-attribute
+guard would wave through a problem that carries `num_nodes` but no adjacency accessor.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+
+import pytest
+
+from mfgarchon.alg.numerical.network_solvers.hjb_network import (
+    NetworkHJBSolver,
+    NetworkPolicyIterationHJBSolver,
+)
+from mfgarchon.core.mfg_problem import MFGProblem
+from mfgarchon.geometry.boundary import no_flux_bc
+from mfgarchon.geometry.grids import TensorProductGrid
+
+
+def _grid_problem():
+    from tests.integration.test_hjb_with_obstacle import _default_components
+
+    grid = TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1))
+    return MFGProblem(geometry=grid, T=0.2, Nt=4, sigma=0.2, components=_default_components())
+
+
+@pytest.fixture(autouse=True)
+def _quiet():
+    logging.disable(logging.CRITICAL)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        yield
+    logging.disable(logging.NOTSET)
+
+
+@pytest.mark.parametrize("solver_cls", [NetworkHJBSolver, NetworkPolicyIterationHJBSolver])
+def test_a_grid_problem_is_refused_loudly(solver_cls):
+    """`NotImplementedError`, not `AttributeError`. The type is the contract here: it is what
+    separates "this solver does not apply to your problem" from "this solver is broken"."""
+    with pytest.raises(NotImplementedError):
+        solver_cls(_grid_problem())
+
+
+def test_the_policy_iteration_refusal_names_what_it_needs():
+    """It skips the base class's node-BC refusal, so its own message is the only one a caller of
+    that solver ever sees. A refusal that does not say what would satisfy it is a dead end."""
+    with pytest.raises(NotImplementedError) as excinfo:
+        NetworkPolicyIterationHJBSolver(_grid_problem())
+
+    message = str(excinfo.value)
+    assert "network problem" in message
+    assert "num_nodes" in message, "the requirement must be nameable, not just gestured at"
+    assert "TensorProductGrid" in message, "and the caller's actual geometry, so they can see the mismatch"
+
+
+def test_a_problem_with_num_nodes_but_no_adjacency_is_also_refused():
+    """Why the guard wraps all three reads instead of testing one attribute.
+
+    A single-attribute guard passes a half-network problem through to the next line, where the
+    AttributeError this issue is about reappears one statement later.
+    """
+
+    class _HalfNetwork:
+        num_nodes = 7
+
+        def __getattr__(self, name):
+            if name in {"get_adjacency_matrix", "get_laplacian_matrix"}:
+                raise AttributeError(name)
+            return getattr(_grid_problem(), name)
+
+    with pytest.raises(NotImplementedError, match="adjacency"):
+        NetworkPolicyIterationHJBSolver(_HalfNetwork())
+
+
+def test_the_guard_does_not_use_hasattr():
+    """The fail-fast ratchet counts `hasattr` calls, and this guard moved it 107 -> 108 in its
+    first form. Pinned because the obvious rewrite of a try/except is the thing the policy forbids.
+    """
+    import inspect
+
+    source = inspect.getsource(NetworkHJBSolver.__init__)
+    assert "hasattr(problem" not in source, "use try/except AttributeError, per the fail-fast policy"

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -830,3 +830,44 @@ def test_every_cell_that_solves_records_the_picard_verdict():
         n.name for n in solving if "_picard_verdict" not in ast.dump(n) and "_picard_verdict" not in ast.unparse(n)
     )
     assert not missing, f"these solve a problem and never record whether it converged: {missing}"
+
+
+# ---------------------------------------------------------------------------------------------
+# #2041: `_solved`'s truth table. The defect was that a key could VETO a verdict without being
+# able to TRIGGER one, so an artifact whose only convergence evidence was negative gated green.
+# Nothing here read `_solved` directly before -- `test_every_cell_that_solves_records_the_picard_
+# verdict` reads the SOURCE for record-and-gate presence, which is a different question.
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("artifact", "expected", "why"),
+    [
+        ({"picard_converged": True}, True, "the unprefixed flag, converged"),
+        ({"picard_converged": False}, False, "the unprefixed flag, not converged"),
+        ({"fdm_picard_converged": True, "fvm_picard_converged": True}, True, "both sides converged"),
+        ({"fdm_picard_converged": True, "fvm_picard_converged": False}, False, "the FVM side vetoes"),
+        ({"fdm_picard_converged": False, "fvm_picard_converged": True}, False, "the FDM side vetoes"),
+        (
+            {"fvm_picard_converged": False},
+            False,
+            "#2041: the ONLY evidence says it did not converge -- this gated GREEN before, because "
+            "the fvm_ key could veto but never trigger",
+        ),
+        ({"all_finite": True, "max_drift": 0.0}, True, "no flag at all: absent means NOT APPLICABLE"),
+        ({"picard_converged": None}, False, "None is not convergence; fail safe"),
+    ],
+)
+def test_solved_truth_table(cm, artifact, expected, why):
+    assert cm._solved(artifact) is expected, why
+
+
+def test_any_prefixed_convergence_flag_both_triggers_and_contributes(cm):
+    """The general property, so a NEW prefix added later is covered by construction.
+
+    `_picard_verdict(result, prefix=...)` takes an arbitrary prefix and nothing pairs the keys it
+    writes. The old hardcoded trigger pair meant a future `sl_`-prefixed cell would gate green on
+    an unconverged solve; this asserts the shape rather than the two prefixes that exist today.
+    """
+    assert cm._solved({"anything_at_all_picard_converged": False}) is False
+    assert cm._solved({"anything_at_all_picard_converged": True}) is True


### PR DESCRIPTION
Both were verified during the #2002/#2005 work and are fully specified by their issues. Neither changes numerics.

## #2041 — a field that can only *weaken* a verdict was the field that *triggered* one

`_solved`'s trigger tuple was `("picard_converged", "fdm_picard_converged")`; `fvm_picard_converged` appeared only in the `and` clause. Measured before the fix:

| artifact | `_solved` |
|---|---|
| `fdm=True, fvm=False` | `False` |
| `fdm=False, fvm=True` | `False` |
| **`fvm=False` alone** | **`True`** |

That last row fell through to `return True` — the *"absent means not applicable"* branch, meant for construction cells that run no coupled iteration at all. **The only convergence evidence present said the solve did not converge, and the cell gated green.**

Unreachable at the time, because the one prefixed caller writes both keys in a single expression. But `_picard_verdict(result, prefix=...)` takes an arbitrary prefix and nothing pairs them, so an FVM-only cell was one addition away.

Every `*picard_converged` key now both triggers and contributes, so a future prefix is covered by construction rather than by someone remembering to extend a tuple. Pinned by an 8-row truth table **and** by the general property (`anything_at_all_picard_converged`); mutation-verified against the restored hardcoded pair.

## #2045 — two siblings failing differently, and only one on purpose

| solver | on a grid problem, before |
|---|---|
| `NetworkHJBSolver` | `NotImplementedError`, naming node BCs |
| `NetworkPolicyIterationHJBSolver` | `AttributeError: 'MFGProblem' object has no attribute 'num_nodes'` |

The asymmetry is subtle rather than accidental: the policy-iteration solver sets `_honors_node_bc`, so it **skips** the base class's deliberate refusal and fell through to the first network-only attribute read. An `AttributeError` from inside construction is indistinguishable from a defect in the solver — and it is the bucket a capability sweep reads as "harness problem" rather than "solver refused".

## The guard is `try/except`, not `hasattr`, and that was not a style choice

The first draft used `hasattr(problem, "num_nodes")`. The fail-fast ratchet caught it:

```
FAIL: new fail-fast violations introduced
  hasattr: 107 -> 108 (+1)
```

That policy names try-except as the replacement for `hasattr` — and the same trap caught me earlier in this session, inside a fix for silent skipping. It is also the better guard on the merits: wrapping all three network reads catches a problem that carries `num_nodes` but no adjacency accessor, where a single-attribute guard hands it to the next line and the `AttributeError` reappears one statement later. There is a test for exactly that case, and one asserting the guard does not reintroduce `hasattr`.

Mutation-verified: restoring the bare `AttributeError` reddens three of the five tests.

65 passed across the capability-matrix and network suites; the fail-fast ratchet is back at 107.