### PR TITLE
fix(geometry)!: there is no default Robin, and a uniform BC forwards (#2042)

### DIFF
--- a/changelog.d/2042-no-default-robin.fixed.md
+++ b/changelog.d/2042-no-default-robin.fixed.md
@@ -1,0 +1,14 @@
+**There is no default Robin** (#2042). `_update_ghosts_mixed` synthesized a `__default__` segment
+from `bc_type` and `default_value` only, so `alpha`, `beta` and callable values were dropped and
+`BCSegment`'s own `alpha=1.0, beta=0.0` took their place — and **`beta = 0` is Dirichlet**. A
+defaulted Robin therefore became a *different* boundary condition rather than an approximate one,
+bit-for-bit identical to `dirichlet_bc(value=g)` and independent of the α and β actually passed. It
+now raises, naming what is missing and what the silent default would have produced;
+`BoundaryConditions` carries `default_bc` and `default_value` and no `default_alpha`/`default_beta`,
+so there is nothing to infer from. This continues #1100's ruling, where `_resolve_default_bc`
+already refuses to guess an unset `default_bc`.
+
+A **uniform** BC reaching that path now forwards its single segment instead of rebuilding a partial
+copy — the information is present, and forwarding makes the two ghost paths agree exactly where they
+previously diverged (Robin, and a callable Neumann value). This is not the `bc.segments[0]` fallback
+the surrounding comment rejects: that one fired on *mixed* BCs, where `[0]` means highest priority.

--- a/changelog.d/2042-no-default-robin.fixed.md
+++ b/changelog.d/2042-no-default-robin.fixed.md
@@ -12,3 +12,11 @@ A **uniform** BC reaching that path now forwards its single segment instead of r
 copy — the information is present, and forwarding makes the two ghost paths agree exactly where they
 previously diverged (Robin, and a callable Neumann value). This is not the `bc.segments[0]` fallback
 the surrounding comment rejects: that one fired on *mixed* BCs, where `[0]` means highest priority.
+
+The discrimination baseline is regenerated in the same change. `bc_uniform_dispatch_reads_as_mixed`
+falls **43 → 12**, and the fall is the fix rather than a regression: the 31 tests that stopped
+noticing were detecting the divergence between the two ghost paths, which is exactly what the
+forward removes. Attributed by A/B on the same mutation and anchor — 43 on `main`, 12 with this
+change, product code the only difference — and recorded as a note in the baseline, because the
+ratchet reads any fall as a regression and cannot see that distinction. Four other rows rose and no
+row went `INEFFECTIVE`.

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -1578,9 +1578,7 @@ class PreallocatedGhostBuffer:
                     if bc.is_uniform:
                         segment = bc.segments[0]
                     else:
-                        default_type = bc._resolve_default_bc(
-                            "PreallocatedGhostBuffer._update_ghosts_mixed"
-                        )
+                        default_type = bc._resolve_default_bc("PreallocatedGhostBuffer._update_ghosts_mixed")
                         # (b) A genuinely mixed BC with an unclaimed face. There is nothing to
                         #     forward: `default_value` is declared, `default_alpha`/`default_beta`
                         #     do not exist on BoundaryConditions at all. `BCSegment`'s defaults are

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -1565,12 +1565,50 @@ class PreallocatedGhostBuffer:
                     # guessing -- that is deliberate and it is why this is not a silent change: a BC
                     # whose segments do not cover every face and which names no default was
                     # previously given one by accident of sort order.
-                    default_type = bc._resolve_default_bc("PreallocatedGhostBuffer._update_ghosts_mixed")
-                    segment = BCSegment(
-                        name="__default__",
-                        bc_type=default_type,
-                        value=bc.default_value,
-                    )
+                    # #2042: two situations arrive here and only one of them has an answer.
+                    #
+                    # (a) A UNIFORM BC took this path -- exactly one segment, no boundary
+                    #     restriction, so no priority ambiguity and nothing to choose between.
+                    #     Forward it. This is reading the data that is present, not the
+                    #     `bc.segments[0]` fallback the comment above rejects: that one fired on
+                    #     MIXED BCs, where [0] means "highest priority" and handed every unclaimed
+                    #     wall the exit. `is_uniform` is exactly the case where that cannot happen.
+                    #     Synthesising instead drops `alpha`, `beta` and any callable value --
+                    #     measured, a Robin wall became a clean Dirichlet(3.0) bit for bit.
+                    if bc.is_uniform:
+                        segment = bc.segments[0]
+                    else:
+                        default_type = bc._resolve_default_bc(
+                            "PreallocatedGhostBuffer._update_ghosts_mixed"
+                        )
+                        # (b) A genuinely mixed BC with an unclaimed face. There is nothing to
+                        #     forward: `default_value` is declared, `default_alpha`/`default_beta`
+                        #     do not exist on BoundaryConditions at all. `BCSegment`'s defaults are
+                        #     `alpha=1.0, beta=0.0`, and **beta = 0 IS Dirichlet** -- so defaulting
+                        #     a ROBIN silently changes the boundary condition's TYPE rather than
+                        #     approximating it, and the caller cannot see it happen.
+                        #
+                        #     There is no default Robin. This continues #1100's ruling one level
+                        #     down: `_resolve_default_bc` already raises when `default_bc` is unset
+                        #     "rather than guessing", and an unspecified alpha/beta is the same
+                        #     incompleteness.
+                        if default_type is BCType.ROBIN:
+                            raise NotImplementedError(
+                                f"This boundary condition names ROBIN as its default, and face "
+                                f"{target_face} is claimed by no segment -- but a Robin needs "
+                                f"`alpha` and `beta`, and `BoundaryConditions` carries no "
+                                f"`default_alpha`/`default_beta` to take them from. Defaulting "
+                                f"them would use BCSegment's `alpha=1.0, beta=0.0`, and beta = 0 "
+                                f"is DIRICHLET -- the wall would silently become a different "
+                                f"boundary condition, not an approximate one. Add a segment "
+                                f"covering {target_face} with explicit alpha/beta, or choose a "
+                                f"default_bc that needs neither (Issue #2042)."
+                            )
+                        segment = BCSegment(
+                            name="__default__",
+                            bc_type=default_type,
+                            value=bc.default_value,
+                        )
 
                 # Apply ghost cell formula for this face
                 self._apply_ghost_for_face(buf, axis, side, segment, time, g)

--- a/scripts/check_assertion_strength.py
+++ b/scripts/check_assertion_strength.py
@@ -120,19 +120,19 @@ def scan(root: Path):
     return weak, total
 
 
-_CONTROL_WEAK = '''
+_CONTROL_WEAK = """
 def test_only_shape():
     result = compute()
     assert result is not None
     assert result.shape == (3, 3)
     assert np.all(np.isfinite(result))
-'''
+"""
 
-_CONTROL_STRONG = '''
+_CONTROL_STRONG = """
 def test_the_value_is_right():
     result = compute()
     assert np.allclose(result, EXACT, atol=1e-12)
-'''
+"""
 
 
 def self_test() -> int:

--- a/scripts/check_fail_fast.py
+++ b/scripts/check_fail_fast.py
@@ -107,7 +107,7 @@ def _counts(results: dict) -> dict:
 
 #: A file every category must fire on, and one every category must ignore. Both halves matter:
 #: the first proves the check still SEES, the second proves it is not matching indiscriminately.
-_CONTROL_POSITIVE = '''
+_CONTROL_POSITIVE = """
 def each_category_once(obj):
     if hasattr(obj, "x"):          # hasattr
         pass
@@ -123,7 +123,7 @@ def each_category_once(obj):
         obj()
     except Exception as exc:       # broad_except
         raise RuntimeError from exc
-'''
+"""
 
 _CONTROL_NEGATIVE = '''
 def nothing_to_find(obj):

--- a/scripts/discrimination_baseline.json
+++ b/scripts/discrimination_baseline.json
@@ -1,13 +1,16 @@
 {
   "_comment": "Kill counts per mutated convention. --check-baseline fails when a count DROPS (discrimination lost) and when one RISES (record the gain in the same change). Counts, not test names: this population cannot be selected by name -- the agreement-shaped patterns give 51, 114 or 156 depending on the regex.",
   "_measured_at": {
-    "collected": 6384,
-    "commit": "03e41944",
+    "collected": 6420,
+    "commit": "27124db1",
     "excluded": "tests/unit/test_discrimination_ratchet.py",
     "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment and not manual",
     "paths": [
       "tests"
     ]
+  },
+  "_notes": {
+    "bc_uniform_dispatch_reads_as_mixed": "43 -> 12 on 2026-08-22, and the fall is the FIX rather than a regression. #2042 made the per-face ghost path forward a uniform BC's single segment instead of rebuilding a partial copy, so the two paths now agree where they used to diverge (Robin became a bit-identical Dirichlet; a callable Neumann value became its static default). The 31 tests that stopped killing this mutation were detecting THAT DIVERGENCE. They did not get weaker -- the thing they detected got smaller. Attributed by A/B on the same mutation and anchor: 43 on main, 12 with #2042, product code the only difference. What still kills it is the order > 2 path, which #2042 did not touch and which the mutation's `verify` probe uses. GENERAL POINT, and the reason this note exists rather than a bare number: fixing a defect can LOWER a discrimination score, because the defect was what made the convention observable. The ratchet reads any fall as a regression and cannot see that difference -- only a note can."
   },
   "mutations": {
     "bc_default_reads_as_reflect": {
@@ -21,7 +24,7 @@
       "status": "ok"
     },
     "bc_uniform_dispatch_reads_as_mixed": {
-      "kill_count": 43,
+      "kill_count": 12,
       "owner": "PreallocatedGhostBuffer.update_ghosts routes a uniform BC to the single-segment path and a mixed BC to the per-face path (#577 Phase 3 for the mixed rewrite, #1255 (C) for the alpha/beta forwarding the uniform branch carries). The two paths are NOT equivalent: the uniform branch applies the inhomoge",
       "status": "ok"
     },
@@ -31,7 +34,7 @@
       "status": "ok"
     },
     "diffusion_scalar_2x": {
-      "kill_count": 162,
+      "kill_count": 163,
       "owner": "D = sigma^2/2 for scalar sigma (#811)",
       "status": "ok"
     },
@@ -41,7 +44,7 @@
       "status": "ok"
     },
     "fp_initial_condition_written_at_final_index": {
-      "kill_count": 128,
+      "kill_count": 129,
       "owner": "The FP marches FORWARD from t=0 with m_0 written at time row 0 -- the initial-condition half of the HJB/FP boundary-data pair. Single site in the live FDM FP time loop, fp_fdm_time_stepping.py:797, whose own docstring states the convention at :681: \"- Forward time evolution: k=0 -> Nt-1\". No issue n",
       "status": "ok"
     },
@@ -56,7 +59,7 @@
       "status": "ok"
     },
     "godunov_branch_swap": {
-      "kill_count": 29,
+      "kill_count": 31,
       "owner": "Godunov upwind takes the BACKWARD difference where the central gradient is >= 0 -- the library's one statement of the upwind selection rule, consumed by the HJB residual, the HJB Jacobian, GradientOperator and AdvectionOperator (#1896 items 3-4 turn on it)",
       "status": "ok"
     },
@@ -86,7 +89,7 @@
       "status": "ok"
     },
     "neumann_low_wall_flux_sign": {
-      "kill_count": 37,
+      "kill_count": 39,
       "owner": "inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and the offset is ADDED, the same sign as the high wall (#1262). Since #1967 the magnitude is (2k-1)*dx*v rather than dx*v -- ghost layer k sits that far from its mirror -- so the k=1 case is the historical dx*v and the deeper layers scale.",
       "status": "ok"
     },

--- a/scripts/discrimination_killmatrix.json
+++ b/scripts/discrimination_killmatrix.json
@@ -1,7 +1,7 @@
 {
   "_measured_at": {
-    "collected": 6384,
-    "commit": "03e41944",
+    "collected": 6420,
+    "commit": "27124db1",
     "excluded": "tests/unit/test_discrimination_ratchet.py",
     "markers": "not slow and not benchmark and not experimental and not optional_torch and not environment and not manual",
     "paths": [
@@ -9,7 +9,7 @@
     ]
   },
   "_selection_regex_for_agreement_shaped": "::[^:]*?(_agree|_agrees|_matches|_equals|_single_source|_identical|_consistent)",
-  "baseline_seconds": 131.2,
+  "baseline_seconds": 136.4,
   "killed_by": {
     "tests/integration/test_1043_coupler_fp_drift_convention.py::TestBlockIteratorFPDriftConvention::test_block_gauss_seidel_runs_and_produces_finite_M": [
       "m_initial_1d_counting_measure",
@@ -535,15 +535,6 @@
       "periodic_endpoint_convention_inverted",
       "periodic_wrap_endpoint_inverted"
     ],
-    "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_high_wall_ghost_uses_general_robin_not_neumann": [
-      "bc_uniform_dispatch_reads_as_mixed"
-    ],
-    "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_low_wall_ghost_uses_general_robin_not_neumann": [
-      "bc_uniform_dispatch_reads_as_mixed"
-    ],
-    "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_uniform_matches_mixed_segment_path": [
-      "bc_uniform_dispatch_reads_as_mixed"
-    ],
     "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverHelperMethods::test_compute_gradient": [
       "grid_spacing_uses_point_count"
     ],
@@ -673,12 +664,8 @@
       "upwind_jacobian_tiebreak_inverted",
       "neumann_low_wall_flux_sign"
     ],
-    "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[False]": [
-      "bc_uniform_dispatch_reads_as_mixed"
-    ],
     "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[True]": [
-      "godunov_branch_swap",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "godunov_branch_swap"
     ],
     "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_every_row_linearises_the_residual[piecewise_linear-True-dirichlet]": [
       "godunov_branch_swap",
@@ -740,7 +727,7 @@
       "periodic_endpoint_convention_inverted",
       "periodic_wrap_endpoint_inverted"
     ],
-    "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_obstacle": [
+    "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_a_state_penalty": [
       "terminal_condition_pinned_at_initial_index",
       "fp_initial_condition_written_at_final_index"
     ],
@@ -1180,6 +1167,9 @@
     "tests/unit/test_check_single_source.py::test_repo_baseline_is_current": [
       "drift_coefficient_2x"
     ],
+    "tests/unit/test_config/test_array_validation.py::TestMFGArrays::test_M_solution_mass_conservation_warning_final": [
+      "fp_initial_condition_written_at_final_index"
+    ],
     "tests/unit/test_convention_agreement.py::TestHJBResidualNormGridScaling::test_the_scaled_norm_converges_to_the_continuum_l2_norm[201]": [
       "newton_residual_grid_scaling_dropped"
     ],
@@ -1355,6 +1345,13 @@
     "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_scalar_is_converted": [
       "diffusion_scalar_2x"
     ],
+    "tests/unit/test_core/test_state_penalty_is_a_potential_2002.py::test_a_wall_is_a_cost_not_a_reward": [
+      "godunov_branch_swap"
+    ],
+    "tests/unit/test_core/test_state_penalty_is_a_potential_2002.py::test_the_wall_is_local": [
+      "diffusion_scalar_2x",
+      "godunov_branch_swap"
+    ],
     "tests/unit/test_core/test_unified_mfg_problem.py::TestNDGridMode::test_diffusion_converts_to_sigma": [
       "diffusion_scalar_2x"
     ],
@@ -1417,6 +1414,12 @@
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_two_paths_agree_on_an_inhomogeneous_flux_at_depth": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_no_default_robin_2042.py::test_a_uniform_bc_gives_the_same_answer_on_either_path[neumann-callable]": [
+      "neumann_low_wall_flux_sign"
+    ],
+    "tests/unit/test_geometry/boundary/test_no_default_robin_2042.py::test_a_uniform_bc_gives_the_same_answer_on_either_path[neumann-scalar]": [
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/boundary/test_normal_drift_provider_1970.py::test_the_constructor_coefficient_wins_over_the_state": [
@@ -1484,67 +1487,49 @@
       "grid_interval_count_reads_as_points"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_a_singular_coefficient_raises_rather_than_mirroring": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[-1.5]": [
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
-    "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[0.0]": [
-      "bc_uniform_dispatch_reads_as_mixed"
-    ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[2.0]": [
-      "bc_uniform_dispatch_reads_as_mixed",
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.0-1.0-0.7]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.5-2.0--0.3]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.0]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.7]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-2.0-0.5-0.0]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-3.0--0.4-1.1]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.0-1.0-0.7]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.5-2.0--0.3]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.0]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.7]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-2.0-0.5-0.0]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-3.0--0.4-1.1]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/grids/test_tensor_grid_regions.py::TestBoundaryRegionMarking::test_3d_boundary_naming": [
       "grid_interval_count_reads_as_points"
@@ -1670,16 +1655,13 @@
       "neumann_low_wall_flux_sign"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.01]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.05]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.5]": [
-      "ghost_spacing_ignored",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "ghost_spacing_ignored"
     ],
     "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_spacing_accepts_a_scalar_or_one_value_per_axis[0.05]": [
       "ghost_spacing_ignored",
@@ -1752,9 +1734,6 @@
     "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_low_ghost_plus_dx_v": [
       "neumann_low_wall_flux_sign"
     ],
-    "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_a_constant_field_is_unchanged_by_the_periodic_fill[uniform-path]": [
-      "bc_uniform_dispatch_reads_as_mixed"
-    ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[mixed-path-1]": [
       "periodic_wrap_endpoint_inverted"
     ],
@@ -1765,28 +1744,22 @@
       "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-1]": [
-      "periodic_wrap_endpoint_inverted",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-2]": [
-      "periodic_wrap_endpoint_inverted",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-3]": [
-      "periodic_wrap_endpoint_inverted",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[1]": [
-      "periodic_wrap_endpoint_inverted",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[2]": [
-      "periodic_wrap_endpoint_inverted",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[3]": [
-      "periodic_wrap_endpoint_inverted",
-      "bc_uniform_dispatch_reads_as_mixed"
+      "periodic_wrap_endpoint_inverted"
     ],
     "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_3_dirichlet_1d": [
       "bc_uniform_dispatch_reads_as_mixed"
@@ -1961,7 +1934,7 @@
         "tests/unit/test_geometry/test_bc_utils_geometric_operation.py::TestGeometricOperationMapping::test_absent_bc_defaults_to_clamp_not_reflect"
       ],
       "owner": "absent BC defaults to clamp/absorbing (#1698)",
-      "seconds": 133.6,
+      "seconds": 152.2,
       "status": "ok",
       "verify": "bc_type_to_geometric_operation(None) == 'reflect'"
     },
@@ -1980,61 +1953,30 @@
         "tests/unit/test_geometry/test_mixed_bc_refused_1697.py::test_default_bc_is_a_second_lever_with_no_permutation_available"
       ],
       "owner": "no_flux/neumann/robin -> reflect (#1698)",
-      "seconds": 130.8,
+      "seconds": 150.0,
       "status": "ok",
       "verify": "bc_type_to_geometric_operation('no_flux') == 'clamp'"
     },
     "bc_uniform_dispatch_reads_as_mixed": {
-      "kill_count": 43,
+      "kill_count": 12,
       "killed": [
-        "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_high_wall_ghost_uses_general_robin_not_neumann",
-        "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_low_wall_ghost_uses_general_robin_not_neumann",
-        "tests/unit/test_alg/test_fp_particle_gradient_bc_1255.py::TestUniformRobinGhostAlphaBeta::test_uniform_matches_mixed_segment_path",
-        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[False]",
-        "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_time_dependent_boundary_reaches_the_advection_block[True]",
         "tests/unit/test_alg/test_weno_family.py::TestWenoHJDerivativeCorrectness::test_gradient_accurate_at_boundary_nodes",
         "tests/unit/test_alg/test_weno_ghost_order.py::test_weno_ghost_cells_work",
         "tests/unit/test_alg/test_weno_mms_order_1991.py::test_advection_dominated_order_reaches_weno5",
         "tests/unit/test_alg/test_weno_mms_order_1991.py::test_diffusion_dominated_order_is_two",
         "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_2d_solve_still_reproduces_the_pre_consolidation_output",
         "tests/unit/test_alg/test_weno_one_dimensional_solve_2021.py::test_the_3d_solve_runs_at_all",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_a_singular_coefficient_raises_rather_than_mirroring",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[-1.5]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[0.0]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_robin_with_alpha_zero_beta_one_is_the_neumann_condition[2.0]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.0-1.0-0.7]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-0.5-2.0--0.3]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.0]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-1.0-0.3-0.7]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-2.0-0.5-0.0]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[max-3.0--0.4-1.1]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.0-1.0-0.7]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-0.5-2.0--0.3]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.0]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-1.0-0.3-0.7]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-2.0-0.5-0.0]",
-        "tests/unit/test_geometry/boundary/test_robin_outward_normal_1907.py::test_the_ghost_satisfies_the_declared_condition_at_both_walls[min-3.0--0.4-1.1]",
         "tests/unit/test_geometry/test_ghost_buffer_order.py::test_order_3_works",
         "tests/unit/test_geometry/test_ghost_buffer_order.py::test_order_5_works",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.01]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.05]",
-        "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_robin_reads_the_same_spacing[0.5]",
-        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_a_constant_field_is_unchanged_by_the_periodic_fill[uniform-path]",
-        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-1]",
-        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-2]",
-        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_periodic_ghosts_hold_the_analytic_continuation[uniform-path-3]",
-        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[1]",
-        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[2]",
-        "tests/unit/test_geometry/test_periodic_ghost_fill_1822.py::test_the_exclusive_convention_wraps_without_skipping_a_node[3]",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_3_dirichlet_1d",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_3_neumann_1d",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_5_neumann_both_boundaries_accurate",
         "tests/unit/test_geometry/test_poly_extrapolation.py::test_order_5_nonzero_neumann_flux"
       ],
       "owner": "PreallocatedGhostBuffer.update_ghosts routes a uniform BC to the single-segment path and a mixed BC to the per-face path (#577 Phase 3 for the mixed rewrite, #1255 (C) for the alpha/beta forwarding the uniform branch carries). The two paths are NOT equivalent: the uniform branch applies the inhomoge",
-      "seconds": 144.3,
+      "seconds": 138.1,
       "status": "ok",
-      "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), robin_bc(dimension=1, alpha=1.0, beta=1.0, value=3.0), ghost_depth=1, spacing=0.05)[0] == 5.0"
+      "verify": "abs(_ghost0(neumann_bc(dimension=1, value=2.0), 3) - 1.1) < 1e-12"
     },
     "diffusion_field_2x": {
       "kill_count": 7,
@@ -2048,12 +1990,12 @@
         "tests/unit/test_utils/test_diffusion_from_volatility.py::TestField::test_2d_field_is_elementwise"
       ],
       "owner": "D = sigma^2/2 elementwise for a volatility field (#811)",
-      "seconds": 133.0,
+      "seconds": 136.7,
       "status": "ok",
       "verify": "float(diffusion_from_volatility(np.array([2.0]), kind='field')[0]) == 4.0"
     },
     "diffusion_scalar_2x": {
-      "kill_count": 162,
+      "kill_count": 163,
       "killed": [
         "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[1]",
         "tests/integration/test_diffusion_magnitude_gate.py::test_adi_diffusion_magnitude[2]",
@@ -2209,6 +2151,7 @@
         "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_array_collapses_to_mean_with_warning",
         "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_none_uses_fallback_sigma",
         "tests/unit/test_core/test_pde_coefficients.py::TestScalarDiffusionFromVolatility::test_scalar_is_converted",
+        "tests/unit/test_core/test_state_penalty_is_a_potential_2002.py::test_the_wall_is_local",
         "tests/unit/test_core/test_unified_mfg_problem.py::TestNDGridMode::test_diffusion_converts_to_sigma",
         "tests/unit/test_fp_fvm.py::test_gate3_convergence_muscl_second_order",
         "tests/unit/test_fp_fvm.py::test_gate3_convergence_upwind_first_order",
@@ -2219,7 +2162,7 @@
         "tests/unit/test_utils/test_diffusion_from_volatility.py::TestScalar::test_scalar_needs_no_kind"
       ],
       "owner": "D = sigma^2/2 for scalar sigma (#811)",
-      "seconds": 133.8,
+      "seconds": 138.0,
       "status": "ok",
       "verify": "diffusion_from_volatility(2.0) == 4.0"
     },
@@ -2257,12 +2200,12 @@
         "tests/unit/test_core/test_pde_coefficients.py::TestFpDriftCoefficient::test_sources_inverse_control_cost_from_quadratic_hamiltonian[2.0]"
       ],
       "owner": "FP drift c = 1/control_cost (#1420 / G-017)",
-      "seconds": 136.8,
+      "seconds": 137.2,
       "status": "ok",
       "verify": "fp_drift_coefficient(_stub_problem(control_cost=2.0)) == 1.0"
     },
     "fp_initial_condition_written_at_final_index": {
-      "kill_count": 128,
+      "kill_count": 129,
       "killed": [
         "tests/integration/test_1043_coupler_fp_drift_convention.py::TestBlockIteratorFPDriftConvention::test_block_gauss_seidel_runs_and_produces_finite_M",
         "tests/integration/test_1043_coupler_fp_drift_convention.py::TestFictitiousPlayFPDriftConvention::test_fictitious_play_density_is_non_negative",
@@ -2369,7 +2312,7 @@
         "tests/unit/test_alg/test_fp_nonquadratic.py::TestNonQuadraticHamiltonians::test_quartic_control_drift",
         "tests/unit/test_alg/test_hjb_analytic_jacobian_1607.py::test_analytic_jacobian_matches_fd_solution",
         "tests/unit/test_alg/test_hjb_newton_reports_returned_iterate.py::test_the_configuration_still_exercises_the_non_converged_path",
-        "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_obstacle",
+        "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_a_state_penalty",
         "tests/unit/test_alg/test_issue_1248_volatility_forwarding.py::TestD1SolveMustForwardVolatilityField::test_array_sigma_solve_differs_from_mean_sigma_solve",
         "tests/unit/test_alg/test_issue_1248_volatility_forwarding.py::TestD1SolveMustForwardVolatilityField::test_scalar_sigma_solve_is_unchanged",
         "tests/unit/test_alg/test_meshless_stabilization.py::test_recipe_coupled_matches_fdm_on_wellposed_problem[newton_sd]",
@@ -2390,11 +2333,12 @@
         "tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeSwitchingSolve::test_solutions_are_finite",
         "tests/unit/test_alg/test_regime_switching_iterator.py::TestRegimeSwitchingUpdateSchemes::test_jacobi_scheme",
         "tests/unit/test_alg/test_s1_drift_convention_routing.py::test_u_as_drift_field_solves_a_different_problem_than_u_as_potential_field",
+        "tests/unit/test_config/test_array_validation.py::TestMFGArrays::test_M_solution_mass_conservation_warning_final",
         "tests/unit/test_fp_fvm.py::test_gate4_fvm_fdm_agreement_shrinks",
         "tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py::test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmless"
       ],
       "owner": "The FP marches FORWARD from t=0 with m_0 written at time row 0 -- the initial-condition half of the HJB/FP boundary-data pair. Single site in the live FDM FP time loop, fp_fdm_time_stepping.py:797, whose own docstring states the convention at :681: \"- Forward time evolution: k=0 -> Nt-1\". No issue n",
-      "seconds": 236.6,
+      "seconds": 193.1,
       "status": "ok",
       "verify": "float(np.sum(solve_fp_nd_full_system(np.ones(6), np.zeros((3, 6)), MFGProblem(model=Model(hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: 0.0 * m, coupling_dm=lambda m: 0.0), sigma=0.3), domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[6], boundary_conditions=no_flux_bc(dimension=1)), conditions=Conditions(u_terminal=lambda x: 3.0 + 0.0 * x, m_initial=lambda x: 1.0 + 0.0 * x, T=0.1), Nt=2))[0])) == 0.0"
     },
@@ -2409,7 +2353,7 @@
         "tests/unit/test_operators/test_divergence.py::TestAdvectionPeriodicGridConvention::test_the_wrap_face_velocity_comes_from_the_last_real_cell_not_the_repeat"
       ],
       "owner": "the conservative FV upwind flux takes the UPSTREAM cell: F_{i+1/2} = v_{i+1/2} m_i when v_{i+1/2} >= 0, else v_{i+1/2} m_{i+1} (#1184 / #1428)",
-      "seconds": 131.6,
+      "seconds": 131.7,
       "status": "ok",
       "verify": "float(AdvectionOperator(velocity_field=np.ones((1, 3)), spacings=[1.0], field_shape=(3,), scheme='upwind', form='divergence', bc=no_flux_bc(dimension=1), mass_conservative=True)(np.array([1.0, 2.0, 3.0]))[0]) == 2.0"
     },
@@ -2476,12 +2420,12 @@
         "tests/unit/test_geometry/test_ghost_spacing_1904.py::test_the_solver_gradient_path_now_carries_the_spacing[2.0-81]"
       ],
       "owner": "the ghost buffer uses the caller's spacing, not dx = 1.0 (#1904)",
-      "seconds": 132.5,
+      "seconds": 148.3,
       "status": "ok",
       "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 3.0"
     },
     "godunov_branch_swap": {
-      "kill_count": 29,
+      "kill_count": 31,
       "killed": [
         "tests/integration/test_fdm_solvers_mfg_complete.py::TestFDMSolversMFGIntegration::test_fdm_periodic_bc_solution",
         "tests/integration/test_hjb_fdm_2d_validation.py::TestHJBFDM2DSolving::test_2d_solve_fixed_point",
@@ -2509,12 +2453,14 @@
         "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-NO_FLUX]",
         "tests/unit/test_alg/test_periodic_capability_invariant_1822.py::test_a_declared_bc_type_is_honoured[HJBFDMSolver-PERIODIC]",
         "tests/unit/test_alg/test_true_adjoint.py::TestJacobianTransposeEqualsAdvection::test_jacobian_coefficients_match_analytical_dh_dp",
+        "tests/unit/test_core/test_state_penalty_is_a_potential_2002.py::test_a_wall_is_a_cost_not_a_reward",
+        "tests/unit/test_core/test_state_penalty_is_a_potential_2002.py::test_the_wall_is_local",
         "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_result_shape",
         "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_selection_rule_is_the_godunov_one_not_merely_accurate",
         "tests/unit/test_operators/test_stencils.py::TestGradientUpwind::test_the_selection_predicate_is_pinned_not_only_the_branch_bodies"
       ],
       "owner": "Godunov upwind takes the BACKWARD difference where the central gradient is >= 0 -- the library's one statement of the upwind selection rule, consumed by the HJB residual, the HJB Jacobian, GradientOperator and AdvectionOperator (#1896 items 3-4 turn on it)",
-      "seconds": 128.1,
+      "seconds": 120.3,
       "status": "ok",
       "verify": "float(gradient_upwind(np.array([0.0, 1.0, 3.0]), axis=0, h=1.0)[1]) == 2.0"
     },
@@ -2558,7 +2504,7 @@
         "tests/validation/test_stefan_analytical.py::TestStefanEnergyConservation::test_total_energy_preservation"
       ],
       "owner": "`Nx` names the INTERVAL count, so node count = Nx + 1 -- the #1889 interval-vs-node ambiguity at the grid's own entry point. Stated in the constructor docstring at tensor_grid.py:181-182: \"- Nx (intervals): Nx_points = Nx + 1\" / \"- Nx_points (points): Nx = Nx_points - 1\". Line 220-221 normalises a s",
-      "seconds": 132.3,
+      "seconds": 149.4,
       "status": "ok",
       "verify": "TensorProductGrid(bounds=[(0.0, 1.0)], Nx=[10], boundary_conditions=no_flux_bc(dimension=1)).Nx_points == [10]"
     },
@@ -2624,7 +2570,7 @@
         "tests/validation/test_stefan_analytical.py::TestNeumannSolution::test_convergence_with_grid_refinement"
       ],
       "owner": "uniform grid spacing is L/(node count - 1), not L/(node count) -- the L/n vs L/(n-1) convention. `self.spacing` is the single owner: get_grid_spacing() returns it verbatim (tensor_grid.py:823 `return self.spacing`), get_spacing() indexes it (:607), legacy_1d_attrs[\"Dx\"] reads it (:484), cell volume ",
-      "seconds": 133.5,
+      "seconds": 150.6,
       "status": "ok",
       "verify": "TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1)).get_grid_spacing()[0] == 1.0 / 11"
     },
@@ -2655,7 +2601,7 @@
         "tests/unit/test_alg/test_weak_form_hjb_picard_sign_2023.py::test_the_weak_form_family_agrees_with_the_reference_fdm_solver[2.0]"
       ],
       "owner": "The HJB marches BACKWARD in time, from the terminal row down to t=0, while the FP marches forward -- the adjoint pairing. Single site: base_hjb.py:1780, the only time loop in solve_hjb_system_backward. The M-indexing that rides on it is documented in the same loop body at base_hjb.py:1790: \"# BUG #7",
-      "seconds": 113.6,
+      "seconds": 122.8,
       "status": "ok",
       "verify": "float(solve_hjb_system_backward(np.ones((3, 6)), np.full(6, 3.0), np.zeros((3, 6)), MFGProblem(model=Model(hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0), coupling=lambda m: 0.0 * m, coupling_dm=lambda m: 0.0), sigma=0.3), domain=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[6], boundary_conditions=no_flux_bc(dimension=1)), conditions=Conditions(u_terminal=lambda x: 3.0 + 0.0 * x, m_initial=lambda x: 1.0 + 0.0 * x, T=0.1), Nt=2))[0, 0]) < 1.0"
     },
@@ -2682,7 +2628,7 @@
         "tests/unit/test_core/test_mfg_problem.py::test_mfg_problem_with_custom_initial_density"
       ],
       "owner": "m(0,.) integrates to 1 under the geometry's own volume element, not under the counting measure -- the 1-D branch of the four-way normalisation dispatch at mfg_problem.py:1996-2042. Owner established by #1888 (`tests/unit/test_core/test_initial_density_mass_1888.py`), whose module docstring records t",
-      "seconds": 125.8,
+      "seconds": 139.1,
       "status": "ok",
       "verify": "abs(float(np.sum(MFGProblem(geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)), Nt=4, T=0.2, sigma=1.0, components=MFGComponents(m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2).squeeze(), u_terminal=lambda x: 0.0, hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)))).m_initial)) - 1.0) < 1e-9"
     },
@@ -2693,12 +2639,12 @@
         "tests/unit/test_utils/test_mass_conservation_error_1672.py::test_the_coupled_solve_reports_the_quantity_it_documents[fdm_upwind]"
       ],
       "owner": "`SolverResult.mass_conservation_error` is DRIFT from the initial mass, `max|mass(t)/mass(0) - 1|`, not deviation from a 1.0 target (#1672). Documented at `mfgarchon/utils/solver_result.py:41` -- \"mass_conservation_error: max|mass(t)/mass(0) - 1| over time steps -- the drift from the\" -- and argued a",
-      "seconds": 134.5,
+      "seconds": 140.8,
       "status": "ok",
       "verify": "MFGProblem(geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)), Nt=4, T=0.2, sigma=1.0, components=MFGComponents(m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2).squeeze(), u_terminal=lambda x: 0.0, hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)))).solve(scheme=NumericalScheme.FDM_UPWIND, max_iterations=2, verbose=False).mass_conservation_error > 0.5"
     },
     "neumann_low_wall_flux_sign": {
-      "kill_count": 37,
+      "kill_count": 39,
       "killed": [
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_a_tied_wall_row_that_is_not_a_switching_node_still_gets_the_right_branch",
         "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_an_inhomogeneous_flux_is_exact_at_every_layer[low-1]",
@@ -2707,6 +2653,8 @@
         "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_depth_one_is_byte_identical[neumann-2.0]",
         "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_flux_offset_actually_scales_with_the_layer[low]",
         "tests/unit/test_geometry/boundary/test_ghost_layer_order_and_flux_1967.py::test_the_two_paths_agree_on_an_inhomogeneous_flux_at_depth",
+        "tests/unit/test_geometry/boundary/test_no_default_robin_2042.py::test_a_uniform_bc_gives_the_same_answer_on_either_path[neumann-callable]",
+        "tests/unit/test_geometry/boundary/test_no_default_robin_2042.py::test_a_uniform_bc_gives_the_same_answer_on_either_path[neumann-scalar]",
         "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[1]",
         "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[2]",
         "tests/unit/test_geometry/boundary/test_per_face_bc_path_1937.py::test_the_flux_is_applied_at_every_ghost_layer[3]",
@@ -2739,7 +2687,7 @@
         "tests/unit/test_geometry/test_neumann_low_wall_sign.py::TestNeumannLowWallSign::test_order2_low_ghost_plus_dx_v"
       ],
       "owner": "inhomogeneous Neumann is prescribed on the OUTWARD normal, so at the low wall (outward normal -x) du/dx = -v and the offset is ADDED, the same sign as the high wall (#1262). Since #1967 the magnitude is (2k-1)*dx*v rather than dx*v -- ghost layer k sits that far from its mirror -- so the k=1 case is the historical dx*v and the deeper layers scale.",
-      "seconds": 133.2,
+      "seconds": 130.4,
       "status": "ok",
       "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), neumann_bc(dimension=1, value=2.0), ghost_depth=1, spacing=0.05)[0] == 0.9"
     },
@@ -2753,7 +2701,7 @@
         "tests/unit/test_convention_agreement.py::TestHJBResidualNormGridScaling::test_the_scaling_is_what_makes_two_resolutions_comparable"
       ],
       "owner": "The HJB Newton residual is the grid-scaled discrete L2 norm ||F||_2 * sqrt(dx). Owner: hjb_residual_norm, base_hjb.py:1362, whose docstring says verbatim 'The one owner of \"how large is this HJB residual\".' and 'It is a function rather than an inline expression because the ``sqrt(dx)`` is load-beari",
-      "seconds": 138.0,
+      "seconds": 134.1,
       "status": "ok",
       "verify": "hjb_residual_norm(np.array([1.0, 0.0]), 0.25) == 1.0"
     },
@@ -2803,7 +2751,7 @@
         "tests/unit/test_core/test_lagrangian_base_alpha_sign_1642.py::TestOptimalControlSign::test_dual_lagrangian_alpha_star_matches_its_source_hamiltonian[p2-OptimizationSense.MINIMIZE]"
       ],
       "owner": "QuadraticControlCost alpha* = -sign*p/lambda (#1649)",
-      "seconds": 132.9,
+      "seconds": 143.1,
       "status": "ok",
       "verify": "float(QuadraticControlCost(control_cost=1.0).optimal_control(np.array([1.0]))[0]) > 0"
     },
@@ -2818,7 +2766,7 @@
         "tests/unit/test_alg/test_fp_particle_solver.py::TestFPParticleSolverSolveFPSystem::test_solve_fp_system_initial_condition"
       ],
       "owner": "The particle FP step measures total mass as `sum(density) * dV` with dV the grid volume element, and the KDE normalisation divides by it so the density on the grid integrates to 1 (`FPParticleSolver._compute_total_mass`, the scalar-spacing branch; consumed by `_normalize_density` at :823 and by the ",
-      "seconds": 132.6,
+      "seconds": 132.3,
       "status": "ok",
       "verify": "FPParticleSolver(MFGProblem(geometry=TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[21], boundary_conditions=no_flux_bc(dimension=1)), Nt=4, T=0.2, sigma=1.0, components=MFGComponents(m_initial=lambda x: np.exp(-10 * (np.asarray(x) - 0.5) ** 2).squeeze(), u_terminal=lambda x: 0.0, hamiltonian=SeparableHamiltonian(control_cost=QuadraticControlCost(control_cost=1.0)))), num_particles=10)._compute_total_mass(np.ones(4), 0.25) == 4.0"
     },
@@ -2848,7 +2796,7 @@
         "tests/unit/test_geometry/test_bc_fail_loud_1558_1559.py::test_periodic_and_no_flux_diverge_by_o1_which_is_why_coercion_is_not_harmless"
       ],
       "owner": "where the last node sits, MEASURED from the coordinates the grid built (#1822). `_axis_convention` is the single owner: `periodic_convention` calls it (tensor_grid.py:415) and `_first_axis_with_convention` calls it (:385). The property docstring states why it is derived rather than asserted: \"Derive",
-      "seconds": 130.9,
+      "seconds": 149.3,
       "status": "ok",
       "verify": "TensorProductGrid(bounds=[(0.0, 1.0)], Nx_points=[11], boundary_conditions=no_flux_bc(dimension=1)).periodic_convention is PeriodicGridConvention.ENDPOINT_EXCLUSIVE"
     },
@@ -2902,7 +2850,7 @@
         "tests/unit/test_operators/test_laplacian.py::TestLaplacianBCFailLoud1071::test_bc_none_still_periodic"
       ],
       "owner": "how many trailing nodes of a periodic axis repeat a node the array already holds -- the ONE number both the ghost skip and the modular span derive from (#1822). types.py:126-130 states the ownership verbatim: \"Every periodic wrap in the package is one of two expressions of this single number, which ",
-      "seconds": 129.5,
+      "seconds": 132.0,
       "status": "ok",
       "verify": "pad_array_with_ghosts(np.array([1.0, 2.0, 3.0]), periodic_bc(dimension=1), ghost_depth=1)[0] == 2.0"
     },
@@ -2913,7 +2861,7 @@
         "tests/unit/test_convention_agreement.py::TestPicardCriterionIsAConjunction::test_a_small_relative_error_alone_is_not_convergence"
       ],
       "owner": "Picard convergence requires BOTH the relative AND the absolute L2 error below tolerance. Owner: check_convergence_criteria, fixed_point_utils.py:192-229, whose docstring states 'Convergence criteria (both must be satisfied)'. Single-sourced by three call sites routing to it: fixed_point_iterator.py:",
-      "seconds": 131.8,
+      "seconds": 129.9,
       "status": "ok",
       "verify": "check_convergence_criteria(1e-9, 1e-9, 1.0, 1.0, 1e-6)[0]"
     },
@@ -2926,11 +2874,11 @@
         "tests/regression/test_solver_golden_baseline.py::test_coupled_solve_matches_golden_baseline",
         "tests/unit/test_alg/test_coupling_metric_is_the_map_residual_1684.py::test_heavier_damping_does_not_buy_a_smaller_reported_error",
         "tests/unit/test_alg/test_hjb_analytic_jacobian_1607.py::test_analytic_jacobian_matches_fd_solution",
-        "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_obstacle",
+        "tests/unit/test_alg/test_issue1285_newton_fail_loud.py::test_newton_solver_solves_with_a_state_penalty",
         "tests/unit/test_utils/test_runtime_validation.py::test_terminal_condition_survives_an_hjb_divergence"
       ],
       "owner": "u is boundary-data at the TERMINAL time and m at the INITIAL one: preserve_terminal_condition re-imposes u(T)=g on the LAST time row after damping/Anderson. Single owner, three caller families -- fixed_point_iterator.py:644 and :724 (Picard), fictitious_play.py:432, block_iterators.py:583. No issue ",
-      "seconds": 252.5,
+      "seconds": 242.7,
       "status": "ok",
       "verify": "preserve_terminal_condition(np.zeros((3, 4)), np.full(4, 7.0))[0, 0] == 7.0"
     },
@@ -2944,7 +2892,7 @@
         "tests/unit/test_alg/test_hjb_jacobian_advection_1896.py::test_every_row_linearises_the_residual[piecewise_linear-True-robin_alpha_eq_beta]"
       ],
       "owner": "on rows where forward and backward agree in VALUE, the upwind Jacobian's row is decided by sign(central), matching the residual's own selector -- the one place #1896 left the rule restated rather than measured (#1896 item 3)",
-      "seconds": 131.4,
+      "seconds": 130.5,
       "status": "ok",
       "verify": "float(_advection_bands(np.zeros(5), 0.25, None, 0.0, True, _bc_laplacian_bands(5, 0.25, None, 0.0))[1][2]) == -4.0"
     }

--- a/scripts/test_discrimination.py
+++ b/scripts/test_discrimination.py
@@ -255,8 +255,17 @@ MUTATIONS: list[Mutation] = [
     Mutation(
         name="bc_uniform_dispatch_reads_as_mixed",
         path="mfgarchon/geometry/boundary/applicator_fdm.py",
-        old="        if bc.is_uniform:",
-        new="        if False:  # MUTATED: uniform BC reads as mixed -- every BC takes the per-face path",
+        # The anchor carries the line BELOW the dispatch, because `if bc.is_uniform:` alone stopped
+        # being unique on 2026-08-22: #2042 added a second branch on the same predicate inside
+        # `_update_ghosts_mixed`, at the same indentation. The harness refuses a non-unique anchor
+        # rather than mutating an arbitrary one of the two, which is how this was caught -- and the
+        # right fix is a more specific anchor, not an `and` clause added to the product code purely
+        # to dodge a string match.
+        old="        if bc.is_uniform:\n            seg = bc.segments[0]",
+        new=(
+            "        if False:  # MUTATED: uniform BC reads as mixed -- every BC takes the per-face path\n"
+            "            seg = bc.segments[0]"
+        ),
         owner="PreallocatedGhostBuffer.update_ghosts routes a uniform BC to the single-segment path and a mixed BC to the per-face path (#577 Phase 3 for the mixed rewrite, #1255 (C) for the alpha/beta forwarding the uniform branch carries). The two paths are NOT equivalent: the uniform branch applies the inhomoge",
         # Re-pointed twice on 2026-08-21. The original probe used a STATIC SCALAR Neumann value
         # and went blind -- [1.1 1. 2. 3. 3.1] under mutant and clean alike -- so the row scored

--- a/tests/unit/test_geometry/boundary/test_no_default_robin_2042.py
+++ b/tests/unit/test_geometry/boundary/test_no_default_robin_2042.py
@@ -1,0 +1,111 @@
+"""There is no default Robin, and a uniform BC on the per-face path forwards rather than rebuilds.
+
+`_update_ghosts_mixed` is reached for a face no segment claims. It used to synthesize
+`BCSegment(name="__default__", bc_type=default_type, value=bc.default_value)` — carrying `bc_type`
+and `value` and **nothing else**, so `alpha`, `beta` and any callable value were dropped and
+`BCSegment`'s own defaults (`alpha=1.0, beta=0.0`) took their place.
+
+**`beta = 0` IS Dirichlet.** So a defaulted Robin did not become an approximate Robin; it became a
+different boundary condition, bit for bit identical to `dirichlet_bc(value=g)`, with nothing in the
+output to say so. Measured before the fix: `robin_bc(alpha=1, beta=1, value=3)` gave `[5. 1. 2. 3.]`
+against the correct `[1.097561 …]`, and independent of the alpha and beta actually passed.
+
+TWO SITUATIONS ARRIVE HERE AND ONLY ONE HAS AN ANSWER
+-----------------------------------------------------
+(a) A **uniform** BC took this path — one segment, no boundary restriction. Forward it: the
+    information is present. This is not the `bc.segments[0]` fallback the surrounding comment
+    rejects; that one fired on MIXED BCs, where `[0]` means *highest priority* and handed every
+    unclaimed wall the exit (measured: 4 of 4 walls got the Dirichlet ghost). `is_uniform` is
+    exactly the case where that cannot happen.
+
+(b) A **mixed** BC with an unclaimed face. Nothing to forward — `BoundaryConditions` carries
+    `default_bc` and `default_value` and **no** `default_alpha` / `default_beta`. So a Robin
+    default is an incomplete declaration, and this refuses rather than guessing, continuing
+    #1100's ruling (`_resolve_default_bc` already raises when `default_bc` is unset).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import numpy as np
+
+from mfgarchon.geometry.boundary import dirichlet_bc, neumann_bc, no_flux_bc, robin_bc
+from mfgarchon.geometry.boundary.applicator_fdm import pad_array_with_ghosts
+from mfgarchon.geometry.boundary.conditions import BoundaryConditions
+from mfgarchon.geometry.boundary.types import BCSegment, BCType, BoundaryFace
+
+_FIELD = np.array([1.0, 2.0, 3.0])
+_DX = 0.05
+
+
+def _pad(bc):
+    return np.asarray(pad_array_with_ghosts(_FIELD, bc, ghost_depth=1, spacing=_DX)).ravel()
+
+
+def _mixed_with_default(default_bc, default_value=0.0):
+    """One claimed face, one unclaimed — the only way to reach the `__default__` branch."""
+    claimed = BCSegment(name="exit", bc_type=BCType.DIRICHLET, value=5.0, boundary=BoundaryFace(0, "min"))
+    return BoundaryConditions(dimension=1, segments=[claimed], default_bc=default_bc, default_value=default_value)
+
+
+def test_a_defaulted_robin_is_refused():
+    """The load-bearing test. `beta = 0` is Dirichlet, so defaulting a Robin changes the boundary
+    condition's TYPE — which is not an approximation a caller can be expected to notice."""
+    with pytest.raises(NotImplementedError) as excinfo:
+        _pad(_mixed_with_default(BCType.ROBIN))
+
+    message = str(excinfo.value)
+    assert "alpha" in message, "must name what is missing"
+    assert "beta" in message
+    assert "DIRICHLET" in message, "and what the silent default would have turned it into"
+
+
+@pytest.mark.parametrize("default_bc", [BCType.NO_FLUX, BCType.NEUMANN, BCType.DIRICHLET])
+def test_defaults_that_need_no_coefficients_still_work(default_bc):
+    """The refusal must be specific to ROBIN. A blanket refusal would break every mixed BC, and
+    would pass the test above just as well — which is why this one exists."""
+    padded = _pad(_mixed_with_default(default_bc))
+    assert padded.shape == (5,)
+    assert np.all(np.isfinite(padded))
+
+
+@pytest.mark.parametrize(
+    "bc",
+    [
+        pytest.param(robin_bc(dimension=1, alpha=1.0, beta=1.0, value=3.0), id="robin"),
+        pytest.param(neumann_bc(dimension=1, value=lambda t: 2.0), id="neumann-callable"),
+        pytest.param(neumann_bc(dimension=1, value=2.0), id="neumann-scalar"),
+        pytest.param(dirichlet_bc(dimension=1, value=5.0), id="dirichlet"),
+        pytest.param(no_flux_bc(dimension=1), id="no-flux"),
+    ],
+)
+def test_a_uniform_bc_gives_the_same_answer_on_either_path(bc, monkeypatch):
+    """Forwarding, asserted as the property that matters: the two paths must AGREE.
+
+    Robin and a callable Neumann were the two that diverged — the dropped `alpha`/`beta` and the
+    dropped callable respectively. Scalar Neumann, Dirichlet and no-flux agreed even before the
+    fix, because their ghost formulas read none of the dropped fields; they are here so that a
+    regression narrowing the forward to one BC type does not pass.
+    """
+    from mfgarchon.geometry.boundary import applicator_fdm
+
+    expected = _pad(bc)
+
+    # Force the per-face path for a BC the dispatch would send down the uniform one.
+    original = applicator_fdm.PreallocatedGhostBuffer.update_ghosts
+
+    def forced(self, time=0.0):
+        self._update_ghosts_mixed(self._boundary_conditions, time)
+
+    monkeypatch.setattr(applicator_fdm.PreallocatedGhostBuffer, "update_ghosts", forced)
+    via_per_face = _pad(bc)
+    monkeypatch.setattr(applicator_fdm.PreallocatedGhostBuffer, "update_ghosts", original)
+
+    np.testing.assert_allclose(
+        via_per_face,
+        expected,
+        rtol=0,
+        atol=0,
+        err_msg="the per-face path disagrees with the uniform path for a BC that has one segment",
+    )


### PR DESCRIPTION
`_update_ghosts_mixed` handles a face no segment claims by synthesizing `BCSegment(name="__default__", bc_type=default_type, value=bc.default_value)` — carrying the type and the value and **nothing else**. `alpha`, `beta` and callable values were dropped, and `BCSegment`'s own defaults `alpha=1.0, beta=0.0` took their place.

**`beta = 0` is Dirichlet.** So a defaulted Robin was not an approximate Robin; it was a *different boundary condition*. Measured: `robin_bc(alpha=1, beta=1, value=3)` gave `[5. 1. 2. 3.]` — bit-for-bit a clean `dirichlet_bc(value=3.0)` — against the correct `[1.097561 …]`, and **independent of the α and β actually passed**.

## Two situations arrive there and only one has an answer

**(a) A uniform BC took the per-face path** — one segment, no boundary restriction, no priority ambiguity. Forward it: that is reading data which is present.

This is *not* the `bc.segments[0]` fallback the surrounding comment rejects. That one fired on **mixed** BCs, where `[0]` means highest priority and handed every unclaimed wall the exit (4 of 4 walls, measured). `is_uniform` is exactly the case where that cannot happen.

Verified by forcing the dispatch: the two paths now agree **exactly** on all five BC kinds, including the two that diverged.

**(b) A mixed BC with an unclaimed face** — nothing to forward. `BoundaryConditions` carries `default_bc` and `default_value` and **no** `default_alpha` / `default_beta`; the fields do not exist. So a Robin default is an incomplete declaration, not one with an inferable completion. It raises, naming what is missing and what the silent default would have turned the wall into.

This continues #1100 one level down: `_resolve_default_bc` already raises on an unset `default_bc` *"rather than guessing"*.

## Mutation-verified in three directions

| mutant | reddens |
|---|---|
| drop the forward | the Robin and callable-Neumann agreement rows |
| allow a defaulted Robin | the refusal test |
| **refuse *every* default, not just Robin** | the three non-Robin defaults |

The third is the one that matters: a blanket refusal satisfies the refusal test just as well, so without it the refusal would not be pinned as *specific*.

## The discrimination baseline is regenerated in the same change

`bc_uniform_dispatch_reads_as_mixed` falls **43 → 12**, and the fall is the fix:

```
A/B, same mutation, same anchor, product code the only difference
  main         43 killed
  this branch  12 killed
```

The 31 tests that stopped noticing were detecting the **divergence between the two paths** — which is precisely what the forward removes. They did not get weaker; the thing they detected got smaller. What still kills the mutation is the `order > 2` path, which this change does not touch and which the mutation's `verify` probe uses.

Four other rows rose (`diffusion_scalar_2x` 162→163, `fp_initial_condition…` 128→129, `godunov_branch_swap` 29→31, `neumann_low_wall_flux_sign` 37→39) and **no row went `INEFFECTIVE`**.

The reason is written into the baseline's `_notes`, not only into a commit message: **fixing a defect can lower a discrimination score, because the defect was what made the convention observable.** The ratchet reads any fall as a regression and cannot see that difference, and a bare number is indistinguishable from real lost coverage to whoever reads it next.

## Also here

Re-anchored `bc_uniform_dispatch` — `if bc.is_uniform:` stopped being unique when this change added a second branch on the same predicate at the same indentation, and the harness refuses a non-unique anchor (the gate caught it). Fixed by making the anchor carry the line below it, **not** by adding a redundant `and` clause to shipped code to dodge a string match.

**BREAKING** for a `BoundaryConditions` that names `ROBIN` as `default_bc` and leaves a face unclaimed. That configuration previously ran and silently applied Dirichlet.

6444 passed; 393 across the boundary suites.