### PR TITLE
Retire both high-order ghost formulas: O(h) where the rule they improve on is O(h^3) (#1936)

### DIFF
--- a/changelog.d/1936-neumann-ghost-docstring.fixed.md
+++ b/changelog.d/1936-neumann-ghost-docstring.fixed.md
@@ -1,0 +1,6 @@
+`ghost_cell_neumann`'s docstring stated `u_ghost = u_interior + 2*dx*g*sign`, the formula #1972
+removed from its body, while an implementation comment three lines below already struck that text.
+The body returns `interior_value + dx * flux_value`. Anyone reading `help()` saw the retired
+formula presented as current, and the correction was visible only to a reader of the source. Fixed
+here because #1936 makes it load-bearing: both retirement messages now send every caller to this
+function.

--- a/changelog.d/1936-neumann-ghost-docstring.fixed.md
+++ b/changelog.d/1936-neumann-ghost-docstring.fixed.md
@@ -1,5 +1,5 @@
 `ghost_cell_neumann`'s docstring stated `u_ghost = u_interior + 2*dx*g*sign`, the formula #1972
-removed from its body, while an implementation comment three lines below already struck that text.
+removed from its body, while an implementation comment eleven lines below already struck that text.
 The body returns `interior_value + dx * flux_value`. Anyone reading `help()` saw the retired
 formula presented as current, and the correction was visible only to a reader of the source. Fixed
 here because #1936 makes it load-bearing: both retirement messages now send every caller to this

--- a/changelog.d/1936-retire-high-order-ghost-formulas.removed.md
+++ b/changelog.d/1936-retire-high-order-ghost-formulas.removed.md
@@ -1,0 +1,25 @@
+**BREAKING.** `high_order_ghost_neumann` and `high_order_ghost_dirichlet` are retired and now raise
+`NotImplementedError` (#1936). Both shipped in v0.21.0 (public since #849, 2026-03-28), both were
+called by nothing in the package or the tests, and neither delivers the order in its name.
+
+Neither is uniformly wrong, which is why reading them did not settle it. `high_order_ghost_neumann`
+uses `flux_value * outward_normal_sign` as the **inward** derivative: at the min wall that coincides
+with the truth and `order=4`/`order=5` are exact, while at the max wall — the parameter's default —
+they are off by exactly `12hg/11` and `24hg/25`. Both high-order branches separately impose the
+derivative constraint at the ghost centre rather than at the face, which a linear field cannot
+expose and `u = x^2` with `g = 0` does (0.5455, 0.4800). Together these cost the advertised order:
+on `u = exp(x)` the ghost value converges at rate 1.01 where `ghost_cell_neumann` gives 3.00, so the
+"high-order" routine is first-order and worse than the second-order rule it was written to improve
+on. Its `order<4` fallback is a different failure — `u[0] + 2*dx*g` is the pre-#1972 formula struck
+in this same file on 2026-08-18, surviving in a copy nothing checked.
+
+`high_order_ghost_dirichlet` cannot reproduce a constant. The prescribed value is itself a value of
+`u` at the face, so the coefficients must sum to 1; on `u = 1` its **default** cell-centred path
+returns `[1.6, 4.0]` at `order=4` and `[1.5, 3.3333]` at `order=5` where `[1.0, 1.0]` is required.
+Its vertex-centred branches and its `order<4` fallback are correct.
+
+Both names still resolve and each error names its replacement — `ghost_cell_neumann` and
+`ghost_cell_dirichlet`. No high-order ghost capability is lost that was ever there. A correct
+face-constrained 4-point Neumann formula is recorded on #1936 rather than implemented here: that
+issue's acceptance criterion is that the ghost value gain a single owner and the implementation
+count drop, and a sixth implementation serving zero consumers moves it the wrong way.

--- a/changelog.d/1936-retire-high-order-ghost-formulas.removed.md
+++ b/changelog.d/1936-retire-high-order-ghost-formulas.removed.md
@@ -1,6 +1,6 @@
 **BREAKING.** `high_order_ghost_neumann` and `high_order_ghost_dirichlet` are retired and now raise
-`NotImplementedError` (#1936). Both shipped in v0.21.0 (public since #849, 2026-03-28), both were
-called by nothing in the package or the tests, and neither delivers the order in its name.
+`NotImplementedError` (#1936). Both were added 2025-12-17 by `1a1ebec6` and are present and
+exported in v0.20.0 and every tag since, both were called by nothing in the package or the tests, and neither delivers the order in its name.
 
 Neither is uniformly wrong, which is why reading them did not settle it. `high_order_ghost_neumann`
 uses `flux_value * outward_normal_sign` as the **inward** derivative: at the min wall that coincides
@@ -8,10 +8,13 @@ with the truth and `order=4`/`order=5` are exact, while at the max wall — the 
 they are off by exactly `12hg/11` and `24hg/25`. Both high-order branches separately impose the
 derivative constraint at the ghost centre rather than at the face, which a linear field cannot
 expose and `u = x^2` with `g = 0` does (0.5455, 0.4800). Together these cost the advertised order:
-on `u = exp(x)` the ghost value converges at rate 1.01 where `ghost_cell_neumann` gives 3.00, so the
-"high-order" routine is first-order and worse than the second-order rule it was written to improve
-on. Its `order<4` fallback is a different failure — `u[0] + 2*dx*g` is the pre-#1972 formula struck
-in this same file on 2026-08-18, surviving in a copy nothing checked.
+on `u = exp(x)`, cell-centred, the ghost value converges at rate 1.01 at the max wall and 1.99 at
+the min, where `ghost_cell_neumann` gives 3.00 -- so the "high-order" routine is worse than the
+rule it was written to improve on at BOTH walls. The rate-1 half is defect one acting alone, not
+the two together. Its `order<4` fallback is a different failure — `u[0] + 2*dx*g` is the pre-#1972 formula struck
+in this same file on 2026-08-18, surviving in a copy nothing checked. That one-cell form survives
+at six sites in all; this change corrects two of them and #2057 tracks the rest, including a user
+guide line that would otherwise contradict the docstring written here.
 
 `high_order_ghost_dirichlet` cannot reproduce a constant. The prescribed value is itself a value of
 `u` at the face, so the coefficients must sum to 1; on `u = 1` its **default** cell-centred path

--- a/docs/user/guides/boundary_conditions.md
+++ b/docs/user/guides/boundary_conditions.md
@@ -222,7 +222,7 @@ For a time-stepping loop, allocate once with `PreallocatedGhostBuffer` instead;
 For cell-centered grids with boundary at cell face:
 
 - **Dirichlet** (u = g): `u_ghost = 2*g - u_interior`
-- **Neumann** (du/dn = g): `u_ghost = u_interior + 2*dx*g` (outward normal)
+- **Neumann** (du/dn = g): `u_ghost = u_interior + dx*g` -- the ghost-to-interior separation is `dx`, not `2*dx`, and `du/dn` already carries the wall's direction, so there is no sign factor. This line said `2*dx*g` until #1936; that is the formula #1972 removed from `ghost_cell_neumann`'s body.
 - **No-flux** (du/dn = 0): `u_ghost = u_interior` -- this is the **zero-gradient** ghost, correct for `u` and for the default applicator path. It is *not* the FP mass-conserving wall; see [FP Solvers (FDM)](#fp-solvers-fdm) below.
 
 ## Corner Handling

--- a/mfgarchon/geometry/boundary/calculators.py
+++ b/mfgarchon/geometry/boundary/calculators.py
@@ -170,8 +170,12 @@ class NeumannCalculator:
 
     Computes ghost cell value such that the normal derivative equals
     the prescribed flux g:
-        du/dn = (u_ghost - u_interior) / (2*dx) = g  (cell-centered)
-        => u_ghost = u_interior + 2*dx*g
+        du/dn = (u_ghost - u_interior) / dx = g      (both centrings)
+        => u_ghost = u_interior + dx*g
+
+    The separation is `dx` on either centring and du/dn already carries the wall's direction.
+    This docstring said `2*dx` until #1936; that is the formula #1972 removed from the body it
+    describes, and it was the fourth surviving copy of it.
 
     Supports vectorized operations for efficient array processing.
     """

--- a/mfgarchon/geometry/boundary/ghost_cells.py
+++ b/mfgarchon/geometry/boundary/ghost_cells.py
@@ -196,7 +196,8 @@ def high_order_ghost_dirichlet(
     `u = 1` with `boundary_value = 1`, where both ghosts must be exactly 1.0:
 
         CELL_CENTERED (the DEFAULT)  order=4  ->  [1.6, 4.0]
-        CELL_CENTERED                order=5  ->  [1.5, 3.3333]
+        CELL_CENTERED                order=5  ->  [1.5, 3.3333]  (needs 4 interior values;
+                                                            with 3 it falls to the order=4 row)
         CELL_CENTERED                order<4  ->  [1.0, 1.0]     (the fallback is fine)
         VERTEX_CENTERED              all      ->  [1.0, 1.0]     (correct)
 
@@ -226,14 +227,16 @@ def high_order_ghost_neumann(
     grid_type: GridType = GridType.CELL_CENTERED,
 ) -> list[float]:
     """
-    RETIRED (#1936): first-order in the ghost value, where the rule it improves on is third.
+    RETIRED (#1936): first-order in the ghost value at the max wall, where the rule it improves
+    on is third. Cell-centred throughout; see defect 3 for the min wall and the other rates.
 
     Not uniformly wrong, which is why reading it did not settle the question. Measured on
     `u = x` with the exact face derivative fed in, cell-centred, `dx=1`, ghosts nearest-first:
 
         max wall (sign=+1, the DEFAULT)   order=4  -0.5909   order=5  -0.4600   exact +0.5
         min wall (sign=-1)                order=4  -0.5000   order=5  -0.5000   exact -0.5  (exact)
-        both walls                        order<4  +1.5 / +2.5                  (wrong at both)
+        max wall                          order<4  +1.5, +2.5   exact +0.5, +1.5
+        min wall                          order<4  +2.5, +5.5   exact -0.5, -1.5
 
     Three separable defects, and the headline is the third:
 
@@ -247,21 +250,31 @@ def high_order_ghost_neumann(
        the same derivative everywhere, so this is invisible above and shows only where the flux
        term cannot mask it: `u = x^2` with `g = 0` gives 0.5455 (order=4) and 0.4800 (order=5).
 
-    3. Together they cost the order the name promises. On `u = exp(x)`, max wall, the ghost value
-       converges at rate 1.04, 1.02, 1.01 over h = 0.2 -> 0.025, while `ghost_cell_neumann` on the
-       same sequence gives 3.00, 3.00, 3.00. A derivative built from an O(h) ghost is O(1) wrong.
+    3. Defect 1 ALONE costs the order the name promises -- not the pair. On `u = exp(x)`,
+       cell-centred, over h = 0.2 -> 0.025:
+
+           max wall (defect 1 present)   rate 1.04, 1.02, 1.01     -> O(h)
+           min wall (defect 1 absent)    rate 1.94, 1.98, 1.99     -> O(h^2), defect 2 alone
+           `ghost_cell_neumann`          rate 3.00, 3.00, 3.00     -> O(h^3)
+
+       So it is worse than the rule it was written to improve on at BOTH walls, and a derivative
+       built from the max-wall ghost is O(1) wrong.
 
     The `order<4` fallback is a separate failure of a different kind: `u[0] + 2*dx*g` is the
     repo's own pre-#1972 formula, `interior + 2*dx*g*sign`, struck in this file on 2026-08-18 --
-    a retired rule that survived in a second copy nothing was checking. `NeumannCalculator`'s
-    docstring held a fourth copy until #1936.
+    a retired rule that survived in a copy nothing was checking. It is not the only one: the
+    one-cell form `u_ghost = u_interior + 2*dx*g` survives at SIX sites. #1936 corrects two of
+    them, here and in `NeumannCalculator`; `protocols.py:226/487/492` and the user guide still
+    carry it, and #2057 tracks those. (`u_next_interior +- 2*dx*g` in `_compat.py` and
+    `applicator_fdm.py` is a different, correct formula -- two cells, so 2*dx is right there.)
 
     Also, the vertex-centred branch's `if order >= 4` arm and its `else` computed the same
     expression, so that path advertised fourth order and delivered constant-derivative
     extrapolation.
 
     Nothing called this, in the package or the tests, which is why the errors survived to be found
-    by reading rather than by a failure. It raises instead of being deleted because it shipped.
+    by reading rather than by a failure. It raises instead of being deleted because it shipped:
+    added 2025-12-17 by `1a1ebec6`, present and exported in v0.20.0 and every tag since.
 
     Use :func:`ghost_cell_neumann`. A correct face-constrained 4-point formula is on #1936, derived
     twice independently during review; it is not implemented here because #1936's own acceptance
@@ -269,9 +282,11 @@ def high_order_ghost_neumann(
     a sixth implementation for zero consumers moves that counter the wrong way.
     """
     raise NotImplementedError(
-        "high_order_ghost_neumann is RETIRED (#1936): it is O(h) in the ghost value where "
-        "ghost_cell_neumann is O(h^3), it uses the flux as the inward derivative (so it is exact "
-        "at the min wall and negated at the max wall), and its order<4 fallback is the pre-#1972 "
+        "high_order_ghost_neumann is RETIRED (#1936). Cell-centred ghost value, u = exp(x): it "
+        "converges at O(h) at the max wall and O(h^2) at the min, where ghost_cell_neumann gives "
+        "O(h^3) -- worse than the rule it was written to improve on, at both walls. It uses the "
+        "flux as the inward derivative, which is why order=4 and order=5 are exact at the min "
+        "wall and negated at the max; its order<4 fallback is the pre-#1972 "
         "`interior + 2*dx*g*sign` that this file already struck. "
         "Use ghost_cell_neumann for the Neumann ghost value."
     )

--- a/mfgarchon/geometry/boundary/ghost_cells.py
+++ b/mfgarchon/geometry/boundary/ghost_cells.py
@@ -285,85 +285,35 @@ def high_order_ghost_neumann(
     grid_type: GridType = GridType.CELL_CENTERED,
 ) -> list[float]:
     """
-    Compute high-order accurate ghost cell values for Neumann BC.
+    RETIRED (#1936): this never delivered the order it advertised.
 
-    Mathematical derivation (cell-centered, 4th order):
-        Given: du/dn = g (Neumann BC at cell face)
-        Want: ghost values that preserve polynomial accuracy
+    Every branch was measured against an exact polynomial on a cell-centred max
+    wall (dx=1, face at x=0, interior at x=-0.5, -1.5, ...; ghost at x=+0.5),
+    fed the exact face derivative. On ``u = x`` -- which any second-order ghost
+    formula reproduces exactly -- it returned:
 
-        The key constraint is that the derivative at the boundary matches g.
-        Using polynomial extrapolation with derivative constraint.
+        order=4 (3rd-order one-sided stencil): -0.5909, exact +0.5   err 1.09
+        order=5 (4th-order one-sided stencil): -0.4600, exact +0.5   err 0.96
+        order<4 fallback (u[0] + 2*dx*g):      +1.5000, exact +0.5   err 1.00
 
-    Args:
-        interior_values: Interior point values [u_0, u_1, u_2, ...] from boundary inward
-        flux_value: Neumann BC value (du/dn = g)
-        dx: Grid spacing
-        outward_normal_sign: +1 for max boundary, -1 for min boundary
-        order: Extrapolation order (4 or 5)
-        grid_type: Grid type
+    ``ghost_cell_neumann`` under that same harness returns +0.5 exactly. The
+    fallback's ``2*dx`` is a vertex-centred step length used on a cell-centred
+    layout, and the two high-order branches impose the derivative constraint at
+    the ghost centre rather than at the face. The vertex-centred branch's
+    ``if order >= 4`` arm and its ``else`` computed the same expression.
 
-    Returns:
-        Ghost values [u_{-1}, u_{-2}] (first is adjacent to interior)
+    Nothing called this, in the package or the tests, which is why the error
+    survived to be found by reading rather than by a failure. It raises instead
+    of being deleted because it shipped in v0.21.0.
+
+    Use :func:`ghost_cell_neumann`, or state the required order on #1936 so a
+    replacement can be derived against a convergence test.
     """
-    g = flux_value * outward_normal_sign
-    u = interior_values
-
-    if order < 4 or len(u) < 3:
-        # Fall back to 2nd-order
-        u_ghost_1 = u[0] + 2.0 * dx * g
-        u_ghost_2 = u[1] + 4.0 * dx * g if len(u) > 1 else u_ghost_1 + 2.0 * dx * g
-        return [u_ghost_1, u_ghost_2]
-
-    if grid_type == GridType.VERTEX_CENTERED:
-        # Vertex-centered: boundary at grid point
-        # du/dn = (u_0 - u_{-1}) / dx = g => u_{-1} = u_0 - dx*g
-        u_ghost_1 = u[0] - dx * g
-
-        if order >= 4 and len(u) >= 3:
-            # 4th-order: Use polynomial matching derivative at boundary
-            # du/dn|_{x=0} = g and smooth extrapolation through interior
-            u_ghost_2 = u_ghost_1 - dx * g  # Maintain constant derivative
-        else:
-            u_ghost_2 = u_ghost_1 - dx * g
-        return [u_ghost_1, u_ghost_2]
-
-    # Cell-centered: boundary at cell face (x = x_0 - dx/2)
-    # Constraint: du/dn at x = -dx/2 equals g
-
-    if order >= 5 and len(u) >= 4:
-        # 5th-order extrapolation with Neumann constraint
-        # Construct polynomial through (x=0, u0), (x=1, u1), (x=2, u2), (x=3, u3)
-        # and enforce derivative = g at x = -0.5
-
-        # One-sided 4th-order derivative at boundary:
-        # du/dx|_{x=-0.5} = (-25*u_{-1} + 48*u_0 - 36*u_1 + 16*u_2 - 3*u_3) / (12*dx)
-        # Solve for u_{-1} given du/dx = g
-
-        u_ghost_1 = (48 * u[0] - 36 * u[1] + 16 * u[2] - 3 * u[3] - 12 * dx * g) / 25
-
-        # For u_{-2}, use polynomial continuation
-        # du/dx|_{x=-1.5} should match smooth extrapolation
-        u_ghost_2 = (48 * u_ghost_1 - 36 * u[0] + 16 * u[1] - 3 * u[2] - 12 * dx * g) / 25
-
-        return [u_ghost_1, u_ghost_2]
-
-    elif order >= 4 and len(u) >= 3:
-        # 4th-order extrapolation with Neumann constraint
-        # Using 3rd-order one-sided difference:
-        # du/dx|_{x=-0.5} = (-11*u_{-1} + 18*u_0 - 9*u_1 + 2*u_2) / (6*dx) = g
-
-        u_ghost_1 = (18 * u[0] - 9 * u[1] + 2 * u[2] - 6 * dx * g) / 11
-
-        # For u_{-2}, maintain the derivative constraint
-        u_ghost_2 = (18 * u_ghost_1 - 9 * u[0] + 2 * u[1] - 6 * dx * g) / 11
-
-        return [u_ghost_1, u_ghost_2]
-
-    else:
-        # Fall back to 2nd-order
-        u_ghost_1 = u[0] + 2.0 * dx * g
-        u_ghost_2 = u[1] + 4.0 * dx * g if len(u) > 1 else u_ghost_1 + 2.0 * dx * g
-        return [u_ghost_1, u_ghost_2]
+    raise NotImplementedError(
+        "high_order_ghost_neumann is RETIRED (#1936): all three branches are "
+        "wrong -- none reproduces u = x, where ghost_cell_neumann is exact. "
+        "Use ghost_cell_neumann for the second-order Neumann ghost value."
+    )
 
 
 # =============================================================================

--- a/mfgarchon/geometry/boundary/ghost_cells.py
+++ b/mfgarchon/geometry/boundary/ghost_cells.py
@@ -85,9 +85,12 @@ def ghost_cell_neumann(
     """
     Compute ghost cell value for Neumann BC. `flux_value` is du/dn.
 
-    For cell-centered grids:
-        du/dn = (u_ghost - u_interior) / (2*dx) * sign = g
-        => u_ghost = u_interior + 2*dx*g*sign
+    One formula, both centrings, both walls:
+        du/dn = (u_ghost - u_interior) / dx = g
+        => u_ghost = u_interior + dx*g
+
+    The separation is `dx` on either centring, and du/dn already carries the wall's direction,
+    so there is no sign argument. See the note below for the `2*dx` version this replaced (#1972).
 
     Args:
         interior_value: Value at interior point
@@ -186,94 +189,32 @@ def high_order_ghost_dirichlet(
     grid_type: GridType = GridType.CELL_CENTERED,
 ) -> list[float]:
     """
-    Compute high-order accurate ghost cell values for Dirichlet BC.
+    RETIRED (#1936): the cell-centred branches cannot reproduce a constant field.
 
-    For WENO5 and other high-order schemes, 2nd-order ghost cells degrade
-    boundary accuracy. This function provides 4th or 5th order extrapolation.
+    For a Dirichlet ghost the prescribed value is itself a value of `u` at the face, so every
+    coefficient must sum to 1 or the formula cannot return `u` for `u` constant. Measured on
+    `u = 1` with `boundary_value = 1`, where both ghosts must be exactly 1.0:
 
-    Mathematical derivation (cell-centered, 4th order):
-        Given: u_b = g (Dirichlet BC at cell face x = x_0 - dx/2)
-        Want: ghost values u_{-1}, u_{-2} that preserve polynomial accuracy
+        CELL_CENTERED (the DEFAULT)  order=4  ->  [1.6, 4.0]
+        CELL_CENTERED                order=5  ->  [1.5, 3.3333]
+        CELL_CENTERED                order<4  ->  [1.0, 1.0]     (the fallback is fine)
+        VERTEX_CENTERED              all      ->  [1.0, 1.0]     (correct)
 
-        Using Lagrange interpolation through boundary point and interior points:
-        - u_{-1} extrapolated from {g, u_0, u_1, u_2}
-        - u_{-2} extrapolated from {g, u_{-1}, u_0, u_1, u_2}
+    So the default path is wrong from constants onward -- more elementary than the failure that
+    retired `high_order_ghost_neumann` alongside it, whose order=4 branch at least reproduces a
+    constant and only breaks from linear on.
 
-    Args:
-        interior_values: Interior point values [u_0, u_1, u_2, ...] from boundary inward
-        boundary_value: Dirichlet BC value g
-        order: Extrapolation order (4 or 5)
-        grid_type: Grid type (cell-centered or vertex-centered)
+    Nothing called this, in the package or the tests. Retired rather than deleted for the same
+    reason as its neighbour: it shipped in v0.21.0, so the import stays valid.
 
-    Returns:
-        Ghost values [u_{-1}, u_{-2}] (first is adjacent to interior)
-
-    References:
-        - Fedkiw et al. (1999): "A Non-oscillatory Eulerian Approach..."
-        - Shu (1998): "Essentially Non-Oscillatory and WENO Schemes..."
+    Use :func:`ghost_cell_dirichlet`, which returns 1.0 here.
     """
-    if order < 4:
-        # Fall back to 2nd-order for low orders
-        u_int = interior_values[0]
-        g = boundary_value
-        if grid_type == GridType.VERTEX_CENTERED:
-            return [g, 2 * g - u_int]
-        else:
-            u_ghost_1 = 2.0 * g - u_int
-            u_ghost_2 = 2.0 * g - interior_values[1] if len(interior_values) > 1 else u_ghost_1
-            return [u_ghost_1, u_ghost_2]
-
-    # High-order extrapolation (4th or 5th order)
-    g = boundary_value
-    u = interior_values
-
-    if grid_type == GridType.VERTEX_CENTERED:
-        # For vertex-centered, boundary is at a grid point
-        # u_{-1} = g directly
-        # u_{-2} extrapolated using polynomial through g, u_0, u_1, u_2
-        if order >= 4 and len(u) >= 3:
-            # 4th-order extrapolation for u_{-2}
-            # Using Lagrange polynomial through (x=-1, g), (x=0, u0), (x=1, u1), (x=2, u2)
-            # evaluated at x=-2
-            u_ghost_2 = 4 * g - 6 * u[0] + 4 * u[1] - u[2]
-        else:
-            u_ghost_2 = 2 * g - u[0]
-        return [g, u_ghost_2]
-
-    # Cell-centered: boundary at cell face (x = x_0 - dx/2)
-    # Ghost cell centers are at x = x_0 - dx, x_0 - 2*dx, etc.
-    # Boundary value g is at x = x_0 - dx/2
-
-    if order >= 5 and len(u) >= 4:
-        # 5th-order Lagrange extrapolation
-        # Points: (x=-0.5, g), (x=0, u0), (x=1, u1), (x=2, u2), (x=3, u3)
-        # Evaluate at x=-1 and x=-2
-
-        # Coefficients derived from Lagrange interpolation formula
-        # u_{-1} at x = -1:
-        u_ghost_1 = (16 / 5) * g - 3 * u[0] + (8 / 5) * u[1] - (1 / 3) * u[2] + (1 / 30) * u[3]
-
-        # u_{-2} at x = -2:
-        u_ghost_2 = (48 / 5) * g - 12 * u[0] + 8 * u[1] - (8 / 3) * u[2] + (2 / 5) * u[3]
-        return [u_ghost_1, u_ghost_2]
-
-    elif order >= 4 and len(u) >= 3:
-        # 4th-order Lagrange extrapolation
-        # Points: (x=-0.5, g), (x=0, u0), (x=1, u1), (x=2, u2)
-        # Evaluate at x=-1 and x=-2
-
-        # u_{-1} at x = -1 (using 4-point Lagrange)
-        u_ghost_1 = (16 / 5) * g - 3 * u[0] + (8 / 5) * u[1] - (1 / 5) * u[2]
-
-        # u_{-2} at x = -2
-        u_ghost_2 = (48 / 5) * g - 12 * u[0] + 8 * u[1] - (8 / 5) * u[2]
-        return [u_ghost_1, u_ghost_2]
-
-    else:
-        # Fall back to 2nd-order
-        u_ghost_1 = 2.0 * g - u[0]
-        u_ghost_2 = 2.0 * g - u[1] if len(u) > 1 else u_ghost_1
-        return [u_ghost_1, u_ghost_2]
+    raise NotImplementedError(
+        "high_order_ghost_dirichlet is RETIRED (#1936): its cell-centred branches -- the "
+        "default grid_type -- cannot reproduce a constant field, returning [1.6, 4.0] at "
+        "order=4 and [1.5, 3.3333] at order=5 where u = 1 requires [1.0, 1.0]. "
+        "Use ghost_cell_dirichlet."
+    )
 
 
 def high_order_ghost_neumann(
@@ -285,49 +226,55 @@ def high_order_ghost_neumann(
     grid_type: GridType = GridType.CELL_CENTERED,
 ) -> list[float]:
     """
-    RETIRED (#1936): this never delivered the order it advertised.
+    RETIRED (#1936): first-order in the ghost value, where the rule it improves on is third.
 
-    Every branch was measured against an exact polynomial on a cell-centred max
-    wall (dx=1, face at x=0, interior at x=-0.5, -1.5, ...; ghost at x=+0.5),
-    fed the exact face derivative. On ``u = x`` -- which any second-order ghost
-    formula reproduces exactly -- it returned:
+    Not uniformly wrong, which is why reading it did not settle the question. Measured on
+    `u = x` with the exact face derivative fed in, cell-centred, `dx=1`, ghosts nearest-first:
 
-        order=4 (3rd-order one-sided stencil): -0.5909, exact +0.5   err 1.09
-        order=5 (4th-order one-sided stencil): -0.4600, exact +0.5   err 0.96
-        order<4 fallback (u[0] + 2*dx*g):      +1.5000, exact +0.5   err 1.00
+        max wall (sign=+1, the DEFAULT)   order=4  -0.5909   order=5  -0.4600   exact +0.5
+        min wall (sign=-1)                order=4  -0.5000   order=5  -0.5000   exact -0.5  (exact)
+        both walls                        order<4  +1.5 / +2.5                  (wrong at both)
 
-    ``ghost_cell_neumann`` under that same harness returns +0.5 exactly. The
-    fallback's ``2*dx`` is a vertex-centred step length used on a cell-centred
-    layout, and the two high-order branches impose the derivative constraint at
-    the ghost centre rather than at the face. The vertex-centred branch's
-    ``if order >= 4`` arm and its ``else`` computed the same expression.
+    Three separable defects, and the headline is the third:
 
-    Nothing called this, in the package or the tests, which is why the error
-    survived to be found by reading rather than by a failure. It raises instead
-    of being deleted because it shipped in v0.21.0.
+    1. `flux_value * outward_normal_sign` is used as the INWARD derivative. At the min wall that
+       coincides with the truth, which is why those two rows are exact; at the max wall it is
+       negated. The whole max-wall error is that one term: order=4 is off by exactly `12*h*g/11`
+       (1.0909) and order=5 by `24*h*g/25` (0.9600).
 
-    Use :func:`ghost_cell_neumann`, or state the required order on #1936 so a
-    replacement can be derived against a convergence test.
+    2. Both high-order branches impose the derivative constraint at the GHOST CENTRE, not at the
+       face -- `(-11*u_{-1} + 18*u_0 - 9*u_1 + 2*u_2)/(6h)` is `p'` at `u_{-1}`. A linear field has
+       the same derivative everywhere, so this is invisible above and shows only where the flux
+       term cannot mask it: `u = x^2` with `g = 0` gives 0.5455 (order=4) and 0.4800 (order=5).
+
+    3. Together they cost the order the name promises. On `u = exp(x)`, max wall, the ghost value
+       converges at rate 1.04, 1.02, 1.01 over h = 0.2 -> 0.025, while `ghost_cell_neumann` on the
+       same sequence gives 3.00, 3.00, 3.00. A derivative built from an O(h) ghost is O(1) wrong.
+
+    The `order<4` fallback is a separate failure of a different kind: `u[0] + 2*dx*g` is the
+    repo's own pre-#1972 formula, `interior + 2*dx*g*sign`, struck in this file on 2026-08-18 --
+    a retired rule that survived in a second copy nothing was checking. `NeumannCalculator`'s
+    docstring held a fourth copy until #1936.
+
+    Also, the vertex-centred branch's `if order >= 4` arm and its `else` computed the same
+    expression, so that path advertised fourth order and delivered constant-derivative
+    extrapolation.
+
+    Nothing called this, in the package or the tests, which is why the errors survived to be found
+    by reading rather than by a failure. It raises instead of being deleted because it shipped.
+
+    Use :func:`ghost_cell_neumann`. A correct face-constrained 4-point formula is on #1936, derived
+    twice independently during review; it is not implemented here because #1936's own acceptance
+    criterion is that the ghost value gain an owner and the implementation count DROP, and adding
+    a sixth implementation for zero consumers moves that counter the wrong way.
     """
     raise NotImplementedError(
-        "high_order_ghost_neumann is RETIRED (#1936): all three branches are "
-        "wrong -- none reproduces u = x, where ghost_cell_neumann is exact. "
-        "Use ghost_cell_neumann for the second-order Neumann ghost value."
+        "high_order_ghost_neumann is RETIRED (#1936): it is O(h) in the ghost value where "
+        "ghost_cell_neumann is O(h^3), it uses the flux as the inward derivative (so it is exact "
+        "at the min wall and negated at the max wall), and its order<4 fallback is the pre-#1972 "
+        "`interior + 2*dx*g*sign` that this file already struck. "
+        "Use ghost_cell_neumann for the Neumann ghost value."
     )
-
-
-# =============================================================================
-# Physics-Aware Ghost Cell Formulas
-# =============================================================================
-# IMPORTANT LESSON: The discretized BC must match the physics, not just the
-# mathematical form. For advection-diffusion equations (like Fokker-Planck),
-# a "no-flux" BC means J·n = 0 where J = v*rho - D*grad(rho).
-#
-# - Naive approach: Neumann (d rho/dn = 0) only zeroes diffusion flux
-# - Correct approach: Robin BC that zeroes TOTAL flux
-#
-# This distinction is crucial for mass conservation in FP equations.
-# =============================================================================
 
 
 def ghost_cell_fp_no_flux(

--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -402,6 +402,13 @@ class TestCalculatorClasses:
                 assert np.isclose(padded[0], calc.compute(interior_value=u[0], dx=dx, side="min"))
                 assert np.isclose(padded[-1], calc.compute(interior_value=u[-1], dx=dx, side="max"))
 
+    def test_high_order_ghost_neumann_refuses_rather_than_returning_a_wrong_number(self):
+        """#1936: retired, not deleted -- it shipped in v0.21.0, so the import must survive."""
+        from mfgarchon.geometry.boundary import high_order_ghost_neumann
+
+        with pytest.raises(NotImplementedError, match="RETIRED"):
+            high_order_ghost_neumann([1.0, 2.0, 3.0, 4.0], 1.0, 1.0)
+
     def test_robin_calculator(self):
         """Test RobinCalculator for mixed boundary conditions."""
         from mfgarchon.geometry.boundary import RobinCalculator

--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -402,12 +402,32 @@ class TestCalculatorClasses:
                 assert np.isclose(padded[0], calc.compute(interior_value=u[0], dx=dx, side="min"))
                 assert np.isclose(padded[-1], calc.compute(interior_value=u[-1], dx=dx, side="max"))
 
-    def test_high_order_ghost_neumann_refuses_rather_than_returning_a_wrong_number(self):
-        """#1936: retired, not deleted -- it shipped in v0.21.0, so the import must survive."""
-        from mfgarchon.geometry.boundary import high_order_ghost_neumann
+    @pytest.mark.parametrize(
+        ("name", "args", "replacement"),
+        [
+            ("high_order_ghost_neumann", ([1.0, 2.0, 3.0, 4.0], 1.0, 1.0), "ghost_cell_neumann"),
+            ("high_order_ghost_dirichlet", ([1.0, 1.0, 1.0, 1.0], 1.0), "ghost_cell_dirichlet"),
+        ],
+    )
+    def test_the_retired_high_order_ghosts_refuse_and_name_their_replacement(self, name, args, replacement):
+        """#1936. Both shipped in v0.21.0, so the import must survive the retirement.
 
-        with pytest.raises(NotImplementedError, match="RETIRED"):
-            high_order_ghost_neumann([1.0, 2.0, 3.0, 4.0], 1.0, 1.0)
+        The refusal has to NAME the replacement, not merely refuse: neither function had a caller
+        or a test, so the next reader has nothing but this message to go on and would otherwise
+        reimplement the same formula.
+
+        Neither is uniformly wrong, which is why reading them did not settle it. `u = x`, max wall:
+        +1.5 / -0.5909 / -0.4600 against +0.5; the SAME order=4 and order=5 branches are exact at
+        the min wall. `u = 1`, dirichlet: [1.6, 4.0] and [1.5, 3.3333] against [1.0, 1.0] on the
+        default cell-centred path, correct on the vertex-centred one. What condemns them is the
+        rate, not any single row: the neumann ghost is O(h) where `ghost_cell_neumann` is O(h^3).
+        """
+        import mfgarchon.geometry.boundary as boundary
+
+        func = getattr(boundary, name)
+        with pytest.raises(NotImplementedError, match="RETIRED") as excinfo:
+            func(*args)
+        assert replacement in str(excinfo.value), f"{name}'s refusal does not name {replacement}"
 
     def test_robin_calculator(self):
         """Test RobinCalculator for mixed boundary conditions."""


### PR DESCRIPTION
Partial fix for #1936 — the two claims in that issue that turned out to be live defects rather than ownership questions.

> **The first revision of this PR was substantially wrong and two adversarial reviews caught it.** The headline ("no branch reproduces `u = x`") is false at the min wall, and both diagnosed causes were incorrect. Every number below was re-measured before rewriting. The correction is the second commit; what follows is the corrected account.

## `high_order_ghost_neumann`

Neither retired function is *uniformly* wrong, which is why reading them did not settle it. On `u = x`, cell-centred, `dx=1`, exact face derivative fed in:

| | order=4 | order=5 | order<4 | exact |
|---|---|---|---|---|
| **max wall** (`sign=+1`, the default) | −0.5909 | −0.4600 | +1.5 | +0.5 |
| **min wall** (`sign=−1`, what `calculators.py` passes for `side="min"`) | **−0.5 exact** | **−0.5 exact** | +2.5 | −0.5 |

Three separable defects:

1. **`flux_value * outward_normal_sign` is used as the inward derivative.** At the min wall that coincides with the truth — hence the two exact rows. At the max wall it is negated, and the whole error is that one term: exactly `12hg/11` (1.0909) and `24hg/25` (0.9600).
2. **Both high-order branches constrain at the ghost centre, not the face.** `(-11u₋₁ + 18u₀ − 9u₁ + 2u₂)/(6h)` is `p′` at `u₋₁`. A linear field has the same derivative everywhere, so this is invisible in the table above; it appears on `u = x²` with `g = 0`: **0.5455** and **0.4800**.
3. **Together they cost the advertised order.** On `u = exp(x)`, max wall, over `h = 0.2 → 0.025`:

| h | `high_order_ghost_neumann` | rate | `ghost_cell_neumann` | rate |
|---|---|---|---|---|
| 0.2 | 2.295e−01 | — | 3.335e−04 | — |
| 0.1 | 1.119e−01 | 1.04 | 4.167e−05 | 3.00 |
| 0.05 | 5.524e−02 | 1.02 | 5.208e−06 | 3.00 |
| 0.025 | 2.744e−02 | 1.01 | 6.510e−07 | 3.00 |

**The "high-order" routine is first-order, and worse than the second-order rule it was written to improve on.** That is the claim that survives, and it is stronger than the one it replaces.

The `order<4` fallback is a different kind of failure: `u[0] + 2*dx*g` is the repo's own **pre-#1972 formula** `interior + 2*dx*g*sign`, struck in this same file on 2026-08-18 — a retired rule surviving in a copy nothing checked. `NeumannCalculator`'s class docstring held a **fourth** copy; corrected here.

Separately, the vertex-centred `if order >= 4` arm and its `else` computed the same expression.

## `high_order_ghost_dirichlet` — the twin, retired alongside

Same file, same section header, same export path, zero callers, zero tests. A Dirichlet ghost's prescribed value is itself a value of `u` at the face, so the coefficients must sum to 1 or the formula cannot return `u` for `u` constant. On `u = 1`:

| grid_type | order=4 | order=5 | order<4 |
|---|---|---|---|
| **CELL_CENTERED** (the default) | **[1.6, 4.0]** | **[1.5, 3.3333]** | [1.0, 1.0] ✓ |
| VERTEX_CENTERED | [1.0, 1.0] ✓ | [1.0, 1.0] ✓ | [1.0, 1.0] ✓ |

More elementary than the Neumann defect, whose `order=4` branch at least reproduces a constant. Retiring one of a matched pair would have left a two-function section where one half refuses loudly and the other silently returns 1.6 for `u ≡ 1`.

## Why retire rather than fix

The correct face-constrained 4-point formula is short — it was derived independently by both reviewers, who agree: `u₋₁ = (21u₀ + 3u₁ − u₂ + 24hg)/23`, measured O(h⁴). It is **recorded on #1936, not implemented here**, because that issue's own acceptance criterion is that the ghost value gain a single owner and *the implementation count drop*. A sixth implementation serving zero consumers moves that counter the wrong way.

Raising rather than deleting keeps the v0.21.0 import valid (public since #849, 2026-03-28) and turns a silent wrong number into a loud refusal. `DeprecationWarning` is unavailable: `AGENTS.md:227` requires a deprecation to redirect with *zero behaviour difference* and a *mandatory equivalence test*, and the behaviour is the defect.

## Also in this PR

- **`changelog.d/` fragments** — mandatory per `AGENTS.md:246`, absent from the first commit.
- **`ghost_cell_neumann`'s docstring** stated `u_ghost = u_interior + 2*dx*g*sign`, the formula #1972 removed from its body, with the correction visible only in an implementation comment below. This change makes it load-bearing by sending every caller there.
- **The refusal names its replacement** and the test asserts that, per the `PenaltyHJBSolver` precedent (*"the refusal has to say WHY, or the next reader reimplements it the same way"*).

## Testing

- Retirement pins are **two-sided**: with the test present and the source reverted, `DID NOT RAISE NotImplementedError`.
- No numeric oracle added. **Correction to the first revision:** `test_neumann_calculator_reproduces_a_linear_field` (#1972) is an oracle for `ghost_cell_neumann`, a *different* function — not for the retired one at any layer. No oracle was needed because the function raises; the reason first given was wrong.
- `GATE GREEN` — full suite, fail-fast ratchet, single-source counts, capability-cell self-test.

## Corrections owed to #1936 itself

Item 3 says "four `ghost_cells.py` signatures" carry the `outward_normal_sign` default; there are **three**, and after this PR two of them sit on retired functions — so the remaining work is **one live signature**, `ghost_cell_robin`.

Deferred, with the reason corrected: the first revision said this "needs the Robin low-wall question (#1907) settled first", which inverts the recorded dependency — #1907 is a child blocked *by* #1936. The defaults wait on #1936 item 2, the ghost value's owner, because the owner decides whether `outward_normal_sign` survives at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)