### PR TITLE
Make CRITICAL visible to LogAnalyzer: the padding and the regex disagreed (#1918)

### DIFF
--- a/changelog.d/1918-critical-invisible-to-log-analyser.fixed.md
+++ b/changelog.d/1918-critical-invisible-to-log-analyser.fixed.md
@@ -1,0 +1,23 @@
+`LogAnalyzer` could never parse a `CRITICAL` log line, and `CRITICAL` is one of the two levels its
+failure reports select for (#1918). The writer formats with `%(levelname)-8s`; `CRITICAL` is exactly
+8 characters, so it is the one level that arrives with no padding, leaving a single space before the
+separator where the reader's `(\w+)\s+ - ` needed two — one for `\s+` and one literal. Every shorter
+level is padded and matched. Measured end-to-end through the real `MFGFormatter` and the real
+`LogAnalyzer`: 5 levels emitted, 4 parsed, `CRITICAL` the only miss. `get_summary_statistics` and
+`find_error_patterns` both select `level in ("ERROR", "CRITICAL")`, so the highest severity was
+absent from both — a gap on the error channel, which reads as "no critical events" rather than as a
+parse failure.
+
+The level field now matches `(\w+)\s+- ` with a **literal** trailing space. `\s+` there would be greedy and
+eat whitespace belonging to the message — leading indentation, and on an empty message under
+`include_location=True` the `[location]` field itself, which parses as `message="[solver.py:42]"`,
+`location=None`. The literal space is byte-identical to the previous behaviour by construction, not
+by sweep: `([^-]+?)` cannot contain a dash, so neither group can backtrack, and both forms consume
+exactly one space after the dash.
+
+This fixes one reader against one writer. Two other writers — `LoggingHook`
+(`hooks/visualization.py:328`) and `setup_workflow_logging` (`workflow/common.py:107`) — install
+formatters with no `datefmt`, so their `asctime` carries milliseconds and `LogAnalyzer` returns zero
+entries for every line they write, at every level. That is a larger instance of the same shape and
+is #2058, for which this change is a prerequisite: with `datefmt` added but this fix absent, their
+unpadded levelname leaves a single space at *every* level and none of the five parse.

--- a/mfgarchon/utils/mfg_logging/analysis.py
+++ b/mfgarchon/utils/mfg_logging/analysis.py
@@ -52,7 +52,21 @@ class LogAnalyzer:
         log_pattern = re.compile(
             r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) - "  # timestamp
             r"([^-]+?) - "  # logger name
-            r"(\w+)\s+ - "  # level
+            # `\s+ - ` needed TWO spaces before the dash: one for `\s+`, one literal. The
+            # writer's format is `%(levelname)-8s`, and CRITICAL is exactly 8 characters, so it
+            # is the one level that gets zero padding and reaches this line with a single space.
+            # It is a level `get_summary_statistics` and `find_error_patterns` both filter FOR,
+            # so the highest severity was absent from both failure reports.
+            #
+            # The trailing separator is a LITERAL space, not `\s+`, and the difference is not a
+            # preference. `([^-]+?)` cannot contain a dash, so the logger group is pinned to the
+            # first `-` in the line and neither group can backtrack; `\s+- ` therefore accepts a
+            # strict superset of what `\s+ - ` accepted, and both consume exactly one space after
+            # the dash, so the message group starts at the same offset on every line the old form
+            # matched. Byte-identical groups by construction, not by sweep. A greedy `\s+` there
+            # would instead eat leading whitespace and, on an empty message under
+            # include_location=True, swallow the `[location]` field into the message.
+            r"(\w+)\s+- "  # level
             r"(.*?)(?:\s+\[([^\]]+)\])?$"  # message and optional location
         )
 

--- a/tests/unit/test_utils/test_mfg_logging.py
+++ b/tests/unit/test_utils/test_mfg_logging.py
@@ -132,3 +132,55 @@ class TestHandlerDeduplication:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestLogAnalyserSeesEveryLevel:
+    """#1918: the writer's padding and the reader's regex are two owners of one line format."""
+
+    def test_every_level_written_by_the_real_formatter_is_parsed_back(self, tmp_path):
+        r"""CRITICAL was invisible to the analyser, and it is the level the analyser filters FOR.
+
+        Both ends are the real thing: `MFGFormatter` is the writer (`logger.py`), `LogAnalyzer` is
+        the reader (`analysis.py`), and nothing here restates either one's format.
+
+        What it catches, mutation-tested rather than asserted: a reader regression, a change to the
+        ` - ` separator, a dropped `datefmt`, and a reordering of the name/level fields. What it
+        does NOT catch is a change to the PADDING WIDTH -- `-8s` to `-9s` still passes -- which is
+        the exact class this bug came from. That is the repaired regex being tolerant of padding,
+        not the test being weak, but it is the limit of what this pins.
+
+        `%(levelname)-8s` pads to width 8. CRITICAL is exactly 8 characters, so it is the one level
+        that arrives with no padding, leaving a single space where the reader's `(\w+)\s+ - ` needed
+        two. Measured before the fix: 5 levels emitted, 4 parsed, CRITICAL the only miss -- and
+        `get_summary_statistics` and `find_error_patterns` both select
+        `level in ("ERROR", "CRITICAL")`, so the highest severity was absent from both failure
+        reports. (Named, not cited by line: this test's own edits move those lines.)
+        """
+        import logging
+
+        from mfgarchon.utils.mfg_logging.analysis import LogAnalyzer
+        from mfgarchon.utils.mfg_logging.logger import MFGFormatter
+
+        levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+        log_path = tmp_path / "probe.log"
+        logger = logging.getLogger("mfgarchon.test.levels")
+        previous_propagate, previous_level = logger.propagate, logger.level
+        logger.handlers.clear()
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
+        handler = logging.FileHandler(log_path, mode="w")
+        handler.setFormatter(MFGFormatter())
+        logger.addHandler(handler)
+        try:
+            for level in levels:
+                logger.log(getattr(logging, level), f"probe line for {level}")
+        finally:
+            handler.close()
+            logger.handlers.clear()
+            logger.propagate, logger.level = previous_propagate, previous_level
+
+        analyzer = LogAnalyzer(str(log_path))
+        analyzer.parse_log_file()
+        parsed = {entry["level"] for entry in analyzer.entries}
+
+        assert parsed == set(levels), f"emitted {levels}, parsed back {sorted(parsed)}"


### PR DESCRIPTION
One instance from #1918's *"declared but not delivered"* shape, and one where the declaration is on the **error channel**, so its failure reads as good news.

> **Revised after review.** The first revision shipped an unrelated `calculators.py` change and 1258 lines of `uv.lock` swept in by a `git add -A`, and used a regex form with 32 measured regressions. Both are corrected below; the branch was force-pushed to a clean three-file commit.

## The defect

Two owners of one line format, drifted:

| owner | file | what it says |
|---|---|---|
| writer | `logger.py` — `MFGFormatter` | `"%(asctime)s - %(name)-20s - %(levelname)-8s - %(message)s"` |
| reader | `analysis.py` — `LogAnalyzer` | `r"(\w+)\s+ - "` for the level field |

`\s+` followed by a literal space needs **two** spaces before the separator. `%(levelname)-8s` pads to width 8, and `CRITICAL` is exactly 8 characters — the one level that arrives with **zero** padding and therefore a single space. Every shorter level is padded and matches. `\w+` cannot backtrack into `CRITICAL`, so the match fails outright.

Measured end-to-end through both real owners: 5 levels emitted, 4 parsed, `CRITICAL` the only miss. INFO parses on the same run — the positive control that puts the miss in the level and not the harness.

## Why it is not cosmetic

`get_summary_statistics` and `find_error_patterns` both select `level in ("ERROR", "CRITICAL")`. The highest severity was absent from both failure reports, and the output reads as *"no critical events"* rather than as a parse failure.

## The fix uses a literal trailing space, not `\s+`

`(\w+)\s+- `, **not** `(\w+)\s+-\s+`. The greedy form fixes CRITICAL and then eats whitespace belonging to the message. Swept over 180 generated lines — 5 levels × 18 message shapes × `include_location` on/off:

| regex | parses | differs from main on lines main already parsed |
|---|---|---|
| `(\w+)\s+ - ` (main) | 136/180 | — |
| `(\w+)\s+-\s+` (first revision) | 170/180 | **32** |
| `(\w+)\s+- ` (this PR) | 170/180 | **0** |

The zero is **structural, not merely measured**: `([^-]+?)` cannot contain a dash, so the logger group is pinned to the first `-` and neither group can backtrack; `\s+- ` accepts a strict superset of `\s+ - `, and both consume exactly one space after the dash, so the message group starts at the same offset on every line the old form matched.

The 32 (counted over lines main already parsed — unrestricted it is 30/10): 24 lines silently stripped of leading indentation, and 8 where the `[location]` field was swallowed — an empty message under `include_location=True`, the **default** of `configure_development_logging`, parsing as `message="[solver.py:42]"`, `location=None`.

**The first revision claimed "nothing that parsed before parses differently."** That was tested on a single message shape (`"probe line for {LEVEL}"`), a population that structurally cannot exhibit the defect. The check cleared the query, not the claim.

## Testing

- Drives `MFGFormatter` and `LogAnalyzer` directly; restates neither one's format.
- **Two-sided**: against `main`'s `analysis.py` it fails with `parsed back ['DEBUG', 'ERROR', 'INFO', 'WARNING']`.
- **Mutation-tested rather than asserted.** Catches: reader regression, separator change, dropped `datefmt`, name/level reordering. Does **not** catch a change to the padding width — the class this bug came from — because the repaired regex tolerates padding. The docstring states that limit instead of claiming it fails on any drift.
- Restores `propagate` and `level` on the probe logger, following `TestThreadSafety.setup_method`'s precedent in the same file.

## Filed, not fixed here

**#2058** — **two** other writers, `LoggingHook` (`hooks/visualization.py:328`) and `setup_workflow_logging` (`workflow/common.py:107`), install formatters with **no `datefmt`**, so their `asctime` carries milliseconds and `LogAnalyzer` returns **zero entries** for every line they write, at every level — failing at the timestamp, before the level is examined.

**This PR is a strict prerequisite for that fix, not merely compatible**: with `datefmt` added but this change absent, their unpadded levelname leaves a single space at every level, so `main`'s reader parses **0 of 5**. With this change, **5 of 5**.

## Corrections to claims made earlier on this PR

**On #2058 itself, caught by review before any of it was acted on:** I filed **three** writers; there are two. `config/configs/experiment.yaml:22` contains the exact broken format string and is read by **nothing** — verified with a positive control on the same query surface, since a negative result was the whole claim. And I named the second writer `configure_logging`; the enclosing function is `setup_workflow_logging`. That is a misattributed function name for the second time in two PRs.

Both Scope claims in the first revision were also false, and both failed the same way — a measurement that sampled the one branch that cannot fail:

- `create_gradient_operators_3d` **does exist**, at `mfgarchon/utils/performance/optimization.py:237`. My import test looked for a module-level function; it is a `@staticmethod` on `SparseMatrixOptimizer`.
- `create_solver_result` **does still upgrade** an explicit `converged=False`. Measured: `converged=False` alone → `False`, but `converged=False, tolerance=1e-6` with an error history → **`True`**. My earlier measurement omitted `tolerance`. #1918's original claim stands and my "stale" verdict on it was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

