### PR TITLE
MFGFormatter is the only owner of the log line format (#2058)

### DIFF
--- a/changelog.d/2058-log-writers-use-the-shared-formatter.fixed.md
+++ b/changelog.d/2058-log-writers-use-the-shared-formatter.fixed.md
@@ -1,0 +1,22 @@
+`MFGFormatter` is now the only owner of the log line format (#2058). Two hand-rolled copies of
+`"%(asctime)s - %(name)s - %(levelname)s - %(message)s"` — in `LoggingHook`
+(`hooks/visualization.py`) and `setup_workflow_logging` (`workflow/common.py`) — are replaced by
+`MFGFormatter()`, and no rival format string remains in the package.
+
+Each copy departed from the owner in two independent ways, either of which alone defeats
+`LogAnalyzer`: no `datefmt`, so `asctime` carries milliseconds and the timestamp field never
+matches, and no `-8s` padding, so the level field never matches. Measured through `LoggingHook`
+before the change: **0 entries at every level**, failing at the timestamp before the level was
+examined.
+
+**This was latent, not live**, and the issue overstated it in both directions before it was
+measured. `setup_workflow_logging` builds no handler at all for production callers — `get_logger`
+always attaches a StreamHandler, so its `if not logger.handlers:` guard is False and neither the
+FileHandler nor the console handler is constructed; its copy was never installed. `LoggingHook`
+does install its formatter, but only when a caller passes `log_file`, and the only site that does
+is inside a docstring Example. So nothing currently writes an unreadable log — a rival string was
+simply standing ready to.
+
+Fixed as a single-source change rather than by adding `datefmt=` to each copy: one owner, both
+rivals deleted in the same change, which is what stops the drift recurring rather than repairing
+this instance of it.

--- a/changelog.d/2058-log-writers-use-the-shared-formatter.fixed.md
+++ b/changelog.d/2058-log-writers-use-the-shared-formatter.fixed.md
@@ -1,22 +1,29 @@
-`MFGFormatter` is now the only owner of the log line format (#2058). Two hand-rolled copies of
-`"%(asctime)s - %(name)s - %(levelname)s - %(message)s"` — in `LoggingHook`
-(`hooks/visualization.py`) and `setup_workflow_logging` (`workflow/common.py`) — are replaced by
-`MFGFormatter()`, and no rival format string remains in the package.
+`MFGFormatter` is now the only owner of the log line format, and is exported from
+`mfgarchon.utils.mfg_logging` (#2058). Three rival copies of
+`"%(asctime)s - %(name)s - %(levelname)s - %(message)s"` are gone: two hand-rolled formatters in
+`LoggingHook` (`hooks/visualization.py`) and `setup_workflow_logging` (`workflow/common.py`) now use
+`MFGFormatter()`, and the third — an inert `logging.format` key in `config/configs/experiment.yaml`
+that nothing reads — is deleted. No copy of that literal remains under `mfgarchon/`.
 
-Each copy departed from the owner in two independent ways, either of which alone defeats
-`LogAnalyzer`: no `datefmt`, so `asctime` carries milliseconds and the timestamp field never
-matches, and no `-8s` padding, so the level field never matches. Measured through `LoggingHook`
-before the change: **0 entries at every level**, failing at the timestamp before the level was
-examined.
+Each copy departed from the owner in two ways, of which **one** matters. The missing `datefmt` makes
+`asctime` carry milliseconds, so `LogAnalyzer`'s timestamp field never matches and the line is
+dropped before its level is examined. The missing `-8s` padding costs nothing, because #2056 widened
+the reader's level group to accept the single space an unpadded levelname leaves. Measured 2×2
+against the current reader: `datefmt` alone gives 5/5 at every level with or without padding, no
+`datefmt` gives 0/5 either way.
 
-**This was latent, not live**, and the issue overstated it in both directions before it was
-measured. `setup_workflow_logging` builds no handler at all for production callers — `get_logger`
-always attaches a StreamHandler, so its `if not logger.handlers:` guard is False and neither the
-FileHandler nor the console handler is constructed; its copy was never installed. `LoggingHook`
-does install its formatter, but only when a caller passes `log_file`, and the only site that does
-is inside a docstring Example. So nothing currently writes an unreadable log — a rival string was
-simply standing ready to.
+**Latent, not live.** `setup_workflow_logging` builds no handler at all for production callers —
+`get_logger` always attaches a StreamHandler, so its `if not logger.handlers:` guard is False;
+measured with `log_file` set and `console=True`, it returns one StreamHandler carrying the correct
+format and writes no file. `LoggingHook` does install its formatter, but only when a caller passes
+`log_file`, and outside this change's own test nothing does. So no unreadable log is being written
+today; a rival string was standing ready to write one.
 
-Fixed as a single-source change rather than by adding `datefmt=` to each copy: one owner, both
-rivals deleted in the same change, which is what stops the drift recurring rather than repairing
-this instance of it.
+Fixed as a single-source change rather than by adding `datefmt=` to each copy: one owner, every
+rival deleted in the same change, which is what stops the drift recurring.
+
+**This does not make workflow logs readable**, and #2062 tracks the reason: workflow loggers are
+named `mfg_workflow.<uuid>`, and `LogAnalyzer`'s logger-name group is `([^-]+?)`, which cannot match
+a hyphen. Measured through the real reader: `MFGSolver` and `mfg_workflow_manager` parse, while
+`mfg_workflow.48151c9d-a6d5-...` and a user-chosen `my-experiment` both yield zero entries. Any
+logger name containing a hyphen is silently dropped.

--- a/mfgarchon/config/configs/experiment.yaml
+++ b/mfgarchon/config/configs/experiment.yaml
@@ -19,7 +19,6 @@ experiment:
     console_output: true
     file_output: true
     log_file: "${experiment.output.experiment_dir}/experiment.log"
-    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
   # Visualization configuration
   visualization:

--- a/mfgarchon/hooks/visualization.py
+++ b/mfgarchon/hooks/visualization.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from mfgarchon.utils.mfg_logging import get_logger
-from mfgarchon.utils.mfg_logging.logger import MFGFormatter
+from mfgarchon.utils.mfg_logging import MFGFormatter, get_logger
 
 from .base import SolverHooks
 
@@ -328,10 +327,12 @@ class LoggingHook(SolverHooks):
             handler = logging.FileHandler(log_file)
             # MFGFormatter, not a hand-rolled string: it is the format LogAnalyzer parses.
             # This line was `logging.Formatter("%(asctime)s - %(name)s - %(levelname)s -
-            # %(message)s")`, which differs in two ways that both defeat the reader -- no
-            # `datefmt`, so asctime carries milliseconds and the timestamp field never matches,
-            # and no `-8s` padding, so the level field never matches either. Measured: a file
-            # written that way yields 0 entries from LogAnalyzer at every level (#2058).
+            # %(message)s")`. It differs in two ways, and only ONE of them matters: the missing
+            # `datefmt` makes asctime carry milliseconds, so the reader's timestamp field never
+            # matches and the line is dropped before its level is examined. The missing `-8s`
+            # padding costs nothing since #2056 widened the level group to accept a single space.
+            # Measured 2x2: datefmt alone gives 5/5 with or without padding, no datefmt gives 0/5
+            # either way (#2058).
             formatter = MFGFormatter()
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)

--- a/mfgarchon/hooks/visualization.py
+++ b/mfgarchon/hooks/visualization.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.mfg_logging.logger import MFGFormatter
 
 from .base import SolverHooks
 
@@ -325,7 +326,13 @@ class LoggingHook(SolverHooks):
         # Set up handlers
         if log_file:
             handler = logging.FileHandler(log_file)
-            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+            # MFGFormatter, not a hand-rolled string: it is the format LogAnalyzer parses.
+            # This line was `logging.Formatter("%(asctime)s - %(name)s - %(levelname)s -
+            # %(message)s")`, which differs in two ways that both defeat the reader -- no
+            # `datefmt`, so asctime carries milliseconds and the timestamp field never matches,
+            # and no `-8s` padding, so the level field never matches either. Measured: a file
+            # written that way yields 0 entries from LogAnalyzer at every level (#2058).
+            formatter = MFGFormatter()
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
 

--- a/mfgarchon/utils/mfg_logging/__init__.py
+++ b/mfgarchon/utils/mfg_logging/__init__.py
@@ -43,6 +43,7 @@ from .decorators import (
 from .logger import (
     # Classes
     LoggedOperation,
+    MFGFormatter,
     # Environment-specific configurations
     configure_development_logging,
     # Primary API
@@ -84,6 +85,7 @@ __all__ = [
     "log_validation_error",
     # Classes
     "LoggedOperation",
+    "MFGFormatter",
     # Decorators
     "LoggingMixin",
     "add_logging_to_class",

--- a/mfgarchon/workflow/common.py
+++ b/mfgarchon/workflow/common.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 import numpy as np
 
 from mfgarchon.utils.mfg_logging import get_logger
+from mfgarchon.utils.mfg_logging.logger import MFGFormatter
 
 
 class ExecutionStatus(Enum):
@@ -104,7 +105,12 @@ def setup_workflow_logging(
     logger.setLevel(logging.INFO)
 
     if not logger.handlers:
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        # MFGFormatter owns this format; a hand-rolled copy here was the second of two rivals
+        # (#2058). This branch is dead for production callers -- `get_logger` always attaches a
+        # StreamHandler, so the guard above is False and neither handler is built, measured -- but
+        # a dead rival string is still a rival, and it is what a future lift of that guard would
+        # install.
+        formatter = MFGFormatter()
 
         if log_file is not None:
             file_handler = logging.FileHandler(log_file)

--- a/mfgarchon/workflow/common.py
+++ b/mfgarchon/workflow/common.py
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
 
 import numpy as np
 
-from mfgarchon.utils.mfg_logging import get_logger
-from mfgarchon.utils.mfg_logging.logger import MFGFormatter
+from mfgarchon.utils.mfg_logging import MFGFormatter, get_logger
 
 
 class ExecutionStatus(Enum):

--- a/tests/unit/test_utils/test_mfg_logging.py
+++ b/tests/unit/test_utils/test_mfg_logging.py
@@ -192,10 +192,16 @@ class TestEveryWriterUsesTheOwnedFormat:
     def test_the_logging_hook_writes_a_file_LogAnalyzer_can_read(self, tmp_path):
         """`LoggingHook` built its own `logging.Formatter` and produced unreadable files.
 
-        Two independent departures from `MFGFormatter`, either of which alone defeats the reader:
-        no `datefmt`, so `asctime` carries milliseconds and the timestamp field never matches; and
-        no `-8s` padding, so the level field never matches. Measured on the old formatter: 0
-        entries at every level, failing at the timestamp before the level was examined.
+        Two departures from `MFGFormatter`, and only ONE of them matters. The missing `datefmt`
+        makes `asctime` carry milliseconds, so the reader's timestamp field never matches and the
+        line is dropped before its level is examined -- necessary and sufficient. The missing
+        `-8s` padding costs nothing, because #2056 widened the level group to accept the single
+        space an unpadded levelname leaves; the test 47 lines above pins exactly that tolerance.
+
+        Measured 2x2 against the current reader: `datefmt` alone gives 5/5 at every level with or
+        without padding, no `datefmt` gives 0/5 either way. An earlier revision of this docstring
+        said both defects were independently fatal -- true of the pre-#1918 reader, and carried
+        forward without re-measuring against the one #2056 shipped.
 
         This goes through the writer a user actually gets -- `LoggingHook(log_file=...)` -- rather
         than through `MFGFormatter` directly, because the defect was that the hook did not use it.
@@ -211,6 +217,8 @@ class TestEveryWriterUsesTheOwnedFormat:
         # that does not clean up leaks a handler into every later construction.
         existing = logging.getLogger("MFGSolver")
         saved_handlers, saved_level = list(existing.handlers), existing.level
+        saved_propagate = existing.propagate
+        cached_logger = MFGLogger._loggers.get("MFGSolver")
         existing.handlers.clear()
         try:
             hook = LoggingHook(log_file=str(log_path), log_level="DEBUG")
@@ -224,6 +232,15 @@ class TestEveryWriterUsesTheOwnedFormat:
             logging.getLogger("MFGSolver").handlers.clear()
             existing.handlers.extend(saved_handlers)
             existing.level = saved_level
+            existing.propagate = saved_propagate
+            # MFGLogger caches by name and short-circuits _setup_logger on a hit, so leaving
+            # "MFGSolver" in the cache hands every later get_logger a handler-less,
+            # non-propagating logger: INFO vanishes and WARNING+ falls through to lastResort on
+            # unformatted stderr. Restoring handlers is not enough; the cache entry has to go.
+            if cached_logger is None:
+                MFGLogger._loggers.pop("MFGSolver", None)
+            else:
+                MFGLogger._loggers["MFGSolver"] = cached_logger
 
         analyzer = LogAnalyzer(str(log_path))
         analyzer.parse_log_file()

--- a/tests/unit/test_utils/test_mfg_logging.py
+++ b/tests/unit/test_utils/test_mfg_logging.py
@@ -184,3 +184,49 @@ class TestLogAnalyserSeesEveryLevel:
         parsed = {entry["level"] for entry in analyzer.entries}
 
         assert parsed == set(levels), f"emitted {levels}, parsed back {sorted(parsed)}"
+
+
+class TestEveryWriterUsesTheOwnedFormat:
+    """#2058: MFGFormatter owns the line format; a hand-rolled copy is a second owner."""
+
+    def test_the_logging_hook_writes_a_file_LogAnalyzer_can_read(self, tmp_path):
+        """`LoggingHook` built its own `logging.Formatter` and produced unreadable files.
+
+        Two independent departures from `MFGFormatter`, either of which alone defeats the reader:
+        no `datefmt`, so `asctime` carries milliseconds and the timestamp field never matches; and
+        no `-8s` padding, so the level field never matches. Measured on the old formatter: 0
+        entries at every level, failing at the timestamp before the level was examined.
+
+        This goes through the writer a user actually gets -- `LoggingHook(log_file=...)` -- rather
+        than through `MFGFormatter` directly, because the defect was that the hook did not use it.
+        """
+        import logging
+
+        from mfgarchon.hooks.visualization import LoggingHook
+        from mfgarchon.utils.mfg_logging.analysis import LogAnalyzer
+
+        levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+        log_path = tmp_path / "solver.log"
+        # LoggingHook uses the fixed logger name "MFGSolver" and always addHandler()s, so a test
+        # that does not clean up leaks a handler into every later construction.
+        existing = logging.getLogger("MFGSolver")
+        saved_handlers, saved_level = list(existing.handlers), existing.level
+        existing.handlers.clear()
+        try:
+            hook = LoggingHook(log_file=str(log_path), log_level="DEBUG")
+            for level in levels:
+                hook.logger.log(getattr(logging, level), f"probe line for {level}")
+            for handler in hook.logger.handlers:
+                handler.flush()
+                if isinstance(handler, logging.FileHandler):
+                    handler.close()
+        finally:
+            logging.getLogger("MFGSolver").handlers.clear()
+            existing.handlers.extend(saved_handlers)
+            existing.level = saved_level
+
+        analyzer = LogAnalyzer(str(log_path))
+        analyzer.parse_log_file()
+        parsed = {entry["level"] for entry in analyzer.entries}
+
+        assert parsed == set(levels), f"emitted {levels}, parsed back {sorted(parsed)}"

--- a/tests/unit/test_workflow/test_common.py
+++ b/tests/unit/test_workflow/test_common.py
@@ -158,6 +158,16 @@ class TestSetupWorkflowLogging:
             if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
         ]
 
+        # #2058: both handlers must carry the OWNED format, not a hand-rolled copy. Asserting
+        # handler TYPES alone left this branch green under any formatter, which is how a second
+        # format string lived here. Type, not string: the string belongs to MFGFormatter.
+        from mfgarchon.utils.mfg_logging import MFGFormatter
+
+        for handler in logger.handlers:
+            assert isinstance(handler.formatter, MFGFormatter), (
+                f"{type(handler).__name__} carries {type(handler.formatter).__name__}, not MFGFormatter"
+            )
+
         assert len(file_handlers) >= 1
         assert len(stream_handlers) >= 1
 


### PR DESCRIPTION
Closes #2058, and narrows it: the defect is real but **latent**, and the issue overstated it in both directions before it was measured.

## The change

Two hand-rolled copies of `"%(asctime)s - %(name)s - %(levelname)s - %(message)s"` are replaced by `MFGFormatter()`:

| site | was |
|---|---|
| `LoggingHook` — `hooks/visualization.py` | `logging.Formatter("…%(name)s - %(levelname)s…")` |
| `setup_workflow_logging` — `workflow/common.py` | the same string, again |

After: `grep` for that literal in `mfgarchon/` returns **0**. Control: the owner's `%(levelname)-8s` is still present in `logger.py` (both the colored and plain branches) and nowhere else.

## Why each copy was unreadable

Two independent departures from the owner, **either of which alone** defeats `LogAnalyzer`:

- **no `datefmt`** → `asctime` becomes `2026-08-22 09:28:46,764`, and the reader's timestamp field requires ` - ` where the `,764` sits
- **no `-8s` padding** → the level field arrives with a single space at *every* level, which is the #1918 defect generalised from CRITICAL to all five

Measured through `LoggingHook` before the change: **0 entries at every level**. It fails at the timestamp, before the level is ever examined.

## Latent, not live — corrected from the issue

| writer | copy is wrong | installed in production? |
|---|---|---|
| `setup_workflow_logging` | yes | **no** |
| `LoggingHook` | yes | only if a caller passes `log_file`, and **none does** |

`setup_workflow_logging`'s handlers are both inside `if not logger.handlers:`, and `get_logger` always attaches a StreamHandler before returning — so the guard is False for production callers. Measured: called with `log_file` set **and** `console=True`, it returns a single `StreamHandler` carrying the **correct** format, and writes no file. Its copy was never installed.

`LoggingHook`'s only `log_file=` call site is `visualization.py:297`, which is inside a **docstring Example block**. Control: the same query finds 44 hook instantiations, so the empty result is the population.

So nothing currently writes an unreadable log. A rival string was standing ready to.

## Why this is a single-source change and not a repair

Adding `datefmt=` to each copy would fix this instance and leave the fork open — three owners of one format, two of them agreeing by coincidence. The rule is one owner plus deletion of the rivals in the same change, and the mechanical check is that the rival count drops to zero, which it does.

This is also the structural reason #1918 was possible at all: the format lives in `MFGFormatter.__init__` and had no importable owner, so every writer that wanted it had to copy it.

## Testing

- Drives `LoggingHook(log_file=...)` — the writer a user actually gets — into `LogAnalyzer`, **not** `MFGFormatter` directly, because the defect was that the hook did not use it.
- **Two-sided**: against `main`'s `visualization.py` it fails with `parsed back []`.
- Saves and restores the `"MFGSolver"` logger's handlers and level. `LoggingHook` uses a fixed logger name and calls `addHandler` unconditionally, so a test without cleanup leaks a handler into every later construction.
- `GATE GREEN`.

## Not fixed here

`setup_workflow_logging`'s dead-handler guard is deliberate (`common.py:79-86` records why lifting it wrote 298 KB from 37 output directories into one file at the repo root). Reviving workflow file logging remains a separate decision, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)