### PR TITLE
Delete Robin's outward_normal_sign, require FP's (#2063, #1936 item 3)

### DIFF
--- a/changelog.d/2063-robin-sign-and-fp-default.fixed.md
+++ b/changelog.d/2063-robin-sign-and-fp-default.fixed.md
@@ -1,0 +1,45 @@
+**BREAKING.** `ghost_cell_robin` no longer takes `outward_normal_sign`, and
+`ghost_cell_fp_no_flux` no longer defaults it (#2063, #1936 item 3). The two functions get
+opposite treatment because the parameter was doing opposite things in them.
+
+**`ghost_cell_robin`: the argument was wrong, not merely dangerously defaulted.** It was unused in
+the cell-centred branch and applied *backwards* in the vertex-centred one. `RobinCalculator` was
+the only caller in the package that passed it — AST census over every call site, with the
+parameter's index read from the signature — and passing the physically correct `-1.0` at the min
+wall is exactly what broke it. Measured through the public calculator on `u = 3x`, `dx = 0.1`,
+`alpha = 0, beta = 1` (which makes Robin the same condition as Neumann, so a linear field must come
+back exactly):
+
+| grid_type | side | was | exact |
+|---|---|---|---|
+| CELL_CENTERED | max / min | +3.3000 / −0.3000 | ✓ |
+| VERTEX_CENTERED | max | +3.3000 | ✓ |
+| **VERTEX_CENTERED** | **min** | **+0.3000** | **−0.3000** |
+
+A sign inversion, not a truncation error. The seven callers that omitted the argument took the
+`+1.0` default and were right by accident; they are now right by construction. Ignoring the
+argument entirely is exact on 8 of 8 — two centrings × two walls × two slopes — which is why it is
+deleted rather than made required. Same removal and same reason as #1972's from
+`ghost_cell_neumann`: `du/dn` already carries the wall's direction.
+
+Nothing caught this because the cell-centred branch never used the parameter and `grid_type`
+defaults to cell-centred, so every default-taking path was doubly insulated and the one path that
+could reach the bug had no test. It has one now.
+
+**`ghost_cell_fp_no_flux`: the parameter stays, the default goes, and the docstring was inverted.**
+Here it does real work — it reconciles `ghost_cell_advection_diffusion_no_flux`, which holds `v·n`
+and passes `1.0` deliberately, with `ZeroFluxCalculator`, which holds the axis velocity `v_x` and
+passes the wall's sign. Both callers pass it and **none relied on the default**, so requiring it is
+free and removes a `+1.0` that silently means "max wall".
+
+Its `Args:` line said `drift_velocity` is "the normal component v*n (positive = outward)" while the
+body multiplies by `outward_normal_sign` to *obtain* `v·n`, and its own `Example` passes `-0.5` for
+a leftward drift at a left wall — where `v·n` would be `+0.5`. The body and the Example agree; the
+`Args:` line was the outlier. Decided by the function's own contract, `J·n = 0`: fed `v_x` the
+residual is machine zero at both walls; fed `v·n` the min wall leaves **1.25**. Corrected.
+
+Not fixed here, and filed while validating the lines this change edits: the vertex-centred
+`alpha != 0` arm of `ghost_cell_robin` is wrong at both walls independently of any sign, returning
+−10.5 where 3.3 is exact (#2064). And #1907, which recorded the cell-centred symptom of the Robin
+sign, no longer reproduces — re-measured with its own harness, 0.000000 where it recorded 0.2 /
+0.05 / 0.0125.

--- a/changelog.d/2063-robin-sign-and-fp-default.removed.md
+++ b/changelog.d/2063-robin-sign-and-fp-default.removed.md
@@ -38,8 +38,27 @@ a leftward drift at a left wall — where `v·n` would be `+0.5`. The body and t
 `Args:` line was the outlier. Decided by the function's own contract, `J·n = 0`: fed `v_x` the
 residual is machine zero at both walls; fed `v·n` the min wall leaves **1.25**. Corrected.
 
-Not fixed here, and filed while validating the lines this change edits: the vertex-centred
-`alpha != 0` arm of `ghost_cell_robin` is wrong at both walls independently of any sign, returning
-−10.5 where 3.3 is exact (#2064). And #1907, which recorded the cell-centred symptom of the Robin
-sign, no longer reproduces — re-measured with its own harness, 0.000000 where it recorded 0.2 /
-0.05 / 0.0125.
+The `Args:` entry for `outward_normal_sign` is corrected too. It read "+1 for max boundary, −1 for
+min boundary", as though the parameter identified the wall; it does not.
+`ghost_cell_advection_diffusion_no_flux` passes `+1.0` at **both** walls because it already holds
+`v·n`. The parameter is the conversion factor, and reading it as a wall identifier is what made the
+`drift_velocity` line say `v·n` in the first place.
+
+`RobinCalculator` and `ZeroFluxCalculator` now pass `grid_type` by **keyword**. Passed positionally
+it lands on whatever slot follows `dx`, so reintroducing an `outward_normal_sign` parameter would
+silently rebind `GridType` onto it and fall back to cell-centred — mutation-tested during review:
+that restoration leaves 51/51 green. The keyword makes the binding structural rather than lucky.
+
+Not fixed here, and filed while validating the lines this change edits:
+
+- **#2064** — the vertex-centred `alpha != 0` arm of `ghost_cell_robin` is wrong at both walls
+  independently of any sign, returning −10.5 where 3.3 is exact.
+- **#2068** — `ghost_cell_fp_no_flux`'s VERTEX_CENTERED branch leaves a total flux that does not
+  converge under refinement, settling at `−0.5 = −v_x·rho` where the cell-centred branch is machine
+  zero at every resolution. It is self-consistent with a wall at separation `2*dx`, which is the
+  #1972 pathology in the same file. **The `J·n = 0` test this change adds exercises only the
+  cell-centred branch** — the one that already satisfied the contract; replacing the vertex formula
+  with arbitrary values leaves 1309/1309 green.
+- **#1907**, which recorded the cell-centred symptom of the Robin sign, no longer reproduces —
+  re-measured with its own harness, 0.000000 where it recorded 0.2 / 0.05 / 0.0125. It already did
+  not reproduce before this change; nothing here fixes it.

--- a/mfgarchon/geometry/boundary/calculators.py
+++ b/mfgarchon/geometry/boundary/calculators.py
@@ -267,13 +267,17 @@ class RobinCalculator:
         is what #2063 removed -- this was the only caller in the package that did, and it was the
         only one getting a wrong answer, inverting the vertex-centred min wall.
         """
+        # grid_type by KEYWORD, not position. Passed positionally it lands on whatever slot
+        # follows `dx`, so reintroducing an `outward_normal_sign` parameter would silently rebind
+        # GridType onto it and fall back to cell-centred -- mutation-tested: that restoration
+        # leaves 51/51 green. The keyword makes the binding structural rather than lucky (#2063).
         return ghost_cell_robin(
             interior_value,
             self._rhs_value,
             self._alpha,
             self._beta,
             dx,
-            self._grid_type,
+            grid_type=self._grid_type,
         )
 
     def __repr__(self) -> str:
@@ -484,7 +488,7 @@ class ZeroFluxCalculator:
             self._diffusion,
             dx,
             outward_sign,
-            self._grid_type,
+            grid_type=self._grid_type,  # keyword, for the reason given in RobinCalculator (#2063)
         )
 
     def __repr__(self) -> str:

--- a/mfgarchon/geometry/boundary/calculators.py
+++ b/mfgarchon/geometry/boundary/calculators.py
@@ -260,15 +260,19 @@ class RobinCalculator:
         side: str,
         **kwargs,
     ) -> T:
-        """Compute ghost value for Robin BC (vectorized)."""
-        outward_sign = 1.0 if side == "max" else -1.0
+        """Compute ghost value for Robin BC (vectorized).
+
+        `side` is accepted for the protocol and not used: `rhs_value` carries `du/dn`, which
+        already has the wall's direction. Deriving an outward sign from `side` and passing it on
+        is what #2063 removed -- this was the only caller in the package that did, and it was the
+        only one getting a wrong answer, inverting the vertex-centred min wall.
+        """
         return ghost_cell_robin(
             interior_value,
             self._rhs_value,
             self._alpha,
             self._beta,
             dx,
-            outward_sign,
             self._grid_type,
         )
 

--- a/mfgarchon/geometry/boundary/ghost_cells.py
+++ b/mfgarchon/geometry/boundary/ghost_cells.py
@@ -120,7 +120,6 @@ def ghost_cell_robin(
     alpha: float,
     beta: float,
     dx: float,
-    outward_normal_sign: float = 1.0,
     grid_type: GridType = GridType.CELL_CENTERED,
 ) -> float:
     """
@@ -135,26 +134,32 @@ def ghost_cell_robin(
     Solving for u_ghost:
         u_ghost * (alpha/2 + beta/dx) = g - u_interior * (alpha/2 - beta/dx)
 
-    IMPORTANT: For cell-centered grids, du/dn = (u_ghost - u_interior)/dx for BOTH
-    boundaries because ghost is always "outside" and interior is always "inside"
-    regardless of left/right. The outward_normal_sign parameter is kept for backward
-    compatibility but is NOT used in the cell-centered formula.
+    There is NO sign argument, at either centring. `du/dn` already carries the wall's direction,
+    and the ghost sits outside while the interior sits inside at both walls, so
+    `(u_ghost - u_interior)/dx` is the outward normal derivative either way.
 
-    For vertex-centered grids, the sign convention differs.
+    This took an `outward_normal_sign` until #2063, unused cell-centred and APPLIED BACKWARDS
+    vertex-centred. `RobinCalculator` was the only caller in the package that passed it, and
+    passing the physically correct -1.0 at the min wall is what broke it: measured on `u = 3x`,
+    dx = 0.1, alpha = 0, beta = 1, it returned +0.3000 where -0.3000 is exact. The seven callers
+    that omitted it took the +1.0 default and were right by accident. Ignoring the argument
+    entirely is exact on 8 of 8 -- two centrings, two walls, two slopes -- which is why it is
+    gone rather than merely un-defaulted. Same removal, and the same reason, as #1972's from
+    `ghost_cell_neumann`.
+
+    NOT fixed here: the vertex-centred `alpha != 0` arm below is wrong at both walls independently
+    of any sign, returning -10.5 where 3.3 is exact. It solves for a quantity multiplied by alpha
+    rather than for the ghost. #2064.
     """
     if grid_type == GridType.VERTEX_CENTERED:
-        # Vertex-centered: sign matters because derivative direction differs
         if abs(alpha) > 1e-12:
-            return (rhs_value - beta * outward_normal_sign * interior_value / dx) / alpha
-        else:
-            return interior_value + dx * rhs_value / beta * outward_normal_sign
+            # WRONG at both walls, independently of the sign this branch used to apply: #2064.
+            return (rhs_value - beta * interior_value / dx) / alpha
+        return interior_value + dx * rhs_value / beta
 
-    # Cell-centered: ghost and interior are dx apart
-    # CRITICAL: du/dn = (u_ghost - u_interior)/dx for BOTH left and right boundaries
-    # The outward_normal_sign is NOT used here because the geometry is symmetric:
-    # - At left boundary: ghost at -dx/2, interior at +dx/2
-    # - At right boundary: interior at L-dx/2, ghost at L+dx/2
-    # In both cases, (u_ghost - u_interior)/dx gives the outward normal derivative.
+    # Cell-centered: ghost and interior are dx apart, and the geometry is symmetric --
+    # ghost at -dx/2 / interior at +dx/2 on the left, interior at L-dx/2 / ghost at L+dx/2 on the
+    # right -- so (u_ghost - u_interior)/dx is the outward normal derivative at both walls.
     coeff_ghost = alpha / 2.0 + beta / dx
     coeff_interior = alpha / 2.0 - beta / dx
 
@@ -297,7 +302,7 @@ def ghost_cell_fp_no_flux(
     drift_velocity: float,
     diffusion_coeff: float,
     dx: float,
-    outward_normal_sign: float = 1.0,
+    outward_normal_sign: float,
     grid_type: GridType = GridType.CELL_CENTERED,
 ) -> float:
     """
@@ -331,7 +336,13 @@ def ghost_cell_fp_no_flux(
 
     Args:
         interior_value: Density at interior point rho_interior
-        drift_velocity: Normal component of drift velocity v*n (positive = outward)
+        drift_velocity: Drift velocity in the AXIS direction, v_x -- not v*n. This routine
+            multiplies it by `outward_normal_sign` to obtain v*n, so passing v*n instead
+            double-counts the orientation: measured at a min wall, that leaves a total flux
+            residual of 1.25 rather than 0. A caller that already holds v*n passes it here with
+            `outward_normal_sign=1.0`, which is what `ghost_cell_advection_diffusion_no_flux`
+            does. No default: it is required precisely because the two callers disagree about
+            which quantity they hold, and +1.0 silently means "max wall" (#2063)
         diffusion_coeff: Diffusion coefficient D = sigma^2/2
         dx: Grid spacing
         outward_normal_sign: +1 for max boundary (outward normal points positive),

--- a/mfgarchon/geometry/boundary/ghost_cells.py
+++ b/mfgarchon/geometry/boundary/ghost_cells.py
@@ -345,8 +345,12 @@ def ghost_cell_fp_no_flux(
             which quantity they hold, and +1.0 silently means "max wall" (#2063)
         diffusion_coeff: Diffusion coefficient D = sigma^2/2
         dx: Grid spacing
-        outward_normal_sign: +1 for max boundary (outward normal points positive),
-                            -1 for min boundary (outward normal points negative)
+        outward_normal_sign: the factor converting `drift_velocity` to v*n -- NOT "which wall
+            this is". A caller holding the axis velocity v_x passes the wall's outward normal
+            (+1 max, -1 min), which is what `ZeroFluxCalculator` does; a caller already holding
+            v*n passes +1.0 at BOTH walls, which is what
+            `ghost_cell_advection_diffusion_no_flux` does. Reading it as a wall identifier is what
+            made the `drift_velocity` line above say v*n (#2063). Required, no default.
         grid_type: Grid type (cell-centered or vertex-centered)
 
     Returns:

--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -9,6 +9,7 @@ import pytest
 import numpy as np
 
 from mfgarchon.geometry.boundary import (
+    GridType,
     dirichlet_bc,
     neumann_bc,
     no_flux_bc,
@@ -383,6 +384,58 @@ class TestCalculatorClasses:
             g = -slope if side == "min" else +slope  # du/dn: the outward normal flips at the min wall
             got = NeumannCalculator(flux_value=g).compute(interior_value=slope * x_interior, dx=dx, side=side)
             assert np.isclose(got, slope * x_ghost), f"{side}: {got} != {slope * x_ghost} for u = {slope}x"
+
+    @pytest.mark.parametrize("grid_type", [GridType.CELL_CENTERED, GridType.VERTEX_CENTERED])
+    @pytest.mark.parametrize("side", ["min", "max"])
+    def test_robin_with_alpha_zero_reproduces_a_linear_field(self, grid_type, side):
+        """#2063: the vertex-centred min wall was inverted, and only this path reached it.
+
+        `alpha = 0, beta = 1` makes Robin the same condition as Neumann, so `u = a*x` must come
+        back exactly -- an external oracle, not either formula restated. Measured before the fix,
+        VERTEX_CENTERED/min: +0.3000 where -0.3000 is exact. The other three cells passed, which is
+        why nothing caught it; the cell-centred branch never used the sign and `grid_type` defaults
+        to cell-centred, so the only path that could reach the bug had no test.
+
+        The cause was `RobinCalculator` deriving an outward sign from `side` and passing it on --
+        the only caller in the package that did. Passing the physically correct -1.0 was what broke
+        it, so the six callers that omitted the argument were right by accident.
+        """
+        from mfgarchon.geometry.boundary import RobinCalculator
+
+        slope, dx = 3.0, 0.1
+        x_interior, x_ghost = (0.0, -dx) if side == "min" else (1.0, 1.0 + dx)
+        outward_normal = -1.0 if side == "min" else +1.0
+
+        calc = RobinCalculator(alpha=0.0, beta=1.0, rhs_value=slope * outward_normal, grid_type=grid_type)
+        got = calc.compute(interior_value=slope * x_interior, dx=dx, side=side)
+
+        assert np.isclose(got, slope * x_ghost), f"{grid_type.name}/{side}: {got} != {slope * x_ghost}"
+
+    def test_the_fp_no_flux_ghost_zeroes_the_TOTAL_flux_given_an_axis_velocity(self):
+        """#2063: `drift_velocity` is v_x, not v*n, and the docstring said the opposite.
+
+        The contract is J.n = 0 with J = v*rho - D*grad(rho), so the check is the residual itself,
+        not a formula restated. Fed v*n as the Args line instructed, the min wall leaves a residual
+        of 1.25 instead of 0; fed v_x it is machine zero. The max wall cannot discriminate, since
+        v*n = v_x there.
+
+        `outward_normal_sign` has no default, because the two callers hold different quantities --
+        `ghost_cell_advection_diffusion_no_flux` already has v*n and passes 1.0, `ZeroFluxCalculator`
+        has v_x and passes the wall's sign -- and +1.0 silently means "max wall".
+        """
+        from mfgarchon.geometry.boundary.ghost_cells import ghost_cell_fp_no_flux
+
+        D, dx, rho_interior = 0.125, 0.1, 1.0
+        for outward_normal in (+1.0, -1.0):
+            for v_x in (+0.5, -0.5):
+                ghost = ghost_cell_fp_no_flux(rho_interior, v_x, D, dx, outward_normal)
+                v_n = v_x * outward_normal
+                rho_face = (ghost + rho_interior) / 2.0
+                drho_dn = (ghost - rho_interior) / dx
+                assert np.isclose(v_n * rho_face - D * drho_dn, 0.0, atol=1e-12)
+
+        with pytest.raises(TypeError):
+            ghost_cell_fp_no_flux(rho_interior, 0.5, D, dx)
 
     def test_neumann_calculator_agrees_with_the_live_applicator_path(self):
         """The two implementations of this ghost disagreed by a factor of 2 and a sign until #1972.

--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -398,7 +398,7 @@ class TestCalculatorClasses:
 
         The cause was `RobinCalculator` deriving an outward sign from `side` and passing it on --
         the only caller in the package that did. Passing the physically correct -1.0 was what broke
-        it, so the six callers that omitted the argument were right by accident.
+        it, so the seven callers that omitted the argument were right by accident.
         """
         from mfgarchon.geometry.boundary import RobinCalculator
 
@@ -434,7 +434,7 @@ class TestCalculatorClasses:
                 drho_dn = (ghost - rho_interior) / dx
                 assert np.isclose(v_n * rho_face - D * drho_dn, 0.0, atol=1e-12)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="outward_normal_sign"):
             ghost_cell_fp_no_flux(rho_interior, 0.5, D, dx)
 
     def test_neumann_calculator_agrees_with_the_live_applicator_path(self):


### PR DESCRIPTION
Closes #2063. Settles item 3 of #1936.

> **Revised after review.** Five required items applied: the "six callers" line (it is **seven** — the wrong number was inherited verbatim from #2063's own body, corrected there too), `grid_type` now passed by **keyword** in `RobinCalculator` and `ZeroFluxCalculator` (positional binding made a restored bug invisible — mutation-tested, 51/51 green), the still-inverted `outward_normal_sign` **`Args:` entry** six lines above this PR's own new text, the fragment recategorised `.fixed` → `.removed`, and the vertex-centred flux defect filed as **#2068**.
>
> **The `J·n = 0` test this PR adds exercises only the cell-centred branch** — the one that already satisfied the contract. #2068 is the other one, and it is worse.

The same parameter, opposite treatment in two functions, because it was doing opposite things in them.

## `ghost_cell_robin` — the argument was wrong, not merely dangerously defaulted

Unused in the cell-centred branch (its own docstring said so), **applied backwards** in the vertex-centred one. Measured through the public `RobinCalculator` on `u = 3x`, `dx = 0.1`, `alpha = 0, beta = 1` — which makes Robin the same condition as Neumann, so a linear field must come back exactly:

| grid_type | side | was | exact | error |
|---|---|---|---|---|
| CELL_CENTERED | max | +3.3000 | +3.3000 | 4e−16 |
| CELL_CENTERED | min | −0.3000 | −0.3000 | 6e−17 |
| VERTEX_CENTERED | max | +3.3000 | +3.3000 | 4e−16 |
| **VERTEX_CENTERED** | **min** | **+0.3000** | **−0.3000** | **6.0e−01** |

A sign inversion, not a truncation error.

**Passing the physically correct value is what broke it.** AST census over every call site, with the parameter's positional index read from the signature rather than assumed:

| site | passed the sign? |
|---|---|
| `calculators.py` — `RobinCalculator` | **yes** — and it is the only one |
| `_compat.py` ×3, `applicator_fdm.py` ×3, `protocols.py` ×1 | no — took the `+1.0` default |

The seven that omitted it were right *by accident*. The one that supplied the true outward normal at the min wall got the inversion.

**Deleted rather than made required**: ignoring the argument entirely is exact on **8 of 8** — 2 centrings × 2 walls × 2 slopes. `du/dn` already carries the wall's direction, which is the same argument that removed it from `ghost_cell_neumann` in #1972.

Why nothing caught it: the cell-centred branch never used the parameter and `grid_type` defaults to cell-centred, so every default-taking path was doubly insulated, and the only path that could reach the bug had no test.

## `ghost_cell_fp_no_flux` — the parameter stays, the default and the `Args:` line go

Here it does real work: it reconciles two callers holding **different quantities**.

| caller | holds | passes |
|---|---|---|
| `ghost_cell_advection_diffusion_no_flux` | `v·n` already | `outward_normal_sign=1.0`, deliberately |
| `ZeroFluxCalculator` | the axis velocity `v_x` | the wall's sign |

Both pass it; **none relied on the default**, so requiring it costs nothing and removes a `+1.0` that silently means "max wall".

Its `Args:` line said `drift_velocity` is *"the normal component v*n (positive = outward)"* while the body multiplies by `outward_normal_sign` to **obtain** `v·n` — and its own `Example` passes `-0.5` for a leftward drift at a left wall, where `v·n` would be `+0.5`. Body and Example agree; the `Args:` line was the outlier.

Decided by the function's own contract, `J·n = 0` with `J = v·ρ − D∇ρ`:

| fed | max wall residual | min wall residual |
|---|---|---|
| `v_x` (what the body needs) | ~1e−16 | ~1e−16 |
| `v·n` (what `Args:` instructed) | ~1e−16 | **1.25** |

The max wall cannot discriminate, since `v·n = v_x` there — the same one-wall blindness as the Robin case.

## Testing

- Both tests are **external oracles**, not either formula restated: a linear field for Robin, the flux residual itself for FP.
- **Two-sided**: against `main` the Robin test fails `VERTEX_CENTERED/min: 0.3 != -0.3`.
- The FP test also pins that omitting the argument now raises.
- Every call site re-bound against the new signatures programmatically (`inspect.Signature.bind`), not by eye.
- `GATE GREEN`.

## Found while validating these lines, filed not fixed

- **#2064** — the vertex-centred `alpha != 0` arm is wrong at **both** walls independently of any sign, returning −10.5 where 3.3 is exact. It solves for a quantity multiplied by `alpha` rather than for the ghost. Not folded in: the correct form divides by `beta`, so it cannot serve the `beta == 0` case the current branch structure exists to avoid, and deciding that is a design call.
- **#1907**, which recorded the cell-centred symptom of the Robin sign, **no longer reproduces** — re-measured with its own harness: `0.000000` where it recorded `0.2 / 0.05 / 0.0125`, with its `neumann` column matching exactly, so the harness is the same and only the `robin` column moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

