### PR TITLE
The decomposition guard accepted what it exists to refuse (#2072)

### DIFF
--- a/changelog.d/2072-howard-guard-coverage.fixed.md
+++ b/changelog.d/2072-howard-guard-coverage.fixed.md
@@ -1,0 +1,44 @@
+Howard's decomposition guard had two coverage holes that made it **accept what it exists to refuse**
+(#2072). Both are pre-existing on `main`, independent of #2069.
+
+**The momentum ladder stepped over the operating range.** `_mags` was
+`sorted({0.5, 1, 2, 0.5*_gT, _gT, 2*_gT})`, which on this file's own fixture is
+`{0.5, 1, 2, 20, 40, 80}` — while the solve's `max|∇u_T|` for `u_T = cos(2πx)` is `2π = 6.2832`,
+sitting in the unsampled `(2, 20)` gap. `_gT` is a *spacing* bound, not a gradient, and overestimates
+by 6.4× here, which is what pushed the upper rungs past the hole the widening was meant to close.
+
+Measured on `H = |p|²/2 + bump(|p|²)` with the bump supported on `|p| ∈ (3, 10)` and **no** alpha-free
+part, so `_af_bad` cannot be what catches it:
+
+| | old ladder | geometric span |
+|---|---|---|
+| the bumped Hamiltonian | **ACCEPTED** — finite, plausible, wrong | **REFUSED** |
+| `H = \|p\|²/2` exactly (control) | ACCEPTED | ACCEPTED |
+
+The ladder is now `np.geomspace(0.5, max(2*_gT, 2), 12)` unioned with `{0.5, 1, 2}`. A span cannot
+have that hole. Overestimating `_gT` stays safe for the original reason — a genuine quadratic matches
+the kinetic reference at *every* `|p|`, so more sample points can only make a true refusal stricter,
+never invent a false one — and the existing suite confirms it: **13 passed before, 16 after**, with no
+previously-accepted Hamiltonian newly refused.
+
+**A single NaN defeated the guard entirely, and the comment claimed the opposite.** It said
+`np.maximum` was used rather than the builtin because `max(0.0, nan)` returns `0.0` and would zero
+the measurement — "a fail-silent inside the fail-loud guard". It does not prevent that:
+
+```
+np.maximum(0.0, nan) = nan     nan > tol = False   -> ACCEPT
+max(0.0, nan)        = 0.0     0.0 > tol = False   -> ACCEPT
+```
+
+Identical. Measured on a quartic returning NaN only at `|p| = 80`, a probe magnitude the solve never
+visits: **accepted**, all-finite output, **153% wrong** against Newton. The guard now refuses on a
+non-finite `_af`, `_ke` or `_scale` before comparing anything to a tolerance — a probe that could not
+be evaluated is not a probe that passed.
+
+**Not changed here**, and #2072 flags it as a separate decision: `hjb_howard.py:506` returns the
+previous timestep with a `logger.warning` when the policy iterate is non-finite. That fallback is
+what turns a poisoned solve into a plausible finite field rather than a visible NaN, but it has five
+test references and changing a fallback to a raise is a behaviour change owing its own review.
+
+**#2069 is parked as a draft on this**; it removes the `_af_bad` refusal, which was incidentally
+covering the bumped class for an unrelated reason.

--- a/changelog.d/2072-howard-guard-coverage.fixed.md
+++ b/changelog.d/2072-howard-guard-coverage.fixed.md
@@ -1,44 +1,59 @@
 Howard's decomposition guard had two coverage holes that made it **accept what it exists to refuse**
 (#2072). Both are pre-existing on `main`, independent of #2069.
 
-**The momentum ladder stepped over the operating range.** `_mags` was
-`sorted({0.5, 1, 2, 0.5*_gT, _gT, 2*_gT})`, which on this file's own fixture is
-`{0.5, 1, 2, 20, 40, 80}` — while the solve's `max|∇u_T|` for `u_T = cos(2πx)` is `2π = 6.2832`,
-sitting in the unsampled `(2, 20)` gap. `_gT` is a *spacing* bound, not a gradient, and overestimates
-by 6.4× here, which is what pushed the upper rungs past the hole the widening was meant to close.
+**The gradient bound had the wrong dimensional content, and that is what made the probe miss.**
+`_gT` was `spread / hmin` — a *global* range divided by a *local* spacing — so it **diverges under
+refinement** while the gradient it stands for converges:
 
-Measured on `H = |p|²/2 + bump(|p|²)` with the bump supported on `|p| ∈ (3, 10)` and **no** alpha-free
-part, so `_af_bad` cannot be what catches it:
+| `u_T = cos(2πx)` | nx=11 | nx=21 | nx=41 | nx=201 |
+|---|---|---|---|---|
+| `spread/hmin` | 10 | 20 | 40 | 200 |
+| discrete Lipschitz | 3.090 | 3.090 | 3.129 | 3.141 |
+| true `max\|du/dx\|` | 3.142 | 3.142 | 3.142 | 3.142 |
 
-| | old ladder | geometric span |
+On a linear ramp it gives 200 where the true gradient is 1. This is why the *previous* widening
+failed: told the probe missed `|p| = 6.18`, it widened the ladder to multiples of a quantity 6.5×
+too large, moving the new rungs **further from** the hole. `_gT` is now
+`max |u_i − u_j| / |x_i − x_j|` — a genuine upper bound that converges to the truth, over arrays
+already materialised at that point.
+
+**The ladder is denser, not hole-free**, and an earlier revision of this note claimed otherwise.
+Adjacent rungs of a 12-point geomspace sit at a ratio of ~1.59, so a bump narrower than that in
+relative width still fits between two. What closes the operating-range hole is the corrected bound
+putting the rungs where the solve lives. The old ladder's **exact** rungs at `0.5·_gT` and `_gT` are
+kept in the union rather than dropped — a geomspace grid lands on neither — and the low end is
+`min(0.5, _gT/4)` rather than a hard `0.5`, which stopped scaling down when `_gT < 1`.
+
+Measured, all with **no alpha-free part** so `_af_bad` cannot be what catches them:
+
+| fixture | old bound + old ladder | corrected |
 |---|---|---|
-| the bumped Hamiltonian | **ACCEPTED** — finite, plausible, wrong | **REFUSED** |
+| bump on \|p\| ∈ (5.1, 7.9), straddling the operating magnitude | **ACCEPTED** | **REFUSED** |
+| bump on \|p\| ∈ (3, 10) | **ACCEPTED** | **REFUSED** |
 | `H = \|p\|²/2` exactly (control) | ACCEPTED | ACCEPTED |
 
-The ladder is now `np.geomspace(0.5, max(2*_gT, 2), 12)` unioned with `{0.5, 1, 2}`. A span cannot
-have that hole. Overestimating `_gT` stays safe for the original reason — a genuine quadratic matches
-the kinetic reference at *every* `|p|`, so more sample points can only make a true refusal stricter,
-never invent a false one — and the existing suite confirms it: **13 passed before, 16 after**, with no
-previously-accepted Hamiltonian newly refused.
-
-**A single NaN defeated the guard entirely, and the comment claimed the opposite.** It said
-`np.maximum` was used rather than the builtin because `max(0.0, nan)` returns `0.0` and would zero
-the measurement — "a fail-silent inside the fail-loud guard". It does not prevent that:
+**A single NaN defeated the guard, and the comment claimed the opposite:**
 
 ```
 np.maximum(0.0, nan) = nan     nan > tol = False   -> ACCEPT
 max(0.0, nan)        = 0.0     0.0 > tol = False   -> ACCEPT
 ```
 
-Identical. Measured on a quartic returning NaN only at `|p| = 80`, a probe magnitude the solve never
-visits: **accepted**, all-finite output, **153% wrong** against Newton. The guard now refuses on a
-non-finite `_af`, `_ke` or `_scale` before comparing anything to a tolerance — a probe that could not
-be evaluated is not a probe that passed.
+Identical. Measured on a quartic returning NaN at one probe magnitude: **accepted**, all-finite
+output, **153% wrong** against Newton. The guard now refuses on a non-finite `_af`, `_ke` or
+`_scale` before comparing anything to a tolerance.
 
-**Not changed here**, and #2072 flags it as a separate decision: `hjb_howard.py:506` returns the
-previous timestep with a `logger.warning` when the policy iterate is non-finite. That fallback is
-what turns a poisoned solve into a plausible finite field rather than a visible NaN, but it has five
-test references and changing a fallback to a raise is a behaviour change owing its own review.
+The NaN fixture places its NaN at `|p| = 1`, which is in the unconditional `{0.5, 1, 2}` union. An
+earlier revision used `|p| = 80` — a magnitude that existed only because `spread/hmin` was 40 on
+that fixture, so the test was coupled to the very quantity this change replaces and would have gone
+green-by-vacuity the moment the bound was corrected.
 
-**#2069 is parked as a draft on this**; it removes the `_af_bad` refusal, which was incidentally
-covering the bumped class for an unrelated reason.
+**False-refusal check.** No legitimate configuration is newly refused: the review that found the
+ladder defect swept 52 (declared `control_cost` with λ ∈ [0.1, 1000], potentials and couplings
+across 9 decades, four grid sizes, four terminal amplitudes) with a validated positive control and
+found **0**. My own confirmation covered 8 — 24 of my 32 intended configurations never reached the
+guard, failing at construction on the `potential` signature, which an accounting line caught before
+the result was reported as 32.
+
+**Not changed here**, and now its own PR: `hjb_howard.py:506` returned the previous timestep with a
+`logger.warning` on a non-finite policy iterate.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -3348,12 +3348,28 @@ class HJBGFDMSolver(BaseHJBSolver):
             # super-quadratic above stayed accepted. This form cannot fail, and OVERESTIMATING is the
             # safe direction: the kinetic reference tracks a genuine quadratic exactly at every |p|,
             # so a larger probe cannot produce a false refusal, only a stricter true one.
+            # THE DISCRETE LIPSCHITZ CONSTANT OF u_T, not `spread / hmin`. The latter is a spacing
+            # bound with the wrong dimensional content: it divides a GLOBAL range by a LOCAL
+            # spacing, so it diverges linearly under refinement while the gradient it stands for
+            # converges. Measured on u_T = cos(2 pi x): spread/hmin gives 20, 40, 80, 200 at
+            # nx = 11, 21, 41, 201 while max|du/dx| goes 3.09 -> 3.14; on a linear ramp it gives
+            # 200 where the true gradient is 1. The overestimate reaches 63x by nx = 201.
+            #
+            # That is why the earlier widening failed. It was told the probe missed |p| = 6.18 and
+            # widened the ladder to multiples of a quantity 6.4x too large, moving the new rungs
+            # FURTHER from the hole. `max |u_i - u_j| / |x_i - x_j|` is a genuine upper bound on
+            # the discrete gradient, converges to it rather than away, and costs nothing: both
+            # arrays are already materialised here. (#2072)
             _uT = np.asarray(U_terminal_colloc, dtype=float).ravel()
-            _spread = float(np.ptp(_uT)) if _uT.size else 0.0
             _dists = np.linalg.norm(_pts[:, None, :] - _pts[None, :, :], axis=-1)
             np.fill_diagonal(_dists, np.inf)
-            _hmin = float(np.min(_dists)) if _pts.shape[0] > 1 else 1.0
-            _gT = _spread / _hmin if np.isfinite(_hmin) and _hmin > 0.0 else 0.0
+            if _pts.shape[0] > 1 and _uT.size == _pts.shape[0]:
+                _du = np.abs(_uT[:, None] - _uT[None, :])
+                with np.errstate(invalid="ignore", divide="ignore"):
+                    _ratios = np.where(np.isfinite(_dists) & (_dists > 0.0), _du / _dists, 0.0)
+                _gT = float(np.max(_ratios)) if _ratios.size else 0.0
+            else:
+                _gT = 0.0
             _gT = _gT if np.isfinite(_gT) and _gT > 0.0 else 1.0
             # GEOMETRIC SPAN, not a few multiples of _gT. The previous form was
             # sorted({0.5, 1, 2, 0.5*_gT, _gT, 2*_gT}), which on this file's own fixture is
@@ -3368,7 +3384,21 @@ class HJBGFDMSolver(BaseHJBSolver):
             # before -- a genuine quadratic matches the kinetic reference at EVERY |p|, so more
             # sample points can only make a true refusal stricter, never invent a false one -- and
             # the span keeps the old ladder's reach while filling what it stepped over. (#2072)
-            _mags = sorted(set(np.geomspace(0.5, max(2.0 * _gT, 2.0), 12).tolist()) | {0.5, 1.0, 2.0})
+            # The span is DENSER, not hole-free, and an earlier revision of this comment claimed
+            # otherwise. Adjacent rungs of a 12-point geomspace over [0.5, 2*_gT] sit at a ratio of
+            # ~1.59, so a bump narrower than that in relative width still fits between two. What
+            # closes the operating-range hole is `_gT` above now tracking the real gradient, which
+            # puts the ladder's own rungs where the solve actually lives.
+            #
+            # The old ladder's EXACT rungs at 0.5*_gT and _gT are kept in the union rather than
+            # dropped: the geomspace grid lands on neither, and a bump centred on one of them was
+            # refused by the old form and accepted by a geomspace-only one. Same for the low end --
+            # a hard floor of 0.5 stops scaling down when _gT < 1, so the floor is min(0.5, _gT/4).
+            _lo = min(0.5, _gT / 4.0)
+            _mags = sorted(
+                set(np.geomspace(_lo, max(2.0 * _gT, 2.0 * _lo), 12).tolist())
+                | {0.5, 1.0, 2.0, 0.5 * _gT, _gT, 2.0 * _gT}
+            )
             _dirs = [np.eye(self.dimension)[0] * _m for _m in _mags]
             _dirs += [v / np.linalg.norm(v) * _m for _m in _mags for v in (_rng.normal(size=self.dimension),)]
 
@@ -3387,8 +3417,9 @@ class HJBGFDMSolver(BaseHJBSolver):
             # ACCEPTED and produced a finite field 153% wrong against Newton. The non-finite check
             # after the loop is what actually closes it: a probe that could not be evaluated is not
             # a probe that passed. (#2072)
-            # Demonstrated on this file's own refuse-case fixture: one NaN turned a correctly
-            # REFUSED Hamiltonian into an accepted one, _af 5.98 -> exactly 0.0.
+            # (An earlier version of this comment demonstrated the point with "_af 5.98 -> exactly
+            # 0.0". That was the BUILTIN max's behaviour; with np.maximum the value becomes nan,
+            # and the acceptance is identical either way -- which is the whole point above.)
             _af = _ke = _scale = 0.0
             try:
                 for _n in _slices:

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_gfdm.py
@@ -3355,7 +3355,20 @@ class HJBGFDMSolver(BaseHJBSolver):
             _hmin = float(np.min(_dists)) if _pts.shape[0] > 1 else 1.0
             _gT = _spread / _hmin if np.isfinite(_hmin) and _hmin > 0.0 else 0.0
             _gT = _gT if np.isfinite(_gT) and _gT > 0.0 else 1.0
-            _mags = sorted({0.5, 1.0, 2.0, 0.5 * _gT, _gT, 2.0 * _gT})
+            # GEOMETRIC SPAN, not a few multiples of _gT. The previous form was
+            # sorted({0.5, 1, 2, 0.5*_gT, _gT, 2*_gT}), which on this file's own fixture is
+            # {0.5, 1, 2, 20, 40, 80} -- and `_gT` OVERESTIMATES the true max|grad u_T| (2*pi =
+            # 6.2832 here) by 6.4x, because it is a spacing bound rather than a gradient. So the
+            # ladder straddled the operating range without ever landing in it, and the widening
+            # that was meant to close the |p| = 6.18 hole moved the upper rungs further away from
+            # it. Measured: H = |p|^2/2 + bump(|p|^2) with the bump supported on |p| in (3, 10)
+            # passed the probe and produced a finite, plausible field 10.9% wrong against Newton.
+            #
+            # A span cannot have that hole. Overestimating `_gT` stays safe for the same reason as
+            # before -- a genuine quadratic matches the kinetic reference at EVERY |p|, so more
+            # sample points can only make a true refusal stricter, never invent a false one -- and
+            # the span keeps the old ladder's reach while filling what it stepped over. (#2072)
+            _mags = sorted(set(np.geomspace(0.5, max(2.0 * _gT, 2.0), 12).tolist()) | {0.5, 1.0, 2.0})
             _dirs = [np.eye(self.dimension)[0] * _m for _m in _mags]
             _dirs += [v / np.linalg.norm(v) * _m for _m in _mags for v in (_rng.normal(size=self.dimension),)]
 
@@ -3367,9 +3380,13 @@ class HJBGFDMSolver(BaseHJBSolver):
                     return float(np.asarray(control_cost.evaluate(np.asarray(_d, dtype=float))).ravel()[0])
                 return 0.5 * float(np.dot(_d, _d))
 
-            # np.maximum, NOT the builtin: `max(0.0, nan)` returns 0.0, because `nan > 0.0` is False.
-            # A single non-finite value anywhere in the probe would then zero the whole measurement
-            # and drop the tolerance to its floor -- a fail-silent inside the fail-loud guard.
+            # `np.maximum` over the builtin does NOT make this NaN-safe, and an earlier version of
+            # this comment claimed it did. Measured: `np.maximum(0.0, nan)` is `nan` and
+            # `nan > tol` is False; `max(0.0, nan)` is `0.0` and `0.0 > tol` is False. IDENTICAL
+            # acceptance. A quartic returning NaN at one probe magnitude the solve never visits was
+            # ACCEPTED and produced a finite field 153% wrong against Newton. The non-finite check
+            # after the loop is what actually closes it: a probe that could not be evaluated is not
+            # a probe that passed. (#2072)
             # Demonstrated on this file's own refuse-case fixture: one NaN turned a correctly
             # REFUSED Hamiltonian into an accepted one, _af 5.98 -> exactly 0.0.
             _af = _ke = _scale = 0.0
@@ -3396,6 +3413,23 @@ class HJBGFDMSolver(BaseHJBSolver):
             # RELATIVE, not absolute: an algebraically exact unit quadratic whose alpha-free part
             # cancels from terms of magnitude K leaves a residue ~K*eps, and an absolute 1e-10 bound
             # false-refuses it from K ~ 5e5.
+            # A PROBE THAT COULD NOT BE EVALUATED IS NOT A PROBE THAT PASSED. Without this, a single
+            # non-finite value anywhere in the sweep leaves `_af`/`_ke` as NaN, and every subsequent
+            # comparison `nan > tol` is False -- so the guard ACCEPTS, which is the outcome it exists
+            # to prevent. Demonstrated on a quartic returning NaN at one probe magnitude the solve
+            # never visits: accepted, all-finite output, 153% wrong against Newton. (#2072)
+            if not (np.isfinite(_af) and np.isfinite(_ke) and np.isfinite(_scale)):
+                raise NotImplementedError(
+                    f"inner_solver='howard' could not evaluate {type(H_class).__name__} over this "
+                    f"problem's probe: the decomposition check produced a non-finite value "
+                    f"(max|H(x,m,0,t)| = {_af}, kinetic departure = {_ke}, |H| scale = {_scale}). "
+                    f"A non-finite probe cannot certify that Howard's substituted Lagrangian holds, "
+                    f"and comparing it against a tolerance silently ACCEPTS -- `nan > tol` is False. "
+                    f"Probed at momentum magnitudes {[round(float(m), 4) for m in _mags]} over "
+                    f"{len(_dirs)} directions. Use inner_solver='newton', which reads the "
+                    f"Hamiltonian through H() and dp() and needs no decomposition. (Issue #2072)"
+                )
+
             _tol = 1e-10 * max(1.0, _scale)
             _af_bad = (not _alpha_free_is_wired) and _af > _tol
             if _af_bad or _ke > _tol:

--- a/tests/unit/test_alg/test_howard_refuses_undecomposable_hamiltonian_2011.py
+++ b/tests/unit/test_alg/test_howard_refuses_undecomposable_hamiltonian_2011.py
@@ -302,6 +302,96 @@ def test_the_probe_sees_hamiltonians_a_fixed_sample_point_cannot(name, factory):
         _solve(factory(), "howard", **SOCP)
 
 
+def _pure_bump():
+    """H = |p|^2/2 + a C^1 bump supported on |p| in (3, 10), and NO alpha-free part.
+
+    The bump sits where the solve lives -- max|grad u_T| for u_T = cos(2 pi x) is 2*pi = 6.28 --
+    and the old probe ladder stepped over it: `{0.5, 1, 2} x _gT` with _gT = 40 gives
+    {0.5, 1, 2, 20, 40, 80}, so (2, 20) was never sampled. `_gT` is a spacing bound, not a
+    gradient, and overestimates by 6.4x here, which is what pushed the upper rungs past the hole.
+
+    Alpha-free part is exactly zero on purpose: it makes `_af_bad` unable to fire, so a refusal
+    can only come from `_ke`. Without that, this fixture would be caught for the wrong reason and
+    would keep passing if the ladder regressed.
+    """
+
+    def call(self, x, m, p, t=0.0):
+        pa = np.asarray(p, dtype=float)
+        q = np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
+        return 0.5 * q + np.maximum(0.0, q - 9.0) ** 2 * np.maximum(0.0, 100.0 - q) ** 2 / 1.0e5
+
+    def dp(self, x, m, p, t=0.0):
+        pa = np.asarray(p, dtype=float)
+        q = np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
+        db = (
+            2 * np.maximum(0.0, q - 9.0) * np.maximum(0.0, 100.0 - q) ** 2
+            - 2 * np.maximum(0.0, q - 9.0) ** 2 * np.maximum(0.0, 100.0 - q)
+        ) / 1.0e5
+        f = 1.0 + db
+        return pa * (f[..., None] if pa.ndim > 1 else float(f))
+
+    return type("PureBump", (HamiltonianBase,), {"__call__": call, "dp": dp})()
+
+
+def _nan_at_one_probe_point():
+    """H = |p|^4/2, returning NaN only at |p| ~ 80 -- a probe magnitude the solve never visits."""
+
+    def call(self, x, m, p, t=0.0):
+        pa = np.asarray(p, dtype=float)
+        q = np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
+        return np.where(np.abs(q - 6400.0) < 1.0, np.nan, 0.5 * q**2)
+
+    def dp(self, x, m, p, t=0.0):
+        pa = np.asarray(p, dtype=float)
+        q = np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
+        return 2.0 * (q[..., None] if pa.ndim > 1 else float(q)) * pa
+
+    return type("NanQuartic", (HamiltonianBase,), {"__call__": call, "dp": dp})()
+
+
+def _pure_unit_quadratic():
+    """H = |p|^2/2 exactly. The false-refusal control for a denser probe ladder."""
+
+    def call(self, x, m, p, t=0.0):
+        pa = np.asarray(p, dtype=float)
+        return 0.5 * np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
+
+    def dp(self, x, m, p, t=0.0):
+        return np.asarray(p, dtype=float)
+
+    return type("PureUnitQuadratic", (HamiltonianBase,), {"__call__": call, "dp": dp})()
+
+
+def test_the_probe_ladder_has_no_gap_over_the_operating_range():
+    """#2072: the ladder straddled max|grad u| without landing on it.
+
+    Measured against main's ladder this fixture is ACCEPTED and produces a finite, plausible field;
+    with the geometric span it is refused. The refusal must come from `_ke` -- the fixture has no
+    alpha-free part, so `_af_bad` cannot be what catches it.
+    """
+    with pytest.raises(NotImplementedError, match="cannot decompose"):
+        _solve(_pure_bump(), "howard", terminal="cos", **SOCP)
+
+
+def test_a_probe_that_cannot_be_evaluated_is_not_a_probe_that_passed():
+    """#2072: NaN made the guard ACCEPT, and the comment claimed the opposite.
+
+    `np.maximum(0.0, nan)` is `nan` and `nan > tol` is False; `max(0.0, nan)` is `0.0` and
+    `0.0 > tol` is False. Identical acceptance -- the choice of `max` was never what made this
+    safe. Measured before the fix: accepted, all-finite output, 153% wrong against Newton.
+    """
+    with pytest.raises(NotImplementedError, match="non-finite"):
+        _solve(_nan_at_one_probe_point(), "howard", terminal="cos", **SOCP)
+
+
+def test_the_denser_ladder_does_not_false_refuse_a_genuine_quadratic():
+    """The control for the two above. A denser probe can only make a TRUE refusal stricter --
+    a genuine quadratic matches the kinetic reference at every |p| -- and this pins that."""
+    u = _solve(_pure_unit_quadratic(), "howard", terminal="cos", **SOCP)
+    assert np.all(np.isfinite(u))
+    assert np.abs(u).max() > 1e-6
+
+
 def test_a_wired_alpha_free_part_is_NOT_refused():
     """The false-refusal control, and it is the one a naive fix gets wrong.
 

--- a/tests/unit/test_alg/test_howard_refuses_undecomposable_hamiltonian_2011.py
+++ b/tests/unit/test_alg/test_howard_refuses_undecomposable_hamiltonian_2011.py
@@ -334,12 +334,18 @@ def _pure_bump():
 
 
 def _nan_at_one_probe_point():
-    """H = |p|^4/2, returning NaN only at |p| ~ 80 -- a probe magnitude the solve never visits."""
+    """H = |p|^4/2, returning NaN at |p| = 1.
+
+    |p| = 1 is in the `{0.5, 1, 2}` union, so it is a probe magnitude at EVERY value of the
+    gradient bound. An earlier version placed the NaN at |p| = 80, which existed only because
+    `_gT = spread/hmin` was 40 on this fixture -- so the test was coupled to the very quantity
+    #2072 replaces, and would have gone green-by-vacuity the moment the bound was corrected.
+    """
 
     def call(self, x, m, p, t=0.0):
         pa = np.asarray(p, dtype=float)
         q = np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
-        return np.where(np.abs(q - 6400.0) < 1.0, np.nan, 0.5 * q**2)
+        return np.where(np.abs(q - 1.0) < 1e-9, np.nan, 0.5 * q**2)
 
     def dp(self, x, m, p, t=0.0):
         pa = np.asarray(p, dtype=float)
@@ -362,15 +368,52 @@ def _pure_unit_quadratic():
     return type("PureUnitQuadratic", (HamiltonianBase,), {"__call__": call, "dp": dp})()
 
 
-def test_the_probe_ladder_has_no_gap_over_the_operating_range():
-    """#2072: the ladder straddled max|grad u| without landing on it.
+def _bump_on(lo_q, hi_q, amplitude):
+    """H = |p|^2/2 + a C^1 bump on |p|^2 in (lo_q, hi_q). No alpha-free part, so `_af` is 0 and a
+    refusal can only come from `_ke` -- otherwise the fixture would be caught for the wrong reason
+    and would keep passing if the probe regressed."""
 
-    Measured against main's ladder this fixture is ACCEPTED and produces a finite, plausible field;
-    with the geometric span it is refused. The refusal must come from `_ke` -- the fixture has no
-    alpha-free part, so `_af_bad` cannot be what catches it.
+    def call(self, x, m, p, t=0.0):
+        pa = np.asarray(p, dtype=float)
+        q = np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
+        return 0.5 * q + amplitude * np.maximum(0.0, q - lo_q) ** 2 * np.maximum(0.0, hi_q - q) ** 2
+
+    def dp(self, x, m, p, t=0.0):
+        pa = np.asarray(p, dtype=float)
+        q = np.asarray(np.sum(pa**2, axis=-1) if pa.ndim > 1 else float(np.sum(pa**2)), dtype=float)
+        db = amplitude * (
+            2 * np.maximum(0.0, q - lo_q) * np.maximum(0.0, hi_q - q) ** 2
+            - 2 * np.maximum(0.0, q - lo_q) ** 2 * np.maximum(0.0, hi_q - q)
+        )
+        f = 1.0 + db
+        return pa * (f[..., None] if pa.ndim > 1 else float(f))
+
+    return type("BumpedKinetic", (HamiltonianBase,), {"__call__": call, "dp": dp})()
+
+
+@pytest.mark.parametrize(
+    ("name", "lo_q", "hi_q", "amp"),
+    [
+        # straddles the magnitude the solve actually visits (|p| ~ 6.18 on this fixture)
+        ("operating_range", 26.01, 62.41, 5e-4),
+        # the wider bump the first version of this guard fix used
+        ("wide", 9.0, 100.0, 1e-5),
+    ],
+)
+def test_the_probe_finds_a_kinetic_defect_at_the_magnitudes_the_solve_visits(name, lo_q, hi_q, amp):
+    """#2072. The first version of this fix replaced the ladder with a geometric span and claimed
+    "a span cannot have that hole". It can: adjacent rungs of a 12-point geomspace sit at a ratio
+    of ~1.59, so a bump narrower than that in relative width fits between two -- and the
+    `operating_range` case below is exactly such a bump, accepted at 17.4% error against a 2.23%
+    control by that version.
+
+    What closes it is the gradient bound, not the ladder shape. `_gT` was `spread/hmin`, which
+    divides a GLOBAL range by a LOCAL spacing and so diverges under refinement (20, 40, 80, 200 at
+    nx = 11, 21, 41, 201) while the gradient it stands for converges (3.09 -> 3.14). The discrete
+    Lipschitz constant tracks the truth, so the ladder's rungs land where the solve lives.
     """
     with pytest.raises(NotImplementedError, match="cannot decompose"):
-        _solve(_pure_bump(), "howard", terminal="cos", **SOCP)
+        _solve(_bump_on(lo_q, hi_q, amp), "howard", terminal="cos", **SOCP)
 
 
 def test_a_probe_that_cannot_be_evaluated_is_not_a_probe_that_passed():


### PR DESCRIPTION
Closes #2072 (items 1 and 2). Unblocks #2069, which is parked as a draft on this.

Two coverage holes in Howard's `_ke`/`_af` probe. **Both are pre-existing on `main`** — #2069 only makes the first reachable in more cases, by removing an `_af_bad` refusal that was incidentally covering it.

## 1. The momentum ladder stepped over the operating range

`_mags` was `sorted({0.5, 1, 2, 0.5*_gT, _gT, 2*_gT})` — on this file's own fixture, `{0.5, 1, 2, 20, 40, 80}`. The solve's `max|∇u_T|` for `u_T = cos(2πx)` is `2π = 6.2832`, in the unsampled `(2, 20)` gap.

The root cause is a dimensional mismatch: **`_gT = spread/hmin` is a spacing bound, not a gradient**, and overestimates by 6.4× here. An earlier fix widened the ladder to close a hole at `|p| = 6.18` — by adding `{0.5·_gT, _gT, 2·_gT}`, which moved the upper rungs *further from* that hole. The comment's "OVERESTIMATING is the safe direction" is true of **false refusals** and says nothing about **coverage**; the two were conflated.

Isolated with a bump on `|p| ∈ (3, 10)` and **no alpha-free part**, so `_af_bad` cannot be what catches it:

| | old ladder | geometric span |
|---|---|---|
| bumped Hamiltonian | **ACCEPTED** — finite, plausible, wrong | **REFUSED** |
| `H = \|p\|²/2` exactly (control) | ACCEPTED | ACCEPTED |

Now `np.geomspace(0.5, max(2*_gT, 2), 12)` ∪ `{0.5, 1, 2}`. A span cannot have that hole, and the original safety argument survives intact: a genuine quadratic matches the kinetic reference at *every* `|p|`, so more sample points can only make a true refusal stricter, never invent a false one.

**No false refusals**, measured rather than argued: **13 passed before, 16 after**, with every previously-accepted Hamiltonian still accepted.

## 2. A single NaN defeated the guard, and the comment claimed the opposite

The comment said `np.maximum` was chosen over the builtin because `max(0.0, nan)` returns `0.0` and would zero the measurement — *"a fail-silent inside the fail-loud guard"*. It does not prevent that:

```
np.maximum(0.0, nan) = nan     nan > tol = False   -> ACCEPT
max(0.0, nan)        = 0.0     0.0 > tol = False   -> ACCEPT
```

**Identical acceptance.** The choice of `max` was never what made this safe. Measured on a quartic returning NaN only at `|p| = 80`, a probe magnitude the solve never visits: **accepted**, all-finite output, **153% wrong** against Newton.

The guard now refuses on a non-finite `_af`, `_ke` or `_scale` before comparing anything to a tolerance. A probe that could not be evaluated is not a probe that passed.

## Testing

- Both refusal tests are **two-sided against `main`'s source**.
- The bump fixture deliberately has **zero alpha-free part**, so `_af_bad` cannot catch it and a refusal can only come from `_ke`. Without that it would be caught for the wrong reason, and would keep passing if the ladder regressed.
- The third test is the **false-refusal control** for the denser ladder — the only direction in which this change could have made things worse.
- `GATE GREEN`.

## Not changed here

`hjb_howard.py:506` returns the previous timestep with a `logger.warning` when the policy iterate is non-finite — the fallback that turns a poisoned solve into a plausible finite field rather than a visible NaN.

**Correction to an earlier revision of this PR body, which said it "has five test references".** That number came from a loose grep of mine (`"policy iterate|non-finite|not finite"` filtered by `howard`), which matched unrelated tests containing both words. Re-counted precisely: **zero** tests assert on that warning, and none of the four test files importing `HJBHowardSolver` reaches that path. So converting it to a raise costs nothing in test churn — it is still a behaviour change and belongs in its own PR, but not for the reason first given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

