### PR TITLE
GhostBuffer served a different boundary condition than pad_array_with_ghosts (#2059)

### DIFF
--- a/changelog.d/2059-ghost-buffer-supplies-the-extrapolation-stencil.fixed.md
+++ b/changelog.d/2059-ghost-buffer-supplies-the-extrapolation-stencil.fixed.md
@@ -1,0 +1,31 @@
+**BREAKING for direct callers of the extrapolation calculators.** `GhostBuffer` served a *different
+boundary condition* than `pad_array_with_ghosts` for `EXTRAPOLATION_LINEAR` and
+`EXTRAPOLATION_QUADRATIC`, and both calculators now refuse rather than degrade (#2059).
+
+`GhostBuffer.update()` never supplied `second_interior_value`, so `LinearExtrapolationCalculator`
+took its `return interior_value` fallback — **the zero-gradient ghost**. Not a rare degradation: on
+that path it was the *only* branch that ever ran, so every `EXTRAPOLATION_LINEAR` request served
+through `GhostBuffer` got a Neumann-0 wall, silently.
+
+Measured on `u = [2.5, 3.1, 4.0, 5.2, 6.6]`, `ghost_depth=1`:
+
+| | `pad_array_with_ghosts` | `GhostBuffer` before | after |
+|---|---|---|---|
+| LINEAR, low ghost | 1.9 | **2.5** — literally `u[0]` | 1.9 |
+| LINEAR, high ghost | 8.0 | — | 8.0 |
+| QUADRATIC | 2.2 / 8.2 | — | 2.2 / 8.2 |
+
+**The repo had already decided this question**, in the path that works. `pad_array_with_ghosts` reads
+the stencil inward from the wall (`buf[g + j]` low, `buf[-g - 1 - j]` high) and **refuses** when the
+grid cannot carry it, with the reason written in the code: *"Refuse rather than silently dropping to
+a lower order."* `GhostBuffer` simply had not followed. It now uses the same indices, so the two
+public paths compute the same ghost from the same cells.
+
+The quadratic calculator's degradation chain was worse than a single fallback: `quadratic → linear →
+edge extension`, all silent, so a caller asking for `EXTRAPOLATION_QUADRATIC` could receive any of
+**three different boundary conditions** depending on how many arguments happened to arrive. Both
+calculators now raise, naming the formula and what the substitution would have imposed instead.
+
+The test's oracle is **agreement between the two public paths**, not a formula restated in the test —
+with #1958's own measured figures pinned alongside, so a change breaking both paths identically is
+still caught.

--- a/mfgarchon/geometry/boundary/applicator_fdm.py
+++ b/mfgarchon/geometry/boundary/applicator_fdm.py
@@ -764,18 +764,57 @@ class GhostBuffer:
             interior_lo = buf[tuple(lo_interior)]
             interior_hi = buf[tuple(hi_interior)]
 
+            # #2059: the extrapolation calculators need cells the mirror pairing above does not
+            # supply. `LinearExtrapolationCalculator` wants (u_0, u_1) and the quadratic one
+            # (u_0, u_1, u_2), all measured INWARD FROM THE WALL -- not the per-layer mirror
+            # partner. Called without them, both fell back to `return interior_value`, which is
+            # the zero-GRADIENT ghost: a different boundary condition, silently substituted for
+            # the one the caller asked for, on every extrapolation request served through this
+            # class.
+            #
+            # The indices are the ones `pad_array_with_ghosts` already uses for the same BC types
+            # (`buf[g + j]` low, `buf[-g - 1 - j]` high), so the two public paths now compute the
+            # same ghost from the same cells rather than one of them quietly answering a different
+            # question.
+            extra: dict = {}
+            if self._calculator.__class__.__name__ in (
+                "LinearExtrapolationCalculator",
+                "QuadraticExtrapolationCalculator",
+            ):
+                n_pts = 3 if "Quadratic" in self._calculator.__class__.__name__ else 2
+                if buf.shape[axis] - 2 * g < n_pts:
+                    raise ValueError(
+                        f"{self._calculator.__class__.__name__} needs {n_pts} interior cells along "
+                        f"axis {axis} to build its one-sided stencil; this grid has "
+                        f"{buf.shape[axis] - 2 * g}. Refuse rather than silently dropping to a "
+                        f"lower order (#2059)."
+                    )
+
+                def _at(idx: int, ax: int = axis) -> object:
+                    sl = [slice(None)] * d
+                    sl[ax] = idx
+                    return buf[tuple(sl)]
+
+                extra["lo"] = {"second_interior_value": _at(g + 1)}
+                extra["hi"] = {"second_interior_value": _at(-g - 2)}
+                if n_pts == 3:
+                    extra["lo"]["third_interior_value"] = _at(g + 2)
+                    extra["hi"]["third_interior_value"] = _at(-g - 3)
+
             # VECTORIZED: Apply calculator to entire boundary array at once
             # All Calculator implementations support NDArray via NumPy broadcasting
             ghost_lo = self._calculator.compute(
                 interior_value=interior_lo,
                 dx=dx,
                 side="min",
+                **extra.get("lo", {}),
                 **kwargs,
             )
             ghost_hi = self._calculator.compute(
                 interior_value=interior_hi,
                 dx=dx,
                 side="max",
+                **extra.get("hi", {}),
                 **kwargs,
             )
 

--- a/mfgarchon/geometry/boundary/calculators.py
+++ b/mfgarchon/geometry/boundary/calculators.py
@@ -368,8 +368,17 @@ class LinearExtrapolationCalculator:
             Ghost value = 2*u_0 - u_1
         """
         if second_interior_value is None:
-            # Fall back to edge extension if second value not provided
-            return interior_value
+            # #2059: this returned `interior_value` -- the zero-GRADIENT ghost, a DIFFERENT
+            # boundary condition silently substituted for the one requested. It was not a rare
+            # fallback either: `GhostBuffer.update()` never supplied the argument, so on that path
+            # it was the ONLY branch that ever ran, and every EXTRAPOLATION_LINEAR request served
+            # through it got a Neumann-0 wall. The caller now supplies it, from the same cells
+            # `pad_array_with_ghosts` uses.
+            raise ValueError(
+                "LinearExtrapolationCalculator requires second_interior_value: the ghost is "
+                "2*u_0 - u_1 and u_1 is not optional. Returning u_0 instead would impose the "
+                "zero-gradient condition, which is a different boundary condition (#2059)."
+            )
         # Vectorized: works for both scalar and array
         return 2.0 * interior_value - second_interior_value
 
@@ -411,10 +420,17 @@ class QuadraticExtrapolationCalculator:
             Ghost value = 3*u_0 - 3*u_1 + u_2
         """
         if second_interior_value is None or third_interior_value is None:
-            # Fall back to linear if not enough points
-            if second_interior_value is not None:
-                return 2.0 * interior_value - second_interior_value
-            return interior_value
+            # #2059: this degraded quadratic -> linear -> edge extension without telling anyone,
+            # so a caller asking for EXTRAPOLATION_QUADRATIC could receive any of three different
+            # boundary conditions depending on how many arguments happened to arrive. The
+            # `pad_array_with_ghosts` path already refuses when the grid cannot carry the stencil,
+            # with the reason "Refuse rather than silently dropping to a lower order"; this now
+            # agrees with it.
+            raise ValueError(
+                "QuadraticExtrapolationCalculator requires second_interior_value and "
+                "third_interior_value: the ghost is 3*u_0 - 3*u_1 + u_2. Silently dropping to "
+                "linear or to edge extension imposes a different boundary condition (#2059)."
+            )
         # Vectorized: works for both scalar and array
         return 3.0 * interior_value - 3.0 * second_interior_value + third_interior_value
 

--- a/tests/unit/test_geometry/test_bc_applicator.py
+++ b/tests/unit/test_geometry/test_bc_applicator.py
@@ -9,6 +9,9 @@ import pytest
 import numpy as np
 
 from mfgarchon.geometry.boundary import (
+    BCSegment,
+    BCType,
+    BoundaryConditions,
     GridType,
     dirichlet_bc,
     neumann_bc,
@@ -410,6 +413,64 @@ class TestCalculatorClasses:
         got = calc.compute(interior_value=slope * x_interior, dx=dx, side=side)
 
         assert np.isclose(got, slope * x_ghost), f"{grid_type.name}/{side}: {got} != {slope * x_ghost}"
+
+    @pytest.mark.parametrize(
+        ("bc_type", "expected_lo", "expected_hi"),
+        [
+            (BCType.EXTRAPOLATION_LINEAR, 1.9, 8.0),
+            (BCType.EXTRAPOLATION_QUADRATIC, 2.2, 8.2),
+        ],
+    )
+    def test_the_two_ghost_paths_agree_on_extrapolation(self, bc_type, expected_lo, expected_hi):
+        """#2059: `GhostBuffer` served a DIFFERENT boundary condition than `pad_array_with_ghosts`.
+
+        It never supplied `second_interior_value`, so both extrapolation calculators took their
+        `return interior_value` fallback -- the zero-GRADIENT ghost. Not a rare degradation: on
+        that path it was the only branch that ever ran, so every EXTRAPOLATION_LINEAR request
+        served through `GhostBuffer` got a Neumann-0 wall, silently.
+
+        The oracle is AGREEMENT BETWEEN THE TWO PUBLIC PATHS, not a formula restated here. The
+        expected values are #1958's own measured figures for `u = [2.5, 3.1, 4.0, 5.2, 6.6]`, so a
+        change that broke both paths identically would still be caught.
+        """
+        from mfgarchon.geometry.boundary.applicator_fdm import (
+            create_ghost_buffer_from_bc,
+            pad_array_with_ghosts,
+        )
+
+        u = np.array([2.5, 3.1, 4.0, 5.2, 6.6])
+        bc = BoundaryConditions(dimension=1, segments=[BCSegment(name="all", bc_type=bc_type)])
+
+        padded = pad_array_with_ghosts(u, bc, ghost_depth=1, spacing=1.0)
+        buffer = create_ghost_buffer_from_bc(bc, (len(u),), 1.0, ghost_depth=1)
+        buffer.interior[...] = u
+        buffer.update()
+        via_buffer = np.asarray(buffer.padded)
+
+        assert np.isclose(padded[0], expected_lo)
+        assert np.isclose(padded[-1], expected_hi)
+        assert np.isclose(via_buffer[0], padded[0]), f"lo: buffer {via_buffer[0]} vs pad {padded[0]}"
+        assert np.isclose(via_buffer[-1], padded[-1]), f"hi: buffer {via_buffer[-1]} vs pad {padded[-1]}"
+
+    def test_extrapolation_refuses_rather_than_dropping_to_a_lower_order(self):
+        """#2059: the quadratic calculator degraded quadratic -> linear -> edge extension silently.
+
+        A caller asking for EXTRAPOLATION_QUADRATIC could receive any of three different boundary
+        conditions depending on how many arguments happened to arrive. `pad_array_with_ghosts`
+        already refused when the grid could not carry the stencil, with the reason "Refuse rather
+        than silently dropping to a lower order"; the calculators now agree with it.
+        """
+        from mfgarchon.geometry.boundary import (
+            LinearExtrapolationCalculator,
+            QuadraticExtrapolationCalculator,
+        )
+
+        with pytest.raises(ValueError, match="second_interior_value"):
+            LinearExtrapolationCalculator().compute(interior_value=1.0, dx=0.1, side="min")
+        with pytest.raises(ValueError, match="third_interior_value"):
+            QuadraticExtrapolationCalculator().compute(
+                interior_value=1.0, dx=0.1, side="min", second_interior_value=2.0
+            )
 
     def test_the_fp_no_flux_ghost_zeroes_the_TOTAL_flux_given_an_axis_velocity(self):
         """#2063: `drift_velocity` is v_x, not v*n, and the docstring said the opposite.


### PR DESCRIPTION
Closes #2059.

`GhostBuffer.update()` never supplied `second_interior_value`, so `LinearExtrapolationCalculator` took its `return interior_value` fallback — **the zero-gradient ghost**.

Not a rare degradation: on that path it was the **only branch that ever ran**, so every `EXTRAPOLATION_LINEAR` request served through `GhostBuffer` got a Neumann-0 wall, silently.

Measured on `u = [2.5, 3.1, 4.0, 5.2, 6.6]`, `ghost_depth=1`:

| | low ghost | high ghost |
|---|---|---|
| `pad_array_with_ghosts` | 1.9 | 8.0 |
| `GhostBuffer` **before** | **2.5** — literally `u[0]` | — |
| `GhostBuffer` after | 1.9 | 8.0 |

## The repo had already decided this question

The issue framed it as a choice — supply the value, or refuse. `pad_array_with_ghosts` does **both**: it reads the stencil inward from the wall (`buf[g + j]` low, `buf[-g - 1 - j]` high) **and** refuses when the grid cannot carry it, with the reason written in the code:

> *"Refuse rather than silently dropping to a lower order."*

`GhostBuffer` had simply not followed. It now uses the same indices, so the two public paths compute the same ghost from the same cells rather than one of them quietly answering a different question.

## The quadratic chain was worse than one fallback

`quadratic → linear → edge extension`, all silent — so a caller asking for `EXTRAPOLATION_QUADRATIC` could receive any of **three different boundary conditions** depending on how many arguments happened to arrive. Both calculators now raise, naming the formula and what the substitution would have imposed instead.

## Testing

**The oracle is agreement between the two public paths**, not a formula restated in the test — so it does not rest on my judgement of which formula is right. #1958's own measured figures (1.9 / 8.0, 2.2 / 8.2) are pinned alongside, so a change breaking both paths identically is still caught.

- **Two-sided**: against `main` the test fails `lo: buffer 2.5 vs pad 1.9` — and 2.5 is `u[0]`, so the diagnostic names the defect without further explanation.
- 1282 passed in `tests/unit/test_geometry/`, `GATE GREEN`.

## Related

The stashed working-tree change that #2059 was filed from proposed the raise **without** the caller supplying the value, which would have crashed this path rather than fixing it. Supplying and refusing are both needed, which is what `pad_array_with_ghosts` already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)