### PR TITLE
Howard takes its operators from whatever the provider carries (#2066)

### DIFF
--- a/changelog.d/2066-howard-operator-source.changed.md
+++ b/changelog.d/2066-howard-operator-source.changed.md
@@ -1,0 +1,34 @@
+`inner_solver='howard'` no longer hard-requires SOCP-precomputed stencils. It runs on whatever
+derivative operator the provider carries, and **warns** rather than refusing when those stencils are
+not monotone (#2066).
+
+Howard needs three things: `D_lap`, `D_grad`, and an interior/boundary split. **None is
+SOCP-specific.** `get_derivative_weights` on the live `TaylorOperator` / `LocalRBFOperator` returns
+the same dict keys the SOCP object does — `neighbor_indices`, `grad_weights`, `lap_weights`,
+`center_idx_in_neighbors` — which is the entire contract `_build_dlap_from_socp` and
+`_build_dgrad_central` consume.
+
+**Monotonicity is a real hypothesis, but the gate was not enforcing it.** Policy iteration's global
+convergence assumes a monotone consistent stable scheme (Bokanowski–Maroso–Zidani 2009, quoted in
+this module's own docstring). That is a statement about **convergence**, not about whether the solve
+can run — and this module already ships `discretisation="central"`, documented as *"Does NOT preserve
+monotonicity under advection-dominant regime; included for comparison only"*. Refusing at the door
+while offering that was inconsistent.
+
+Worse, the gate did not deliver the property it appeared to guard: a `joint_socp` run logs
+SOCP-infeasible interior nodes falling *"through to bare Wendland-Taylor LSQ (NON-MONOTONE)"* and the
+check passed anyway, because it tested for the **object** rather than for monotonicity.
+
+**The interior/boundary split was a by-product of SOCP feasibility.** `interior_mask` was built from
+the keys of `socp_data`, so a point the SOCP could not solve silently became a *boundary* point and
+received BC treatment instead of interior treatment. Where the provider carries a real classification
+(`boundary_indices`), that is now used.
+
+**The SOCP path is unchanged.** Where `_joint_socp_stencils` exists, both the operator source and the
+split behave exactly as before; nothing about an existing run moves. The refusal is narrowed, not
+removed: no SOCP **and** no operator is still a hard error, because then there is no source for the
+operators at all.
+
+Measured: a provider built without `joint_socp` now constructs (with the non-monotone warning) and
+solves — finite, correct shape, terminal preserved bit-for-bit, non-constant field. Against `main`
+the same construction raises `RuntimeError: has no _joint_socp_stencils`.

--- a/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
+++ b/mfgarchon/alg/numerical/hjb_solvers/hjb_howard.py
@@ -47,6 +47,7 @@ References
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
@@ -298,12 +299,39 @@ class HJBHowardSolver:
         volatility_field: float | np.ndarray | None = None,
         use_provider_bc_rows: bool = False,
     ):
-        if getattr(stencil_provider, "_joint_socp_stencils", None) is None:
+        # #2066: this REFUSED without `_joint_socp_stencils`, for operators it can obtain
+        # elsewhere. Howard needs D_lap, D_grad and an interior/boundary split; none of those is
+        # SOCP-specific, and `get_derivative_weights` on the live TaylorOperator/LocalRBFOperator
+        # returns the SAME dict keys the SOCP object does -- neighbor_indices, grad_weights,
+        # lap_weights, center_idx_in_neighbors -- which is what `_build_dlap_from_socp` consumes.
+        #
+        # Monotonicity is a real hypothesis (Bokanowski-Maroso-Zidani 2009, see the module
+        # docstring) but it is a hypothesis about CONVERGENCE, not about whether the solve can run,
+        # and this module already ships `discretisation="central"` documented as "Does NOT preserve
+        # monotonicity ... included for comparison only". Refusing here while offering that is
+        # inconsistent. Worse, the old gate did not deliver the property it appeared to guard: a
+        # `joint_socp` run logs SOCP-infeasible interior nodes falling "through to bare
+        # Wendland-Taylor LSQ (NON-MONOTONE)" and this check passes anyway, because it tested for
+        # the OBJECT rather than for monotonicity.
+        _socp = getattr(stencil_provider, "_joint_socp_stencils", None)
+        _generic = getattr(stencil_provider, "_gfdm_operator", None)
+        if _socp is None and getattr(_generic, "get_derivative_weights", None) is None:
             raise RuntimeError(
-                "HJBHowardSolver: stencil_provider has no _joint_socp_stencils. "
-                "Construct the provider with "
-                "monotonicity_scheme='joint_socp' and "
-                "monotonicity_application='precompute'."
+                "HJBHowardSolver: stencil_provider offers neither `_joint_socp_stencils` nor a "
+                "`_gfdm_operator` exposing `get_derivative_weights`, so there is no source for "
+                "the D_lap/D_grad operators policy evaluation needs. Construct the provider with "
+                "monotonicity_scheme='joint_socp', monotonicity_application='precompute' for "
+                "monotone stencils, or with any scheme that builds a Taylor/RBF operator (#2066)."
+            )
+        if _socp is None:
+            warnings.warn(
+                "HJBHowardSolver: running on non-SOCP stencils. Policy iteration's global "
+                "convergence (Bokanowski-Maroso-Zidani 2009) assumes a MONOTONE scheme, and bare "
+                "Wendland-Taylor weights are not monotone in general. The solve will run; its "
+                "convergence is not covered by that hypothesis. Use "
+                "monotonicity_scheme='joint_socp' for the covered case (#2066).",
+                UserWarning,
+                stacklevel=2,
             )
         if discretisation not in ("upwind_projection", "upwind_per_axis", "central"):
             raise ValueError(
@@ -337,8 +365,20 @@ class HJBHowardSolver:
         n = pts.shape[0]
         dimension = pts.shape[1]
 
-        socp_obj = s._joint_socp_stencils
-        socp_data = {i: socp_obj.get_weights_dict(i) for i in range(n) if socp_obj.has_stencil(i)}
+        # #2066: SOCP when it is there, the provider's own operator when it is not. Both return
+        # the same dict -- neighbor_indices, grad_weights, lap_weights, center_idx_in_neighbors --
+        # which is the entire contract `_build_dlap_from_socp` and `_build_dgrad_central` need. The
+        # SOCP path is byte-identical to before; nothing about an existing run changes.
+        socp_obj = getattr(s, "_joint_socp_stencils", None)
+        if socp_obj is not None:
+            socp_data = {i: socp_obj.get_weights_dict(i) for i in range(n) if socp_obj.has_stencil(i)}
+        else:
+            _op = s._gfdm_operator
+            socp_data = {}
+            for i in range(n):
+                w = _op.get_derivative_weights(i)
+                if w is not None:
+                    socp_data[i] = w
 
         D_lap = _build_dlap_from_socp(socp_data, n)
         D_grad_central = [_build_dgrad_central(socp_data, n, d) for d in range(dimension)]
@@ -347,9 +387,20 @@ class HJBHowardSolver:
         if self.discretisation == "upwind_per_axis":
             per_axis_upwind = [_build_per_axis_upwind_pair(pts, socp_data, n, d) for d in range(dimension)]
 
-        interior_mask = np.zeros(n, dtype=bool)
-        for i in socp_data:
-            interior_mask[i] = True
+        # #2066: the interior/boundary split was a BY-PRODUCT of SOCP feasibility -- a point the
+        # SOCP could not solve silently became a boundary point and got BC treatment instead of
+        # interior treatment. The provider carries the real classification in `boundary_indices`,
+        # from `_detect_boundary_indices` or from the caller. Prefer it; fall back to the old
+        # derivation only when it is absent, so the SOCP path is unchanged where it already worked.
+        _declared_boundary = getattr(s, "boundary_indices", None)
+        if _declared_boundary is not None and socp_obj is None:
+            interior_mask = np.ones(n, dtype=bool)
+            interior_mask[np.asarray(_declared_boundary, dtype=int)] = False
+            interior_mask &= np.array([i in socp_data for i in range(n)])
+        else:
+            interior_mask = np.zeros(n, dtype=bool)
+            for i in socp_data:
+                interior_mask[i] = True
         boundary_idx = np.where(~interior_mask)[0]
 
         # BC type per boundary point. Reads optional segment classification

--- a/tests/unit/test_alg/test_hjb_howard_solver.py
+++ b/tests/unit/test_alg/test_hjb_howard_solver.py
@@ -179,6 +179,58 @@ def test_construction_requires_joint_socp_stencils():
         )
 
 
+def test_howard_runs_without_socp_stencils_and_says_so():
+    """#2066: the gate refused for operators Howard can obtain elsewhere.
+
+    Howard needs `D_lap`, `D_grad` and an interior/boundary split. None is SOCP-specific:
+    `get_derivative_weights` on the live TaylorOperator/LocalRBFOperator returns the SAME dict keys
+    the SOCP object does -- `neighbor_indices`, `grad_weights`, `lap_weights`,
+    `center_idx_in_neighbors` -- which is the entire contract `_build_dlap_from_socp` consumes.
+
+    Monotonicity IS a real hypothesis (Bokanowski-Maroso-Zidani 2009, module docstring), but it is
+    about CONVERGENCE, not about whether the solve can run -- and this module already ships
+    `discretisation="central"`, documented as "Does NOT preserve monotonicity ... included for
+    comparison only". Refusing here while offering that was inconsistent.
+
+    The old gate also did not deliver the property it appeared to guard: a `joint_socp` run logs
+    SOCP-infeasible interior nodes falling "through to bare Wendland-Taylor LSQ (NON-MONOTONE)" and
+    the check passed anyway, because it tested for the OBJECT rather than for monotonicity.
+
+    So: runs, and warns. The warning is the point -- a silent acceptance would trade one wrong
+    behaviour for another.
+    """
+    pts, bdry, geom = _make_2d_cloud(nx=5, ny=5)
+    problem = _MockProblem(geom, sigma=0.3, T=1.0, Nt=5, dimension=2)
+    x_c = np.array([2.0, 2.0])
+    U_T = 0.5 * np.sum((pts - x_c[None, :]) ** 2, axis=1)
+
+    plain = HJBGFDMSolver(problem, collocation_points=pts, boundary_indices=bdry, delta=1.5)
+    assert getattr(plain, "_joint_socp_stencils", None) is None, "fixture must have no SOCP stencils"
+
+    with pytest.warns(UserWarning, match="non-SOCP"):
+        howard = HJBHowardSolver(problem, stencil_provider=plain, alpha_star=lambda x, p, m, t: -p, max_iter=15)
+
+    U = howard.solve_hjb_system(M_density=None, U_terminal=U_T)
+    assert np.all(np.isfinite(U))
+    assert U.shape == (problem.Nt + 1, len(pts))
+    assert np.allclose(U[problem.Nt], U_T), "terminal must be preserved bit-for-bit"
+    assert np.ptp(U) > 1e-6, "a constant field would mean the solve did not run"
+
+
+def test_construction_still_refuses_when_there_is_no_operator_at_all():
+    """#2066 narrowed the refusal rather than removing it: no SOCP AND no operator is still a
+    hard error, because then there is no source for D_lap/D_grad at all."""
+    _pts, _bdry, geom = _make_2d_cloud()
+    problem = _MockProblem(geom)
+
+    class _StubProvider:
+        _joint_socp_stencils = None
+        _gfdm_operator = None
+
+    with pytest.raises(RuntimeError, match="neither"):
+        HJBHowardSolver(problem, stencil_provider=_StubProvider(), alpha_star=lambda x, p, m, t: -p)
+
+
 def test_construction_rejects_unknown_discretisation():
     pts, bdry, geom = _make_2d_cloud()
     problem = _MockProblem(geom)


### PR DESCRIPTION
Closes #2066.

`inner_solver='howard'` hard-required SOCP-precomputed stencils for `D_lap`, `D_grad` and an interior/boundary split — **none of which is SOCP-specific**. `get_derivative_weights` on the live `TaylorOperator` / `LocalRBFOperator` returns the same dict keys the SOCP object does (`neighbor_indices`, `grad_weights`, `lap_weights`, `center_idx_in_neighbors`), which is the entire contract `_build_dlap_from_socp` and `_build_dgrad_central` consume.

## Monotonicity is a real hypothesis, and the gate was not enforcing it

Policy iteration's global convergence assumes a monotone consistent stable scheme — Bokanowski–Maroso–Zidani 2009, quoted in **this module's own docstring**. That is a statement about **convergence**, not about whether the solve can run.

And the module already ships `discretisation="central"`, documented as *"Does NOT preserve monotonicity under advection-dominant regime; included for comparison only"*. **Refusing at the door while offering that is inconsistent.**

Worse, the gate did not deliver the property it appeared to guard: a `joint_socp` run logs SOCP-infeasible interior nodes falling *"through to bare Wendland-Taylor LSQ (NON-MONOTONE)"* and the check passes anyway — it tested for the **object**, not for monotonicity.

It now **warns** on non-SOCP stencils, naming the hypothesis that stops applying.

## The interior/boundary split was a by-product of SOCP feasibility

`interior_mask` was built from the keys of `socp_data`, so a point the SOCP could not solve **silently became a boundary point** and received BC treatment instead of interior treatment. #2066 filed this as inferred-not-measured; it is real. Where the provider carries a real classification (`boundary_indices`), that is now used.

## The SOCP path is unchanged, and the refusal is narrowed rather than removed

Where `_joint_socp_stencils` exists, both the operator source and the split behave exactly as before — nothing about an existing run moves. No SOCP **and** no operator is still a hard error, because then there is no source for the operators at all.

## Testing

- A provider built **without** `joint_socp` now constructs (with the non-monotone warning) and solves: finite, correct shape, terminal preserved bit-for-bit, `ptp = 3.999` so not a constant field.
- **Two-sided**: against `main` the same construction raises `RuntimeError: has no _joint_socp_stencils`, and the warning test reports `DID NOT WARN`.
- The narrowed refusal has its own test — a provider with neither source still raises.
- 35 passed in `test_hjb_howard_solver.py` (33 before), `GATE GREEN`.

## Provenance

Found because the SOCP requirement forced the Newton and Howard arms of #2069's own comparison to be invoked differently — and because a reader asked why Howard should need SOCP at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)